### PR TITLE
feat: Add WebSocket event streaming to ApiServerProcessor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ pyo3 = { version = "0.27.0", features = ["extension-module"] }
 str0m = "0.11.1"
 
 # HTTP/Web
-axum = "0.8.8"
+axum = { version = "0.8.8", features = ["ws"] }
 tower-http = "0.6.8"
 hyper = "1.7.0"
 

--- a/examples/api-server-demo/Cargo.toml
+++ b/examples/api-server-demo/Cargo.toml
@@ -10,3 +10,4 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 serde_json = "1.0"
+tungstenite = "0.28"  # WebSocket client for event verification

--- a/examples/api-server-demo/src/main.rs
+++ b/examples/api-server-demo/src/main.rs
@@ -3,11 +3,15 @@
 
 //! API Server Processor Demo
 //!
-//! Tests all API endpoints of the ApiServerProcessor.
+//! Tests all API endpoints of the ApiServerProcessor, including WebSocket event streaming.
 
+use std::sync::{Arc, Mutex};
+use std::thread;
 use streamlib::{ApiServerConfig, ApiServerProcessor, Result, StreamRuntime};
+use tungstenite::{connect, stream::MaybeTlsStream, Message};
 
 const BASE_URL: &str = "http://127.0.0.1:9000";
