### PR TITLE
chore(broker): socket activation + lifecycle tests (#424)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,3 +109,10 @@ jobs:
 
       - name: Check streamlib-broker
         run: cargo check -p streamlib-broker
+
+      - name: Run streamlib-broker tests
+        # Includes lib tests and the daemon-lifecycle integration tests
+        # (socket activation, idle-exit, stale-socket cleanup, systemd
+        # unit parsing, dead-runtime pruning). These run on the Linux
+        # job because the broker is Linux-only.
+        run: cargo test -p streamlib-broker

--- a/docs/operations/broker.md
+++ b/docs/operations/broker.md
@@ -1,0 +1,181 @@
+# streamlib-broker — operations
+
+`streamlib-broker` is the Linux daemon that brokers cross-process
+DMA-BUF surface sharing between the streamlib host and any polyglot
+subprocess (Python, Deno). Every FD that crosses a process boundary on
+Linux passes through it, so its availability is a hard prerequisite for
+every polyglot pipeline.
+
+This doc is operator-facing: how to install it, how to tell whether it's
+healthy, where to look when things break. For implementation details
+see [`libs/streamlib-broker`](../../libs/streamlib-broker) and the
+consumer-side helpers in
+[`libs/streamlib-broker-client`](../../libs/streamlib-broker-client).
+
+---
+
+## Install flavors
+
+| Flavor     | Use when                                               | Broker binary                     |
+| ---------- | ------------------------------------------------------ | --------------------------------- |
+| Production | Installed streamlib release                            | `~/.streamlib/bin/streamlib-broker` (prebuilt) |
+| Dev        | Working on streamlib; want the broker to track source  | `cargo run -p streamlib-broker` (always rebuilt) |
+| Test       | CI / integration tests                                 | `target/debug/streamlib-broker` (built once per run) |
+
+The **invariant** that keeps dev sane: *in dev, the broker you connect
+to is the current source tree.* If you build a fix and connect, you're
+exercising the fix — no manual reinstall step.
+
+---
+
+## Production: socket-activated systemd install
+
+This is the recommended deployment path. The `.socket` unit keeps the
+listening socket available at all times; the daemon starts on the first
+client connect and can idle-exit later without losing the socket.
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp scripts/streamlib-broker.socket  ~/.config/systemd/user/
+cp scripts/streamlib-broker.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now streamlib-broker.socket
+```
+
+From then on, every client that connects to
+`~/.streamlib/broker.sock` activates the daemon automatically. No
+`systemctl start streamlib-broker.service` step is required in the
+onboarding flow.
+
+### Mechanics
+
+systemd binds the listening socket itself, then passes it to the daemon
+as fd 3 with `LISTEN_FDS=1` and `LISTEN_PID=<daemon pid>` in the
+environment. The broker's hand-rolled probe
+(`libs/streamlib-broker/src/main.rs::sd_listen_fd`) reads those env
+vars, validates pid match when present, and hands the inherited
+listener straight to `UnixSocketSurfaceService::with_inherited_listener`
+so no `bind()` call is ever made from the daemon.
+
+When the daemon exits (crash, SIGTERM, idle-exit), systemd keeps the
+socket. The next client connect re-activates the daemon and it inherits
+the same listening socket again. The socket file itself is never
+unlinked until the `.socket` unit is stopped.
+
+### Idle-exit (optional)
+
+Pass `--idle-exit-seconds=N` on the daemon's `ExecStart=` line to have
+it self-terminate after N seconds with no active client connections.
+Combined with socket activation, this gives "run only when needed"
+behavior. Leave it unset for long-running deployments.
+
+### Non-activated fallback
+
+If `LISTEN_FDS` is not set, the daemon falls back to binding
+`--socket-path` itself. This is the code path used by:
+
+- Legacy installs (`systemctl --user enable streamlib-broker.service`
+  without the `.socket`).
+- Non-systemd environments.
+- Ad-hoc dev (`scripts/streamlib-broker-dev.sh`, tests).
+
+Stale-socket cleanup applies on this path: the daemon unlinks a leftover
+socket file from a previous crash before `bind()`.
+
+---
+
+## Dev flavor: cargo run + standalone helper
+
+For ad-hoc dev work (no `dev-setup.sh` bootstrap needed), use the
+standalone lifecycle helper:
+
+```bash
+scripts/streamlib-broker-dev.sh start    # cargo build, spawn, probe until ready
+scripts/streamlib-broker-dev.sh status   # prints pid / socket
+scripts/streamlib-broker-dev.sh probe    # 0 on pong, 1 otherwise
+scripts/streamlib-broker-dev.sh stop     # SIGTERM, wait, SIGKILL fallback
+scripts/streamlib-broker-dev.sh restart
+```
+
+The helper is pid-file-gated (`$STREAMLIB_HOME/broker.pid`) to prevent
+double-spawn. By default it uses:
+
+| Env                           | Default                                 |
+| ----------------------------- | --------------------------------------- |
+| `STREAMLIB_HOME`              | `<repo>/.streamlib`                     |
+| `STREAMLIB_BROKER_SOCKET`     | `$STREAMLIB_HOME/broker.sock`           |
+| `STREAMLIB_BROKER_PORT`       | `50052`                                 |
+| `STREAMLIB_BROKER_LOG`        | `/tmp/streamlib-broker-dev.log`         |
+
+For the full dev-environment bootstrap (proxy scripts, `.env`,
+user-service install), use `scripts/dev-setup.sh`.
+
+---
+
+## Test flavor: `streamlib_broker.sh` fixture
+
+Integration tests that need a real daemon (not the in-process
+`UnixSocketSurfaceService`) use
+[`libs/streamlib/tests/fixtures/streamlib_broker.sh`](../../libs/streamlib/tests/fixtures/streamlib_broker.sh):
+
+```bash
+SOCKET=$(./libs/streamlib/tests/fixtures/streamlib_broker.sh start)
+./libs/streamlib/tests/fixtures/streamlib_broker.sh probe "$SOCKET"
+./libs/streamlib/tests/fixtures/streamlib_broker.sh stop  "$SOCKET"
+```
+
+The fixture always uses `target/debug/streamlib-broker` (builds it if
+missing) so tests aren't paying `cargo run`'s per-invocation cost.
+
+---
+
+## Probing the broker
+
+The daemon ships with a `--probe` subcommand. It connects to the socket,
+sends `{"op":"ping"}`, expects `{"pong":true}`, and exits 0 on success
+or 1 on any failure:
+
+```bash
+streamlib-broker --probe ~/.streamlib/broker.sock && echo ok
+```
+
+This is the same command the fixture and dev helper use. It's safe to
+call against a socket-activated broker (the ping itself triggers
+activation) and against a running daemon.
+
+---
+
+## Log paths
+
+| Deployment        | Log sink                                          |
+| ----------------- | ------------------------------------------------- |
+| systemd           | `journalctl --user -u streamlib-broker.service`   |
+| `streamlib-broker-dev.sh` | `/tmp/streamlib-broker-dev.log` (or `$STREAMLIB_BROKER_LOG`) |
+| Fixture           | alongside the socket: `<socket-dir>/broker.log`   |
+
+---
+
+## Common failures
+
+- **"Failed to bind Unix socket … Address already in use"** — a previous
+  daemon is still running. `streamlib-broker-dev.sh status` to check, or
+  `ps` / `systemctl --user status`. If the socket file exists but no
+  daemon does, the bind-path cleanup (`remove_file` before bind) handles
+  it on the next start. Under socket activation this error can't happen
+  — the socket is owned by systemd.
+
+- **Client connects but hangs** — with socket activation, this usually
+  means the daemon crashed while starting. Check
+  `journalctl --user -u streamlib-broker.service` for a stack trace.
+  The `.socket` unit will hold queued client connects until a successful
+  daemon start, so a crash loop manifests as client-side hangs.
+
+- **"LISTEN_FDS set but invalid" warning** — the env vars were
+  inconsistent (wrong pid, wrong count, non-integer). The daemon falls
+  back to bind. Check whether systemd actually activated you (set
+  `LISTEN_PID`) or whether the env leaked from a grandparent.
+
+- **Tests can't find the broker binary** — they rely on
+  `CARGO_BIN_EXE_streamlib-broker`, which requires `cargo test -p
+  streamlib-broker`. Running a single-test invocation from elsewhere
+  won't trigger the binary build.

--- a/libs/streamlib-broker/src/main.rs
+++ b/libs/streamlib-broker/src/main.rs
@@ -14,7 +14,7 @@ use tracing::info;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use streamlib_broker::{
-    proto::broker_service_server::BrokerServiceServer, BrokerGrpcService, BrokerState,
+    BrokerGrpcService, BrokerState, proto::broker_service_server::BrokerServiceServer,
 };
 
 #[cfg(target_os = "macos")]
@@ -38,10 +38,26 @@ struct Cli {
     #[arg(long, env = "STREAMLIB_XPC_SERVICE_NAME")]
     xpc_service_name: Option<String>,
 
-    /// Unix socket path for surface store (from STREAMLIB_BROKER_SOCKET env var)
+    /// Unix socket path for surface store (from STREAMLIB_BROKER_SOCKET env var).
+    /// Ignored when the listener is inherited via systemd socket activation
+    /// (LISTEN_FDS).
     #[cfg(target_os = "linux")]
     #[arg(long, env = "STREAMLIB_BROKER_SOCKET")]
     socket_path: Option<String>,
+
+    /// Exit after N seconds of no active client connections. Intended for
+    /// socket-activated deployments where systemd re-spawns the daemon on
+    /// the next client connect. Disabled when unset (default).
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    idle_exit_seconds: Option<u64>,
+
+    /// Probe an existing broker on the given Unix socket and exit.
+    /// Returns exit code 0 on successful `ping`, 1 otherwise. Does not start
+    /// the gRPC server, surface service, or telemetry pipeline.
+    #[cfg(target_os = "linux")]
+    #[arg(long, value_name = "SOCKET")]
+    probe: Option<String>,
 }
 
 #[cfg(target_os = "macos")]
@@ -141,9 +157,20 @@ async fn main() {
 #[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() {
+    use std::os::fd::FromRawFd;
+    use std::os::unix::net::UnixListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
     use streamlib_broker::unix_socket_service::UnixSocketSurfaceService;
 
     let cli = Cli::parse();
+
+    // --probe: short-circuit — connect to the given socket and send a ping.
+    // Exits 0 on pong, 1 otherwise. Does not touch telemetry / gRPC / state.
+    if let Some(socket) = cli.probe.as_deref() {
+        std::process::exit(run_probe(socket));
+    }
 
     // Initialize telemetry for the broker's OWN logs
     let _telemetry_guard =
@@ -176,26 +203,53 @@ async fn main() {
     // Create shared state for diagnostics
     let state = BrokerState::new();
 
-    // Determine socket path
-    let socket_path = cli.socket_path.unwrap_or_else(|| {
-        let streamlib_home = std::env::var("STREAMLIB_HOME")
-            .unwrap_or_else(|_| format!("{}/.streamlib", std::env::var("HOME").unwrap()));
-        format!("{}/broker.sock", streamlib_home)
-    });
+    // Decide how we obtain the Unix socket listener: inherited from systemd
+    // via LISTEN_FDS, or bound by us from --socket-path / STREAMLIB_BROKER_SOCKET.
+    //
+    // Systemd socket-activation convention: when the daemon is spawned by a
+    // matching `.socket` unit, systemd sets `LISTEN_PID` to the spawned
+    // process's pid, `LISTEN_FDS` to the count of inherited sockets (we
+    // require exactly 1), and passes the listening fd starting at fd 3.
+    // `LISTEN_PID` lets us guard against inheriting an env accidentally
+    // leaked from a grandparent process.
+    let inherited_listener = match sd_listen_fd() {
+        Ok(Some(fd)) => {
+            info!(
+                "[Broker] Inherited listening socket from systemd (fd {})",
+                fd
+            );
+            // SAFETY: systemd guarantees fd 3 is a valid listening Unix socket
+            // when LISTEN_FDS=1 and LISTEN_PID matches our pid. From this
+            // point on we own the fd.
+            Some(unsafe { UnixListener::from_raw_fd(fd) })
+        }
+        Ok(None) => None,
+        Err(msg) => {
+            tracing::warn!(
+                "[Broker] LISTEN_FDS set but invalid ({}), falling back to bind",
+                msg
+            );
+            None
+        }
+    };
 
-    // Start Unix socket surface service
-    let mut unix_socket_service =
-        UnixSocketSurfaceService::new(state.clone(), std::path::PathBuf::from(&socket_path));
+    let mut unix_socket_service = if let Some(listener) = inherited_listener {
+        UnixSocketSurfaceService::with_inherited_listener(state.clone(), listener)
+    } else {
+        let socket_path = cli.socket_path.clone().unwrap_or_else(|| {
+            let streamlib_home = std::env::var("STREAMLIB_HOME")
+                .unwrap_or_else(|_| format!("{}/.streamlib", std::env::var("HOME").unwrap()));
+            format!("{}/broker.sock", streamlib_home)
+        });
+        UnixSocketSurfaceService::new(state.clone(), std::path::PathBuf::from(&socket_path))
+    };
+
     match unix_socket_service.start() {
         Ok(()) => {
-            info!(
-                "[Broker] Unix socket surface service started on '{}'",
-                socket_path
-            );
+            info!("[Broker] Unix socket surface service started");
         }
         Err(e) => {
             tracing::error!("[Broker] Failed to start Unix socket service: {}", e);
-            // Continue without surface service - gRPC still works
         }
     }
 
@@ -228,6 +282,34 @@ async fn main() {
         }
     });
 
+    // Optional idle-exit watchdog.
+    if let Some(idle_seconds) = cli.idle_exit_seconds {
+        let active_count: Arc<AtomicUsize> = unix_socket_service.active_connection_count_arc();
+        info!(
+            "[Broker] Idle-exit enabled: will exit after {}s of no active clients",
+            idle_seconds
+        );
+        tokio::spawn(async move {
+            // Start the idle clock on launch — if nobody ever connects, we
+            // should still exit after `idle_seconds`.
+            let mut last_active = Instant::now();
+            loop {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                if active_count.load(Ordering::Relaxed) > 0 {
+                    last_active = Instant::now();
+                    continue;
+                }
+                if last_active.elapsed() >= Duration::from_secs(idle_seconds) {
+                    tracing::info!(
+                        "[Broker] Idle-exit after {}s with no active clients",
+                        idle_seconds
+                    );
+                    std::process::exit(0);
+                }
+            }
+        });
+    }
+
     // Start gRPC server (blocks forever)
     // Keep _unix_socket_service alive so it doesn't get dropped
     let _unix_socket_service = unix_socket_service;
@@ -235,6 +317,78 @@ async fn main() {
         tracing::error!("[Broker] gRPC server error: {}", e);
         std::process::exit(1);
     }
+}
+
+/// Probe an existing broker by sending `{"op":"ping"}` over the given socket.
+/// Returns an exit code suitable for `std::process::exit`: 0 on pong, 1 on any
+/// failure (connect, send, unexpected payload).
+#[cfg(target_os = "linux")]
+fn run_probe(socket_path: &str) -> i32 {
+    use std::path::Path;
+    use streamlib_broker::unix_socket_service::{connect_to_broker, send_request};
+
+    let path = Path::new(socket_path);
+    let stream = match connect_to_broker(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("probe: connect {:?} failed: {}", path, e);
+            return 1;
+        }
+    };
+    let req = serde_json::json!({"op": "ping"});
+    match send_request(&stream, &req, None) {
+        Ok((resp, _fd)) => {
+            if resp.get("pong").and_then(|v| v.as_bool()) == Some(true) {
+                0
+            } else {
+                eprintln!("probe: unexpected response {}", resp);
+                1
+            }
+        }
+        Err(e) => {
+            eprintln!("probe: ping {:?} failed: {}", path, e);
+            1
+        }
+    }
+}
+
+/// Hand-rolled systemd LISTEN_FDS probe. Returns `Ok(Some(fd))` when exactly
+/// one listening fd has been inherited and it was intended for this process;
+/// `Ok(None)` when socket activation was not requested; `Err` when the env
+/// vars are set but inconsistent (should fall back to bind with a warning).
+#[cfg(target_os = "linux")]
+fn sd_listen_fd() -> Result<Option<std::os::unix::io::RawFd>, String> {
+    let listen_fds = match std::env::var("LISTEN_FDS") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let count: i32 = listen_fds
+        .parse()
+        .map_err(|_| format!("LISTEN_FDS={} is not an integer", listen_fds))?;
+    if count <= 0 {
+        return Ok(None);
+    }
+    // Validate LISTEN_PID matches our pid if set; otherwise accept (some
+    // minimal activation harnesses omit it). This avoids consuming an env
+    // leaked from a parent process.
+    if let Ok(pid_str) = std::env::var("LISTEN_PID") {
+        let pid: i32 = pid_str
+            .parse()
+            .map_err(|_| format!("LISTEN_PID={} is not an integer", pid_str))?;
+        if pid != std::process::id() as i32 {
+            return Err(format!(
+                "LISTEN_PID={} does not match our pid {}",
+                pid,
+                std::process::id()
+            ));
+        }
+    }
+    if count != 1 {
+        return Err(format!("expected LISTEN_FDS=1, got {}", count));
+    }
+    // Systemd convention: first inherited fd is fd 3.
+    const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;
+    Ok(Some(SD_LISTEN_FDS_START))
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/libs/streamlib-broker/src/unix_socket_service.rs
+++ b/libs/streamlib-broker/src/unix_socket_service.rs
@@ -11,6 +11,7 @@ use std::os::unix::io::RawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread;
 
 use streamlib_broker_client::{recv_message_with_fd, send_message_with_fd};
@@ -23,41 +24,72 @@ use crate::state::BrokerState;
 // canonical implementations.
 pub use streamlib_broker_client::{connect_to_broker, send_request};
 
+enum ListenerSource {
+    BindPath(PathBuf),
+    Inherited(Option<UnixListener>),
+}
+
 /// Unix socket surface service for cross-process DMA-BUF sharing.
 pub struct UnixSocketSurfaceService {
     state: BrokerState,
-    socket_path: PathBuf,
+    source: ListenerSource,
     listener_thread: Option<thread::JoinHandle<()>>,
-    shutdown_flag: Arc<std::sync::atomic::AtomicBool>,
+    shutdown_flag: Arc<AtomicBool>,
+    active_count: Arc<AtomicUsize>,
 }
 
 impl UnixSocketSurfaceService {
-    /// Create a new Unix socket surface service.
+    /// Create a new Unix socket surface service that will bind `socket_path`
+    /// when [`start`](Self::start) is called.
     pub fn new(state: BrokerState, socket_path: PathBuf) -> Self {
         Self {
             state,
-            socket_path,
+            source: ListenerSource::BindPath(socket_path),
             listener_thread: None,
-            shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+            active_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Create a new Unix socket surface service backed by a listener inherited
+    /// from systemd socket activation (or equivalent). The service will not
+    /// attempt to `bind` or to remove the socket file on stop — the listener's
+    /// lifetime is the caller's responsibility (systemd for real activation;
+    /// the test harness for simulated activation).
+    pub fn with_inherited_listener(state: BrokerState, listener: UnixListener) -> Self {
+        Self {
+            state,
+            source: ListenerSource::Inherited(Some(listener)),
+            listener_thread: None,
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+            active_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     /// Start listening for connections.
     pub fn start(&mut self) -> Result<(), String> {
-        // Remove stale socket file if it exists
-        if self.socket_path.exists() {
-            std::fs::remove_file(&self.socket_path)
-                .map_err(|e| format!("Failed to remove stale socket: {}", e))?;
-        }
+        let listener = match &mut self.source {
+            ListenerSource::BindPath(socket_path) => {
+                // Remove stale socket file if it exists
+                if socket_path.exists() {
+                    std::fs::remove_file(&*socket_path)
+                        .map_err(|e| format!("Failed to remove stale socket: {}", e))?;
+                }
 
-        // Ensure parent directory exists
-        if let Some(parent) = self.socket_path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create socket directory: {}", e))?;
-        }
+                // Ensure parent directory exists
+                if let Some(parent) = socket_path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| format!("Failed to create socket directory: {}", e))?;
+                }
 
-        let listener = UnixListener::bind(&self.socket_path)
-            .map_err(|e| format!("Failed to bind Unix socket at {:?}: {}", self.socket_path, e))?;
+                UnixListener::bind(&*socket_path).map_err(|e| {
+                    format!("Failed to bind Unix socket at {:?}: {}", socket_path, e)
+                })?
+            }
+            ListenerSource::Inherited(slot) => slot.take().ok_or_else(|| {
+                "inherited listener already consumed (start() called twice)".to_string()
+            })?,
+        };
 
         // Set non-blocking so we can check the shutdown flag
         listener
@@ -66,16 +98,20 @@ impl UnixSocketSurfaceService {
 
         let state = self.state.clone();
         let shutdown_flag = self.shutdown_flag.clone();
+        let active_count = self.active_count.clone();
 
         let handle = thread::spawn(move || {
-            run_listener(listener, state, shutdown_flag);
+            run_listener(listener, state, shutdown_flag, active_count);
         });
 
         self.listener_thread = Some(handle);
 
         tracing::info!(
-            "[Broker] Unix socket surface service listening on {:?}",
-            self.socket_path
+            "[Broker] Unix socket surface service listening ({})",
+            match &self.source {
+                ListenerSource::BindPath(p) => format!("bound: {:?}", p),
+                ListenerSource::Inherited(_) => "inherited".to_string(),
+            }
         );
 
         Ok(())
@@ -83,24 +119,42 @@ impl UnixSocketSurfaceService {
 
     /// Stop the Unix socket service.
     pub fn stop(&mut self) {
-        self.shutdown_flag
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.shutdown_flag.store(true, Ordering::Relaxed);
 
         if let Some(handle) = self.listener_thread.take() {
             let _ = handle.join();
         }
 
-        // Clean up socket file
-        if self.socket_path.exists() {
-            let _ = std::fs::remove_file(&self.socket_path);
+        // Only clean up the socket file if we bound it ourselves — for an
+        // inherited listener the socket is owned by systemd (or the test
+        // harness) and must outlive the daemon.
+        if let ListenerSource::BindPath(socket_path) = &self.source
+            && socket_path.exists()
+        {
+            let _ = std::fs::remove_file(socket_path);
         }
 
         tracing::info!("[Broker] Unix socket surface service stopped");
     }
 
-    /// Get the socket path.
-    pub fn socket_path(&self) -> &Path {
-        &self.socket_path
+    /// Current number of in-flight client connections.
+    pub fn active_connection_count(&self) -> usize {
+        self.active_count.load(Ordering::Relaxed)
+    }
+
+    /// Shared handle to the active-connection counter, for external idle-exit
+    /// monitors.
+    pub fn active_connection_count_arc(&self) -> Arc<AtomicUsize> {
+        self.active_count.clone()
+    }
+
+    /// Get the socket path, if this service bound its own socket. Returns
+    /// `None` for inherited listeners.
+    pub fn socket_path(&self) -> Option<&Path> {
+        match &self.source {
+            ListenerSource::BindPath(p) => Some(p.as_path()),
+            ListenerSource::Inherited(_) => None,
+        }
     }
 }
 
@@ -110,21 +164,41 @@ impl Drop for UnixSocketSurfaceService {
     }
 }
 
+/// RAII guard that increments the active-connection counter on construction
+/// and decrements on drop.
+struct ActiveConnectionGuard(Arc<AtomicUsize>);
+
+impl ActiveConnectionGuard {
+    fn new(count: Arc<AtomicUsize>) -> Self {
+        count.fetch_add(1, Ordering::Relaxed);
+        Self(count)
+    }
+}
+
+impl Drop for ActiveConnectionGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 /// Main listener loop.
 fn run_listener(
     listener: UnixListener,
     state: BrokerState,
-    shutdown_flag: Arc<std::sync::atomic::AtomicBool>,
+    shutdown_flag: Arc<AtomicBool>,
+    active_count: Arc<AtomicUsize>,
 ) {
     loop {
-        if shutdown_flag.load(std::sync::atomic::Ordering::Relaxed) {
+        if shutdown_flag.load(Ordering::Relaxed) {
             break;
         }
 
         match listener.accept() {
             Ok((stream, _addr)) => {
                 let state = state.clone();
+                let active_count = active_count.clone();
                 thread::spawn(move || {
+                    let _guard = ActiveConnectionGuard::new(active_count);
                     if let Err(e) = handle_client_connection(stream, state) {
                         tracing::debug!("[Broker] Client connection ended: {}", e);
                     }
@@ -135,7 +209,7 @@ fn run_listener(
                 thread::sleep(std::time::Duration::from_millis(50));
             }
             Err(e) => {
-                if shutdown_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                if shutdown_flag.load(Ordering::Relaxed) {
                     break;
                 }
                 tracing::warn!("[Broker] Unix socket accept error: {}", e);
@@ -178,15 +252,16 @@ fn handle_client_connection(
 
         // Parse JSON
         let request: serde_json::Value = serde_json::from_slice(&json_bytes).map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Invalid JSON: {}", e))
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid JSON: {}", e),
+            )
         })?;
 
-        let op = request
-            .get("op")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let op = request.get("op").and_then(|v| v.as_str()).unwrap_or("");
 
         let (response, reply_fd) = match op {
+            "ping" => (serde_json::json!({"pong": true}), None),
             "register" => handle_register(&state, &request, received_fd),
             "lookup" => handle_lookup(&state, &request),
             "unregister" => handle_unregister(&state, &request),
@@ -250,14 +325,8 @@ fn handle_register(
         }
     };
 
-    let width = request
-        .get("width")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
-    let height = request
-        .get("height")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+    let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let height = request.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let format = request
         .get("format")
         .and_then(|v| v.as_str())
@@ -276,7 +345,15 @@ fn handle_register(
         );
     }
 
-    let success = state.register_surface(surface_id, runtime_id, dup_fd, width, height, format, resource_type);
+    let success = state.register_surface(
+        surface_id,
+        runtime_id,
+        dup_fd,
+        width,
+        height,
+        format,
+        resource_type,
+    );
 
     if success {
         tracing::debug!(
@@ -326,7 +403,12 @@ fn handle_lookup(
             let surfaces = state.get_surfaces();
             let metadata = surfaces.iter().find(|s| s.surface_id == surface_id);
             let (width, height, format, resource_type) = match metadata {
-                Some(m) => (m.width, m.height, m.format.as_str(), m.resource_type.as_str()),
+                Some(m) => (
+                    m.width,
+                    m.height,
+                    m.format.as_str(),
+                    m.resource_type.as_str(),
+                ),
                 None => (0, 0, "unknown", "pixel_buffer"),
             };
             (
@@ -394,14 +476,8 @@ fn handle_check_in(
         }
     };
 
-    let width = request
-        .get("width")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
-    let height = request
-        .get("height")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+    let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let height = request.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let format = request
         .get("format")
         .and_then(|v| v.as_str())
@@ -423,7 +499,15 @@ fn handle_check_in(
         );
     }
 
-    let success = state.register_surface(&surface_id, runtime_id, dup_fd, width, height, format, resource_type);
+    let success = state.register_surface(
+        &surface_id,
+        runtime_id,
+        dup_fd,
+        width,
+        height,
+        format,
+        resource_type,
+    );
 
     if !success {
         unsafe { libc::close(dup_fd) };
@@ -473,7 +557,11 @@ mod tests {
 
         let name = std::ffi::CString::new("streamlib-broker-test").unwrap();
         let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
-        assert!(fd >= 0, "memfd_create failed: {}", std::io::Error::last_os_error());
+        assert!(
+            fd >= 0,
+            "memfd_create failed: {}",
+            std::io::Error::last_os_error()
+        );
         let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
         file.write_all(contents).expect("memfd write");
         file.seek(SeekFrom::Start(0)).expect("memfd rewind");
@@ -614,5 +702,94 @@ mod tests {
 
         drop(stream);
         service.stop();
+    }
+
+    /// `ping` returns `{"pong": true}` — used by `--probe` and the fixture
+    /// script to confirm the daemon is responding on the socket. Keeping the
+    /// shape stable matters: `scripts/streamlib_broker.sh` asserts the exact
+    /// key name.
+    #[test]
+    fn ping_returns_pong() {
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_broker(&socket_path).expect("connect");
+        let req = serde_json::json!({"op": "ping"});
+        let (resp, fd) = send_request(&stream, &req, None).expect("ping request");
+        assert!(fd.is_none(), "ping returns no fd");
+        assert_eq!(resp.get("pong").and_then(|v| v.as_bool()), Some(true));
+
+        drop(stream);
+        service.stop();
+    }
+
+    /// Active-connection counter rises with in-flight clients and falls to
+    /// zero once they disconnect. Drives the idle-exit logic in `main.rs`.
+    #[test]
+    fn active_connection_count_tracks_in_flight_clients() {
+        let state = BrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        assert_eq!(service.active_connection_count(), 0);
+
+        let stream = connect_to_broker(&socket_path).expect("connect");
+        // One round-trip so the server-side handler thread has been spawned
+        // and the guard incremented.
+        let (_resp, _fd) =
+            send_request(&stream, &serde_json::json!({"op": "ping"}), None).expect("ping request");
+        assert_eq!(service.active_connection_count(), 1);
+
+        drop(stream);
+        // The server-side handler returns from its read loop on UnexpectedEof
+        // and drops the guard. Give the scheduler a moment.
+        for _ in 0..50 {
+            if service.active_connection_count() == 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert_eq!(service.active_connection_count(), 0);
+
+        service.stop();
+    }
+
+    /// When the service is handed a pre-bound listener (as in systemd socket
+    /// activation), `start()` must use it directly — no bind attempt, no
+    /// stale-socket removal — and `stop()` must leave the socket file alone
+    /// because it's owned by the caller.
+    #[test]
+    fn inherited_listener_path_does_not_bind_or_unlink() {
+        let socket_path = tmp_socket_path();
+        // Bind ourselves first, as systemd would have done.
+        let listener = UnixListener::bind(&socket_path).expect("pre-bind");
+
+        let state = BrokerState::new();
+        let mut service = UnixSocketSurfaceService::with_inherited_listener(state, listener);
+        assert!(service.socket_path().is_none());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // A client can still round-trip through the inherited listener.
+        let stream = connect_to_broker(&socket_path).expect("connect");
+        let (resp, _) =
+            send_request(&stream, &serde_json::json!({"op": "ping"}), None).expect("ping");
+        assert_eq!(resp.get("pong").and_then(|v| v.as_bool()), Some(true));
+        drop(stream);
+
+        service.stop();
+
+        // The socket file must still exist — systemd (or, in this test, the
+        // caller) owns its lifetime.
+        assert!(
+            socket_path.exists(),
+            "inherited listener path must not be unlinked on stop"
+        );
+        let _ = std::fs::remove_file(&socket_path);
     }
 }

--- a/libs/streamlib-broker/tests/daemon_lifecycle.rs
+++ b/libs/streamlib-broker/tests/daemon_lifecycle.rs
@@ -1,0 +1,476 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Daemon-lifecycle integration tests for the Linux broker binary.
+//!
+//! These tests spawn the built `streamlib-broker` binary out of
+//! `target/debug` (located via `env!("CARGO_BIN_EXE_streamlib-broker")`),
+//! exercise it as a client over its Unix-socket protocol, and prove the
+//! lifecycle guarantees the daemon advertises: stale-socket cleanup on
+//! restart, systemd socket-activation cold start via `LISTEN_FDS=1` +
+//! inherited fd 3, `--idle-exit-seconds` auto-exit and subsequent
+//! re-activation, dead-runtime pruning, and the shape of the shipped
+//! systemd units.
+
+#![cfg(target_os = "linux")]
+
+use std::io::Read;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixListener;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const BROKER_BIN: &str = env!("CARGO_BIN_EXE_streamlib-broker");
+
+/// Build a unique per-test temp directory plus child paths for the
+/// socket + log + pid. Monotonic nanos keep parallel test runs from
+/// colliding on a shared filesystem.
+struct TestEnv {
+    dir: PathBuf,
+    socket: PathBuf,
+    log: PathBuf,
+}
+
+impl TestEnv {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "streamlib-broker-lifecycle-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let socket = dir.join("broker.sock");
+        let log = dir.join("broker.log");
+        Self { dir, socket, log }
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Spawn the broker binary in the conventional `--socket-path` mode (no
+/// socket activation). Stdout+stderr are redirected to `env.log`.
+fn spawn_bound_broker(env: &TestEnv, extra_args: &[&str]) -> Child {
+    let log = std::fs::File::create(&env.log).expect("create log");
+    let err = log.try_clone().expect("clone log");
+    let mut cmd = Command::new(BROKER_BIN);
+    cmd.arg("--port")
+        .arg(unique_port_arg())
+        .arg("--socket-path")
+        .arg(&env.socket)
+        .args(extra_args)
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(err));
+    // Don't inherit LISTEN_FDS from the parent (the test harness might set
+    // it for a different test).
+    cmd.env_remove("LISTEN_FDS").env_remove("LISTEN_PID");
+    cmd.spawn().expect("spawn broker")
+}
+
+/// Spawn the broker binary with a pre-bound `UnixListener` handed over as
+/// fd 3 + `LISTEN_FDS=1`, mimicking what systemd does for a socket-
+/// activated service. Returns the child handle; the caller owns the
+/// listener and is responsible for keeping it alive across restarts.
+fn spawn_activated_broker(env: &TestEnv, listener: &UnixListener, extra_args: &[&str]) -> Child {
+    let log = std::fs::File::create(&env.log).expect("create log");
+    let err = log.try_clone().expect("clone log");
+    let listener_fd = listener.as_raw_fd();
+    let mut cmd = Command::new(BROKER_BIN);
+    cmd.arg("--port")
+        .arg(unique_port_arg())
+        // --socket-path is ignored when LISTEN_FDS is set — pass it
+        // anyway so the binary doesn't complain about missing flags.
+        .arg("--socket-path")
+        .arg(&env.socket)
+        .args(extra_args)
+        .env("LISTEN_FDS", "1")
+        // LISTEN_PID deliberately omitted — `sd_listen_fd` accepts the
+        // absence and skips the pid check. Setting it here would require
+        // knowing the child's pid before exec, which is awkward.
+        .env_remove("LISTEN_PID")
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(err));
+    unsafe {
+        cmd.pre_exec(move || {
+            // Move the listener to fd 3. In the common case dup2
+            // clears CLOEXEC on the destination, but when source ==
+            // destination POSIX treats dup2 as a no-op and leaves
+            // flags alone — so the original fd's CLOEXEC would still
+            // be set and exec would close it, leaving the broker with
+            // no inherited listener. Always clear CLOEXEC explicitly.
+            if libc::dup2(listener_fd, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let flags = libc::fcntl(3, libc::F_GETFD);
+            if flags < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::fcntl(3, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn().expect("spawn broker (activated)")
+}
+
+/// Return a port string that changes per invocation to avoid collisions
+/// between parallel tests. The gRPC port is bound by the broker; tests
+/// don't talk to it but two daemons cannot both own the same port.
+fn unique_port_arg() -> String {
+    use std::sync::atomic::{AtomicU16, Ordering};
+    static NEXT: AtomicU16 = AtomicU16::new(51000);
+    let port = NEXT.fetch_add(1, Ordering::Relaxed);
+    port.to_string()
+}
+
+/// Poll the broker with the binary's `--probe` subcommand until it
+/// responds, or the deadline expires. Returns true on success.
+fn wait_until_ready(socket: &Path, deadline: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        let status = Command::new(BROKER_BIN)
+            .arg("--probe")
+            .arg(socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            // Child inherits the parent's env; strip LISTEN_FDS so the
+            // probe subprocess doesn't try to inherit anything.
+            .env_remove("LISTEN_FDS")
+            .env_remove("LISTEN_PID")
+            .status();
+        if matches!(status, Ok(s) if s.success()) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+/// Kill the child (SIGTERM, then SIGKILL after 3s) and reap. Idempotent.
+fn stop_broker(mut child: Child) {
+    let pid = child.id() as i32;
+    unsafe { libc::kill(pid, libc::SIGTERM) };
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(3) {
+        if let Ok(Some(_)) = child.try_wait() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Baseline: the daemon starts, binds a socket, and accepts a ping from
+/// a client. If this breaks, every other test in this file is suspect.
+#[test]
+fn daemon_starts_and_accepts_client() {
+    let env = TestEnv::new("starts");
+    let child = spawn_bound_broker(&env, &[]);
+    assert!(
+        wait_until_ready(&env.socket, Duration::from_secs(10)),
+        "broker did not become ready; log at {:?}",
+        env.log
+    );
+    stop_broker(child);
+}
+
+/// A stale socket file left by a previous crash must not block the next
+/// start. The bind-path start() does `remove_file` before `bind` when a
+/// stale file is present.
+#[test]
+fn daemon_cleans_up_stale_socket_on_restart() {
+    let env = TestEnv::new("stale-socket");
+    // Plant a stale file that looks like a socket but isn't bound to
+    // anything. A previous daemon that was SIGKILLed leaves this shape.
+    std::fs::write(&env.socket, b"stale").expect("plant stale file");
+    assert!(env.socket.exists());
+
+    let child = spawn_bound_broker(&env, &[]);
+    assert!(
+        wait_until_ready(&env.socket, Duration::from_secs(10)),
+        "broker did not replace stale socket; log at {:?}",
+        env.log
+    );
+    stop_broker(child);
+}
+
+/// Simulate systemd socket activation: pre-bind a UnixListener in this
+/// process, hand it to the daemon as fd 3 with `LISTEN_FDS=1`, and
+/// confirm the client can round-trip a ping through the inherited
+/// listener — AND that the inherited listener is actually what's
+/// serving the ping, not a replacement socket bound by the fallback
+/// path.
+///
+/// The invariant is checked by inode equality: the bind-path start()
+/// `remove_file`s the socket before `bind`ing, so a broker that falls
+/// back to the bind path creates a new filesystem entry with a new
+/// inode. A broker that honors `LISTEN_FDS` leaves the pre-bound
+/// socket file untouched and reuses its inode.
+#[test]
+fn socket_activation_cold_start() {
+    use std::os::unix::fs::MetadataExt;
+
+    let env = TestEnv::new("activation-cold");
+    let listener = UnixListener::bind(&env.socket).expect("pre-bind listener");
+    let inode_before = std::fs::metadata(&env.socket)
+        .expect("stat pre-bind socket")
+        .ino();
+
+    let child = spawn_activated_broker(&env, &listener, &[]);
+    assert!(
+        wait_until_ready(&env.socket, Duration::from_secs(10)),
+        "activated broker did not become ready; log at {:?}",
+        env.log
+    );
+
+    let inode_after = std::fs::metadata(&env.socket)
+        .expect("stat live socket")
+        .ino();
+    assert_eq!(
+        inode_before, inode_after,
+        "inherited listener must serve on the pre-bound socket inode; \
+         got before={} after={} — a re-bind fallback would change this",
+        inode_before, inode_after
+    );
+
+    stop_broker(child);
+
+    // systemd would hold the socket through the restart — the parent
+    // listener is still alive here, and the socket file is still on
+    // disk.
+    assert!(env.socket.exists());
+    drop(listener);
+    let _ = std::fs::remove_file(&env.socket);
+}
+
+/// `--idle-exit-seconds` makes the daemon self-terminate after N seconds
+/// with no active connections; the test-harness listener (playing
+/// systemd) survives, and a second daemon spawned against the same
+/// listener serves the next client. This is the re-activation path.
+#[test]
+fn socket_activation_idle_exit_and_restart() {
+    let env = TestEnv::new("idle-exit");
+    let listener = UnixListener::bind(&env.socket).expect("pre-bind listener");
+
+    // First daemon: --idle-exit-seconds=2. It should come up, then exit
+    // by itself after ~2s of no clients.
+    let mut child = spawn_activated_broker(&env, &listener, &["--idle-exit-seconds", "2"]);
+    assert!(
+        wait_until_ready(&env.socket, Duration::from_secs(10)),
+        "first activated broker did not become ready; log at {:?}",
+        env.log
+    );
+
+    // Wait for the idle-exit. The probe loop above counts as one client
+    // round-trip per probe, so the idle clock effectively starts now.
+    // Give it a generous 6s to exit.
+    let exited_within = {
+        let start = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_status)) => break Some(start.elapsed()),
+                Ok(None) => {
+                    if start.elapsed() > Duration::from_secs(8) {
+                        break None;
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                Err(e) => panic!("try_wait failed: {}", e),
+            }
+        }
+    };
+    assert!(
+        exited_within.is_some(),
+        "broker did not self-exit after --idle-exit-seconds=2; log tail:\n{}",
+        tail_log(&env.log)
+    );
+
+    // The listener (systemd's role) still holds the socket; a fresh
+    // daemon spawned against it should serve a client again. This proves
+    // the socket-activation re-spawn path works end-to-end.
+    let child2 = spawn_activated_broker(&env, &listener, &[]);
+    assert!(
+        wait_until_ready(&env.socket, Duration::from_secs(10)),
+        "restarted activated broker did not become ready; log at {:?}",
+        env.log
+    );
+    stop_broker(child2);
+
+    drop(listener);
+    let _ = std::fs::remove_file(&env.socket);
+}
+
+/// When a runtime registers a surface and then dies, a later call to
+/// `prune_dead_runtimes` on the BrokerState releases that runtime's
+/// surfaces as part of the prune pass. Driven purely through the library
+/// so the test doesn't need a daemon, but it's the behavior the daemon's
+/// periodic prune loop relies on.
+#[test]
+fn prune_dead_runtimes_releases_orphaned_surfaces() {
+    use streamlib_broker::BrokerState;
+
+    let state = BrokerState::new();
+
+    // Register a runtime with a pid that definitely isn't us and is
+    // unlikely to be alive. Pid 1 is always alive on Linux (init/systemd),
+    // so pick a "reserved" sentinel: we fork a short-lived child, reap
+    // it, and use its pid. After waitpid, that pid is free to be
+    // re-assigned but the short window is enough for the test.
+    let dead_pid = {
+        // SAFETY: fork in a test with no threads running in the
+        // process — std's test harness runs tests in threads but the
+        // fork is on the current thread only, and the child exits
+        // immediately without doing work that would hit shared state.
+        // This is the minimum-risk pattern — a kernel-assigned dead pid.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+        if pid == 0 {
+            // Child: exit immediately.
+            unsafe { libc::_exit(0) };
+        }
+        // Parent: reap.
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+        pid
+    };
+
+    state.register_runtime_with_metadata("rt-dead", "dead-runtime", "", "", dead_pid);
+    state.register_surface("orphan-1", "rt-dead", -1, 640, 480, "Rgba8Unorm", "texture");
+    state.register_surface(
+        "orphan-2",
+        "rt-dead",
+        -1,
+        320,
+        240,
+        "Rgba8Unorm",
+        "pixel_buffer",
+    );
+    assert_eq!(state.surface_count(), 2);
+    assert_eq!(state.runtime_count(), 1);
+
+    let pruned = state.prune_dead_runtimes();
+    assert_eq!(pruned.len(), 1);
+    assert_eq!(pruned[0], "dead-runtime");
+    assert_eq!(
+        state.surface_count(),
+        0,
+        "orphaned surfaces must be released when their runtime is pruned"
+    );
+}
+
+/// Parse a systemd unit file into `(section, key, value)` directive
+/// tuples. Comment lines (`#` or `;`) and blank lines are skipped, and
+/// only content before an unquoted `#` on a directive line counts —
+/// otherwise a comment containing `Accept=no` would falsely satisfy
+/// the "has this directive" assertions below.
+fn parse_unit_directives(contents: &str) -> Vec<(String, String, String)> {
+    let mut section = String::new();
+    let mut out = Vec::new();
+    for raw in contents.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            section = line[1..line.len() - 1].to_string();
+            continue;
+        }
+        // Strip an inline comment if present. systemd unit files permit
+        // `Key=value # comment` but only before `=` parsing matters here.
+        let effective = line.splitn(2, '#').next().unwrap_or(line).trim();
+        if let Some((k, v)) = effective.split_once('=') {
+            out.push((section.clone(), k.trim().to_string(), v.trim().to_string()));
+        }
+    }
+    out
+}
+
+/// Parse-level invariants on the shipped systemd units. If these keys
+/// drift silently a socket-activated install would quietly fail (broker
+/// would block in bind(), or never get the inherited fd).
+#[test]
+fn systemd_units_have_required_fields() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has a parent")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf();
+    let socket_unit = repo_root.join("scripts/streamlib-broker.socket");
+    let service_unit = repo_root.join("scripts/streamlib-broker.service");
+
+    let socket = std::fs::read_to_string(&socket_unit)
+        .unwrap_or_else(|e| panic!("read {:?} failed: {}", socket_unit, e));
+    let service = std::fs::read_to_string(&service_unit)
+        .unwrap_or_else(|e| panic!("read {:?} failed: {}", service_unit, e));
+
+    let socket_dirs = parse_unit_directives(&socket);
+    let service_dirs = parse_unit_directives(&service);
+
+    let has_directive = |dirs: &[(String, String, String)], section: &str, key: &str| -> bool {
+        dirs.iter().any(|(s, k, _)| s == section && k == key)
+    };
+    let directive_value =
+        |dirs: &[(String, String, String)], section: &str, key: &str| -> Option<String> {
+            dirs.iter()
+                .find(|(s, k, _)| s == section && k == key)
+                .map(|(_, _, v)| v.clone())
+        };
+
+    // .socket unit essentials
+    assert!(
+        has_directive(&socket_dirs, "Socket", "ListenStream"),
+        "streamlib-broker.socket missing [Socket] ListenStream= — nothing to listen on"
+    );
+    assert_eq!(
+        directive_value(&socket_dirs, "Socket", "Accept").as_deref(),
+        Some("no"),
+        "streamlib-broker.socket must set Accept=no — a per-connection \
+         fork would break the persistent-state daemon"
+    );
+
+    // .service unit essentials
+    let exec_start = directive_value(&service_dirs, "Service", "ExecStart").unwrap_or_default();
+    assert!(
+        !exec_start.is_empty(),
+        "streamlib-broker.service missing [Service] ExecStart="
+    );
+    assert!(
+        exec_start.contains("streamlib-broker"),
+        "streamlib-broker.service's ExecStart= ({}) does not reference \
+         the broker binary",
+        exec_start
+    );
+    let binds_to_socket = service_dirs.iter().any(|(section, key, value)| {
+        section == "Unit"
+            && (key == "Requires" || key == "Also")
+            && value
+                .split_whitespace()
+                .any(|v| v == "streamlib-broker.socket")
+    });
+    assert!(
+        binds_to_socket,
+        "streamlib-broker.service must set [Unit] Requires=streamlib-broker.socket \
+         (or Also=) so systemd starts the socket unit alongside the service"
+    );
+}
+
+fn tail_log(log: &Path) -> String {
+    let mut buf = String::new();
+    let _ = std::fs::File::open(log).and_then(|mut f| f.read_to_string(&mut buf));
+    let lines: Vec<_> = buf.lines().collect();
+    let start = lines.len().saturating_sub(30);
+    lines[start..].join("\n")
+}

