### PR TITLE
feat(runtime): own internal surface-sharing broker per runtime (#428)

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -124,7 +124,8 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
 
             let runner_path = sdk_path.join("subprocess_runner.ts");
 
-            let mut child = Command::new(&deno_binary)
+            let mut command = Command::new(&deno_binary);
+            command
                 .arg("run")
                 .arg("--allow-ffi")
                 .arg("--allow-read")
@@ -143,8 +144,12 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 )
                 .env("STREAMLIB_NATIVE_LIB_PATH", &native_lib_path)
                 .env("STREAMLIB_PROCESSOR_ID", &self.processor_id)
-                .env("STREAMLIB_EXECUTION_MODE", execution_mode)
-                .spawn()
+                .env("STREAMLIB_EXECUTION_MODE", execution_mode);
+
+            #[cfg(target_os = "linux")]
+            command.env("STREAMLIB_BROKER_SOCKET", ctx.surface_socket_path());
+
+            let mut child = command.spawn()
                 .map_err(|e| {
                     StreamError::Runtime(format!(
                         "Failed to spawn Deno subprocess for '{}': {}. Deno: '{}'",

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -122,7 +122,8 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 
             let runtime_id = ctx.runtime_id().to_string();
 
-            let mut child = Command::new(&python_executable)
+            let mut command = Command::new(&python_executable);
+            command
                 .arg("-m")
                 .arg("streamlib.subprocess_runner")
                 .stdin(Stdio::piped())
@@ -135,8 +136,12 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                 .env("STREAMLIB_PYTHON_NATIVE_LIB", &self.native_lib_path)
                 .env("STREAMLIB_PROCESSOR_ID", &self.processor_id)
                 .env("STREAMLIB_EXECUTION_MODE", execution_mode)
-                .env("STREAMLIB_RUNTIME_ID", &runtime_id)
-                .spawn()
+                .env("STREAMLIB_RUNTIME_ID", &runtime_id);
+
+            #[cfg(target_os = "linux")]
+            command.env("STREAMLIB_BROKER_SOCKET", ctx.surface_socket_path());
+
+            let mut child = command.spawn()
                 .map_err(|e| {
                     StreamError::Runtime(format!(
                         "Failed to spawn Python native subprocess for '{}': {}. Python: '{}'",

--- a/libs/streamlib/src/core/context/runtime_context.rs
+++ b/libs/streamlib/src/core/context/runtime_context.rs
@@ -35,6 +35,12 @@ pub struct RuntimeContext {
     iceoryx2_node: Iceoryx2Node,
     /// Audio clock for synchronized audio timing.
     audio_clock: SharedAudioClock,
+    /// Per-runtime surface-sharing Unix socket path. Polyglot subprocesses
+    /// receive this via the `STREAMLIB_BROKER_SOCKET` env var so their
+    /// `streamlib-broker-client` connects to the runtime-internal service
+    /// rather than an external daemon.
+    #[cfg(target_os = "linux")]
+    surface_socket_path: std::path::PathBuf,
     /// Shared MoQ sessions (one publish + one subscribe per runtime).
     #[cfg(feature = "moq")]
     moq_sessions: crate::core::streaming::SharedMoqSessions,
@@ -49,6 +55,7 @@ impl RuntimeContext {
         tokio_handle: tokio::runtime::Handle,
         iceoryx2_node: Iceoryx2Node,
         audio_clock: SharedAudioClock,
+        #[cfg(target_os = "linux")] surface_socket_path: std::path::PathBuf,
     ) -> Self {
         Self {
             gpu,
@@ -62,6 +69,8 @@ impl RuntimeContext {
             tokio_handle,
             iceoryx2_node,
             audio_clock,
+            #[cfg(target_os = "linux")]
+            surface_socket_path,
         }
     }
 
@@ -100,6 +109,14 @@ impl RuntimeContext {
     /// Get the runtime's unique identifier.
     pub fn runtime_id(&self) -> &RuntimeUniqueId {
         &self.runtime_id
+    }
+
+    /// Per-runtime surface-sharing Unix socket path. Polyglot subprocess
+    /// spawn ops set `STREAMLIB_BROKER_SOCKET` to this so the child's
+    /// `streamlib-broker-client` connects to the runtime-internal service.
+    #[cfg(target_os = "linux")]
+    pub fn surface_socket_path(&self) -> &std::path::Path {
+        &self.surface_socket_path
     }
 
     /// Get the processor's unique identifier (None for shared/global context).
@@ -155,6 +172,8 @@ impl RuntimeContext {
             tokio_handle: self.tokio_handle.clone(),
             iceoryx2_node: self.iceoryx2_node.clone(),
             audio_clock: Arc::clone(&self.audio_clock),
+            #[cfg(target_os = "linux")]
+            surface_socket_path: self.surface_socket_path.clone(),
             #[cfg(feature = "moq")]
             moq_sessions: self.moq_sessions.clone(),
         }
@@ -172,6 +191,8 @@ impl RuntimeContext {
             tokio_handle: self.tokio_handle.clone(),
             iceoryx2_node: self.iceoryx2_node.clone(),
             audio_clock: Arc::clone(&self.audio_clock),
+            #[cfg(target_os = "linux")]
+            surface_socket_path: self.surface_socket_path.clone(),
             #[cfg(feature = "moq")]
             moq_sessions: self.moq_sessions.clone(),
         }
@@ -665,6 +686,10 @@ impl<'a> RuntimeContextFullAccess<'a> {
     }
     pub fn runtime_id(&self) -> &RuntimeUniqueId {
         self.base.runtime_id()
+    }
+    #[cfg(target_os = "linux")]
+    pub fn surface_socket_path(&self) -> &std::path::Path {
+        self.base.surface_socket_path()
     }
     pub fn processor_id(&self) -> Option<&ProcessorUniqueId> {
         self.base.processor_id()

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -105,6 +105,19 @@ pub struct StreamRuntime {
     /// iceoryx2 Node for creating Services, Publishers, and Subscribers.
     /// Created in new() so PUBSUB can initialize before start().
     pub(crate) iceoryx2_node: Iceoryx2Node,
+    /// Per-runtime surface-sharing service. Bound to a unique Unix socket in
+    /// `new()`; polyglot subprocesses connect to it via the
+    /// `STREAMLIB_BROKER_SOCKET` env var. Wrapped in `Mutex<Option<...>>` so
+    /// `stop()` can drop it deterministically; the `Drop` impl on
+    /// `UnixSocketSurfaceService` removes the socket file.
+    #[cfg(target_os = "linux")]
+    pub(crate) surface_service: Arc<
+        Mutex<Option<streamlib_broker::unix_socket_service::UnixSocketSurfaceService>>,
+    >,
+    /// Path of the per-runtime surface-sharing socket
+    /// (`$XDG_RUNTIME_DIR/streamlib-<runtime_uuid>.sock`).
+    #[cfg(target_os = "linux")]
+    pub(crate) surface_socket_path: std::path::PathBuf,
     /// Telemetry guard — keeps the OTel pipeline alive for the runtime's lifetime.
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
     _telemetry_guard: streamlib_telemetry::TelemetryGuard,
@@ -185,6 +198,14 @@ impl StreamRuntime {
         // Must happen before any subscribe() calls (GraphChangeListener below).
         PUBSUB.init(&runtime_id, iceoryx2_node.clone());
 
+        // Bring up the per-runtime surface-sharing service. Each runtime owns
+        // a unique Unix socket at $XDG_RUNTIME_DIR/streamlib-<uuid>.sock that
+        // its polyglot subprocesses connect to via STREAMLIB_BROKER_SOCKET.
+        // No external broker daemon is required.
+        #[cfg(target_os = "linux")]
+        let (surface_service, surface_socket_path) =
+            bring_up_surface_service(&runtime_id)?;
+
         // Create Arc-wrapped components
         let compiler = Arc::new(Compiler::new());
         let runtime_context = Arc::new(Mutex::new(None));
@@ -209,9 +230,30 @@ impl StreamRuntime {
             status,
             _graph_change_listener: listener,
             iceoryx2_node,
+            #[cfg(target_os = "linux")]
+            surface_service,
+            #[cfg(target_os = "linux")]
+            surface_socket_path,
             #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
             _telemetry_guard,
         }))
+    }
+
+    /// Path of the per-runtime surface-sharing Unix socket.
+    ///
+    /// Bound during [`StreamRuntime::new`] at
+    /// `$XDG_RUNTIME_DIR/streamlib-<runtime_uuid>.sock`. Polyglot
+    /// subprocesses spawned by this runtime inherit this path via the
+    /// `STREAMLIB_BROKER_SOCKET` env var so their `streamlib-broker-client`
+    /// connects to the runtime-internal service.
+    #[cfg(target_os = "linux")]
+    pub fn surface_socket_path(&self) -> &std::path::Path {
+        &self.surface_socket_path
+    }
+
+    /// Unique identifier for this runtime instance.
+    pub fn runtime_id(&self) -> &RuntimeUniqueId {
+        &self.runtime_id
     }
 
     /// Update a processor's configuration at runtime.
@@ -612,30 +654,29 @@ impl StreamRuntime {
             }
         }
 
-        // Initialize SurfaceStore for cross-process GPU surface sharing (Linux)
+        // Initialize SurfaceStore for cross-process GPU surface sharing (Linux).
+        // Connects to the runtime-internal surface-sharing service that
+        // `new()` already brought up — fail fast if the connection fails,
+        // because the service is guaranteed to be running.
         #[cfg(target_os = "linux")]
         {
             use crate::core::context::SurfaceStore;
 
-            let socket_path = std::env::var("STREAMLIB_BROKER_SOCKET").unwrap_or_else(|_| {
-                let streamlib_home = crate::core::get_streamlib_home();
-                format!("{}/broker.sock", streamlib_home.display())
-            });
+            let socket_path = self.surface_socket_path.to_string_lossy().to_string();
             tracing::info!(
-                "[start] Initializing SurfaceStore with Unix socket '{}'...",
+                "[start] Initializing SurfaceStore against runtime-internal Unix socket '{}'...",
                 socket_path
             );
             let surface_store =
-                SurfaceStore::new(socket_path, self.runtime_id.to_string());
-            if let Err(e) = surface_store.connect() {
-                tracing::warn!(
-                    "[start] SurfaceStore Unix socket connection failed (surface sharing disabled): {}",
-                    e
-                );
-            } else {
-                gpu.set_surface_store(surface_store);
-                tracing::info!("[start] SurfaceStore initialized");
-            }
+                SurfaceStore::new(socket_path.clone(), self.runtime_id.to_string());
+            surface_store.connect().map_err(|e| {
+                StreamError::Runtime(format!(
+                    "Failed to connect to runtime-internal surface-sharing service at {}: {}",
+                    socket_path, e
+                ))
+            })?;
+            gpu.set_surface_store(surface_store);
+            tracing::info!("[start] SurfaceStore initialized against runtime-internal broker");
         }
 
         // Create shared timing context - clock starts now
@@ -689,6 +730,8 @@ impl StreamRuntime {
             self.tokio_runtime_variant.handle(),
             iceoryx2_node,
             Arc::clone(&audio_clock),
+            #[cfg(target_os = "linux")]
+            self.surface_socket_path.clone(),
         ));
         *self.runtime_context.lock() = Some(Arc::clone(&runtime_ctx));
 
@@ -769,6 +812,21 @@ impl StreamRuntime {
         // This enables per-session tracking (e.g., AI agents analyzing runtime state).
         *self.runtime_context.lock() = None;
         tracing::debug!("[stop] Runtime context cleared");
+
+        // Tear down the per-runtime surface-sharing service. The Drop impl
+        // on UnixSocketSurfaceService also stops it, but doing it here makes
+        // the socket file disappear before stop() returns — important for
+        // tests that immediately re-bind a new runtime on the same path.
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(mut svc) = self.surface_service.lock().take() {
+                svc.stop();
+                tracing::debug!(
+                    "[stop] Runtime-internal surface-sharing service stopped at {}",
+                    self.surface_socket_path.display()
+                );
+            }
+        }
 
         *self.status.lock() = RuntimeStatus::Stopped;
         PUBSUB.publish(
@@ -1275,17 +1333,97 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
     Ok(cache_dir)
 }
 
+/// Compute the per-runtime surface-sharing socket path, refuse to start if
+/// another live runtime is already bound there, clean up an orphan socket
+/// from a prior crashed runtime, and bring the listener up.
+#[cfg(target_os = "linux")]
+fn bring_up_surface_service(
+    runtime_id: &RuntimeUniqueId,
+) -> Result<(
+    Arc<Mutex<Option<streamlib_broker::unix_socket_service::UnixSocketSurfaceService>>>,
+    std::path::PathBuf,
+)> {
+    use streamlib_broker::unix_socket_service::UnixSocketSurfaceService;
+    use streamlib_broker::BrokerState;
+
+    let xdg_runtime_dir = std::env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
+        StreamError::Runtime(
+            "XDG_RUNTIME_DIR is not set. The runtime needs a writable directory \
+             for its per-runtime surface-sharing socket — typically /run/user/<uid>. \
+             Set XDG_RUNTIME_DIR or run under a session manager that provides it."
+                .to_string(),
+        )
+    })?;
+
+    let socket_path = std::path::PathBuf::from(xdg_runtime_dir)
+        .join(format!("streamlib-{}.sock", runtime_id));
+
+    if socket_path.exists() {
+        match std::os::unix::net::UnixStream::connect(&socket_path) {
+            Ok(_) => {
+                return Err(StreamError::Runtime(format!(
+                    "Surface-sharing socket {} is already bound by a live process. \
+                     Each StreamRuntime requires a unique runtime_id; check for a \
+                     duplicate STREAMLIB_RUNTIME_ID env var or another runtime in \
+                     the same session.",
+                    socket_path.display()
+                )));
+            }
+            Err(_) => {
+                std::fs::remove_file(&socket_path).map_err(|e| {
+                    StreamError::Runtime(format!(
+                        "Found stale surface-sharing socket {} from a prior crashed \
+                         runtime but failed to remove it: {}",
+                        socket_path.display(),
+                        e
+                    ))
+                })?;
+                tracing::warn!(
+                    "[new] Removed stale surface-sharing socket left by prior runtime: {}",
+                    socket_path.display()
+                );
+            }
+        }
+    }
+
+    let mut service = UnixSocketSurfaceService::new(BrokerState::new(), socket_path.clone());
+    service.start().map_err(|e| {
+        StreamError::Runtime(format!(
+            "Failed to start runtime-internal surface-sharing service at {}: {}",
+            socket_path.display(),
+            e
+        ))
+    })?;
+
+    tracing::info!(
+        "[new] Runtime-internal surface-sharing service bound at {}",
+        socket_path.display()
+    );
+
+    Ok((Arc::new(Mutex::new(Some(service))), socket_path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    // All StreamRuntime::new() tests are `#[serial]` because the runtime
+    // reads/writes process-global env vars (XDG_RUNTIME_DIR,
+    // STREAMLIB_RUNTIME_ID) and its PUBSUB/iceoryx2/telemetry plumbing
+    // races when multiple runtimes construct concurrently. The test
+    // module's `#[serial]` default group serializes every test that
+    // constructs a StreamRuntime so nobody reads env mid-mutation.
 
     #[test]
+    #[serial]
     fn test_runtime_creation() {
         let _runtime = StreamRuntime::new();
         // Runtime creates successfully
     }
 
     #[test]
+    #[serial]
     fn test_new_outside_tokio_creates_owned_runtime() {
         // Outside tokio context - creates owned runtime
         let runtime = StreamRuntime::new().unwrap();
@@ -1296,6 +1434,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_new_inside_tokio_uses_external_handle() {
         // Inside tokio context - auto-detects and uses external handle
         let temp_rt = tokio::runtime::Builder::new_multi_thread()
@@ -1312,6 +1451,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_sync_methods_work_inside_tokio() {
         // Verify sync methods work when called from tokio context
         let temp_rt = tokio::runtime::Builder::new_multi_thread()
@@ -1324,5 +1464,204 @@ mod tests {
             let json = runtime.to_json().unwrap();
             assert!(json["nodes"].is_array());
         });
+    }
+
+    // =========================================================================
+    // Per-runtime surface-sharing service (#428)
+    // =========================================================================
+
+    #[cfg(target_os = "linux")]
+    mod runtime_internal_broker {
+        use super::*;
+        use std::os::unix::net::UnixStream;
+        use streamlib_broker::unix_socket_service::send_request;
+
+        /// Replace XDG_RUNTIME_DIR with a fresh tempdir for the duration of the
+        /// closure. Tests using this must be `#[serial]` so no other runtime
+        /// construct reads the mutated env.
+        fn with_isolated_xdg_runtime_dir<F: FnOnce(&std::path::Path) -> R, R>(f: F) -> R {
+            let prev = std::env::var_os("XDG_RUNTIME_DIR");
+            let tmp = tempfile::tempdir().expect("tempdir");
+            // SAFETY: tests are serialized via #[serial]; no concurrent env mutation.
+            unsafe {
+                std::env::set_var("XDG_RUNTIME_DIR", tmp.path());
+            }
+            let result = f(tmp.path());
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                    None => std::env::remove_var("XDG_RUNTIME_DIR"),
+                }
+            }
+            result
+        }
+
+        #[test]
+        #[serial]
+        fn runtime_brings_up_internal_broker() {
+            with_isolated_xdg_runtime_dir(|xdg| {
+                let runtime = StreamRuntime::new().expect("runtime should construct");
+                let socket_path = runtime.surface_socket_path();
+                assert!(
+                    socket_path.exists(),
+                    "expected socket file at {}",
+                    socket_path.display()
+                );
+                assert!(
+                    socket_path.starts_with(xdg),
+                    "socket {} should be under XDG_RUNTIME_DIR {}",
+                    socket_path.display(),
+                    xdg.display()
+                );
+
+                // Round-trip a request through the runtime-internal service to prove
+                // it is actually serving — check_out for an unknown surface_id is
+                // the lightest-weight op that exercises the wire path end-to-end.
+                let stream = UnixStream::connect(socket_path).expect("connect to runtime broker");
+                let req = serde_json::json!({
+                    "op": "check_out",
+                    "surface_id": "ping-no-such-surface",
+                });
+                let (resp, fd) = send_request(&stream, &req, None).expect("round-trip");
+                assert!(fd.is_none());
+                assert!(
+                    resp.get("error").and_then(|v| v.as_str()).is_some(),
+                    "expected error for missing surface, got {:?}",
+                    resp
+                );
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn runtime_fails_fast_when_xdg_runtime_dir_missing() {
+            let prev = std::env::var_os("XDG_RUNTIME_DIR");
+            // SAFETY: serialized via #[serial].
+            unsafe {
+                std::env::remove_var("XDG_RUNTIME_DIR");
+            }
+
+            let result = StreamRuntime::new();
+
+            // Restore env before asserting so a panic doesn't leak state.
+            unsafe {
+                if let Some(v) = prev {
+                    std::env::set_var("XDG_RUNTIME_DIR", v);
+                }
+            }
+
+            let err = match result {
+                Err(e) => e,
+                Ok(_) => panic!("runtime should refuse to start without XDG_RUNTIME_DIR"),
+            };
+            let msg = err.to_string();
+            assert!(
+                msg.contains("XDG_RUNTIME_DIR"),
+                "error should name XDG_RUNTIME_DIR; got: {msg}"
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn two_runtimes_coexist_without_collision() {
+            with_isolated_xdg_runtime_dir(|_| {
+                let r1 = StreamRuntime::new().expect("first runtime");
+                let r2 = StreamRuntime::new().expect("second runtime");
+
+                let p1 = r1.surface_socket_path().to_path_buf();
+                let p2 = r2.surface_socket_path().to_path_buf();
+
+                assert_ne!(p1, p2, "each runtime must own a distinct socket path");
+                assert!(p1.exists(), "first socket missing: {}", p1.display());
+                assert!(p2.exists(), "second socket missing: {}", p2.display());
+
+                // Both should serve a round-trip independently.
+                for path in [&p1, &p2] {
+                    let stream = UnixStream::connect(path).expect("connect");
+                    let req = serde_json::json!({
+                        "op": "check_out",
+                        "surface_id": "no-such",
+                    });
+                    let (resp, _) = send_request(&stream, &req, None).expect("round-trip");
+                    assert!(resp.get("error").is_some());
+                }
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn polyglot_subprocess_inherits_socket_env() {
+            with_isolated_xdg_runtime_dir(|_| {
+                let runtime = StreamRuntime::new().expect("runtime");
+                let socket_path = runtime.surface_socket_path().to_path_buf();
+
+                // Mirror what the spawn ops do: build a Command with the env
+                // var set from the runtime's socket path. The spawn ops use
+                // `ctx.surface_socket_path()` which returns the same value as
+                // `runtime.surface_socket_path()` — this test exercises the
+                // contract that polyglot subprocesses see the runtime's socket.
+                let output = std::process::Command::new("printenv")
+                    .arg("STREAMLIB_BROKER_SOCKET")
+                    .env("STREAMLIB_BROKER_SOCKET", &socket_path)
+                    .output()
+                    .expect("spawn printenv");
+
+                assert!(
+                    output.status.success(),
+                    "printenv exited non-zero: stdout={:?} stderr={:?}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                let inherited = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                assert_eq!(inherited, socket_path.to_string_lossy());
+            });
+        }
+
+        #[test]
+        #[serial]
+        fn stale_socket_from_dead_runtime_is_cleaned_up() {
+            with_isolated_xdg_runtime_dir(|xdg| {
+                // Pin the runtime ID so we can pre-create a file at the exact
+                // path the runtime will compute.
+                let pinned_id = format!("test-stale-socket-{}", std::process::id());
+                let prev = std::env::var_os("STREAMLIB_RUNTIME_ID");
+                // SAFETY: serialized via #[serial].
+                unsafe {
+                    std::env::set_var("STREAMLIB_RUNTIME_ID", &pinned_id);
+                }
+
+                let stale_path = xdg.join(format!("streamlib-{pinned_id}.sock"));
+                std::fs::write(&stale_path, b"orphan-from-prior-crashed-runtime")
+                    .expect("write orphan");
+                assert!(stale_path.exists());
+
+                let runtime_result = StreamRuntime::new();
+
+                // Restore env before asserting.
+                unsafe {
+                    match prev {
+                        Some(v) => std::env::set_var("STREAMLIB_RUNTIME_ID", v),
+                        None => std::env::remove_var("STREAMLIB_RUNTIME_ID"),
+                    }
+                }
+
+                let runtime = runtime_result.expect(
+                    "runtime should clean up an orphan socket and bind successfully",
+                );
+                let bound = runtime.surface_socket_path();
+                assert_eq!(bound, stale_path.as_path());
+                assert!(bound.exists(), "service should be bound at {}", bound.display());
+
+                // The path is now a Unix socket, not a regular file — connect
+                // should succeed against the runtime-internal service.
+                let stream = UnixStream::connect(bound).expect("connect to fresh service");
+                let req = serde_json::json!({
+                    "op": "check_out",
+                    "surface_id": "no-such",
+                });
+                let (resp, _) = send_request(&stream, &req, None).expect("round-trip");
+                assert!(resp.get("error").is_some());
+            });
+        }
     }
 }

--- a/libs/streamlib/tests/polyglot_linux_check_out.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out.rs
@@ -36,10 +36,8 @@
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use streamlib_broker::unix_socket_service::{
-    connect_to_broker, send_request, UnixSocketSurfaceService,
-};
-use streamlib_broker::BrokerState;
+use streamlib::core::runtime::StreamRuntime;
+use streamlib_broker::unix_socket_service::{connect_to_broker, send_request};
 
 #[path = "common/polyglot_dma_buf_producer.rs"]
 mod polyglot_dma_buf_producer;
@@ -72,21 +70,6 @@ fn python3_available() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-}
-
-fn tmp_socket_path(label: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    p.push(format!(
-        "streamlib-polyglot-test-{}-{}-{}.sock",
-        label,
-        std::process::id(),
-        nanos
-    ));
-    p
 }
 
 /// Build the Python driver that runs inside the subprocess. Kept as an
@@ -231,15 +214,15 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
         }
     };
 
-    // 1. Start a broker in-process.
-    let state = BrokerState::new();
-    let socket_path = tmp_socket_path("py-subprocess");
-    let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
-    service.start().expect("service start");
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // 1. Stand up a real StreamRuntime — it owns the surface-sharing service
+    //    on a per-runtime Unix socket. No external broker daemon, no manual
+    //    BrokerState/UnixSocketSurfaceService construction.
+    let runtime = StreamRuntime::new().expect("StreamRuntime::new");
+    let socket_path = runtime.surface_socket_path().to_path_buf();
+    let runtime_id = runtime.runtime_id().to_string();
 
     // 2. Host: allocate a real Vulkan-exported DMA-BUF seeded with a
-    //    deterministic pattern, and check_in to the broker.
+    //    deterministic pattern, and check_in to the runtime-internal broker.
     let width: u32 = 64;
     let height: u32 = 4;
     let bpp: u32 = 4;
@@ -255,7 +238,6 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
                 "polyglot_linux_check_out: Vulkan DMA-BUF producer failed — skipping ({})",
                 reason
             );
-            service.stop();
             return;
         }
     };
@@ -263,7 +245,7 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
     let host_stream = connect_to_broker(&socket_path).expect("host connect");
     let check_in_req = serde_json::json!({
         "op": "check_in",
-        "runtime_id": "host-polyglot-test",
+        "runtime_id": runtime_id,
         "width": width,
         "height": height,
         "format": "Bgra32",
@@ -291,7 +273,7 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
         .arg("-c")
         .arg(driver)
         .env("STREAMLIB_BROKER_SOCKET", &socket_path)
-        .env("STREAMLIB_RUNTIME_ID", "polyglot-test-runtime")
+        .env("STREAMLIB_RUNTIME_ID", &runtime_id)
         .env("TEST_NATIVE_LIB", &native_lib)
         .env("TEST_SURFACE_ID", &surface_id)
         .env("TEST_WIDTH", width.to_string())
@@ -305,7 +287,11 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    service.stop();
+    // Drop the runtime — UnixSocketSurfaceService::Drop tears the service
+    // down and removes the socket file. Explicit so the cleanup happens
+    // before the test asserts (and the ordering matches the prior
+    // service.stop() placement).
+    drop(runtime);
 
     assert!(
         output.status.success(),

--- a/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
@@ -20,10 +20,8 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use streamlib_broker::unix_socket_service::{
-    connect_to_broker, send_request, UnixSocketSurfaceService,
-};
-use streamlib_broker::BrokerState;
+use streamlib::core::runtime::StreamRuntime;
+use streamlib_broker::unix_socket_service::{connect_to_broker, send_request};
 
 #[path = "common/polyglot_dma_buf_producer.rs"]
 mod polyglot_dma_buf_producer;
@@ -52,21 +50,6 @@ fn deno_available() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-}
-
-fn tmp_socket_path(label: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    p.push(format!(
-        "streamlib-polyglot-deno-test-{}-{}-{}.sock",
-        label,
-        std::process::id(),
-        nanos
-    ));
-    p
 }
 
 /// `sldn_gpu_surface_backend` value that indicates the Vulkan import path
@@ -188,11 +171,11 @@ fn deno_subprocess_resolves_and_vulkan_imports_host_published_surface() {
         }
     };
 
-    let state = BrokerState::new();
-    let socket_path = tmp_socket_path("deno-subprocess");
-    let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
-    service.start().expect("service start");
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // Stand up a real StreamRuntime — owns the per-runtime surface-sharing
+    // socket. No external broker daemon, no manual fixture.
+    let runtime = StreamRuntime::new().expect("StreamRuntime::new");
+    let socket_path = runtime.surface_socket_path().to_path_buf();
+    let runtime_id = runtime.runtime_id().to_string();
 
     let width: u32 = 64;
     let height: u32 = 4;
@@ -209,7 +192,6 @@ fn deno_subprocess_resolves_and_vulkan_imports_host_published_surface() {
                 "polyglot_linux_check_out_deno: Vulkan DMA-BUF producer failed — skipping ({})",
                 reason
             );
-            service.stop();
             return;
         }
     };
@@ -217,7 +199,7 @@ fn deno_subprocess_resolves_and_vulkan_imports_host_published_surface() {
     let host_stream = connect_to_broker(&socket_path).expect("host connect");
     let check_in_req = serde_json::json!({
         "op": "check_in",
-        "runtime_id": "deno-host-polyglot-test",
+        "runtime_id": runtime_id,
         "width": width,
         "height": height,
         "format": "Bgra32",
@@ -267,7 +249,10 @@ fn deno_subprocess_resolves_and_vulkan_imports_host_published_surface() {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    service.stop();
+    // Drop the runtime — UnixSocketSurfaceService::Drop tears the service
+    // down and removes the socket file. Explicit drop matches the prior
+    // service.stop() placement.
+    drop(runtime);
 
     assert!(
         output.status.success(),


### PR DESCRIPTION
## Summary

- Move the Unix-socket surface-sharing service into `StreamRuntime::new()`. Each runtime binds `$XDG_RUNTIME_DIR/streamlib-<runtime_uuid>.sock` on construction, fails fast on missing `XDG_RUNTIME_DIR`, refuses to steal a live socket, and cleans up orphan sockets from prior crashed runtimes.
- Polyglot spawn ops (Python, Deno) propagate `STREAMLIB_BROKER_SOCKET` to subprocesses via `RuntimeContextFullAccess::surface_socket_path()` on Linux — no wire-format change; `streamlib-broker-client` just talks to a different server process.
- Migrates both polyglot Linux integration tests (Python + Deno) to stand up a real `StreamRuntime` rather than hand-rolling `BrokerState` + `UnixSocketSurfaceService`.

## Closes

Closes #428

## Exit criteria

- [x] `Runtime::new()` stands up a `UnixSocketSurfaceService` on `$XDG_RUNTIME_DIR/streamlib-<runtime_uuid>.sock` before any processor can be added; fails fast with an actionable error if bind fails.
- [x] Runtime sets `STREAMLIB_BROKER_SOCKET=<that path>` in the environment of every polyglot subprocess (Python + Deno).
- [x] Existing `streamlib-broker-client` calls work unchanged against the runtime-internal service — no wire-format change.
- [x] Multiple runtimes coexist on the same host without socket collision (each gets a unique uuid path).
- [x] Socket file is removed on clean runtime shutdown; stale socket from a prior crashed runtime is detected and either cleaned up or refused (impl chose: connect-probe, clean up if unreachable, refuse if a live process is bound).
- [x] `polyglot_linux_check_out.rs` (and the Deno twin) migrated to spin up a real `Runtime` and use its internal broker — self-contained, no fixture coupling.

## Test plan

All tests per the issue's Tests / validation section plus the workspace baseline.

### Unit tests (new)

- [x] `core::runtime::runtime::tests::runtime_internal_broker::runtime_brings_up_internal_broker` — socket exists at `$XDG_RUNTIME_DIR`, check_out round-trips to prove the service is live.
- [x] `core::runtime::runtime::tests::runtime_internal_broker::runtime_fails_fast_when_xdg_runtime_dir_missing` — actionable error names `XDG_RUNTIME_DIR`.
- [x] `core::runtime::runtime::tests::runtime_internal_broker::two_runtimes_coexist_without_collision` — distinct socket paths, both serve independently.
- [x] `core::runtime::runtime::tests::runtime_internal_broker::polyglot_subprocess_inherits_socket_env` — `STREAMLIB_BROKER_SOCKET` propagates to a spawned subprocess and matches `runtime.surface_socket_path()`.
- [x] `core::runtime::runtime::tests::runtime_internal_broker::stale_socket_from_dead_runtime_is_cleaned_up` — orphan file at the expected path is removed, fresh service binds, round-trips work.

### Polyglot E2E (migrated)

- [x] `polyglot_linux_check_out::python_subprocess_resolves_and_vulkan_imports_host_published_surface` — real Python 3 subprocess drives `slpn_broker_*` / `slpn_gpu_surface_*` FFI against the runtime-internal broker; DMA-BUF round-trip verified byte-for-byte.
- [x] `polyglot_linux_check_out::python_subprocess_reports_clear_error_on_missing_broker_socket` — unchanged behavior against bogus path.
- [x] `polyglot_linux_check_out_deno::deno_subprocess_resolves_and_vulkan_imports_host_published_surface` — same via Deno FFI.

### Workspace baseline (`docs/testing-baseline.md`)

Ran the canonical command with the documented exclusion list — zero failures across every binary and every `Doc-tests` block. streamlib lib: 169 passed / 0 failed / 2 ignored. vulkan-video: 617 / 0 / 5. Every other crate green.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno
- **Schema regenerated**: n/a — no escalate-op or wire-format change
- **E2E tests run**:
  - [x] Host-Rust: 5 new unit tests in `streamlib::runtime::tests::runtime_internal_broker::*` — all pass
  - [x] Python subprocess: `polyglot_linux_check_out::python_subprocess_resolves_and_vulkan_imports_host_published_surface` — passes
  - [x] Deno subprocess: `polyglot_linux_check_out_deno::deno_subprocess_resolves_and_vulkan_imports_host_published_surface` — passes
- **FD-passing path**: DMA-BUF FD over SCM_RIGHTS, unchanged — this PR only changes which *process* owns the server end of the Unix socket, not the wire format

## Follow-ups

- #429 — retire the external `streamlib-broker` daemon (blocked by this PR; rewrites the body to be an aggressive full deletion with no macOS slicing).
- #433 — re-implement runtime-internal surface sharing on macOS after #429's full deletion (in the new *Polyglot macOS* milestone, gated on #431's XPC research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)