### PR TITLE
fix(moq): configure QUIC keep-alive to prevent relay idle timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ str0m = "0.11.1"
 moq-transport = "0.14"
 web-transport = "0.10"
 quinn = "0.11"
+rustls-native-certs = "0.8"
 
 # HTTP/Web
 axum = { version = "0.8.8", features = ["ws"] }

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -23,7 +23,7 @@ ffmpeg = ["dep:ffmpeg-next"]
 # Vulkan Video hardware encoding (requires GPU with VK_KHR_video_encode_h264)
 vulkan-video = ["backend-vulkan"]
 # MoQ (Media over QUIC) transport layer for network-transparent IPC
-moq = ["dep:moq-transport", "dep:web-transport", "dep:quinn", "dep:url"]
+moq = ["dep:moq-transport", "dep:web-transport", "dep:quinn", "dep:url", "dep:rustls-native-certs"]
 
 [dependencies]
 # Execution types (shared with macros for code generation)
@@ -92,6 +92,7 @@ moq-transport = { workspace = true, optional = true }
 web-transport = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 url = { version = "2", optional = true }
+rustls-native-certs = { workspace = true, optional = true }
 
 # HTTP client for WHIP signaling (reuses existing hyper from workspace)
 hyper = { workspace = true }  # HTTP client core

--- a/libs/streamlib/src/core/streaming/moq_session.rs
+++ b/libs/streamlib/src/core/streaming/moq_session.rs
@@ -12,6 +12,56 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+
+/// Accepts any TLS certificate without verification (development only).
+#[derive(Debug)]
+struct NoTlsCertificateVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for NoTlsCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
 
 // ============================================================================
 // MOQ SESSION CONFIGURATION
@@ -53,29 +103,64 @@ impl MoqRelayConfig {
     }
 }
 
-/// Create a WebTransport client based on TLS configuration.
+/// Create a WebTransport client with QUIC keep-alive to prevent relay idle timeouts.
 ///
-/// Uses `web_transport::quinn` (re-exported web-transport-quinn) to ensure
-/// type compatibility with `web_transport::Session`.
+/// Bypasses `ClientBuilder` to configure [`quinn::TransportConfig`] directly,
+/// setting a 4-second keep-alive interval (< Cloudflare's ~10-15s idle timeout).
 fn create_webtransport_client(
     tls_disable_verify: bool,
 ) -> Result<web_transport::quinn::Client> {
-    if tls_disable_verify {
-        web_transport::quinn::ClientBuilder::new()
+    let provider = web_transport::quinn::crypto::default_provider();
+
+    let crypto = if tls_disable_verify {
+        rustls::ClientConfig::builder_with_provider(provider.clone())
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .map_err(|e| {
+                StreamError::Runtime(format!("TLS config failed: {e}"))
+            })?
             .dangerous()
-            .with_no_certificate_verification()
-            .map_err(|e| {
-                StreamError::Runtime(format!(
-                    "MoQ WebTransport client init (insecure) failed: {e}"
-                ))
-            })
+            .with_custom_certificate_verifier(Arc::new(
+                NoTlsCertificateVerification(provider),
+            ))
+            .with_no_client_auth()
     } else {
-        web_transport::quinn::ClientBuilder::new()
-            .with_system_roots()
+        let mut roots = rustls::RootCertStore::empty();
+        let native_certs = rustls_native_certs::load_native_certs();
+        for cert in native_certs.certs {
+            roots.add(cert).map_err(|e| {
+                StreamError::Runtime(format!("Failed to add root cert: {e}"))
+            })?;
+        }
+        rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
             .map_err(|e| {
-                StreamError::Runtime(format!("MoQ WebTransport client init failed: {e}"))
-            })
-    }
+                StreamError::Runtime(format!("TLS config failed: {e}"))
+            })?
+            .with_root_certificates(roots)
+            .with_no_client_auth()
+    };
+
+    let mut crypto = crypto;
+    crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let quic_client_config =
+        quinn::crypto::rustls::QuicClientConfig::try_from(crypto).map_err(|e| {
+            StreamError::Runtime(format!("QUIC client config failed: {e}"))
+        })?;
+
+    let mut client_config = quinn::ClientConfig::new(Arc::new(quic_client_config));
+
+    let mut transport = quinn::TransportConfig::default();
+    transport.keep_alive_interval(Some(Duration::from_secs(4)));
+    client_config.transport_config(Arc::new(transport));
+
+    let endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap()).map_err(|e| {
+        StreamError::Runtime(format!("QUIC endpoint creation failed: {e}"))
+    })?;
+
+    tracing::info!(keep_alive_secs = 4, "QUIC transport configured with keep-alive");
+
+    Ok(web_transport::quinn::Client::new(endpoint, client_config))
 }
 
 // ============================================================================

--- a/plan/217-moq-transport-integration.md
+++ b/plan/217-moq-transport-integration.md
@@ -87,12 +87,12 @@ Original plan proposed moq-lite/moq-native/hang — replaced with moq-transport 
 | Issue | Title | Status |
 |-------|-------|--------|
 | #237 | Schema codegen fix | Done — `read_mode` and `buffer_size` wired from schema YAML into macro-generated `add_port()` calls. Continuous video decode verified working. |
+| #238 | QUIC keep-alive | Done — Bypassed `ClientBuilder` to construct `Client::new()` with custom `TransportConfig`. `keep_alive_interval(4s)` set on Quinn transport, well under Cloudflare's ~10-15s idle timeout. Added `NoTlsCertificateVerification` for dev TLS path. Added `rustls-native-certs` dep. |
 
 ### Critical — Blocks Stable Video Streaming
 
 | Issue | Title | Description |
 |-------|-------|-------------|
-| #238 | QUIC keep-alive | Configure `keep_alive_interval` on Quinn transport to prevent Cloudflare relay idle timeout (~10-15s). Root cause of subscribe disconnects that break video decode. Highest priority — single config change, eliminates the disconnect cycle entirely. |
 | #242 | SPS/DPB ref frame mismatch | `VulkanVideoSession` declares `max_num_ref_frames=1` in SPS but encoder uses 2 DPB slots (ping-pong). FFmpeg discards references, making decoder fragile after any frame loss. Compounds with #238. |
 
 ### High — Performance & Quality


### PR DESCRIPTION
## Summary
- Bypass `web-transport-quinn`'s `ClientBuilder` to construct `Client::new()` directly with custom `TransportConfig`
- Set `keep_alive_interval(4s)` on Quinn transport, well under Cloudflare's ~10-15s idle timeout
- Add `NoTlsCertificateVerification` struct for the dev `tls_disable_verify` path (upstream's is private)
- Add `rustls-native-certs` as optional dependency gated on `moq` feature

Closes #238

## Test plan
- [x] `cargo check -p streamlib --features moq` passes (0 errors, no new warnings)
- [x] Live test against Cloudflare draft-14 relay: QUIC keep-alive log confirmed, subscribe connections stay up
- [x] Verified subscriber reconnect works on initial race (expected 1 retry on startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)