### PR TITLE
feat: Add JSON Schema generation for API endpoints

### DIFF
--- a/docs/schemas/graph-response.schema.json
+++ b/docs/schemas/graph-response.schema.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GraphResponse",
+  "description": "Response from the `/api/graph` endpoint.",
+  "type": "object",
+  "required": [
+    "links",
+    "nodes"
+  ],
+  "properties": {
+    "links": {
+      "description": "All links (connections) between processors.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LinkOutput"
+      }
+    },
+    "nodes": {
+      "description": "All processor nodes in the graph.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProcessorNodeOutput"
+      }
+    }
+  },
+  "definitions": {
+    "LinkOutput": {
+      "description": "A link (connection) between two processor ports.",
+      "type": "object",
+      "required": [
+        "components",
+        "id",
+        "source",
+        "target"
+      ],
+      "properties": {
+        "capacity": {
+          "description": "Ring buffer capacity for the channel.",
+          "default": 0,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "components": {
+          "description": "Runtime components (dynamic, varies based on link state).",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "id": {
+          "description": "Unique identifier for this link.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Source endpoint (output port).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LinkPortRefOutput"
+            }
+          ]
+        },
+        "state": {
+          "description": "Current state of the link.",
+          "default": "pending",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LinkStateOutput"
+            }
+          ]
+        },
+        "target": {
+          "description": "Target endpoint (input port).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LinkPortRefOutput"
+            }
+          ]
+        }
+      }
+    },
+    "LinkPortRefOutput": {
+      "description": "Reference to a port on a processor.",
+      "type": "object",
+      "required": [
+        "port_name",
+        "processor_id"
+      ],
+      "properties": {
+        "port_name": {
+          "description": "Port name on that processor.",
+          "type": "string"
+        },
+        "processor_id": {
+          "description": "Processor instance ID.",
+          "type": "string"
+        }
+      }
+    },
+    "LinkStateOutput": {
+      "description": "State of a link in the graph.",
+      "oneOf": [
+        {
+          "description": "Link exists in graph but not yet wired.",
+          "type": "string",
+          "enum": [
+            "pending"
+          ]
+        },
+        {
+          "description": "Link is actively wired with a ring buffer channel.",
+          "type": "string",
+          "enum": [
+            "wired"
+          ]
+        },
+        {
+          "description": "Link is being disconnected.",
+          "type": "string",
+          "enum": [
+            "disconnecting"
+          ]
+        },
+        {
+          "description": "Link was disconnected.",
+          "type": "string",
+          "enum": [
+            "disconnected"
+          ]
+        },
+        {
+          "description": "Link is in error state.",
+          "type": "string",
+          "enum": [
+            "error"
+          ]
+        }
+      ]
+    },
+    "PortInfoOutput": {
+      "description": "Metadata about a port.",
+      "type": "object",
+      "required": [
+        "data_type",
+        "name"
+      ],
+      "properties": {
+        "data_type": {
+          "description": "Data type flowing through this port.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Port name (e.g., \"video_in\", \"audio_out\").",
+          "type": "string"
+        },
+        "port_kind": {
+          "description": "Kind of port: data, event, or control.",
+          "default": "data",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PortKindOutput"
+            }
+          ]
+        }
+      }
+    },
+    "PortKindOutput": {
+      "description": "The kind of port - determines how data flows.",
+      "type": "string",
+      "enum": [
+        "data",
+        "event",
+        "control"
+      ]
+    },
+    "ProcessorNodeOutput": {
+      "description": "A processor node in the graph.",
+      "type": "object",
+      "required": [
+        "components",
+        "display_name",
+        "id",
+        "ports",
+        "type"
+      ],
+      "properties": {
+        "components": {
+          "description": "Runtime components (dynamic, varies based on processor state).",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "config": {
+          "description": "Processor configuration as JSON."
+        },
+        "config_checksum": {
+          "description": "Checksum of config for change detection.",
+          "default": 0,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "display_name": {
+          "description": "Display name for UI. May differ from type for hosted processors.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique identifier for this processor instance.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "Input and output ports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ProcessorNodePortsOutput"
+            }
+          ]
+        },
+        "type": {
+          "description": "The processor type name (e.g., \"CameraProcessor\", \"DisplayProcessor\").",
+          "type": "string"
+        }
+      }
+    },
+    "ProcessorNodePortsOutput": {
+      "description": "Container for processor input and output ports.",
+      "type": "object",
+      "required": [
+        "inputs",
+        "outputs"
+      ],
+      "properties": {
+        "inputs": {
+          "description": "Input ports that receive data.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortInfoOutput"
+          }
+        },
+        "outputs": {
+          "description": "Output ports that send data.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortInfoOutput"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/registry-response.schema.json
+++ b/docs/schemas/registry-response.schema.json
@@ -1,0 +1,294 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RegistryResponse",
+  "description": "Response from the `/api/registry` endpoint.",
+  "type": "object",
+  "required": [
+    "processors",
+    "schemas"
+  ],
+  "properties": {
+    "processors": {
+      "description": "Available processor types with their descriptors.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProcessorDescriptorOutput"
+      }
+    },
+    "schemas": {
+      "description": "Available data frame schemas.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SchemaDescriptorOutput"
+      }
+    }
+  },
+  "definitions": {
+    "CodeExamplesOutput": {
+      "description": "Code examples for a processor in different languages.",
+      "type": "object",
+      "required": [
+        "python",
+        "rust",
+        "typescript"
+      ],
+      "properties": {
+        "python": {
+          "description": "Python code example.",
+          "type": "string"
+        },
+        "rust": {
+          "description": "Rust code example.",
+          "type": "string"
+        },
+        "typescript": {
+          "description": "TypeScript code example.",
+          "type": "string"
+        }
+      }
+    },
+    "ConfigFieldOutput": {
+      "description": "A configuration field for a processor.",
+      "type": "object",
+      "required": [
+        "description",
+        "name",
+        "required",
+        "type"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Field name.",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether the field is required.",
+          "type": "boolean"
+        },
+        "type": {
+          "description": "Field type as string (e.g., \"String\", \"u32\", \"Option<PathBuf>\").",
+          "type": "string"
+        }
+      }
+    },
+    "LinkBufferReadModeOutput": {
+      "description": "How data is read from the link buffer.",
+      "oneOf": [
+        {
+          "description": "Drain buffer and return only the newest frame (optimal for video).",
+          "type": "string",
+          "enum": [
+            "skip_to_latest"
+          ]
+        },
+        {
+          "description": "Read next frame in FIFO order (required for audio).",
+          "type": "string",
+          "enum": [
+            "read_next_in_order"
+          ]
+        }
+      ]
+    },
+    "PortDescriptorOutput": {
+      "description": "Descriptor for a processor port.",
+      "type": "object",
+      "required": [
+        "description",
+        "name",
+        "required",
+        "schema"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Port name.",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether the port is required.",
+          "type": "boolean"
+        },
+        "schema": {
+          "description": "Schema name for data flowing through this port.",
+          "type": "string"
+        }
+      }
+    },
+    "ProcessorDescriptorOutput": {
+      "description": "Descriptor for a processor type.",
+      "type": "object",
+      "required": [
+        "config",
+        "description",
+        "examples",
+        "inputs",
+        "name",
+        "outputs",
+        "repository",
+        "version"
+      ],
+      "properties": {
+        "config": {
+          "description": "Configuration fields.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConfigFieldOutput"
+          }
+        },
+        "description": {
+          "description": "Human-readable description.",
+          "type": "string"
+        },
+        "examples": {
+          "description": "Code examples in different languages.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CodeExamplesOutput"
+            }
+          ]
+        },
+        "inputs": {
+          "description": "Input port descriptors.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortDescriptorOutput"
+          }
+        },
+        "name": {
+          "description": "Processor type name.",
+          "type": "string"
+        },
+        "outputs": {
+          "description": "Output port descriptors.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortDescriptorOutput"
+          }
+        },
+        "repository": {
+          "description": "Repository URL.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Semantic version string.",
+          "type": "string"
+        }
+      }
+    },
+    "SchemaDescriptorOutput": {
+      "description": "Descriptor for a data schema.",
+      "type": "object",
+      "required": [
+        "default_capacity",
+        "fields",
+        "name",
+        "read_behavior",
+        "version"
+      ],
+      "properties": {
+        "default_capacity": {
+          "description": "Default ring buffer capacity.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "fields": {
+          "description": "Fields in this schema.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SchemaFieldOutput"
+          }
+        },
+        "name": {
+          "description": "Schema name (e.g., \"VideoFrame\", \"AudioFrame\").",
+          "type": "string"
+        },
+        "read_behavior": {
+          "description": "How data is read from the link buffer.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LinkBufferReadModeOutput"
+            }
+          ]
+        },
+        "version": {
+          "description": "Semantic version.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SemanticVersionOutput"
+            }
+          ]
+        }
+      }
+    },
+    "SchemaFieldOutput": {
+      "description": "A field in a data schema.",
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description.",
+          "type": "string"
+        },
+        "internal": {
+          "description": "Whether this is an internal field (not serializable).",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Field name.",
+          "type": "string"
+        },
+        "shape": {
+          "description": "Shape for multi-dimensional fields (e.g., [512] for embeddings).",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        },
+        "type": {
+          "description": "Type name (e.g., \"u32\", \"Arc<wgpu::Texture>\").",
+          "type": "string"
+        }
+      }
+    },
+    "SemanticVersionOutput": {
+      "description": "Semantic version (major.minor.patch).",
+      "type": "object",
+      "required": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "properties": {
+        "major": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "minor": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "patch": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
+}

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -50,6 +50,7 @@ dirs = "6.0"   # Cross-platform home directory resolution
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+schemars = "0.8"  # JSON Schema generation from Rust types
 
 # WebGPU for cross-platform GPU abstraction
 wgpu.workspace = true

--- a/libs/streamlib/src/bin/generate_schemas.rs
+++ b/libs/streamlib/src/bin/generate_schemas.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Generates JSON Schema files for streamlib API responses.
+//!
+//! Run with: `cargo run --bin generate_schemas`
+//!
+//! This generates schema files in `docs/schemas/` that can be used for:
+//! - API documentation
+//! - Client code generation
+//! - Runtime validation
+//! - Web UI development
+
+use schemars::schema_for;
+use std::fs;
+use std::path::Path;
+
+use streamlib::core::json_schema::{GraphResponse, RegistryResponse};
+
+fn main() {
+    let schema_dir = Path::new("docs/schemas");
+
+    // Create the schema directory if it doesn't exist
+    if !schema_dir.exists() {
+        fs::create_dir_all(schema_dir).expect("Failed to create schema directory");
+        println!("Created directory: {}", schema_dir.display());
+    }
+
+    // Generate GraphResponse schema
+    let graph_schema = schema_for!(GraphResponse);
+    let graph_json =
+        serde_json::to_string_pretty(&graph_schema).expect("Failed to serialize schema");
+    let graph_path = schema_dir.join("graph-response.schema.json");
+    fs::write(&graph_path, &graph_json).expect("Failed to write graph schema");
+    println!("Generated: {}", graph_path.display());
+
+    // Generate RegistryResponse schema
+    let registry_schema = schema_for!(RegistryResponse);
+    let registry_json =
+        serde_json::to_string_pretty(&registry_schema).expect("Failed to serialize schema");
+    let registry_path = schema_dir.join("registry-response.schema.json");
+    fs::write(&registry_path, &registry_json).expect("Failed to write registry schema");
+    println!("Generated: {}", registry_path.display());
+
+    println!("\nSchema generation complete!");
+    println!("Files written to: {}", schema_dir.display());
+}

--- a/libs/streamlib/src/core/json_schema.rs
+++ b/libs/streamlib/src/core/json_schema.rs
@@ -1,0 +1,437 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! JSON Schema output types for API documentation.
+//!
+//! These structs mirror the serialization output of the runtime types and are used
+//! for generating JSON Schema files. They implement both `Serialize` and `JsonSchema`
+//! to ensure schemas stay in sync with actual serialization.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::core::graph::{GraphEdgeWithComponents, GraphNodeWithComponents};
+
+// =============================================================================
+// Graph Response Schema (/api/graph)
+// =============================================================================
+
+/// Response from the `/api/graph` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GraphResponse {
+    /// All processor nodes in the graph.
+    pub nodes: Vec<ProcessorNodeOutput>,
+    /// All links (connections) between processors.
+    pub links: Vec<LinkOutput>,
+}
+
+/// A processor node in the graph.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProcessorNodeOutput {
+    /// Unique identifier for this processor instance.
+    pub id: String,
+    /// The processor type name (e.g., "CameraProcessor", "DisplayProcessor").
+    #[serde(rename = "type")]
+    pub processor_type: String,
+    /// Display name for UI. May differ from type for hosted processors.
+    pub display_name: String,
+    /// Processor configuration as JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+    /// Checksum of config for change detection.
+    #[serde(default)]
+    pub config_checksum: u64,
+    /// Input and output ports.
+    pub ports: ProcessorNodePortsOutput,
+    /// Runtime components (dynamic, varies based on processor state).
+    pub components: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Container for processor input and output ports.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProcessorNodePortsOutput {
+    /// Input ports that receive data.
+    pub inputs: Vec<PortInfoOutput>,
+    /// Output ports that send data.
+    pub outputs: Vec<PortInfoOutput>,
+}
+
+/// Metadata about a port.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PortInfoOutput {
+    /// Port name (e.g., "video_in", "audio_out").
+    pub name: String,
+    /// Data type flowing through this port.
+    pub data_type: String,
+    /// Kind of port: data, event, or control.
+    #[serde(default)]
+    pub port_kind: PortKindOutput,
+}
+
+/// The kind of port - determines how data flows.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PortKindOutput {
+    #[default]
+    Data,
+    Event,
+    Control,
+}
+
+/// A link (connection) between two processor ports.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LinkOutput {
+    /// Unique identifier for this link.
+    pub id: String,
+    /// Source endpoint (output port).
+    pub source: LinkPortRefOutput,
+    /// Target endpoint (input port).
+    pub target: LinkPortRefOutput,
+    /// Ring buffer capacity for the channel.
+    #[serde(default)]
+    pub capacity: usize,
+    /// Current state of the link.
+    #[serde(default)]
+    pub state: LinkStateOutput,
+    /// Runtime components (dynamic, varies based on link state).
+    pub components: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Reference to a port on a processor.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LinkPortRefOutput {
+    /// Processor instance ID.
+    pub processor_id: String,
+    /// Port name on that processor.
+    pub port_name: String,
+}
+
+/// State of a link in the graph.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LinkStateOutput {
+    /// Link exists in graph but not yet wired.
+    #[default]
+    Pending,
+    /// Link is actively wired with a ring buffer channel.
+    Wired,
+    /// Link is being disconnected.
+    Disconnecting,
+    /// Link was disconnected.
+    Disconnected,
+    /// Link is in error state.
+    Error,
+}
+
+// =============================================================================
+// Registry Response Schema (/api/registry)
+// =============================================================================
+
+/// Response from the `/api/registry` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct RegistryResponse {
+    /// Available processor types with their descriptors.
+    pub processors: Vec<ProcessorDescriptorOutput>,
+    /// Available data frame schemas.
+    pub schemas: Vec<SchemaDescriptorOutput>,
+}
+
+/// Descriptor for a processor type.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct ProcessorDescriptorOutput {
+    /// Processor type name.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Semantic version string.
+    pub version: String,
+    /// Repository URL.
+    pub repository: String,
+    /// Configuration fields.
+    pub config: Vec<ConfigFieldOutput>,
+    /// Input port descriptors.
+    pub inputs: Vec<PortDescriptorOutput>,
+    /// Output port descriptors.
+    pub outputs: Vec<PortDescriptorOutput>,
+    /// Code examples in different languages.
+    pub examples: CodeExamplesOutput,
+}
+
+/// A configuration field for a processor.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct ConfigFieldOutput {
+    /// Field name.
+    pub name: String,
+    /// Field type as string (e.g., "String", "u32", "Option<PathBuf>").
+    #[serde(rename = "type")]
+    pub field_type: String,
+    /// Whether the field is required.
+    pub required: bool,
+    /// Human-readable description.
+    pub description: String,
+}
+
+/// Descriptor for a processor port.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct PortDescriptorOutput {
+    /// Port name.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Schema name for data flowing through this port.
+    pub schema: String,
+    /// Whether the port is required.
+    pub required: bool,
+}
+
+/// Code examples for a processor in different languages.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct CodeExamplesOutput {
+    /// Rust code example.
+    pub rust: String,
+    /// Python code example.
+    pub python: String,
+    /// TypeScript code example.
+    pub typescript: String,
+}
+
+/// Descriptor for a data schema.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct SchemaDescriptorOutput {
+    /// Schema name (e.g., "VideoFrame", "AudioFrame").
+    pub name: String,
+    /// Semantic version.
+    pub version: SemanticVersionOutput,
+    /// Fields in this schema.
+    pub fields: Vec<SchemaFieldOutput>,
+    /// How data is read from the link buffer.
+    pub read_behavior: LinkBufferReadModeOutput,
+    /// Default ring buffer capacity.
+    pub default_capacity: usize,
+}
+
+/// Semantic version (major.minor.patch).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct SemanticVersionOutput {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+/// A field in a data schema.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+pub struct SchemaFieldOutput {
+    /// Field name.
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// Type name (e.g., "u32", "Arc<wgpu::Texture>").
+    #[serde(rename = "type")]
+    pub type_name: String,
+    /// Shape for multi-dimensional fields (e.g., [512] for embeddings).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shape: Vec<usize>,
+    /// Whether this is an internal field (not serializable).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub internal: bool,
+}
+
+/// How data is read from the link buffer.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkBufferReadModeOutput {
+    /// Drain buffer and return only the newest frame (optimal for video).
+    #[default]
+    SkipToLatest,
+    /// Read next frame in FIFO order (required for audio).
+    ReadNextInOrder,
+}
+
+// =============================================================================
+// Conversion from Runtime Types
+// =============================================================================
+
+impl From<&crate::core::graph::ProcessorNode> for ProcessorNodeOutput {
+    fn from(node: &crate::core::graph::ProcessorNode) -> Self {
+        Self {
+            id: node.id.to_string(),
+            processor_type: node.processor_type.clone(),
+            display_name: node.display_name.clone(),
+            config: node.config.clone(),
+            config_checksum: node.config_checksum,
+            ports: ProcessorNodePortsOutput::from(&node.ports),
+            components: node.serialize_components(),
+        }
+    }
+}
+
+impl From<&crate::core::graph::ProcessorNodePorts> for ProcessorNodePortsOutput {
+    fn from(ports: &crate::core::graph::ProcessorNodePorts) -> Self {
+        Self {
+            inputs: ports.inputs.iter().map(PortInfoOutput::from).collect(),
+            outputs: ports.outputs.iter().map(PortInfoOutput::from).collect(),
+        }
+    }
+}
+
+impl From<&crate::core::graph::PortInfo> for PortInfoOutput {
+    fn from(port: &crate::core::graph::PortInfo) -> Self {
+        Self {
+            name: port.name.clone(),
+            data_type: port.data_type.clone(),
+            port_kind: PortKindOutput::from(port.port_kind),
+        }
+    }
+}
+
+impl From<crate::core::graph::PortKind> for PortKindOutput {
+    fn from(kind: crate::core::graph::PortKind) -> Self {
+        match kind {
+            crate::core::graph::PortKind::Data => PortKindOutput::Data,
+            crate::core::graph::PortKind::Event => PortKindOutput::Event,
+            crate::core::graph::PortKind::Control => PortKindOutput::Control,
+        }
+    }
+}
+
+impl From<&crate::core::graph::Link> for LinkOutput {
+    fn from(link: &crate::core::graph::Link) -> Self {
+        Self {
+            id: link.id.to_string(),
+            source: LinkPortRefOutput::from(&link.source),
+            target: LinkPortRefOutput::from(&link.target),
+            capacity: link.capacity.get(),
+            state: LinkStateOutput::from(link.state),
+            components: link.serialize_components(),
+        }
+    }
+}
+
+impl From<&crate::core::graph::OutputLinkPortRef> for LinkPortRefOutput {
+    fn from(port_ref: &crate::core::graph::OutputLinkPortRef) -> Self {
+        Self {
+            processor_id: port_ref.processor_id.to_string(),
+            port_name: port_ref.port_name.clone(),
+        }
+    }
+}
+
+impl From<&crate::core::graph::InputLinkPortRef> for LinkPortRefOutput {
+    fn from(port_ref: &crate::core::graph::InputLinkPortRef) -> Self {
+        Self {
+            processor_id: port_ref.processor_id.to_string(),
+            port_name: port_ref.port_name.clone(),
+        }
+    }
+}
+
+impl From<crate::core::graph::LinkState> for LinkStateOutput {
+    fn from(state: crate::core::graph::LinkState) -> Self {
+        match state {
+            crate::core::graph::LinkState::Pending => LinkStateOutput::Pending,
+            crate::core::graph::LinkState::Wired => LinkStateOutput::Wired,
+            crate::core::graph::LinkState::Disconnecting => LinkStateOutput::Disconnecting,
+            crate::core::graph::LinkState::Disconnected => LinkStateOutput::Disconnected,
+            crate::core::graph::LinkState::Error => LinkStateOutput::Error,
+        }
+    }
+}
+
+impl From<&crate::core::schema::ProcessorDescriptor> for ProcessorDescriptorOutput {
+    fn from(desc: &crate::core::schema::ProcessorDescriptor) -> Self {
+        Self {
+            name: desc.name.clone(),
+            description: desc.description.clone(),
+            version: desc.version.clone(),
+            repository: desc.repository.clone(),
+            config: desc.config.iter().map(ConfigFieldOutput::from).collect(),
+            inputs: desc.inputs.iter().map(PortDescriptorOutput::from).collect(),
+            outputs: desc
+                .outputs
+                .iter()
+                .map(PortDescriptorOutput::from)
+                .collect(),
+            examples: CodeExamplesOutput::from(&desc.examples),
+        }
+    }
+}
+
+impl From<&crate::core::schema::ConfigField> for ConfigFieldOutput {
+    fn from(field: &crate::core::schema::ConfigField) -> Self {
+        Self {
+            name: field.name.clone(),
+            field_type: field.field_type.clone(),
+            required: field.required,
+            description: field.description.clone(),
+        }
+    }
+}
+
+impl From<&crate::core::schema::PortDescriptor> for PortDescriptorOutput {
+    fn from(port: &crate::core::schema::PortDescriptor) -> Self {
+        Self {
+            name: port.name.clone(),
+            description: port.description.clone(),
+            schema: port.schema.clone(),
+            required: port.required,
+        }
+    }
+}
+
+impl From<&crate::core::schema::CodeExamples> for CodeExamplesOutput {
+    fn from(examples: &crate::core::schema::CodeExamples) -> Self {
+        Self {
+            rust: examples.rust.clone(),
+            python: examples.python.clone(),
+            typescript: examples.typescript.clone(),
+        }
+    }
+}
+
+impl From<&crate::core::schema_registry::SchemaDescriptor> for SchemaDescriptorOutput {
+    fn from(desc: &crate::core::schema_registry::SchemaDescriptor) -> Self {
+        Self {
+            name: desc.name.clone(),
+            version: SemanticVersionOutput::from(&desc.version),
+            fields: desc.fields.iter().map(SchemaFieldOutput::from).collect(),
+            read_behavior: LinkBufferReadModeOutput::from(desc.read_behavior),
+            default_capacity: desc.default_capacity,
+        }
+    }
+}
+
+impl From<&crate::core::schema::SemanticVersion> for SemanticVersionOutput {
+    fn from(version: &crate::core::schema::SemanticVersion) -> Self {
+        Self {
+            major: version.major,
+            minor: version.minor,
+            patch: version.patch,
+        }
+    }
+}
+
+impl From<&crate::core::schema::DataFrameSchemaField> for SchemaFieldOutput {
+    fn from(field: &crate::core::schema::DataFrameSchemaField) -> Self {
+        Self {
+            name: field.name.clone(),
+            description: field.description.clone(),
+            type_name: field.type_name.clone(),
+            shape: field.shape.clone(),
+            internal: field.internal,
+        }
+    }
+}
+
+impl From<crate::core::links::LinkBufferReadMode> for LinkBufferReadModeOutput {
+    fn from(mode: crate::core::links::LinkBufferReadMode) -> Self {
+        match mode {
+            crate::core::links::LinkBufferReadMode::SkipToLatest => {
+                LinkBufferReadModeOutput::SkipToLatest
+            }
+            crate::core::links::LinkBufferReadMode::ReadNextInOrder => {
+                LinkBufferReadModeOutput::ReadNextInOrder
+            }
+        }
+    }
+}

