### PR TITLE
fix(#296): size render_finished semaphore per swapchain image

### DIFF
--- a/docs/learnings/vulkan-frames-in-flight.md
+++ b/docs/learnings/vulkan-frames-in-flight.md
@@ -28,7 +28,7 @@ const MAX_FRAMES_IN_FLIGHT: usize = 2;
 | Resource | Size to | Rationale |
 |---|---|---|
 | Acquire-image semaphore | `MAX_FRAMES_IN_FLIGHT` | Per-frame sync |
-| Render-finished semaphore | `MAX_FRAMES_IN_FLIGHT` | Per-frame sync |
+| Render-finished / present-wait semaphore | `image_count` | **Per-swapchain-image** — see below |
 | Command buffer | `MAX_FRAMES_IN_FLIGHT` | Per-frame recording |
 | Descriptor set | `MAX_FRAMES_IN_FLIGHT` | Per-frame texture binding |
 | Render-target ring texture | `MAX_FRAMES_IN_FLIGHT` | Per-frame WAR avoidance |
@@ -36,7 +36,34 @@ const MAX_FRAMES_IN_FLIGHT: usize = 2;
 | Swapchain image views | `image_count` | Per-image, attaches to swapchain image |
 
 Index per-frame resources with `current_frame ∈ [0, MAX_FRAMES_IN_FLIGHT)`.
-Index per-image resources with `image_index` from `acquire_next_image_khr`.
+Index per-image resources (including the render-finished semaphore) with
+`image_index` from `acquire_next_image_khr`.
+
+## Exception: render-finished / present-wait semaphore is per-image
+
+The "render-finished" semaphore is the one passed to `vkQueuePresentKHR`
+via `VkPresentInfoKHR::pWaitSemaphores`. It looks per-frame at first
+glance — one render submission signals it, one present waits on it —
+but it must be sized to `image_count` and indexed by `image_index`.
+
+**Why:** After `vkQueuePresentKHR` consumes the wait, the present engine
+still holds the binary semaphore in an unsignaled-but-not-yet-released
+state until the image is actually released for reuse (compositor has
+finished with it, next acquire can return it). If the next submission
+for the same per-frame slot tries to *signal* that same semaphore before
+the present engine has let go, the driver reports
+`VUID-vkQueueSubmit2-semaphore-03868` ("semaphore must not have another
+signal operation pending") and validation trips.
+
+Sizing to `image_count` and keying by `image_index` gives every
+swapchain image its own binary semaphore, and the present engine's hold
+on image N's semaphore can't collide with the next signal for image
+M ≠ N. This is the standard Vulkan pattern — the frame-count sizing in
+tutorials is a common, driver-tolerated bug.
+
+Acquire-image semaphores do NOT have this issue: they are signaled by
+`vkAcquireNextImageKHR` and waited by the next render submit — there's
+no external holder. They stay sized to `MAX_FRAMES_IN_FLIGHT`.
 
 ## Why 2
 
@@ -53,4 +80,5 @@ Index per-image resources with `image_index` from `acquire_next_image_khr`.
 
 ## Reference
 - Refactor commit: `6816f54` `refactor(display): decouple frames-in-flight from swapchain image count`
-- Implementation: `libs/streamlib/src/linux/processors/display.rs` (search `MAX_FRAMES_IN_FLIGHT`)
+- Per-image render-finished semaphore fix: issue #296
+- Implementation: `libs/streamlib/src/linux/processors/display.rs` (search `MAX_FRAMES_IN_FLIGHT` and `render_finished_semaphores`)

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -637,7 +637,6 @@ impl DisplayEventLoopHandler {
         }
 
         let image_available_semaphore = state.image_available_semaphores[frame_index];
-        let render_finished_semaphore = state.render_finished_semaphores[frame_index];
         let command_buffer = state.command_buffers[frame_index];
 
         // Acquire next swapchain image
@@ -665,6 +664,10 @@ impl DisplayEventLoopHandler {
         };
 
         let swapchain_image = state.swapchain_images[image_index as usize];
+        // render_finished is per-swapchain-image: the present engine holds the
+        // binary semaphore until the image is released, so signal/wait must be
+        // keyed by image_index rather than frame_index.
+        let render_finished_semaphore = state.render_finished_semaphores[image_index as usize];
 
         // Reset and re-record the pre-allocated command buffer
         let begin_info = vk::CommandBufferBeginInfo::builder()
@@ -1187,20 +1190,25 @@ fn create_swapchain_state(
     let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
         .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {}", e)))?;
 
-    // Per-FRAME synchronization primitives sized to MAX_FRAMES_IN_FLIGHT.
+    // image_available: per-frame-in-flight (CPU↔GPU pipelining).
+    // render_finished: per-swapchain-image — the present engine keeps a hold
+    // on the binary semaphore until it releases the image for reuse, so the
+    // signal must match the acquired image_index (not the CPU frame_index)
+    // to avoid VUID-vkQueueSubmit2-semaphore-03868.
     let image_count = swapchain_images.len();
     let semaphore_info = vk::SemaphoreCreateInfo::builder().build();
 
     let mut image_available_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
-    let mut render_finished_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
-
     for _ in 0..MAX_FRAMES_IN_FLIGHT {
         let image_available = unsafe { device.create_semaphore(&semaphore_info, None) }
             .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+        image_available_semaphores.push(image_available);
+    }
+
+    let mut render_finished_semaphores = Vec::with_capacity(image_count);
+    for _ in 0..image_count {
         let render_finished = unsafe { device.create_semaphore(&semaphore_info, None) }
             .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
-
-        image_available_semaphores.push(image_available);
         render_finished_semaphores.push(render_finished);
     }
 
@@ -1587,20 +1595,22 @@ fn recreate_swapchain(
     let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
         .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {}", e)))?;
 
-    // Per-FRAME synchronization primitives sized to MAX_FRAMES_IN_FLIGHT.
+    // image_available: per-frame-in-flight. render_finished: per-swapchain-image
+    // (see create path for rationale).
     let new_image_count = swapchain_images.len();
     let semaphore_info = vk::SemaphoreCreateInfo::builder().build();
 
     let mut image_available_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
-    let mut render_finished_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
-
     for _ in 0..MAX_FRAMES_IN_FLIGHT {
         let image_available = unsafe { device.create_semaphore(&semaphore_info, None) }
             .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+        image_available_semaphores.push(image_available);
+    }
+
+    let mut render_finished_semaphores = Vec::with_capacity(new_image_count);
+    for _ in 0..new_image_count {
         let render_finished = unsafe { device.create_semaphore(&semaphore_info, None) }
             .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
-
-        image_available_semaphores.push(image_available);
         render_finished_semaphores.push(render_finished);
     }
 

--- a/plan/294-post-vulkan-cleanup-retest.md
+++ b/plan/294-post-vulkan-cleanup-retest.md
@@ -2,7 +2,7 @@
 whoami: amos
 name: Retest camera + encoder + display roundtrip after Vulkan cleanup
 status: pending
-description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, #303, #304, #305, and #306 land and confirm release SIGSEGV and Cam Link OOM are both gone.
+description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, #303, #304, #305, #306, #315, and #316 land and confirm release SIGSEGV and Cam Link OOM are both gone.
 github_issue: 294
 dependencies:
   - "down:Vulkanalia builder lifetime audit across RHI and processors"
@@ -18,6 +18,8 @@ dependencies:
   - "down:Flaky H.265 decoder DEVICE_LOST during setup"
   - "down:Fixture-based PSNR rig for encoder/decoder roundtrips"
   - "down:Expose encoder quality_level with real-time default"
+  - "down:Enable samplerYcbcrConversion feature and audit NV12 image-create flags"
+  - "down:Swapchain-descriptor image in UNDEFINED layout at sample time"
 adapters:
   github: builtin
 ---
@@ -35,7 +37,7 @@ Create `test/post-vulkan-cleanup-retest` from `main` after all dependencies merg
 3. `cargo run --release -p vulkan-video-roundtrip -- h264 /dev/video2 30` (vivid)
 4. Repeat 1-3 in debug.
 5. Dynamic processor add/remove: start camera-only, then add encoder + display live.
-6. Optional: run each scenario under `VK_LOADER_LAYERS_ENABLE="*validation*"` and confirm silence on the VUIDs targeted by #287-#291.
+6. Optional: run each scenario under `VK_LOADER_LAYERS_ENABLE="*validation*"` and confirm silence on the VUIDs targeted by #287-#291, #296, #300, #315, #316.
 
 ## Exit criteria
 

--- a/plan/296-present-semaphore-per-image.md
+++ b/plan/296-present-semaphore-per-image.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Display render_finished semaphore must be per-swapchain-image
-status: pending
+status: in_review
 description: Size render_finished_semaphores to swapchain image_count and index by image_index, not MAX_FRAMES_IN_FLIGHT / frame_index, so the present engine's hold on the binary semaphore doesn't collide with the next signal.
 github_issue: 296
 adapters:

--- a/plan/315-samplerycbcr-feature-and-nv12-flags.md
+++ b/plan/315-samplerycbcr-feature-and-nv12-flags.md
@@ -1,0 +1,39 @@
+---
+whoami: amos
+name: Enable samplerYcbcrConversion feature and audit NV12 image-create flags
+status: pending
+description: Turn on the samplerYcbcrConversion device feature in VulkanDevice and audit the encoder-src NV12 image / image-view flags so VUID-vkCreateSamplerYcbcrConversion-None-01648, VUID-VkImageCreateInfo-pNext-06811, and VUID-VkImageViewCreateInfo-usage-02275 go silent.
+github_issue: 315
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#315
+
+## Branch
+
+Create `fix/samplerycbcr-feature-and-nv12-flags` from `main`.
+
+## Steps
+
+1. In `libs/streamlib/src/vulkan/rhi/vulkan_device.rs` at device creation:
+   - Chain `VkPhysicalDeviceVulkan11Features { samplerYcbcrConversion = VK_TRUE, .. }` into `VkPhysicalDeviceFeatures2` passed via `VkDeviceCreateInfo::pNext`.
+   - Confirm no other Vulkan 1.1/1.2/1.3/1.4 features chain drops it accidentally.
+2. Audit NV12 (`VK_FORMAT_G8_B8R8_2PLANE_420_UNORM`) image + image-view creation sites in `libs/vulkan-video/`:
+   - `src/rgb_to_nv12.rs` (encoder source)
+   - `src/encode/staging.rs`
+   - `src/encode/session.rs`
+   - `src/vk_video_decoder/vk_video_decoder.rs`
+   Match each create flag / usage / view-usage against what
+   `vkGetPhysicalDeviceVideoFormatPropertiesKHR` reports for the active profile. Drop unsupported combos (notably `STORAGE_BIT` on views that do not need it) or split into separate views.
+3. Re-run `vulkan-video-roundtrip h264 /dev/video2 15` and `h265` under `VK_LOADER_LAYERS_ENABLE=*validation*` and confirm zero instances of each of the three target VUIDs.
+
+## Verification
+
+- Validation layer silent on `VUID-vkCreateSamplerYcbcrConversion-None-01648`, `VUID-VkImageCreateInfo-pNext-06811`, `VUID-VkImageViewCreateInfo-usage-02275` across a 300-frame run.
+- Encoded output is still a valid bitstream (encoder and decoder frame counts match).
+- No regression on `VUID-VkImageViewCreateInfo-format-06415` (the VUID #289 fixed).
+
+## Context
+
+Discovered during #296 E2E validation sweep. Not a regression of #289 — #289 fixed a neighboring VUID (`-06415`) on image-view creation; this issue fixes the underlying device-feature + format-flag hygiene that `-01648`, `-06811`, `-02275` are complaining about. Adjacent to but distinct from #300 (encoder-src *profile* chaining).

--- a/plan/316-swapchain-descriptor-undefined-layout.md
+++ b/plan/316-swapchain-descriptor-undefined-layout.md
@@ -1,0 +1,36 @@
+---
+whoami: amos
+name: Swapchain-descriptor image in UNDEFINED layout at sample time
+status: pending
+description: Fix the display render submit path so every sampled/storage image bound via descriptor is in the layout the descriptor was written for, silencing VUID-vkCmdDraw-None-09600 (sees UNDEFINED, expects PRESENT_SRC_KHR).
+github_issue: 316
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#316
+
+## Branch
+
+Create `fix/swapchain-descriptor-undefined-layout` from `main`.
+
+## Steps
+
+1. Reproduce under `VK_LOADER_LAYERS_ENABLE=*validation*` with `vulkan-video-roundtrip h264 /dev/video2 15` and capture the exact `VkImage` handle reported by `VUID-vkCmdDraw-None-09600`.
+2. Cross-reference the handle against:
+   - `state.swapchain_images` (swapchain side — UNDEFINED only until the first pre-render barrier fires)
+   - The camera ring textures (sampled by the fragment shader, expected in `SHADER_READ_ONLY_OPTIMAL`)
+3. Whichever image it is, fix the mismatch:
+   - If it's a swapchain image: confirm the pre-render `UNDEFINED → COLOR_ATTACHMENT_OPTIMAL` barrier still fires before any command that samples the image, and the post-render `→ PRESENT_SRC_KHR` barrier still fires before present. Validate ordering around the per-image `render_finished_semaphore` change in #296.
+   - If it's a camera texture: confirm the descriptor binding uses the layout the camera-side barrier left it in, not `PRESENT_SRC_KHR`. Likely a stale layout in the image info struct passed to `VkWriteDescriptorSet`.
+4. Re-run with validation layer on and confirm `-09600` is silent across the entire run (not just steady state — the current occurrences are clustered in the first few frames).
+
+## Verification
+
+- `VK_LOADER_LAYERS_ENABLE=*validation*` `vulkan-video-roundtrip h264 /dev/video2 15` 300-frame run: zero instances of `VUID-vkCmdDraw-None-09600`.
+- Same for h265 and for `camera-display`.
+- No visual regressions in the PNG samples.
+
+## Context
+
+Discovered during #296 E2E validation sweep. Baseline `main` has 8 occurrences per 300-frame run, patched #296 build still has 8 — the VUID is orthogonal to the `render_finished_semaphore` fix. Worth confirming the count does not increase after #296 lands.


### PR DESCRIPTION
## Summary

- `render_finished_semaphores` is now sized to `swapchain_images.len()` and indexed by `image_index` (not `frame_index`) on both the render submit and the present wait. `image_available_semaphores` stays at `MAX_FRAMES_IN_FLIGHT`.
- `docs/learnings/vulkan-frames-in-flight.md` updated: the reference table now calls out the present-engine-holds-it-until-release exception so the rule isn't "always size to MAX_FRAMES_IN_FLIGHT".
- Two follow-up issues filed and wired into the #294 retest umbrella: **#315** (samplerYcbcrConversion feature + NV12 flags), **#316** (descriptor image in UNDEFINED layout).

## Issue

Closes #296.

## Evidence

Release build, `vulkan-video-roundtrip h264 /dev/video2 15`, 300 frames, `VK_LOADER_LAYERS_ENABLE=*validation*`:

| VUID | main | this branch |
|---|---|---|
| **`VUID-vkQueueSubmit2-semaphore-03868`** (target) | **4** | **0** |
| `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206` | 20 | 20 | (#300) |
| `VUID-vkCreateSamplerYcbcrConversion-None-01648` | 6 | 6 | (#315) |
| `VUID-VkImageCreateInfo-pNext-06811` | 2 | 2 | (#315) |
| `VUID-VkImageViewCreateInfo-usage-02275` | 2 | 2 | (#315) |
| `VUID-vkCmdDraw-None-09600` | 8 | 8 | (#316) |

Target VUID goes to zero. All other VUID counts identical to baseline — no regression.

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 (h265 also run as a spot-check, same result)
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 20 s
- **Build profile**: release
- **Command**:
    ```
    VK_LOADER_LAYERS_ENABLE='*validation*' \
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-296/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
    timeout --kill-after=3 30 \
    target/release/vulkan-video-roundtrip h264 /dev/video2 15
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `VUID-vkQueueSubmit2-semaphore-03868`: **0** (main baseline: 4)
- `First frame encoded` / decoded / captured: seen
- `Encode progress` / `Decode progress`: progressed to shutdown

#### PNG samples

- Directory: `/tmp/e2e-296/png_samples/`
- Sample count: 3 (frames 0, 30, 60)
- PNG read with Read tool: `display_001_frame_000060.png`
- What was in the image: Vivid test pattern — vertical green bars of varying brightness with a small black-bg text/timecode overlay in the upper left corner. Matches the expected `vivid` SMPTE-style output; no black frame, no corruption, no tearing.
- Image: https://raw.githubusercontent.com/tato123/streamlib-pr-296-evidence/main/display_001_frame_000060.png

![PR 296 vivid h264 frame 60](https://raw.githubusercontent.com/tato123/streamlib-pr-296-evidence/main/display_001_frame_000060.png)

- Anomalies: none

#### PSNR

- Reference frame: n/a — no frame-aligned reference for vivid's synthetic source in this repo yet. Tracked in #305 (fixture-based PSNR rig).
- Y / U / V PSNR: n/a

#### Outcome

- **Pass**
- Caveats / follow-ups filed: #315, #316

## Test plan

- [x] `cargo check -p streamlib` passes
- [x] `cargo test -p streamlib --lib` — 147 passed, 0 failed, 2 ignored
- [x] `cargo build -p vulkan-video-roundtrip --release` passes
- [x] E2E release `h264 /dev/video2` 300-frame run with validation layer on: target VUID silent, all others unchanged vs. main
- [x] E2E release `h265 /dev/video2` 300-frame run with validation layer on: target VUID silent

## Follow-ups

- **#315** (pending) — enable `samplerYcbcrConversion` feature + audit NV12 image-create flags. Wired into #294.
- **#316** (pending) — swapchain-descriptor image in UNDEFINED layout at sample time (`VUID-vkCmdDraw-None-09600`). Wired into #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)