### PR TITLE
feat(#306): expose encoder quality_level with real-time default

### DIFF
--- a/examples/vulkan-video-psnr/src/main.rs
+++ b/examples/vulkan-video-psnr/src/main.rs
@@ -46,16 +46,25 @@ fn main() -> Result<()> {
     ))?;
     println!("+ BgraFileSource: {source}");
 
+    // Optional quality_level override (used by the #306 PSNR-sweep harness to
+    // pick the real-time default). `STREAMLIB_ENCODER_QUALITY_LEVEL` unset →
+    // library default for the codec.
+    let quality_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_QUALITY_LEVEL")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
     let encoder = if is_h265 {
         runtime.add_processor(H265EncoderProcessor::node(H265EncoderProcessor::Config {
             width: Some(width),
             height: Some(height),
+            quality_level,
             ..Default::default()
         }))?
     } else {
         runtime.add_processor(H264EncoderProcessor::node(H264EncoderProcessor::Config {
             width: Some(width),
             height: Some(height),
+            quality_level,
             ..Default::default()
         }))?
     };

--- a/examples/vulkan-video-roundtrip/src/main.rs
+++ b/examples/vulkan-video-roundtrip/src/main.rs
@@ -44,11 +44,18 @@ fn main() -> Result<()> {
     println!("+ Camera: {camera}");
 
     // --- Encoder ---
+    // Optional quality_level override (used by the #306 verification harness).
+    // Unset → library default for the codec.
+    let quality_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_QUALITY_LEVEL")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
     let encoder = if is_h265 {
         runtime.add_processor(H265EncoderProcessor::node(
             H265EncoderProcessor::Config {
                 width: Some(1920),
                 height: Some(1080),
+                quality_level,
                 ..Default::default()
             },
         ))?
@@ -57,6 +64,7 @@ fn main() -> Result<()> {
             H264EncoderProcessor::Config {
                 width: Some(1920),
                 height: Some(1080),
+                quality_level,
                 ..Default::default()
             },
         ))?

--- a/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
@@ -39,5 +39,5 @@ optionalProperties:
     type: string
   quality_level:
     metadata:
-      description: "Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher = better quality, more GPU compute per frame; does not add frame delay. Unset = codec-specific real-time default; clamped against VkVideoEncodeCapabilitiesKHR::maxQualityLevels."
+      description: "Vulkan API encoder-effort index (VkVideoEncodeQualityLevelInfoKHR::quality_level). NOT the H.264 profile, NOT QP, NOT rate-control — those are configured elsewhere. Valid values are 0..VkVideoEncodeCapabilitiesKHR::maxQualityLevels; the session clamps as a safety floor. Unset = codec default."
     type: uint32

--- a/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml
@@ -37,3 +37,7 @@ optionalProperties:
     metadata:
       description: "H.264 profile: baseline, main, or high (default: main)."
     type: string
+  quality_level:
+    metadata:
+      description: "Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher = better quality, more GPU compute per frame; does not add frame delay. Unset = codec-specific real-time default; clamped against VkVideoEncodeCapabilitiesKHR::maxQualityLevels."
+    type: uint32

--- a/libs/streamlib/schemas/com.streamlib.h265_encoder.config@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.h265_encoder.config@1.0.0.yaml
@@ -33,3 +33,7 @@ optionalProperties:
     metadata:
       description: "Seconds between keyframes (default: 2.0). Converted to frames using the encoder's fps. Ignored if keyframe_interval (frames) is set."
     type: float32
+  quality_level:
+    metadata:
+      description: "Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher = better quality, more GPU compute per frame; does not add frame delay. Unset = codec-specific real-time default; clamped against VkVideoEncodeCapabilitiesKHR::maxQualityLevels. Note: NVIDIA RTX 3090 exposes only level 0 for H.265."
+    type: uint32

--- a/libs/streamlib/schemas/com.streamlib.h265_encoder.config@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.h265_encoder.config@1.0.0.yaml
@@ -35,5 +35,5 @@ optionalProperties:
     type: float32
   quality_level:
     metadata:
-      description: "Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher = better quality, more GPU compute per frame; does not add frame delay. Unset = codec-specific real-time default; clamped against VkVideoEncodeCapabilitiesKHR::maxQualityLevels. Note: NVIDIA RTX 3090 exposes only level 0 for H.265."
+      description: "Vulkan API encoder-effort index (VkVideoEncodeQualityLevelInfoKHR::quality_level). NOT the H.265 level_idc (e.g. 4.1, 5.0), NOT the profile/tier, NOT QP/rate-control — those are configured elsewhere. Valid values are 0..VkVideoEncodeCapabilitiesKHR::maxQualityLevels; the session clamps as a safety floor. Unset = codec default. The correct framing of this knob on NVIDIA's Vulkan driver for H.265 is under research in #330."
     type: uint32

--- a/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
@@ -3,38 +3,46 @@
 
 //! Generated from JTD schema using jtd-codegen. DO NOT EDIT.
 
+
 use serde::{Deserialize, Serialize};
 
 /// Configuration for H.264 video encoding.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct H264EncoderConfig {
-    /// Video width in pixels (default: 1280).
-    #[serde(rename = "width")]
-    pub width: Option<u32>,
-
-    /// Video height in pixels (default: 720).
-    #[serde(rename = "height")]
-    pub height: Option<u32>,
-
     /// Target bitrate in bits per second (default: 2000000).
     #[serde(rename = "bitrate_bps")]
     pub bitrate_bps: Option<u32>,
-
-    /// Frames between keyframes (overrides keyframe_interval_seconds if set).
-    #[serde(rename = "keyframe_interval")]
-    pub keyframe_interval: Option<u32>,
-
-    /// Seconds between keyframes (default: 2.0). Converted to frames using
-    /// the encoder's fps. Ignored if keyframe_interval (frames) is set.
-    #[serde(rename = "keyframe_interval_seconds")]
-    pub keyframe_interval_seconds: Option<f32>,
 
     /// Frames per second for encoder timing (default: 60).
     #[serde(rename = "fps")]
     pub fps: Option<u32>,
 
+    /// Video height in pixels (default: 720).
+    #[serde(rename = "height")]
+    pub height: Option<u32>,
+
+    /// Frames between keyframes (overrides keyframe_interval_seconds if set).
+    #[serde(rename = "keyframe_interval")]
+    pub keyframe_interval: Option<u32>,
+
+    /// Seconds between keyframes (default: 2.0). Converted to frames using the
+    /// encoder's fps. Ignored if keyframe_interval (frames) is set.
+    #[serde(rename = "keyframe_interval_seconds")]
+    pub keyframe_interval_seconds: Option<f32>,
+
     /// H.264 profile: baseline, main, or high (default: main).
     #[serde(rename = "profile")]
     pub profile: Option<String>,
+
+    /// Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher
+    /// = better quality, more GPU compute per frame; does not add frame
+    /// delay. Unset = codec-specific real-time default; clamped against
+    /// VkVideoEncodeCapabilitiesKHR::maxQualityLevels.
+    #[serde(rename = "quality_level")]
+    pub quality_level: Option<u32>,
+
+    /// Video width in pixels (default: 1280).
+    #[serde(rename = "width")]
+    pub width: Option<u32>,
 }

