### PR TITLE
feat(#351): typed capability ctx for Python polyglot SDK

### DIFF
--- a/examples/camera-python-display/python/avatar_character.py
+++ b/examples/camera-python-display/python/avatar_character.py
@@ -23,6 +23,8 @@ import sys
 import time
 from pathlib import Path
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,7 +123,7 @@ class AvatarCharacter:
     Signals readiness by delaying output until first pose is stable.
     """
 
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         """Initialize standalone CGL context, MediaPipe, and 3D rendering."""
         # Lazy import heavy dependencies
         _lazy_import()
@@ -245,7 +247,7 @@ class AvatarCharacter:
         self._setup_complete_time = time.monotonic()
         logger.info(f"AvatarCharacter: 3D renderer initialized ({width}x{height}) - sliding in after {self._ready_delay_seconds}s")
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         """Process frame: detect pose, render 3D character."""
         frame = ctx.inputs.read("video_in")
         if frame is None:
@@ -283,7 +285,7 @@ class AvatarCharacter:
                 )
 
         # Resolve input surface → bind as GL texture for readback
-        input_handle = ctx.gpu.resolve_surface(frame["surface_id"])
+        input_handle = ctx.gpu_limited_access.resolve_surface(frame["surface_id"])
         bind_iosurface_to_texture(
             self.cgl_ctx, self.input_tex_id,
             input_handle.iosurface_ref, w, h
@@ -338,8 +340,14 @@ class AvatarCharacter:
         # Convert RGBA to BGRA for output (swap R and B channels)
         rendered_bgra = rendered_array[:, :, [2, 1, 0, 3]].copy()
 
-        # Acquire output surface → bind as GL texture → upload rendered pixels
-        out_surface_id, output_handle = ctx.gpu.acquire_surface(width=w, height=h, format="bgra")
+        # TODO(#325/#369): surface allocation is a privileged op — once the
+        # polyglot escalate IPC grows an acquire_texture op, replace this
+        # AttributeError-at-runtime access pattern with a proper
+        # `ctx.escalate_acquire_pixel_buffer(...)` call. Mirrors the Deno
+        # halftone example's pending-escalate pattern.
+        out_surface_id, output_handle = ctx.gpu_full_access.acquire_surface(  # type: ignore[attr-defined]
+            width=w, height=h, format="bgra",
+        )
         bind_iosurface_to_texture(
             self.cgl_ctx, self.output_tex_id,
             output_handle.iosurface_ref, w, h
@@ -376,7 +384,7 @@ class AvatarCharacter:
         if self.frame_count % 300 == 0:
             logger.debug(f"AvatarCharacter: {self.frame_count} frames processed (ready={self._is_ready})")
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         """Cleanup resources."""
         if self.pose_landmarker is not None:
             self.pose_landmarker.close()

--- a/examples/camera-python-display/python/cyberpunk_glitch.py
+++ b/examples/camera-python-display/python/cyberpunk_glitch.py
@@ -23,6 +23,8 @@ import random
 import numpy as np
 from OpenGL.GL import *
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 logger = logging.getLogger(__name__)
 
 
@@ -262,7 +264,7 @@ class CyberpunkGlitch:
     Runs GLSL fragment shaders directly on GL textures backed by IOSurfaces.
     """
 
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         """Initialize standalone CGL context and compile shaders."""
         from streamlib.cgl_context import create_cgl_context, make_current
 
@@ -373,7 +375,7 @@ class CyberpunkGlitch:
 
         glBindVertexArray(0)
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         """Apply glitch effect using OpenGL shaders."""
         frame = ctx.inputs.read("video_in")
         if frame is None:
@@ -404,14 +406,20 @@ class CyberpunkGlitch:
         make_current(self.cgl_ctx)
 
         # Resolve input surface → IOSurface handle → bind as GL texture
-        input_handle = ctx.gpu.resolve_surface(frame["surface_id"])
+        input_handle = ctx.gpu_limited_access.resolve_surface(frame["surface_id"])
         bind_iosurface_to_texture(
             self.cgl_ctx, self.input_tex_id,
             input_handle.iosurface_ref, w, h
         )
 
-        # Acquire output surface → bind as GL texture
-        out_surface_id, output_handle = ctx.gpu.acquire_surface(width=w, height=h, format="bgra")
+        # TODO(#325/#369): surface allocation is a privileged op — once the
+        # polyglot escalate IPC grows an acquire_texture op, replace this
+        # AttributeError-at-runtime access pattern with a proper
+        # `ctx.escalate_acquire_pixel_buffer(...)` call. Mirrors the Deno
+        # halftone example's pending-escalate pattern.
+        out_surface_id, output_handle = ctx.gpu_full_access.acquire_surface(  # type: ignore[attr-defined]
+            width=w, height=h, format="bgra",
+        )
         bind_iosurface_to_texture(
             self.cgl_ctx, self.output_tex_id,
             output_handle.iosurface_ref, w, h
@@ -487,7 +495,7 @@ class CyberpunkGlitch:
         if self.frame_count % 120 == 0:
             logger.debug(f"Glitch processor: {self.frame_count} frames (active={glitch_active})")
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         """Cleanup OpenGL resources."""
         from streamlib.cgl_context import make_current, destroy_cgl_context
 

--- a/examples/camera-python-display/python/cyberpunk_lower_third.py
+++ b/examples/camera-python-display/python/cyberpunk_lower_third.py
@@ -26,6 +26,8 @@ import time
 import skia
 from OpenGL.GL import glGenTextures
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 logger = logging.getLogger(__name__)
 
 # OpenGL constants
@@ -532,7 +534,7 @@ class CyberpunkLowerThird:
     for compositing by BlendingCompositor.
     """
 
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         """Initialize standalone CGL context and Skia."""
         from streamlib.cgl_context import create_cgl_context, make_current
 
@@ -583,15 +585,19 @@ class CyberpunkLowerThird:
             f"({self.width}x{self.height}, font: {self.typeface.getFamilyName()})"
         )
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         """Generate lower third overlay frame with transparent background."""
         from streamlib.cgl_context import make_current, bind_iosurface_to_texture, flush
 
         make_current(self.cgl_ctx)
 
-        # Acquire output surface from Rust pool
-        surface_id, handle = ctx.gpu.acquire_surface(
-            width=self.width, height=self.height, format="bgra"
+        # TODO(#325/#369): surface allocation is a privileged op — once the
+        # polyglot escalate IPC grows an acquire_texture op, replace this
+        # AttributeError-at-runtime access pattern with a proper
+        # `ctx.escalate_acquire_pixel_buffer(...)` call. Mirrors the Deno
+        # halftone example's pending-escalate pattern.
+        surface_id, handle = ctx.gpu_full_access.acquire_surface(  # type: ignore[attr-defined]
+            width=self.width, height=self.height, format="bgra",
         )
 
         # Bind IOSurface as GL texture (zero-copy)
@@ -702,7 +708,7 @@ class CyberpunkLowerThird:
         if self.frame_count % 300 == 0:
             logger.debug(f"Lower Third: generated {self.frame_count} frames")
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         """Cleanup."""
         self.static_picture = None  # Release picture before context
         if hasattr(self, 'skia_ctx') and self.skia_ctx:

--- a/examples/camera-python-display/python/cyberpunk_watermark.py
+++ b/examples/camera-python-display/python/cyberpunk_watermark.py
@@ -23,6 +23,8 @@ import time
 import skia
 from OpenGL.GL import glGenTextures
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 logger = logging.getLogger(__name__)
 
 # OpenGL constants
@@ -197,7 +199,7 @@ class CyberpunkWatermark:
     for compositing by BlendingCompositor.
     """
 
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         """Initialize standalone CGL context and Skia."""
         from streamlib.cgl_context import create_cgl_context, make_current
 
@@ -237,15 +239,19 @@ class CyberpunkWatermark:
             f"static picture cached)"
         )
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         """Generate watermark overlay frame with transparent background."""
         from streamlib.cgl_context import make_current, bind_iosurface_to_texture, flush
 
         make_current(self.cgl_ctx)
 
-        # Acquire output surface from Rust pool
-        surface_id, handle = ctx.gpu.acquire_surface(
-            width=self.width, height=self.height, format="bgra"
+        # TODO(#325/#369): surface allocation is a privileged op — once the
+        # polyglot escalate IPC grows an acquire_texture op, replace this
+        # AttributeError-at-runtime access pattern with a proper
+        # `ctx.escalate_acquire_pixel_buffer(...)` call. Mirrors the Deno
+        # halftone example's pending-escalate pattern.
+        surface_id, handle = ctx.gpu_full_access.acquire_surface(  # type: ignore[attr-defined]
+            width=self.width, height=self.height, format="bgra",
         )
 
         # Bind IOSurface as GL texture (zero-copy)
@@ -319,7 +325,7 @@ class CyberpunkWatermark:
         if self.frame_count % 300 == 0:
             logger.debug(f"Watermark: generated {self.frame_count} frames")
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         """Cleanup."""
         self.static_picture = None  # Release picture before context
         if hasattr(self, 'skia_ctx') and self.skia_ctx:

--- a/examples/camera-python-subprocess/python/grayscale_processor.py
+++ b/examples/camera-python-subprocess/python/grayscale_processor.py
@@ -3,18 +3,20 @@
 
 import numpy as np
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 
 class GrayscaleProcessor:
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         print("[GrayscaleProcessor] setup")
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         frame = ctx.inputs.read("video_in")
         if frame is None:
             return
 
         # Resolve input surface → zero-copy IOSurface handle
-        input_surface = ctx.gpu.resolve_surface(frame["surface_id"])
+        input_surface = ctx.gpu_limited_access.resolve_surface(frame["surface_id"])
         input_surface.lock(read_only=True)
         input_pixels = input_surface.as_numpy()  # numpy VIEW, no copy
 
@@ -27,9 +29,13 @@ class GrayscaleProcessor:
 
         input_surface.unlock(read_only=True)
 
-        # Acquire new output surface from Rust pool
+        # TODO(#325/#369): surface allocation is a privileged op — once the
+        # polyglot escalate IPC grows an acquire_texture op, replace this
+        # AttributeError-at-runtime access pattern with a proper
+        # `ctx.escalate_acquire_pixel_buffer(...)` call. For now this mirrors
+        # the Deno halftone example's pending-escalate pattern.
         w, h = input_surface.width, input_surface.height
-        new_surface_id, output_surface = ctx.gpu.acquire_surface(
+        new_surface_id, output_surface = ctx.gpu_full_access.acquire_surface(  # type: ignore[attr-defined]
             width=w, height=h, format="bgra"
         )
 
@@ -50,5 +56,5 @@ class GrayscaleProcessor:
         frame["surface_id"] = new_surface_id
         ctx.outputs.write("video_out", frame)
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print("[GrayscaleProcessor] teardown")

--- a/examples/camera-python-subprocess/python/passthrough_processor.py
+++ b/examples/camera-python-subprocess/python/passthrough_processor.py
@@ -1,15 +1,17 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+
 
 class PassthroughProcessor:
-    def setup(self, ctx):
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
         print("[PassthroughProcessor] setup")
 
-    def process(self, ctx):
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
         frame = ctx.inputs.read("video_in")
         if frame is not None:
             ctx.outputs.write("video_out", frame)
 
-    def teardown(self, ctx):
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print("[PassthroughProcessor] teardown")

--- a/libs/streamlib-python/python/streamlib/__init__.py
+++ b/libs/streamlib-python/python/streamlib/__init__.py
@@ -14,7 +14,8 @@ class PixelFormat:
 
     Usage:
         from streamlib import PixelFormat
-        buffer = ctx.gpu.acquire_pixel_buffer(1920, 1080, PixelFormat.BGRA32)
+        # setup() / teardown() — ctx is RuntimeContextFullAccess
+        _, buffer = ctx.gpu_full_access.acquire_surface(1920, 1080, PixelFormat.BGRA32)
     """
     BGRA32 = "bgra32"
     RGBA32 = "rgba32"
@@ -49,6 +50,20 @@ from .decorators import (
     output_port,
 )
 
+# Re-export capability-typed runtime context views for processor authors
+from .processor_context import (
+    NativeGpuContextFullAccess,
+    NativeGpuContextLimitedAccess,
+    NativeRuntimeContextFullAccess,
+    NativeRuntimeContextLimitedAccess,
+)
+
+# Public type aliases for processor lifecycle annotations
+RuntimeContextFullAccess = NativeRuntimeContextFullAccess
+RuntimeContextLimitedAccess = NativeRuntimeContextLimitedAccess
+GpuContextFullAccess = NativeGpuContextFullAccess
+GpuContextLimitedAccess = NativeGpuContextLimitedAccess
+
 __all__ = [
     # Processor decorators
     "processor",
@@ -68,4 +83,13 @@ __all__ = [
     "input_port",
     "output_port",
     "PixelFormat",
+    # Capability-typed runtime context
+    "RuntimeContextFullAccess",
+    "RuntimeContextLimitedAccess",
+    "GpuContextFullAccess",
+    "GpuContextLimitedAccess",
+    "NativeRuntimeContextFullAccess",
+    "NativeRuntimeContextLimitedAccess",
+    "NativeGpuContextFullAccess",
+    "NativeGpuContextLimitedAccess",
 ]

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -1,26 +1,35 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""Subprocess processor context — native FFI to iceoryx2 + lifecycle protocol.
+"""Capability-typed Python runtime context views for subprocess processors.
 
-Provides the `ctx` object passed to Python processor methods:
-  - ctx.inputs.read("port_name") -> deserialized msgpack data or None
-  - ctx.outputs.write("port_name", data) -> serializes and sends via iceoryx2
-  - ctx.time -> monotonic clock (nanoseconds)
-  - ctx.config -> processor config dict
+Two concrete classes mirror the Rust capability split:
 
-Data I/O uses direct FFI to libstreamlib_python_native via ctypes.
-Lifecycle commands (setup/run/stop/teardown) use length-prefixed JSON over pipes.
+- :class:`NativeRuntimeContextLimitedAccess` — passed to ``process`` /
+  ``on_pause`` / ``on_resume``. Carries no ``gpu_full_access`` attribute, so
+  reaching privileged ops from the hot path raises ``AttributeError`` at
+  runtime (and is flagged by type checkers).
+- :class:`NativeRuntimeContextFullAccess` — passed to ``setup`` /
+  ``teardown`` / Manual-mode ``start`` / ``stop``. Exposes both
+  ``gpu_limited_access`` and ``gpu_full_access``.
+
+Data I/O uses direct FFI to ``libstreamlib_python_native`` via ctypes.
+Lifecycle commands use length-prefixed JSON over stdin/stdout pipes.
 
 Protocol (lifecycle only):
   All messages are length-prefixed: [4 bytes u32 BE length][JSON bytes]
 """
 
+from __future__ import annotations
+
 import json
 import struct
-import time
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
 import msgpack
+
+if TYPE_CHECKING:
+    from .escalate import EscalateChannel
 
 
 # ============================================================================
@@ -289,18 +298,22 @@ class NativeGpuSurfaceHandle:
         self.release()
 
 
-class NativeGpu:
-    """GPU context for IOSurface access via FFI, with broker XPC resolution."""
+# ============================================================================
+# GPU capability views
+# ============================================================================
 
-    SURFACE_POOL_SIZE = 3
+
+class NativeGpuContextLimitedAccess:
+    """Non-allocating GPU capability — resolve existing surfaces only.
+
+    Mirrors the Rust [`GpuContextLimitedAccess`] surface. Available in
+    every lifecycle phase, including ``process`` / ``on_pause`` /
+    ``on_resume``.
+    """
 
     def __init__(self, lib, broker_ptr):
         self._lib = lib
         self._broker_ptr = broker_ptr
-        self._output_pool = []  # list of (pool_id, handle_ptr)
-        self._output_pool_index = 0
-        self._output_pool_width = 0
-        self._output_pool_height = 0
 
     def resolve_surface(self, surface_id):
         """Resolve a broker surface_id UUID to a GPU surface handle."""
@@ -319,6 +332,23 @@ class NativeGpu:
         if not handle_ptr:
             raise RuntimeError(f"IOSurface not found: {surface_id}")
         return NativeGpuSurfaceHandle(self._lib, handle_ptr)
+
+
+class NativeGpuContextFullAccess(NativeGpuContextLimitedAccess):
+    """Privileged GPU capability — limited ops plus IOSurface allocation.
+
+    Mirrors the Rust [`GpuContextFullAccess`] surface. Only available in
+    ``setup`` / ``teardown`` / Manual-mode ``start`` / ``stop``.
+    """
+
+    SURFACE_POOL_SIZE = 3
+
+    def __init__(self, lib, broker_ptr):
+        super().__init__(lib, broker_ptr)
+        self._output_pool = []  # list of (pool_id, handle_ptr)
+        self._output_pool_index = 0
+        self._output_pool_width = 0
+        self._output_pool_height = 0
 
     def acquire_surface(self, width, height, format="bgra"):
         """Acquire a pixel buffer from the pool (triple-buffered, round-robin)."""
@@ -389,49 +419,170 @@ class NativeGpu:
         self.release_pool()
 
 
-class NativeProcessorContext:
-    """Context using direct FFI to iceoryx2."""
+# ============================================================================
+# Capability-typed runtime context views
+# ============================================================================
 
-    def __init__(self, lib, ctx_ptr, config, broker_ptr=None, escalate_channel=None):
+
+class NativeProcessorState:
+    """Shared FFI-backed state reused by both capability views for a single
+    processor lifecycle.
+
+    Construction is internal — ``subprocess_runner`` builds one of these per
+    ``setup`` and wraps it in the appropriate view per lifecycle method.
+    """
+
+    def __init__(
+        self,
+        lib,
+        ctx_ptr,
+        config: Optional[Dict[str, Any]],
+        broker_ptr=None,
+        escalate_channel: "Optional[EscalateChannel]" = None,
+    ) -> None:
         self._lib = lib
         self._ctx_ptr = ctx_ptr
         self._config = config or {}
+        self._broker_ptr = broker_ptr
+        self._escalate_channel = escalate_channel
         self.inputs = NativeInputs(lib, ctx_ptr)
         self.outputs = NativeOutputs(lib, ctx_ptr)
-        self.gpu = NativeGpu(lib, broker_ptr)
-        self._escalate_channel = escalate_channel
+        # One instance of each GPU view shared across per-call context
+        # wrappers so pool state and handle lifetimes are stable across
+        # lifecycle phases.
+        self._gpu_limited = NativeGpuContextLimitedAccess(lib, broker_ptr)
+        self._gpu_full = NativeGpuContextFullAccess(lib, broker_ptr)
 
     @property
-    def config(self):
+    def config(self) -> Dict[str, Any]:
         """Processor configuration dictionary."""
         return self._config
 
     @property
-    def time(self):
+    def time(self) -> int:
         """Current monotonic time in nanoseconds."""
         return self._lib.slpn_context_time_ns(self._ctx_ptr)
 
-    def escalate_acquire_pixel_buffer(self, width, height, format="bgra"):
-        """Ask the host to allocate a new-shape pixel buffer on our behalf.
+    def gpu_limited_access(self) -> NativeGpuContextLimitedAccess:
+        """Return the limited-access GPU view (resolution only)."""
+        return self._gpu_limited
 
-        Routes through the Rust host's `GpuContextLimitedAccess::escalate`,
-        which serializes against every other escalation in the runtime. The
-        buffer lives in the host's pool; we reference it by the returned
-        ``handle_id`` until ``escalate_release_handle(handle_id)``.
-        """
+    def gpu_full_access(self) -> NativeGpuContextFullAccess:
+        """Return the full-access GPU view (allocations + resolution)."""
+        return self._gpu_full
+
+    def escalate_acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a new-shape pixel buffer on our behalf."""
         channel = self._require_channel()
         return channel.acquire_pixel_buffer(width, height, format)
 
-    def escalate_release_handle(self, handle_id):
+    def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Drop the host's strong reference to a previously-escalated handle."""
         channel = self._require_channel()
         return channel.release_handle(handle_id)
 
-    def _require_channel(self):
+    def _require_channel(self) -> "EscalateChannel":
         if self._escalate_channel is None:
-            # Fall back to the process-wide singleton so code written for
-            # the run-loop ctx still works if someone calls escalate_* from
-            # a helper that didn't receive `ctx`.
+            # Fall back to the process-wide singleton so helpers that didn't
+            # receive ctx still work inside the subprocess lifecycle.
             from .escalate import channel as _singleton
             return _singleton()
         return self._escalate_channel
+
+    def release_pool(self) -> None:
+        """Release the full-access pool (called during teardown)."""
+        self._gpu_full.release_pool()
+
+
+class NativeRuntimeContextLimitedAccess:
+    """Restricted-capability runtime context passed to ``process`` /
+    ``on_pause`` / ``on_resume``.
+
+    Exposes :class:`NativeGpuContextLimitedAccess` only — attempting to
+    reach ``gpu_full_access`` raises :class:`AttributeError` at runtime
+    and is flagged by type checkers.
+
+    Mirrors the Rust [`RuntimeContextLimitedAccess`] view.
+    """
+
+    __slots__ = (
+        "_state",
+        "config",
+        "inputs",
+        "outputs",
+        "gpu_limited_access",
+    )
+
+    def __init__(self, state: NativeProcessorState) -> None:
+        self._state = state
+        self.config = state.config
+        self.inputs = state.inputs
+        self.outputs = state.outputs
+        self.gpu_limited_access = state.gpu_limited_access()
+
+    @property
+    def time(self) -> int:
+        """Current monotonic time in nanoseconds."""
+        return self._state.time
+
+    def escalate_acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a new-shape pixel buffer on our behalf.
+
+        The escalate channel is the capability-preserving path for
+        allocation in the hot loop — it routes through the Rust host's
+        [`GpuContextLimitedAccess::escalate`], which serializes against
+        every other escalation in the runtime.
+        """
+        return self._state.escalate_acquire_pixel_buffer(width, height, format)
+
+    def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
+        """Drop the host's strong reference to a previously-escalated handle."""
+        return self._state.escalate_release_handle(handle_id)
+
+
+class NativeRuntimeContextFullAccess:
+    """Privileged runtime context passed to ``setup`` / ``teardown`` and
+    Manual-mode ``start`` / ``stop``.
+
+    Exposes both :class:`NativeGpuContextFullAccess` (for allocations) and
+    :class:`NativeGpuContextLimitedAccess` (so privileged methods can hand a
+    stashable limited handle to downstream workers).
+
+    Mirrors the Rust [`RuntimeContextFullAccess`] view.
+    """
+
+    __slots__ = (
+        "_state",
+        "config",
+        "inputs",
+        "outputs",
+        "gpu_limited_access",
+        "gpu_full_access",
+    )
+
+    def __init__(self, state: NativeProcessorState) -> None:
+        self._state = state
+        self.config = state.config
+        self.inputs = state.inputs
+        self.outputs = state.outputs
+        self.gpu_limited_access = state.gpu_limited_access()
+        self.gpu_full_access = state.gpu_full_access()
+
+    @property
+    def time(self) -> int:
+        """Current monotonic time in nanoseconds."""
+        return self._state.time
+
+    def escalate_acquire_pixel_buffer(
+        self, width: int, height: int, format: str = "bgra"
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a new-shape pixel buffer on our behalf."""
+        return self._state.escalate_acquire_pixel_buffer(width, height, format)
+
+    def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
+        """Drop the host's strong reference to a previously-escalated handle."""
+        return self._state.escalate_release_handle(handle_id)

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -29,7 +29,9 @@ import traceback
 
 from .escalate import EscalateChannel, install_channel
 from .processor_context import (
-    NativeProcessorContext,
+    NativeProcessorState,
+    NativeRuntimeContextFullAccess,
+    NativeRuntimeContextLimitedAccess,
     bridge_read_message,
     bridge_send_message,
     load_native_lib,
@@ -50,8 +52,8 @@ def _load_processor_class(entrypoint: str, project_path: str):
     return getattr(module, class_name)
 
 
-def _setup_native_context(msg, native_lib_path, processor_id, escalate_channel=None):
-    """Set up native FFI context with iceoryx2 subscriptions and publishers."""
+def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=None):
+    """Set up native FFI state with iceoryx2 subscriptions and publishers."""
     config = msg.get("config")
     ports = msg.get("ports", {})
 
@@ -118,22 +120,42 @@ def _setup_native_context(msg, native_lib_path, processor_id, escalate_channel=N
                 "Broker connect failed for '%s'", xpc_service_name,
             )
 
-    ctx = NativeProcessorContext(
-        lib, ctx_ptr, config, broker_ptr, escalate_channel=escalate_channel
+    state = NativeProcessorState(
+        lib, ctx_ptr, config, broker_ptr, escalate_channel=escalate_channel,
     )
-    return lib, ctx_ptr, broker_ptr, ctx
+    return lib, ctx_ptr, broker_ptr, state
 
 
-def _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr):
+def _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr, state=None):
     """Destroy native context and disconnect broker."""
+    if state is not None:
+        state.release_pool()
     if native_lib and native_broker_ptr:
         native_lib.slpn_broker_disconnect(native_broker_ptr)
     if native_lib and native_ctx_ptr:
         native_lib.slpn_context_destroy(native_ctx_ptr)
 
 
-def _handle_stdin_during_run(stdin, stdout, processor, ctx, processor_id,
-                              escalate_channel=None):
+def _assert_capability(processor_id: str, cmd: str, msg: dict, expected: str) -> None:
+    """Belt-and-braces check that the wire-format capability field matches
+    what this lifecycle method expects.
+
+    The Rust host is the source of truth; mismatches indicate a wire-format
+    drift bug and are logged but not fatal — the subprocess still dispatches
+    the matching typed ctx.
+    """
+    actual = msg.get("capability")
+    if actual is not None and actual != expected:
+        _logger.error(
+            "[%s] capability mismatch for '%s': expected '%s', got '%s'",
+            processor_id, cmd, expected, actual,
+        )
+
+
+def _handle_stdin_during_run(
+    stdin, stdout, processor, full_ctx, limited_ctx, processor_id,
+    escalate_channel=None,
+):
     """Non-blocking check for lifecycle commands during the run loop.
 
     Also drains any lifecycle commands the escalate channel may have buffered
@@ -146,7 +168,9 @@ def _handle_stdin_during_run(stdin, stdout, processor, ctx, processor_id,
     if escalate_channel and escalate_channel.has_deferred_lifecycle_messages():
         deferred = escalate_channel.take_deferred_lifecycle_messages()
         for dm in deferred:
-            result = _dispatch_lifecycle_msg(dm, stdout, processor, ctx)
+            result = _dispatch_lifecycle_msg(
+                dm, stdout, processor, full_ctx, limited_ctx, processor_id,
+            )
             if result is not None:
                 # Re-queue any messages we didn't process this turn so a
                 # stop/teardown coming from a deferred slot takes precedence.
@@ -158,29 +182,36 @@ def _handle_stdin_during_run(stdin, stdout, processor, ctx, processor_id,
         return None
 
     msg = bridge_read_message(stdin)
-    return _dispatch_lifecycle_msg(msg, stdout, processor, ctx)
+    return _dispatch_lifecycle_msg(
+        msg, stdout, processor, full_ctx, limited_ctx, processor_id,
+    )
 
 
-def _dispatch_lifecycle_msg(msg, stdout, processor, ctx):
+def _dispatch_lifecycle_msg(
+    msg, stdout, processor, full_ctx, limited_ctx, processor_id,
+):
     """Execute a lifecycle message and reply. Returns 'stop'/'teardown'/None."""
     cmd = msg.get("cmd", "")
 
     if cmd == "stop" or cmd == "teardown":
+        _assert_capability(processor_id, cmd, msg, "full")
         return cmd
 
     if cmd == "on_pause":
+        _assert_capability(processor_id, cmd, msg, "limited")
         if hasattr(processor, "on_pause"):
             try:
-                processor.on_pause(ctx)
+                processor.on_pause(limited_ctx)
             except Exception as e:
                 _logger.error("on_pause() error: %s", e)
         bridge_send_message(stdout, {"rpc": "ok"})
         return None
 
     if cmd == "on_resume":
+        _assert_capability(processor_id, cmd, msg, "limited")
         if hasattr(processor, "on_resume"):
             try:
-                processor.on_resume(ctx)
+                processor.on_resume(limited_ctx)
             except Exception as e:
                 _logger.error("on_resume() error: %s", e)
         bridge_send_message(stdout, {"rpc": "ok"})
@@ -234,7 +265,9 @@ def main():
     processor_class = _load_processor_class(entrypoint, project_path)
     processor = processor_class()
 
-    ctx = None
+    state: NativeProcessorState | None = None
+    full_ctx: NativeRuntimeContextFullAccess | None = None
+    limited_ctx: NativeRuntimeContextLimitedAccess | None = None
     native_lib = None
     native_ctx_ptr = None
     native_broker_ptr = None
@@ -248,9 +281,10 @@ def main():
             cmd = msg.get("cmd", "")
 
             if cmd == "setup":
+                _assert_capability(processor_id, cmd, msg, "full")
                 _logger.info("Native mode: loading %s", native_lib_path)
                 try:
-                    native_lib, native_ctx_ptr, native_broker_ptr, ctx = _setup_native_context(
+                    native_lib, native_ctx_ptr, native_broker_ptr, state = _setup_native_state(
                         msg, native_lib_path, processor_id,
                         escalate_channel=escalate_channel,
                     )
@@ -259,16 +293,24 @@ def main():
                     bridge_send_message(stdout, {"rpc": "error", "error": str(e)})
                     continue
 
+                # Build both capability views once per lifecycle. Each view
+                # wraps the same underlying FFI state, so input/output ports
+                # and timing are shared; the capability split is enforced
+                # purely by what each view exposes.
+                full_ctx = NativeRuntimeContextFullAccess(state)
+                limited_ctx = NativeRuntimeContextLimitedAccess(state)
+
                 try:
                     if hasattr(processor, "setup"):
-                        processor.setup(ctx)
+                        # setup() — privileged, receives full-access ctx
+                        processor.setup(full_ctx)
                     bridge_send_message(stdout, {"rpc": "ready"})
                 except Exception as e:
                     traceback.print_exc(file=sys.stderr)
                     bridge_send_message(stdout, {"rpc": "error", "error": str(e)})
 
             elif cmd == "run":
-                if not native_lib or not ctx:
+                if not native_lib or state is None:
                     _logger.warning("run before setup")
                     continue
 
@@ -290,25 +332,28 @@ def main():
                                 )
                             try:
                                 if hasattr(processor, "process"):
-                                    processor.process(ctx)
+                                    # process() — hot loop, receives limited ctx
+                                    processor.process(limited_ctx)
                             except Exception as e:
                                 _logger.error("process() error: %s", e)
                         else:
                             time.sleep(0.001)  # 1ms yield
 
                         lifecycle_cmd = _handle_stdin_during_run(
-                            stdin, stdout, processor, ctx, processor_id,
-                            escalate_channel=escalate_channel,
+                            stdin, stdout, processor, full_ctx, limited_ctx,
+                            processor_id, escalate_channel=escalate_channel,
                         )
                         if lifecycle_cmd == "teardown":
                             running = False
                             if hasattr(processor, "teardown"):
                                 try:
-                                    processor.teardown(ctx)
+                                    processor.teardown(full_ctx)
                                 except Exception as e:
                                     _logger.error("teardown() error: %s", e)
                             bridge_send_message(stdout, {"rpc": "done"})
-                            _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr)
+                            _cleanup_native(
+                                native_lib, native_ctx_ptr, native_broker_ptr, state,
+                            )
                             sys.exit(0)
                         elif lifecycle_cmd == "stop":
                             running = False
@@ -319,7 +364,7 @@ def main():
                         native_lib.slpn_input_poll(native_ctx_ptr)
                         try:
                             if hasattr(processor, "process"):
-                                processor.process(ctx)
+                                processor.process(limited_ctx)
                         except Exception as e:
                             _logger.error("process() error: %s", e)
                         if interval_ms > 0:
@@ -328,64 +373,70 @@ def main():
                             time.sleep(0)  # yield
 
                         lifecycle_cmd = _handle_stdin_during_run(
-                            stdin, stdout, processor, ctx, processor_id,
-                            escalate_channel=escalate_channel,
+                            stdin, stdout, processor, full_ctx, limited_ctx,
+                            processor_id, escalate_channel=escalate_channel,
                         )
                         if lifecycle_cmd == "teardown":
                             running = False
                             if hasattr(processor, "teardown"):
                                 try:
-                                    processor.teardown(ctx)
+                                    processor.teardown(full_ctx)
                                 except Exception as e:
                                     _logger.error("teardown() error: %s", e)
                             bridge_send_message(stdout, {"rpc": "done"})
-                            _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr)
+                            _cleanup_native(
+                                native_lib, native_ctx_ptr, native_broker_ptr, state,
+                            )
                             sys.exit(0)
                         elif lifecycle_cmd == "stop":
                             running = False
                             bridge_send_message(stdout, {"rpc": "stopped"})
 
                 elif execution_mode == "manual":
-                    # Manual mode: start() returns, outer loop handles stop/teardown
+                    # Manual mode: start() is a resource-lifecycle op → full access
                     if hasattr(processor, "start"):
                         try:
-                            processor.start(ctx)
+                            processor.start(full_ctx)
                         except Exception as e:
                             _logger.error("start() error: %s", e)
 
             elif cmd == "teardown":
+                _assert_capability(processor_id, cmd, msg, "full")
                 try:
-                    if hasattr(processor, "teardown"):
-                        processor.teardown(ctx)
+                    if hasattr(processor, "teardown") and full_ctx is not None:
+                        processor.teardown(full_ctx)
                 except Exception as e:
                     traceback.print_exc(file=sys.stderr)
                 bridge_send_message(stdout, {"rpc": "done"})
                 if native_lib and native_ctx_ptr:
-                    _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr)
+                    _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr, state)
                 break
 
             elif cmd == "stop":
+                _assert_capability(processor_id, cmd, msg, "full")
                 running = False
                 try:
-                    if hasattr(processor, "stop"):
-                        processor.stop(ctx)
+                    if hasattr(processor, "stop") and full_ctx is not None:
+                        processor.stop(full_ctx)
                     bridge_send_message(stdout, {"rpc": "stopped"})
                 except Exception as e:
                     traceback.print_exc(file=sys.stderr)
                     bridge_send_message(stdout, {"rpc": "stopped", "error": str(e)})
 
             elif cmd == "on_pause":
-                if hasattr(processor, "on_pause"):
+                _assert_capability(processor_id, cmd, msg, "limited")
+                if hasattr(processor, "on_pause") and limited_ctx is not None:
                     try:
-                        processor.on_pause(ctx)
+                        processor.on_pause(limited_ctx)
                     except Exception as e:
                         traceback.print_exc(file=sys.stderr)
                 bridge_send_message(stdout, {"rpc": "ok"})
 
             elif cmd == "on_resume":
-                if hasattr(processor, "on_resume"):
+                _assert_capability(processor_id, cmd, msg, "limited")
+                if hasattr(processor, "on_resume") and limited_ctx is not None:
                     try:
-                        processor.on_resume(ctx)
+                        processor.on_resume(limited_ctx)
                     except Exception as e:
                         traceback.print_exc(file=sys.stderr)
                 bridge_send_message(stdout, {"rpc": "ok"})
@@ -407,10 +458,10 @@ def main():
     except Exception as e:
         _logger.error("Fatal error: %s", e, exc_info=True)
         if native_lib and native_ctx_ptr:
-            _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr)
+            _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr, state)
         sys.exit(1)
 
-    _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr)
+    _cleanup_native(native_lib, native_ctx_ptr, native_broker_ptr, state)
 
     _logger.info("Subprocess runner exiting")
 

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -192,13 +192,17 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             self.child = Some(child);
             self.bridge = Some(bridge);
 
-            // Send setup command with processor config and port wiring info
+            // Send setup command with processor config and port wiring info.
+            // `capability: "full"` mirrors the Rust-side `RuntimeContextFullAccess`
+            // passed to `__generated_setup` — the subprocess must construct a
+            // full-access ctx for the Python `setup(ctx)` call.
             let config = self
                 .processor_config
                 .clone()
                 .unwrap_or(serde_json::Value::Null);
             self.bridge_send(&serde_json::json!({
                 "cmd": "setup",
+                "capability": "full",
                 "config": config,
                 "processor_id": self.processor_id,
                 "ports": {
@@ -243,7 +247,9 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 
             // Send teardown command (best-effort)
             if self.bridge.is_some() {
-                if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "teardown"})) {
+                if let Err(e) = self.bridge_send(
+                    &serde_json::json!({"cmd": "teardown", "capability": "full"}),
+                ) {
                     tracing::warn!(
                         "[{}] Failed to send teardown command: {}",
                         self.processor_id,
@@ -309,7 +315,9 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "on_pause"})) {
+            if let Err(e) = self.bridge_send(
+                &serde_json::json!({"cmd": "on_pause", "capability": "limited"}),
+            ) {
                 tracing::warn!("[{}] Failed to send on_pause: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
@@ -337,7 +345,9 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             if self.subprocess_dead {
                 return Ok(());
             }
-            if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "on_resume"})) {
+            if let Err(e) = self.bridge_send(
+                &serde_json::json!({"cmd": "on_resume", "capability": "limited"}),
+            ) {
                 tracing::warn!("[{}] Failed to send on_resume: {}", self.processor_id, e);
                 self.subprocess_dead = true;
                 return Ok(());
@@ -378,8 +388,13 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 
         let interval_ms = self.execution_config.execution.interval_ms().unwrap_or(0);
 
+        // `run` enters the subprocess's execution loop; inside the loop
+        // `process()` is dispatched with limited access, `on_pause`/`on_resume`
+        // delivered concurrently are also limited. No single capability applies
+        // to the command itself — the `capability` field is informational.
         self.bridge_send(&serde_json::json!({
             "cmd": "run",
+            "capability": "limited",
             "execution": execution_mode,
             "interval_ms": interval_ms,
         }))?;
@@ -392,7 +407,9 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
         if self.subprocess_dead {
             return Ok(());
         }
-        if let Err(e) = self.bridge_send(&serde_json::json!({"cmd": "stop"})) {
+        if let Err(e) = self.bridge_send(
+            &serde_json::json!({"cmd": "stop", "capability": "full"}),
+        ) {
             tracing::warn!(
                 "[{}] Subprocess pipe broken on stop: {}",
                 self.processor_id,

--- a/plan/351-python-polyglot-typed-lifecycle-ctx.md
+++ b/plan/351-python-polyglot-typed-lifecycle-ctx.md
@@ -1,7 +1,7 @@
 ---
 whoami: amos
 name: "Python polyglot SDK — typed lifecycle ctx over IPC"
-status: pending
+status: in_review
 description: Propagate the capability-typed lifecycle ctx (RuntimeContextFullAccess / RuntimeContextLimitedAccess) from the Rust-side Python SubprocessHostProcessor into the Python-side SDK so Python processor authors get capability-aware type hints and runtime enforcement matching the Rust API.
 github_issue: 351
 dependencies:

--- a/plan/380-python-sdk-rhi-realignment.md
+++ b/plan/380-python-sdk-rhi-realignment.md
@@ -1,0 +1,47 @@
+---
+whoami: amos
+name: "[BLOCKED — do not start] Umbrella: realign Python polyglot SDK to RHI-mediated GPU model"
+status: pending
+description: "BLOCKED — queued behind #319 (GPU capability umbrella) and all its children, plus #347 DMA-BUF FD research and #369 polyglot acquire_texture. Do NOT pick up. Umbrella to rip the parallel GPU stack (IOSurface FFI, CGL helpers, XPC broker) out of libstreamlib_python_native and libs/streamlib-python, and route every GPU op through escalate IPC → host → GpuContext → RHI so platform-specific code stays inside the RHI's platform subdirectories instead of the Python cdylib."
+github_issue: 380
+dependencies:
+  - "down:GPU capability-based access (sandbox + escalate)"
+  - "down:Research: DMA-BUF FD passing for Linux polyglot escalation"
+  - "down:Polyglot escalate: add acquire_texture op"
+adapters:
+  github: builtin
+---
+
+@github:tatolab/streamlib#380
+
+See the GitHub issue for full context.
+
+## Why this exists
+
+The Python polyglot SDK predates the RHI stabilization. It carries its
+own IOSurface FFI, CGL OpenGL helpers, and XPC broker client inside
+`libstreamlib_python_native` — a parallel GPU stack that bypasses
+`VulkanDevice` / `GpuContext`. That violates the engine model in
+CLAUDE.md and frames the Linux port as "implement a second SDK
+backend" rather than "turn on the Linux RHI backend and Python follows
+for free."
+
+## Shape of the fix
+
+Python sees opaque surface handles only. All GPU allocation, resolution,
+and host-visible mapping routes through escalate IPC → host → RHI.
+`libstreamlib_python_native` shrinks to: msgpack I/O + escalate plumbing
++ host-visible pointer access. `cgl_context.py` moves out of the SDK
+into per-example helpers. Examples needing their own GL/WebGPU context
+carry that code at the project level.
+
+## Sequencing
+
+Gated behind #319 and its children closing. Do NOT pick up before. A
+naive Linux port of the current Python SDK should also land (or be
+explicitly skipped) first so there is something concrete to rip out and
+a working E2E reference to simplify.
+
+## Branch
+
+`refactor/python-sdk-rhi-realignment` from `main` once unblocked.


### PR DESCRIPTION
## Summary
- Mirror the Deno #350 pattern for the Python subprocess SDK: split
  `NativeProcessorContext` into `NativeProcessorState` plus two
  capability views (`NativeRuntimeContextFullAccess` /
  `NativeRuntimeContextLimitedAccess`). Limited is `__slots__`-defined
  with no `gpu_full_access` attribute — accessing it from
  `process()`/`on_pause`/`on_resume` raises `AttributeError` at runtime
  and is flagged by type checkers.
- Rust host (`spawn_python_native_subprocess_op.rs`) now sends a
  `"capability": "full" | "limited"` field on every lifecycle command.
  `subprocess_runner.py` builds both views once per `setup` and
  dispatches the correct one per lifecycle method, with a wire-format
  belt-and-braces check.
- Python example processors (`passthrough`, `grayscale`,
  `avatar_character`, `cyberpunk_glitch`, `cyberpunk_lower_third`,
  `cyberpunk_watermark`) updated to the new signatures. In-`process()`
  `acquire_surface` calls moved to `ctx.gpu_full_access` with
  `TODO(#325/#369)` comments marking the pending escalate-IPC rewrite —
  mirrors the Deno halftone example's pending-escalate pattern.

## Issue
Closes #351.

## Test Plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p streamlib --lib` — 160/160 passing
- [x] Python `ast.parse` of every modified file
- [x] Capability invariants verified: `RuntimeContextLimitedAccess`
  has no `gpu_full_access` in `__slots__`; access raises
  `AttributeError` on a Limited instance, works on a Full instance
- [ ] End-to-end subprocess runs — not executed here; IOSurface/CGL
  paths need a macOS environment. Track under #353 (macOS verify of
  #322) and #360 (subprocess host E2E post-#322).

## Follow-ups
- #369 (polyglot escalate: `acquire_texture` op) — examples that still
  call `ctx.gpu_full_access.acquire_surface` in `process()` will get
  their proper runtime fix once that lands.
- `cyberpunk_processor.py` in `camera-python-display/python/` was left
  untouched: it uses a legacy in-process pyo3 context API and is not
  wired into `pipeline.json`. If still live under a separate runtime,
  it needs its own migration.
- Pre-existing edition-2024 `unsafe_op_in_unsafe_fn` warnings across
  `vulkan-video` / `streamlib-python-native` / `streamlib` unrelated
  to this change (tracked by #355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)