### PR TITLE
fix(#278): hold device-level resource lock during video session and DPB/bitstream setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,61 +22,44 @@ See [LICENSE](LICENSE) and [docs/license/](docs/license/) for full terms.
 
 ---
 
-## 🚨 ABSOLUTE RESTRICTIONS - READ FIRST 🚨
+## 🚨 CORE OPERATING PRINCIPLES — READ FIRST 🚨
 
-**Claude Code operates as a CODE HELPER ONLY. The user is the principal architect and implementor.**
+**Claude Code operates as a collaborator with the user, who is the principal architect. Think before you add; reuse before you create.**
 
-### BANNED Actions (Applies to ALL files in the codebase):
+### The StreamLib Engine Model
 
-1. **NO NEW ABSTRACTIONS**: You are BANNED from creating:
-   - New helper methods
-   - New utility functions
-   - New structs
-   - New traits
-   - New modules
-   - Any abstraction "for convenience"
+StreamLib is built like a game engine: a small set of **core systems** are reused across the entire codebase. The RHI is the canonical example — all GPU work in every platform, codec, and processor flows through `VulkanDevice` and `GpuContext`. There are NOT multiple ways to allocate GPU memory, submit to a queue, or create a texture. There is ONE way, and everything uses it.
 
-2. **NO DRY REFACTORING**: Do NOT follow the DRY principle. Duplicate code is acceptable. Do NOT extract common code into helpers.
+Past models repeatedly created parallel abstractions without reading existing code, producing module and crate sprawl where the same concern was solved N different ways. **Do not do this.** Before introducing any new abstraction, you must prove no existing core system already covers the concern — and if one does, extend it rather than build a parallel.
 
-3. **NO AUTO-FIXING**: After running `cargo check`, `cargo test`, `cargo clippy`, etc.:
-   - Report errors/warnings to the user
-   - Do NOT automatically fix them
-   - Wait for explicit instructions on what to fix
+### Before Creating Any New Abstraction
 
-4. **SCOPE RESTRICTIONS**:
-   - You may ONLY modify code within the exact scope of your current task
-   - Before editing ANY file outside the immediate scope: **STOP and ask permission**
-   - Before making changes that affect other files: **STOP and ask permission**
+"Abstraction" here means: a new trait, struct, helper method, utility function, or module intended to be reused across more than one call site.
 
-5. **MODIFICATION LIMITS**:
-   - Simple in-method fixes: Allowed
-   - Rewriting a file or large sections: **STOP and summarize your plan first**
-   - Adding new public API: **STOP and get approval**
-   - Changing existing signatures: **STOP and get approval**
+1. **Search first.** Use Grep / Glob / Agent(Explore) to find existing types, traits, or modules that already solve the concern. Typical core systems to check: `vulkan/rhi/`, `core/context/`, `core/processors/`, `core/pubsub.rs`, `rhi.rs` in sub-crates.
+2. **Prefer extending a core system** (adding a method to an existing trait or struct) over creating a new one. The RHI, GpuContext, and pubsub are deliberately central — grow them, don't route around them.
+3. **Evaluate benefits vs drawbacks explicitly.** Write down: what problem does this solve that existing abstractions don't, what is the coupling cost, is there a simpler solution (inline the logic, duplicate at two call sites, pass a closure).
+4. **If you still need a new abstraction**, propose it before implementing:
+   - **Why**: the problem and why existing systems don't cover it
+   - **What**: the new trait/struct/module and its shape
+   - **Changes**: what existing code would change
+   - **Alternatives considered**: inline, duplicate, extend existing — and why each was rejected
+   - **Risks**: coupling, lifetime, thread-safety, API surface
+5. **Document the decision in the PR description** so reviewers know a new core-shape concern was added intentionally. If the abstraction is load-bearing (used by multiple crates or platforms), add a short section in the PR explaining where it fits in the engine model.
 
-### When You Think You Need Something Banned:
+Minor helpers within a single module, bug-fix-scoped private functions, and extensions to existing traits generally do not require this process — but still search first and default to the smallest change that works.
 
-If you believe a new struct, trait, helper, or abstraction is genuinely required, you MUST:
+### Other Guardrails
 
-1. **STOP IMMEDIATELY** - Do not implement it
-2. Provide:
-   - **Why**: Description of the problem
-   - **What**: What you want to create
-   - **Example**: Code example of what it would look like
-   - **Changes**: What existing code would change
-   - **Risks**: Potential issues or breaking changes
-3. **WAIT** for explicit approval before proceeding
+1. **No silent DRY refactors.** Duplicate code across unrelated call sites is fine. Extracting a helper is fine IF it replaces real duplication in a core system AND the extraction is mentioned in the PR. Don't refactor out of aesthetic preference alone.
 
-### Violations of These Rules Are Unacceptable
+2. **No auto-fixing on the side.** If `cargo check`, `cargo test`, or `cargo clippy` surfaces problems outside the current task, report them — do not silently fix unrelated issues in the same branch.
 
-Previous violations included:
-- Creating "helper" traits that bypass the API
-- Adding structs "for convenience"
-- Refactoring to reduce duplication without permission
-- Auto-fixing test failures
-- Modifying files outside the requested scope
-
-**These rules override ALL other instructions in this document.**
+3. **Scope discipline.**
+   - Modify files within the task's scope. Files outside scope: ask before editing.
+   - Simple in-method fixes: allowed.
+   - Rewriting a file or large section: summarize the plan first.
+   - Adding new public API or changing existing signatures: get approval.
 
 ### Work Tracking
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -1066,6 +1066,11 @@ impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
             .unwrap_or_else(|e| e.into_inner());
         self.device.queue_submit(queue, submits, fence).map(|_| ())
     }
