### PR TITLE
fix(#316): use UNDEFINED old_layout on swapchain pre-render barrier

### DIFF
--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -700,12 +700,17 @@ impl DisplayEventLoopHandler {
             // Camera texture is already in SHADER_READ_ONLY_OPTIMAL (set by camera
             // after compute dispatch). Only need swapchain barrier.
             // Camera timeline semaphore wait in queue_submit2 ensures the texture is ready.
+            // UNDEFINED old_layout: on first use each swapchain image is in UNDEFINED,
+            // and on subsequent uses the previous contents are unconditionally discarded
+            // by the CLEAR load_op below — so declaring UNDEFINED (which permits any
+            // current layout) is valid for every frame and avoids a VUID-vkCmdDraw-None-09600
+            // mismatch on the first submit for each image.
             let swapchain_barrier = vk::ImageMemoryBarrier2::builder()
                 .src_stage_mask(vk::PipelineStageFlags2::NONE)
                 .src_access_mask(vk::AccessFlags2::NONE)
                 .dst_stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
                 .dst_access_mask(vk::AccessFlags2::COLOR_ATTACHMENT_WRITE)
-                .old_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+                .old_layout(vk::ImageLayout::UNDEFINED)
                 .new_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
                 .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                 .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)

--- a/plan/316-swapchain-descriptor-undefined-layout.md
+++ b/plan/316-swapchain-descriptor-undefined-layout.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Swapchain-descriptor image in UNDEFINED layout at sample time
-status: pending
+status: in_review
 description: Fix the display render submit path so every sampled/storage image bound via descriptor is in the layout the descriptor was written for, silencing VUID-vkCmdDraw-None-09600 (sees UNDEFINED, expects PRESENT_SRC_KHR).
 github_issue: 316
 adapters:


### PR DESCRIPTION
## Summary
- Pre-render swapchain barrier in `linux/processors/display.rs` declared `old_layout = PRESENT_SRC_KHR`, but on the first use of each swapchain image the image is in `UNDEFINED`, tripping `VUID-vkCmdDraw-None-09600` 8×/300-frame run on main.
- Since `load_op = CLEAR` discards prior contents every frame, `old_layout = UNDEFINED` (which permits any current layout) is valid for both first and subsequent uses — the simplest canonical fix.

## Issue
Closes #316

## Test Plan
- [x] `cargo check -p streamlib` passes
- [x] `vulkan-video-roundtrip h264 /dev/video2 15` under `VK_LOADER_LAYERS_ENABLE=*validation*` — `VUID-vkCmdDraw-None-09600` = 0 (was 8), 0 OOM / DEVICE_LOST / process() failed
- [x] `vulkan-video-roundtrip h265 /dev/video2 15` same — 0 VUID-09600
- [x] `camera-display` with `/dev/video2` under validation — 0 VUID-09600
- [x] PNG samples inspected — vivid green/grey SMPTE gradient + timecode/control overlay renders correctly on both h264 and h265

### E2E Test Report

- **Scenario**: encoder/decoder + camera+display-only
- **Example**: `vulkan-video-roundtrip` (h264, h265) + `camera-display`
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`
- **Build profile**: debug

#### Log signals (both codecs + camera-display)

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `VUID-vkCmdDraw-None-09600`: **0** (baseline main: 8 per 300-frame h264 run)
- First frame encoded / decoded / captured: all seen

#### PNG samples

- Directories: `/tmp/vuid09600-{h264,h265,camdisp}-fix-*/png_samples/`
- PNGs read with Read tool: h264 `display_001_frame_000060_input_000062.png`, h265 `display_001_frame_000060_input_000062.png`
- **What was in the image(s)**: h264 — vivid SMPTE green/grey-gradient vertical bars with the vivid control panel (brightness, contrast, saturation lines) overlaid in the top-left. h265 — full vivid pattern with green/purple bars, frame counter `62` and timecode `00:00:12:406` plus the control panel visible in the top-left. Both match the expected vivid test pattern.

![h264](https://github.com/tatolab/streamlib/releases/download/fix-316-evidence-1776615600/pr316-h264-small.png)

![h265](https://github.com/tatolab/streamlib/releases/download/fix-316-evidence-1776615600/pr316-h265-small.png)

- Anomalies: none

#### PSNR

- n/a — live vivid frame indices shift between runs; PSNR coverage is owned by the fixture rig (#305) and orthogonal to this fix.

#### Outcome

- **Pass**

## Follow-ups
- None