### PR TITLE
fix(#300): align rgb_to_nv12 source image profile with encode session

### DIFF
--- a/libs/vulkan-video/src/rgb_to_nv12.rs
+++ b/libs/vulkan-video/src/rgb_to_nv12.rs
@@ -175,11 +175,19 @@ impl RgbToNv12Converter {
         let mut h265_profile = vk::VideoEncodeH265ProfileInfoKHR::builder()
             .std_profile_idc(vk::video::STD_VIDEO_H265_PROFILE_IDC_MAIN);
 
+        // Source image profile MUST match the video session profile exactly,
+        // including the encode_usage pNext chain. Without this, the validation
+        // layer reports VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206. Keep every
+        // field here in sync with `encode/session.rs` and `encode/staging.rs`.
+        let mut encode_usage = vk::VideoEncodeUsageInfoKHR::builder()
+            .tuning_mode(vk::VideoEncodeTuningModeKHR::LOW_LATENCY);
+
         let mut profile_info = vk::VideoProfileInfoKHR::builder()
             .video_codec_operation(codec_flag)
             .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::_420)
             .luma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::_8)
-            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::_8);
+            .chroma_bit_depth(vk::VideoComponentBitDepthFlagsKHR::_8)
+            .push_next(&mut encode_usage);
 
         if codec_flag == vk::VideoCodecOperationFlagsKHR::ENCODE_H264 {
             profile_info = profile_info.push_next(&mut h264_profile);
@@ -206,9 +214,7 @@ impl RgbToNv12Converter {
             .samples(vk::SampleCountFlags::_1)
             .tiling(vk::ImageTiling::OPTIMAL)
             .flags(
-                vk::ImageCreateFlags::MUTABLE_FORMAT
-                    | vk::ImageCreateFlags::EXTENDED_USAGE
-                    | vk::ImageCreateFlags::VIDEO_PROFILE_INDEPENDENT_KHR,
+                vk::ImageCreateFlags::MUTABLE_FORMAT | vk::ImageCreateFlags::EXTENDED_USAGE,
             )
             .usage(
                 vk::ImageUsageFlags::STORAGE

--- a/plan/300-encode-src-profile-mismatch.md
+++ b/plan/300-encode-src-profile-mismatch.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Encoder src picture profile mismatch
-status: pending
+status: in_review
 description: Chain VkVideoEncodeUsageInfoKHR into the RGB→NV12 converter's source image profile so srcPictureResource.imageViewBinding is compatible with the session's video profile, silencing VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206.
 github_issue: 300
 adapters:


### PR DESCRIPTION
## Summary

- Chain `VkVideoEncodeUsageInfoKHR { tuningMode = LOW_LATENCY }` into the NV12 source image's `VkVideoProfileInfoKHR` pNext chain in `rgb_to_nv12.rs` so it matches the profile used to create the video encode session in `encode/session.rs`.
- Drop `VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR` from the NV12 image flags. With that flag set, the attached profile list was not accepted as binding the image to the session's profile on NVIDIA, so `VUID-08206` continued to fire even with the corrected chain. `MUTABLE_FORMAT` and `EXTENDED_USAGE` stay (still required for per-plane R8 / R8G8 storage views used by the compute shader).

## Issue

Closes #300

## Test Plan

- [x] `cargo check -p streamlib -p vulkan-video`
- [x] `cargo test -p vulkan-video --lib` — 617 passed, 0 failed
- [x] H.264 vivid `/dev/video2` roundtrip under `VK_LOADER_LAYERS_ENABLE=*validation*`: zero `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206`, zero `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed`, first frame encoded + decoded, PNG samples render vivid SMPTE bars.
- [x] H.265 vivid `/dev/video2` roundtrip under same conditions: same pass criteria, PNG sample shows vivid pattern with timecode `00:00:06.496`.

### E2E evidence

H.264 vivid, frame 30:

![H.264 vivid frame 30](https://github.com/tatolab/streamlib/releases/download/pr300-evidence-20260418-233348/pr300-h264-f30.png)

H.265 vivid, frame 30:

![H.265 vivid frame 30](https://github.com/tatolab/streamlib/releases/download/pr300-evidence-20260418-233348/pr300-h265-f30.png)

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 + h265 (both runs)
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=150`, 8s per codec
- **Build profile**: debug
- **Command**:
    ```
    VK_LOADER_LAYERS_ENABLE='*validation*' \
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=$OUT/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=150 \
    timeout --kill-after=3 20 cargo run -q -p vulkan-video-roundtrip -- {h264|h265} /dev/video2 8
    ```

#### Log signals

- `VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206`: 0 (was 20 before this change)
- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `First frame encoded` / decoded / captured: all observed

#### PNG samples

- PNGs read with Read tool: `display_001_frame_000030.png` for both h264 and h265.
- **What was in the image(s)**: H.264 frame 30 shows vivid's green-channel test pattern with vivid metadata overlay (resolution, input, brightness/contrast etc.) in the upper-left. H.265 frame 30 shows the same vivid green/purple SMPTE-style bars with timecode `00:00:06.496` and `1920x1080, input 0` overlay lines.
- Anomalies: none related to encode src path.

#### PSNR

- Reference frame: n/a — no frame-aligned reference for vivid (rig is tracked separately in #305).
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass**

## Follow-ups

- Pre-existing validation errors unrelated to #300 still fire and are tracked separately:
  - `VUID-vkCmdDraw-None-09600` (swapchain descriptor UNDEFINED layout) → #316
  - `VUID-vkCreateSamplerYcbcrConversion-None-01648`, `VUID-VkImageViewCreateInfo-usage-02275`, `VUID-VkImageCreateInfo-pNext-06811` → #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)