### PR TITLE
feat(polyglot): add acquire_texture op to escalate IPC

### DIFF
--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -8,7 +8,10 @@
 /**
  * Polyglot subprocess escalate-on-behalf request (subprocess → host)
  */
-export type EscalateRequest = EscalateRequestAcquirePixelBuffer | EscalateRequestReleaseHandle;
+export type EscalateRequest =
+  | EscalateRequestAcquirePixelBuffer
+  | EscalateRequestAcquireTexture
+  | EscalateRequestReleaseHandle;
 
 export interface EscalateRequestAcquirePixelBuffer {
   op: "acquire_pixel_buffer";
@@ -30,6 +33,36 @@ export interface EscalateRequestAcquirePixelBuffer {
 
   /**
    * Pixel width of the buffer.
+   */
+  width: number;
+}
+
+export interface EscalateRequestAcquireTexture {
+  op: "acquire_texture";
+
+  /**
+   * Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+   */
+  format: string;
+
+  /**
+   * Pixel height of the texture.
+   */
+  height: number;
+
+  /**
+   * Correlates request with response. UUID string.
+   */
+  request_id: string;
+
+  /**
+   * Usage tokens (copy_src, copy_dst, texture_binding, storage_binding,
+   * render_attachment).
+   */
+  usage: string[];
+
+  /**
+   * Pixel width of the texture.
    */
   width: number;
 }

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_response.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_response.ts
@@ -30,7 +30,9 @@ export interface EscalateResponseOk {
   /**
    * Opaque handle returned by the host. For acquire_pixel_buffer this is the
    * PixelBufferPoolId the host registered with its pixel-buffer pool and broker
-   * SurfaceStore. For release_handle this echoes the released id.
+   * SurfaceStore. For acquire_texture this is a host-side UUID keying the
+   * EscalateHandleRegistry's texture slot. For release_handle this echoes the
+   * released id.
    */
   handle_id: string;
 
@@ -40,17 +42,24 @@ export interface EscalateResponseOk {
   request_id: string;
 
   /**
-   * Resolved pixel format identifier.
+   * Resolved pixel or texture format identifier.
    */
   format?: string;
 
   /**
-   * Height in pixels (set on acquire_pixel_buffer responses).
+   * Height in pixels (set on acquire_pixel_buffer and acquire_texture
+   * responses).
    */
   height?: number;
 
   /**
-   * Width in pixels (set on acquire_pixel_buffer responses).
+   * Resolved usage tokens (set on acquire_texture responses).
+   */
+  usage?: string[];
+
+  /**
+   * Width in pixels (set on acquire_pixel_buffer and acquire_texture
+   * responses).
    */
   width?: number;
 }

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -78,8 +78,27 @@ export class NativeProcessorState {
     return this.escalate.acquirePixelBuffer(width, height, format);
   }
 
+  /**
+   * Ask the host to acquire a pooled GPU texture on the subprocess's behalf.
+   * `usage` is a non-empty list of tokens drawn from `copy_src`, `copy_dst`,
+   * `texture_binding`, `storage_binding`, `render_attachment`.
+   */
+  async escalateAcquireTexture(
+    width: number,
+    height: number,
+    format: string,
+    usage: readonly string[],
+  ): Promise<EscalateOkResponse> {
+    if (!this.escalate) {
+      throw new Error(
+        "escalate channel not installed — escalateAcquireTexture is only available inside the subprocess lifecycle",
+      );
+    }
+    return this.escalate.acquireTexture(width, height, format, usage);
+  }
+
   /** Drop the host's strong reference to a previously-escalated handle. */
-  async escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
+  escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
     if (!this.escalate) {
       throw new Error(
         "escalate channel not installed — escalateReleaseHandle is only available inside the subprocess lifecycle",
@@ -136,6 +155,15 @@ export class NativeRuntimeContextLimitedAccess
     return this.state.escalateAcquirePixelBuffer(width, height, format);
   }
 
+  escalateAcquireTexture(
+    width: number,
+    height: number,
+    format: string,
+    usage: readonly string[],
+  ): Promise<EscalateOkResponse> {
+    return this.state.escalateAcquireTexture(width, height, format, usage);
+  }
+
   escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {
     return this.state.escalateReleaseHandle(handleId);
   }
@@ -174,6 +202,15 @@ export class NativeRuntimeContextFullAccess implements RuntimeContextFullAccess 
     format = "bgra",
   ): Promise<EscalateOkResponse> {
     return this.state.escalateAcquirePixelBuffer(width, height, format);
+  }
+
+  escalateAcquireTexture(
+    width: number,
+    height: number,
+    format: string,
+    usage: readonly string[],
+  ): Promise<EscalateOkResponse> {
+    return this.state.escalateAcquireTexture(width, height, format, usage);
   }
 
   escalateReleaseHandle(handleId: string): Promise<EscalateOkResponse> {

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -20,6 +20,7 @@
 import type {
   EscalateRequest,
   EscalateRequestAcquirePixelBuffer,
+  EscalateRequestAcquireTexture,
   EscalateRequestReleaseHandle,
 } from "./_generated_/com_streamlib_escalate_request.ts";
 import type {
@@ -31,6 +32,7 @@ import type {
 export type {
   EscalateRequest,
   EscalateRequestAcquirePixelBuffer,
+  EscalateRequestAcquireTexture,
   EscalateRequestReleaseHandle,
   EscalateResponse,
   EscalateResponseErr,
@@ -52,6 +54,7 @@ export const ESCALATE_RESPONSE_RPC = "escalate_response";
  */
 export type EscalateOpPayload =
   | Omit<EscalateRequestAcquirePixelBuffer, "request_id">
+  | Omit<EscalateRequestAcquireTexture, "request_id">
   | Omit<EscalateRequestReleaseHandle, "request_id">;
 
 export class EscalateError extends Error {}
@@ -85,6 +88,24 @@ export class EscalateChannel {
       width,
       height,
       format,
+    });
+  }
+
+  async acquireTexture(
+    width: number,
+    height: number,
+    format: string,
+    usage: readonly string[],
+  ): Promise<EscalateOkResponse> {
+    if (usage.length === 0) {
+      throw new EscalateError("acquireTexture: usage must not be empty");
+    }
+    return this.request({
+      op: "acquire_texture",
+      width,
+      height,
+      format,
+      usage: [...usage],
     });
   }
 

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -8,7 +8,7 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Type, Union, get_args, get_origin
+from typing import Any, Dict, List, Type, Union, get_args, get_origin
 
 
 @dataclass
@@ -23,6 +23,7 @@ class EscalateRequest:
     def from_json_data(cls, data: Any) -> 'EscalateRequest':
         variants: Dict[str, Type[EscalateRequest]] = {
             "acquire_pixel_buffer": EscalateRequestAcquirePixelBuffer,
+            "acquire_texture": EscalateRequestAcquireTexture,
             "release_handle": EscalateRequestReleaseHandle,
         }
 
@@ -69,6 +70,55 @@ class EscalateRequestAcquirePixelBuffer(EscalateRequest):
         data["format"] = _to_json_data(self.format)
         data["height"] = _to_json_data(self.height)
         data["request_id"] = _to_json_data(self.request_id)
+        data["width"] = _to_json_data(self.width)
+        return data
+
+@dataclass
+class EscalateRequestAcquireTexture(EscalateRequest):
+    format: 'str'
+    """
+    Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+    """
+
+    height: 'int'
+    """
+    Pixel height of the texture.
+    """
+
+    request_id: 'str'
+    """
+    Correlates request with response. UUID string.
+    """
+
+    usage: 'List[str]'
+    """
+    Usage tokens (copy_src, copy_dst, texture_binding, storage_binding,
+    render_attachment).
+    """
+
+    width: 'int'
+    """
+    Pixel width of the texture.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestAcquireTexture':
+        return cls(
+            "acquire_texture",
+            _from_json_data(str, data.get("format")),
+            _from_json_data(int, data.get("height")),
+            _from_json_data(str, data.get("request_id")),
+            _from_json_data(List[str], data.get("usage")),
+            _from_json_data(int, data.get("width")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "acquire_texture" }
+        data["format"] = _to_json_data(self.format)
+        data["height"] = _to_json_data(self.height)
+        data["request_id"] = _to_json_data(self.request_id)
+        data["usage"] = _to_json_data(self.usage)
         data["width"] = _to_json_data(self.width)
         return data
 

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_response.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_response.py
@@ -8,7 +8,7 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Type, Union, get_args, get_origin
+from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
 
 
 @dataclass
@@ -64,7 +64,9 @@ class EscalateResponseOk(EscalateResponse):
     """
     Opaque handle returned by the host. For acquire_pixel_buffer this is the
     PixelBufferPoolId the host registered with its pixel-buffer pool and broker
-    SurfaceStore. For release_handle this echoes the released id.
+    SurfaceStore. For acquire_texture this is a host-side UUID keying the
+    EscalateHandleRegistry's texture slot. For release_handle this echoes the
+    released id.
     """
 
     request_id: 'str'
@@ -74,17 +76,24 @@ class EscalateResponseOk(EscalateResponse):
 
     format: 'Optional[str]'
     """
-    Resolved pixel format identifier.
+    Resolved pixel or texture format identifier.
     """
 
     height: 'Optional[int]'
     """
-    Height in pixels (set on acquire_pixel_buffer responses).
+    Height in pixels (set on acquire_pixel_buffer and acquire_texture
+    responses).
+    """
+
+    usage: 'Optional[List[str]]'
+    """
+    Resolved usage tokens (set on acquire_texture responses).
     """
 
     width: 'Optional[int]'
     """
-    Width in pixels (set on acquire_pixel_buffer responses).
+    Width in pixels (set on acquire_pixel_buffer and acquire_texture
+    responses).
     """
 
 
@@ -96,6 +105,7 @@ class EscalateResponseOk(EscalateResponse):
             _from_json_data(str, data.get("request_id")),
             _from_json_data(Optional[str], data.get("format")),
             _from_json_data(Optional[int], data.get("height")),
+            _from_json_data(Optional[List[str]], data.get("usage")),
             _from_json_data(Optional[int], data.get("width")),
         )
 
@@ -107,6 +117,8 @@ class EscalateResponseOk(EscalateResponse):
              data["format"] = _to_json_data(self.format)
         if self.height is not None:
              data["height"] = _to_json_data(self.height)
+        if self.usage is not None:
+             data["usage"] = _to_json_data(self.usage)
         if self.width is not None:
              data["width"] = _to_json_data(self.width)
         return data

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import threading
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from .processor_context import bridge_read_message, bridge_send_message
 
@@ -71,6 +71,37 @@ class EscalateChannel:
                 "width": int(width),
                 "height": int(height),
                 "format": format,
+            }
+        )
+
+    def acquire_texture(
+        self,
+        width: int,
+        height: int,
+        format: str,
+        usage: Sequence[str],
+    ) -> Dict[str, Any]:
+        """Request a pooled GPU texture from the host.
+
+        ``format`` is a wire token such as ``"rgba8_unorm"``,
+        ``"bgra8_unorm_srgb"``, ``"rgba16_float"``, ``"nv12"``.
+        ``usage`` is a non-empty iterable of tokens drawn from
+        ``copy_src``, ``copy_dst``, ``texture_binding``, ``storage_binding``,
+        ``render_attachment``.
+
+        Returns the ``ok``-payload dict; on failure raises
+        :class:`EscalateError`.
+        """
+        usage_list = [str(u) for u in usage]
+        if not usage_list:
+            raise ValueError("acquire_texture: usage must not be empty")
+        return self.request(
+            {
+                "op": "acquire_texture",
+                "width": int(width),
+                "height": int(height),
+                "format": format,
+                "usage": usage_list,
             }
         )
 

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json
 import struct
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import msgpack
 
@@ -478,6 +478,17 @@ class NativeProcessorState:
         channel = self._require_channel()
         return channel.acquire_pixel_buffer(width, height, format)
 
+    def escalate_acquire_texture(
+        self,
+        width: int,
+        height: int,
+        format: str,
+        usage: "Sequence[str]",
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a pooled GPU texture on our behalf."""
+        channel = self._require_channel()
+        return channel.acquire_texture(width, height, format, usage)
+
     def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Drop the host's strong reference to a previously-escalated handle."""
         channel = self._require_channel()
@@ -539,6 +550,16 @@ class NativeRuntimeContextLimitedAccess:
         """
         return self._state.escalate_acquire_pixel_buffer(width, height, format)
 
+    def escalate_acquire_texture(
+        self,
+        width: int,
+        height: int,
+        format: str,
+        usage: "Sequence[str]",
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a pooled GPU texture on our behalf."""
+        return self._state.escalate_acquire_texture(width, height, format, usage)
+
     def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Drop the host's strong reference to a previously-escalated handle."""
         return self._state.escalate_release_handle(handle_id)
@@ -582,6 +603,16 @@ class NativeRuntimeContextFullAccess:
     ) -> Dict[str, Any]:
         """Ask the host to allocate a new-shape pixel buffer on our behalf."""
         return self._state.escalate_acquire_pixel_buffer(width, height, format)
+
+    def escalate_acquire_texture(
+        self,
+        width: int,
+        height: int,
+        format: str,
+        usage: "Sequence[str]",
+    ) -> Dict[str, Any]:
+        """Ask the host to allocate a pooled GPU texture on our behalf."""
+        return self._state.escalate_acquire_texture(width, height, format, usage)
 
     def escalate_release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Drop the host's strong reference to a previously-escalated handle."""

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -40,6 +40,36 @@ mapping:
         metadata:
           description: "Pixel format identifier (e.g. bgra32, nv12_video_range, gray8)."
         type: string
+  acquire_texture:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      width:
+        metadata:
+          description: "Pixel width of the texture."
+        type: uint32
+      height:
+        metadata:
+          description: "Pixel height of the texture."
+        type: uint32
+      format:
+        metadata:
+          description: >
+            Texture format identifier. Lowercase snake-case names:
+            rgba8_unorm, rgba8_unorm_srgb, bgra8_unorm, bgra8_unorm_srgb,
+            rgba16_float, rgba32_float, nv12.
+        type: string
+      usage:
+        metadata:
+          description: >
+            Usage flags the texture must support. Non-empty array of lowercase
+            snake-case tokens drawn from: copy_src, copy_dst, texture_binding,
+            storage_binding, render_attachment. Host validates — unknown
+            tokens return an error response.
+        elements:
+          type: string
   release_handle:
     properties:
       request_id:

--- a/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
@@ -29,22 +29,30 @@ mapping:
           description: >
             Opaque handle returned by the host. For acquire_pixel_buffer this
             is the PixelBufferPoolId the host registered with its
-            pixel-buffer pool and broker SurfaceStore. For release_handle this
-            echoes the released id.
+            pixel-buffer pool and broker SurfaceStore. For acquire_texture
+            this is a host-side UUID keying the EscalateHandleRegistry's
+            texture slot. For release_handle this echoes the released id.
         type: string
     optionalProperties:
       width:
         metadata:
-          description: "Width in pixels (set on acquire_pixel_buffer responses)."
+          description: "Width in pixels (set on acquire_pixel_buffer and acquire_texture responses)."
         type: uint32
       height:
         metadata:
-          description: "Height in pixels (set on acquire_pixel_buffer responses)."
+          description: "Height in pixels (set on acquire_pixel_buffer and acquire_texture responses)."
         type: uint32
       format:
         metadata:
-          description: "Resolved pixel format identifier."
+          description: "Resolved pixel or texture format identifier."
         type: string
+      usage:
+        metadata:
+          description: >
+            Resolved usage tokens (set on acquire_texture responses). Array
+            reflects the exact flags the host honored.
+        elements:
+          type: string
   err:
     properties:
       request_id:

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
@@ -13,6 +13,9 @@ pub enum EscalateRequest {
     #[serde(rename = "acquire_pixel_buffer")]
     AcquirePixelBuffer(EscalateRequestAcquirePixelBuffer),
 
+    #[serde(rename = "acquire_texture")]
+    AcquireTexture(EscalateRequestAcquireTexture),
+
     #[serde(rename = "release_handle")]
     ReleaseHandle(EscalateRequestReleaseHandle),
 }
@@ -33,6 +36,30 @@ pub struct EscalateRequestAcquirePixelBuffer {
     pub request_id: String,
 
     /// Pixel width of the buffer.
+    #[serde(rename = "width")]
+    pub width: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestAcquireTexture {
+    /// Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+    #[serde(rename = "format")]
+    pub format: String,
+
+    /// Pixel height of the texture.
+    #[serde(rename = "height")]
+    pub height: u32,
+
+    /// Correlates request with response. UUID string.
+    #[serde(rename = "request_id")]
+    pub request_id: String,
+
+    /// Usage tokens (copy_src, copy_dst, texture_binding, storage_binding, render_attachment).
+    #[serde(rename = "usage")]
+    pub usage: Vec<String>,
+
+    /// Pixel width of the texture.
     #[serde(rename = "width")]
     pub width: u32,
 }

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
@@ -34,7 +34,9 @@ pub struct EscalateResponseErr {
 pub struct EscalateResponseOk {
     /// Opaque handle returned by the host. For acquire_pixel_buffer this is
     /// the PixelBufferPoolId the host registered with its pixel-buffer pool and
-    /// broker SurfaceStore. For release_handle this echoes the released id.
+    /// broker SurfaceStore. For acquire_texture this is a host-side UUID
+    /// keying the EscalateHandleRegistry's texture slot. For release_handle
+    /// this echoes the released id.
     #[serde(rename = "handle_id")]
     pub handle_id: String,
 
@@ -42,17 +44,22 @@ pub struct EscalateResponseOk {
     #[serde(rename = "request_id")]
     pub request_id: String,
 
-    /// Resolved pixel format identifier.
+    /// Resolved pixel or texture format identifier.
     #[serde(rename = "format")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
 
-    /// Height in pixels (set on acquire_pixel_buffer responses).
+    /// Height in pixels (set on acquire_pixel_buffer and acquire_texture responses).
     #[serde(rename = "height")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
 
-    /// Width in pixels (set on acquire_pixel_buffer responses).
+    /// Resolved usage tokens (set on acquire_texture responses).
+    #[serde(rename = "usage")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Vec<String>>,
+
+    /// Width in pixels (set on acquire_pixel_buffer and acquire_texture responses).
     #[serde(rename = "width")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -17,15 +17,19 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use uuid::Uuid;
+
 use crate::_generated_::com_streamlib_escalate_request::{
-    EscalateRequestAcquirePixelBuffer, EscalateRequestReleaseHandle,
+    EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
+    EscalateRequestReleaseHandle,
 };
 use crate::_generated_::com_streamlib_escalate_response::{
     EscalateResponseErr, EscalateResponseOk,
 };
 use crate::_generated_::{EscalateRequest, EscalateResponse};
+use crate::core::context::{PooledTextureHandle, TexturePoolDescriptor};
 use crate::core::context::GpuContextLimitedAccess;
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer};
+use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
 
 #[cfg(test)]
 use crate::core::error::{Result, StreamError};
@@ -40,18 +44,32 @@ pub(crate) const ESCALATE_RESPONSE_RPC: &str = "escalate_response";
 fn request_id(op: &EscalateRequest) -> &str {
     match op {
         EscalateRequest::AcquirePixelBuffer(p) => &p.request_id,
+        EscalateRequest::AcquireTexture(p) => &p.request_id,
         EscalateRequest::ReleaseHandle(p) => &p.request_id,
     }
 }
 
+/// Resource kept alive on behalf of a subprocess by
+/// [`EscalateHandleRegistry`]. The fields are only read via the `Drop`
+/// side-effect that releases them back to the host pool when removed
+/// from the registry — the map keeps the resource live, the resource's
+/// destructor does the release on removal.
+pub(crate) enum RegisteredHandle {
+    #[allow(dead_code)]
+    PixelBuffer(RhiPixelBuffer),
+    #[allow(dead_code)]
+    Texture(PooledTextureHandle),
+}
+
 /// Tracks resources acquired on behalf of a subprocess so `release_handle` —
-/// or subprocess death — can drop the host's strong reference. Buffers stay
+/// or subprocess death — can drop the host's strong reference. Resources stay
 /// alive for the duration of the host pool; this map simply prevents the
-/// buffer from being immediately recycled while the subprocess still
-/// references it by ID.
+/// resource from being immediately recycled while the subprocess still
+/// references it by ID. Dropping a [`PooledTextureHandle`] releases the pool
+/// slot; dropping an [`RhiPixelBuffer`] releases its refcount.
 #[derive(Default)]
 pub(crate) struct EscalateHandleRegistry {
-    buffers: Mutex<HashMap<String, RhiPixelBuffer>>,
+    handles: Mutex<HashMap<String, RegisteredHandle>>,
 }
 
 impl EscalateHandleRegistry {
@@ -60,24 +78,29 @@ impl EscalateHandleRegistry {
     }
 
     pub(crate) fn insert_buffer(&self, handle_id: String, buffer: RhiPixelBuffer) {
-        let mut map = self.buffers.lock().expect("poisoned");
-        map.insert(handle_id, buffer);
+        let mut map = self.handles.lock().expect("poisoned");
+        map.insert(handle_id, RegisteredHandle::PixelBuffer(buffer));
     }
 
-    pub(crate) fn remove_buffer(&self, handle_id: &str) -> bool {
-        let mut map = self.buffers.lock().expect("poisoned");
+    pub(crate) fn insert_texture(&self, handle_id: String, texture: PooledTextureHandle) {
+        let mut map = self.handles.lock().expect("poisoned");
+        map.insert(handle_id, RegisteredHandle::Texture(texture));
+    }
+
+    pub(crate) fn remove_handle(&self, handle_id: &str) -> bool {
+        let mut map = self.handles.lock().expect("poisoned");
         map.remove(handle_id).is_some()
     }
 
     pub(crate) fn clear(&self) {
-        let mut map = self.buffers.lock().expect("poisoned");
+        let mut map = self.handles.lock().expect("poisoned");
         map.clear();
     }
 
     /// Number of currently-held handles; visible for tests.
     #[cfg(test)]
-    pub(crate) fn buffer_count(&self) -> usize {
-        self.buffers.lock().expect("poisoned").len()
+    pub(crate) fn handle_count(&self) -> usize {
+        self.handles.lock().expect("poisoned").len()
     }
 }
 
@@ -109,6 +132,7 @@ pub(crate) fn handle_escalate_op(
                             width: Some(width),
                             height: Some(height),
                             format: Some(pixel_format_to_wire(parsed).to_string()),
+                            usage: None,
                         })
                     }
                     Err(e) => EscalateResponse::Err(EscalateResponseErr {
@@ -122,11 +146,57 @@ pub(crate) fn handle_escalate_op(
                 message: e,
             }),
         },
+        EscalateRequest::AcquireTexture(EscalateRequestAcquireTexture {
+            request_id: _,
+            width,
+            height,
+            format,
+            usage,
+        }) => {
+            let parsed_format = match parse_texture_format(&format) {
+                Ok(f) => f,
+                Err(e) => {
+                    return EscalateResponse::Err(EscalateResponseErr {
+                        request_id: rid,
+                        message: e,
+                    });
+                }
+            };
+            let parsed_usage = match parse_texture_usages(&usage) {
+                Ok(u) => u,
+                Err(e) => {
+                    return EscalateResponse::Err(EscalateResponseErr {
+                        request_id: rid,
+                        message: e,
+                    });
+                }
+            };
+            let desc = TexturePoolDescriptor::new(width, height, parsed_format)
+                .with_usage(parsed_usage);
+            match sandbox.escalate(|full| full.acquire_texture(&desc)) {
+                Ok(texture) => {
+                    let handle_id = Uuid::new_v4().to_string();
+                    registry.insert_texture(handle_id.clone(), texture);
+                    EscalateResponse::Ok(EscalateResponseOk {
+                        request_id: rid,
+                        handle_id,
+                        width: Some(width),
+                        height: Some(height),
+                        format: Some(texture_format_to_wire(parsed_format).to_string()),
+                        usage: Some(texture_usages_to_wire(parsed_usage)),
+                    })
+                }
+                Err(e) => EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: format!("acquire_texture failed: {e}"),
+                }),
+            }
+        }
         EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
             request_id: _,
             handle_id,
         }) => {
-            let removed = registry.remove_buffer(&handle_id);
+            let removed = registry.remove_handle(&handle_id);
             if removed {
                 EscalateResponse::Ok(EscalateResponseOk {
                     request_id: rid,
@@ -134,6 +204,7 @@ pub(crate) fn handle_escalate_op(
                     width: None,
                     height: None,
                     format: None,
+                    usage: None,
                 })
             } else {
                 EscalateResponse::Err(EscalateResponseErr {
@@ -194,6 +265,84 @@ fn pixel_format_to_wire(fmt: PixelFormat) -> &'static str {
         PixelFormat::Gray8 => "gray8",
         PixelFormat::Unknown => "unknown",
     }
+}
+
+/// Parse a wire-format texture format string into a [`TextureFormat`].
+///
+/// Lowercase snake-case matches the variant name. Kept separate from
+/// [`parse_pixel_format`] so the vocabularies can evolve independently —
+/// pixel formats include video-specific YUV variants that textures don't
+/// expose, and texture formats include float variants that pixel buffers
+/// don't.
+fn parse_texture_format(s: &str) -> std::result::Result<TextureFormat, String> {
+    let normalized = s.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "rgba8_unorm" => Ok(TextureFormat::Rgba8Unorm),
+        "rgba8_unorm_srgb" => Ok(TextureFormat::Rgba8UnormSrgb),
+        "bgra8_unorm" => Ok(TextureFormat::Bgra8Unorm),
+        "bgra8_unorm_srgb" => Ok(TextureFormat::Bgra8UnormSrgb),
+        "rgba16_float" => Ok(TextureFormat::Rgba16Float),
+        "rgba32_float" => Ok(TextureFormat::Rgba32Float),
+        "nv12" => Ok(TextureFormat::Nv12),
+        other => Err(format!("unknown texture format '{other}'")),
+    }
+}
+
+fn texture_format_to_wire(fmt: TextureFormat) -> &'static str {
+    match fmt {
+        TextureFormat::Rgba8Unorm => "rgba8_unorm",
+        TextureFormat::Rgba8UnormSrgb => "rgba8_unorm_srgb",
+        TextureFormat::Bgra8Unorm => "bgra8_unorm",
+        TextureFormat::Bgra8UnormSrgb => "bgra8_unorm_srgb",
+        TextureFormat::Rgba16Float => "rgba16_float",
+        TextureFormat::Rgba32Float => "rgba32_float",
+        TextureFormat::Nv12 => "nv12",
+    }
+}
+
+/// Parse an array of usage tokens into a combined [`TextureUsages`] bitmask.
+///
+/// An empty list is rejected — a texture must have at least one usage or the
+/// RHI can't create it. Unknown tokens surface as an error so typos fail
+/// loudly on the wire rather than silently dropping flags.
+fn parse_texture_usages(tokens: &[String]) -> std::result::Result<TextureUsages, String> {
+    if tokens.is_empty() {
+        return Err("texture usage list must not be empty".to_string());
+    }
+    let mut out = TextureUsages::NONE;
+    for token in tokens {
+        let normalized = token.trim().to_ascii_lowercase();
+        let flag = match normalized.as_str() {
+            "copy_src" => TextureUsages::COPY_SRC,
+            "copy_dst" => TextureUsages::COPY_DST,
+            "texture_binding" => TextureUsages::TEXTURE_BINDING,
+            "storage_binding" => TextureUsages::STORAGE_BINDING,
+            "render_attachment" => TextureUsages::RENDER_ATTACHMENT,
+            other => return Err(format!("unknown texture usage '{other}'")),
+        };
+        out |= flag;
+    }
+    Ok(out)
+}
+
+fn texture_usages_to_wire(usage: TextureUsages) -> Vec<String> {
+    let mut out = Vec::new();
+    if usage.contains(TextureUsages::COPY_SRC) {
+        out.push("copy_src".to_string());
+    }
+    if usage.contains(TextureUsages::COPY_DST) {
+        out.push("copy_dst".to_string());
+    }
+    if usage.contains(TextureUsages::TEXTURE_BINDING) {
+        out.push("texture_binding".to_string());
+    }
+    if usage.contains(TextureUsages::STORAGE_BINDING) {
+        out.push("storage_binding".to_string());
+    }
+    if usage.contains(TextureUsages::RENDER_ATTACHMENT) {
+        out.push("render_attachment".to_string());
+    }
+    out
 }
 
 /// Try to parse an incoming bridge message as an [`EscalateRequest`].
@@ -361,6 +510,7 @@ mod tests {
             width: Some(16),
             height: Some(16),
             format: Some("bgra32".into()),
+            usage: None,
         });
         let env = envelope_response(resp);
         assert_eq!(
@@ -381,8 +531,55 @@ mod tests {
         // machines without a GPU still build+run the rest of the
         // suite.
         let registry = EscalateHandleRegistry::new();
-        assert_eq!(registry.buffer_count(), 0);
-        assert!(!registry.remove_buffer("missing"));
+        assert_eq!(registry.handle_count(), 0);
+        assert!(!registry.remove_handle("missing"));
+    }
+
+    #[test]
+    fn parse_texture_format_roundtrips_known_variants() {
+        assert_eq!(
+            parse_texture_format("bgra8_unorm"),
+            Ok(TextureFormat::Bgra8Unorm)
+        );
+        assert_eq!(
+            parse_texture_format("RGBA16_FLOAT"),
+            Ok(TextureFormat::Rgba16Float)
+        );
+        assert_eq!(parse_texture_format("nv12"), Ok(TextureFormat::Nv12));
+        assert!(parse_texture_format("xyz").is_err());
+    }
+
+    #[test]
+    fn parse_texture_usages_combines_tokens() {
+        let usage = parse_texture_usages(&[
+            "texture_binding".to_string(),
+            "copy_src".to_string(),
+        ])
+        .expect("known tokens");
+        assert!(usage.contains(TextureUsages::TEXTURE_BINDING));
+        assert!(usage.contains(TextureUsages::COPY_SRC));
+        assert!(!usage.contains(TextureUsages::STORAGE_BINDING));
+    }
+
+    #[test]
+    fn parse_texture_usages_rejects_empty_and_unknown() {
+        assert!(parse_texture_usages(&[]).is_err());
+        assert!(parse_texture_usages(&["bogus".to_string()]).is_err());
+    }
+
+    #[test]
+    fn texture_usages_to_wire_is_stable_order() {
+        let usage = TextureUsages::STORAGE_BINDING
+            | TextureUsages::COPY_SRC
+            | TextureUsages::TEXTURE_BINDING;
+        assert_eq!(
+            texture_usages_to_wire(usage),
+            vec![
+                "copy_src".to_string(),
+                "texture_binding".to_string(),
+                "storage_binding".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -408,12 +605,13 @@ mod tests {
                 format: "bgra".to_string(),
             });
         let response = handle_escalate_op(&sandbox, &registry, acquire);
-        let handle_id = match response {
+        let buffer_handle_id = match response {
             EscalateResponse::Ok(ref ok) => {
                 assert_eq!(ok.request_id, "req-1");
                 assert_eq!(ok.width, Some(320));
                 assert_eq!(ok.height, Some(240));
                 assert_eq!(ok.format.as_deref(), Some("bgra32"));
+                assert!(ok.usage.is_none(), "pixel buffers have no usage field");
                 assert!(!ok.handle_id.is_empty(), "handle id should not be empty");
                 ok.handle_id.clone()
             }
@@ -421,21 +619,68 @@ mod tests {
                 panic!("acquire_pixel_buffer escalate failed: {}", err.message);
             }
         };
-        assert_eq!(registry.buffer_count(), 1);
+        assert_eq!(registry.handle_count(), 1);
+
+        let acquire_tex =
+            EscalateRequest::AcquireTexture(EscalateRequestAcquireTexture {
+                request_id: "req-tex".to_string(),
+                width: 256,
+                height: 128,
+                format: "rgba8_unorm".to_string(),
+                usage: vec![
+                    "texture_binding".to_string(),
+                    "copy_src".to_string(),
+                ],
+            });
+        let response = handle_escalate_op(&sandbox, &registry, acquire_tex);
+        let texture_handle_id = match response {
+            EscalateResponse::Ok(ref ok) => {
+                assert_eq!(ok.request_id, "req-tex");
+                assert_eq!(ok.width, Some(256));
+                assert_eq!(ok.height, Some(128));
+                assert_eq!(ok.format.as_deref(), Some("rgba8_unorm"));
+                let usage = ok.usage.as_deref().expect("acquire_texture sets usage");
+                assert!(usage.iter().any(|u| u == "texture_binding"));
+                assert!(usage.iter().any(|u| u == "copy_src"));
+                assert!(!ok.handle_id.is_empty(), "texture handle id should not be empty");
+                assert_ne!(
+                    ok.handle_id, buffer_handle_id,
+                    "texture and buffer should get distinct handle ids"
+                );
+                ok.handle_id.clone()
+            }
+            EscalateResponse::Err(err) => {
+                panic!("acquire_texture escalate failed: {}", err.message);
+            }
+        };
+        assert_eq!(registry.handle_count(), 2);
+
+        let release_tex = EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
+            request_id: "req-tex-rel".to_string(),
+            handle_id: texture_handle_id.clone(),
+        });
+        match handle_escalate_op(&sandbox, &registry, release_tex) {
+            EscalateResponse::Ok(ok) => {
+                assert_eq!(ok.request_id, "req-tex-rel");
+                assert_eq!(ok.handle_id, texture_handle_id);
+            }
+            EscalateResponse::Err(err) => panic!("release_handle (texture) failed: {}", err.message),
+        }
+        assert_eq!(registry.handle_count(), 1);
 
         let release = EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
             request_id: "req-2".to_string(),
-            handle_id: handle_id.clone(),
+            handle_id: buffer_handle_id.clone(),
         });
         let response = handle_escalate_op(&sandbox, &registry, release);
         match response {
             EscalateResponse::Ok(ok) => {
                 assert_eq!(ok.request_id, "req-2");
-                assert_eq!(ok.handle_id, handle_id);
+                assert_eq!(ok.handle_id, buffer_handle_id);
             }
             EscalateResponse::Err(err) => panic!("release_handle failed: {}", err.message),
         }
-        assert_eq!(registry.buffer_count(), 0);
+        assert_eq!(registry.handle_count(), 0);
 
         let release_unknown =
             EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {


### PR DESCRIPTION
## Summary

- Extend the polyglot escalate-on-behalf IPC with `acquire_texture`, mirroring `GpuContextFullAccess::acquire_texture(&TexturePoolDescriptor) -> PooledTextureHandle`.
- Unify `EscalateHandleRegistry` to hold both pixel buffers and pooled textures via `RegisteredHandle::{PixelBuffer, Texture}`; `release_handle` now drops the right resource type.
- Keep all three runtimes (Rust host, Python SDK, Deno SDK) in sync with the new wire shape, since jtd-codegen still lacks discriminator support.

## Closes

Closes #369

## Wire-format decisions

Flat record: `{request_id, width, height, format, usage}`.

- **`format`** — lowercase snake-case tokens (`rgba8_unorm`, `bgra8_unorm`, `rgba16_float`, `nv12`, etc.). Matches the existing pattern for `acquire_pixel_buffer`'s `format` field.
- **`usage`** — array of lowercase snake-case tokens (`copy_src`, `copy_dst`, `texture_binding`, `storage_binding`, `render_attachment`). Chose string-array over `uint32` bitmask so the wire stays uniformly strings-in / strings-out (consistent with `format`), is self-documenting in logs, and fails loudly on typos. Cost is ~36 extra wire bytes per request — trivial for a pool-setup-time call, not per-frame.
- **Omitted**: `dim`, `mip_levels`, `label`. Rust's `TexturePoolDescriptor` doesn't carry these today — the pool is hardcoded 2D / single mip / no runtime-meaningful label. Adding them to the wire without Rust support would silently drop caller intent. When the Rust struct grows (e.g. 2D-array textures for batched AI inference), the wire schema bumps to match in the same PR.
- **Texture handle IDs** — UUIDs (`Uuid::new_v4().to_string()`). Distinct from pixel-buffer handles, which continue to use `PixelBufferPoolId`.

## Exit criteria

- [x] `EscalateRequest::AcquireTexture { request_id, width, height, format, usage }` variant added.
- [x] `EscalateHandleRegistry` tracks `RegisteredHandle::{PixelBuffer, Texture}`; `remove_buffer` → `remove_handle`.
- [x] Python SDK: `EscalateChannel.acquire_texture(...)` + `escalate_acquire_texture(...)` on both `NativeRuntimeContextLimitedAccess` and `NativeRuntimeContextFullAccess`.
- [x] Deno SDK: `EscalateChannel.acquireTexture(...)` + `escalateAcquireTexture(...)` on `NativeProcessorState` + both runtime-context wrappers.
- [x] Schemas `com.streamlib.escalate_{request,response}@1.0.0.yaml` document the new discriminator arm.
- [x] Hand-authored Rust / Python / Deno types regenerated manually (jtd-codegen discriminator support still pending).

## Test plan

- [x] `cargo test -p streamlib --lib` — **164 passed, 0 failed, 2 ignored**. Includes:
  - `subprocess_escalate::tests::handle_escalate_op_end_to_end` (extended): acquires a pixel buffer and a 256×128 `rgba8_unorm` texture with `[texture_binding, copy_src]` usage, verifies distinct handle IDs, verifies release works for each independently, verifies registry count bookkeeping.
  - 4 new parser tests: `parse_texture_format_roundtrips_known_variants`, `parse_texture_usages_combines_tokens`, `parse_texture_usages_rejects_empty_and_unknown`, `texture_usages_to_wire_is_stable_order`.
- [x] Python smoke: round-trip `EscalateRequestAcquireTexture` / `EscalateResponseOk` through `from_json_data` / `to_json_data`; verifies usage array preservation and that `usage` stays `None` for pixel-buffer responses.
- [x] Deno smoke: `deno check libs/streamlib-deno/context.ts libs/streamlib-deno/escalate.ts libs/streamlib-deno/_generated_/*.ts` — **no new errors** vs `main` (7 pre-existing `Uint8Array<ArrayBufferLike>` FFI errors identical to main; unaffected by this PR).
- [x] `cargo check -p streamlib-python-native` — compiles clean.

E2E subprocess-host exercise (Python + Deno) is **intentionally out of scope** per the issue's *Out of scope* section — it rolls into #360 when that harness lands.

## Polyglot coverage

- **Runtimes affected**: all (rust + python + deno)
- **Schema regenerated**: n/a (jtd-codegen discriminator support pending; hand-edited in lockstep)
- **E2E tests run**:
  - [x] Host-Rust: `handle_escalate_op_end_to_end` — passes against real `GpuContext::init_for_platform_sync()`
  - [ ] Python subprocess: deferred to #360
  - [ ] Deno subprocess: deferred to #360
- **FD-passing path**: pool-ID only (Linux DMA-BUF FD passing is gated on #347)

## Follow-ups filed

Noticed during this work, filed as separate issues so they don't scope-creep this PR:

- #386 — Deno: resolve 7 pre-existing `Uint8Array` / `BufferSource` type errors in `context.ts`
- #387 — Rust 2024 forward-compat: wrap inner unsafe calls in explicit `unsafe { ... }` blocks (workspace-wide sweep)
- #388 — Python: `_generated_/__init__.py` imports `ApiServerConfig` but the file exports `APIServerConfig` (jtd-codegen name-mapping glitch)
- #389 — Python: jtd-codegen emits non-raw regex strings, triggers `SyntaxWarning: invalid escape sequence`
- #390 — Triage: dead stores in `linux/processors/camera.rs` (`timeline_signal_value`, `frame_sequence`) — possible leftover capability-rewrite scaffolding or missing timeline-semaphore wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)