### PR TITLE
fix(#277): route vulkan-video queue submits through VulkanDevice mutexes

### DIFF
--- a/libs/streamlib/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_decoder.rs
@@ -50,12 +50,16 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
             StreamError::Runtime("No video decode queue family".into())
         })?;
 
+        let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
+            ctx.gpu.device().inner.clone();
+
         let mut decoder = SimpleDecoder::from_device(
             decoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
             vulkan_device.physical_device(),
             vulkan_device.allocator().clone(),
+            submitter,
             decode_queue,
             decode_queue_family,
             vulkan_device.queue(),

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -66,12 +66,16 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             StreamError::Runtime("No video encode queue family".into())
         })?;
 
+        let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
+            ctx.gpu.device().inner.clone();
+
         let encoder = SimpleEncoder::from_device(
             encoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
             vulkan_device.physical_device(),
             vulkan_device.allocator().clone(),
+            submitter,
             encode_queue,
             encode_queue_family,
             vulkan_device.transfer_queue(),

--- a/libs/streamlib/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_decoder.rs
@@ -50,12 +50,16 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
             StreamError::Runtime("No video decode queue family".into())
         })?;
 
+        let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
+            ctx.gpu.device().inner.clone();
+
         let mut decoder = SimpleDecoder::from_device(
             decoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
             vulkan_device.physical_device(),
             vulkan_device.allocator().clone(),
+            submitter,
             decode_queue,
             decode_queue_family,
             vulkan_device.queue(),

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -66,12 +66,16 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             StreamError::Runtime("No video encode queue family".into())
         })?;
 
+        let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
+            ctx.gpu.device().inner.clone();
+
         let encoder = SimpleEncoder::from_device(
             encoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
             vulkan_device.physical_device(),
             vulkan_device.allocator().clone(),
+            submitter,
             encode_queue,
             encode_queue_family,
             vulkan_device.transfer_queue(),

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -1053,7 +1053,22 @@ impl VulkanDevice {
     pub fn lock_device(&self) -> std::sync::MutexGuard<'_, ()> {
         self.device_mutex.lock().unwrap_or_else(|e| e.into_inner())
     }
+}
 
+impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
+    unsafe fn submit_to_queue_legacy(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo],
+        fence: vk::Fence,
+    ) -> vulkanalia::VkResult<()> {
+        let _lock = self.mutex_for_queue(queue).lock()
+            .unwrap_or_else(|e| e.into_inner());
+        self.device.queue_submit(queue, submits, fence).map(|_| ())
+    }
+}
+
+impl VulkanDevice {
     /// Copy a host-visible VkBuffer to a device-local VkImage (RGBA upload).
     ///
     /// Transitions the image UNDEFINED → TRANSFER_DST → SHADER_READ_ONLY.

--- a/libs/streamlib/tests/fixtures/capture_window.py
+++ b/libs/streamlib/tests/fixtures/capture_window.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
 """Capture a specific X11 window by ID to a PNG file.
 
 Usage: capture_window.py <window_id> <output.png>

--- a/libs/vulkan-video/src/bin/pipeline_test.rs
+++ b/libs/vulkan-video/src/bin/pipeline_test.rs
@@ -1382,11 +1382,12 @@ fn main() {
     //   - PSNR against CPU reference conversion
     // =====================================================================
     if decode_qf.is_some() && compute_qf.is_some() {
-        use vulkan_video::Nv12ToRgbConverter;
+        use vulkan_video::{Nv12ToRgbConverter, RawQueueSubmitter};
 
         let compute_qf_val = compute_qf.unwrap();
         let decode_qf_val = decode_qf.unwrap();
         let compute_q = compute_queue.unwrap();
+        let submitter = RawQueueSubmitter::new(device.clone());
 
         let test_name = "NV12→RGB post-process filter".to_string();
         println!("[TEST] {}", test_name);
@@ -1563,6 +1564,7 @@ fn main() {
                     &ctx, width, height,
                     compute_qf_val, compute_q,
                     decode_qf_val,
+                    submitter.clone(),
                 ).map_err(|e| format!("Nv12ToRgbConverter::new: {e}"))?;
 
                 let (rgba_image, _rgba_view) = converter.convert(

--- a/libs/vulkan-video/src/decode/mod.rs
+++ b/libs/vulkan-video/src/decode/mod.rs
@@ -135,6 +135,9 @@ pub struct SimpleDecoder {
     // Compute/transfer queue info for converter (graphics queue supports compute)
     compute_queue: vk::Queue,
     compute_queue_family: u32,
+
+    // Host-side queue submission gateway (per-queue mutex synchronization).
+    submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
 }
 
 /// Metadata for a frame whose GPU decode has been submitted but not yet read back.
@@ -176,6 +179,7 @@ impl SimpleDecoder {
         device: vulkanalia::Device,
         physical_device: vk::PhysicalDevice,
         allocator: Arc<vma::Allocator>,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
         decode_queue: vk::Queue,
         decode_queue_family: u32,
         transfer_queue: vk::Queue,
@@ -258,6 +262,7 @@ impl SimpleDecoder {
             rgba_staging: None,
             compute_queue: transfer_queue,
             compute_queue_family: transfer_queue_family,
+            submitter,
         })
     }
 
@@ -435,6 +440,8 @@ impl SimpleDecoder {
 
         info!(codec = ?config.codec, "SimpleDecoder created");
 
+        let submitter = crate::rhi::RawQueueSubmitter::new(device.clone());
+
         Ok(Self {
             _entry: entry,
             _instance: instance,
@@ -472,6 +479,7 @@ impl SimpleDecoder {
             rgba_staging: None,
             compute_queue: compute_queue_obj,
             compute_queue_family: compute_qf,
+            submitter,
         })
     }
 
@@ -916,8 +924,8 @@ impl SimpleDecoder {
                 self.device.end_command_buffer(self.transfer_cb).map_err(VideoError::from)?;
                 self.device.reset_fences(&[self.transfer_fence]).map_err(VideoError::from)?;
                 let cbs = [self.transfer_cb];
-                let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs);
-                self.device.queue_submit(
+                let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs).build();
+                self.submitter.submit_to_queue_legacy(
                     self.transfer_queue,
                     &[submit_info],
                     self.transfer_fence,

--- a/libs/vulkan-video/src/decode/session.rs
+++ b/libs/vulkan-video/src/decode/session.rs
@@ -55,6 +55,7 @@ impl SimpleDecoder {
             self.decode_queue_family,
             self.decode_queue,
             codec_flag,
+            self.submitter.clone(),
         )?;
 
         // Propagate sharing queue families for CONCURRENT DPB access.
@@ -138,6 +139,7 @@ impl SimpleDecoder {
                 self.decode_queue_family,
                 self.decode_queue,
                 codec_flag,
+                self.submitter.clone(),
             )?;
 
             {
@@ -193,6 +195,7 @@ impl SimpleDecoder {
                     self.compute_queue_family,
                     self.compute_queue,
                     self.decode_queue_family,
+                    self.submitter.clone(),
                 )?
             };
             self.nv12_converter = Some(converter);

--- a/libs/vulkan-video/src/encode/mod.rs
+++ b/libs/vulkan-video/src/encode/mod.rs
@@ -200,6 +200,9 @@ pub struct SimpleEncoder {
     // Config
     pub(crate) config: SimpleEncoderConfig,
     pub(crate) prepend_header: bool,
+
+    // Host-side queue submission gateway (per-queue mutex synchronization).
+    pub(crate) submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
 }
 
 // SAFETY: Vulkan handles are only accessed through &mut self methods.
@@ -241,6 +244,7 @@ impl SimpleEncoder {
         device: vulkanalia::Device,
         physical_device: vk::PhysicalDevice,
         allocator: Arc<vma::Allocator>,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
         encode_queue: vk::Queue,
         encode_queue_family: u32,
         transfer_queue: vk::Queue,
@@ -252,7 +256,7 @@ impl SimpleEncoder {
 
         unsafe {
             Self::create_from_external(
-                config, instance, device, physical_device, allocator,
+                config, instance, device, physical_device, allocator, submitter,
                 encode_queue, encode_queue_family,
                 transfer_queue, transfer_queue_family,
                 compute_queue, compute_queue_family,

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -187,6 +187,8 @@ impl SimpleEncoder {
         let gop = config.to_gop_structure();
         let prepend_header = config.effective_prepend_header();
 
+        let submitter = crate::rhi::RawQueueSubmitter::new(device.clone());
+
         let mut this = SimpleEncoder {
             _entry: entry,
             _instance: instance.clone(),
@@ -249,6 +251,7 @@ impl SimpleEncoder {
             cached_header: Vec::new(),
             config,
             prepend_header,
+            submitter,
         };
 
         // Configure encoder (creates video session, DPB, etc.)
@@ -418,6 +421,7 @@ impl SimpleEncoder {
         device: vulkanalia::Device,
         physical_device: vk::PhysicalDevice,
         allocator: Arc<vma::Allocator>,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
         encode_queue: vk::Queue,
         encode_queue_family: u32,
         transfer_queue: vk::Queue,
@@ -509,6 +513,7 @@ impl SimpleEncoder {
             cached_header: Vec::new(),
             config,
             prepend_header,
+            submitter,
         };
 
         // Configure encoder (creates video session, DPB, etc.) — same as create_internal
@@ -773,11 +778,12 @@ impl SimpleEncoder {
 
         // Submit transfer
         let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&self.transfer_cb));
+            .command_buffers(std::slice::from_ref(&self.transfer_cb))
+            .build();
 
         self.device.reset_fences(&[self.transfer_fence])?;
-        self.device
-            .queue_submit(self.transfer_queue, &[submit], self.transfer_fence)?;
+        self.submitter
+            .submit_to_queue_legacy(self.transfer_queue, &[submit], self.transfer_fence)?;
         self.device
             .wait_for_fences(&[self.transfer_fence], true, u64::MAX)?;
 
@@ -829,6 +835,7 @@ impl SimpleEncoder {
                 self.compute_queue,
                 self.encode_queue_family,
                 codec_flag,
+                self.submitter.clone(),
             )?;
             self.rgb_to_nv12 = Some(converter);
         }

--- a/libs/vulkan-video/src/encode/submit.rs
+++ b/libs/vulkan-video/src/encode/submit.rs
@@ -1148,10 +1148,13 @@ impl SimpleEncoder {
 
         // --- Submit to queue ---
         let command_buffers = [self.command_buffer];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&command_buffers);
+        let submit_info = vk::SubmitInfo::builder()
+            .command_buffers(&command_buffers)
+            .build();
 
         device.reset_fences(&[self.fence])?;
-        device.queue_submit(self.encode_queue, &[submit_info], self.fence)?;
+        self.submitter
+            .submit_to_queue_legacy(self.encode_queue, &[submit_info], self.fence)?;
         device.wait_for_fences(&[self.fence], true, u64::MAX)?;
 
         // --- Query encode feedback ---

--- a/libs/vulkan-video/src/lib.rs
+++ b/libs/vulkan-video/src/lib.rs
@@ -22,6 +22,7 @@ pub mod decode;
 pub mod encode;
 pub mod rgb_to_nv12;
 pub mod nv12_to_rgb;
+pub mod rhi;
 
 // Re-export key types at crate root for convenience
 pub use video_context::{
@@ -33,6 +34,7 @@ pub use encode::{EncodedOutput, FrameType};
 pub use encode::{SimpleEncoder, SimpleEncoderConfig, EncodePacket, Codec, Preset};
 pub use rgb_to_nv12::RgbToNv12Converter;
 pub use nv12_to_rgb::Nv12ToRgbConverter;
+pub use rhi::{RhiQueueSubmitter, RawQueueSubmitter};
 
 // --- Internal modules (ported 1-to-1 from nvpro C++) ---
 pub mod codec_utils;

--- a/libs/vulkan-video/src/nv12_to_rgb.rs
+++ b/libs/vulkan-video/src/nv12_to_rgb.rs
@@ -67,6 +67,9 @@ pub struct Nv12ToRgbConverter {
     compute_queue: vk::Queue,
     _compute_queue_family: u32,
 
+    // Host-side queue submission gateway.
+    submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
+
     // Dimensions
     width: u32,
     height: u32,
@@ -90,6 +93,7 @@ impl Nv12ToRgbConverter {
         compute_queue_family: u32,
         compute_queue: vk::Queue,
         decode_queue_family: u32,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
     ) -> Result<Self, VideoError> {
         let device = ctx.device().clone();
         let allocator = ctx.allocator().clone();
@@ -285,6 +289,7 @@ impl Nv12ToRgbConverter {
             fence,
             compute_queue,
             _compute_queue_family: compute_queue_family,
+            submitter,
             width,
             height,
         })
@@ -468,11 +473,12 @@ impl Nv12ToRgbConverter {
 
         // --- Submit and wait ---
         let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&cb));
+            .command_buffers(std::slice::from_ref(&cb))
+            .build();
 
         self.device.reset_fences(&[self.fence])?;
-        self.device
-            .queue_submit(self.compute_queue, &[submit], self.fence)?;
+        self.submitter
+            .submit_to_queue_legacy(self.compute_queue, &[submit], self.fence)?;
         self.device
             .wait_for_fences(&[self.fence], true, u64::MAX)?;
 

--- a/libs/vulkan-video/src/rgb_to_nv12.rs
+++ b/libs/vulkan-video/src/rgb_to_nv12.rs
@@ -63,6 +63,9 @@ pub struct RgbToNv12Converter {
     compute_queue: vk::Queue,
     _compute_queue_family: u32,
 
+    // Host-side queue submission gateway.
+    submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
+
     // Dimensions
     width: u32,
     height: u32,
@@ -88,6 +91,7 @@ impl RgbToNv12Converter {
         compute_queue: vk::Queue,
         encode_queue_family: u32,
         codec_flag: vk::VideoCodecOperationFlagsKHR,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
     ) -> Result<Self, VideoError> {
         let device = ctx.device().clone();
         let allocator = ctx.allocator().clone();
@@ -323,6 +327,7 @@ impl RgbToNv12Converter {
             fence,
             compute_queue,
             _compute_queue_family: compute_queue_family,
+            submitter,
             width,
             height,
         })
@@ -473,11 +478,12 @@ impl RgbToNv12Converter {
 
         // --- Submit and wait ---
         let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&cb));
+            .command_buffers(std::slice::from_ref(&cb))
+            .build();
 
         self.device.reset_fences(&[self.fence])?;
-        self.device
-            .queue_submit(self.compute_queue, &[submit], self.fence)?;
+        self.submitter
+            .submit_to_queue_legacy(self.compute_queue, &[submit], self.fence)?;
         self.device
             .wait_for_fences(&[self.fence], true, u64::MAX)?;
 

--- a/libs/vulkan-video/src/rhi.rs
+++ b/libs/vulkan-video/src/rhi.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host RHI integration points for vulkan-video.
+//!
+//! vulkan-video submits command buffers through an [`RhiQueueSubmitter`]
+//! supplied by the host so the host's per-queue synchronization (mutexes,
+//! command queue ownership) is honored. Without this, concurrent submissions
+//! from streamlib processors and vulkan-video encode/decode threads race on
+//! the same `VkQueue` and crash the NVIDIA driver.
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+use vulkanalia::VkResult;
+
+/// Host-side gateway for `vkQueueSubmit` calls.
+pub trait RhiQueueSubmitter: Send + Sync {
+    /// Submit command buffers using the Vulkan 1.0 submit API under host
+    /// synchronization.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure the command buffers, submit info chains, and fence
+    /// are valid Vulkan handles and that `queue` belongs to the host device.
+    unsafe fn submit_to_queue_legacy(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo],
+        fence: vk::Fence,
+    ) -> VkResult<()>;
+}
+
+/// Unsynchronized submitter used when vulkan-video owns its own Vulkan device
+/// (the `SimpleEncoder::new` / `SimpleDecoder::new` paths and standalone
+/// binaries). No concurrent submissions happen in those cases, so we submit
+/// directly without taking any lock.
+pub struct RawQueueSubmitter {
+    device: vulkanalia::Device,
+}
+
+impl RawQueueSubmitter {
+    pub fn new(device: vulkanalia::Device) -> Arc<dyn RhiQueueSubmitter> {
+        Arc::new(Self { device })
+    }
+}
+
+impl RhiQueueSubmitter for RawQueueSubmitter {
+    unsafe fn submit_to_queue_legacy(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo],
+        fence: vk::Fence,
+    ) -> VkResult<()> {
+        self.device.queue_submit(queue, submits, fence).map(|_| ())
+    }
+}

--- a/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
@@ -304,6 +304,9 @@ pub struct VkVideoDecoder {
     queue: vk::Queue,
     queue_family_index: u32,
 
+    // Host-side queue submission gateway (per-queue mutex synchronization).
+    submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
+
     current_video_queue_indx: i32,
     coded_extent: vk::Extent2D,
     video_format: VkParserDetectedVideoFormat,
@@ -372,6 +375,7 @@ impl VkVideoDecoder {
         queue_family_index: u32,
         queue: vk::Queue,
         codec_operation: vk::VideoCodecOperationFlagsKHR,
+        submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
     ) -> VideoResult<Self> {
         let device = ctx.device();
 
@@ -438,6 +442,7 @@ impl VkVideoDecoder {
             ctx,
             queue,
             queue_family_index,
+            submitter,
             current_video_queue_indx: 0,
             coded_extent: vk::Extent2D::default(),
             video_format: VkParserDetectedVideoFormat::default(),
@@ -1330,8 +1335,8 @@ impl VkVideoDecoder {
         device.end_command_buffer(self.command_buffer).map_err(VideoError::from)?;
         device.reset_fences(&[self.fence]).map_err(VideoError::from)?;
         let cbs = [self.command_buffer];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs);
-        device.queue_submit(self.queue, &[submit_info], self.fence)
+        let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs).build();
+        self.submitter.submit_to_queue_legacy(self.queue, &[submit_info], self.fence)
             .map_err(VideoError::from)?;
         self.decode_in_flight = true;
 

--- a/libs/vulkan-video/tests/shared_device_test.rs
+++ b/libs/vulkan-video/tests/shared_device_test.rs
@@ -25,6 +25,7 @@ use vulkanalia_vma as vma;
 use vulkan_video::{
     SimpleEncoder, SimpleEncoderConfig, Codec, Preset,
     SimpleDecoder, SimpleDecoderConfig,
+    RawQueueSubmitter,
     decode::DpbOutputMode,
 };
 
@@ -462,12 +463,15 @@ fn h265_shared_device_encode_decode_roundtrip() {
         ..Default::default()
     };
 
+    let submitter = RawQueueSubmitter::new(device.clone());
+
     let mut encoder = SimpleEncoder::from_device(
         encoder_config,
         instance.clone(),
         device.clone(),
         physical_device,
         allocator.clone(),
+        submitter.clone(),
         encode_queue,
         encode_qf,
         transfer_queue,
@@ -577,6 +581,7 @@ fn h265_shared_device_encode_decode_roundtrip() {
         device.clone(),
         physical_device,
         allocator.clone(),
+        submitter.clone(),
         decode_queue,
         decode_qf,
         transfer_queue,

--- a/plan/277-vulkan-video-queue-sync.md
+++ b/plan/277-vulkan-video-queue-sync.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: vulkan-video synchronized queue submission via VulkanDevice
-status: pending
+status: in_review
 description: Route SimpleEncoder/SimpleDecoder queue_submit() calls through VulkanDevice's mutex-protected submit_to_queue() methods. Fixes release build SIGSEGV.
 github_issue: 277
 dependencies:

--- a/plan/282-vulkan-video-sync2-migration.md
+++ b/plan/282-vulkan-video-sync2-migration.md
@@ -1,0 +1,38 @@
+---
+whoami: amos
+name: Migrate vulkan-video to Vulkan 1.4 sync2 / SubmitInfo2
+status: pending
+description: Migrate vulkan-video's ported nvpro-samples code to Vulkan 1.4 sync2 (SubmitInfo2, cmd_pipeline_barrier_2) and delete submit_to_queue_legacy. Finishes the modernization #261 started on the streamlib side.
+github_issue: 282
+dependencies:
+  - "down:Retest camera + encoder + display roundtrip in release build"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#282
+
+## Branch
+
+Create `refactor/vulkan-video-sync2` from `main` (after #279 validates the per-queue mutex + device-lock fixes work).
+
+## Steps
+
+1. Migrate all `cmd_pipeline_barrier` calls in `libs/vulkan-video/src` to `cmd_pipeline_barrier_2` with `DependencyInfo` + `ImageMemoryBarrier2` / `BufferMemoryBarrier2`
+2. Migrate all 6 `vk::SubmitInfo` submit sites in vulkan-video to `vk::SubmitInfo2` (encode/submit.rs, encode/staging.rs, decode/mod.rs, vk_video_decoder.rs, nv12_to_rgb.rs, rgb_to_nv12.rs)
+3. Rename `RhiQueueSubmitter::submit_to_queue_legacy` → `submit_to_queue` taking `&[vk::SubmitInfo2]`
+4. Update `VulkanDevice` impl to call `queue_submit_2`; update `RawQueueSubmitter` likewise
+5. Delete the standalone `VulkanDevice::submit_to_queue_legacy` inherent method
+6. Grep-verify zero remaining `queue_submit(`, `cmd_pipeline_barrier(`, `submit_to_queue_legacy` in non-test code
+7. Run encoder + decoder unit tests
+8. Re-run the full roundtrip from #279 (release build) to confirm no regression
+
+## Testing goals
+
+- Positive: encode/decode unit tests pass; full roundtrip passes in release build
+- Negative: grep confirms no Vulkan 1.0 submit/barrier patterns remain in production code
+- Regression: no new flakiness; no perf regression (expect modest improvement from precise stage masks)
+
+## Scope notes
+
+This is mechanical but touch-heavy. Keep it as its own PR — no behavioral changes beyond the API migration. Any logic changes discovered along the way become separate follow-ups.


### PR DESCRIPTION
## Summary

- Adds `RhiQueueSubmitter` trait in `libs/vulkan-video/src/rhi.rs` as the host-provided submission gateway, plus a `RawQueueSubmitter` default impl for paths that own their own `VkDevice` (internal `::new()`, binaries, tests).
- `SimpleEncoder::from_device` / `SimpleDecoder::from_device` now take `Arc<dyn RhiQueueSubmitter>`. All six `vkQueueSubmit` sites in vulkan-video route through it (`encode/submit.rs`, `encode/staging.rs`, `decode/mod.rs`, `vk_video_decoder.rs`, `rgb_to_nv12.rs`, `nv12_to_rgb.rs`).
- streamlib's `VulkanDevice` implements the trait, forwarding to the per-queue mutex layer added in #273. H264/H265 encoder + decoder processors pass `Arc<VulkanDevice>` via `ctx.gpu.device().inner.clone()`.

Concurrent processor threads and the encoder/decoder worker threads now share the same mutex-guarded queues, fixing the release-build SIGSEGV on NVIDIA Linux caused by concurrent `vkQueueSubmit` calls.

## Issue

Closes #277

## Test Plan

- [x] `cargo check -p vulkan-video -p streamlib --all-targets` — clean (only pre-existing warnings)
- [x] `cargo build -p vulkan-video --release` — clean
- [x] `cargo build -p streamlib -p camera-display --release` — clean
- [x] `cargo test -p vulkan-video --lib` — 613 passed, 5 ignored
- [x] `cargo test -p streamlib --lib` — 146 passed, 2 ignored. Known-flaky `test_shutdown_event_exits_loop` (documented in `docs/learnings/pubsub-lazy-init-silent-noop.md`) passes in isolation; not related to this change.
- [ ] Full camera + encoder + display roundtrip in release build — deferred to #279 which is the dedicated end-to-end validation task.

## Follow-ups

- **#282** — migrate vulkan-video to Vulkan 1.4 sync2 / `SubmitInfo2`, then rename `submit_to_queue_legacy` → `submit_to_queue` and drop the 1.0 submit path. Scheduled after #279.
- **#281** — research note for future `vkQueueSubmit` batching investigation; only relevant for high-submission-rate AR compositing scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)