### PR TITLE
feat: widen CLAP plugin host to cross-platform (#198)

### DIFF
--- a/libs/streamlib/src/core/clap/host.rs
+++ b/libs/streamlib/src/core/clap/host.rs
@@ -6,7 +6,7 @@
 #![allow(dead_code)]
 
 use clack_host::{
-    bundle::PluginBundle,
+    entry::PluginEntry,
     events::{event_types::ParamValueEvent, io::EventBuffer},
     host::HostInfo,
     plugin::PluginInstance,
@@ -72,7 +72,7 @@ impl<'a> SharedHandler<'a> for HostShared {
 }
 
 pub struct ClapPluginHost {
-    bundle: PluginBundle,
+    entry: PluginEntry,
 
     plugin_id: std::ffi::CString,
 
@@ -95,7 +95,7 @@ pub struct ClapPluginHost {
     last_parameter_generation: usize,
 }
 
-// SAFETY: ClapPluginHost is Send despite PluginBundle containing raw pointers
+// SAFETY: ClapPluginHost is Send despite PluginEntry containing raw pointers
 unsafe impl Send for ClapPluginHost {}
 
 impl ClapPluginHost {
@@ -209,7 +209,7 @@ impl ClapPluginHost {
 
         // SAFETY: Loading CLAP plugins is inherently unsafe as it loads dynamic libraries
         let bundle = unsafe {
-            PluginBundle::load(&binary_path).map_err(|e| {
+            PluginEntry::load(&binary_path).map_err(|e| {
                 StreamError::Configuration(format!(
                     "Failed to load CLAP plugin from {:?}: {:?}",
                     path, e
@@ -269,7 +269,7 @@ impl ClapPluginHost {
 
         Ok(Self {
             plugin_info,
-            bundle,
+            entry: bundle,
             plugin_id: plugin_id_cstring,
             instance: Arc::new(ParkingLotMutex::new(None)),
             audio_processor: Arc::new(ParkingLotMutex::new(None)),
@@ -352,7 +352,7 @@ impl ClapPluginHost {
                 state: Arc::clone(&shared_state_clone),
             },
             |_shared| (), // Main thread handler factory
-            &self.bundle,
+            &self.entry,
             &self.plugin_id,
             &host_info,
         )

--- a/libs/streamlib/src/core/clap/mod.rs
+++ b/libs/streamlib/src/core/clap/mod.rs
@@ -1,18 +1,14 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod host;
 pub mod parameter_automation;
 pub mod parameter_modulation;
 pub mod plugin_info;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod scanner;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use host::ClapPluginHost;
 pub use parameter_automation::{ClapParameterControl, ParameterAutomation};
 pub use parameter_modulation::{LfoWaveform, ParameterModulator};
 pub use plugin_info::{ParameterInfo, PluginInfo};
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use scanner::{ClapPluginInfo, ClapScanner};

--- a/libs/streamlib/src/core/clap/scanner.rs
+++ b/libs/streamlib/src/core/clap/scanner.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use clack_host::bundle::PluginBundle;
+use clack_host::entry::PluginEntry;
 
 use crate::core::{Result, StreamError};
 use std::path::{Path, PathBuf};
@@ -113,7 +113,7 @@ impl ClapScanner {
 
         // SAFETY: Loading CLAP plugins is inherently unsafe as it loads dynamic libraries
         let bundle = unsafe {
-            PluginBundle::load(&binary_path).map_err(|e| {
+            PluginEntry::load(&binary_path).map_err(|e| {
                 StreamError::Configuration(format!("Failed to load bundle {:?}: {:?}", path, e))
             })?
         };

--- a/libs/streamlib/src/core/processors/clap_effect.rs
+++ b/libs/streamlib/src/core/processors/clap_effect.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::_generated_::Audioframe;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 use crate::core::clap::ClapPluginHost;
 use crate::core::clap::{ParameterInfo, PluginInfo};
 use crate::core::utils::ProcessorAudioConverterTargetFormat;
@@ -308,5 +307,4 @@ impl crate::core::clap::ClapParameterControl for ClapEffectProcessor::Processor 
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use crate::core::clap::{ClapPluginInfo, ClapScanner};

--- a/libs/streamlib/src/core/processors/mod.rs
+++ b/libs/streamlib/src/core/processors/mod.rs
@@ -51,7 +51,6 @@ pub mod audio_channel_converter;
 pub mod audio_mixer;
 pub mod audio_resampler;
 pub mod buffer_rechunker;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod clap_effect;
 pub mod simple_passthrough;
 
@@ -76,7 +75,6 @@ pub use audio_channel_converter::AudioChannelConverterProcessor;
 pub use audio_mixer::AudioMixerProcessor;
 pub use audio_resampler::AudioResamplerProcessor;
 pub use buffer_rechunker::BufferRechunkerProcessor;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use clap_effect::{ClapEffectProcessor, ClapPluginInfo, ClapScanner};
 pub use simple_passthrough::SimplePassthroughProcessor;
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -118,8 +118,10 @@ pub use core::ApiServerProcessor;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use core::{
     convert_audio_to_sample, convert_video_to_samples, AudioEncoderConfig, AudioEncoderOpus,
-    ClapEffectProcessor, ClapPluginInfo, ClapScanner, OpusEncoder,
+    OpusEncoder,
 };
+
+pub use core::{ClapEffectProcessor, ClapPluginInfo, ClapScanner};
 
 // GPU Backends - Metal and Vulkan
 // Metal module is always available on macOS/iOS since Apple platform services need Metal types


### PR DESCRIPTION
## Summary
- Remove macOS/iOS `#[cfg]` gates from CLAP host, scanner, and effect processor (8 gates across 6 files)
- Migrate `clack_host::bundle::PluginBundle` → `clack_host::entry::PluginEntry` (API renamed upstream, was never compiled due to cfg gates)
- CLAP scanner already had Linux search paths (`~/.clap`, `/usr/lib/clap`, `/usr/local/lib/clap`) built in

## Files changed
- `core/clap/mod.rs` — ungate `host`, `scanner` modules and re-exports
- `core/clap/host.rs` — `PluginBundle` → `PluginEntry` migration
- `core/clap/scanner.rs` — `PluginBundle` → `PluginEntry` migration
- `core/processors/clap_effect.rs` — ungate `ClapPluginHost` import and re-exports
- `core/processors/mod.rs` — ungate `clap_effect` module and re-exports
- `lib.rs` — move CLAP re-exports out of macOS/iOS cfg block

## Test plan
- [x] `cargo check -p streamlib` passes (0 errors)
- [ ] Load a CLAP plugin on Linux (runtime validation)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)