### PR TITLE
feat: Support StreamRuntime integration with existing tokio runtimes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -606,26 +606,20 @@ Use `#[cfg(target_os = "macos")]` in examples that depend on platform-specific p
 
 ## Tool Preferences
 
-### Rust Analyzer MCP - USE THIS
+### Rust Analyzer Plugin - USE THIS
 
-When working with Rust code, **prefer rust-analyzer MCP tools** over grep/search for understanding code:
+This project uses the **rust-analyzer-lsp** Claude Code plugin (`rust-analyzer-lsp@claude-plugins-official`) for semantic code understanding.
 
-```
-mcp__rust-analyzer__rust_analyzer_hover      - Get type info at position
-mcp__rust-analyzer__rust_analyzer_definition - Jump to definition
-mcp__rust-analyzer__rust_analyzer_references - Find all usages
-mcp__rust-analyzer__rust_analyzer_symbols    - List symbols in file
-mcp__rust-analyzer__rust_analyzer_diagnostics - Get compiler errors
-```
-
-**Why**: Rust-analyzer understands the code semantically. It knows types, traits, and relationships. Grep just matches text.
+**Why use rust-analyzer over grep**:
+- **Semantic understanding**: Knows types, traits, and relationships
+- **Accurate navigation**: Handles macros, generics, and complex imports
+- **Cross-file context**: Understands the entire crate graph
 
 **When to use rust-analyzer**:
-- Understanding what a type is: `rust_analyzer_hover`
-- Finding where something is defined: `rust_analyzer_definition`
-- Finding all usages before renaming: `rust_analyzer_references`
-- Getting an overview of a file: `rust_analyzer_symbols`
-- Checking if code compiles: `rust_analyzer_diagnostics`
+- Understanding type definitions and signatures
+- Finding where symbols are defined
+- Finding all usages before refactoring
+- Exploring symbol visibility and scoping
 
 **When grep is still fine**:
 - Searching for string literals

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "examples/runtime-graph-json-demo",   # Example: Runtime graph JSON serialization
     "examples/graph-json-export",         # Example: Graph data structure JSON export (no runtime)
     "examples/api-server-demo",           # Example: API server processor demo
+    "examples/tokio-integration",         # Example: StreamRuntime with existing tokio runtime
     # Note: news-cast is a standalone workspace (has its own [workspace] declaration)
 ]
 

--- a/examples/api-server-demo/Cargo.toml
+++ b/examples/api-server-demo/Cargo.toml
@@ -8,6 +8,7 @@ streamlib = { path = "../../libs/streamlib" }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json"] }
 serde_json = "1.0"
-tungstenite = "0.28"  # WebSocket client for event verification
+tokio-tungstenite = "0.26"  # Async WebSocket client for event verification
+futures-util = "0.3"  # For StreamExt

--- a/examples/api-server-demo/src/main.rs
+++ b/examples/api-server-demo/src/main.rs
@@ -4,16 +4,19 @@
 //! API Server Processor Demo
 //!
 //! Tests all API endpoints of the ApiServerProcessor, including WebSocket event streaming.
+//! Demonstrates StreamRuntime integration with #[tokio::main] async context.
 
-use std::sync::{Arc, Mutex};
-use std::thread;
+use futures_util::StreamExt;
+use std::sync::Arc;
 use streamlib::{ApiServerConfig, ApiServerProcessor, Result, StreamRuntime};
