### PR TITLE
feat: widen macOS-only cfg gates for Linux runtime (#192)

### DIFF
--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -137,9 +137,11 @@ ash = { version = "0.38", default-features = false, features = ["std", "loaded"]
 gpu-allocator = { version = "0.28", default-features = false, features = ["vulkan", "std"] }
 libc.workspace = true
 ffmpeg-next = { version = "7.0", optional = true }
+opus = "0.3"  # Opus audio codec encoder/decoder
 # TODO: extract broker protocol helpers (send_request, framing) to a shared crate
 # to avoid this inverted dependency (streamlib depending on streamlib-broker)
 streamlib-broker = { path = "../streamlib-broker" }
+streamlib-telemetry = { workspace = true, features = ["broker"] }  # Unified telemetry pipeline
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -13,7 +13,7 @@ use super::RuntimeOperations;
 use super::RuntimeStatus;
 use super::RuntimeUniqueId;
 use crate::core::compiler::{Compiler, PendingOperation};
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 use crate::core::context::SoftwareAudioClock;
 use crate::core::context::{
     AudioClockConfig, GpuContext, RuntimeContext, SharedAudioClock, TimeContext,
@@ -106,7 +106,7 @@ pub struct StreamRuntime {
     /// Created in new() so PUBSUB can initialize before start().
     pub(crate) iceoryx2_node: Iceoryx2Node,
     /// Telemetry guard — keeps the OTel pipeline alive for the runtime's lifetime.
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
     _telemetry_guard: streamlib_telemetry::TelemetryGuard,
 }
 
@@ -139,7 +139,7 @@ impl StreamRuntime {
         // Safe to call multiple times — only the first call sets up the subscriber.
         let tokio_handle = tokio_runtime_variant.handle();
         let _enter_guard = tokio_handle.enter();
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
         let broker_endpoint = {
             let port = std::env::var("STREAMLIB_BROKER_PORT")
                 .ok()
@@ -147,7 +147,7 @@ impl StreamRuntime {
                 .unwrap_or(streamlib_broker::GRPC_PORT);
             format!("http://127.0.0.1:{}", port)
         };
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
         let _telemetry_guard =
             streamlib_telemetry::init_telemetry(streamlib_telemetry::TelemetryConfig {
                 service_name: format!("runtime:{}", runtime_id),
@@ -209,7 +209,7 @@ impl StreamRuntime {
             status,
             _graph_change_listener: listener,
             iceoryx2_node,
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
             _telemetry_guard,
         }))
     }
@@ -612,6 +612,32 @@ impl StreamRuntime {
             }
         }
 
+        // Initialize SurfaceStore for cross-process GPU surface sharing (Linux)
+        #[cfg(target_os = "linux")]
+        {
+            use crate::core::context::SurfaceStore;
+
+            let socket_path = std::env::var("STREAMLIB_BROKER_SOCKET").unwrap_or_else(|_| {
+                let streamlib_home = crate::core::get_streamlib_home();
+                format!("{}/broker.sock", streamlib_home.display())
+            });
+            tracing::info!(
+                "[start] Initializing SurfaceStore with Unix socket '{}'...",
+                socket_path
+            );
+            let surface_store =
+                SurfaceStore::new(socket_path, self.runtime_id.to_string());
+            if let Err(e) = surface_store.connect() {
+                tracing::warn!(
+                    "[start] SurfaceStore Unix socket connection failed (surface sharing disabled): {}",
+                    e
+                );
+            } else {
+                gpu.set_surface_store(surface_store);
+                tracing::info!("[start] SurfaceStore initialized");
+            }
+        }
+
         // Create shared timing context - clock starts now
         let time = Arc::new(TimeContext::new());
 
@@ -630,7 +656,16 @@ impl StreamRuntime {
                 );
                 Arc::new(crate::apple::CoreAudioClock::new(audio_clock_config))
             }
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(target_os = "linux")]
+            {
+                tracing::info!(
+                    "[start] Creating LinuxTimerFdAudioClock: {}Hz, {} samples/tick",
+                    audio_clock_config.sample_rate,
+                    audio_clock_config.buffer_size
+                );
+                Arc::new(crate::linux::LinuxTimerFdAudioClock::new(audio_clock_config))
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
             {
                 tracing::info!(
                     "[start] Creating SoftwareAudioClock: {}Hz, {} samples/tick",
@@ -722,8 +757,8 @@ impl StreamRuntime {
                 tracing::warn!("[stop] Failed to stop audio clock: {}", e);
             }
 
-            // Cleanup SurfaceStore (macOS only) - releases all surfaces and disconnects XPC
-            #[cfg(target_os = "macos")]
+            // Cleanup SurfaceStore - releases all surfaces and disconnects
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             {
                 ctx.gpu.clear_surface_store();
                 tracing::debug!("[stop] SurfaceStore cleared");

--- a/libs/streamlib/src/core/streaming/mod.rs
+++ b/libs/streamlib/src/core/streaming/mod.rs
@@ -6,9 +6,9 @@
 // Core streaming components for audio/video encoding/decoding and RTP/WebRTC.
 
 pub mod h264_rtp;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 pub mod opus;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 pub mod opus_decoder;
 pub mod rtp;
 pub mod webrtc_session;
@@ -16,18 +16,18 @@ pub mod whep_client;
 pub mod whip_client;
 
 pub use h264_rtp::H264RtpDepacketizer;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 pub use opus::{AudioEncoderConfig, AudioEncoderOpus, EncodedAudioFrame, OpusEncoder};
 
 /// Encoded audio frame (cross-platform definition for muxer support).
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
 #[derive(Clone, Debug)]
 pub struct EncodedAudioFrame {
     pub data: Vec<u8>,
     pub timestamp_ns: i64,
     pub sample_count: usize,
 }
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 pub use opus_decoder::OpusDecoder;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use rtp::convert_video_to_samples;


### PR DESCRIPTION
## Summary

- Widen `#[cfg(any(target_os = "macos", target_os = "ios"))]` gates in runtime, streaming, and Cargo.toml to include Linux
- Add Linux-specific SurfaceStore init path using Unix socket broker (`STREAMLIB_BROKER_SOCKET` env var)
- Use `LinuxTimerFdAudioClock` on Linux instead of `SoftwareAudioClock` fallback
- Enable Opus encoder/decoder modules on Linux (cross-platform `opus` crate)
- Add `opus` and `streamlib-telemetry` to Linux dependencies

## What stays macOS-only

- NSApplication event loop (legitimately Apple-specific)
- Metal texture/command queue RHI methods
- RTP NAL unit parsing (`convert_video_to_samples`) — depends on `apple::videotoolbox::parse_nal_units`
- WebRTC WHIP processor — depends on macOS-only RTP converters
- Codec wrappers already had Linux FFmpeg paths, no changes needed

## Test plan

- [x] `cargo check -p streamlib` passes
- [x] `cargo check -p streamlib --features ffmpeg` passes
- [x] `cargo check -p streamlib-broker` passes
- [ ] Manual test: Linux runtime start/stop with broker running
- [ ] Manual test: Telemetry traces appear in broker on Linux

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)