--- a/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_h264_encoder_config.rs
@@ -35,10 +35,11 @@ pub struct H264EncoderConfig {
     #[serde(rename = "profile")]
     pub profile: Option<String>,
 
-    /// Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher
-    /// = better quality, more GPU compute per frame; does not add frame
-    /// delay. Unset = codec-specific real-time default; clamped against
-    /// VkVideoEncodeCapabilitiesKHR::maxQualityLevels.
+    /// Vulkan API encoder-effort index
+    /// (VkVideoEncodeQualityLevelInfoKHR::quality_level). NOT the H.264
+    /// profile, NOT QP, NOT rate-control — those are configured elsewhere.
+    /// Valid values are 0..VkVideoEncodeCapabilitiesKHR::maxQualityLevels; the
+    /// session clamps as a safety floor. Unset = codec default.
     #[serde(rename = "quality_level")]
     pub quality_level: Option<u32>,
 

--- a/libs/streamlib/src/_generated_/com_streamlib_h265_encoder_config.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_h265_encoder_config.rs
@@ -31,11 +31,13 @@ pub struct H265EncoderConfig {
     #[serde(rename = "keyframe_interval_seconds")]
     pub keyframe_interval_seconds: Option<f32>,
 
-    /// Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher
-    /// = better quality, more GPU compute per frame; does not add frame
-    /// delay. Unset = codec-specific real-time default; clamped against
-    /// VkVideoEncodeCapabilitiesKHR::maxQualityLevels. Note: NVIDIA RTX 3090
-    /// exposes only level 0 for H.265.
+    /// Vulkan API encoder-effort index
+    /// (VkVideoEncodeQualityLevelInfoKHR::quality_level). NOT the H.265
+    /// level_idc (e.g. 4.1, 5.0), NOT the profile/tier, NOT QP/rate-
+    /// control — those are configured elsewhere. Valid values are
+    /// 0..VkVideoEncodeCapabilitiesKHR::maxQualityLevels; the session clamps as
+    /// a safety floor. Unset = codec default. The correct framing of this knob
+    /// on NVIDIA's Vulkan driver for H.265 is under research in #330.
     #[serde(rename = "quality_level")]
     pub quality_level: Option<u32>,
 

--- a/libs/streamlib/src/_generated_/com_streamlib_h265_encoder_config.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_h265_encoder_config.rs
@@ -3,20 +3,13 @@
 
 //! Generated from JTD schema using jtd-codegen. DO NOT EDIT.
 
+
 use serde::{Deserialize, Serialize};
 
 /// Configuration for H.265 video encoding.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct H265EncoderConfig {
-    /// Video width in pixels (default: 1280).
-    #[serde(rename = "width")]
-    pub width: Option<u32>,
-
-    /// Video height in pixels (default: 720).
-    #[serde(rename = "height")]
-    pub height: Option<u32>,
-
     /// Target bitrate in bits per second (default: 2000000).
     #[serde(rename = "bitrate_bps")]
     pub bitrate_bps: Option<u32>,
@@ -25,12 +18,28 @@ pub struct H265EncoderConfig {
     #[serde(rename = "fps")]
     pub fps: Option<u32>,
 
+    /// Video height in pixels (default: 720).
+    #[serde(rename = "height")]
+    pub height: Option<u32>,
+
     /// Frames between keyframes (overrides keyframe_interval_seconds if set).
     #[serde(rename = "keyframe_interval")]
     pub keyframe_interval: Option<u32>,
 
-    /// Seconds between keyframes (default: 2.0). Converted to frames using
-    /// the encoder's fps. Ignored if keyframe_interval (frames) is set.
+    /// Seconds between keyframes (default: 2.0). Converted to frames using the
+    /// encoder's fps. Ignored if keyframe_interval (frames) is set.
     #[serde(rename = "keyframe_interval_seconds")]
     pub keyframe_interval_seconds: Option<f32>,
+
+    /// Driver encode quality level (VkVideoEncodeQualityLevelInfoKHR). Higher
+    /// = better quality, more GPU compute per frame; does not add frame
+    /// delay. Unset = codec-specific real-time default; clamped against
+    /// VkVideoEncodeCapabilitiesKHR::maxQualityLevels. Note: NVIDIA RTX 3090
+    /// exposes only level 0 for H.265.
+    #[serde(rename = "quality_level")]
+    pub quality_level: Option<u32>,
+
+    /// Video width in pixels (default: 1280).
+    #[serde(rename = "width")]
+    pub width: Option<u32>,
 }

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -50,6 +50,7 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             idr_interval_secs: self.config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
             bitrate_bps: self.config.bitrate_bps,
             prepend_header_to_idr: Some(true),
+            quality_level: self.config.quality_level,
             ..Default::default()
         };
 

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -50,6 +50,7 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             idr_interval_secs: self.config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
             bitrate_bps: self.config.bitrate_bps,
             prepend_header_to_idr: Some(true),
+            quality_level: self.config.quality_level,
             ..Default::default()
         };
 

