### PR TITLE
docs(#293): close narrow CI validation task, file #343 umbrella

### DIFF
--- a/plan/293-ci-vulkan-validation.md
+++ b/plan/293-ci-vulkan-validation.md
@@ -1,8 +1,8 @@
 ---
 whoami: amos
 name: CI with Vulkan validation layer
-status: pending
-description: Run at least one release-build roundtrip in CI with VK_LOADER_LAYERS_ENABLE=*validation* and fail on any validation error.
+status: completed
+description: Superseded by #343. The original narrow plan assumed StreamRuntime already honored VK_LOADER_LAYERS_ENABLE. #294's retest disproved that and surfaced two other blockers (#337 hermeticity, #213 GPU runner), so the task was closed with its discovery documented and the full CI-lifecycle scope was moved to umbrella #343.
 github_issue: 293
 dependencies:
   - "down:Retest camera + encoder + display roundtrip after Vulkan cleanup"
@@ -12,18 +12,56 @@ adapters:
 
 @github:tatolab/streamlib#293
 
-## Branch
+## Outcome
+
+**Closed without implementation — superseded by #343.**
+
+The narrow plan below was drafted before the #294 retest. That retest
+(see `docs/retests/294-post-vulkan-cleanup-retest.md`, follow-up items
+C and D) surfaced three blockers that invalidate the original approach:
+
+1. **#338 — `StreamRuntime` does not honor `VK_LOADER_LAYERS_ENABLE` /
+   `VK_INSTANCE_LAYERS`.** Confirmed locally: `libs/streamlib/src/vulkan/rhi/`
+   has no `ppEnabledLayerNames` wiring. Running any example under
+   `VK_LOADER_LAYERS_ENABLE=*validation*` today produces zero VUIDs
+   because the layer is never actually loaded, so the CI gate would
+   pass vacuously.
+2. **#337 — E2E harness non-hermetic on NVIDIA Linux.** Multi-scenario
+   runs in one shell hit driver-state contamination (`DEVICE_LOST` in
+   position N that passes cold). Any CI job that runs more than one
+   scenario back-to-back is unreliable until the harness adds
+   per-scenario process isolation, GPU-idle barrier, and cooldown.
+3. **#213 — No GPU-capable CI runner exists.** GitHub's
+   `ubuntu-latest` has no GPU; Vulkan Video encode/decode requires
+   NVENC/NVDEC hardware. Container / cloud-GPU runner design lives in
+   #213 and is not built.
+
+Given those, a minimal validation-layer job landed in isolation would
+either pass vacuously (pre-#338) or flake on driver contamination
+(pre-#337) or fail to schedule at all (pre-#213). Rather than ship a
+narrow task that doesn't close the real CI gap, #293 is closed and the
+full CI-lifecycle plan moves to umbrella **#343**, which waits for all
+three blockers before any CI work resumes.
+
+## Original plan (for reference)
+
+### Branch
 
 Create `test/ci-validation-layer` from `main`.
 
-## Steps
+### Steps
 
-1. Add `vulkan-validationlayers` to the CI runner image / dev bootstrap script.
-2. Create a runner helper (shell or Rust) that spawns an example under `VK_LOADER_LAYERS_ENABLE="*validation*"`, parses output, and exits non-zero on any `Validation Error`.
-3. Add a CI job that runs a ≤ 5 s vivid H.264 roundtrip under the helper.
-4. Baseline: land after #294 rollup retest confirms #287-#292 and #296 fixes cleaned up the validation output. No allowlist needed.
+1. Add `vulkan-validationlayers` to the CI runner image / dev
+   bootstrap script.
+2. Create a runner helper (shell or Rust) that spawns an example under
+   `VK_LOADER_LAYERS_ENABLE="*validation*"`, parses output, and exits
+   non-zero on any `Validation Error`.
+3. Add a CI job that runs a ≤ 5 s vivid H.264 roundtrip under the
+   helper.
+4. Baseline: land after #294 rollup retest confirms #287-#292 and #296
+   fixes cleaned up the validation output. No allowlist needed.
 
-## Verification
+### Verification
 
 - CI job exists and runs on PRs.
 - New validation errors introduced by a PR fail its build.

--- a/plan/343-ci-lifecycle-umbrella.md
+++ b/plan/343-ci-lifecycle-umbrella.md
@@ -1,0 +1,93 @@
+---
+whoami: amos
+name: "[BLOCKED — do not start] Umbrella: End-to-end CI lifecycle — GPU runners, validation gates, hermetic harness"
+status: pending
+description: "BLOCKED — queued behind #213 (container/GPU runner), #337 (hermetic harness), #338 (VkInstance validation-layer wiring). Do NOT pick up. Umbrella that replaces the narrow #293 approach with a full CI lifecycle: reviving the disabled test.yml, wiring unit-test / clippy / fmt gates, adding validation-layer roundtrip gates for H.264/H.265, wiring the PSNR fixture rig, and packaging the dev-bootstrap + container image."
+github_issue: 343
+dependencies:
+  - "down:Container/Docker integration for cloud GPU deployment (runpod)"
+  - "down:E2E test harness non-hermetic on NVIDIA Linux"
+  - "down:StreamRuntime does not honor VK_LOADER_LAYERS_ENABLE / VK_INSTANCE_LAYERS"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#343
+
+# 🛑 STOP — DO NOT WORK ON THIS PLAN YET 🛑
+
+This plan is **intentionally queued**. Every child task either requires
+a GPU runner that doesn't exist yet (#213), validation-layer wiring
+that isn't there yet (#338), or would flake on the shared runner under
+NVIDIA's driver-state contamination (#337). Adding any of the CI jobs
+below before those land would either skip vacuously or be flaky enough
+to poison the signal.
+
+## Why this exists
+
+#293 originally set out to add a single CI job that runs a roundtrip
+under `VK_LOADER_LAYERS_ENABLE=*validation*` and fails on any
+`Validation Error`. The #294 retest exposed that this is far too
+narrow — the real gap is that StreamLib has no GPU-capable CI at all.
+
+Rather than land a narrow task that doesn't actually close the CI gap,
+#293 was closed with its discovery written up, and this umbrella was
+opened to hold the full CI-lifecycle plan so it can be built as one
+coherent initiative once the prerequisites land.
+
+## Dependencies
+
+- #213 — Container/Docker integration for cloud GPU deployment
+  (runpod). Without this, there is no runner that can execute Vulkan
+  Video at all.
+- #337 — E2E harness non-hermetic on NVIDIA Linux. Without this,
+  multi-scenario CI runs are non-deterministic.
+- #338 — `StreamRuntime` must honor `VK_LOADER_LAYERS_ENABLE` /
+  `VK_INSTANCE_LAYERS`. Without this, validation output is vacuously
+  zero and the validation-layer gate is meaningless.
+
+## Scope
+
+Children to file and sequence once this unblocks:
+
+1. **Runner helper script** — spawns an example with validation env,
+   parses output, exits non-zero on `Validation Error`. Portable, no
+   GPU required to write; can be tested against any example once #338
+   lands.
+2. **Re-enable `test.yml`** — the workflow is currently
+   `workflow_dispatch`-only for cost. Revive PR / push triggers once
+   #213 defines the runner target.
+3. **Validation-layer CI jobs** — H.264 vivid roundtrip, H.265 vivid
+   roundtrip, each under the helper. Zero `Validation Error` pass bar.
+4. **PSNR fixture-rig CI job** — run `e2e_fixture_psnr.sh` for H.264
+   and H.265 on a schedule; fail on Y PSNR drops below the WARN
+   threshold.
+5. **Unit / clippy / fmt gates** — re-enable the existing Linux and
+   macOS jobs in `test.yml`.
+6. **Allowlist mechanism** — if the post-#338 baseline still shows
+   benign VUIDs (unlikely but possible), add an allowlist file and CI
+   logic to ignore them while failing on anything new.
+7. **Dev-bootstrap / container image** — ensure
+   `vulkan-validationlayers` is installed in both the dev setup script
+   and whatever container image #213 produces, so local runs match CI.
+
+## Non-goals
+
+- Containerization design itself — that's #213.
+- Validation-layer wiring itself — that's #338.
+- Harness hermeticity itself — that's #337.
+- Adding new E2E scenarios beyond what `docs/testing.md` already
+  specifies.
+
+## Supersedes
+
+- #293 — narrow "add a validation-layer CI job" task, closed with its
+  PR capturing the discovery.
+
+## Reference
+
+- `docs/retests/294-post-vulkan-cleanup-retest.md` — items C (P1
+  harness) and D (P2 validation wiring) that blocked the original
+  #293 premise.
+- `.github/workflows/test.yml` — the disabled workflow this umbrella
+  will revive.


### PR DESCRIPTION
## Summary

- Closes #293 without implementation — its premise is invalidated by the #294 retest.
- Files umbrella #343 to hold the full CI-lifecycle plan, intentionally blocked on #213 / #337 / #338.
- Documents the discovery (what we learned, why we pivoted) on both plan files.

## Why

Starting #293 on this branch surfaced that the narrow plan cannot
produce a useful CI gate today:

1. **#338** — `StreamRuntime` does not honor `VK_LOADER_LAYERS_ENABLE` /
   `VK_INSTANCE_LAYERS`. Verified locally: `libs/streamlib/src/vulkan/rhi/`
   has no `ppEnabledLayerNames` wiring. A CI job running under the
   validation env today would produce zero VUIDs because the layer is
   never loaded, so the gate passes vacuously.
2. **#337** — E2E harness non-hermetic on NVIDIA Linux. Multi-scenario
   runs in one shell hit driver-state contamination; any CI job
   running more than one scenario back-to-back flakes until this
   lands.
3. **#213** — No GPU-capable CI runner exists. GitHub's
   `ubuntu-latest` has no GPU; Vulkan Video needs NVENC/NVDEC
   hardware. Container/cloud-GPU design lives in #213 and is not
   built.

All three were filed as follow-ups from #294's retest report
(`docs/retests/294-post-vulkan-cleanup-retest.md`, items C and D).

Rather than ship a narrow task that doesn't close the real CI gap,
close #293 and move the full scope to umbrella #343 so the CI
lifecycle can be built as one coherent initiative once the blockers
land.

## What's in this PR

- `plan/293-ci-vulkan-validation.md` — status set to `completed`; adds
  an **Outcome** section explaining the discovery; retains the
  original plan for historical reference.
- `plan/343-ci-lifecycle-umbrella.md` — new. Mirrors #312's
  `[BLOCKED — do not start]` convention so it won't surface as the
  next task in `amos graph` / PROMPT.md selectors.

## Dependency markers on #343

Belt-and-suspenders so #343 doesn't accidentally surface as "ready":

- `name:` prefixed `[BLOCKED — do not start]` (same pattern as #312).
- STOP banner at the top of the plan body.
- `dependencies:` listing #213 / #337 / #338 by name.
- GitHub issue title prefixed `[BLOCKED — awaiting #213/#337/#338]`.

## No code changes

Doc-only PR. No workflow files, no runtime wiring, no helper
scripts — all deferred to #343's children.

## Follow-ups

None in this PR. Everything the original #293 plan intended now lives
as a checklist item under #343.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)