+const WS_URL: &str = "ws://127.0.0.1:9000/ws/events";
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -34,7 +38,20 @@ fn main() -> Result<()> {
     // Give server a moment to start
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    println!("\n--- Running API Tests ---\n");
+    // Start WebSocket event collector
+    let events = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
+    let ws_events = Arc::clone(&events);
+    let ws_stop = Arc::new(Mutex::new(false));
+    let ws_stop_flag = Arc::clone(&ws_stop);
+
+    let ws_handle = thread::spawn(move || {
+        collect_websocket_events(ws_events, ws_stop_flag);
+    });
+
+    // Give WebSocket a moment to connect
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    println!("\n--- Running REST API Tests ---\n");
 
     let client = reqwest::blocking::Client::new();
 
@@ -75,12 +92,168 @@ fn main() -> Result<()> {
     // Test 12: Verify processors removed
     test_get_graph(&client, "After deleting processors");
 
+    println!("\n--- REST API Tests Complete ---\n");
+
+    // Give events time to be delivered
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // Stop WebSocket collector
+    *ws_stop.lock().unwrap() = true;
+    let _ = ws_handle.join();
+
+    // Verify WebSocket events
+    println!("--- Verifying WebSocket Events ---\n");
+    verify_websocket_events(&events);
+
     println!("\n--- All Tests Complete ---\n");
 
     // Shutdown
     runtime.stop()?;
 
     Ok(())
+}
+
+/// Collect WebSocket events in background
+fn collect_websocket_events(events: Arc<Mutex<Vec<serde_json::Value>>>, stop: Arc<Mutex<bool>>) {
+    let (mut socket, _response) = match connect(WS_URL) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("WebSocket connection error: {}", e);
+            return;
+        }
+    };
+
+    println!("WebSocket connected to {}", WS_URL);
+
+    // Set socket to non-blocking for polling
+    let stream = socket.get_mut();
+    if let MaybeTlsStream::Plain(tcp) = stream {
+        if let Err(e) = tcp.set_nonblocking(true) {
+            eprintln!("Failed to set non-blocking: {}", e);
+            return;
+        }
+    }
+
+    loop {
+        // Check stop flag
+        if *stop.lock().unwrap() {
+            break;
+        }
+
+        match socket.read() {
+            Ok(Message::Text(text)) => {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                    events.lock().unwrap().push(json);
+                }
+            }
+            Ok(Message::Close(_)) => break,
+            Err(tungstenite::Error::Io(ref e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // No data available, sleep briefly and retry
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(e) => {
+                // Connection closed or error
+                if !*stop.lock().unwrap() {
+                    eprintln!("WebSocket read error: {}", e);
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let _ = socket.close(None);
+}
+
+/// Verify that expected events were received via WebSocket
+fn verify_websocket_events(events: &Arc<Mutex<Vec<serde_json::Value>>>) {
+    let events = events.lock().unwrap();
+    println!("Received {} WebSocket events", events.len());
+
+    // Count event types
+    let mut processor_add_count = 0;
+    let mut processor_remove_count = 0;
+    let mut link_wire_count = 0;
+    let mut link_unwire_count = 0;
+    let mut graph_change_count = 0;
+    let mut compiler_count = 0;
+
+    for event in events.iter() {
+        if let Some(runtime_event) = event.get("RuntimeGlobal") {
+            // Check for specific event types
+            if runtime_event.get("RuntimeDidAddProcessor").is_some() {
+                processor_add_count += 1;
+            } else if runtime_event.get("RuntimeDidRemoveProcessor").is_some() {
+                processor_remove_count += 1;
+            } else if runtime_event.get("CompilerDidWireLink").is_some() {
+                link_wire_count += 1;
+            } else if runtime_event.get("CompilerDidUnwireLink").is_some() {
+                link_unwire_count += 1;
+            } else if runtime_event.get("GraphDidChange").is_some() {
+                graph_change_count += 1;
+            } else if runtime_event.get("CompilerDidCompile").is_some() {
+                compiler_count += 1;
+            }
+        }
+    }
+
+    // Report results
+    println!("Event Summary:");
+    println!("  - Processor added events:   {}", processor_add_count);
+    println!("  - Processor removed events: {}", processor_remove_count);
+    println!("  - Link wired events:        {}", link_wire_count);
+    println!("  - Link unwired events:      {}", link_unwire_count);
+    println!("  - Graph change events:      {}", graph_change_count);
+    println!("  - Compiler complete events: {}", compiler_count);
+
+    // Verify expected counts (2 processors added, 2 removed, 1 link wired, 1 unwired)
+    let mut passed = true;
+
+    print!("\nVerifying processor add events (expected 2): ");
+    if processor_add_count >= 2 {
+        println!("PASS");
+    } else {
+        println!("FAIL (got {})", processor_add_count);
+        passed = false;
+    }
+
+    print!("Verifying processor remove events (expected 2): ");
+    if processor_remove_count >= 2 {
+        println!("PASS");
+    } else {
+        println!("FAIL (got {})", processor_remove_count);
+        passed = false;
+    }
+
+    print!("Verifying link wire events (expected 1): ");
+    if link_wire_count >= 1 {
+        println!("PASS");
+    } else {
+        println!("FAIL (got {})", link_wire_count);
+        passed = false;
+    }
+
+    print!("Verifying link unwire events (expected 1): ");
+    if link_unwire_count >= 1 {
+        println!("PASS");
+    } else {
+        println!("FAIL (got {})", link_unwire_count);
+        passed = false;
+    }
+
+    print!("Verifying graph change events (expected 1+): ");
+    if graph_change_count >= 1 {
+        println!("PASS");
+    } else {
+        println!("FAIL (got {})", graph_change_count);
+        passed = false;
+    }
+
+    if passed {
+        println!("\n✓ All WebSocket event verifications passed!");
+    } else {
+        println!("\n✗ Some WebSocket event verifications failed!");
+    }
 }
 
 fn test_health(client: &reqwest::blocking::Client) {

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -92,6 +92,7 @@ vello = { git = "https://github.com/linebender/vello", rev = "5e3e12559781891b20
 skrifa = { version = "0.22", optional = true }
 wgpu-profiler = { version = "0.23.0", optional = true }
 axum.workspace = true
+futures-util = "0.3"  # For StreamExt/SinkExt on WebSocket
 
 # MCP and Python dependencies removed - needs redesign for Phase 1
 # See feature comments above for TODO notes

--- a/libs/streamlib/src/core/pubsub/events.rs
+++ b/libs/streamlib/src/core/pubsub/events.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 
 /// Common topic constants for system events
 pub mod topics {
+    /// Wildcard topic - receives ALL events from any topic
+    pub const ALL: &str = "*";
+
     /// Runtime global events (lifecycle, errors)
     pub const RUNTIME_GLOBAL: &str = "runtime:global";
 


### PR DESCRIPTION
## Summary

- Add real-time event streaming via WebSocket at `/ws/events` endpoint
- Clients receive all runtime events through a wildcard topic subscription (`topics::ALL`)
- Events include: processor add/remove, link wire/unwire, graph changes, compiler events

## Key Changes

- **Wildcard topic support**: Added `topics::ALL` ("*") constant and dual-dispatch in `publish()` - events go to specific topic AND wildcard subscribers
- **WebSocket endpoint**: `/ws/events` using axum's built-in WebSocket support
- **Event bridging**: Sync `EventListener` bridged to async WebSocket via mpsc channel
- **Example updated**: `api-server-demo` includes WebSocket event verification tests

## Usage

```bash
# Connect with any WebSocket client
websocat ws://127.0.0.1:9000/ws/events

# Events stream as JSON:
{"RuntimeGlobal":{"RuntimeDidAddProcessor":{"id":"P..."}}}
{"RuntimeGlobal":{"CompilerDidWireLink":{"link_id":"L..."}}}
```

## Test plan

- [x] All 152 library tests pass
- [x] api-server-demo runs and verifies WebSocket events
- [x] Link wire/unwire events verified via WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)