### PR TITLE
refactor(#282): migrate vulkan-video to Vulkan 1.4 sync2 / SubmitInfo2

### DIFF
--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -1037,21 +1037,6 @@ impl VulkanDevice {
             .map_err(|e| StreamError::GpuError(format!("queue_submit2 failed: {e}")))
     }
 
-    /// Submit command buffers using legacy Vulkan 1.0 API with synchronization.
-    pub unsafe fn submit_to_queue_legacy(
-        &self,
-        queue: vk::Queue,
-        submits: &[vk::SubmitInfo],
-        fence: vk::Fence,
-    ) -> Result<()> {
-        let _lock = self.mutex_for_queue(queue).lock()
-            .unwrap_or_else(|e| e.into_inner());
-        self.device
-            .queue_submit(queue, submits, fence)
-            .map(|_| ())
-            .map_err(|e| StreamError::GpuError(format!("queue_submit failed: {e}")))
-    }
-
     /// Present to a queue with per-queue mutex synchronization.
     pub unsafe fn present_to_queue(
         &self,
@@ -1070,15 +1055,15 @@ impl VulkanDevice {
 }
 
 impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
-    unsafe fn submit_to_queue_legacy(
+    unsafe fn submit_to_queue(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo],
+        submits: &[vk::SubmitInfo2],
         fence: vk::Fence,
     ) -> vulkanalia::VkResult<()> {
         let _lock = self.mutex_for_queue(queue).lock()
             .unwrap_or_else(|e| e.into_inner());
-        self.device.queue_submit(queue, submits, fence).map(|_| ())
+        self.device.queue_submit2(queue, submits, fence).map(|_| ())
     }
 
     fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
@@ -1128,7 +1113,11 @@ impl VulkanDevice {
         ).map_err(|e| StreamError::GpuError(format!("begin cb: {e}")))?;
 
         // Barrier: UNDEFINED → TRANSFER_DST
-        let barrier_to_dst = vk::ImageMemoryBarrier::builder()
+        let barrier_to_dst = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::NONE)
+            .src_access_mask(vk::AccessFlags2::empty())
+            .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+            .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
             .old_layout(vk::ImageLayout::UNDEFINED)
             .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -1140,17 +1129,11 @@ impl VulkanDevice {
                 level_count: 1,
                 base_array_layer: 0,
                 layer_count: 1,
-            })
-            .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
-        device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::TOP_OF_PIPE,
-            vk::PipelineStageFlags::TRANSFER,
-            vk::DependencyFlags::empty(),
-            &[] as &[vk::MemoryBarrier],
-            &[] as &[vk::BufferMemoryBarrier],
-            &[barrier_to_dst],
-        );
+            });
+        let barriers_to_dst = [barrier_to_dst];
+        let dep_to_dst = vk::DependencyInfo::builder()
+            .image_memory_barriers(&barriers_to_dst);
+        device.cmd_pipeline_barrier2(cb, &dep_to_dst);
 
         // Copy buffer → image
         let region = vk::BufferImageCopy {
@@ -1172,7 +1155,11 @@ impl VulkanDevice {
         );
 
         // Barrier: TRANSFER_DST → SHADER_READ_ONLY
-        let barrier_to_read = vk::ImageMemoryBarrier::builder()
+        let barrier_to_read = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COPY)
+            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::FRAGMENT_SHADER)
+            .dst_access_mask(vk::AccessFlags2::SHADER_SAMPLED_READ)
             .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
             .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -1184,24 +1171,22 @@ impl VulkanDevice {
                 level_count: 1,
                 base_array_layer: 0,
                 layer_count: 1,
-            })
-            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
-            .dst_access_mask(vk::AccessFlags::SHADER_READ);
-        device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::TRANSFER,
-            vk::PipelineStageFlags::FRAGMENT_SHADER,
-            vk::DependencyFlags::empty(),
-            &[] as &[vk::MemoryBarrier],
-            &[] as &[vk::BufferMemoryBarrier],
-            &[barrier_to_read],
-        );
+            });
+        let barriers_to_read = [barrier_to_read];
+        let dep_to_read = vk::DependencyInfo::builder()
+            .image_memory_barriers(&barriers_to_read);
+        device.cmd_pipeline_barrier2(cb, &dep_to_read);
 
         device.end_command_buffer(cb).map_err(|e| StreamError::GpuError(format!("end cb: {e}")))?;
 
