### PR TITLE
fix(#291): request transfer queue family in DeviceQueueCreateInfo

### DIFF
--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -324,6 +324,17 @@ impl VulkanDevice {
 
         // Request separate video encode/decode queues if they're different families
         let mut requested_families = vec![queue_family_index];
+        if transfer_queue_family_index != queue_family_index
+            && !requested_families.contains(&transfer_queue_family_index)
+        {
+            requested_families.push(transfer_queue_family_index);
+            queue_create_infos.push(
+                vk::DeviceQueueCreateInfo::builder()
+                    .queue_family_index(transfer_queue_family_index)
+                    .queue_priorities(&queue_priorities)
+                    .build(),
+            );
+        }
         if let Some(ve_family) = video_encode_queue_family_index {
             if !requested_families.contains(&ve_family) {
                 requested_families.push(ve_family);


### PR DESCRIPTION
## Summary
- Add `transfer_queue_family_index` to `VkDeviceQueueCreateInfo` when it differs from the graphics family.
- Silences `VUID-vkGetDeviceQueue-queueFamilyIndex-00384` on devices with a dedicated TRANSFER-only family (e.g. NVIDIA RTX 3090, family 1).
- No invalid queue handle returned anymore from `device.get_device_queue(transfer_queue_family_index, 0)`.

## Issue
Closes #291

## Test Plan
- [x] `cargo check -p streamlib` passes
- [x] `cargo test -p streamlib --lib vulkan` — 36 passed, 0 failed
- [x] `VK_LOADER_LAYERS_ENABLE=*validation* cargo test -p streamlib --lib vulkan::rhi::vulkan_device::tests::test_device_creation`:
    - **pre-fix**: `Validation Error: [ VUID-vkGetDeviceQueue-queueFamilyIndex-00384 ] vkGetDeviceQueue(): queueFamilyIndex (1) is not one of the queue families given via VkDeviceQueueCreateInfo`
    - **post-fix**: no validation output
- [ ] Full E2E roundtrip retest folds into #294.

## Follow-ups
- None. Pre-existing warnings in `libs/vulkan-video/` are unrelated and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)