--- a/libs/streamlib/tests/fixtures/streamlib_broker.sh
+++ b/libs/streamlib/tests/fixtures/streamlib_broker.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# E2E fixture: start / stop / probe a streamlib-broker daemon using a
+# pre-built binary from target/debug. Intended for integration tests that
+# need a real broker running (not the in-process UnixSocketSurfaceService)
+# but should not pay the cost of `cargo run` inside the test.
+#
+# Usage:
+#   streamlib_broker.sh start [socket_path]
+#       Build the broker if needed, spawn it, probe until ready.
+#       Prints the socket path on stdout; the pid is written to
+#       $STREAMLIB_BROKER_FIXTURE_PID (default: same dir as socket).
+#   streamlib_broker.sh stop [socket_path]
+#       Stop the daemon, remove the pid file + socket file.
+#   streamlib_broker.sh probe [socket_path]
+#       Connect + ping; exit 0 on pong, 1 otherwise.
+#
+# Default socket path: $(mktemp -d)/broker.sock per start invocation.
+#
+# The fixture always uses target/debug — it is a test harness, not a dev
+# daemon. For ad-hoc dev use, prefer scripts/streamlib-broker-dev.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+BROKER_BIN="${REPO_ROOT}/target/debug/streamlib-broker"
+
+build_if_missing() {
+    if [[ ! -x "$BROKER_BIN" ]]; then
+        echo "[streamlib_broker.sh] building streamlib-broker..." >&2
+        cargo build --manifest-path "${REPO_ROOT}/Cargo.toml" -p streamlib-broker --quiet
+    fi
+}
+
+probe_cmd() {
+    local socket="$1"
+    "$BROKER_BIN" --probe "$socket"
+}
+
+start() {
+    build_if_missing
+    local socket="${1:-}"
+    if [[ -z "$socket" ]]; then
+        local dir
+        dir="$(mktemp -d -t streamlib-broker-fixture.XXXXXX)"
+        socket="$dir/broker.sock"
+    else
+        mkdir -p "$(dirname "$socket")"
+    fi
+    local pid_file="${STREAMLIB_BROKER_FIXTURE_PID:-${socket%.sock}.pid}"
+    local log_file="${socket%.sock}.log"
+
+    # Use a port that is unlikely to collide with a running dev broker (50052)
+    # or production (50051). Let the OS pick via 0 would be nicer, but the
+    # broker's CLI takes an explicit u16. Use 50099 as the fixture default,
+    # allow STREAMLIB_BROKER_FIXTURE_PORT to override for parallel runs.
+    local port="${STREAMLIB_BROKER_FIXTURE_PORT:-50099}"
+
+    setsid "$BROKER_BIN" \
+        --port "$port" \
+        --socket-path "$socket" \
+        >"$log_file" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$pid_file"
+
+    # Wait for readiness via --probe.
+    local attempt=0
+    while (( attempt < 50 )); do
+        if probe_cmd "$socket" >/dev/null 2>&1; then
+            echo "$socket"
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "[streamlib_broker.sh] broker exited before ready; log tail:" >&2
+            tail -20 "$log_file" >&2 || true
+            rm -f "$pid_file"
+            return 1
+        fi
+        sleep 0.1
+        attempt=$((attempt + 1))
+    done
+
+    echo "[streamlib_broker.sh] broker did not become ready within 5s; log tail:" >&2
+    tail -20 "$log_file" >&2 || true
+    kill "$pid" 2>/dev/null || true
+    rm -f "$pid_file"
+    return 1
+}
+
+stop() {
+    local socket="${1:-}"
+    if [[ -z "$socket" ]]; then
+        echo "usage: $0 stop <socket_path>" >&2
+        return 2
+    fi
+    local pid_file="${STREAMLIB_BROKER_FIXTURE_PID:-${socket%.sock}.pid}"
+    if [[ -f "$pid_file" ]]; then
+        local pid
+        pid="$(cat "$pid_file")"
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            # Wait up to 2s for clean shutdown.
+            local attempt=0
+            while kill -0 "$pid" 2>/dev/null; do
+                if (( attempt >= 20 )); then
+                    kill -9 "$pid" 2>/dev/null || true
+                    break
+                fi
+                sleep 0.1
+                attempt=$((attempt + 1))
+            done
+        fi
+        rm -f "$pid_file"
+    fi
+    [[ -S "$socket" ]] && rm -f "$socket"
+}
+
+probe() {
+    local socket="${1:-}"
+    if [[ -z "$socket" ]]; then
+        echo "usage: $0 probe <socket_path>" >&2
+        return 2
+    fi
+    probe_cmd "$socket"
+}
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+    start) start "$@" ;;
+    stop)  stop "$@" ;;
+    probe) probe "$@" ;;
+    *)
+        echo "usage: $0 {start [socket]|stop <socket>|probe <socket>}" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -10,6 +10,9 @@
 #   ./scripts/dev-setup.sh uninstall    # Uninstall dev broker and clean up
 #   ./scripts/dev-setup.sh reinstall    # Uninstall then reinstall (rebuilds broker)
 #   ./scripts/dev-setup.sh --clean      # Alias for reinstall
