### PR TITLE
fix(xtask): rewrite Python class names in jtd-codegen post-processor

### DIFF
--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_api_server_config.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_api_server_config.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional, Union, get_args, get_origin
 
 
 @dataclass
-class APIServerConfig:
+class ApiServerConfig:
     """
     Configuration for the runtime API server
     """
@@ -39,7 +39,7 @@ class APIServerConfig:
 
 
     @classmethod
-    def from_json_data(cls, data: Any) -> 'APIServerConfig':
+    def from_json_data(cls, data: Any) -> 'ApiServerConfig':
         return cls(
             _from_json_data(str, data.get("host")),
             _from_json_data(int, data.get("port")),

--- a/libs/streamlib-python/python/streamlib/_generated_/com_tatolab_mp4_writer_config.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_tatolab_mp4_writer_config.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional, Union, get_args, get_origin
 
 
 @dataclass
-class Mp4writerConfig:
+class Mp4WriterConfig:
     """
     Configuration for MP4 file writer processor
     """
@@ -49,7 +49,7 @@ class Mp4writerConfig:
 
 
     @classmethod
-    def from_json_data(cls, data: Any) -> 'Mp4writerConfig':
+    def from_json_data(cls, data: Any) -> 'Mp4WriterConfig':
         return cls(
             _from_json_data(str, data.get("output_path")),
             _from_json_data(Optional[int], data.get("audio_bitrate")),

--- a/xtask/src/generate_schemas.rs
+++ b/xtask/src/generate_schemas.rs
@@ -335,8 +335,8 @@ fn run_jtd_codegen_python(schema_files: &[PathBuf], output_dir: &Path) -> Result
             )
         })?;
 
-        // Post-process: add copyright header
-        let processed_code = post_process_python(&python_code);
+        // Post-process: add copyright header and enforce expected class name
+        let processed_code = post_process_python(&python_code, &class_name);
 
         let output_path = output_dir.join(format!("{}.py", module_name));
         fs::write(&output_path, &processed_code)
@@ -846,14 +846,74 @@ fn camel_to_snake(s: &str) -> String {
 }
 
 /// Post-process jtd-codegen Python output.