-use tungstenite::{connect, stream::MaybeTlsStream, Message};
+use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::Message;
 
 const BASE_URL: &str = "http://127.0.0.1:9000";
 const WS_URL: &str = "ws://127.0.0.1:9000/ws/events";
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -23,6 +26,7 @@ fn main() -> Result<()> {
 
     println!("=== API Server Processor Demo ===\n");
 
+    // StreamRuntime::new() auto-detects tokio context and uses the current handle
     let runtime = StreamRuntime::new()?;
 
     // Add the API server processor
@@ -36,74 +40,74 @@ fn main() -> Result<()> {
     runtime.start()?;
 
     // Give server a moment to start
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Start WebSocket event collector
+    // Start WebSocket event collector as async task
     let events = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
     let ws_events = Arc::clone(&events);
     let ws_stop = Arc::new(Mutex::new(false));
     let ws_stop_flag = Arc::clone(&ws_stop);
 
-    let ws_handle = thread::spawn(move || {
-        collect_websocket_events(ws_events, ws_stop_flag);
+    let ws_handle = tokio::spawn(async move {
+        collect_websocket_events(ws_events, ws_stop_flag).await;
     });
 
     // Give WebSocket a moment to connect
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     println!("\n--- Running REST API Tests ---\n");
 
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::Client::new();
 
     // Test 1: Health endpoint
-    test_health(&client);
+    test_health(&client).await;
 
     // Test 2: Get registry
-    test_registry(&client);
+    test_registry(&client).await;
 
     // Test 3: Get initial graph
-    test_get_graph(&client, "Initial graph");
+    test_get_graph(&client, "Initial graph").await;
 
     // Test 4: Create a processor
-    let processor_id = test_create_processor(&client);
+    let processor_id = test_create_processor(&client).await;
 
     // Test 5: Verify processor in graph
-    test_get_graph(&client, "After adding processor");
+    test_get_graph(&client, "After adding processor").await;
 
     // Test 6: Create another processor for connection test
-    let processor_id_2 = test_create_processor_2(&client);
+    let processor_id_2 = test_create_processor_2(&client).await;
 
     // Test 7: Create connection between processors
-    let connection_id = test_create_connection(&client, &processor_id, &processor_id_2);
+    let connection_id = test_create_connection(&client, &processor_id, &processor_id_2).await;
 
     // Test 8: Verify connection in graph
-    test_get_graph(&client, "After adding connection");
+    test_get_graph(&client, "After adding connection").await;
 
     // Test 9: Delete connection
-    test_delete_connection(&client, &connection_id);
+    test_delete_connection(&client, &connection_id).await;
 
     // Test 10: Verify connection removed
-    test_get_graph(&client, "After deleting connection");
+    test_get_graph(&client, "After deleting connection").await;
 
     // Test 11: Delete processors
-    test_delete_processor(&client, &processor_id);
-    test_delete_processor(&client, &processor_id_2);
+    test_delete_processor(&client, &processor_id).await;
+    test_delete_processor(&client, &processor_id_2).await;
 
     // Test 12: Verify processors removed
-    test_get_graph(&client, "After deleting processors");
+    test_get_graph(&client, "After deleting processors").await;
 
     println!("\n--- REST API Tests Complete ---\n");
 
     // Give events time to be delivered
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     // Stop WebSocket collector
-    *ws_stop.lock().unwrap() = true;
-    let _ = ws_handle.join();
+    *ws_stop.lock().await = true;
+    let _ = ws_handle.await;
 
     // Verify WebSocket events
     println!("--- Verifying WebSocket Events ---\n");
-    verify_websocket_events(&events);
+    verify_websocket_events(&events).await;
 
     println!("\n--- All Tests Complete ---\n");
 
@@ -113,10 +117,13 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Collect WebSocket events in background
-fn collect_websocket_events(events: Arc<Mutex<Vec<serde_json::Value>>>, stop: Arc<Mutex<bool>>) {
-    let (mut socket, _response) = match connect(WS_URL) {
-        Ok(s) => s,
+/// Collect WebSocket events in background using async tokio-tungstenite
+async fn collect_websocket_events(
+    events: Arc<Mutex<Vec<serde_json::Value>>>,
+    stop: Arc<Mutex<bool>>,
+) {
+    let ws_stream = match tokio_tungstenite::connect_async(WS_URL).await {
+        Ok((stream, _response)) => stream,
         Err(e) => {
             eprintln!("WebSocket connection error: {}", e);
             return;
@@ -125,49 +132,44 @@ fn collect_websocket_events(events: Arc<Mutex<Vec<serde_json::Value>>>, stop: Ar
 
     println!("WebSocket connected to {}", WS_URL);
 
-    // Set socket to non-blocking for polling
-    let stream = socket.get_mut();
-    if let MaybeTlsStream::Plain(tcp) = stream {
-        if let Err(e) = tcp.set_nonblocking(true) {
-            eprintln!("Failed to set non-blocking: {}", e);
-            return;
-        }
-    }
+    let (_write, mut read) = ws_stream.split();
 
     loop {
         // Check stop flag
-        if *stop.lock().unwrap() {
+        if *stop.lock().await {
             break;
         }
 
-        match socket.read() {
-            Ok(Message::Text(text)) => {
-                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
-                    events.lock().unwrap().push(json);
+        // Use tokio::select! to poll both the stop flag and incoming messages
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                            events.lock().await.push(json);
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) => break,
+                    Some(Err(e)) => {
+                        if !*stop.lock().await {
+                            eprintln!("WebSocket read error: {}", e);
+                        }
+                        break;
+                    }
+                    None => break,
+                    _ => {}
                 }
             }
-            Ok(Message::Close(_)) => break,
-            Err(tungstenite::Error::Io(ref e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // No data available, sleep briefly and retry
-                std::thread::sleep(std::time::Duration::from_millis(10));
+            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {
+                // Periodic check for stop flag
             }
-            Err(e) => {
-                // Connection closed or error
-                if !*stop.lock().unwrap() {
-                    eprintln!("WebSocket read error: {}", e);
-                }
-                break;
-            }
-            _ => {}
         }
     }
-
-    let _ = socket.close(None);
 }
 
 /// Verify that expected events were received via WebSocket
-fn verify_websocket_events(events: &Arc<Mutex<Vec<serde_json::Value>>>) {
-    let events = events.lock().unwrap();
+async fn verify_websocket_events(events: &Arc<Mutex<Vec<serde_json::Value>>>) {
+    let events = events.lock().await;
     println!("Received {} WebSocket events", events.len());
 
     // Count event types
@@ -256,12 +258,12 @@ fn verify_websocket_events(events: &Arc<Mutex<Vec<serde_json::Value>>>) {
     }
 }
 
-fn test_health(client: &reqwest::blocking::Client) {
+async fn test_health(client: &reqwest::Client) {
     print!("Testing GET /health ... ");
-    let resp = client.get(format!("{}/health", BASE_URL)).send();
+    let resp = client.get(format!("{}/health", BASE_URL)).send().await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let body = r.text().unwrap_or_default();
+            let body = r.text().await.unwrap_or_default();
             println!("OK ({})", body);
         }
         Ok(r) => println!("FAIL (status: {})", r.status()),
@@ -269,12 +271,15 @@ fn test_health(client: &reqwest::blocking::Client) {
     }
 }
 
-fn test_registry(client: &reqwest::blocking::Client) {
+async fn test_registry(client: &reqwest::Client) {
     print!("Testing GET /api/registry ... ");
-    let resp = client.get(format!("{}/api/registry", BASE_URL)).send();
+    let resp = client
+        .get(format!("{}/api/registry", BASE_URL))
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let json: serde_json::Value = r.json().unwrap_or_default();
+            let json: serde_json::Value = r.json().await.unwrap_or_default();
             let count = json["processors"].as_array().map(|a| a.len()).unwrap_or(0);
             println!("OK ({} processors registered)", count);
         }
@@ -283,12 +288,12 @@ fn test_registry(client: &reqwest::blocking::Client) {
     }
 }
 
-fn test_get_graph(client: &reqwest::blocking::Client, label: &str) {
+async fn test_get_graph(client: &reqwest::Client, label: &str) {
     print!("Testing GET /api/graph ({}) ... ", label);
-    let resp = client.get(format!("{}/api/graph", BASE_URL)).send();
+    let resp = client.get(format!("{}/api/graph", BASE_URL)).send().await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let json: serde_json::Value = r.json().unwrap_or_default();
+            let json: serde_json::Value = r.json().await.unwrap_or_default();
             let nodes = json["nodes"].as_array().map(|a| a.len()).unwrap_or(0);
             let links = json["links"].as_array().map(|a| a.len()).unwrap_or(0);
             println!("OK ({} nodes, {} links)", nodes, links);
@@ -303,7 +308,7 @@ fn test_get_graph(client: &reqwest::blocking::Client, label: &str) {
     }
 }
 
-fn test_create_processor(client: &reqwest::blocking::Client) -> String {
+async fn test_create_processor(client: &reqwest::Client) -> String {
     print!("Testing POST /api/processor (SimplePassthroughProcessor) ... ");
     let body = serde_json::json!({
         "processor_type": "SimplePassthroughProcessor",
@@ -312,10 +317,11 @@ fn test_create_processor(client: &reqwest::blocking::Client) -> String {
     let resp = client
         .post(format!("{}/api/processor", BASE_URL))
         .json(&body)
-        .send();
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let json: serde_json::Value = r.json().unwrap_or_default();
+            let json: serde_json::Value = r.json().await.unwrap_or_default();
             let id = json["id"].as_str().unwrap_or("unknown").to_string();
             println!("OK (id: {})", id);
             id
@@ -331,7 +337,7 @@ fn test_create_processor(client: &reqwest::blocking::Client) -> String {
     }
 }
 
-fn test_create_processor_2(client: &reqwest::blocking::Client) -> String {
+async fn test_create_processor_2(client: &reqwest::Client) -> String {
     print!("Testing POST /api/processor (SimplePassthroughProcessor #2) ... ");
     let body = serde_json::json!({
         "processor_type": "SimplePassthroughProcessor",
@@ -340,10 +346,11 @@ fn test_create_processor_2(client: &reqwest::blocking::Client) -> String {
     let resp = client
         .post(format!("{}/api/processor", BASE_URL))
         .json(&body)
-        .send();
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let json: serde_json::Value = r.json().unwrap_or_default();
+            let json: serde_json::Value = r.json().await.unwrap_or_default();
             let id = json["id"].as_str().unwrap_or("unknown").to_string();
             println!("OK (id: {})", id);
             id
@@ -359,8 +366,8 @@ fn test_create_processor_2(client: &reqwest::blocking::Client) -> String {
     }
 }
 
-fn test_create_connection(
-    client: &reqwest::blocking::Client,
+async fn test_create_connection(
+    client: &reqwest::Client,
     from_processor: &str,
     to_processor: &str,
 ) -> String {
@@ -374,16 +381,17 @@ fn test_create_connection(
     let resp = client
         .post(format!("{}/api/connections", BASE_URL))
         .json(&body)
-        .send();
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => {
-            let json: serde_json::Value = r.json().unwrap_or_default();
+            let json: serde_json::Value = r.json().await.unwrap_or_default();
             let id = json["id"].as_str().unwrap_or("unknown").to_string();
             println!("OK (id: {})", id);
             id
         }
         Ok(r) => {
-            let body = r.text().unwrap_or_default();
+            let body = r.text().await.unwrap_or_default();
             println!("FAIL (status: {}, body: {})", body, body);
             String::new()
         }
@@ -394,11 +402,12 @@ fn test_create_connection(
     }
 }
 
-fn test_delete_connection(client: &reqwest::blocking::Client, connection_id: &str) {
+async fn test_delete_connection(client: &reqwest::Client, connection_id: &str) {
     print!("Testing DELETE /api/connections/{} ... ", connection_id);
     let resp = client
         .delete(format!("{}/api/connections/{}", BASE_URL, connection_id))
-        .send();
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => println!("OK"),
         Ok(r) => println!("FAIL (status: {})", r.status()),
@@ -406,11 +415,12 @@ fn test_delete_connection(client: &reqwest::blocking::Client, connection_id: &st
     }
 }
 
-fn test_delete_processor(client: &reqwest::blocking::Client, processor_id: &str) {
+async fn test_delete_processor(client: &reqwest::Client, processor_id: &str) {
     print!("Testing DELETE /api/processors/{} ... ", processor_id);
     let resp = client
         .delete(format!("{}/api/processors/{}", BASE_URL, processor_id))
-        .send();
+        .send()
+        .await;
     match resp {
         Ok(r) if r.status().is_success() => println!("OK"),
         Ok(r) => println!("FAIL (status: {})", r.status()),

--- a/examples/tokio-integration/Cargo.toml
+++ b/examples/tokio-integration/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tokio-integration"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tokio-integration/src/main.rs
+++ b/examples/tokio-integration/src/main.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Tokio Integration Example
+//!
+//! Demonstrates StreamRuntime integration with existing tokio applications.
+//! StreamRuntime::new() auto-detects the tokio context and works seamlessly.
+//!
+//! Previously, calling StreamRuntime::new() from within #[tokio::main] would panic.
+//! With issue #92 implemented, it now auto-detects the tokio runtime and uses
+//! the current handle instead of trying to create a new runtime.
+
+use streamlib::{Result, StreamRuntime};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".parse().unwrap()),
+        )
+        .init();
+
+    println!("=== Tokio Integration Example ===\n");
+
+    // Just call new() - it auto-detects the tokio context!
+    // No special constructor needed. This used to panic, now it works.
+    let runtime = StreamRuntime::new()?;
+    println!("StreamRuntime created (auto-detected tokio context)");
+
+    // Start the runtime
+    runtime.start()?;
+    println!("Runtime started");
+
+    // Demonstrate that async tokio operations work alongside StreamRuntime
+    println!("Running async operations...");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Get graph state using sync method (uses spawn + channel internally)
+    let graph_json = runtime.to_json()?;
+    println!(
+        "Graph state: {} nodes",
+        graph_json["nodes"].as_array().map(|a| a.len()).unwrap_or(0)
+    );
+
+    // Shutdown
+    runtime.stop()?;
+    println!("Runtime stopped");
+
+    println!("\n=== Example Complete ===");
+    Ok(())
+}

--- a/libs/streamlib/src/core/runtime/operations_runtime.rs
+++ b/libs/streamlib/src/core/runtime/operations_runtime.rs
@@ -1,9 +1,12 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use std::sync::Arc;
+
 use super::operations::{BoxFuture, RuntimeOperations};
+use super::runtime::TokioRuntimeVariant;
 use super::StreamRuntime;
-use crate::core::compiler::PendingOperation;
+use crate::core::compiler::{Compiler, PendingOperation};
 use crate::core::graph::{
     GraphEdgeWithComponents, GraphNodeWithComponents, LinkUniqueId, PendingDeletionComponent,
     ProcessorUniqueId,
@@ -12,98 +15,211 @@ use crate::core::processors::ProcessorSpec;
 use crate::core::pubsub::{topics, Event, RuntimeEvent, PUBSUB};
 use crate::core::{InputLinkPortRef, OutputLinkPortRef, Result, StreamError};
 
+// =============================================================================
+// Core Implementation Functions ('static async fns for spawn compatibility)
+// =============================================================================
+
+/// Core implementation for add_processor - takes owned Arcs for 'static lifetime.
+async fn add_processor_impl(
+    compiler: Arc<Compiler>,
+    spec: ProcessorSpec,
+) -> Result<ProcessorUniqueId> {
+    let emit_will_add = |id: &ProcessorUniqueId| {
+        PUBSUB.publish(
+            topics::RUNTIME_GLOBAL,
+            &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillAddProcessor {
+                processor_id: id.clone(),
+            }),
+        );
+    };
+
+    let emit_did_add = |id: &ProcessorUniqueId| {
+        PUBSUB.publish(
+            topics::RUNTIME_GLOBAL,
+            &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidAddProcessor {
+                processor_id: id.clone(),
+            }),
+        );
+    };
+
+    let processor_id = compiler.scope(|graph, tx| {
+        graph
+            .traversal_mut()
+            .add_v(spec)
+            .inspect(|node| emit_will_add(&node.id))
+            .inspect(|node| tx.log(PendingOperation::AddProcessor(node.id.clone())))
+            .inspect(|node| emit_did_add(&node.id))
+            .first()
+            .map(|node| node.id.clone())
+            .ok_or_else(|| StreamError::GraphError("Could not create node".into()))
+    })?;
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
+    );
+
+    Ok(processor_id)
+}
+
+/// Core implementation for remove_processor - takes owned Arcs for 'static lifetime.
+async fn remove_processor_impl(
+    compiler: Arc<Compiler>,
+    processor_id: ProcessorUniqueId,
+) -> Result<()> {
+    compiler.scope(|graph, tx| {
+        if !graph.traversal().v(&processor_id).exists() {
+            return Err(StreamError::ProcessorNotFound(processor_id.to_string()));
+        }
+
+        if let Some(node) = graph.traversal_mut().v(&processor_id).first_mut() {
+            node.insert(PendingDeletionComponent);
+        }
+
+        tx.log(PendingOperation::RemoveProcessor(processor_id.clone()));
+
+        Ok(())
+    })?;
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillRemoveProcessor {
+            processor_id: processor_id.clone(),
+        }),
+    );
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidRemoveProcessor {
+            processor_id: processor_id.clone(),
+        }),
+    );
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
+    );
+
+    Ok(())
+}
+
+/// Core implementation for connect - takes owned Arcs for 'static lifetime.
+async fn connect_impl(
+    compiler: Arc<Compiler>,
+    from: OutputLinkPortRef,
+    to: InputLinkPortRef,
+) -> Result<LinkUniqueId> {
+    let from_processor = from.processor_id.clone();
+    let from_port = from.port_name.clone();
+    let to_processor = to.processor_id.clone();
+    let to_port = to.port_name.clone();
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillConnect {
+            from_processor,
+            from_port: from_port.clone(),
+            to_processor,
+            to_port: to_port.clone(),
+        }),
+    );
+
+    let link_id = compiler.scope(|graph, tx| {
+        let id = graph
+            .traversal_mut()
+            .add_e(from, to)
+            .inspect(|link| tx.log(PendingOperation::AddLink(link.id.clone())))
+            .first()
+            .map(|link| link.id.clone())
+            .ok_or_else(|| StreamError::GraphError("failed to create link".into()))?;
+
+        Ok::<_, StreamError>(id)
+    })?;
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidConnect {
+            link_id: link_id.to_string(),
+            from_port,
+            to_port,
+        }),
+    );
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
+    );
+
+    Ok(link_id)
+}
+
+/// Core implementation for disconnect - takes owned Arcs for 'static lifetime.
+async fn disconnect_impl(compiler: Arc<Compiler>, link_id: LinkUniqueId) -> Result<()> {
+    let link_info = compiler.scope(|graph, tx| {
+        let (from_value, to_value) = graph
+            .traversal()
+            .e(&link_id)
+            .first()
+            .map(|l| (l.from_port(), l.to_port()))
+            .ok_or_else(|| StreamError::NotFound(format!("Link '{}' not found", link_id)))?;
+
+        let info = (
+            OutputLinkPortRef::new(from_value.processor_id.clone(), to_value.port_name.clone()),
+            InputLinkPortRef::new(to_value.processor_id.clone(), to_value.port_name.clone()),
+        );
+
+        if let Some(link) = graph.traversal_mut().e(&link_id).first_mut() {
+            link.insert(PendingDeletionComponent);
+        }
+
+        tx.log(PendingOperation::RemoveLink(link_id.clone()));
+
+        Ok::<_, StreamError>(info)
+    })?;
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillDisconnect {
+            link_id: link_id.to_string(),
+            from_port: link_info.0.to_string(),
+            to_port: link_info.1.to_string(),
+        }),
+    );
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidDisconnect {
+            link_id: link_id.to_string(),
+            from_port: link_info.0.to_string(),
+            to_port: link_info.1.to_string(),
+        }),
+    );
+
+    PUBSUB.publish(
+        topics::RUNTIME_GLOBAL,
+        &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
+    );
+
+    Ok(())
+}
+
+// =============================================================================
+// RuntimeOperations Implementation
+// =============================================================================
+
 impl RuntimeOperations for StreamRuntime {
     // =========================================================================
-    // Async Methods (primary implementation)
+    // Async Methods (delegate to _impl functions)
     // =========================================================================
 
     fn add_processor_async(&self, spec: ProcessorSpec) -> BoxFuture<'_, Result<ProcessorUniqueId>> {
-        Box::pin(async move {
-            // Declare side effects upfront
-            let emit_will_add = |id: &ProcessorUniqueId| {
-                PUBSUB.publish(
-                    topics::RUNTIME_GLOBAL,
-                    &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillAddProcessor {
-                        processor_id: id.clone(),
-                    }),
-                );
-            };
-
-            let emit_did_add = |id: &ProcessorUniqueId| {
-                PUBSUB.publish(
-                    topics::RUNTIME_GLOBAL,
-                    &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidAddProcessor {
-                        processor_id: id.clone(),
-                    }),
-                );
-            };
-
-            // Use compiler.scope() to access graph and transaction
-            let processor_id = self.compiler.scope(|graph, tx| {
-                graph
-                    .traversal_mut()
-                    .add_v(spec)
-                    .inspect(|node| emit_will_add(&node.id))
-                    .inspect(|node| tx.log(PendingOperation::AddProcessor(node.id.clone())))
-                    .inspect(|node| emit_did_add(&node.id))
-                    .first()
-                    .map(|node| node.id.clone())
-                    .ok_or_else(|| StreamError::GraphError("Could not create node".into()))
-            })?;
-
-            // Notify listeners that graph changed (triggers commit via GraphChangeListener)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
-            );
-
-            Ok(processor_id)
-        })
+        let compiler = Arc::clone(&self.compiler);
+        Box::pin(add_processor_impl(compiler, spec))
     }
 
     fn remove_processor_async(&self, processor_id: ProcessorUniqueId) -> BoxFuture<'_, Result<()>> {
-        Box::pin(async move {
-            // Validate processor exists and mark for deletion
-            self.compiler.scope(|graph, tx| {
-                if !graph.traversal().v(&processor_id).exists() {
-                    return Err(StreamError::ProcessorNotFound(processor_id.to_string()));
-                }
-
-                // Mark for soft-delete by adding PendingDeletion component
-                if let Some(node) = graph.traversal_mut().v(&processor_id).first_mut() {
-                    node.insert(PendingDeletionComponent);
-                }
-
-                // Queue operation for commit
-                tx.log(PendingOperation::RemoveProcessor(processor_id.clone()));
-
-                Ok(())
-            })?;
-
-            // Emit WillRemoveProcessor before the action
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillRemoveProcessor {
-                    processor_id: processor_id.clone(),
-                }),
-            );
-
-            // Emit DidRemoveProcessor after queueing (actual removal happens at commit)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidRemoveProcessor {
-                    processor_id: processor_id.clone(),
-                }),
-            );
-
-            // Notify listeners that graph changed (triggers commit via GraphChangeListener)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
-            );
-
-            Ok(())
-        })
+        let compiler = Arc::clone(&self.compiler);
+        Box::pin(remove_processor_impl(compiler, processor_id))
     }
 
     fn connect_async(
@@ -111,146 +227,93 @@ impl RuntimeOperations for StreamRuntime {
         from: OutputLinkPortRef,
         to: InputLinkPortRef,
     ) -> BoxFuture<'_, Result<LinkUniqueId>> {
-        Box::pin(async move {
-            // Capture for events before moving into add_e
-            let from_processor = from.processor_id.clone();
-            let from_port = from.port_name.clone();
-            let to_processor = to.processor_id.clone();
-            let to_port = to.port_name.clone();
+        let compiler = Arc::clone(&self.compiler);
+        Box::pin(connect_impl(compiler, from, to))
+    }
 
-            // Emit WillConnect before the action
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillConnect {
-                    from_processor,
-                    from_port: from_port.clone(),
-                    to_processor,
-                    to_port: to_port.clone(),
-                }),
-            );
-
-            // Use compiler.scope() to access graph and transaction
-            let link_id = self.compiler.scope(|graph, tx| {
-                let id = graph
-                    .traversal_mut()
-                    .add_e(from, to)
-                    .inspect(|link| tx.log(PendingOperation::AddLink(link.id.clone())))
-                    .first()
-                    .map(|link| link.id.clone())
-                    .ok_or_else(|| StreamError::GraphError("failed to create link".into()))?;
-
-                Ok::<_, StreamError>(id)
-            })?;
-
-            // Emit DidConnect after the action
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidConnect {
-                    link_id: link_id.to_string(),
-                    from_port,
-                    to_port,
-                }),
-            );
-
-            // Notify listeners that graph changed (triggers commit via GraphChangeListener)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
-            );
-
-            Ok(link_id)
-        })
+    fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
+        let compiler = Arc::clone(&self.compiler);
+        Box::pin(disconnect_impl(compiler, link_id))
     }
 
     fn to_json_async(&self) -> BoxFuture<'_, Result<serde_json::Value>> {
         Box::pin(async move { StreamRuntime::to_json(self) })
     }
 
