### PR TITLE
feat(logging): fd-level stdio interceptor

### DIFF
--- a/libs/streamlib/src/core/logging/config.rs
+++ b/libs/streamlib/src/core/logging/config.rs
@@ -111,14 +111,17 @@ impl StreamlibLoggingConfig {
         }
     }
 
-    /// Full config for a long-lived runtime: stdout + JSONL to disk.
+    /// Full config for a long-lived runtime: stdout + JSONL to disk,
+    /// with fd-level stdio interception on by default so raw
+    /// `println!` / `printf` output lands in the JSONL flagged as
+    /// intercepted.
     pub fn for_runtime(service_name: impl Into<String>, runtime_id: Arc<RuntimeUniqueId>) -> Self {
         Self {
             service_name: service_name.into(),
             runtime_id: Some(runtime_id),
             stdout: true,
             jsonl: true,
-            intercept_stdio: false,
+            intercept_stdio: true,
             tunables: LoggingTunables::default(),
         }
     }

--- a/libs/streamlib/src/core/logging/init.rs
+++ b/libs/streamlib/src/core/logging/init.rs
@@ -20,6 +20,8 @@ use crate::core::logging::config::{ResolvedTunables, StreamlibLoggingConfig};
 use crate::core::logging::event::Source;
 use crate::core::logging::layer::JsonlSinkLayer;
 use crate::core::logging::paths::runtime_log_path;
+#[cfg(unix)]
+use crate::core::logging::stdio_interceptor::{self, StdioInterceptor};
 use crate::core::logging::worker::{spawn as spawn_worker, WorkerConfig, WorkerHandle, WorkerSignal};
 use crate::core::logging::writer::JsonlBatchedWriter;
 
@@ -32,6 +34,11 @@ pub struct StreamlibLoggingGuard {
     /// Thread-local scope guard for test-mode installations. Dropped
     /// before the worker so no more events arrive during shutdown.
     default_scope: Option<tracing::dispatcher::DefaultGuard>,
+    /// Fd-level stdio interceptor (if installed). Dropped BEFORE the
+    /// worker so the reader threads' tail events drain into the
+    /// worker queue before shutdown.
+    #[cfg(unix)]
+    interceptor: Option<StdioInterceptor>,
 }
 
 impl StreamlibLoggingGuard {
@@ -40,6 +47,8 @@ impl StreamlibLoggingGuard {
             worker: None,
             jsonl_path: None,
             default_scope: None,
+            #[cfg(unix)]
+            interceptor: None,
         }
     }
 
