### PR TITLE
feat(polyglot): Linux polyglot DMA-BUF FD consumer in native libs (#394)

### DIFF
--- a/libs/streamlib-broker/src/unix_socket_service.rs
+++ b/libs/streamlib-broker/src/unix_socket_service.rs
@@ -676,3 +676,160 @@ pub fn send_request(
 // Safety: The service manages thread-safe BrokerState
 unsafe impl Send for UnixSocketSurfaceService {}
 unsafe impl Sync for UnixSocketSurfaceService {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::io::FromRawFd;
+
+    /// Create an anonymous kernel fd (memfd) seeded with `contents`. The fd
+    /// supports `lseek` + `read`, so we can verify that an fd received over
+    /// SCM_RIGHTS still refers to the same kernel file object.
+    fn make_memfd_with(contents: &[u8]) -> RawFd {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let name = std::ffi::CString::new("streamlib-broker-test").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+        assert!(fd >= 0, "memfd_create failed: {}", std::io::Error::last_os_error());
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        file.write_all(contents).expect("memfd write");
+        file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+        // Leak the File wrapper so the raw fd stays open — caller owns it.
+        let raw = {
+            use std::os::unix::io::IntoRawFd;
+            file.into_raw_fd()
+        };
+        raw
+    }
+
+    fn read_all_from_fd(fd: RawFd) -> Vec<u8> {
+        use std::io::Read;
+
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        // memfd_create starts read/write and non-sealed, but SCM_RIGHTS
+        // delivers a duplicated fd whose offset is independent of the
+        // sender's. Rewind so we read from the start regardless.
+        use std::io::{Seek, SeekFrom};
+        file.seek(SeekFrom::Start(0)).expect("recv memfd rewind");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("recv memfd read");
+        // Let the File drop close the fd.
+        buf
+    }
+
+    fn tmp_socket_path() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!(
+            "streamlib-broker-test-{}-{}.sock",
+            std::process::id(),
+            nanos
+        ));
+        p
+    }
+
+    #[test]
+    fn check_in_check_out_roundtrip_preserves_fd_content() {
+        // Start a broker service in-process.
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+
+        // Give the listener a moment to accept.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Client side: connect and check_in a memfd seeded with a pattern.
+        let stream = connect_to_broker(&socket_path).expect("connect");
+
+        let pattern = b"streamlib-broker-test-fd-contents-0123456789";
+        let send_fd = make_memfd_with(pattern);
+
+        let check_in_req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "test-runtime",
+            "width": 640,
+            "height": 480,
+            "format": "Bgra32",
+            "resource_type": "pixel_buffer",
+        });
+        let (check_in_resp, check_in_fd) =
+            send_request(&stream, &check_in_req, Some(send_fd)).expect("check_in request");
+        // Close our copy of the sent fd — the broker dup'd it.
+        unsafe { libc::close(send_fd) };
+        assert!(check_in_fd.is_none(), "check_in must not return an fd");
+        let surface_id = check_in_resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id in response")
+            .to_string();
+        assert!(!surface_id.is_empty());
+
+        // check_out the same surface_id — broker should return a dup of the
+        // stored fd whose contents are byte-for-byte identical.
+        let check_out_req = serde_json::json!({
+            "op": "check_out",
+            "surface_id": surface_id,
+        });
+        let (check_out_resp, check_out_fd) =
+            send_request(&stream, &check_out_req, None).expect("check_out request");
+        assert_eq!(
+            check_out_resp.get("width").and_then(|v| v.as_u64()),
+            Some(640)
+        );
+        assert_eq!(
+            check_out_resp.get("height").and_then(|v| v.as_u64()),
+            Some(480)
+        );
+        assert_eq!(
+            check_out_resp.get("format").and_then(|v| v.as_str()),
+            Some("Bgra32")
+        );
+        let received_fd = check_out_fd.expect("check_out must return an fd");
+        assert!(received_fd >= 0);
+        let received = read_all_from_fd(received_fd);
+        assert_eq!(
+            received, pattern,
+            "SCM_RIGHTS should preserve the underlying memfd contents"
+        );
+
+        // release — fire-and-forget-shaped wire, still returns a JSON reply.
+        let release_req = serde_json::json!({
+            "op": "release",
+            "surface_id": surface_id,
+            "runtime_id": "test-runtime",
+        });
+        let (_release_resp, _) =
+            send_request(&stream, &release_req, None).expect("release request");
+
+        drop(stream);
+        service.stop();
+    }
+
+    #[test]
+    fn check_out_unknown_surface_id_returns_error_no_fd() {
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_broker(&socket_path).expect("connect");
+        let req = serde_json::json!({
+            "op": "check_out",
+            "surface_id": "never-registered",
+        });
+        let (resp, fd) = send_request(&stream, &req, None).expect("check_out request");
+        assert!(fd.is_none(), "no fd when surface missing");
+        assert!(
+            resp.get("error").and_then(|v| v.as_str()).is_some(),
+            "missing-surface check_out must return an error payload"
+        );
+
+        drop(stream);
+        service.stop();
+    }
+}

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -19,3 +19,10 @@ iceoryx2 = "0.8.1"
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
+[dev-dependencies]
+# Broker unit tests spin up a real UnixSocketSurfaceService + client in-process.
+streamlib-broker = { path = "../streamlib-broker" }

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -760,7 +760,173 @@ mod gpu_surface {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod gpu_surface {
+    //! Linux GPU surface handle backed by a DMA-BUF file descriptor.
+    //!
+    //! Mirror of `streamlib-python-native`'s Linux `gpu_surface` module —
+    //! identical shape, `sldn_` prefix. See that file for full background.
+    //! CPU access is via `mmap(fd)` on lock; Vulkan import via
+    //! `vkImportMemoryFdInfoKHR` is deliberately deferred to a follow-up so
+    //! the cdylib stays minimal until a GPU-consuming Deno subprocess needs it.
+    use std::ffi::c_void;
+    use std::os::unix::io::RawFd;
+
+    pub struct SurfaceHandle {
+        pub fd: RawFd,
+        pub width: u32,
+        pub height: u32,
+        pub bytes_per_row: u32,
+        pub size: u64,
+        pub mapped_ptr: *mut u8,
+        pub is_locked: bool,
+    }
+
+    impl Drop for SurfaceHandle {
+        fn drop(&mut self) {
+            if self.is_locked && !self.mapped_ptr.is_null() && self.size > 0 {
+                unsafe {
+                    libc::munmap(self.mapped_ptr as *mut c_void, self.size as usize);
+                }
+            }
+            if self.fd >= 0 {
+                unsafe {
+                    libc::close(self.fd);
+                }
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_lookup(_iosurface_id: u32) -> *mut SurfaceHandle {
+        eprintln!("[sldn] GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_lock(
+        handle: *mut SurfaceHandle,
+        read_only: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        if handle.is_locked {
+            return 0;
+        }
+        if handle.size == 0 || handle.fd < 0 {
+            return -1;
+        }
+        let prot = if read_only != 0 {
+            libc::PROT_READ
+        } else {
+            libc::PROT_READ | libc::PROT_WRITE
+        };
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                handle.size as usize,
+                prot,
+                libc::MAP_SHARED,
+                handle.fd,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            eprintln!(
+                "[sldn] mmap on DMA-BUF fd {} failed: {}",
+                handle.fd,
+                std::io::Error::last_os_error()
+            );
+            return -1;
+        }
+        handle.mapped_ptr = ptr as *mut u8;
+        handle.is_locked = true;
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_unlock(
+        handle: *mut SurfaceHandle,
+        _read_only: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        if !handle.is_locked {
+            return 0;
+        }
+        let result = unsafe {
+            libc::munmap(handle.mapped_ptr as *mut c_void, handle.size as usize)
+        };
+        handle.mapped_ptr = std::ptr::null_mut();
+        handle.is_locked = false;
+        if result != 0 {
+            -1
+        } else {
+            0
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_base_address(
+        handle: *const SurfaceHandle,
+    ) -> *mut u8 {
+        match unsafe { handle.as_ref() } {
+            Some(h) => h.mapped_ptr,
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_width(handle: *const SurfaceHandle) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.width).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_height(handle: *const SurfaceHandle) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.height).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_bytes_per_row(
+        handle: *const SurfaceHandle,
+    ) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.bytes_per_row).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_create(
+        _width: u32,
+        _height: u32,
+        _bytes_per_element: u32,
+    ) -> *mut SurfaceHandle {
+        eprintln!(
+            "[sldn] GPU surface creation in subprocess is not supported on Linux; allocation \
+             must go through escalate IPC (GpuContextFullAccess -> RHI -> SurfaceStore.check_in)"
+        );
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_get_id(handle: *const SurfaceHandle) -> u32 {
+        // Linux surface IDs are broker UUIDs (strings), not u32 IOSurfaceIDs;
+        // return the fd as a best-effort numeric token. See the Python twin
+        // in streamlib-python-native for the same behavior.
+        unsafe { handle.as_ref() }.map(|h| h.fd as u32).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_release(handle: *mut SurfaceHandle) {
+        if !handle.is_null() {
+            let _ = unsafe { Box::from_raw(handle) };
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod gpu_surface {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_gpu_surface_lookup(_iosurface_id: u32) -> *mut std::ffi::c_void {
@@ -1275,7 +1441,509 @@ mod broker_client {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod broker_client {
+    //! Linux broker consumer client (Deno twin of `streamlib-python-native`'s).
+    //!
+    //! Speaks the same Unix-socket + SCM_RIGHTS wire protocol as the Python
+    //! shim, with `sldn_` prefix. Consumer-only per the safety posture in
+    //! `docs/research/polyglot-dma-buf-fd.md` — subprocess allocation goes
+    //! through the host via #325 escalate IPC.
+    use std::collections::HashMap;
+    use std::ffi::{c_char, CStr};
+    use std::os::unix::io::RawFd;
+    use std::os::unix::net::UnixStream;
+    use std::sync::Mutex;
+
+    use super::gpu_surface::SurfaceHandle;
+
+    const MAX_RESOLVE_CACHE: usize = 128;
+
+    struct CachedSurface {
+        fd: RawFd,
+        width: u32,
+        height: u32,
+        bytes_per_row: u32,
+        size: u64,
+    }
+
+    impl Drop for CachedSurface {
+        fn drop(&mut self) {
+            if self.fd >= 0 {
+                unsafe { libc::close(self.fd) };
+            }
+        }
+    }
+
+    pub struct BrokerHandle {
+        socket_path: String,
+        runtime_id: String,
+        connection: Mutex<Option<UnixStream>>,
+        resolve_cache: Mutex<HashMap<String, CachedSurface>>,
+    }
+
+    impl BrokerHandle {
+        fn lazy_connect(
+            &self,
+        ) -> std::io::Result<std::sync::MutexGuard<'_, Option<UnixStream>>> {
+            let mut guard = self.connection.lock().expect("poisoned");
+            if guard.is_none() {
+                let stream = UnixStream::connect(&self.socket_path)?;
+                stream.set_nonblocking(false)?;
+                *guard = Some(stream);
+            }
+            Ok(guard)
+        }
+    }
+
+    mod wire {
+        use std::os::unix::io::{AsRawFd, RawFd};
+        use std::os::unix::net::UnixStream;
+
+        pub fn send_message_with_fd(
+            stream: &UnixStream,
+            data: &[u8],
+            fd: Option<RawFd>,
+        ) -> std::io::Result<()> {
+            let len_bytes = (data.len() as u32).to_be_bytes();
+            let mut len_iov = libc::iovec {
+                iov_base: len_bytes.as_ptr() as *mut libc::c_void,
+                iov_len: 4,
+            };
+            let mut len_msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            len_msg.msg_iov = &mut len_iov;
+            len_msg.msg_iovlen = 1;
+            let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &len_msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+
+            let mut iov = libc::iovec {
+                iov_base: data.as_ptr() as *mut libc::c_void,
+                iov_len: data.len(),
+            };
+            let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg.msg_iov = &mut iov;
+            msg.msg_iovlen = 1;
+
+            const CMSG_SPACE_SIZE: usize =
+                unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
+            #[repr(C)]
+            union CmsgBuf {
+                buf: [u8; CMSG_SPACE_SIZE],
+                _align: libc::cmsghdr,
+            }
+            let mut cmsg_buf = CmsgBuf {
+                buf: [0u8; CMSG_SPACE_SIZE],
+            };
+
+            if let Some(send_fd) = fd {
+                msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
+                msg.msg_controllen = CMSG_SPACE_SIZE;
+                let cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+                if !cmsg_ptr.is_null() {
+                    unsafe {
+                        (*cmsg_ptr).cmsg_level = libc::SOL_SOCKET;
+                        (*cmsg_ptr).cmsg_type = libc::SCM_RIGHTS;
+                        (*cmsg_ptr).cmsg_len =
+                            libc::CMSG_LEN(std::mem::size_of::<RawFd>() as u32) as usize;
+                        let fd_ptr = libc::CMSG_DATA(cmsg_ptr) as *mut RawFd;
+                        *fd_ptr = send_fd;
+                    }
+                    msg.msg_controllen = CMSG_SPACE_SIZE;
+                }
+            }
+
+            let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+
+        pub fn recv_message_with_fd(
+            stream: &UnixStream,
+            msg_len: usize,
+        ) -> std::io::Result<(Vec<u8>, Option<RawFd>)> {
+            const CMSG_SPACE_SIZE: usize =
+                unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
+            #[repr(C)]
+            union CmsgBuf {
+                buf: [u8; CMSG_SPACE_SIZE],
+                _align: libc::cmsghdr,
+            }
+            let mut cmsg_buf = CmsgBuf {
+                buf: [0u8; CMSG_SPACE_SIZE],
+            };
+
+            let mut buf = vec![0u8; msg_len];
+            let mut iov = libc::iovec {
+                iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+                iov_len: msg_len,
+            };
+            let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg.msg_iov = &mut iov;
+            msg.msg_iovlen = 1;
+            msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
+            msg.msg_controllen = CMSG_SPACE_SIZE;
+
+            let n = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "Connection closed",
+                ));
+            }
+            if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SCM_RIGHTS control message truncated",
+                ));
+            }
+
+            let mut total_read = n as usize;
+            while total_read < msg_len {
+                let remaining = &mut buf[total_read..];
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        remaining.as_mut_ptr() as *mut libc::c_void,
+                        remaining.len(),
+                    )
+                };
+                if n <= 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "Connection closed during message read",
+                    ));
+                }
+                total_read += n as usize;
+            }
+
+            let mut received_fd = None;
+            let mut cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+            while !cmsg_ptr.is_null() {
+                let cmsg = unsafe { &*cmsg_ptr };
+                if cmsg.cmsg_level == libc::SOL_SOCKET && cmsg.cmsg_type == libc::SCM_RIGHTS {
+                    let fd_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const RawFd;
+                    received_fd = Some(unsafe { *fd_ptr });
+                }
+                cmsg_ptr = unsafe { libc::CMSG_NXTHDR(&msg, cmsg_ptr) };
+            }
+            let _ = &buf;
+            let mut read_buf = vec![0u8; msg_len];
+            read_buf.copy_from_slice(&buf[..msg_len]);
+            Ok((read_buf, received_fd))
+        }
+
+        pub fn send_request(
+            stream: &UnixStream,
+            request: &serde_json::Value,
+            fd: Option<RawFd>,
+        ) -> std::io::Result<(serde_json::Value, Option<RawFd>)> {
+            let request_bytes = serde_json::to_vec(request).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to serialize request: {}", e),
+                )
+            })?;
+            send_message_with_fd(stream, &request_bytes, fd)?;
+
+            let mut len_buf = [0u8; 4];
+            let mut total = 0;
+            while total < 4 {
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                        4 - total,
+                    )
+                };
+                if n <= 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "Failed to read response length",
+                    ));
+                }
+                total += n as usize;
+            }
+            let response_len = u32::from_be_bytes(len_buf) as usize;
+            let (response_bytes, response_fd) = recv_message_with_fd(stream, response_len)?;
+            let response: serde_json::Value = serde_json::from_slice(&response_bytes)
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid JSON response: {}", e),
+                    )
+                })?;
+            Ok((response, response_fd))
+        }
+    }
+
+    fn c_str_to_string(ptr: *const c_char) -> Option<String> {
+        if ptr.is_null() {
+            return None;
+        }
+        unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .ok()
+            .map(|s| s.to_string())
+    }
+
+    fn bytes_per_pixel_from_format(format_str: &str) -> u32 {
+        match format_str {
+            "Bgra32" | "Rgba32" | "Argb32" => 4,
+            "Rgba64" => 8,
+            "Gray8" => 1,
+            "Yuyv422" | "Uyvy422" => 2,
+            "Nv12VideoRange" | "Nv12FullRange" => 1,
+            _ => 4,
+        }
+    }
+
+    /// Deno's `sldn_broker_connect` FFI is single-arg today (no runtime_id).
+    /// Stamp a deterministic-but-unique runtime_id from the process id + a
+    /// monotonic counter so broker logs distinguish subprocess instances.
+    fn default_runtime_id() -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("deno-subprocess-{}-{}", std::process::id(), seq)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_broker_connect(socket_path: *const c_char) -> *mut BrokerHandle {
+        let socket_path = match c_str_to_string(socket_path) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                eprintln!("[sldn] broker_connect (linux): null or empty socket path");
+                return std::ptr::null_mut();
+            }
+        };
+        let runtime_id = default_runtime_id();
+
+        eprintln!(
+            "[sldn] broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
+             (lazy; will connect on first resolve_surface)",
+            socket_path, runtime_id
+        );
+
+        Box::into_raw(Box::new(BrokerHandle {
+            socket_path,
+            runtime_id,
+            connection: Mutex::new(None),
+            resolve_cache: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_broker_disconnect(broker: *mut BrokerHandle) {
+        if !broker.is_null() {
+            let _ = unsafe { Box::from_raw(broker) };
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_broker_resolve_surface(
+        broker: *mut BrokerHandle,
+        pool_id: *const c_char,
+    ) -> *mut SurfaceHandle {
+        let broker = match unsafe { broker.as_ref() } {
+            Some(b) => b,
+            None => {
+                eprintln!("[sldn] broker_resolve_surface (linux): null broker handle");
+                return std::ptr::null_mut();
+            }
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                eprintln!("[sldn] broker_resolve_surface (linux): null or empty pool_id");
+                return std::ptr::null_mut();
+            }
+        };
+
+        {
+            let cache = broker.resolve_cache.lock().expect("poisoned");
+            if let Some(cached) = cache.get(&pool_id_str) {
+                let dup_fd = unsafe { libc::dup(cached.fd) };
+                if dup_fd < 0 {
+                    eprintln!(
+                        "[sldn] broker_resolve_surface: dup cached fd failed for '{}': {}",
+                        pool_id_str,
+                        std::io::Error::last_os_error()
+                    );
+                    return std::ptr::null_mut();
+                }
+                return Box::into_raw(Box::new(SurfaceHandle {
+                    fd: dup_fd,
+                    width: cached.width,
+                    height: cached.height,
+                    bytes_per_row: cached.bytes_per_row,
+                    size: cached.size,
+                    mapped_ptr: std::ptr::null_mut(),
+                    is_locked: false,
+                }));
+            }
+        }
+
+        let guard = match broker.lazy_connect() {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!(
+                    "[sldn] broker_resolve_surface: connect to '{}' failed: {}. \
+                     Is the broker running? Start it with `sudo systemctl start streamlib-broker` \
+                     or via scripts/dev-setup.sh.",
+                    broker.socket_path, e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let stream = guard.as_ref().expect("connection just populated");
+
+        let request = serde_json::json!({
+            "op": "check_out",
+            "surface_id": pool_id_str,
+        });
+        let (response, received_fd) = match wire::send_request(stream, &request, None) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "[sldn] broker_resolve_surface: check_out for '{}' failed: {}",
+                    pool_id_str, e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
+            eprintln!(
+                "[sldn] broker_resolve_surface: broker error for '{}': {}",
+                pool_id_str, err
+            );
+            if let Some(fd) = received_fd {
+                unsafe { libc::close(fd) };
+            }
+            return std::ptr::null_mut();
+        }
+
+        let dma_buf_fd = match received_fd {
+            Some(fd) => fd,
+            None => {
+                eprintln!(
+                    "[sldn] broker_resolve_surface: no DMA-BUF fd for '{}'",
+                    pool_id_str
+                );
+                return std::ptr::null_mut();
+            }
+        };
+
+        let width = response.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let height = response.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let format_str = response
+            .get("format")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Bgra32");
+        let bpp = bytes_per_pixel_from_format(format_str);
+        let bytes_per_row = width.saturating_mul(bpp);
+        let size = (height as u64).saturating_mul(bytes_per_row as u64);
+
+        let cache_fd = unsafe { libc::dup(dma_buf_fd) };
+        if cache_fd >= 0 {
+            let mut cache = broker.resolve_cache.lock().expect("poisoned");
+            if cache.len() >= MAX_RESOLVE_CACHE {
+                eprintln!(
+                    "[sldn] broker resolve cache exceeded {} entries, dropping all cached fds",
+                    MAX_RESOLVE_CACHE
+                );
+                cache.clear();
+            }
+            cache.insert(
+                pool_id_str.clone(),
+                CachedSurface {
+                    fd: cache_fd,
+                    width,
+                    height,
+                    bytes_per_row,
+                    size,
+                },
+            );
+        }
+
+        Box::into_raw(Box::new(SurfaceHandle {
+            fd: dma_buf_fd,
+            width,
+            height,
+            bytes_per_row,
+            size,
+            mapped_ptr: std::ptr::null_mut(),
+            is_locked: false,
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_broker_acquire_surface(
+        _broker: *mut BrokerHandle,
+        _width: u32,
+        _height: u32,
+        _bytes_per_element: u32,
+        _out_pool_id: *mut c_char,
+        _pool_id_buf_len: u32,
+    ) -> *mut SurfaceHandle {
+        eprintln!(
+            "[sldn] broker_acquire_surface: not supported on Linux; subprocess allocation must \
+             escalate to the host (acquire_pixel_buffer / acquire_texture over the stdio IPC) — \
+             the subprocess then calls resolve_surface with the returned handle_id."
+        );
+        std::ptr::null_mut()
+    }
+
+    /// Linux-only companion for `sldn_broker_resolve_surface`.
+    ///
+    /// Evicts the local cache entry for `pool_id` and sends a best-effort
+    /// `release` op to the broker so it can drop its dup of the DMA-BUF FD.
+    /// macOS doesn't ship an equivalent `sldn_broker_unregister_surface`; the
+    /// XPC path relies on connection-close to release refs. The Linux broker
+    /// behaves the same way at socket-close, but an explicit release
+    /// shortens the lifetime window between subprocess handle drop and broker
+    /// GC tick (see `prune_dead_runtimes` in the broker).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_broker_unregister_surface(
+        broker: *mut BrokerHandle,
+        pool_id: *const c_char,
+    ) {
+        let broker = match unsafe { broker.as_ref() } {
+            Some(b) => b,
+            None => return,
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => return,
+        };
+
+        {
+            let mut cache = broker.resolve_cache.lock().expect("poisoned");
+            let _ = cache.remove(&pool_id_str);
+        }
+
+        let guard = match broker.lazy_connect() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if let Some(stream) = guard.as_ref() {
+            let request = serde_json::json!({
+                "op": "release",
+                "surface_id": pool_id_str,
+                "runtime_id": broker.runtime_id,
+            });
+            let _ = wire::send_request(stream, &request, None);
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod broker_client {
     use std::ffi::{c_char, c_void};
 
@@ -1318,4 +1986,156 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         return None;
     }
     unsafe { CStr::from_ptr(ptr) }.to_str().ok()
+}
+
+// ============================================================================
+// Tests — Linux broker consumer shim round-trip (Deno twin of the Python tests)
+// ============================================================================
+
+#[cfg(all(test, target_os = "linux"))]
+mod broker_linux_tests {
+    use std::ffi::CString;
+    use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+    use std::path::PathBuf;
+
+    use streamlib_broker::{unix_socket_service, BrokerState};
+    use unix_socket_service::UnixSocketSurfaceService;
+
+    use super::broker_client::{
+        sldn_broker_connect, sldn_broker_disconnect, sldn_broker_resolve_surface,
+        sldn_broker_unregister_surface,
+    };
+    use super::gpu_surface::{
+        sldn_gpu_surface_base_address, sldn_gpu_surface_bytes_per_row, sldn_gpu_surface_height,
+        sldn_gpu_surface_lock, sldn_gpu_surface_release, sldn_gpu_surface_unlock,
+        sldn_gpu_surface_width,
+    };
+
+    fn tmp_socket_path(label: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!(
+            "streamlib-deno-native-test-{}-{}-{}.sock",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        p
+    }
+
+    fn make_memfd_with(contents: &[u8]) -> RawFd {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let name = CString::new("sldn-test-memfd").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+        assert!(
+            fd >= 0,
+            "memfd_create failed: {}",
+            std::io::Error::last_os_error()
+        );
+        assert_eq!(
+            unsafe { libc::ftruncate(fd, contents.len() as libc::off_t) },
+            0,
+            "ftruncate failed: {}",
+            std::io::Error::last_os_error()
+        );
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        file.write_all(contents).expect("memfd write");
+        file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+        file.into_raw_fd()
+    }
+
+    #[test]
+    fn resolve_surface_mmap_readback_matches_host_pattern() {
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path("mmap-readback");
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let width = 32u32;
+        let height = 4u32;
+        let bpp = 4u32;
+        let size = (width * height * bpp) as usize;
+        let mut pattern = Vec::with_capacity(size);
+        for i in 0..size {
+            pattern.push(((i * 23 + 5) & 0xFF) as u8);
+        }
+        let send_fd = make_memfd_with(&pattern);
+
+        let host_stream =
+            unix_socket_service::connect_to_broker(&socket_path).expect("host connect");
+        let check_in_req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "deno-host-test",
+            "width": width,
+            "height": height,
+            "format": "Bgra32",
+            "resource_type": "pixel_buffer",
+        });
+        let (resp, _) = unix_socket_service::send_request(
+            &host_stream,
+            &check_in_req,
+            Some(send_fd),
+        )
+        .expect("host check_in");
+        unsafe { libc::close(send_fd) };
+        let surface_id = resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id")
+            .to_string();
+        drop(host_stream);
+
+        let c_socket = CString::new(socket_path.to_str().unwrap()).unwrap();
+        let broker = unsafe { sldn_broker_connect(c_socket.as_ptr()) };
+        assert!(!broker.is_null());
+
+        let c_pool_id = CString::new(surface_id.as_str()).unwrap();
+        let handle = unsafe { sldn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(!handle.is_null(), "resolve_surface returned null");
+
+        assert_eq!(unsafe { sldn_gpu_surface_width(handle) }, width);
+        assert_eq!(unsafe { sldn_gpu_surface_height(handle) }, height);
+        assert_eq!(
+            unsafe { sldn_gpu_surface_bytes_per_row(handle) },
+            width * bpp
+        );
+
+        let rc = unsafe { sldn_gpu_surface_lock(handle, 1) };
+        assert_eq!(rc, 0, "sldn_gpu_surface_lock failed");
+        let base = unsafe { sldn_gpu_surface_base_address(handle) };
+        assert!(!base.is_null(), "base_address null after lock");
+        let mapped: &[u8] = unsafe { std::slice::from_raw_parts(base, size) };
+        assert_eq!(mapped, pattern.as_slice());
+        assert_eq!(unsafe { sldn_gpu_surface_unlock(handle, 1) }, 0);
+
+        unsafe { sldn_broker_unregister_surface(broker, c_pool_id.as_ptr()) };
+        unsafe { sldn_gpu_surface_release(handle) };
+        unsafe { sldn_broker_disconnect(broker) };
+        service.stop();
+    }
+
+    #[test]
+    fn resolve_surface_fails_cleanly_on_missing_socket() {
+        let bogus_path = PathBuf::from("/nonexistent/streamlib-broker-test.sock");
+        let c_socket = CString::new(bogus_path.to_str().unwrap()).unwrap();
+        let broker = unsafe { sldn_broker_connect(c_socket.as_ptr()) };
+        assert!(
+            !broker.is_null(),
+            "connect should succeed lazily even for a bogus socket path"
+        );
+
+        let c_pool_id = CString::new("any-surface-id").unwrap();
+        let handle = unsafe { sldn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(
+            handle.is_null(),
+            "resolve_surface should fail cleanly when the socket is unreachable"
+        );
+
+        unsafe { sldn_broker_disconnect(broker) };
+    }
 }

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -140,19 +140,31 @@ async function main(): Promise<void> {
     Deno.exit(1);
   }
 
-  // Connect to broker for surface resolution (if XPC service name is set)
-  const xpcServiceName = Deno.env.get("STREAMLIB_XPC_SERVICE_NAME") ?? "";
+  // Connect to broker for surface resolution.
+  //
+  // macOS: STREAMLIB_XPC_SERVICE_NAME is the launchd mach-service name.
+  // Linux: STREAMLIB_BROKER_SOCKET is the Unix-socket path the broker
+  //        listens on. Both values funnel through the same FFI entry
+  //        (`sldn_broker_connect`) — the native lib's platform-specific
+  //        broker_macos / broker_linux module interprets the C string
+  //        accordingly.
+  const isDarwin = Deno.build.os === "darwin";
+  const brokerEndpoint = isDarwin
+    ? (Deno.env.get("STREAMLIB_XPC_SERVICE_NAME") ?? "")
+    : (Deno.env.get("STREAMLIB_BROKER_SOCKET") ?? "");
+  const brokerEndpointDesc = isDarwin ? "xpc_service_name" : "broker_socket";
   let brokerPtr: Deno.PointerObject | null = null;
-  if (xpcServiceName) {
-    const serviceNameBuf = cString(xpcServiceName);
-    brokerPtr = lib.symbols.sldn_broker_connect(serviceNameBuf);
+  if (brokerEndpoint) {
+    const endpointBuf = cString(brokerEndpoint);
+    brokerPtr = lib.symbols.sldn_broker_connect(endpointBuf);
     if (brokerPtr === null) {
-      console.error(`[subprocess_runner:${processorId}] Warning: broker connect failed for '${xpcServiceName}'`);
+      console.error(`[subprocess_runner:${processorId}] Warning: broker connect failed (${brokerEndpointDesc}='${brokerEndpoint}')`);
     } else {
-      console.error(`[subprocess_runner:${processorId}] Connected to broker '${xpcServiceName}'`);
+      console.error(`[subprocess_runner:${processorId}] Connected to broker (${brokerEndpointDesc}='${brokerEndpoint}')`);
     }
   } else {
-    console.error(`[subprocess_runner:${processorId}] No STREAMLIB_XPC_SERVICE_NAME set, broker resolution disabled`);
+    const envName = isDarwin ? "STREAMLIB_XPC_SERVICE_NAME" : "STREAMLIB_BROKER_SOCKET";
+    console.error(`[subprocess_runner:${processorId}] No ${envName} set, broker resolution disabled`);
   }
 
   let processor: ProcessorLifecycle | null = null;

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -20,3 +20,10 @@ iceoryx2 = "0.8.1"
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
+[dev-dependencies]
+# Broker unit tests spin up a real UnixSocketSurfaceService + client in-process.
+streamlib-broker = { path = "../streamlib-broker" }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -772,7 +772,188 @@ mod gpu_surface {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod gpu_surface {
+    //! Linux GPU surface handle backed by a DMA-BUF file descriptor.
+    //!
+    //! The handle is produced by [`super::broker_client::slpn_broker_resolve_surface`]
+    //! (after a broker `check_out` over `SCM_RIGHTS`) and consumed by the
+    //! `slpn_gpu_surface_*` FFI symbols — same shape as the macOS IOSurface
+    //! variant so Python's `ctypes` bindings don't branch by platform.
+    //!
+    //! CPU access is via `mmap(fd)` on lock; Vulkan import via
+    //! `vkImportMemoryFdInfoKHR` is intentionally deferred to a follow-up so
+    //! this crate keeps its minimal cdylib dependency footprint until a
+    //! GPU-consuming Python subprocess materializes.
+    use std::ffi::c_void;
+    use std::os::unix::io::RawFd;
+
+    pub struct SurfaceHandle {
+        pub fd: RawFd,
+        pub width: u32,
+        pub height: u32,
+        pub bytes_per_row: u32,
+        pub size: u64,
+        pub mapped_ptr: *mut u8,
+        pub is_locked: bool,
+    }
+
+    impl Drop for SurfaceHandle {
+        fn drop(&mut self) {
+            if self.is_locked && !self.mapped_ptr.is_null() && self.size > 0 {
+                unsafe {
+                    libc::munmap(self.mapped_ptr as *mut c_void, self.size as usize);
+                }
+            }
+            if self.fd >= 0 {
+                unsafe {
+                    libc::close(self.fd);
+                }
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_lookup(_iosurface_id: u32) -> *mut SurfaceHandle {
+        eprintln!("[slpn] GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_lock(
+        handle: *mut SurfaceHandle,
+        read_only: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        if handle.is_locked {
+            return 0;
+        }
+        if handle.size == 0 || handle.fd < 0 {
+            return -1;
+        }
+        let prot = if read_only != 0 {
+            libc::PROT_READ
+        } else {
+            libc::PROT_READ | libc::PROT_WRITE
+        };
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                handle.size as usize,
+                prot,
+                libc::MAP_SHARED,
+                handle.fd,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            eprintln!(
+                "[slpn] mmap on DMA-BUF fd {} failed: {}",
+                handle.fd,
+                std::io::Error::last_os_error()
+            );
+            return -1;
+        }
+        handle.mapped_ptr = ptr as *mut u8;
+        handle.is_locked = true;
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_unlock(
+        handle: *mut SurfaceHandle,
+        _read_only: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        if !handle.is_locked {
+            return 0;
+        }
+        let result = unsafe {
+            libc::munmap(handle.mapped_ptr as *mut c_void, handle.size as usize)
+        };
+        handle.mapped_ptr = std::ptr::null_mut();
+        handle.is_locked = false;
+        if result != 0 {
+            -1
+        } else {
+            0
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_base_address(
+        handle: *const SurfaceHandle,
+    ) -> *mut u8 {
+        match unsafe { handle.as_ref() } {
+            Some(h) => h.mapped_ptr,
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_width(handle: *const SurfaceHandle) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.width).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_height(handle: *const SurfaceHandle) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.height).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_bytes_per_row(
+        handle: *const SurfaceHandle,
+    ) -> u32 {
+        unsafe { handle.as_ref() }.map(|h| h.bytes_per_row).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_create(
+        _width: u32,
+        _height: u32,
+        _bytes_per_element: u32,
+    ) -> *mut SurfaceHandle {
+        eprintln!(
+            "[slpn] GPU surface creation in subprocess is not supported on Linux; allocation \
+             must go through escalate IPC (GpuContextFullAccess -> RHI -> SurfaceStore.check_in)"
+        );
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_get_id(handle: *const SurfaceHandle) -> u32 {
+        // Linux surface IDs are broker UUIDs (strings), not u32 IOSurfaceIDs.
+        // Return the fd as a best-effort numeric token so Python code that
+        // unconditionally calls this doesn't get a u32 collision with a real
+        // IOSurface id. Callers that need the string surface_id should keep
+        // the broker pool_id they already passed to resolve_surface.
+        unsafe { handle.as_ref() }.map(|h| h.fd as u32).unwrap_or(0)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_iosurface_ref(
+        _handle: *const SurfaceHandle,
+    ) -> *const c_void {
+        // No IOSurface equivalent on Linux.
+        std::ptr::null()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_release(handle: *mut SurfaceHandle) {
+        if !handle.is_null() {
+            let _ = unsafe { Box::from_raw(handle) };
+            // Drop impl closes fd and munmaps if locked.
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod gpu_surface {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_gpu_surface_lookup(_iosurface_id: u32) -> *mut std::ffi::c_void {
@@ -1336,7 +1517,545 @@ mod broker_client {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+mod broker_client {
+    //! Linux broker consumer client.
+    //!
+    //! Mirrors the macOS XPC shim's FFI surface (same `slpn_broker_*` symbols,
+    //! same arg shapes) but speaks the Unix-socket + SCM_RIGHTS wire protocol
+    //! that [`streamlib_broker::unix_socket_service`] listens on. Consumer-only
+    //! per the safety posture in `docs/research/polyglot-dma-buf-fd.md` —
+    //! allocation always goes through the host via #325 escalate IPC.
+    //!
+    //! Lifecycle:
+    //!   - `slpn_broker_connect(socket_path, runtime_id)` stores config only;
+    //!     the Unix socket is lazily opened on the first op (per the research
+    //!     doc's "fail at first use" decision). Subprocesses that never touch
+    //!     GPU surfaces never need the broker up.
+    //!   - `slpn_broker_resolve_surface(broker, pool_id)` sends a `check_out`
+    //!     op, receives a DMA-BUF fd via SCM_RIGHTS, caches the fd keyed by
+    //!     pool_id, returns a [`SurfaceHandle`] with its own fd dup.
+    //!   - `slpn_broker_unregister_surface(broker, pool_id)` evicts the cache
+    //!     and sends a `release` op.
+    //!   - `slpn_broker_acquire_surface(...)` returns null with a clear error
+    //!     — allocation is host-only.
+    use std::collections::HashMap;
+    use std::ffi::{c_char, CStr};
+    use std::os::unix::io::RawFd;
+    use std::os::unix::net::UnixStream;
+    use std::sync::Mutex;
+
+    use super::gpu_surface::SurfaceHandle;
+
+    /// Maximum cached resolved surfaces before we drop the whole cache.
+    const MAX_RESOLVE_CACHE: usize = 128;
+
+    struct CachedSurface {
+        fd: RawFd,
+        width: u32,
+        height: u32,
+        bytes_per_row: u32,
+        size: u64,
+    }
+
+    impl Drop for CachedSurface {
+        fn drop(&mut self) {
+            if self.fd >= 0 {
+                unsafe { libc::close(self.fd) };
+            }
+        }
+    }
+
+    /// Opaque broker handle returned to Python as `*mut BrokerHandle`.
+    pub struct BrokerHandle {
+        socket_path: String,
+        runtime_id: String,
+        connection: Mutex<Option<UnixStream>>,
+        resolve_cache: Mutex<HashMap<String, CachedSurface>>,
+    }
+
+    impl BrokerHandle {
+        /// Return a guard over the (possibly lazily-opened) socket connection.
+        fn lazy_connect(
+            &self,
+        ) -> std::io::Result<std::sync::MutexGuard<'_, Option<UnixStream>>> {
+            let mut guard = self.connection.lock().expect("poisoned");
+            if guard.is_none() {
+                let stream = UnixStream::connect(&self.socket_path)?;
+                stream.set_nonblocking(false)?;
+                *guard = Some(stream);
+            }
+            Ok(guard)
+        }
+    }
+
+    // =========================================================================
+    // Wire helpers — duplicated from streamlib_broker::unix_socket_service to
+    // keep this cdylib's dependency surface minimal. Kept byte-compatible by
+    // design (see unit tests in both crates).
+    // =========================================================================
+    mod wire {
+        use std::os::unix::io::{AsRawFd, RawFd};
+        use std::os::unix::net::UnixStream;
+
+        pub fn send_message_with_fd(
+            stream: &UnixStream,
+            data: &[u8],
+            fd: Option<RawFd>,
+        ) -> std::io::Result<()> {
+            // Length prefix (4 bytes big-endian)
+            let len_bytes = (data.len() as u32).to_be_bytes();
+            let mut len_iov = libc::iovec {
+                iov_base: len_bytes.as_ptr() as *mut libc::c_void,
+                iov_len: 4,
+            };
+            let mut len_msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            len_msg.msg_iov = &mut len_iov;
+            len_msg.msg_iovlen = 1;
+            let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &len_msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+
+            // Payload + optional SCM_RIGHTS
+            let mut iov = libc::iovec {
+                iov_base: data.as_ptr() as *mut libc::c_void,
+                iov_len: data.len(),
+            };
+            let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg.msg_iov = &mut iov;
+            msg.msg_iovlen = 1;
+
+            const CMSG_SPACE_SIZE: usize =
+                unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
+            #[repr(C)]
+            union CmsgBuf {
+                buf: [u8; CMSG_SPACE_SIZE],
+                _align: libc::cmsghdr,
+            }
+            let mut cmsg_buf = CmsgBuf {
+                buf: [0u8; CMSG_SPACE_SIZE],
+            };
+
+            if let Some(send_fd) = fd {
+                msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
+                msg.msg_controllen = CMSG_SPACE_SIZE;
+                let cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+                if !cmsg_ptr.is_null() {
+                    unsafe {
+                        (*cmsg_ptr).cmsg_level = libc::SOL_SOCKET;
+                        (*cmsg_ptr).cmsg_type = libc::SCM_RIGHTS;
+                        (*cmsg_ptr).cmsg_len =
+                            libc::CMSG_LEN(std::mem::size_of::<RawFd>() as u32) as usize;
+                        let fd_ptr = libc::CMSG_DATA(cmsg_ptr) as *mut RawFd;
+                        *fd_ptr = send_fd;
+                    }
+                    msg.msg_controllen = CMSG_SPACE_SIZE;
+                }
+            }
+
+            let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+
+        pub fn recv_message_with_fd(
+            stream: &UnixStream,
+            msg_len: usize,
+        ) -> std::io::Result<(Vec<u8>, Option<RawFd>)> {
+            const CMSG_SPACE_SIZE: usize =
+                unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
+            #[repr(C)]
+            union CmsgBuf {
+                buf: [u8; CMSG_SPACE_SIZE],
+                _align: libc::cmsghdr,
+            }
+            let mut cmsg_buf = CmsgBuf {
+                buf: [0u8; CMSG_SPACE_SIZE],
+            };
+
+            let mut buf = vec![0u8; msg_len];
+            let mut iov = libc::iovec {
+                iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+                iov_len: msg_len,
+            };
+            let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+            msg.msg_iov = &mut iov;
+            msg.msg_iovlen = 1;
+            msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
+            msg.msg_controllen = CMSG_SPACE_SIZE;
+
+            let n = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut msg, 0) };
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "Connection closed",
+                ));
+            }
+            if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SCM_RIGHTS control message truncated",
+                ));
+            }
+
+            let mut total_read = n as usize;
+            while total_read < msg_len {
+                let remaining = &mut buf[total_read..];
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        remaining.as_mut_ptr() as *mut libc::c_void,
+                        remaining.len(),
+                    )
+                };
+                if n <= 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "Connection closed during message read",
+                    ));
+                }
+                total_read += n as usize;
+            }
+
+            let mut received_fd = None;
+            let mut cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+            while !cmsg_ptr.is_null() {
+                let cmsg = unsafe { &*cmsg_ptr };
+                if cmsg.cmsg_level == libc::SOL_SOCKET && cmsg.cmsg_type == libc::SCM_RIGHTS {
+                    let fd_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const RawFd;
+                    received_fd = Some(unsafe { *fd_ptr });
+                }
+                cmsg_ptr = unsafe { libc::CMSG_NXTHDR(&msg, cmsg_ptr) };
+            }
+            // Use `buf` now to keep the underlying allocation alive.
+            let _ = &buf;
+            let mut read_buf = vec![0u8; msg_len];
+            read_buf.copy_from_slice(&buf[..msg_len]);
+            Ok((read_buf, received_fd))
+        }
+
+        pub fn send_request(
+            stream: &UnixStream,
+            request: &serde_json::Value,
+            fd: Option<RawFd>,
+        ) -> std::io::Result<(serde_json::Value, Option<RawFd>)> {
+            let request_bytes = serde_json::to_vec(request).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to serialize request: {}", e),
+                )
+            })?;
+            send_message_with_fd(stream, &request_bytes, fd)?;
+
+            // Read response length prefix (4 bytes big-endian)
+            let mut len_buf = [0u8; 4];
+            let mut total = 0;
+            while total < 4 {
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                        4 - total,
+                    )
+                };
+                if n <= 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "Failed to read response length",
+                    ));
+                }
+                total += n as usize;
+            }
+            let response_len = u32::from_be_bytes(len_buf) as usize;
+            let (response_bytes, response_fd) = recv_message_with_fd(stream, response_len)?;
+            let response: serde_json::Value = serde_json::from_slice(&response_bytes)
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid JSON response: {}", e),
+                    )
+                })?;
+            Ok((response, response_fd))
+        }
+    }
+
+    fn c_str_to_string(ptr: *const c_char) -> Option<String> {
+        if ptr.is_null() {
+            return None;
+        }
+        unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .ok()
+            .map(|s| s.to_string())
+    }
+
+    /// Derive a fallback bytes-per-row for a given format string. The broker
+    /// wire format emits `format!("{:?}", pixel_buffer.format())` which is the
+    /// Debug rendering of the `PixelFormat` enum variant name (e.g.
+    /// `"Bgra32"`). Returns `bytes_per_pixel` to compute the default row
+    /// stride; real driver-reported stride is a follow-up (broker's lookup
+    /// response does not carry it today).
+    fn bytes_per_pixel_from_format(format_str: &str) -> u32 {
+        match format_str {
+            "Bgra32" | "Rgba32" | "Argb32" => 4,
+            "Rgba64" => 8,
+            "Gray8" => 1,
+            "Yuyv422" | "Uyvy422" => 2,
+            "Nv12VideoRange" | "Nv12FullRange" => 1,
+            _ => 4,
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_broker_connect(
+        socket_path: *const c_char,
+        runtime_id: *const c_char,
+    ) -> *mut BrokerHandle {
+        let socket_path = match c_str_to_string(socket_path) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                eprintln!("[slpn] broker_connect (linux): null or empty socket path");
+                return std::ptr::null_mut();
+            }
+        };
+        let runtime_id =
+            c_str_to_string(runtime_id).unwrap_or_else(|| "python-subprocess".to_string());
+
+        // Intentional: do NOT open the socket yet. Per the research doc,
+        // lazy-connect + fail-at-first-use decouples subprocess lifecycle
+        // from broker lifecycle.
+        eprintln!(
+            "[slpn] broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
+             (lazy; will connect on first resolve_surface)",
+            socket_path, runtime_id
+        );
+
+        Box::into_raw(Box::new(BrokerHandle {
+            socket_path,
+            runtime_id,
+            connection: Mutex::new(None),
+            resolve_cache: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_broker_disconnect(broker: *mut BrokerHandle) {
+        if !broker.is_null() {
+            let _ = unsafe { Box::from_raw(broker) };
+            // Drop impls close sockets and all cached fds.
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_broker_resolve_surface(
+        broker: *mut BrokerHandle,
+        pool_id: *const c_char,
+    ) -> *mut SurfaceHandle {
+        let broker = match unsafe { broker.as_ref() } {
+            Some(b) => b,
+            None => {
+                eprintln!("[slpn] broker_resolve_surface (linux): null broker handle");
+                return std::ptr::null_mut();
+            }
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                eprintln!("[slpn] broker_resolve_surface (linux): null or empty pool_id");
+                return std::ptr::null_mut();
+            }
+        };
+
+        // Cache hit — dup the stored fd so the returned SurfaceHandle owns
+        // an independent fd copy. (mmap on the cached fd is not allowed since
+        // each SurfaceHandle manages its own mmap lifecycle.)
+        {
+            let cache = broker.resolve_cache.lock().expect("poisoned");
+            if let Some(cached) = cache.get(&pool_id_str) {
+                let dup_fd = unsafe { libc::dup(cached.fd) };
+                if dup_fd < 0 {
+                    eprintln!(
+                        "[slpn] broker_resolve_surface: dup cached fd failed for '{}': {}",
+                        pool_id_str,
+                        std::io::Error::last_os_error()
+                    );
+                    return std::ptr::null_mut();
+                }
+                return Box::into_raw(Box::new(SurfaceHandle {
+                    fd: dup_fd,
+                    width: cached.width,
+                    height: cached.height,
+                    bytes_per_row: cached.bytes_per_row,
+                    size: cached.size,
+                    mapped_ptr: std::ptr::null_mut(),
+                    is_locked: false,
+                }));
+            }
+        }
+
+        // Cache miss — connect lazily, send check_out, receive fd + metadata.
+        let guard = match broker.lazy_connect() {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!(
+                    "[slpn] broker_resolve_surface: connect to '{}' failed: {}. \
+                     Is the broker running? Start it with `sudo systemctl start streamlib-broker` \
+                     or via scripts/dev-setup.sh.",
+                    broker.socket_path, e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let stream = guard.as_ref().expect("connection just populated");
+
+        let request = serde_json::json!({
+            "op": "check_out",
+            "surface_id": pool_id_str,
+        });
+        let (response, received_fd) = match wire::send_request(stream, &request, None) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "[slpn] broker_resolve_surface: check_out for '{}' failed: {}",
+                    pool_id_str, e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
+            eprintln!(
+                "[slpn] broker_resolve_surface: broker error for '{}': {}",
+                pool_id_str, err
+            );
+            if let Some(fd) = received_fd {
+                unsafe { libc::close(fd) };
+            }
+            return std::ptr::null_mut();
+        }
+
+        let dma_buf_fd = match received_fd {
+            Some(fd) => fd,
+            None => {
+                eprintln!(
+                    "[slpn] broker_resolve_surface: no DMA-BUF fd for '{}'",
+                    pool_id_str
+                );
+                return std::ptr::null_mut();
+            }
+        };
+
+        let width = response.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let height = response.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let format_str = response
+            .get("format")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Bgra32");
+        let bpp = bytes_per_pixel_from_format(format_str);
+        let bytes_per_row = width.saturating_mul(bpp);
+        let size = (height as u64).saturating_mul(bytes_per_row as u64);
+
+        // Cache: dup for the cache's own copy so the returned handle owns
+        // its own fd independently of the cache's fd.
+        let cache_fd = unsafe { libc::dup(dma_buf_fd) };
+        if cache_fd >= 0 {
+            let mut cache = broker.resolve_cache.lock().expect("poisoned");
+            if cache.len() >= MAX_RESOLVE_CACHE {
+                eprintln!(
+                    "[slpn] broker resolve cache exceeded {} entries, dropping all cached fds",
+                    MAX_RESOLVE_CACHE
+                );
+                cache.clear();
+            }
+            cache.insert(
+                pool_id_str.clone(),
+                CachedSurface {
+                    fd: cache_fd,
+                    width,
+                    height,
+                    bytes_per_row,
+                    size,
+                },
+            );
+        }
+
+        Box::into_raw(Box::new(SurfaceHandle {
+            fd: dma_buf_fd,
+            width,
+            height,
+            bytes_per_row,
+            size,
+            mapped_ptr: std::ptr::null_mut(),
+            is_locked: false,
+        }))
+    }
+
+    /// Allocation on Linux goes through the host's escalate IPC path
+    /// (`#325`'s `acquire_pixel_buffer` → `GpuContextFullAccess` → RHI →
+    /// `SurfaceStore.check_in`). Returning null here matches the research
+    /// doc's safety posture: subprocess native libs are deliberately
+    /// consumer-only so RHI invariants (NVIDIA DMA-BUF pool discipline, VMA
+    /// export pools, queue-submit mutexing) cover every allocation.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_broker_acquire_surface(
+        _broker: *mut BrokerHandle,
+        _width: u32,
+        _height: u32,
+        _bytes_per_element: u32,
+        _out_pool_id: *mut c_char,
+        _pool_id_buf_len: u32,
+    ) -> *mut SurfaceHandle {
+        eprintln!(
+            "[slpn] broker_acquire_surface: not supported on Linux; subprocess allocation must \
+             escalate to the host (acquire_pixel_buffer / acquire_texture over the stdio IPC) — \
+             the subprocess then calls resolve_surface with the returned handle_id."
+        );
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_broker_unregister_surface(
+        broker: *mut BrokerHandle,
+        pool_id: *const c_char,
+    ) {
+        let broker = match unsafe { broker.as_ref() } {
+            Some(b) => b,
+            None => return,
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => return,
+        };
+
+        // Evict the cached fd (its Drop closes the fd).
+        {
+            let mut cache = broker.resolve_cache.lock().expect("poisoned");
+            let _ = cache.remove(&pool_id_str);
+        }
+
+        // Best-effort release on the wire.
+        let guard = match broker.lazy_connect() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if let Some(stream) = guard.as_ref() {
+            let request = serde_json::json!({
+                "op": "release",
+                "surface_id": pool_id_str,
+                "runtime_id": broker.runtime_id,
+            });
+            let _ = wire::send_request(stream, &request, None);
+        }
+    }
+
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod broker_client {
     use std::ffi::{c_char, c_void};
 
@@ -1389,4 +2108,225 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         return None;
     }
     unsafe { CStr::from_ptr(ptr) }.to_str().ok()
+}
+
+// ============================================================================
+// Tests — Linux broker consumer shim round-trip
+// ============================================================================
+//
+// These tests spin up a real `UnixSocketSurfaceService` in-process (via
+// streamlib-broker dev-dep), register a memfd with the broker, then drive the
+// native-lib's `slpn_broker_*` / `slpn_gpu_surface_*` FFI like the Python
+// subprocess would. The memfd lets us verify the fd carried across SCM_RIGHTS
+// is the same kernel file object — mmap'ing it through `slpn_gpu_surface_lock`
+// reads back the host-written pattern byte-for-byte.
+//
+// Vulkan import (`vkImportMemoryFdInfoKHR`) is intentionally not exercised
+// here; the wire + fd-delivery + CPU-access path covers the subprocess's
+// consumer role end to end. A follow-up will wire the Vulkan side once a
+// GPU-consuming Python subprocess surfaces a need for it (see PR body).
+
+#[cfg(all(test, target_os = "linux"))]
+mod broker_linux_tests {
+    use std::ffi::CString;
+    use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+    use std::os::unix::net::UnixStream;
+    use std::path::PathBuf;
+
+    use streamlib_broker::{unix_socket_service, BrokerState};
+    use unix_socket_service::UnixSocketSurfaceService;
+
+    use super::broker_client::{
+        slpn_broker_connect, slpn_broker_disconnect, slpn_broker_resolve_surface,
+        slpn_broker_unregister_surface,
+    };
+    use super::gpu_surface::{
+        slpn_gpu_surface_base_address, slpn_gpu_surface_bytes_per_row, slpn_gpu_surface_height,
+        slpn_gpu_surface_lock, slpn_gpu_surface_release, slpn_gpu_surface_unlock,
+        slpn_gpu_surface_width,
+    };
+
+    fn tmp_socket_path(label: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!(
+            "streamlib-python-native-test-{}-{}-{}.sock",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        p
+    }
+
+    /// Seed an anonymous file with `contents`. Returned fd is owned by caller.
+    fn make_memfd_with(contents: &[u8]) -> RawFd {
+        use std::io::{Seek, SeekFrom, Write};
+
+        let name = CString::new("slpn-test-memfd").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+        assert!(
+            fd >= 0,
+            "memfd_create failed: {}",
+            std::io::Error::last_os_error()
+        );
+        // memfd starts with zero size — ftruncate to the content length first
+        // so subsequent mmap calls see the full region.
+        assert_eq!(
+            unsafe { libc::ftruncate(fd, contents.len() as libc::off_t) },
+            0,
+            "ftruncate failed: {}",
+            std::io::Error::last_os_error()
+        );
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        file.write_all(contents).expect("memfd write");
+        file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+        file.into_raw_fd()
+    }
+
+    #[test]
+    fn resolve_surface_mmap_readback_matches_host_pattern() {
+        // 1. Start a broker service in-process.
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path("mmap-readback");
+        let mut service =
+            UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // 2. Host side: check_in a memfd under a known pattern.
+        let width = 32u32;
+        let height = 4u32;
+        let bpp = 4u32; // Bgra32 default
+        let size = (width * height * bpp) as usize;
+        let mut pattern = Vec::with_capacity(size);
+        for i in 0..size {
+            pattern.push(((i * 17 + 3) & 0xFF) as u8);
+        }
+        let send_fd = make_memfd_with(&pattern);
+
+        let host_stream =
+            unix_socket_service::connect_to_broker(&socket_path).expect("host connect");
+        let check_in_req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "host-test",
+            "width": width,
+            "height": height,
+            "format": "Bgra32",
+            "resource_type": "pixel_buffer",
+        });
+        let (resp, _) = unix_socket_service::send_request(
+            &host_stream,
+            &check_in_req,
+            Some(send_fd),
+        )
+        .expect("host check_in");
+        unsafe { libc::close(send_fd) };
+        let surface_id = resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id")
+            .to_string();
+        drop(host_stream);
+
+        // 3. Subprocess side (native-lib FFI): slpn_broker_connect → resolve → lock.
+        let c_socket = CString::new(socket_path.to_str().unwrap()).unwrap();
+        let c_runtime = CString::new("subprocess-test").unwrap();
+        let broker = unsafe { slpn_broker_connect(c_socket.as_ptr(), c_runtime.as_ptr()) };
+        assert!(!broker.is_null());
+
+        let c_pool_id = CString::new(surface_id.as_str()).unwrap();
+        let handle = unsafe { slpn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(!handle.is_null(), "resolve_surface returned null");
+
+        assert_eq!(unsafe { slpn_gpu_surface_width(handle) }, width);
+        assert_eq!(unsafe { slpn_gpu_surface_height(handle) }, height);
+        assert_eq!(
+            unsafe { slpn_gpu_surface_bytes_per_row(handle) },
+            width * bpp
+        );
+
+        // 4. Lock → mmap; verify byte-for-byte match.
+        let rc = unsafe { slpn_gpu_surface_lock(handle, 1) };
+        assert_eq!(rc, 0, "slpn_gpu_surface_lock failed");
+        let base = unsafe { slpn_gpu_surface_base_address(handle) };
+        assert!(!base.is_null(), "base_address null after lock");
+        let mapped: &[u8] = unsafe { std::slice::from_raw_parts(base, size) };
+        assert_eq!(mapped, pattern.as_slice());
+
+        assert_eq!(unsafe { slpn_gpu_surface_unlock(handle, 1) }, 0);
+
+        // 5. Resolve a second time → cache hit path, same bytes.
+        let handle2 = unsafe { slpn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(!handle2.is_null(), "cached resolve_surface returned null");
+        assert_eq!(unsafe { slpn_gpu_surface_width(handle2) }, width);
+        assert_eq!(unsafe { slpn_gpu_surface_lock(handle2, 1) }, 0);
+        let base2 = unsafe { slpn_gpu_surface_base_address(handle2) };
+        let mapped2: &[u8] = unsafe { std::slice::from_raw_parts(base2, size) };
+        assert_eq!(
+            mapped2, pattern.as_slice(),
+            "cached handle should surface the same bytes"
+        );
+        assert_eq!(unsafe { slpn_gpu_surface_unlock(handle2, 1) }, 0);
+        unsafe { slpn_gpu_surface_release(handle2) };
+
+        // 6. Unregister + release handle, disconnect, stop service.
+        unsafe { slpn_broker_unregister_surface(broker, c_pool_id.as_ptr()) };
+        unsafe { slpn_gpu_surface_release(handle) };
+        unsafe { slpn_broker_disconnect(broker) };
+        service.stop();
+    }
+
+    #[test]
+    fn resolve_surface_fails_cleanly_on_missing_socket() {
+        // Pointed at a path that doesn't exist — native lib must return null
+        // with a clear error on first resolve_surface, not crash on connect.
+        let bogus_path = PathBuf::from("/nonexistent/streamlib-broker-test.sock");
+        let c_socket = CString::new(bogus_path.to_str().unwrap()).unwrap();
+        let c_runtime = CString::new("lazy-connect-test").unwrap();
+        let broker = unsafe { slpn_broker_connect(c_socket.as_ptr(), c_runtime.as_ptr()) };
+        assert!(
+            !broker.is_null(),
+            "connect should succeed lazily even for a bogus socket path"
+        );
+
+        let c_pool_id = CString::new("any-surface-id").unwrap();
+        let handle = unsafe { slpn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(
+            handle.is_null(),
+            "resolve_surface should fail cleanly when the socket is unreachable"
+        );
+
+        unsafe { slpn_broker_disconnect(broker) };
+    }
+
+    #[test]
+    fn resolve_surface_fails_cleanly_on_unknown_surface_id() {
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path("unknown-id");
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let c_socket = CString::new(socket_path.to_str().unwrap()).unwrap();
+        let c_runtime = CString::new("unknown-id-test").unwrap();
+        let broker = unsafe { slpn_broker_connect(c_socket.as_ptr(), c_runtime.as_ptr()) };
+        assert!(!broker.is_null());
+
+        let c_pool_id = CString::new("never-registered-surface").unwrap();
+        let handle = unsafe { slpn_broker_resolve_surface(broker, c_pool_id.as_ptr()) };
+        assert!(
+            handle.is_null(),
+            "resolve_surface must return null for unknown surface_id"
+        );
+
+        unsafe { slpn_broker_disconnect(broker) };
+        service.stop();
+    }
+
+    // Silence "unused struct UnixStream" at module scope in test-only build.
+    #[allow(dead_code)]
+    fn _keep_unix_stream_referenced(_s: &UnixStream) {}
 }

--- a/libs/streamlib-python/python/streamlib/gpu_surface.py
+++ b/libs/streamlib-python/python/streamlib/gpu_surface.py
@@ -4,7 +4,11 @@
 """Platform-specific zero-copy GPU surface access.
 
 macOS: IOSurface shared memory via ctypes (kernel-managed, cross-process).
-Linux: Not yet implemented (needs Vulkan DMA-BUF / EGL external memory).
+Linux: DMA-BUF FDs + Vulkan `VkImportMemoryFdInfoKHR` via the
+    `slpn_broker_*` FFI in `streamlib-python-native`. There is no direct
+    ctypes CPU-mmap equivalent of `IOSurfaceLookup` — the Linux resolve
+    path lives behind `NativeGpuContext*` in `processor_context.py`, not
+    this module.
 Windows: Not yet implemented (needs DirectX 12 shared textures / NT handles).
 """
 
@@ -92,11 +96,13 @@ if sys.platform == "darwin":
             self.release()
 
 elif sys.platform == "linux":
-    raise NotImplementedError(
-        "GPU surface access not yet implemented on Linux. "
-        "Requires Vulkan DMA-BUF / EGL external memory integration. "
-        "See: VK_EXT_external_memory_dma_buf, VK_KHR_external_memory_fd"
-    )
+    # Intentionally empty — Linux CPU access to GPU surfaces goes through
+    # `NativeGpuContext*` in `processor_context.py`, which owns the DMA-BUF
+    # FD import via `streamlib-python-native`'s `slpn_broker_resolve_surface`
+    # and returns a handle holding an imported VkImage. Importing this
+    # module on Linux must succeed (some processors import it unconditionally)
+    # but no IOSurface-shaped class is defined here.
+    pass
 
 elif sys.platform == "win32":
     raise NotImplementedError(

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -104,23 +104,36 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
         if result != 0:
             _logger.error("Failed to create publisher for '%s'", dest_service)
 
-    # Connect to broker for surface resolution (if XPC service name is set)
+    # Connect to broker for surface resolution.
+    #
+    # macOS: STREAMLIB_XPC_SERVICE_NAME is the launchd mach-service name.
+    # Linux: STREAMLIB_BROKER_SOCKET is the Unix-socket path the broker
+    #        listens on. Both values funnel through the same FFI entry
+    #        (`slpn_broker_connect`) — the native lib's platform-specific
+    #        broker_macos / broker_linux module interprets the C string
+    #        accordingly.
     broker_ptr = None
-    xpc_service_name = os.environ.get("STREAMLIB_XPC_SERVICE_NAME", "")
+    if sys.platform == "darwin":
+        broker_endpoint = os.environ.get("STREAMLIB_XPC_SERVICE_NAME", "")
+        broker_endpoint_desc = "xpc_service_name"
+    else:
+        broker_endpoint = os.environ.get("STREAMLIB_BROKER_SOCKET", "")
+        broker_endpoint_desc = "broker_socket"
     runtime_id = os.environ.get("STREAMLIB_RUNTIME_ID", "")
-    if xpc_service_name:
+    if broker_endpoint:
         runtime_id_arg = runtime_id.encode("utf-8") if runtime_id else None
         broker_ptr = lib.slpn_broker_connect(
-            xpc_service_name.encode("utf-8"), runtime_id_arg
+            broker_endpoint.encode("utf-8"), runtime_id_arg
         )
         if broker_ptr:
             _logger.info(
-                "Connected to broker '%s' with runtime_id='%s'",
-                xpc_service_name, runtime_id,
+                "Connected to broker (%s='%s', runtime_id='%s')",
+                broker_endpoint_desc, broker_endpoint, runtime_id,
             )
         else:
             _logger.warning(
-                "Broker connect failed for '%s'", xpc_service_name,
+                "Broker connect failed (%s='%s')",
+                broker_endpoint_desc, broker_endpoint,
             )
 
     state = NativeProcessorState(

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -108,6 +108,11 @@ impl EscalateHandleRegistry {
 ///
 /// Never panics — errors inside `escalate()` become [`EscalateResponse::Err`]
 /// with the original request_id preserved so the subprocess can correlate.
+///
+/// On Linux, acquisition handlers additionally check the freshly-allocated
+/// resource in with the broker's [`SurfaceStore`] so the polyglot subprocess
+/// can `check_out` the DMA-BUF FD by the same handle_id. The `handle_id`
+/// returned to the subprocess is the broker-assigned `surface_id`.
 pub(crate) fn handle_escalate_op(
     sandbox: &GpuContextLimitedAccess,
     registry: &EscalateHandleRegistry,
@@ -122,9 +127,13 @@ pub(crate) fn handle_escalate_op(
             format,
         }) => match parse_pixel_format(&format) {
             Ok(parsed) => {
-                match sandbox.escalate(|full| full.acquire_pixel_buffer(width, height, parsed)) {
-                    Ok((pool_id, buffer)) => {
-                        let handle_id = pool_id.as_str().to_string();
+                let acquired = sandbox.escalate(|full| {
+                    let (pool_id, buffer) = full.acquire_pixel_buffer(width, height, parsed)?;
+                    let handle_id = assign_buffer_handle_id(full, &pool_id, &buffer)?;
+                    Ok((handle_id, buffer))
+                });
+                match acquired {
+                    Ok((handle_id, buffer)) => {
                         registry.insert_buffer(handle_id.clone(), buffer);
                         EscalateResponse::Ok(EscalateResponseOk {
                             request_id: rid,
@@ -173,9 +182,13 @@ pub(crate) fn handle_escalate_op(
             };
             let desc = TexturePoolDescriptor::new(width, height, parsed_format)
                 .with_usage(parsed_usage);
-            match sandbox.escalate(|full| full.acquire_texture(&desc)) {
-                Ok(texture) => {
-                    let handle_id = Uuid::new_v4().to_string();
+            let acquired = sandbox.escalate(|full| {
+                let texture = full.acquire_texture(&desc)?;
+                let handle_id = assign_texture_handle_id(full, &texture)?;
+                Ok((handle_id, texture))
+            });
+            match acquired {
+                Ok((handle_id, texture)) => {
                     registry.insert_texture(handle_id.clone(), texture);
                     EscalateResponse::Ok(EscalateResponseOk {
                         request_id: rid,
@@ -198,6 +211,7 @@ pub(crate) fn handle_escalate_op(
         }) => {
             let removed = registry.remove_handle(&handle_id);
             if removed {
+                release_broker_surface(sandbox, &handle_id);
                 EscalateResponse::Ok(EscalateResponseOk {
                     request_id: rid,
                     handle_id,
@@ -211,6 +225,69 @@ pub(crate) fn handle_escalate_op(
                     request_id: rid,
                     message: format!("handle_id '{handle_id}' not found in registry"),
                 })
+            }
+        }
+    }
+}
+
+/// Resolve the `handle_id` returned to the subprocess for a pixel buffer.
+///
+/// On Linux, the buffer is checked in with the broker so the polyglot
+/// subprocess shim can later `check_out` the DMA-BUF FD; the broker-assigned
+/// `surface_id` becomes the handle_id. On other platforms the pool id stays
+/// as-is (macOS uses its own XPC `check_in_surface` path via the native lib
+/// directly; see `streamlib-python-native/src/lib.rs` broker_macos).
+#[allow(unused_variables)]
+fn assign_buffer_handle_id(
+    full: &crate::core::context::GpuContextFullAccess,
+    pool_id: &crate::core::rhi::PixelBufferPoolId,
+    buffer: &RhiPixelBuffer,
+) -> crate::core::error::Result<String> {
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(store) = full.surface_store() {
+            return store.check_in(buffer);
+        }
+    }
+    Ok(pool_id.as_str().to_string())
+}
+
+/// Resolve the `handle_id` returned to the subprocess for a pooled texture.
+///
+/// On Linux, register the texture's DMA-BUF with the broker under a fresh UUID
+/// so the subprocess can `check_out` it; on other platforms just mint a UUID.
+#[allow(unused_variables)]
+fn assign_texture_handle_id(
+    full: &crate::core::context::GpuContextFullAccess,
+    texture: &PooledTextureHandle,
+) -> crate::core::error::Result<String> {
+    let handle_id = Uuid::new_v4().to_string();
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(store) = full.surface_store() {
+            store.register_texture(&handle_id, texture.texture())?;
+        }
+    }
+    Ok(handle_id)
+}
+
+/// Best-effort broker release paired with registry eviction on Linux.
+///
+/// The registry drop alone releases the host's strong refcount on the
+/// underlying resource, but the broker still holds a dup of the DMA-BUF FD
+/// until we explicitly call `release`. Errors here are logged, not returned —
+/// the subprocess is not waiting on the broker handshake at this point.
+#[allow(unused_variables)]
+fn release_broker_surface(sandbox: &GpuContextLimitedAccess, handle_id: &str) {
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(store) = sandbox.surface_store() {
+            if let Err(e) = store.release(handle_id) {
+                tracing::debug!(
+                    "[escalate] broker release for '{}' returned error: {}",
+                    handle_id,
+                    e
+                );
             }
         }
     }

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -729,6 +729,30 @@ impl SurfaceStore {
         Ok(mach_port)
     }
 
+    /// Release a single surface from the broker. Platform-dispatched.
+    ///
+    /// Fire-and-forget on macOS (mirrors `release_from_broker`). On Linux the
+    /// broker's `release` op is best-effort; a missing connection returns Ok
+    /// since the broker already treats the client's socket-close as a full
+    /// release.
+    pub fn release(&self, surface_id: &str) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        {
+            self.release_from_broker(surface_id)
+        }
+        #[cfg(target_os = "linux")]
+        {
+            self.release_from_broker_unix(surface_id)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            let _ = surface_id;
+            Err(StreamError::NotSupported(
+                "SurfaceStore::release is only supported on macOS and Linux".into(),
+            ))
+        }
+    }
+
     /// Send release request to broker via XPC.
     #[cfg(target_os = "macos")]
     fn release_from_broker(&self, surface_id: &str) -> Result<()> {

--- a/libs/streamlib/tests/polyglot_linux_check_out.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out.rs
@@ -1,0 +1,369 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Linux polyglot consumer integration test (#394).
+//!
+//! Spawns a real Python 3 subprocess that loads `libstreamlib_python_native.so`
+//! via ctypes, drives the `slpn_broker_*` / `slpn_gpu_surface_*` FFI exactly
+//! like `subprocess_runner.py` does, and verifies the bytes it reads through
+//! `mmap` match a host-written DMA-BUF pattern.
+//!
+//! The goal is to catch breakage between the three moving parts that the
+//! native-lib's in-process unit tests don't exercise together:
+//!   - wire protocol through a second OS process (different FD table),
+//!   - ctypes-level ABI for every FFI symbol Python calls,
+//!   - `STREAMLIB_BROKER_SOCKET` env propagation.
+//!
+//! Uses a `memfd` as the DMA-BUF stand-in — the subprocess consumer path
+//! (`mmap(fd)`) is identical for both. A real Vulkan-exported DMA-BUF is not
+//! required for this particular gate: the native-lib does not call
+//! `vkImportMemoryFdInfoKHR` yet (see PR body on the deferred Vulkan import).
+//!
+//! Skips gracefully when:
+//!   - `python3` is not on PATH (non-Linux CI, minimal sandboxes),
+//!   - `libstreamlib_python_native.so` has not been built under
+//!     `target/debug/` (test ran before `cargo build -p streamlib-python-native`).
+
+#![cfg(target_os = "linux")]
+
+use std::io::Write;
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use streamlib_broker::unix_socket_service::{
+    connect_to_broker, send_request, UnixSocketSurfaceService,
+};
+use streamlib_broker::BrokerState;
+
+/// Locate `libstreamlib_python_native.so` under the workspace target dir.
+///
+/// `CARGO_MANIFEST_DIR` points at `libs/streamlib`; go up two levels to the
+/// workspace root, then descend into `target/{debug,release}`.
+fn locate_native_lib() -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    for profile in &["debug", "release"] {
+        let candidate = workspace
+            .join("target")
+            .join(profile)
+            .join("libstreamlib_python_native.so");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn python3_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn tmp_socket_path(label: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    p.push(format!(
+        "streamlib-polyglot-test-{}-{}-{}.sock",
+        label,
+        std::process::id(),
+        nanos
+    ));
+    p
+}
+
+fn make_memfd_with(contents: &[u8]) -> RawFd {
+    use std::io::{Seek, SeekFrom};
+
+    let name = std::ffi::CString::new("polyglot-test-memfd").unwrap();
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+    assert!(fd >= 0, "memfd_create: {}", std::io::Error::last_os_error());
+    assert_eq!(
+        unsafe { libc::ftruncate(fd, contents.len() as libc::off_t) },
+        0,
+        "ftruncate: {}",
+        std::io::Error::last_os_error()
+    );
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.write_all(contents).expect("memfd write");
+    file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+    file.into_raw_fd()
+}
+
+/// Build the Python driver that runs inside the subprocess. Kept as an
+/// embedded string so the test is self-contained and doesn't have to ship
+/// a fixture .py file.
+fn python_driver_source() -> &'static str {
+    r#"
+import ctypes
+import os
+import sys
+
+native_lib_path = os.environ["TEST_NATIVE_LIB"]
+socket_path = os.environ["STREAMLIB_BROKER_SOCKET"]
+runtime_id = os.environ["STREAMLIB_RUNTIME_ID"]
+surface_id = os.environ["TEST_SURFACE_ID"]
+expected_width = int(os.environ["TEST_WIDTH"])
+expected_height = int(os.environ["TEST_HEIGHT"])
+expected_bpr = int(os.environ["TEST_BYTES_PER_ROW"])
+expected_head_hex = os.environ["TEST_EXPECTED_HEAD_HEX"]
+
+lib = ctypes.cdll.LoadLibrary(native_lib_path)
+
+lib.slpn_broker_connect.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+lib.slpn_broker_connect.restype = ctypes.c_void_p
+lib.slpn_broker_disconnect.argtypes = [ctypes.c_void_p]
+lib.slpn_broker_disconnect.restype = None
+lib.slpn_broker_resolve_surface.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+lib.slpn_broker_resolve_surface.restype = ctypes.c_void_p
+lib.slpn_broker_unregister_surface.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+lib.slpn_broker_unregister_surface.restype = None
+
+lib.slpn_gpu_surface_lock.argtypes = [ctypes.c_void_p, ctypes.c_int32]
+lib.slpn_gpu_surface_lock.restype = ctypes.c_int32
+lib.slpn_gpu_surface_unlock.argtypes = [ctypes.c_void_p, ctypes.c_int32]
+lib.slpn_gpu_surface_unlock.restype = ctypes.c_int32
+lib.slpn_gpu_surface_base_address.argtypes = [ctypes.c_void_p]
+lib.slpn_gpu_surface_base_address.restype = ctypes.c_void_p
+lib.slpn_gpu_surface_width.argtypes = [ctypes.c_void_p]
+lib.slpn_gpu_surface_width.restype = ctypes.c_uint32
+lib.slpn_gpu_surface_height.argtypes = [ctypes.c_void_p]
+lib.slpn_gpu_surface_height.restype = ctypes.c_uint32
+lib.slpn_gpu_surface_bytes_per_row.argtypes = [ctypes.c_void_p]
+lib.slpn_gpu_surface_bytes_per_row.restype = ctypes.c_uint32
+lib.slpn_gpu_surface_release.argtypes = [ctypes.c_void_p]
+lib.slpn_gpu_surface_release.restype = None
+
+def fatal(msg):
+    sys.stderr.write("FAIL: " + msg + "\n")
+    sys.stderr.flush()
+    sys.exit(1)
+
+broker = lib.slpn_broker_connect(socket_path.encode("utf-8"), runtime_id.encode("utf-8"))
+if not broker:
+    fatal("slpn_broker_connect returned null")
+
+handle = lib.slpn_broker_resolve_surface(broker, surface_id.encode("utf-8"))
+if not handle:
+    fatal("slpn_broker_resolve_surface returned null")
+
+width = lib.slpn_gpu_surface_width(handle)
+height = lib.slpn_gpu_surface_height(handle)
+bpr = lib.slpn_gpu_surface_bytes_per_row(handle)
+if width != expected_width:
+    fatal("width: expected %d got %d" % (expected_width, width))
+if height != expected_height:
+    fatal("height: expected %d got %d" % (expected_height, height))
+if bpr != expected_bpr:
+    fatal("bytes_per_row: expected %d got %d" % (expected_bpr, bpr))
+
+if lib.slpn_gpu_surface_lock(handle, 1) != 0:
+    fatal("slpn_gpu_surface_lock returned non-zero")
+
+base = lib.slpn_gpu_surface_base_address(handle)
+if not base:
+    fatal("base_address null after lock")
+
+n = len(expected_head_hex) // 2
+head = (ctypes.c_uint8 * n).from_address(base)
+actual_hex = bytes(head).hex()
+if actual_hex != expected_head_hex:
+    fatal("first %d bytes mismatch: expected %s got %s" % (n, expected_head_hex, actual_hex))
+
+if lib.slpn_gpu_surface_unlock(handle, 1) != 0:
+    fatal("slpn_gpu_surface_unlock returned non-zero")
+
+# Second resolve_surface should hit the cache and return identical metadata.
+handle2 = lib.slpn_broker_resolve_surface(broker, surface_id.encode("utf-8"))
+if not handle2:
+    fatal("second resolve_surface returned null (cache miss should still succeed)")
+if lib.slpn_gpu_surface_width(handle2) != expected_width:
+    fatal("cached handle width mismatch")
+lib.slpn_gpu_surface_release(handle2)
+
+lib.slpn_broker_unregister_surface(broker, surface_id.encode("utf-8"))
+lib.slpn_gpu_surface_release(handle)
+lib.slpn_broker_disconnect(broker)
+
+sys.stdout.write("OK " + actual_hex + "\n")
+sys.stdout.flush()
+"#
+}
+
+#[test]
+fn python_subprocess_resolves_and_mmaps_host_published_surface() {
+    let native_lib = match locate_native_lib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "polyglot_linux_check_out: libstreamlib_python_native.so not built; \
+                 run `cargo build -p streamlib-python-native` first — skipping"
+            );
+            return;
+        }
+    };
+    if !python3_available() {
+        eprintln!("polyglot_linux_check_out: python3 not on PATH — skipping");
+        return;
+    }
+
+    // 1. Start a broker in-process.
+    let state = BrokerState::new();
+    let socket_path = tmp_socket_path("py-subprocess");
+    let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+    service.start().expect("service start");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // 2. Host: check_in a memfd seeded with a deterministic pattern.
+    let width: u32 = 64;
+    let height: u32 = 4;
+    let bpp: u32 = 4;
+    let size: usize = (width * height * bpp) as usize;
+    let mut pattern = Vec::with_capacity(size);
+    for i in 0..size {
+        pattern.push(((i * 13 + 7) & 0xFF) as u8);
+    }
+    let fd = make_memfd_with(&pattern);
+
+    let host_stream = connect_to_broker(&socket_path).expect("host connect");
+    let check_in_req = serde_json::json!({
+        "op": "check_in",
+        "runtime_id": "host-polyglot-test",
+        "width": width,
+        "height": height,
+        "format": "Bgra32",
+        "resource_type": "pixel_buffer",
+    });
+    let (resp, _) =
+        send_request(&host_stream, &check_in_req, Some(fd)).expect("host check_in");
+    unsafe { libc::close(fd) };
+    let surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("surface_id")
+        .to_string();
+    drop(host_stream);
+
+    // 3. Spawn a Python subprocess driving the native-lib FFI.
+    let head_bytes = 32usize.min(size);
+    let expected_head_hex: String = pattern[..head_bytes]
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+
+    let driver = python_driver_source();
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(driver)
+        .env("STREAMLIB_BROKER_SOCKET", &socket_path)
+        .env("STREAMLIB_RUNTIME_ID", "polyglot-test-runtime")
+        .env("TEST_NATIVE_LIB", &native_lib)
+        .env("TEST_SURFACE_ID", &surface_id)
+        .env("TEST_WIDTH", width.to_string())
+        .env("TEST_HEIGHT", height.to_string())
+        .env("TEST_BYTES_PER_ROW", (width * bpp).to_string())
+        .env("TEST_EXPECTED_HEAD_HEX", &expected_head_hex)
+        .output()
+        .expect("spawn python3");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    service.stop();
+
+    assert!(
+        output.status.success(),
+        "python subprocess failed (exit={:?})\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.starts_with("OK "),
+        "expected OK prefix from python driver, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains(&expected_head_hex),
+        "expected head hex '{}' in stdout '{}'",
+        expected_head_hex,
+        stdout
+    );
+}
+
+#[test]
+fn python_subprocess_reports_clear_error_on_missing_broker_socket() {
+    let native_lib = match locate_native_lib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "polyglot_linux_check_out: libstreamlib_python_native.so not built; skipping"
+            );
+            return;
+        }
+    };
+    if !python3_available() {
+        eprintln!("polyglot_linux_check_out: python3 not on PATH — skipping");
+        return;
+    }
+
+    // Driver that lazy-connects to a bogus socket and expects the first
+    // resolve to fail (null handle), without crashing the subprocess.
+    let driver = r#"
+import ctypes
+import os
+import sys
+
+native_lib_path = os.environ["TEST_NATIVE_LIB"]
+socket_path = os.environ["STREAMLIB_BROKER_SOCKET"]
+
+lib = ctypes.cdll.LoadLibrary(native_lib_path)
+lib.slpn_broker_connect.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+lib.slpn_broker_connect.restype = ctypes.c_void_p
+lib.slpn_broker_resolve_surface.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+lib.slpn_broker_resolve_surface.restype = ctypes.c_void_p
+lib.slpn_broker_disconnect.argtypes = [ctypes.c_void_p]
+lib.slpn_broker_disconnect.restype = None
+
+broker = lib.slpn_broker_connect(socket_path.encode("utf-8"), b"lazy-test")
+assert broker, "connect must succeed lazily even for a bad socket"
+handle = lib.slpn_broker_resolve_surface(broker, b"any-surface")
+assert not handle, "resolve must return null when the socket is unreachable"
+lib.slpn_broker_disconnect(broker)
+
+sys.stdout.write("LAZY_FAIL_OK\n")
+sys.stdout.flush()
+"#;
+
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(driver)
+        .env("STREAMLIB_BROKER_SOCKET", "/nonexistent/broker.sock")
+        .env("TEST_NATIVE_LIB", &native_lib)
+        .output()
+        .expect("spawn python3");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        output.status.success(),
+        "python subprocess must exit cleanly on lazy-connect failure (exit={:?})\nstderr:\n{}",
+        output.status.code(),
+        stderr
+    );
+    assert!(
+        stdout.contains("LAZY_FAIL_OK"),
+        "expected LAZY_FAIL_OK in stdout, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+}

--- a/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Linux polyglot Deno consumer integration test (#394).
+//!
+//! Deno twin of `polyglot_linux_check_out.rs`. Spawns `deno` with an inline
+//! TypeScript driver that loads `libstreamlib_deno_native.so` via
+//! `Deno.dlopen`, drives the `sldn_broker_*` / `sldn_gpu_surface_*` FFI like
+//! `subprocess_runner.ts` does, and verifies the bytes it reads through
+//! `mmap` match a host-written memfd pattern.
+//!
+//! Same skip conditions as the Python test: no `deno` on PATH → skip; no
+//! `libstreamlib_deno_native.so` under target/debug|release → skip.
+
+#![cfg(target_os = "linux")]
+
+use std::io::Write;
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use streamlib_broker::unix_socket_service::{
+    connect_to_broker, send_request, UnixSocketSurfaceService,
+};
+use streamlib_broker::BrokerState;
+
+fn locate_native_lib() -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    for profile in &["debug", "release"] {
+        let candidate = workspace
+            .join("target")
+            .join(profile)
+            .join("libstreamlib_deno_native.so");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn deno_available() -> bool {
+    Command::new("deno")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn tmp_socket_path(label: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    p.push(format!(
+        "streamlib-polyglot-deno-test-{}-{}-{}.sock",
+        label,
+        std::process::id(),
+        nanos
+    ));
+    p
+}
+
+fn make_memfd_with(contents: &[u8]) -> RawFd {
+    use std::io::{Seek, SeekFrom};
+
+    let name = std::ffi::CString::new("polyglot-deno-test-memfd").unwrap();
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+    assert!(fd >= 0, "memfd_create: {}", std::io::Error::last_os_error());
+    assert_eq!(
+        unsafe { libc::ftruncate(fd, contents.len() as libc::off_t) },
+        0,
+        "ftruncate: {}",
+        std::io::Error::last_os_error()
+    );
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.write_all(contents).expect("memfd write");
+    file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+    file.into_raw_fd()
+}
+
+fn deno_driver() -> &'static str {
+    // `Deno.dlopen` uses `buffer` for C-string args, `pointer` for opaque
+    // handles. `Deno.UnsafePointerView` gives us byte access to the mmap'd
+    // region once we get a base_address pointer back from the native lib.
+    r#"
+const nativeLibPath = Deno.env.get("TEST_NATIVE_LIB")!;
+const socketPath = Deno.env.get("STREAMLIB_BROKER_SOCKET")!;
+const surfaceId = Deno.env.get("TEST_SURFACE_ID")!;
+const expectedWidth = parseInt(Deno.env.get("TEST_WIDTH")!);
+const expectedHeight = parseInt(Deno.env.get("TEST_HEIGHT")!);
+const expectedBpr = parseInt(Deno.env.get("TEST_BYTES_PER_ROW")!);
+const expectedHeadHex = Deno.env.get("TEST_EXPECTED_HEAD_HEX")!;
+
+const lib = Deno.dlopen(nativeLibPath, {
+  sldn_broker_connect: { parameters: ["buffer"], result: "pointer" },
+  sldn_broker_disconnect: { parameters: ["pointer"], result: "void" },
+  sldn_broker_resolve_surface: { parameters: ["pointer", "buffer"], result: "pointer" },
+  sldn_broker_unregister_surface: { parameters: ["pointer", "buffer"], result: "void" },
+  sldn_gpu_surface_lock: { parameters: ["pointer", "i32"], result: "i32" },
+  sldn_gpu_surface_unlock: { parameters: ["pointer", "i32"], result: "i32" },
+  sldn_gpu_surface_base_address: { parameters: ["pointer"], result: "pointer" },
+  sldn_gpu_surface_width: { parameters: ["pointer"], result: "u32" },
+  sldn_gpu_surface_height: { parameters: ["pointer"], result: "u32" },
+  sldn_gpu_surface_bytes_per_row: { parameters: ["pointer"], result: "u32" },
+  sldn_gpu_surface_release: { parameters: ["pointer"], result: "void" },
+});
+
+function cStr(s: string): Uint8Array {
+  return new TextEncoder().encode(s + "\0");
+}
+
+function fatal(msg: string): never {
+  console.error("FAIL: " + msg);
+  Deno.exit(1);
+}
+
+const broker = lib.symbols.sldn_broker_connect(cStr(socketPath));
+if (broker === null) fatal("sldn_broker_connect returned null");
+
+const handle = lib.symbols.sldn_broker_resolve_surface(broker, cStr(surfaceId));
+if (handle === null) fatal("sldn_broker_resolve_surface returned null");
+
+const width = lib.symbols.sldn_gpu_surface_width(handle);
+const height = lib.symbols.sldn_gpu_surface_height(handle);
+const bpr = lib.symbols.sldn_gpu_surface_bytes_per_row(handle);
+if (width !== expectedWidth) fatal(`width: expected ${expectedWidth} got ${width}`);
+if (height !== expectedHeight) fatal(`height: expected ${expectedHeight} got ${height}`);
+if (bpr !== expectedBpr) fatal(`bytes_per_row: expected ${expectedBpr} got ${bpr}`);
+
+if (lib.symbols.sldn_gpu_surface_lock(handle, 1) !== 0) fatal("lock returned non-zero");
+
+const base = lib.symbols.sldn_gpu_surface_base_address(handle);
+if (base === null) fatal("base_address null after lock");
+
+const n = expectedHeadHex.length / 2;
+const view = new Deno.UnsafePointerView(base);
+const headBuf = new Uint8Array(n);
+view.copyInto(headBuf);
+const actualHex = Array.from(headBuf).map((b) => b.toString(16).padStart(2, "0")).join("");
+if (actualHex !== expectedHeadHex) {
+  fatal(`first ${n} bytes mismatch: expected ${expectedHeadHex} got ${actualHex}`);
+}
+
+if (lib.symbols.sldn_gpu_surface_unlock(handle, 1) !== 0) fatal("unlock returned non-zero");
+
+// Second resolve — cache hit path.
+const handle2 = lib.symbols.sldn_broker_resolve_surface(broker, cStr(surfaceId));
+if (handle2 === null) fatal("cached resolve_surface returned null");
+if (lib.symbols.sldn_gpu_surface_width(handle2) !== expectedWidth) fatal("cached width mismatch");
+lib.symbols.sldn_gpu_surface_release(handle2);
+
+lib.symbols.sldn_broker_unregister_surface(broker, cStr(surfaceId));
+lib.symbols.sldn_gpu_surface_release(handle);
+lib.symbols.sldn_broker_disconnect(broker);
+lib.close();
+
+console.log("OK " + actualHex);
+"#
+}
+
+#[test]
+fn deno_subprocess_resolves_and_mmaps_host_published_surface() {
+    let native_lib = match locate_native_lib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "polyglot_linux_check_out_deno: libstreamlib_deno_native.so not built; \
+                 run `cargo build -p streamlib-deno-native` first — skipping"
+            );
+            return;
+        }
+    };
+    if !deno_available() {
+        eprintln!("polyglot_linux_check_out_deno: deno not on PATH — skipping");
+        return;
+    }
+
+    let state = BrokerState::new();
+    let socket_path = tmp_socket_path("deno-subprocess");
+    let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+    service.start().expect("service start");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let width: u32 = 64;
+    let height: u32 = 4;
+    let bpp: u32 = 4;
+    let size: usize = (width * height * bpp) as usize;
+    let mut pattern = Vec::with_capacity(size);
+    for i in 0..size {
+        pattern.push(((i * 19 + 11) & 0xFF) as u8);
+    }
+    let fd = make_memfd_with(&pattern);
+
+    let host_stream = connect_to_broker(&socket_path).expect("host connect");
+    let check_in_req = serde_json::json!({
+        "op": "check_in",
+        "runtime_id": "deno-host-polyglot-test",
+        "width": width,
+        "height": height,
+        "format": "Bgra32",
+        "resource_type": "pixel_buffer",
+    });
+    let (resp, _) = send_request(&host_stream, &check_in_req, Some(fd)).expect("host check_in");
+    unsafe { libc::close(fd) };
+    let surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("surface_id")
+        .to_string();
+    drop(host_stream);
+
+    let head_bytes = 32usize.min(size);
+    let expected_head_hex: String = pattern[..head_bytes]
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+
+    // `deno run -` reads the script from stdin. Stage the script to a tmpfile
+    // and pass the path instead — simpler than juggling ChildStdin, and deno
+    // flushes / closes on EOF either way.
+    let mut script_file = tempfile::NamedTempFile::new().expect("tempfile");
+    script_file
+        .write_all(deno_driver().as_bytes())
+        .expect("write driver");
+    let script_path = script_file.path().to_path_buf();
+
+    let output = Command::new("deno")
+        .arg("run")
+        .arg("--allow-ffi")
+        .arg("--allow-env")
+        .arg("--allow-read")
+        .arg(&script_path)
+        .env("STREAMLIB_BROKER_SOCKET", &socket_path)
+        .env("TEST_NATIVE_LIB", &native_lib)
+        .env("TEST_SURFACE_ID", &surface_id)
+        .env("TEST_WIDTH", width.to_string())
+        .env("TEST_HEIGHT", height.to_string())
+        .env("TEST_BYTES_PER_ROW", (width * bpp).to_string())
+        .env("TEST_EXPECTED_HEAD_HEX", &expected_head_hex)
+        .output()
+        .expect("spawn deno");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    service.stop();
+
+    assert!(
+        output.status.success(),
+        "deno subprocess failed (exit={:?})\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("OK "),
+        "expected OK prefix from deno driver, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains(&expected_head_hex),
+        "expected head hex '{}' in stdout '{}'",
+        expected_head_hex,
+        stdout
+    );
+}


### PR DESCRIPTION
## Summary

- Fills the `#[cfg(not(target_os = "macos"))]` broker stubs in `streamlib-python-native` and `streamlib-deno-native` with a real Linux consumer client: lazy-connect Unix socket, `check_out` via SCM_RIGHTS, `release`, and a local surface-id → fd cache. Same `slpn_*` / `sldn_*` FFI surface as the macOS XPC shim so `processor_context.py` and `context.ts` stay platform-branchless.
- Teaches the host escalate path to register freshly-allocated buffers/textures with the broker's `SurfaceStore` on Linux, so the polyglot subprocess can resolve the DMA-BUF by the same handle_id the host returned over `#325`'s stdio IPC.
- Wires `STREAMLIB_BROKER_SOCKET` through both subprocess runners and drops the import-time `NotImplementedError` wall in `gpu_surface.py`.

## Closes

Closes #394

## Exit criteria

- [x] `streamlib-python-native` Linux broker shim with matching FFI signatures (`slpn_broker_connect`, `slpn_broker_resolve_surface`, `slpn_broker_unregister_surface`; lazy-connect, actionable error on first use when `STREAMLIB_BROKER_SOCKET` is unset or broker unreachable).
- [x] `streamlib-deno-native` Linux broker shim with matching FFI signatures (`sldn_broker_*` — added a Linux-only `sldn_broker_unregister_surface` to match Python, since the XPC path had no equivalent).
- [x] Broker wire ops used: `check_out` + `release`. Reused `send/recv_message_with_fd` semantics verbatim — the 60 LOC of SCM_RIGHTS plumbing is duplicated inline per cdylib (kept byte-compatible by design; cross-crate unit tests lock the wire format). A shared `streamlib-broker-client` crate is a natural follow-up if this duplication grows.
- [ ] **⏭ DEFERRED** — `VkImportMemoryFdInfoKHR` inside the native libs. The shim returns a `SurfaceHandle` that wraps the DMA-BUF fd + metadata; `slpn/sldn_gpu_surface_lock` uses `libc::mmap(fd)` for CPU access, which matches the existing `lock` / `base_address` API surface used by Python/Deno callers today. Adding `vulkanalia` to these cdylibs for zero current consumers is premature; the import slot is ready to fill in when a GPU-consuming Python/Deno processor API materializes. See follow-up below.
- [x] `libs/streamlib-python/python/streamlib/subprocess_runner.py`: reads `STREAMLIB_BROKER_SOCKET` on Linux alongside `STREAMLIB_XPC_SERVICE_NAME` on macOS.
- [x] `libs/streamlib-deno/subprocess_runner.ts`: same for Deno.
- [x] `libs/streamlib-python/python/streamlib/gpu_surface.py`: Linux `NotImplementedError` removed (module now imports cleanly; the real Linux DMA-BUF path lives behind `NativeGpuContext*` in `processor_context.py`).
- [x] Host-side `subprocess_escalate.rs`: Linux arm of `acquire_pixel_buffer` / `acquire_texture` calls `SurfaceStore.check_in` / `register_texture` inside the escalate closure and returns the broker `surface_id` as the subprocess-facing `handle_id`. `ReleaseHandle` additionally calls `SurfaceStore.release` so the broker drops its DMA-BUF fd dup. Non-Linux paths unchanged.
- [x] Short-circuit cache: repeated `resolve_surface(same_id)` returns the cached fd (dup'd for each handle) without going back to the broker.
- [x] No changes to escalate schemas or `SubprocessBridge`.

## Test plan

All tests run on this branch, workspace baseline included.

**Native-lib wire + FFI unit tests**

- [x] `streamlib-python-native::broker_linux_tests::resolve_surface_mmap_readback_matches_host_pattern` — in-process broker + memfd roundtrip, mmap readback matches byte-for-byte. **Pass**.
- [x] `streamlib-python-native::broker_linux_tests::resolve_surface_fails_cleanly_on_missing_socket` — lazy-connect semantics. **Pass**.
- [x] `streamlib-python-native::broker_linux_tests::resolve_surface_fails_cleanly_on_unknown_surface_id` — broker returns an error payload, no fd, shim returns null without crashing. **Pass**.
- [x] `streamlib-deno-native::broker_linux_tests::resolve_surface_mmap_readback_matches_host_pattern` — Deno twin of the Python test. **Pass**.
- [x] `streamlib-deno-native::broker_linux_tests::resolve_surface_fails_cleanly_on_missing_socket` — lazy-connect negative. **Pass**.

**Broker wire regression**

- [x] `streamlib-broker::unix_socket_service::tests::check_in_check_out_roundtrip_preserves_fd_content` — SCM_RIGHTS preserves a memfd's bytes across dup. **Pass**.
- [x] `streamlib-broker::unix_socket_service::tests::check_out_unknown_surface_id_returns_error_no_fd` — error shape for missing surface_id. **Pass**.

**Python + Deno subprocess integration tests** (real `python3` / `deno` binaries, real cross-process fd table)

- [x] `libs/streamlib/tests/polyglot_linux_check_out.rs::python_subprocess_resolves_and_mmaps_host_published_surface` — host check_in → python3 subprocess via ctypes → resolve → lock → byte match. **Pass**.
- [x] `libs/streamlib/tests/polyglot_linux_check_out.rs::python_subprocess_reports_clear_error_on_missing_broker_socket` — bogus socket path, lazy-connect, no subprocess crash. **Pass**.
- [x] `libs/streamlib/tests/polyglot_linux_check_out_deno.rs::deno_subprocess_resolves_and_mmaps_host_published_surface` — same for `deno run --allow-ffi`. **Pass**.

**Host-side escalate regression**

- [x] `cargo test -p streamlib --lib subprocess_escalate` — 13/13 pass, including the GPU end-to-end test that now flows through the new `assign_buffer_handle_id` / `assign_texture_handle_id` helpers (with no SurfaceStore attached the non-Linux fallback is exercised, matching production for tests).

**Workspace baseline**

```
cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess \
    --exclude camera-python-subprocess --exclude camera-rust-plugin \
    --exclude webrtc-cloudflare-stream --no-fail-fast
```

Result: **passed=869 failed=0 ignored=21** on this branch.

## E2E Test Report

- **Scenario**: polyglot Python / Deno subprocess DMA-BUF consumer roundtrip
- **Example**: n/a — exercised directly by `libs/streamlib/tests/polyglot_linux_check_out{,_deno}.rs`
- **Codec**: n/a
- **Camera device**: n/a — memfd stand-in; kernel-backed fd with identical consumer semantics for the paths this PR covers (SCM_RIGHTS delivery + `mmap(fd)`)
- **Resolution**: 64×4 BGRA (test-sized — the gate is fd delivery + byte integrity, not pixel count)
- **Duration / frame limit**: single-roundtrip
- **Build profile**: debug
- **Command**:
    ```
    cargo build -p streamlib-python-native -p streamlib-deno-native && \
    cargo test -p streamlib --test polyglot_linux_check_out --test polyglot_linux_check_out_deno
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0 (n/a — no Vulkan device in the consumer path)
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame captured`: n/a (no pipeline) — subprocess driver prints `OK <hex>` on byte match
- `Encode progress` / `Decode progress`: n/a

#### PNG samples

- Directory: n/a
- Sample count: n/a
- Sample interval: n/a
- PNGs read with Read tool: n/a
- **What was in the image(s)**: n/a — this PR intentionally uses byte-level pattern verification in the subprocess rather than a pipeline PNG sample, because the host-allocated DMA-BUF pattern is known and the gate is "subprocess sees the same bytes as the host wrote," not visual frame content.
- Anomalies: none.

#### PSNR

- Reference frame: n/a — byte-level match, not a lossy codec pass
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass with caveats** — full pipeline E2E (`vulkan-video-roundtrip`-style with a polyglot consumer processor sampling a host camera output) is deferred to a follow-up: no such consumer processor exists in-tree today, and building one is a substantial scope expansion beyond this issue. The FFI / wire / env-var correctness that the E2E gate would stress are fully covered by the subprocess integration tests above.
- Caveats / follow-ups filed: see *Follow-ups* below.

## Polyglot coverage

- **Runtimes affected**: rust (host + native libs) · python (subprocess_runner env) · deno (subprocess_runner env). Schema: **unchanged** — no wire-format drift.
- **Schema regenerated**: n/a (no escalate schema change).
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib --lib subprocess_escalate` — 13 pass including `handle_escalate_op_end_to_end`.
  - [x] Python subprocess: `cargo test -p streamlib --test polyglot_linux_check_out` — 2 pass.
  - [x] Deno subprocess: `cargo test -p streamlib --test polyglot_linux_check_out_deno` — 1 pass.
- **FD-passing path**: DMA-BUF FD (via broker SCM_RIGHTS over `STREAMLIB_BROKER_SOCKET`; pool-ID-only escalate IPC stays the control plane).

## Follow-ups

All filed under the `Polyglot SDK Realignment` milestone as sub-issues of #319, matching #394's structure:

1. **#420 — `feat(polyglot): Vulkan DMA-BUF import in native-lib consumers`** — once a GPU-consuming Python/Deno processor API materializes, wire the subprocess's own Vulkan device (via `vulkanalia`) and switch the consumer path from `mmap(fd)` to `vkAllocateMemory` + `VkImportMemoryFdInfoKHR` + `vkMapMemory`. The import slot is already carved out in `SurfaceHandle`. Research doc: `docs/research/polyglot-dma-buf-fd.md` §Deliverable 4.
2. **#421 — `test(polyglot): E2E — polyglot consumer Python processor on vulkan-video-roundtrip`** — build a minimal polyglot consumer Python processor that samples a host camera output, wire it into a fixture scenario, and follow the `docs/testing.md` PNG-sampling workflow. Needs the consumer processor first; large enough that it doesn't belong in this PR. **Blocked by #424** — the polyglot E2E can't meaningfully validate anything until the broker's own reliability is proven.
3. **#422 — `refactor(broker): extract shared SCM_RIGHTS consumer-client helpers`** — the `wire::send_request` / `recv_message_with_fd` / `send_message_with_fd` trio is now duplicated in three places (`streamlib-broker::unix_socket_service`, `streamlib-python-native`, `streamlib-deno-native`). Extract to a `streamlib-broker-client` crate (or a `consumer` feature of `streamlib-broker`) with tests that lock the wire format cross-crate.
4. **#423 — `feat(broker): multi-FD SCM_RIGHTS for disjoint-plane DMA-BUFs`** — the single-FD broker helper is sufficient for contiguous BGRA/RGBA/NV12 (`docs/research/polyglot-dma-buf-fd.md` open question 1). If/when a format with disjoint planes lands (DRM-format-modifier-tiled NV12 with separate Y/UV FDs), widen the broker helpers and the consumer shim together.
5. **#424 — `chore(broker): reliable Linux daemon lifecycle + socket-activation + validation tests`** — adopt systemd socket activation so clients never need to `systemctl start` first, make `cargo run -p streamlib-broker` the dev/test default so the running broker always matches source, and add daemon-lifecycle tests (start, `kill -9` recovery, stale-socket cleanup, `prune_dead_runtimes`, socket-activation cold start + idle-exit). **Blocks #421**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)