+#
+# For ad-hoc broker lifecycle without the full environment bootstrap, use
+# `scripts/streamlib-broker-dev.sh` (start|stop|restart|status|probe).
 
 set -euo pipefail
 

--- a/scripts/streamlib-broker-dev.sh
+++ b/scripts/streamlib-broker-dev.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# StreamLib Broker - dev-mode lifecycle helper.
+#
+# Starts / stops / probes a `cargo run -p streamlib-broker` daemon backed by
+# the current source tree. The invariant this enforces: in dev, the broker
+# you connect to is whatever the working tree currently builds.
+#
+# Usage:
+#   streamlib-broker-dev.sh start     # start if not already running
+#   streamlib-broker-dev.sh stop      # stop the running dev broker
+#   streamlib-broker-dev.sh restart   # stop then start
+#   streamlib-broker-dev.sh status    # print status + PID
+#   streamlib-broker-dev.sh probe     # exit 0 if the socket responds, 1 otherwise
+#
+# Env:
+#   STREAMLIB_HOME           default: $REPO_ROOT/.streamlib
+#   STREAMLIB_BROKER_SOCKET  default: $STREAMLIB_HOME/broker.sock
+#   STREAMLIB_BROKER_PORT    default: 50052
+#   STREAMLIB_BROKER_LOG     default: /tmp/streamlib-broker-dev.log
+#
+# The pidfile / lockfile at $STREAMLIB_HOME/broker.pid prevents double-spawn.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+STREAMLIB_HOME="${STREAMLIB_HOME:-${REPO_ROOT}/.streamlib}"
+BROKER_SOCKET="${STREAMLIB_BROKER_SOCKET:-${STREAMLIB_HOME}/broker.sock}"
+BROKER_PORT="${STREAMLIB_BROKER_PORT:-50052}"
+BROKER_LOG="${STREAMLIB_BROKER_LOG:-/tmp/streamlib-broker-dev.log}"
+PID_FILE="${STREAMLIB_HOME}/broker.pid"
+
+log() { echo "[streamlib-broker-dev] $*" >&2; }
+
+ensure_home() {
+    mkdir -p "$STREAMLIB_HOME"
+}
+
+is_running() {
+    # Returns 0 if a PID file exists and the process is alive.
+    [[ -f "$PID_FILE" ]] || return 1
+    local pid
+    pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    [[ -n "$pid" ]] || return 1
+    kill -0 "$pid" 2>/dev/null
+}
+
+probe() {
+    # Uses the broker binary's own --probe subcommand (connects + pings).
+    cargo run --manifest-path "${REPO_ROOT}/Cargo.toml" -p streamlib-broker --quiet -- \
+        --probe "$BROKER_SOCKET"
+}
+
+start() {
+    ensure_home
+
+    if is_running; then
+        log "already running (pid $(cat "$PID_FILE"))"
+        return 0
+    fi
+
+    # Build once so the subsequent cargo-run is fast and the "start" completion
+    # signal reflects a ready binary, not a compile-in-progress.
+    log "building streamlib-broker (debug)..."
+    cargo build --manifest-path "${REPO_ROOT}/Cargo.toml" -p streamlib-broker --quiet
+
+    log "starting broker (socket $BROKER_SOCKET, port $BROKER_PORT)"
+    # Use `setsid` so the broker keeps running when this shell exits. Redirect
+    # stdout/stderr to the log file. Record the child pid.
+    STREAMLIB_HOME="$STREAMLIB_HOME" \
+    STREAMLIB_BROKER_SOCKET="$BROKER_SOCKET" \
+    setsid "${REPO_ROOT}/target/debug/streamlib-broker" \
+        --port "$BROKER_PORT" \
+        --socket-path "$BROKER_SOCKET" \
+        >"$BROKER_LOG" 2>&1 &
+    echo "$!" > "$PID_FILE"
+
+    # Poll the socket via --probe until it responds (up to 10s).
+    local attempt=0
+    while (( attempt < 50 )); do
+        if probe >/dev/null 2>&1; then
+            log "broker ready (pid $(cat "$PID_FILE"), log $BROKER_LOG)"
+            return 0
+        fi
+        sleep 0.2
+        attempt=$((attempt + 1))
+    done
+
+    log "broker did not become ready within 10s; tail -20 of log:"
+    tail -20 "$BROKER_LOG" >&2 || true
+    return 1
+}
+
+stop() {
+    if ! is_running; then
+        log "not running"
+        rm -f "$PID_FILE"
+        return 0
+    fi
+    local pid
+    pid="$(cat "$PID_FILE")"
+    log "stopping broker (pid $pid)"
+    kill "$pid" 2>/dev/null || true
+    # Wait up to 5s for clean shutdown.
+    local attempt=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if (( attempt >= 25 )); then
+            log "broker did not exit cleanly, SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+            break
+        fi
+        sleep 0.2
+        attempt=$((attempt + 1))
+    done
+    rm -f "$PID_FILE"
+    # Socket file should be cleaned up by broker's own Drop, but be safe.
+    [[ -S "$BROKER_SOCKET" ]] && rm -f "$BROKER_SOCKET"
+    log "stopped"
+}
+
+status() {
+    if is_running; then
+        local pid
+        pid="$(cat "$PID_FILE")"
+        echo "running (pid $pid, socket $BROKER_SOCKET)"
+        return 0
+    fi
+    echo "not running"
+    return 1
+}
+
+cmd="${1:-status}"
+case "$cmd" in
+    start)   start ;;
+    stop)    stop ;;
+    restart) stop; start ;;
+    status)  status ;;
+    probe)   probe ;;
+    *)
+        echo "usage: $0 {start|stop|restart|status|probe}" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/streamlib-broker.service
+++ b/scripts/streamlib-broker.service
@@ -3,11 +3,21 @@
 #
 # StreamLib Broker - systemd user service template
 #
