### PR TITLE
feat(ipc): migrate iceoryx2 to slice API — eliminate stack overflow

### DIFF
--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -331,6 +331,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     port_name: *const c_char,
     dest_port: *const c_char,
     schema_name: *const c_char,
+    max_payload_bytes: usize,
 ) -> i32 {
     let ctx = match ctx.as_mut() {
         Some(c) => c,
@@ -382,7 +383,7 @@ pub unsafe extern "C" fn sldn_output_publish(
         }
     };
 
-    let publisher = match service.publisher_builder().initial_max_slice_len(4 * 1024 * 1024).create() {
+    let publisher = match service.publisher_builder().initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE).create() {
         Ok(p) => p,
         Err(e) => {
             eprintln!(

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -16,7 +16,7 @@ use std::ffi::{c_char, CStr};
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
-use streamlib_ipc_types::FramePayload;
+use streamlib_ipc_types::{FrameHeader, FRAME_HEADER_SIZE};
 
 // ============================================================================
 // Context
@@ -38,13 +38,13 @@ pub struct DenoNativeContext {
 }
 
 struct SubscriberState {
-    subscriber: Subscriber<ipc::Service, FramePayload, ()>,
+    subscriber: Subscriber<ipc::Service, [u8], ()>,
     /// Buffered payloads per port name (after poll).
     pending: HashMap<String, Vec<(Vec<u8>, i64)>>,
 }
 
 struct PublisherState {
-    publisher: Publisher<ipc::Service, FramePayload, ()>,
+    publisher: Publisher<ipc::Service, [u8], ()>,
     schema_name: String,
     dest_port: String,
 }
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     let service = match ctx
         .node
         .service_builder(&service_name_iox)
-        .publish_subscribe::<FramePayload>()
+        .publish_subscribe::<[u8]>()
         .max_publishers(16)
         .subscriber_max_buffer_size(16)
         .open_or_create()
@@ -216,10 +216,20 @@ pub unsafe extern "C" fn sldn_input_poll(ctx: *mut DenoNativeContext) -> i32 {
 
     for (_service_name, state) in ctx.subscribers.iter_mut() {
         while let Ok(Some(sample)) = state.subscriber.receive() {
-            let payload = &*sample;
-            let port_name = payload.port().to_string();
-            let data = payload.data().to_vec();
-            let ts = payload.timestamp_ns;
+            let buf: &[u8] = sample.payload();
+            if buf.len() < FRAME_HEADER_SIZE {
+                eprintln!("[sldn] received frame smaller than header ({} bytes)", buf.len());
+                continue;
+            }
+            let header = FrameHeader::read_from_slice(buf);
+            let port_name = header.port().to_string();
+            let ts = header.timestamp_ns;
+            let data_len = header.len as usize;
+            if FRAME_HEADER_SIZE + data_len > buf.len() {
+                eprintln!("[sldn] frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
+                continue;
+            }
+            let data = buf[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + data_len].to_vec();
 
             state.pending.entry(port_name).or_default().push((data, ts));
             has_data = true;
@@ -357,7 +367,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     let service = match ctx
         .node
         .service_builder(&service_name_iox)
-        .publish_subscribe::<FramePayload>()
+        .publish_subscribe::<[u8]>()
         .max_publishers(16)
         .subscriber_max_buffer_size(16)
         .open_or_create()
@@ -372,7 +382,7 @@ pub unsafe extern "C" fn sldn_output_publish(
         }
     };
 
-    let publisher = match service.publisher_builder().create() {
+    let publisher = match service.publisher_builder().initial_max_slice_len(4 * 1024 * 1024).create() {
         Ok(p) => p,
         Err(e) => {
             eprintln!(
@@ -432,27 +442,26 @@ pub unsafe extern "C" fn sldn_output_write(
         std::slice::from_raw_parts(data, data_len as usize)
     };
 
-    let sample = match state.publisher.loan_uninit() {
+    let total_len = FRAME_HEADER_SIZE + data_slice.len();
+    let mut frame = vec![0u8; total_len];
+    FrameHeader::new(&state.dest_port, &state.schema_name, timestamp_ns, data_slice.len() as u32)
+        .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+    frame[FRAME_HEADER_SIZE..].copy_from_slice(data_slice);
+
+    let sample = match state.publisher.loan_slice_uninit(total_len) {
         Ok(s) => s,
         Err(e) => {
             eprintln!(
-                "[sldn:{}] Failed to loan sample for port '{}': {}",
+                "[sldn:{}] Failed to loan slice for port '{}': {:?}",
                 ctx.processor_id, port_name, e
             );
             return -1;
         }
     };
-
-    let sample = sample.write_payload(FramePayload::new(
-        &state.dest_port,
-        &state.schema_name,
-        timestamp_ns,
-        data_slice,
-    ));
-
+    let sample = sample.write_from_slice(&frame);
     if let Err(e) = sample.send() {
         eprintln!(
-            "[sldn:{}] Failed to send sample for port '{}': {}",
+            "[sldn:{}] Failed to send sample for port '{}': {:?}",
             ctx.processor_id, port_name, e
         );
         return -1;

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -43,7 +43,7 @@ const symbols = {
 
   // Output
   sldn_output_publish: {
-    parameters: ["pointer", "buffer", "buffer", "buffer", "buffer"] as const,
+    parameters: ["pointer", "buffer", "buffer", "buffer", "buffer", "usize"] as const,
     result: "i32" as const,
   },
   sldn_output_write: {

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -168,6 +168,7 @@ async function main(): Promise<void> {
               cString(output.name),
               cString(output.dest_port),
               cString(output.schema_name),
+              BigInt(output.max_payload_bytes ?? 65536),
             );
             if (result !== 0) {
               console.error(

--- a/libs/streamlib-ipc-types/src/lib.rs
+++ b/libs/streamlib-ipc-types/src/lib.rs
@@ -11,6 +11,9 @@ pub const MAX_PORT_KEY_SIZE: usize = 64;
 pub const MAX_EVENT_PAYLOAD_SIZE: usize = 8192;
 pub const MAX_TOPIC_KEY_SIZE: usize = 128;
 
+/// Size of the frame header in the `[u8]` slice wire format.
+pub const FRAME_HEADER_SIZE: usize = MAX_PORT_KEY_SIZE + MAX_SCHEMA_NAME_SIZE + 8 + 4; // 204 bytes
+
 /// Fixed-size port name for zero-copy IPC.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, ZeroCopySend)]
 #[repr(C)]
@@ -146,6 +149,86 @@ impl std::fmt::Debug for FramePayload {
             .field("timestamp_ns", &self.timestamp_ns)
             .field("len", &self.len)
             .finish()
+    }
+}
+
+/// Header for slice-based iceoryx2 frame transport.
+///
+/// Wire format in a `[u8]` slice:
+/// `[port_key: 64][schema_name: 128][timestamp_ns: 8][len: 4][data: len]`
+pub struct FrameHeader {
+    pub port_key: PortKey,
+    pub schema_name: SchemaName,
+    pub timestamp_ns: i64,
+    pub len: u32,
+}
+
+impl FrameHeader {
+    /// Create a new frame header.
+    pub fn new(port: &str, schema: &str, timestamp_ns: i64, data_len: u32) -> Self {
+        Self {
+            port_key: PortKey::new(port),
+            schema_name: SchemaName::new(schema),
+            timestamp_ns,
+            len: data_len,
+        }
+    }
+
+    /// Write the header to the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
+    pub fn write_to_slice(&self, buf: &mut [u8]) {
+        // port_key: [len: 1][name: 63] = 64 bytes
+        buf[0] = self.port_key.len;
+        buf[1..MAX_PORT_KEY_SIZE].copy_from_slice(&self.port_key.name);
+        // schema_name: [len: 1][name: 127] = 128 bytes
+        let s = MAX_PORT_KEY_SIZE;
+        buf[s] = self.schema_name.len;
+        buf[s + 1..s + MAX_SCHEMA_NAME_SIZE].copy_from_slice(&self.schema_name.name);
+        // timestamp_ns: 8 bytes little-endian
+        let t = s + MAX_SCHEMA_NAME_SIZE;
+        buf[t..t + 8].copy_from_slice(&self.timestamp_ns.to_le_bytes());
+        // len: 4 bytes little-endian
+        buf[t + 8..t + 12].copy_from_slice(&self.len.to_le_bytes());
+    }
+
+    /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
+    pub fn read_from_slice(buf: &[u8]) -> Self {
+        let mut port_key = PortKey::default();
+        port_key.len = buf[0];
+        port_key.name.copy_from_slice(&buf[1..MAX_PORT_KEY_SIZE]);
+
+        let s = MAX_PORT_KEY_SIZE;
+        let mut schema_name = SchemaName::default();
+        schema_name.len = buf[s];
+        schema_name
+            .name
+            .copy_from_slice(&buf[s + 1..s + MAX_SCHEMA_NAME_SIZE]);
+
+        let t = s + MAX_SCHEMA_NAME_SIZE;
+        let timestamp_ns = i64::from_le_bytes(buf[t..t + 8].try_into().unwrap());
+        let len = u32::from_le_bytes(buf[t + 8..t + 12].try_into().unwrap());
+
+        Self {
+            port_key,
+            schema_name,
+            timestamp_ns,
+            len,
+        }
+    }
+
+    /// Read the port key string from a raw slice without parsing the full header.
+    pub fn read_port_from_slice(buf: &[u8]) -> &str {
+        let len = buf[0] as usize;
+        std::str::from_utf8(&buf[1..1 + len]).unwrap_or("")
+    }
+
+    /// Get the port key as a string.
+    pub fn port(&self) -> &str {
+        self.port_key.as_str()
+    }
+
+    /// Get the schema name as a string.
+    pub fn schema(&self) -> &str {
+        self.schema_name.as_str()
     }
 }
 

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -331,6 +331,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     port_name: *const c_char,
     dest_port: *const c_char,
     schema_name: *const c_char,
+    max_payload_bytes: usize,
 ) -> i32 {
     let ctx = match ctx.as_mut() {
         Some(c) => c,
@@ -382,7 +383,7 @@ pub unsafe extern "C" fn slpn_output_publish(
         }
     };
 
-    let publisher = match service.publisher_builder().initial_max_slice_len(4 * 1024 * 1024).create() {
+    let publisher = match service.publisher_builder().initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE).create() {
         Ok(p) => p,
         Err(e) => {
             eprintln!(

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -16,7 +16,7 @@ use std::ffi::{c_char, CStr};
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
-use streamlib_ipc_types::FramePayload;
+use streamlib_ipc_types::{FrameHeader, FRAME_HEADER_SIZE};
 
 // ============================================================================
 // Context
@@ -38,13 +38,13 @@ pub struct PythonNativeContext {
 }
 
 struct SubscriberState {
-    subscriber: Subscriber<ipc::Service, FramePayload, ()>,
+    subscriber: Subscriber<ipc::Service, [u8], ()>,
     /// Buffered payloads per port name (after poll).
     pending: HashMap<String, Vec<(Vec<u8>, i64)>>,
 }
 
 struct PublisherState {
-    publisher: Publisher<ipc::Service, FramePayload, ()>,
+    publisher: Publisher<ipc::Service, [u8], ()>,
     schema_name: String,
     dest_port: String,
 }
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     let service = match ctx
         .node
         .service_builder(&service_name_iox)
-        .publish_subscribe::<FramePayload>()
+        .publish_subscribe::<[u8]>()
         .max_publishers(16)
         .subscriber_max_buffer_size(16)
         .open_or_create()
@@ -216,10 +216,20 @@ pub unsafe extern "C" fn slpn_input_poll(ctx: *mut PythonNativeContext) -> i32 {
 
     for (_service_name, state) in ctx.subscribers.iter_mut() {
         while let Ok(Some(sample)) = state.subscriber.receive() {
-            let payload = &*sample;
-            let port_name = payload.port().to_string();
-            let data = payload.data().to_vec();
-            let ts = payload.timestamp_ns;
+            let buf: &[u8] = sample.payload();
+            if buf.len() < FRAME_HEADER_SIZE {
+                eprintln!("[slpn] received frame smaller than header ({} bytes)", buf.len());
+                continue;
+            }
+            let header = FrameHeader::read_from_slice(buf);
+            let port_name = header.port().to_string();
+            let ts = header.timestamp_ns;
+            let data_len = header.len as usize;
+            if FRAME_HEADER_SIZE + data_len > buf.len() {
+                eprintln!("[slpn] frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
+                continue;
+            }
+            let data = buf[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + data_len].to_vec();
 
             state.pending.entry(port_name).or_default().push((data, ts));
             has_data = true;
@@ -357,7 +367,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     let service = match ctx
         .node
         .service_builder(&service_name_iox)
-        .publish_subscribe::<FramePayload>()
+        .publish_subscribe::<[u8]>()
         .max_publishers(16)
         .subscriber_max_buffer_size(16)
         .open_or_create()
@@ -372,7 +382,7 @@ pub unsafe extern "C" fn slpn_output_publish(
         }
     };
 
-    let publisher = match service.publisher_builder().create() {
+    let publisher = match service.publisher_builder().initial_max_slice_len(4 * 1024 * 1024).create() {
         Ok(p) => p,
         Err(e) => {
             eprintln!(
@@ -432,27 +442,26 @@ pub unsafe extern "C" fn slpn_output_write(
         std::slice::from_raw_parts(data, data_len as usize)
     };
 
-    let sample = match state.publisher.loan_uninit() {
+    let total_len = FRAME_HEADER_SIZE + data_slice.len();
+    let mut frame = vec![0u8; total_len];
+    FrameHeader::new(&state.dest_port, &state.schema_name, timestamp_ns, data_slice.len() as u32)
+        .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+    frame[FRAME_HEADER_SIZE..].copy_from_slice(data_slice);
+
+    let sample = match state.publisher.loan_slice_uninit(total_len) {
         Ok(s) => s,
         Err(e) => {
             eprintln!(
-                "[slpn:{}] Failed to loan sample for port '{}': {}",
+                "[slpn:{}] Failed to loan slice for port '{}': {:?}",
                 ctx.processor_id, port_name, e
             );
             return -1;
         }
     };
-
-    let sample = sample.write_payload(FramePayload::new(
-        &state.dest_port,
-        &state.schema_name,
-        timestamp_ns,
-        data_slice,
-    ));
-
+    let sample = sample.write_from_slice(&frame);
     if let Err(e) = sample.send() {
         eprintln!(
-            "[slpn:{}] Failed to send sample for port '{}': {}",
+            "[slpn:{}] Failed to send sample for port '{}': {:?}",
             ctx.processor_id, port_name, e
         );
         return -1;

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -87,7 +87,7 @@ def load_native_lib(lib_path):
     # Output
     lib.slpn_output_publish.argtypes = [
         ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p,
-        ctypes.c_char_p, ctypes.c_char_p,
+        ctypes.c_char_p, ctypes.c_char_p, ctypes.c_size_t,
     ]
     lib.slpn_output_publish.restype = ctypes.c_int32
     lib.slpn_output_write.argtypes = [

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -93,6 +93,7 @@ def _setup_native_context(msg, native_lib_path, processor_id):
             port_name.encode("utf-8"),
             dest_port.encode("utf-8"),
             schema_name.encode("utf-8"),
+            out.get("max_payload_bytes", 65536),
         )
         if result != 0:
             _logger.error("Failed to create publisher for '%s'", dest_service)

--- a/libs/streamlib/schemas/com.tatolab.audioframe.yaml
+++ b/libs/streamlib/schemas/com.tatolab.audioframe.yaml
@@ -9,6 +9,7 @@ metadata:
   description: "Audio frame with interleaved samples (1-8 channels)"
   read_mode: read_next_in_order
   buffer_size: 32
+  max_payload_bytes: 65536
 
 properties:
   samples:

--- a/libs/streamlib/schemas/com.tatolab.encodedvideoframe.yaml
+++ b/libs/streamlib/schemas/com.tatolab.encodedvideoframe.yaml
@@ -9,6 +9,7 @@ metadata:
   description: "Encoded video frame with H.264/H.265 NAL unit data"
   read_mode: read_next_in_order
   buffer_size: 16
+  max_payload_bytes: 524288
 
 properties:
   data:

--- a/libs/streamlib/schemas/com.tatolab.videoframe.yaml
+++ b/libs/streamlib/schemas/com.tatolab.videoframe.yaml
@@ -9,6 +9,7 @@ metadata:
   description: "Video frame for IPC - references GPU surface by ID"
   read_mode: skip_to_latest
   buffer_size: 4
+  max_payload_bytes: 65536
 
 properties:
   surface_id:

--- a/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::core::context::RuntimeContext;
+use crate::core::embedded_schemas::max_payload_bytes_for_schema;
 use crate::core::error::{Result, StreamError};
 use crate::core::graph::{
     Graph, GraphEdgeWithComponents, GraphNodeWithComponents, LinkState, LinkStateComponent,
@@ -236,19 +237,8 @@ fn open_iceoryx2_pubsub(
         dest_proc_id
     );
 
-    // Create iceoryx2 Service, Publisher, and Subscriber using the Node
-    let iceoryx2_node = runtime_ctx.iceoryx2_node();
-    let service = iceoryx2_node.open_or_create_service(&service_name)?;
-
-    // Create Publisher for source processor (each upstream gets its own publisher)
-    let publisher = service.create_publisher()?;
-    tracing::debug!(
-        "Created iceoryx2 Publisher for '{}' -> service '{}'",
-        source_proc_id,
-        service_name
-    );
-
-    // Look up schema for the output port from the registry
+    // Look up schema for the output port before creating the publisher so we can size
+    // the shared memory slot correctly via max_payload_bytes_for_schema.
     let output_schema = {
         let source_proc_type = graph
             .traversal_mut()
@@ -272,6 +262,18 @@ fn open_iceoryx2_pubsub(
         "Output port '{}' has schema '{}'",
         source_port,
         output_schema
+    );
+
+    // Create iceoryx2 Service, Publisher, and Subscriber using the Node
+    let iceoryx2_node = runtime_ctx.iceoryx2_node();
+    let service = iceoryx2_node.open_or_create_service(&service_name)?;
+
+    // Create Publisher sized for this schema's declared max payload.
+    let publisher = service.create_publisher(max_payload_bytes_for_schema(&output_schema))?;
+    tracing::debug!(
+        "Created iceoryx2 Publisher for '{}' -> service '{}'",
+        source_proc_id,
+        service_name
     );
 
     // Configure source OutputWriter with port mapping and publisher
@@ -379,6 +381,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                 .unwrap_or_default()
         };
 
+        let max_payload = max_payload_bytes_for_schema(&output_schema);
         let source_proc_arc = get_single_processor(graph, source_proc_id)?;
         let mut source_guard = source_proc_arc.lock();
         if let Some(deno_host) = source_guard
@@ -390,6 +393,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                 "dest_port": dest_port,
                 "dest_service_name": service_name,
                 "schema_name": output_schema,
+                "max_payload_bytes": max_payload,
             }));
         } else if let Some(python_native_host) = source_guard
             .as_any_mut()
@@ -402,6 +406,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                     "dest_port": dest_port,
                     "dest_service_name": service_name,
                     "schema_name": output_schema,
+                    "max_payload_bytes": max_payload,
                 }));
         }
     }
@@ -496,6 +501,7 @@ fn open_iceoryx2_subprocess_to_rust(
                 .unwrap_or_default()
         };
 
+        let max_payload = max_payload_bytes_for_schema(&output_schema);
         let source_proc_arc = get_single_processor(graph, source_proc_id)?;
         let mut source_guard = source_proc_arc.lock();
         if let Some(deno_host) = source_guard
@@ -507,6 +513,7 @@ fn open_iceoryx2_subprocess_to_rust(
                 "dest_port": dest_port,
                 "dest_service_name": service_name,
                 "schema_name": output_schema,
+                "max_payload_bytes": max_payload,
             }));
             tracing::debug!(
                 "Stored output wiring on Deno processor '{}': port='{}', dest_port='{}', dest_service='{}', schema='{}'",
@@ -523,6 +530,7 @@ fn open_iceoryx2_subprocess_to_rust(
                     "dest_port": dest_port,
                     "dest_service_name": service_name,
                     "schema_name": output_schema,
+                    "max_payload_bytes": max_payload,
                 }));
             tracing::debug!(
                 "Stored output wiring on Python native processor '{}': port='{}', dest_port='{}', dest_service='{}', schema='{}'",
@@ -588,13 +596,7 @@ fn open_iceoryx2_rust_to_subprocess(
         dest_proc_id
     );
 
-    let iceoryx2_node = runtime_ctx.iceoryx2_node();
-    let service = iceoryx2_node.open_or_create_service(&service_name)?;
-
-    // Create Publisher for source processor (Rust side)
-    let publisher = service.create_publisher()?;
-
-    // Look up schema for the output port
+    // Look up schema before creating the publisher to size the slot correctly.
     let output_schema = {
         let source_proc_type = graph
             .traversal_mut()
@@ -613,6 +615,12 @@ fn open_iceoryx2_rust_to_subprocess(
             })
             .unwrap_or_default()
     };
+
+    let iceoryx2_node = runtime_ctx.iceoryx2_node();
+    let service = iceoryx2_node.open_or_create_service(&service_name)?;
+
+    // Create Publisher sized for this schema's declared max payload.
+    let publisher = service.create_publisher(max_payload_bytes_for_schema(&output_schema))?;
 
     // Configure source OutputWriter with port mapping and publisher
     {

--- a/libs/streamlib/src/core/embedded_schemas.rs
+++ b/libs/streamlib/src/core/embedded_schemas.rs
@@ -75,6 +75,27 @@ pub fn get_embedded_schema_definition(name: &str) -> Option<&'static str> {
     }
 }
 
+/// Extract `max_payload_bytes` from a schema's metadata section.
+///
+/// Strips any version suffix (e.g. `com.tatolab.audioframe@1.0.0` → `com.tatolab.audioframe`)
+/// before lookup. Returns [`MAX_PAYLOAD_SIZE`] if the schema is unknown or has no declaration.
+pub fn max_payload_bytes_for_schema(schema_name: &str) -> usize {
+    use crate::iceoryx2::MAX_PAYLOAD_SIZE;
+    let base_name = schema_name.split('@').next().unwrap_or(schema_name);
+    if let Some(yaml) = get_embedded_schema_definition(base_name) {
+        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(yaml) {
+            if let Some(n) = value
+                .get("metadata")
+                .and_then(|m| m.get("max_payload_bytes"))
+                .and_then(|v| v.as_u64())
+            {
+                return n as usize;
+            }
+        }
+    }
+    MAX_PAYLOAD_SIZE as usize
+}
+
 /// List all embedded schema names.
 pub fn list_embedded_schema_names() -> Vec<&'static str> {
     vec![

--- a/libs/streamlib/src/iceoryx2/input.rs
+++ b/libs/streamlib/src/iceoryx2/input.rs
@@ -12,7 +12,7 @@ use serde::de::DeserializeOwned;
 
 use super::mailbox::PortMailbox;
 use super::read_mode::ReadMode;
-use super::FramePayload;
+use super::{FrameHeader, FRAME_HEADER_SIZE};
 use crate::core::error::{Result, StreamError};
 
 /// Thread-local subscriber wrapper.
@@ -22,7 +22,7 @@ use crate::core::error::{Result, StreamError};
 /// 1. The Subscriber is only ever set AFTER the processor is spawned on its execution thread
 /// 2. Once set, the Subscriber is only accessed from that same thread
 /// 3. The wrapper starts with `None` and is populated during wiring on the target thread
-struct SendableSubscriber(UnsafeCell<Option<Subscriber<ipc::Service, FramePayload, ()>>>);
+struct SendableSubscriber(UnsafeCell<Option<Subscriber<ipc::Service, [u8], ()>>>);
 
 // SAFETY: The Subscriber is only accessed from a single thread after being set.
 // The processor lifecycle ensures that:
@@ -37,14 +37,14 @@ impl SendableSubscriber {
         Self(UnsafeCell::new(None))
     }
 
-    fn set(&self, subscriber: Subscriber<ipc::Service, FramePayload, ()>) {
+    fn set(&self, subscriber: Subscriber<ipc::Service, [u8], ()>) {
         // SAFETY: Only called from the processor's execution thread after spawn
         unsafe {
             *self.0.get() = Some(subscriber);
         }
     }
 
-    fn get(&self) -> Option<&Subscriber<ipc::Service, FramePayload, ()>> {
+    fn get(&self) -> Option<&Subscriber<ipc::Service, [u8], ()>> {
         // SAFETY: Only called from the processor's execution thread
         unsafe { (*self.0.get()).as_ref() }
     }
@@ -107,7 +107,7 @@ impl InputMailboxes {
     /// Set the iceoryx2 Subscriber for receiving payloads.
     ///
     /// Note: This should only be called from the processor's execution thread.
-    pub fn set_subscriber(&self, subscriber: Subscriber<ipc::Service, FramePayload, ()>) {
+    pub fn set_subscriber(&self, subscriber: Subscriber<ipc::Service, [u8], ()>) {
         self.subscriber.set(subscriber);
     }
 
@@ -122,13 +122,23 @@ impl InputMailboxes {
             return;
         };
 
-        // Receive and route payloads directly
+        // Receive [u8] slices and route to mailboxes
         loop {
             match subscriber.receive() {
                 Ok(Some(sample)) => {
-                    let payload = *sample.payload();
-                    let routed = self.route(payload);
-                    if !routed {
+                    let slice: &[u8] = sample.payload();
+                    if slice.len() < FRAME_HEADER_SIZE {
+                        tracing::warn!(
+                            "InputMailboxes: received slice too small ({} < {})",
+                            slice.len(),
+                            FRAME_HEADER_SIZE
+                        );
+                        continue;
+                    }
+                    let port_name = FrameHeader::read_port_from_slice(slice);
+                    if let Some(port_config) = self.ports.get(port_name) {
+                        port_config.mailbox.push(slice.to_vec());
+                    } else {
                         tracing::warn!("InputMailboxes: received sample but no matching port");
                     }
                 }
@@ -160,13 +170,15 @@ impl InputMailboxes {
             .get(port)
             .ok_or_else(|| StreamError::Link(format!("Unknown input port: {}", port)))?;
 
-        let payload = match port_config.read_mode {
+        let raw = match port_config.read_mode {
             ReadMode::SkipToLatest => port_config.mailbox.pop_latest(),
             ReadMode::ReadNextInOrder => port_config.mailbox.pop(),
         }
         .ok_or_else(|| StreamError::Link(format!("No data available on port: {}", port)))?;
 
-        rmp_serde::from_slice(payload.data())
+        let header = FrameHeader::read_from_slice(&raw);
+        let data = &raw[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + header.len as usize];
+        rmp_serde::from_slice(data)
             .map_err(|e| StreamError::Link(format!("Failed to deserialize frame: {}", e)))
     }
 
@@ -182,13 +194,17 @@ impl InputMailboxes {
             .get(port)
             .ok_or_else(|| StreamError::Link(format!("Unknown input port: {}", port)))?;
 
-        let payload = match port_config.read_mode {
+        let raw = match port_config.read_mode {
             ReadMode::SkipToLatest => port_config.mailbox.pop_latest(),
             ReadMode::ReadNextInOrder => port_config.mailbox.pop(),
         };
 
-        match payload {
-            Some(p) => Ok(Some((p.data().to_vec(), p.timestamp_ns))),
+        match raw {
+            Some(r) => {
+                let header = FrameHeader::read_from_slice(&r);
+                let data = r[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + header.len as usize].to_vec();
+                Ok(Some((data, header.timestamp_ns)))
+            }
             None => Ok(None),
         }
     }
@@ -204,22 +220,25 @@ impl InputMailboxes {
             .unwrap_or(false)
     }
 
-    /// Drain all payloads from the given port's mailbox.
-    pub fn drain(&self, port: &str) -> impl Iterator<Item = FramePayload> + '_ {
+    /// Drain all raw frame slices from the given port's mailbox.
+    pub fn drain(&self, port: &str) -> impl Iterator<Item = Vec<u8>> + '_ {
         self.ports
             .get(port)
             .into_iter()
             .flat_map(|p| p.mailbox.drain())
     }
 
-    /// Route a payload to the appropriate mailbox based on its port_key.
+    /// Route a raw frame slice to the appropriate mailbox based on port_key in the header.
     ///
     /// Returns true if the payload was routed, false if no matching mailbox exists.
     /// Thread-safe: can be called from any thread.
-    pub fn route(&self, payload: FramePayload) -> bool {
-        let port = payload.port();
+    pub fn route(&self, raw: Vec<u8>) -> bool {
+        if raw.len() < FRAME_HEADER_SIZE {
+            return false;
+        }
+        let port = FrameHeader::read_port_from_slice(&raw);
         if let Some(port_config) = self.ports.get(port) {
-            port_config.mailbox.push(payload);
+            port_config.mailbox.push(raw);
             true
         } else {
             false

--- a/libs/streamlib/src/iceoryx2/mailbox.rs
+++ b/libs/streamlib/src/iceoryx2/mailbox.rs
@@ -5,14 +5,13 @@
 
 use crossbeam_queue::ArrayQueue;
 
-use super::FramePayload;
-
 /// Per-port mailbox with configurable history depth.
 ///
+/// Stores raw wire-format `[u8]` slices (header + data) as `Vec<u8>`.
 /// Uses a crossbeam ArrayQueue internally for lock-free, thread-safe access.
 /// Multiple threads can push and pop concurrently (MPMC).
 pub struct PortMailbox {
-    queue: ArrayQueue<FramePayload>,
+    queue: ArrayQueue<Vec<u8>>,
     capacity: usize,
 }
 
@@ -26,32 +25,34 @@ impl PortMailbox {
         }
     }
 
-    /// Push a payload into the mailbox.
+    /// Push a raw frame slice into the mailbox.
     ///
-    /// If the mailbox is full, the oldest payload is dropped to make room.
+    /// If the mailbox is full, the oldest entry is dropped to make room.
     /// Thread-safe: can be called from any thread.
-    pub fn push(&self, payload: FramePayload) {
+    pub fn push(&self, payload: Vec<u8>) {
         // If full, pop oldest to make room
         while self.queue.is_full() {
             let _ = self.queue.pop();
         }
         // Push should succeed now (may fail if another thread filled it, retry)
-        while self.queue.push(payload).is_err() {
+        let mut val = payload;
+        while let Err(v) = self.queue.push(val) {
+            val = v;
             let _ = self.queue.pop();
         }
     }
 
-    /// Pop the oldest payload from the mailbox (FIFO).
+    /// Pop the oldest entry from the mailbox (FIFO).
     ///
     /// Thread-safe: can be called from any thread.
-    pub fn pop(&self) -> Option<FramePayload> {
+    pub fn pop(&self) -> Option<Vec<u8>> {
         self.queue.pop()
     }
 
-    /// Drain buffer and return only the newest payload.
+    /// Drain buffer and return only the newest entry.
     ///
     /// Thread-safe: can be called from any thread.
-    pub fn pop_latest(&self) -> Option<FramePayload> {
+    pub fn pop_latest(&self) -> Option<Vec<u8>> {
         let mut latest = None;
         while let Some(value) = self.queue.pop() {
             latest = Some(value);
@@ -64,7 +65,7 @@ impl PortMailbox {
         self.queue.is_empty()
     }
 
-    /// Get the number of payloads currently in the mailbox.
+    /// Get the number of entries currently in the mailbox.
     pub fn len(&self) -> usize {
         self.queue.len()
     }
@@ -74,10 +75,10 @@ impl PortMailbox {
         self.capacity
     }
 
-    /// Drain all payloads from the mailbox.
+    /// Drain all entries from the mailbox.
     ///
     /// Thread-safe: can be called from any thread.
-    pub fn drain(&self) -> impl Iterator<Item = FramePayload> + '_ {
+    pub fn drain(&self) -> impl Iterator<Item = Vec<u8>> + '_ {
         std::iter::from_fn(move || self.queue.pop())
     }
 }

--- a/libs/streamlib/src/iceoryx2/mod.rs
+++ b/libs/streamlib/src/iceoryx2/mod.rs
@@ -15,7 +15,7 @@ pub use mailbox::PortMailbox;
 pub use node::{Iceoryx2EventService, Iceoryx2Node, Iceoryx2Service};
 pub use output::OutputWriter;
 pub use payload::{
-    EventPayload, FramePayload, PortKey, SchemaName, TopicKey, MAX_EVENT_PAYLOAD_SIZE,
-    MAX_PAYLOAD_SIZE, MAX_SCHEMA_NAME_SIZE, MAX_TOPIC_KEY_SIZE,
+    EventPayload, FrameHeader, FramePayload, PortKey, SchemaName, TopicKey, FRAME_HEADER_SIZE,
+    MAX_EVENT_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE, MAX_SCHEMA_NAME_SIZE, MAX_TOPIC_KEY_SIZE,
 };
 pub use read_mode::ReadMode;

--- a/libs/streamlib/src/iceoryx2/node.rs
+++ b/libs/streamlib/src/iceoryx2/node.rs
@@ -9,7 +9,7 @@ use iceoryx2::node::Node;
 use iceoryx2::prelude::*;
 use parking_lot::Mutex;
 
-use super::{EventPayload, FramePayload};
+use super::{EventPayload, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE};
 use crate::core::error::{Result, StreamError};
 
 /// Thread-safe wrapper for iceoryx2 Node.
@@ -55,7 +55,7 @@ impl Iceoryx2Node {
         Ok(Iceoryx2EventService { inner: service })
     }
 
-    /// Open or create a publish-subscribe service for FramePayload.
+    /// Open or create a publish-subscribe service for `[u8]` slices.
     ///
     /// The service name should follow the format: "streamlib/{source_processor}/{dest_processor}"
     pub fn open_or_create_service(&self, service_name: &str) -> Result<Iceoryx2Service> {
@@ -66,7 +66,7 @@ impl Iceoryx2Node {
 
         let service = node
             .service_builder(&service_name)
-            .publish_subscribe::<FramePayload>()
+            .publish_subscribe::<[u8]>()
             .max_publishers(16)
             .subscriber_max_buffer_size(16)
             .open_or_create()
@@ -76,11 +76,11 @@ impl Iceoryx2Node {
     }
 }
 
-/// Handle to an iceoryx2 publish-subscribe service.
+/// Handle to an iceoryx2 publish-subscribe service for `[u8]` slices.
 pub struct Iceoryx2Service {
     inner: iceoryx2::service::port_factory::publish_subscribe::PortFactory<
         ipc::Service,
-        FramePayload,
+        [u8],
         (),
     >,
 }
@@ -89,9 +89,10 @@ impl Iceoryx2Service {
     /// Create a publisher for this service.
     pub fn create_publisher(
         &self,
-    ) -> Result<iceoryx2::port::publisher::Publisher<ipc::Service, FramePayload, ()>> {
+    ) -> Result<iceoryx2::port::publisher::Publisher<ipc::Service, [u8], ()>> {
         self.inner
             .publisher_builder()
+            .initial_max_slice_len(MAX_PAYLOAD_SIZE + FRAME_HEADER_SIZE)
             .create()
             .map_err(|e| StreamError::Runtime(format!("Failed to create publisher: {:?}", e)))
     }
@@ -99,7 +100,7 @@ impl Iceoryx2Service {
     /// Create a subscriber for this service.
     pub fn create_subscriber(
         &self,
-    ) -> Result<iceoryx2::port::subscriber::Subscriber<ipc::Service, FramePayload, ()>> {
+    ) -> Result<iceoryx2::port::subscriber::Subscriber<ipc::Service, [u8], ()>> {
         self.inner
             .subscriber_builder()
             .buffer_size(16)

--- a/libs/streamlib/src/iceoryx2/node.rs
+++ b/libs/streamlib/src/iceoryx2/node.rs
@@ -9,7 +9,7 @@ use iceoryx2::node::Node;
 use iceoryx2::prelude::*;
 use parking_lot::Mutex;
 
-use super::{EventPayload, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE};
+use super::{EventPayload, FRAME_HEADER_SIZE};
 use crate::core::error::{Result, StreamError};
 
 /// Thread-safe wrapper for iceoryx2 Node.
@@ -87,12 +87,17 @@ pub struct Iceoryx2Service {
 
 impl Iceoryx2Service {
     /// Create a publisher for this service.
+    ///
+    /// `max_payload_bytes` sets the per-slot shared memory capacity (data only, header is added
+    /// internally). Use [`crate::core::embedded_schemas::max_payload_bytes_for_schema`] to derive
+    /// this value from the output port's schema declaration.
     pub fn create_publisher(
         &self,
+        max_payload_bytes: usize,
     ) -> Result<iceoryx2::port::publisher::Publisher<ipc::Service, [u8], ()>> {
         self.inner
             .publisher_builder()
-            .initial_max_slice_len(MAX_PAYLOAD_SIZE + FRAME_HEADER_SIZE)
+            .initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE)
             .create()
             .map_err(|e| StreamError::Runtime(format!("Failed to create publisher: {:?}", e)))
     }

--- a/libs/streamlib/src/iceoryx2/output.rs
+++ b/libs/streamlib/src/iceoryx2/output.rs
@@ -10,7 +10,7 @@ use iceoryx2::prelude::*;
 use parking_lot::Mutex;
 use serde::Serialize;
 
-use super::FramePayload;
+use super::{FrameHeader, FRAME_HEADER_SIZE};
 use crate::core::error::{Result, StreamError};
 use crate::core::media_clock::MediaClock;
 
@@ -23,7 +23,7 @@ pub struct OutputWriter {
     /// Map from output port name to downstream connections.
     /// Each connection is (schema, dest_port, publisher).
     connections:
-        Mutex<HashMap<String, Vec<(String, String, Publisher<ipc::Service, FramePayload, ()>)>>>,
+        Mutex<HashMap<String, Vec<(String, String, Publisher<ipc::Service, [u8], ()>)>>>,
 }
 
 // OutputWriter is Send + Sync via Mutex
@@ -47,7 +47,7 @@ impl OutputWriter {
         output_port: &str,
         schema: &str,
         dest_port: &str,
-        publisher: Publisher<ipc::Service, FramePayload, ()>,
+        publisher: Publisher<ipc::Service, [u8], ()>,
     ) {
         self.connections
             .lock()
@@ -86,17 +86,20 @@ impl OutputWriter {
             .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
 
         for (schema, dest_port, publisher) in port_connections {
-            let payload = FramePayload::new(dest_port, schema, timestamp_ns, &data);
+            let total_len = FRAME_HEADER_SIZE + data.len();
+            let mut frame = vec![0u8; total_len];
+            FrameHeader::new(dest_port, schema, timestamp_ns, data.len() as u32)
+                .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+            frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);
 
             let sample = publisher
-                .loan_uninit()
-                .map_err(|e| StreamError::Link(format!("Failed to loan sample: {:?}", e)))?;
+                .loan_slice_uninit(total_len)
+                .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
 
-            let sample = sample.write_payload(payload);
+            let sample = sample.write_from_slice(&frame);
             sample
                 .send()
                 .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;
-
         }
 
         Ok(())
@@ -112,13 +115,17 @@ impl OutputWriter {
             .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
 
         for (schema, dest_port, publisher) in port_connections {
-            let payload = FramePayload::new(dest_port, schema, timestamp_ns, data);
+            let total_len = FRAME_HEADER_SIZE + data.len();
+            let mut frame = vec![0u8; total_len];
+            FrameHeader::new(dest_port, schema, timestamp_ns, data.len() as u32)
+                .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+            frame[FRAME_HEADER_SIZE..].copy_from_slice(data);
 
             let sample = publisher
-                .loan_uninit()
-                .map_err(|e| StreamError::Link(format!("Failed to loan sample: {:?}", e)))?;
+                .loan_slice_uninit(total_len)
+                .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
 
-            let sample = sample.write_payload(payload);
+            let sample = sample.write_from_slice(&frame);
             sample
                 .send()
                 .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;

--- a/libs/streamlib/src/iceoryx2/payload.rs
+++ b/libs/streamlib/src/iceoryx2/payload.rs
@@ -7,6 +7,7 @@
 //! `streamlib-deno-native` share the same wire-compatible types.
 
 pub use streamlib_ipc_types::{
-    EventPayload, FramePayload, PortKey, SchemaName, TopicKey, MAX_EVENT_PAYLOAD_SIZE,
-    MAX_PAYLOAD_SIZE, MAX_SCHEMA_NAME_SIZE, MAX_TOPIC_KEY_SIZE,
+    EventPayload, FrameHeader, FramePayload, PortKey, SchemaName, TopicKey,
+    FRAME_HEADER_SIZE, MAX_EVENT_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE, MAX_SCHEMA_NAME_SIZE,
+    MAX_TOPIC_KEY_SIZE,
 };

--- a/libs/streamlib/tests/ipc_payload_size_test.rs
+++ b/libs/streamlib/tests/ipc_payload_size_test.rs
@@ -1,0 +1,270 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration tests for iceoryx2 publisher payload size limits.
+//!
+//! Tests are grouped into three layers:
+//!
+//! A) Direct iceoryx2 — validates the slice loan limit behavior independently of
+//!    the schema system.  These are the boundary tests that prove the problem and the fix.
+//!
+//! B) Schema parser — validates that `max_payload_bytes_for_schema` returns the values
+//!    declared in the schema YAML metadata.
+//!
+//! C) Schema-driven publish/subscribe — creates a publisher via the production
+//!    `Iceoryx2Node::create_publisher(max_payload_bytes_for_schema(...))` path and
+//!    verifies that large payloads (which would fail with the old hardcoded 64 KB limit)
+//!    are sent and received correctly.
+
+use std::time::{Duration, Instant};
+
+use iceoryx2::prelude::*;
+use streamlib::core::embedded_schemas::max_payload_bytes_for_schema;
+use streamlib::iceoryx2::{Iceoryx2Node, MAX_PAYLOAD_SIZE};
+
+// =============================================================================
+// A) Direct iceoryx2 slice limit tests
+//
+// These tests bypass our wrapper and call iceoryx2 directly so the expected
+// behavior of `loan_slice_uninit` is observable in isolation.
+// =============================================================================
+
+/// Small payload (1 KB) loans successfully from a publisher configured with a 64 KB limit.
+/// GREEN today and after the fix.
+#[test]
+fn test_loan_1kb_succeeds_with_64kb_publisher_limit() {
+    let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+    let service = node
+        .service_builder(&"streamlib/test/size-1kb-ok".try_into().unwrap())
+        .publish_subscribe::<[u8]>()
+        .open_or_create()
+        .unwrap();
+    let publisher = service
+        .publisher_builder()
+        .initial_max_slice_len(64 * 1024)
+        .create()
+        .unwrap();
+
+    let result = publisher.loan_slice_uninit(1024);
+    assert!(
+        result.is_ok(),
+        "Expected 1 KB loan to succeed with 64 KB limit, got: {:?}",
+        result.err()
+    );
+}
+
+/// 256 KB payload loan FAILS when the publisher is configured with a 64 KB limit.
+///
+/// RED today — this documents the problem we are solving.
+/// After the fix this test still passes: audioframe schema declares 64 KB, so a
+/// connection carrying audio frames would still reject a 256 KB loan (correctly).
+#[test]
+fn test_loan_256kb_fails_with_64kb_publisher_limit() {
+    let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+    let service = node
+        .service_builder(&"streamlib/test/size-256kb-fail".try_into().unwrap())
+        .publish_subscribe::<[u8]>()
+        .open_or_create()
+        .unwrap();
+    let publisher = service
+        .publisher_builder()
+        .initial_max_slice_len(64 * 1024)
+        .create()
+        .unwrap();
+
+    let result = publisher.loan_slice_uninit(256 * 1024);
+    assert!(
+        result.is_err(),
+        "Expected 256 KB loan to fail with a 64 KB publisher limit — \
+         the problem is not reproducible on this platform"
+    );
+}
+
+/// 256 KB payload loans successfully when the publisher is sized at 512 KB.
+/// Proves the fix mechanism works at the iceoryx2 level.
+/// GREEN today and after the fix.
+#[test]
+fn test_loan_256kb_succeeds_with_512kb_publisher_limit() {
+    let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+    let service = node
+        .service_builder(&"streamlib/test/size-256kb-ok".try_into().unwrap())
+        .publish_subscribe::<[u8]>()
+        .open_or_create()
+        .unwrap();
+    let publisher = service
+        .publisher_builder()
+        .initial_max_slice_len(512 * 1024)
+        .create()
+        .unwrap();
+
+    let result = publisher.loan_slice_uninit(256 * 1024);
+    assert!(
+        result.is_ok(),
+        "Expected 256 KB loan to succeed with 512 KB limit, got: {:?}",
+        result.err()
+    );
+}
+
+// =============================================================================
+// B) Schema parser tests
+//
+// Verify max_payload_bytes_for_schema() returns the values declared in the
+// schema YAML metadata section.
+// =============================================================================
+
+#[test]
+fn test_schema_max_payload_bytes_audioframe() {
+    let bytes = max_payload_bytes_for_schema("com.tatolab.audioframe");
+    assert_eq!(bytes, 65536, "audioframe should declare 64 KB");
+}
+
+#[test]
+fn test_schema_max_payload_bytes_audioframe_with_version_suffix() {
+    // Schema names arrive from PROCESSOR_REGISTRY with a version like "@1.0.0" appended.
+    let bytes = max_payload_bytes_for_schema("com.tatolab.audioframe@1.0.0");
+    assert_eq!(
+        bytes, 65536,
+        "version suffix should be stripped before lookup"
+    );
+}
+
+#[test]
+fn test_schema_max_payload_bytes_encodedvideoframe() {
+    let bytes = max_payload_bytes_for_schema("com.tatolab.encodedvideoframe");
+    assert_eq!(
+        bytes,
+        512 * 1024,
+        "encodedvideoframe should declare 512 KB for 1080p60 H.264/H.265 at 8 Mbps CBR"
+    );
+}
+
+#[test]
+fn test_schema_max_payload_bytes_videoframe() {
+    let bytes = max_payload_bytes_for_schema("com.tatolab.videoframe");
+    assert_eq!(
+        bytes, 65536,
+        "videoframe carries surface IDs only — 64 KB default is correct"
+    );
+}
+
+#[test]
+fn test_schema_max_payload_bytes_unknown_schema_returns_default() {
+    let bytes = max_payload_bytes_for_schema("com.unknown.does.not.exist");
+    assert_eq!(
+        bytes,
+        MAX_PAYLOAD_SIZE as usize,
+        "unknown schema should fall back to MAX_PAYLOAD_SIZE"
+    );
+}
+
+#[test]
+fn test_encodedvideoframe_larger_than_audioframe() {
+    let audio = max_payload_bytes_for_schema("com.tatolab.audioframe");
+    let video = max_payload_bytes_for_schema("com.tatolab.encodedvideoframe");
+    assert!(
+        video > audio,
+        "encodedvideoframe ({} bytes) should declare more capacity than audioframe ({} bytes)",
+        video,
+        audio
+    );
+}
+
+// =============================================================================
+// C) Schema-driven publish/subscribe
+//
+// These tests use the production path:
+//   Iceoryx2Node -> create_publisher(max_payload_bytes_for_schema(...))
+// and verify that large payloads actually transit end-to-end.
+// =============================================================================
+
+/// Publisher sized from the audioframe schema (64 KB) rejects a 256 KB payload.
+/// This mirrors the pre-fix failure mode for any connection carrying audioframes.
+#[test]
+fn test_audioframe_schema_publisher_rejects_256kb() {
+    let node = Iceoryx2Node::new().unwrap();
+    let service = node
+        .open_or_create_service("streamlib/test/schema-audio-reject")
+        .unwrap();
+
+    let max_bytes = max_payload_bytes_for_schema("com.tatolab.audioframe");
+    let publisher = service.create_publisher(max_bytes).unwrap();
+
+    // 256 KB exceeds the 64 KB audioframe limit.
+    let result = publisher.loan_slice_uninit(256 * 1024);
+    assert!(
+        result.is_err(),
+        "Expected 256 KB loan to fail on audioframe-sized publisher ({} bytes)",
+        max_bytes
+    );
+}
+
+/// Publisher sized from the encodedvideoframe schema (4 MB) accepts a 256 KB payload.
+/// This is the GREEN-after-fix test: before the fix all publishers used ~64 KB.
+#[test]
+fn test_encodedvideoframe_schema_publisher_accepts_256kb() {
+    let node = Iceoryx2Node::new().unwrap();
+    let service = node
+        .open_or_create_service("streamlib/test/schema-video-ok")
+        .unwrap();
+
+    let max_bytes = max_payload_bytes_for_schema("com.tatolab.encodedvideoframe");
+    let publisher = service.create_publisher(max_bytes).unwrap();
+
+    let result = publisher.loan_slice_uninit(256 * 1024);
+    assert!(
+        result.is_ok(),
+        "Expected 256 KB loan to succeed on encodedvideoframe-sized publisher ({} bytes), got: {:?}",
+        max_bytes,
+        result.err()
+    );
+}
+
+/// Full publish/subscribe round-trip: publisher sized from encodedvideoframe schema,
+/// 256 KB payload written and received on the same service.
+#[test]
+fn test_encodedvideoframe_schema_publisher_subscriber_roundtrip_256kb() {
+    let node = Iceoryx2Node::new().unwrap();
+    let service = node
+        .open_or_create_service("streamlib/test/schema-video-roundtrip")
+        .unwrap();
+
+    let max_bytes = max_payload_bytes_for_schema("com.tatolab.encodedvideoframe");
+    let publisher = service.create_publisher(max_bytes).unwrap();
+    let subscriber = service.create_subscriber().unwrap();
+
+    // Build 256 KB payload with a recognizable pattern.
+    let payload_size = 256 * 1024;
+    let mut payload = vec![0u8; payload_size];
+    for (i, byte) in payload.iter_mut().enumerate() {
+        *byte = (i % 251) as u8; // prime modulus → non-trivial pattern
+    }
+
+    // Loan and send.
+    let sample = publisher.loan_slice_uninit(payload_size).expect(
+        "loan_slice_uninit should succeed — encodedvideoframe schema declares 4 MB",
+    );
+    let sample = sample.write_from_slice(&payload);
+    sample.send().expect("send should succeed");
+
+    // Poll for receipt with a timeout.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut received: Option<Vec<u8>> = None;
+    while received.is_none() && Instant::now() < deadline {
+        if let Ok(Some(sample)) = subscriber.receive() {
+            received = Some(sample.payload().to_vec());
+        } else {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    let received = received.expect("subscriber should have received the 256 KB sample within 2s");
+    assert_eq!(
+        received.len(),
+        payload_size,
+        "received payload length should match sent length"
+    );
+    assert_eq!(
+        received, payload,
+        "received payload content should match sent content"
+    );
+}

--- a/plan/249-moq-subgroup-fix.md
+++ b/plan/249-moq-subgroup-fix.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: MoQ Subgroup Keyframe Fix
-status: pending
+status: completed
 description: "Bump moq-transport to 0.14.1 (includes LargestObject filter fix) and apply per-GOP subgroup creation. Branch fix/moq-subgroup-keyframe from main."
 github_issue: 249
 dependencies: []

--- a/plan/250-iceoryx2-slice-api.md
+++ b/plan/250-iceoryx2-slice-api.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: iceoryx2 Slice API Migration
-status: pending
+status: in_review
 description: Replace fixed-size FramePayload with iceoryx2 slice-based publish_subscribe for variable-length payloads. Branch feat/iceoryx2-slice-api from main.
 github_issue: 250
 dependencies:


### PR DESCRIPTION
## Summary
- Replace fixed-size `FramePayload` ([u8; 512KB] on stack) with iceoryx2's `publish_subscribe::<[u8]>()` slice API
- Add `FrameHeader` struct with `write_to_slice()`/`read_from_slice()` for the 204-byte wire prefix
- Switch `PortMailbox`, `InputMailboxes`, `OutputWriter`, and `Iceoryx2Service` to operate on `Vec<u8>` and `[u8]` slices

## Issue
Closes #250

## Test Plan
- [x] `cargo check` passes (0 new warnings)
- [x] `cargo test -p streamlib` — 142 passed, 0 new failures (1 pre-existing failure in `vulkan_video_session::test_select_h264_level` unrelated to this change)
- [x] `cargo check -p streamlib-broker` passes

## Follow-ups
- Pre-existing test failure `vulkan::rhi::vulkan_video_session::tests::test_select_h264_level` — present on main before this branch, out of scope