-        let cbs = [cb];
-        let submit = vk::SubmitInfo::builder().command_buffers(&cbs).build();
-        self.submit_to_queue_legacy(queue, &[submit], fence)?;
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cb)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
+            .build();
+        self.submit_to_queue(queue, &[submit], fence)?;
         device.wait_for_fences(&[fence], true, u64::MAX)
             .map_err(|e| StreamError::GpuError(format!("wait: {e}")))?;
 

--- a/libs/vulkan-video/src/bin/pipeline_test.rs
+++ b/libs/vulkan-video/src/bin/pipeline_test.rs
@@ -1233,21 +1233,25 @@ fn main() {
                                 .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                         ).map_err(|e| format!("begin cb: {e}"))?;
 
-                        let barrier_undef = vk::ImageMemoryBarrier::builder()
+                        let barrier_undef = vk::ImageMemoryBarrier2::builder()
+                            .src_stage_mask(vk::PipelineStageFlags2::NONE)
+                            .src_access_mask(vk::AccessFlags2::empty())
+                            .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+                            .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
                             .old_layout(vk::ImageLayout::UNDEFINED)
                             .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                             .image(rgba_image)
                             .subresource_range(vk::ImageSubresourceRange {
                                 aspect_mask: vk::ImageAspectFlags::COLOR,
                                 base_mip_level: 0, level_count: 1,
                                 base_array_layer: 0, layer_count: 1,
-                            })
-                            .src_access_mask(vk::AccessFlags::empty())
-                            .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
-                        device.cmd_pipeline_barrier(tf_cb,
-                            vk::PipelineStageFlags::TOP_OF_PIPE,
-                            vk::PipelineStageFlags::TRANSFER,
-                            vk::DependencyFlags::empty(), &[] as &[vk::MemoryBarrier], &[] as &[vk::BufferMemoryBarrier], &[barrier_undef]);
+                            });
+                        let img_barriers_undef = [barrier_undef];
+                        let dep_undef = vk::DependencyInfo::builder()
+                            .image_memory_barriers(&img_barriers_undef);
+                        device.cmd_pipeline_barrier2(tf_cb, &dep_undef);
 
                         let region = vk::BufferImageCopy {
                             buffer_offset: 0, buffer_row_length: 0, buffer_image_height: 0,
@@ -1263,27 +1267,36 @@ fn main() {
                             vk::ImageLayout::TRANSFER_DST_OPTIMAL, &[region],
                         );
 
-                        let barrier_general = vk::ImageMemoryBarrier::builder()
+                        let barrier_general = vk::ImageMemoryBarrier2::builder()
+                            .src_stage_mask(vk::PipelineStageFlags2::COPY)
+                            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+                            .dst_access_mask(vk::AccessFlags2::SHADER_SAMPLED_READ)
                             .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                             .new_layout(vk::ImageLayout::GENERAL)
+                            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                             .image(rgba_image)
                             .subresource_range(vk::ImageSubresourceRange {
                                 aspect_mask: vk::ImageAspectFlags::COLOR,
                                 base_mip_level: 0, level_count: 1,
                                 base_array_layer: 0, layer_count: 1,
-                            })
-                            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
-                            .dst_access_mask(vk::AccessFlags::SHADER_READ);
-                        device.cmd_pipeline_barrier(tf_cb,
-                            vk::PipelineStageFlags::TRANSFER,
-                            vk::PipelineStageFlags::COMPUTE_SHADER,
-                            vk::DependencyFlags::empty(), &[] as &[vk::MemoryBarrier], &[] as &[vk::BufferMemoryBarrier], &[barrier_general]);
+                            });
+                        let img_barriers_general = [barrier_general];
+                        let dep_general = vk::DependencyInfo::builder()
+                            .image_memory_barriers(&img_barriers_general);
+                        device.cmd_pipeline_barrier2(tf_cb, &dep_general);
 
                         device.end_command_buffer(tf_cb).map_err(|e| format!("end cb: {e}"))?;
                         device.reset_fences(&[tf_fence]).map_err(|e| format!("reset fence: {e}"))?;
