### PR TITLE
fix(#273): add per-queue mutex synchronization to VulkanDevice

### DIFF
--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -425,7 +425,7 @@ impl GpuContext {
     fn create_blitter(device: &Arc<GpuDevice>) -> Arc<dyn RhiBlitter> {
         let vulkan_device = &device.inner;
         match crate::vulkan::rhi::VulkanBlitter::new(
-            vulkan_device.device(),
+            vulkan_device,
             vulkan_device.queue(),
             vulkan_device.queue_family_index(),
         ) {

--- a/libs/streamlib/src/core/rhi/device.rs
+++ b/libs/streamlib/src/core/rhi/device.rs
@@ -79,8 +79,8 @@ impl GpuDevice {
             all(target_os = "linux", not(feature = "backend-metal"))
         ))]
         {
-            let vulkan_device = crate::vulkan::rhi::VulkanDevice::new()?;
-            let vulkan_queue = vulkan_device.create_command_queue_wrapper();
+            let device_arc = std::sync::Arc::new(crate::vulkan::rhi::VulkanDevice::new()?);
+            let vulkan_queue = device_arc.create_command_queue_wrapper();
 
             // On macOS/iOS with Vulkan backend, also create Metal device/queue for Apple services
             #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -95,8 +95,6 @@ impl GpuDevice {
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
                 metal_queue,
             };
-
-            let device_arc = std::sync::Arc::new(vulkan_device);
 
             // Store a global reference for DMA-BUF import (Linux only).
             // The import trait (RhiPixelBufferImport::from_external_handle) is a

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -1592,7 +1592,7 @@ fn capture_thread_loop(
                 .signal_semaphore_infos(&[signal_semaphore])
                 .build();
 
-            if let Err(e) = device.queue_submit2(queue, &[submit], vk::Fence::null()) {
+            if let Err(e) = vulkan_device.submit_to_queue(queue, &[submit], vk::Fence::null()) {
                 if frame_num == 0 {
                     eprintln!(
                         "[Camera {}] Failed to submit compute dispatch: {}",

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -877,7 +877,7 @@ impl DisplayEventLoopHandler {
                 .build();
 
             if let Err(e) =
-                device.queue_submit2(queue, &[submit], vk::Fence::null())
+                self.vulkan_device.submit_to_queue(queue, &[submit], vk::Fence::null())
             {
                 tracing::warn!(
                     "Display {}: Failed to submit render command: {}",
@@ -897,7 +897,7 @@ impl DisplayEventLoopHandler {
                 .image_indices(&image_indices)
                 .build();
 
-            match device.queue_present_khr(queue, &present_info) {
+            match self.vulkan_device.present_to_queue(queue, &present_info) {
                 Ok(_) => {}
                 Err(vk::ErrorCode::OUT_OF_DATE_KHR) => {
                     tracing::debug!(

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use std::sync::Arc;
+
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
@@ -8,8 +10,11 @@ use crate::core::rhi::blitter::RhiBlitter;
 use crate::core::rhi::RhiPixelBuffer;
 use crate::core::{Result, StreamError};
 
+use super::VulkanDevice;
+
 /// Vulkan implementation of [`RhiBlitter`] for GPU copy operations on Linux.
 pub struct VulkanBlitter {
+    vulkan_device: Arc<VulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     #[allow(dead_code)]
@@ -19,7 +24,8 @@ pub struct VulkanBlitter {
 
 impl VulkanBlitter {
     /// Create a new Vulkan blitter with a dedicated command pool.
-    pub fn new(device: &vulkanalia::Device, queue: vk::Queue, queue_family_index: u32) -> Result<Self> {
+    pub fn new(vulkan_device: &Arc<VulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Result<Self> {
+        let device = vulkan_device.device();
         let pool_info = vk::CommandPoolCreateInfo::builder()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index)
@@ -31,6 +37,7 @@ impl VulkanBlitter {
             })?;
 
         Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
             device: device.clone(),
             queue,
             queue_family_index,
@@ -119,13 +126,12 @@ impl RhiBlitter for VulkanBlitter {
                 .signal_semaphore_infos(&[signal_semaphore])
                 .build();
 
-            self.device
-                .queue_submit2(self.queue, &[submit], vk::Fence::null())
+            self.vulkan_device
+                .submit_to_queue(self.queue, &[submit], vk::Fence::null())
                 .map_err(|e| {
                     self.device.destroy_semaphore(timeline_semaphore, None);
-                    StreamError::GpuError(format!("Failed to submit blit command: {e}"))
-                })
-                .map(|_| ())?;
+                    e
+                })?;
 
             let wait_semaphores = [timeline_semaphore];
             let wait_values = [1u64];
@@ -205,7 +211,7 @@ mod tests {
         };
 
         let blitter = VulkanBlitter::new(
-            device.device(),
+            &device,
             device.queue(),
             device.queue_family_index(),
         )
@@ -243,7 +249,7 @@ mod tests {
         };
 
         let blitter = VulkanBlitter::new(
-            device.device(),
+            &device,
             device.queue(),
             device.queue_family_index(),
         )

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
@@ -3,16 +3,19 @@
 
 //! Vulkan command buffer implementation for RHI.
 
+use std::sync::Arc;
+
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use super::VulkanTexture;
+use super::{VulkanDevice, VulkanTexture};
 
 /// Vulkan command buffer wrapper.
 ///
 /// Command buffers are single-use: create, record, commit.
 /// The buffer is automatically begun when created.
 pub struct VulkanCommandBuffer {
+    vulkan_device: Arc<VulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -22,12 +25,14 @@ pub struct VulkanCommandBuffer {
 impl VulkanCommandBuffer {
     /// Create a new command buffer wrapper.
     pub fn new(
-        device: vulkanalia::Device,
+        vulkan_device: Arc<VulkanDevice>,
         queue: vk::Queue,
         command_pool: vk::CommandPool,
         command_buffer: vk::CommandBuffer,
     ) -> Self {
+        let device = vulkan_device.device().clone();
         Self {
+            vulkan_device,
             device,
             queue,
             command_pool,
@@ -177,8 +182,8 @@ impl VulkanCommandBuffer {
                 .signal_semaphore_infos(&[signal_semaphore])
                 .build();
 
-            self.device
-                .queue_submit2(self.queue, &[submit], vk::Fence::null())
+            self.vulkan_device
+                .submit_to_queue(self.queue, &[submit], vk::Fence::null())
                 .expect("Failed to submit command buffer");
 
             // Wait for GPU completion via timeline semaphore before freeing
@@ -239,8 +244,8 @@ impl VulkanCommandBuffer {
                 .signal_semaphore_infos(&[signal_semaphore])
                 .build();
 
-            self.device
-                .queue_submit2(self.queue, &[submit], vk::Fence::null())
+            self.vulkan_device
+                .submit_to_queue(self.queue, &[submit], vk::Fence::null())
                 .expect("Failed to submit command buffer");
 
             // Wait for this specific command buffer via timeline semaphore

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
@@ -3,17 +3,20 @@
 
 //! Vulkan command queue wrapper for RHI.
 
+use std::sync::Arc;
+
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
 use crate::core::{Result, StreamError};
 
-use super::VulkanCommandBuffer;
+use super::{VulkanCommandBuffer, VulkanDevice};
 
 /// Vulkan command queue wrapper.
 ///
 /// Manages the Vulkan queue and command pool for allocating command buffers.
 pub struct VulkanCommandQueue {
+    vulkan_device: Arc<VulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -21,7 +24,9 @@ pub struct VulkanCommandQueue {
 
 impl VulkanCommandQueue {
     /// Create a new command queue wrapper.
-    pub fn new(device: vulkanalia::Device, queue: vk::Queue, queue_family_index: u32) -> Self {
+    pub fn new(vulkan_device: Arc<VulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Self {
+        let device = vulkan_device.device().clone();
+
         // Create command pool for this queue family
         let pool_info = vk::CommandPoolCreateInfo::builder()
             .queue_family_index(queue_family_index)
@@ -32,6 +37,7 @@ impl VulkanCommandQueue {
             .expect("Failed to create command pool");
 
         Self {
+            vulkan_device,
             device,
             queue,
             command_pool,
@@ -65,7 +71,7 @@ impl VulkanCommandQueue {
         .map_err(|e| StreamError::GpuError(format!("Failed to begin command buffer: {e}")))?;
 
         Ok(VulkanCommandBuffer::new(
-            self.device.clone(),
+            Arc::clone(&self.vulkan_device),
             self.queue,
             self.command_pool,
             command_buffer,
@@ -99,7 +105,7 @@ mod tests {
     #[test]
     fn test_creates_command_buffer() {
         let device = match VulkanDevice::new() {
-            Ok(d) => d,
+            Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -114,7 +120,7 @@ mod tests {
     #[test]
     fn test_empty_command_buffer_commit_and_wait_completes() {
         let device = match VulkanDevice::new() {
-            Ok(d) => d,
+            Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -4,12 +4,12 @@
 //! Vulkan device implementation for RHI.
 
 use std::ffi::{c_char, CStr};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use vulkanalia::loader::{LibloadingLoader, LIBRARY};
 use vulkanalia::prelude::v1_4::*;
-use vulkanalia::vk;
+use vulkanalia::vk::{self, KhrSwapchainExtensionDeviceCommands};
 use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
@@ -66,6 +66,18 @@ pub struct VulkanDevice {
     _dma_buf_image_export_info: Option<Box<vk::ExportMemoryAllocateInfo>>,
     /// Tracks DMA-BUF import-path allocations (raw vkAllocateMemory for import only).
     live_allocation_count: AtomicUsize,
+    /// Per-queue mutex for thread-safe queue submission (Vulkan spec requirement).
+    graphics_queue_mutex: Mutex<()>,
+    /// Per-queue mutex for the dedicated transfer queue.
+    transfer_queue_mutex: Mutex<()>,
+    /// Per-queue mutex for the video encode queue (if available).
+    video_encode_queue_mutex: Mutex<()>,
+    /// Per-queue mutex for the video decode queue (if available).
+    video_decode_queue_mutex: Mutex<()>,
+    /// Per-queue mutex for the dedicated compute queue (if available).
+    compute_queue_mutex: Mutex<()>,
+    /// Device-level mutex for resource creation (video sessions, VMA allocations).
+    device_mutex: Mutex<()>,
 }
 
 impl VulkanDevice {
@@ -681,6 +693,12 @@ impl VulkanDevice {
             #[cfg(target_os = "linux")]
             _dma_buf_image_export_info: dma_buf_image_export_info,
             live_allocation_count: AtomicUsize::new(0),
+            graphics_queue_mutex: Mutex::new(()),
+            transfer_queue_mutex: Mutex::new(()),
+            video_encode_queue_mutex: Mutex::new(()),
+            video_decode_queue_mutex: Mutex::new(()),
+            compute_queue_mutex: Mutex::new(()),
+            device_mutex: Mutex::new(()),
         })
     }
 
@@ -857,8 +875,8 @@ impl VulkanDevice {
     }
 
     /// Create a VulkanCommandQueue wrapper for the shared command queue.
-    pub fn create_command_queue_wrapper(&self) -> VulkanCommandQueue {
-        VulkanCommandQueue::new(self.device.clone(), self.queue, self.queue_family_index)
+    pub fn create_command_queue_wrapper(self: &Arc<Self>) -> VulkanCommandQueue {
+        VulkanCommandQueue::new(Arc::clone(self), self.queue, self.queue_family_index)
     }
 
     /// Get the device name.
@@ -963,6 +981,77 @@ impl VulkanDevice {
     #[allow(dead_code)]
     pub fn compute_queue(&self) -> Option<vk::Queue> {
         self.compute_queue
+    }
+
+    // ---- Thread-safe queue submission ----
+    //
+    // Vulkan requires external synchronization for vkQueueSubmit on the same
+    // VkQueue from multiple threads. NVIDIA's driver also has internal
+    // thread-safety issues during concurrent device-level operations.
+    // These methods acquire per-queue mutexes before submitting.
+
+    /// Look up the mutex that guards a given queue handle.
+    fn mutex_for_queue(&self, queue: vk::Queue) -> &Mutex<()> {
+        if queue == self.queue {
+            &self.graphics_queue_mutex
+        } else if queue == self.transfer_queue {
+            &self.transfer_queue_mutex
+        } else if self.video_encode_queue == Some(queue) {
+            &self.video_encode_queue_mutex
+        } else if self.video_decode_queue == Some(queue) {
+            &self.video_decode_queue_mutex
+        } else if self.compute_queue == Some(queue) {
+            &self.compute_queue_mutex
+        } else {
+            // Unknown queue — fall back to graphics mutex as safety net
+            &self.graphics_queue_mutex
+        }
+    }
+
+    /// Submit command buffers to a queue with per-queue mutex synchronization.
+    pub unsafe fn submit_to_queue(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo2],
+        fence: vk::Fence,
+    ) -> Result<()> {
+        let _lock = self.mutex_for_queue(queue).lock()
+            .unwrap_or_else(|e| e.into_inner());
+        self.device
+            .queue_submit2(queue, submits, fence)
+            .map(|_| ())
+            .map_err(|e| StreamError::GpuError(format!("queue_submit2 failed: {e}")))
+    }
+
+    /// Submit command buffers using legacy Vulkan 1.0 API with synchronization.
+    pub unsafe fn submit_to_queue_legacy(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo],
+        fence: vk::Fence,
+    ) -> Result<()> {
+        let _lock = self.mutex_for_queue(queue).lock()
+            .unwrap_or_else(|e| e.into_inner());
+        self.device
+            .queue_submit(queue, submits, fence)
+            .map(|_| ())
+            .map_err(|e| StreamError::GpuError(format!("queue_submit failed: {e}")))
+    }
+
+    /// Present to a queue with per-queue mutex synchronization.
+    pub unsafe fn present_to_queue(
+        &self,
+        queue: vk::Queue,
+        present_info: &vk::PresentInfoKHR,
+    ) -> std::result::Result<vk::SuccessCode, vk::ErrorCode> {
+        let _lock = self.mutex_for_queue(queue).lock()
+            .unwrap_or_else(|e| e.into_inner());
+        self.device.queue_present_khr(queue, present_info)
+    }
+
+    /// Acquire the device-level mutex for resource creation operations.
+    pub fn lock_device(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.device_mutex.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Copy a host-visible VkBuffer to a device-local VkImage (RGBA upload).
@@ -1077,9 +1166,8 @@ impl VulkanDevice {
         device.end_command_buffer(cb).map_err(|e| StreamError::GpuError(format!("end cb: {e}")))?;
 
         let cbs = [cb];
-        let submit = vk::SubmitInfo::builder().command_buffers(&cbs);
-        device.queue_submit(queue, &[submit], fence)
-            .map_err(|e| StreamError::GpuError(format!("submit: {e}")))?;
+        let submit = vk::SubmitInfo::builder().command_buffers(&cbs).build();
+        self.submit_to_queue_legacy(queue, &[submit], fence)?;
         device.wait_for_fences(&[fence], true, u64::MAX)
             .map_err(|e| StreamError::GpuError(format!("wait: {e}")))?;
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
@@ -1,14 +1,19 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use std::sync::Arc;
+
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer};
 use crate::core::{Result, StreamError};
 
+use super::VulkanDevice;
+
 /// Vulkan format converter for pixel buffer format conversion via GPU compute.
 pub struct VulkanFormatConverter {
+    vulkan_device: Arc<VulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     queue_family_index: u32,
@@ -28,12 +33,13 @@ pub struct VulkanFormatConverter {
 impl VulkanFormatConverter {
     /// Create a new format converter with GPU compute pipelines.
     pub fn new(
-        device: &vulkanalia::Device,
+        vulkan_device: &Arc<VulkanDevice>,
         queue: vk::Queue,
         queue_family_index: u32,
         source_bytes_per_pixel: u32,
         dest_bytes_per_pixel: u32,
     ) -> Result<Self> {
+        let device = vulkan_device.device();
         // Command pool
         let pool_info = vk::CommandPoolCreateInfo::builder()
             .queue_family_index(queue_family_index)
@@ -226,6 +232,7 @@ impl VulkanFormatConverter {
         })?;
 
         Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
             device: device.clone(),
             queue,
             queue_family_index,
@@ -410,12 +417,8 @@ impl VulkanFormatConverter {
                 .command_buffer_infos(&[cmd_info])
                 .build();
 
-            self.device
-                .queue_submit2(self.queue, &[submit], self.compute_fence)
-                .map(|_| ())
-                .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to submit compute dispatch: {e}"))
-                })?;
+            self.vulkan_device
+                .submit_to_queue(self.queue, &[submit], self.compute_fence)?;
 
             // Wait for the compute dispatch to complete, ensuring the output
             // buffer data is visible before the caller submits dependent work.
@@ -473,7 +476,7 @@ mod tests {
     #[test]
     fn test_new_creates_compute_pipeline_successfully() {
         let device = match VulkanDevice::new() {
-            Ok(d) => d,
+            Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -485,7 +488,7 @@ mod tests {
         // descriptor set layout, pipeline layout, compute pipeline, and command pool —
         // validating the ash → vulkanalia migration of the most complex RHI file.
         let result = VulkanFormatConverter::new(
-            device.device(),
+            &device,
             device.queue(),
             device.queue_family_index(),
             2, // source: NV12 packed as 2 bytes/pixel for dispatch sizing

--- a/plan/277-vulkan-video-queue-sync.md
+++ b/plan/277-vulkan-video-queue-sync.md
@@ -1,0 +1,28 @@
+---
+whoami: amos
+name: vulkan-video synchronized queue submission via VulkanDevice
+status: pending
+description: Route SimpleEncoder/SimpleDecoder queue_submit() calls through VulkanDevice's mutex-protected submit_to_queue() methods. Fixes release build SIGSEGV.
+github_issue: 277
+dependencies:
+  - "down:VulkanDevice thread-safe queue submission synchronization"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#277
+
+## Branch
+
+Create `fix/vulkan-video-queue-sync` from `main` (after #273 merges).
+
+## Steps
+
+1. Modify `SimpleEncoder::from_device()` to accept `Arc<VulkanDevice>` alongside existing device/queue params
+2. Modify `SimpleDecoder::from_device()` similarly
+3. Replace `device.queue_submit()` in `encode/submit.rs` with `vulkan_device.submit_to_queue_legacy()`
+4. Replace `device.queue_submit()` in `vk_video_decoder.rs` with `vulkan_device.submit_to_queue_legacy()`
+5. Replace `device.queue_submit()` in `decode/mod.rs` (transfer queue) with `vulkan_device.submit_to_queue_legacy()`
+6. Update H264/H265 encoder processors to pass `Arc<VulkanDevice>` from GpuContext
+7. Update H264/H265 decoder processors to pass `Arc<VulkanDevice>` from GpuContext
+8. Run existing encoder/decoder tests to confirm no regressions

--- a/plan/278-device-level-resource-lock.md
+++ b/plan/278-device-level-resource-lock.md
@@ -1,0 +1,26 @@
+---
+whoami: amos
+name: Device-level lock for GPU resource creation during concurrent operations
+status: pending
+description: Wrap vulkan-video session creation and DPB allocation with VulkanDevice::lock_device() to prevent races with concurrent GPU submissions.
+github_issue: 278
+dependencies:
+  - "down:vulkan-video synchronized queue submission via VulkanDevice"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#278
+
+## Branch
+
+Create `fix/device-resource-creation-lock` from `main` (after #277 merges).
+
+## Steps
+
+1. Wrap `create_video_session_khr()` calls with `vulkan_device.lock_device()`
+2. Wrap DPB image allocation (VMA `create_image`) with `lock_device()`
+3. Wrap bitstream buffer allocation (VMA `create_buffer`) with `lock_device()`
+4. Wrap video session memory binding (`bind_video_session_memory_khr`) with `lock_device()`
+5. Verify encoder + decoder session setup doesn't deadlock with concurrent camera submissions
+6. Run existing tests to confirm no regressions

--- a/plan/279-release-roundtrip-retest.md
+++ b/plan/279-release-roundtrip-retest.md
@@ -1,0 +1,27 @@
+---
+whoami: amos
+name: Retest camera + encoder + display roundtrip in release build
+status: pending
+description: Validate full GPU pipeline (camera + encoder + decoder + display) in release build after synchronization fixes land. Confirms no SIGSEGV or OOM.
+github_issue: 279
+dependencies:
+  - "down:vulkan-video synchronized queue submission via VulkanDevice"
+  - "down:Device-level lock for GPU resource creation during concurrent operations"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#279
+
+## Branch
+
+Create `test/release-roundtrip-retest` from `main` (after #277 + #278 merge).
+
+## Steps
+
+1. H.264 roundtrip with Cam Link 4K: `cargo run --release -p vulkan-video-roundtrip -- h264 /dev/video0 30`
+2. H.265 roundtrip with Cam Link 4K: `cargo run --release -p vulkan-video-roundtrip -- h265 /dev/video0 30`
+3. Vivid virtual camera roundtrip: `cargo run --release -p vulkan-video-roundtrip -- h264 /dev/video10 30`
+4. Dynamic processor add/remove: start camera-only, add encoder while running
+5. Release vs debug parity: run all above in both modes
+6. Document results and close retest items from #273 and #272/PR #275


### PR DESCRIPTION
## Summary

- Add per-queue-family `Mutex<()>` fields to `VulkanDevice` with `submit_to_queue()`, `submit_to_queue_legacy()`, `present_to_queue()`, and `lock_device()` methods
- Route all 7 queue submission sites in the streamlib RHI layer through the synchronized path (camera, display, blitter, format converter, command buffer, upload)
- Thread `Arc<VulkanDevice>` through `VulkanCommandBuffer`, `VulkanCommandQueue`, `VulkanBlitter`, and `VulkanFormatConverter` so they can call the synchronized methods

## Issue

Closes #273

## Test Plan

- [x] `cargo check -p streamlib` passes (0 errors)
- [x] `cargo check -p camera-display -p vulkan-video-roundtrip` passes
- [x] All 36 Vulkan RHI tests pass (device, command buffer, blitter, format converter, texture, pixel buffer)
- [x] `commit_and_wait` test exercises full synchronized submit path
- [x] `blit_copy` tests exercise synchronized blitter path
- [ ] Release build roundtrip verification (blocked on #277 + #278 — tracked in #279)

## Follow-ups

- #277 — Route vulkan-video encoder/decoder `queue_submit()` through `VulkanDevice` (the actual SIGSEGV fix)
- #278 — Wrap video session + DPB allocation with `lock_device()` (resource creation race fix)
- #279 — Full release build roundtrip retest after both land

🤖 Generated with [Claude Code](https://claude.com/claude-code)