### PR TITLE
feat: Vulkan blitter — RhiBlitter for Linux

### DIFF
--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -19,7 +19,7 @@ const POOL_MAX_BUFFER_COUNT: usize = 64;
 /// Maximum number of entries in the buffer_cache before eviction.
 const MAX_BUFFER_CACHE_SIZE: usize = 512;
 
-/// No-op blitter for non-macOS platforms.
+/// No-op blitter for platforms without a native blitter.
 #[cfg(not(target_os = "macos"))]
 struct NoOpBlitter;
 
@@ -380,7 +380,26 @@ impl GpuContext {
         Arc::new(crate::metal::rhi::MetalBlitter::new(command_queue))
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    fn create_blitter(device: &Arc<GpuDevice>) -> Arc<dyn RhiBlitter> {
+        let vulkan_device = &device.inner;
+        match crate::vulkan::rhi::VulkanBlitter::new(
+            vulkan_device.device(),
+            vulkan_device.queue(),
+            vulkan_device.queue_family_index(),
+        ) {
+            Ok(blitter) => Arc::new(blitter),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to create VulkanBlitter: {}, falling back to no-op",
+                    e
+                );
+                Arc::new(NoOpBlitter)
+            }
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     fn create_blitter(_device: &Arc<GpuDevice>) -> Arc<dyn RhiBlitter> {
         Arc::new(NoOpBlitter)
     }

--- a/libs/streamlib/src/vulkan/mod.rs
+++ b/libs/streamlib/src/vulkan/mod.rs
@@ -7,4 +7,6 @@ pub mod rhi;
 
 // Re-exports for public API (intentionally exposed for external use)
 #[allow(unused_imports)]
-pub use rhi::{VulkanCommandBuffer, VulkanCommandQueue, VulkanDevice, VulkanTexture};
+pub use rhi::{
+    VulkanBlitter, VulkanCommandBuffer, VulkanCommandQueue, VulkanDevice, VulkanTexture,
+};

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -18,3 +18,6 @@ pub use vulkan_device::VulkanDevice;
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 pub use vulkan_texture::VulkanTexture;
+
+mod vulkan_blitter;
+pub use vulkan_blitter::VulkanBlitter;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use ash::vk;
+
+use crate::core::rhi::blitter::RhiBlitter;
+use crate::core::rhi::RhiPixelBuffer;
+use crate::core::{Result, StreamError};
+
+/// Vulkan implementation of [`RhiBlitter`] for GPU copy operations on Linux.
+pub struct VulkanBlitter {
+    device: ash::Device,
+    #[allow(dead_code)]
+    queue: vk::Queue,
+    #[allow(dead_code)]
+    queue_family_index: u32,
+    command_pool: vk::CommandPool,
+}
+
+impl VulkanBlitter {
+    /// Create a new Vulkan blitter with a dedicated command pool.
+    pub fn new(device: &ash::Device, queue: vk::Queue, queue_family_index: u32) -> Result<Self> {
+        let pool_info = vk::CommandPoolCreateInfo::default()
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
+            .queue_family_index(queue_family_index);
+
+        let command_pool =
+            unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
+                StreamError::GpuError(format!("Failed to create blitter command pool: {e}"))
+            })?;
+
+        Ok(Self {
+            device: device.clone(),
+            queue,
+            queue_family_index,
+            command_pool,
+        })
+    }
+}
+
+impl RhiBlitter for VulkanBlitter {
+    fn blit_copy(&self, _src: &RhiPixelBuffer, _dest: &RhiPixelBuffer) -> Result<()> {
+        Err(StreamError::NotSupported(
+            "Vulkan blitter blit_copy not yet implemented".into(),
+        ))
+    }
+
+    unsafe fn blit_copy_iosurface_raw(
+        &self,
+        _src: *const std::ffi::c_void,
+        _dest: &RhiPixelBuffer,
+        _width: u32,
+        _height: u32,
+    ) -> Result<()> {
+        Err(StreamError::NotSupported(
+            "IOSurface not available on Linux".into(),
+        ))
+    }
+
+    fn clear_cache(&self) {}
+}
+
+impl Drop for VulkanBlitter {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_command_pool(self.command_pool, None);
+        }
+    }
+}
+
+unsafe impl Send for VulkanBlitter {}
+unsafe impl Sync for VulkanBlitter {}


### PR DESCRIPTION
## Summary
- Add `VulkanBlitter` struct implementing the `RhiBlitter` trait for Linux GPU copy operations
- Creates a dedicated Vulkan command pool (with RESET_COMMAND_BUFFER flag) for blit operations
- `blit_copy()` returns `NotSupported` stub (pixel buffer wiring in progress by Agent A)
- `blit_copy_iosurface_raw()` returns `NotSupported` (macOS-only API)
- Wire `GpuContext::create_blitter()` on Linux to use `VulkanBlitter` with `NoOpBlitter` fallback
- Re-export `VulkanBlitter` from `vulkan::rhi` and `vulkan` modules

## Test plan
- [x] `cargo check -p streamlib --features backend-vulkan 2>&1 | grep -E "error.*vulkan"` shows no new errors
- [x] Pre-existing errors (clack_host, pixel_format, streamlib_broker) are unrelated macOS-only code


🤖 Generated with [Claude Code](https://claude.com/claude-code)