-                        let cbs = [tf_cb];
-                        let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs);
-                        device.queue_submit(transfer_queue, &[submit_info], tf_fence)
+                        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+                            .command_buffer(tf_cb)
+                            .build();
+                        let cb_submits = [cb_submit];
+                        let submit_info = vk::SubmitInfo2::builder()
+                            .command_buffer_infos(&cb_submits)
+                            .build();
+                        device.queue_submit2(transfer_queue, &[submit_info], tf_fence)
                             .map_err(|e| format!("queue submit: {e}"))?;
                         device.wait_for_fences(&[tf_fence], true, 1_000_000_000)
                             .map_err(|e| format!("wait fence: {e}"))?;
@@ -1491,7 +1504,11 @@ fn main() {
                     .map_err(|e| format!("begin cb: {e}"))?;
 
                 // Transition NV12 UNDEFINED → TRANSFER_DST
-                let barrier_dst = vk::ImageMemoryBarrier::builder()
+                let barrier_dst = vk::ImageMemoryBarrier2::builder()
+                    .src_stage_mask(vk::PipelineStageFlags2::NONE)
+                    .src_access_mask(vk::AccessFlags2::empty())
+                    .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+                    .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
                     .old_layout(vk::ImageLayout::UNDEFINED)
                     .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                     .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -1503,17 +1520,11 @@ fn main() {
                         level_count: 1,
                         base_array_layer: 0,
                         layer_count: 1,
-                    })
-                    .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
-                let no_mem: &[vk::MemoryBarrier] = &[];
-                let no_buf: &[vk::BufferMemoryBarrier] = &[];
-                device.cmd_pipeline_barrier(
-                    tf_cb,
-                    vk::PipelineStageFlags::TOP_OF_PIPE,
-                    vk::PipelineStageFlags::TRANSFER,
-                    vk::DependencyFlags::empty(),
-                    no_mem, no_buf, &[barrier_dst],
-                );
+                    });
+                let img_barriers_dst = [barrier_dst];
+                let dep_dst = vk::DependencyInfo::builder()
+                    .image_memory_barriers(&img_barriers_dst);
+                device.cmd_pipeline_barrier2(tf_cb, &dep_dst);
 
                 // Copy Y and UV planes
                 let y_region = vk::BufferImageCopy {
@@ -1553,8 +1564,14 @@ fn main() {
 
                 device.end_command_buffer(tf_cb).map_err(|e| format!("end cb: {e}"))?;
 
-                let submit = vk::SubmitInfo::builder().command_buffers(std::slice::from_ref(&tf_cb));
-                device.queue_submit(tf_q, &[submit], tf_fence).map_err(|e| format!("submit: {e}"))?;
+                let cb_submit = vk::CommandBufferSubmitInfo::builder()
+                    .command_buffer(tf_cb)
+                    .build();
+                let cb_submits = [cb_submit];
+                let submit = vk::SubmitInfo2::builder()
+                    .command_buffer_infos(&cb_submits)
+                    .build();
+                device.queue_submit2(tf_q, &[submit], tf_fence).map_err(|e| format!("submit: {e}"))?;
                 device.wait_for_fences(&[tf_fence], true, u64::MAX).map_err(|e| format!("wait: {e}"))?;
 
                 allocator.destroy_buffer(stg_buf, stg_alloc);
@@ -1619,8 +1636,14 @@ fn main() {
                 );
 
                 device.end_command_buffer(tf_cb).map_err(|e| format!("end cb: {e}"))?;
-                let submit = vk::SubmitInfo::builder().command_buffers(std::slice::from_ref(&tf_cb));
-                device.queue_submit(tf_q, &[submit], tf_fence).map_err(|e| format!("submit: {e}"))?;
+                let cb_submit = vk::CommandBufferSubmitInfo::builder()
+                    .command_buffer(tf_cb)
+                    .build();
+                let cb_submits = [cb_submit];
+                let submit = vk::SubmitInfo2::builder()
+                    .command_buffer_infos(&cb_submits)
+                    .build();
+                device.queue_submit2(tf_q, &[submit], tf_fence).map_err(|e| format!("submit: {e}"))?;
                 device.wait_for_fences(&[tf_fence], true, u64::MAX).map_err(|e| format!("wait: {e}"))?;
 
                 let rb_ai = allocator.get_allocation_info(rb_alloc);

--- a/libs/vulkan-video/src/decode/mod.rs
+++ b/libs/vulkan-video/src/decode/mod.rs
@@ -923,9 +923,14 @@ impl SimpleDecoder {
 
                 self.device.end_command_buffer(self.transfer_cb).map_err(VideoError::from)?;
                 self.device.reset_fences(&[self.transfer_fence]).map_err(VideoError::from)?;
-                let cbs = [self.transfer_cb];
-                let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs).build();
-                self.submitter.submit_to_queue_legacy(
+                let cb_submit = vk::CommandBufferSubmitInfo::builder()
+                    .command_buffer(self.transfer_cb)
+                    .build();
+                let cb_submits = [cb_submit];
+                let submit_info = vk::SubmitInfo2::builder()
+                    .command_buffer_infos(&cb_submits)
+                    .build();
+                self.submitter.submit_to_queue(
                     self.transfer_queue,
                     &[submit_info],
                     self.transfer_fence,

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -718,7 +718,11 @@ impl SimpleEncoder {
         )?;
 
         // Barrier: UNDEFINED -> TRANSFER_DST
-        let barrier_to_transfer = vk::ImageMemoryBarrier::builder()
+        let barrier_to_transfer = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::NONE)
+            .src_access_mask(vk::AccessFlags2::empty())
+            .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+            .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
             .old_layout(vk::ImageLayout::UNDEFINED)
             .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -730,20 +734,13 @@ impl SimpleEncoder {
                 level_count: 1,
                 base_array_layer: 0,
                 layer_count: 1,
-            })
-            .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
+            });
 
