### PR TITLE
fix(#287): bind vulkanalia builder slice temporaries to locals

### DIFF
--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -1210,9 +1210,11 @@ fn capture_thread_loop(
             let frame_num_peek = frame_counter.load(Ordering::Relaxed);
             if frame_num_peek >= RING_TEXTURE_COUNT as u64 {
                 let wait_value = frame_num_peek - (RING_TEXTURE_COUNT as u64 - 1);
+                let wait_semaphores = [camera_timeline_semaphore];
+                let wait_values = [wait_value];
                 let wait_info = vk::SemaphoreWaitInfo::builder()
-                    .semaphores(&[camera_timeline_semaphore])
-                    .values(&[wait_value])
+                    .semaphores(&wait_semaphores)
+                    .values(&wait_values)
                     .build();
                 unsafe {
                     let _ = device.wait_semaphores(&wait_info, u64::MAX);
@@ -1265,9 +1267,11 @@ fn capture_thread_loop(
             let frame_num_peek = frame_counter.load(Ordering::Relaxed);
             if frame_num_peek >= RING_TEXTURE_COUNT as u64 {
                 let wait_value = frame_num_peek - (RING_TEXTURE_COUNT as u64 - 1);
+                let wait_semaphores = [camera_timeline_semaphore];
+                let wait_values = [wait_value];
                 let wait_info = vk::SemaphoreWaitInfo::builder()
-                    .semaphores(&[camera_timeline_semaphore])
-                    .values(&[wait_value])
+                    .semaphores(&wait_semaphores)
+                    .values(&wait_values)
                     .build();
                 unsafe {
                     let _ = device.wait_semaphores(&wait_info, u64::MAX);
@@ -1587,9 +1591,11 @@ fn capture_thread_loop(
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(compute_command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
+            let signal_semaphore_infos = [signal_semaphore];
             let submit = vk::SubmitInfo2::builder()
-                .command_buffer_infos(&[cmd_info])
-                .signal_semaphore_infos(&[signal_semaphore])
+                .command_buffer_infos(&cmd_infos)
+                .signal_semaphore_infos(&signal_semaphore_infos)
                 .build();
 
             if let Err(e) = vulkan_device.submit_to_queue(queue, &[submit], vk::Fence::null()) {
@@ -1610,9 +1616,11 @@ fn capture_thread_loop(
             }
 
             // Wait for GPU to finish so the pixel buffer is host-readable for IPC
+            let wait_semaphores = [camera_timeline_semaphore];
+            let wait_values = [timeline_signal_value];
             let wait_info = vk::SemaphoreWaitInfo::builder()
-                .semaphores(&[camera_timeline_semaphore])
-                .values(&[timeline_signal_value])
+                .semaphores(&wait_semaphores)
+                .values(&wait_values)
                 .build();
             let _ = device.wait_semaphores(&wait_info, u64::MAX);
         }

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -709,8 +709,9 @@ impl DisplayEventLoopHandler {
                 .image(swapchain_image)
                 .subresource_range(color_subresource_range)
                 .build();
+            let swapchain_barriers = [swapchain_barrier];
             let dep = vk::DependencyInfo::builder()
-                .image_memory_barriers(&[swapchain_barrier])
+                .image_memory_barriers(&swapchain_barriers)
                 .build();
             device.cmd_pipeline_barrier2(command_buffer, &dep);
 
@@ -824,8 +825,9 @@ impl DisplayEventLoopHandler {
                 .subresource_range(color_subresource_range)
                 .build();
 
+            let present_barriers = [present_barrier];
             let post_render_dep = vk::DependencyInfo::builder()
-                .image_memory_barriers(&[present_barrier])
+                .image_memory_barriers(&present_barriers)
                 .build();
             device.cmd_pipeline_barrier2(command_buffer, &post_render_dep);
 
@@ -869,11 +871,12 @@ impl DisplayEventLoopHandler {
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
 
             let submit = vk::SubmitInfo2::builder()
                 .wait_semaphore_infos(&wait_semaphore_infos)
                 .signal_semaphore_infos(&signal_semaphore_infos)
-                .command_buffer_infos(&[cmd_info])
+                .command_buffer_infos(&cmd_infos)
                 .build();
 
             if let Err(e) =

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -121,9 +121,11 @@ impl RhiBlitter for VulkanBlitter {
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
+            let signal_semaphore_infos = [signal_semaphore];
             let submit = vk::SubmitInfo2::builder()
-                .command_buffer_infos(&[cmd_info])
-                .signal_semaphore_infos(&[signal_semaphore])
+                .command_buffer_infos(&cmd_infos)
+                .signal_semaphore_infos(&signal_semaphore_infos)
                 .build();
 
             self.vulkan_device

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
@@ -177,9 +177,11 @@ impl VulkanCommandBuffer {
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(self.command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
+            let signal_semaphore_infos = [signal_semaphore];
             let submit = vk::SubmitInfo2::builder()
-                .command_buffer_infos(&[cmd_info])
-                .signal_semaphore_infos(&[signal_semaphore])
+                .command_buffer_infos(&cmd_infos)
+                .signal_semaphore_infos(&signal_semaphore_infos)
                 .build();
 
             self.vulkan_device
@@ -239,9 +241,11 @@ impl VulkanCommandBuffer {
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(self.command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
+            let signal_semaphore_infos = [signal_semaphore];
             let submit = vk::SubmitInfo2::builder()
-                .command_buffer_infos(&[cmd_info])
-                .signal_semaphore_infos(&[signal_semaphore])
+                .command_buffer_infos(&cmd_infos)
+                .signal_semaphore_infos(&signal_semaphore_infos)
                 .build();
 
             self.vulkan_device

--- a/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
@@ -413,8 +413,9 @@ impl VulkanFormatConverter {
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
                 .command_buffer(self.compute_command_buffer)
                 .build();
+            let cmd_infos = [cmd_info];
             let submit = vk::SubmitInfo2::builder()
-                .command_buffer_infos(&[cmd_info])
+                .command_buffer_infos(&cmd_infos)
                 .build();
 
             self.vulkan_device


### PR DESCRIPTION
## Summary
- Inline `&[...]` slice arguments passed to vulkanalia builders (`SubmitInfo2`, `SemaphoreWaitInfo`, `DependencyInfo`) were anonymous temporaries freed at end-of-statement. `.build()` strips the builder lifetime, leaving the raw Vulkan struct with dangling `p_command_buffer_infos`, `p_signal_semaphore_infos`, `p_semaphores`, `p_values`, and `p_image_memory_barriers` pointers when read by the driver on the next statement.
- Bound each array to a named local so the backing storage outlives the struct. 11 call sites fixed across `camera.rs`, `display.rs`, `vulkan_blitter.rs`, `vulkan_command_buffer.rs`, and `vulkan_format_converter.rs`.
- Verified under `VK_LAYER_KHRONOS_validation` on release build: all 5 targeted VUID categories from #287 (`VkCommandBufferSubmitInfo-*`, `VkSemaphoreSubmitInfo-*`, `VkSemaphoreWaitInfo-*`, `VkImageMemoryBarrier2-sType-sType`, `VkImageMemoryBarrier2-*-parameter`) are silent.

## Issue
Closes #287

## Test Plan
- [x] `cargo check -p streamlib` passes
- [x] `cargo test -p streamlib --lib` — 147 passed, 0 failed
- [x] `cargo build --release -p streamlib` passes
- [x] `libs/streamlib/tests/fixtures/e2e_camera_display.sh` — 120 frames captured, clean shutdown, 0 OOM, 6 PNG samples
- [x] Release run under `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` — 65 frames, zero `VkCommandBufferSubmitInfo` / `VkSemaphoreSubmitInfo` / `VkSemaphoreWaitInfo` / `VkImageMemoryBarrier2-sType` / `VkImageMemoryBarrier2-*-parameter` errors

## Follow-ups
Remaining validation errors observed during verification belong to other open tasks:
- `VUID-VkImageMemoryBarrier2-oldLayout-01212` + `VUID-vkCmdCopyImageToBuffer-srcImage-00186` — #288 (camera ring texture missing `TRANSFER_SRC_BIT`)
- `VUID-vkBindBufferMemory-memory-01035` — #290 (VMA memory-type mismatch)
- `VUID-vkGetDeviceQueue-queueFamilyIndex-00384` — #291 (unexposed queue family)
- `VUID-vkQueueSubmit2-semaphore-03868` — new: binary render-finished semaphore reused before prior present completes; not yet filed