### PR TITLE
feat(polyglot-deno): streamlib.log API + interceptors + print audit

### DIFF
--- a/libs/streamlib-deno/_log_interceptors.ts
+++ b/libs/streamlib-deno/_log_interceptors.ts
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Subprocess-side interceptors that route `console.*` output and raw
+ * `Deno.stdout` / `Deno.stderr` writes through `streamlib.log`.
+ *
+ * Two layers, independent and additive:
+ *
+ * 1. `globalThis.console.{log,info,debug,warn,error}` overridden to enqueue
+ *    `intercepted=true, channel="console.<level>"` records.
+ * 2. `Deno.stdout.write` / `Deno.stderr.write` (and their `Sync` siblings)
+ *    monkey-patched in place. Records are line-buffered — one record per
+ *    `\n`; the trailing partial stays buffered until the next write or
+ *    until `restoreStdio()` flushes on shutdown.
+ *
+ * Parent-side fd-level capture lives on the host
+ * (`spawn_deno_subprocess_op.rs::__generated_setup`): it reads fd2 lines
+ * and emits `intercepted=true, channel="fd2", source="deno"` directly into
+ * the host JSONL pipeline. fd1 is the IPC channel and is NOT intercepted —
+ * any raw write to fd1 would corrupt the bridge framing. Tracked for
+ * future relocation onto a dedicated fd pair on issue #451.
+ */
+
+import * as log from "./log.ts";
+
+let _installed = false;
+
+// ============================================================================
+// console.* overrides
+// ============================================================================
+
+interface ConsoleSlot {
+  level: log.LogLevel;
+  channel: string;
+  original: (...args: unknown[]) => void;
+}
+
+const _consoleSlots: ConsoleSlot[] = [];
+
+const CONSOLE_LEVEL_MAP: Array<{
+  method: "log" | "info" | "debug" | "warn" | "error";
+  level: log.LogLevel;
+}> = [
+  { method: "log", level: "info" },
+  { method: "info", level: "info" },
+  { method: "debug", level: "debug" },
+  { method: "warn", level: "warn" },
+  { method: "error", level: "error" },
+];
+
+function formatConsoleArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === "string") return arg;
+      if (arg instanceof Error) return arg.stack ?? arg.message;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join(" ");
+}
+
+function installConsoleOverrides(): void {
+  for (const { method, level } of CONSOLE_LEVEL_MAP) {
+    const original = (globalThis.console as unknown as Record<string, unknown>)[
+      method
+    ] as (...args: unknown[]) => void;
+    _consoleSlots.push({
+      level,
+      channel: `console.${method}`,
+      original,
+    });
+    (globalThis.console as unknown as Record<string, unknown>)[method] = (
+      ...args: unknown[]
+    ) => {
+      log.emitIntercepted(level, formatConsoleArgs(args), `console.${method}`);
+    };
+  }
+}
+
+function restoreConsoleOverrides(): void {
+  for (let i = 0; i < _consoleSlots.length; i++) {
+    const slot = _consoleSlots[i];
+    const method = CONSOLE_LEVEL_MAP[i].method;
+    (globalThis.console as unknown as Record<string, unknown>)[method] =
+      slot.original;
+  }
+  _consoleSlots.length = 0;
+}
+
+// ============================================================================
+// Deno.stdout / Deno.stderr write monkey-patches
+// ============================================================================
+
+interface StdioWrap {
+  stream: typeof Deno.stdout | typeof Deno.stderr;
+  channel: "stdout" | "stderr";
+  buffer: string;
+  originalWrite: (p: Uint8Array) => Promise<number>;
+  originalWriteSync: (p: Uint8Array) => number;
+}
+
+const _stdioWraps: StdioWrap[] = [];
+
+const _decoder = new TextDecoder("utf-8", { fatal: false });
+
+function bufferAndEmit(wrap: StdioWrap, bytes: Uint8Array): void {
+  const text = _decoder.decode(bytes, { stream: true });
+  if (text.length === 0) return;
+  const combined = wrap.buffer + text;
+  const newlineIdx = combined.lastIndexOf("\n");
+  if (newlineIdx === -1) {
+    wrap.buffer = combined;
+    return;
+  }
+  const completeBlock = combined.slice(0, newlineIdx);
+  wrap.buffer = combined.slice(newlineIdx + 1);
+  for (const line of completeBlock.split("\n")) {
+    log.emitIntercepted("warn", line, wrap.channel);
+  }
+}
+
+function installStdioWraps(): void {
+  for (
+    const stream of [
+      { stream: Deno.stdout, channel: "stdout" as const },
+      { stream: Deno.stderr, channel: "stderr" as const },
+    ]
+  ) {
+    const target = stream.stream as unknown as {
+      write(p: Uint8Array): Promise<number>;
+      writeSync(p: Uint8Array): number;
+    };
+    const wrap: StdioWrap = {
+      stream: stream.stream,
+      channel: stream.channel,
+      buffer: "",
+      originalWrite: target.write.bind(target),
+      originalWriteSync: target.writeSync.bind(target),
+    };
+    _stdioWraps.push(wrap);
+
+    target.write = (p: Uint8Array) => {
+      bufferAndEmit(wrap, p);
+      return Promise.resolve(p.byteLength);
+    };
+    target.writeSync = (p: Uint8Array) => {
+      bufferAndEmit(wrap, p);
+      return p.byteLength;
+    };
+  }
+}
+
+function flushStdioWraps(): void {
+  for (const wrap of _stdioWraps) {
+    if (wrap.buffer.length > 0) {
+      log.emitIntercepted("warn", wrap.buffer, wrap.channel);
+      wrap.buffer = "";
+    }
+  }
+}
+
+function restoreStdioWraps(): void {
+  flushStdioWraps();
+  for (const wrap of _stdioWraps) {
+    const target = wrap.stream as unknown as {
+      write(p: Uint8Array): Promise<number>;
+      writeSync(p: Uint8Array): number;
+    };
+    target.write = wrap.originalWrite;
+    target.writeSync = wrap.originalWriteSync;
+  }
+  _stdioWraps.length = 0;
+}
+
+// ============================================================================
+// Install / uninstall
+// ============================================================================
+
+/**
+ * Override `globalThis.console.*` and monkey-patch `Deno.stdout/stderr.write`
+ * to route through `streamlib.log`. Idempotent.
+ */
+export function install(): void {
+  if (_installed) return;
+  installConsoleOverrides();
+  installStdioWraps();
+  _installed = true;
+}
+
+/**
+ * Restore the original `console` and `Deno.stdout/stderr.write` impls.
+ * Used by tests and during subprocess shutdown.
+ */
+export function uninstall(): void {
+  if (!_installed) return;
+  restoreStdioWraps();
+  restoreConsoleOverrides();
+  _installed = false;
+}
+
+/** Test helper: flush partial stdio buffers without uninstalling. */
+export function _flushForTests(): void {
+  flushStdioWraps();
+}

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -16,6 +16,7 @@ import * as msgpack from "@msgpack/msgpack";
 import type { NativeLib } from "./native.ts";
 import { cString } from "./native.ts";
 import type { EscalateChannel, EscalateOkResponse } from "./escalate.ts";
+import * as log from "./log.ts";
 import type {
   GpuContextFullAccess,
   GpuContextLimitedAccess,
@@ -70,9 +71,11 @@ export function decodeReadResult(
   }
   const len = outLen[0];
   if (len > readBufBytes) {
-    console.error(
-      `[streamlib-deno] payload truncated on port '${portName}': native reported ${len} bytes but read buffer is ${readBufBytes}`,
-    );
+    log.warn("payload truncated on port", {
+      port: portName,
+      reported_bytes: len,
+      read_buf_bytes: readBufBytes,
+    });
     return null;
   }
   const data = new Uint8Array(new ArrayBuffer(len));
@@ -366,7 +369,7 @@ class NativeOutputPorts implements OutputPorts {
     );
 
     if (result !== 0) {
-      console.error(`[streamlib-deno] Failed to write to port '${portName}'`);
+      log.error("Failed to write to port", { port: portName });
     }
   }
 }

--- a/libs/streamlib-deno/context_test.ts
+++ b/libs/streamlib-deno/context_test.ts
@@ -32,6 +32,7 @@ import {
   decodeReadResult,
   DEFAULT_READ_BUF_BYTES,
 } from "./context.ts";
+import * as log from "./log.ts";
 
 // ============================================================================
 // Helpers
@@ -77,21 +78,21 @@ function patternBytes(size: number): Uint8Array {
 }
 
 /**
- * Capture stderr writes for the duration of `fn` so we can assert that
- * truncation paths log without polluting the test runner output.
+ * Run `fn`, then drain the `streamlib.log` queue and return a single
+ * string containing every queued message + serialized attrs. The
+ * truncation path under test enqueues into the local queue without
+ * needing the writer task / escalate channel to be running.
  */
