### PR TITLE
feat(#325): polyglot escalate-on-behalf IPC for Python/Deno subprocesses

### DIFF
--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -15,6 +15,7 @@
 import * as msgpack from "@msgpack/msgpack";
 import type { NativeLib } from "./native.ts";
 import { cString } from "./native.ts";
+import type { EscalateChannel, EscalateOkResponse } from "./escalate.ts";
 import type {
   GpuContextFullAccess,
   GpuContextLimitedAccess,
@@ -37,6 +38,7 @@ export class NativeProcessorState {
   readonly config: Record<string, unknown>;
   readonly inputs: NativeInputPorts;
   readonly outputs: NativeOutputPorts;
+  readonly escalate: EscalateChannel | null;
 
   private lib: NativeLib;
   private ctxPtr: Deno.PointerObject;
@@ -47,6 +49,7 @@ export class NativeProcessorState {
     ctxPtr: Deno.PointerObject,
     config: Record<string, unknown>,
     brokerPtr: Deno.PointerObject | null = null,
+    escalate: EscalateChannel | null = null,
   ) {
     this.lib = lib;
     this.ctxPtr = ctxPtr;
@@ -54,6 +57,35 @@ export class NativeProcessorState {
     this.brokerPtr = brokerPtr;
     this.inputs = new NativeInputPorts(lib, ctxPtr);
     this.outputs = new NativeOutputPorts(lib, ctxPtr);
+    this.escalate = escalate;
+  }
+
+  /**
+   * Ask the host to acquire a new-shape pixel buffer on the subprocess's
+   * behalf. Throws if no escalate channel is wired (i.e. outside the
+   * subprocess_runner lifecycle).
+   */
+  async escalateAcquirePixelBuffer(
+    width: number,
+    height: number,
+    format = "bgra",
+  ): Promise<EscalateOkResponse> {
+    if (!this.escalate) {
+      throw new Error(
+        "escalate channel not installed — escalateAcquirePixelBuffer is only available inside the subprocess lifecycle",
+      );
+    }
+    return this.escalate.acquirePixelBuffer(width, height, format);
+  }
+
+  /** Drop the host's strong reference to a previously-escalated handle. */
+  async escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
+    if (!this.escalate) {
+      throw new Error(
+        "escalate channel not installed — escalateReleaseHandle is only available inside the subprocess lifecycle",
+      );
+    }
+    return this.escalate.releaseHandle(handleId);
   }
 
   get timeNs(): bigint {
@@ -95,6 +127,18 @@ export class NativeRuntimeContextLimitedAccess
   get timeNs(): bigint {
     return this.state.timeNs;
   }
+
+  escalateAcquirePixelBuffer(
+    width: number,
+    height: number,
+    format = "bgra",
+  ): Promise<EscalateOkResponse> {
+    return this.state.escalateAcquirePixelBuffer(width, height, format);
+  }
+
+  escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
+    return this.state.escalateReleaseHandle(handleId);
+  }
 }
 
 /**
@@ -122,6 +166,18 @@ export class NativeRuntimeContextFullAccess implements RuntimeContextFullAccess 
 
   get timeNs(): bigint {
     return this.state.timeNs;
+  }
+
+  escalateAcquirePixelBuffer(
+    width: number,
+    height: number,
+    format = "bgra",
+  ): Promise<EscalateOkResponse> {
+    return this.state.escalateAcquirePixelBuffer(width, height, format);
+  }
+
+  escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
+    return this.state.escalateReleaseHandle(handleId);
   }
 }
 

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot GPU escalation channel — subprocess → host IPC for Deno.
+ *
+ * Mirrors the Python SDK's `escalate.py`. The subprocess sees a limited
+ * GPU capability; anything that needs the privileged surface routes
+ * through the Rust host via an `escalate_request` on stdout. The host
+ * runs the op inside `GpuContextLimitedAccess::escalate` and replies
+ * with `escalate_response` on stdin.
+ *
+ * The channel is designed to be multiplexed into the existing stdin
+ * reader loop in `subprocess_runner.ts`. Outstanding requests are
+ * keyed by `request_id`; `handleIncoming(msg)` consumes an escalate
+ * response and resolves the corresponding promise.
+ */
+
+export const ESCALATE_REQUEST_RPC = "escalate_request";
+export const ESCALATE_RESPONSE_RPC = "escalate_response";
+
+export type EscalateOpPayload =
+  | {
+    op: "acquire_pixel_buffer";
+    width: number;
+    height: number;
+    format: string;
+  }
+  | {
+    op: "release_handle";
+    handle_id: string;
+  };
+
+export interface EscalateOkResponse {
+  result: "ok";
+  request_id: string;
+  handle_id: string;
+  width?: number;
+  height?: number;
+  format?: string;
+}
+
+export interface EscalateErrResponse {
+  result: "err";
+  request_id: string;
+  message: string;
+}
+
+export type EscalateResponse = EscalateOkResponse | EscalateErrResponse;
+
+export class EscalateError extends Error {}
+
+type Pending = {
+  resolve: (value: EscalateOkResponse) => void;
+  reject: (err: Error) => void;
+};
+
+/**
+ * Bidirectional escalate channel wired into the subprocess_runner's
+ * stdin demux. Call `handleIncoming(msg)` from the central stdin
+ * reader for every message tagged `rpc: "escalate_response"`.
+ */
+export class EscalateChannel {
+  private pending = new Map<string, Pending>();
+  private counter = 0;
+  private writer: (msg: Record<string, unknown>) => Promise<void>;
+
+  constructor(writer: (msg: Record<string, unknown>) => Promise<void>) {
+    this.writer = writer;
+  }
+
+  async acquirePixelBuffer(
+    width: number,
+    height: number,
+    format = "bgra",
+  ): Promise<EscalateOkResponse> {
+    return this.request({
+      op: "acquire_pixel_buffer",
+      width,
+      height,
+      format,
+    });
+  }
+
+  async releaseHandle(handleId: string): Promise<EscalateOkResponse> {
+    return this.request({ op: "release_handle", handle_id: handleId });
+  }
+
+  async request(op: EscalateOpPayload): Promise<EscalateOkResponse> {
+    const requestId = this.nextRequestId();
+    const msg = {
+      rpc: ESCALATE_REQUEST_RPC,
+      request_id: requestId,
+      ...op,
+    } as Record<string, unknown>;
+    const promise = new Promise<EscalateOkResponse>((resolve, reject) => {
+      this.pending.set(requestId, { resolve, reject });
+    });
+    try {
+      await this.writer(msg);
+    } catch (e) {
+      const p = this.pending.get(requestId);
+      if (p) {
+        this.pending.delete(requestId);
+        p.reject(e as Error);
+      }
+    }
+    return promise;
+  }
+
+  /**
+   * Consume an escalate_response. Returns true if the message was
+   * recognised as an escalate response (so the caller can skip
+   * lifecycle dispatch for it).
+   */
+  handleIncoming(msg: Record<string, unknown>): boolean {
+    if (msg.rpc !== ESCALATE_RESPONSE_RPC) return false;
+    const requestId = msg.request_id as string | undefined;
+    if (!requestId) return true; // malformed; eaten
+    const pending = this.pending.get(requestId);
+    if (!pending) return true;
+    this.pending.delete(requestId);
+    if (msg.result === "ok") {
+      pending.resolve(msg as unknown as EscalateOkResponse);
+    } else {
+      const err = new EscalateError(
+        (msg.message as string | undefined) ?? "escalate failed",
+      );
+      pending.reject(err);
+    }
+    return true;
+  }
+
+  /** Reject all in-flight requests (e.g. on shutdown). */
+  cancelAll(reason = "subprocess shutting down"): void {
+    for (const [id, pending] of this.pending.entries()) {
+      pending.reject(new EscalateError(reason));
+      this.pending.delete(id);
+    }
+  }
+
+  private nextRequestId(): string {
+    this.counter += 1;
+    // Short correlation id is enough — request_id only has to be unique
+    // within this subprocess's escalate channel.
+    return `dn-${Date.now().toString(36)}-${this.counter}`;
+  }
+}

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -21,6 +21,7 @@ import {
   NativeRuntimeContextFullAccess,
   NativeRuntimeContextLimitedAccess,
 } from "./context.ts";
+import { EscalateChannel } from "./escalate.ts";
 import type {
   ContinuousProcessor,
   ManualProcessor,
@@ -66,9 +67,22 @@ async function bridgeSendJson(msg: Record<string, unknown>): Promise<void> {
   const view = new DataView(lenBuf.buffer);
   view.setUint32(0, encoded.length, false); // big-endian
 
-  await stdout.write(lenBuf);
-  await stdout.write(encoded);
+  // Serialize concurrent writes (lifecycle replies + escalate requests) so
+  // the length prefix and payload aren't interleaved across async tasks.
+  await writeLock;
+  let release: () => void;
+  writeLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await stdout.write(lenBuf);
+    await stdout.write(encoded);
+  } finally {
+    release!();
+  }
 }
+
+let writeLock: Promise<void> = Promise.resolve();
 
 /**
  * Validate that the wire-format capability field matches what the lifecycle
@@ -146,10 +160,23 @@ async function main(): Promise<void> {
   let limitedCtx: NativeRuntimeContextLimitedAccess | null = null;
   let running = false;
 
+  // Escalate channel — requests from the TS processor go out on stdout,
+  // host responses arrive on stdin and are routed here from every stdin
+  // read site (outer loop + run-phase concurrent reader).
+  const escalateChannel = new EscalateChannel(bridgeSendJson);
+
   // Command loop
   try {
     while (true) {
       const msg = await bridgeReadJson();
+      // Drop escalate responses at the outer level too — defensive: the
+      // run-phase concurrent reader is normally the only site that sees
+      // them, but a late-arriving response after `running` flips to
+      // false should still be routed to the channel (it may reject a
+      // pending request so subprocess teardown isn't blocked).
+      if (escalateChannel.handleIncoming(msg)) {
+        continue;
+      }
       const cmd = msg.cmd as string;
 
       switch (cmd) {
@@ -234,7 +261,13 @@ async function main(): Promise<void> {
             // lifecycle. Each view wraps the same underlying FFI ctx, so
             // input/output ports and timing are shared; the capability split
             // is enforced purely by what each view exposes.
-            state = new NativeProcessorState(lib, ctxPtr, config, brokerPtr);
+            state = new NativeProcessorState(
+              lib,
+              ctxPtr,
+              config,
+              brokerPtr,
+              escalateChannel,
+            );
             fullCtx = new NativeRuntimeContextFullAccess(state);
             limitedCtx = new NativeRuntimeContextLimitedAccess(state);
 
@@ -288,6 +321,10 @@ async function main(): Promise<void> {
             try {
               while (running) {
                 const nextMsg = await bridgeReadJson();
+                // Demultiplex escalate responses out of the lifecycle path.
+                if (escalateChannel.handleIncoming(nextMsg)) {
+                  continue;
+                }
                 const nextCmd = nextMsg.cmd as string;
                 if (nextCmd === "teardown") {
                   assertCapability(processorId, nextCmd, nextMsg, "full");
@@ -499,6 +536,7 @@ async function main(): Promise<void> {
         // ignore teardown errors during shutdown
       }
     }
+    escalateChannel.cancelAll("subprocess shutting down");
     lib.symbols.sldn_context_destroy(ctxPtr);
     lib.close();
     Deno.exit(isStdinClosed ? 0 : 1);

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot GPU escalation channel — subprocess → host IPC.
+
+A Python processor running in a subprocess only sees a
+``GpuContextLimitedAccess`` sandbox (no raw allocations). When it needs the
+privileged ``GpuContextFullAccess`` surface — e.g. to acquire a new-shape
+pixel buffer mid-stream — it sends an ``escalate_request`` to the Rust host
+over the subprocess's stdout, and the host replies with an
+``escalate_response`` on stdin. The host runs the work inside
+``GpuContextLimitedAccess::escalate``, which serializes against every other
+escalation in the runtime.
+
+This module is small on purpose: it owns the request-id bookkeeping and the
+deferred-lifecycle buffer that lets ``EscalateChannel.request()`` step over
+any lifecycle commands (``on_pause``, ``stop``, …) that happen to arrive
+while it's blocked waiting for its correlated response. The outer
+``subprocess_runner`` loop drains those buffered messages through
+``EscalateChannel.take_deferred_lifecycle_messages()`` before polling stdin
+again.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from typing import Any, Dict, List, Optional
+
+from .processor_context import bridge_read_message, bridge_send_message
+
+
+ESCALATE_REQUEST_RPC = "escalate_request"
+ESCALATE_RESPONSE_RPC = "escalate_response"
+
+
+class EscalateError(RuntimeError):
+    """Raised when the host returns an ``Err`` escalate response."""
+
+
+class EscalateChannel:
+    """Synchronous request/response channel over the subprocess's stdio pipes.
+
+    The channel is single-flight: only one escalate request is in flight at
+    a time, matching the single-threaded structure of the Python subprocess
+    runner. Lifecycle messages that the host sends while we're waiting on a
+    correlated response are captured in ``_deferred_lifecycle`` and drained
+    by the outer loop through
+    :meth:`take_deferred_lifecycle_messages`.
+    """
+
+    def __init__(self, stdin, stdout) -> None:
+        self._stdin = stdin
+        self._stdout = stdout
+        self._send_lock = threading.Lock()
+        self._deferred_lifecycle: List[Dict[str, Any]] = []
+
+    # -------------------- public SDK surface --------------------
+
+    def acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> Dict[str, Any]:
+        """Request a new-shape pixel buffer from the host.
+
+        Returns the ``ok``-payload dict; on failure raises
+        :class:`EscalateError`.
+        """
+        return self.request(
+            {
+                "op": "acquire_pixel_buffer",
+                "width": int(width),
+                "height": int(height),
+                "format": format,
+            }
+        )
+
+    def release_handle(self, handle_id: str) -> Dict[str, Any]:
+        """Tell the host to drop its strong reference to ``handle_id``."""
+        return self.request(
+            {
+                "op": "release_handle",
+                "handle_id": handle_id,
+            }
+        )
+
+    # -------------------- core request/response --------------------
+
+    def request(self, op: Dict[str, Any]) -> Dict[str, Any]:
+        """Send an escalate request and block until the correlated response."""
+        request_id = str(uuid.uuid4())
+        req = {"rpc": ESCALATE_REQUEST_RPC, "request_id": request_id, **op}
+        with self._send_lock:
+            bridge_send_message(self._stdout, req)
+            return self._await_response(request_id)
+
+    def _await_response(self, request_id: str) -> Dict[str, Any]:
+        while True:
+            msg = bridge_read_message(self._stdin)
+            rpc = msg.get("rpc", "")
+            if rpc == ESCALATE_RESPONSE_RPC and msg.get("request_id") == request_id:
+                if msg.get("result") == "ok":
+                    return msg
+                raise EscalateError(msg.get("message") or "escalate failed")
+            # Any other message during our blocking read is a lifecycle
+            # command (stop / teardown / on_pause / on_resume / update_config).
+            # Defer it so the outer loop consumes it in FIFO order.
+            self._deferred_lifecycle.append(msg)
+
+    # -------------------- lifecycle cooperation --------------------
+
+    def take_deferred_lifecycle_messages(self) -> List[Dict[str, Any]]:
+        """Drain and return buffered lifecycle messages, FIFO."""
+        out = self._deferred_lifecycle
+        self._deferred_lifecycle = []
+        return out
+
+    def has_deferred_lifecycle_messages(self) -> bool:
+        return bool(self._deferred_lifecycle)
+
+
+_channel_singleton: Optional[EscalateChannel] = None
+
+
+def install_channel(channel: EscalateChannel) -> None:
+    """Install the process-wide escalate channel.
+
+    Called once by ``subprocess_runner.main`` after it opens the stdio pipes.
+    Subsequent calls replace the channel, which is only sensible in test
+    setups.
+    """
+    global _channel_singleton
+    _channel_singleton = channel
+
+
+def channel() -> EscalateChannel:
+    """Return the process-wide escalate channel.
+
+    Raises ``RuntimeError`` if :func:`install_channel` hasn't been called
+    yet — that only happens when processor code runs outside the normal
+    subprocess_runner lifecycle (e.g. bare unit tests without a host).
+    """
+    if _channel_singleton is None:
+        raise RuntimeError(
+            "escalate channel not installed — ctx.escalate is only available "
+            "inside the subprocess lifecycle"
+        )
+    return _channel_singleton

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -392,13 +392,14 @@ class NativeGpu:
 class NativeProcessorContext:
     """Context using direct FFI to iceoryx2."""
 
-    def __init__(self, lib, ctx_ptr, config, broker_ptr=None):
+    def __init__(self, lib, ctx_ptr, config, broker_ptr=None, escalate_channel=None):
         self._lib = lib
         self._ctx_ptr = ctx_ptr
         self._config = config or {}
         self.inputs = NativeInputs(lib, ctx_ptr)
         self.outputs = NativeOutputs(lib, ctx_ptr)
         self.gpu = NativeGpu(lib, broker_ptr)
+        self._escalate_channel = escalate_channel
 
     @property
     def config(self):
@@ -409,3 +410,28 @@ class NativeProcessorContext:
     def time(self):
         """Current monotonic time in nanoseconds."""
         return self._lib.slpn_context_time_ns(self._ctx_ptr)
+
+    def escalate_acquire_pixel_buffer(self, width, height, format="bgra"):
+        """Ask the host to allocate a new-shape pixel buffer on our behalf.
+
+        Routes through the Rust host's `GpuContextLimitedAccess::escalate`,
+        which serializes against every other escalation in the runtime. The
+        buffer lives in the host's pool; we reference it by the returned
+        ``handle_id`` until ``escalate_release_handle(handle_id)``.
+        """
+        channel = self._require_channel()
+        return channel.acquire_pixel_buffer(width, height, format)
+
+    def escalate_release_handle(self, handle_id):
+        """Drop the host's strong reference to a previously-escalated handle."""
+        channel = self._require_channel()
+        return channel.release_handle(handle_id)
+
+    def _require_channel(self):
+        if self._escalate_channel is None:
+            # Fall back to the process-wide singleton so code written for
+            # the run-loop ctx still works if someone calls escalate_* from
+            # a helper that didn't receive `ctx`.
+            from .escalate import channel as _singleton
+            return _singleton()
+        return self._escalate_channel

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -27,6 +27,7 @@ import sys
 import time
 import traceback
 
+from .escalate import EscalateChannel, install_channel
 from .processor_context import (
     NativeProcessorContext,
     bridge_read_message,
@@ -49,7 +50,7 @@ def _load_processor_class(entrypoint: str, project_path: str):
     return getattr(module, class_name)
 
 
-def _setup_native_context(msg, native_lib_path, processor_id):
+def _setup_native_context(msg, native_lib_path, processor_id, escalate_channel=None):
     """Set up native FFI context with iceoryx2 subscriptions and publishers."""
     config = msg.get("config")
     ports = msg.get("ports", {})
@@ -117,7 +118,9 @@ def _setup_native_context(msg, native_lib_path, processor_id):
                 "Broker connect failed for '%s'", xpc_service_name,
             )
 
-    ctx = NativeProcessorContext(lib, ctx_ptr, config, broker_ptr)
+    ctx = NativeProcessorContext(
+        lib, ctx_ptr, config, broker_ptr, escalate_channel=escalate_channel
+    )
     return lib, ctx_ptr, broker_ptr, ctx
 
 
@@ -129,16 +132,37 @@ def _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr):
         native_lib.slpn_context_destroy(native_ctx_ptr)
 
 
-def _handle_stdin_during_run(stdin, stdout, processor, ctx, processor_id):
+def _handle_stdin_during_run(stdin, stdout, processor, ctx, processor_id,
+                              escalate_channel=None):
     """Non-blocking check for lifecycle commands during the run loop.
 
-    Handles on_pause, on_resume, and update_config inline.
-    Returns "stop", "teardown", or None.
+    Also drains any lifecycle commands the escalate channel may have buffered
+    while blocked on a correlated response. Handles on_pause, on_resume, and
+    update_config inline. Returns "stop", "teardown", or None.
     """
+    # Drain deferred lifecycle messages first — they arrived while a
+    # process() call was blocked on ctx.escalate_*, so they're older than
+    # anything still in the pipe.
+    if escalate_channel and escalate_channel.has_deferred_lifecycle_messages():
+        deferred = escalate_channel.take_deferred_lifecycle_messages()
+        for dm in deferred:
+            result = _dispatch_lifecycle_msg(dm, stdout, processor, ctx)
+            if result is not None:
+                # Re-queue any messages we didn't process this turn so a
+                # stop/teardown coming from a deferred slot takes precedence.
+                remaining = deferred[deferred.index(dm) + 1 :]
+                escalate_channel._deferred_lifecycle[:0] = remaining
+                return result
+
     if not select.select([stdin], [], [], 0)[0]:
         return None
 
     msg = bridge_read_message(stdin)
+    return _dispatch_lifecycle_msg(msg, stdout, processor, ctx)
+
+
+def _dispatch_lifecycle_msg(msg, stdout, processor, ctx):
+    """Execute a lifecycle message and reply. Returns 'stop'/'teardown'/None."""
     cmd = msg.get("cmd", "")
 
     if cmd == "stop" or cmd == "teardown":
@@ -200,6 +224,12 @@ def main():
     stdin = sys.stdin.buffer
     stdout = sys.stdout.buffer
 
+    # Install the escalate channel so processors can call ctx.escalate_*
+    # during setup() and process(). The channel shares the same stdio pipes
+    # as the lifecycle protocol and demultiplexes responses by request_id.
+    escalate_channel = EscalateChannel(stdin, stdout)
+    install_channel(escalate_channel)
+
     # Load processor class and instantiate
     processor_class = _load_processor_class(entrypoint, project_path)
     processor = processor_class()
@@ -221,7 +251,8 @@ def main():
                 _logger.info("Native mode: loading %s", native_lib_path)
                 try:
                     native_lib, native_ctx_ptr, native_broker_ptr, ctx = _setup_native_context(
-                        msg, native_lib_path, processor_id
+                        msg, native_lib_path, processor_id,
+                        escalate_channel=escalate_channel,
                     )
                 except Exception as e:
                     traceback.print_exc(file=sys.stderr)
@@ -266,7 +297,8 @@ def main():
                             time.sleep(0.001)  # 1ms yield
 
                         lifecycle_cmd = _handle_stdin_during_run(
-                            stdin, stdout, processor, ctx, processor_id
+                            stdin, stdout, processor, ctx, processor_id,
+                            escalate_channel=escalate_channel,
                         )
                         if lifecycle_cmd == "teardown":
                             running = False
@@ -296,7 +328,8 @@ def main():
                             time.sleep(0)  # yield
 
                         lifecycle_cmd = _handle_stdin_during_run(
-                            stdin, stdout, processor, ctx, processor_id
+                            stdin, stdout, processor, ctx, processor_id,
+                            escalate_channel=escalate_channel,
                         )
                         if lifecycle_cmd == "teardown":
                             running = False

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for polyglot GPU escalation requests.
+#
+# Sent from a Python or Deno subprocess over its stdout to the Rust host
+# processor. The host routes the op through `GpuContextLimitedAccess::escalate`
+# and replies with [`EscalateResponse`] on the same stdin pipe.
+#
+# This schema is checked in as design documentation. It is **not** wired into
+# `cargo xtask generate-schemas` because jtd-codegen v0.4.1's discriminator
+# support emits tagged Rust enums whose shape collides with the existing
+# post-processing rules for plain config/payload schemas. The hand-authored
+# types live in
+# `libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs`
+# and are kept in sync with this file manually.
+
+metadata:
+  name: com.streamlib.escalate_request
+  version: 1.0.0
+  description: "Polyglot subprocess escalate-on-behalf request (subprocess → host)"
+
+discriminator: op
+mapping:
+  acquire_pixel_buffer:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      width:
+        metadata:
+          description: "Pixel width of the buffer."
+        type: uint32
+      height:
+        metadata:
+          description: "Pixel height of the buffer."
+        type: uint32
+      format:
+        metadata:
+          description: "Pixel format identifier (e.g. bgra32, nv12_video_range, gray8)."
+        type: string
+  release_handle:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      handle_id:
+        metadata:
+          description: "Opaque handle ID previously returned by acquire_*."
+        type: string

--- a/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for polyglot GPU escalation responses.
+#
+# Sent from the Rust host processor over the subprocess's stdin in reply to an
+# [`EscalateRequest`]. Correlated by `request_id`.
+#
+# See the sibling escalate_request schema for the rationale behind keeping
+# this file out of the `cargo xtask generate-schemas` pipeline; the
+# hand-authored types live in
+# `libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs`.
+
+metadata:
+  name: com.streamlib.escalate_response
+  version: 1.0.0
+  description: "Polyglot subprocess escalate-on-behalf response (host → subprocess)"
+
+discriminator: result
+mapping:
+  ok:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates response with request. Matches request_id in EscalateRequest."
+        type: string
+      handle_id:
+        metadata:
+          description: >
+            Opaque handle returned by the host. For acquire_pixel_buffer this
+            is the PixelBufferPoolId the host registered with its
+            pixel-buffer pool and broker SurfaceStore. For release_handle this
+            echoes the released id.
+        type: string
+    optionalProperties:
+      width:
+        metadata:
+          description: "Width in pixels (set on acquire_pixel_buffer responses)."
+        type: uint32
+      height:
+        metadata:
+          description: "Height in pixels (set on acquire_pixel_buffer responses)."
+        type: uint32
+      format:
+        metadata:
+          description: "Resolved pixel format identifier."
+        type: string
+  err:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates response with request."
+        type: string
+      message:
+        metadata:
+          description: "Human-readable error message from the host side."
+        type: string

--- a/libs/streamlib/src/core/compiler/compiler_ops/mod.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/mod.rs
@@ -7,6 +7,8 @@ mod spawn_deno_subprocess_op;
 mod spawn_processor_op;
 mod spawn_python_native_subprocess_op;
 mod spawn_python_subprocess_op;
+mod subprocess_bridge;
+mod subprocess_escalate;
 
 pub use open_iceoryx2_service_op::{close_iceoryx2_service, open_iceoryx2_service};
 pub(crate) use prepare_processor_op::prepare_processor;

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::core::error::{Result, StreamError};
 use crate::core::execution::ExecutionConfig;
@@ -14,6 +14,8 @@ use crate::core::runtime::BoxFuture;
 use crate::core::{
     ProcessorDescriptor, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
+
+use super::subprocess_bridge::SubprocessBridge;
 
 // ============================================================================
 // DenoSubprocessHostProcessor — Rust host for Deno subprocess processors
@@ -28,12 +30,13 @@ use crate::core::{
 /// The Rust host is purely a lifecycle manager:
 /// - Spawns `deno run` with the subprocess runner
 /// - Sends lifecycle commands (setup, run, stop, teardown) via stdin/stdout pipes
+/// - Relays escalate-on-behalf requests from the subprocess through
+///   [`GpuContextLimitedAccess::escalate`]
 /// - Always runs in Manual execution mode on the Rust side
 pub(crate) struct DenoSubprocessHostProcessor {
     // Subprocess management (populated during setup)
     child: Option<Child>,
-    stdin_writer: Option<BufWriter<ChildStdin>>,
-    stdout_reader: Option<BufReader<ChildStdout>>,
+    bridge: Option<SubprocessBridge>,
 
     // Config for spawning (set at construction, used during setup)
     entrypoint: String,
@@ -63,7 +66,7 @@ pub(crate) struct DenoSubprocessHostProcessor {
 impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProcessor {
     fn __generated_setup<'a>(
         &'a mut self,
-        _ctx: &'a RuntimeContextFullAccess<'a>,
+        ctx: &'a RuntimeContextFullAccess<'a>,
     ) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
             let project_path = PathBuf::from(&self.project_path);
@@ -163,9 +166,13 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 StreamError::Runtime("Failed to capture subprocess stdout".to_string())
             })?;
 
+            // Clone the sandbox so the bridge reader thread can dispatch
+            // escalate requests on behalf of the subprocess.
+            let sandbox = ctx.gpu_limited_access().clone();
+            let bridge = SubprocessBridge::new(stdin, stdout, sandbox, self.processor_id.clone());
+
             self.child = Some(child);
-            self.stdin_writer = Some(BufWriter::new(stdin));
-            self.stdout_reader = Some(BufReader::new(stdout));
+            self.bridge = Some(bridge);
 
             // Send setup command with processor config and port wiring info.
             // `capability: "full"` mirrors the Rust-side `RuntimeContextFullAccess`
@@ -175,7 +182,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 .processor_config
                 .clone()
                 .unwrap_or(serde_json::Value::Null);
-            self.bridge_send_json(&serde_json::json!({
+            self.bridge_send(&serde_json::json!({
                 "cmd": "setup",
                 "capability": "full",
                 "config": config,
@@ -187,7 +194,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             }))?;
 
             // Wait for "ready" response
-            let response = self.bridge_read_json()?;
+            let response = self.bridge_recv()?;
             let rpc = response.get("rpc").and_then(|v| v.as_str()).unwrap_or("");
             if rpc != "ready" {
                 let error = response
@@ -218,8 +225,8 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             tracing::info!("[{}] Tearing down Deno subprocess", self.processor_id);
 
             // Send teardown command (best-effort)
-            if self.stdin_writer.is_some() {
-                if let Err(e) = self.bridge_send_json(
+            if self.bridge.is_some() {
+                if let Err(e) = self.bridge_send(
                     &serde_json::json!({"cmd": "teardown", "capability": "full"}),
                 ) {
                     tracing::warn!(
@@ -228,8 +235,8 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                         e
                     );
                 } else {
-                    // Wait for done (with timeout via read)
-                    match self.bridge_read_json() {
+                    // Wait for done (bounded so a stuck subprocess doesn't block teardown)
+                    match self.bridge_recv_timeout(Duration::from_secs(5)) {
                         Ok(_) => {}
                         Err(e) => {
                             tracing::warn!(
@@ -242,9 +249,9 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 }
             }
 
-            // Drop pipes to signal EOF
-            self.stdin_writer = None;
-            self.stdout_reader = None;
+            // Drop bridge — closes stdin, reader thread sees EOF on stdout
+            // and exits, escalate registry is cleared.
+            self.bridge.take();
 
             // Wait for subprocess to exit (with timeout)
             if let Some(mut child) = self.child.take() {
@@ -287,14 +294,14 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send_json(
+            if let Err(e) = self.bridge_send(
                 &serde_json::json!({"cmd": "on_pause", "capability": "limited"}),
             ) {
                 tracing::warn!("[{}] Failed to send on_pause: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
             }
-            match self.bridge_read_json() {
+            match self.bridge_recv() {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(
@@ -317,14 +324,14 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send_json(
+            if let Err(e) = self.bridge_send(
                 &serde_json::json!({"cmd": "on_resume", "capability": "limited"}),
             ) {
                 tracing::warn!("[{}] Failed to send on_resume: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
             }
-            match self.bridge_read_json() {
+            match self.bridge_recv() {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(
@@ -364,7 +371,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
         // `process()` is dispatched with limited access, `on_pause`/`on_resume`
         // delivered concurrently are also limited. No single capability applies
         // to the command itself — the `capability` field is informational.
-        self.bridge_send_json(&serde_json::json!({
+        self.bridge_send(&serde_json::json!({
             "cmd": "run",
             "capability": "limited",
             "execution": execution_mode,
@@ -379,7 +386,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
         if self.subprocess_dead {
             return Ok(());
         }
-        if let Err(e) = self.bridge_send_json(
+        if let Err(e) = self.bridge_send(
             &serde_json::json!({"cmd": "stop", "capability": "full"}),
         ) {
             tracing::warn!(
@@ -390,7 +397,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             self.subprocess_dead = true;
             return Ok(());
         }
-        match self.bridge_read_json() {
+        match self.bridge_recv() {
             Ok(response) => {
                 let rpc = response.get("rpc").and_then(|v| v.as_str()).unwrap_or("");
                 if rpc != "stopped" {
@@ -479,53 +486,28 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
 
 impl DenoSubprocessHostProcessor {
     /// Send a length-prefixed JSON message to the subprocess stdin.
-    fn bridge_send_json(&mut self, msg: &serde_json::Value) -> Result<()> {
-        let writer = self
-            .stdin_writer
-            .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Subprocess stdin not available".to_string()))?;
-
-        let json_bytes = serde_json::to_vec(msg).map_err(|e| {
-            StreamError::Runtime(format!("Failed to serialize bridge message: {}", e))
+    fn bridge_send(&mut self, msg: &serde_json::Value) -> Result<()> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
-
-        let len = json_bytes.len() as u32;
-        writer.write_all(&len.to_be_bytes()).map_err(|e| {
-            StreamError::Runtime(format!("Failed to write to subprocess stdin: {}", e))
-        })?;
-        writer.write_all(&json_bytes).map_err(|e| {
-            StreamError::Runtime(format!("Failed to write to subprocess stdin: {}", e))
-        })?;
-        writer.flush().map_err(|e| {
-            StreamError::Runtime(format!("Failed to flush subprocess stdin: {}", e))
-        })?;
-
-        Ok(())
+        bridge.send(msg)
     }
 
     /// Read a length-prefixed JSON message from the subprocess stdout.
-    fn bridge_read_json(&mut self) -> Result<serde_json::Value> {
-        let reader = self
-            .stdout_reader
-            .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Subprocess stdout not available".to_string()))?;
-
-        let mut len_buf = [0u8; 4];
-        reader.read_exact(&mut len_buf).map_err(|e| {
-            StreamError::Runtime(format!("Failed to read from subprocess stdout: {}", e))
+    fn bridge_recv(&mut self) -> Result<serde_json::Value> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
+        bridge.recv_lifecycle()
+    }
 
-        let len = u32::from_be_bytes(len_buf) as usize;
-        let mut msg_buf = vec![0u8; len];
-        reader.read_exact(&mut msg_buf).map_err(|e| {
-            StreamError::Runtime(format!(
-                "Failed to read message from subprocess stdout: {}",
-                e
-            ))
+    fn bridge_recv_timeout(&mut self, timeout: Duration) -> Result<serde_json::Value> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
-
-        serde_json::from_slice(&msg_buf)
-            .map_err(|e| StreamError::Runtime(format!("Failed to parse subprocess message: {}", e)))
+        bridge
+            .recv_lifecycle_timeout(timeout)
+            .map_err(|e| StreamError::Runtime(format!("bridge recv timed out: {e}")))
     }
 }
 
@@ -550,8 +532,7 @@ pub(crate) fn create_deno_subprocess_host_constructor(
     Box::new(move |node: &ProcessorNode| {
         Ok(Box::new(DenoSubprocessHostProcessor {
             child: None,
-            stdin_writer: None,
-            stdout_reader: None,
+            bridge: None,
             entrypoint: entrypoint.clone(),
             project_path: project_path_str.clone(),
             processor_id: node.id.to_string(),

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -1,10 +1,11 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::BufReader;
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::core::error::{Result, StreamError};
 use crate::core::execution::ExecutionConfig;
@@ -16,6 +17,7 @@ use crate::core::{
 };
 
 use super::spawn_python_subprocess_op::ensure_processor_venv;
+use super::subprocess_bridge::SubprocessBridge;
 
 // ============================================================================
 // PythonNativeSubprocessHostProcessor — Rust host for Python native-mode processors
@@ -30,6 +32,8 @@ use super::spawn_python_subprocess_op::ensure_processor_venv;
 /// The Rust host is purely a lifecycle manager:
 /// - Spawns Python subprocess with the subprocess runner
 /// - Sends lifecycle commands (setup, run, stop, teardown) via stdin/stdout pipes
+/// - Relays escalate-on-behalf requests from the subprocess through
+///   [`GpuContextLimitedAccess::escalate`]
 /// - Always runs in Manual execution mode on the Rust side
 pub(crate) struct PythonNativeSubprocessHostProcessor {
     // NO InputMailboxes — subprocess manages its own iceoryx2 subscribers
@@ -37,8 +41,7 @@ pub(crate) struct PythonNativeSubprocessHostProcessor {
 
     // Subprocess management (populated during setup)
     child: Option<Child>,
-    stdin_writer: Option<BufWriter<ChildStdin>>,
-    stdout_reader: Option<BufReader<ChildStdout>>,
+    bridge: Option<SubprocessBridge>,
 
 
     // Config for spawning (set at construction, used during setup)
@@ -181,16 +184,20 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                     .ok();
             }
 
+            // Clone the sandbox for the bridge reader thread so escalate
+            // requests can be served on behalf of the subprocess.
+            let sandbox = ctx.gpu_limited_access().clone();
+            let bridge = SubprocessBridge::new(stdin, stdout, sandbox, self.processor_id.clone());
+
             self.child = Some(child);
-            self.stdin_writer = Some(BufWriter::new(stdin));
-            self.stdout_reader = Some(BufReader::new(stdout));
+            self.bridge = Some(bridge);
 
             // Send setup command with processor config and port wiring info
             let config = self
                 .processor_config
                 .clone()
                 .unwrap_or(serde_json::Value::Null);
-            self.bridge_send_json(&serde_json::json!({
+            self.bridge_send(&serde_json::json!({
                 "cmd": "setup",
                 "config": config,
                 "processor_id": self.processor_id,
@@ -201,7 +208,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             }))?;
 
             // Wait for "ready" response
-            let response = self.bridge_read_json()?;
+            let response = self.bridge_recv()?;
             let rpc = response.get("rpc").and_then(|v| v.as_str()).unwrap_or("");
             if rpc != "ready" {
                 let error = response
@@ -235,16 +242,16 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             );
 
             // Send teardown command (best-effort)
-            if self.stdin_writer.is_some() {
-                if let Err(e) = self.bridge_send_json(&serde_json::json!({"cmd": "teardown"})) {
+            if self.bridge.is_some() {
+                if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "teardown"})) {
                     tracing::warn!(
                         "[{}] Failed to send teardown command: {}",
                         self.processor_id,
                         e
                     );
                 } else {
-                    // Wait for done (with timeout via read)
-                    match self.bridge_read_json() {
+                    // Wait for done (bounded so a stuck subprocess doesn't block teardown)
+                    match self.bridge_recv_timeout(Duration::from_secs(5)) {
                         Ok(_) => {}
                         Err(e) => {
                             tracing::warn!(
@@ -257,9 +264,9 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                 }
             }
 
-            // Drop pipes to signal EOF
-            self.stdin_writer = None;
-            self.stdout_reader = None;
+            // Drop bridge — closes stdin, reader thread sees EOF on stdout
+            // and exits, escalate registry is cleared.
+            self.bridge.take();
 
             // Wait for subprocess to exit (with timeout)
             if let Some(mut child) = self.child.take() {
@@ -302,12 +309,12 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send_json(&serde_json::json!({"cmd": "on_pause"})) {
+            if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "on_pause"})) {
                 tracing::warn!("[{}] Failed to send on_pause: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
             }
-            match self.bridge_read_json() {
+            match self.bridge_recv() {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(
@@ -330,12 +337,12 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send_json(&serde_json::json!({"cmd": "on_resume"})) {
+            if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "on_resume"})) {
                 tracing::warn!("[{}] Failed to send on_resume: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
             }
-            match self.bridge_read_json() {
+            match self.bridge_recv() {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(
@@ -371,7 +378,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 
         let interval_ms = self.execution_config.execution.interval_ms().unwrap_or(0);
 
-        self.bridge_send_json(&serde_json::json!({
+        self.bridge_send(&serde_json::json!({
             "cmd": "run",
             "execution": execution_mode,
             "interval_ms": interval_ms,
@@ -385,7 +392,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
         if self.subprocess_dead {
             return Ok(());
         }
-        if let Err(e) = self.bridge_send_json(&serde_json::json!({"cmd": "stop"})) {
+        if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "stop"})) {
             tracing::warn!(
                 "[{}] Subprocess pipe broken on stop: {}",
                 self.processor_id,
@@ -394,7 +401,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             self.subprocess_dead = true;
             return Ok(());
         }
-        match self.bridge_read_json() {
+        match self.bridge_recv() {
             Ok(response) => {
                 let rpc = response.get("rpc").and_then(|v| v.as_str()).unwrap_or("");
                 if rpc != "stopped" {
@@ -486,54 +493,27 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 // ============================================================================
 
 impl PythonNativeSubprocessHostProcessor {
-    /// Send a length-prefixed JSON message to the subprocess stdin.
-    fn bridge_send_json(&mut self, msg: &serde_json::Value) -> Result<()> {
-        let writer = self
-            .stdin_writer
-            .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Subprocess stdin not available".to_string()))?;
-
-        let json_bytes = serde_json::to_vec(msg).map_err(|e| {
-            StreamError::Runtime(format!("Failed to serialize bridge message: {}", e))
+    fn bridge_send(&mut self, msg: &serde_json::Value) -> Result<()> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
-
-        let len = json_bytes.len() as u32;
-        writer.write_all(&len.to_be_bytes()).map_err(|e| {
-            StreamError::Runtime(format!("Failed to write to subprocess stdin: {}", e))
-        })?;
-        writer.write_all(&json_bytes).map_err(|e| {
-            StreamError::Runtime(format!("Failed to write to subprocess stdin: {}", e))
-        })?;
-        writer.flush().map_err(|e| {
-            StreamError::Runtime(format!("Failed to flush subprocess stdin: {}", e))
-        })?;
-
-        Ok(())
+        bridge.send(msg)
     }
 
-    /// Read a length-prefixed JSON message from the subprocess stdout.
-    fn bridge_read_json(&mut self) -> Result<serde_json::Value> {
-        let reader = self
-            .stdout_reader
-            .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Subprocess stdout not available".to_string()))?;
-
-        let mut len_buf = [0u8; 4];
-        reader.read_exact(&mut len_buf).map_err(|e| {
-            StreamError::Runtime(format!("Failed to read from subprocess stdout: {}", e))
+    fn bridge_recv(&mut self) -> Result<serde_json::Value> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
+        bridge.recv_lifecycle()
+    }
 
-        let len = u32::from_be_bytes(len_buf) as usize;
-        let mut msg_buf = vec![0u8; len];
-        reader.read_exact(&mut msg_buf).map_err(|e| {
-            StreamError::Runtime(format!(
-                "Failed to read message from subprocess stdout: {}",
-                e
-            ))
+    fn bridge_recv_timeout(&mut self, timeout: Duration) -> Result<serde_json::Value> {
+        let bridge = self.bridge.as_ref().ok_or_else(|| {
+            StreamError::Runtime("Subprocess bridge not initialized".to_string())
         })?;
-
-        serde_json::from_slice(&msg_buf)
-            .map_err(|e| StreamError::Runtime(format!("Failed to parse subprocess message: {}", e)))
+        bridge
+            .recv_lifecycle_timeout(timeout)
+            .map_err(|e| StreamError::Runtime(format!("bridge recv timed out: {e}")))
     }
 }
 
@@ -559,8 +539,7 @@ pub(crate) fn create_python_native_subprocess_host_constructor(
     Box::new(move |node: &ProcessorNode| {
         Ok(Box::new(PythonNativeSubprocessHostProcessor {
             child: None,
-            stdin_writer: None,
-            stdout_reader: None,
+            bridge: None,
             entrypoint: entrypoint.clone(),
             project_path: project_path_str.clone(),
             processor_id: node.id.to_string(),

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_bridge.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_bridge.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Length-prefixed JSON stdio bridge shared by the Python and Deno
+//! subprocess host processors.
+//!
+//! Two roles travel over the same pair of pipes:
+//! 1. Lifecycle RPC (`setup`, `run`, `stop`, `teardown`, `on_pause`,
+//!    `on_resume`, …) — initiated by the host, the subprocess replies with
+//!    `rpc: "ready" | "stopped" | "ok" | "done" | "error"`.
+//! 2. Escalate-on-behalf (`rpc: "escalate_request"`) — initiated by the
+//!    subprocess, the host replies with `rpc: "escalate_response"`.
+//!
+//! A dedicated reader thread (`bridge-reader-…`) owns the subprocess stdout
+//! and demultiplexes incoming messages: escalate requests are dispatched
+//! inline through [`subprocess_escalate::process_bridge_message`], and
+//! anything else is forwarded to the main thread over an mpsc channel for
+//! the lifecycle RPC to consume. Writes in both directions serialize through
+//! a shared `Arc<Mutex<BufWriter<ChildStdin>>>` so the main thread and the
+//! reader thread can't interleave halves of a length-prefixed frame.
+
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::process::{ChildStdin, ChildStdout};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::core::context::GpuContextLimitedAccess;
+use crate::core::error::{Result, StreamError};
+
+use super::subprocess_escalate::{process_bridge_message, EscalateHandleRegistry};
+
+/// Shared writer handle. The host's lifecycle path and the reader thread's
+/// escalate-response path both write through this mutex.
+type SharedWriter = Arc<Mutex<BufWriter<ChildStdin>>>;
+
+/// Bridge for one subprocess. Drop the value to tear the reader thread down
+/// cleanly (stdin close propagates EOF; reader thread exits).
+pub(crate) struct SubprocessBridge {
+    processor_id: String,
+    stdin: SharedWriter,
+    lifecycle_rx: Receiver<serde_json::Value>,
+    registry: Arc<EscalateHandleRegistry>,
+    reader: Option<JoinHandle<()>>,
+    dead: Arc<Mutex<bool>>,
+}
+
+impl SubprocessBridge {
+    /// Wrap the subprocess pipes and spawn the reader thread.
+    ///
+    /// `sandbox` is cloned into the reader thread so escalate requests can
+    /// be dispatched without blocking the main thread. `processor_id` is
+    /// used for thread naming and tracing.
+    pub(crate) fn new(
+        stdin: ChildStdin,
+        stdout: ChildStdout,
+        sandbox: GpuContextLimitedAccess,
+        processor_id: String,
+    ) -> Self {
+        let stdin: SharedWriter = Arc::new(Mutex::new(BufWriter::new(stdin)));
+        let registry = EscalateHandleRegistry::new();
+        let (tx, rx) = mpsc::channel();
+        let dead = Arc::new(Mutex::new(false));
+
+        let thread_name = thread_name(&processor_id);
+        let reader_stdin = Arc::clone(&stdin);
+        let reader_registry = Arc::clone(&registry);
+        let reader_dead = Arc::clone(&dead);
+        let reader_processor_id = processor_id.clone();
+
+        let reader = thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                reader_loop(
+                    BufReader::new(stdout),
+                    reader_stdin,
+                    sandbox,
+                    reader_registry,
+                    tx,
+                    reader_dead,
+                    reader_processor_id,
+                );
+            })
+            .expect("failed to spawn bridge reader thread");
+
+        Self {
+            processor_id,
+            stdin,
+            lifecycle_rx: rx,
+            registry,
+            reader: Some(reader),
+            dead,
+        }
+    }
+
+    /// Write a length-prefixed JSON message to the subprocess stdin.
+    pub(crate) fn send(&self, msg: &serde_json::Value) -> Result<()> {
+        if self.is_dead() {
+            return Err(StreamError::Runtime(format!(
+                "[{}] bridge marked dead, cannot send",
+                self.processor_id
+            )));
+        }
+        let mut writer = self
+            .stdin
+            .lock()
+            .map_err(|_| StreamError::Runtime("subprocess stdin mutex poisoned".to_string()))?;
+        write_frame(&mut *writer, msg).map_err(|e| {
+            self.mark_dead();
+            e
+        })
+    }
+
+    /// Block until the next lifecycle-tagged message arrives.
+    pub(crate) fn recv_lifecycle(&self) -> Result<serde_json::Value> {
+        self.lifecycle_rx.recv().map_err(|_| {
+            self.mark_dead();
+            StreamError::Runtime(format!(
+                "[{}] subprocess stdout closed before reply",
+                self.processor_id
+            ))
+        })
+    }
+
+    /// Block up to `timeout` for the next lifecycle-tagged message.
+    pub(crate) fn recv_lifecycle_timeout(
+        &self,
+        timeout: Duration,
+    ) -> std::result::Result<serde_json::Value, RecvTimeoutError> {
+        self.lifecycle_rx.recv_timeout(timeout)
+    }
+
+    /// Mark the bridge dead; subsequent sends return immediately.
+    pub(crate) fn mark_dead(&self) {
+        if let Ok(mut dead) = self.dead.lock() {
+            *dead = true;
+        }
+    }
+
+    pub(crate) fn is_dead(&self) -> bool {
+        self.dead.lock().map(|g| *g).unwrap_or(true)
+    }
+
+    /// Count of escalate-acquired handles the host still holds. Used by
+    /// teardown logging and tests.
+    pub(crate) fn registry(&self) -> &Arc<EscalateHandleRegistry> {
+        &self.registry
+    }
+}
+
+impl Drop for SubprocessBridge {
+    fn drop(&mut self) {
+        self.mark_dead();
+        self.registry.clear();
+        // Dropping stdin (and its Arc) isn't enough on its own because the
+        // reader thread holds a clone. We can't force the subprocess to
+        // close its stdout from this side, but the host processor's
+        // teardown() has already sent the teardown command and waited for
+        // the reply — at this point the subprocess has exited and the
+        // reader thread will see EOF. Join with a short timeout via
+        // `join()` on the handle we stashed.
+        if let Some(reader) = self.reader.take() {
+            // Detach rather than join; the OS reaps the thread when the
+            // process exits. A blocking join here would deadlock if the
+            // subprocess is stuck and stdout hasn't closed.
+            drop(reader);
+        }
+    }
+}
+
+/// Reader loop: drain stdout, dispatch escalate traffic, forward lifecycle
+/// responses to `lifecycle_tx`.
+fn reader_loop(
+    mut stdout: BufReader<ChildStdout>,
+    stdin: SharedWriter,
+    sandbox: GpuContextLimitedAccess,
+    registry: Arc<EscalateHandleRegistry>,
+    lifecycle_tx: mpsc::Sender<serde_json::Value>,
+    dead: Arc<Mutex<bool>>,
+    processor_id: String,
+) {
+    loop {
+        let msg = match read_frame(&mut stdout) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!("[{}] bridge reader exiting: {}", processor_id, e);
+                if let Ok(mut dead) = dead.lock() {
+                    *dead = true;
+                }
+                break;
+            }
+        };
+
+        if let Some(response) = process_bridge_message(&sandbox, &registry, &msg) {
+            // Escalate request handled inline. Write response with the
+            // shared stdin lock.
+            let send_result: Result<()> = {
+                let mut writer = match stdin.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        tracing::warn!("[{}] bridge reader saw poisoned stdin mutex", processor_id);
+                        break;
+                    }
+                };
+                write_frame(&mut *writer, &response)
+            };
+            if let Err(e) = send_result {
+                tracing::warn!(
+                    "[{}] bridge reader failed to write escalate response: {}",
+                    processor_id,
+                    e
+                );
+                if let Ok(mut dead) = dead.lock() {
+                    *dead = true;
+                }
+                break;
+            }
+            continue;
+        }
+
+        // Lifecycle response — forward to main thread. Send failure means
+        // the receiver is gone (host dropped), exit cleanly.
+        if lifecycle_tx.send(msg).is_err() {
+            tracing::debug!(
+                "[{}] bridge reader exiting: lifecycle channel dropped",
+                processor_id
+            );
+            break;
+        }
+    }
+}
+
+fn thread_name(processor_id: &str) -> String {
+    // Thread names are limited to 15 chars on Linux; truncate the processor
+    // id the same way the Python stderr-forwarder thread does.
+    let short = &processor_id[..8.min(processor_id.len())];
+    format!("br-{}", short)
+}
+
+fn write_frame<W: Write>(writer: &mut W, msg: &serde_json::Value) -> Result<()> {
+    let bytes = serde_json::to_vec(msg)
+        .map_err(|e| StreamError::Runtime(format!("failed to serialize bridge message: {e}")))?;
+    let len = bytes.len() as u32;
+    writer
+        .write_all(&len.to_be_bytes())
+        .map_err(|e| StreamError::Runtime(format!("failed to write bridge frame: {e}")))?;
+    writer
+        .write_all(&bytes)
+        .map_err(|e| StreamError::Runtime(format!("failed to write bridge frame: {e}")))?;
+    writer
+        .flush()
+        .map_err(|e| StreamError::Runtime(format!("failed to flush bridge frame: {e}")))?;
+    Ok(())
+}
+
+fn read_frame<R: Read>(reader: &mut R) -> Result<serde_json::Value> {
+    let mut len_buf = [0u8; 4];
+    reader
+        .read_exact(&mut len_buf)
+        .map_err(|e| StreamError::Runtime(format!("bridge read failed: {e}")))?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| StreamError::Runtime(format!("bridge read failed: {e}")))?;
+    serde_json::from_slice(&buf)
+        .map_err(|e| StreamError::Runtime(format!("bridge frame decode failed: {e}")))
+}

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -1,0 +1,502 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Polyglot escalate-on-behalf IPC for Python and Deno subprocess host
+//! processors. The subprocess can only see a `GpuContextLimitedAccess`
+//! sandbox; when it needs the privileged GPU surface it sends an
+//! [`EscalateRequest`] to the host over its stdout, the host executes the
+//! operation inside [`GpuContextLimitedAccess::escalate`], and replies with
+//! an [`EscalateResponse`] on the subprocess's stdin.
+//!
+//! Wire format is the existing length-prefixed JSON stdio bridge used for
+//! lifecycle commands (see `SubprocessBridge`). Requests and responses are
+//! discriminated by `op` and `result` fields respectively; see the
+//! `schemas/com.streamlib.escalate_{request,response}@1.0.0.yaml` design
+//! documents for the JTD source of truth.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::context::GpuContextLimitedAccess;
+use crate::core::rhi::{PixelFormat, RhiPixelBuffer};
+
+#[cfg(test)]
+use crate::core::error::{Result, StreamError};
+
+/// Wire tag marking a message as an escalate request. Bridges demux on this
+/// before falling through to lifecycle dispatch.
+pub(crate) const ESCALATE_REQUEST_RPC: &str = "escalate_request";
+
+/// Wire tag for responses written back to the subprocess.
+pub(crate) const ESCALATE_RESPONSE_RPC: &str = "escalate_response";
+
+/// Escalate request shape: `{ rpc: "escalate_request", op: "…", request_id, … }`.
+///
+/// Mirrors `com.streamlib.escalate_request@1.0.0.yaml`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub(crate) enum EscalateOp {
+    AcquirePixelBuffer {
+        request_id: String,
+        width: u32,
+        height: u32,
+        format: String,
+    },
+    ReleaseHandle {
+        request_id: String,
+        handle_id: String,
+    },
+}
+
+impl EscalateOp {
+    pub(crate) fn request_id(&self) -> &str {
+        match self {
+            EscalateOp::AcquirePixelBuffer { request_id, .. } => request_id,
+            EscalateOp::ReleaseHandle { request_id, .. } => request_id,
+        }
+    }
+}
+
+/// Escalate response shape written back to the subprocess.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub(crate) enum EscalateResult {
+    Ok {
+        request_id: String,
+        handle_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        width: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        height: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        format: Option<String>,
+    },
+    Err {
+        request_id: String,
+        message: String,
+    },
+}
+
+/// Tracks resources acquired on behalf of a subprocess so `release_handle` —
+/// or subprocess death — can drop the host's strong reference. Buffers stay
+/// alive for the duration of the host pool; this map simply prevents the
+/// buffer from being immediately recycled while the subprocess still references
+/// it by ID.
+#[derive(Default)]
+pub(crate) struct EscalateHandleRegistry {
+    buffers: Mutex<HashMap<String, RhiPixelBuffer>>,
+}
+
+impl EscalateHandleRegistry {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub(crate) fn insert_buffer(&self, handle_id: String, buffer: RhiPixelBuffer) {
+        let mut map = self.buffers.lock().expect("poisoned");
+        map.insert(handle_id, buffer);
+    }
+
+    pub(crate) fn remove_buffer(&self, handle_id: &str) -> bool {
+        let mut map = self.buffers.lock().expect("poisoned");
+        map.remove(handle_id).is_some()
+    }
+
+    pub(crate) fn clear(&self) {
+        let mut map = self.buffers.lock().expect("poisoned");
+        map.clear();
+    }
+
+    /// Number of currently-held handles; visible for tests.
+    #[cfg(test)]
+    pub(crate) fn buffer_count(&self) -> usize {
+        self.buffers.lock().expect("poisoned").len()
+    }
+}
+
+/// Dispatch an [`EscalateOp`] against `sandbox` and produce a response payload.
+///
+/// Never panics — errors inside `escalate()` become [`EscalateResult::Err`]
+/// with the original request_id preserved so the subprocess can correlate.
+pub(crate) fn handle_escalate_op(
+    sandbox: &GpuContextLimitedAccess,
+    registry: &EscalateHandleRegistry,
+    op: EscalateOp,
+) -> EscalateResult {
+    let request_id = op.request_id().to_string();
+    match op {
+        EscalateOp::AcquirePixelBuffer {
+            request_id: _,
+            width,
+            height,
+            format,
+        } => match parse_pixel_format(&format) {
+            Ok(parsed) => {
+                match sandbox.escalate(|full| full.acquire_pixel_buffer(width, height, parsed)) {
+                    Ok((pool_id, buffer)) => {
+                        let handle_id = pool_id.as_str().to_string();
+                        registry.insert_buffer(handle_id.clone(), buffer);
+                        EscalateResult::Ok {
+                            request_id,
+                            handle_id,
+                            width: Some(width),
+                            height: Some(height),
+                            format: Some(pixel_format_to_wire(parsed).to_string()),
+                        }
+                    }
+                    Err(e) => EscalateResult::Err {
+                        request_id,
+                        message: format!("acquire_pixel_buffer failed: {e}"),
+                    },
+                }
+            }
+            Err(e) => EscalateResult::Err {
+                request_id,
+                message: e,
+            },
+        },
+        EscalateOp::ReleaseHandle {
+            request_id: _,
+            handle_id,
+        } => {
+            let removed = registry.remove_buffer(&handle_id);
+            if removed {
+                EscalateResult::Ok {
+                    request_id,
+                    handle_id,
+                    width: None,
+                    height: None,
+                    format: None,
+                }
+            } else {
+                EscalateResult::Err {
+                    request_id,
+                    message: format!("handle_id '{handle_id}' not found in registry"),
+                }
+            }
+        }
+    }
+}
+
+/// Wrap a [`EscalateResult`] in the outer `{ rpc, payload… }` envelope the
+/// bridge reader writes to the subprocess stdin.
+pub(crate) fn envelope_response(result: EscalateResult) -> serde_json::Value {
+    let mut obj = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+    if let Some(map) = obj.as_object_mut() {
+        map.insert(
+            "rpc".to_string(),
+            serde_json::Value::String(ESCALATE_RESPONSE_RPC.to_string()),
+        );
+    }
+    obj
+}
+
+/// Parse a wire-format pixel-format string into a [`PixelFormat`] enum.
+///
+/// The wire format uses lowercase snake-case names (`bgra32`, `nv12_video_range`,
+/// etc.) so Python / Deno callers don't have to know FourCC codes. Also
+/// accepts the mnemonic `"bgra"` for [`PixelFormat::Bgra32`], matching the
+/// existing `NativeGpu.acquire_surface(format="bgra")` default on the Python
+/// side.
+fn parse_pixel_format(s: &str) -> std::result::Result<PixelFormat, String> {
+    let normalized = s.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "bgra" | "bgra32" => Ok(PixelFormat::Bgra32),
+        "rgba" | "rgba32" => Ok(PixelFormat::Rgba32),
+        "argb" | "argb32" => Ok(PixelFormat::Argb32),
+        "rgba64" => Ok(PixelFormat::Rgba64),
+        "nv12" | "nv12_video_range" => Ok(PixelFormat::Nv12VideoRange),
+        "nv12_full_range" => Ok(PixelFormat::Nv12FullRange),
+        "uyvy" | "uyvy422" => Ok(PixelFormat::Uyvy422),
+        "yuyv" | "yuyv422" => Ok(PixelFormat::Yuyv422),
+        "gray" | "gray8" => Ok(PixelFormat::Gray8),
+        other => Err(format!("unknown pixel format '{other}'")),
+    }
+}
+
+fn pixel_format_to_wire(fmt: PixelFormat) -> &'static str {
+    match fmt {
+        PixelFormat::Bgra32 => "bgra32",
+        PixelFormat::Rgba32 => "rgba32",
+        PixelFormat::Argb32 => "argb32",
+        PixelFormat::Rgba64 => "rgba64",
+        PixelFormat::Nv12VideoRange => "nv12_video_range",
+        PixelFormat::Nv12FullRange => "nv12_full_range",
+        PixelFormat::Uyvy422 => "uyvy422",
+        PixelFormat::Yuyv422 => "yuyv422",
+        PixelFormat::Gray8 => "gray8",
+        PixelFormat::Unknown => "unknown",
+    }
+}
+
+/// Try to parse an incoming bridge message as an [`EscalateOp`]. Returns
+/// `None` when the message isn't an escalate request (lifecycle traffic).
+/// Returns `Some(Err(...))` when the message was tagged as an escalate
+/// request but the payload couldn't be decoded — the bridge still replies
+/// with an `Err` response keyed by `request_id` if possible.
+pub(crate) fn try_parse_escalate_request(
+    value: &serde_json::Value,
+) -> Option<std::result::Result<EscalateOp, EscalateParseError>> {
+    let rpc = value.get("rpc").and_then(|v| v.as_str())?;
+    if rpc != ESCALATE_REQUEST_RPC {
+        return None;
+    }
+    let request_id = value
+        .get("request_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    match serde_json::from_value::<EscalateOp>(value.clone()) {
+        Ok(op) => Some(Ok(op)),
+        Err(e) => Some(Err(EscalateParseError {
+            request_id,
+            message: format!("failed to decode escalate_request: {e}"),
+        })),
+    }
+}
+
+/// Error detail for a malformed escalate request. The bridge converts this
+/// into an [`EscalateResult::Err`] response so the subprocess doesn't block
+/// forever waiting on a correlated response.
+pub(crate) struct EscalateParseError {
+    pub(crate) request_id: Option<String>,
+    pub(crate) message: String,
+}
+
+impl EscalateParseError {
+    pub(crate) fn into_response(self) -> EscalateResult {
+        EscalateResult::Err {
+            request_id: self.request_id.unwrap_or_default(),
+            message: self.message,
+        }
+    }
+}
+
+/// Convenience wrapper used by host processors: parse, dispatch, envelope.
+/// Anything the subprocess sends that carries `rpc: escalate_request` flows
+/// through this single function; lifecycle traffic is handled by the caller.
+pub(crate) fn process_bridge_message(
+    sandbox: &GpuContextLimitedAccess,
+    registry: &EscalateHandleRegistry,
+    value: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    let parsed = try_parse_escalate_request(value)?;
+    let response = match parsed {
+        Ok(op) => handle_escalate_op(sandbox, registry, op),
+        Err(err) => err.into_response(),
+    };
+    Some(envelope_response(response))
+}
+
+/// Public view of a failure to unwrap a response envelope. Hoisted so tests
+/// can assert on the error text without stringly comparisons against
+/// serde_json diagnostics.
+#[cfg(test)]
+pub(crate) fn parse_op_for_tests(value: &serde_json::Value) -> Result<EscalateOp> {
+    try_parse_escalate_request(value)
+        .ok_or_else(|| StreamError::Runtime("not an escalate_request".to_string()))?
+        .map_err(|e| StreamError::Runtime(e.message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pixel_format_accepts_common_aliases() {
+        assert_eq!(parse_pixel_format("bgra"), Ok(PixelFormat::Bgra32));
+        assert_eq!(parse_pixel_format("BGRA32"), Ok(PixelFormat::Bgra32));
+        assert_eq!(parse_pixel_format("nv12"), Ok(PixelFormat::Nv12VideoRange));
+        assert_eq!(
+            parse_pixel_format("nv12_full_range"),
+            Ok(PixelFormat::Nv12FullRange)
+        );
+        assert_eq!(parse_pixel_format("gray8"), Ok(PixelFormat::Gray8));
+    }
+
+    #[test]
+    fn parse_pixel_format_rejects_unknown() {
+        assert!(parse_pixel_format("xyz").is_err());
+    }
+
+    #[test]
+    fn try_parse_rejects_lifecycle_traffic() {
+        let lifecycle = serde_json::json!({"rpc": "ready"});
+        assert!(try_parse_escalate_request(&lifecycle).is_none());
+    }
+
+    #[test]
+    fn try_parse_accepts_acquire_pixel_buffer() {
+        let msg = serde_json::json!({
+            "rpc": "escalate_request",
+            "op": "acquire_pixel_buffer",
+            "request_id": "r-1",
+            "width": 640,
+            "height": 480,
+            "format": "bgra",
+        });
+        let op = parse_op_for_tests(&msg).expect("decodes");
+        match op {
+            EscalateOp::AcquirePixelBuffer {
+                request_id,
+                width,
+                height,
+                format,
+            } => {
+                assert_eq!(request_id, "r-1");
+                assert_eq!(width, 640);
+                assert_eq!(height, 480);
+                assert_eq!(format, "bgra");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn try_parse_accepts_release_handle() {
+        let msg = serde_json::json!({
+            "rpc": "escalate_request",
+            "op": "release_handle",
+            "request_id": "r-2",
+            "handle_id": "h-abc",
+        });
+        let op = parse_op_for_tests(&msg).expect("decodes");
+        match op {
+            EscalateOp::ReleaseHandle {
+                request_id,
+                handle_id,
+            } => {
+                assert_eq!(request_id, "r-2");
+                assert_eq!(handle_id, "h-abc");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn try_parse_surfaces_error_with_request_id() {
+        let msg = serde_json::json!({
+            "rpc": "escalate_request",
+            "op": "acquire_pixel_buffer",
+            "request_id": "r-3",
+            // missing width / height / format
+        });
+        let parsed = try_parse_escalate_request(&msg).expect("escalate-shaped");
+        let err = parsed.expect_err("missing fields");
+        assert_eq!(err.request_id.as_deref(), Some("r-3"));
+        assert!(err.message.contains("failed to decode"));
+    }
+
+    #[test]
+    fn envelope_response_tags_rpc() {
+        let resp = EscalateResult::Ok {
+            request_id: "r-1".into(),
+            handle_id: "h-1".into(),
+            width: Some(16),
+            height: Some(16),
+            format: Some("bgra32".into()),
+        };
+        let env = envelope_response(resp);
+        assert_eq!(
+            env.get("rpc").and_then(|v| v.as_str()),
+            Some("escalate_response")
+        );
+        assert_eq!(env.get("result").and_then(|v| v.as_str()), Some("ok"));
+        assert_eq!(env.get("width").and_then(|v| v.as_u64()), Some(16));
+    }
+
+    #[test]
+    fn release_handle_flags_unknown_handle() {
+        // Registry-level release of an unknown handle. A full
+        // integration test that exercises [`handle_escalate_op`]
+        // against a real `GpuContextLimitedAccess` lives in the
+        // `handle_escalate_op_end_to_end` test below — it is gated
+        // on [`GpuContext::init_for_platform`] succeeding so CI
+        // machines without a GPU still build+run the rest of the
+        // suite.
+        let registry = EscalateHandleRegistry::new();
+        assert_eq!(registry.buffer_count(), 0);
+        assert!(!registry.remove_buffer("missing"));
+    }
+
+    #[test]
+    fn handle_escalate_op_end_to_end() {
+        use crate::core::context::GpuContext;
+        use crate::core::context::GpuContextLimitedAccess;
+
+        let gpu = match GpuContext::init_for_platform_sync() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("handle_escalate_op_end_to_end: no GPU device — skipping");
+                return;
+            }
+        };
+        let sandbox = GpuContextLimitedAccess::new(gpu);
+        let registry = EscalateHandleRegistry::new();
+
+        // Acquire a pixel buffer via escalate — registers a handle.
+        let acquire = EscalateOp::AcquirePixelBuffer {
+            request_id: "req-1".to_string(),
+            width: 320,
+            height: 240,
+            format: "bgra".to_string(),
+        };
+        let response = handle_escalate_op(&sandbox, &registry, acquire);
+        let handle_id = match response {
+            EscalateResult::Ok {
+                ref request_id,
+                ref handle_id,
+                width,
+                height,
+                ref format,
+            } => {
+                assert_eq!(request_id, "req-1");
+                assert_eq!(width, Some(320));
+                assert_eq!(height, Some(240));
+                assert_eq!(format.as_deref(), Some("bgra32"));
+                assert!(!handle_id.is_empty(), "handle id should not be empty");
+                handle_id.clone()
+            }
+            EscalateResult::Err { message, .. } => {
+                panic!("acquire_pixel_buffer escalate failed: {message}");
+            }
+        };
+        assert_eq!(registry.buffer_count(), 1);
+
+        // Release the handle → registry drains.
+        let release = EscalateOp::ReleaseHandle {
+            request_id: "req-2".to_string(),
+            handle_id: handle_id.clone(),
+        };
+        let response = handle_escalate_op(&sandbox, &registry, release);
+        match response {
+            EscalateResult::Ok {
+                request_id,
+                handle_id: echoed,
+                ..
+            } => {
+                assert_eq!(request_id, "req-2");
+                assert_eq!(echoed, handle_id);
+            }
+            EscalateResult::Err { message, .. } => panic!("release_handle failed: {message}"),
+        }
+        assert_eq!(registry.buffer_count(), 0);
+
+        // Releasing an unknown handle is an Err response, not a panic.
+        let release_unknown = EscalateOp::ReleaseHandle {
+            request_id: "req-3".to_string(),
+            handle_id: "never-existed".to_string(),
+        };
+        match handle_escalate_op(&sandbox, &registry, release_unknown) {
+            EscalateResult::Err {
+                request_id,
+                message,
+            } => {
+                assert_eq!(request_id, "req-3");
+                assert!(message.contains("not found"));
+            }
+            EscalateResult::Ok { .. } => panic!("unknown handle should not succeed"),
+        }
+    }
+}

--- a/plan/319-gpu-capability-based-access.md
+++ b/plan/319-gpu-capability-based-access.md
@@ -11,6 +11,8 @@ dependencies:
   - "down:Implement sandbox.escalate() reusing the setup mutex"
   - "down:Restrict GpuContextLimitedAccess API surface to safe ops"
   - "down:Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+  - "down:Polyglot escalate: add acquire_texture op"
+  - "down:xtask: support JTD discriminator schemas in generate-schemas"
   - "down:Learning doc: GPU capability typestate pattern"
 adapters:
   github: builtin
@@ -37,8 +39,10 @@ The #304 setup barrier enforces "resource creation is serialized" at runtime wit
 3. #322 — Migrate processor trait signatures
 4. #323 — Implement `escalate()` primitive; compiler phase 4 becomes a consumer
 5. #324 — Restrict Sandbox's surface (enforcement lands here; compile errors surface)
-6. #325 — Polyglot IPC: escalate-on-behalf
-7. #326 — Learning doc
+6. #325 — Polyglot IPC: escalate-on-behalf (MVP: `acquire_pixel_buffer` + `release_handle`)
+7. #369 — Polyglot escalate: `acquire_texture` op (follow-up to #325)
+8. #370 — xtask: JTD discriminator support so #325/#369 wire-types drop the hand-authored copy
+9. #326 — Learning doc (captures the final shape, after #369 + #370 settle the polyglot wire)
 
 ## Dependencies / impact
 

--- a/plan/325-polyglot-escalate-ipc.md
+++ b/plan/325-polyglot-escalate-ipc.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: "Polyglot IPC: escalate-on-behalf for Python/Deno processors"
-status: pending
+status: in_review
 description: Extend subprocess-host processors to accept escalate IPC requests from Python/Deno. Subprocess sees only a sandbox; IPC is its escalate channel, routed through the host's serialized queue.
 github_issue: 325
 dependencies:

--- a/plan/369-polyglot-escalate-acquire-texture.md
+++ b/plan/369-polyglot-escalate-acquire-texture.md
@@ -1,0 +1,31 @@
+---
+whoami: amos
+name: "Polyglot escalate: add acquire_texture op"
+status: pending
+description: "Follow-up to #325. Extend the polyglot escalate IPC with AcquireTexture so Python / Deno subprocesses can reach GpuContextFullAccess::acquire_texture on behalf. MVP #325 shipped acquire_pixel_buffer + release_handle only."
+github_issue: 369
+dependencies:
+  - "down:Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#369
+
+See the GitHub issue for full context.
+
+## Priority
+
+medium
+
+## Parent
+
+#319
+
+## Depends on
+
+#325 (lands the `EscalateOp` enum + `EscalateHandleRegistry` this ticket extends).
+
+## Branch
+
+`feat/polyglot-escalate-acquire-texture` from `main`.

--- a/plan/370-xtask-jtd-discriminator.md
+++ b/plan/370-xtask-jtd-discriminator.md
@@ -1,0 +1,31 @@
+---
+whoami: amos
+name: "xtask: support JTD discriminator schemas in generate-schemas"
+status: pending
+description: "Update xtask/src/generate_schemas.rs post-processing so jtd-codegen v0.4.1 discriminator output (tagged Rust enums, TS unions, Python discriminated classes) is emitted cleanly for all three runtimes. Unblocks replacing hand-authored escalate_request/escalate_response types with generated ones; required before adding further escalate ops."
+github_issue: 370
+dependencies:
+  - "down:Polyglot IPC: escalate-on-behalf for Python/Deno processors"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#370
+
+See the GitHub issue for full context.
+
+## Priority
+
+medium
+
+## Parent
+
+#319
+
+## Depends on
+
+#325 (introduces the first discriminator schemas and the hand-authored types this ticket replaces).
+
+## Branch
+
+`feat/xtask-jtd-discriminator-schemas` from `main`.


### PR DESCRIPTION
## Summary

- Adds the Rust host-side escalate handler (`subprocess_escalate` +
  `subprocess_bridge`) so a Python or Deno subprocess sandboxed to a
  `GpuContextLimitedAccess` view can route GPU-resource-creation
  through the privileged `GpuContextFullAccess` surface via
  `GpuContextLimitedAccess::escalate(|full| …)`. A dedicated bridge
  reader thread demultiplexes `rpc: \"escalate_request\"` messages
  from lifecycle traffic on the shared stdio pipe; the host replies
  with `rpc: \"escalate_response\"` under the same mutex-shared
  stdin writer.
- Adds `ctx.escalate_acquire_pixel_buffer` / `ctx.escalate_release_handle`
  helpers to both polyglot SDKs (Python `NativeProcessorContext`,
  Deno `NativeProcessorState` + both runtime-context views). Python
  uses a synchronous request/response helper that defers any lifecycle
  commands received during the blocking read; Deno uses a
  Promise-keyed `EscalateChannel` wired into the runner's existing
  async stdin loop.
- Schema YAML files for `EscalateRequest` / `EscalateResponse` ship as
  design documentation. The types are hand-authored across languages
  because jtd-codegen v0.4.1's discriminator output doesn't survive
  the project's existing post-processing rules (no other schema uses
  `discriminator:` yet). Wiring codegen for this shape is left as a
  follow-up.

## Issue

Closes #325.

## Scope decisions, deferred work

- **MVP ops**: `acquire_pixel_buffer` + `release_handle`. Additional
  ops (`acquire_texture`, buffer import, etc.) are trivially added to
  the same `EscalateOp` enum — omitted here to keep the surface
  minimal and reviewable.
- **End-to-end subprocess verification**: not included. The Rust-side
  `handle_escalate_op_end_to_end` test exercises the full escalate
  path against a real `GpuContext`, but spinning up a Python / Deno
  subprocess that calls `ctx.escalate_*` mid-stream requires runnable
  examples and host-fixture plumbing that belongs alongside the
  subprocess-spawn verification work (#360). I recommend we land #360
  first and fold an escalate-exercising subprocess example into that
  verification.
- **Linux DMA-BUF FD passing**: JSON-RPC can't carry FDs, so
  cross-process texture sharing on Linux needs a second iteration —
  tracked in #347 (research task already in flight).
- **jtd-codegen for discriminator schemas**: design-doc schemas live in
  `libs/streamlib/schemas/` but aren't in the `[package.metadata.
  streamlib].schemas` list. Follow-up to extend `xtask generate-
  schemas` + post-processing to emit tagged Rust enums / TypeScript
  unions / Python discriminated classes.

## Test Plan

- [x] `cargo check -p streamlib --lib`
- [x] `cargo test -p streamlib --lib` (160 passed, 2 ignored)
- [x] `cargo test -p streamlib --lib subprocess_escalate` (9 passed,
      including end-to-end against real GPU on this workstation)
- [x] New Rust files pass `rustfmt` (rest of tree has pre-existing
      style drift)
- [x] `deno check escalate.ts` passes; `context.ts` shows no new
      errors beyond the 6 pre-existing `TS2345` `Uint8Array<ArrayBufferLike>`
      issues that pre-date this branch (my diff adds no new TS errors)
- [ ] Subprocess-spawn end-to-end (Python + Deno): deferred to #360 —
      see \"Scope decisions\" above
- [ ] Concurrent host Rust + subprocess escalate serialization: the
      Rust-side mutex is already validated by
      `test_escalate_serializes_concurrent_callers` in `gpu_context.rs`;
      the subprocess path just routes through the same mutex

## Follow-ups

- #347: DMA-BUF FD passing research (already tracked)
- jtd-codegen support for discriminator schemas so hand-authored
  escalate types can become generated
- Fold an escalate-exercising example into #360's subprocess-host
  verification work

🤖 Generated with [Claude Code](https://claude.com/claude-code)