-# Install:
+# Prefer the socket-activated install (clients don't need to start the
+# broker first):
 #   mkdir -p ~/.config/systemd/user
+#   cp scripts/streamlib-broker.socket  ~/.config/systemd/user/
 #   cp scripts/streamlib-broker.service ~/.config/systemd/user/
 #   systemctl --user daemon-reload
+#   systemctl --user enable --now streamlib-broker.socket
+#
+# First client connect to %h/.streamlib/broker.sock activates this service;
+# systemd hands the listening socket to the daemon on fd 3 via LISTEN_FDS=1.
+#
+# Non-activated install (legacy):
 #   systemctl --user enable --now streamlib-broker.service
+# The daemon will bind %h/.streamlib/broker.sock itself and fall back to the
+# non-activation code path.
 #
 # Check status:
 #   systemctl --user status streamlib-broker.service
@@ -16,12 +26,16 @@
 [Unit]
 Description=StreamLib Broker Service
 Documentation=https://github.com/tatolab/streamlib
-After=default.target
+Requires=streamlib-broker.socket
+After=streamlib-broker.socket default.target
 
 [Service]
 Type=simple
 Environment=STREAMLIB_HOME=%h/.streamlib
 Environment=STREAMLIB_BROKER_SOCKET=%h/.streamlib/broker.sock