-function withStderrCapture(fn: () => void): string {
-  const buffered: string[] = [];
-  const original = console.error;
-  console.error = (...args: unknown[]) => {
-    buffered.push(args.map((a) => String(a)).join(" "));
-  };
-  try {
-    fn();
-  } finally {
-    console.error = original;
-  }
-  return buffered.join("\n");
+function withLogCapture(fn: () => void): string {
+  // No `install()` — the queue accepts records without a writer running,
+  // and `_drainForTests()` reads them directly. Reset first so tests
+  // don't see records from other tests in the same process.
+  void log._resetForTests();
+  fn();
+  return log
+    ._drainForTests()
+    .map((rec) => `${rec.message} ${JSON.stringify(rec.attrs)}`)
+    .join("\n");
 }
 
 // ============================================================================
@@ -172,7 +173,7 @@ Deno.test("decodeReadResult: zero-length read returns null without logging", () 
     new Uint8Array(0),
     123n,
   );
-  const log = withStderrCapture(() => {
+  const captured = withLogCapture(() => {
     const result = decodeReadResult(
       readBuf,
       outLen,
@@ -182,7 +183,7 @@ Deno.test("decodeReadResult: zero-length read returns null without logging", () 
     );
     assertEquals(result, null);
   });
-  assertEquals(log, "");
+  assertEquals(captured, "");
 });
 
 // Happy paths — parameterize over a matrix of (read_buf_bytes, data_len)
@@ -237,7 +238,7 @@ for (const { label, readBufBytes, dataLen } of happyPathMatrix) {
     const ts = BigInt(dataLen) * 1000n;
     const { readBuf, outLen, outTs } = makeFfiResult(readBufBytes, data, ts);
 
-    const log = withStderrCapture(() => {
+    const captured = withLogCapture(() => {
       const result = decodeReadResult(
         readBuf,
         outLen,
@@ -260,7 +261,7 @@ for (const { label, readBufBytes, dataLen } of happyPathMatrix) {
         "returned Uint8Array should own its own ArrayBuffer",
       );
     });
-    assertEquals(log, "", "happy path must not log truncation warnings");
+    assertEquals(captured, "", "happy path must not log truncation warnings");
   });
 }
 
@@ -299,7 +300,7 @@ for (const { label, readBufBytes, dataLen } of truncationMatrix) {
     const data = patternBytes(dataLen);
     const { readBuf, outLen, outTs } = makeFfiResult(readBufBytes, data, 42n);
 
-    const log = withStderrCapture(() => {
+    const captured = withLogCapture(() => {
       const result = decodeReadResult(
         readBuf,
         outLen,
@@ -314,11 +315,12 @@ for (const { label, readBufBytes, dataLen } of truncationMatrix) {
       );
     });
     assertStringIncludes(
-      log,
-      "payload truncated on port 'truncated_port'",
-      "truncation must log a descriptive error identifying the port",
+      captured,
+      "payload truncated on port",
+      "truncation must log a descriptive message",
     );
-    assertStringIncludes(log, String(dataLen));
-    assertStringIncludes(log, String(readBufBytes));
+    assertStringIncludes(captured, "truncated_port");
+    assertStringIncludes(captured, String(dataLen));
+    assertStringIncludes(captured, String(readBufBytes));
   });
 }

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -21,6 +21,7 @@ import type {
   EscalateRequest,
   EscalateRequestAcquirePixelBuffer,
   EscalateRequestAcquireTexture,
+  EscalateRequestLog,
   EscalateRequestReleaseHandle,
 } from "./_generated_/com_streamlib_escalate_request.ts";
 import type {
@@ -33,6 +34,7 @@ export type {
   EscalateRequest,
   EscalateRequestAcquirePixelBuffer,
   EscalateRequestAcquireTexture,
+  EscalateRequestLog,
   EscalateRequestReleaseHandle,
   EscalateResponse,
   EscalateResponseErr,
@@ -111,6 +113,21 @@ export class EscalateChannel {
 
   async releaseHandle(handleId: string): Promise<EscalateOkResponse> {
     return this.request({ op: "release_handle", handle_id: handleId });
+  }
+
+  /**
+   * Send a fire-and-forget `log` op. The host enqueues the record into
+   * the unified JSONL pipeline and returns nothing — no `request_id`,
+   * no correlated response. The frame goes through the same writer lock
+   * as request/response traffic so length-prefix and payload stay
+   * contiguous on the wire.
+   */
+  async logFireAndForget(payload: EscalateRequestLog): Promise<void> {
+    const msg = {
+      rpc: ESCALATE_REQUEST_RPC,
+      ...payload,
+    } as Record<string, unknown>;
+    await this.writer(msg);
   }
 
   async request(op: EscalateOpPayload): Promise<EscalateOkResponse> {

--- a/libs/streamlib-deno/log.ts
+++ b/libs/streamlib-deno/log.ts
@@ -1,0 +1,435 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot unified logging for the Deno subprocess SDK.
+ *
+ * Public API:
+ *
+ *     import { log } from "@tatolab/streamlib-deno";
+ *     log.info("captured frame", { frame_index: 42 });
+ *     log.error("decode failed", { error: String(e) });
+ *
+ * Records are serialized as `{op: "log", ...}` escalate-IPC payloads and
+ * enqueued into a bounded local queue. An async writer task drains the queue
+ * and fires each payload over the escalate channel — fire-and-forget, no
+ * correlated response. The host handler routes into the unified JSONL pathway
+ * (see `streamlib::core::logging::polyglot_sink`).
+ *
+ * The hot path is intentionally cheap — a struct construction plus an
+ * `Array.push` (drop-oldest if full) — so `streamlib.log.info(...)` from
+ * inside `process()` doesn't stall the frame loop. ISO8601 formatting and
+ * JSON encoding happen on the writer task.
+ *
+ * Mirrors `libs/streamlib-python/python/streamlib/log.py`. Divergence between
+ * the two SDKs in queue capacity, drop-oldest policy, or heartbeat cadence
+ * would be a bug — see issue #444.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { EscalateChannel } from "./escalate.ts";
+import type {
+  EscalateRequestLog,
+  EscalateRequestLogLevel,
+  EscalateRequestLogSource,
+} from "./_generated_/com_streamlib_escalate_request.ts";
+
+// ============================================================================
+// Public constants
+// ============================================================================
+
+/** Default bounded-queue capacity. Oldest record is dropped when full. */
+export const DEFAULT_QUEUE_CAPACITY = 65536;
+
+/** Emit a synthetic `dropped=N` heartbeat every N accumulated drops. */
+const HEARTBEAT_DROP_THRESHOLD = 1000;
+
+/**
+ * Emit a synthetic `dropped=N` heartbeat at least once per this many
+ * milliseconds while drops are outstanding.
+ */
+const HEARTBEAT_INTERVAL_MS = 1000;
+
+const DRAIN_TICK_MS = 5;
+
+const SOURCE_DENO: EscalateRequestLogSource = "deno" as EscalateRequestLogSource;
+
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error";
+
+const VALID_LEVELS: ReadonlySet<string> = new Set([
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+]);
+
+// ============================================================================
+// Processor-context — read on the hot path, set by subprocess_runner via
+// `runWithProcessorContext`. AsyncLocalStorage is the Deno equivalent of
+// Python's contextvars — it propagates through `await` boundaries without
+// requiring callers to thread the values.
+// ============================================================================
+
+interface ProcessorContext {
+  pipelineId: string | null;
+  processorId: string | null;
+}
+
+const _als = new AsyncLocalStorage<ProcessorContext>();
+
+let _ambientContext: ProcessorContext = { pipelineId: null, processorId: null };
+
+/**
+ * Run `fn` with the given processor / pipeline IDs visible to every
+ * `streamlib.log.*` call inside it. Use this to scope IDs to a lifecycle
+ * method's async tree without having to pass them explicitly.
+ */
+export function runWithProcessorContext<T>(
+  ctx: { pipelineId?: string | null; processorId?: string | null },
+  fn: () => T,
+): T {
+  return _als.run(
+    {
+      pipelineId: ctx.pipelineId ?? null,
+      processorId: ctx.processorId ?? null,
+    },
+    fn,
+  );
+}
+
+/** Set the ambient processor/pipeline IDs (fallback when ALS is not active). */
+export function setProcessorContext(
+  ctx: { pipelineId?: string | null; processorId?: string | null },
+): void {
+  _ambientContext = {
+    pipelineId: ctx.pipelineId ?? null,
+    processorId: ctx.processorId ?? null,
+  };
+}
+
+function readProcessorContext(): ProcessorContext {
+  return _als.getStore() ?? _ambientContext;
+}
+
+// ============================================================================
+// Queued record — intermediate representation between hot path and writer
+// ============================================================================
+
+interface QueuedRecord {
+  level: LogLevel;
+  message: string;
+  attrs: Record<string, unknown>;
+  intercepted: boolean;
+  channel: string | null;
+  pipelineId: string | null;
+  processorId: string | null;
+  sourceSeq: bigint;
+  sourceTsMs: number;
+}
+
+// ============================================================================
+// Module state — bounded queue, counters, writer task handle
+// ============================================================================
+
+let _queue: QueuedRecord[] = [];
+let _queueCapacity = DEFAULT_QUEUE_CAPACITY;
+let _seqCounter: bigint = 0n;
+
+let _dropCount = 0;
+let _lastHeartbeatMs = 0;
+
+let _writerActive = false;
+let _writerStop = false;
+let _writerDone: Promise<void> | null = null;
+let _channel: EscalateChannel | null = null;
+
+// Cancellable sleep handle. The writer's idle wait between drain ticks
+// installs a resolver here so `shutdown()` can wake it immediately and
+// avoid a timer leak (the Deno test runner flags any unresolved
+// setTimeout as a leak).
+let _writerSleepResolve: (() => void) | null = null;
+let _writerSleepTimer: number = -1;
+
+// ============================================================================
+// Hot path — build payload and enqueue
+// ============================================================================
+
+function nextSeq(): bigint {
+  const seq = _seqCounter;
+  _seqCounter = _seqCounter + 1n;
+  return seq;
+}
+
+function emit(
+  level: LogLevel,
+  message: string,
+  attrs: Record<string, unknown>,
+  options: { intercepted?: boolean; channel?: string | null } = {},
+): void {
+  const ctx = readProcessorContext();
+  const rec: QueuedRecord = {
+    level,
+    message,
+    attrs,
+    intercepted: options.intercepted ?? false,
+    channel: options.channel ?? null,
+    pipelineId: ctx.pipelineId,
+    processorId: ctx.processorId,
+    sourceSeq: nextSeq(),
+    sourceTsMs: Date.now(),
+  };
+  if (_queue.length >= _queueCapacity) {
+    // Drop-oldest: pop the head, increment drop counter. Matches Python's
+    // bounded queue.Queue with the lossy `put_nowait` + drop counter
+    // pattern — the Deno queue is single-threaded so no lock is needed.
+    _queue.shift();
+    _dropCount += 1;
+  }
+  _queue.push(rec);
+}
+
+export function trace(message: string, attrs: Record<string, unknown> = {}): void {
+  emit("trace", message, attrs);
+}
+
+export function debug(message: string, attrs: Record<string, unknown> = {}): void {
+  emit("debug", message, attrs);
+}
+
+export function info(message: string, attrs: Record<string, unknown> = {}): void {
+  emit("info", message, attrs);
+}
+
+export function warn(message: string, attrs: Record<string, unknown> = {}): void {
+  emit("warn", message, attrs);
+}
+
+export function error(message: string, attrs: Record<string, unknown> = {}): void {
+  emit("error", message, attrs);
+}
+
+/**
+ * Enqueue a record captured by an interceptor (stdout/stderr/console/fd*).
+ * Used by `_log_interceptors`; not part of the processor-author surface.
+ */
+export function emitIntercepted(
+  level: LogLevel | string,
+  message: string,
+  channel: string,
+  attrs: Record<string, unknown> = {},
+): void {
+  const lvl = (VALID_LEVELS.has(level) ? level : "warn") as LogLevel;
+  emit(lvl, message, attrs, { intercepted: true, channel });
+}
+
+// ============================================================================
+// Writer — drain queue, format payload, send over escalate IPC
+// ============================================================================
+
+function formatSourceTs(sourceTsMs: number): string {
+  // Date.toISOString gives millisecond precision with `Z` suffix —
+  // the Python side pads ns. Millisecond precision is sufficient for
+  // human ordering; the host stamps `host_ts` as the authoritative key.
+  return new Date(sourceTsMs).toISOString();
+}
+
+function buildPayload(rec: QueuedRecord): EscalateRequestLog {
+  return {
+    op: "log",
+    source: SOURCE_DENO,
+    source_seq: rec.sourceSeq.toString(),
+    source_ts: formatSourceTs(rec.sourceTsMs),
+    level: rec.level as EscalateRequestLogLevel,
+    message: rec.message,
+    attrs: rec.attrs,
+    intercepted: rec.intercepted,
+    channel: rec.channel,
+    pipeline_id: rec.pipelineId,
+    processor_id: rec.processorId,
+  };
+}
+
+function buildDropHeartbeat(drops: number): EscalateRequestLog {
+  const ctx = readProcessorContext();
+  return {
+    op: "log",
+    source: SOURCE_DENO,
+    source_seq: nextSeq().toString(),
+    source_ts: formatSourceTs(Date.now()),
+    level: "warn" as EscalateRequestLogLevel,
+    message: `dropped ${drops} log records (subprocess queue saturated)`,
+    attrs: { dropped: drops },
+    intercepted: false,
+    channel: null,
+    pipeline_id: ctx.pipelineId,
+    processor_id: ctx.processorId,
+  };
+}
+
+async function sendDirect(payload: EscalateRequestLog): Promise<boolean> {
+  const channel = _channel;
+  if (!channel) return true;
+  try {
+    await channel.logFireAndForget(payload);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function maybeEmitHeartbeat(): Promise<void> {
+  const drops = _dropCount;
+  if (drops === 0) return;
+  const now = Date.now();
+  const elapsed = now - _lastHeartbeatMs;
+  if (drops < HEARTBEAT_DROP_THRESHOLD && elapsed < HEARTBEAT_INTERVAL_MS) {
+    return;
+  }
+  _dropCount = 0;
+  _lastHeartbeatMs = now;
+  await sendDirect(buildDropHeartbeat(drops));
+}
+
+function writerSleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    _writerSleepResolve = () => {
+      _writerSleepResolve = null;
+      if (_writerSleepTimer >= 0) {
+        clearTimeout(_writerSleepTimer);
+        _writerSleepTimer = -1;
+      }
+      resolve();
+    };
+    _writerSleepTimer = setTimeout(() => {
+      _writerSleepResolve = null;
+      _writerSleepTimer = -1;
+      resolve();
+    }, ms);
+  });
+}
+
+function wakeWriterSleep(): void {
+  if (_writerSleepResolve) {
+    _writerSleepResolve();
+  }
+}
+
+async function writerLoop(): Promise<void> {
+  while (!_writerStop) {
+    if (_queue.length === 0) {
+      await maybeEmitHeartbeat();
+      if (_writerStop) break;
+      await writerSleep(DRAIN_TICK_MS);
+      continue;
+    }
+    const rec = _queue.shift()!;
+    if (!(await sendDirect(buildPayload(rec)))) {
+      // Bridge pipe broken — subprocess is going away. Stop trying so
+      // teardown isn't blocked behind a broken stdout.
+      _writerStop = true;
+      break;
+    }
+    await maybeEmitHeartbeat();
+  }
+  // Drain remaining records on shutdown so flush() has the expected effect.
+  while (_queue.length > 0) {
+    const rec = _queue.shift()!;
+    if (!(await sendDirect(buildPayload(rec)))) break;
+  }
+  await maybeEmitHeartbeat();
+  _writerActive = false;
+}
+
+// ============================================================================
+// Install / shutdown — called by subprocess_runner
+// ============================================================================
+
+export interface InstallOptions {
+  installInterceptors?: boolean;
+  queueCapacity?: number;
+}
+
+/**
+ * Start the writer task and (optionally) install subprocess-side
+ * interceptors. Idempotent — a second call is a no-op.
+ *
+ * Called by `subprocess_runner` after the escalate channel is wired.
+ */
+export async function install(
+  channel: EscalateChannel,
+  options: InstallOptions = {},
+): Promise<void> {
+  if (_writerActive) return;
+  _channel = channel;
+  _queueCapacity = options.queueCapacity ?? DEFAULT_QUEUE_CAPACITY;
+  _lastHeartbeatMs = Date.now();
+  _writerStop = false;
+  _writerActive = true;
+  _writerDone = writerLoop();
+
+  if (options.installInterceptors ?? true) {
+    const interceptors = await import("./_log_interceptors.ts");
+    interceptors.install();
+  }
+}
+
+/**
+ * Stop the writer task and flush remaining records. Safe to call multiple
+ * times.
+ */
+export async function shutdown(timeoutMs = 2000): Promise<void> {
+  _writerStop = true;
+  // Wake the writer's idle sleep so it sees the stop flag immediately
+  // — this avoids leaving a setTimeout pending past shutdown, which
+  // Deno's test runner reports as a leak.
+  wakeWriterSleep();
+  if (_writerDone) {
+    let timeoutId = -1;
+    const timer = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(resolve, timeoutMs);
+    });
+    await Promise.race([_writerDone, timer]);
+    if (timeoutId >= 0) clearTimeout(timeoutId);
+  }
+  _writerDone = null;
+  _writerActive = false;
+  _channel = null;
+}
+
+// ============================================================================
+// Test helpers — not part of the public API
+// ============================================================================
+
+/** Reset module state between Deno.test cases. NOT for production use. */
+export async function _resetForTests(): Promise<void> {
+  await shutdown(500);
+  _queue = [];
+  _queueCapacity = DEFAULT_QUEUE_CAPACITY;
+  _seqCounter = 0n;
+  _dropCount = 0;
+  _lastHeartbeatMs = 0;
+  _writerActive = false;
+  _writerStop = false;
+  _writerDone = null;
+  _channel = null;
+  _ambientContext = { pipelineId: null, processorId: null };
+}
+
+/** Current queue depth. NOT for production use. */
+export function _queueSizeForTests(): number {
+  return _queue.length;
+}
+
+/** Current drop count. NOT for production use. */
+export function _dropCountForTests(): number {
+  return _dropCount;
+}
+
+/** Drain the queue synchronously and return all pending records' payloads. */
+export function _drainForTests(): EscalateRequestLog[] {
+  const out = _queue.map(buildPayload);
+  _queue = [];
+  return out;
+}

--- a/libs/streamlib-deno/log_test.ts
+++ b/libs/streamlib-deno/log_test.ts
@@ -1,0 +1,331 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the polyglot logging producer + interceptors.
+ *
+ * Mirrors `libs/streamlib-python/python/streamlib/tests/test_log.py` —
+ * the policy choices (queue capacity, drop-oldest, heartbeat cadence,
+ * line-buffering, level routing) must match between Python and Deno.
+ *
+ * These tests cover the in-process path only: payload shape, queue
+ * drops, ContextVar propagation via AsyncLocalStorage, and the JS-level
+ * interceptors (console.* + Deno.stdout/stderr.write). End-to-end via a
+ * real Deno subprocess + host JSONL is covered by the Rust E2E tests in
+ * `subprocess_escalate.rs::tests::deno_subprocess`.
+ *
+ * Every test awaits `log._resetForTests()` first — `_resetForTests` is
+ * async (it shuts down any prior writer task), and a non-awaited call
+ * races with the test's own `install` / `info` calls.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import * as log from "./log.ts";
+import * as interceptors from "./_log_interceptors.ts";
+
+// ============================================================================
+// API surface
+// ============================================================================
+
+Deno.test("log.info produces a wire payload with op=log, source=deno", async () => {
+  await log._resetForTests();
+  log.info("hello", { count: 7 });
+  const records = log._drainForTests();
+  assertEquals(records.length, 1);
+  const r = records[0];
+  assertEquals(r.op, "log");
+  assertEquals(r.source, "deno");
+  assertEquals(r.level, "info");
+  assertEquals(r.message, "hello");
+  assertEquals(r.attrs.count, 7);
+  assertEquals(r.intercepted, false);
+  assertEquals(r.channel, null);
+});
+
+Deno.test("level routing — trace/debug/info/warn/error each map 1:1", async () => {
+  await log._resetForTests();
+  log.trace("t");
+  log.debug("d");
+  log.info("i");
+  log.warn("w");
+  log.error("e");
+  const levels = log._drainForTests().map((r) => r.level);
+  assertEquals(levels, ["trace", "debug", "info", "warn", "error"]);
+});
+
+Deno.test("source_seq is monotonic within the subprocess", async () => {
+  await log._resetForTests();
+  for (let i = 0; i < 50; i++) log.info(`msg-${i}`);
+  const records = log._drainForTests();
+  const seqs = records.map((r) => BigInt(r.source_seq));
+  for (let i = 1; i < seqs.length; i++) {
+    assert(
+      seqs[i] > seqs[i - 1],
+      `expected strict monotonic increase: seqs[${i}] (${seqs[i]}) > seqs[${i - 1}] (${seqs[i - 1]})`,
+    );
+  }
+});
+
+Deno.test("source_ts is ISO8601 UTC", async () => {
+  await log._resetForTests();
+  log.info("hi");
+  const r = log._drainForTests()[0];
+  // Round-trip: the ISO string must parse back to a finite millisecond
+  // timestamp roughly equal to "now".
+  const parsed = Date.parse(r.source_ts);
+  assert(Number.isFinite(parsed), `source_ts not parseable: ${r.source_ts}`);
+  assert(
+    Math.abs(Date.now() - parsed) < 5_000,
+    `source_ts not within 5s of now: ${r.source_ts}`,
+  );
+  assert(r.source_ts.endsWith("Z"), `source_ts must be UTC: ${r.source_ts}`);
+});
+
+// ============================================================================
+// Processor context propagation (AsyncLocalStorage + ambient)
+// ============================================================================
+
+Deno.test("ambient processor context is read on the hot path", async () => {
+  await log._resetForTests();
+  log.setProcessorContext({ processorId: "pr-amb", pipelineId: "pl-amb" });
+  log.info("hi");
+  const r = log._drainForTests()[0];
+  assertEquals(r.processor_id, "pr-amb");
+  assertEquals(r.pipeline_id, "pl-amb");
+});
+
+Deno.test("AsyncLocalStorage scope overrides ambient", async () => {
+  await log._resetForTests();
+  log.setProcessorContext({ processorId: "pr-amb", pipelineId: "pl-amb" });
+
+  log.runWithProcessorContext({ processorId: "pr-scoped" }, () => {
+    log.info("inside");
+  });
+
+  log.info("outside");
+
+  const records = log._drainForTests();
+  assertEquals(records[0].processor_id, "pr-scoped");
+  assertEquals(records[0].pipeline_id, null);
+  assertEquals(records[1].processor_id, "pr-amb");
+  assertEquals(records[1].pipeline_id, "pl-amb");
+});
+
+// ============================================================================
+// Bounded queue — drop-oldest
+// ============================================================================
+
+Deno.test(
+  "queue overflow drops oldest and surfaces drop count via test helper",
+  async () => {
+    await log._resetForTests();
+    // Use install with a tiny capacity. Pass a stub channel so the writer
+    // stays inert during the synchronous burst.
+    const sentChannel = {
+      logFireAndForget: () => Promise.resolve(),
+    } as unknown as Parameters<typeof log.install>[0];
+    await log.install(sentChannel, {
+      queueCapacity: 4,
+      installInterceptors: false,
+    });
+    // Stop the writer so records pile up.
+    await log.shutdown(500);
+
+    for (let i = 0; i < 10; i++) log.info("msg", { i });
+
+    // Queue is capped at 4, 6 should be dropped.
+    assertEquals(log._queueSizeForTests(), 4);
+    assertEquals(log._dropCountForTests(), 6);
+
+    // The 4 retained records must be the most recent (i = 6..9).
+    const indices = log
+      ._drainForTests()
+      .map((r) => (r.attrs as { i: number }).i);
+    assertEquals(indices, [6, 7, 8, 9]);
+  },
+);
+
+// ============================================================================
+// emitIntercepted — captured-channel records carry intercepted=true
+// ============================================================================
+
+Deno.test("emitIntercepted tags channel and intercepted=true", async () => {
+  await log._resetForTests();
+  log.emitIntercepted("warn", "raw line", "stdout");
+  const r = log._drainForTests()[0];
+  assertEquals(r.intercepted, true);
+  assertEquals(r.channel, "stdout");
+  assertEquals(r.level, "warn");
+  assertEquals(r.message, "raw line");
+});
+
+Deno.test("emitIntercepted falls back to warn when level is unknown", async () => {
+  await log._resetForTests();
+  log.emitIntercepted("verbose", "x", "logging");
+  assertEquals(log._drainForTests()[0].level, "warn");
+});
+
+// ============================================================================
+// console.* interceptors
+// ============================================================================
+
+Deno.test("console.log routes through streamlib.log with channel=console.log", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    console.log("hi from console");
+  } finally {
+    interceptors.uninstall();
+  }
+  const r = log._drainForTests()[0];
+  assertEquals(r.intercepted, true);
+  assertEquals(r.channel, "console.log");
+  assertEquals(r.message, "hi from console");
+});
+
+Deno.test("console levels route to matching channel + streamlib level", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    console.warn("w");
+    console.error("e");
+    console.info("i");
+    console.debug("d");
+  } finally {
+    interceptors.uninstall();
+  }
+  const records = log._drainForTests();
+  const byChannel = Object.fromEntries(
+    records.map((r) => [r.channel, r.level]),
+  );
+  assertEquals(byChannel["console.warn"], "warn");
+  assertEquals(byChannel["console.error"], "error");
+  assertEquals(byChannel["console.info"], "info");
+  assertEquals(byChannel["console.debug"], "debug");
+});
+
+Deno.test("console.* override is restored on uninstall", async () => {
+  await log._resetForTests();
+  const before = console.log;
+  interceptors.install();
+  const installed = console.log;
+  interceptors.uninstall();
+  assert(installed !== before, "interceptor should replace console.log");
+  assertEquals(console.log, before, "uninstall must restore the original");
+});
+
+// ============================================================================
+// Deno.stdout/stderr.write interceptors
+// ============================================================================
+
+Deno.test("Deno.stdout.write surfaces a line-buffered intercepted record", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    await Deno.stdout.write(new TextEncoder().encode("hi from stdout\n"));
+  } finally {
+    interceptors.uninstall();
+  }
+  const r = log._drainForTests().find((r) => r.channel === "stdout");
+  assert(r !== undefined, "expected a stdout record");
+  assertEquals(r.intercepted, true);
+  assertEquals(r.message, "hi from stdout");
+});
+
+Deno.test("Deno.stderr.write surfaces a line-buffered intercepted record", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    await Deno.stderr.write(new TextEncoder().encode("hi from stderr\n"));
+  } finally {
+    interceptors.uninstall();
+  }
+  const r = log._drainForTests().find((r) => r.channel === "stderr");
+  assert(r !== undefined, "expected a stderr record");
+  assertEquals(r.message, "hi from stderr");
+});
+
+Deno.test("multi-line write produces one record per newline", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    await Deno.stdout.write(new TextEncoder().encode("a\nb\nc\n"));
+  } finally {
+    interceptors.uninstall();
+  }
+  const messages = log
+    ._drainForTests()
+    .filter((r) => r.channel === "stdout")
+    .map((r) => r.message);
+  assertEquals(messages, ["a", "b", "c"]);
+});
+
+Deno.test("partial trailing line buffers until next newline", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    await Deno.stdout.write(new TextEncoder().encode("part-1 "));
+    // Nothing yet — no newline.
+    assertEquals(
+      log._drainForTests().filter((r) => r.channel === "stdout").length,
+      0,
+    );
+    await Deno.stdout.write(new TextEncoder().encode("part-2\n"));
+  } finally {
+    interceptors.uninstall();
+  }
+  const messages = log
+    ._drainForTests()
+    .filter((r) => r.channel === "stdout")
+    .map((r) => r.message);
+  assertEquals(messages, ["part-1 part-2"]);
+});
+
+Deno.test("flush on uninstall surfaces buffered partial line", async () => {
+  await log._resetForTests();
+  interceptors.install();
+  try {
+    await Deno.stdout.write(new TextEncoder().encode("orphan-no-newline"));
+  } finally {
+    interceptors.uninstall();
+  }
+  const messages = log
+    ._drainForTests()
+    .filter((r) => r.channel === "stdout")
+    .map((r) => r.message);
+  assertEquals(messages, ["orphan-no-newline"]);
+});
+
+// ============================================================================
+// install() round-trip — writer drains queued records to the channel
+// ============================================================================
+
+Deno.test(
+  "writer task drains queued records via channel.logFireAndForget",
+  async () => {
+    await log._resetForTests();
+    const sent: unknown[] = [];
+    const stubChannel = {
+      logFireAndForget: (payload: unknown) => {
+        sent.push(payload);
+        return Promise.resolve();
+      },
+    } as unknown as Parameters<typeof log.install>[0];
+
+    await log.install(stubChannel, { installInterceptors: false });
+    log.info("drain me", { mark: "x" });
+
+    // Wait briefly for the writer task to pick up the record.
+    const deadline = Date.now() + 1000;
+    while (sent.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await log.shutdown(500);
+
+    assert(sent.length >= 1, `expected at least one drained record, got ${sent.length}`);
+    const payload = sent[0] as Record<string, unknown>;
+    assertEquals(payload.op, "log");
+    assertEquals(payload.message, "drain me");
+    assertStringIncludes(JSON.stringify(payload.attrs), '"mark":"x"');
+  },
+);

--- a/libs/streamlib-deno/mod.ts
+++ b/libs/streamlib-deno/mod.ts
@@ -30,3 +30,6 @@ export {
 } from "./context.ts";
 export { cString, loadNativeLib } from "./native.ts";
 export type { NativeLib } from "./native.ts";
+
+// Unified polyglot logging — see issue #444 / parent #430.
+export * as log from "./log.ts";

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -23,12 +23,28 @@ import {
   NativeRuntimeContextLimitedAccess,
 } from "./context.ts";
 import { EscalateChannel } from "./escalate.ts";
+import * as log from "./log.ts";
 import type {
   ContinuousProcessor,
   ManualProcessor,
   ProcessorLifecycle,
   ReactiveProcessor,
 } from "./types.ts";
+
+/**
+ * Pre-install fatal — escalate channel not up yet, so fall back to raw
+ * stderr. The host's fd2 reader will still capture this line and surface
+ * it as `intercepted=true, channel="fd2", source="deno"`.
+ */
+function fatalPreInstall(message: string): never {
+  const text = `[streamlib-deno] ${message}\n`;
+  try {
+    Deno.stderr.writeSync(new TextEncoder().encode(text));
+  } catch {
+    // Even raw stderr broken; nothing else to try.
+  }
+  Deno.exit(1);
+}
 
 // ============================================================================
 // Bridge protocol (length-prefixed JSON over stdin/stdout)
@@ -98,9 +114,12 @@ function assertCapability(
 ): void {
   const actual = msg.capability as string | undefined;
   if (actual !== undefined && actual !== expected) {
-    console.error(
-      `[subprocess_runner:${processorId}] capability mismatch for '${cmd}': expected '${expected}', got '${actual}'`,
-    );
+    log.error("capability mismatch", {
+      processor_id: processorId,
+      cmd,
+      expected,
+      actual,
+    });
   }
 }
 
@@ -115,19 +134,43 @@ async function main(): Promise<void> {
   const processorId = Deno.env.get("STREAMLIB_PROCESSOR_ID") ?? "unknown";
   const executionMode = Deno.env.get("STREAMLIB_EXECUTION_MODE") ?? "reactive";
 
-  console.error(`[subprocess_runner:${processorId}] Starting`);
-  console.error(`  entrypoint: ${entrypoint}`);
-  console.error(`  project_path: ${projectPath}`);
-  console.error(`  native_lib: ${nativeLibPath}`);
-  console.error(`  execution_mode: ${executionMode}`);
+  if (!entrypoint) {
+    fatalPreInstall("STREAMLIB_ENTRYPOINT not set");
+  }
+
+  // Escalate channel — requests from the TS processor go out on stdout,
+  // host responses arrive on stdin and are routed here from every stdin
+  // read site (outer loop + run-phase concurrent reader). Constructed
+  // BEFORE installing logging so `log.install` has a channel to drain to.
+  const escalateChannel = new EscalateChannel(bridgeSendJson);
+
+  // Install unified logging: writer task + console / Deno.stdout/stderr
+  // interceptors. After this point, `console.*` and `Deno.stdout.write`
+  // route through `streamlib.log.*` with `intercepted: true`. fd1 is the
+  // IPC channel and is NOT intercepted; raw fd1 writes would corrupt
+  // bridge framing — see #444 / #451.
+  log.setProcessorContext({ processorId });
+  await log.install(escalateChannel);
+
+  log.info("Subprocess runner starting", {
+    processor_id: processorId,
+    entrypoint,
+    project_path: projectPath,
+    native_lib: nativeLibPath,
+    execution_mode: executionMode,
+  });
 
   // Load native library
   let lib: NativeLib;
   try {
     lib = loadNativeLib(nativeLibPath);
   } catch (e) {
-    console.error(`[subprocess_runner:${processorId}] Failed to load native lib: ${e}`);
+    log.error("Failed to load native lib", {
+      processor_id: processorId,
+      error: String(e),
+    });
     await bridgeSendJson({ rpc: "error", error: `Failed to load native lib: ${e}` });
+    await log.shutdown();
     Deno.exit(1);
   }
 
@@ -135,8 +178,9 @@ async function main(): Promise<void> {
   const processorIdBuf = cString(processorId);
   const ctxPtr = lib.symbols.sldn_context_create(processorIdBuf);
   if (ctxPtr === null) {
-    console.error(`[subprocess_runner:${processorId}] Failed to create native context`);
+    log.error("Failed to create native context", { processor_id: processorId });
     await bridgeSendJson({ rpc: "error", error: "Failed to create native context" });
+    await log.shutdown();
     Deno.exit(1);
   }
 
@@ -158,13 +202,19 @@ async function main(): Promise<void> {
     const endpointBuf = cString(brokerEndpoint);
     brokerPtr = lib.symbols.sldn_broker_connect(endpointBuf);
     if (brokerPtr === null) {
-      console.error(`[subprocess_runner:${processorId}] Warning: broker connect failed (${brokerEndpointDesc}='${brokerEndpoint}')`);
+      log.warn("Broker connect failed", {
+        endpoint_kind: brokerEndpointDesc,
+        endpoint: brokerEndpoint,
+      });
     } else {
-      console.error(`[subprocess_runner:${processorId}] Connected to broker (${brokerEndpointDesc}='${brokerEndpoint}')`);
+      log.info("Connected to broker", {
+        endpoint_kind: brokerEndpointDesc,
+        endpoint: brokerEndpoint,
+      });
     }
   } else {
     const envName = isDarwin ? "STREAMLIB_XPC_SERVICE_NAME" : "STREAMLIB_BROKER_SOCKET";
-    console.error(`[subprocess_runner:${processorId}] No ${envName} set, broker resolution disabled`);
+    log.info("Broker resolution disabled", { missing_env: envName });
   }
 
   let processor: ProcessorLifecycle | null = null;
@@ -172,11 +222,6 @@ async function main(): Promise<void> {
   let fullCtx: NativeRuntimeContextFullAccess | null = null;
   let limitedCtx: NativeRuntimeContextLimitedAccess | null = null;
   let running = false;
-
-  // Escalate channel — requests from the TS processor go out on stdout,
-  // host responses arrive on stdin and are routed here from every stdin
-  // read site (outer loop + run-phase concurrent reader).
-  const escalateChannel = new EscalateChannel(bridgeSendJson);
 
   // Command loop
   try {
@@ -216,17 +261,20 @@ async function main(): Promise<void> {
           const inputPorts = ports.inputs ?? [];
           for (const input of inputPorts) {
             const readMode = input.read_mode ?? "skip_to_latest";
-            console.error(
-              `[subprocess_runner:${processorId}] Subscribing to input: port='${input.name}', service='${input.service_name}', read_mode='${readMode}', max_payload_bytes=${input.max_payload_bytes ?? "default"}`,
-            );
+            log.info("Subscribing to input", {
+              port: input.name,
+              service: input.service_name,
+              read_mode: readMode,
+              max_payload_bytes: input.max_payload_bytes ?? null,
+            });
             const result = lib.symbols.sldn_input_subscribe(
               ctxPtr,
               cString(input.service_name),
             );
             if (result !== 0) {
-              console.error(
-                `[subprocess_runner:${processorId}] Failed to subscribe to '${input.service_name}'`,
-              );
+              log.error("Failed to subscribe to input", {
+                service: input.service_name,
+              });
             }
             // Configure per-port read mode (0 = skip_to_latest, 1 = read_next_in_order)
             const modeInt = readMode === "skip_to_latest" ? 0 : 1;
@@ -236,9 +284,12 @@ async function main(): Promise<void> {
           // Create publishers for output iceoryx2 services
           const outputPorts = ports.outputs ?? [];
           for (const output of outputPorts) {
-            console.error(
-              `[subprocess_runner:${processorId}] Publishing to output: port='${output.name}', dest_port='${output.dest_port}', service='${output.dest_service_name}', schema='${output.schema_name}'`,
-            );
+            log.info("Publishing to output", {
+              port: output.name,
+              dest_port: output.dest_port,
+              service: output.dest_service_name,
+              schema: output.schema_name,
+            });
             const result = lib.symbols.sldn_output_publish(
               ctxPtr,
               cString(output.dest_service_name),
@@ -248,9 +299,9 @@ async function main(): Promise<void> {
               BigInt(output.max_payload_bytes ?? 65536),
             );
             if (result !== 0) {
-              console.error(
-                `[subprocess_runner:${processorId}] Failed to create publisher for '${output.dest_service_name}'`,
-              );
+              log.error("Failed to create publisher", {
+                service: output.dest_service_name,
+              });
             }
           }
 
@@ -260,9 +311,10 @@ async function main(): Promise<void> {
             ? `${projectPath}/${modulePath}`
             : modulePath;
 
-          console.error(
-            `[subprocess_runner:${processorId}] Importing ${fullModulePath}:${exportName}`,
-          );
+          log.info("Importing processor module", {
+            module: fullModulePath,
+            export: exportName,
+          });
 
           try {
             const module = await import(`file://${fullModulePath}`);
@@ -305,9 +357,7 @@ async function main(): Promise<void> {
 
             await bridgeSendJson({ rpc: "ready" });
           } catch (e) {
-            console.error(
-              `[subprocess_runner:${processorId}] Setup failed: ${e}`,
-            );
+            log.error("Setup failed", { error: String(e) });
             await bridgeSendJson({ rpc: "error", error: String(e) });
           }
           break;
@@ -315,16 +365,12 @@ async function main(): Promise<void> {
 
         case "run": {
           if (!processor || !state || !fullCtx || !limitedCtx) {
-            console.error(
-              `[subprocess_runner:${processorId}] run before setup`,
-            );
+            log.warn("run before setup");
             break;
           }
 
           running = true;
-          console.error(
-            `[subprocess_runner:${processorId}] Entering ${executionMode} loop`,
-          );
+          log.info("Entering execution loop", { mode: executionMode });
 
           if (executionMode === "manual") {
             // Manual mode: start() is a resource-lifecycle op → full access
@@ -332,9 +378,7 @@ async function main(): Promise<void> {
             try {
               await manualProc.start(fullCtx);
             } catch (e) {
-              console.error(
-                `[subprocess_runner:${processorId}] start() error: ${e}`,
-              );
+              log.error("start() error", { error: String(e) });
             }
             break;
           }
@@ -382,9 +426,7 @@ async function main(): Promise<void> {
                   await processor.updateConfig(config);
                   await bridgeSendJson({ rpc: "ok" });
                 } else {
-                  console.error(
-                    `[subprocess_runner:${processorId}] Unknown command during run: ${nextCmd}`,
-                  );
+                  log.warn("Unknown command during run", { cmd: nextCmd });
                 }
               }
             } catch {
@@ -407,22 +449,19 @@ async function main(): Promise<void> {
               if (hasData === 1) {
                 dataCount++;
                 if (dataCount <= 3 || dataCount % 60 === 0) {
-                  console.error(
-                    `[subprocess_runner:${processorId}] poll: data received (frame #${dataCount})`,
-                  );
+                  log.debug("poll: data received", { frame_index: dataCount });
                 }
                 try {
                   await reactiveProc.process(limitedCtx);
                 } catch (e) {
-                  console.error(
-                    `[subprocess_runner:${processorId}] process() error: ${e}`,
-                  );
+                  log.error("process() error", { error: String(e) });
                 }
               } else {
                 if (pollCount === 100) {
-                  console.error(
-                    `[subprocess_runner:${processorId}] poll: no data after ${pollCount} polls (${dataCount} frames so far)`,
-                  );
+                  log.debug("poll: no data", {
+                    polls: pollCount,
+                    frames_so_far: dataCount,
+                  });
                 }
                 // No data, yield to event loop briefly
                 await new Promise((resolve) => setTimeout(resolve, 1));
@@ -437,9 +476,7 @@ async function main(): Promise<void> {
               try {
                 await continuousProc.process(limitedCtx);
               } catch (e) {
-                console.error(
-                  `[subprocess_runner:${processorId}] process() error: ${e}`,
-                );
+                log.error("process() error", { error: String(e) });
               }
               if (intervalMs > 0) {
                 await new Promise((resolve) =>
@@ -458,9 +495,7 @@ async function main(): Promise<void> {
               try {
                 await processor.teardown(fullCtx);
               } catch (e) {
-                console.error(
-                  `[subprocess_runner:${processorId}] teardown() error: ${e}`,
-                );
+                log.error("teardown() error", { error: String(e) });
               }
             }
             try {
@@ -470,6 +505,7 @@ async function main(): Promise<void> {
             }
             lib.symbols.sldn_context_destroy(ctxPtr);
             lib.close();
+            await log.shutdown();
             Deno.exit(0);
           }
           break;
@@ -484,9 +520,7 @@ async function main(): Promise<void> {
               try {
                 await manualProc.stop(fullCtx);
               } catch (e) {
-                console.error(
-                  `[subprocess_runner:${processorId}] stop() error: ${e}`,
-                );
+                log.error("stop() error", { error: String(e) });
               }
             }
           }
@@ -528,9 +562,7 @@ async function main(): Promise<void> {
             try {
               await processor.teardown(fullCtx);
             } catch (e) {
-              console.error(
-                `[subprocess_runner:${processorId}] teardown() error: ${e}`,
-              );
+              log.error("teardown() error", { error: String(e) });
             }
           }
           await bridgeSendJson({ rpc: "done" });
@@ -538,13 +570,12 @@ async function main(): Promise<void> {
           // Cleanup native context
           lib.symbols.sldn_context_destroy(ctxPtr);
           lib.close();
+          await log.shutdown();
           Deno.exit(0);
         }
 
         default: {
-          console.error(
-            `[subprocess_runner:${processorId}] Unknown command: ${cmd}`,
-          );
+          log.warn("Unknown command", { cmd });
           break;
         }
       }
@@ -552,9 +583,9 @@ async function main(): Promise<void> {
   } catch (e) {
     const isStdinClosed = e instanceof Error && e.message === "stdin closed";
     if (isStdinClosed) {
-      console.error(`[subprocess_runner:${processorId}] stdin closed, shutting down`);
+      log.info("stdin closed, shutting down");
     } else {
-      console.error(`[subprocess_runner:${processorId}] Fatal error: ${e}`);
+      log.error("Fatal error", { error: String(e) });
     }
     if (processor?.teardown && fullCtx) {
       try {
@@ -566,6 +597,7 @@ async function main(): Promise<void> {
     escalateChannel.cancelAll("subprocess shutting down");
     lib.symbols.sldn_context_destroy(ctxPtr);
     lib.close();
+    await log.shutdown();
     Deno.exit(isStdinClosed ? 0 : 1);
   }
 }

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -136,7 +136,13 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 .arg(runner_path.to_str().unwrap_or(""))
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
-                .stderr(Stdio::inherit())
+                // Pipe stderr (was inherit) so we can intercept fd2 writes
+                // — both Deno runtime chatter and any third-party native
+                // module writing directly to fd2 — and surface them as
+                // `intercepted=true, channel="fd2", source="deno"` records
+                // in the unified JSONL pipeline. fd1 is reserved for the
+                // length-prefixed IPC channel and is NOT captured. See #444.
+                .stderr(Stdio::piped())
                 .env("STREAMLIB_ENTRYPOINT", &self.entrypoint)
                 .env(
                     "STREAMLIB_PROJECT_PATH",
@@ -170,6 +176,41 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             let stdout = child.stdout.take().ok_or_else(|| {
                 StreamError::Runtime("Failed to capture subprocess stdout".to_string())
             })?;
+
+            // Defense-in-depth log capture on the subprocess's fd2 (stderr).
+            // Records are tagged `intercepted=true, channel="fd2",
+            // source="deno"` so a JSONL consumer can tell these apart from
+            // first-party `streamlib.log.*` records. fd1 is reserved for
+            // the length-prefixed IPC channel and is NOT captured — any
+            // raw writes to fd1 would desynchronize bridge framing. See
+            // #444 / #451.
+            if let Some(stderr) = child.stderr.take() {
+                let proc_id = self.processor_id.clone();
+                std::thread::Builder::new()
+                    .name(format!("dn-stderr-{}", &proc_id[..8.min(proc_id.len())]))
+                    .spawn(move || {
+                        use std::io::{BufRead, BufReader};
+                        let reader = BufReader::new(stderr);
+                        for line in reader.lines() {
+                            match line {
+                                Ok(text) if !text.is_empty() => {
+                                    tracing::warn!(
+                                        target: "streamlib::polyglot::deno",
+                                        intercepted = true,
+                                        channel = "fd2",
+                                        source = "deno",
+                                        processor_id = %proc_id,
+                                        "{}",
+                                        text
+                                    );
+                                }
+                                Err(_) => break,
+                                _ => {}
+                            }
+                        }
+                    })
+                    .ok();
+            }
 
             // Clone the sandbox so the bridge reader thread can dispatch
             // escalate requests on behalf of the subprocess.

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -1311,4 +1311,266 @@ log.shutdown()
             );
         }
     }
+
+    /// End-to-end tests that spawn a real Deno subprocess, have it call
+    /// `streamlib.log.*`, read framed escalate-IPC traffic off its
+    /// stdout, dispatch each frame through the host handler, and assert
+    /// the records land in the unified JSONL.
+    ///
+    /// Mirrors `python_subprocess` above for the Deno runtime.
+    ///
+    /// Skipped when `deno` is not on PATH or when the streamlib-deno
+    /// source tree is not present.
+    mod deno_subprocess {
+        use std::io::{BufReader, Read, Write};
+        use std::path::PathBuf;
+        use std::process::{Command, Stdio};
+
+        use super::*;
+        use crate::core::logging::{
+            init_for_tests, LogLevel, RuntimeLogEvent, Source,
+            StreamlibLoggingConfig, StreamlibLoggingGuard,
+        };
+        use crate::core::runtime::RuntimeUniqueId;
+        use serial_test::serial;
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        fn deno_binary() -> Option<PathBuf> {
+            let path_env = std::env::var_os("PATH")?;
+            for dir in std::env::split_paths(&path_env) {
+                let candidate = dir.join("deno");
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+            None
+        }
+
+        fn streamlib_deno_path() -> PathBuf {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("streamlib-deno")
+        }
+
+        fn install_logging(tag: &str) -> (TempDir, StreamlibLoggingGuard) {
+            let tmp = TempDir::new().unwrap();
+            unsafe {
+                std::env::set_var("XDG_STATE_HOME", tmp.path());
+                std::env::set_var("RUST_LOG", "debug");
+                std::env::remove_var("STREAMLIB_QUIET");
+            }
+            let runtime_id = Arc::new(RuntimeUniqueId::from(tag));
+            let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+            let guard = init_for_tests(config).unwrap();
+            (tmp, guard)
+        }
+
+        fn read_jsonl(path: &std::path::Path) -> Vec<RuntimeLogEvent> {
+            let contents = std::fs::read_to_string(path).unwrap_or_default();
+            contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| {
+                    serde_json::from_str::<RuntimeLogEvent>(l).expect("valid JSONL")
+                })
+                .collect()
+        }
+
+        /// Build a Deno helper script (TypeScript) that imports `log` +
+        /// `EscalateChannel` from the streamlib-deno SDK at `sdk_path`,
+        /// sets the processor context, installs the writer, and runs the
+        /// caller-supplied `body` inside a top-level async IIFE. Writes
+        /// the script to a temp file inside `tmp` and returns its path.
+        fn write_helper_script(
+            tmp: &TempDir,
+            sdk_path: &std::path::Path,
+            body: &str,
+        ) -> PathBuf {
+            let log_url = format!("file://{}/log.ts", sdk_path.display());
+            let escalate_url =
+                format!("file://{}/escalate.ts", sdk_path.display());
+            let script = format!(
+                r#"// auto-generated test helper
+import * as log from "{log_url}";
+import {{ EscalateChannel }} from "{escalate_url}";
+
+async function bridgeWrite(msg: Record<string, unknown>): Promise<void> {{
+  const text = JSON.stringify(msg);
+  const encoded = new TextEncoder().encode(text);
+  const lenBuf = new Uint8Array(4);
+  new DataView(lenBuf.buffer).setUint32(0, encoded.length, false);
+  await Deno.stdout.write(lenBuf);
+  await Deno.stdout.write(encoded);
+}}
+
+const channel = new EscalateChannel(bridgeWrite);
+log.setProcessorContext({{ processorId: "pr-test", pipelineId: "pl-test" }});
+await log.install(channel, {{ installInterceptors: false }});
+
+(async () => {{
+{body}
+await log.shutdown();
+}})();
+"#,
+                log_url = log_url,
+                escalate_url = escalate_url,
+                body = body,
+            );
+            let script_path = tmp.path().join("deno_log_helper.ts");
+            std::fs::write(&script_path, script).expect("write helper script");
+            script_path
+        }
+
+        /// Run the helper, drain framed escalate frames from the
+        /// subprocess's stdout, dispatch each `log` op into the host
+        /// JSONL pipeline. Returns frame count, or `None` when `deno`
+        /// or the SDK source isn't available.
+        fn run_and_drain(body: &str) -> Option<usize> {
+            let deno = deno_binary()?;
+            let sdk = streamlib_deno_path();
+            if !sdk.exists() {
+                return None;
+            }
+            let tmp = TempDir::new().unwrap();
+            let script = write_helper_script(&tmp, &sdk, body);
+
+            let mut child = Command::new(deno)
+                .arg("run")
+                .arg("--quiet")
+                .arg("--allow-read")
+                .arg("--allow-env")
+                .arg("--no-prompt")
+                .arg(&script)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("spawn deno");
+
+            // Subprocess never reads from stdin; close it so the writer
+            // task can drain and shutdown returns cleanly.
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(&[]);
+            }
+
+            let stdout = child.stdout.take().expect("child stdout");
+            let mut reader = BufReader::new(stdout);
+            let mut frame_count = 0usize;
+
+            loop {
+                let mut len_buf = [0u8; 4];
+                match reader.read_exact(&mut len_buf) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => panic!("bridge read failed: {e}"),
+                }
+                let len = u32::from_be_bytes(len_buf) as usize;
+                let mut buf = vec![0u8; len];
+                reader.read_exact(&mut buf).expect("read frame body");
+                let value: serde_json::Value =
+                    serde_json::from_slice(&buf).expect("valid JSON frame");
+                let parsed = match try_parse_escalate_request(&value) {
+                    Some(Ok(op)) => op,
+                    Some(Err(e)) => panic!("escalate decode failed: {}", e.message),
+                    None => panic!(
+                        "deno subprocess only sends escalate traffic; got {value}"
+                    ),
+                };
+                if let EscalateRequest::Log(log_op) = parsed {
+                    push_polyglot_record(log_record_from_wire(log_op));
+                    frame_count += 1;
+                } else {
+                    panic!("unexpected escalate op from helper snippet");
+                }
+            }
+
+            // Drain stderr for diagnostics.
+            if let Some(mut stderr) = child.stderr.take() {
+                let mut s = String::new();
+                let _ = stderr.read_to_string(&mut s);
+                if !s.is_empty() {
+                    eprintln!("deno subprocess stderr:\n{s}");
+                }
+            }
+
+            let _ = child.wait();
+            Some(frame_count)
+        }
+
+        /// `streamlib.log.info("hi", ...)` from Deno surfaces in the
+        /// host JSONL with `source=deno`, correct message, level, and
+        /// context fields.
+        #[test]
+        #[serial]
+        fn deno_log_surfaces_in_host_jsonl() {
+            let (_tmp, guard) = install_logging("DenoLogSurf");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let body = r#"log.info("hi from deno", { count: 7 });"#;
+            let frames = match run_and_drain(body) {
+                Some(n) => n,
+                None => {
+                    println!(
+                        "deno or streamlib-deno source missing — skipping"
+                    );
+                    return;
+                }
+            };
+            assert!(frames >= 1, "expected at least one frame, got {frames}");
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| {
+                    e.source == Source::Deno && e.message == "hi from deno"
+                })
+                .unwrap_or_else(|| panic!("no deno record; got {events:#?}"));
+            assert_eq!(record.level, LogLevel::Info);
+            assert_eq!(record.pipeline_id.as_deref(), Some("pl-test"));
+            assert_eq!(record.processor_id.as_deref(), Some("pr-test"));
+            assert_eq!(
+                record.attrs.get("count").and_then(|v| v.as_i64()),
+                Some(7)
+            );
+            assert!(record.host_ts > 0);
+        }
+
+        /// A burst of 20 records arrives fully ordered and distinct —
+        /// FIFO holds across the queue → writer-task → length-prefixed-
+        /// frame → wire path.
+        #[test]
+        #[serial]
+        fn deno_log_burst_preserves_order() {
+            let (_tmp, guard) = install_logging("DenoLogBurst");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let body = r#"for (let i = 0; i < 20; i++) log.info("burst", { index: i });"#;
+            let frames = match run_and_drain(body) {
+                Some(n) => n,
+                None => {
+                    println!("deno missing — skipping");
+                    return;
+                }
+            };
+            assert_eq!(frames, 20, "subprocess should emit all 20 frames");
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let indices: Vec<i64> = events
+                .iter()
+                .filter(|e| e.source == Source::Deno && e.message == "burst")
+                .filter_map(|e| e.attrs.get("index").and_then(|v| v.as_i64()))
+                .collect();
+            assert_eq!(indices.len(), 20, "all 20 records should land");
+            assert_eq!(
+                indices,
+                (0..20).collect::<Vec<i64>>(),
+                "order must match emission order"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Mirrors the Python producer (#443) on the Deno side. Adds a unified
`streamlib.log.{trace,debug,info,warn,error}` API in the Deno SDK with a
bounded lossy queue, a writer task that drains via
`EscalateChannel.logFireAndForget`, and JS-level interceptors on
`console.*` and `Deno.stdout/stderr.write`. Subprocess-side records
land in the host JSONL pipeline with `source=deno`, joining the
`source=python` and `source=rust` records already shipping.

Host-side, switches `spawn_deno_subprocess_op.rs` from
`Stdio::inherit()` stderr to `Stdio::piped()` and adds an fd2 forwarder
thread tagging records as `intercepted=true, channel="fd2",
source="deno"` — defense-in-depth for native modules that bypass the
JS-level interceptors.

## Closes

Closes #444

## Exit criteria (from issue)

### Deno SDK surface
- [x] `streamlib.log` exposes `trace`/`debug`/`info`/`warn`/`error`
- [x] Each call builds a `{op:"log", ...}` payload using the generated
      bindings from #442 — `source="deno"`, monotonic `source_seq`,
      ISO8601 `source_ts`, `level`, `message`, `attrs`, optional
      `pipeline_id` / `processor_id` from AsyncLocalStorage
- [x] Bounded local queue (lossy drop-oldest, default 65536)
- [x] Synthetic `dropped=N` heartbeat every 1 s or 1000 drops

### Subprocess interceptors (JS-level)
- [x] `globalThis.console.{log,info,debug,warn,error}` overridden to
      route through `streamlib.log.*` with `intercepted: true,
      channel: "console.<level>"`
- [x] `Deno.stdout` / `Deno.stderr` `.write` / `.writeSync`
      monkey-patched in place (per AI notes — replacing the whole
      object breaks Deno runtime internals)
- [x] Line-buffered: one record per `\n`, partial tail flushes on
      uninstall

### Subprocess interceptors (fd-level, parent-side)
- [x] `spawn_deno_subprocess_op.rs` pipes stderr and forwards lines as
      `tracing::warn!(intercepted=true, channel="fd2", source="deno",
      processor_id=...)` with target `streamlib::polyglot::deno`

### Audit
- [x] `console.error` removed from every first-party
      `libs/streamlib-deno/**/*.ts` (subprocess_runner.ts +
      context.ts) — basis for #441 lint enforcement
- [ ] `cargo xtask lint-logging` enforcement — gated on #441

## Test plan

### Deno SDK + host round-trip (Rust E2E)
- [x] `deno_subprocess::deno_log_surfaces_in_host_jsonl` — spawns real
      `deno run`, asserts JSONL has `source=deno, message="hi from
      deno", count=7, pl/pr-test`
- [x] `deno_subprocess::deno_log_burst_preserves_order` — 20 records,
      FIFO across queue → writer task → wire → host

### Deno-side unit tests (`log_test.ts`)
- [x] `console.log` intercepted with `channel: "console.log"`
- [x] `console.{warn,error,info,debug}` route to matching channels +
      streamlib level
- [x] `Deno.stdout.write` line-buffered → `channel: "stdout"`
- [x] `Deno.stderr.write` line-buffered → `channel: "stderr"`
- [x] Multi-line write produces one record per newline
- [x] Partial trailing line buffers until next newline / uninstall
- [x] Bounded queue drops oldest; drop count surfaces
- [x] Writer task drains queued records via channel
- [x] AsyncLocalStorage processor context overrides ambient
- [x] Monotonic `source_seq`, ISO8601 `source_ts`

### Audit
- [x] `console.*` removed from `libs/streamlib-deno/{subprocess_runner,context}.ts`
- [x] Existing Deno SDK integration tests still pass
      (`context_test.ts` migrated to drain the log queue)

### Cross-language coherence
- [ ] `cross_language_source_seq_monotonic_within_source` — deferred
      (cross-cutting; touches Python state)

### Test gate results

- `cargo test --workspace` (with standard excludes per
  docs/testing-baseline.md): **905 passed, 0 failed, 21 ignored**
  (up from 901 in #443 — +2 new Rust E2E tests + 2 already-landed)
- `deno test libs/streamlib-deno`: **36 passed, 0 failed**
- `cargo check` + `deno check`: clean

## Follow-ups

- **#451** — fd1 native-module interception (impossible while fd1 is
  the IPC transport; needs a dedicated fd pair). The deferred
  `deno_fd1_native_module_captured` test belongs there.
- **#447** — hot-path latency bench (`deno_hot_path_latency`)
- **#441** — `cargo xtask lint-logging` enforcement against
  `libs/streamlib-deno/`
- Cross-language `source_seq_monotonic_within_source` test — file as a
  separate issue if/when needed; not strictly required for this PR
  since each runtime is independently verified.

## Polyglot coverage

- **Runtimes affected**: deno (primary), rust (host-side fd2
  forwarder; shares infra introduced in #443)
- **Schema regenerated**: n/a (consumed from #442)
- **E2E tests run**:
  - [x] Host-Rust: `deno_subprocess::deno_log_surfaces_in_host_jsonl`
        + `deno_log_burst_preserves_order` — real `deno run` spawn,
        framed IPC drained, JSONL asserted
  - [x] Deno subprocess: 18 `Deno.test` cases via `deno test`
  - [x] Python subprocess: n/a (covered by #443)
- **FD-passing path**: n/a (log op carries no fds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)