### PR TITLE
feat: Vulkan texture cache — VkImageView caching for Linux

### DIFF
--- a/libs/streamlib/src/core/rhi/texture_cache.rs
+++ b/libs/streamlib/src/core/rhi/texture_cache.rs
@@ -15,7 +15,10 @@ pub struct RhiTextureCache {
     #[cfg(target_os = "macos")]
     pub(crate) inner: crate::metal::rhi::texture_cache::TextureCacheMacOS,
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    pub(crate) inner: crate::vulkan::rhi::VulkanTextureCache,
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub(crate) _marker: std::marker::PhantomData<()>,
 }
 
@@ -29,7 +32,17 @@ impl RhiTextureCache {
         {
             self.inner.create_view(buffer)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            // VulkanTextureCache needs a VkImage to create a view from,
+            // but RhiPixelBuffer on Linux wraps a VkBuffer (not VkImage).
+            // For now, return NotSupported until pixel buffer -> texture path is wired.
+            let _ = buffer;
+            Err(crate::core::StreamError::NotSupported(
+                "Vulkan texture cache create_view not yet implemented".into(),
+            ))
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = buffer;
             Err(crate::core::StreamError::Configuration(
@@ -43,6 +56,10 @@ impl RhiTextureCache {
     /// Call periodically (e.g., every few seconds) to free memory.
     pub fn flush(&self) {
         #[cfg(target_os = "macos")]
+        {
+            self.inner.flush();
+        }
+        #[cfg(target_os = "linux")]
         {
             self.inner.flush();
         }
@@ -63,7 +80,10 @@ pub struct RhiTextureView {
     #[cfg(target_os = "macos")]
     pub(crate) inner: crate::metal::rhi::texture_cache::TextureViewMacOS,
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    pub(crate) vulkan_image_view_handle: u64,
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub(crate) _marker: std::marker::PhantomData<()>,
 
     /// Keep the source buffer alive while this view exists.

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -18,3 +18,6 @@ pub use vulkan_device::VulkanDevice;
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 pub use vulkan_texture::VulkanTexture;
+
+mod vulkan_texture_cache;
+pub use vulkan_texture_cache::VulkanTextureCache;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use ash::vk;
+use ash::vk::Handle;
+
+use crate::core::{Result, StreamError};
+
+/// Vulkan texture cache — creates and caches VkImageView from VkImage.
+///
+/// Vulkan equivalent of CVMetalTextureCache on macOS.
+pub struct VulkanTextureCache {
+    device: ash::Device,
+    view_cache: Mutex<HashMap<u64, vk::ImageView>>,
+}
+
+impl VulkanTextureCache {
+    /// Create a new texture cache for the given Vulkan device.
+    pub fn new(device: &ash::Device) -> Self {
+        Self {
+            device: device.clone(),
+            view_cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create or retrieve a cached VkImageView for the given VkImage.
+    pub fn create_view_from_image(
+        &self,
+        image: vk::Image,
+        format: vk::Format,
+        width: u32,
+        height: u32,
+    ) -> Result<vk::ImageView> {
+        let key = image.as_raw();
+
+        let mut cache = self
+            .view_cache
+            .lock()
+            .map_err(|e| StreamError::GpuError(format!("Failed to lock texture cache: {e}")))?;
+
+        if let Some(&existing_view) = cache.get(&key) {
+            return Ok(existing_view);
+        }
+
+        let view_info = vk::ImageViewCreateInfo::default()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(format)
+            .components(vk::ComponentMapping {
+                r: vk::ComponentSwizzle::IDENTITY,
+                g: vk::ComponentSwizzle::IDENTITY,
+                b: vk::ComponentSwizzle::IDENTITY,
+                a: vk::ComponentSwizzle::IDENTITY,
+            })
+            .subresource_range(vk::ImageSubresourceRange {
+                aspect_mask: vk::ImageAspectFlags::COLOR,
+                base_mip_level: 0,
+                level_count: 1,
+                base_array_layer: 0,
+                layer_count: 1,
+            });
+
+        let _ = width;
+        let _ = height;
+
+        let view = unsafe { self.device.create_image_view(&view_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to create VkImageView: {e}")))?;
+
+        cache.insert(key, view);
+        Ok(view)
+    }
+
+    /// Destroy all cached views and clear the cache.
+    pub fn flush(&self) {
+        if let Ok(mut cache) = self.view_cache.lock() {
+            for (_, view) in cache.drain() {
+                unsafe {
+                    self.device.destroy_image_view(view, None);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for VulkanTextureCache {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+// VulkanTextureCache is thread-safe: Vulkan handles are externally synchronized via Mutex
+unsafe impl Send for VulkanTextureCache {}
+unsafe impl Sync for VulkanTextureCache {}


### PR DESCRIPTION
## Summary
- Add `VulkanTextureCache` struct that creates and caches `VkImageView` from `VkImage` with a `Mutex<HashMap<u64, ImageView>>` lookup by raw image handle
- Wire Linux `#[cfg]` gates into `RhiTextureCache` (struct field, `create_view`, `flush`) and `RhiTextureView` (vulkan_image_view_handle as `u64`)
- `create_view` on Linux returns `NotSupported` until the pixel buffer to texture path is wired

## Test plan
- [x] `cargo check -p streamlib --features backend-vulkan` shows no new vulkan-related errors
- [x] `cargo fmt` passes
- [ ] Verify on macOS that existing Metal path is unaffected (cfg gates are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)