### PR TITLE
feat(polyglot): escalate-IPC {op:"log"} wire format + host handler

### DIFF
--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -8,10 +8,7 @@
 /**
  * Polyglot subprocess escalate-on-behalf request (subprocess → host)
  */
-export type EscalateRequest =
-  | EscalateRequestAcquirePixelBuffer
-  | EscalateRequestAcquireTexture
-  | EscalateRequestReleaseHandle;
+export type EscalateRequest = EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestReleaseHandle;
 
 export interface EscalateRequestAcquirePixelBuffer {
   op: "acquire_pixel_buffer";
@@ -41,7 +38,9 @@ export interface EscalateRequestAcquireTexture {
   op: "acquire_texture";
 
   /**
-   * Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+   * Texture format identifier. Lowercase snake-case names: rgba8_unorm,
+   * rgba8_unorm_srgb, bgra8_unorm, bgra8_unorm_srgb, rgba16_float,
+   * rgba32_float, nv12.
    */
   format: string;
 
@@ -56,8 +55,10 @@ export interface EscalateRequestAcquireTexture {
   request_id: string;
 
   /**
-   * Usage tokens (copy_src, copy_dst, texture_binding, storage_binding,
-   * render_attachment).
+   * Usage flags the texture must support. Non-empty array of lowercase
+   * snake-case tokens drawn from: copy_src, copy_dst, texture_binding,
+   * storage_binding, render_attachment. Host validates — unknown tokens return
+   * an error response.
    */
   usage: string[];
 
@@ -65,6 +66,94 @@ export interface EscalateRequestAcquireTexture {
    * Pixel width of the texture.
    */
   width: number;
+}
+
+/**
+ * Severity level of the record. Maps 1:1 onto tracing::Level.
+ */
+export enum EscalateRequestLogLevel {
+  Debug = "debug",
+  Error = "error",
+  Info = "info",
+  Trace = "trace",
+  Warn = "warn",
+}
+
+/**
+ * Origin runtime of the record. Always "python" or "deno" on the wire — Rust
+ * never routes through escalate; Rust call sites hit `tracing::*!()` directly
+ * on the host.
+ */
+export enum EscalateRequestLogSource {
+  Deno = "deno",
+  Python = "python",
+}
+
+export interface EscalateRequestLog {
+  op: "log";
+
+  /**
+   * User-supplied structured fields. Copied flat onto the emitted
+   * RuntimeLogEvent's `attrs` map — not nested under an `attrs.key` path in
+   * the JSONL.
+   */
+  attrs: { [key: string]: any };
+
+  /**
+   * Interceptor channel when `intercepted: true`. Conventional values:
+   * "stdout", "stderr", "console.log", "logging", "fd1", "fd2". Null when
+   * `intercepted: false`.
+   */
+  channel: (string | null);
+
+  /**
+   * True when the record was captured from subprocess stdout/stderr,
+   * console.log, root logging handler, or a raw fd write, rather than a direct
+   * `streamlib.log.*` call.
+   */
+  intercepted: boolean;
+
+  /**
+   * Severity level of the record. Maps 1:1 onto tracing::Level.
+   */
+  level: EscalateRequestLogLevel;
+
+  /**
+   * Primary human-readable message.
+   */
+  message: string;
+
+  /**
+   * Pipeline identifier. Null for runtime-level records.
+   */
+  pipeline_id: (string | null);
+
+  /**
+   * Processor identifier. Null outside a processor.
+   */
+  processor_id: (string | null);
+
+  /**
+   * Origin runtime of the record. Always "python" or "deno" on the wire — Rust
+   * never routes through escalate; Rust call sites hit `tracing::*!()` directly
+   * on the host.
+   */
+  source: EscalateRequestLogSource;
+
+  /**
+   * Subprocess-monotonic sequence number (uint64 as string — JTD has no native
+   * u64). Escape hatch for recovering subprocess-local order within a single
+   * source. Not authoritative across sources — use `host_ts` for merged-stream
+   * ordering.
+   */
+  source_seq: string;
+
+  /**
+   * Subprocess wall-clock timestamp ISO8601 (advisory). Never used for
+   * ordering; the host stamps `host_ts` on receipt as the authoritative sort
+   * key.
+   */
+  source_ts: string;
 }
 
 export interface EscalateRequestReleaseHandle {

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -8,7 +8,8 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Type, Union, get_args, get_origin
+from enum import Enum
+from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
 
 
 @dataclass
@@ -24,6 +25,7 @@ class EscalateRequest:
         variants: Dict[str, Type[EscalateRequest]] = {
             "acquire_pixel_buffer": EscalateRequestAcquirePixelBuffer,
             "acquire_texture": EscalateRequestAcquireTexture,
+            "log": EscalateRequestLog,
             "release_handle": EscalateRequestReleaseHandle,
         }
 
@@ -77,7 +79,9 @@ class EscalateRequestAcquirePixelBuffer(EscalateRequest):
 class EscalateRequestAcquireTexture(EscalateRequest):
     format: 'str'
     """
-    Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+    Texture format identifier. Lowercase snake-case names: rgba8_unorm,
+    rgba8_unorm_srgb, bgra8_unorm, bgra8_unorm_srgb, rgba16_float, rgba32_float,
+    nv12.
     """
 
     height: 'int'
@@ -92,8 +96,10 @@ class EscalateRequestAcquireTexture(EscalateRequest):
 
     usage: 'List[str]'
     """
-    Usage tokens (copy_src, copy_dst, texture_binding, storage_binding,
-    render_attachment).
+    Usage flags the texture must support. Non-empty array of lowercase
+    snake-case tokens drawn from: copy_src, copy_dst, texture_binding,
+    storage_binding, render_attachment. Host validates — unknown tokens return
+    an error response.
     """
 
     width: 'int'
@@ -120,6 +126,134 @@ class EscalateRequestAcquireTexture(EscalateRequest):
         data["request_id"] = _to_json_data(self.request_id)
         data["usage"] = _to_json_data(self.usage)
         data["width"] = _to_json_data(self.width)
+        return data
+
+class EscalateRequestLogLevel(Enum):
+    """
+    Severity level of the record. Maps 1:1 onto tracing::Level.
+    """
+
+    DEBUG = "debug"
+    ERROR = "error"
+    INFO = "info"
+    TRACE = "trace"
+    WARN = "warn"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestLogLevel':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestLogSource(Enum):
+    """
+    Origin runtime of the record. Always "python" or "deno" on the wire — Rust
+    never routes through escalate; Rust call sites hit `tracing::*!()` directly
+    on the host.
+    """
+
+    DENO = "deno"
+    PYTHON = "python"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestLogSource':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestLog(EscalateRequest):
+    attrs: 'Dict[str, Any]'
+    """
+    User-supplied structured fields. Copied flat onto the emitted
+    RuntimeLogEvent's `attrs` map — not nested under an `attrs.key` path in
+    the JSONL.
+    """
+
+    channel: 'Optional[str]'
+    """
+    Interceptor channel when `intercepted: true`. Conventional values: "stdout",
+    "stderr", "console.log", "logging", "fd1", "fd2". Null when `intercepted:
+    false`.
+    """
+
+    intercepted: 'bool'
+    """
+    True when the record was captured from subprocess stdout/stderr,
+    console.log, root logging handler, or a raw fd write, rather than a direct
+    `streamlib.log.*` call.
+    """
+
+    level: 'EscalateRequestLogLevel'
+    """
+    Severity level of the record. Maps 1:1 onto tracing::Level.
+    """
+
+    message: 'str'
+    """
+    Primary human-readable message.
+    """
+
+    pipeline_id: 'Optional[str]'
+    """
+    Pipeline identifier. Null for runtime-level records.
+    """
+
+    processor_id: 'Optional[str]'
+    """
+    Processor identifier. Null outside a processor.
+    """
+
+    source: 'EscalateRequestLogSource'
+    """
+    Origin runtime of the record. Always "python" or "deno" on the wire — Rust
+    never routes through escalate; Rust call sites hit `tracing::*!()` directly
+    on the host.
+    """
+
+    source_seq: 'str'
+    """
+    Subprocess-monotonic sequence number (uint64 as string — JTD has no native
+    u64). Escape hatch for recovering subprocess-local order within a single
+    source. Not authoritative across sources — use `host_ts` for merged-stream
+    ordering.
+    """
+
+    source_ts: 'str'
+    """
+    Subprocess wall-clock timestamp ISO8601 (advisory). Never used for ordering;
+    the host stamps `host_ts` on receipt as the authoritative sort key.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestLog':
+        return cls(
+            "log",
+            _from_json_data(Dict[str, Any], data.get("attrs")),
+            _from_json_data(Optional[str], data.get("channel")),
+            _from_json_data(bool, data.get("intercepted")),
+            _from_json_data(EscalateRequestLogLevel, data.get("level")),
+            _from_json_data(str, data.get("message")),
+            _from_json_data(Optional[str], data.get("pipeline_id")),
+            _from_json_data(Optional[str], data.get("processor_id")),
+            _from_json_data(EscalateRequestLogSource, data.get("source")),
+            _from_json_data(str, data.get("source_seq")),
+            _from_json_data(str, data.get("source_ts")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "log" }
+        data["attrs"] = _to_json_data(self.attrs)
+        data["channel"] = _to_json_data(self.channel)
+        data["intercepted"] = _to_json_data(self.intercepted)
+        data["level"] = _to_json_data(self.level)
+        data["message"] = _to_json_data(self.message)
+        data["pipeline_id"] = _to_json_data(self.pipeline_id)
+        data["processor_id"] = _to_json_data(self.processor_id)
+        data["source"] = _to_json_data(self.source)
+        data["source_seq"] = _to_json_data(self.source_seq)
+        data["source_ts"] = _to_json_data(self.source_ts)
         return data
 
 @dataclass

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -1,19 +1,15 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 #
-# JSON Type Definition (RFC 8927) schema for polyglot GPU escalation requests.
+# JSON Type Definition (RFC 8927) schema for polyglot escalation requests.
 #
 # Sent from a Python or Deno subprocess over its stdout to the Rust host
-# processor. The host routes the op through `GpuContextLimitedAccess::escalate`
-# and replies with [`EscalateResponse`] on the same stdin pipe.
-#
-# This schema is checked in as design documentation. It is **not** wired into
-# `cargo xtask generate-schemas` because jtd-codegen v0.4.1's discriminator
-# support emits tagged Rust enums whose shape collides with the existing
-# post-processing rules for plain config/payload schemas. The hand-authored
-# types live in
-# `libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs`
-# and are kept in sync with this file manually.
+# processor. Acquire/release ops are request/response — the host routes the
+# op through `GpuContextLimitedAccess::escalate` and replies with
+# [`EscalateResponse`] on the same stdin pipe. The `log` op is fire-and-
+# forget: the host enriches the record with an authoritative `host_ts` and
+# enqueues it into the unified JSONL pipeline (see parent #430), no reply
+# is written back.
 
 metadata:
   name: com.streamlib.escalate_request
@@ -80,3 +76,74 @@ mapping:
         metadata:
           description: "Opaque handle ID previously returned by acquire_*."
         type: string
+  log:
+    properties:
+      source:
+        metadata:
+          description: >
+            Origin runtime of the record. Always "python" or "deno" on the
+            wire — Rust never routes through escalate; Rust call sites hit
+            `tracing::*!()` directly on the host.
+        enum:
+          - python
+          - deno
+      source_seq:
+        metadata:
+          description: >
+            Subprocess-monotonic sequence number (uint64 as string — JTD has
+            no native u64). Escape hatch for recovering subprocess-local
+            order within a single source. Not authoritative across sources
+            — use `host_ts` for merged-stream ordering.
+        type: string
+      source_ts:
+        metadata:
+          description: >
+            Subprocess wall-clock timestamp ISO8601 (advisory). Never used
+            for ordering; the host stamps `host_ts` on receipt as the
+            authoritative sort key.
+        type: string
+      level:
+        metadata:
+          description: "Severity level of the record. Maps 1:1 onto tracing::Level."
+        enum:
+          - trace
+          - debug
+          - info
+          - warn
+          - error
+      message:
+        metadata:
+          description: "Primary human-readable message."
+        type: string
+      intercepted:
+        metadata:
+          description: >
+            True when the record was captured from subprocess stdout/stderr,
+            console.log, root logging handler, or a raw fd write, rather
+            than a direct `streamlib.log.*` call.
+        type: boolean
+      channel:
+        metadata:
+          description: >
+            Interceptor channel when `intercepted: true`. Conventional
+            values: "stdout", "stderr", "console.log", "logging", "fd1",
+            "fd2". Null when `intercepted: false`.
+        type: string
+        nullable: true
+      pipeline_id:
+        metadata:
+          description: "Pipeline identifier. Null for runtime-level records."
+        type: string
+        nullable: true
+      processor_id:
+        metadata:
+          description: "Processor identifier. Null outside a processor."
+        type: string
+        nullable: true
+      attrs:
+        metadata:
+          description: >
+            User-supplied structured fields. Copied flat onto the emitted
+            RuntimeLogEvent's `attrs` map — not nested under an `attrs.key`
+            path in the JSONL.
+        values: {}

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
@@ -5,6 +5,8 @@
 
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 
 /// Polyglot subprocess escalate-on-behalf request (subprocess → host)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -15,6 +17,9 @@ pub enum EscalateRequest {
 
     #[serde(rename = "acquire_texture")]
     AcquireTexture(EscalateRequestAcquireTexture),
+
+    #[serde(rename = "log")]
+    Log(EscalateRequestLog),
 
     #[serde(rename = "release_handle")]
     ReleaseHandle(EscalateRequestReleaseHandle),
@@ -43,7 +48,9 @@ pub struct EscalateRequestAcquirePixelBuffer {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EscalateRequestAcquireTexture {
-    /// Texture format identifier (rgba8_unorm, bgra8_unorm, rgba16_float, ...).
+    /// Texture format identifier. Lowercase snake-case names: rgba8_unorm,
+    /// rgba8_unorm_srgb, bgra8_unorm, bgra8_unorm_srgb, rgba16_float,
+    /// rgba32_float, nv12.
     #[serde(rename = "format")]
     pub format: String,
 
@@ -55,13 +62,106 @@ pub struct EscalateRequestAcquireTexture {
     #[serde(rename = "request_id")]
     pub request_id: String,
 
-    /// Usage tokens (copy_src, copy_dst, texture_binding, storage_binding, render_attachment).
+    /// Usage flags the texture must support. Non-empty array of lowercase
+    /// snake-case tokens drawn from: copy_src, copy_dst, texture_binding,
+    /// storage_binding, render_attachment. Host validates — unknown tokens
+    /// return an error response.
     #[serde(rename = "usage")]
     pub usage: Vec<String>,
 
     /// Pixel width of the texture.
     #[serde(rename = "width")]
     pub width: u32,
+}
+
+/// Severity level of the record. Maps 1:1 onto tracing::Level.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestLogLevel {
+    #[serde(rename = "debug")]
+    #[default]
+    Debug,
+
+    #[serde(rename = "error")]
+    Error,
+
+    #[serde(rename = "info")]
+    Info,
+
+    #[serde(rename = "trace")]
+    Trace,
+
+    #[serde(rename = "warn")]
+    Warn,
+}
+
+/// Origin runtime of the record. Always "python" or "deno" on the wire — Rust
+/// never routes through escalate; Rust call sites hit `tracing::*!()` directly
+/// on the host.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestLogSource {
+    #[serde(rename = "deno")]
+    #[default]
+    Deno,
+
+    #[serde(rename = "python")]
+    Python,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestLog {
+    /// User-supplied structured fields. Copied flat onto the emitted
+    /// RuntimeLogEvent's `attrs` map — not nested under an `attrs.key` path in
+    /// the JSONL.
+    #[serde(rename = "attrs")]
+    pub attrs: HashMap<String, Option<Value>>,
+
+    /// Interceptor channel when `intercepted: true`. Conventional values:
+    /// "stdout", "stderr", "console.log", "logging", "fd1", "fd2". Null when
+    /// `intercepted: false`.
+    #[serde(rename = "channel")]
+    pub channel: Option<String>,
+
+    /// True when the record was captured from subprocess stdout/stderr,
+    /// console.log, root logging handler, or a raw fd write, rather than a
+    /// direct `streamlib.log.*` call.
+    #[serde(rename = "intercepted")]
+    pub intercepted: bool,
+
+    /// Severity level of the record. Maps 1:1 onto tracing::Level.
+    #[serde(rename = "level")]
+    pub level: EscalateRequestLogLevel,
+
+    /// Primary human-readable message.
+    #[serde(rename = "message")]
+    pub message: String,
+
+    /// Pipeline identifier. Null for runtime-level records.
+    #[serde(rename = "pipeline_id")]
+    pub pipeline_id: Option<String>,
+
+    /// Processor identifier. Null outside a processor.
+    #[serde(rename = "processor_id")]
+    pub processor_id: Option<String>,
+
+    /// Origin runtime of the record. Always "python" or "deno" on the wire —
+    /// Rust never routes through escalate; Rust call sites hit `tracing::*!()`
+    /// directly on the host.
+    #[serde(rename = "source")]
+    pub source: EscalateRequestLogSource,
+
+    /// Subprocess-monotonic sequence number (uint64 as string — JTD has no
+    /// native u64). Escape hatch for recovering subprocess-local order within
+    /// a single source. Not authoritative across sources — use `host_ts` for
+    /// merged-stream ordering.
+    #[serde(rename = "source_seq")]
+    pub source_seq: String,
+
+    /// Subprocess wall-clock timestamp ISO8601 (advisory). Never used for
+    /// ordering; the host stamps `host_ts` on receipt as the authoritative
+    /// sort key.
+    #[serde(rename = "source_ts")]
+    pub source_ts: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -14,14 +14,15 @@
 //! owned by `schemas/com.streamlib.escalate_{request,response}@1.0.0.yaml`
 //! and the generated Rust types live in `_generated_`.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use uuid::Uuid;
 
 use crate::_generated_::com_streamlib_escalate_request::{
-    EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
-    EscalateRequestReleaseHandle,
+    EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture, EscalateRequestLog,
+    EscalateRequestLogLevel, EscalateRequestLogSource, EscalateRequestReleaseHandle,
 };
 use crate::_generated_::com_streamlib_escalate_response::{
     EscalateResponseErr, EscalateResponseOk,
@@ -29,6 +30,7 @@ use crate::_generated_::com_streamlib_escalate_response::{
 use crate::_generated_::{EscalateRequest, EscalateResponse};
 use crate::core::context::{PooledTextureHandle, TexturePoolDescriptor};
 use crate::core::context::GpuContextLimitedAccess;
+use crate::core::logging::{push_polyglot_record, LogLevel, LogRecord, Source};
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
 
 #[cfg(test)]
@@ -41,11 +43,15 @@ pub(crate) const ESCALATE_REQUEST_RPC: &str = "escalate_request";
 /// Wire tag for responses written back to the subprocess.
 pub(crate) const ESCALATE_RESPONSE_RPC: &str = "escalate_response";
 
-fn request_id(op: &EscalateRequest) -> &str {
+/// Extract `request_id` from a request/response-shaped op. Returns `None`
+/// for fire-and-forget ops ([`EscalateRequest::Log`]), which carry no
+/// correlation token because the host never writes a reply.
+fn request_id(op: &EscalateRequest) -> Option<&str> {
     match op {
-        EscalateRequest::AcquirePixelBuffer(p) => &p.request_id,
-        EscalateRequest::AcquireTexture(p) => &p.request_id,
-        EscalateRequest::ReleaseHandle(p) => &p.request_id,
+        EscalateRequest::AcquirePixelBuffer(p) => Some(&p.request_id),
+        EscalateRequest::AcquireTexture(p) => Some(&p.request_id),
+        EscalateRequest::ReleaseHandle(p) => Some(&p.request_id),
+        EscalateRequest::Log(_) => None,
     }
 }
 
@@ -104,7 +110,11 @@ impl EscalateHandleRegistry {
     }
 }
 
-/// Dispatch an [`EscalateRequest`] against `sandbox` and produce a response.
+/// Dispatch an [`EscalateRequest`] against `sandbox`. Returns
+/// `Some(EscalateResponse)` for request/response ops so the bridge can
+/// write a reply; returns `None` for fire-and-forget ops
+/// ([`EscalateRequest::Log`]) whose effect lands directly in the unified
+/// logging pathway and needs no correlated reply.
 ///
 /// Never panics — errors inside `escalate()` become [`EscalateResponse::Err`]
 /// with the original request_id preserved so the subprocess can correlate.
@@ -117,15 +127,15 @@ pub(crate) fn handle_escalate_op(
     sandbox: &GpuContextLimitedAccess,
     registry: &EscalateHandleRegistry,
     op: EscalateRequest,
-) -> EscalateResponse {
-    let rid = request_id(&op).to_string();
+) -> Option<EscalateResponse> {
+    let rid = request_id(&op).map(str::to_string).unwrap_or_default();
     match op {
         EscalateRequest::AcquirePixelBuffer(EscalateRequestAcquirePixelBuffer {
             request_id: _,
             width,
             height,
             format,
-        }) => match parse_pixel_format(&format) {
+        }) => Some(match parse_pixel_format(&format) {
             Ok(parsed) => {
                 let acquired = sandbox.escalate(|full| {
                     let (pool_id, buffer) = full.acquire_pixel_buffer(width, height, parsed)?;
@@ -154,7 +164,7 @@ pub(crate) fn handle_escalate_op(
                 request_id: rid,
                 message: e,
             }),
-        },
+        }),
         EscalateRequest::AcquireTexture(EscalateRequestAcquireTexture {
             request_id: _,
             width,
@@ -165,19 +175,19 @@ pub(crate) fn handle_escalate_op(
             let parsed_format = match parse_texture_format(&format) {
                 Ok(f) => f,
                 Err(e) => {
-                    return EscalateResponse::Err(EscalateResponseErr {
+                    return Some(EscalateResponse::Err(EscalateResponseErr {
                         request_id: rid,
                         message: e,
-                    });
+                    }));
                 }
             };
             let parsed_usage = match parse_texture_usages(&usage) {
                 Ok(u) => u,
                 Err(e) => {
-                    return EscalateResponse::Err(EscalateResponseErr {
+                    return Some(EscalateResponse::Err(EscalateResponseErr {
                         request_id: rid,
                         message: e,
-                    });
+                    }));
                 }
             };
             let desc = TexturePoolDescriptor::new(width, height, parsed_format)
@@ -187,7 +197,7 @@ pub(crate) fn handle_escalate_op(
                 let handle_id = assign_texture_handle_id(full, &texture)?;
                 Ok((handle_id, texture))
             });
-            match acquired {
+            Some(match acquired {
                 Ok((handle_id, texture)) => {
                     registry.insert_texture(handle_id.clone(), texture);
                     EscalateResponse::Ok(EscalateResponseOk {
@@ -203,14 +213,14 @@ pub(crate) fn handle_escalate_op(
                     request_id: rid,
                     message: format!("acquire_texture failed: {e}"),
                 }),
-            }
+            })
         }
         EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
             request_id: _,
             handle_id,
         }) => {
             let removed = registry.remove_handle(&handle_id);
-            if removed {
+            Some(if removed {
                 release_broker_surface(sandbox, &handle_id);
                 EscalateResponse::Ok(EscalateResponseOk {
                     request_id: rid,
@@ -225,9 +235,67 @@ pub(crate) fn handle_escalate_op(
                     request_id: rid,
                     message: format!("handle_id '{handle_id}' not found in registry"),
                 })
-            }
+            })
+        }
+        EscalateRequest::Log(log_op) => {
+            push_polyglot_record(log_record_from_wire(log_op));
+            None
         }
     }
+}
+
+/// Convert a wire-format [`EscalateRequestLog`] into a host-side
+/// [`LogRecord`]. Stamps `host_ts` at the moment of receipt — the
+/// subprocess-supplied `source_ts` is advisory only and never used for
+/// ordering. Parses `source_seq` from its string wire encoding (JTD has
+/// no native u64); silently drops the value on parse failure so a
+/// malformed subprocess can't block log delivery.
+fn log_record_from_wire(log: EscalateRequestLog) -> LogRecord {
+    let source = match log.source {
+        EscalateRequestLogSource::Python => Source::Python,
+        EscalateRequestLogSource::Deno => Source::Deno,
+    };
+    let level = match log.level {
+        EscalateRequestLogLevel::Trace => LogLevel::Trace,
+        EscalateRequestLogLevel::Debug => LogLevel::Debug,
+        EscalateRequestLogLevel::Info => LogLevel::Info,
+        EscalateRequestLogLevel::Warn => LogLevel::Warn,
+        EscalateRequestLogLevel::Error => LogLevel::Error,
+    };
+    let target = match source {
+        Source::Python => "streamlib::polyglot::python",
+        Source::Deno => "streamlib::polyglot::deno",
+        Source::Rust => "streamlib::polyglot",
+    };
+    let source_seq = log.source_seq.parse::<u64>().ok();
+    let attrs: BTreeMap<String, serde_json::Value> = log
+        .attrs
+        .into_iter()
+        .map(|(k, v)| (k, v.unwrap_or(serde_json::Value::Null)))
+        .collect();
+
+    LogRecord {
+        host_ts: now_ns(),
+        level,
+        target: target.to_string(),
+        message: log.message,
+        pipeline_id: log.pipeline_id,
+        processor_id: log.processor_id,
+        rhi_op: None,
+        intercepted: log.intercepted,
+        channel: log.channel,
+        attrs,
+        source: Some(source),
+        source_ts: Some(log.source_ts),
+        source_seq,
+    }
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
 }
 
 /// Resolve the `handle_id` returned to the subprocess for a pixel buffer.
@@ -482,7 +550,9 @@ pub(crate) fn process_bridge_message(
 ) -> Option<serde_json::Value> {
     let parsed = try_parse_escalate_request(value)?;
     let response = match parsed {
-        Ok(op) => handle_escalate_op(sandbox, registry, op),
+        // Fire-and-forget ops (log) return `None` from the handler — no
+        // reply is written back to the subprocess.
+        Ok(op) => handle_escalate_op(sandbox, registry, op)?,
         Err(err) => err.into_response(),
     };
     Some(envelope_response(response))
@@ -681,7 +751,8 @@ mod tests {
                 height: 240,
                 format: "bgra".to_string(),
             });
-        let response = handle_escalate_op(&sandbox, &registry, acquire);
+        let response = handle_escalate_op(&sandbox, &registry, acquire)
+            .expect("acquire_pixel_buffer must produce a response");
         let buffer_handle_id = match response {
             EscalateResponse::Ok(ref ok) => {
                 assert_eq!(ok.request_id, "req-1");
@@ -709,7 +780,8 @@ mod tests {
                     "copy_src".to_string(),
                 ],
             });
-        let response = handle_escalate_op(&sandbox, &registry, acquire_tex);
+        let response = handle_escalate_op(&sandbox, &registry, acquire_tex)
+            .expect("acquire_texture must produce a response");
         let texture_handle_id = match response {
             EscalateResponse::Ok(ref ok) => {
                 assert_eq!(ok.request_id, "req-tex");
@@ -736,7 +808,9 @@ mod tests {
             request_id: "req-tex-rel".to_string(),
             handle_id: texture_handle_id.clone(),
         });
-        match handle_escalate_op(&sandbox, &registry, release_tex) {
+        match handle_escalate_op(&sandbox, &registry, release_tex)
+            .expect("release_handle must produce a response")
+        {
             EscalateResponse::Ok(ok) => {
                 assert_eq!(ok.request_id, "req-tex-rel");
                 assert_eq!(ok.handle_id, texture_handle_id);
@@ -749,7 +823,8 @@ mod tests {
             request_id: "req-2".to_string(),
             handle_id: buffer_handle_id.clone(),
         });
-        let response = handle_escalate_op(&sandbox, &registry, release);
+        let response = handle_escalate_op(&sandbox, &registry, release)
+            .expect("release_handle must produce a response");
         match response {
             EscalateResponse::Ok(ok) => {
                 assert_eq!(ok.request_id, "req-2");
@@ -764,12 +839,237 @@ mod tests {
                 request_id: "req-3".to_string(),
                 handle_id: "never-existed".to_string(),
             });
-        match handle_escalate_op(&sandbox, &registry, release_unknown) {
+        match handle_escalate_op(&sandbox, &registry, release_unknown)
+            .expect("release_handle must produce a response")
+        {
             EscalateResponse::Err(err) => {
                 assert_eq!(err.request_id, "req-3");
                 assert!(err.message.contains("not found"));
             }
             EscalateResponse::Ok(_) => panic!("unknown handle should not succeed"),
+        }
+    }
+
+    /// Tests for the escalate-IPC `{op:"log"}` variant (issue #442).
+    ///
+    /// These tests assert the full pipeline: wire parse → host dispatch →
+    /// polyglot sink → drain worker → JSONL file. Each test runs with
+    /// `#[serial]` and its own `TempDir`-scoped `XDG_STATE_HOME` so the
+    /// JSONL writer writes to a path we can read back.
+    mod log_op {
+        use super::*;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use serial_test::serial;
+        use tempfile::TempDir;
+
+        use crate::core::logging::{
+            init_for_tests, LogLevel, RuntimeLogEvent, Source,
+            StreamlibLoggingConfig, StreamlibLoggingGuard,
+        };
+        use crate::core::runtime::RuntimeUniqueId;
+
+        fn install_logging(runtime_tag: &str) -> (TempDir, StreamlibLoggingGuard) {
+            let tmp = TempDir::new().unwrap();
+            unsafe {
+                std::env::set_var("XDG_STATE_HOME", tmp.path());
+                // Capture debug+ so all the test levels surface.
+                std::env::set_var("RUST_LOG", "debug");
+                std::env::remove_var("STREAMLIB_QUIET");
+            }
+            let runtime_id = Arc::new(RuntimeUniqueId::from(runtime_tag));
+            let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+            let guard = init_for_tests(config).unwrap();
+            (tmp, guard)
+        }
+
+        fn read_jsonl(path: &std::path::Path) -> Vec<RuntimeLogEvent> {
+            let contents = std::fs::read_to_string(path).unwrap_or_default();
+            contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str::<RuntimeLogEvent>(l).expect("valid JSONL"))
+                .collect()
+        }
+
+        fn dispatch_log(log: EscalateRequestLog) {
+            push_polyglot_record(log_record_from_wire(log));
+        }
+
+        fn sample_log(seq: &str, ts: &str, level: EscalateRequestLogLevel) -> EscalateRequestLog {
+            EscalateRequestLog {
+                source: EscalateRequestLogSource::Python,
+                source_seq: seq.to_string(),
+                source_ts: ts.to_string(),
+                level,
+                message: format!("record {seq}"),
+                intercepted: false,
+                channel: None,
+                pipeline_id: Some("pl-1".into()),
+                processor_id: Some("pr-1".into()),
+                attrs: HashMap::new(),
+            }
+        }
+
+        /// Every optional and required field on the wire round-trips
+        /// byte-for-byte through serde; the discriminator dispatches to
+        /// [`EscalateRequest::Log`] on decode.
+        #[test]
+        fn schema_round_trip() {
+            let mut attrs = HashMap::new();
+            attrs.insert("device".to_string(), Some(serde_json::json!("/dev/video0")));
+            attrs.insert("count".to_string(), Some(serde_json::json!(3)));
+            let original = EscalateRequestLog {
+                source: EscalateRequestLogSource::Python,
+                source_seq: "9001".into(),
+                source_ts: "2026-04-23T14:00:00Z".into(),
+                level: EscalateRequestLogLevel::Warn,
+                message: "hello".into(),
+                intercepted: true,
+                channel: Some("fd1".into()),
+                pipeline_id: Some("pl-42".into()),
+                processor_id: Some("camera-1".into()),
+                attrs: attrs.clone(),
+            };
+            let wrapped = EscalateRequest::Log(original.clone());
+            let json = serde_json::to_value(&wrapped).expect("serializes");
+            assert_eq!(json.get("op").and_then(|v| v.as_str()), Some("log"));
+
+            let decoded: EscalateRequest = serde_json::from_value(json).expect("decodes");
+            match decoded {
+                EscalateRequest::Log(back) => {
+                    assert_eq!(back.source, original.source);
+                    assert_eq!(back.source_seq, original.source_seq);
+                    assert_eq!(back.source_ts, original.source_ts);
+                    assert_eq!(back.level, original.level);
+                    assert_eq!(back.message, original.message);
+                    assert_eq!(back.intercepted, original.intercepted);
+                    assert_eq!(back.channel, original.channel);
+                    assert_eq!(back.pipeline_id, original.pipeline_id);
+                    assert_eq!(back.processor_id, original.processor_id);
+                    assert_eq!(back.attrs, original.attrs);
+                }
+                other => panic!("expected Log variant, got {other:?}"),
+            }
+        }
+
+        /// `level: "warn"` on the wire produces a JSONL record with
+        /// `level: "warn"`; required structured fields land in their
+        /// dedicated columns (not `attrs`) and `host_ts` is stamped
+        /// non-zero by the host.
+        #[test]
+        #[serial]
+        fn host_emits_jsonl_record_at_correct_level() {
+            let (_tmp, guard) = install_logging("RlogOpLv");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            dispatch_log(sample_log("42", "2026-04-23T14:00:00Z", EscalateRequestLogLevel::Warn));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| e.source == Source::Python && e.message == "record 42")
+                .unwrap_or_else(|| panic!("no polyglot record; got {events:#?}"));
+            assert_eq!(record.level, LogLevel::Warn);
+            assert_eq!(record.source_seq, Some(42));
+            assert_eq!(record.source_ts.as_deref(), Some("2026-04-23T14:00:00Z"));
+            assert_eq!(record.pipeline_id.as_deref(), Some("pl-1"));
+            assert_eq!(record.processor_id.as_deref(), Some("pr-1"));
+            assert!(record.host_ts > 0, "host stamp must be non-zero");
+        }
+
+        /// Two records with identical `source_ts` receive distinct
+        /// monotonically-increasing `host_ts` — subprocesses with broken
+        /// clocks can't collapse ordering by accident.
+        #[test]
+        #[serial]
+        fn host_stamps_host_ts() {
+            let (_tmp, guard) = install_logging("RlogOpTs");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let ts = "2026-04-23T14:00:00Z";
+            dispatch_log(sample_log("1", ts, EscalateRequestLogLevel::Info));
+            std::thread::sleep(Duration::from_millis(2));
+            dispatch_log(sample_log("2", ts, EscalateRequestLogLevel::Info));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let polyglot: Vec<_> = events
+                .iter()
+                .filter(|e| e.source == Source::Python)
+                .collect();
+            assert_eq!(polyglot.len(), 2, "expected exactly 2 polyglot records");
+            assert_eq!(polyglot[0].source_ts, polyglot[1].source_ts);
+            assert!(
+                polyglot[1].host_ts > polyglot[0].host_ts,
+                "host_ts must be monotonic: {} vs {}",
+                polyglot[0].host_ts,
+                polyglot[1].host_ts,
+            );
+        }
+
+        /// `intercepted: true` + `channel: "fd1"` survive the wire → host
+        /// → JSONL hop untouched, landing in their dedicated columns.
+        #[test]
+        #[serial]
+        fn intercepted_flag_round_trip() {
+            let (_tmp, guard) = install_logging("RlogOpInt");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let mut log = sample_log("7", "2026-04-23T14:00:00Z", EscalateRequestLogLevel::Error);
+            log.intercepted = true;
+            log.channel = Some("fd1".into());
+            log.message = "fd1 capture".into();
+            dispatch_log(log);
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| e.source == Source::Python && e.message == "fd1 capture")
+                .unwrap_or_else(|| panic!("no polyglot record; got {events:#?}"));
+            assert!(record.intercepted);
+            assert_eq!(record.channel.as_deref(), Some("fd1"));
+            assert_eq!(record.level, LogLevel::Error);
+        }
+
+        /// 1000 records with strictly increasing `source_seq` arrive at
+        /// the JSONL file in the same order. Proves the single-producer
+        /// path preserves FIFO without extra sequencing logic.
+        #[test]
+        #[serial]
+        fn within_source_fifo_preserved() {
+            let (_tmp, guard) = install_logging("RlogOpFif");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            for i in 0..1000 {
+                dispatch_log(sample_log(
+                    &i.to_string(),
+                    "2026-04-23T14:00:00Z",
+                    EscalateRequestLogLevel::Debug,
+                ));
+            }
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let seqs: Vec<u64> = events
+                .iter()
+                .filter(|e| e.source == Source::Python)
+                .filter_map(|e| e.source_seq)
+                .collect();
+            assert_eq!(seqs.len(), 1000, "all records must land in JSONL");
+            for (expected, got) in seqs.iter().enumerate() {
+                assert_eq!(
+                    *got, expected as u64,
+                    "records out of order at index {expected}",
+                );
+            }
         }
     }
 }

--- a/libs/streamlib/src/core/logging/init.rs
+++ b/libs/streamlib/src/core/logging/init.rs
@@ -20,6 +20,7 @@ use crate::core::logging::config::{ResolvedTunables, StreamlibLoggingConfig};
 use crate::core::logging::event::Source;
 use crate::core::logging::layer::JsonlSinkLayer;
 use crate::core::logging::paths::runtime_log_path;
+use crate::core::logging::polyglot_sink::{self, PolyglotLogSink};
 #[cfg(unix)]
 use crate::core::logging::stdio_interceptor::{self, StdioInterceptor};
 use crate::core::logging::worker::{spawn as spawn_worker, WorkerConfig, WorkerHandle, WorkerSignal};
@@ -71,6 +72,9 @@ impl Drop for StreamlibLoggingGuard {
         // Restore the previous thread-local dispatcher first so no new
         // events reach our queue while we're draining.
         drop(self.default_scope.take());
+        // Clear the polyglot sink before shutting the worker down so
+        // late-arriving escalate-IPC log pushes can't race a dead queue.
+        polyglot_sink::uninstall();
         // Drop the interceptor before the worker: restoring fds 1/2
         // unblocks the reader threads with EOF, so their final
         // intercepted events land in the worker queue while the
@@ -195,6 +199,12 @@ fn build_components(
         stdout_sink,
         writer,
     });
+
+    // Install the process-wide polyglot sink so escalate-IPC log records
+    // relayed from Python/Deno subprocesses converge on the same drain
+    // worker as local tracing events. See [`polyglot_sink`] for why this
+    // bypasses `tracing::*!()` rather than routing through it.
+    polyglot_sink::install(Arc::new(PolyglotLogSink::from_worker(&worker)));
 
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"));

--- a/libs/streamlib/src/core/logging/layer.rs
+++ b/libs/streamlib/src/core/logging/layer.rs
@@ -76,6 +76,12 @@ where
             intercepted: visitor.intercepted,
             channel: visitor.channel,
             attrs: visitor.attrs,
+            // Tracing events are always local call-site events; they
+            // inherit the worker's configured source and have no
+            // subprocess timestamp / sequence number.
+            source: None,
+            source_ts: None,
+            source_seq: None,
         };
 
         self.enqueue(record);

--- a/libs/streamlib/src/core/logging/mod.rs
+++ b/libs/streamlib/src/core/logging/mod.rs
@@ -11,12 +11,18 @@ pub use config::{LoggingTunables, StreamlibLoggingConfig};
 pub use event::{LogLevel, RuntimeLogEvent, Source, SCHEMA_VERSION};
 pub use init::{init, StreamlibLoggingGuard};
 pub use paths::{log_dir, runtime_log_path};
+pub(crate) use polyglot_sink::push_polyglot_record;
+pub(crate) use record::LogRecord;
+
+#[cfg(test)]
+pub(crate) use init::init_for_tests;
 
 mod config;
 mod event;
 mod init;
 mod layer;
 mod paths;
+mod polyglot_sink;
 mod record;
 #[cfg(unix)]
 mod stdio_interceptor;

--- a/libs/streamlib/src/core/logging/polyglot_sink.rs
+++ b/libs/streamlib/src/core/logging/polyglot_sink.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Direct-enqueue sink for polyglot (Python / Deno subprocess) log records.
+//!
+//! # Why this bypasses `tracing::*!()`
+//!
+//! Polyglot log records arrive on the host as already-deserialized data
+//! relayed from a subprocess via escalate IPC. They are *not* events in
+//! the host's call graph. Two concrete reasons for the split:
+//!
+//! 1. **Semantic honesty.** `tracing::Event` represents something that
+//!    happened inside this process's call graph. Any `tracing::span!`
+//!    context on the thread receiving the escalate IPC would falsely
+//!    decorate the polyglot record as if the subprocess work had
+//!    happened inside that span. Treating polyglot records as data
+//!    rather than events avoids that class of bug.
+//!
+//! 2. **Fidelity of `source` / `source_ts` / `source_seq`.** The JSONL
+//!    schema ([`RuntimeLogEvent`]) has these fields as top-level
+//!    columns, but [`JsonlSinkLayer`] captures tracing events into a
+//!    [`LogRecord`] that carries `source: None` and funnels everything
+//!    through the worker's configured `Source`. Routing polyglot
+//!    records through `tracing::*!()` would stamp them as
+//!    `source: "rust"` and drop `source_ts` / `source_seq` into
+//!    `attrs` rather than their proper columns.
+//!
+//! Both producers (tracing layer + this sink) converge on the same
+//! [`LogRecord`] queue; the worker handles drain, serialization, and
+//! fan-out identically. Only the producer boundary differs.
+//!
+//! Design decision recorded in issue #442, PR that landed the
+//! escalate-IPC `log` op.
+//!
+//! [`RuntimeLogEvent`]: crate::core::logging::event::RuntimeLogEvent
+//! [`JsonlSinkLayer`]: crate::core::logging::layer::JsonlSinkLayer
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use crossbeam_channel::Sender;
+use crossbeam_queue::ArrayQueue;
+
+use crate::core::logging::record::LogRecord;
+use crate::core::logging::worker::{WorkerHandle, WorkerSignal};
+
+/// Handle onto the drain worker's queue. Clone-friendly; pushing is
+/// lock-free up to the bounded-queue capacity (drop-oldest beyond that).
+pub(crate) struct PolyglotLogSink {
+    queue: Arc<ArrayQueue<LogRecord>>,
+    doorbell: Sender<WorkerSignal>,
+    dropped: Arc<AtomicU64>,
+}
+
+impl PolyglotLogSink {
+    pub(crate) fn from_worker(handle: &WorkerHandle) -> Self {
+        Self {
+            queue: Arc::clone(&handle.queue),
+            doorbell: handle.doorbell.clone(),
+            dropped: Arc::clone(&handle.dropped),
+        }
+    }
+
+    /// Enqueue a polyglot-origin record. Drop-oldest when the queue is
+    /// full; the lost record is counted into the shared dropped counter
+    /// so the worker can surface a synthetic `dropped=N` record.
+    pub(crate) fn push(&self, record: LogRecord) {
+        if self.queue.force_push(record).is_some() {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        let _ = self.doorbell.try_send(WorkerSignal::Record);
+    }
+}
+
+/// Process-wide sink. Installed by [`crate::core::logging::init`] when it
+/// spawns the drain worker, cleared when the guard drops. Tests that use
+/// `init_for_tests` reinstall a fresh sink per test (guarded by
+/// `#[serial]`).
+static GLOBAL: RwLock<Option<Arc<PolyglotLogSink>>> = RwLock::new(None);
+
+pub(crate) fn install(sink: Arc<PolyglotLogSink>) {
+    *GLOBAL.write().expect("polyglot sink lock poisoned") = Some(sink);
+}
+
+pub(crate) fn uninstall() {
+    *GLOBAL.write().expect("polyglot sink lock poisoned") = None;
+}
+
+/// Enqueue a polyglot-origin record into the unified JSONL pipeline.
+///
+/// Silently no-ops when no logging runtime is installed — matches the
+/// behaviour of `tracing::*!()` calls made before `init()` runs.
+pub(crate) fn push_polyglot_record(record: LogRecord) {
+    let guard = GLOBAL.read().expect("polyglot sink lock poisoned");
+    if let Some(sink) = guard.as_ref() {
+        sink.push(record);
+    }
+}

--- a/libs/streamlib/src/core/logging/record.rs
+++ b/libs/streamlib/src/core/logging/record.rs
@@ -1,13 +1,18 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Intermediate record pushed onto the channel by the tracing layer and
-//! drained by the worker. Owns all its strings — we can't borrow from
-//! `tracing::Event` across the channel send.
+//! Intermediate record pushed onto the drain channel. Two producers enqueue
+//! records here: the [`JsonlSinkLayer`] (tracing events from local call
+//! sites) and [`push_polyglot_record`] (records relayed from Python/Deno
+//! subprocesses via escalate IPC). Owns all its strings — we can't borrow
+//! from `tracing::Event` across the channel send.
+//!
+//! [`JsonlSinkLayer`]: crate::core::logging::layer::JsonlSinkLayer
+//! [`push_polyglot_record`]: crate::core::logging::push_polyglot_record
 
 use std::collections::BTreeMap;
 
-use crate::core::logging::event::LogLevel;
+use crate::core::logging::event::{LogLevel, Source};
 
 /// Record pushed onto the drain channel. Owned strings.
 #[derive(Debug, Clone)]
@@ -22,4 +27,15 @@ pub(crate) struct LogRecord {
     pub intercepted: bool,
     pub channel: Option<String>,
     pub attrs: BTreeMap<String, serde_json::Value>,
+    /// Override the worker's default [`Source`] for this record. `None`
+    /// means "inherit the worker's configured source" (i.e. `Rust` for
+    /// local tracing events). `Some(Python)` / `Some(Deno)` is used by
+    /// records that originate in a subprocess and arrive via escalate IPC.
+    pub source: Option<Source>,
+    /// Subprocess wall-clock timestamp ISO8601. Advisory — never used for
+    /// ordering. `None` for local tracing records.
+    pub source_ts: Option<String>,
+    /// Subprocess-monotonic sequence number. Escape hatch for recovering
+    /// per-source order. `None` for local tracing records.
+    pub source_seq: Option<u64>,
 }

--- a/libs/streamlib/src/core/logging/worker.rs
+++ b/libs/streamlib/src/core/logging/worker.rs
@@ -185,6 +185,9 @@ fn run_worker(
                     );
                     m
                 },
+                source: None,
+                source_ts: None,
+                source_seq: None,
             };
             write_one(
                 &synthetic,
@@ -262,12 +265,17 @@ fn drain_queue(
 fn write_one(
     record: &LogRecord,
     runtime_id: &str,
-    source: Source,
+    worker_source: Source,
     writer: &mut Option<JsonlBatchedWriter>,
     stdout_sink: &mut Option<Box<dyn std::io::Write + Send>>,
     serialize_buf: &mut Vec<u8>,
     pretty_buf: &mut String,
 ) {
+    // A record carries its own `source` only when it originated outside the
+    // worker's runtime (polyglot subprocess records). Tracing-sourced
+    // records leave it `None` and inherit the worker's configured source.
+    let source = record.source.unwrap_or(worker_source);
+
     // Build a full JSONL event and serialize once.
     let event = RuntimeLogEvent {
         schema_version: SCHEMA_VERSION,
@@ -280,8 +288,8 @@ fn write_one(
         pipeline_id: record.pipeline_id.clone(),
         processor_id: record.processor_id.clone(),
         rhi_op: record.rhi_op.clone(),
-        source_ts: None,
-        source_seq: None,
+        source_ts: record.source_ts.clone(),
+        source_seq: record.source_seq,
         intercepted: record.intercepted,
         channel: record.channel.clone(),
         attrs: record.attrs.clone(),

--- a/xtask/src/generate_schemas.rs
+++ b/xtask/src/generate_schemas.rs
@@ -676,9 +676,16 @@ fn post_process_rust(code: &str, expected_struct_name: &str) -> Result<String> {
                 }
             }
 
-            processed_line = processed_line.replace("Option<Box<", "Option<");
-            if processed_line.contains("Option<") {
-                processed_line = processed_line.replacen(">>", ">", 1);
+            // Strip the `Box<...>` that jtd-codegen wraps optional recursive
+            // field types in, but only touch `>>` that we actually opened —
+            // otherwise unrelated nested generics like
+            // `HashMap<String, Option<Value>>` lose their closing bracket.
+            let boxed_count = processed_line.matches("Option<Box<").count();
+            if boxed_count > 0 {
+                processed_line = processed_line.replace("Option<Box<", "Option<");
+                for _ in 0..boxed_count {
+                    processed_line = processed_line.replacen(">>", ">", 1);
+                }
             }
 
             for (full_name, short_name) in &name_renames {


### PR DESCRIPTION
## Summary

- Adds a `log` discriminator variant to the escalate-request JTD schema and regenerates Rust/Python/Deno bindings in one commit.
- Wires a host-side dispatcher that stamps `host_ts`, maps wire enums to internal types, and enqueues a `LogRecord` directly onto the drain worker's queue from #437.
- Fixes a pre-existing xtask bug where the Rust post-processor's `Option<Box<>>` strip corrupted unrelated nested generics (e.g. `HashMap<String, Option<Value>>` came out as `HashMap<String, Option<Value>,`).

## Closes

Closes #442

## Architecture decision — direct enqueue, not `tracing::*!()`

The issue described the host dispatch as "map `level` → `tracing::<level>!()` call." This PR deviates: polyglot records bypass the tracing macro and enqueue directly onto the unified drain worker's queue via a new `push_polyglot_record` API.

Reasons:

1. **Semantic honesty** — `tracing::Event` represents a local call-site event. Any surrounding `tracing::span!` context on the receiving thread would falsely decorate records that actually originated in a subprocess.
2. **Fidelity** — `source` / `source_ts` / `source_seq` are top-level columns on the JSONL schema. Routing through `tracing::*!()` would either stamp polyglot records as `source: "rust"` or land those fields in `attrs` rather than their dedicated columns.
3. **Precedent** — the existing drop-counter in `worker.rs` already constructs a `LogRecord` directly and calls `write_one` without going through tracing. A second non-tracing producer is a natural extension, not a new pattern.
4. **Performance** — `tracing`'s macro machinery re-formats every field via `Debug` and strips quote wrappers (see `layer.rs::record_debug`). For data that arrives already-deserialized as structured JSON, that round-trip is pure overhead.

Backpressure is *not* a motivator — the worker's existing drop-oldest + `dropped=N` synthetic-record mechanism applies uniformly to both producers, and that's the right semantic for a log pipeline. The direct-enqueue seam is about producer identity, not about treating polyglot records as second-class.

Both producers (`JsonlSinkLayer` for local tracing events and `polyglot_sink` for relayed subprocess records) converge on the same `LogRecord` queue. The wire contract and JSONL schema are unchanged either way — only the producer boundary shifts. Decision is also recorded in the `polyglot_sink.rs` module doc-comment so future readers see it next to the API.

## Exit criteria

- [x] `log` variant added to `libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml` with the 10 specified fields.
- [x] `cargo xtask generate-schemas` run; Rust + Python + Deno bindings regenerated and committed in the same PR.
- [x] Host-side dispatch stamps `host_ts`, maps level / source enums, and emits a record into the unified JSONL pathway.
- [x] Within-source FIFO preserved by the channel itself — no extra sequencing code.
- [x] Python + Deno SDKs expose the generated `EscalateRequestLog` type. User-facing `streamlib.log.*` API is #G / #H, not this PR.

## Test plan

All five issue-specified tests plus Python/Deno smoke:

- [x] `subprocess_escalate::tests::log_op::schema_round_trip` — serialize + parse round-trip with every optional field set.
- [x] `subprocess_escalate::tests::log_op::host_emits_jsonl_record_at_correct_level` — `level: "warn"` produces a JSONL record at `warn`; structured fields land in dedicated columns.
- [x] `subprocess_escalate::tests::log_op::host_stamps_host_ts` — two records with identical `source_ts` receive distinct monotonically-increasing `host_ts`.
- [x] `subprocess_escalate::tests::log_op::intercepted_flag_round_trip` — `intercepted: true` + `channel: "fd1"` survive the hop.
- [x] `subprocess_escalate::tests::log_op::within_source_fifo_preserved` — 1000 records with increasing `source_seq` land in-order.
- [x] Python smoke: `EscalateRequestLog` round-trips through `to_json_data` / `from_json_data`.
- [x] Deno smoke: `deno check` + `JSON.stringify` / `JSON.parse` round-trip.
- [x] Workspace baseline: **901 passed, 0 failed, 21 ignored** (`cargo test --workspace` with the `docs/testing-baseline.md` excludes).
- [x] xtask regen is idempotent — re-running on the updated schema produces byte-identical output to the committed files.

## Notable schema choice

`source_seq` is wired as `string` rather than `uint64` — JTD (RFC 8927) has no native `uint64`. This matches the existing convention for 64-bit integers in the schemas directory: see `com.tatolab.videoframe.yaml` / `com.tatolab.encodedaudioframe.yaml`. The host handler parses the string to `u64` on receipt; parse failure drops the value silently so a malformed subprocess can't block log delivery.

## xtask fix — `Option<Box<>>` strip

The Rust post-processor in `xtask/src/generate_schemas.rs` collapsed `Option<Box<T>>` → `Option<T>` by first replacing `Option<Box<` with `Option<`, then unconditionally replacing the leftmost `>>` with `>`. That second step didn't check whether we actually opened a `Box<` on that line, so unrelated nested generics lost a closing bracket. Gated the close-bracket strip on the count of `Option<Box<` matches. This only surfaced now because the `log` variant's `attrs: map<string, any>` is the first JTD-generated field in the workspace with a `HashMap<_, Option<_>>` shape.

## Polyglot coverage

- **Runtimes affected**: all three (rust, python, deno)
- **Schema regenerated**: yes
- **E2E tests run**:
  - [x] Host-Rust: escalate `{op:"log"}` end-to-end through the unified JSONL pipeline (5 unit tests listed above)
  - [x] Python subprocess: construct + serialize + round-trip a `{op:"log"}` message (smoke test)
  - [x] Deno subprocess: construct + serialize + round-trip a `{op:"log"}` message (smoke test)
- **FD-passing path**: n/a (log op carries no fds)

## Follow-ups

- Subprocess-side `streamlib.log.*` user-facing API and stdout/stderr/console/fd interceptors land separately in the placeholder issues #G (Python) and #H (Deno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)