### PR TITLE
feat(polyglot): dedicated IPC fd pair — free fd1/fd2 for log capture

### DIFF
--- a/libs/streamlib-deno/escalate_fd.ts
+++ b/libs/streamlib-deno/escalate_fd.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Length-prefixed JSON framing over a raw, inherited file descriptor.
+ *
+ * Used by `subprocess_runner.ts` to speak the escalate IPC protocol over
+ * the dedicated `AF_UNIX` socketpair advertised by the host via
+ * `STREAMLIB_ESCALATE_FD`. Previously the framing rode on
+ * `Deno.stdin` / `Deno.stdout`; moving it off fd0/fd1 frees those for
+ * host-side `intercepted` log capture (see #451).
+ *
+ * Deno has no stable API to wrap an existing fd as a duplex stream, so
+ * we bind the libc `read(2)` / `write(2)` syscalls via FFI. Nonblocking
+ * mode lets the calls run on Deno's FFI worker threads without stalling
+ * the event loop.
+ */
+
+const LIBC_SYMBOLS = {
+  read: {
+    parameters: ["i32", "buffer", "usize"],
+    result: "isize",
+    nonblocking: true,
+  },
+  write: {
+    parameters: ["i32", "buffer", "usize"],
+    result: "isize",
+    nonblocking: true,
+  },
+} as const;
+
+type LibcHandle = Deno.DynamicLibrary<typeof LIBC_SYMBOLS>;
+
+let _libc: LibcHandle | null = null;
+
+function libcPath(): string {
+  // Linux is the only supported target for subprocess-host polyglot
+  // work today. macOS support will land with the macOS milestone; add
+  // the `libc.dylib` branch then.
+  if (Deno.build.os === "darwin") return "libc.dylib";
+  return "libc.so.6";
+}
+
+function libc(): LibcHandle {
+  if (_libc) return _libc;
+  _libc = Deno.dlopen(libcPath(), LIBC_SYMBOLS);
+  return _libc;
+}
+
+/**
+ * Resolve the inherited escalate socketpair fd from
+ * `STREAMLIB_ESCALATE_FD`. Throws when the env var is missing or
+ * unparseable — the host always sets it, so a missing value indicates
+ * a spawn-path regression.
+ */
+export function resolveEscalateFd(): number {
+  const raw = Deno.env.get("STREAMLIB_ESCALATE_FD");
+  if (!raw) {
+    throw new Error(
+      "STREAMLIB_ESCALATE_FD not set — escalate IPC transport unavailable",
+    );
+  }
+  const fd = Number.parseInt(raw, 10);
+  if (!Number.isFinite(fd) || fd < 0) {
+    throw new Error(`STREAMLIB_ESCALATE_FD is not a valid fd: ${raw}`);
+  }
+  return fd;
+}
+
+async function readExact(
+  fd: number,
+  buf: Uint8Array<ArrayBuffer>,
+): Promise<void> {
+  const sym = libc().symbols.read;
+  let offset = 0;
+  while (offset < buf.byteLength) {
+    const slice = buf.subarray(offset) as Uint8Array<ArrayBuffer>;
+    const n = Number(await sym(fd, slice, BigInt(slice.byteLength)));
+    if (n === 0) {
+      throw new Error("escalate fd closed");
+    }
+    if (n < 0) {
+      throw new Error(`escalate fd read failed (errno-style: ${n})`);
+    }
+    offset += n;
+  }
+}
+
+async function writeAll(
+  fd: number,
+  buf: Uint8Array<ArrayBuffer>,
+): Promise<void> {
+  const sym = libc().symbols.write;
+  let offset = 0;
+  while (offset < buf.byteLength) {
+    const slice = buf.subarray(offset) as Uint8Array<ArrayBuffer>;
+    const n = Number(await sym(fd, slice, BigInt(slice.byteLength)));
+    if (n < 0) {
+      throw new Error(`escalate fd write failed (errno-style: ${n})`);
+    }
+    offset += n;
+  }
+}
+
+/**
+ * Read one length-prefixed JSON frame from `fd`. Throws on short read
+ * (fd closed mid-frame) or malformed JSON.
+ */
+export async function readFrame(fd: number): Promise<Record<string, unknown>> {
+  const lenBuf = new Uint8Array(new ArrayBuffer(4));
+  await readExact(fd, lenBuf);
+  const len = new DataView(lenBuf.buffer).getUint32(0, false);
+  const msgBuf = new Uint8Array(new ArrayBuffer(len));
+  await readExact(fd, msgBuf);
+  const text = new TextDecoder().decode(msgBuf);
+  return JSON.parse(text);
+}
+
+/**
+ * Write one length-prefixed JSON frame to `fd`. The caller must hold
+ * the shared write lock so concurrent writes can't interleave framing
+ * bytes.
+ */
+export async function writeFrame(
+  fd: number,
+  msg: Record<string, unknown>,
+): Promise<void> {
+  const text = JSON.stringify(msg);
+  const encodedRaw = new TextEncoder().encode(text);
+  const encoded = new Uint8Array(new ArrayBuffer(encodedRaw.byteLength));
+  encoded.set(encodedRaw);
+  const lenBuf = new Uint8Array(new ArrayBuffer(4));
+  new DataView(lenBuf.buffer).setUint32(0, encoded.byteLength, false);
+  await writeAll(fd, lenBuf);
+  await writeAll(fd, encoded);
+}
+
+/**
+ * Close the libc FFI handle. Safe to call multiple times; used during
+ * subprocess shutdown.
+ */
+export function closeLibcHandle(): void {
+  if (_libc) {
+    _libc.close();
+    _libc = null;
+  }
+}

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -23,6 +23,12 @@ import {
   NativeRuntimeContextLimitedAccess,
 } from "./context.ts";
 import { EscalateChannel } from "./escalate.ts";
+import {
+  closeLibcHandle,
+  readFrame as readEscalateFrame,
+  resolveEscalateFd,
+  writeFrame as writeEscalateFrame,
+} from "./escalate_fd.ts";
 import * as log from "./log.ts";
 import type {
   ContinuousProcessor,
@@ -47,53 +53,33 @@ function fatalPreInstall(message: string): never {
 }
 
 // ============================================================================
-// Bridge protocol (length-prefixed JSON over stdin/stdout)
+// Bridge protocol — length-prefixed JSON over the dedicated
+// `STREAMLIB_ESCALATE_FD` socketpair. fd0/fd1 stay free for log capture
+// (see #451).
 // ============================================================================
 
-const stdin = Deno.stdin;
-const stdout = Deno.stdout;
+let _escalateFd = -1;
+
+function escalateFd(): number {
+  if (_escalateFd < 0) _escalateFd = resolveEscalateFd();
+  return _escalateFd;
+}
 
 async function bridgeReadJson(): Promise<Record<string, unknown>> {
-  const lenBuf = new Uint8Array(4);
-  let bytesRead = 0;
-  while (bytesRead < 4) {
-    const n = await stdin.read(lenBuf.subarray(bytesRead));
-    if (n === null) throw new Error("stdin closed");
-    bytesRead += n;
-  }
-
-  const view = new DataView(lenBuf.buffer);
-  const len = view.getUint32(0, false); // big-endian
-
-  const msgBuf = new Uint8Array(len);
-  bytesRead = 0;
-  while (bytesRead < len) {
-    const n = await stdin.read(msgBuf.subarray(bytesRead));
-    if (n === null) throw new Error("stdin closed");
-    bytesRead += n;
-  }
-
-  const text = new TextDecoder().decode(msgBuf);
-  return JSON.parse(text);
+  return await readEscalateFrame(escalateFd());
 }
 
 async function bridgeSendJson(msg: Record<string, unknown>): Promise<void> {
-  const text = JSON.stringify(msg);
-  const encoded = new TextEncoder().encode(text);
-  const lenBuf = new Uint8Array(4);
-  const view = new DataView(lenBuf.buffer);
-  view.setUint32(0, encoded.length, false); // big-endian
-
-  // Serialize concurrent writes (lifecycle replies + escalate requests) so
-  // the length prefix and payload aren't interleaved across async tasks.
+  // Serialize concurrent writes (lifecycle replies + escalate requests)
+  // so the length prefix and payload aren't interleaved across async
+  // tasks sharing the same fd.
   await writeLock;
   let release: () => void;
   writeLock = new Promise<void>((resolve) => {
     release = resolve;
   });
   try {
-    await stdout.write(lenBuf);
-    await stdout.write(encoded);
+    await writeEscalateFrame(escalateFd(), msg);
   } finally {
     release!();
   }
@@ -170,6 +156,7 @@ async function main(): Promise<void> {
       error: String(e),
     });
     await bridgeSendJson({ rpc: "error", error: `Failed to load native lib: ${e}` });
+    closeLibcHandle();
     await log.shutdown();
     Deno.exit(1);
   }
@@ -180,6 +167,7 @@ async function main(): Promise<void> {
   if (ctxPtr === null) {
     log.error("Failed to create native context", { processor_id: processorId });
     await bridgeSendJson({ rpc: "error", error: "Failed to create native context" });
+    closeLibcHandle();
     await log.shutdown();
     Deno.exit(1);
   }
@@ -505,6 +493,7 @@ async function main(): Promise<void> {
             }
             lib.symbols.sldn_context_destroy(ctxPtr);
             lib.close();
+            closeLibcHandle();
             await log.shutdown();
             Deno.exit(0);
           }
@@ -570,6 +559,7 @@ async function main(): Promise<void> {
           // Cleanup native context
           lib.symbols.sldn_context_destroy(ctxPtr);
           lib.close();
+          closeLibcHandle();
           await log.shutdown();
           Deno.exit(0);
         }
@@ -581,9 +571,10 @@ async function main(): Promise<void> {
       }
     }
   } catch (e) {
-    const isStdinClosed = e instanceof Error && e.message === "stdin closed";
-    if (isStdinClosed) {
-      log.info("stdin closed, shutting down");
+    const isEscalateClosed = e instanceof Error &&
+      e.message === "escalate fd closed";
+    if (isEscalateClosed) {
+      log.info("escalate fd closed, shutting down");
     } else {
       log.error("Fatal error", { error: String(e) });
     }
@@ -597,8 +588,9 @@ async function main(): Promise<void> {
     escalateChannel.cancelAll("subprocess shutting down");
     lib.symbols.sldn_context_destroy(ctxPtr);
     lib.close();
+    closeLibcHandle();
     await log.shutdown();
-    Deno.exit(isStdinClosed ? 0 : 1);
+    Deno.exit(isEscalateClosed ? 0 : 1);
   }
 }
 

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -5,7 +5,9 @@
 
 Entry point for Python subprocess processors spawned by the Rust runtime.
 Lifecycle commands (setup/run/stop/teardown) use length-prefixed JSON over
-stdin/stdout pipes. Data I/O uses direct iceoryx2 FFI via
+a dedicated Unix-domain socketpair advertised via STREAMLIB_ESCALATE_FD;
+fd1/fd2 stay as free log pipes that the host captures as `intercepted`
+records in the unified JSONL. Data I/O uses direct iceoryx2 FFI via
 libstreamlib_python_native.
 
 Usage:
@@ -17,11 +19,14 @@ Environment variables:
     STREAMLIB_PYTHON_NATIVE_LIB: Path to libstreamlib_python_native.dylib
     STREAMLIB_PROCESSOR_ID: Unique processor ID
     STREAMLIB_EXECUTION_MODE: "reactive", "continuous", or "manual"
+    STREAMLIB_ESCALATE_FD: Inherited child-end fd of the escalate IPC
+        socketpair (decimal). The host sets this before spawn.
 """
 
 import importlib
 import os
 import select
+import socket
 import sys
 import time
 import traceback
@@ -37,6 +42,38 @@ from .processor_context import (
     compute_read_buf_bytes,
     load_native_lib,
 )
+
+
+def _open_escalate_fd_stream():
+    """Resolve STREAMLIB_ESCALATE_FD and return `(read_stream, write_stream, socket)`.
+
+    Both streams wrap the inherited socketpair fd; the `socket` return is
+    kept alive so the underlying fd stays open for the life of the
+    subprocess. Exits with code 1 if the env var is missing or unparseable
+    — the host always sets it, so a missing value indicates a spawn-path
+    regression.
+    """
+    raw = os.environ.get("STREAMLIB_ESCALATE_FD")
+    if not raw:
+        sys.stderr.write(
+            "[streamlib] STREAMLIB_ESCALATE_FD not set — "
+            "escalate IPC transport unavailable\n"
+        )
+        sys.stderr.flush()
+        sys.exit(1)
+    try:
+        fd = int(raw)
+    except ValueError:
+        sys.stderr.write(
+            f"[streamlib] STREAMLIB_ESCALATE_FD is not an integer: {raw!r}\n"
+        )
+        sys.stderr.flush()
+        sys.exit(1)
+
+    sock = socket.socket(fileno=fd)
+    reader = sock.makefile("rb", buffering=0)
+    writer = sock.makefile("wb", buffering=0)
+    return reader, writer, sock
 
 
 def _load_processor_class(entrypoint: str, project_path: str):
@@ -275,15 +312,15 @@ def main():
         sys.stderr.flush()
         sys.exit(1)
 
-    # Use binary stdin/stdout for the lifecycle protocol. Capture these
-    # references BEFORE installing the stdio interceptors so the bridge
-    # keeps writing framed IPC traffic to the real fd1.
-    stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Bridge framing rides a dedicated socketpair, not stdin/stdout —
+    # fd1/fd2 stay as log pipes (see #451). Capture the escalate fds
+    # BEFORE installing the stdio interceptors so the bridge never
+    # touches sys.stdin/sys.stdout.
+    stdin, stdout, _escalate_sock = _open_escalate_fd_stream()
 
     # Install the escalate channel so processors can call ctx.escalate_*
-    # during setup() and process(). The channel shares the same stdio pipes
-    # as the lifecycle protocol and demultiplexes responses by request_id.
+    # during setup() and process(). The channel demultiplexes responses
+    # by request_id.
     escalate_channel = EscalateChannel(stdin, stdout)
     install_channel(escalate_channel)
 

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -15,7 +15,7 @@ use crate::core::{
     ProcessorDescriptor, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
 
-use super::subprocess_bridge::SubprocessBridge;
+use super::subprocess_bridge::{spawn_fd_line_reader, EscalateTransport, SubprocessBridge};
 
 // ============================================================================
 // DenoSubprocessHostProcessor — Rust host for Deno subprocess processors
@@ -136,12 +136,6 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 .arg(runner_path.to_str().unwrap_or(""))
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
-                // Pipe stderr (was inherit) so we can intercept fd2 writes
-                // — both Deno runtime chatter and any third-party native
-                // module writing directly to fd2 — and surface them as
-                // `intercepted=true, channel="fd2", source="deno"` records
-                // in the unified JSONL pipeline. fd1 is reserved for the
-                // length-prefixed IPC channel and is NOT captured. See #444.
                 .stderr(Stdio::piped())
                 .env("STREAMLIB_ENTRYPOINT", &self.entrypoint)
                 .env(
@@ -155,6 +149,12 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
             #[cfg(target_os = "linux")]
             command.env("STREAMLIB_BROKER_SOCKET", ctx.surface_socket_path());
 
+            // Escalate IPC rides a dedicated `AF_UNIX` socketpair, not
+            // fd1/fd2, so the subprocess's stdout/stderr can be captured
+            // as `intercepted` log pipes without corrupting the framed
+            // JSON protocol. See #451.
+            let mut escalate_transport = EscalateTransport::attach(&mut command)?;
+
             let mut child = command.spawn()
                 .map_err(|e| {
                     StreamError::Runtime(format!(
@@ -163,6 +163,8 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                     ))
                 })?;
 
+            escalate_transport.release_child_end();
+
             let child_pid = child.id();
             tracing::info!(
                 "[{}] Deno subprocess spawned: pid={}",
@@ -170,52 +172,38 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                 child_pid
             );
 
-            let stdin = child.stdin.take().ok_or_else(|| {
-                StreamError::Runtime("Failed to capture subprocess stdin".to_string())
-            })?;
-            let stdout = child.stdout.take().ok_or_else(|| {
-                StreamError::Runtime("Failed to capture subprocess stdout".to_string())
-            })?;
-
-            // Defense-in-depth log capture on the subprocess's fd2 (stderr).
-            // Records are tagged `intercepted=true, channel="fd2",
-            // source="deno"` so a JSONL consumer can tell these apart from
-            // first-party `streamlib.log.*` records. fd1 is reserved for
-            // the length-prefixed IPC channel and is NOT captured — any
-            // raw writes to fd1 would desynchronize bridge framing. See
-            // #444 / #451.
+            // Capture fd1 and fd2 from the subprocess as `intercepted`
+            // log pipes. Each line produced on either pipe surfaces as
+            // `tracing::warn!(intercepted=true, channel="fd1"|"fd2",
+            // source="deno")` in the unified JSONL. fd1 used to be
+            // reserved for framed IPC; #451 moved IPC to a socketpair
+            // so fd1 is now free to capture raw writes.
+            if let Some(stdout) = child.stdout.take() {
+                spawn_fd_line_reader(
+                    stdout,
+                    "dn-stdout",
+                    "fd1",
+                    &self.processor_id,
+                );
+            }
             if let Some(stderr) = child.stderr.take() {
-                let proc_id = self.processor_id.clone();
-                std::thread::Builder::new()
-                    .name(format!("dn-stderr-{}", &proc_id[..8.min(proc_id.len())]))
-                    .spawn(move || {
-                        use std::io::{BufRead, BufReader};
-                        let reader = BufReader::new(stderr);
-                        for line in reader.lines() {
-                            match line {
-                                Ok(text) if !text.is_empty() => {
-                                    tracing::warn!(
-                                        target: "streamlib::polyglot::deno",
-                                        intercepted = true,
-                                        channel = "fd2",
-                                        source = "deno",
-                                        processor_id = %proc_id,
-                                        "{}",
-                                        text
-                                    );
-                                }
-                                Err(_) => break,
-                                _ => {}
-                            }
-                        }
-                    })
-                    .ok();
+                spawn_fd_line_reader(
+                    stderr,
+                    "dn-stderr",
+                    "fd2",
+                    &self.processor_id,
+                );
             }
 
             // Clone the sandbox so the bridge reader thread can dispatch
             // escalate requests on behalf of the subprocess.
             let sandbox = ctx.gpu_limited_access().clone();
-            let bridge = SubprocessBridge::new(stdin, stdout, sandbox, self.processor_id.clone());
+            let escalate_stream = escalate_transport.into_parent_stream();
+            let bridge = SubprocessBridge::new(
+                escalate_stream,
+                sandbox,
+                self.processor_id.clone(),
+            )?;
 
             self.child = Some(child);
             self.bridge = Some(bridge);

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::io::BufReader;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
@@ -17,7 +16,7 @@ use crate::core::{
 };
 
 use super::spawn_python_subprocess_op::ensure_processor_venv;
-use super::subprocess_bridge::SubprocessBridge;
+use super::subprocess_bridge::{spawn_fd_line_reader, EscalateTransport, SubprocessBridge};
 
 // ============================================================================
 // PythonNativeSubprocessHostProcessor — Rust host for Python native-mode processors
@@ -141,6 +140,12 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
             #[cfg(target_os = "linux")]
             command.env("STREAMLIB_BROKER_SOCKET", ctx.surface_socket_path());
 
+            // Escalate IPC rides a dedicated `AF_UNIX` socketpair, not
+            // fd1/fd2, so the subprocess's stdout/stderr can be captured
+            // as `intercepted` log pipes without corrupting the framed
+            // JSON protocol. See #451.
+            let mut escalate_transport = EscalateTransport::attach(&mut command)?;
+
             let mut child = command.spawn()
                 .map_err(|e| {
                     StreamError::Runtime(format!(
@@ -149,6 +154,10 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                     ))
                 })?;
 
+            // Drop the parent's reference to the child-end socketpair fd
+            // so only the subprocess keeps it open.
+            escalate_transport.release_child_end();
+
             let child_pid = child.id();
             tracing::info!(
                 "[{}] Python native subprocess spawned: pid={}",
@@ -156,52 +165,38 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                 child_pid
             );
 
-            let stdin = child.stdin.take().ok_or_else(|| {
-                StreamError::Runtime("Failed to capture subprocess stdin".to_string())
-            })?;
-            let stdout = child.stdout.take().ok_or_else(|| {
-                StreamError::Runtime("Failed to capture subprocess stdout".to_string())
-            })?;
-
-            // Defense-in-depth log capture on the subprocess's fd2 (stderr).
-            // Records are tagged `intercepted=true, channel="fd2",
-            // source="python"` so a consumer of the unified JSONL can tell
-            // these apart from first-party `streamlib.log.*` records. fd1 is
-            // reserved for the length-prefixed IPC channel and is NOT
-            // captured — any raw writes to fd1 would desynchronize the
-            // bridge framing. See #443.
+            // Capture fd1 and fd2 from the subprocess as `intercepted`
+            // log pipes. Each line produced on either pipe surfaces as
+            // `tracing::warn!(intercepted=true, channel="fd1"|"fd2",
+            // source="python")` in the unified JSONL. This catches both
+            // raw C-extension writes (`os.write(1, …)`, C `printf`) and
+            // anything else bypassing the `streamlib.log` pathway.
+            if let Some(stdout) = child.stdout.take() {
+                spawn_fd_line_reader(
+                    stdout,
+                    "py-stdout",
+                    "fd1",
+                    &self.processor_id,
+                );
+            }
             if let Some(stderr) = child.stderr.take() {
-                let proc_id = self.processor_id.clone();
-                std::thread::Builder::new()
-                    .name(format!("py-stderr-{}", &proc_id[..8.min(proc_id.len())]))
-                    .spawn(move || {
-                        use std::io::BufRead;
-                        let reader = BufReader::new(stderr);
-                        for line in reader.lines() {
-                            match line {
-                                Ok(text) if !text.is_empty() => {
-                                    tracing::warn!(
-                                        target: "streamlib::polyglot::python",
-                                        intercepted = true,
-                                        channel = "fd2",
-                                        source = "python",
-                                        processor_id = %proc_id,
-                                        "{}",
-                                        text
-                                    );
-                                }
-                                Err(_) => break,
-                                _ => {}
-                            }
-                        }
-                    })
-                    .ok();
+                spawn_fd_line_reader(
+                    stderr,
+                    "py-stderr",
+                    "fd2",
+                    &self.processor_id,
+                );
             }
 
             // Clone the sandbox for the bridge reader thread so escalate
             // requests can be served on behalf of the subprocess.
             let sandbox = ctx.gpu_limited_access().clone();
-            let bridge = SubprocessBridge::new(stdin, stdout, sandbox, self.processor_id.clone());
+            let escalate_stream = escalate_transport.into_parent_stream();
+            let bridge = SubprocessBridge::new(
+                escalate_stream,
+                sandbox,
+                self.processor_id.clone(),
+            )?;
 
             self.child = Some(child);
             self.bridge = Some(bridge);

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_bridge.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_bridge.rs
@@ -1,26 +1,36 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Length-prefixed JSON stdio bridge shared by the Python and Deno
+//! Length-prefixed JSON escalate-IPC bridge shared by the Python and Deno
 //! subprocess host processors.
 //!
-//! Two roles travel over the same pair of pipes:
+//! Frames travel over a dedicated [`UnixStream`] pair created by
+//! [`EscalateTransport::attach`] before spawn — not over the subprocess's
+//! stdin/stdout. The parent keeps one half of the socketpair and the
+//! child inherits the other via `STREAMLIB_ESCALATE_FD`, freeing fd1/fd2
+//! to be captured as intercepted log pipes by the host.
+//!
+//! Two roles travel over the same socket:
 //! 1. Lifecycle RPC (`setup`, `run`, `stop`, `teardown`, `on_pause`,
 //!    `on_resume`, …) — initiated by the host, the subprocess replies with
 //!    `rpc: "ready" | "stopped" | "ok" | "done" | "error"`.
 //! 2. Escalate-on-behalf (`rpc: "escalate_request"`) — initiated by the
 //!    subprocess, the host replies with `rpc: "escalate_response"`.
 //!
-//! A dedicated reader thread (`bridge-reader-…`) owns the subprocess stdout
-//! and demultiplexes incoming messages: escalate requests are dispatched
+//! A dedicated reader thread (`br-…`) owns the parent-side read half and
+//! demultiplexes incoming messages: escalate requests are dispatched
 //! inline through [`subprocess_escalate::process_bridge_message`], and
 //! anything else is forwarded to the main thread over an mpsc channel for
-//! the lifecycle RPC to consume. Writes in both directions serialize through
-//! a shared `Arc<Mutex<BufWriter<ChildStdin>>>` so the main thread and the
-//! reader thread can't interleave halves of a length-prefixed frame.
+//! the lifecycle RPC to consume. Writes in both directions serialize
+//! through a shared `Arc<Mutex<BufWriter<UnixStream>>>` so the main
+//! thread and the reader thread can't interleave halves of a
+//! length-prefixed frame.
 
 use std::io::{BufReader, BufWriter, Read, Write};
-use std::process::{ChildStdin, ChildStdout};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -31,15 +41,83 @@ use crate::core::error::{Result, StreamError};
 
 use super::subprocess_escalate::{process_bridge_message, EscalateHandleRegistry};
 
-/// Shared writer handle. The host's lifecycle path and the reader thread's
-/// escalate-response path both write through this mutex.
-type SharedWriter = Arc<Mutex<BufWriter<ChildStdin>>>;
+/// Env var advertising the inherited child-end fd number of the escalate
+/// socketpair. The subprocess opens this fd as a duplex UNIX socket and
+/// uses it as the framed-IPC transport.
+pub(crate) const ESCALATE_FD_ENV: &str = "STREAMLIB_ESCALATE_FD";
 
-/// Bridge for one subprocess. Drop the value to tear the reader thread down
-/// cleanly (stdin close propagates EOF; reader thread exits).
+/// Socketpair-backed escalate IPC transport. The parent holds one half
+/// and the subprocess inherits the other via [`ESCALATE_FD_ENV`].
+pub(crate) struct EscalateTransport {
+    parent_end: UnixStream,
+    /// Kept alive so the child fd stays open across `Command::spawn`. The
+    /// caller drops this after spawn so only the subprocess holds the
+    /// child end.
+    child_end: Option<UnixStream>,
+}
+
+impl EscalateTransport {
+    /// Create a socketpair, register `pre_exec` on `command` to clear
+    /// `FD_CLOEXEC` on the child-end fd, and set [`ESCALATE_FD_ENV`] on
+    /// the command's environment.
+    ///
+    /// After `command.spawn()`, call [`Self::release_child_end`] so only
+    /// the subprocess retains the child-side fd.
+    pub(crate) fn attach(command: &mut Command) -> Result<Self> {
+        let (parent_end, child_end) = UnixStream::pair().map_err(|e| {
+            StreamError::Runtime(format!("failed to create escalate socketpair: {e}"))
+        })?;
+
+        let child_fd: RawFd = child_end.as_raw_fd();
+
+        // Clear FD_CLOEXEC on the child-end fd between fork and exec so
+        // the execed subprocess inherits it. `fcntl` is async-signal-safe
+        // so it's legal to call from `pre_exec`.
+        unsafe {
+            command.pre_exec(move || {
+                let flags = libc::fcntl(child_fd, libc::F_GETFD);
+                if flags < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let rc = libc::fcntl(child_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+                if rc < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        command.env(ESCALATE_FD_ENV, child_fd.to_string());
+
+        Ok(Self {
+            parent_end,
+            child_end: Some(child_end),
+        })
+    }
+
+    /// Drop the parent's reference to the child-end fd. Call this after
+    /// `command.spawn()` succeeds so only the subprocess keeps it open.
+    pub(crate) fn release_child_end(&mut self) {
+        self.child_end.take();
+    }
+
+    /// Consume the transport and return the parent-side [`UnixStream`].
+    pub(crate) fn into_parent_stream(mut self) -> UnixStream {
+        self.child_end.take();
+        self.parent_end
+    }
+}
+
+/// Shared writer handle. The host's lifecycle path and the reader
+/// thread's escalate-response path both write through this mutex.
+type SharedWriter = Arc<Mutex<BufWriter<UnixStream>>>;
+
+/// Bridge for one subprocess. Drop the value to tear the reader thread
+/// down cleanly (shutdown the parent-side socket read half; reader
+/// thread exits on EOF).
 pub(crate) struct SubprocessBridge {
     processor_id: String,
-    stdin: SharedWriter,
+    writer: SharedWriter,
     lifecycle_rx: Receiver<serde_json::Value>,
     registry: Arc<EscalateHandleRegistry>,
     reader: Option<JoinHandle<()>>,
@@ -47,24 +125,28 @@ pub(crate) struct SubprocessBridge {
 }
 
 impl SubprocessBridge {
-    /// Wrap the subprocess pipes and spawn the reader thread.
+    /// Wrap a socketpair parent end and spawn the reader thread.
     ///
-    /// `sandbox` is cloned into the reader thread so escalate requests can
-    /// be dispatched without blocking the main thread. `processor_id` is
-    /// used for thread naming and tracing.
+    /// `sandbox` is cloned into the reader thread so escalate requests
+    /// can be dispatched without blocking the main thread. `processor_id`
+    /// is used for thread naming and tracing.
     pub(crate) fn new(
-        stdin: ChildStdin,
-        stdout: ChildStdout,
+        stream: UnixStream,
         sandbox: GpuContextLimitedAccess,
         processor_id: String,
-    ) -> Self {
-        let stdin: SharedWriter = Arc::new(Mutex::new(BufWriter::new(stdin)));
+    ) -> Result<Self> {
+        let read_half = stream.try_clone().map_err(|e| {
+            StreamError::Runtime(format!(
+                "failed to clone escalate socketpair for reader: {e}"
+            ))
+        })?;
+        let writer: SharedWriter = Arc::new(Mutex::new(BufWriter::new(stream)));
         let registry = EscalateHandleRegistry::new();
         let (tx, rx) = mpsc::channel();
         let dead = Arc::new(Mutex::new(false));
 
         let thread_name = thread_name(&processor_id);
-        let reader_stdin = Arc::clone(&stdin);
+        let reader_writer = Arc::clone(&writer);
         let reader_registry = Arc::clone(&registry);
         let reader_dead = Arc::clone(&dead);
         let reader_processor_id = processor_id.clone();
@@ -73,8 +155,8 @@ impl SubprocessBridge {
             .name(thread_name)
             .spawn(move || {
                 reader_loop(
-                    BufReader::new(stdout),
-                    reader_stdin,
+                    BufReader::new(read_half),
+                    reader_writer,
                     sandbox,
                     reader_registry,
                     tx,
@@ -84,17 +166,17 @@ impl SubprocessBridge {
             })
             .expect("failed to spawn bridge reader thread");
 
-        Self {
+        Ok(Self {
             processor_id,
-            stdin,
+            writer,
             lifecycle_rx: rx,
             registry,
             reader: Some(reader),
             dead,
-        }
+        })
     }
 
-    /// Write a length-prefixed JSON message to the subprocess stdin.
+    /// Write a length-prefixed JSON message to the subprocess.
     pub(crate) fn send(&self, msg: &serde_json::Value) -> Result<()> {
         if self.is_dead() {
             return Err(StreamError::Runtime(format!(
@@ -103,9 +185,9 @@ impl SubprocessBridge {
             )));
         }
         let mut writer = self
-            .stdin
+            .writer
             .lock()
-            .map_err(|_| StreamError::Runtime("subprocess stdin mutex poisoned".to_string()))?;
+            .map_err(|_| StreamError::Runtime("subprocess writer mutex poisoned".to_string()))?;
         write_frame(&mut *writer, msg).map_err(|e| {
             self.mark_dead();
             e
@@ -117,7 +199,7 @@ impl SubprocessBridge {
         self.lifecycle_rx.recv().map_err(|_| {
             self.mark_dead();
             StreamError::Runtime(format!(
-                "[{}] subprocess stdout closed before reply",
+                "[{}] subprocess escalate socket closed before reply",
                 self.processor_id
             ))
         })
@@ -153,27 +235,23 @@ impl Drop for SubprocessBridge {
     fn drop(&mut self) {
         self.mark_dead();
         self.registry.clear();
-        // Dropping stdin (and its Arc) isn't enough on its own because the
-        // reader thread holds a clone. We can't force the subprocess to
-        // close its stdout from this side, but the host processor's
-        // teardown() has already sent the teardown command and waited for
-        // the reply — at this point the subprocess has exited and the
-        // reader thread will see EOF. Join with a short timeout via
-        // `join()` on the handle we stashed.
+        // Shut down the write half so the reader thread sees EOF on its
+        // clone if the subprocess is still alive. The OS reaps the
+        // thread on process exit; we avoid blocking on join.
+        if let Ok(writer) = self.writer.lock() {
+            let _ = writer.get_ref().shutdown(std::net::Shutdown::Both);
+        }
         if let Some(reader) = self.reader.take() {
-            // Detach rather than join; the OS reaps the thread when the
-            // process exits. A blocking join here would deadlock if the
-            // subprocess is stuck and stdout hasn't closed.
             drop(reader);
         }
     }
 }
 
-/// Reader loop: drain stdout, dispatch escalate traffic, forward lifecycle
-/// responses to `lifecycle_tx`.
+/// Reader loop: drain the parent-side socket, dispatch escalate traffic,
+/// forward lifecycle responses to `lifecycle_tx`.
 fn reader_loop(
-    mut stdout: BufReader<ChildStdout>,
-    stdin: SharedWriter,
+    mut reader: BufReader<UnixStream>,
+    writer: SharedWriter,
     sandbox: GpuContextLimitedAccess,
     registry: Arc<EscalateHandleRegistry>,
     lifecycle_tx: mpsc::Sender<serde_json::Value>,
@@ -181,7 +259,7 @@ fn reader_loop(
     processor_id: String,
 ) {
     loop {
-        let msg = match read_frame(&mut stdout) {
+        let msg = match read_frame(&mut reader) {
             Ok(v) => v,
             Err(e) => {
                 tracing::debug!("[{}] bridge reader exiting: {}", processor_id, e);
@@ -194,12 +272,15 @@ fn reader_loop(
 
         if let Some(response) = process_bridge_message(&sandbox, &registry, &msg) {
             // Escalate request handled inline. Write response with the
-            // shared stdin lock.
+            // shared writer lock.
             let send_result: Result<()> = {
-                let mut writer = match stdin.lock() {
+                let mut writer = match writer.lock() {
                     Ok(g) => g,
                     Err(_) => {
-                        tracing::warn!("[{}] bridge reader saw poisoned stdin mutex", processor_id);
+                        tracing::warn!(
+                            "[{}] bridge reader saw poisoned writer mutex",
+                            processor_id
+                        );
                         break;
                     }
                 };
@@ -219,8 +300,8 @@ fn reader_loop(
             continue;
         }
 
-        // Lifecycle response — forward to main thread. Send failure means
-        // the receiver is gone (host dropped), exit cleanly.
+        // Lifecycle response — forward to main thread. Send failure
+        // means the receiver is gone (host dropped), exit cleanly.
         if lifecycle_tx.send(msg).is_err() {
             tracing::debug!(
                 "[{}] bridge reader exiting: lifecycle channel dropped",
@@ -231,9 +312,93 @@ fn reader_loop(
     }
 }
 
+/// Per-line reader that tags each non-empty line with
+/// `intercepted=true, channel=<channel>, source=python|deno` and emits
+/// it as a `tracing::warn!` event. Used by the Python and Deno spawn
+/// paths on the subprocess's fd1 (stdout) and fd2 (stderr). `channel`
+/// must be `"fd1"` or `"fd2"`; the source and tracing target are
+/// inferred from `thread_prefix` (`"py-…"` → python, `"dn-…"` → deno).
+///
+/// Captures the caller's current [`tracing::Dispatch`] and installs it
+/// as the reader thread's default, so events route through whatever
+/// subscriber the owning runtime installed (global for production,
+/// thread-local for `init_for_tests`).
+pub(crate) fn spawn_fd_line_reader<R>(
+    reader: R,
+    thread_prefix: &str,
+    channel: &'static str,
+    processor_id: &str,
+) -> Option<JoinHandle<()>>
+where
+    R: Read + Send + 'static,
+{
+    let proc_id = processor_id.to_string();
+    let short = &proc_id[..8.min(proc_id.len())];
+    let name = format!("{}-{}", thread_prefix, short);
+    let (source, target): (&'static str, &'static str) =
+        if thread_prefix.starts_with("py") {
+            ("python", "streamlib::polyglot::python")
+        } else {
+            ("deno", "streamlib::polyglot::deno")
+        };
+    let dispatch = tracing::dispatcher::get_default(|d| d.clone());
+
+    thread::Builder::new()
+        .name(name)
+        .spawn(move || {
+            use std::io::BufRead;
+            tracing::dispatcher::with_default(&dispatch, || {
+                let reader = BufReader::new(reader);
+                for line in reader.lines() {
+                    match line {
+                        Ok(text) if !text.is_empty() => {
+                            emit_intercepted_line(
+                                target, channel, source, &proc_id, &text,
+                            );
+                        }
+                        Err(_) => break,
+                        _ => {}
+                    }
+                }
+            });
+        })
+        .ok()
+}
+
+fn emit_intercepted_line(
+    target: &'static str,
+    channel: &'static str,
+    source: &'static str,
+    processor_id: &str,
+    text: &str,
+) {
+    // `tracing` macros require a literal target, so dispatch on the two
+    // known targets here. Fields are identical across both call sites.
+    match target {
+        "streamlib::polyglot::python" => tracing::warn!(
+            target: "streamlib::polyglot::python",
+            intercepted = true,
+            channel = channel,
+            source = source,
+            processor_id = %processor_id,
+            "{}",
+            text
+        ),
+        _ => tracing::warn!(
+            target: "streamlib::polyglot::deno",
+            intercepted = true,
+            channel = channel,
+            source = source,
+            processor_id = %processor_id,
+            "{}",
+            text
+        ),
+    }
+}
+
 fn thread_name(processor_id: &str) -> String {
-    // Thread names are limited to 15 chars on Linux; truncate the processor
-    // id the same way the Python stderr-forwarder thread does.
+    // Thread names are limited to 15 chars on Linux; truncate the
+    // processor id the same way the Python stderr-forwarder thread does.
     let short = &processor_id[..8.min(processor_id.len())];
     format!("br-{}", short)
 }

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -1087,8 +1087,12 @@ mod tests {
         use std::io::{BufReader, Read};
         use std::path::PathBuf;
         use std::process::{Command, Stdio};
+        use std::time::Duration;
 
         use super::*;
+        use crate::core::compiler::compiler_ops::subprocess_bridge::{
+            spawn_fd_line_reader, EscalateTransport,
+        };
         use crate::core::logging::{
             init_for_tests, LogLevel, RuntimeLogEvent, Source,
             StreamlibLoggingConfig, StreamlibLoggingGuard,
@@ -1310,6 +1314,146 @@ log.shutdown()
                 "order must match emission order"
             );
         }
+
+        /// Spawn `python3` with the host's escalate-transport + fd1/fd2
+        /// line readers installed exactly like the real spawn path does,
+        /// then run a caller-supplied snippet. Parent closes its end of
+        /// the escalate socketpair immediately so the child is free to
+        /// exit once the snippet finishes. Returns the child handle +
+        /// the kept-alive parent-side socket half (dropped by the
+        /// caller after it's done with the run). `None` when `python3`
+        /// isn't available.
+        fn spawn_python_with_host_fd_readers(
+            snippet: &str,
+            processor_id: &str,
+        ) -> Option<(std::process::Child, std::os::unix::net::UnixStream)> {
+            let py = python3()?;
+            let lib = streamlib_python_path();
+            if !lib.exists() {
+                return None;
+            }
+            let mut command = Command::new(py);
+            command
+                .arg("-c")
+                .arg(snippet)
+                .env("PYTHONPATH", &lib)
+                .env_remove("PYTHONHOME")
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut transport =
+                EscalateTransport::attach(&mut command).expect("attach transport");
+
+            let mut child = command.spawn().expect("spawn python3");
+            transport.release_child_end();
+
+            if let Some(stdout) = child.stdout.take() {
+                spawn_fd_line_reader(stdout, "py-stdout", "fd1", processor_id);
+            }
+            if let Some(stderr) = child.stderr.take() {
+                spawn_fd_line_reader(stderr, "py-stderr", "fd2", processor_id);
+            }
+
+            let parent_socket = transport.into_parent_stream();
+            Some((child, parent_socket))
+        }
+
+        /// A raw `os.write(1, …)` from a Python subprocess — the
+        /// canonical case a C-extension or `printf` from a loaded C
+        /// library would hit — must now surface in the host JSONL as
+        /// `intercepted=true, channel="fd1", source="python"`. Deferred
+        /// from #443; unlocked by moving escalate IPC onto the
+        /// dedicated socketpair so fd1 is free to capture raw writes.
+        #[cfg(unix)]
+        #[test]
+        #[serial]
+        fn python_os_write_fd1_intercepted() {
+            let (_tmp, guard) = install_logging("PyFd1Intercept");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let snippet = r#"
+import os
+os.write(1, b"hi from c\n")
+"#;
+            let (mut child, _sock) =
+                match spawn_python_with_host_fd_readers(snippet, "pr-fd1") {
+                    Some(v) => v,
+                    None => {
+                        println!("python3 missing — skipping");
+                        return;
+                    }
+                };
+
+            // Wait for child to exit and for the fd1 reader thread to
+            // flush the final line into the JSONL worker queue.
+            let _ = child.wait();
+            std::thread::sleep(Duration::from_millis(200));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| {
+                    e.intercepted
+                        && e.channel.as_deref() == Some("fd1")
+                        && e.source == Source::Python
+                        && e.message == "hi from c"
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no fd1-intercepted record for python; got {events:#?}"
+                    )
+                });
+            assert_eq!(record.level, LogLevel::Warn);
+            assert_eq!(record.processor_id.as_deref(), Some("pr-fd1"));
+        }
+
+        /// Sanity: fd2 capture survives the transport move. Confirms
+        /// the existing fd2 path from #443 still works after #451
+        /// promoted fd1 to a captured log pipe.
+        #[cfg(unix)]
+        #[test]
+        #[serial]
+        fn python_stderr_fd2_intercepted_on_dedicated_fd_transport() {
+            let (_tmp, guard) = install_logging("PyFd2Intercept");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let snippet = r#"
+import os
+os.write(2, b"stderr after transport move\n")
+"#;
+            let (mut child, _sock) =
+                match spawn_python_with_host_fd_readers(snippet, "pr-fd2") {
+                    Some(v) => v,
+                    None => {
+                        println!("python3 missing — skipping");
+                        return;
+                    }
+                };
+
+            let _ = child.wait();
+            std::thread::sleep(Duration::from_millis(200));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| {
+                    e.intercepted
+                        && e.channel.as_deref() == Some("fd2")
+                        && e.source == Source::Python
+                        && e.message == "stderr after transport move"
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no fd2-intercepted record for python; got {events:#?}"
+                    )
+                });
+            assert_eq!(record.level, LogLevel::Warn);
+            assert_eq!(record.processor_id.as_deref(), Some("pr-fd2"));
+        }
     }
 
     /// End-to-end tests that spawn a real Deno subprocess, have it call
@@ -1325,8 +1469,12 @@ log.shutdown()
         use std::io::{BufReader, Read, Write};
         use std::path::PathBuf;
         use std::process::{Command, Stdio};
+        use std::time::Duration;
 
         use super::*;
+        use crate::core::compiler::compiler_ops::subprocess_bridge::{
+            spawn_fd_line_reader, EscalateTransport,
+        };
         use crate::core::logging::{
             init_for_tests, LogLevel, RuntimeLogEvent, Source,
             StreamlibLoggingConfig, StreamlibLoggingGuard,
@@ -1571,6 +1719,126 @@ await log.shutdown();
                 (0..20).collect::<Vec<i64>>(),
                 "order must match emission order"
             );
+        }
+
+        /// Spawn `deno eval` with the host's escalate-transport +
+        /// fd1/fd2 line readers installed. Mirrors the Python helper.
+        /// Returns `(child, parent_socket)` or `None` when Deno is
+        /// missing.
+        fn spawn_deno_with_host_fd_readers(
+            snippet: &str,
+            processor_id: &str,
+        ) -> Option<(std::process::Child, std::os::unix::net::UnixStream)> {
+            let deno = deno_binary()?;
+            let mut command = Command::new(deno);
+            command
+                .arg("eval")
+                .arg(snippet)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut transport =
+                EscalateTransport::attach(&mut command).expect("attach transport");
+
+            let mut child = command.spawn().expect("spawn deno");
+            transport.release_child_end();
+
+            if let Some(stdout) = child.stdout.take() {
+                spawn_fd_line_reader(stdout, "dn-stdout", "fd1", processor_id);
+            }
+            if let Some(stderr) = child.stderr.take() {
+                spawn_fd_line_reader(stderr, "dn-stderr", "fd2", processor_id);
+            }
+
+            let parent_socket = transport.into_parent_stream();
+            Some((child, parent_socket))
+        }
+
+        /// Raw `Deno.stdout.writeSync(…)` from a Deno subprocess lands
+        /// in the host JSONL as
+        /// `intercepted=true, channel="fd1", source="deno"`. Equivalent
+        /// to `python_os_write_fd1_intercepted`; unlocked by #451
+        /// moving escalate IPC onto the dedicated socketpair.
+        #[cfg(unix)]
+        #[test]
+        #[serial]
+        fn deno_stdout_fd1_intercepted() {
+            let (_tmp, guard) = install_logging("DenoFd1Intercept");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let snippet = r#"Deno.stdout.writeSync(new TextEncoder().encode("hi from deno\n"));"#;
+            let (mut child, _sock) =
+                match spawn_deno_with_host_fd_readers(snippet, "pr-fd1-deno") {
+                    Some(v) => v,
+                    None => {
+                        println!("deno missing — skipping");
+                        return;
+                    }
+                };
+
+            let _ = child.wait();
+            std::thread::sleep(Duration::from_millis(200));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| {
+                    e.intercepted
+                        && e.channel.as_deref() == Some("fd1")
+                        && e.source == Source::Deno
+                        && e.message == "hi from deno"
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no fd1-intercepted record for deno; got {events:#?}"
+                    )
+                });
+            assert_eq!(record.level, LogLevel::Warn);
+            assert_eq!(record.processor_id.as_deref(), Some("pr-fd1-deno"));
+        }
+
+        /// Sanity: fd2 capture survives the Deno transport move.
+        /// Mirrors `python_stderr_fd2_intercepted_on_dedicated_fd_transport`.
+        #[cfg(unix)]
+        #[test]
+        #[serial]
+        fn deno_stderr_fd2_intercepted_on_dedicated_fd_transport() {
+            let (_tmp, guard) = install_logging("DenoFd2Intercept");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            let snippet = r#"Deno.stderr.writeSync(new TextEncoder().encode("stderr after transport move\n"));"#;
+            let (mut child, _sock) =
+                match spawn_deno_with_host_fd_readers(snippet, "pr-fd2-deno") {
+                    Some(v) => v,
+                    None => {
+                        println!("deno missing — skipping");
+                        return;
+                    }
+                };
+
+            let _ = child.wait();
+            std::thread::sleep(Duration::from_millis(200));
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+            let record = events
+                .iter()
+                .find(|e| {
+                    e.intercepted
+                        && e.channel.as_deref() == Some("fd2")
+                        && e.source == Source::Deno
+                        && e.message == "stderr after transport move"
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no fd2-intercepted record for deno; got {events:#?}"
+                    )
+                });
+            assert_eq!(record.level, LogLevel::Warn);
+            assert_eq!(record.processor_id.as_deref(), Some("pr-fd2-deno"));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Move the subprocess escalate-IPC channel off stdin/stdout onto a dedicated `AF_UNIX` socketpair advertised via `STREAMLIB_ESCALATE_FD`.
- Install fd1 + fd2 line-reader threads on both Python and Deno spawn paths, surfacing raw writes (C-extension `os.write(1, …)`, third-party `console.*` fallbacks, dependency chatter) as `intercepted=true, channel="fd1"|"fd2"` records in the unified JSONL.
- Wire format (4-byte BE length + JSON body) is **unchanged** — this is a transport-layer move only. iceoryx2, processor lifecycle RPC, and escalate ops are byte-for-byte compatible.

## Closes

Closes #451

## Exit criteria

- [x] Rust spawn path creates a `socketpair`, marks the child end inheritable via `pre_exec` + `fcntl(F_SETFD)`, passes the fd number via env var, and closes the parent's child-end reference after spawn.
- [x] `SubprocessBridge` reads/writes through the dedicated `UnixStream` instead of `ChildStdin`/`ChildStdout`.
- [x] Python `subprocess_runner.py` resolves `STREAMLIB_ESCALATE_FD` and wraps it via `socket.socket(fileno=fd)` + `makefile("rb"/"wb")`; `sys.stdin.buffer`/`sys.stdout.buffer` are no longer touched by the bridge.
- [x] Host fd1 reader mirrors the existing fd2 reader: per-line `tracing::warn!(intercepted=true, channel="fd1", source="python"|"deno", processor_id=…)`.
- [x] Deno gets the same transport move: new `libs/streamlib-deno/escalate_fd.ts` binds libc `read`/`write` via `Deno.dlopen` (nonblocking=true); `subprocess_runner.ts` replaces `Deno.stdin`/`Deno.stdout` bridge I/O.
- [x] Existing escalate tests still pass; workspace baseline is green.

## Test plan

- [x] `subprocess_escalate::tests::python_subprocess::python_os_write_fd1_intercepted` — **new**, deferred from #443. `os.write(1, b"hi from c\n")` surfaces as `intercepted=true, channel="fd1", source="python"` in the host JSONL. ✅
- [x] `subprocess_escalate::tests::python_subprocess::python_stderr_fd2_intercepted_on_dedicated_fd_transport` — **new**, sanity check that fd2 capture still works after the transport move. ✅
- [x] `subprocess_escalate::tests::python_subprocess::python_log_surfaces_in_host_jsonl` — still passes, proves `streamlib.log.info` still round-trips. ✅
- [x] `subprocess_escalate::tests::python_subprocess::python_log_burst_preserves_order` — still passes, 20-record FIFO burst holds. ✅
- [x] `subprocess_escalate::tests::deno_subprocess::deno_stdout_fd1_intercepted` — **new**, Deno equivalent. ✅
- [x] `subprocess_escalate::tests::deno_subprocess::deno_stderr_fd2_intercepted_on_dedicated_fd_transport` — **new**, Deno equivalent. ✅
- [x] `subprocess_escalate::tests::deno_subprocess::deno_log_surfaces_in_host_jsonl` + `deno_log_burst_preserves_order` — still pass. ✅
- [x] Workspace baseline per `docs/testing-baseline.md`: **909 passed, 0 failed, 21 ignored**. ✅
- [x] Python SDK pytest (`libs/streamlib-python`): **35 passed**. ✅
- [x] Deno SDK tests (`libs/streamlib-deno`): **36 passed**. ✅

## Polyglot coverage

- **Runtimes affected**: rust | python | deno
- **Schema regenerated**: n/a (transport-layer change, wire format unchanged)
- **E2E tests run**:
  - [x] Host-Rust: `subprocess_escalate::tests::` (26 passed including 4 new fd-interception tests)
  - [x] Python subprocess: `python_os_write_fd1_intercepted`, `python_stderr_fd2_intercepted_on_dedicated_fd_transport`, `python_log_surfaces_in_host_jsonl`, `python_log_burst_preserves_order` — all pass
  - [x] Deno subprocess: `deno_stdout_fd1_intercepted`, `deno_stderr_fd2_intercepted_on_dedicated_fd_transport`, `deno_log_surfaces_in_host_jsonl`, `deno_log_burst_preserves_order` — all pass
- **FD-passing path**: n/a for escalate traffic (JSON frames); DMA-BUF path is unaffected

## Notes for reviewers

- **`pre_exec` safety**: `fcntl(F_GETFD)`/`fcntl(F_SETFD, flags & ~FD_CLOEXEC)` are async-signal-safe, legal to call between fork and exec.
- **Deno fd wrapping**: Deno has no stable API to wrap an inherited raw fd as a stream, so `escalate_fd.ts` calls libc `read(2)` / `write(2)` via `Deno.dlopen("libc.so.6", …)` with `nonblocking: true`. Calls run on Deno's FFI worker threads without blocking the event loop. macOS support (`libc.dylib`) will land with the macOS milestone.
- **`spawn_fd_line_reader` dispatch capture**: reader thread captures the caller's `tracing::Dispatch` via `tracing::dispatcher::get_default` and installs it as the thread-local default, so tracing events route correctly under both `init` (global) and `init_for_tests` (thread-local) subscribers.
- **`#[cfg(unix)]` guards** on the new tests keep them Linux/macOS-scoped; the escalate socketpair itself is currently `std::os::unix::net::UnixStream`, so the whole bridge is Unix-only (matching the existing spawn paths).

## Follow-ups

None — scope is fully covered in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)