+# When activated via the socket unit, systemd sets LISTEN_FDS=1 and passes
+# the listening fd as fd 3 — --socket-path is ignored in that case. The
+# flag is still present for the non-activated install path.
 ExecStart=%h/.streamlib/bin/streamlib-broker --port 50051 --socket-path %h/.streamlib/broker.sock
 Restart=on-failure
 RestartSec=5

--- a/scripts/streamlib-broker.socket
+++ b/scripts/streamlib-broker.socket
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# StreamLib Broker - systemd user socket unit (socket activation)
+#
+# Pair with streamlib-broker.service. Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/streamlib-broker.socket  ~/.config/systemd/user/
+#   cp scripts/streamlib-broker.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now streamlib-broker.socket
+#
+# The socket unit keeps %h/.streamlib/broker.sock listening regardless of
+# whether the daemon is running. The first client connect activates
+# streamlib-broker.service, which inherits this socket via LISTEN_FDS=1.
+# If the daemon exits (e.g. --idle-exit-seconds), systemd re-activates it
+# on the next connect.
+
+[Unit]
+Description=StreamLib Broker Socket
+Documentation=https://github.com/tatolab/streamlib
+
+[Socket]
+ListenStream=%h/.streamlib/broker.sock
+SocketMode=0600
+# Accept=no: pass the listening socket to one long-running daemon, not a
+# handler-per-connection (inetd-style).
+Accept=no
+# Keep the socket fd around across daemon restarts.
+RemoveOnStop=false
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
## Summary

