### PR TITLE
fix(#304): serialize processor setup() via GpuContext mutex

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -370,7 +370,7 @@ fn spawn_dedicated_thread(
                 (state, shutdown_rx, pause_gate_inner, exec_config)
             }; // Lock released here
 
-            // === PHASE 4: Setup (NO LOCK HELD - safe to call runtime ops) ===
+            // === PHASE 4: Setup (serialized across processors) ===
             // Create processor-specific context with both processor ID and pause gate
             let processor_context = runtime_ctx_clone
                 .with_processor_id(proc_id_clone.clone())
@@ -378,8 +378,17 @@ fn spawn_dedicated_thread(
             {
                 let tokio_handle = runtime_ctx_clone.tokio_handle();
 
+                // Hold the GPU setup mutex for the duration of setup() and the
+                // subsequent device-idle wait. This serializes processor setup
+                // across threads so concurrent video session / DPB / swapchain
+                // creation can't race on the device (fixes flaky NVIDIA
+                // DEVICE_LOST during H.265 decoder + display startup, #304).
+                // Already-running processors continue to execute in parallel —
+                // only the brief setup window is serialized.
+                let _setup_guard = runtime_ctx_clone.gpu.lock_processor_setup();
+
                 tracing::info!(
-                    "[{}] Calling setup on thread '{}' (id={:?}) - no locks held",
+                    "[{}] Calling setup on thread '{}' (id={:?}) - setup mutex held",
                     proc_id_clone,
                     thread_name,
                     thread_id
@@ -392,6 +401,18 @@ fn spawn_dedicated_thread(
                     *state_arc.lock() = ProcessorState::Error;
                     return;
                 }
+                drop(guard);
+
+                if let Err(e) = runtime_ctx_clone.gpu.wait_device_idle() {
+                    tracing::error!(
+                        "[{}] wait_device_idle after setup failed: {}",
+                        proc_id_clone,
+                        e
+                    );
+                    *state_arc.lock() = ProcessorState::Error;
+                    return;
+                }
+
                 tracing::info!("[{}] Setup completed successfully", proc_id_clone);
             }
 

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -379,6 +379,11 @@ pub struct GpuContext {
     /// Raw handle for the camera's timeline semaphore (same-process GPU-GPU sync).
     /// Stored as u64 for platform-agnostic GpuContext (0 = not set).
     camera_timeline_semaphore_handle: Arc<AtomicU64>,
+    /// Serializes processor setup() across threads so concurrent GPU resource
+    /// creation (video sessions, DPB images, swapchain) can't race on the
+    /// device. The compiler acquires this during Phase 4 of spawn_processor
+    /// and releases it after waiting for the device to go idle.
+    processor_setup_lock: Arc<Mutex<()>>,
 }
 
 impl GpuContext {
@@ -395,6 +400,7 @@ impl GpuContext {
             blitter,
             texture_cache: Arc::new(Mutex::new(HashMap::new())),
             camera_timeline_semaphore_handle: Arc::new(AtomicU64::new(0)),
+            processor_setup_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -411,7 +417,33 @@ impl GpuContext {
             blitter,
             texture_cache: Arc::new(Mutex::new(HashMap::new())),
             camera_timeline_semaphore_handle: Arc::new(AtomicU64::new(0)),
+            processor_setup_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// Acquire the processor-setup mutex. The compiler wraps each processor's
+    /// `setup()` call with this lock and a subsequent wait-for-idle so
+    /// concurrent setups can't race on GPU resource creation.
+    pub fn lock_processor_setup(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.processor_setup_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Wait for the GPU device to become idle. On Vulkan backends this calls
+    /// `vkDeviceWaitIdle`; on other backends this is a no-op.
+    pub fn wait_device_idle(&self) -> Result<()> {
+        #[cfg(any(
+            feature = "backend-vulkan",
+            all(target_os = "linux", not(feature = "backend-metal"))
+        ))]
+        {
+            use vulkanalia::vk::DeviceV1_0;
+            unsafe { self.device.inner.device().device_wait_idle() }.map_err(|e| {
+                StreamError::GpuError(format!("device_wait_idle failed: {e}"))
+            })?;
+        }
+        Ok(())
     }
 
     /// Create platform-specific blitter.

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -14,7 +14,6 @@ use crate::_generated_::{Encodedvideoframe, Videoframe};
 use crate::core::context::GpuContext;
 use crate::core::{Result, RuntimeContext, StreamError};
 
-use vulkanalia::prelude::v1_4::*;
 use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
 // ============================================================================
@@ -93,14 +92,6 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
         // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
         encoder.prepare_gpu_encode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
-        })?;
-
-        // Wait for all device operations to complete before other processors
-        // start submitting work. The encoder's configure() creates video session,
-        // DPB images, and command pools — concurrent Vulkan operations from other
-        // threads during this window crash the NVIDIA driver.
-        unsafe { vulkan_device.device().device_wait_idle() }.map_err(|e| {
-            StreamError::GpuError(format!("device_wait_idle failed: {e}"))
         })?;
 
         tracing::info!(

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -14,7 +14,6 @@ use crate::_generated_::{Encodedvideoframe, Videoframe};
 use crate::core::context::GpuContext;
 use crate::core::{Result, RuntimeContext, StreamError};
 
-use vulkanalia::prelude::v1_4::*;
 use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
 // ============================================================================
@@ -93,14 +92,6 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
         // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
         encoder.prepare_gpu_encode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
-        })?;
-
-        // Wait for all device operations to complete before other processors
-        // start submitting work. The encoder's configure() creates video session,
-        // DPB images, and command pools — concurrent Vulkan operations from other
-        // threads during this window crash the NVIDIA driver.
-        unsafe { vulkan_device.device().device_wait_idle() }.map_err(|e| {
-            StreamError::GpuError(format!("device_wait_idle failed: {e}"))
         })?;
 
         tracing::info!(

--- a/plan/304-h265-decoder-setup-race.md
+++ b/plan/304-h265-decoder-setup-race.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Flaky H.265 decoder DEVICE_LOST during setup
-status: pending
+status: in_review
 description: One-in-N runs of vulkan-video-roundtrip h265 /dev/video2 hit a DEVICE_LOST on the H.265 decoder between first-frame-encoded and display swapchain creation. Retry passes clean. Suspected concurrent-Vulkan-ops race during decoder/display setup, same window h264_encoder.rs already guards via device_wait_idle.
 github_issue: 304
 adapters:

--- a/plan/310-pipeline-resolution-propagation.md
+++ b/plan/310-pipeline-resolution-propagation.md
@@ -6,6 +6,7 @@ description: Design and implement a mechanism so camera → encoder → decoder 
 github_issue: 310
 dependencies:
   - "down:Retest camera + encoder + display roundtrip after Vulkan cleanup"
+  - "down:GPU capability-based access (sandbox + escalate)"
 adapters:
   github: builtin
 ---

--- a/plan/319-gpu-capability-based-access.md
+++ b/plan/319-gpu-capability-based-access.md
@@ -1,0 +1,48 @@
+---
+whoami: amos
+name: GPU capability-based access (sandbox + escalate)
+status: pending
+description: Umbrella — replace runtime-phase checks with compile-time capability types. `process()` receives `GpuContextSandbox`; escalation to `GpuContextFullAccess` goes through a closure that reuses the setup mutex from #304. Setup becomes "compiler pre-escalates on behalf of the processor." Huge DX and correctness win; unblocks dynamic reconfigure.
+github_issue: 319
+dependencies:
+  - "down:Design doc: GpuContextSandbox + GpuContextFullAccess API surface"
+  - "down:Introduce GpuContextSandbox + GpuContextFullAccess newtype wrappers"
+  - "down:Migrate processor trait signatures to capability-aware setup/process"
+  - "down:Implement sandbox.escalate() reusing the setup mutex"
+  - "down:Restrict GpuContextSandbox API surface to safe ops"
+  - "down:Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+  - "down:Learning doc: GPU capability typestate pattern"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#319
+
+## Why
+
+The #304 setup barrier enforces "resource creation is serialized" at runtime with a mutex. This umbrella is the compile-time half of the same invariant: the wrong method isn't in scope during `process()`, so the bad program can't be written. Every future processor, codec integration, and polyglot binding benefits; every current "3am `acquire_texture()` in a hot loop" bug becomes a compile error.
+
+## Shape
+
+- `process()` receives `&GpuContextSandbox` — pool-backed acquires, sampling, writes to pre-reserved buffers. No heavy-allocation methods in scope.
+- `sandbox.escalate(|full: &GpuContextFullAccess| { … })` is the single primitive for resource creation. It acquires the setup mutex (reused from #304), runs the closure, `wait_device_idle`, releases.
+- `setup()` receives `&GpuContextFullAccess` — equivalent to the compiler calling `escalate()` on the processor's behalf before invoking setup.
+- Reconfigure (mid-run resolution change, codec swap) is just a running processor calling `escalate()` itself. Same queue, same guarantees.
+- Polyglot subprocesses inherently only have a sandbox (can't reach the host Vulkan device). IPC becomes their escalate channel, serialized on the host.
+
+## Children (order)
+
+1. #320 — Design doc (gates everything downstream)
+2. #321 — Introduce the two newtypes (compile-only, identical API)
+3. #322 — Migrate processor trait signatures
+4. #323 — Implement `escalate()` primitive; compiler phase 4 becomes a consumer
+5. #324 — Restrict Sandbox's surface (enforcement lands here; compile errors surface)
+6. #325 — Polyglot IPC: escalate-on-behalf
+7. #326 — Learning doc
+
+## Dependencies / impact
+
+- Depends on #304 (setup mutex is the primitive `escalate` reuses).
+- Blocks #310 (pipeline resolution propagation — reconfigure wants this).
+- Peer to #294 (driver-visible Vulkan cleanup). Orthogonal; either can land first.
+- Scope: 2–4 weeks. Task #320 (design doc) is the gating deliverable.

--- a/plan/320-gpu-capability-design-doc.md
+++ b/plan/320-gpu-capability-design-doc.md
@@ -1,0 +1,37 @@
+---
+whoami: amos
+name: "Design doc: GpuContextSandbox + GpuContextFullAccess API surface"
+status: pending
+description: Write the design doc gating all downstream work in #319. Output is a reviewable document, not code.
+github_issue: 320
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#320
+
+## Branch
+
+`design/gpu-capability-sandbox` from `main`. Doc-only PR.
+
+## Deliverable
+
+`docs/design/gpu-capability-sandbox.md` covering:
+
+- **API split table**: every current `GpuContext` method classified as `Sandbox`, `FullAccess`, or `Both`. Pool acquire (pre-reserved) → Sandbox. `vmaCreate*` / new texture / new session → FullAccess. Ambiguous cases called out.
+- **Escalate closure signature**: sync vs async, `FnOnce` vs `FnMut`, error propagation, `FullAccess` lifetime scoped to the closure.
+- **Compiler integration**: how `spawn_processor_op.rs` Phase 4 wraps setup in `escalate()`. What today's setup mutex becomes (primitive, consumed by `escalate` — not a peer).
+- **RuntimeContext changes**: sandbox vs full-access accessors. `ReactiveProcessor::setup` / `process` signature impact.
+- **Polyglot mapping**: IPC schema for escalate-on-behalf; subprocess-host routing.
+- **Migration plan**: order of operations for tasks #321–#326. Which changes are compile-only vs behavior-changing.
+- **Alternatives considered**: runtime phase check only (#304 mutex, shipping), single-thread render-thread (rejected — loses queue-level parallelism), builder pattern, etc. With explicit reasons each was rejected.
+- **Open questions** flagged for review.
+
+## Verification
+
+- Doc is reviewed and approved before any type-introducing code (#321) lands.
+- Every current `GpuContext` method appears in the API-split table.
+
+## Parent
+
+#319

--- a/plan/321-introduce-capability-newtypes.md
+++ b/plan/321-introduce-capability-newtypes.md
@@ -1,0 +1,34 @@
+---
+whoami: amos
+name: Introduce GpuContextSandbox + GpuContextFullAccess newtype wrappers
+status: pending
+description: Add the two capability types as thin newtype wrappers around `GpuContext`. Both expose the same full API initially — pure compile-time change with no behavioral impact.
+github_issue: 321
+dependencies:
+  - "down:Design doc: GpuContextSandbox + GpuContextFullAccess API surface"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#321
+
+## Branch
+
+`refactor/gpu-capability-types` from `main`.
+
+## Steps
+
+1. Add `GpuContextSandbox` and `GpuContextFullAccess` in `libs/streamlib/src/core/context/gpu_context.rs`. Each holds an `Arc<GpuContext>` (or equivalent) internally.
+2. Implement every existing `GpuContext` method on both, delegating to the inner context. No method hidden or removed yet.
+3. Provide `pub(crate)` or marker-based conversion between the two — full enforcement comes in #324.
+4. No call-site changes in this task — existing code keeps using `GpuContext` directly.
+
+## Verification
+
+- `cargo check` clean, no observable API changes.
+- `cargo test -p streamlib` passes.
+- Doc-comment lines make clear which type is which in IntelliSense.
+
+## Parent
+
+#319

--- a/plan/322-migrate-processor-signatures.md
+++ b/plan/322-migrate-processor-signatures.md
@@ -1,0 +1,34 @@
+---
+whoami: amos
+name: Migrate processor trait signatures to capability-aware setup/process
+status: pending
+description: Flip `ReactiveProcessor` so `setup()` receives a `GpuContextFullAccess` handle and `process()` sees only a `GpuContextSandbox` via `RuntimeContext`. Purely mechanical; no behavior change.
+github_issue: 322
+dependencies:
+  - "down:Introduce GpuContextSandbox + GpuContextFullAccess newtype wrappers"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#322
+
+## Branch
+
+`refactor/processor-capability-signatures` from `main`.
+
+## Steps
+
+1. Update `ReactiveProcessor` trait signatures in `libs/streamlib/src/core/processors/` — `setup(&mut self, ctx: RuntimeContext)` remains but `RuntimeContext` now carries a `FullAccess` handle internally; `process()` sees sandbox-only.
+2. Expose `sandbox()` / `full_access()` accessors on `RuntimeContext` (or equivalent split); wire up in `libs/streamlib/src/core/context/runtime_context.rs`.
+3. Update `libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs` to hand the right handle into each phase.
+4. Update every in-tree processor (camera, display, h264/h265 encoder+decoder, audio, MP4 writer, WebRTC, MoQ, CLAP host, subprocess hosts) to the new signatures. Identical API on both types at this point, so the changes are cosmetic.
+
+## Verification
+
+- `cargo check` / `cargo test` clean.
+- Full E2E roundtrip (camera → encoder → decoder → display) per `docs/testing.md` passes for h264 + h265 on vivid.
+- No observable runtime behavior change.
+
+## Parent
+
+#319

--- a/plan/323-escalate-primitive.md
+++ b/plan/323-escalate-primitive.md
@@ -1,0 +1,34 @@
+---
+whoami: amos
+name: Implement sandbox.escalate() reusing the setup mutex
+status: pending
+description: Add `GpuContextSandbox::escalate(|full| …)` as the single primitive for all GPU resource-creation work. Internally acquires the mutex from #304, hands the closure a `FullAccess`, waits for idle on exit, releases.
+github_issue: 323
+dependencies:
+  - "down:Migrate processor trait signatures to capability-aware setup/process"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#323
+
+## Branch
+
+`feat/sandbox-escalate-primitive` from `main`.
+
+## Steps
+
+1. Add `GpuContextSandbox::escalate<F, T>(&self, f: F) -> Result<T> where F: FnOnce(&GpuContextFullAccess) -> Result<T>` in `libs/streamlib/src/core/context/gpu_context.rs`. Grab `processor_setup_lock`, construct a `FullAccess` scoped to the closure, run `wait_device_idle` on exit, release.
+2. Rewrite `libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs` Phase 4 so it calls `sandbox.escalate(|full| invoke_setup(full))` instead of the bespoke manual lock-grab shipped in #304. The mutex and wait_idle become private implementation details of `escalate`.
+3. Expose enough RuntimeContext plumbing for a running processor to call `escalate()` itself (mid-run reconfigure path).
+
+## Verification
+
+- Re-run the #304 h265 20× loop (`/dev/video2`); zero `DEVICE_LOST`.
+- Unit test: multiple threads concurrently call `escalate`; each closure sees exclusive access (verifiable via a shared counter / sleep).
+- `device_wait_idle` fires exactly once per escalation.
+- Dynamic graph add/remove still works.
+
+## Parent
+
+#319

--- a/plan/324-restrict-sandbox-surface.md
+++ b/plan/324-restrict-sandbox-surface.md
@@ -1,0 +1,35 @@
+---
+whoami: amos
+name: Restrict GpuContextSandbox API surface to safe ops
+status: pending
+description: The enforcement task. Remove every heavy-allocation method from `GpuContextSandbox`. Process() bodies that call privileged methods become compile errors; fix each by pre-reserving in setup() or wrapping in `escalate()`.
+github_issue: 324
+dependencies:
+  - "down:Implement sandbox.escalate() reusing the setup mutex"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#324
+
+## Branch
+
+`feat/sandbox-restrict-surface` from `main`.
+
+## Steps
+
+1. Per the API-split table from #320, strip `GpuContextSandbox`'s impl down to pool acquires (pre-reserved blocks only), texture sampling, writes to mapped pixel buffers, and read-only queries.
+2. Fix every resulting compile error in `process()` bodies: either move the call into an `escalate(|full| …)` closure, or pre-reserve the resource in `setup()` and have `process()` reuse it.
+3. Ensure pool-growth paths internally call `escalate()`. Sandbox callers must never observe a growth allocation that bypasses serialization.
+4. Audit `acquire_pixel_buffer` / `acquire_texture` carefully — fast path on Sandbox, slow/growth path goes through `escalate`.
+5. Debug-build only: add a counter that warns if a single processor calls `escalate` more than N times per second (signals misuse — escalation should be rare).
+
+## Verification
+
+- `cargo build -p streamlib` fails loudly if old unrestricted API is called from `process()` anywhere in the tree (there should be none by the end of this task).
+- E2E roundtrip (vivid + Cam Link) per `docs/testing.md`; zero `DEVICE_LOST`, zero `OUT_OF_DEVICE_MEMORY`.
+- Spot-check via the new counter: steady-state `process()` fires zero escalations.
+
+## Parent
+
+#319

--- a/plan/325-polyglot-escalate-ipc.md
+++ b/plan/325-polyglot-escalate-ipc.md
@@ -1,0 +1,35 @@
+---
+whoami: amos
+name: "Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+status: pending
+description: Extend subprocess-host processors to accept escalate IPC requests from Python/Deno. Subprocess sees only a sandbox; IPC is its escalate channel, routed through the host's serialized queue.
+github_issue: 325
+dependencies:
+  - "down:Restrict GpuContextSandbox API surface to safe ops"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#325
+
+## Branch
+
+`feat/polyglot-escalate-ipc` from `main`.
+
+## Steps
+
+1. Define IPC schema: `EscalateRequest { op: AcquireTexture { … } | AcquirePixelBuffer { … } | ReleaseHandle { id } | … }`, `EscalateResponse { handle_id, error? }`. Place in `schemas/` per existing JTD conventions.
+2. In `SubprocessHostProcessor` (Python) and `DenoSubprocessHostProcessor` (Deno), add control-channel handling: receive `EscalateRequest`, call `self.sandbox.escalate(|full| full.acquire_*(…))`, ship the resulting handle / ID back.
+3. Update Python bindings: add `ctx.escalate(op)` helper that awaits the response over IPC.
+4. Update Deno bindings likewise.
+5. Handle lifetime: allocations live in the host's pools; subprocess references by ID and releases via `ReleaseHandle` (or drop signal on subprocess death).
+
+## Verification
+
+- Python example: processor requests a new-shape pixel buffer mid-stream via escalate, writes to it, returns it.
+- Deno equivalent.
+- Concurrency: host Rust + subprocess escalate simultaneously — serialized correctly, no race, no `DEVICE_LOST`.
+
+## Parent
+
+#319

--- a/plan/326-capability-learning-doc.md
+++ b/plan/326-capability-learning-doc.md
@@ -1,0 +1,35 @@
+---
+whoami: amos
+name: "Learning doc: GPU capability typestate pattern"
+status: pending
+description: Capture the "why" of the sandbox/escalate pattern in `docs/learnings/` so the invariant survives future refactors.
+github_issue: 326
+dependencies:
+  - "down:Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#326
+
+## Branch
+
+`docs/gpu-capability-learning` from `main` (post-#325, so the doc can cite concrete code).
+
+## Steps
+
+1. Create `docs/learnings/gpu-capability-typestate.md`. Cover:
+    - The invariant: Sandbox in `process()`, FullAccess only inside `escalate` closures.
+    - Why it matters: NVIDIA Linux concurrent-resource-creation races, per-queue parallelism model, DX/autocomplete enforcement.
+    - Rejected alternatives (runtime phase check only, single render thread).
+    - Links to the design doc from #320 for depth.
+2. Update `docs/learnings/README.md` index.
+3. Add a short bullet in `CLAUDE.md`'s "Hard-won learnings" section pointing to the new file.
+
+## Verification
+
+- Doc reads cleanly as a standalone learning — a contributor who hasn't touched #319 can understand the rule and the reason from this file alone.
+
+## Parent
+
+#319


### PR DESCRIPTION
## Summary

- Hoists `device_wait_idle` out of individual encoders and into a runtime-wide setup barrier on `GpuContext`. The compiler's `spawn_processor_op.rs` Phase 4 now holds a mutex and waits for the device to go idle around every processor's `setup()`. Concurrent GPU resource creation can no longer race on the NVIDIA Linux driver.
- Already-running processors continue executing in parallel on their own threads — only the brief setup window is serialized, so dynamic graph add/remove keeps working.
- Removes the now-redundant per-encoder `device_wait_idle()` from `h264_encoder.rs` / `h265_encoder.rs` (the plan's "removes per-codec-processor boilerplate, forward-proof for new codecs" step).

## Issue

Closes #304.

## Plan additions (follow-up work)

Adds the #319 umbrella and 7 children (#320–#326) for the compile-time half of the story: `GpuContextSandbox` for `process()`, `sandbox.escalate(|full| …)` for resource creation, Unreal-style capability typing without adopting a single render thread (keeps per-queue parallelism). Updates #310 (resolution propagation) to depend on #319 so reconfigure gets designed once, on top of the capability primitive.

## Test Plan

- [x] `cargo check -p streamlib` passes (23 pre-existing warnings, no new errors).
- [x] `cargo test -p streamlib --lib`: 147 passed, 0 failed, 2 ignored.
- [x] `cargo build -p vulkan-video-roundtrip` passes.
- [x] Verified with 20/20 h265 vivid roundtrips + 10/10 h264 regression loop (see report below).

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h265 (primary), h264 (regression check)
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=120`, 8 s per run
- **Build profile**: debug
- **Command (one of 20)**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-304-h265-final/iter1 \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=120 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=120 \
    timeout --kill-after=3 25 \
      cargo run -q -p vulkan-video-roundtrip -- h265 /dev/video2 8
    ```

#### Log signals (aggregated across 30 runs: 20×h265 + 10×h264)

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST` / "device has been lost": 0 (pre-fix: 1/10 on h265)
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame encoded` / `First frame decoded` / `First frame captured`: seen on every run
- Result: h265 20/20 pass, h264 10/10 pass

#### PNG samples

- Directory: `/tmp/e2e-304-h265-final/iter*/`, `/tmp/e2e-304-h264-v2/iter*/`
- Sample count: 30 (one per iteration)
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=120`
- PNG read with Read tool: `/tmp/e2e-304-h265-v2/iter1/display_001_frame_000000.png`
- What was in the image: frame 0 — vivid SMPTE-style test pattern with vertical green / purple color bars, timecode overlay `00:00:00:000:0`, `1920x1088 input 0`, and V4L2 control labels (`brightness 128, contrast 128, saturation 128, hue 0`, `autogain 1, gain 239, alpha 0x00`, etc.). Matches expected vivid output.
- Anomalies: none.

#### PSNR

- Reference frame: n/a — `vulkan-video-roundtrip` has no paired pre-encode PNG; tracked under #305 (fixture-based PSNR rig).
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass**
- Caveats / follow-ups filed: #319 umbrella (compile-time capability enforcement, the durable fix for mid-process allocation bugs this class of race belongs to).

## Follow-ups

- #319 umbrella + #320–#326 children — the compile-time half of this story. Ships `GpuContextSandbox` / `GpuContextFullAccess` types so `process()` can't even call resource-creation APIs.
- #310 now blocks on #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)