### PR TITLE
fix(moq): MoQ subgroup keyframe fix — pin 0.14.1 + keyframe_interval_seconds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libc = "0.2.177"
 str0m = "0.11.1"
 
 # MoQ (Media over QUIC) - optional transport layer (cloudflare/moq-rs)
-moq-transport = "0.14"
+moq-transport = "0.14.1"
 web-transport = "0.10"
 quinn = "0.11"
 rustls-native-certs = "0.8"

--- a/examples/moq-roundtrip/src/main.rs
+++ b/examples/moq-roundtrip/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
     // Video: Camera → H264 Encoder → MoQ Publish
     let camera = runtime.add_processor(CameraProcessor::Processor::node(Default::default()))?;
     let h264_enc = runtime.add_processor(H264EncoderProcessor::Processor::node(H264EncoderConfig {
-        profile: Some("main".to_string()), // Main profile — better compression via CABAC
+        keyframe_interval_seconds: Some(2.0), // 2-second GOP (industry standard for streaming)
         ..Default::default()
     }))?;
     let video_pub = runtime.add_processor(MoqPublishTrackProcessor::Processor::node(

--- a/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
@@ -23,8 +23,12 @@ optionalProperties:
     type: uint32
   keyframe_interval:
     metadata:
-      description: "Frames between keyframes (default: 60)"
+      description: "Frames between keyframes (overrides keyframe_interval_seconds if set)"
     type: uint32
+  keyframe_interval_seconds:
+    metadata:
+      description: "Seconds between keyframes (default: 2.0). Ignored if keyframe_interval is set."
+    type: float32
   profile:
     metadata:
       description: "H.264 profile: baseline, main, or high (default: main)"

--- a/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
@@ -21,9 +21,14 @@ pub struct H264EncoderConfig {
     #[serde(rename = "bitrate_bps")]
     pub bitrate_bps: Option<u32>,
 
-    /// Frames between keyframes (default: 60).
+    /// Frames between keyframes (overrides keyframe_interval_seconds if set).
     #[serde(rename = "keyframe_interval")]
     pub keyframe_interval: Option<u32>,
+
+    /// Seconds between keyframes (default: 2.0). Converted to frames using
+    /// the encoder's fps. Ignored if keyframe_interval (frames) is set.
+    #[serde(rename = "keyframe_interval_seconds")]
+    pub keyframe_interval_seconds: Option<f32>,
 
     /// H.264 profile: baseline, main, or high (default: main).
     #[serde(rename = "profile")]

--- a/libs/streamlib/src/core/processors/h264_encoder.rs
+++ b/libs/streamlib/src/core/processors/h264_encoder.rs
@@ -78,12 +78,20 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
                 _ => H264Profile::Main, // default: Main (better compression than Baseline)
             };
 
+            let fps = 30u32;
+            let keyframe_interval_frames = if let Some(frames) = self.config.keyframe_interval {
+                frames
+            } else {
+                let seconds = self.config.keyframe_interval_seconds.unwrap_or(2.0);
+                (seconds * fps as f32).round() as u32
+            };
+
             let encoder_config = VideoEncoderConfig {
                 width,
                 height,
-                fps: 30,
+                fps,
                 bitrate_bps: self.config.bitrate_bps.unwrap_or(2_500_000),
-                keyframe_interval_frames: self.config.keyframe_interval.unwrap_or(15),
+                keyframe_interval_frames,
                 codec: VideoCodec::H264(profile),
                 low_latency: true,
             };


### PR DESCRIPTION
## Summary
- Pin `moq-transport` to `0.14.1` which contains the upstream `FilterType::LargestObject` fix; remove reliance on an untracked vendor copy
- Add `keyframe_interval_seconds` config to `H264EncoderConfig` (default 2.0s GOP) with conversion to frames at encoder init; explicit frame-count override still works
- Update `moq-roundtrip` example to use `keyframe_interval_seconds: Some(2.0)`

## Issue
Closes #249

## Test Plan
- [x] `cargo check -p streamlib` passes (0 errors, pre-existing warnings only)
- [x] `cargo test -p streamlib --lib` — 142 passed; 1 pre-existing failure in `vulkan_video_session::tests::test_select_h264_level` (unrelated to this change)
- [ ] Manual: run `moq-roundtrip` example end-to-end to verify continuous video across GOP boundaries

## Notes
`moq_session.rs` per-GOP subgroup fix was already present on `main` (landed in commit `a8bacc9`); no duplicate change needed. `vendor/moq-transport` was never committed to `main`, so no deletion commit required.

## Follow-ups
- None

🤖 Generated with [Claude Code](https://claude.ai/claude-code)