### PR TITLE
fix(#290): chain external memory info on DMA-BUF VMA pool probes

### DIFF
--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -719,6 +719,14 @@ impl VulkanDevice {
         Box<vk::ExportMemoryAllocateInfo>,
     )> {
         // ── Find memory type for HOST_VISIBLE DMA-BUF exportable buffers ──
+        // The probe must mirror the real buffer create info used by
+        // `VulkanPixelBuffer::new`, including the `ExternalMemoryBufferCreateInfo`
+        // pNext chain — DMA-BUF external buffers have a narrower
+        // `memoryTypeBits` than plain buffers, and omitting the chain lets VMA
+        // pick a memory type the real buffer won't accept at bind time
+        // (VUID-vkBindBufferMemory-memory-01035).
+        let mut probe_buffer_external_info = vk::ExternalMemoryBufferCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
         let probe_buffer_info = vk::BufferCreateInfo::builder()
             .size(64 * 1024)
             .usage(
@@ -726,7 +734,8 @@ impl VulkanDevice {
                     | vk::BufferUsageFlags::TRANSFER_DST
                     | vk::BufferUsageFlags::STORAGE_BUFFER,
             )
-            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .push_next(&mut probe_buffer_external_info);
         let probe_buffer_alloc_opts = vma::AllocationOptions {
             flags: vma::AllocationCreateFlags::DEDICATED_MEMORY
                 | vma::AllocationCreateFlags::MAPPED
@@ -748,6 +757,11 @@ impl VulkanDevice {
         })?;
 
         // ── Find memory type for DEVICE_LOCAL DMA-BUF exportable images ──
+        // Same rationale: the real image (`VulkanTexture::new`) carries
+        // `ExternalMemoryImageCreateInfo::DMA_BUF_EXT` which can narrow
+        // `memoryTypeBits`.
+        let mut probe_image_external_info = vk::ExternalMemoryImageCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
         let probe_image_info = vk::ImageCreateInfo::builder()
             .image_type(vk::ImageType::_2D)
             .format(vk::Format::B8G8R8A8_UNORM)
@@ -762,7 +776,8 @@ impl VulkanDevice {
                     | vk::ImageUsageFlags::SAMPLED,
             )
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .initial_layout(vk::ImageLayout::UNDEFINED);
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push_next(&mut probe_image_external_info);
         let probe_image_alloc_opts = vma::AllocationOptions {
             flags: vma::AllocationCreateFlags::DEDICATED_MEMORY,
             required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,

--- a/plan/290-vma-memory-type-mismatch.md
+++ b/plan/290-vma-memory-type-mismatch.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: VMA bind-buffer-memory type mismatch
-status: pending
+status: in_review
 description: Fix the VMA pool memory-type selection so bound memory is in the buffer's allowed memoryTypeBits.
 github_issue: 290
 adapters:


### PR DESCRIPTION
## Summary
- Chain `VkExternalMemoryBufferCreateInfo::DMA_BUF_EXT` and `VkExternalMemoryImageCreateInfo::DMA_BUF_EXT` onto the probe `BufferCreateInfo` / `ImageCreateInfo` passed to `vmaFindMemoryTypeIndexFor{Buffer,Image}Info` in `create_dma_buf_pools`.
- Without the chain, VMA probes plain buffers/images whose `memoryTypeBits` are wider than the real DMA-BUF-exportable resources, so the chosen pool memory type (e.g. index 5 on NVIDIA RTX 3090) is not in the real buffer's allowed mask (0x1b = types 0, 1, 3, 4) — triggering `VUID-vkBindBufferMemory-memory-01035` at bind time.

## Issue
Closes #290

## Test Plan
- [x] `cargo check -p streamlib` clean (only pre-existing warnings)
- [x] `cargo test -p streamlib --lib vulkan::rhi` — 36 passed, 0 failed
- [x] Release-build `vulkan-video-roundtrip h264 /dev/video2` with `VK_LOADER_LAYERS_ENABLE=*validation*`: `VUID-vkBindBufferMemory-memory-01035` 16 → 0
- [x] Release-build `vulkan-video-roundtrip h265 /dev/video2` with validation: `VUID-vkBindBufferMemory-memory-01035` = 0
- [x] Both runs: 0× `OUT_OF_DEVICE_MEMORY`, 0× `DEVICE_LOST`, 0× `process() failed`
- [x] PNG sample read — vivid SMPTE pattern with timecode overlay visible

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 + h265
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=180`, 10 s
- **Build profile**: release

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0 (both codecs)
- `DEVICE_LOST`: 0 (both)
- `process() failed`: 0 (both)
- `VUID-vkBindBufferMemory-memory-01035`: **0** (both; was 16 on `main`)
- `First frame captured` / `encoded` / `decoded`: all present

#### PNG evidence

vivid test pattern captured at `display_001_frame_000000.png` (h264 run). Green/purple vertical bars, scrolling timecode (`00:00:00:001.0`) and metadata overlay (`1920x1080, input: 0`) in the upper-left. Matches vivid's expected SMPTE pattern. No black frames, no tearing.

![vivid PNG — display_001_frame_000000](https://gist.githubusercontent.com/tato123/ddfce900e674b4e7b9a46ee0b5300d3b/raw/pr311-evidence.png)

#### PSNR

- n/a — no reference frame available for vivid testsrc. Visual check only.

#### Outcome

- **Pass** — VUID-01035 eliminated, no new regressions.
- Pre-existing VUIDs (08206, 09600, 03868, YCbcr, queue family) remain — tracked by #300, #291, #296, #289. Out of scope.

## Follow-ups
- None for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)