### PR TITLE
feat: hash-based venv caching for Python subprocess processors

### DIFF
--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -54,6 +54,7 @@ anymap2 = "0.13"  # TypeMap for embedded component storage on graph weights
 cuid2 = "0.1"  # Collision-resistant unique identifiers for processor/link IDs
 uuid = { version = "1.11", features = ["v4"] }  # UUID generation for PixelBufferPoolId
 dirs = "6.0"   # Cross-platform home directory resolution
+sha2.workspace = true  # SHA-256 hashing for venv cache keys
 dotenvy = "0.15"  # Load .env files for development environment
 
 # Serialization

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
@@ -62,7 +62,6 @@ impl crate::core::processors::DynGeneratedProcessor for SubprocessHostProcessor 
         Box::pin(async move {
             self.runtime_context = Some(ctx.clone());
 
-            let runtime_id = ctx.runtime_id().to_string();
             let project_path = PathBuf::from(&self.project_path);
 
             tracing::info!(
@@ -73,8 +72,7 @@ impl crate::core::processors::DynGeneratedProcessor for SubprocessHostProcessor 
             );
 
             // Create venv and get python executable path
-            let python_executable =
-                ensure_processor_venv(&runtime_id, &self.processor_id, &project_path)?;
+            let python_executable = ensure_processor_venv(&self.processor_id, &project_path)?;
 
             // Build PYTHONPATH for the subprocess.
             // In dev mode, the streamlib package source lives at
@@ -675,18 +673,52 @@ pub(crate) fn create_subprocess_host_constructor(
 // Venv management
 // ============================================================================
 
-/// Ensure a processor venv exists in STREAMLIB_HOME, install deps, and return the python path.
+/// Ensure a hash-keyed cached venv exists, install deps on miss, and return the python path.
 ///
-/// Venv location: `~/.streamlib/runtimes/{runtime_id}/processors/{processor_id}/venv`
-/// Uses `uv` for fast venv creation and dependency installation.
-/// The shared UV cache (`~/.streamlib/cache/uv`) avoids re-downloading packages.
-fn ensure_processor_venv(
-    runtime_id: &str,
-    processor_id: &str,
-    project_path: &Path,
-) -> Result<String> {
-    let venv_dir = crate::core::streamlib_home::get_processor_venv_dir(runtime_id, processor_id);
+/// Venv location: `~/.streamlib/cache/venvs/{sha256_hex}/`
+/// Cache key: SHA-256 of `(pyproject.toml contents + canonical project_path)`.
+/// If no pyproject.toml exists, falls back to SHA-256 of `processor_id`.
+/// On cache hit (python binary exists), returns immediately with zero `uv` calls.
+/// On cache miss, creates venv and installs deps. On install failure, removes the
+/// venv directory and returns an error.
+fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+
     let uv_cache_dir = crate::core::streamlib_home::get_uv_cache_dir();
+
+    let pyproject_path = if !project_path.as_os_str().is_empty() {
+        let p = project_path.join("pyproject.toml");
+        if p.exists() {
+            Some(p)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Compute hash for cache key
+    let hash_hex = if let Some(ref pyproject) = pyproject_path {
+        let contents = std::fs::read_to_string(pyproject)
+            .map_err(|e| StreamError::Runtime(format!("Failed to read pyproject.toml: {}", e)))?;
+        let canonical = project_path.canonicalize().map_err(|e| {
+            StreamError::Runtime(format!(
+                "Failed to canonicalize project_path '{}': {}",
+                project_path.display(),
+                e
+            ))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(contents.as_bytes());
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        format!("{:x}", hasher.finalize())
+    } else {
+        let mut hasher = Sha256::new();
+        hasher.update(processor_id.as_bytes());
+        format!("{:x}", hasher.finalize())
+    };
+
+    let venv_dir = crate::core::streamlib_home::get_cached_venv_dir(&hash_hex);
 
     // Platform-specific python binary path within venv
     #[cfg(unix)]
@@ -694,39 +726,47 @@ fn ensure_processor_venv(
     #[cfg(windows)]
     let venv_python = venv_dir.join("Scripts").join("python.exe");
 
-    // Create venv if it doesn't exist
-    if !venv_python.exists() {
-        tracing::info!("[{}] Creating venv at {}", processor_id, venv_dir.display());
-
-        // Ensure parent directories exist
-        std::fs::create_dir_all(venv_dir.parent().unwrap_or(&venv_dir)).map_err(|e| {
-            StreamError::Runtime(format!("Failed to create venv parent directory: {}", e))
-        })?;
-
-        let output = run_uv(
-            &["venv", venv_dir.to_str().unwrap_or(""), "--python", "3.12"],
-            &uv_cache_dir,
-        )?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(StreamError::Runtime(format!(
-                "Failed to create venv for processor '{}': {}",
-                processor_id, stderr
-            )));
-        }
-
-        tracing::info!("[{}] Venv created", processor_id);
-    } else {
+    // Cache hit — venv already exists and has a python binary
+    if venv_python.exists() {
         tracing::debug!(
-            "[{}] Reusing existing venv at {}",
+            "[{}] Cache hit: reusing venv at {} (hash={})",
             processor_id,
-            venv_dir.display()
+            venv_dir.display(),
+            &hash_hex[..12]
         );
+        return Ok(venv_python.to_string_lossy().to_string());
     }
 
-    // Install project dependencies (if project_path is valid)
-    if !project_path.as_os_str().is_empty() && project_path.join("pyproject.toml").exists() {
+    // Cache miss — create venv
+    tracing::info!(
+        "[{}] Cache miss: creating venv at {} (hash={})",
+        processor_id,
+        venv_dir.display(),
+        &hash_hex[..12]
+    );
+
+    std::fs::create_dir_all(venv_dir.parent().unwrap_or(&venv_dir)).map_err(|e| {
+        StreamError::Runtime(format!("Failed to create venv parent directory: {}", e))
+    })?;
+
+    let output = run_uv(
+        &["venv", venv_dir.to_str().unwrap_or(""), "--python", "3.12"],
+        &uv_cache_dir,
+    )?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = std::fs::remove_dir_all(&venv_dir);
+        return Err(StreamError::Runtime(format!(
+            "Failed to create venv for processor '{}': {}",
+            processor_id, stderr
+        )));
+    }
+
+    tracing::info!("[{}] Venv created", processor_id);
+
+    // Install project dependencies (only when pyproject.toml exists)
+    if pyproject_path.is_some() {
         tracing::info!(
             "[{}] Installing project deps from {}",
             processor_id,
@@ -750,11 +790,11 @@ fn ensure_processor_venv(
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!(
-                "[{}] Failed to install project deps (continuing): {}",
-                processor_id,
-                stderr
-            );
+            let _ = std::fs::remove_dir_all(&venv_dir);
+            return Err(StreamError::Runtime(format!(
+                "Failed to install project deps for processor '{}': {}",
+                processor_id, stderr
+            )));
         }
     }
 

--- a/libs/streamlib/src/core/streamlib_home.rs
+++ b/libs/streamlib/src/core/streamlib_home.rs
@@ -15,12 +15,14 @@ use std::path::PathBuf;
 /// ~/.streamlib/
 /// ├── config.toml                    # Future: system-wide settings
 /// ├── cache/
-/// │   └── uv/                        # Shared PyPI cache (UV_CACHE_DIR)
+/// │   ├── uv/                        # Shared PyPI cache (UV_CACHE_DIR)
+/// │   └── venvs/                     # Hash-keyed Python venvs
+/// │       └── {sha256_hex}/          # Venv keyed by hash of pyproject.toml + project_path
 /// └── runtimes/
 ///     └── {runtime_id}/
 ///         └── processors/
 ///             └── {processor_id}/
-///                 ├── venv/          # Isolated Python venv
+///                 ├── venv/          # Isolated Python venv (legacy)
 ///                 └── data/          # Processor-specific storage
 /// ```
 pub fn get_streamlib_home() -> PathBuf {
@@ -50,6 +52,7 @@ pub fn ensure_streamlib_home() -> std::io::Result<PathBuf> {
     // Create standard subdirectories
     std::fs::create_dir_all(home.join("cache/wheels"))?;
     std::fs::create_dir_all(home.join("cache/uv"))?;
+    std::fs::create_dir_all(home.join("cache/venvs"))?;
     std::fs::create_dir_all(home.join("runtimes"))?;
 
     Ok(home)
@@ -58,6 +61,11 @@ pub fn ensure_streamlib_home() -> std::io::Result<PathBuf> {
 /// Get the path to the uv cache directory.
 pub fn get_uv_cache_dir() -> PathBuf {
     get_streamlib_home().join("cache/uv")
+}
+
+/// Get the path to a hash-keyed cached venv directory.
+pub fn get_cached_venv_dir(hash: &str) -> PathBuf {
+    get_streamlib_home().join("cache/venvs").join(hash)
 }
 
 /// Get the path to a runtime's directory.


### PR DESCRIPTION
## Summary
- Key Python subprocess venvs on SHA-256 hash of `(pyproject.toml contents + canonical project_path)` instead of `(runtime_id, processor_id)` — venvs are now stable across runtime restarts
- Venvs cached at `~/.streamlib/cache/venvs/{hash}/` — cache hit skips all `uv` calls for near-instant startup
- Failed dependency installs now remove the broken venv dir and return an error instead of warn-and-continue

Closes #131

## Test plan
- [x] `cargo check -p streamlib` passes
- [x] `cargo clippy -p streamlib` passes (no warnings)
- [x] `cargo test -p streamlib` — 171 tests pass
- [x] Manual: run a Python subprocess processor, verify venv created under `cache/venvs/`
- [x] Manual: restart runtime, verify cache hit (no `uv` calls in logs)
- [x] Manual: change `pyproject.toml`, verify new venv created (different hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)