-    fn disconnect_async(&self, link_id: LinkUniqueId) -> BoxFuture<'_, Result<()>> {
-        Box::pin(async move {
-            // Validate link exists and get info for events, then mark for deletion
-            let link_info = self.compiler.scope(|graph, tx| {
-                let (from_value, to_value) = graph
-                    .traversal()
-                    .e(&link_id)
-                    .first()
-                    .map(|l| (l.from_port(), l.to_port()))
-                    .ok_or_else(|| {
-                        StreamError::NotFound(format!("Link '{}' not found", link_id))
-                    })?;
-
-                let info = (
-                    OutputLinkPortRef::new(
-                        from_value.processor_id.clone(),
-                        to_value.port_name.clone(),
-                    ),
-                    InputLinkPortRef::new(
-                        to_value.processor_id.clone(),
-                        to_value.port_name.clone(),
-                    ),
-                );
-
-                // Mark for soft-delete by adding PendingDeletion component to link
-                if let Some(link) = graph.traversal_mut().e(&link_id).first_mut() {
-                    link.insert(PendingDeletionComponent);
-                }
-
-                // Queue operation for commit
-                tx.log(PendingOperation::RemoveLink(link_id.clone()));
-
-                Ok::<_, StreamError>(info)
-            })?;
-
-            // Emit WillDisconnect before the action
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeWillDisconnect {
-                    link_id: link_id.to_string(),
-                    from_port: link_info.0.to_string(),
-                    to_port: link_info.1.to_string(),
-                }),
-            );
-
-            // Emit DidDisconnect after queueing (actual removal happens at commit)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::RuntimeDidDisconnect {
-                    link_id: link_id.to_string(),
-                    from_port: link_info.0.to_string(),
-                    to_port: link_info.1.to_string(),
-                }),
-            );
-
-            // Notify listeners that graph changed (triggers commit via GraphChangeListener)
-            PUBSUB.publish(
-                topics::RUNTIME_GLOBAL,
-                &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
-            );
-
-            Ok(())
-        })
-    }
-
     // =========================================================================