-        let no_mem_barriers: &[vk::MemoryBarrier] = &[];
-        let no_buf_barriers: &[vk::BufferMemoryBarrier] = &[];
-        self.device.cmd_pipeline_barrier(
-            self.transfer_cb,
-            vk::PipelineStageFlags::TOP_OF_PIPE,
-            vk::PipelineStageFlags::TRANSFER,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_to_transfer],
-        );
+        let image_barriers_to_transfer = [barrier_to_transfer];
+        let dep_to_transfer = vk::DependencyInfo::builder()
+            .image_memory_barriers(&image_barriers_to_transfer);
+        self.device
+            .cmd_pipeline_barrier2(self.transfer_cb, &dep_to_transfer);
 
         // Copy Y plane
         let y_region = vk::BufferImageCopy::builder()
@@ -783,8 +780,11 @@ impl SimpleEncoder {
         );
 
         // Barrier: TRANSFER_DST -> VIDEO_ENCODE_SRC
-        let barrier_to_encode = vk::ImageMemoryBarrier::builder()
-            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+        let barrier_to_encode = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COPY)
+            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::NONE)
+            .dst_access_mask(vk::AccessFlags2::empty())
             .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
             .new_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -798,26 +798,26 @@ impl SimpleEncoder {
                 layer_count: 1,
             });
 
