### PR TITLE
chore: wrap unsafe calls in explicit unsafe blocks (#387)

### DIFF
--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn sldn_context_create(
     let id = if processor_id.is_null() {
         "unknown"
     } else {
-        CStr::from_ptr(processor_id).to_str().unwrap_or("unknown")
+        unsafe { CStr::from_ptr(processor_id) }.to_str().unwrap_or("unknown")
     };
 
     match DenoNativeContext::new(id) {
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn sldn_context_create(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sldn_context_destroy(ctx: *mut DenoNativeContext) {
     if !ctx.is_null() {
-        let _ = Box::from_raw(ctx);
+        let _ = unsafe { Box::from_raw(ctx) };
     }
 }
 
@@ -117,11 +117,11 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     ctx: *mut DenoNativeContext,
     service_name: *const c_char,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let service_name = match c_str_to_str(service_name) {
+    let service_name = match unsafe { c_str_to_str(service_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -189,11 +189,11 @@ pub unsafe extern "C" fn sldn_input_set_read_mode(
     port_name: *const c_char,
     mode: i32,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn sldn_input_set_read_mode(
 /// Returns 1 if any data was received, 0 if none, -1 on error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sldn_input_poll(ctx: *mut DenoNativeContext) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
@@ -262,11 +262,11 @@ pub unsafe extern "C" fn sldn_input_read(
     out_len: *mut u32,
     out_ts: *mut i64,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -297,13 +297,13 @@ pub unsafe extern "C" fn sldn_input_read(
 
             let copy_len = data.len().min(buf_len as usize);
             if !out_buf.is_null() && copy_len > 0 {
-                std::ptr::copy_nonoverlapping(data.as_ptr(), out_buf, copy_len);
+                unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), out_buf, copy_len) };
             }
             if !out_len.is_null() {
-                *out_len = data.len() as u32;
+                unsafe { *out_len = data.len() as u32 };
             }
             if !out_ts.is_null() {
-                *out_ts = ts;
+                unsafe { *out_ts = ts };
             }
             return 0;
         }
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn sldn_input_read(
 
     // No data available
     if !out_len.is_null() {
-        *out_len = 0;
+        unsafe { *out_len = 0 };
     }
     1
 }
@@ -333,23 +333,23 @@ pub unsafe extern "C" fn sldn_output_publish(
     schema_name: *const c_char,
     max_payload_bytes: usize,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let service_name = match c_str_to_str(service_name) {
+    let service_name = match unsafe { c_str_to_str(service_name) } {
         Some(s) => s,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
-    let dest_port_str = match c_str_to_str(dest_port) {
+    let dest_port_str = match unsafe { c_str_to_str(dest_port) } {
         Some(s) => s,
         None => return -1,
     };
-    let schema = match c_str_to_str(schema_name) {
+    let schema = match unsafe { c_str_to_str(schema_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -417,11 +417,11 @@ pub unsafe extern "C" fn sldn_output_write(
     data_len: u32,
     timestamp_ns: i64,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn sldn_output_write(
     let data_slice = if data.is_null() || data_len == 0 {
         &[]
     } else {
-        std::slice::from_raw_parts(data, data_len as usize)
+        unsafe { std::slice::from_raw_parts(data, data_len as usize) }
     };
 
     let total_len = FRAME_HEADER_SIZE + data_slice.len();
@@ -1317,5 +1317,5 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
     if ptr.is_null() {
         return None;
     }
-    CStr::from_ptr(ptr).to_str().ok()
+    unsafe { CStr::from_ptr(ptr) }.to_str().ok()
 }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn slpn_context_create(
     let id = if processor_id.is_null() {
         "unknown"
     } else {
-        CStr::from_ptr(processor_id).to_str().unwrap_or("unknown")
+        unsafe { CStr::from_ptr(processor_id) }.to_str().unwrap_or("unknown")
     };
 
     match PythonNativeContext::new(id) {
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn slpn_context_create(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_context_destroy(ctx: *mut PythonNativeContext) {
     if !ctx.is_null() {
-        let _ = Box::from_raw(ctx);
+        let _ = unsafe { Box::from_raw(ctx) };
     }
 }
 
@@ -117,11 +117,11 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     ctx: *mut PythonNativeContext,
     service_name: *const c_char,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let service_name = match c_str_to_str(service_name) {
+    let service_name = match unsafe { c_str_to_str(service_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -189,11 +189,11 @@ pub unsafe extern "C" fn slpn_input_set_read_mode(
     port_name: *const c_char,
     mode: i32,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn slpn_input_set_read_mode(
 /// Returns 1 if any data was received, 0 if none, -1 on error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_input_poll(ctx: *mut PythonNativeContext) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
@@ -262,11 +262,11 @@ pub unsafe extern "C" fn slpn_input_read(
     out_len: *mut u32,
     out_ts: *mut i64,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -297,13 +297,13 @@ pub unsafe extern "C" fn slpn_input_read(
 
             let copy_len = data.len().min(buf_len as usize);
             if !out_buf.is_null() && copy_len > 0 {
-                std::ptr::copy_nonoverlapping(data.as_ptr(), out_buf, copy_len);
+                unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), out_buf, copy_len) };
             }
             if !out_len.is_null() {
-                *out_len = data.len() as u32;
+                unsafe { *out_len = data.len() as u32 };
             }
             if !out_ts.is_null() {
-                *out_ts = ts;
+                unsafe { *out_ts = ts };
             }
             return 0;
         }
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn slpn_input_read(
 
     // No data available
     if !out_len.is_null() {
-        *out_len = 0;
+        unsafe { *out_len = 0 };
     }
     1
 }
@@ -333,23 +333,23 @@ pub unsafe extern "C" fn slpn_output_publish(
     schema_name: *const c_char,
     max_payload_bytes: usize,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let service_name = match c_str_to_str(service_name) {
+    let service_name = match unsafe { c_str_to_str(service_name) } {
         Some(s) => s,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
-    let dest_port_str = match c_str_to_str(dest_port) {
+    let dest_port_str = match unsafe { c_str_to_str(dest_port) } {
         Some(s) => s,
         None => return -1,
     };
-    let schema = match c_str_to_str(schema_name) {
+    let schema = match unsafe { c_str_to_str(schema_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -417,11 +417,11 @@ pub unsafe extern "C" fn slpn_output_write(
     data_len: u32,
     timestamp_ns: i64,
 ) -> i32 {
-    let ctx = match ctx.as_mut() {
+    let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
         None => return -1,
     };
-    let port_name = match c_str_to_str(port_name) {
+    let port_name = match unsafe { c_str_to_str(port_name) } {
         Some(s) => s,
         None => return -1,
     };
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn slpn_output_write(
     let data_slice = if data.is_null() || data_len == 0 {
         &[]
     } else {
-        std::slice::from_raw_parts(data, data_len as usize)
+        unsafe { std::slice::from_raw_parts(data, data_len as usize) }
     };
 
     let total_len = FRAME_HEADER_SIZE + data_slice.len();
@@ -1388,5 +1388,5 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
     if ptr.is_null() {
         return None;
     }
-    CStr::from_ptr(ptr).to_str().ok()
+    unsafe { CStr::from_ptr(ptr) }.to_str().ok()
 }

--- a/libs/streamlib/src/linux/processors/audio_output.rs
+++ b/libs/streamlib/src/linux/processors/audio_output.rs
@@ -27,7 +27,7 @@ impl SendableInputsPtr {
     /// Get a reference to the InputMailboxes.
     /// SAFETY: Caller must ensure the pointed-to data is still valid.
     unsafe fn get(&self) -> &crate::iceoryx2::InputMailboxes {
-        &*self.0
+        unsafe { &*self.0 }
     }
 }
 
@@ -45,7 +45,7 @@ impl SendableAudioConverterPtr {
     /// SAFETY: Caller must ensure the pointed-to data is still valid
     /// and no other thread is accessing it.
     unsafe fn get_mut(&self) -> &mut crate::core::utils::ProcessorAudioConverter {
-        &mut *self.0
+        unsafe { &mut *self.0 }
     }
 }
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -1066,8 +1066,7 @@ impl VulkanDevice {
     ) -> Result<()> {
         let _lock = self.mutex_for_queue(queue).lock()
             .unwrap_or_else(|e| e.into_inner());
-        self.device
-            .queue_submit2(queue, submits, fence)
+        unsafe { self.device.queue_submit2(queue, submits, fence) }
             .map(|_| ())
             .map_err(|e| StreamError::GpuError(format!("queue_submit2 failed: {e}")))
     }
@@ -1080,7 +1079,7 @@ impl VulkanDevice {
     ) -> std::result::Result<vk::SuccessCode, vk::ErrorCode> {
         let _lock = self.mutex_for_queue(queue).lock()
             .unwrap_or_else(|e| e.into_inner());
-        self.device.queue_present_khr(queue, present_info)
+        unsafe { self.device.queue_present_khr(queue, present_info) }
     }
 
     /// Acquire the device-level mutex for resource creation operations.
@@ -1098,7 +1097,7 @@ impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
     ) -> vulkanalia::VkResult<()> {
         let _lock = self.mutex_for_queue(queue).lock()
             .unwrap_or_else(|e| e.into_inner());
-        self.device.queue_submit2(queue, submits, fence).map(|_| ())
+        unsafe { self.device.queue_submit2(queue, submits, fence) }.map(|_| ())
     }
 
     fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
@@ -1124,28 +1123,34 @@ impl VulkanDevice {
         let queue = self.queue;
         let qf = self.queue_family_index;
 
-        let pool = device.create_command_pool(
-            &vk::CommandPoolCreateInfo::builder()
-                .queue_family_index(qf)
-                .flags(vk::CommandPoolCreateFlags::TRANSIENT),
-            None,
-        ).map_err(|e| StreamError::GpuError(format!("upload cmd pool: {e}")))?;
+        let pool = unsafe {
+            device.create_command_pool(
+                &vk::CommandPoolCreateInfo::builder()
+                    .queue_family_index(qf)
+                    .flags(vk::CommandPoolCreateFlags::TRANSIENT),
+                None,
+            )
+        }.map_err(|e| StreamError::GpuError(format!("upload cmd pool: {e}")))?;
 
-        let cb = device.allocate_command_buffers(
-            &vk::CommandBufferAllocateInfo::builder()
-                .command_pool(pool)
-                .level(vk::CommandBufferLevel::PRIMARY)
-                .command_buffer_count(1),
-        ).map_err(|e| StreamError::GpuError(format!("upload cmd buf: {e}")))?[0];
+        let cb = unsafe {
+            device.allocate_command_buffers(
+                &vk::CommandBufferAllocateInfo::builder()
+                    .command_pool(pool)
+                    .level(vk::CommandBufferLevel::PRIMARY)
+                    .command_buffer_count(1),
+            )
+        }.map_err(|e| StreamError::GpuError(format!("upload cmd buf: {e}")))?[0];
 
-        let fence = device.create_fence(&vk::FenceCreateInfo::default(), None)
+        let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }
             .map_err(|e| StreamError::GpuError(format!("upload fence: {e}")))?;
 
-        device.begin_command_buffer(
-            cb,
-            &vk::CommandBufferBeginInfo::builder()
-                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
-        ).map_err(|e| StreamError::GpuError(format!("begin cb: {e}")))?;
+        unsafe {
+            device.begin_command_buffer(
+                cb,
+                &vk::CommandBufferBeginInfo::builder()
+                    .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
+            )
+        }.map_err(|e| StreamError::GpuError(format!("begin cb: {e}")))?;
 
         // Barrier: UNDEFINED → TRANSFER_DST
         let barrier_to_dst = vk::ImageMemoryBarrier2::builder()
@@ -1168,7 +1173,7 @@ impl VulkanDevice {
         let barriers_to_dst = [barrier_to_dst];
         let dep_to_dst = vk::DependencyInfo::builder()
             .image_memory_barriers(&barriers_to_dst);
-        device.cmd_pipeline_barrier2(cb, &dep_to_dst);
+        unsafe { device.cmd_pipeline_barrier2(cb, &dep_to_dst) };
 
         // Copy buffer → image
         let region = vk::BufferImageCopy {
@@ -1184,10 +1189,12 @@ impl VulkanDevice {
             image_offset: vk::Offset3D::default(),
             image_extent: vk::Extent3D { width, height, depth: 1 },
         };
-        device.cmd_copy_buffer_to_image(
-            cb, src_buffer, dst_image,
-            vk::ImageLayout::TRANSFER_DST_OPTIMAL, &[region],
-        );
+        unsafe {
+            device.cmd_copy_buffer_to_image(
+                cb, src_buffer, dst_image,
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL, &[region],
+            )
+        };
 
         // Barrier: TRANSFER_DST → SHADER_READ_ONLY
         let barrier_to_read = vk::ImageMemoryBarrier2::builder()
@@ -1210,9 +1217,10 @@ impl VulkanDevice {
         let barriers_to_read = [barrier_to_read];
         let dep_to_read = vk::DependencyInfo::builder()
             .image_memory_barriers(&barriers_to_read);
-        device.cmd_pipeline_barrier2(cb, &dep_to_read);
+        unsafe { device.cmd_pipeline_barrier2(cb, &dep_to_read) };
 
-        device.end_command_buffer(cb).map_err(|e| StreamError::GpuError(format!("end cb: {e}")))?;
+        unsafe { device.end_command_buffer(cb) }
+            .map_err(|e| StreamError::GpuError(format!("end cb: {e}")))?;
 
         let cb_submit = vk::CommandBufferSubmitInfo::builder()
             .command_buffer(cb)
@@ -1221,12 +1229,12 @@ impl VulkanDevice {
         let submit = vk::SubmitInfo2::builder()
             .command_buffer_infos(&cb_submits)
             .build();
-        self.submit_to_queue(queue, &[submit], fence)?;
-        device.wait_for_fences(&[fence], true, u64::MAX)
+        unsafe { self.submit_to_queue(queue, &[submit], fence) }?;
+        unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
             .map_err(|e| StreamError::GpuError(format!("wait: {e}")))?;
 
-        device.destroy_fence(fence, None);
-        device.destroy_command_pool(pool, None);
+        unsafe { device.destroy_fence(fence, None) };
+        unsafe { device.destroy_command_pool(pool, None) };
 
         Ok(())
     }

--- a/libs/vulkan-video/examples/h264-codec/src/main.rs
+++ b/libs/vulkan-video/examples/h264-codec/src/main.rs
@@ -306,22 +306,24 @@ unsafe fn create_bgra_upload_resources(
         required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
         ..Default::default()
     };
-    let (image, allocation) = allocator.create_image(image_info, &alloc_options)?;
+    let (image, allocation) = unsafe { allocator.create_image(image_info, &alloc_options) }?;
 
-    let view = device.create_image_view(
-        &vk::ImageViewCreateInfo::builder()
-            .image(image)
-            .view_type(vk::ImageViewType::_2D)
-            .format(vk::Format::B8G8R8A8_UNORM)
-            .subresource_range(vk::ImageSubresourceRange {
-                aspect_mask: vk::ImageAspectFlags::COLOR,
-                base_mip_level: 0,
-                level_count: 1,
-                base_array_layer: 0,
-                layer_count: 1,
-            }),
-        None,
-    )?;
+    let view = unsafe {
+        device.create_image_view(
+            &vk::ImageViewCreateInfo::builder()
+                .image(image)
+                .view_type(vk::ImageViewType::_2D)
+                .format(vk::Format::B8G8R8A8_UNORM)
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                }),
+            None,
+        )
+    }?;
 
     // Staging buffer (host-visible, for CPU → GPU upload).
     let staging_size = (aligned_w * aligned_h * 4) as u64;
@@ -336,7 +338,7 @@ unsafe fn create_bgra_upload_resources(
             | vma::AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE,
         ..Default::default()
     };
-    let (staging_buf, staging_alloc) = allocator.create_buffer(staging_info, &staging_opts)?;
+    let (staging_buf, staging_alloc) = unsafe { allocator.create_buffer(staging_info, &staging_opts) }?;
     let info = allocator.get_allocation_info(staging_alloc);
     let staging_ptr = info.pMappedData as *mut u8;
 
@@ -364,41 +366,49 @@ unsafe fn upload_and_encode(
     let src_row_bytes = (WIDTH * 4) as usize;
     let dst_row_bytes = (aligned_w * 4) as usize;
     if src_row_bytes == dst_row_bytes && WIDTH == aligned_w && HEIGHT == aligned_h {
-        std::ptr::copy_nonoverlapping(bgra_data.as_ptr(), staging_ptr, bgra_data.len());
+        unsafe { std::ptr::copy_nonoverlapping(bgra_data.as_ptr(), staging_ptr, bgra_data.len()) };
     } else {
         // Clear the staging buffer first (padding rows/columns).
-        std::ptr::write_bytes(staging_ptr, 0, (aligned_w * aligned_h * 4) as usize);
+        unsafe { std::ptr::write_bytes(staging_ptr, 0, (aligned_w * aligned_h * 4) as usize) };
         for row in 0..HEIGHT as usize {
             let src_off = row * src_row_bytes;
             let dst_off = row * dst_row_bytes;
-            std::ptr::copy_nonoverlapping(
-                bgra_data.as_ptr().add(src_off),
-                staging_ptr.add(dst_off),
-                src_row_bytes,
-            );
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bgra_data.as_ptr().add(src_off),
+                    staging_ptr.add(dst_off),
+                    src_row_bytes,
+                )
+            };
         }
     }
 
     // Record transfer commands: copy staging → GPU image, then transition.
     // We create a one-shot command pool per call for simplicity.
-    let pool = device.create_command_pool(
-        &vk::CommandPoolCreateInfo::builder()
-            .queue_family_index(transfer_qf)
-            .flags(vk::CommandPoolCreateFlags::TRANSIENT),
-        None,
-    )?;
-    let cb = device.allocate_command_buffers(
-        &vk::CommandBufferAllocateInfo::builder()
-            .command_pool(pool)
-            .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1),
-    )?[0];
+    let pool = unsafe {
+        device.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(transfer_qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT),
+            None,
+        )
+    }?;
+    let cb = unsafe {
+        device.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1),
+        )
+    }?[0];
 
-    device.begin_command_buffer(
-        cb,
-        &vk::CommandBufferBeginInfo::builder()
-            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
-    )?;
+    unsafe {
+        device.begin_command_buffer(
+            cb,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
+        )
+    }?;
 
     // Transition BGRA image: UNDEFINED → TRANSFER_DST_OPTIMAL
     let barrier_to_dst = vk::ImageMemoryBarrier::builder()
@@ -416,15 +426,17 @@ unsafe fn upload_and_encode(
         })
         .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
 
-    device.cmd_pipeline_barrier(
-        cb,
-        vk::PipelineStageFlags::TOP_OF_PIPE,
-        vk::PipelineStageFlags::TRANSFER,
-        vk::DependencyFlags::empty(),
-        &[] as &[vk::MemoryBarrier],
-        &[] as &[vk::BufferMemoryBarrier],
-        &[barrier_to_dst],
-    );
+    unsafe {
+        device.cmd_pipeline_barrier(
+            cb,
+            vk::PipelineStageFlags::TOP_OF_PIPE,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::DependencyFlags::empty(),
+            &[] as &[vk::MemoryBarrier],
+            &[] as &[vk::BufferMemoryBarrier],
+            &[barrier_to_dst],
+        )
+    };
 
     // Copy staging buffer → BGRA image.
     let region = vk::BufferImageCopy::builder()
@@ -443,13 +455,15 @@ unsafe fn upload_and_encode(
             depth: 1,
         });
 
-    device.cmd_copy_buffer_to_image(
-        cb,
-        staging_buf,
-        bgra_image,
-        vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-        &[region],
-    );
+    unsafe {
+        device.cmd_copy_buffer_to_image(
+            cb,
+            staging_buf,
+            bgra_image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &[region],
+        )
+    };
 
     // Transition BGRA image: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
     let barrier_to_read = vk::ImageMemoryBarrier::builder()
@@ -468,28 +482,32 @@ unsafe fn upload_and_encode(
         .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
         .dst_access_mask(vk::AccessFlags::SHADER_READ);
 
-    device.cmd_pipeline_barrier(
-        cb,
-        vk::PipelineStageFlags::TRANSFER,
-        vk::PipelineStageFlags::COMPUTE_SHADER,
-        vk::DependencyFlags::empty(),
-        &[] as &[vk::MemoryBarrier],
-        &[] as &[vk::BufferMemoryBarrier],
-        &[barrier_to_read],
-    );
+    unsafe {
+        device.cmd_pipeline_barrier(
+            cb,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::PipelineStageFlags::COMPUTE_SHADER,
+            vk::DependencyFlags::empty(),
+            &[] as &[vk::MemoryBarrier],
+            &[] as &[vk::BufferMemoryBarrier],
+            &[barrier_to_read],
+        )
+    };
 
-    device.end_command_buffer(cb)?;
+    unsafe { device.end_command_buffer(cb) }?;
 
     // Submit and wait.
-    let fence = device.create_fence(&vk::FenceCreateInfo::default(), None)?;
-    device.queue_submit(
-        transfer_queue,
-        &[vk::SubmitInfo::builder().command_buffers(&[cb])],
-        fence,
-    )?;
-    device.wait_for_fences(&[fence], true, u64::MAX)?;
-    device.destroy_fence(fence, None);
-    device.destroy_command_pool(pool, None);
+    let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }?;
+    unsafe {
+        device.queue_submit(
+            transfer_queue,
+            &[vk::SubmitInfo::builder().command_buffers(&[cb])],
+            fence,
+        )
+    }?;
+    unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }?;
+    unsafe { device.destroy_fence(fence, None) };
+    unsafe { device.destroy_command_pool(pool, None) };
 
     // Now the BGRA image is in SHADER_READ_ONLY_OPTIMAL — encode it.
     let packets = encoder.encode_image(bgra_view, timestamp_ns)?;

--- a/libs/vulkan-video/examples/h265-codec/src/main.rs
+++ b/libs/vulkan-video/examples/h265-codec/src/main.rs
@@ -268,22 +268,24 @@ unsafe fn create_bgra_upload_resources(
         required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
         ..Default::default()
     };
-    let (image, allocation) = allocator.create_image(image_info, &alloc_options)?;
+    let (image, allocation) = unsafe { allocator.create_image(image_info, &alloc_options) }?;
 
-    let view = device.create_image_view(
-        &vk::ImageViewCreateInfo::builder()
-            .image(image)
-            .view_type(vk::ImageViewType::_2D)
-            .format(vk::Format::B8G8R8A8_UNORM)
-            .subresource_range(vk::ImageSubresourceRange {
-                aspect_mask: vk::ImageAspectFlags::COLOR,
-                base_mip_level: 0,
-                level_count: 1,
-                base_array_layer: 0,
-                layer_count: 1,
-            }),
-        None,
-    )?;
+    let view = unsafe {
+        device.create_image_view(
+            &vk::ImageViewCreateInfo::builder()
+                .image(image)
+                .view_type(vk::ImageViewType::_2D)
+                .format(vk::Format::B8G8R8A8_UNORM)
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                }),
+            None,
+        )
+    }?;
 
     // Staging buffer (host-visible, for CPU → GPU upload).
     let staging_size = (aligned_w * aligned_h * 4) as u64;
@@ -298,7 +300,7 @@ unsafe fn create_bgra_upload_resources(
             | vma::AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE,
         ..Default::default()
     };
-    let (staging_buf, staging_alloc) = allocator.create_buffer(staging_info, &staging_opts)?;
+    let (staging_buf, staging_alloc) = unsafe { allocator.create_buffer(staging_info, &staging_opts) }?;
     let info = allocator.get_allocation_info(staging_alloc);
     let staging_ptr = info.pMappedData as *mut u8;
 
@@ -326,41 +328,49 @@ unsafe fn upload_and_encode(
     let src_row_bytes = (WIDTH * 4) as usize;
     let dst_row_bytes = (aligned_w * 4) as usize;
     if src_row_bytes == dst_row_bytes && WIDTH == aligned_w && HEIGHT == aligned_h {
-        std::ptr::copy_nonoverlapping(bgra_data.as_ptr(), staging_ptr, bgra_data.len());
+        unsafe { std::ptr::copy_nonoverlapping(bgra_data.as_ptr(), staging_ptr, bgra_data.len()) };
     } else {
         // Clear the staging buffer first (padding rows/columns).
-        std::ptr::write_bytes(staging_ptr, 0, (aligned_w * aligned_h * 4) as usize);
+        unsafe { std::ptr::write_bytes(staging_ptr, 0, (aligned_w * aligned_h * 4) as usize) };
         for row in 0..HEIGHT as usize {
             let src_off = row * src_row_bytes;
             let dst_off = row * dst_row_bytes;
-            std::ptr::copy_nonoverlapping(
-                bgra_data.as_ptr().add(src_off),
-                staging_ptr.add(dst_off),
-                src_row_bytes,
-            );
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bgra_data.as_ptr().add(src_off),
+                    staging_ptr.add(dst_off),
+                    src_row_bytes,
+                )
+            };
         }
     }
 
     // Record transfer commands: copy staging → GPU image, then transition.
     // We create a one-shot command pool per call for simplicity.
-    let pool = device.create_command_pool(
-        &vk::CommandPoolCreateInfo::builder()
-            .queue_family_index(transfer_qf)
-            .flags(vk::CommandPoolCreateFlags::TRANSIENT),
-        None,
-    )?;
-    let cb = device.allocate_command_buffers(
-        &vk::CommandBufferAllocateInfo::builder()
-            .command_pool(pool)
-            .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1),
-    )?[0];
+    let pool = unsafe {
+        device.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(transfer_qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT),
+            None,
+        )
+    }?;
+    let cb = unsafe {
+        device.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1),
+        )
+    }?[0];
 
-    device.begin_command_buffer(
-        cb,
-        &vk::CommandBufferBeginInfo::builder()
-            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
-    )?;
+    unsafe {
+        device.begin_command_buffer(
+            cb,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
+        )
+    }?;
 
     // Transition BGRA image: UNDEFINED → TRANSFER_DST_OPTIMAL
     let barrier_to_dst = vk::ImageMemoryBarrier::builder()
@@ -378,15 +388,17 @@ unsafe fn upload_and_encode(
         })
         .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
 
-    device.cmd_pipeline_barrier(
-        cb,
-        vk::PipelineStageFlags::TOP_OF_PIPE,
-        vk::PipelineStageFlags::TRANSFER,
-        vk::DependencyFlags::empty(),
-        &[] as &[vk::MemoryBarrier],
-        &[] as &[vk::BufferMemoryBarrier],
-        &[barrier_to_dst],
-    );
+    unsafe {
+        device.cmd_pipeline_barrier(
+            cb,
+            vk::PipelineStageFlags::TOP_OF_PIPE,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::DependencyFlags::empty(),
+            &[] as &[vk::MemoryBarrier],
+            &[] as &[vk::BufferMemoryBarrier],
+            &[barrier_to_dst],
+        )
+    };
 
     // Copy staging buffer → BGRA image.
     let region = vk::BufferImageCopy::builder()
@@ -405,13 +417,15 @@ unsafe fn upload_and_encode(
             depth: 1,
         });
 
-    device.cmd_copy_buffer_to_image(
-        cb,
-        staging_buf,
-        bgra_image,
-        vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-        &[region],
-    );
+    unsafe {
+        device.cmd_copy_buffer_to_image(
+            cb,
+            staging_buf,
+            bgra_image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &[region],
+        )
+    };
 
     // Transition BGRA image: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
     let barrier_to_read = vk::ImageMemoryBarrier::builder()
@@ -430,28 +444,32 @@ unsafe fn upload_and_encode(
         .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
         .dst_access_mask(vk::AccessFlags::SHADER_READ);
 
-    device.cmd_pipeline_barrier(
-        cb,
-        vk::PipelineStageFlags::TRANSFER,
-        vk::PipelineStageFlags::COMPUTE_SHADER,
-        vk::DependencyFlags::empty(),
-        &[] as &[vk::MemoryBarrier],
-        &[] as &[vk::BufferMemoryBarrier],
-        &[barrier_to_read],
-    );
+    unsafe {
+        device.cmd_pipeline_barrier(
+            cb,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::PipelineStageFlags::COMPUTE_SHADER,
+            vk::DependencyFlags::empty(),
+            &[] as &[vk::MemoryBarrier],
+            &[] as &[vk::BufferMemoryBarrier],
+            &[barrier_to_read],
+        )
+    };
 
-    device.end_command_buffer(cb)?;
+    unsafe { device.end_command_buffer(cb) }?;
 
     // Submit and wait.
-    let fence = device.create_fence(&vk::FenceCreateInfo::default(), None)?;
-    device.queue_submit(
-        transfer_queue,
-        &[vk::SubmitInfo::builder().command_buffers(&[cb])],
-        fence,
-    )?;
-    device.wait_for_fences(&[fence], true, u64::MAX)?;
-    device.destroy_fence(fence, None);
-    device.destroy_command_pool(pool, None);
+    let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }?;
+    unsafe {
+        device.queue_submit(
+            transfer_queue,
+            &[vk::SubmitInfo::builder().command_buffers(&[cb])],
+            fence,
+        )
+    }?;
+    unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }?;
+    unsafe { device.destroy_fence(fence, None) };
+    unsafe { device.destroy_command_pool(pool, None) };
 
     // Now the BGRA image is in SHADER_READ_ONLY_OPTIMAL — encode it.
     let packets = encoder.encode_image(bgra_view, timestamp_ns)?;


### PR DESCRIPTION
## Summary

- Mechanical sweep of all 101 `unsafe_op_in_unsafe_fn` (E0133) warnings across 6 files — each flagged call now sits in its own `unsafe { ... }` block.
- Outer `unsafe fn` keywords, signatures, and caller contracts are unchanged — no functional effect; this is forward-compat only.
- Unblocks a future `edition = "2024"` bump in one clean mechanical PR instead of rolling it up inside a feature change.

## Closes

Closes #387

## Exit criteria

- [x] `cargo check --workspace` emits zero `unsafe_op_in_unsafe_fn` / E0133 warnings
- [x] Fix is purely mechanical: wrap each flagged call in `unsafe { ... }` — outer `unsafe fn` keyword and signatures preserved
- [x] No functional changes — additive-only diff (new `unsafe { ... }` braces)
- [x] Workspace still compiles on the current edition (no premature `edition = "2024"` bump)

## Test plan

- [x] `cargo check --workspace 2>&1 | grep -c unsafe_op_in_unsafe_fn` → `0` ✅
- [x] `cargo check --workspace --all-targets` → `0` E0133 warnings ✅
- [x] `cargo test --workspace` baseline (per `docs/testing-baseline.md`) → `passed=859 failed=0 ignored=21` ✅
- [x] Spot-checked `vulkan_device.rs::submit_to_queue` manually — wrap hugs only the `queue_submit2` call; `.map(|_| ())` / `.map_err(...)` chain stays outside the `unsafe` block.

## Files touched

| File | Wraps |
|---|---|
| `libs/streamlib/src/vulkan/rhi/vulkan_device.rs` | 15 |
| `libs/streamlib/src/linux/processors/audio_output.rs` | 2 |
| `libs/streamlib-python-native/src/lib.rs` | 22 |
| `libs/streamlib-deno-native/src/lib.rs` | 22 |
| `libs/vulkan-video/examples/h264-codec/src/main.rs` | 20 |
| `libs/vulkan-video/examples/h265-codec/src/main.rs` | 20 |
| **Total** | **101** |

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)