### PR TITLE
fix(#289): chain VkSamplerYcbcrConversionInfo on NV12 image views

### DIFF
--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -853,6 +853,8 @@ impl SimpleEncoder {
                 });
                 let (image, allocation) = alloc_result?;
 
+                let mut ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+                    .conversion(self.ctx.nv12_ycbcr_conversion());
                 let view_info = vk::ImageViewCreateInfo::builder()
                     .image(image)
                     .view_type(vk::ImageViewType::_2D)
@@ -863,7 +865,8 @@ impl SimpleEncoder {
                         level_count: 1,
                         base_array_layer: 0,
                         layer_count: 1,
-                    });
+                    })
+                    .push_next(&mut ycbcr_info);
 
                 let view = device.create_image_view(&view_info, None)?;
 
@@ -911,6 +914,9 @@ impl SimpleEncoder {
             });
             let (image, allocation) = alloc_result?;
 
+            let mut ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+                .conversion(self.ctx.nv12_ycbcr_conversion());
+
             for i in 0..count {
                 let view_info = vk::ImageViewCreateInfo::builder()
                     .image(image)
@@ -922,7 +928,8 @@ impl SimpleEncoder {
                         level_count: 1,
                         base_array_layer: i,
                         layer_count: 1,
-                    });
+                    })
+                    .push_next(&mut ycbcr_info);
 
                 let view = device.create_image_view(&view_info, None)?;
 

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -348,6 +348,8 @@ impl SimpleEncoder {
         });
         let (source_image, source_allocation) = img_result.map_err(VideoError::from)?;
 
+        let mut source_ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+            .conversion(ctx.nv12_ycbcr_conversion());
         let source_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
                 .image(source_image)
@@ -359,7 +361,8 @@ impl SimpleEncoder {
                     level_count: 1,
                     base_array_layer: 0,
                     layer_count: 1,
-                }),
+                })
+                .push_next(&mut source_ycbcr_info),
             None,
         )?;
 
@@ -606,6 +609,8 @@ impl SimpleEncoder {
         });
         let (source_image, source_allocation) = img_result.map_err(VideoError::from)?;
 
+        let mut source_ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+            .conversion(ctx.nv12_ycbcr_conversion());
         let source_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
                 .image(source_image)
@@ -615,7 +620,8 @@ impl SimpleEncoder {
                     aspect_mask: vk::ImageAspectFlags::COLOR,
                     base_mip_level: 0, level_count: 1,
                     base_array_layer: 0, layer_count: 1,
-                }),
+                })
+                .push_next(&mut source_ycbcr_info),
             None,
         )?;
 

--- a/libs/vulkan-video/src/rgb_to_nv12.rs
+++ b/libs/vulkan-video/src/rgb_to_nv12.rs
@@ -241,6 +241,8 @@ impl RgbToNv12Converter {
         // --- 6. Image views ---
 
         // COLOR view for vkCmdEncodeVideoKHR (combined planes).
+        let mut color_view_ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+            .conversion(ctx.nv12_ycbcr_conversion());
         let nv12_color_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
                 .image(nv12_image)
@@ -252,7 +254,8 @@ impl RgbToNv12Converter {
                     level_count: 1,
                     base_array_layer: 0,
                     layer_count: 1,
-                }),
+                })
+                .push_next(&mut color_view_ycbcr_info),
             None,
         )?;
 

--- a/libs/vulkan-video/src/video_context.rs
+++ b/libs/vulkan-video/src/video_context.rs
@@ -60,6 +60,27 @@ pub fn reject_software_renderer(
     )
 }
 
+fn create_nv12_ycbcr_conversion(
+    device: &vulkanalia::Device,
+) -> VideoResult<vk::SamplerYcbcrConversion> {
+    let info = vk::SamplerYcbcrConversionCreateInfo::builder()
+        .format(vk::Format::G8_B8R8_2PLANE_420_UNORM)
+        .ycbcr_model(vk::SamplerYcbcrModelConversion::YCBCR_709)
+        .ycbcr_range(vk::SamplerYcbcrRange::ITU_NARROW)
+        .components(vk::ComponentMapping {
+            r: vk::ComponentSwizzle::IDENTITY,
+            g: vk::ComponentSwizzle::IDENTITY,
+            b: vk::ComponentSwizzle::IDENTITY,
+            a: vk::ComponentSwizzle::IDENTITY,
+        })
+        .x_chroma_offset(vk::ChromaLocation::MIDPOINT)
+        .y_chroma_offset(vk::ChromaLocation::MIDPOINT)
+        .chroma_filter(vk::Filter::LINEAR)
+        .force_explicit_reconstruction(false);
+
+    Ok(unsafe { device.create_sampler_ycbcr_conversion(&info, None)? })
+}
+
 /// Shared Vulkan device context for video operations.
 ///
 /// Wraps the caller's [`vulkanalia::Device`] and [`vulkanalia::Instance`] along
@@ -82,6 +103,7 @@ pub struct VideoContext {
     physical_device: vk::PhysicalDevice,
     memory_properties: vk::PhysicalDeviceMemoryProperties,
     allocator: Arc<vma::Allocator>,
+    nv12_ycbcr_conversion: vk::SamplerYcbcrConversion,
 }
 
 /// Errors that can occur during video context or session creation.
