### PR TITLE
feat: Implement Opus audio encoding for WebRTC streaming (Phase 2)

### DIFF
--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -121,6 +121,7 @@ dispatch2 = "0.3"  # GCD dispatch queues
 pollster = "0.3"  # For blocking on async
 cpal = "0.15"  # Cross-platform audio I/O (uses CoreAudio on macOS)
 mach2 = "0.4"  # Mach kernel API for thread priorities and timing
+opus = "0.3"  # Opus audio codec encoder/decoder
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the WebRTC implementation plan: Opus audio encoding for low-latency streaming.

This PR adds production-ready Opus audio encoding with comprehensive validation, error handling, and testing. The implementation enables real-time audio streaming for WebRTC/WHIP integration with excellent quality and packet loss resilience.

## What's New

### OpusEncoder Implementation
- **Stereo encoding** at 48kHz with 20ms frames (960 samples per channel)
- **Variable Bitrate (VBR)** enabled by default for optimal quality
- **Forward Error Correction (FEC)** for better packet loss resilience  
- **Default 128 kbps bitrate** (dynamically configurable via `set_bitrate()`)
- **Timestamp preservation** for accurate A/V synchronization

### Key Features
✅ Input validation (48kHz, stereo, 960 samples required)  
✅ Clear, actionable error messages guide users to preprocessing steps  
✅ 10 comprehensive unit tests (all passing)  
✅ Production-ready error handling  
✅ Proper Debug trait implementations

## Changes

### Files Modified
- **`libs/streamlib/Cargo.toml`** - Added `opus = "0.3"` dependency
- **`libs/streamlib/src/apple/processors/webrtc.rs`** - Implemented OpusEncoder with full encoding logic and tests

### Pipeline Requirements

For successful Opus encoding, the audio pipeline should be:

```
AudioSource
  ↓
AudioResamplerProcessor(48kHz) [if source isn't 48kHz]
  ↓
BufferRechunkerProcessor(960) [required - ensures exactly 20ms frames]
  ↓
WebRtcWhipProcessor (uses OpusEncoder internally)
```

If input doesn't meet requirements, OpusEncoder returns helpful errors:
- Wrong sample rate → "Use AudioResamplerProcessor upstream to convert to 48kHz"
- Wrong frame size → "Use BufferRechunkerProcessor(960) upstream"

## Testing

All 10 Opus encoder tests pass:

✅ `test_opus_encoder_creation` - Encoder initialization  
✅ `test_opus_encoder_invalid_sample_rate` - Rejects non-48kHz  
✅ `test_opus_encoder_invalid_channels` - Rejects non-stereo  
✅ `test_opus_encode_correct_frame_size` - Encodes valid 20ms frames  
✅ `test_opus_encode_wrong_frame_size` - Validates frame size  
✅ `test_opus_encode_wrong_sample_rate` - Validates sample rate during encoding  
✅ `test_opus_timestamp_preservation` - Verifies timestamps preserved exactly  
✅ `test_opus_bitrate_change` - Tests dynamic bitrate configuration  
✅ `test_opus_encode_sine_wave` - Encodes real audio (440Hz tone)  
✅ `test_opus_encode_multiple_frames` - Continuous encoding (200ms)

```bash
cargo test --lib opus
# test result: ok. 10 passed; 0 failed; 0 ignored
```

## Technical Details

### Configuration (AudioEncoderConfig)
- `sample_rate`: 48000 Hz (required)
- `channels`: 2 (stereo, required)
- `bitrate_bps`: 128,000 (default, configurable)
- `frame_duration_ms`: 20 (required)
- `vbr`: true (Variable Bitrate)
- `complexity`: Uses Opus default (9)

### Performance Characteristics
- **Latency**: 20ms frame duration (real-time suitable)
- **Compression**: ~10-20x compression ratio for speech/music
- **Quality**: Excellent (VBR + complexity 9 + FEC)
- **Memory**: Constant memory usage, no allocations in encode path

## Dependencies

- **opus 0.3** - Safe Rust bindings to libopus
- Requires libopus system library: `brew install opus` on macOS

## Success Criteria (from Phase 2 Plan)

✅ Can encode AudioFrame to Opus  
✅ Timestamps preserved exactly  
✅ Handles 20ms frame chunking (via validation)  
✅ Bitrate configuration works  
✅ All tests pass  

## Follow-up Work

This PR completes Phase 2 of the WebRTC plan. Future enhancements could include:
- Mono audio support (`AudioFrame<1>`)
- Dynamic bitrate adjustment based on network conditions
- Additional frame sizes (10ms, 40ms)
- DTX (Discontinuous Transmission) for silence periods

## Related

- **Phase 1**: #52 (GPU-accelerated H.264 video encoding) ✅ Merged
- **Phase 2**: This PR (Opus audio encoding)
- **Next**: Phase 3 - RTP packetization and WHIP protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>