### PR TITLE
fix(#303): remove pre-poll in camera MMAP path so v4l2loopback streams

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,10 @@ timeout --kill-after=3 25 \
   (MMAP fallback, DMA-BUF, UVC), also run against a real UVC device such as
   `/dev/video0` (Cam Link 4K on this workstation) — several past bugs
   (#288/#289/#292) only reproduced on real hardware.
+- For **motion-sensitive** changes (frame ordering, frame drops, timestamp
+  drift, skipped DPB frames) use the [v4l2loopback motion
+  scenario](#v4l2loopback-motion-scenario) — vivid's built-in animation is
+  slow enough that many motion bugs hide behind it.
 - `STREAMLIB_DISPLAY_FRAME_LIMIT` makes the run self-terminate so no stranded
   winit window survives the test.
 - `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30` writes one PNG per 30 displayed
@@ -130,6 +134,88 @@ When there is no reference PNG readily available (the common case on
 - Reproduced and fixed this way: #288, #289, #292.
 - Driver-specific notes: [`docs/learnings/nvidia-dma-buf-after-swapchain.md`](learnings/nvidia-dma-buf-after-swapchain.md),
   [`docs/learnings/camera-display-e2e-validation.md`](learnings/camera-display-e2e-validation.md).
+
+---
+
+## v4l2loopback motion scenario
+
+vivid's test pattern animates slowly — motion-related bugs (duplicated
+frames, skipped frames, timestamp drift, reordered output) can hide
+behind a source that barely changes frame-to-frame. `ffmpeg`'s
+`testsrc2` pattern has both a scrolling timecode and a per-frame
+counter embedded in the image, so a dropped or repeated frame is
+visible by eye in a PNG sample.
+
+### Host setup (one-time)
+
+```bash
+sudo apt-get install v4l2loopback-dkms ffmpeg
+sudo modprobe v4l2loopback video_nr=10 card_label=Virtual_Camera exclusive_caps=0
+# exclusive_caps=0 (NOT 1) — caps=1 breaks ffmpeg→v4l2loopback writes.
+```
+
+Verify: `v4l2-ctl -d /dev/video10 --get-fmt-video` should report
+`1920x1080 NV12` (or whatever ffmpeg last pushed). The device survives
+until reboot.
+
+### Run it
+
+Start the writer in one terminal (leave it running for the whole test
+session):
+
+```bash
+ffmpeg -re -f lavfi -i 'testsrc2=size=1920x1080:rate=30,format=nv12' \
+       -f v4l2 /dev/video10
+```
+
+Then run the example against `/dev/video10` exactly like any other
+camera device:
+
+```bash
+# camera-only
+OUT=/tmp/camdisp-v4l2loop-$(date +%s)
+mkdir -p "$OUT/png_samples"
+STREAMLIB_CAMERA_DEVICE=/dev/video10 \
+STREAMLIB_DISPLAY_PNG_SAMPLE_DIR="$OUT/png_samples" \
+STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
+STREAMLIB_DISPLAY_FRAME_LIMIT=150 \
+timeout --kill-after=3 15 cargo run -q -p camera-display \
+    2>&1 | tee "$OUT/pipeline.log"
+
+# encoder/decoder roundtrip
+cargo run -q -p vulkan-video-roundtrip -- h264 /dev/video10 15
+cargo run -q -p vulkan-video-roundtrip -- h265 /dev/video10 15
+```
+
+### Verify
+
+1. Same log gates as the other scenarios — zero `OUT_OF_DEVICE_MEMORY`,
+   `DEVICE_LOST`, `process() failed`.
+2. Read at least one PNG with the Read tool. testsrc2 produces vertical
+   color bars (red, green, yellow, blue, magenta, cyan), a diagonal
+   rainbow line, a moving numeric timecode in the upper-left corner
+   (`HH:MM:SS.mmm`), and a per-frame counter just below the timecode.
+   All of those should be visible and crisp; a blank or solid-color
+   frame is a regression.
+3. Between two consecutive PNG samples (N and N+30), the timecode and
+   frame counter should advance by roughly 30 frames' worth of time at
+   30fps (~1s). A gap substantially larger than that flags a
+   frame-drop bug in the pipeline.
+
+### When to use
+
+- Any change that touches frame ordering, timestamping, FPS
+  propagation, dropped-frame handling, or decoder reordering.
+- Any camera MMAP / DMA-BUF path change that should be re-verified
+  against a strict-conformance V4L2 driver (v4l2loopback does **not**
+  tolerate `poll()` before `VIDIOC_STREAMON`, which exposed #303).
+- Any encoder rate-control / VBV change where the source frame
+  complexity needs to be steady and reproducible across runs.
+
+### Reference
+
+- Added in #303, which fixed the camera MMAP path so it actually
+  streams frames from v4l2loopback.
 
 ---
 

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -1225,28 +1225,12 @@ fn capture_thread_loop(
                 }
             }
         } else {
-            // MMAP path: poll with timeout before stream.next() so the
-            // thread can check is_capturing during shutdown. Without this,
-            // stream.next() blocks on V4L2 DQBUF indefinitely and
-            // SA_RESTART prevents SIGTERM from interrupting it.
-            unsafe {
-                let mut pollfd = libc::pollfd {
-                    fd: device_fd,
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                let poll_result = libc::poll(&mut pollfd, 1, 1000);
-                if poll_result == 0 {
-                    continue; // Timeout — check is_capturing and retry
-                }
-                if poll_result < 0 {
-                    if is_capturing.load(Ordering::Acquire) {
-                        eprintln!("[Camera {}] V4L2 poll error (MMAP path)", camera_name);
-                    }
-                    break;
-                }
-            }
-
+            // MMAP path: stream.next() issues VIDIOC_QBUF + VIDIOC_STREAMON on
+            // its first call, then blocks on VIDIOC_DQBUF. set_timeout()
+            // (applied in start()) caps that wait so the thread can observe
+            // is_capturing during shutdown. Do NOT poll the fd before
+            // stream.next() — strict-conformance drivers (v4l2loopback) only
+            // signal POLLIN after STREAMON, so an earlier poll hangs the loop.
             let (buf, meta) = match stream.next() {
                 Ok(frame) => frame,
                 Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {

--- a/plan/303-camera-v4l2loopback-mmap.md
+++ b/plan/303-camera-v4l2loopback-mmap.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Camera MMAP path sees 0 frames on v4l2loopback
-status: pending
+status: in_review
 description: LinuxCameraProcessor opens /dev/video10 (v4l2loopback) cleanly, logs V4L2 capture started, then its poll loop receives zero frames — while v4l2-ctl and ffmpeg on the same device get frames immediately. Blocks using v4l2loopback + ffmpeg testsrc2 as a deterministic motion fixture.
 github_issue: 303
 adapters:


### PR DESCRIPTION
## Summary

- Remove the unconditional `libc::poll()` call that preceded `stream.next()` in the camera MMAP branch. The v4l crate only issues `VIDIOC_STREAMON` (and the initial per-buffer `VIDIOC_QBUF`) on the first `stream.next()`, so strict V4L2 drivers (v4l2loopback) never signaled `POLLIN` and the loop starved forever. vivid / UVC happened to tolerate poll-before-STREAMON, which masked the bug.
- Rely on `stream.set_timeout(Duration::from_secs(1))` inside the v4l crate's poll wrapper to still give the thread a wake-up point for observing `is_capturing` during shutdown.
- Extend [`docs/testing.md`](docs/testing.md) with a `v4l2loopback + testsrc2` **motion scenario** now that the camera processor can actually consume it — the embedded scrolling timecode and per-frame counter make frame-drop / reorder bugs visible in a PNG sample.

## Issue

Closes #303

## Test Plan

- [x] `cargo check` / `cargo build` pass
- [x] `cargo test -p streamlib --lib linux::processors::camera` passes (2 passed, 1 ignored)
- [x] `camera-display` on `/dev/video10` (v4l2loopback + `ffmpeg testsrc2`) captures ≥ 1 frame within 5 s; PNG samples show the testsrc2 color bars + timecode overlay + frame counter.
- [x] `camera-display` on `/dev/video2` (vivid): no regression.
- [x] `camera-display` on `/dev/video0` (Cam Link 4K UVC): no regression, real scene (Secretlab chair + door + wall) visible.
- [x] `vulkan-video-roundtrip h264 /dev/video10`: 0 `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed`.
- [x] `vulkan-video-roundtrip h265 /dev/video10`: 0 errors on 2nd run (1st run hit the known flaky #304 setup race, retry clean — unrelated to this fix).
- [x] `vulkan-video-roundtrip h264 /dev/video0` (Cam Link): 0 errors, decoded scene visible.
- [x] Sample PNGs per codec posted to Telegram for visual confirmation.

### E2E Test Report

- **Scenario**: camera+display-only (primary) + encoder/decoder (regression)
- **Example**: `camera-display`, `vulkan-video-roundtrip`
- **Codec**: h264 + h265
- **Camera device**: `/dev/video10` (v4l2loopback + `ffmpeg testsrc2`), `/dev/video2` (vivid), `/dev/video0` (Cam Link 4K)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=150` for camera-display, `=300` for roundtrip
- **Build profile**: debug
- **Command**: see commit body / Test Plan above

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0 across all runs
- `DEVICE_LOST`: 0 across all runs (after retrying #304 flake once)
- `process() failed`: 0 across all runs
- `Validation Error`: not enabled
- `First frame encoded` / `decoded` / `captured`: all fired in every codec run
- `Encode progress` / `Decode progress` high-water: 600 frames (H.264 Cam Link), 300 frames elsewhere

#### PNG samples

- `camera-display /dev/video10`: frame 60 — testsrc2 SMPTE-style vertical color bars (red/green/yellow/blue/magenta/cyan), diagonal rainbow line, timecode `00:04:21.133`, frame counter `7834` in upper-left. Matches `ffmpeg testsrc2` expected output.
- `camera-display /dev/video0`: frame 90 — Secretlab chair back (embroidered logo faintly visible), wood-panel door top-right, dark-blue wall. Matches Cam Link live scene.
- `vulkan-video-roundtrip h264 /dev/video10`: frame 90/150 — decoded testsrc2 color bars + timecode visible (encode artifacts are the known #306 quality-level cap on NVIDIA, pre-existing).
- `vulkan-video-roundtrip h265 /dev/video10`: frame 90 — decoded testsrc2 pattern with same quality-level caveat.
- `vulkan-video-roundtrip h264 /dev/video0`: frame 90 — decoded Secretlab chair + door + wall, clean.
- Anomalies: none attributable to this fix.

#### PSNR

- Reference frame: n/a — a fixture-based PSNR rig is the job of #305; testsrc2 overlaid timecode changes every frame so it isn't a viable PSNR reference either.

#### Outcome

- **Pass**
- Caveats / follow-ups filed: #304 (flaky H.265 DEVICE_LOST at setup) and #306 (encoder quality-level default) both pre-existing, out of scope.

## Follow-ups

- None from this fix.