-        self.device.cmd_pipeline_barrier(
-            self.transfer_cb,
-            vk::PipelineStageFlags::TRANSFER,
-            vk::PipelineStageFlags::BOTTOM_OF_PIPE,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_to_encode],
-        );
+        let image_barriers_to_encode = [barrier_to_encode];
+        let dep_to_encode = vk::DependencyInfo::builder()
+            .image_memory_barriers(&image_barriers_to_encode);
+        self.device
+            .cmd_pipeline_barrier2(self.transfer_cb, &dep_to_encode);
 
         self.device.end_command_buffer(self.transfer_cb)?;
 
         // Submit transfer
-        let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&self.transfer_cb))
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(self.transfer_cb)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
             .build();
 
         self.device.reset_fences(&[self.transfer_fence])?;
         self.submitter
-            .submit_to_queue_legacy(self.transfer_queue, &[submit], self.transfer_fence)?;
+            .submit_to_queue(self.transfer_queue, &[submit], self.transfer_fence)?;
         self.device
             .wait_for_fences(&[self.transfer_fence], true, u64::MAX)?;
 

--- a/libs/vulkan-video/src/encode/submit.rs
+++ b/libs/vulkan-video/src/encode/submit.rs
@@ -1147,14 +1147,17 @@ impl SimpleEncoder {
         device.end_command_buffer(self.command_buffer)?;
 
         // --- Submit to queue ---
-        let command_buffers = [self.command_buffer];
-        let submit_info = vk::SubmitInfo::builder()
-            .command_buffers(&command_buffers)
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(self.command_buffer)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit_info = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
             .build();
 
         device.reset_fences(&[self.fence])?;
         self.submitter
-            .submit_to_queue_legacy(self.encode_queue, &[submit_info], self.fence)?;
+            .submit_to_queue(self.encode_queue, &[submit_info], self.fence)?;
         device.wait_for_fences(&[self.fence], true, u64::MAX)?;
 
         // --- Query encode feedback ---

--- a/libs/vulkan-video/src/nv12_to_rgb.rs
+++ b/libs/vulkan-video/src/nv12_to_rgb.rs
@@ -333,8 +333,6 @@ impl Nv12ToRgbConverter {
         )?;
 
         let cb = self.command_buffer;
-        let no_mem_barriers: &[vk::MemoryBarrier] = &[];
-        let no_buf_barriers: &[vk::BufferMemoryBarrier] = &[];
 
         self.device
             .reset_command_buffer(cb, vk::CommandBufferResetFlags::empty())?;
@@ -345,7 +343,11 @@ impl Nv12ToRgbConverter {
         )?;
 
         // --- Barrier: NV12 source → SHADER_READ_ONLY_OPTIMAL ---
-        let barrier_nv12 = vk::ImageMemoryBarrier::builder()
+        let barrier_nv12 = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .dst_access_mask(vk::AccessFlags2::SHADER_SAMPLED_READ)
             .old_layout(src_layout)
             .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -357,12 +359,14 @@ impl Nv12ToRgbConverter {
                 level_count: 1,
                 base_array_layer: array_layer,
                 layer_count: 1,
-            })
-            .src_access_mask(vk::AccessFlags::MEMORY_WRITE)
-            .dst_access_mask(vk::AccessFlags::SHADER_READ);
+            });
 
         // --- Barrier: RGBA output UNDEFINED → GENERAL (for compute writes) ---
-        let barrier_rgba = vk::ImageMemoryBarrier::builder()
+        let barrier_rgba = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::NONE)
+            .src_access_mask(vk::AccessFlags2::empty())
+            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .dst_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
             .old_layout(vk::ImageLayout::UNDEFINED)
             .new_layout(vk::ImageLayout::GENERAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -374,18 +378,12 @@ impl Nv12ToRgbConverter {
                 level_count: 1,
                 base_array_layer: 0,
                 layer_count: 1,
-            })
-            .dst_access_mask(vk::AccessFlags::SHADER_WRITE);
+            });
 