--- a/libs/vulkan-video/src/encode/config.rs
+++ b/libs/vulkan-video/src/encode/config.rs
@@ -361,30 +361,35 @@ pub struct SimpleEncoderConfig {
     /// When `true`, SPS/PPS bytes are prepended to every IDR packet.
     /// Defaults to `true` in streaming mode, `false` otherwise.
     pub prepend_header_to_idr: Option<bool>,
-    /// Driver quality level knob (maps to `VkVideoEncodeQualityLevelInfoKHR`).
-    /// `None` = codec-specific real-time default from [`default_quality_level`].
-    /// Clamped to `max_quality_levels - 1` as a safety floor in the session.
+    /// Vulkan API encoder-effort index passed via `VkVideoEncodeQualityLevelInfoKHR`.
+    /// This is NOT the H.265 stream `level_idc` (e.g. 4.1, 5.0), NOT the
+    /// profile/tier, and NOT QP / rate-control — those live elsewhere in the
+    /// encoder config. Valid values are `0..VkVideoEncodeCapabilitiesKHR::max_quality_levels`;
+    /// the session clamps to that range as a safety floor. `None` uses the
+    /// per-codec default from [`default_quality_level`]. The correct framing
+    /// of this knob on NVIDIA's driver for H.265 is under research in #330.
     pub quality_level: Option<u32>,
 }
 
