### PR TITLE
fix(#386): deno type errors + propagate max_payload_bytes to subprocess read buffers

### DIFF
--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -224,16 +224,16 @@ export class NativeRuntimeContextFullAccess implements RuntimeContextFullAccess 
 class NativeInputPorts implements InputPorts {
   private lib: NativeLib;
   private ctxPtr: Deno.PointerObject;
-  private readBuf: Uint8Array;
-  private outLen: Uint32Array;
-  private outTs: BigInt64Array;
+  private readBuf: Uint8Array<ArrayBuffer>;
+  private outLen: Uint32Array<ArrayBuffer>;
+  private outTs: BigInt64Array<ArrayBuffer>;
 
   constructor(lib: NativeLib, ctxPtr: Deno.PointerObject) {
     this.lib = lib;
     this.ctxPtr = ctxPtr;
-    this.readBuf = new Uint8Array(MAX_PAYLOAD_SIZE);
-    this.outLen = new Uint32Array(1);
-    this.outTs = new BigInt64Array(1);
+    this.readBuf = new Uint8Array(new ArrayBuffer(MAX_PAYLOAD_SIZE));
+    this.outLen = new Uint32Array(new ArrayBuffer(4));
+    this.outTs = new BigInt64Array(new ArrayBuffer(8));
   }
 
   read<T = unknown>(
@@ -245,7 +245,9 @@ class NativeInputPorts implements InputPorts {
     return { value, timestampNs: raw.timestampNs };
   }
 
-  readRaw(portName: string): { data: Uint8Array; timestampNs: bigint } | null {
+  readRaw(
+    portName: string,
+  ): { data: Uint8Array<ArrayBuffer>; timestampNs: bigint } | null {
     const portNameBuf = cString(portName);
     const outLenPtr = Deno.UnsafePointer.of(this.outLen);
     const outTsPtr = Deno.UnsafePointer.of(this.outTs);
@@ -265,7 +267,7 @@ class NativeInputPorts implements InputPorts {
     }
 
     const len = this.outLen[0];
-    const data = new Uint8Array(len);
+    const data = new Uint8Array(new ArrayBuffer(len));
     data.set(this.readBuf.subarray(0, len));
     return { data, timestampNs: this.outTs[0] };
   }
@@ -284,11 +286,17 @@ class NativeOutputPorts implements OutputPorts {
   }
 
   write(portName: string, value: unknown, timestampNs: bigint): void {
-    const data = msgpack.encode(value);
-    this.writeRaw(portName, new Uint8Array(data), timestampNs);
+    const encoded = msgpack.encode(value);
+    const buf = new Uint8Array(new ArrayBuffer(encoded.byteLength));
+    buf.set(encoded);
+    this.writeRaw(portName, buf, timestampNs);
   }
 
-  writeRaw(portName: string, data: Uint8Array, timestampNs: bigint): void {
+  writeRaw(
+    portName: string,
+    data: Uint8Array<ArrayBuffer>,
+    timestampNs: bigint,
+  ): void {
     const portNameBuf = cString(portName);
     const dataPtr = Deno.UnsafePointer.of(data);
 

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -26,7 +26,59 @@ import type {
   RuntimeContextLimitedAccess,
 } from "./types.ts";
 
-const MAX_PAYLOAD_SIZE = 32768;
+/**
+ * Default read-buffer capacity when the host sends no per-input
+ * `max_payload_bytes`. Matches Rust's `streamlib_ipc_types::MAX_PAYLOAD_SIZE`.
+ */
+export const DEFAULT_READ_BUF_BYTES = 65536;
+
+/**
+ * Size the input read buffer to the largest per-port `max_payload_bytes` the
+ * host declared, with [`DEFAULT_READ_BUF_BYTES`] as a floor. A fixed smaller
+ * buffer silently truncates payloads larger than it — including encoded video
+ * frames, which can be arbitrarily large depending on how the schema is
+ * configured.
+ */
+export function computeReadBufBytes(
+  inputs: readonly { max_payload_bytes?: number }[],
+): number {
+  return inputs.reduce(
+    (acc, port) => Math.max(acc, port.max_payload_bytes ?? 0),
+    DEFAULT_READ_BUF_BYTES,
+  );
+}
+
+/**
+ * Build the return value of a single FFI read given the output-parameter state
+ * after `sldn_input_read` has populated it. Extracted for testing so the
+ * empty / happy / truncated branches can be exercised without spinning up
+ * iceoryx2.
+ *
+ * Returns `null` when the read produced no data or when the payload the native
+ * side reported exceeds the caller's read buffer (truncation). Otherwise
+ * returns an owned copy of the first `outLen[0]` bytes of `readBuf`.
+ */
+export function decodeReadResult(
+  readBuf: Uint8Array<ArrayBuffer>,
+  outLen: Uint32Array<ArrayBuffer>,
+  outTs: BigInt64Array<ArrayBuffer>,
+  readBufBytes: number,
+  portName: string,
+): { data: Uint8Array<ArrayBuffer>; timestampNs: bigint } | null {
+  if (outLen[0] === 0) {
+    return null;
+  }
+  const len = outLen[0];
+  if (len > readBufBytes) {
+    console.error(
+      `[streamlib-deno] payload truncated on port '${portName}': native reported ${len} bytes but read buffer is ${readBufBytes}`,
+    );
+    return null;
+  }
+  const data = new Uint8Array(new ArrayBuffer(len));
+  data.set(readBuf.subarray(0, len));
+  return { data, timestampNs: outTs[0] };
+}
 
 /**
  * Shared FFI-backed state reused by both capability views for a single
@@ -50,12 +102,13 @@ export class NativeProcessorState {
     config: Record<string, unknown>,
     brokerPtr: Deno.PointerObject | null = null,
     escalate: EscalateChannel | null = null,
+    readBufBytes: number = DEFAULT_READ_BUF_BYTES,
   ) {
     this.lib = lib;
     this.ctxPtr = ctxPtr;
     this.config = config;
     this.brokerPtr = brokerPtr;
-    this.inputs = new NativeInputPorts(lib, ctxPtr);
+    this.inputs = new NativeInputPorts(lib, ctxPtr, readBufBytes);
     this.outputs = new NativeOutputPorts(lib, ctxPtr);
     this.escalate = escalate;
   }
@@ -225,13 +278,15 @@ class NativeInputPorts implements InputPorts {
   private lib: NativeLib;
   private ctxPtr: Deno.PointerObject;
   private readBuf: Uint8Array<ArrayBuffer>;
+  private readBufBytes: number;
   private outLen: Uint32Array<ArrayBuffer>;
   private outTs: BigInt64Array<ArrayBuffer>;
 
-  constructor(lib: NativeLib, ctxPtr: Deno.PointerObject) {
+  constructor(lib: NativeLib, ctxPtr: Deno.PointerObject, readBufBytes: number) {
     this.lib = lib;
     this.ctxPtr = ctxPtr;
-    this.readBuf = new Uint8Array(new ArrayBuffer(MAX_PAYLOAD_SIZE));
+    this.readBufBytes = readBufBytes;
+    this.readBuf = new Uint8Array(new ArrayBuffer(readBufBytes));
     this.outLen = new Uint32Array(new ArrayBuffer(4));
     this.outTs = new BigInt64Array(new ArrayBuffer(8));
   }
@@ -257,19 +312,21 @@ class NativeInputPorts implements InputPorts {
       this.ctxPtr,
       portNameBuf,
       readBufPtr!,
-      MAX_PAYLOAD_SIZE,
+      this.readBufBytes,
       outLenPtr!,
       outTsPtr!,
     );
 
-    if (result !== 0 || this.outLen[0] === 0) {
+    if (result !== 0) {
       return null;
     }
-
-    const len = this.outLen[0];
-    const data = new Uint8Array(new ArrayBuffer(len));
-    data.set(this.readBuf.subarray(0, len));
-    return { data, timestampNs: this.outTs[0] };
+    return decodeReadResult(
+      this.readBuf,
+      this.outLen,
+      this.outTs,
+      this.readBufBytes,
+      portName,
+    );
   }
 }
 

--- a/libs/streamlib-deno/context_test.ts
+++ b/libs/streamlib-deno/context_test.ts
@@ -1,0 +1,324 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for buffer-sizing + truncation-detection logic.
+ *
+ * These cover every branch of the read-path size check:
+ *
+ *   A) `computeReadBufBytes` — picks the largest declared input size with a
+ *      default floor. Happy paths for every kind of input shape a host might
+ *      emit (empty, missing field, below default, above default, multiple).
+ *
+ *   B) `decodeReadResult` — the pure post-FFI decode step. Runs the full
+ *      matrix of (data_len, read_buf_bytes) cases to confirm:
+ *        - Zero-length reads return null without logging.
+ *        - Reads where `data_len <= read_buf_bytes` return the first
+ *          `data_len` bytes of the buffer exactly, with the reported
+ *          timestamp.
+ *        - Reads where `data_len > read_buf_bytes` (the truncation case the
+ *          pre-fix 32 KB hard-coded buffer triggered) return null and log a
+ *          descriptive error.
+ *
+ * The iceoryx2 / FFI wire itself is covered by the Rust integration test
+ * `test_frame_header_plus_256kb_roundtrip_through_slice_service`; this suite
+ * is deliberately pure so it runs without spawning a subprocess or loading
+ * the cdylib.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  computeReadBufBytes,
+  decodeReadResult,
+  DEFAULT_READ_BUF_BYTES,
+} from "./context.ts";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build the scratch state `NativeInputPorts` owns: a read buffer, a one-slot
+ * Uint32Array for the reported length, and a one-slot BigInt64Array for the
+ * timestamp. Simulates an FFI read completing by writing `data` into the
+ * first `data.length` bytes of the buffer and populating the length/timestamp
+ * the way `sldn_input_read` does — including reporting the original
+ * (pre-truncation) length when `data` is larger than `readBufBytes`.
+ */
+function makeFfiResult(
+  readBufBytes: number,
+  data: Uint8Array,
+  timestampNs: bigint,
+): {
+  readBuf: Uint8Array<ArrayBuffer>;
+  outLen: Uint32Array<ArrayBuffer>;
+  outTs: BigInt64Array<ArrayBuffer>;
+} {
+  const readBuf = new Uint8Array(new ArrayBuffer(readBufBytes));
+  // Native does `copy_nonoverlapping(data, out_buf, min(data.len, buf_len))`.
+  const copyLen = Math.min(data.length, readBufBytes);
+  readBuf.set(data.subarray(0, copyLen));
+  const outLen = new Uint32Array(new ArrayBuffer(4));
+  // Native writes the original data.len, not copyLen — that's what makes the
+  // `data_len > read_buf_bytes` branch observable to the caller.
+  outLen[0] = data.length;
+  const outTs = new BigInt64Array(new ArrayBuffer(8));
+  outTs[0] = timestampNs;
+  return { readBuf, outLen, outTs };
+}
+
+/** Build a `data_len`-byte buffer with a deterministic, non-trivial pattern. */
+function patternBytes(size: number): Uint8Array {
+  const out = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    out[i] = i % 251; // prime modulus — non-trivial, easy to regenerate
+  }
+  return out;
+}
+
+/**
+ * Capture stderr writes for the duration of `fn` so we can assert that
+ * truncation paths log without polluting the test runner output.
+ */
+function withStderrCapture(fn: () => void): string {
+  const buffered: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    buffered.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.error = original;
+  }
+  return buffered.join("\n");
+}
+
+// ============================================================================
+// A) computeReadBufBytes — host-declared size derivation
+// ============================================================================
+
+Deno.test("computeReadBufBytes: no inputs returns default floor", () => {
+  assertEquals(computeReadBufBytes([]), DEFAULT_READ_BUF_BYTES);
+});
+
+Deno.test("computeReadBufBytes: input missing max_payload_bytes falls back to default", () => {
+  assertEquals(
+    computeReadBufBytes([{}]),
+    DEFAULT_READ_BUF_BYTES,
+  );
+});
+
+Deno.test("computeReadBufBytes: declared size below default clamps up to default", () => {
+  // A schema may legitimately declare something small (say 16 KB for an
+  // audio-only port). We still ceiling the buffer at the default so shared
+  // code paths have a consistent minimum.
+  const smallSize = 16 * 1024;
+  assert(smallSize < DEFAULT_READ_BUF_BYTES);
+  assertEquals(
+    computeReadBufBytes([{ max_payload_bytes: smallSize }]),
+    DEFAULT_READ_BUF_BYTES,
+  );
+});
+
+Deno.test("computeReadBufBytes: declared size equal to default returns default", () => {
+  assertEquals(
+    computeReadBufBytes([{ max_payload_bytes: DEFAULT_READ_BUF_BYTES }]),
+    DEFAULT_READ_BUF_BYTES,
+  );
+});
+
+Deno.test("computeReadBufBytes: declared size above default wins", () => {
+  const oneMb = 1 * 1024 * 1024;
+  assertEquals(
+    computeReadBufBytes([{ max_payload_bytes: oneMb }]),
+    oneMb,
+  );
+});
+
+Deno.test("computeReadBufBytes: multi-input picks the max across ports", () => {
+  const small = 16 * 1024;
+  const medium = 128 * 1024;
+  const large = 512 * 1024;
+  assertEquals(
+    computeReadBufBytes([
+      { max_payload_bytes: small },
+      {},
+      { max_payload_bytes: medium },
+      { max_payload_bytes: large },
+    ]),
+    large,
+  );
+});
+
+Deno.test("computeReadBufBytes: multi-input all below default clamps to default", () => {
+  assertEquals(
+    computeReadBufBytes([
+      { max_payload_bytes: 1024 },
+      { max_payload_bytes: 8192 },
+      { max_payload_bytes: 16384 },
+    ]),
+    DEFAULT_READ_BUF_BYTES,
+  );
+});
+
+// ============================================================================
+// B) decodeReadResult — post-FFI decode matrix
+// ============================================================================
+
+Deno.test("decodeReadResult: zero-length read returns null without logging", () => {
+  const { readBuf, outLen, outTs } = makeFfiResult(
+    DEFAULT_READ_BUF_BYTES,
+    new Uint8Array(0),
+    123n,
+  );
+  const log = withStderrCapture(() => {
+    const result = decodeReadResult(
+      readBuf,
+      outLen,
+      outTs,
+      DEFAULT_READ_BUF_BYTES,
+      "port_a",
+    );
+    assertEquals(result, null);
+  });
+  assertEquals(log, "");
+});
+
+// Happy paths — parameterize over a matrix of (read_buf_bytes, data_len)
+// chosen to exercise several boundary conditions:
+//
+//   - 1 KB data in a default-sized buffer          (tiny payload, default buf)
+//   - 32 KB data in a default-sized buffer         (former hard-coded limit; must still work)
+//   - 32 KB + 1 byte data in a default-sized buffer (proves old cap is gone)
+//   - `DEFAULT_READ_BUF_BYTES` exactly in a default buffer  (boundary)
+//   - 256 KB data in a 1 MB buffer                 (grown buffer via schema)
+//   - 1 MB data in a 1 MB buffer                   (exact fit at the top end)
+const happyPathMatrix: {
+  label: string;
+  readBufBytes: number;
+  dataLen: number;
+}[] = [
+  {
+    label: "1 KB data in default-sized buffer",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: 1024,
+  },
+  {
+    label: "32 KB data in default-sized buffer",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: 32 * 1024,
+  },
+  {
+    label: "32 KB + 1 B in default-sized buffer",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: 32 * 1024 + 1,
+  },
+  {
+    label: "exact-default in default-sized buffer",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: DEFAULT_READ_BUF_BYTES,
+  },
+  {
+    label: "256 KB data in 1 MB buffer",
+    readBufBytes: 1024 * 1024,
+    dataLen: 256 * 1024,
+  },
+  {
+    label: "1 MB data in 1 MB buffer (exact fit)",
+    readBufBytes: 1024 * 1024,
+    dataLen: 1024 * 1024,
+  },
+];
+
+for (const { label, readBufBytes, dataLen } of happyPathMatrix) {
+  Deno.test(`decodeReadResult: happy path — ${label}`, () => {
+    const data = patternBytes(dataLen);
+    const ts = BigInt(dataLen) * 1000n;
+    const { readBuf, outLen, outTs } = makeFfiResult(readBufBytes, data, ts);
+
+    const log = withStderrCapture(() => {
+      const result = decodeReadResult(
+        readBuf,
+        outLen,
+        outTs,
+        readBufBytes,
+        "happy_port",
+      );
+      assert(result !== null, "happy-path read must return a value");
+      assertEquals(result.data.length, dataLen);
+      assertEquals(
+        result.data,
+        data,
+        "decoded bytes should match source payload byte-for-byte",
+      );
+      assertEquals(result.timestampNs, ts);
+      // The returned buffer must be an independent allocation so mutating the
+      // scratch readBuf afterwards can't corrupt it.
+      assert(
+        result.data.buffer !== readBuf.buffer,
+        "returned Uint8Array should own its own ArrayBuffer",
+      );
+    });
+    assertEquals(log, "", "happy path must not log truncation warnings");
+  });
+}
+
+// Truncation paths — native reported more bytes than the read buffer can hold.
+// This is the exact shape the pre-fix 32 KB hard-coded buffer triggered when
+// a publisher sent encoded-video-sized frames.
+const truncationMatrix: {
+  label: string;
+  readBufBytes: number;
+  dataLen: number;
+}[] = [
+  {
+    label: "1 B over default",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: DEFAULT_READ_BUF_BYTES + 1,
+  },
+  {
+    label: "old 32 KB buffer vs 65 KB payload",
+    readBufBytes: 32 * 1024,
+    dataLen: DEFAULT_READ_BUF_BYTES,
+  },
+  {
+    label: "256 KB payload in default 64 KB buffer",
+    readBufBytes: DEFAULT_READ_BUF_BYTES,
+    dataLen: 256 * 1024,
+  },
+  {
+    label: "1 MB payload in 512 KB buffer",
+    readBufBytes: 512 * 1024,
+    dataLen: 1024 * 1024,
+  },
+];
+
+for (const { label, readBufBytes, dataLen } of truncationMatrix) {
+  Deno.test(`decodeReadResult: truncation — ${label}`, () => {
+    const data = patternBytes(dataLen);
+    const { readBuf, outLen, outTs } = makeFfiResult(readBufBytes, data, 42n);
+
+    const log = withStderrCapture(() => {
+      const result = decodeReadResult(
+        readBuf,
+        outLen,
+        outTs,
+        readBufBytes,
+        "truncated_port",
+      );
+      assertEquals(
+        result,
+        null,
+        "truncation must surface as null, not a short/corrupt payload",
+      );
+    });
+    assertStringIncludes(
+      log,
+      "payload truncated on port 'truncated_port'",
+      "truncation must log a descriptive error identifying the port",
+    );
+    assertStringIncludes(log, String(dataLen));
+    assertStringIncludes(log, String(readBufBytes));
+  });
+}

--- a/libs/streamlib-deno/deno.json
+++ b/libs/streamlib-deno/deno.json
@@ -3,7 +3,8 @@
   "version": "0.3.0",
   "exports": "./mod.ts",
   "imports": {
-    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2",
+    "@std/assert": "jsr:@std/assert@^1.0.19"
   },
   "compilerOptions": {
     "strict": true

--- a/libs/streamlib-deno/deno.lock
+++ b/libs/streamlib-deno/deno.lock
@@ -1,8 +1,22 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
     "npm:@msgpack/msgpack@3.0.0-beta2": "3.0.0-beta2",
     "npm:typegpu@0.8.2": "0.8.2"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    }
   },
   "npm": {
     "@msgpack/msgpack@3.0.0-beta2": {
@@ -25,6 +39,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@std/assert@^1.0.19",
       "npm:@msgpack/msgpack@3.0.0-beta2"
     ]
   }

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -124,10 +124,10 @@ export function loadNativeLib(path: string): NativeLib {
 /**
  * Encode a string to a null-terminated UTF-8 buffer.
  */
-export function cString(str: string): Uint8Array {
+export function cString(str: string): Uint8Array<ArrayBuffer> {
   const encoder = new TextEncoder();
   const encoded = encoder.encode(str);
-  const buf = new Uint8Array(encoded.length + 1);
+  const buf = new Uint8Array(new ArrayBuffer(encoded.length + 1));
   buf.set(encoded);
   buf[encoded.length] = 0; // null terminator
   return buf;

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -17,6 +17,7 @@
 
 import { cString, loadNativeLib, type NativeLib } from "./native.ts";
 import {
+  computeReadBufBytes,
   NativeProcessorState,
   NativeRuntimeContextFullAccess,
   NativeRuntimeContextLimitedAccess,
@@ -184,8 +185,19 @@ async function main(): Promise<void> {
           assertCapability(processorId, cmd, msg, "full");
           const config = (msg.config as Record<string, unknown>) ?? {};
           const ports = (msg.ports as {
-            inputs?: { name: string; service_name: string; read_mode?: string }[];
-            outputs?: { name: string; dest_port: string; dest_service_name: string; schema_name: string }[];
+            inputs?: {
+              name: string;
+              service_name: string;
+              read_mode?: string;
+              max_payload_bytes?: number;
+            }[];
+            outputs?: {
+              name: string;
+              dest_port: string;
+              dest_service_name: string;
+              schema_name: string;
+              max_payload_bytes?: number;
+            }[];
           }) ?? { inputs: [], outputs: [] };
 
           // Subscribe to input iceoryx2 services
@@ -193,7 +205,7 @@ async function main(): Promise<void> {
           for (const input of inputPorts) {
             const readMode = input.read_mode ?? "skip_to_latest";
             console.error(
-              `[subprocess_runner:${processorId}] Subscribing to input: port='${input.name}', service='${input.service_name}', read_mode='${readMode}'`,
+              `[subprocess_runner:${processorId}] Subscribing to input: port='${input.name}', service='${input.service_name}', read_mode='${readMode}', max_payload_bytes=${input.max_payload_bytes ?? "default"}`,
             );
             const result = lib.symbols.sldn_input_subscribe(
               ctxPtr,
@@ -257,6 +269,8 @@ async function main(): Promise<void> {
               processor = ProcessorClass as ProcessorLifecycle;
             }
 
+            const readBufBytes = computeReadBufBytes(inputPorts);
+
             // Build shared FFI state and the two capability views once per
             // lifecycle. Each view wraps the same underlying FFI ctx, so
             // input/output ports and timing are shared; the capability split
@@ -267,6 +281,7 @@ async function main(): Promise<void> {
               config,
               brokerPtr,
               escalateChannel,
+              readBufBytes,
             );
             fullCtx = new NativeRuntimeContextFullAccess(state);
             limitedCtx = new NativeRuntimeContextLimitedAccess(state);

--- a/libs/streamlib-deno/types.ts
+++ b/libs/streamlib-deno/types.ts
@@ -9,7 +9,9 @@ export interface InputPorts {
   read<T = unknown>(portName: string): { value: T; timestampNs: bigint } | null;
 
   /** Read raw msgpack-encoded bytes from a port. Returns null if no data available. */
-  readRaw(portName: string): { data: Uint8Array; timestampNs: bigint } | null;
+  readRaw(
+    portName: string,
+  ): { data: Uint8Array<ArrayBuffer>; timestampNs: bigint } | null;
 }
 
 /**
@@ -20,7 +22,11 @@ export interface OutputPorts {
   write(portName: string, value: unknown, timestampNs: bigint): void;
 
   /** Write raw bytes to a port. */
-  writeRaw(portName: string, data: Uint8Array, timestampNs: bigint): void;
+  writeRaw(
+    portName: string,
+    data: Uint8Array<ArrayBuffer>,
+    timestampNs: bigint,
+  ): void;
 }
 
 /**

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -62,7 +62,48 @@ def bridge_send_message(stdout, msg):
 # ============================================================================
 
 
-MAX_PAYLOAD_SIZE = 32768
+#: Default read-buffer capacity when the host sends no per-input
+#: ``max_payload_bytes``. Matches Rust's ``streamlib_ipc_types::MAX_PAYLOAD_SIZE``.
+DEFAULT_READ_BUF_BYTES = 65536
+
+
+def compute_read_buf_bytes(inputs) -> int:
+    """Size the input read buffer to the largest per-port ``max_payload_bytes``
+    the host declared, floored at :data:`DEFAULT_READ_BUF_BYTES`.
+
+    A fixed smaller buffer silently truncates payloads larger than it —
+    including encoded video frames, which can be arbitrarily large depending
+    on how the schema is configured.
+    """
+    declared = [
+        inp.get("max_payload_bytes") or 0
+        for inp in inputs
+    ]
+    return max(DEFAULT_READ_BUF_BYTES, *declared) if declared else DEFAULT_READ_BUF_BYTES
+
+
+def decode_read_result(read_buf, read_buf_bytes: int, data_len: int, timestamp_ns: int, port_name: str):
+    """Build the return value of a single FFI read given the output state
+    ``slpn_input_read`` populated.
+
+    Returns ``(bytes, timestamp_ns)`` for a valid read, ``(None, None)`` when
+    the read produced no data or when the native side reported more bytes than
+    the read buffer can hold (truncation). Extracted for testing so the empty
+    / happy / truncated branches can be exercised without spinning up iceoryx2.
+    """
+    if data_len == 0:
+        return None, None
+    if data_len > read_buf_bytes:
+        import sys
+
+        print(
+            f"[streamlib-python] payload truncated on port '{port_name}': "
+            f"native reported {data_len} bytes but read buffer is "
+            f"{read_buf_bytes}",
+            file=sys.stderr,
+        )
+        return None, None
+    return bytes(read_buf[:data_len]), timestamp_ns
 
 
 def load_native_lib(lib_path):
@@ -155,50 +196,52 @@ def load_native_lib(lib_path):
 class NativeInputs:
     """Input ports backed by iceoryx2 subscribers via FFI."""
 
-    def __init__(self, lib, ctx_ptr):
+    def __init__(self, lib, ctx_ptr, read_buf_bytes: int = DEFAULT_READ_BUF_BYTES):
         import ctypes
 
         self._lib = lib
         self._ctx_ptr = ctx_ptr
-        self._read_buf = (ctypes.c_uint8 * MAX_PAYLOAD_SIZE)()
+        self._read_buf_bytes = read_buf_bytes
+        self._read_buf = (ctypes.c_uint8 * read_buf_bytes)()
         self._out_len = ctypes.c_uint32(0)
         self._out_ts = ctypes.c_int64(0)
 
-    def read(self, port_name):
-        """Read latest data from a port. Returns deserialized msgpack data or None."""
+    def _read_raw(self, port_name):
+        """Call into FFI and return ``(data_bytes, timestamp_ns)`` or
+        ``(None, None)``. Logs on truncation."""
         import ctypes
 
         result = self._lib.slpn_input_read(
             self._ctx_ptr,
             port_name.encode("utf-8"),
             ctypes.cast(self._read_buf, ctypes.c_void_p),
-            MAX_PAYLOAD_SIZE,
+            self._read_buf_bytes,
             ctypes.byref(self._out_len),
             ctypes.byref(self._out_ts),
         )
-        if result != 0 or self._out_len.value == 0:
+        if result != 0:
+            return None, None
+        return decode_read_result(
+            self._read_buf,
+            self._read_buf_bytes,
+            self._out_len.value,
+            self._out_ts.value,
+            port_name,
+        )
+
+    def read(self, port_name):
+        """Read latest data from a port. Returns deserialized msgpack data or None."""
+        raw, _ = self._read_raw(port_name)
+        if raw is None:
             return None
-        data_len = self._out_len.value
-        raw = bytes(self._read_buf[:data_len])
         return msgpack.unpackb(raw, raw=False)
 
     def read_with_timestamp(self, port_name):
         """Read latest data and timestamp. Returns (data, timestamp_ns) or (None, None)."""
-        import ctypes
-
-        result = self._lib.slpn_input_read(
-            self._ctx_ptr,
-            port_name.encode("utf-8"),
-            ctypes.cast(self._read_buf, ctypes.c_void_p),
-            MAX_PAYLOAD_SIZE,
-            ctypes.byref(self._out_len),
-            ctypes.byref(self._out_ts),
-        )
-        if result != 0 or self._out_len.value == 0:
+        raw, ts = self._read_raw(port_name)
+        if raw is None:
             return None, None
-        data_len = self._out_len.value
-        raw = bytes(self._read_buf[:data_len])
-        return msgpack.unpackb(raw, raw=False), self._out_ts.value
+        return msgpack.unpackb(raw, raw=False), ts
 
 
 class NativeOutputs:
@@ -439,13 +482,14 @@ class NativeProcessorState:
         config: Optional[Dict[str, Any]],
         broker_ptr=None,
         escalate_channel: "Optional[EscalateChannel]" = None,
+        read_buf_bytes: int = DEFAULT_READ_BUF_BYTES,
     ) -> None:
         self._lib = lib
         self._ctx_ptr = ctx_ptr
         self._config = config or {}
         self._broker_ptr = broker_ptr
         self._escalate_channel = escalate_channel
-        self.inputs = NativeInputs(lib, ctx_ptr)
+        self.inputs = NativeInputs(lib, ctx_ptr, read_buf_bytes=read_buf_bytes)
         self.outputs = NativeOutputs(lib, ctx_ptr)
         # One instance of each GPU view shared across per-call context
         # wrappers so pool state and handle lifetimes are stable across

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -34,6 +34,7 @@ from .processor_context import (
     NativeRuntimeContextLimitedAccess,
     bridge_read_message,
     bridge_send_message,
+    compute_read_buf_bytes,
     load_native_lib,
 )
 from .telemetry import setup_subprocess_telemetry
@@ -65,13 +66,15 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
         raise RuntimeError("Failed to create native context")
 
     # Subscribe to input iceoryx2 services
-    for inp in ports.get("inputs", []):
+    inputs = ports.get("inputs", [])
+    read_buf_bytes = compute_read_buf_bytes(inputs)
+    for inp in inputs:
         port_name = inp["name"]
         service_name = inp["service_name"]
         read_mode = inp.get("read_mode", "skip_to_latest")
         _logger.info(
-            "Subscribing to input: port='%s', service='%s', read_mode='%s'",
-            port_name, service_name, read_mode,
+            "Subscribing to input: port='%s', service='%s', read_mode='%s', max_payload_bytes=%s",
+            port_name, service_name, read_mode, inp.get("max_payload_bytes"),
         )
         result = lib.slpn_input_subscribe(ctx_ptr, service_name.encode("utf-8"))
         if result != 0:
@@ -121,7 +124,9 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
             )
 
     state = NativeProcessorState(
-        lib, ctx_ptr, config, broker_ptr, escalate_channel=escalate_channel,
+        lib, ctx_ptr, config, broker_ptr,
+        escalate_channel=escalate_channel,
+        read_buf_bytes=read_buf_bytes,
     )
     return lib, ctx_ptr, broker_ptr, state
 

--- a/libs/streamlib-python/python/streamlib/tests/__init__.py
+++ b/libs/streamlib-python/python/streamlib/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1

--- a/libs/streamlib-python/python/streamlib/tests/test_payload_sizing.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_payload_sizing.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Unit tests for buffer-sizing + truncation-detection logic.
+
+These cover every branch of the read-path size check:
+
+  A) ``compute_read_buf_bytes`` — picks the largest declared input size with
+     a default floor. Happy paths for every kind of input shape a host might
+     emit (empty, missing field, below default, above default, multiple).
+
+  B) ``decode_read_result`` — the pure post-FFI decode step. Runs the full
+     matrix of (data_len, read_buf_bytes) cases to confirm:
+
+     - Zero-length reads return ``(None, None)`` without logging.
+     - Reads where ``data_len <= read_buf_bytes`` return the first
+       ``data_len`` bytes of the buffer exactly, with the reported
+       timestamp.
+     - Reads where ``data_len > read_buf_bytes`` (the truncation case the
+       pre-fix 32 KB hard-coded buffer triggered) return
+       ``(None, None)`` and log a descriptive error.
+
+The iceoryx2 / FFI wire itself is covered by the Rust integration test
+``test_frame_header_plus_256kb_roundtrip_through_slice_service``; this suite
+is deliberately pure so it runs without spawning a subprocess or loading
+the cdylib.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+
+import pytest
+
+from streamlib.processor_context import (
+    DEFAULT_READ_BUF_BYTES,
+    compute_read_buf_bytes,
+    decode_read_result,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def make_ffi_result(read_buf_bytes: int, data: bytes):
+    """Build the scratch state ``NativeInputs`` owns and simulate an FFI read
+    completing: copy ``data`` into the first ``min(len(data), read_buf_bytes)``
+    bytes of the buffer and return the reported data length.
+
+    Mirrors what ``slpn_input_read`` does: it reports the ORIGINAL payload
+    length even when ``len(data) > read_buf_bytes``, leaving the caller to
+    detect truncation.
+    """
+    read_buf = (ctypes.c_uint8 * read_buf_bytes)()
+    copy_len = min(len(data), read_buf_bytes)
+    ctypes.memmove(read_buf, data, copy_len)
+    return read_buf, len(data)
+
+
+def pattern_bytes(size: int) -> bytes:
+    """Return a ``size``-byte buffer with a deterministic, non-trivial pattern."""
+    return bytes(i % 251 for i in range(size))  # prime modulus
+
+
+# ============================================================================
+# A) compute_read_buf_bytes — host-declared size derivation
+# ============================================================================
+
+
+def test_compute_read_buf_bytes_no_inputs_returns_default():
+    assert compute_read_buf_bytes([]) == DEFAULT_READ_BUF_BYTES
+
+
+def test_compute_read_buf_bytes_missing_field_falls_back_to_default():
+    assert compute_read_buf_bytes([{}]) == DEFAULT_READ_BUF_BYTES
+
+
+def test_compute_read_buf_bytes_declared_below_default_clamps_up():
+    # A schema may legitimately declare something small (say 16 KB for an
+    # audio-only port). We still ceiling the buffer at the default so shared
+    # code paths have a consistent minimum.
+    small = 16 * 1024
+    assert small < DEFAULT_READ_BUF_BYTES
+    assert (
+        compute_read_buf_bytes([{"max_payload_bytes": small}])
+        == DEFAULT_READ_BUF_BYTES
+    )
+
+
+def test_compute_read_buf_bytes_declared_equal_to_default():
+    assert (
+        compute_read_buf_bytes([{"max_payload_bytes": DEFAULT_READ_BUF_BYTES}])
+        == DEFAULT_READ_BUF_BYTES
+    )
+
+
+def test_compute_read_buf_bytes_declared_above_default_wins():
+    one_mb = 1 * 1024 * 1024
+    assert compute_read_buf_bytes([{"max_payload_bytes": one_mb}]) == one_mb
+
+
+def test_compute_read_buf_bytes_multi_input_picks_max():
+    small = 16 * 1024
+    medium = 128 * 1024
+    large = 512 * 1024
+    assert compute_read_buf_bytes(
+        [
+            {"max_payload_bytes": small},
+            {},
+            {"max_payload_bytes": medium},
+            {"max_payload_bytes": large},
+        ]
+    ) == large
+
+
+def test_compute_read_buf_bytes_multi_input_all_below_default_clamps():
+    assert compute_read_buf_bytes(
+        [
+            {"max_payload_bytes": 1024},
+            {"max_payload_bytes": 8192},
+            {"max_payload_bytes": 16384},
+        ]
+    ) == DEFAULT_READ_BUF_BYTES
+
+
+# ============================================================================
+# B) decode_read_result — post-FFI decode matrix
+# ============================================================================
+
+
+def test_decode_read_result_zero_length_returns_none_without_logging(capsys):
+    read_buf, _ = make_ffi_result(DEFAULT_READ_BUF_BYTES, b"")
+    data, ts = decode_read_result(
+        read_buf, DEFAULT_READ_BUF_BYTES, 0, 123, "port_a"
+    )
+    assert data is None
+    assert ts is None
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# Happy paths — parameterize over a matrix of (read_buf_bytes, data_len)
+# chosen to exercise several boundary conditions:
+#
+#   - 1 KB data in a default-sized buffer             (tiny payload, default buf)
+#   - 32 KB data in a default-sized buffer            (former hard-coded limit; must still work)
+#   - 32 KB + 1 B data in a default-sized buffer      (proves old cap is gone)
+#   - DEFAULT_READ_BUF_BYTES exactly in a default buf (boundary)
+#   - 256 KB data in a 1 MB buffer                    (grown buffer via schema)
+#   - 1 MB data in a 1 MB buffer                      (exact fit at the top end)
+HAPPY_PATH_MATRIX = [
+    pytest.param(DEFAULT_READ_BUF_BYTES, 1024,                      id="1KB-in-default-buf"),
+    pytest.param(DEFAULT_READ_BUF_BYTES, 32 * 1024,                 id="32KB-in-default-buf"),
+    pytest.param(DEFAULT_READ_BUF_BYTES, 32 * 1024 + 1,             id="32KB+1B-in-default-buf"),
+    pytest.param(DEFAULT_READ_BUF_BYTES, DEFAULT_READ_BUF_BYTES,    id="exact-default-in-default-buf"),
+    pytest.param(1024 * 1024, 256 * 1024,                           id="256KB-in-1MB-buf"),
+    pytest.param(1024 * 1024, 1024 * 1024,                          id="1MB-in-1MB-buf-exact-fit"),
+]
+
+
+@pytest.mark.parametrize(("read_buf_bytes", "data_len"), HAPPY_PATH_MATRIX)
+def test_decode_read_result_happy_path(capsys, read_buf_bytes, data_len):
+    payload = pattern_bytes(data_len)
+    read_buf, reported_len = make_ffi_result(read_buf_bytes, payload)
+    ts = data_len * 1000
+
+    data, out_ts = decode_read_result(
+        read_buf, read_buf_bytes, reported_len, ts, "happy_port"
+    )
+
+    assert data is not None
+    assert len(data) == data_len
+    assert data == payload, (
+        "decoded bytes should match source payload byte-for-byte"
+    )
+    assert out_ts == ts
+    # Ensure decode_read_result hands back a distinct `bytes` — mutating the
+    # scratch read buffer after the call must not affect the returned value.
+    read_buf[0] = (read_buf[0] + 1) % 256
+    assert data[0] == payload[0]
+
+    captured = capsys.readouterr()
+    assert captured.err == "", "happy path must not log truncation warnings"
+
+
+# Truncation paths — native reported more bytes than the read buffer can hold.
+# This is the exact shape the pre-fix 32 KB hard-coded buffer triggered when a
+# publisher sent encoded-video-sized frames.
+TRUNCATION_MATRIX = [
+    pytest.param(DEFAULT_READ_BUF_BYTES, DEFAULT_READ_BUF_BYTES + 1,  id="1B-over-default"),
+    pytest.param(32 * 1024, DEFAULT_READ_BUF_BYTES,                   id="32KB-buf-vs-65KB-payload"),
+    pytest.param(DEFAULT_READ_BUF_BYTES, 256 * 1024,                  id="256KB-in-default-buf"),
+    pytest.param(512 * 1024, 1024 * 1024,                             id="1MB-in-512KB-buf"),
+]
+
+
+@pytest.mark.parametrize(("read_buf_bytes", "data_len"), TRUNCATION_MATRIX)
+def test_decode_read_result_truncation(capsys, read_buf_bytes, data_len):
+    payload = pattern_bytes(data_len)
+    read_buf, reported_len = make_ffi_result(read_buf_bytes, payload)
+
+    data, out_ts = decode_read_result(
+        read_buf, read_buf_bytes, reported_len, 42, "truncated_port"
+    )
+
+    assert data is None, "truncation must surface as None, not a short/corrupt payload"
+    assert out_ts is None
+
+    captured = capsys.readouterr()
+    assert "payload truncated on port 'truncated_port'" in captured.err
+    assert str(data_len) in captured.err
+    assert str(read_buf_bytes) in captured.err

--- a/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -360,28 +360,28 @@ fn open_iceoryx2_subprocess_to_subprocess(
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let _service = iceoryx2_node.open_or_create_service(&service_name)?;
 
+    let output_schema = {
+        let source_proc_type = graph
+            .traversal_mut()
+            .v(source_proc_id)
+            .first()
+            .map(|node| node.processor_type().to_string())
+            .unwrap_or_default();
+
+        PROCESSOR_REGISTRY
+            .port_info(&source_proc_type)
+            .and_then(|(_, outputs)| {
+                outputs
+                    .iter()
+                    .find(|p| p.name == source_port)
+                    .map(|p| p.data_type.clone())
+            })
+            .unwrap_or_default()
+    };
+    let max_payload = max_payload_bytes_for_schema(&output_schema);
+
     // Store output wiring info on the source subprocess
     {
-        let output_schema = {
-            let source_proc_type = graph
-                .traversal_mut()
-                .v(source_proc_id)
-                .first()
-                .map(|node| node.processor_type().to_string())
-                .unwrap_or_default();
-
-            PROCESSOR_REGISTRY
-                .port_info(&source_proc_type)
-                .and_then(|(_, outputs)| {
-                    outputs
-                        .iter()
-                        .find(|p| p.name == source_port)
-                        .map(|p| p.data_type.clone())
-                })
-                .unwrap_or_default()
-        };
-
-        let max_payload = max_payload_bytes_for_schema(&output_schema);
         let source_proc_arc = get_single_processor(graph, source_proc_id)?;
         let mut source_guard = source_proc_arc.lock();
         if let Some(deno_host) = source_guard
@@ -423,6 +423,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                 "name": dest_port,
                 "service_name": service_name,
                 "read_mode": "skip_to_latest",
+                "max_payload_bytes": max_payload,
             }));
         } else if let Some(python_native_host) = dest_guard
             .as_any_mut()
@@ -434,6 +435,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                     "name": dest_port,
                     "service_name": service_name,
                     "read_mode": "skip_to_latest",
+                    "max_payload_bytes": max_payload,
                 }));
         }
     }
@@ -620,7 +622,8 @@ fn open_iceoryx2_rust_to_subprocess(
     let service = iceoryx2_node.open_or_create_service(&service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
-    let publisher = service.create_publisher(max_payload_bytes_for_schema(&output_schema))?;
+    let max_payload = max_payload_bytes_for_schema(&output_schema);
+    let publisher = service.create_publisher(max_payload)?;
 
     // Configure source OutputWriter with port mapping and publisher
     {
@@ -648,6 +651,7 @@ fn open_iceoryx2_rust_to_subprocess(
                 "name": dest_port,
                 "service_name": service_name,
                 "read_mode": "skip_to_latest",
+                "max_payload_bytes": max_payload,
             }));
             tracing::debug!(
                 "Stored input wiring on Deno processor '{}': port='{}', service='{}'",
@@ -665,6 +669,7 @@ fn open_iceoryx2_rust_to_subprocess(
                     "name": dest_port,
                     "service_name": service_name,
                     "read_mode": "skip_to_latest",
+                    "max_payload_bytes": max_payload,
                 }));
             tracing::debug!(
                 "Stored input wiring on Python native processor '{}': port='{}', service='{}'",

--- a/libs/streamlib/tests/ipc_payload_size_test.rs
+++ b/libs/streamlib/tests/ipc_payload_size_test.rs
@@ -20,7 +20,9 @@ use std::time::{Duration, Instant};
 
 use iceoryx2::prelude::*;
 use streamlib::core::embedded_schemas::max_payload_bytes_for_schema;
-use streamlib::iceoryx2::{Iceoryx2Node, MAX_PAYLOAD_SIZE};
+use streamlib::iceoryx2::{
+    FrameHeader, Iceoryx2Node, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE,
+};
 
 // =============================================================================
 // A) Direct iceoryx2 slice limit tests
@@ -216,6 +218,75 @@ fn test_encodedvideoframe_schema_publisher_accepts_256kb() {
         "Expected 256 KB loan to succeed on encodedvideoframe-sized publisher ({} bytes), got: {:?}",
         max_bytes,
         result.err()
+    );
+}
+
+/// Full publish/subscribe round-trip using the subprocess FFI wire format:
+/// `[FrameHeader (204 bytes)][encoded video data (256 KB)]` — the exact layout
+/// `sldn_output_write` / `slpn_output_write` build and `sldn_input_poll` /
+/// `slpn_input_poll` parse when a Deno or Python subprocess carries an
+/// encodedvideoframe. Before the per-input `max_payload_bytes` wiring fix,
+/// the TS/Python read buffer was hard-coded to 32 KB and this payload would
+/// have been silently truncated on receipt.
+#[test]
+fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
+    let node = Iceoryx2Node::new().unwrap();
+    let service = node
+        .open_or_create_service("streamlib/test/frame-header-256kb")
+        .unwrap();
+
+    let data_size = 256 * 1024;
+    let max_bytes = max_payload_bytes_for_schema("com.tatolab.encodedvideoframe");
+    // Publisher sized like the FFI layer: schema max + header.
+    let publisher = service.create_publisher(max_bytes).unwrap();
+    let subscriber = service.create_subscriber().unwrap();
+
+    let mut data = vec![0u8; data_size];
+    for (i, byte) in data.iter_mut().enumerate() {
+        *byte = (i % 251) as u8;
+    }
+
+    let total_len = FRAME_HEADER_SIZE + data_size;
+    let mut frame = vec![0u8; total_len];
+    FrameHeader::new("dest_port", "com.tatolab.encodedvideoframe", 42, data_size as u32)
+        .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+    frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);
+
+    let sample = publisher.loan_slice_uninit(total_len).expect(
+        "loan_slice_uninit should succeed at FRAME_HEADER_SIZE + 256 KB on an \
+         encodedvideoframe-sized publisher",
+    );
+    let sample = sample.write_from_slice(&frame);
+    sample.send().expect("send should succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut received: Option<Vec<u8>> = None;
+    while received.is_none() && Instant::now() < deadline {
+        if let Ok(Some(sample)) = subscriber.receive() {
+            received = Some(sample.payload().to_vec());
+        } else {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    let buf = received.expect("subscriber should have received the frame within 2s");
+    assert_eq!(
+        buf.len(),
+        total_len,
+        "received frame length should match header + data"
+    );
+
+    let header = FrameHeader::read_from_slice(&buf);
+    assert_eq!(header.port(), "dest_port");
+    assert_eq!(header.schema(), "com.tatolab.encodedvideoframe");
+    assert_eq!(header.timestamp_ns, 42);
+    assert_eq!(header.len as usize, data_size);
+    assert_eq!(
+        &buf[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + data_size],
+        data.as_slice(),
+        "received payload bytes should match sent payload — truncation or \
+         corruption would indicate the slice subscriber dropped data past the \
+         old 32 KB limit"
     );
 }
 


### PR DESCRIPTION
## Summary

- **Commit 1 (`fix(deno)`, closes #386)** — Resolves the 7 pre-existing `Uint8Array<ArrayBuffer>` type errors in `libs/streamlib-deno/context.ts`, plus two matching call sites in `native.ts` and `types.ts`. Fix is purely type-system; `deno check libs/streamlib-deno/context.ts` passes with 0 errors.

- **Commit 2 (`feat(polyglot)`)** — Surfaced while fixing #386: the Deno and Python subprocess SDKs both hard-coded a 32 KB FFI read buffer, so anything larger the host sent (notably a 256 KB `encodedvideoframe`) was silently truncated. Propagates schema-declared `max_payload_bytes` from the compiler through the iceoryx2 wiring message to each subprocess, sizes the read buffer from that (with a 64 KB floor), and adds defensive truncation detection + logging on both SDK sides.

## #386 exit criteria

- [x] `deno check libs/streamlib-deno/context.ts` passes with 0 errors on Deno 2.7+
- [x] `deno check` on every other `.ts` in `libs/streamlib-deno/` also passes
- [x] Root-cause fix chosen: declare typed-array fields/params as `Uint8Array<ArrayBuffer>` etc. and construct scratch buffers via `new Uint8Array(new ArrayBuffer(N))` so the backing store is an `ArrayBuffer`. Rationale — minimal, no library dependency, matches the direction Deno's FFI is heading.
- [x] No runtime behavior change in commit 1 (the behavior change is in commit 2, deliberately separated).

## Verification

- `deno check` — 30 files, 0 errors.
- `deno test libs/streamlib-deno/context_test.ts` — 18/18 pass.
- `deno lint` / `deno fmt --check` on new `context_test.ts` — clean.
- `python3 -m pytest libs/streamlib-python/python/streamlib/tests/test_payload_sizing.py -v` — 18/18 pass.
- `cargo test -p streamlib --test ipc_payload_size_test` — 13/13 pass, including the new `test_frame_header_plus_256kb_roundtrip_through_slice_service`.
- `cargo check -p streamlib` — clean.

## What this PR does NOT do

- Does not touch pre-existing `deno lint` drift on `main` (6 errors: `require-await` x5 in `escalate.ts`/`context.ts`, `no-fallthrough` x1 in `subprocess_runner.ts`) — out of scope, intentionally left alone.
- Does not touch pre-existing `deno fmt` drift on `main` (4 unformatted files) — same rationale.
- Does not touch Rust `fmt` drift in `libs/streamlib/tests/whip_client_test.rs` (hyper import ordering) — pre-existing, untouched.
- Does not exercise the full `Rust host → cdylib → iceoryx2 → Deno/Python subprocess` end-to-end loop with a real frame. That coverage is scoped to #360's subprocess harness, which was [updated](https://github.com/tatolab/streamlib/issues/360) to include a 256 KB round-trip via a small echo fixture processor on each SDK side.

## Test plan

- [ ] Reviewer runs `deno check libs/streamlib-deno/context.ts` (the #386 exit criterion) — expects 0 errors.
- [ ] Reviewer runs the three test suites above and confirms they pass locally.
- [ ] Reviewer skims commit 1 for the type fix and commit 2 for the IPC-sizing propagation; both are split so they can be reviewed independently.
- [ ] Reviewer agrees the scope expansion (type errors → type errors + IPC-sizing) is worth one PR instead of two, given the 32 KB truncation bug was discovered while fixing #386 and would otherwise silently regress the polyglot story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)