-        self.device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::ALL_COMMANDS,
-            vk::PipelineStageFlags::COMPUTE_SHADER,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_nv12, barrier_rgba],
-        );
+        let pre_barriers = [barrier_nv12, barrier_rgba];
+        let pre_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&pre_barriers);
+        self.device.cmd_pipeline_barrier2(cb, &pre_dep);
 
         // --- Bind compute pipeline ---
         self.device
@@ -444,8 +442,11 @@ impl Nv12ToRgbConverter {
         self.device.cmd_dispatch(cb, group_x, group_y, 1);
 
         // --- Barrier: RGBA GENERAL → TRANSFER_SRC_OPTIMAL (for readback) ---
-        let barrier_to_transfer = vk::ImageMemoryBarrier::builder()
-            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+        let barrier_to_transfer = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .src_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+            .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
             .old_layout(vk::ImageLayout::GENERAL)
             .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -459,26 +460,25 @@ impl Nv12ToRgbConverter {
                 layer_count: 1,
             });
 
-        self.device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::COMPUTE_SHADER,
-            vk::PipelineStageFlags::TRANSFER,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_to_transfer],
-        );
+        let post_barriers = [barrier_to_transfer];
+        let post_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&post_barriers);
+        self.device.cmd_pipeline_barrier2(cb, &post_dep);
 
         self.device.end_command_buffer(cb)?;
 
         // --- Submit and wait ---
-        let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&cb))
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cb)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
             .build();
 
         self.device.reset_fences(&[self.fence])?;
         self.submitter
-            .submit_to_queue_legacy(self.compute_queue, &[submit], self.fence)?;
+            .submit_to_queue(self.compute_queue, &[submit], self.fence)?;
         self.device
             .wait_for_fences(&[self.fence], true, u64::MAX)?;
 

--- a/libs/vulkan-video/src/rgb_to_nv12.rs
+++ b/libs/vulkan-video/src/rgb_to_nv12.rs
@@ -349,8 +349,6 @@ impl RgbToNv12Converter {
         rgba_image_view: vk::ImageView,
     ) -> Result<(vk::Image, vk::ImageView), VideoError> {
         let cb = self.command_buffer;
-        let no_mem_barriers: &[vk::MemoryBarrier] = &[];
-        let no_buf_barriers: &[vk::BufferMemoryBarrier] = &[];
 
         self.device
             .reset_command_buffer(cb, vk::CommandBufferResetFlags::empty())?;
@@ -361,7 +359,11 @@ impl RgbToNv12Converter {
         )?;
 
         // --- Barrier: NV12 UNDEFINED → GENERAL (for compute writes) ---
-        let barrier_to_general = vk::ImageMemoryBarrier::builder()
+        let barrier_to_general = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::NONE)
+            .src_access_mask(vk::AccessFlags2::empty())
+            .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .dst_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
             .old_layout(vk::ImageLayout::UNDEFINED)
             .new_layout(vk::ImageLayout::GENERAL)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -373,18 +375,12 @@ impl RgbToNv12Converter {
                 level_count: 1,
                 base_array_layer: 0,
                 layer_count: 1,
-            })
-            .dst_access_mask(vk::AccessFlags::SHADER_WRITE);
+            });
 
-        self.device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::TOP_OF_PIPE,
-            vk::PipelineStageFlags::COMPUTE_SHADER,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_to_general],
-        );
+        let pre_barriers = [barrier_to_general];
+        let pre_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&pre_barriers);
+        self.device.cmd_pipeline_barrier2(cb, &pre_dep);
 
         // --- Bind compute pipeline ---
         self.device