+
+    fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
+        let _guard = self.lock_device();
+        f();
+    }
 }
 
 impl VulkanDevice {

--- a/libs/vulkan-video/src/codec_utils/vulkan_video_session.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_video_session.rs
@@ -95,6 +95,7 @@ impl VulkanVideoSession {
         _instance: &vulkanalia::Instance,
         _physical_device: vk::PhysicalDevice,
         allocator: &Arc<vma::Allocator>,
+        submitter: &Arc<dyn crate::rhi::RhiQueueSubmitter>,
         params: &VideoSessionCreateParams,
     ) -> Result<Arc<Self>, vk::Result> {
         // --- Build the std header version based on codec type ---------
@@ -113,9 +114,28 @@ impl VulkanVideoSession {
             .reference_picture_format(params.reference_pictures_format)
             .std_header_version(&std_header_version);
 
+        // Session creation, memory allocation, and binding all run under the
+        // host's device-level resource lock so concurrent queue submissions on
+        // NVIDIA Linux cannot race with them (fixes #278).
+        let mut result: Result<Arc<Self>, vk::Result> =
+            Err(vk::Result::ERROR_INITIALIZATION_FAILED);
+        let result_ref = &mut result;
+        submitter.with_device_resource_lock(&mut || {
+            *result_ref = Self::create_locked(device, allocator, params, &create_info);
+        });
+        result
+    }
+
+    /// Must be called while holding the host's device-level resource lock.
+    unsafe fn create_locked(
+        device: &vulkanalia::Device,
+        allocator: &Arc<vma::Allocator>,
+        params: &VideoSessionCreateParams,
+        create_info: &vk::VideoSessionCreateInfoKHRBuilder,
+    ) -> Result<Arc<Self>, vk::Result> {
         // --- Create the VkVideoSessionKHR ----------------------------
         let video_session = device
-            .create_video_session_khr(&create_info, None)
+            .create_video_session_khr(create_info, None)
             .map_err(|e| e)?;
 
         let mut allocations: Vec<vma::Allocation> = Vec::new();

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -228,38 +228,59 @@ impl SimpleEncoder {
             )
             .std_header_version(&caps.std_header_version);
 
-        let video_session = device.create_video_session_khr(&session_create_info, None)?;
-
-        // --- Bind session memory ---
-        let mem_requirements = device.get_video_session_memory_requirements_khr(video_session)?;
-
-        let mut session_memory = Vec::with_capacity(mem_requirements.len());
-        let mut bind_infos = Vec::with_capacity(mem_requirements.len());
-
+        // Video session creation, memory allocation, and binding run under the
+        // host's device-level resource lock (fixes #278 — prevents NVIDIA
+        // driver crashes when concurrent processors submit during setup).
         let allocator = self.ctx.allocator();
-        for req in &mem_requirements {
-            let alloc_options = vma::AllocationOptions {
-                usage: vma::MemoryUsage::Unknown,
-                memory_type_bits: req.memory_requirements.memory_type_bits,
-                ..Default::default()
-            };
+        let mut session_result: VideoResult<(
+            vk::VideoSessionKHR,
+            Vec<vma::Allocation>,
+        )> = Err(VideoError::Vulkan(vk::Result::ERROR_INITIALIZATION_FAILED));
+        let session_result_ref = &mut session_result;
+        self.submitter.with_device_resource_lock(&mut || {
+            *session_result_ref = (|| {
+                let video_session = device
+                    .create_video_session_khr(&session_create_info, None)
+                    .map_err(VideoError::from)?;
 
-            let allocation = allocator
-                .allocate_memory(req.memory_requirements, &alloc_options)?;
+                let mem_requirements = device
+                    .get_video_session_memory_requirements_khr(video_session)
+                    .map_err(VideoError::from)?;
 
-            let alloc_info = allocator.get_allocation_info(allocation);
-            session_memory.push(allocation);
+                let mut session_memory = Vec::with_capacity(mem_requirements.len());
+                let mut bind_infos = Vec::with_capacity(mem_requirements.len());
 
-            bind_infos.push(
-                vk::BindVideoSessionMemoryInfoKHR::builder()
-                    .memory_bind_index(req.memory_bind_index)
-                    .memory(alloc_info.deviceMemory)
-                    .memory_offset(alloc_info.offset)
-                    .memory_size(req.memory_requirements.size),
-            );
-        }
+                for req in &mem_requirements {
+                    let alloc_options = vma::AllocationOptions {
+                        usage: vma::MemoryUsage::Unknown,
+                        memory_type_bits: req.memory_requirements.memory_type_bits,
+                        ..Default::default()
+                    };
 
-        device.bind_video_session_memory_khr(video_session, &bind_infos)?;
+                    let allocation = allocator
+                        .allocate_memory(req.memory_requirements, &alloc_options)
+                        .map_err(VideoError::from)?;
+
+                    let alloc_info = allocator.get_allocation_info(allocation);
+                    session_memory.push(allocation);
+
+                    bind_infos.push(
+                        vk::BindVideoSessionMemoryInfoKHR::builder()
+                            .memory_bind_index(req.memory_bind_index)
+                            .memory(alloc_info.deviceMemory)
+                            .memory_offset(alloc_info.offset)
+                            .memory_size(req.memory_requirements.size),
+                    );
+                }
+
+                device
+                    .bind_video_session_memory_khr(video_session, &bind_infos)
+                    .map_err(VideoError::from)?;
+
+                Ok((video_session, session_memory))
+            })();
+        });
+        let (video_session, session_memory) = session_result?;
 
         // --- Determine H.265 CTB size from capabilities ---
         // The driver reports supported CTB sizes; we pick the largest supported
@@ -820,7 +841,17 @@ impl SimpleEncoder {
                 image_create_info.next =
                     &*profile_list as *const vk::VideoProfileListInfoKHR as *const std::ffi::c_void;
 
-                let (image, allocation) = allocator.create_image(image_create_info, &alloc_options)?;
+                // DPB image allocation runs under the host's device-level
+                // resource lock (fixes #278).
+                let mut alloc_result: VideoResult<(vk::Image, vma::Allocation)> =
+                    Err(VideoError::Vulkan(vk::Result::ERROR_INITIALIZATION_FAILED));
+                let alloc_result_ref = &mut alloc_result;
+                self.submitter.with_device_resource_lock(&mut || {
+                    *alloc_result_ref = allocator
+                        .create_image(image_create_info, &alloc_options)
+                        .map_err(VideoError::from);
+                });
+                let (image, allocation) = alloc_result?;
 
                 let view_info = vk::ImageViewCreateInfo::builder()
                     .image(image)
@@ -868,7 +899,17 @@ impl SimpleEncoder {
             image_create_info.next =
                 &*profile_list as *const vk::VideoProfileListInfoKHR as *const std::ffi::c_void;
 
-            let (image, allocation) = allocator.create_image(image_create_info, &alloc_options)?;
+            // DPB image allocation runs under the host's device-level
+            // resource lock (fixes #278).
+            let mut alloc_result: VideoResult<(vk::Image, vma::Allocation)> =
+                Err(VideoError::Vulkan(vk::Result::ERROR_INITIALIZATION_FAILED));
+            let alloc_result_ref = &mut alloc_result;
+            self.submitter.with_device_resource_lock(&mut || {
+                *alloc_result_ref = allocator
+                    .create_image(image_create_info, &alloc_options)
+                    .map_err(VideoError::from);
+            });
+            let (image, allocation) = alloc_result?;
 
             for i in 0..count {
                 let view_info = vk::ImageViewCreateInfo::builder()
@@ -931,7 +972,17 @@ impl SimpleEncoder {
             ..Default::default()
         };
 
-        let (buffer, allocation) = allocator.create_buffer(buffer_create_info, &alloc_options)?;
+        // Bitstream buffer allocation runs under the host's device-level
+        // resource lock (fixes #278).
+        let mut alloc_result: VideoResult<(vk::Buffer, vma::Allocation)> =
+            Err(VideoError::Vulkan(vk::Result::ERROR_INITIALIZATION_FAILED));
+        let alloc_result_ref = &mut alloc_result;
+        self.submitter.with_device_resource_lock(&mut || {
+            *alloc_result_ref = allocator
+                .create_buffer(buffer_create_info, &alloc_options)
+                .map_err(VideoError::from);
+        });
+        let (buffer, allocation) = alloc_result?;
 
         let info = allocator.get_allocation_info(allocation);
         let mapped = info.pMappedData as *mut u8;

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -251,7 +251,7 @@ impl SimpleEncoder {
             cached_header: Vec::new(),
             config,
             prepend_header,
-            submitter,
+            submitter: submitter.clone(),
         };
 
         // Configure encoder (creates video session, DPB, etc.)
@@ -338,8 +338,15 @@ impl SimpleEncoder {
             required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
             ..Default::default()
         };
-        let (source_image, source_allocation) =
-            allocator.create_image(src_image_info, &src_alloc_options)?;
+        // Staging source image allocation runs under the host's device-level
+        // resource lock (fixes #278 — same race window as session setup).
+        let mut img_result: vulkanalia::VkResult<(vk::Image, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let img_result_ref = &mut img_result;
+        submitter.with_device_resource_lock(&mut || {
+            *img_result_ref = allocator.create_image(src_image_info, &src_alloc_options);
+        });
+        let (source_image, source_allocation) = img_result.map_err(VideoError::from)?;
 
         let source_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
@@ -372,8 +379,15 @@ impl SimpleEncoder {
             ..Default::default()
         };
 
-        let (staging_buffer, staging_allocation) =
-            allocator.create_buffer(stg_create_info, &stg_alloc_options)?;
+        // Staging buffer allocation runs under the host's device-level
+        // resource lock (fixes #278).
+        let mut buf_result: vulkanalia::VkResult<(vk::Buffer, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let buf_result_ref = &mut buf_result;
+        submitter.with_device_resource_lock(&mut || {
+            *buf_result_ref = allocator.create_buffer(stg_create_info, &stg_alloc_options);
+        });
+        let (staging_buffer, staging_allocation) = buf_result.map_err(VideoError::from)?;
 
         let stg_info = allocator.get_allocation_info(staging_allocation);
         let staging_mapped_ptr = stg_info.pMappedData as *mut u8;
@@ -513,7 +527,7 @@ impl SimpleEncoder {
             cached_header: Vec::new(),
             config,
             prepend_header,
-            submitter,
+            submitter: submitter.clone(),
         };
 
         // Configure encoder (creates video session, DPB, etc.) — same as create_internal
@@ -582,8 +596,15 @@ impl SimpleEncoder {
             required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
             ..Default::default()
         };
-        let (source_image, source_allocation) =
-            allocator.create_image(src_image_info, &src_alloc_options)?;
+        // Staging source image allocation runs under the host's device-level
+        // resource lock (fixes #278).
+        let mut img_result: vulkanalia::VkResult<(vk::Image, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let img_result_ref = &mut img_result;
+        submitter.with_device_resource_lock(&mut || {
+            *img_result_ref = allocator.create_image(src_image_info, &src_alloc_options);
+        });
+        let (source_image, source_allocation) = img_result.map_err(VideoError::from)?;
 
         let source_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
@@ -610,8 +631,15 @@ impl SimpleEncoder {
                 | vk::MemoryPropertyFlags::HOST_COHERENT,
             ..Default::default()
         };
-        let (staging_buffer, staging_allocation) =
-            allocator.create_buffer(stg_create_info, &stg_alloc_options)?;
+        // Staging buffer allocation runs under the host's device-level
+        // resource lock (fixes #278).
+        let mut buf_result: vulkanalia::VkResult<(vk::Buffer, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let buf_result_ref = &mut buf_result;
+        submitter.with_device_resource_lock(&mut || {
+            *buf_result_ref = allocator.create_buffer(stg_create_info, &stg_alloc_options);
+        });
+        let (staging_buffer, staging_allocation) = buf_result.map_err(VideoError::from)?;
         let stg_info = allocator.get_allocation_info(staging_allocation);
         let staging_mapped_ptr = stg_info.pMappedData as *mut u8;
         if staging_mapped_ptr.is_null() {

--- a/libs/vulkan-video/src/rhi.rs
+++ b/libs/vulkan-video/src/rhi.rs
@@ -30,6 +30,12 @@ pub trait RhiQueueSubmitter: Send + Sync {
         submits: &[vk::SubmitInfo],
         fence: vk::Fence,
     ) -> VkResult<()>;
+
+    /// Run `f` while holding the host's device-level resource-creation lock.
+    /// Wraps `vkCreateVideoSessionKHR`, DPB image allocation, bitstream buffer
+    /// allocation, and `vkBindVideoSessionMemoryKHR` so they cannot race with
+    /// concurrent submissions from other processors on NVIDIA Linux.
+    fn with_device_resource_lock(&self, f: &mut dyn FnMut());
 }
 
 /// Unsynchronized submitter used when vulkan-video owns its own Vulkan device
@@ -54,5 +60,11 @@ impl RhiQueueSubmitter for RawQueueSubmitter {
         fence: vk::Fence,
     ) -> VkResult<()> {
         self.device.queue_submit(queue, submits, fence).map(|_| ())
+    }
+
+    fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
+        // Standalone mode owns the Vulkan device exclusively; no concurrent
+        // submissions exist, so no locking is required.
+        f();
     }
 }

--- a/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
@@ -609,6 +609,7 @@ impl VkVideoDecoder {
             self.ctx.instance(),
             self.ctx.physical_device(),
             self.ctx.allocator(),
+            &self.submitter,
             &session_params,
         ) } {
             Ok(s) => s,
@@ -663,7 +664,18 @@ impl VkVideoDecoder {
             ..Default::default()
         };
 
-        match unsafe { self.ctx.allocator().create_image(image_create, &alloc_options) } {
+        // DPB image allocation runs under the host's device-level resource
+        // lock (fixes #278).
+        let mut dpb_result: vulkanalia::VkResult<(vk::Image, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let dpb_result_ref = &mut dpb_result;
+        let dpb_allocator = self.ctx.allocator();
+        self.submitter.with_device_resource_lock(&mut || {
+            *dpb_result_ref = unsafe {
+                dpb_allocator.create_image(image_create, &alloc_options)
+            };
+        });
+        match dpb_result {
             Ok((image, allocation)) => {
                 self.dpb_image = image;
                 self.dpb_allocation = allocation;
@@ -721,7 +733,18 @@ impl VkVideoDecoder {
             ..Default::default()
         };
 
-        match unsafe { self.ctx.allocator().create_buffer(bs_create, &bs_alloc_options) } {
+        // Bitstream buffer allocation runs under the host's device-level
+        // resource lock (fixes #278).
+        let mut bs_result: vulkanalia::VkResult<(vk::Buffer, vma::Allocation)> =
+            Err(vk::ErrorCode::INITIALIZATION_FAILED);
+        let bs_result_ref = &mut bs_result;
+        let bs_allocator = self.ctx.allocator();
+        self.submitter.with_device_resource_lock(&mut || {
+            *bs_result_ref = unsafe {
+                bs_allocator.create_buffer(bs_create, &bs_alloc_options)
+            };
+        });
+        match bs_result {
             Ok((buffer, allocation)) => {
                 let info = self.ctx.allocator().get_allocation_info(allocation);
                 self.bitstream_buffer = buffer;
@@ -866,8 +889,18 @@ impl VkVideoDecoder {
                     | vk::MemoryPropertyFlags::HOST_COHERENT,
                 ..Default::default()
             };
-            let (buf, alloc) = self.ctx.allocator().create_buffer(bs_create, &bs_alloc)
-                .map_err(VideoError::from)?;
+            // Bitstream resize runs under the host's device-level resource
+            // lock (fixes #278).
+            let mut resize_result: vulkanalia::VkResult<(vk::Buffer, vma::Allocation)> =
+                Err(vk::ErrorCode::INITIALIZATION_FAILED);
+            let resize_result_ref = &mut resize_result;
+            let resize_allocator = self.ctx.allocator();
+            self.submitter.with_device_resource_lock(&mut || {
+                *resize_result_ref = unsafe {
+                    resize_allocator.create_buffer(bs_create, &bs_alloc)
+                };
+            });
+            let (buf, alloc) = resize_result.map_err(VideoError::from)?;
             let info = self.ctx.allocator().get_allocation_info(alloc);
             self.bitstream_buffer = buf;
             self.bitstream_allocation = alloc;

--- a/plan/278-device-level-resource-lock.md
+++ b/plan/278-device-level-resource-lock.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Device-level lock for GPU resource creation during concurrent operations
-status: pending
+status: in_review
 description: Wrap vulkan-video session creation and DPB allocation with VulkanDevice::lock_device() to prevent races with concurrent GPU submissions.
 github_issue: 278
 dependencies:


### PR DESCRIPTION
## Summary

- Adds `with_device_resource_lock` to the `RhiQueueSubmitter` trait so vulkan-video can run resource-creation calls under the host's device-level mutex (the mutex added in #273, previously unused).
- Wraps all vulkan-video setup-time allocation sites: `vkCreateVideoSessionKHR`, session memory allocation, `vkBindVideoSessionMemoryKHR`, DPB `VMA create_image` (encoder separate + shared-array paths, decoder), bitstream `VMA create_buffer` (encoder, decoder initial + resize path), and the staging source image + staging buffer in `encode/staging.rs`.
- Fixes the NVIDIA Linux driver races where concurrent processor submissions during encoder/decoder setup produced SIGSEGV or spurious `ERROR_OUT_OF_DEVICE_MEMORY`.

## Issue

Closes #278

## Architecture note — new trait method on `RhiQueueSubmitter`

Per the revised CLAUDE.md guidance (search-first, prefer extending core systems), this change extends the existing `RhiQueueSubmitter` trait rather than introducing a parallel \"resource lock\" abstraction. `RhiQueueSubmitter` is already the sole host↔vulkan-video gateway for synchronization concerns (queue submission), wired through `Arc<dyn RhiQueueSubmitter>` to `SimpleEncoder`, `SimpleDecoder`, and `VkVideoDecoder`. Adding a second trait would have duplicated the gateway and required threading two trait objects to every call site that needs either concern.

The new method uses a closure signature (`fn with_device_resource_lock(&self, f: &mut dyn FnMut())`) for object safety without introducing a new guard struct:
- `VulkanDevice` impl acquires `self.device_mutex` via the existing `lock_device()` and invokes `f()` under the guard.
- `RawQueueSubmitter` (standalone `SimpleEncoder::new` / `SimpleDecoder::new` paths, no concurrent submissions) runs `f()` directly.

Alternatives considered:
- **New `RhiResourceLock` trait** — rejected: duplicates the host-gateway concept and doubles the trait-object plumbing.
- **`Arc<Mutex<()>>` passed directly** — rejected: leaks an implementation detail across the crate boundary; standalone mode would need a dummy mutex.
- **Guard-returning method** — rejected: Rust trait object safety + `MutexGuard<'_, ()>` lifetime gymnastics would have required a new helper struct (`DeviceResourceLockGuard`) without a clear benefit over the closure form.

Zero ergonomic impact on processors — the lock lives entirely inside the host-gateway seam and never reaches code that uses `GpuContext`.

## Not in this PR (intentional)

Three C++-port `create` helpers (`codec_utils/vk_image_resource.rs::create`, `codec_utils/vk_buffer_resource.rs::create`, `codec_utils/vulkan_bitstream_buffer_impl.rs::create_buffer`) are listed in the #278 plan but have no production callers. Wrapping them would thread a `submitter` parameter through inert code; if/when they are resurrected, the author will need to re-audit locking based on the calling context anyway.

## Test Plan

- [x] `cargo check -p streamlib` passes
- [x] `cargo check -p vulkan-video` passes
- [x] `cargo test -p streamlib --lib` — 147 passed
- [x] `cargo test -p vulkan-video --lib` — 613 passed
- [x] `cargo build --release -p streamlib -p vulkan-video` passes
- [ ] End-to-end release roundtrip (camera + encoder + decoder + display) — covered by #279

## Follow-ups

- #279 (release-build roundtrip retest) — the next task in the chain, now unblocked.

## Related

Also includes a revision to `CLAUDE.md` that replaces the blanket no-new-abstractions ban with an engine-model framing (search-first, reuse core systems, document in PRs). This trait extension is the first change made under the new guidance.