### PR TITLE
fix(#292): pre-allocate encode/decode DMA-BUF resources before swapchain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,8 @@ Use the `/refine-name` command to get suggestions that follow this pattern. The 
 
 Tests are the **first gate in automated development**. They must give high confidence the code works before a single example is run. High-quality tests remove the need for manual validation via examples. Examples showcase features; tests prove the system works.
 
+**When end-to-end validation is needed**, follow @docs/testing.md — it specifies which example/fixture and PNG-sampling workflow to use for each scenario (encoder/decoder vs. camera+display-only), and requires reading sample PNGs with the Read tool to confirm frame content.
+
 **Creating, updating, and deleting tests never requires approval. Tests are standard scope for every task, AMOS node, and GitHub issue.**
 
 When creating a task or issue, include testing goals — the types of tests needed and what conditions they cover (positive, negative, error). Not the exact code, just the intent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,49 @@ These docs capture surprising, non-obvious behavior — driver bugs,
 library quirks, allocation patterns. Look them up when the trigger
 condition matches what you're seeing.
 
+### How to treat them
+
+Learnings are **notes from past-me to current-me** — a conversation
+across sessions, not a spec. Treat them the way any engineer treats
+their own older notes: useful prior context, **not authority**.
+
+- **Be skeptical.** A learning is a snapshot of what was true when it
+  was written. Drivers update, code refactors, assumptions shift. If
+  reality disagrees with a learning, trust what you observe now.
+- **Always be learning.** You can discover new things a learning
+  missed, realize the problem was framed wrong, or find a simpler /
+  better fix. Prefer the current understanding over the recorded one
+  when they conflict.
+- **Edit freely.** A learning can be updated, rewritten, split, merged,
+  or deleted whenever you have evidence it's out of date, wrong,
+  incomplete, too narrow, too broad, or simply no longer relevant.
+  These edits don't need approval beyond the normal PR review — treat
+  them like any other doc change.
+- **Don't follow them blindly.** A learning telling you "do X" is a
+  hypothesis for your current situation, not a command. Verify the
+  trigger still matches, verify the prescribed fix still applies,
+  and re-derive the conclusion from first principles when the stakes
+  are non-trivial.
+
+### What makes a good learning
+
+- **Specific enough to be useful** — name the symptom precisely (exact
+  error string, exact VUID, exact failure pattern) so a search-match
+  fires when it should.
+- **Not so specific that it rots** — tie the lesson to a concept,
+  constraint, or invariant, not to a single line number or a single
+  file path. If the fix is "chain `VkExportMemoryAllocateInfo` through
+  VMA pools instead of the global allocator config," that's portable;
+  if it's "edit line 137 of `vulkan_device.rs`," it will be wrong
+  within a month. Link to the relevant files for orientation, but
+  make the lesson hold even after the surrounding code moves.
+- **Say *why*, not just *what*** — the underlying driver/library/spec
+  constraint is what survives refactors; the code that happened to
+  trip over it is not.
+
+If you're writing a new learning, aim for something that would still
+make sense if the surrounding files were renamed or restructured.
+
 - @docs/learnings/nvidia-dma-buf-after-swapchain.md — `VK_ERROR_OUT_OF_DEVICE_MEMORY`
   from `vmaCreateImage`/`vkAllocateMemory` on NVIDIA Linux when a swapchain
   has been created. NOT real OOM.

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -4,15 +4,43 @@ This directory captures **specific, non-obvious** discoveries made while
 working on streamlib — things you would NOT have known from reading the
 code, the Vulkan spec, or generic Rust patterns.
 
-Each file documents:
-- The exact symptom that triggers the lookup
-- Specific root cause
-- Concrete fix pattern (with code)
-- Reference to the commit / file where it lives
+## These notes are not authoritative
 
-If you're about to add a generic note like "be careful with X" or "the
-codebase uses Y" — DON'T. Those go in CLAUDE.md or the code itself. This
-directory is for the surprises.
+Learnings are a conversation between past-me and current-me, not a spec.
+Drivers update, code refactors, assumptions shift. Be skeptical:
+
+- **Trust what you observe now over what's written here.** If reality
+  disagrees with a learning, the learning is probably out of date.
+- **Edit, rewrite, or delete freely.** A learning may be wrong, too
+  narrow, too broad, or simply no longer relevant. Changing it is part
+  of normal PR scope — no special approval needed.
+- **Verify before applying.** A learning that says "do X" is a
+  hypothesis for your current situation, not a command. Confirm the
+  trigger still matches and re-derive the conclusion when the stakes
+  are non-trivial.
+
+See CLAUDE.md's "Hard-won learnings" section for the full framing.
+
+## What makes a good learning
+
+Each file should document:
+- The **exact symptom** that triggers the lookup (specific error
+  strings, VUIDs, failure patterns — specific enough that a search
+  matches when it should)
+- The **underlying driver/library/spec constraint** — the invariant
+  that survives refactors, not the line number that tripped over it
+- A **concrete fix pattern** (with code, in terms of the constraint)
+- **Orientation links** to the files where the pattern currently lives
+  (for navigation, not as the load-bearing truth — those files will
+  move)
+
+Avoid the two failure modes:
+
+- **Too generic** (`be careful with X`, `the codebase uses Y`) — those
+  go in CLAUDE.md or the code itself. This directory is for surprises.
+- **Too specific to one spot** (`edit line 137 of file X`) — the fix
+  will be wrong within a month. Write lessons that hold even after the
+  surrounding code is renamed or restructured.
 
 ## Index
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,350 @@
+# Testing guide
+
+When to use which testing technique in streamlib. Unit tests are always the first
+line of defense — this doc focuses on the cases where unit tests are not enough
+and you need to exercise the real pipeline.
+
+---
+
+## Decision tree
+
+1. **Can the change be covered by a unit test?** (pure logic, parser, state
+   machine, DPB bookkeeping, etc.) → Write a unit test. Done.
+2. **Does it touch GPU memory, Vulkan drivers, V4L2, or the swapchain?** →
+   Unit tests will miss driver-only failure modes (see
+   [`nvidia-dma-buf-after-swapchain`](learnings/nvidia-dma-buf-after-swapchain.md)).
+   You need a real end-to-end run. Pick the scenario below that matches your
+   change.
+3. **Does the change affect an encoder or decoder?** →
+   [Encoder/decoder scenario](#encoderdecoder-scenario).
+4. **Does the change affect only camera, display, GPU-compute, or GPU texture
+   flow (no codec)?** →
+   [Camera/display-only scenario](#cameradisplay-only-scenario).
+
+If you're unsure, default to the more demanding scenario (encode/decode) — it
+also exercises camera and display.
+
+---
+
+## Encoder/decoder scenario
+
+**Use `examples/vulkan-video-roundtrip`** (`camera → encoder → decoder → display`)
+and sample the decoded frames as PNGs through the display processor's
+debug hooks, then **read the PNGs with the Read tool to visually confirm
+content**.
+
+### When to use
+
+- Changes to `libs/vulkan-video/` (RHI coupling, session/DPB, NV12 conversion,
+  rate control, etc.).
+- Changes to `libs/streamlib/src/linux/processors/{h264,h265}_{encoder,decoder}.rs`.
+- Changes to any GPU code that the encoder or decoder reaches through
+  `GpuContext`, `VulkanDevice`, or the RHI.
+- Changes to the H.264/H.265 validator, MP4 writer, or anything consuming
+  `Encodedvideoframe`.
+
+### Run it
+
+```bash
+OUT=/tmp/e2e-$(date +%s)
+mkdir -p "$OUT/png_samples"
+
+STREAMLIB_DISPLAY_PNG_SAMPLE_DIR="$OUT/png_samples" \
+STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
+STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
+timeout --kill-after=3 25 \
+    cargo run -q -p vulkan-video-roundtrip -- h264 /dev/video2 15 \
+    2>&1 | tee "$OUT/pipeline.log"
+```
+
+- First positional arg is `h264` or `h265` — run **both** for encode/decode
+  changes.
+- Second arg is the camera device. Use `/dev/video2` (vivid, always available
+  in CI-like setups) as the baseline. If the change is driver-path-sensitive
+  (MMAP fallback, DMA-BUF, UVC), also run against a real UVC device such as
+  `/dev/video0` (Cam Link 4K on this workstation) — several past bugs
+  (#288/#289/#292) only reproduced on real hardware.
+- `STREAMLIB_DISPLAY_FRAME_LIMIT` makes the run self-terminate so no stranded
+  winit window survives the test.
+- `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30` writes one PNG per 30 displayed
+  frames (adjust for longer runs).
+
+### Verify
+
+1. Grep the log for `OUT_OF_DEVICE_MEMORY`, `DEVICE_LOST`, `process() failed`,
+   and `Validation Error`. Zero occurrences for the first three is the pass
+   bar. Validation errors are acceptable only if they exist on `main` for the
+   same run — otherwise fix or file a follow-up.
+2. Confirm progress markers fired: `[H{264,265}Encoder] First frame encoded`,
+   `[H{264,265}Decoder] First frame decoded`, plus at least one `Encode
+   progress` / `Decode progress` line.
+3. **Read at least one PNG sample with the Read tool** and visually confirm
+   the content matches the source:
+   - vivid → green/purple SMPTE-style test pattern with `00:00:…` timecode
+     overlay.
+   - Cam Link / real UVC camera → the physical scene the camera sees.
+   - A uniform black or magenta frame is a regression even if the run didn't
+     error out.
+4. **PSNR validation (when a reference frame is available).** For synthetic
+   sources (vivid, BGRA file source, fixture video), compute PSNR between the
+   source frame and the corresponding decoded PNG to catch lossy-but-silent
+   regressions (wrong color matrix, wrong range, off-by-one plane strides,
+   chroma on wrong subsample, etc.). For real cameras, PSNR against the raw
+   source isn't practical — treat the Read-tool visual check as the sole
+   gate.
+
+```
+# inside this codebase, with the agent:
+Read("/tmp/e2e-.../png_samples/display_001_frame_000060.png")
+```
+
+#### PSNR — how to compute
+
+Easiest path is ffmpeg against a same-resolution reference PNG (captured
+pre-encode from the `camera-display` run at the same frame number, or a
+fixture PNG):
+
+```bash
+ffmpeg -hide_banner -i "$OUT/png_samples/display_001_frame_000060.png" \
+       -i reference_frame_000060.png \
+       -lavfi "psnr=stats_file=$OUT/psnr.log" -f null - 2>&1 \
+    | grep -E "PSNR|average:"
+# Pass bar (rule of thumb for 1080p H.264 / H.265 at default quality):
+#   Y PSNR ≥ 35 dB  — good quality
+#   Y PSNR 30–35 dB — acceptable, flag it
+#   Y PSNR < 30 dB  — regression, investigate color-matrix / range / plane layout
+```
+
+When there is no reference PNG readily available (the common case on
+`vulkan-video-roundtrip`), instead:
+
+- Capture a PNG from `camera-display` at the same source device, crop to
+  the nearest IDR boundary, and use that as the reference. Document the
+  pairing in the [test-report template](#standardized-test-output-template)
+  under **PSNR**.
+- If PSNR isn't feasible for a run, state that explicitly in the report
+  under **PSNR** rather than skipping the line.
+
+### Reference
+
+- Reproduced and fixed this way: #288, #289, #292.
+- Driver-specific notes: [`docs/learnings/nvidia-dma-buf-after-swapchain.md`](learnings/nvidia-dma-buf-after-swapchain.md),
+  [`docs/learnings/camera-display-e2e-validation.md`](learnings/camera-display-e2e-validation.md).
+
+---
+
+## Camera/display-only scenario
+
+**Use `examples/camera-display`** (`camera → display`, no codec) with the
+same PNG sampling hooks, and **read the PNGs with the Read tool** to verify.
+Prefer this over the roundtrip example when no codec is involved — it
+isolates the camera + GPU-compute + display path from encode/decode noise
+and runs faster.
+
+### When to use
+
+- Changes to `libs/streamlib/src/linux/processors/camera.rs` (V4L2, MMAP,
+  DMA-BUF import, NV12/YUYV compute shaders, ring textures).
+- Changes to `libs/streamlib/src/linux/processors/display.rs` (swapchain,
+  acquire/present, descriptor layout, PNG sampler itself).
+- Changes to `GpuContext`, `PixelBufferPool`, `TextureCache`, or `VulkanTexture`
+  that do **not** involve a codec.
+- Changes to the RHI surface/DMA-BUF paths when there's no encode/decode
+  coupling.
+
+### Run it
+
+Prefer the packaged fixture script — it loads vivid, sets the env vars,
+and handles cleanup:
+
+```bash
+libs/streamlib/tests/fixtures/e2e_camera_display.sh /tmp/streamlib-e2e
+```
+
+Or run the example directly (use this when you need to point at a specific
+device like Cam Link):
+
+```bash
+OUT=/tmp/camdisp-$(date +%s)
+mkdir -p "$OUT/png_samples"
+
+STREAMLIB_CAMERA_DEVICE=/dev/video0 \
+STREAMLIB_DISPLAY_PNG_SAMPLE_DIR="$OUT/png_samples" \
+STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
+STREAMLIB_DISPLAY_FRAME_LIMIT=200 \
+timeout --kill-after=3 20 cargo run -q -p camera-display \
+    2>&1 | tee "$OUT/pipeline.log"
+```
+
+### Verify
+
+1. Log: zero `OUT_OF_DEVICE_MEMORY`, `DEVICE_LOST`, `process() failed`.
+2. `First frame captured` appears, and PNGs accumulate in
+   `$OUT/png_samples/`.
+3. **Read at least one PNG with the Read tool** and confirm the expected
+   visual content (vivid test pattern or the real camera scene).
+
+### Reference
+
+- Full fixture script:
+  [`libs/streamlib/tests/fixtures/e2e_camera_display.sh`](../libs/streamlib/tests/fixtures/e2e_camera_display.sh).
+- Prerequisites, troubleshooting, and PNG details:
+  [`docs/learnings/camera-display-e2e-validation.md`](learnings/camera-display-e2e-validation.md).
+
+---
+
+## Display PNG sampler — env var reference
+
+Read by `linux::processors::display` at processor start.
+
+| Env var | Effect |
+| --- | --- |
+| `STREAMLIB_DISPLAY_PNG_SAMPLE_DIR` | Directory to write PNG samples into. Unset disables sampling. |
+| `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY` | Sample interval in displayed frames (default 30). |
+| `STREAMLIB_DISPLAY_FRAME_LIMIT` | Auto-exit after N displayed frames. Always set this for automated runs — avoids stranded winit windows. |
+| `STREAMLIB_CAMERA_DEVICE` | Override `/dev/video0` default for the camera processor. |
+
+PNGs are full-resolution (1920×1080) BGRA→RGBA, handwritten encoder — no
+extra dependencies. The sampled data comes from the source HOST_VISIBLE
+pixel buffer, so it validates camera→display data flow but not the
+actual swapchain rendering step.
+
+---
+
+## Standardized test output template
+
+Whenever you run an E2E scenario from this guide, report results using the
+template below. Fill in every field — "N/A" with a reason is acceptable, a
+blank field is not. Paste the filled template into the PR description, the
+task report, or the comment where you're requesting review. Keep it verbatim
+(no rewording) so it's grep-able across PRs.
+
+````markdown
+### E2E Test Report
+
+- **Scenario**: encoder/decoder | camera+display-only
+- **Example**: `vulkan-video-roundtrip` | `camera-display` | `e2e_camera_display.sh`
+- **Codec**: h264 | h265 | n/a
+- **Camera device**: `/dev/videoN` (vivid | Cam Link 4K | other)
+- **Resolution**: 1920x1080 | 1280x720 | other
+- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=… ` (run length in seconds)
+- **Build profile**: debug | release
+- **Command**:
+    ```
+    <exact cargo run command with env vars>
+    ```
+
+#### Log signals
+
+- `OUT_OF_DEVICE_MEMORY`: <count> (0 = pass)
+- `DEVICE_LOST`: <count> (0 = pass)
+- `process() failed`: <count> (0 = pass)
+- `Validation Error` (with `VK_LOADER_LAYERS_ENABLE=*validation*`): <count or "not enabled">
+- `First frame encoded` / `First frame decoded` / `First frame captured`: <timestamps or "not seen">
+- `Encode progress` / `Decode progress` high-water mark: <frames>
+
+#### PNG samples
+
+- Directory: `<OUT>/png_samples/`
+- Sample count: <N>
+- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=<N>`
+- PNGs read with Read tool: `<file1>`, `<file2>`, …
+- **What was in the image(s)**: <one or two sentences per PNG read — what you
+  actually saw. E.g., "frame 60: dark room with chair back and wood door,
+  matches the Cam Link scene" or "frame 30: vivid green/purple SMPTE bars
+  with `00:00:06:603` timecode overlay, matches expected test pattern". A
+  response of "looks fine" is NOT acceptable — describe the content so a
+  reviewer can tell at a glance whether you actually looked.>
+- Anomalies (black frames, tearing, wrong colors, off-center, etc.): <list or "none">
+
+#### PSNR
+
+- Reference frame: `<path>` or `n/a — <reason>`
+- Y / U / V PSNR (dB): <y>, <u>, <v> — or `n/a — <reason>`
+- Command used:
+    ```
+    <ffmpeg or equivalent command>
+    ```
+
+#### Outcome
+
+- **Pass** / **Pass with caveats** / **Fail**
+- Caveats / follow-ups filed: <list of issue numbers, or "none">
+````
+
+Example of a minimal but complete report (from PR #301):
+
+````markdown
+### E2E Test Report
+
+- **Scenario**: encoder/decoder
+- **Example**: `vulkan-video-roundtrip`
+- **Codec**: h264
+- **Camera device**: `/dev/video0` (Cam Link 4K)
+- **Resolution**: 1920x1080
+- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 15 s
+- **Build profile**: debug
+- **Command**:
+    ```
+    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/camlink-e2e-h264/png_samples \
+    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
+    STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
+    timeout --kill-after=3 25 cargo run -q -p vulkan-video-roundtrip -- h264 /dev/video0 15
+    ```
+
+#### Log signals
+
+- `OUT_OF_DEVICE_MEMORY`: 0
+- `DEVICE_LOST`: 0
+- `process() failed`: 0
+- `Validation Error`: not enabled
+- `First frame encoded` / decoded / captured: 22:04:34.662 / 22:04:34.725 / 22:04:34.6xx
+- `Encode progress` high-water: 900 frames; `Decode progress`: 300 frames
+
+#### PNG samples
+
+- Directory: `/tmp/camlink-e2e-h264/png_samples/`
+- Sample count: 8
+- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30`
+- PNGs read with Read tool: `display_001_frame_000090.png`
+- What was in the image(s): "frame 90 — dark room, Secretlab chair back with
+  embroidered logo visible in center, wood-panel door top-right against a
+  dark-blue wall. Matches Cam Link's live scene."
+- Anomalies: none
+
+#### PSNR
+
+- Reference frame: n/a — real-camera source, no ground-truth reference available.
+- Y / U / V PSNR: n/a
+- Command used: n/a
+
+#### Outcome
+
+- **Pass**
+- Caveats / follow-ups filed: #302 (decoder probe hard-coded resolution)
+````
+
+---
+
+## Rules of thumb
+
+- **Always read at least one PNG** when PNG sampling is in play. A run that
+  doesn't error but produces black frames is not a pass.
+- **Always describe what the image shows** in the [test-report
+  template](#standardized-test-output-template). "Looks fine" is not a
+  description — a reviewer should be able to tell at a glance whether you
+  actually inspected the frame.
+- **Always set `STREAMLIB_DISPLAY_FRAME_LIMIT`** for automated runs. winit +
+  X11 don't always respect SIGTERM cleanly.
+- **Run vivid first, real hardware second.** Vivid isolates your change from
+  driver quirks; real hardware catches the driver quirks vivid hides.
+- **Run PSNR when a reference frame exists.** For synthetic sources it
+  catches silent color-space / plane-layout regressions that visual
+  inspection misses.
+- **Keep the PNG sampling interval coarse** (20–60 frames). Every sample is
+  ~8 MB and the PNG encoder is on the display thread.
+- **Report every E2E run using the
+  [standardized template](#standardized-test-output-template)** so reviews
+  and diffs across PRs are grep-able.
+- **Unit tests still come first.** E2E runs are slow and noisy — use them to
+  confirm, not to explore.

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -577,7 +577,11 @@ impl GpuContext {
 
         let desc = TextureDescriptor::new(width, height, TextureFormat::Rgba8Unorm)
             .with_usage(TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING | TextureUsages::STORAGE_BINDING);
-        let texture = self.device.create_texture(&desc)?;
+        // Same-process texture cache path — skip the DMA-BUF export pool so
+        // repeated decode-output allocations don't exhaust NVIDIA's DMA-BUF
+        // budget after the display swapchain is created
+        // (docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        let texture = self.device.create_texture_local(&desc)?;
 
         unsafe {
             let image = texture.inner.image().ok_or_else(|| {

--- a/libs/streamlib/src/core/rhi/device.rs
+++ b/libs/streamlib/src/core/rhi/device.rs
@@ -162,6 +162,17 @@ impl GpuDevice {
         }
     }
 
+    /// Create a non-exportable, device-local texture for same-process consumers.
+    ///
+    /// Skips the DMA-BUF export pool where applicable. Use for textures that
+    /// never cross process boundaries; reduces pressure on NVIDIA Linux's
+    /// DMA-BUF allocation cap.
+    #[cfg(target_os = "linux")]
+    pub fn create_texture_local(&self, desc: &TextureDescriptor) -> Result<StreamTexture> {
+        let vulkan_texture = self.inner.create_texture_local(desc)?;
+        Ok(StreamTexture::from_vulkan(vulkan_texture))
+    }
+
     /// Get the shared command queue.
     ///
     /// All processors should use this shared queue rather than creating their own.

--- a/libs/streamlib/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_decoder.rs
@@ -74,6 +74,14 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to pre-initialize H.264 decoder session: {e}"))
         })?;
 
+        // Pre-allocate the output pixel buffer pool at the codec-aligned height
+        // (multiple of 16) before the display swapchain is created. On NVIDIA
+        // Linux, DMA-BUF exportable buffer allocations can fail with
+        // ERROR_OUT_OF_DEVICE_MEMORY once the swapchain has consumed the
+        // DMA-BUF budget (docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        let (_probe_id, _probe_buffer) =
+            ctx.gpu.acquire_pixel_buffer(1920, 1088, crate::core::rhi::PixelFormat::Rgba32)?;
+
         tracing::info!("[H264Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 
         self.decoder = Some(decoder);

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -69,7 +69,7 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
             ctx.gpu.device().inner.clone();
 
-        let encoder = SimpleEncoder::from_device(
+        let mut encoder = SimpleEncoder::from_device(
             encoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
@@ -84,6 +84,15 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
         ).map_err(|e| {
             StreamError::Runtime(format!("Failed to create H.264 encoder: {e}"))
+        })?;
+
+        // Pre-allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage + per-plane
+        // views + compute pipeline) now, before the display's swapchain is created.
+        // On NVIDIA Linux, new DEVICE_LOCAL allocations can fail with
+        // ERROR_OUT_OF_DEVICE_MEMORY once a swapchain has been created and the
+        // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        encoder.prepare_gpu_encode_resources().map_err(|e| {
+            StreamError::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
         })?;
 
         // Wait for all device operations to complete before other processors

--- a/libs/streamlib/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_decoder.rs
@@ -74,6 +74,14 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to pre-initialize H.265 decoder session: {e}"))
         })?;
 
+        // Pre-allocate the output pixel buffer pool at the codec-aligned height
+        // (multiple of 16) before the display swapchain is created. On NVIDIA
+        // Linux, DMA-BUF exportable buffer allocations can fail with
+        // ERROR_OUT_OF_DEVICE_MEMORY once the swapchain has consumed the
+        // DMA-BUF budget (docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        let (_probe_id, _probe_buffer) =
+            ctx.gpu.acquire_pixel_buffer(1920, 1088, crate::core::rhi::PixelFormat::Rgba32)?;
+
         tracing::info!("[H265Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 
         self.decoder = Some(decoder);

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -69,7 +69,7 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
             ctx.gpu.device().inner.clone();
 
-        let encoder = SimpleEncoder::from_device(
+        let mut encoder = SimpleEncoder::from_device(
             encoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
@@ -84,6 +84,15 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
         ).map_err(|e| {
             StreamError::Runtime(format!("Failed to create H.265 encoder: {e}"))
+        })?;
+
+        // Pre-allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage + per-plane
+        // views + compute pipeline) now, before the display's swapchain is created.
+        // On NVIDIA Linux, new DEVICE_LOCAL allocations can fail with
+        // ERROR_OUT_OF_DEVICE_MEMORY once a swapchain has been created and the
+        // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        encoder.prepare_gpu_encode_resources().map_err(|e| {
+            StreamError::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
         })?;
 
         // Wait for all device operations to complete before other processors

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -874,6 +874,20 @@ impl VulkanDevice {
         VulkanTexture::new(self, desc)
     }
 
+    /// Create a non-exportable device-local texture for same-process consumers.
+    ///
+    /// Unlike [`create_texture`], this skips the DMA-BUF export pool and
+    /// allocates from the default VMA pool. Use this for textures that never
+    /// cross process boundaries — NVIDIA Linux caps DMA-BUF exportable
+    /// allocations after swapchain creation, so minimizing exportable
+    /// allocations is important (see `docs/learnings/nvidia-dma-buf-after-swapchain.md`).
+    pub fn create_texture_local(
+        self: &Arc<Self>,
+        desc: &TextureDescriptor,
+    ) -> Result<VulkanTexture> {
+        VulkanTexture::new_device_local(self, desc)
+    }
+
     /// Create a VulkanCommandQueue wrapper for the shared command queue.
     pub fn create_command_queue_wrapper(self: &Arc<Self>) -> VulkanCommandQueue {
         VulkanCommandQueue::new(Arc::clone(self), self.queue, self.queue_family_index)

--- a/libs/vulkan-video/src/encode/mod.rs
+++ b/libs/vulkan-video/src/encode/mod.rs
@@ -369,6 +369,43 @@ impl SimpleEncoder {
     ) -> Result<Vec<EncodePacket>, VideoError> {
         unsafe { self.encode_image_internal(rgba_image_view, timestamp_ns) }
     }
+
+    /// Eagerly allocate the GPU resources used by [`encode_image`](Self::encode_image).
+    ///
+    /// Creates the RGB→NV12 converter (an NV12 VkImage, per-plane views, compute
+    /// pipeline, command pool/buffer) now instead of on the first `encode_image`
+    /// call. Callers that will feed GPU-resident frames should invoke this
+    /// during setup — before a display swapchain is created — so the NV12 image
+    /// allocation isn't subject to NVIDIA's post-swapchain DMA-BUF budget cap
+    /// (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+    pub fn prepare_gpu_encode_resources(&mut self) -> Result<(), VideoError> {
+        self.prepare_gpu_encode_resources_impl()
+    }
+
+    pub(crate) fn prepare_gpu_encode_resources_impl(&mut self) -> Result<(), VideoError> {
+        if self.rgb_to_nv12.is_some() {
+            return Ok(());
+        }
+        let (aligned_w, aligned_h) = self.aligned_extent();
+        let codec_flag = match self.config.codec {
+            Codec::H264 => vk::VideoCodecOperationFlagsKHR::ENCODE_H264,
+            Codec::H265 => vk::VideoCodecOperationFlagsKHR::ENCODE_H265,
+        };
+        let converter = unsafe {
+            crate::rgb_to_nv12::RgbToNv12Converter::new(
+                &self.ctx,
+                aligned_w,
+                aligned_h,
+                self.compute_queue_family,
+                self.compute_queue,
+                self.encode_queue_family,
+                codec_flag,
+                self.submitter.clone(),
+            )?
+        };
+        self.rgb_to_nv12 = Some(converter);
+        Ok(())
+    }
 }
 
 impl Drop for SimpleEncoder {

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -854,24 +854,10 @@ impl SimpleEncoder {
         rgba_image_view: vk::ImageView,
         timestamp_ns: Option<i64>,
     ) -> Result<Vec<EncodePacket>, VideoError> {
-        // Lazily create the RGB→NV12 converter on first call.
+        // Lazily create the RGB→NV12 converter on first call, unless the caller
+        // pre-allocated it via `prepare_gpu_encode_resources()`.
         if self.rgb_to_nv12.is_none() {
-            let (aligned_w, aligned_h) = self.aligned_extent();
-            let codec_flag = match self.config.codec {
-                Codec::H264 => vk::VideoCodecOperationFlagsKHR::ENCODE_H264,
-                Codec::H265 => vk::VideoCodecOperationFlagsKHR::ENCODE_H265,
-            };
-            let converter = crate::rgb_to_nv12::RgbToNv12Converter::new(
-                &self.ctx,
-                aligned_w,
-                aligned_h,
-                self.compute_queue_family,
-                self.compute_queue,
-                self.encode_queue_family,
-                codec_flag,
-                self.submitter.clone(),
-            )?;
-            self.rgb_to_nv12 = Some(converter);
+            self.prepare_gpu_encode_resources_impl()?;
         }
 
         // Run RGB→NV12 conversion on the GPU.

--- a/plan/292-camlink-encoder-oom.md
+++ b/plan/292-camlink-encoder-oom.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Cam Link encoder ERROR_OUT_OF_DEVICE_MEMORY in debug
-status: pending
+status: in_review
 description: Debug why the H.264/H.265 encoders fail every process() with OOM when capturing from Cam Link 4K (MMAP+memcpy path) while vivid works.
 github_issue: 292
 adapters:

--- a/plan/294-post-vulkan-cleanup-retest.md
+++ b/plan/294-post-vulkan-cleanup-retest.md
@@ -2,7 +2,7 @@
 whoami: amos
 name: Retest camera + encoder + display roundtrip after Vulkan cleanup
 status: pending
-description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, and #300 land and confirm release SIGSEGV and Cam Link OOM are both gone.
+description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, and #302 land and confirm release SIGSEGV and Cam Link OOM are both gone.
 github_issue: 294
 dependencies:
   - "down:Vulkanalia builder lifetime audit across RHI and processors"
@@ -13,6 +13,7 @@ dependencies:
   - "down:Cam Link encoder ERROR_OUT_OF_DEVICE_MEMORY in debug"
   - "down:Display render_finished semaphore must be per-swapchain-image"
   - "down:Encoder src picture profile mismatch"
+  - "down:Decoder pool probe uses hard-coded resolution"
 adapters:
   github: builtin
 ---

--- a/plan/294-post-vulkan-cleanup-retest.md
+++ b/plan/294-post-vulkan-cleanup-retest.md
@@ -2,7 +2,7 @@
 whoami: amos
 name: Retest camera + encoder + display roundtrip after Vulkan cleanup
 status: pending
-description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, and #302 land and confirm release SIGSEGV and Cam Link OOM are both gone.
+description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, and #303 land and confirm release SIGSEGV and Cam Link OOM are both gone.
 github_issue: 294
 dependencies:
   - "down:Vulkanalia builder lifetime audit across RHI and processors"
@@ -14,6 +14,7 @@ dependencies:
   - "down:Display render_finished semaphore must be per-swapchain-image"
   - "down:Encoder src picture profile mismatch"
   - "down:Decoder pool probe uses hard-coded resolution"
+  - "down:Camera MMAP path sees 0 frames on v4l2loopback"
 adapters:
   github: builtin
 ---

--- a/plan/294-post-vulkan-cleanup-retest.md
+++ b/plan/294-post-vulkan-cleanup-retest.md
@@ -2,7 +2,7 @@
 whoami: amos
 name: Retest camera + encoder + display roundtrip after Vulkan cleanup
 status: pending
-description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, and #303 land and confirm release SIGSEGV and Cam Link OOM are both gone.
+description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, #303, #304, #305, and #306 land and confirm release SIGSEGV and Cam Link OOM are both gone.
 github_issue: 294
 dependencies:
   - "down:Vulkanalia builder lifetime audit across RHI and processors"
@@ -15,6 +15,9 @@ dependencies:
   - "down:Encoder src picture profile mismatch"
   - "down:Decoder pool probe uses hard-coded resolution"
   - "down:Camera MMAP path sees 0 frames on v4l2loopback"
+  - "down:Flaky H.265 decoder DEVICE_LOST during setup"
+  - "down:Fixture-based PSNR rig for encoder/decoder roundtrips"
+  - "down:Expose encoder quality_level with real-time default"
 adapters:
   github: builtin
 ---

--- a/plan/302-decoder-probe-dynamic-resolution.md
+++ b/plan/302-decoder-probe-dynamic-resolution.md
@@ -1,0 +1,39 @@
+---
+whoami: amos
+name: Decoder pool probe uses hard-coded resolution
+status: pending
+description: Replace the hard-coded 1920x1088 probe in H264/H265 decoder setup() with a probe derived from decoder config / session capabilities so non-1080p streams don't regress #292.
+github_issue: 302
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#302
+
+## Branch
+
+Create `fix/decoder-probe-dynamic-resolution` from `main`.
+
+## Steps
+
+1. In `libs/vulkan-video/src/decode/` expose the codec-aligned output extent on `SimpleDecoder` (use the existing `max_width`/`max_height` from `SimpleDecoderConfig` plus codec macroblock alignment). Preferred API: `SimpleDecoder::prepare_gpu_decode_resources()` that mirrors `SimpleEncoder::prepare_gpu_encode_resources()` from #301 and internally knows the aligned output extent.
+2. Replace the hard-coded probe in `libs/streamlib/src/linux/processors/h264_decoder.rs` and `h265_decoder.rs`:
+   ```rust
+   let (_probe_id, _probe_buffer) =
+       ctx.gpu.acquire_pixel_buffer(1920, 1088, crate::core::rhi::PixelFormat::Rgba32)?;
+   ```
+   with a call to the new method (or with `acquire_pixel_buffer(aligned_w, aligned_h, ...)` read from the decoder).
+3. Keep the call site **before** the display swapchain is created (i.e., still in `setup()` after `pre_initialize_session`).
+
+## Verification
+
+- Cam Link `/dev/video0` H.264 + H.265 at 1920x1080 (release and debug) remain OOM-free — regression check for #292. Follow the encoder/decoder protocol in [`docs/testing.md`](../docs/testing.md), including PNG Read-tool verification.
+- Add a non-1080p roundtrip scenario (e.g., 1280x720 via vivid config, or a 4K Cam Link mode) that runs camera→encoder→decoder→display with zero `OUT_OF_DEVICE_MEMORY` and valid PNG output.
+- Optional: unit test on `SimpleDecoder::prepare_gpu_decode_resources()` / aligned extent math.
+
+## References
+
+- PR #301 (introduced the hard-coded probe as part of the #292 fix)
+- Issue #292 (Cam Link encoder OOM — root cause + encoder-side pattern to mirror)
+- [`docs/learnings/nvidia-dma-buf-after-swapchain.md`](../docs/learnings/nvidia-dma-buf-after-swapchain.md)
+- [`docs/testing.md`](../docs/testing.md)

--- a/plan/303-camera-v4l2loopback-mmap.md
+++ b/plan/303-camera-v4l2loopback-mmap.md
@@ -1,0 +1,34 @@
+---
+whoami: amos
+name: Camera MMAP path sees 0 frames on v4l2loopback
+status: pending
+description: LinuxCameraProcessor opens /dev/video10 (v4l2loopback) cleanly, logs V4L2 capture started, then its poll loop receives zero frames — while v4l2-ctl and ffmpeg on the same device get frames immediately. Blocks using v4l2loopback + ffmpeg testsrc2 as a deterministic motion fixture.
+github_issue: 303
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#303
+
+## Branch
+
+Create `fix/camera-v4l2loopback-mmap` from `main`.
+
+## Steps
+
+1. Reproduce: load v4l2loopback with `exclusive_caps=0`, feed it with `ffmpeg -re -f lavfi -i 'testsrc2=size=1920x1080:rate=30,format=nv12' -f v4l2 /dev/video10`, then run `STREAMLIB_CAMERA_DEVICE=/dev/video10 cargo run -p camera-display`. Expect "V4L2 capture started" followed by "Stopped (0 frames)".
+2. Narrow: `strace -e ioctl` the camera processor thread, or add targeted `tracing::debug` around `v4l::io::mmap::Stream::with_buffers`, the poll loop, and the post-poll `stream.next()` call. Compare which VIDIOC calls differ vs. `v4l2-ctl --stream-mmap=3`.
+3. Likely suspects (in order): the hard-coded `V4L2_BUFFER_COUNT = 4` in `libs/streamlib/src/linux/processors/camera.rs` exceeds v4l2loopback's reported capacity (make it adaptive to the `VIDIOC_REQBUFS` response); the poll FD chosen by the `v4l` crate doesn't match the actual streaming FD; `VIDIOC_STREAMON` ordering relative to QBUF.
+4. Once frames flow, extend [`docs/testing.md`](../docs/testing.md) with a **motion scenario** that uses v4l2loopback + `testsrc2` (scrolling timecode + frame counter) so frame-drop assertions become tractable.
+
+## Verification
+
+- `cargo run -p camera-display` against `/dev/video10` (fed by `ffmpeg testsrc2`) captures ≥ 1 frame within 5 s and PNG samples show the testsrc2 pattern (color bars + diagonal moving line + timecode overlay). Describe the content per the [test-report template](../docs/testing.md#standardized-test-output-template).
+- `vulkan-video-roundtrip h264 /dev/video10` and `h265 /dev/video10` both roundtrip for 15 s with zero `OUT_OF_DEVICE_MEMORY`, `DEVICE_LOST`, or `process() failed`; encoder/decoder first-frame markers fire; PNG samples show the expected pattern.
+- Send at least one PNG per codec to the user's Telegram chat for visual confirmation.
+
+## References
+
+- Regression observed during PR #301 motion-testing scope conversation.
+- [`docs/learnings/camera-display-e2e-validation.md`](../docs/learnings/camera-display-e2e-validation.md) — documents the historical v4l2loopback trouble and recommends vivid as the current synthetic source.
+- [`docs/testing.md`](../docs/testing.md) — where the new motion scenario will land once this fix makes v4l2loopback consumable.

--- a/plan/304-h265-decoder-setup-race.md
+++ b/plan/304-h265-decoder-setup-race.md
@@ -1,0 +1,35 @@
+---
+whoami: amos
+name: Flaky H.265 decoder DEVICE_LOST during setup
+status: pending
+description: One-in-N runs of vulkan-video-roundtrip h265 /dev/video2 hit a DEVICE_LOST on the H.265 decoder between first-frame-encoded and display swapchain creation. Retry passes clean. Suspected concurrent-Vulkan-ops race during decoder/display setup, same window h264_encoder.rs already guards via device_wait_idle.
+github_issue: 304
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#304
+
+## Branch
+
+Create `fix/h265-decoder-setup-race` from `main`.
+
+## Steps
+
+1. Reproduce by running `vulkan-video-roundtrip h265 /dev/video2 15` in a loop (≥ 20 iterations) and confirm the flake rate.
+2. Add `tracing::debug!` around every VIDIOC/device-level call in `H265DecoderProcessor::setup()` and `DisplayProcessor::setup()` so a failing run shows exactly which thread ran which call at each timestamp.
+3. Mirror the encoder-side pattern: append `vulkan_device.device().device_wait_idle()` at the end of `H264DecoderProcessor::setup()` and `H265DecoderProcessor::setup()` (after `pre_initialize_session` + pixel-buffer probe).
+4. Consider hoisting `device_wait_idle` into a `StreamRuntime` setup barrier so every processor's `setup()` runs against a quiesced device by construction — removes per-codec-processor boilerplate and is forward-proof for new codecs.
+
+## Verification
+
+- `vulkan-video-roundtrip h265 /dev/video2 15` passes 20 consecutive runs (zero `DEVICE_LOST`, each produces ≥ 1 PNG).
+- Same for `h265 /dev/video0` (Cam Link).
+- H.264 vivid/Cam Link still pass per [`docs/testing.md`](../docs/testing.md) with PNG Read-tool verification.
+- File the standardized [test-report](../docs/testing.md#standardized-test-output-template) summarizing all four runs.
+
+## References
+
+- PR #301 retest comment (first observation): https://github.com/tatolab/streamlib/pull/301#issuecomment-4274680105
+- Existing encoder-side mitigation: `libs/streamlib/src/linux/processors/h264_encoder.rs:90-95`
+- [`docs/learnings/nvidia-dual-vulkan-device-crash.md`](../docs/learnings/nvidia-dual-vulkan-device-crash.md)

--- a/plan/305-fixture-psnr-rig.md
+++ b/plan/305-fixture-psnr-rig.md
@@ -1,0 +1,41 @@
+---
+whoami: amos
+name: Fixture-based PSNR rig for encoder/decoder roundtrips
+status: pending
+description: Build a frame-aligned PSNR rig (checked-in reference PNGs fed through BgraFileSource → encoder → decoder) so encoder/decoder PSNR actually measures encode loss instead of timecode drift. Today every scenario ends up as "n/a" per docs/testing.md.
+github_issue: 305
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#305
+
+## Branch
+
+Create `test/fixture-psnr` from `main`.
+
+## Steps
+
+1. Check in a reference PNG set under `libs/streamlib/tests/fixtures/`:
+   - Solid colors at known BT.601 / BT.709 values (catches color-matrix bugs).
+   - Horizontal / vertical gradients (catches plane-stride, chroma-subsample bugs).
+   - A natural photograph (realistic encode quality).
+2. Build a `vulkan-video-psnr` example (or extend `vulkan-video-roundtrip` with a `--fixture <path>` flag) that feeds reference PNGs via `BgraFileSource` deterministically.
+3. Make the display PNG sampler key its outputs by input-frame index (not wall clock) so reference ↔ decoded pairing is exact.
+4. Add a shell / cargo-test harness that runs each reference through encode+decode and computes PSNR via ffmpeg:
+   ```bash
+   ffmpeg -i <input_ref>.png -i <decoded>.png -lavfi "psnr=stats_file=psnr.log" -f null -
+   ```
+5. Enforce the [`docs/testing.md`](../docs/testing.md#psnr--how-to-compute) thresholds: Y ≥ 35 dB pass, 30–35 dB warn, < 30 dB fail.
+6. Update the **PSNR** section of `docs/testing.md` to promote this rig as the primary encoder/decoder PSNR path and demote the camera-based discussion to a best-effort note.
+
+## Verification
+
+- Running the rig on `main` + this branch produces numeric Y/U/V PSNR for every reference frame (no `n/a`).
+- Synthetic bug-injection test: a deliberate BT.601 ↔ BT.709 color-matrix swap drops Y PSNR below the fail threshold and the harness reports `FAIL`.
+- File the standardized [test-report](../docs/testing.md#standardized-test-output-template) including PSNR values at each reference image.
+
+## References
+
+- PR #301 retest — measured 18 dB on vivid-vs-vivid, illustrating why ad-hoc PSNR is useless today: https://github.com/tatolab/streamlib/pull/301#issuecomment-4274680105
+- [`docs/testing.md`](../docs/testing.md)

--- a/plan/306-encoder-quality-level.md
+++ b/plan/306-encoder-quality-level.md
@@ -1,0 +1,44 @@
+---
+whoami: amos
+name: Expose encoder quality_level with real-time default
+status: pending
+description: SimpleEncoderConfig doesn't expose quality_level. Default picks "requested_quality=5" clamped to driver max (H.264→3, H.265→0 on NVIDIA RTX 3090), so H.265 silently runs at the driver's worst quality. Add a configurable knob with a real-time-tuned default.
+github_issue: 306
+adapters:
+  github: builtin
+dependencies:
+  - "down:Fixture-based PSNR rig for encoder/decoder roundtrips"
+---
+
+@github:tatolab/streamlib#306
+
+## Branch
+
+Create `feat/encoder-quality-level` from `main`.
+
+## Steps
+
+1. Add `quality_level: Option<u32>` to `SimpleEncoderConfig` (`libs/vulkan-video/src/encode/config.rs`). `None` = library default.
+2. Pick a per-codec default tuned for real-time / low-latency:
+   - Consult `VkVideoEncodeCapabilitiesKHR::maxQualityLevels` per codec.
+   - Use the #305 PSNR rig to find the lowest quality level that still hits Y ≥ 30 dB on the natural reference image — that's the real-time default.
+   - Stay consistent with the existing `VkVideoEncodeUsageInfoKHR::tuning_mode = LOW_LATENCY` intent.
+   - Document the chosen defaults explicitly; do not silently pick driver zero for H.265.
+3. Replace the hardcoded `requested_quality = 5` in `libs/vulkan-video/src/encode/session.rs` with the configured / defaulted value. Keep the caps-clamp only as a safety floor.
+4. Keep every `VkVideoEncodeUsageInfoKHR` chain in sync — `encode/session.rs`, `encode/staging.rs`, and `rgb_to_nv12.rs` all push their own. Divergence re-triggers `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206` (see #300).
+5. Plumb the knob through streamlib: add `quality_level: Option<u32>` to `H264EncoderProcessor::Config` and `H265EncoderProcessor::Config`.
+6. Log the final effective quality at INFO so operators can see actual vs requested.
+
+## Verification
+
+- `vulkan-video-roundtrip h264 /dev/video0 15` and `h265 /dev/video0 15` with default config: no gross H.265 banding/artifacts on natural scenes per PNG Read-tool inspection. Describe image content per the [test-report template](../docs/testing.md#standardized-test-output-template).
+- Explicit `quality_level = Some(max)` visibly higher quality, slower encode.
+- Explicit `quality_level = Some(0)` reproduces today's worst-quality H.265 — confirms the knob is wired.
+- #305 PSNR rig at default quality: Y PSNR ≥ 30 dB on the natural reference.
+- Send PNGs for at least one codec at default and max quality to the user's Telegram for visual sign-off.
+
+## References
+
+- PR #301 retest — observed H.265 banding at default quality: https://github.com/tatolab/streamlib/pull/301#issuecomment-4274680105
+- #300 — keep all three `VkVideoEncodeUsageInfoKHR` chains in sync.
+- #305 — PSNR rig provides the numeric floor for the default.


### PR DESCRIPTION
## Summary

- On NVIDIA Linux with Cam Link 4K (UVC, MMAP+memcpy path) every H.264/H.265 encode returned `VK_ERROR_OUT_OF_DEVICE_MEMORY`. Root cause: resources requiring DMA-BUF-eligible memory were being allocated lazily on the first `process()` call, after the display swapchain had already consumed NVIDIA's DMA-BUF allocation budget (see [`docs/learnings/nvidia-dma-buf-after-swapchain.md`](docs/learnings/nvidia-dma-buf-after-swapchain.md)). Vivid sidestepped it because its virtual-driver path skips some of those allocations.
- Encoder fix: `SimpleEncoder::prepare_gpu_encode_resources()` eagerly builds the RGB→NV12 converter (NV12 VkImage, views, compute pipeline) in `H264/H265 encoder setup()` before the swapchain exists.
- Decoder fix: new `GpuDevice::create_texture_local` / `VulkanDevice::create_texture_local` for non-exportable device-local textures; `upload_pixel_buffer_as_texture` now uses it (decoder output never crosses processes). `H264/H265 decoder setup()` probe-acquires a 1920×1088 Rgba32 pixel buffer to pre-create the pool before the swapchain.

## Issue

Closes #292

## Test Plan

Verified on NVIDIA RTX 3090 + Cam Link 4K `/dev/video0` (MMAP+memcpy path):
- [x] `cargo check -p streamlib -p vulkan-video -p vulkan-video-roundtrip`
- [x] `cargo test -p vulkan-video --lib` (613 passed)
- [x] `cargo test -p streamlib --lib` (147 passed)
- [x] H.264 Cam Link 15s roundtrip: first frame encoded + decoded, 900+ frames encoded, 300+ decoded, zero process failures, display PNG samples show live camera.
- [x] H.265 Cam Link 15s roundtrip: 600+ encoded, 300+ decoded, zero process failures, display PNG samples confirmed.
- [x] Vivid `/dev/video2` H.264 regression: green/purple test pattern renders end-to-end.

PNG samples captured via `STREAMLIB_DISPLAY_PNG_SAMPLE_DIR` at `/tmp/camlink-e2e-h264`, `/tmp/camlink-e2e-h265`, `/tmp/vivid-e2e-h264`.

## Follow-ups

- The decoder's aligned-size probe (1920×1088) is currently hard-coded to match the common H.264/H.265 alignment. If the pipeline ever runs at other resolutions, this should be derived from the decoder config.
- Many pre-existing validation-layer warnings surfaced while debugging (VUID-06811 NV12 profile, VUID-01035 memory-type mismatch, VUID-08206 src picture profile, VUID-01937/00384 unexposed queue family). These are tracked separately by #290, #291, #296, #300 and are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)