-    // Sync Methods (convenience wrappers using block_on)
+    // Sync Methods (variant-aware blocking strategy)
     // =========================================================================
 
     fn add_processor(&self, spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
-        self.tokio_runtime.block_on(self.add_processor_async(spec))
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
+                rt.block_on(self.add_processor_async(spec))
+            }
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = add_processor_impl(compiler, spec).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+            }
+        }
     }
 
     fn remove_processor(&self, processor_id: &ProcessorUniqueId) -> Result<()> {
-        self.tokio_runtime
-            .block_on(self.remove_processor_async(processor_id.clone()))
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
+                rt.block_on(self.remove_processor_async(processor_id.clone()))
+            }
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let processor_id = processor_id.clone();
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = remove_processor_impl(compiler, processor_id).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+            }
+        }
     }
 
     fn connect(&self, from: OutputLinkPortRef, to: InputLinkPortRef) -> Result<LinkUniqueId> {
-        self.tokio_runtime.block_on(self.connect_async(from, to))
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => rt.block_on(self.connect_async(from, to)),
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = connect_impl(compiler, from, to).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+            }
+        }
     }
 
     fn disconnect(&self, link_id: &LinkUniqueId) -> Result<()> {
-        self.tokio_runtime
-            .block_on(self.disconnect_async(link_id.clone()))
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
+                rt.block_on(self.disconnect_async(link_id.clone()))
+            }
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let link_id = link_id.clone();
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = disconnect_impl(compiler, link_id).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+            }
+        }
     }
 
     // =========================================================================