-/// Real-time encoder quality level default, per codec.
+/// Default Vulkan encoder-effort index per codec.
 ///
-/// Measured via the #305 PSNR rig against the checked-in fixtures. Higher
-/// levels burn more GPU per frame for (potentially) better quality without
-/// adding frame delay. The `session` clamps against
-/// `VkVideoEncodeCapabilitiesKHR::max_quality_levels` as a safety floor.
+/// This is the `VkVideoEncodeQualityLevelInfoKHR::quality_level` index, not
+/// anything from the H.265 or H.264 codec specs. On NVIDIA's Vulkan Video
+/// driver (RTX 3090 reference):
+/// - H.264 reports `max_quality_levels = 4`; indices 0..=3 are accepted, and
+///   the #305 PSNR rig shows identical Y PSNR across all four on natural
+///   content at CQP 18 (the PSNR floor is set by QP/rate-control, not this
+///   index). 0 is picked for the lowest GPU cost per frame; callers can
+///   override with `quality_level = Some(n)` to burn more GPU per frame.
+/// - H.265 currently reports `max_quality_levels = 1` via this specific
+///   Vulkan API. The H.265 codec spec itself has plenty of quality-relevant
+///   knobs (profile, tier, `level_idc`, QP, rate-control) — those are
+///   configured elsewhere in the encoder config. The Vulkan-side framing of
+///   H.265 quality on this driver is still being audited in #330; this
+///   default may move once that research lands.
 pub fn default_quality_level(codec: Codec) -> u32 {
     match codec {
-        // NVIDIA RTX 3090 exposes maxQualityLevels = 4 for H.264 (levels 0..=3).
-        // All four levels produce equivalent Y PSNR on the #305 fixtures
-        // (~29.5 dB on complex_pattern, ≥45 dB on gradients/solids), so the
-        // quality_level knob is not the PSNR bottleneck — CQP/preset is.
-        // Default to 0 for the lowest GPU cost per frame; callers who want to
-        // burn more GPU can set `quality_level = Some(max)` explicitly.
         Codec::H264 => 0,
-        // NVIDIA RTX 3090 exposes maxQualityLevels = 1 for H.265 (only level 0).
-        // Documented explicitly instead of relying on the driver's clamp to
-        // silently land at zero.
         Codec::H265 => 0,
     }
 }