@@ -452,8 +448,11 @@ impl RgbToNv12Converter {
         self.device.cmd_dispatch(cb, group_x, group_y, 1);
 
         // --- Barrier: NV12 GENERAL → VIDEO_ENCODE_SRC ---
-        let barrier_to_encode = vk::ImageMemoryBarrier::builder()
-            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+        let barrier_to_encode = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .src_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::NONE)
+            .dst_access_mask(vk::AccessFlags2::empty())
             .old_layout(vk::ImageLayout::GENERAL)
             .new_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -467,26 +466,25 @@ impl RgbToNv12Converter {
                 layer_count: 1,
             });
 
-        self.device.cmd_pipeline_barrier(
-            cb,
-            vk::PipelineStageFlags::COMPUTE_SHADER,
-            vk::PipelineStageFlags::BOTTOM_OF_PIPE,
-            vk::DependencyFlags::empty(),
-            no_mem_barriers,
-            no_buf_barriers,
-            &[barrier_to_encode],
-        );
+        let post_barriers = [barrier_to_encode];
+        let post_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&post_barriers);
+        self.device.cmd_pipeline_barrier2(cb, &post_dep);
 
         self.device.end_command_buffer(cb)?;
 
         // --- Submit and wait ---
-        let submit = vk::SubmitInfo::builder()
-            .command_buffers(std::slice::from_ref(&cb))
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cb)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
             .build();
 
         self.device.reset_fences(&[self.fence])?;
         self.submitter
-            .submit_to_queue_legacy(self.compute_queue, &[submit], self.fence)?;
+            .submit_to_queue(self.compute_queue, &[submit], self.fence)?;
         self.device
             .wait_for_fences(&[self.fence], true, u64::MAX)?;
 

--- a/libs/vulkan-video/src/rhi.rs
+++ b/libs/vulkan-video/src/rhi.rs
@@ -15,19 +15,19 @@ use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 use vulkanalia::VkResult;
 