@@ -258,7 +321,6 @@ impl RuntimeOperations for StreamRuntime {
     // =========================================================================
 
     fn to_json(&self) -> Result<serde_json::Value> {
-        // Delegate to the existing StreamRuntime::to_json() implementation
         StreamRuntime::to_json(self)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #92. Makes `StreamRuntime::new()` auto-detect tokio context and work seamlessly in both cases:

- **Outside tokio**: Creates owned runtime (existing behavior)
- **Inside tokio** (e.g., `#[tokio::main]`): Uses `Handle::current()` automatically

No new constructor needed - just call `new()` and it works everywhere.

## Key Changes

- Add `TokioRuntimeVariant` enum for owned `Runtime` vs external `Handle`
- Refactor `new()` to auto-detect tokio context via `Handle::try_current()`
- Extract `_impl` async functions for shared logic between async/sync methods
- Update sync methods to use spawn+channel pattern when using external handle
- Add 3 new tests for tokio integration
- Add `tokio-integration` example demonstrating `#[tokio::main]` usage
- Update `api-server-demo` to use async tokio patterns

## Test Plan

- [x] `cargo test -p streamlib core::runtime` - All 4 runtime tests pass
- [x] `cargo run -p tokio-integration` - New example runs successfully
- [x] `cargo run -p api-server-demo` - Updated example runs with async patterns
- [x] `cargo run -p camera-display` - Existing owned-runtime path still works
- [x] Pre-push hooks pass (clippy, tests, examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)