Make the Linux `streamlib-broker` daemon a first-class testable component:

- **Socket activation** via `LISTEN_FDS=1` + inherited fd 3 — first client connect activates the daemon, no `systemctl start` step in onboarding.
- **`--idle-exit-seconds`** so a socket-activated daemon can idle-exit and be re-activated on the next connect.
- **`--probe <socket>`** + `ping` op so fixtures, tests, and `streamlib-broker-dev.sh probe` confirm readiness deterministically.
- **Real daemon-lifecycle integration tests** (stale-socket cleanup, activation cold start, idle-exit-and-restart, dead-runtime prune, systemd unit parse).

## Closes

Closes #424

## Exit criteria

### Socket activation
- [x] `scripts/streamlib-broker.socket` with `ListenStream=%h/.streamlib/broker.sock`, `Accept=no`.
- [x] `scripts/streamlib-broker.service` updated: `Requires=streamlib-broker.socket`, inherits via `LISTEN_FDS` (flag still present for non-activated path).
- [x] `main.rs::sd_listen_fd` probes `LISTEN_FDS` + optional `LISTEN_PID` validation; hands inherited listener straight to `UnixSocketSurfaceService::with_inherited_listener` (no `bind()`). Falls back to bind on env absence or inconsistency.
- [x] `--idle-exit-seconds` CLI flag with watchdog task keyed off an RAII active-connection counter.
- [x] Docs: `docs/operations/broker.md` — no `systemctl start` step in the onboarding flow.

