### PR TITLE
feat(#323): GpuContextLimitedAccess::escalate() primitive

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{scheduling_strategy_for_processor, SchedulingStrategy};
-use crate::core::context::{RuntimeContext, RuntimeContextFullAccess};
+use crate::core::context::{GpuContextLimitedAccess, RuntimeContext, RuntimeContextFullAccess};
 use crate::core::descriptors::ProcessorRuntime;
 use crate::core::error::{Result, StreamError};
 use crate::core::execution::run_processor_loop;
@@ -378,40 +378,29 @@ fn spawn_dedicated_thread(
             {
                 let tokio_handle = runtime_ctx_clone.tokio_handle();
 
-                // Hold the GPU setup mutex for the duration of setup() and the
-                // subsequent device-idle wait. This serializes processor setup
-                // across threads so concurrent video session / DPB / swapchain
-                // creation can't race on the device (fixes flaky NVIDIA
-                // DEVICE_LOST during H.265 decoder + display startup, #304).
-                // Already-running processors continue to execute in parallel —
-                // only the brief setup window is serialized.
-                let _setup_guard = runtime_ctx_clone.gpu.lock_processor_setup();
-
                 tracing::info!(
-                    "[{}] Calling setup on thread '{}' (id={:?}) - setup mutex held",
+                    "[{}] Calling setup on thread '{}' (id={:?}) - escalating via setup mutex",
                     proc_id_clone,
                     thread_name,
                     thread_id
                 );
-                // Build the privileged ctx view for setup. The borrow is
-                // scoped to this block, so `process()` inside the loop
-                // below can never observe a full-access handle.
-                let full_ctx = RuntimeContextFullAccess::new(&processor_context);
-                let mut guard = processor_arc_clone.lock();
-                if let Err(e) = tokio_handle.block_on(guard.__generated_setup(&full_ctx)) {
-                    tracing::error!("[{}] Setup failed: {}", proc_id_clone, e);
-                    *state_arc.lock() = ProcessorState::Error;
-                    return;
-                }
-                drop(guard);
-                drop(full_ctx);
 
-                if let Err(e) = runtime_ctx_clone.gpu.wait_device_idle() {
-                    tracing::error!(
-                        "[{}] wait_device_idle after setup failed: {}",
-                        proc_id_clone,
-                        e
-                    );
+                // Serialize setup across processors and wait for device idle
+                // on exit via the escalate primitive. The setup mutex and the
+                // device-idle wait are private implementation details of
+                // escalate; concurrent video session / DPB / swapchain
+                // creation can't race on the device (#304).
+                let sandbox = GpuContextLimitedAccess::new(runtime_ctx_clone.gpu.clone());
+                let setup_result = sandbox.escalate(|_full_gpu| {
+                    // Build the privileged ctx view for setup. The borrow is
+                    // scoped to this closure, so `process()` inside the loop
+                    // below can never observe a full-access handle.
+                    let full_ctx = RuntimeContextFullAccess::new(&processor_context);
+                    let mut guard = processor_arc_clone.lock();
+                    tokio_handle.block_on(guard.__generated_setup(&full_ctx))
+                });
+                if let Err(e) = setup_result {
+                    tracing::error!("[{}] Setup failed: {}", proc_id_clone, e);
                     *state_arc.lock() = ProcessorState::Error;
                     return;
                 }

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -909,6 +909,36 @@ impl GpuContextLimitedAccess {
             inner: self.inner.clone(),
         }
     }
+
+    /// Serialized escalation to full GPU capability. Acquires the
+    /// processor-setup mutex, hands the closure a [`GpuContextFullAccess`]
+    /// scoped to its body, then waits for the device to go idle before
+    /// releasing the lock.
+    ///
+    /// This is the single primitive for GPU resource-creation work outside
+    /// `setup()` — used by the compiler to run each processor's setup()
+    /// and by running processors that need to reconfigure (acquire a new
+    /// video session, resize a swapchain, etc.).
+    ///
+    /// The `device_wait_idle` fires exactly once per escalation (after the
+    /// closure returns). On closure failure its error is returned; a
+    /// follow-up `wait_device_idle` failure is returned only when the
+    /// closure succeeded.
+    pub fn escalate<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&GpuContextFullAccess) -> Result<T>,
+    {
+        let _setup_guard = self.inner.lock_processor_setup();
+        let full = GpuContextFullAccess::new(self.inner.clone());
+        let closure_result = f(&full);
+        drop(full);
+        let wait_result = self.inner.wait_device_idle();
+        match (closure_result, wait_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(e), _) => Err(e),
+            (Ok(_), Err(e)) => Err(e),
+        }
+    }
 }
 
 impl GpuContextFullAccess {
@@ -1365,5 +1395,85 @@ mod tests {
         assert_eq!(device_ptr_gpu, device_ptr_full);
 
         println!("GpuContextLimitedAccess + GpuContextFullAccess delegation: OK");
+    }
+
+    #[test]
+    fn test_escalate_serializes_concurrent_callers() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        const THREADS: usize = 8;
+        let in_closure = Arc::new(AtomicBool::new(false));
+        let overlap_count = Arc::new(AtomicUsize::new(0));
+        let completed_count = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let gpu = gpu.clone();
+                let in_closure = Arc::clone(&in_closure);
+                let overlap_count = Arc::clone(&overlap_count);
+                let completed_count = Arc::clone(&completed_count);
+                std::thread::spawn(move || {
+                    let limited = GpuContextLimitedAccess::new(gpu);
+                    limited
+                        .escalate(|_full| {
+                            if in_closure.swap(true, Ordering::SeqCst) {
+                                overlap_count.fetch_add(1, Ordering::SeqCst);
+                            }
+                            std::thread::sleep(Duration::from_millis(10));
+                            in_closure.store(false, Ordering::SeqCst);
+                            completed_count.fetch_add(1, Ordering::SeqCst);
+                            Ok(())
+                        })
+                        .expect("escalate closure should succeed");
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        assert_eq!(
+            overlap_count.load(Ordering::SeqCst),
+            0,
+            "escalate closures overlapped — setup mutex not held"
+        );
+        assert_eq!(completed_count.load(Ordering::SeqCst), THREADS);
+
+        println!("escalate serializes concurrent callers: OK");
+    }
+
+    #[test]
+    fn test_escalate_propagates_closure_error() {
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        let limited = GpuContextLimitedAccess::new(gpu);
+        let result: Result<()> = limited.escalate(|_full| {
+            Err(StreamError::Runtime("synthetic failure".to_string()))
+        });
+        match result {
+            Err(StreamError::Runtime(msg)) if msg == "synthetic failure" => {}
+            other => panic!("expected synthetic Runtime error, got {other:?}"),
+        }
+
+        // Mutex must be released after the error — a second escalation should proceed.
+        let after: Result<u32> = limited.escalate(|_full| Ok(7));
+        assert_eq!(after.expect("escalate after error"), 7);
+
+        println!("escalate propagates closure error + releases lock: OK");
     }
 }

--- a/libs/streamlib/src/core/context/runtime_context.rs
+++ b/libs/streamlib/src/core/context/runtime_context.rs
@@ -704,6 +704,12 @@ impl<'a> RuntimeContextLimitedAccess<'a> {
     }
 
     /// Restricted GPU capability — pool-backed, non-allocating ops only.
+    ///
+    /// Call [`GpuContextLimitedAccess::escalate`] on the returned handle to
+    /// temporarily obtain a [`GpuContextFullAccess`] for mid-run
+    /// reconfiguration (new video session, resized swapchain, etc.).
+    /// Escalation serializes against processor setup via the shared
+    /// setup mutex.
     pub fn gpu_limited_access(&self) -> &GpuContextLimitedAccess {
         &self.gpu_limited
     }

--- a/plan/323-escalate-primitive.md
+++ b/plan/323-escalate-primitive.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: Implement sandbox.escalate() reusing the setup mutex
-status: pending
+status: in_review
 description: Add `GpuContextLimitedAccess::escalate(|full| …)` as the single primitive for all GPU resource-creation work. Internally acquires the mutex from #304, hands the closure a `FullAccess`, waits for idle on exit, releases.
 github_issue: 323
 dependencies:


### PR DESCRIPTION
## Summary

- Adds `GpuContextLimitedAccess::escalate(|full| …)` — the single primitive for GPU resource-creation work outside `process()`. Internally acquires `processor_setup_lock`, hands the closure a `GpuContextFullAccess` scoped to its body, and waits for the device to go idle on exit.
- Rewrites `spawn_processor_op.rs` Phase 4 to call `sandbox.escalate(|_full_gpu| invoke_setup(&full_ctx))`. The setup mutex and `wait_device_idle` become private implementation details of `escalate`.
- Running processors can call `ctx.gpu_limited_access().escalate(|full| …)` mid-run (swapchain resize, new video session) — same primitive, same serialization guarantees.

## Issue

Closes #323

## Test Plan

- [x] `cargo check -p streamlib` passes (only pre-existing warnings)
- [x] `cargo test -p streamlib --lib` — 151 passed including two new unit tests:
  - `test_escalate_serializes_concurrent_callers` — 8 threads racing into `escalate`; a shared flag detects any overlap. 0 overlaps observed.
  - `test_escalate_propagates_closure_error` — closure error returned unchanged; mutex released so a second escalation proceeds.
- [x] **#304 h265 20× loop** (`/dev/video2`, the plan's verification gate): 20/20 clean, 0 DEVICE_LOST, 0 OOM.
- [x] Spot-checked h264 roundtrip: clean, vivid pattern visible in sampled PNG.

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h265 (20× loop) + h264 (spot-check)
- **Camera device**: `/dev/video2` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=150` (loop) / `200` (spot-check)
- **Build profile**: debug
- **Command** (loop):
    ```
    for i in $(seq 1 20); do STREAMLIB_DISPLAY_FRAME_LIMIT=150 timeout --kill-after=3 20 \
        cargo run -q -p vulkan-video-roundtrip -- h265 /dev/video2 10; done
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0 across all 20 iterations
- `DEVICE_LOST`: 0 across all 20 iterations
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame encoded` / decoded / captured: seen every iteration

#### PNG samples

- Directory: `/tmp/e2e-323-h264-1776649236/png_samples/`
- PNGs read with Read tool: `display_001_frame_000030_input_000032.png` (h264), `display_001_frame_000060_input_000063.png` (h265)
- What was in the image(s): vivid test pattern — green/purple vertical bars with timecode overlay (`00:00:12:605 63`), "1920x1080 input 0", brightness/contrast/saturation text block in the top-left. Matches expected vivid output.
- Anomalies: none

#### PSNR

- Reference frame: n/a — vivid live source, no frame-aligned reference. Fixture PSNR rig (#305) remains the PSNR gate for encoder/decoder changes.

#### Outcome

- **Pass**

## Follow-ups

- None