--- a/libs/vulkan-video/src/encode/config.rs
+++ b/libs/vulkan-video/src/encode/config.rs
@@ -361,6 +361,32 @@ pub struct SimpleEncoderConfig {
     /// When `true`, SPS/PPS bytes are prepended to every IDR packet.
     /// Defaults to `true` in streaming mode, `false` otherwise.
     pub prepend_header_to_idr: Option<bool>,
+    /// Driver quality level knob (maps to `VkVideoEncodeQualityLevelInfoKHR`).
+    /// `None` = codec-specific real-time default from [`default_quality_level`].
+    /// Clamped to `max_quality_levels - 1` as a safety floor in the session.
+    pub quality_level: Option<u32>,
+}
+
+/// Real-time encoder quality level default, per codec.
+///
+/// Measured via the #305 PSNR rig against the checked-in fixtures. Higher
+/// levels burn more GPU per frame for (potentially) better quality without
+/// adding frame delay. The `session` clamps against
+/// `VkVideoEncodeCapabilitiesKHR::max_quality_levels` as a safety floor.
+pub fn default_quality_level(codec: Codec) -> u32 {
+    match codec {
+        // NVIDIA RTX 3090 exposes maxQualityLevels = 4 for H.264 (levels 0..=3).
+        // All four levels produce equivalent Y PSNR on the #305 fixtures
+        // (~29.5 dB on complex_pattern, ≥45 dB on gradients/solids), so the
+        // quality_level knob is not the PSNR bottleneck — CQP/preset is.
+        // Default to 0 for the lowest GPU cost per frame; callers who want to
+        // burn more GPU can set `quality_level = Some(max)` explicitly.
+        Codec::H264 => 0,
+        // NVIDIA RTX 3090 exposes maxQualityLevels = 1 for H.265 (only level 0).
+        // Documented explicitly instead of relying on the driver's clamp to
+        // silently land at zero.
+        Codec::H265 => 0,
+    }
 }
 
 impl Default for SimpleEncoderConfig {
@@ -376,6 +402,7 @@ impl Default for SimpleEncoderConfig {
             streaming: false,
             idr_interval_secs: 2,
             prepend_header_to_idr: None,
+            quality_level: None,
         }
     }
 }
@@ -452,15 +479,11 @@ impl SimpleEncoderConfig {
             }
         };
 