### `cargo run` is the dev default
- [x] `scripts/streamlib-broker-dev.sh` (new) — standalone lifecycle helper (`start|stop|restart|status|probe`), pidfile-gated, builds once then runs `target/debug/streamlib-broker` via `setsid`.
- [x] `scripts/dev-setup.sh` — thin pointer to the new helper.
- [x] Invariant documented in `docs/operations/broker.md`: *in dev, the broker you connect to is the current source tree.*

### Lifecycle + reliability
- [x] `libs/streamlib/tests/fixtures/streamlib_broker.sh` (new) — `start [socket] / stop <socket> / probe <socket>`.
- [x] `libs/streamlib-broker/tests/daemon_lifecycle.rs` (new) — six integration tests below.
- [x] Systemd unit parse validation — *directive-level*, comments stripped, so an `# Accept=no` comment alone does NOT satisfy the assertion.
- [x] `--probe <socket>` readiness probe + `ping` op.
- [x] `docs/operations/broker.md` — new operator doc covering dev/prod/test, probing, log paths, common failures.

## Test plan

### `cargo test -p streamlib-broker` (Linux) — all green (2.21s)

**Library tests (9 passing, 3 new):**
- `ping_returns_pong` — locks the `{"op":"ping"}` → `{"pong": true}` shape used by `--probe` and the fixture.
- `active_connection_count_tracks_in_flight_clients` — RAII guard raises/lowers correctly; drives idle-exit.
- `inherited_listener_path_does_not_bind_or_unlink` — `with_inherited_listener` never bind()s and leaves the caller's socket file on `stop()`.

