### PR TITLE
fix(#359): pin clack and vulkanalia git deps to specific revs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,9 @@ Run `cargo doc -p streamlib --no-deps` - fix any unresolved link warnings.
 - **macOS/iOS code**: `libs/streamlib/src/apple/`
 - **DO NOT** use `#[cfg]` inside platform-specific directories (already conditionally compiled)
 
+### Dependencies
+- **Git dependencies must be pinned** with `rev = "<commit sha>"` (or `tag = "..."`). Never use a bare `git = "..."` or `branch = "..."` — Cargo resolves those against the remote's current HEAD, so fresh clones drift out of sync with the lockfile and stop compiling. This applies to every `Cargo.toml` in the workspace, including `[patch.crates-io]` entries.
+
 ### Vulkan RHI Boundary — ABSOLUTE RULE
 
 **NOTHING outside the RHI (`vulkan/rhi/`) may touch Vulkan APIs directly.** No processor, utility, codec wrapper, or any other code may call `ash::Device`, `vkAllocateMemory`, `vkCreateImage`, or any Vulkan function without going through the RHI. This is non-negotiable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ objc2-vision = "0.3.2"
 libc = "0.2.177"
 
 # Vulkan bindings (tatolab fork for VMA 3.3.0 patch)
-vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", branch = "tatolab/update-vma-3.3.0-patched", features = ["libloading", "provisional", "window"] }
-vulkanalia-vma = { git = "https://github.com/tatolab/vulkanalia.git", branch = "tatolab/update-vma-3.3.0-patched" }
+vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1", features = ["libloading", "provisional", "window"] }
+vulkanalia-vma = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }
 
 # Shader compilation
 # TODO: Add when implementing HLSL shader compilation:
@@ -114,5 +114,5 @@ streamlib-telemetry = { path = "libs/streamlib-telemetry" }
 # yuv = "0.8"
 
 [patch.crates-io]
-vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", branch = "tatolab/update-vma-3.3.0-patched" }
-vulkanalia-sys = { git = "https://github.com/tatolab/vulkanalia.git", branch = "tatolab/update-vma-3.3.0-patched" }
+vulkanalia = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }
+vulkanalia-sys = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982d32d293e5425753d595978776ee4fa4ded3a1" }

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -65,8 +65,8 @@ toml.workspace = true
 schemars = "0.8"  # JSON Schema generation from Rust types
 
 # CLAP audio plugin hosting
-clack-host = { git = "https://github.com/prokopyl/clack" }
-clack-extensions = { git = "https://github.com/prokopyl/clack", features = ["clack-host", "params"] }
+clack-host = { git = "https://github.com/prokopyl/clack", rev = "f53f8fc132c001a332c0a7221267812dfb654e92" }
+clack-extensions = { git = "https://github.com/prokopyl/clack", rev = "f53f8fc132c001a332c0a7221267812dfb654e92", features = ["clack-host", "params"] }
 
 # Audio resampling for real-time safe sample rate conversion
 rubato = "0.16"

--- a/plan/359-pin-clack-git-deps.md
+++ b/plan/359-pin-clack-git-deps.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: "Pin git dependencies (clack) — main is currently broken for fresh clones"
-status: pending
+status: in_review
 description: '`clack-host` and `clack-plugin` are unpinned git deps (track branch HEAD, not commit). When the upstream moves, fresh clones of main get a different lockfile and stop compiling. Currently main fails to build `streamlib` on a fresh clone due to this drift. Pin to a specific rev + audit the workspace for other unpinned git deps + document in CLAUDE.md.'
 github_issue: 359
 adapters:


### PR DESCRIPTION
## Summary

- Pin `clack-host` / `clack-extensions` to `f53f8fc1…` (the rev currently in `Cargo.lock`) in `libs/streamlib/Cargo.toml`.
- Pin `vulkanalia` / `vulkanalia-vma` / `vulkanalia-sys` to `982d32d2…` in the workspace `Cargo.toml` (including `[patch.crates-io]`).
- Add a **Dependencies** convention in `CLAUDE.md` requiring every git dep to use `rev = "..."` (or `tag = "..."`) so fresh clones don't drift.

## Issue

Closes #359

Unpinned git deps (bare `git = "..."` or `branch = "..."`) resolve against the remote's current HEAD each time the lockfile is regenerated. When upstream `clack` moved past the commit `main`'s `host.rs` was written against, fresh clones ended up with an older `clack` and a broken build (`E0308` in `libs/streamlib/src/core/clap/host.rs`). Pinning every git dep makes the lockfile authoritative regardless of what upstream does.

## Test Plan

- [x] `cargo check -p streamlib` passes (warnings only, all pre-existing)
- [x] `cargo build -p streamlib` passes
- [x] `cargo test -p streamlib --no-run` — all test binaries compile
- [x] `Cargo.lock` unchanged — pinned revs match what was already locked, so no downstream churn for existing clones
- [x] `grep -rn "git =" --include=Cargo.toml` — every remaining entry now has a `rev = ...`

## Follow-ups

- None from this change. Pre-existing build warnings are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)