--- a/libs/streamlib/src/core/mod.rs
+++ b/libs/streamlib/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod execution;
 
 pub mod frames;
 pub mod graph;
+pub mod json_schema;
 pub mod links;
 pub mod media_clock;
 pub mod observability;

--- a/libs/streamlib/src/core/processors/api_server.rs
+++ b/libs/streamlib/src/core/processors/api_server.rs
@@ -75,13 +75,11 @@ struct IdResponse {
     id: String,
 }
 
-#[derive(Serialize, utoipa::ToSchema)]
-struct RegistryResponse {
-    /// Available processor types with their descriptors
-    processors: Vec<serde_json::Value>,
-    /// Available data frame schemas
-    schemas: Vec<serde_json::Value>,
-}
+// Note: RegistryResponse is now defined in crate::core::json_schema
+// and imported below for the get_registry handler.
+use crate::core::json_schema::{
+    ProcessorDescriptorOutput, RegistryResponse, SchemaDescriptorOutput,
+};
 
 #[derive(Serialize, utoipa::ToSchema)]
 struct ErrorResponse {
@@ -353,15 +351,15 @@ async fn delete_connection(
     )
 )]
 async fn get_registry() -> Json<RegistryResponse> {
-    let processors = PROCESSOR_REGISTRY
+    let processors: Vec<ProcessorDescriptorOutput> = PROCESSOR_REGISTRY
         .list_registered()
         .into_iter()
-        .map(|d| serde_json::to_value(d).unwrap_or_default())
+        .map(|d| ProcessorDescriptorOutput::from(&d))
         .collect();
-    let schemas = SCHEMA_REGISTRY
+    let schemas: Vec<SchemaDescriptorOutput> = SCHEMA_REGISTRY
         .list_descriptors()
         .into_iter()
-        .map(|d| serde_json::to_value(d).unwrap_or_default())
+        .map(|d| SchemaDescriptorOutput::from(&d))
         .collect();
     Json(RegistryResponse {
         processors,


### PR DESCRIPTION
## Summary

Add schemars-based JSON Schema generation for `/api/graph` and `/api/registry` endpoints. Schemas are automatically derived from Rust types, ensuring they stay in sync with actual serialization output.

### Key Changes

- Add `schemars` dependency for JSON Schema derivation
- Create `json_schema` module with output structs that derive both `Serialize` and `JsonSchema`
- Refactor `Graph`'s custom `Serialize` impl to use typed output structs
- Update `api_server.rs` to use typed `RegistryResponse`
- Add `generate_schemas` binary to regenerate schema files
- Generate schema files in `docs/schemas/`

### Design

The **output structs pattern** ensures schemas cannot drift from actual API responses. The same structs are used for:
1. Serialization (what the API returns)
2. Schema generation (what the docs say it returns)

If the Rust types change, running `cargo run --bin generate_schemas` regenerates matching schemas.

### Generated Files

- `docs/schemas/graph-response.schema.json` - Schema for `/api/graph`
- `docs/schemas/registry-response.schema.json` - Schema for `/api/registry`

### Regenerating Schemas

```bash
cargo run --bin generate_schemas
```

## Test plan

- [x] All existing tests pass
- [x] Examples run without issues
- [x] Generated schemas are valid JSON Schema draft-07
- [x] Schema structure matches actual API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)