### PR TITLE
fix(#288): add COPY_SRC usage to camera ring textures

### DIFF
--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -760,7 +760,11 @@ fn capture_thread_loop(
     // budget before the swapchain consumes it.
     // -----------------------------------------------------------------------
     let ring_texture_desc = TextureDescriptor::new(width, height, TextureFormat::Rgba8Unorm)
-        .with_usage(TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING);
+        .with_usage(
+            TextureUsages::STORAGE_BINDING
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+        );
 
     let mut ring_textures: Vec<StreamTexture> = Vec::with_capacity(RING_TEXTURE_COUNT);
     let mut ring_texture_ids: Vec<String> = Vec::with_capacity(RING_TEXTURE_COUNT);

--- a/plan/293-ci-vulkan-validation.md
+++ b/plan/293-ci-vulkan-validation.md
@@ -4,6 +4,8 @@ name: CI with Vulkan validation layer
 status: pending
 description: Run at least one release-build roundtrip in CI with VK_LOADER_LAYERS_ENABLE=*validation* and fail on any validation error.
 github_issue: 293
+dependencies:
+  - "down:Retest camera + encoder + display roundtrip after Vulkan cleanup"
 adapters:
   github: builtin
 ---
@@ -19,7 +21,7 @@ Create `test/ci-validation-layer` from `main`.
 1. Add `vulkan-validationlayers` to the CI runner image / dev bootstrap script.
 2. Create a runner helper (shell or Rust) that spawns an example under `VK_LOADER_LAYERS_ENABLE="*validation*"`, parses output, and exits non-zero on any `Validation Error`.
 3. Add a CI job that runs a ≤ 5 s vivid H.264 roundtrip under the helper.
-4. Decide on baseline: either land after #287-#291 clean up the output, or start with an explicit allowlist of currently-known VUIDs and tighten as each issue closes.
+4. Baseline: land after #294 rollup retest confirms #287-#292 and #296 fixes cleaned up the validation output. No allowlist needed.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Add `TextureUsages::COPY_SRC` to the Linux camera ring `TextureDescriptor` so the created `VkImage` has `TRANSFER_SRC_BIT`, making the `cmd_copy_image_to_buffer` fallback path spec-valid.
- Gate #293 (CI validation-layer job) behind #294 rollup retest so it lands only once the VUID-producing bugs (#287–#292, #296) are cleaned up.

## Issue
Closes #288

## Test Plan
- [x] `cargo check -p streamlib` passes
- [x] `cargo test -p streamlib --lib linux::processors::camera` passes (2 passed, 1 ignored live-camera test)
- [ ] Validation-layer E2E confirmed by #294 rollup retest (by design — this PR is one of #294's deps)

## Follow-ups
- None