-/// Host-side gateway for `vkQueueSubmit` calls.
+/// Host-side gateway for `vkQueueSubmit2` calls.
 pub trait RhiQueueSubmitter: Send + Sync {
-    /// Submit command buffers using the Vulkan 1.0 submit API under host
-    /// synchronization.
+    /// Submit command buffers using the Vulkan 1.4 sync2 submit API under
+    /// host synchronization.
     ///
     /// # Safety
     ///
     /// Caller must ensure the command buffers, submit info chains, and fence
     /// are valid Vulkan handles and that `queue` belongs to the host device.
-    unsafe fn submit_to_queue_legacy(
+    unsafe fn submit_to_queue(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo],
+        submits: &[vk::SubmitInfo2],
         fence: vk::Fence,
     ) -> VkResult<()>;
 
@@ -53,13 +53,13 @@ impl RawQueueSubmitter {
 }
 
 impl RhiQueueSubmitter for RawQueueSubmitter {
-    unsafe fn submit_to_queue_legacy(
+    unsafe fn submit_to_queue(
         &self,
         queue: vk::Queue,
-        submits: &[vk::SubmitInfo],
+        submits: &[vk::SubmitInfo2],
         fence: vk::Fence,
     ) -> VkResult<()> {
-        self.device.queue_submit(queue, submits, fence).map(|_| ())
+        self.device.queue_submit2(queue, submits, fence).map(|_| ())
     }
 
     fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {

--- a/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
@@ -1371,9 +1371,14 @@ impl VkVideoDecoder {
         // --- Submit ---
         device.end_command_buffer(self.command_buffer).map_err(VideoError::from)?;
         device.reset_fences(&[self.fence]).map_err(VideoError::from)?;
-        let cbs = [self.command_buffer];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&cbs).build();
-        self.submitter.submit_to_queue_legacy(self.queue, &[submit_info], self.fence)
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(self.command_buffer)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit_info = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
+            .build();
+        self.submitter.submit_to_queue(self.queue, &[submit_info], self.fence)
             .map_err(VideoError::from)?;
         self.decode_in_flight = true;
 

--- a/plan/282-vulkan-video-sync2-migration.md
+++ b/plan/282-vulkan-video-sync2-migration.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Migrate vulkan-video to Vulkan 1.4 sync2 / SubmitInfo2
-status: pending
+status: in_review
 description: Migrate vulkan-video's ported nvpro-samples code to Vulkan 1.4 sync2 (SubmitInfo2, cmd_pipeline_barrier_2) and delete submit_to_queue_legacy. Finishes the modernization #261 started on the streamlib side.
 github_issue: 282
 dependencies:


### PR DESCRIPTION
## Summary

- Migrates every `vkQueueSubmit` / `cmd_pipeline_barrier` in `libs/vulkan-video` to sync2 equivalents (`queue_submit2`, `cmd_pipeline_barrier_2`, `SubmitInfo2` + `CommandBufferSubmitInfo`, `DependencyInfo` + `ImageMemoryBarrier2`).
- Renames `RhiQueueSubmitter::submit_to_queue_legacy` → `submit_to_queue` and switches the trait signature to `&[SubmitInfo2]`. Both impls (`RawQueueSubmitter`, `VulkanDevice`) updated.
- Deletes `VulkanDevice::submit_to_queue_legacy` inherent method and migrates its last internal caller (`upload_buffer_to_image`) to sync2 so the legacy path is gone from streamlib end-to-end.
- `libs/vulkan-video/src/bin/pipeline_test.rs` migrated alongside so the whole crate is sync2-clean.

## Issue

Closes #282

## Test Plan

- [x] `cargo check -p vulkan-video -p streamlib --all-targets` clean
- [x] `cargo test -p vulkan-video --lib` → 613 passed
- [x] `cargo test -p streamlib --lib` → 147 passed
- [x] Grep-verify no remaining Vulkan 1.0 patterns in `libs/`:
  - `submit_to_queue_legacy` → 0
  - `cmd_pipeline_barrier(` → 0
  - `.queue_submit(` in vulkan-video → 0
  - `vk::SubmitInfo` (non-2) → 0

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 _and_ h265
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=150`, 10 s
- **Build profile**: debug
- **Command**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-sync2-*/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=150 \
    timeout --kill-after=5 35 cargo run -q -p vulkan-video-roundtrip -- {h264|h265} /dev/video2 10
    ```

#### Log signals (both codecs)

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame captured` / encoded / decoded: all present
- Exit code: 0 (clean shutdown)

#### PNG samples

- Directory: `/tmp/e2e-sync2-h264-.../png_samples/`, `/tmp/e2e-sync2-h265-.../png_samples/`
- Sample count: 2 per codec
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30`
- PNGs read with Read tool: `display_001_frame_000030.png` (h264), `display_001_frame_000030.png` (h265)
- **What was in the image(s)**: both frames show vivid's green/purple SMPTE-style vertical bars with `00:00:06:606` timecode and camera-info text overlay (`1920x1080, input 0`, `brightness 128…`, etc.) in the upper-left. Matches the expected vivid test pattern end-to-end through the encoder→decoder→display path.
- Anomalies: none

#### PSNR

- Reference frame: n/a — vivid source, no checked-in reference available. (#305 will add a fixture-based PSNR rig.)
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass**
- Caveats / follow-ups filed: none new.

### Implementation note

The submit migration initially reproduced `ERROR_DEVICE_LOST` on the encoder every frame. Root cause: `CommandBufferSubmitInfo::builder()` and `SubmitInfo2::builder()` must be materialized with `.build()` before being placed in an array and passed via slice — passing raw builders compiled but yielded a layout the driver rejected. Fixed by adding `.build()` on all 9 sites to match streamlib's existing pattern. Retest pass.

## Follow-ups

- None. Task scope fully met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)