@@ -62,6 +71,12 @@ impl Drop for StreamlibLoggingGuard {
         // Restore the previous thread-local dispatcher first so no new
         // events reach our queue while we're draining.
         drop(self.default_scope.take());
+        // Drop the interceptor before the worker: restoring fds 1/2
+        // unblocks the reader threads with EOF, so their final
+        // intercepted events land in the worker queue while the
+        // worker is still draining.
+        #[cfg(unix)]
+        drop(self.interceptor.take());
         if let Some(mut worker) = self.worker.take() {
             worker.shutdown_and_join();
         }
@@ -136,11 +151,48 @@ fn build_components(
     };
 
     let stdout_enabled = config.effective_stdout();
+
+    // Install fd redirects before spawning the worker so the dup'd
+    // real-stdout handle can be handed to the worker as its pretty-
+    // mirror sink. Reader threads are started AFTER the dispatch is
+    // built so the intercepted events route through the right
+    // subscriber.
+    #[cfg(unix)]
+    let (pending_interceptor, mut real_stdout_file) = if config.intercept_stdio {
+        match stdio_interceptor::install_redirects() {
+            Ok((pending, files)) => {
+                // stderr mirror not wired today — dropping the file
+                // closes the dup'd fd cleanly.
+                drop(files.real_stderr);
+                (Some(pending), Some(files.real_stdout))
+            }
+            Err(e) => {
+                eprintln!(
+                    "streamlib::logging: failed to install stdio interceptor: {} — continuing without interception",
+                    e
+                );
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+    #[cfg(not(unix))]
+    let mut real_stdout_file: Option<std::fs::File> = None;
+
+    let stdout_sink: Option<Box<dyn std::io::Write + Send>> = if !stdout_enabled {
+        None
+    } else if let Some(file) = real_stdout_file.take() {
+        Some(Box::new(file))
+    } else {
+        Some(Box::new(std::io::stdout()))
+    };
+
     let worker = spawn_worker(WorkerConfig {
         runtime_id: config.runtime_id.clone(),
         source: Source::Rust,
         tunables,
-        stdout: stdout_enabled,
+        stdout_sink,
         writer,
     });
 
@@ -154,10 +206,15 @@ fn build_components(
     let subscriber = Registry::default().with(env_filter).with(layer);
     let dispatch = Dispatch::new(subscriber);
 
+    #[cfg(unix)]
+    let interceptor = pending_interceptor.map(|p| p.start_readers(dispatch.clone()));
+
     let guard = StreamlibLoggingGuard {
         worker: Some(worker),
         jsonl_path,
         default_scope: None,
+        #[cfg(unix)]
+        interceptor,
     };
 
     Ok((dispatch, guard))

--- a/libs/streamlib/src/core/logging/layer.rs
+++ b/libs/streamlib/src/core/logging/layer.rs
@@ -73,6 +73,8 @@ where
             pipeline_id: visitor.pipeline_id,
             processor_id: visitor.processor_id,
             rhi_op: visitor.rhi_op,
+            intercepted: visitor.intercepted,
+            channel: visitor.channel,
             attrs: visitor.attrs,
         };
 
@@ -86,6 +88,8 @@ struct Capture {
     pipeline_id: Option<String>,
     processor_id: Option<String>,
     rhi_op: Option<String>,
+    intercepted: bool,
+    channel: Option<String>,
     attrs: BTreeMap<String, serde_json::Value>,
 }
 
@@ -106,6 +110,10 @@ impl Capture {
             }
             "rhi_op" => {
                 self.rhi_op = Some(value);
+                true
+            }
+            "channel" => {
+                self.channel = Some(value);
                 true
             }
             _ => false,
@@ -143,6 +151,10 @@ impl Visit for Capture {
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "intercepted" {
+            self.intercepted = value;
+            return;
+        }
         self.attrs
             .insert(field.name().to_string(), serde_json::Value::Bool(value));
     }

--- a/libs/streamlib/src/core/logging/mod.rs
+++ b/libs/streamlib/src/core/logging/mod.rs
@@ -18,6 +18,8 @@ mod init;
 mod layer;
 mod paths;
 mod record;
+#[cfg(unix)]
+mod stdio_interceptor;
 mod worker;
 mod writer;
 

--- a/libs/streamlib/src/core/logging/record.rs
+++ b/libs/streamlib/src/core/logging/record.rs
@@ -19,5 +19,7 @@ pub(crate) struct LogRecord {
     pub pipeline_id: Option<String>,
     pub processor_id: Option<String>,
     pub rhi_op: Option<String>,
+    pub intercepted: bool,
+    pub channel: Option<String>,
     pub attrs: BTreeMap<String, serde_json::Value>,
 }

--- a/libs/streamlib/src/core/logging/stdio_interceptor.rs
+++ b/libs/streamlib/src/core/logging/stdio_interceptor.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Fd-level interceptor for stdio. Redirects fds 1 and 2 through pipes
+//! so raw `println!` / `printf` / `libc::write(1, …)` output surfaces
+//! as intercepted `tracing::warn!` events in the unified JSONL
+//! pathway. Defense-in-depth companion to the clippy `disallowed_macros`
+//! lockout (#441): catches third-party dep chatter and transitive C
+//! calls that the compile-time rule can't see.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::thread::JoinHandle;
+
+use tracing::Dispatch;
+
+pub(crate) struct StdioInterceptor {
+    saved_stdout: Option<OwnedFd>,
+    saved_stderr: Option<OwnedFd>,
+    fd1_reader: Option<JoinHandle<()>>,
+    fd2_reader: Option<JoinHandle<()>>,
+}
+
+/// Fd-redirect installed without reader threads yet. Installed first so
+/// the pretty-mirror sink (a [`File`] over the dup'd real stdout) can
+/// be handed to the worker BEFORE the `tracing::Dispatch` — which
+/// wraps the worker's queue — exists. Readers are then started with
+/// [`StdioInterceptorPending::start_readers`] once the dispatch is
+/// built.
+pub(crate) struct StdioInterceptorPending {
+    saved_stdout: OwnedFd,
+    saved_stderr: OwnedFd,
+    fd1_read: OwnedFd,
+    fd2_read: OwnedFd,
+}
+
+/// Dup'd originals of fds 1/2 suitable for the pretty-mirror layer to
+/// write to without re-entering the intercept pipe. The pretty-mirror
+/// MUST write to these and not to fd 1 / fd 2 directly — otherwise
+/// mirror output gets captured by the reader thread and re-emitted,
+/// producing infinite recursion.
+pub(crate) struct StdioInterceptorFiles {
+    pub real_stdout: File,
+    pub real_stderr: File,
+}
+
+/// Install the fd-level redirects. `dup` fds 1/2 for (a) the mirror
+/// sink and (b) later restoration, create pipes, and `dup2` the pipe
+/// write ends onto fds 1/2. Reader threads are NOT spawned yet —
+/// call [`StdioInterceptorPending::start_readers`] once a
+/// `tracing::Dispatch` is available.
+pub(crate) fn install_redirects(
+) -> std::io::Result<(StdioInterceptorPending, StdioInterceptorFiles)> {
+    // Dup fd 1 twice: one copy becomes the pretty-mirror sink, one is
+    // stashed for restoration in Drop. Same for fd 2. MUST happen
+    // BEFORE the dup2 redirects below — otherwise the "real" handles
+    // would end up pointing at the pipe write ends, and the
+    // pretty-mirror would recurse into the interceptor.
+    let mirror_stdout = dup_fd(libc::STDOUT_FILENO)?;
+    let saved_stdout = dup_fd(libc::STDOUT_FILENO)?;
+    let mirror_stderr = dup_fd(libc::STDERR_FILENO)?;
+    let saved_stderr = dup_fd(libc::STDERR_FILENO)?;
+
+    let (fd1_read, fd1_write) = make_pipe()?;
+    let (fd2_read, fd2_write) = make_pipe()?;
+
+    dup2_fd(fd1_write.as_raw_fd(), libc::STDOUT_FILENO)?;
+    dup2_fd(fd2_write.as_raw_fd(), libc::STDERR_FILENO)?;
+
+    // After dup2, fds 1/2 hold the only reference to the pipe write
+    // ends. Drop the explicit OwnedFds so restoring fds 1/2 on Drop
+    // closes the last ref and the readers get EOF.
+    drop(fd1_write);
+    drop(fd2_write);
+
+    let pending = StdioInterceptorPending {
+        saved_stdout,
+        saved_stderr,
+        fd1_read,
+        fd2_read,
+    };
+    let files = StdioInterceptorFiles {
+        real_stdout: owned_fd_to_file(mirror_stdout),
+        real_stderr: owned_fd_to_file(mirror_stderr),
+    };
+    Ok((pending, files))
+}
+
+impl StdioInterceptorPending {
+    /// Start reader threads for the pipes. `dispatch` is cloned into
+    /// each thread and installed as its thread-local subscriber so
+    /// `tracing::warn!` events route through the owning logging
+    /// pathway (works for both global `init` and thread-local
+    /// `init_for_tests`).
+    pub(crate) fn start_readers(self, dispatch: Dispatch) -> StdioInterceptor {
+        let fd1_reader = spawn_reader(self.fd1_read, "fd1", dispatch.clone());
+        let fd2_reader = spawn_reader(self.fd2_read, "fd2", dispatch);
+        StdioInterceptor {
+            saved_stdout: Some(self.saved_stdout),
+            saved_stderr: Some(self.saved_stderr),
+            fd1_reader: Some(fd1_reader),
+            fd2_reader: Some(fd2_reader),
+        }
+    }
+}
+
+impl Drop for StdioInterceptor {
+    fn drop(&mut self) {
+        // Restore fds 1/2 from saved dups. The dup2 overwrites fds
+        // 1/2's prior (pipe write end) reference, dropping it; since
+        // we explicitly closed the original write end OwnedFd on
+        // install, this is the last reference and the reader thread
+        // gets EOF.
+        if let Some(fd) = self.saved_stdout.take() {
+            let _ = dup2_fd(fd.as_raw_fd(), libc::STDOUT_FILENO);
+        }
+        if let Some(fd) = self.saved_stderr.take() {
+            let _ = dup2_fd(fd.as_raw_fd(), libc::STDERR_FILENO);
+        }
+        if let Some(j) = self.fd1_reader.take() {
+            let _ = j.join();
+        }
+        if let Some(j) = self.fd2_reader.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+fn spawn_reader(pipe_read: OwnedFd, channel: &'static str, dispatch: Dispatch) -> JoinHandle<()> {
+    std::thread::Builder::new()
+        .name(format!("streamlib-logging-intercept-{channel}"))
+        .spawn(move || {
+            let _scope = tracing::dispatcher::set_default(&dispatch);
+            let file = owned_fd_to_file(pipe_read);
+            let mut reader = BufReader::new(file);
+            let mut buf: Vec<u8> = Vec::with_capacity(256);
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if buf.last() == Some(&b'\n') {
+                            buf.pop();
+                        }
+                        if buf.is_empty() {
+                            continue;
+                        }
+                        let message = String::from_utf8_lossy(&buf);
+                        tracing::warn!(
+                            intercepted = true,
+                            channel = channel,
+                            source = "rust",
+                            "{}",
+                            message,
+                        );
+                    }
+                    Err(_) => break,
+                }
+            }
+        })
+        .expect("spawn stdio interceptor reader thread")
+}
+
+fn dup_fd(fd: libc::c_int) -> std::io::Result<OwnedFd> {
+    let dup = unsafe { libc::dup(fd) };
+    if dup < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(dup) })
+}
+
+fn dup2_fd(src: libc::c_int, dst: libc::c_int) -> std::io::Result<()> {
+    let rc = unsafe { libc::dup2(src, dst) };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn make_pipe() -> std::io::Result<(OwnedFd, OwnedFd)> {
+    let mut fds: [libc::c_int; 2] = [-1, -1];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok((
+        unsafe { OwnedFd::from_raw_fd(fds[0]) },
+        unsafe { OwnedFd::from_raw_fd(fds[1]) },
+    ))
+}
+
+fn owned_fd_to_file(fd: OwnedFd) -> File {
+    unsafe { File::from_raw_fd(fd.into_raw_fd()) }
+}

--- a/libs/streamlib/src/core/logging/tests.rs
+++ b/libs/streamlib/src/core/logging/tests.rs
@@ -339,6 +339,306 @@ fn hot_path_is_not_blocked_on_io() {
     clear_xdg_state_home();
 }
 
+/// Cargo's libtest installs a thread-local `OUTPUT_CAPTURE` hook
+/// that intercepts `println!` (and `io::stdout()` writes) BEFORE
+/// they reach fd 1, and propagates that capture to threads spawned
+/// via `std::thread::spawn`. So "test `println!`" can't reach fd 1
+/// from inside a cargo test — we simulate the fd-level write that
+/// `println!` performs in a non-test runtime binary by wrapping fd
+/// 1 as a `File` and using `writeln!`. This bypasses
+/// `OUTPUT_CAPTURE` and hits our interceptor pipe exactly as
+/// `println!` would in production.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn rust_println_captured_via_fd_redirect() {
+    use std::io::Write;
+    use std::os::fd::FromRawFd;
+
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFdPrint"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: false,
+        jsonl: true,
+        intercept_stdio: true,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    // Dup fd 1 so the File wrapper owns a separate fd we can close
+    // on drop without touching the interceptor's fd 1.
+    let dup_fd = unsafe { libc::dup(libc::STDOUT_FILENO) };
+    assert!(dup_fd >= 0, "libc::dup failed");
+    let mut f = unsafe { std::fs::File::from_raw_fd(dup_fd) };
+    writeln!(f, "sneaky-fd-interception").unwrap();
+    drop(f);
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        events.iter().any(|e| e.message == "sneaky-fd-interception"
+            && e.intercepted
+            && e.channel.as_deref() == Some("fd1")
+            && e.source == Source::Rust
+            && e.level == LogLevel::Warn),
+        "expected intercepted record (fd1, warn, rust); got {:#?}",
+        events
+    );
+
+    clear_xdg_state_home();
+}
+
+/// `libc::write(1, ...)` bypasses stdlib / libtest entirely and hits
+/// the OS-level fd, so the interceptor pipe catches it.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn rust_c_printf_via_libc_captured() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFdLibc"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: false,
+        jsonl: true,
+        intercept_stdio: true,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    unsafe {
+        let bytes = b"hi-from-libc\n";
+        libc::write(
+            libc::STDOUT_FILENO,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+        );
+    }
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        events.iter().any(|e| e.message == "hi-from-libc"
+            && e.intercepted
+            && e.channel.as_deref() == Some("fd1")
+            && e.source == Source::Rust
+            && e.level == LogLevel::Warn),
+        "expected intercepted libc::write record; got {:#?}",
+        events
+    );
+
+    clear_xdg_state_home();
+}
+
+/// With `intercept_stdio: false`, `libc::write(1, ...)` reaches the
+/// cargo test harness stdout as normal and does NOT appear as an
+/// intercepted record in the JSONL.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn intercept_stdio_off_in_tests() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFdOff"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: false,
+        jsonl: true,
+        intercept_stdio: false,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    unsafe {
+        let bytes = b"off-bypass-interceptor\n";
+        libc::write(
+            libc::STDOUT_FILENO,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+        );
+    }
+
+    std::thread::sleep(Duration::from_millis(50));
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        !events
+            .iter()
+            .any(|e| e.message == "off-bypass-interceptor" && e.intercepted),
+        "expected NO intercepted record when intercept_stdio=false; got {:#?}",
+        events
+    );
+
+    clear_xdg_state_home();
+}
+
+/// Writes to fd 2 land in JSONL with `channel: "fd2"`.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn intercepted_fd2_uses_channel_fd2() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFd2"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: false,
+        jsonl: true,
+        intercept_stdio: true,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    unsafe {
+        let bytes = b"stderr-interception-line\n";
+        libc::write(
+            libc::STDERR_FILENO,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+        );
+    }
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        events.iter().any(|e| e.message == "stderr-interception-line"
+            && e.intercepted
+            && e.channel.as_deref() == Some("fd2")),
+        "expected intercepted record with channel=fd2; got {:#?}",
+        events
+    );
+
+    clear_xdg_state_home();
+}
+
+/// With both the pretty-mirror and the interceptor on, the mirror
+/// writes must go to the dup'd real-stdout handle, NOT to fd 1 — so
+/// they do not re-enter the pipe. Emitting one `tracing::info!`
+/// therefore produces exactly one JSONL record, never two (which
+/// would indicate a recursion).
+#[cfg(unix)]
+#[test]
+#[serial]
+fn no_redirect_loop_when_mirror_enabled() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFdLoop"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: true,
+        jsonl: true,
+        intercept_stdio: true,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    tracing::info!("unique-loop-token-xyz123");
+
+    std::thread::sleep(Duration::from_millis(150));
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    let matching: Vec<_> = events
+        .iter()
+        .filter(|e| e.message.contains("unique-loop-token-xyz123"))
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one record, got {}: {:#?}",
+        matching.len(),
+        matching
+    );
+    assert!(
+        !matching[0].intercepted,
+        "the one record should not be intercepted; got {:#?}",
+        matching[0]
+    );
+
+    clear_xdg_state_home();
+}
+
+/// Dropping the guard restores fds 1/2, closes the pipe write ends,
+/// and joins the reader threads quickly — no stranded threads on
+/// process exit.
+#[cfg(unix)]
+#[test]
+#[serial]
+fn reader_thread_shuts_down_on_runtime_drop() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RintercFdShut"));
+    let config = StreamlibLoggingConfig {
+        service_name: "test".into(),
+        runtime_id: Some(Arc::clone(&runtime_id)),
+        stdout: false,
+        jsonl: true,
+        intercept_stdio: true,
+        tunables: LoggingTunables::default(),
+    };
+    let guard = init_for_tests(config).unwrap();
+
+    // Put the readers through at least one wake-up so we're verifying
+    // shutdown from a live-reader state, not a fresh-spawn state.
+    unsafe {
+        let bytes = b"pre-shutdown\n";
+        libc::write(
+            libc::STDOUT_FILENO,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+        );
+    }
+    std::thread::sleep(Duration::from_millis(50));
+
+    let start = std::time::Instant::now();
+    drop(guard);
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "guard drop took {:?} — reader threads likely stranded",
+        elapsed
+    );
+
+    clear_xdg_state_home();
+}
+
 #[test]
 #[serial]
 fn burst_surfaces_dropped_counter_record() {

--- a/libs/streamlib/src/core/logging/worker.rs
+++ b/libs/streamlib/src/core/logging/worker.rs
@@ -60,7 +60,11 @@ pub(crate) struct WorkerConfig {
     pub runtime_id: Option<Arc<RuntimeUniqueId>>,
     pub source: Source,
     pub tunables: ResolvedTunables,
-    pub stdout: bool,
+    /// Pretty-mirror sink. `None` disables the mirror entirely. When
+    /// the fd-level interceptor is active this MUST point at the
+    /// dup'd real-stdout handle, not at `std::io::stdout()`, otherwise
+    /// mirror output re-enters the pipe and recurses.
+    pub stdout_sink: Option<Box<dyn std::io::Write + Send>>,
     pub writer: Option<JsonlBatchedWriter>,
 }
 
@@ -79,7 +83,7 @@ pub(crate) fn spawn(config: WorkerConfig) -> WorkerHandle {
 
     let queue_worker = Arc::clone(&queue);
     let dropped_worker = Arc::clone(&dropped);
-    let stdout_enabled = config.stdout;
+    let mut stdout_sink = config.stdout_sink;
     let tunables = config.tunables;
     let source = config.source;
     let mut writer = config.writer;
@@ -94,11 +98,12 @@ pub(crate) fn spawn(config: WorkerConfig) -> WorkerHandle {
                 runtime_id_str,
                 source,
                 tunables,
-                stdout_enabled,
+                &mut stdout_sink,
                 &mut writer,
             );
             // Final fsync happens inside run_worker on clean shutdown.
             drop(writer);
+            drop(stdout_sink);
         })
         .expect("spawn drain worker thread");
 