**Integration tests (6 passing, new file):**
- `daemon_starts_and_accepts_client` — baseline lifecycle.
- `daemon_cleans_up_stale_socket_on_restart` — plants a stale socket file; confirms the next start recovers.
- `socket_activation_cold_start` — pre-binds a `UnixListener`, hands it to the daemon as fd 3 with `LISTEN_FDS=1`, asserts inode equality (proves the inherited listener is actually serving, not a silent re-bind).
- `socket_activation_idle_exit_and_restart` — `--idle-exit-seconds=2`, wait for daemon self-exit, spawn a second daemon against the same test-harness listener, confirm it serves the next client.
- `prune_dead_runtimes_releases_orphaned_surfaces` — registers a runtime under a reaped pid + two surfaces, calls `prune_dead_runtimes`, asserts both surfaces released.
- `systemd_units_have_required_fields` — directive-level parse of `.socket` + `.service`; asserts `[Socket] Accept=no`, `[Socket] ListenStream=…`, `[Service] ExecStart=…streamlib-broker…`, `[Unit] Requires=streamlib-broker.socket`.

### Fixture smoke test (local)

```
SOCKET=$(libs/streamlib/tests/fixtures/streamlib_broker.sh start)
libs/streamlib/tests/fixtures/streamlib_broker.sh probe "$SOCKET"   # exit 0
libs/streamlib/tests/fixtures/streamlib_broker.sh stop  "$SOCKET"   # exit 0
libs/streamlib/tests/fixtures/streamlib_broker.sh probe "$SOCKET"   # exit 1
```

## CI evidence

- **Workflow file**: [`.github/workflows/test.yml`](../blob/chore/broker-lifecycle-socket-activation-424/.github/workflows/test.yml) — added `cargo test -p streamlib-broker` step to the Linux job (workflow is currently `workflow_dispatch`-only upstream, so the step runs on manual dispatch).
- **Green baseline**: local `cargo test -p streamlib-broker` reports `9 passed` (lib) + `6 passed` (integration) + `0 passed` (doc), finished in 2.21s. See the summary above for the test names.
- **Negative test #1 — unit parse gate isn't vacuous**: stripping the `Accept=no` directive line from `scripts/streamlib-broker.socket`:
    ```
    ---- systemd_units_have_required_fields stdout ----
    thread 'systemd_units_have_required_fields' panicked at
    libs/streamlib-broker/tests/daemon_lifecycle.rs:419:5:
    assertion `left == right` failed: streamlib-broker.socket must set Accept=no
      left: None
      right: Some("no")
    test result: FAILED. 0 passed; 1 failed; …
    ```
  Restoring the directive: test green again.
- **Negative test #2 — activation behavioral gate isn't vacuous**: forcing `sd_listen_fd()` to always return `Ok(None)` (makes the daemon fall back to the bind path, which `remove_file`s and re-binds the pre-bound socket, changing the inode):
    ```
    ---- socket_activation_cold_start stdout ----
    thread 'socket_activation_cold_start' panicked at
    libs/streamlib-broker/tests/daemon_lifecycle.rs:235:5:
    activated broker did not become ready; log at "/tmp/…/broker.log"
    test result: FAILED. 0 passed; 1 failed; …
    ```
  Restoring the probe: test green again. *(The test fails via the probe timeout because the broker happens to wedge during parallel port/socket setup under the injected bug rather than reaching the inode assertion cleanly — but the gate is still behaviorally red, which is what CI needs.)*
- **Environment validated**: local Linux workstation (Arch/Ubuntu equivalent), `target/debug/streamlib-broker` via `CARGO_BIN_EXE_streamlib-broker`. Tests require Linux (`#![cfg(target_os = "linux")]`).

## Polyglot coverage

- **Runtimes affected**: rust (no schema change)
- **Schema regenerated**: n/a
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-broker` — 15 tests pass (lib + integration)
  - [ ] Python subprocess: n/a — broker-server-side change only; wire format to polyglot cdylibs is unchanged
  - [ ] Deno subprocess: n/a — same reason
- **FD-passing path**: n/a — this PR doesn't touch FD-passing; it makes the listener itself inheritable from systemd

## Follow-ups

None — scope kept to #424 exit criteria. Pre-existing clippy / fmt issues in `libs/streamlib-broker/src/grpc_service.rs`, `libs/streamlib-broker/src/state.rs`, and `libs/streamlib-broker-client/src/linux.rs` were left untouched per CLAUDE.md's "no auto-fixing on the side" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)