@@ -164,12 +186,15 @@ impl VideoContext {
                 .map_err(|e| VideoError::Vulkan(vk::Result::from(e)))?
         });
 
+        let nv12_ycbcr_conversion = create_nv12_ycbcr_conversion(&device)?;
+
         Ok(Self {
             instance,
             device,
             physical_device,
             memory_properties,
             allocator,
+            nv12_ycbcr_conversion,
         })
     }
 
@@ -190,12 +215,15 @@ impl VideoContext {
         let memory_properties =
             unsafe { instance.get_physical_device_memory_properties(physical_device) };
 
+        let nv12_ycbcr_conversion = create_nv12_ycbcr_conversion(&device)?;
+
         Ok(Self {
             instance,
             device,
             physical_device,
             memory_properties,
             allocator,
+            nv12_ycbcr_conversion,
         })
     }
 
@@ -218,6 +246,13 @@ impl VideoContext {
     /// Get a shared reference to the VMA allocator.
     pub fn allocator(&self) -> &Arc<vma::Allocator> {
         &self.allocator
+    }
+
+    /// Shared NV12 sampler Y′CBCR conversion handle for attachment to
+    /// multi-planar image views whose parent image includes `SAMPLED` usage
+    /// (required by `VUID-VkImageViewCreateInfo-format-06415`).
+    pub fn nv12_ycbcr_conversion(&self) -> vk::SamplerYcbcrConversion {
+        self.nv12_ycbcr_conversion
     }
 
     /// Find a queue family that supports the given video codec operation.
@@ -277,6 +312,15 @@ impl VideoContext {
         Err(VideoError::NoVideoQueueFamily)
     }
 
+}
+
+impl Drop for VideoContext {
+    fn drop(&mut self) {
+        unsafe {
+            self.device
+                .destroy_sampler_ycbcr_conversion(self.nv12_ycbcr_conversion, None);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
@@ -692,6 +692,9 @@ impl VkVideoDecoder {
         self.dpb_slot_layouts = vec![vk::ImageLayout::UNDEFINED; dpb_count];
         self.dpb_slot_active = vec![false; dpb_count];
 
+        let mut ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
+            .conversion(self.ctx.nv12_ycbcr_conversion());
+
         for i in 0..dpb_count {
             let view_info = vk::ImageViewCreateInfo::builder()
                 .image(self.dpb_image)
@@ -703,7 +706,8 @@ impl VkVideoDecoder {
                     level_count: 1,
                     base_array_layer: i as u32,
                     layer_count: 1,
-                });
+                })
+                .push_next(&mut ycbcr_info);
 
             match unsafe { device.create_image_view(&view_info, None) } {
                 Ok(view) => self.dpb_image_views.push(view),

--- a/plan/289-nv12-ycbcr-conversion.md
+++ b/plan/289-nv12-ycbcr-conversion.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: NV12 image views require VkSamplerYcbcrConversion
-status: pending
+status: in_review
 description: Chain VkSamplerYcbcrConversionInfo into the pNext of every NV12-backed image view and sampler so spec requirements are met.
 github_issue: 289
 adapters:


### PR DESCRIPTION
## Summary
- Add a single per-`VideoContext` `VkSamplerYcbcrConversion` for `G8_B8R8_2PLANE_420_UNORM` (lazy on context creation, destroyed in `Drop`).
- Chain `VkSamplerYcbcrConversionInfo` into every NV12 color-aspect `VkImageViewCreateInfo` in the video pipeline: decoder DPB (`vk_video_decoder.rs`), encoder DPB (`encode/session.rs` separate + array-layered paths), encode staging source view (`encode/staging.rs` internal + external device paths), and the RGB→NV12 encoder input color view (`rgb_to_nv12.rs`).
- `nv12_to_rgb.rs` already chained its own local conversion — left unchanged.

## Issue
Closes #289

## Verification
Ran `VK_LOADER_LAYERS_ENABLE=*validation* cargo run -p vulkan-video-roundtrip -- h264 /dev/video2 5` before and after:

| VUID | Baseline | After |
| --- | --- | --- |
| `VUID-VkImageViewCreateInfo-format-06415` | 20 | **0** ✅ |
| `VUID-vkCreateSamplerYcbcrConversion-None-01648` | 2 | 6 (+4) |
| `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206` | 20 | 20 |

End-to-end still healthy: `frames_encoded=25`, `frames_decoded=25`, process exits cleanly.

## Test Plan
- [x] `cargo check -p streamlib`
- [x] `cargo check -p vulkan-video`
- [x] `cargo test -p vulkan-video --lib` — 613 passed / 0 failed
- [x] vivid H.264 roundtrip under validation layer (5s, `/dev/video2`)

## Follow-ups
- `VUID-vkCreateSamplerYcbcrConversion-None-01648` is pre-existing (also fired before this PR via `Nv12ToRgbConverter`) and amplified here because we now create a shared conversion at `VideoContext` construction. The root fix is enabling the `samplerYcbcrConversion` feature in `VulkanDevice::new` (`libs/streamlib/src/vulkan/rhi/vulkan_device.rs`) — out of scope for #289, file a follow-up.
- `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206` (`srcPictureResource.imageViewBinding` not compatible with video profile) is pre-existing and unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)