-fn post_process_python(code: &str) -> String {
+///
+/// jtd-codegen's Python backend ignores `--root-name` and runs its own
+/// acronym-upcasing pass on the schema name (`api_server` → `APIServerConfig`,
+/// `http_config` → `HTTPConfig`, etc.), so the root class name drifts from
+/// what the generator config expects and from the Rust/TypeScript outputs.
+/// Rewrite the root class name so every language ends up with the same
+/// symbol.
+fn post_process_python(code: &str, expected_class_name: &str) -> String {
+    let actual = find_python_root_class_name(code);
+    let rewritten = match actual {
+        Some(ref name) if name != expected_class_name => {
+            code.replace(name.as_str(), expected_class_name)
+        }
+        _ => code.to_string(),
+    };
+
     format!(
         "# Copyright (c) 2025 Jonathan Fontanez\n\
          # SPDX-License-Identifier: BUSL-1.1\n\
          #\n\
          # Generated from JTD schema using jtd-codegen. DO NOT EDIT.\n\n{}",
-        code
+        rewritten
     )
+}
+
+/// Return the name of the root class in a jtd-codegen Python file.
+///
+/// For discriminator schemas, jtd-codegen emits the parent class first and
+/// variants that inherit from it afterwards (`class Variant(Root):`) — the
+/// root is whichever local class is referenced as a parent of another.
+///
+/// For plain schemas with sub-types, jtd-codegen emits the sub-types first
+/// and the root last, so the last top-level class is the root.
+fn find_python_root_class_name(code: &str) -> Option<String> {
+    let mut classes: Vec<(String, Option<String>)> = Vec::new();
+    for line in code.lines() {
+        let Some(rest) = line.strip_prefix("class ") else {
+            continue;
+        };
+        let name_end = rest.find(|c: char| c == '(' || c == ':' || c == ' ');
+        let (name, parent) = match name_end {
+            Some(idx) if rest.as_bytes().get(idx) == Some(&b'(') => {
+                let name = rest[..idx].to_string();
+                let after = &rest[idx + 1..];
+                let parent = after
+                    .find(')')
+                    .map(|end| after[..end].trim().to_string())
+                    .filter(|p| !p.is_empty());
+                (name, parent)
+            }
+            Some(idx) => (rest[..idx].to_string(), None),
+            None => (rest.to_string(), None),
+        };
+        if !name.is_empty() {
+            classes.push((name, parent));
+        }
+    }
+
+    let local_names: std::collections::HashSet<&str> =
+        classes.iter().map(|(n, _)| n.as_str()).collect();
+    for (_, parent) in &classes {
+        if let Some(p) = parent {
+            if local_names.contains(p.as_str()) {
+                return Some(p.clone());
+            }
+        }
+    }
+    classes.last().map(|(n, _)| n.clone())
 }
 
 /// Post-process jtd-codegen TypeScript output.
@@ -969,6 +1029,65 @@ fn schema_name_to_struct_name(name: &str) -> String {
 fn schema_name_to_module_name(name: &str) -> String {
     let name = name.split('@').next().unwrap_or(name);
     name.replace('.', "_").to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_python_root_class_name_skips_imports() {
+        let code = "import re\nfrom dataclasses import dataclass\n\n\n@dataclass\nclass APIServerConfig:\n    host: 'str'\n";
+        assert_eq!(
+            find_python_root_class_name(code).as_deref(),
+            Some("APIServerConfig")
+        );
+    }
+
+    #[test]
+    fn find_python_root_class_name_picks_last_for_plain_multiclass() {
+        // jtd-codegen emits sub-types first and the root last for plain
+        // schemas that have nested variant enums (e.g. WebrtcWhepConfig).
+        let code = "class WebrtcWhepConfigWhep:\n    pass\nclass WebrtcWhepConfig:\n    pass\n";
+        assert_eq!(
+            find_python_root_class_name(code).as_deref(),
+            Some("WebrtcWhepConfig")
+        );
+    }
+
+    #[test]
+    fn find_python_root_class_name_picks_parent_for_discriminator() {
+        // For discriminator schemas the root is the parent class that
+        // variants inherit from.
+        let code = "class EscalateRequest:\n    pass\nclass EscalateRequestAcquirePixelBuffer(EscalateRequest):\n    pass\n";
+        assert_eq!(
+            find_python_root_class_name(code).as_deref(),
+            Some("EscalateRequest")
+        );
+    }
+
+    #[test]
+    fn find_python_root_class_name_none_when_no_class() {
+        assert_eq!(find_python_root_class_name("import re\n"), None);
+    }
+
+    #[test]
+    fn post_process_python_renames_upcased_acronym() {
+        let code = "@dataclass\nclass APIServerConfig:\n    @classmethod\n    def from_json_data(cls, data) -> 'APIServerConfig':\n        return cls()\n";
+        let out = post_process_python(code, "ApiServerConfig");
+        assert!(out.contains("class ApiServerConfig:"));
+        assert!(out.contains("-> 'ApiServerConfig':"));
+        assert!(!out.contains("APIServerConfig"));
+    }
+
+    #[test]
+    fn post_process_python_noop_when_names_match() {
+        let code = "class WebrtcWhepConfig:\n    pass\n";
+        let out = post_process_python(code, "WebrtcWhepConfig");
+        // Header added, body unchanged
+        assert!(out.contains("class WebrtcWhepConfig:"));
+        assert_eq!(out.matches("WebrtcWhepConfig").count(), 1);
+    }
 }
 
 /// Convert to PascalCase.


### PR DESCRIPTION
## Summary

- `jtd-codegen`'s Python backend ignores `--root-name` and independently mangles the schema name (`api_server` → `APIServerConfig` via an acronym upcaser, `mp4_writer` → `Mp4writerConfig` by not capitalizing after digits). The generated `__init__.py` still imports the canonical name xtask asked for, so `import streamlib._generated_` crashed with `ImportError` at package-init time.
- Teach `post_process_python` to detect the actual root class in the generated file (variant-parent for discriminator schemas, last class for plain schemas with sub-types) and rewrite every occurrence to match the expected name — the same stickiness trick the Rust post-processor already uses.
- Regenerate the two affected Python files.

## Closes

Closes #388

## Exit criteria

- [x] `python3 -c "from streamlib._generated_ import ApiServerConfig"` succeeds with no `ImportError`
- [x] `__init__.py` and every `.py` class file agree on the root name — verified across all 21 generated modules, not just `api_server_config`
- [x] Canonical naming matches the Rust side: `ApiServerConfig`, `Mp4WriterConfig`
- [x] Fix lives in the xtask post-processor (`post_process_python`), not a one-off file patch — re-running the generator produces byte-identical output

## Test plan

- [x] `cargo test -p xtask` — 6 tests pass (2 new for `post_process_python`, 3 new for `find_python_root_class_name`, 1 noop case)
- [x] `cargo check --workspace` — clean
- [x] `python3 -c "import streamlib._generated_"` — package init succeeds (the exact test the issue called for as a CI gate)
- [x] `python3 -c "from streamlib._generated_ import ApiServerConfig, EscalateRequest, EscalateResponse, Mp4WriterConfig, Videoframe, Audioframe, CameraConfig, DisplayConfig"` — all named imports resolve
- [x] Roundtrip `ApiServerConfig.to_json_data()` / `ApiServerConfig.from_json_data(...)` — preserves equality
- [x] Re-run `cargo xtask generate-schemas --runtime python --schema-file <each>` against a temp dir and `diff` against the committed files — no diff (stickiness)

## Polyglot coverage

- **Runtimes affected**: python (+ xtask post-processor)
- **Schema regenerated**: n/a — no schema changes, only Python output affected
- **E2E tests run**:
  - [x] Host-Rust: `cargo check --workspace` clean; no Rust side changes needed (post_process_rust already handles this class of bug)
  - [x] Python subprocess: package-init import test (`python3 -c "import streamlib._generated_"`) — the exact gate the issue called for
  - [ ] Deno subprocess: n/a — Deno's `_generated_/` uses `export *` re-exports, so the latent `Mp4writerConfig` casing issue there doesn't currently break imports (follow-up below)
- **FD-passing path**: n/a

## Follow-ups

- TS/Deno post-processor has the analogous gap — `libs/streamlib-deno/_generated_/com_tatolab_mp4_writer_config.ts` exports `Mp4writerConfig` instead of the canonical `Mp4WriterConfig`. Latent today (TS barrel file uses `export *`) but will bite anyone importing by name. Will file as a separate issue.
- Issue #389 (`SyntaxWarning: invalid escape sequence '\d'`) is untouched and remains a known follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)