-        // Encode quality level (maps to NVIDIA NVENC P1-P7 presets).
-        // Higher = better quality, slightly more GPU compute per frame.
-        // Zero-latency: does NOT add frame delay, only uses more GPU
-        // time within the same frame's encode pass.
-        let quality = match self.preset {
-            Preset::Fast   => 3,  // ~P4: fast, moderate quality
-            Preset::Medium => 5,  // ~P6: OBS recommended for streaming
-            Preset::Quality => 7, // ~P7: max quality
-        };
+        // Quality level is an independent knob from the preset (which controls
+        // GOP / QP / B-frames). An explicit value wins; otherwise use the
+        // codec-specific real-time default. The session clamps against
+        // VkVideoEncodeCapabilitiesKHR::max_quality_levels as a safety floor.
+        let quality = self.quality_level.unwrap_or_else(|| default_quality_level(self.codec));
 
         EncodeConfig {
             width: self.width,

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -161,12 +161,16 @@ impl SimpleEncoder {
             0
         };
 
-        tracing::debug!(
-            max_dpb = caps.max_dpb_slots,
-            max_active_refs = caps.max_active_reference_pictures,
+        tracing::info!(
+            codec = ?self.codec_flag,
             max_quality_levels = encode_caps.max_quality_levels,
             requested_quality = config.quality_level,
             effective_quality = effective_quality_level,
+            "Encoder quality level"
+        );
+        tracing::debug!(
+            max_dpb = caps.max_dpb_slots,
+            max_active_refs = caps.max_active_reference_pictures,
             picture_access_w = caps.picture_access_granularity.width,
             picture_access_h = caps.picture_access_granularity.height,
             "Video encode capabilities"

--- a/plan/294-post-vulkan-cleanup-retest.md
+++ b/plan/294-post-vulkan-cleanup-retest.md
@@ -2,7 +2,7 @@
 whoami: amos
 name: Retest camera + encoder + display roundtrip after Vulkan cleanup
 status: pending
-description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, #303, #304, #305, #306, #315, and #316 land and confirm release SIGSEGV and Cam Link OOM are both gone.
+description: Rollup retest that supersedes #279. Run the full matrix after #287-#292, #296, #300, #302, #303, #304, #305, #306, #315, #316, and #330 land and confirm release SIGSEGV and Cam Link OOM are both gone.
 github_issue: 294
 dependencies:
   - "down:Vulkanalia builder lifetime audit across RHI and processors"
@@ -20,6 +20,7 @@ dependencies:
   - "down:Expose encoder quality_level with real-time default"
   - "down:Enable samplerYcbcrConversion feature and audit NV12 image-create flags"
   - "down:Swapchain-descriptor image in UNDEFINED layout at sample time"
+  - "down:Research: H.265 encoder quality configuration on Vulkan Video / NVIDIA"
 adapters:
   github: builtin
 ---

--- a/plan/306-encoder-quality-level.md
+++ b/plan/306-encoder-quality-level.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Expose encoder quality_level with real-time default
-status: pending
+status: in_review
 description: SimpleEncoderConfig doesn't expose quality_level. Default picks "requested_quality=5" clamped to driver max (H.264→3, H.265→0 on NVIDIA RTX 3090), so H.265 silently runs at the driver's worst quality. Add a configurable knob with a real-time-tuned default.
 github_issue: 306
 adapters:

--- a/plan/306-encoder-quality-level.md
+++ b/plan/306-encoder-quality-level.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Expose encoder quality_level with real-time default
-status: in_review
+status: completed
 description: SimpleEncoderConfig doesn't expose quality_level. Default picks "requested_quality=5" clamped to driver max (H.264→3, H.265→0 on NVIDIA RTX 3090), so H.265 silently runs at the driver's worst quality. Add a configurable knob with a real-time-tuned default.
 github_issue: 306
 adapters:

--- a/plan/330-h265-encoder-quality-research.md
+++ b/plan/330-h265-encoder-quality-research.md
@@ -1,0 +1,36 @@
+---
+whoami: amos
+name: "Research: H.265 encoder quality configuration on Vulkan Video / NVIDIA"
+status: pending
+description: Audit the distinct quality-affecting knobs on our H.265 encode path (Vulkan API effort index vs. H.265 SPS profile/tier/level vs. QP/rate-control vs. tuning_mode) before #294 retest. #306's framing conflated several concepts; reviewer recalls a specific proper H.265 configuration fix. Research-only deliverable with a question list for interactive review.
+github_issue: 330
+adapters:
+  github: builtin
+dependencies:
+  - "down:Vulkanalia builder lifetime audit across RHI and processors"
+  - "down:Camera ring textures missing TRANSFER_SRC_BIT"
+  - "down:NV12 image views require VkSamplerYcbcrConversion"
+  - "down:VMA bind-buffer-memory type mismatch"
+  - "down:vkGetDeviceQueue called with unexposed family"
+  - "down:Cam Link encoder ERROR_OUT_OF_DEVICE_MEMORY in debug"
+  - "down:Display render_finished semaphore must be per-swapchain-image"
+  - "down:Encoder src picture profile mismatch"
+  - "down:Decoder pool probe uses hard-coded resolution"
+  - "down:Camera MMAP path sees 0 frames on v4l2loopback"
+  - "down:Flaky H.265 decoder DEVICE_LOST during setup"
+  - "down:Fixture-based PSNR rig for encoder/decoder roundtrips"
+  - "down:Expose encoder quality_level with real-time default"
+  - "down:Enable samplerYcbcrConversion feature and audit NV12 image-create flags"
+  - "down:Swapchain-descriptor image in UNDEFINED layout at sample time"
+---
+
+@github:tatolab/streamlib#330
+
+See the GitHub issue for full context. This task is research-only: the
+deliverable is `docs/research/h265-encoder-quality-knobs.md` plus a
+question list to review interactively with Jonathan. No encoder code
+changes land here; any implementation is scoped as a follow-up that
+this research gates.
+
+Gating #294 retest so the retest doesn't run against a known-misframed
+H.265 quality configuration.


### PR DESCRIPTION
## Summary

- Add `SimpleEncoderConfig::quality_level: Option<u32>` wired to `VkVideoEncodeQualityLevelInfoKHR`. `None` = codec-specific real-time default from `default_quality_level()`; the session's `max_quality_levels − 1` clamp stays as a safety floor.
- Plumb the knob through `H264EncoderProcessor::Config` / `H265EncoderProcessor::Config` (YAML schemas + regenerated `_generated_` bindings).
- Promote the existing per-encoder quality log line from DEBUG to INFO so operators see requested-vs-effective quality.

## Per-codec defaults (empirical)

Measured via the #305 PSNR rig on NVIDIA RTX 3090 (maxQualityLevels = 4 for H.264, 1 for H.265). All H.264 levels 0..=3 produce equivalent Y PSNR on the checked-in fixtures (≈ 29.5 dB on `complex_pattern`, ≥ 45 dB on gradients/solids) — quality_level is not the PSNR bottleneck for this CQP 18 / preset=Medium config, so default to 0 for the lowest GPU cost per frame. H.265 exposes only level 0 on this driver; documented explicitly instead of relying on the clamp to silently land at zero.

Full TSVs per level: `/tmp/psnr-h264-default`, `/tmp/psnr-h264-q{1,2,3}`, `/tmp/psnr-h265-default`.

## Issue
Closes #306

## Test plan

- [x] `cargo check -p vulkan-video -p streamlib` — clean
- [x] `cargo test -p vulkan-video --lib` — 617 passed, 0 failed, 5 ignored
- [x] `e2e_fixture_psnr.sh` H.264 default (q=0) — TSV generated, complex_pattern FAIL at Y=29.5 dB is pre-existing / orthogonal to quality_level
- [x] `e2e_fixture_psnr.sh` H.264 q=1/2/3 sweep — identical Y PSNR, confirms knob is wired and default choice is defensible
- [x] `e2e_fixture_psnr.sh` H.265 default (q=0) — TSV generated, same pre-existing complex_pattern floor
- [x] `vulkan-video-roundtrip h264 /dev/video2 15` default + `STREAMLIB_ENCODER_QUALITY_LEVEL=3` — 0 OOM / 0 DEVICE_LOST / 0 process() failed; log shows `requested=0/effective=0` and `requested=3/effective=3`
- [x] `vulkan-video-roundtrip h265 /dev/video2 15` default — 0 errors; log shows `requested=0/effective=0` (driver max = 1)
- [x] Read vivid-source PNGs (Read tool) at default / max: crisp green/purple bars + status text overlay, no banding or regression

## E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 (default q=0), h264 (STREAMLIB_ENCODER_QUALITY_LEVEL=3), h265 (default q=0)
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 15 s
- **Build profile**: debug
- **Command**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=$OUT/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
    [STREAMLIB_ENCODER_QUALITY_LEVEL=3] \
    timeout --kill-after=3 25 cargo run -q -p vulkan-video-roundtrip -- {h264|h265} /dev/video2 15
    ```

### Log signals (all three runs)

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame encoded` / decoded / captured: all observed
- New INFO log: `Encoder quality level codec={H264|H265} max_quality_levels={4|1} requested_quality={0|3} effective_quality={0|3}`

### PNG samples

- PNGs read with Read tool: `display_001_frame_000060_input_000063.png` for each of the three runs
- **What was in the image(s)**:
  - H.264 default (q=0): vivid green gradient bars with dark status-text overlay in upper-left — crisp, matches expected vivid output.
  - H.264 max (q=3): visually equivalent to default run — vivid green gradient bars with status overlay; no visible quality shift (consistent with PSNR sweep showing identical Y PSNR across 0..=3).
  - H.265 default (q=0): vivid's richer frame with timecode `00:00:12:605 63`, `1920x1080, input 0`, `brightness 128, contrast 128, saturation 128, hue 0`, menu strings — green/purple bars, all text readable, no banding regression.
- Anomalies: none

### PSNR

- Reference frame: `libs/streamlib/tests/fixtures/psnr/*.png` (checked-in)
- Y / U / V PSNR (dB): see `$OUT/psnr_report.tsv` per quality level
  - H.264 q=0: complex_pattern Y=29.53, U=29.66, V=24.30 (pre-existing floor); gradients/solids ≥ 45 dB.
  - H.264 q=1/2/3: equivalent within ±0.02 dB — confirms quality_level alone does not move the PSNR floor at CQP 18.
  - H.265 q=0 (only option): complex_pattern Y=29.52, V=24.28; same floor as H.264.
- Command used: `libs/streamlib/tests/fixtures/e2e_fixture_psnr.sh /tmp/psnr-<tag> {h264|h265}` optionally prefixed with `STREAMLIB_ENCODER_QUALITY_LEVEL=<n>`

### Outcome

- **Pass with caveats** — the new knob is correctly wired and logged end-to-end; the complex_pattern PSNR floor predates this PR and is not driven by `quality_level`. Default = 0 is justified on real-time (lowest GPU per frame) grounds given PSNR equivalence across H.264 levels.
- Caveats / follow-ups filed: none new; the complex_pattern PSNR floor is an existing QP/rate-control topic, separate from the quality_level knob.

## Follow-ups

- None. The complex_pattern FAIL in the PSNR rig is pre-existing and orthogonal to `quality_level` (sweep 0..=3 gave identical Y PSNR). If worth chasing, it's a CQP/rate-control investigation, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)