@@ -118,18 +123,12 @@ fn run_worker(
     runtime_id: String,
     source: Source,
     tunables: ResolvedTunables,
-    stdout_enabled: bool,
+    stdout_sink: &mut Option<Box<dyn std::io::Write + Send>>,
     writer: &mut Option<JsonlBatchedWriter>,
 ) {
     let mut last_flush = Instant::now();
     let mut last_dropped_emit = Instant::now();
     let mut last_dropped_seen: u64 = 0;
-
-    let stdout = if stdout_enabled {
-        Some(std::io::stdout())
-    } else {
-        None
-    };
 
     let mut serialize_buf = Vec::with_capacity(1024);
     let mut pretty_buf = String::with_capacity(256);
@@ -150,7 +149,7 @@ fn run_worker(
             &runtime_id,
             source,
             writer,
-            stdout.as_ref(),
+            stdout_sink,
             &mut serialize_buf,
             &mut pretty_buf,
         );
@@ -172,6 +171,8 @@ fn run_worker(
                 pipeline_id: None,
                 processor_id: None,
                 rhi_op: None,
+                intercepted: false,
+                channel: None,
                 attrs: {
                     let mut m = std::collections::BTreeMap::new();
                     m.insert(
@@ -190,7 +191,7 @@ fn run_worker(
                 &runtime_id,
                 source,
                 writer,
-                stdout.as_ref(),
+                stdout_sink,
                 &mut serialize_buf,
                 &mut pretty_buf,
             );
@@ -221,7 +222,7 @@ fn run_worker(
                     &runtime_id,
                     source,
                     writer,
-                    stdout.as_ref(),
+                    stdout_sink,
                     &mut serialize_buf,
                     &mut pretty_buf,
                 );
@@ -240,7 +241,7 @@ fn drain_queue(
     runtime_id: &str,
     source: Source,
     writer: &mut Option<JsonlBatchedWriter>,
-    stdout: Option<&std::io::Stdout>,
+    stdout_sink: &mut Option<Box<dyn std::io::Write + Send>>,
     serialize_buf: &mut Vec<u8>,
     pretty_buf: &mut String,
 ) {
@@ -250,7 +251,7 @@ fn drain_queue(
             runtime_id,
             source,
             writer,
-            stdout,
+            stdout_sink,
             serialize_buf,
             pretty_buf,
         );
@@ -263,7 +264,7 @@ fn write_one(
     runtime_id: &str,
     source: Source,
     writer: &mut Option<JsonlBatchedWriter>,
-    stdout: Option<&std::io::Stdout>,
+    stdout_sink: &mut Option<Box<dyn std::io::Write + Send>>,
     serialize_buf: &mut Vec<u8>,
     pretty_buf: &mut String,
 ) {
@@ -281,8 +282,8 @@ fn write_one(
         rhi_op: record.rhi_op.clone(),
         source_ts: None,
         source_seq: None,
-        intercepted: false,
-        channel: None,
+        intercepted: record.intercepted,
+        channel: record.channel.clone(),
         attrs: record.attrs.clone(),
     };
 
@@ -295,13 +296,12 @@ fn write_one(
         let _ = w.append_record(serialize_buf);
     }
 
-    if let Some(stdout) = stdout {
+    if let Some(sink) = stdout_sink.as_mut() {
         pretty_buf.clear();
         format_pretty(record, runtime_id, source, pretty_buf);
-        let mut handle = stdout.lock();
-        let _ = handle.write_all(pretty_buf.as_bytes());
+        let _ = sink.write_all(pretty_buf.as_bytes());
         // Line-buffered: one flush per record so humans tail it live.
-        let _ = handle.flush();
+        let _ = sink.flush();
     }
 }
 


### PR DESCRIPTION
## Summary

- Redirects fds 1/2 through pipes at `logging::init()` so `println!`/`printf`/`libc::write(1,…)` output — including from third-party deps and transitive C calls that clippy's compile-time lockout (#441) can't see — surfaces as intercepted `tracing::warn!` events tagged `intercepted: true, channel: "fd1"|"fd2", source: "rust"` in the unified JSONL pathway.
- Two-phase install resolves the chicken-and-egg between worker (needs the dup'd real-stdout as its mirror sink) and dispatch (needs the worker's queue): `install_redirects()` runs before the worker spawn, `start_readers(dispatch)` starts pipe readers after the dispatch exists.
- Pretty-mirror writer switched from raw `std::io::stdout()` to an injectable `Box<dyn Write + Send>` sink, so the mirror writes to the dup'd real-stdout File (not fd 1) and cannot re-enter the pipe — no recursion by construction.

## Closes
Closes #438

## Exit criteria

- [x] `StreamlibLoggingConfig::intercept_stdio` defaults `true` in `for_runtime`, `false` in tests.
- [x] When `intercept_stdio` is on: `dup` fds 1/2, pipes created, `dup2` pipe write-ends onto 1/2, reader threads emit `tracing::warn!(intercepted, channel, source=\"rust\", message)` per line.
- [x] Pretty-mirror writes to the dup'd real-stdout File, not fd 1 — no recursive spam.
- [x] Intercepted records land in JSONL with `intercepted: true`, `channel: \"fd1\"|\"fd2\"`, `source: \"rust\"`, `level: \"warn\"`, `message=<line>`.
- [x] Reader threads shut down cleanly on `Runtime::drop` — restoring fds 1/2 closes the last pipe write-ref, readers hit EOF, join within ~100 ms.

## Test plan

All six unit tests from the issue body, gated `#[serial]` + `#[cfg(unix)]`, passing locally:

- [x] `rust_println_captured_via_fd_redirect` — writes via `File::from_raw_fd(dup(1))` to bypass libtest's `OUTPUT_CAPTURE` (see note below); asserts JSONL record with `intercepted: true, channel: \"fd1\", source: rust, level: warn`.
- [x] `rust_c_printf_via_libc_captured` — `libc::write(STDOUT_FILENO, …)`; same assertions.
- [x] `intercept_stdio_off_in_tests` — with `intercept_stdio: false`, an fd-1 write does NOT produce an intercepted JSONL record.
- [x] `intercepted_fd2_uses_channel_fd2` — `libc::write(STDERR_FILENO, …)` routes as `channel: \"fd2\"`.
- [x] `no_redirect_loop_when_mirror_enabled` — mirror on + interceptor on; `tracing::info!` produces exactly one JSONL record (no duplicate from a recursive mirror→pipe path).
- [x] `reader_thread_shuts_down_on_runtime_drop` — `drop(guard)` completes in <500 ms (reader threads joined, no strands).

### Implementation-level note on `rust_println_captured_via_fd_redirect`

Modern Rust's `std::thread::spawn` propagates libtest's `OUTPUT_CAPTURE` thread-local into child threads, so `println!` in a spawned thread still goes through libtest's buffer and never reaches fd 1. User code can't disarm this hook (the setter is `pub(crate)` in stdlib). The test therefore uses `File::from_raw_fd(dup(1))` + `writeln!` to exercise the same underlying fd-level write that `println!` performs in a non-test runtime binary. Runtime `println!` behavior is unaffected — this is a cargo-test plumbing workaround only.

### Workspace baseline

Per `docs/testing-baseline.md`:

- `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — every `test result: ok.` with zero failures.
- `streamlib` lib: 199 passed (193 before, 6 new).
- `vulkan-video`: 617 passed.

## Follow-ups

- #439 / #440 / #441 / #442 / #447 — remaining children of #430 (logging chain): trace-strip feature, CLI reader, clippy lockout, escalate-IPC log op, criterion/strace perf bench.
- Optional: wire a stderr mirror if/when we want a second live output (the dup'd real-stderr File is currently dropped since no mirror consumes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)