### PR TITLE
feat: DMA-BUF external memory support for Vulkan textures

### DIFF
--- a/libs/streamlib/src/core/rhi/external_handle.rs
+++ b/libs/streamlib/src/core/rhi/external_handle.rs
@@ -70,3 +70,27 @@ pub trait RhiPixelBufferImport {
     where
         Self: Sized;
 }
+
+#[cfg(target_os = "linux")]
+impl RhiPixelBufferExport for super::RhiPixelBuffer {
+    fn export_handle(&self) -> Result<RhiExternalHandle> {
+        Err(crate::core::StreamError::NotSupported(
+            "DMA-BUF export for pixel buffers not yet implemented".into(),
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl RhiPixelBufferImport for super::RhiPixelBuffer {
+    fn from_external_handle(
+        handle: RhiExternalHandle,
+        width: u32,
+        height: u32,
+        format: super::PixelFormat,
+    ) -> Result<Self> {
+        let _ = (handle, width, height, format);
+        Err(crate::core::StreamError::NotSupported(
+            "DMA-BUF import for pixel buffers not yet implemented".into(),
+        ))
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -27,6 +27,7 @@ pub struct VulkanDevice {
     queue_family_index: u32,
     #[allow(dead_code)]
     device_name: String,
+    supports_external_memory: bool,
 }
 
 impl VulkanDevice {
@@ -164,6 +165,46 @@ impl VulkanDevice {
             device_extensions.push(c"VK_KHR_portability_subset".as_ptr());
         }
 
+        // On Linux, check for DMA-BUF external memory extensions
+        #[cfg(target_os = "linux")]
+        let has_external_memory = {
+            let available_device_extensions =
+                unsafe { instance.enumerate_device_extension_properties(physical_device) }
+                    .unwrap_or_default();
+
+            let available_device_ext_names: Vec<&CStr> = available_device_extensions
+                .iter()
+                .map(|ext| unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) })
+                .collect();
+
+            let external_memory_ext = c"VK_KHR_external_memory";
+            let external_memory_fd_ext = c"VK_KHR_external_memory_fd";
+            let external_memory_dmabuf_ext = c"VK_EXT_external_memory_dma_buf";
+
+            let has_external_memory = available_device_ext_names.contains(&external_memory_ext)
+                && available_device_ext_names.contains(&external_memory_fd_ext);
+
+            if has_external_memory {
+                device_extensions.push(external_memory_ext.as_ptr());
+                device_extensions.push(external_memory_fd_ext.as_ptr());
+
+                if available_device_ext_names.contains(&external_memory_dmabuf_ext) {
+                    device_extensions.push(external_memory_dmabuf_ext.as_ptr());
+                    tracing::info!("VK_EXT_external_memory_dma_buf available");
+                }
+                tracing::info!("Vulkan external memory extensions enabled");
+            } else {
+                tracing::info!("Vulkan external memory extensions not available");
+            }
+
+            has_external_memory
+        };
+
+        #[cfg(target_os = "linux")]
+        let supports_external_memory = has_external_memory;
+        #[cfg(not(target_os = "linux"))]
+        let supports_external_memory = false;
+
         let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_extension_names(&device_extensions);
@@ -194,6 +235,7 @@ impl VulkanDevice {
             queue,
             queue_family_index,
             device_name: device_name.into_owned(),
+            supports_external_memory,
         })
     }
 
@@ -262,6 +304,11 @@ impl VulkanDevice {
     #[allow(dead_code)]
     pub fn queue_family_index(&self) -> u32 {
         self.queue_family_index
+    }
+
+    /// Whether DMA-BUF external memory extensions are available.
+    pub fn supports_external_memory(&self) -> bool {
+        self.supports_external_memory
     }
 }
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -100,9 +100,18 @@ impl VulkanTexture {
             vk::MemoryPropertyFlags::DEVICE_LOCAL,
         )?;
 
-        let alloc_info = vk::MemoryAllocateInfo::default()
+        let mut alloc_info = vk::MemoryAllocateInfo::default()
             .allocation_size(mem_requirements.size)
             .memory_type_index(memory_type_index);
+
+        #[cfg(target_os = "linux")]
+        let mut export_info = vk::ExportMemoryAllocateInfo::default()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        #[cfg(target_os = "linux")]
+        if vulkan_device.supports_external_memory() {
+            alloc_info = alloc_info.push_next(&mut export_info);
+        }
 
         let memory = unsafe { device.allocate_memory(&alloc_info, None) }
             .map_err(|e| StreamError::GpuError(format!("Failed to allocate memory: {e}")))?;
@@ -233,6 +242,96 @@ impl VulkanTexture {
     /// Texture format.
     pub fn format(&self) -> TextureFormat {
         self.format
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl VulkanTexture {
+    /// Export the texture's memory as a DMA-BUF file descriptor.
+    pub fn export_dma_buf_fd(&self, device: &VulkanDevice) -> Result<std::os::unix::io::RawFd> {
+        let memory = self.memory.ok_or_else(|| {
+            StreamError::GpuError("Cannot export DMA-BUF from texture without owned memory".into())
+        })?;
+
+        let get_fd_info = vk::MemoryGetFdInfoKHR::default()
+            .memory(memory)
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let external_memory_fd =
+            ash::khr::external_memory_fd::Device::new(device.instance(), device.device());
+
+        let fd = unsafe { external_memory_fd.get_memory_fd(&get_fd_info) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to export DMA-BUF fd: {e}")))?;
+
+        Ok(fd)
+    }
+
+    /// Import a texture from a DMA-BUF file descriptor.
+    pub fn from_dma_buf_fd(
+        vulkan_device: &VulkanDevice,
+        fd: std::os::unix::io::RawFd,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        allocation_size: vk::DeviceSize,
+    ) -> Result<Self> {
+        let device = vulkan_device.device();
+        let vk_format = texture_format_to_vk(format);
+
+        let image_info = vk::ImageCreateInfo::default()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D {
+                width,
+                height,
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .tiling(vk::ImageTiling::LINEAR)
+            .usage(
+                vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::TRANSFER_DST
+                    | vk::ImageUsageFlags::SAMPLED,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED);
+
+        let image = unsafe { device.create_image(&image_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!("Failed to create image for DMA-BUF import: {e}"))
+        })?;
+
+        let mut import_info = vk::ImportMemoryFdInfoKHR::default()
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+            .fd(fd);
+
+        let mem_requirements = unsafe { device.get_image_memory_requirements(image) };
+        let memory_type_index = vulkan_device.find_memory_type(
+            mem_requirements.memory_type_bits,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        )?;
+
+        let alloc_info = vk::MemoryAllocateInfo::default()
+            .allocation_size(allocation_size)
+            .memory_type_index(memory_type_index)
+            .push_next(&mut import_info);
+
+        let memory = unsafe { device.allocate_memory(&alloc_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to import DMA-BUF memory: {e}")))?;
+
+        unsafe { device.bind_image_memory(image, memory, 0) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to bind imported memory: {e}")))?;
+
+        Ok(Self {
+            device: Some(device.clone()),
+            image: Some(image),
+            memory: Some(memory),
+            imported_from_iosurface: false,
+            width,
+            height,
+            format,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- Add DMA-BUF extension enumeration and enablement to `VulkanDevice` on Linux (`VK_KHR_external_memory`, `VK_KHR_external_memory_fd`, `VK_EXT_external_memory_dma_buf`)
- Add `VulkanTexture::export_dma_buf_fd()` and `VulkanTexture::from_dma_buf_fd()` for zero-copy cross-process GPU texture sharing on Linux
- Modify `VulkanTexture::new()` to chain `ExportMemoryAllocateInfo` when external memory is supported, making textures exportable by default
- Add stub `RhiPixelBufferExport` and `RhiPixelBufferImport` implementations for Linux (returns `NotSupported` — full pixel buffer DMA-BUF is a future enhancement)

## Test plan
- [x] `cargo check -p streamlib --features backend-vulkan` — zero new vulkan errors (pre-existing macOS-only errors remain)
- [x] `cargo fmt -p streamlib -- --check` — clean formatting
- [ ] Manual test on Linux with Vulkan-capable GPU: create texture, export DMA-BUF fd, import in second VulkanDevice instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)