### PR TITLE
feat: Vulkan pixel buffer — CPU-visible staging buffer

### DIFF
--- a/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
@@ -18,7 +18,10 @@ pub struct RhiPixelBufferRef {
     #[cfg(target_os = "macos")]
     pub(crate) inner: std::ptr::NonNull<std::ffi::c_void>,
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    pub(crate) inner: crate::vulkan::rhi::VulkanPixelBuffer,
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub(crate) _marker: std::marker::PhantomData<()>,
 }
 
@@ -29,7 +32,11 @@ impl RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::format_impl(self)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            PixelFormat::Unknown
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             PixelFormat::Unknown
         }
@@ -41,7 +48,11 @@ impl RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::width_impl(self)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.width()
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             0
         }
@@ -53,7 +64,11 @@ impl RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::height_impl(self)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.height()
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             0
         }
@@ -86,7 +101,13 @@ impl Clone for RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::clone_impl(self)
         }
-        #[cfg(not(target_os = "macos"))]
+        // VulkanPixelBuffer owns GPU resources and cannot be trivially cloned.
+        // A proper implementation requires Arc-based sharing or re-allocation.
+        #[cfg(target_os = "linux")]
+        {
+            panic!("RhiPixelBufferRef::clone not yet implemented for Linux — VulkanPixelBuffer owns GPU resources")
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             Self {
                 _marker: std::marker::PhantomData,
@@ -101,6 +122,8 @@ impl Drop for RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::drop_impl(self);
         }
+        // On Linux, VulkanPixelBuffer handles its own cleanup via its Drop impl.
+        // No additional action needed here.
     }
 }
 

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -18,3 +18,6 @@ pub use vulkan_device::VulkanDevice;
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 pub use vulkan_texture::VulkanTexture;
+
+mod vulkan_pixel_buffer;
+pub use vulkan_pixel_buffer::VulkanPixelBuffer;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use ash::vk;
+
+use crate::core::{Result, StreamError};
+
+use super::VulkanDevice;
+
+/// CPU-visible staging buffer for pixel data upload/readback.
+pub struct VulkanPixelBuffer {
+    device: ash::Device,
+    buffer: vk::Buffer,
+    memory: vk::DeviceMemory,
+    mapped_ptr: *mut u8,
+    width: u32,
+    height: u32,
+    bytes_per_pixel: u32,
+    size: vk::DeviceSize,
+}
+
+impl VulkanPixelBuffer {
+    /// Create a new CPU-visible staging buffer.
+    pub fn new(
+        vulkan_device: &VulkanDevice,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+    ) -> Result<Self> {
+        let size = (width as vk::DeviceSize)
+            * (height as vk::DeviceSize)
+            * (bytes_per_pixel as vk::DeviceSize);
+
+        let buffer_info = vk::BufferCreateInfo::default()
+            .size(size)
+            .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+
+        let device = vulkan_device.device();
+
+        let buffer = unsafe { device.create_buffer(&buffer_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to create staging buffer: {e}")))?;
+
+        let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
+
+        let memory_type_index = vulkan_device.find_memory_type(
+            mem_requirements.memory_type_bits,
+            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+        )?;
+
+        let alloc_info = vk::MemoryAllocateInfo::default()
+            .allocation_size(mem_requirements.size)
+            .memory_type_index(memory_type_index);
+
+        let memory = unsafe { device.allocate_memory(&alloc_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!("Failed to allocate staging memory: {e}"))
+        })?;
+
+        unsafe { device.bind_buffer_memory(buffer, memory, 0) }.map_err(|e| {
+            StreamError::GpuError(format!("Failed to bind staging buffer memory: {e}"))
+        })?;
+
+        let mapped_ptr = unsafe {
+            device.map_memory(
+                memory,
+                0,
+                mem_requirements.size,
+                vk::MemoryMapFlags::empty(),
+            )
+        }
+        .map_err(|e| StreamError::GpuError(format!("Failed to map staging buffer memory: {e}")))?
+            as *mut u8;
+
+        Ok(Self {
+            device: device.clone(),
+            buffer,
+            memory,
+            mapped_ptr,
+            width,
+            height,
+            bytes_per_pixel,
+            size,
+        })
+    }
+
+    /// Persistently mapped pointer for CPU access.
+    pub fn mapped_ptr(&self) -> *mut u8 {
+        self.mapped_ptr
+    }
+
+    /// Buffer width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Buffer height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Bytes per pixel.
+    pub fn bytes_per_pixel(&self) -> u32 {
+        self.bytes_per_pixel
+    }
+
+    /// Total buffer size in bytes.
+    pub fn size(&self) -> vk::DeviceSize {
+        self.size
+    }
+
+    /// Underlying Vulkan buffer handle.
+    pub fn buffer(&self) -> vk::Buffer {
+        self.buffer
+    }
+}
+
+impl Drop for VulkanPixelBuffer {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.unmap_memory(self.memory);
+            self.device.destroy_buffer(self.buffer, None);
+            self.device.free_memory(self.memory, None);
+        }
+    }
+}
+
+// Safety: Vulkan handles are thread-safe
+unsafe impl Send for VulkanPixelBuffer {}
+unsafe impl Sync for VulkanPixelBuffer {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vulkan_pixel_buffer_creation() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping test - Vulkan not available");
+                return;
+            }
+        };
+
+        let result = VulkanPixelBuffer::new(&device, 1920, 1080, 4);
+        match result {
+            Ok(buf) => {
+                assert_eq!(buf.width(), 1920);
+                assert_eq!(buf.height(), 1080);
+                assert_eq!(buf.bytes_per_pixel(), 4);
+                assert_eq!(buf.size(), 1920 * 1080 * 4);
+                assert!(!buf.mapped_ptr().is_null());
+                assert_ne!(buf.buffer(), vk::Buffer::null());
+                println!("VulkanPixelBuffer creation succeeded");
+            }
+            Err(e) => {
+                println!("VulkanPixelBuffer creation failed: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `VulkanPixelBuffer` struct — a CPU-visible staging buffer for pixel data upload/readback on Linux (Vulkan equivalent of CVPixelBuffer on macOS)
- Wire `VulkanPixelBuffer` into `RhiPixelBufferRef` as the Linux backend, replacing the PhantomData stub
- Delegate `width()` and `height()` on `RhiPixelBufferRef` to the inner `VulkanPixelBuffer` on Linux

## Test plan
- [x] `cargo check -p streamlib --features backend-vulkan` introduces 0 new errors in vulkan files (pre-existing 42 errors from macOS-only code unchanged)
- [x] `cargo fmt` passes
- [ ] `VulkanPixelBuffer` unit test passes on a system with Vulkan drivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)