### PR TITLE
feat(ci): lockout enforcement — clippy disallowed-macros + xtask lint-logging + CI wiring

### DIFF
--- a/.github/workflows/lint-logging.yml
+++ b/.github/workflows/lint-logging.yml
@@ -1,0 +1,68 @@
+name: Lint Logging
+
+# Enforces the unified logging pathway — see docs/logging.md.
+# - Rust: clippy `disallowed-macros` denies println!/eprintln!/print!/eprint!/dbg!
+#   in library crates (configured via clippy.toml + [workspace.lints.clippy]).
+# - Python + TypeScript: `cargo xtask lint-logging` bans print()/sys.stdout/
+#   console.log/Deno.stdout.write in libs/streamlib-python and libs/streamlib-deno.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  clippy-disallowed-macros:
+    name: Rust — clippy disallowed-macros
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
+
+      - name: cargo clippy --workspace (enforces disallowed-macros in lib crates)
+        run: cargo clippy --workspace --no-deps
+
+  xtask-lint-logging:
+    name: Python + TypeScript — xtask lint-logging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask lint-logging
+        run: cargo xtask lint-logging
+
+      - name: cargo test -p xtask lint_logging (fixture tests)
+        run: cargo test -p xtask lint_logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,14 @@ authors = ["Jonathan Fontanez <fontanezj1@gmail.com>"]
 license-file = "LICENSE"
 repository = "https://github.com/tato123/streamlib"
 
+# Workspace-wide clippy lints. Library crates opt in by adding
+# `[lints] workspace = true` in their own Cargo.toml. Binary-only crates
+# (streamlib-cli, streamlib-runtime, xtask, examples) do not opt in, because
+# stdout IS the user output channel for them. The `disallowed-macros` list
+# itself lives in clippy.toml at the workspace root. See docs/logging.md.
+[workspace.lints.clippy]
+disallowed_macros = "deny"
+
 [workspace.dependencies]
 # Core dependencies
 thiserror = "2.0.17"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-macros = [
+    { path = "std::println", reason = "Use tracing::info! / streamlib.log.info() instead. See docs/logging.md." },
+    { path = "std::eprintln", reason = "Use tracing::warn! / tracing::error! / streamlib.log.warn() instead. See docs/logging.md." },
+    { path = "std::print", reason = "Use tracing::info! / streamlib.log.info() instead. See docs/logging.md." },
+    { path = "std::eprint", reason = "Use tracing::warn! / tracing::error! / streamlib.log.warn() instead. See docs/logging.md." },
+    { path = "std::dbg", reason = "Use tracing::debug! instead. See docs/logging.md." },
+]

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,122 @@
+# Logging in streamlib
+
+There is **one** sanctioned way to log in streamlib, per runtime. This document
+names it, tells you what to reach for, and explains the enforcement layers that
+keep everyone on the same path.
+
+## The one way
+
+| Runtime     | API                                    |
+| ----------- | -------------------------------------- |
+| Rust        | `tracing::{trace,debug,info,warn,error}!` |
+| Python SDK  | `streamlib.log.{trace,debug,info,warn,error}(message, **attrs)` |
+| Deno SDK    | `streamlib.log.{trace,debug,info,warn,error}(message, attrs)`   |
+
+Both polyglot SDKs and the Rust host subscribe produce the same unified JSONL
+stream on disk (`~/.streamlib/logs/<runtime>.log`) and mirror to stdout. The
+subprocess-side interceptors capture anything that slips through
+(`print()`, `console.log`, raw writes to fd1/fd2) and tag it
+`intercepted=true`. The host handler (escalate IPC `{op:"log"}`) forwards
+records to the subscriber that owns the file.
+
+**Don't reach for `eprintln!` / `println!` / `print` / `console.log` /
+`Deno.stdout.write` / `logging.basicConfig`.** They're banned in library code.
+Use the API above instead.
+
+## Enforcement — three layers, all load-bearing
+
+1. **Compile-time (Rust, clippy)** — `clippy.toml` configures
+   [`disallowed-macros`](https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_macros)
+   to deny `println!`, `eprintln!`, `print!`, `eprint!`, `dbg!`. Library crates
+   opt in via `[lints] workspace = true` in `Cargo.toml`. `cargo clippy
+   --workspace` fails on any violation.
+
+2. **CI lint (Python + TypeScript)** — `cargo xtask lint-logging` scans
+   `libs/streamlib-python/**/*.py` and `libs/streamlib-deno/**/*.ts` for
+   banned substrings (`print(`, `sys.stdout`, `sys.stderr`,
+   `logging.basicConfig`, `console.log`/`warn`/`error`/`info`/`debug`,
+   `Deno.stdout.write`, `Deno.stderr.write`). Exits non-zero with each
+   offending file+line on failure.
+
+3. **Runtime interceptors** — the subprocess-side `_log_interceptors.py` and
+   `_log_interceptors.ts` replace `sys.stdout`/`sys.stderr`/`console.*` with
+   line-buffered shims that emit through `streamlib.log` with
+   `intercepted=true`. The Rust host also captures fd2 at the process level
+   for anything that escapes that (third-party libs, native code).
+
+All three catch different things. The static-analysis layers (1 + 2) stop
+first-party code from regressing. The runtime layer (3) catches third-party
+dependencies and anything that slipped through. Do NOT delete any layer on
+the grounds of redundancy.
+
+## CI
+
+Both checks run on every PR and push to `main` via
+`.github/workflows/lint-logging.yml`. A PR is merge-blocked until both jobs
+are green.
+
+## Exceptions — how to add one when you really need it
+
+### Binary crates
+
+Binary-only crates (`streamlib-cli`, `streamlib-runtime`, `xtask`, examples)
+do NOT opt into the workspace `[lints]` block because stdout IS their user
+output channel. The rule only applies to library crates.
+
+### Individual files
+
+Two kinds of files legitimately bypass the unified pathway, because they
+*install* it: the interceptor itself (`_log_interceptors.py`,
+`_log_interceptors.ts`) and subprocess bootstraps that emit diagnostics
+before the logger is wired (`subprocess_runner.py`, `subprocess_runner.ts`).
+Those files carry a file-level pragma near their copyright header:
+
+```python
+# streamlib:lint-logging:allow-file — installs the unified pathway; must touch sys.stdout/sys.stderr directly
+```
+
+`cargo xtask lint-logging` reads this marker and skips the entire file.
+Don't add the pragma to new files lightly — justify why in the same
+comment.
+
+### Individual lines
+
+For a single-line exception (Python/TS), append a trailing
+`# streamlib:lint-logging:allow-line` or
+`// streamlib:lint-logging:allow-line` comment. Prefer a file-level
+pragma if the whole file justifiably bypasses; prefer per-line for one-off
+shims.
+
+### Rust library exceptions
+
+On the Rust side, bootstrap error paths in `core/logging/init.rs` wrap their
+one `eprintln!` fallback in:
+
+```rust
+#[allow(clippy::disallowed_macros)]
+{
+    eprintln!("streamlib::logging: ...");
+}
+```
+
+Use this pattern sparingly — it should be obvious from context *why* tracing
+is unavailable at the call site. If the call site *could* use tracing,
+please do.
+
+### Third-party chatty dependencies
+
+If a dep writes to stdout/stderr directly and that noise shows up in your
+logs: the runtime fd-level interceptor already captures it and tags the
+records `intercepted=true channel=stdout|stderr`. You don't need to do
+anything. If the noise is genuinely unhelpful, consider filtering it in
+the subscriber rather than suppressing at the source.
+
+## Recap
+
+- One API per language: `tracing::*!` (Rust) / `streamlib.log.*` (Python,
+  Deno).
+- Three enforcement layers: clippy, xtask lint, runtime interceptors.
+- Binary crates and installer/bootstrap files are the only acceptable
+  exceptions.
+- CI fails fast on regressions; don't try to bypass it — extend the
+  pathway instead.

--- a/libs/streamlib-broker-client/Cargo.toml
+++ b/libs/streamlib-broker-client/Cargo.toml
@@ -17,3 +17,6 @@ path = "src/lib.rs"
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/libs/streamlib-codegen-shared/Cargo.toml
+++ b/libs/streamlib-codegen-shared/Cargo.toml
@@ -15,3 +15,6 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -19,6 +19,7 @@ iceoryx2 = "0.8.1"
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
@@ -29,3 +30,6 @@ streamlib-broker-client = { path = "../streamlib-broker-client" }
 # libvulkan.so so the cdylib loads on systems without a Vulkan driver.
 vulkanalia = { workspace = true }
 
+
+[lints]
+workspace = true

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn sldn_context_create(
     match DenoNativeContext::new(id) {
         Ok(ctx) => Box::into_raw(Box::new(ctx)),
         Err(e) => {
-            eprintln!("[sldn] Failed to create context: {}", e);
+            tracing::error!("Failed to create context: {}", e);
             std::ptr::null_mut()
         }
     }
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     let service_name_iox = match ServiceName::new(service_name) {
         Ok(n) => n,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Invalid service name '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Failed to open service '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     let subscriber = match service.subscriber_builder().buffer_size(16).create() {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Failed to create subscriber for '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn sldn_input_poll(ctx: *mut DenoNativeContext) -> i32 {
         while let Ok(Some(sample)) = state.subscriber.receive() {
             let buf: &[u8] = sample.payload();
             if buf.len() < FRAME_HEADER_SIZE {
-                eprintln!("[sldn] received frame smaller than header ({} bytes)", buf.len());
+                tracing::error!("received frame smaller than header ({} bytes)", buf.len());
                 continue;
             }
             let header = FrameHeader::read_from_slice(buf);
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn sldn_input_poll(ctx: *mut DenoNativeContext) -> i32 {
             let ts = header.timestamp_ns;
             let data_len = header.len as usize;
             if FRAME_HEADER_SIZE + data_len > buf.len() {
-                eprintln!("[sldn] frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
+                tracing::error!("frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
                 continue;
             }
             let data = buf[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + data_len].to_vec();
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     let service_name_iox = match ServiceName::new(service_name) {
         Ok(n) => n,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Invalid service name '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -375,7 +375,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Failed to open service '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     let publisher = match service.publisher_builder().initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE).create() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Failed to create publisher for '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -429,7 +429,7 @@ pub unsafe extern "C" fn sldn_output_write(
     let state = match ctx.publishers.get(port_name) {
         Some(s) => s,
         None => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] No publisher for port '{}'",
                 ctx.processor_id, port_name
             );
@@ -452,7 +452,7 @@ pub unsafe extern "C" fn sldn_output_write(
     let sample = match state.publisher.loan_slice_uninit(total_len) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[sldn:{}] Failed to loan slice for port '{}': {:?}",
                 ctx.processor_id, port_name, e
             );
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn sldn_output_write(
     };
     let sample = sample.write_from_slice(&frame);
     if let Err(e) = sample.send() {
-        eprintln!(
+        tracing::error!(
             "[sldn:{}] Failed to send sample for port '{}': {:?}",
             ctx.processor_id, port_name, e
         );
@@ -565,7 +565,7 @@ mod gpu_surface {
     pub unsafe extern "C" fn sldn_gpu_surface_lookup(iosurface_id: u32) -> *mut SurfaceHandle {
         let surface_ref = IOSurfaceLookup(iosurface_id);
         if surface_ref.is_null() {
-            eprintln!("[sldn] IOSurface not found: {}", iosurface_id);
+            tracing::error!("IOSurface not found: {}", iosurface_id);
             return std::ptr::null_mut();
         }
 
@@ -602,8 +602,8 @@ mod gpu_surface {
 
         let result = IOSurfaceLock(handle.surface_ref, options, std::ptr::null_mut());
         if result != 0 {
-            eprintln!(
-                "[sldn] IOSurface lock failed: surface={}, result={}",
+            tracing::error!(
+                "IOSurface lock failed: surface={}, result={}",
                 handle.surface_id, result
             );
             return -1;
@@ -724,8 +724,8 @@ mod gpu_surface {
         }
 
         if surface_ref.is_null() {
-            eprintln!(
-                "[sldn] IOSurfaceCreate failed: {}x{} bpe={}",
+            tracing::error!(
+                "IOSurfaceCreate failed: {}x{} bpe={}",
                 width, height, bytes_per_element
             );
             return std::ptr::null_mut();
@@ -827,7 +827,7 @@ mod gpu_surface {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_gpu_surface_lookup(_iosurface_id: u32) -> *mut SurfaceHandle {
-        eprintln!("[sldn] GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
+        tracing::error!("GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
         std::ptr::null_mut()
     }
 
@@ -849,8 +849,8 @@ mod gpu_surface {
         let device = match handle.vulkan_device.as_ref() {
             Some(d) => Arc::clone(d),
             None => {
-                eprintln!(
-                    "[sldn] gpu_surface_lock: no Vulkan device attached — resolve_surface \
+                tracing::error!(
+                    "gpu_surface_lock: no Vulkan device attached — resolve_surface \
                      must have failed to initialize one"
                 );
                 return -1;
@@ -861,8 +861,8 @@ mod gpu_surface {
         // the caller lock/unlock/lock again (each lock imports a fresh dup).
         let dup_fd = unsafe { libc::dup(handle.fd) };
         if dup_fd < 0 {
-            eprintln!(
-                "[sldn] gpu_surface_lock: dup fd failed: {}",
+            tracing::error!(
+                "gpu_surface_lock: dup fd failed: {}",
                 std::io::Error::last_os_error()
             );
             return -1;
@@ -870,8 +870,8 @@ mod gpu_surface {
         let imported = match device.import_dma_buf_fd(dup_fd, handle.size) {
             Ok(i) => i,
             Err(e) => {
-                eprintln!(
-                    "[sldn] gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
+                tracing::error!(
+                    "gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
                     handle.fd, handle.size, e
                 );
                 // On import failure Vulkan has not taken the fd — we must
@@ -954,8 +954,8 @@ mod gpu_surface {
         _height: u32,
         _bytes_per_element: u32,
     ) -> *mut SurfaceHandle {
-        eprintln!(
-            "[sldn] GPU surface creation in subprocess is not supported on Linux; allocation \
+        tracing::error!(
+            "GPU surface creation in subprocess is not supported on Linux; allocation \
              must go through escalate IPC (GpuContextFullAccess -> RHI -> SurfaceStore.check_in)"
         );
         std::ptr::null_mut()
@@ -981,7 +981,7 @@ mod gpu_surface {
 mod gpu_surface {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_gpu_surface_lookup(_iosurface_id: u32) -> *mut std::ffi::c_void {
-        eprintln!("[sldn] GPU surface operations not supported on this platform");
+        tracing::error!("GPU surface operations not supported on this platform");
         std::ptr::null_mut()
     }
 
@@ -1031,7 +1031,7 @@ mod gpu_surface {
         _height: u32,
         _bytes_per_element: u32,
     ) -> *mut std::ffi::c_void {
-        eprintln!("[sldn] GPU surface creation not supported on this platform");
+        tracing::error!("GPU surface creation not supported on this platform");
         std::ptr::null_mut()
     }
 
@@ -1161,7 +1161,7 @@ mod broker_client {
         xpc_service_name: *const c_char,
     ) -> *mut BrokerHandle {
         if xpc_service_name.is_null() {
-            eprintln!("[sldn] broker_connect: null service name");
+            tracing::error!("broker_connect: null service name");
             return std::ptr::null_mut();
         }
 
@@ -1170,8 +1170,8 @@ mod broker_client {
 
         if connection.is_null() {
             let name = CStr::from_ptr(xpc_service_name).to_string_lossy();
-            eprintln!(
-                "[sldn] broker_connect: failed to create XPC connection to '{}'",
+            tracing::error!(
+                "broker_connect: failed to create XPC connection to '{}'",
                 name
             );
             return std::ptr::null_mut();
@@ -1198,7 +1198,7 @@ mod broker_client {
         xpc_connection_resume(connection);
 
         let name = CStr::from_ptr(xpc_service_name).to_string_lossy();
-        eprintln!("[sldn] broker_connect: connected to '{}'", name);
+        tracing::error!("broker_connect: connected to '{}'", name);
 
         Box::into_raw(Box::new(BrokerHandle {
             connection,
@@ -1230,7 +1230,7 @@ mod broker_client {
         let broker = match broker.as_mut() {
             Some(b) => b,
             None => {
-                eprintln!("[sldn] broker_resolve_surface: null broker handle");
+                tracing::error!("broker_resolve_surface: null broker handle");
                 return std::ptr::null_mut();
             }
         };
@@ -1238,7 +1238,7 @@ mod broker_client {
         let pool_id_str = match c_str_to_str(pool_id) {
             Some(s) => s,
             None => {
-                eprintln!("[sldn] broker_resolve_surface: null pool_id");
+                tracing::error!("broker_resolve_surface: null pool_id");
                 return std::ptr::null_mut();
             }
         };
@@ -1261,7 +1261,7 @@ mod broker_client {
         // Cache miss — XPC lookup to broker
         let request = xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0);
         if request.is_null() {
-            eprintln!("[sldn] broker_resolve_surface: failed to create XPC request");
+            tracing::error!("broker_resolve_surface: failed to create XPC request");
             return std::ptr::null_mut();
         }
 
@@ -1280,8 +1280,8 @@ mod broker_client {
             if !reply.is_null() {
                 xpc_release(reply);
             }
-            eprintln!(
-                "[sldn] broker_resolve_surface: XPC lookup failed for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: XPC lookup failed for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1292,8 +1292,8 @@ mod broker_client {
         let error_ptr = xpc_dictionary_get_string(reply, error_key.as_ptr());
         if !error_ptr.is_null() {
             let error_msg = CStr::from_ptr(error_ptr).to_string_lossy();
-            eprintln!(
-                "[sldn] broker_resolve_surface: broker error for '{}': {}",
+            tracing::error!(
+                "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, error_msg
             );
             xpc_release(reply);
@@ -1306,8 +1306,8 @@ mod broker_client {
         xpc_release(reply);
 
         if mach_port == 0 {
-            eprintln!(
-                "[sldn] broker_resolve_surface: invalid mach port for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: invalid mach port for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1321,8 +1321,8 @@ mod broker_client {
         mach_port_deallocate(task, mach_port);
 
         if surface_ref.is_null() {
-            eprintln!(
-                "[sldn] broker_resolve_surface: IOSurfaceLookupFromMachPort failed for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: IOSurfaceLookupFromMachPort failed for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1388,7 +1388,7 @@ mod broker_client {
         let broker = match broker.as_mut() {
             Some(b) => b,
             None => {
-                eprintln!("[sldn] broker_acquire_surface: null broker handle");
+                tracing::error!("broker_acquire_surface: null broker handle");
                 return std::ptr::null_mut();
             }
         };
@@ -1405,7 +1405,7 @@ mod broker_client {
         // Create mach port for the IOSurface
         let mach_port = IOSurfaceCreateMachPort(surface_handle.surface_ref);
         if mach_port == 0 {
-            eprintln!("[sldn] broker_acquire_surface: IOSurfaceCreateMachPort failed");
+            tracing::error!("broker_acquire_surface: IOSurfaceCreateMachPort failed");
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
         }
@@ -1422,7 +1422,7 @@ mod broker_client {
         // Register with broker via XPC
         let request = xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0);
         if request.is_null() {
-            eprintln!("[sldn] broker_acquire_surface: failed to create XPC request");
+            tracing::error!("broker_acquire_surface: failed to create XPC request");
             let task = mach_task_self();
             mach_port_deallocate(task, mach_port);
             let _ = Box::from_raw(surface_handle_ptr);
@@ -1455,7 +1455,7 @@ mod broker_client {
             if !reply.is_null() {
                 xpc_release(reply);
             }
-            eprintln!("[sldn] broker_acquire_surface: XPC register failed");
+            tracing::error!("broker_acquire_surface: XPC register failed");
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
         }
@@ -1465,7 +1465,7 @@ mod broker_client {
         let error_ptr = xpc_dictionary_get_string(reply, error_key.as_ptr());
         if !error_ptr.is_null() {
             let error_msg = CStr::from_ptr(error_ptr).to_string_lossy();
-            eprintln!("[sldn] broker_acquire_surface: broker error: {}", error_msg);
+            tracing::error!("broker_acquire_surface: broker error: {}", error_msg);
             xpc_release(reply);
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
@@ -1826,8 +1826,8 @@ mod broker_client {
                     Some(cloned)
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[sldn] broker: failed to create Vulkan device for DMA-BUF import: {}. \
+                    tracing::error!(
+                        "broker: failed to create Vulkan device for DMA-BUF import: {}. \
                          resolve_surface will fail — the subprocess cannot map broker-published \
                          surfaces without a Vulkan-capable driver.",
                         e
@@ -1879,14 +1879,14 @@ mod broker_client {
         let socket_path = match c_str_to_string(socket_path) {
             Some(s) if !s.is_empty() => s,
             _ => {
-                eprintln!("[sldn] broker_connect (linux): null or empty socket path");
+                tracing::error!("broker_connect (linux): null or empty socket path");
                 return std::ptr::null_mut();
             }
         };
         let runtime_id = default_runtime_id();
 
-        eprintln!(
-            "[sldn] broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
+        tracing::error!(
+            "broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
              (lazy; will connect on first resolve_surface)",
             socket_path, runtime_id
         );
@@ -1915,14 +1915,14 @@ mod broker_client {
         let broker = match unsafe { broker.as_ref() } {
             Some(b) => b,
             None => {
-                eprintln!("[sldn] broker_resolve_surface (linux): null broker handle");
+                tracing::error!("broker_resolve_surface (linux): null broker handle");
                 return std::ptr::null_mut();
             }
         };
         let pool_id_str = match c_str_to_string(pool_id) {
             Some(s) if !s.is_empty() => s,
             _ => {
-                eprintln!("[sldn] broker_resolve_surface (linux): null or empty pool_id");
+                tracing::error!("broker_resolve_surface (linux): null or empty pool_id");
                 return std::ptr::null_mut();
             }
         };
@@ -1941,8 +1941,8 @@ mod broker_client {
             if let Some(cached) = cache.get(&pool_id_str) {
                 let dup_fd = unsafe { libc::dup(cached.fd) };
                 if dup_fd < 0 {
-                    eprintln!(
-                        "[sldn] broker_resolve_surface: dup cached fd failed for '{}': {}",
+                    tracing::error!(
+                        "broker_resolve_surface: dup cached fd failed for '{}': {}",
                         pool_id_str,
                         std::io::Error::last_os_error()
                     );
@@ -1967,8 +1967,8 @@ mod broker_client {
         let guard = match broker.lazy_connect() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!(
-                    "[sldn] broker_resolve_surface: connect to '{}' failed: {}. \
+                tracing::error!(
+                    "broker_resolve_surface: connect to '{}' failed: {}. \
                      The parent StreamRuntime owns this socket; check the runtime logs \
                      and confirm STREAMLIB_BROKER_SOCKET points at a live runtime.",
                     broker.socket_path, e
@@ -1985,16 +1985,16 @@ mod broker_client {
         let (response, received_fd) = match wire::send_request(stream, &request, None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!(
-                    "[sldn] broker_resolve_surface: check_out for '{}' failed: {}",
+                tracing::error!(
+                    "broker_resolve_surface: check_out for '{}' failed: {}",
                     pool_id_str, e
                 );
                 return std::ptr::null_mut();
             }
         };
         if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
-            eprintln!(
-                "[sldn] broker_resolve_surface: broker error for '{}': {}",
+            tracing::error!(
+                "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, err
             );
             if let Some(fd) = received_fd {
@@ -2006,8 +2006,8 @@ mod broker_client {
         let dma_buf_fd = match received_fd {
             Some(fd) => fd,
             None => {
-                eprintln!(
-                    "[sldn] broker_resolve_surface: no DMA-BUF fd for '{}'",
+                tracing::error!(
+                    "broker_resolve_surface: no DMA-BUF fd for '{}'",
                     pool_id_str
                 );
                 return std::ptr::null_mut();
@@ -2028,8 +2028,8 @@ mod broker_client {
         if cache_fd >= 0 {
             let mut cache = broker.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
-                eprintln!(
-                    "[sldn] broker resolve cache exceeded {} entries, dropping all cached fds",
+                tracing::error!(
+                    "broker resolve cache exceeded {} entries, dropping all cached fds",
                     MAX_RESOLVE_CACHE
                 );
                 cache.clear();
@@ -2070,8 +2070,8 @@ mod broker_client {
         _out_pool_id: *mut c_char,
         _pool_id_buf_len: u32,
     ) -> *mut SurfaceHandle {
-        eprintln!(
-            "[sldn] broker_acquire_surface: not supported on Linux; subprocess allocation must \
+        tracing::error!(
+            "broker_acquire_surface: not supported on Linux; subprocess allocation must \
              escalate to the host (acquire_pixel_buffer / acquire_texture over the stdio IPC) — \
              the subprocess then calls resolve_surface with the returned handle_id."
         );
@@ -2127,7 +2127,7 @@ mod broker_client {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_broker_connect(_xpc_service_name: *const c_char) -> *mut c_void {
-        eprintln!("[sldn] Broker operations not supported on this platform");
+        tracing::error!("Broker operations not supported on this platform");
         std::ptr::null_mut()
     }
 

--- a/libs/streamlib-deno/_log_interceptors.ts
+++ b/libs/streamlib-deno/_log_interceptors.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
+// streamlib:lint-logging:allow-file — installs the unified pathway; must monkey-patch console.* and Deno.stdout/Deno.stderr directly
 
 /**
  * Subprocess-side interceptors that route `console.*` output and raw

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
+// streamlib:lint-logging:allow-file — subprocess bootstrap; writes to Deno.stderr before the log pipeline is installed
 
 /**
  * Subprocess runner — spawned by the Rust DenoSubprocessHostProcessor.

--- a/libs/streamlib-ipc-types/Cargo.toml
+++ b/libs/streamlib-ipc-types/Cargo.toml
@@ -12,3 +12,6 @@ description = "Shared iceoryx2 payload types for StreamLib IPC"
 
 [dependencies]
 iceoryx2 = "0.8.1"
+
+[lints]
+workspace = true

--- a/libs/streamlib-macros/Cargo.toml
+++ b/libs/streamlib-macros/Cargo.toml
@@ -25,3 +25,6 @@ streamlib-codegen-shared = { path = "../streamlib-codegen-shared" }
 [dev-dependencies]
 crossbeam-channel = "0.5"
 serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/libs/streamlib-plugin-abi/Cargo.toml
+++ b/libs/streamlib-plugin-abi/Cargo.toml
@@ -12,3 +12,6 @@ repository.workspace = true
 # Depends on streamlib for ProcessorInstanceFactory type in the registration function signature
 [dependencies]
 streamlib = { path = "../streamlib" }
+
+[lints]
+workspace = true

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -20,6 +20,7 @@ iceoryx2 = "0.8.1"
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
@@ -30,3 +31,6 @@ streamlib-broker-client = { path = "../streamlib-broker-client" }
 # libvulkan.so so the cdylib loads on systems without a Vulkan driver.
 vulkanalia = { workspace = true }
 
+
+[lints]
+workspace = true

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn slpn_context_create(
     match PythonNativeContext::new(id) {
         Ok(ctx) => Box::into_raw(Box::new(ctx)),
         Err(e) => {
-            eprintln!("[slpn] Failed to create context: {}", e);
+            tracing::error!("Failed to create context: {}", e);
             std::ptr::null_mut()
         }
     }
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     let service_name_iox = match ServiceName::new(service_name) {
         Ok(n) => n,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Invalid service name '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Failed to open service '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     let subscriber = match service.subscriber_builder().buffer_size(16).create() {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Failed to create subscriber for '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn slpn_input_poll(ctx: *mut PythonNativeContext) -> i32 {
         while let Ok(Some(sample)) = state.subscriber.receive() {
             let buf: &[u8] = sample.payload();
             if buf.len() < FRAME_HEADER_SIZE {
-                eprintln!("[slpn] received frame smaller than header ({} bytes)", buf.len());
+                tracing::error!("received frame smaller than header ({} bytes)", buf.len());
                 continue;
             }
             let header = FrameHeader::read_from_slice(buf);
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn slpn_input_poll(ctx: *mut PythonNativeContext) -> i32 {
             let ts = header.timestamp_ns;
             let data_len = header.len as usize;
             if FRAME_HEADER_SIZE + data_len > buf.len() {
-                eprintln!("[slpn] frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
+                tracing::error!("frame data truncated: header.len={} buf.len()={}", data_len, buf.len());
                 continue;
             }
             let data = buf[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + data_len].to_vec();
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     let service_name_iox = match ServiceName::new(service_name) {
         Ok(n) => n,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Invalid service name '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -375,7 +375,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Failed to open service '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     let publisher = match service.publisher_builder().initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE).create() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Failed to create publisher for '{}': {}",
                 ctx.processor_id, service_name, e
             );
@@ -429,7 +429,7 @@ pub unsafe extern "C" fn slpn_output_write(
     let state = match ctx.publishers.get(port_name) {
         Some(s) => s,
         None => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] No publisher for port '{}'",
                 ctx.processor_id, port_name
             );
@@ -452,7 +452,7 @@ pub unsafe extern "C" fn slpn_output_write(
     let sample = match state.publisher.loan_slice_uninit(total_len) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            tracing::error!(
                 "[slpn:{}] Failed to loan slice for port '{}': {:?}",
                 ctx.processor_id, port_name, e
             );
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn slpn_output_write(
     };
     let sample = sample.write_from_slice(&frame);
     if let Err(e) = sample.send() {
-        eprintln!(
+        tracing::error!(
             "[slpn:{}] Failed to send sample for port '{}': {:?}",
             ctx.processor_id, port_name, e
         );
@@ -565,7 +565,7 @@ mod gpu_surface {
     pub unsafe extern "C" fn slpn_gpu_surface_lookup(iosurface_id: u32) -> *mut SurfaceHandle {
         let surface_ref = IOSurfaceLookup(iosurface_id);
         if surface_ref.is_null() {
-            eprintln!("[slpn] IOSurface not found: {}", iosurface_id);
+            tracing::error!("IOSurface not found: {}", iosurface_id);
             return std::ptr::null_mut();
         }
 
@@ -602,8 +602,8 @@ mod gpu_surface {
 
         let result = IOSurfaceLock(handle.surface_ref, options, std::ptr::null_mut());
         if result != 0 {
-            eprintln!(
-                "[slpn] IOSurface lock failed: surface={}, result={}",
+            tracing::error!(
+                "IOSurface lock failed: surface={}, result={}",
                 handle.surface_id, result
             );
             return -1;
@@ -735,8 +735,8 @@ mod gpu_surface {
         }
 
         if surface_ref.is_null() {
-            eprintln!(
-                "[slpn] IOSurfaceCreate failed: {}x{} bpe={}",
+            tracing::error!(
+                "IOSurfaceCreate failed: {}x{} bpe={}",
                 width, height, bytes_per_element
             );
             return std::ptr::null_mut();
@@ -842,7 +842,7 @@ mod gpu_surface {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_gpu_surface_lookup(_iosurface_id: u32) -> *mut SurfaceHandle {
-        eprintln!("[slpn] GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
+        tracing::error!("GPU surface lookup by IOSurface id is macOS-only; use broker check_out");
         std::ptr::null_mut()
     }
 
@@ -864,8 +864,8 @@ mod gpu_surface {
         let device = match handle.vulkan_device.as_ref() {
             Some(d) => Arc::clone(d),
             None => {
-                eprintln!(
-                    "[slpn] gpu_surface_lock: no Vulkan device attached — resolve_surface \
+                tracing::error!(
+                    "gpu_surface_lock: no Vulkan device attached — resolve_surface \
                      must have failed to initialize one"
                 );
                 return -1;
@@ -876,8 +876,8 @@ mod gpu_surface {
         // the caller lock/unlock/lock again (each lock imports a fresh dup).
         let dup_fd = unsafe { libc::dup(handle.fd) };
         if dup_fd < 0 {
-            eprintln!(
-                "[slpn] gpu_surface_lock: dup fd failed: {}",
+            tracing::error!(
+                "gpu_surface_lock: dup fd failed: {}",
                 std::io::Error::last_os_error()
             );
             return -1;
@@ -885,8 +885,8 @@ mod gpu_surface {
         let imported = match device.import_dma_buf_fd(dup_fd, handle.size) {
             Ok(i) => i,
             Err(e) => {
-                eprintln!(
-                    "[slpn] gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
+                tracing::error!(
+                    "gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
                     handle.fd, handle.size, e
                 );
                 // On import failure Vulkan has not taken the fd — we must
@@ -972,8 +972,8 @@ mod gpu_surface {
         _height: u32,
         _bytes_per_element: u32,
     ) -> *mut SurfaceHandle {
-        eprintln!(
-            "[slpn] GPU surface creation in subprocess is not supported on Linux; allocation \
+        tracing::error!(
+            "GPU surface creation in subprocess is not supported on Linux; allocation \
              must go through escalate IPC (GpuContextFullAccess -> RHI -> SurfaceStore.check_in)"
         );
         std::ptr::null_mut()
@@ -1010,7 +1010,7 @@ mod gpu_surface {
 mod gpu_surface {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_gpu_surface_lookup(_iosurface_id: u32) -> *mut std::ffi::c_void {
-        eprintln!("[slpn] GPU surface operations not supported on this platform");
+        tracing::error!("GPU surface operations not supported on this platform");
         std::ptr::null_mut()
     }
 
@@ -1060,7 +1060,7 @@ mod gpu_surface {
         _height: u32,
         _bytes_per_element: u32,
     ) -> *mut std::ffi::c_void {
-        eprintln!("[slpn] GPU surface creation not supported on this platform");
+        tracing::error!("GPU surface creation not supported on this platform");
         std::ptr::null_mut()
     }
 
@@ -1200,7 +1200,7 @@ mod broker_client {
         runtime_id: *const c_char,
     ) -> *mut BrokerHandle {
         if xpc_service_name.is_null() {
-            eprintln!("[slpn] broker_connect: null service name");
+            tracing::error!("broker_connect: null service name");
             return std::ptr::null_mut();
         }
 
@@ -1215,8 +1215,8 @@ mod broker_client {
 
         if connection.is_null() {
             let name = CStr::from_ptr(xpc_service_name).to_string_lossy();
-            eprintln!(
-                "[slpn] broker_connect: failed to create XPC connection to '{}'",
+            tracing::error!(
+                "broker_connect: failed to create XPC connection to '{}'",
                 name
             );
             return std::ptr::null_mut();
@@ -1243,8 +1243,8 @@ mod broker_client {
         xpc_connection_resume(connection);
 
         let name = CStr::from_ptr(xpc_service_name).to_string_lossy();
-        eprintln!(
-            "[slpn] broker_connect: connected to '{}' with runtime_id='{}'",
+        tracing::error!(
+            "broker_connect: connected to '{}' with runtime_id='{}'",
             name, rid
         );
 
@@ -1276,7 +1276,7 @@ mod broker_client {
         let broker = match broker.as_mut() {
             Some(b) => b,
             None => {
-                eprintln!("[slpn] broker_resolve_surface: null broker handle");
+                tracing::error!("broker_resolve_surface: null broker handle");
                 return std::ptr::null_mut();
             }
         };
@@ -1284,7 +1284,7 @@ mod broker_client {
         let pool_id_str = match c_str_to_str(pool_id) {
             Some(s) => s,
             None => {
-                eprintln!("[slpn] broker_resolve_surface: null pool_id");
+                tracing::error!("broker_resolve_surface: null pool_id");
                 return std::ptr::null_mut();
             }
         };
@@ -1307,7 +1307,7 @@ mod broker_client {
         // Cache miss — XPC lookup to broker
         let request = xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0);
         if request.is_null() {
-            eprintln!("[slpn] broker_resolve_surface: failed to create XPC request");
+            tracing::error!("broker_resolve_surface: failed to create XPC request");
             return std::ptr::null_mut();
         }
 
@@ -1326,8 +1326,8 @@ mod broker_client {
             if !reply.is_null() {
                 xpc_release(reply);
             }
-            eprintln!(
-                "[slpn] broker_resolve_surface: XPC lookup failed for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: XPC lookup failed for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1338,8 +1338,8 @@ mod broker_client {
         let error_ptr = xpc_dictionary_get_string(reply, error_key.as_ptr());
         if !error_ptr.is_null() {
             let error_msg = CStr::from_ptr(error_ptr).to_string_lossy();
-            eprintln!(
-                "[slpn] broker_resolve_surface: broker error for '{}': {}",
+            tracing::error!(
+                "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, error_msg
             );
             xpc_release(reply);
@@ -1352,8 +1352,8 @@ mod broker_client {
         xpc_release(reply);
 
         if mach_port == 0 {
-            eprintln!(
-                "[slpn] broker_resolve_surface: invalid mach port for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: invalid mach port for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1367,8 +1367,8 @@ mod broker_client {
         mach_port_deallocate(task, mach_port);
 
         if surface_ref.is_null() {
-            eprintln!(
-                "[slpn] broker_resolve_surface: IOSurfaceLookupFromMachPort failed for '{}'",
+            tracing::error!(
+                "broker_resolve_surface: IOSurfaceLookupFromMachPort failed for '{}'",
                 pool_id_str
             );
             return std::ptr::null_mut();
@@ -1429,7 +1429,7 @@ mod broker_client {
         let broker = match broker.as_mut() {
             Some(b) => b,
             None => {
-                eprintln!("[slpn] broker_acquire_surface: null broker handle");
+                tracing::error!("broker_acquire_surface: null broker handle");
                 return std::ptr::null_mut();
             }
         };
@@ -1446,7 +1446,7 @@ mod broker_client {
         // Create mach port for the IOSurface
         let mach_port = IOSurfaceCreateMachPort(surface_handle.surface_ref);
         if mach_port == 0 {
-            eprintln!("[slpn] broker_acquire_surface: IOSurfaceCreateMachPort failed");
+            tracing::error!("broker_acquire_surface: IOSurfaceCreateMachPort failed");
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
         }
@@ -1462,7 +1462,7 @@ mod broker_client {
         // Register with broker via XPC
         let request = xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0);
         if request.is_null() {
-            eprintln!("[slpn] broker_acquire_surface: failed to create XPC request");
+            tracing::error!("broker_acquire_surface: failed to create XPC request");
             let task = mach_task_self();
             mach_port_deallocate(task, mach_port);
             let _ = Box::from_raw(surface_handle_ptr);
@@ -1495,7 +1495,7 @@ mod broker_client {
             if !reply.is_null() {
                 xpc_release(reply);
             }
-            eprintln!("[slpn] broker_acquire_surface: XPC register failed");
+            tracing::error!("broker_acquire_surface: XPC register failed");
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
         }
@@ -1505,7 +1505,7 @@ mod broker_client {
         let error_ptr = xpc_dictionary_get_string(reply, error_key.as_ptr());
         if !error_ptr.is_null() {
             let error_msg = CStr::from_ptr(error_ptr).to_string_lossy();
-            eprintln!("[slpn] broker_acquire_surface: broker error: {}", error_msg);
+            tracing::error!("broker_acquire_surface: broker error: {}", error_msg);
             xpc_release(reply);
             let _ = Box::from_raw(surface_handle_ptr);
             return std::ptr::null_mut();
@@ -1950,8 +1950,8 @@ mod broker_client {
                     Some(cloned)
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[slpn] broker: failed to create Vulkan device for DMA-BUF import: {}. \
+                    tracing::error!(
+                        "broker: failed to create Vulkan device for DMA-BUF import: {}. \
                          resolve_surface will fail — the subprocess cannot map broker-published \
                          surfaces without a Vulkan-capable driver.",
                         e
@@ -2004,7 +2004,7 @@ mod broker_client {
         let socket_path = match c_str_to_string(socket_path) {
             Some(s) if !s.is_empty() => s,
             _ => {
-                eprintln!("[slpn] broker_connect (linux): null or empty socket path");
+                tracing::error!("broker_connect (linux): null or empty socket path");
                 return std::ptr::null_mut();
             }
         };
@@ -2014,8 +2014,8 @@ mod broker_client {
         // Intentional: do NOT open the socket yet. Per the research doc,
         // lazy-connect + fail-at-first-use decouples subprocess lifecycle
         // from broker lifecycle.
-        eprintln!(
-            "[slpn] broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
+        tracing::error!(
+            "broker_connect (linux): registered socket_path='{}' runtime_id='{}' \
              (lazy; will connect on first resolve_surface)",
             socket_path, runtime_id
         );
@@ -2045,14 +2045,14 @@ mod broker_client {
         let broker = match unsafe { broker.as_ref() } {
             Some(b) => b,
             None => {
-                eprintln!("[slpn] broker_resolve_surface (linux): null broker handle");
+                tracing::error!("broker_resolve_surface (linux): null broker handle");
                 return std::ptr::null_mut();
             }
         };
         let pool_id_str = match c_str_to_string(pool_id) {
             Some(s) if !s.is_empty() => s,
             _ => {
-                eprintln!("[slpn] broker_resolve_surface (linux): null or empty pool_id");
+                tracing::error!("broker_resolve_surface (linux): null or empty pool_id");
                 return std::ptr::null_mut();
             }
         };
@@ -2073,8 +2073,8 @@ mod broker_client {
             if let Some(cached) = cache.get(&pool_id_str) {
                 let dup_fd = unsafe { libc::dup(cached.fd) };
                 if dup_fd < 0 {
-                    eprintln!(
-                        "[slpn] broker_resolve_surface: dup cached fd failed for '{}': {}",
+                    tracing::error!(
+                        "broker_resolve_surface: dup cached fd failed for '{}': {}",
                         pool_id_str,
                         std::io::Error::last_os_error()
                     );
@@ -2100,8 +2100,8 @@ mod broker_client {
         let guard = match broker.lazy_connect() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!(
-                    "[slpn] broker_resolve_surface: connect to '{}' failed: {}. \
+                tracing::error!(
+                    "broker_resolve_surface: connect to '{}' failed: {}. \
                      The parent StreamRuntime owns this socket; check the runtime logs \
                      and confirm STREAMLIB_BROKER_SOCKET points at a live runtime.",
                     broker.socket_path, e
@@ -2118,16 +2118,16 @@ mod broker_client {
         let (response, received_fd) = match wire::send_request(stream, &request, None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!(
-                    "[slpn] broker_resolve_surface: check_out for '{}' failed: {}",
+                tracing::error!(
+                    "broker_resolve_surface: check_out for '{}' failed: {}",
                     pool_id_str, e
                 );
                 return std::ptr::null_mut();
             }
         };
         if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
-            eprintln!(
-                "[slpn] broker_resolve_surface: broker error for '{}': {}",
+            tracing::error!(
+                "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, err
             );
             if let Some(fd) = received_fd {
@@ -2139,8 +2139,8 @@ mod broker_client {
         let dma_buf_fd = match received_fd {
             Some(fd) => fd,
             None => {
-                eprintln!(
-                    "[slpn] broker_resolve_surface: no DMA-BUF fd for '{}'",
+                tracing::error!(
+                    "broker_resolve_surface: no DMA-BUF fd for '{}'",
                     pool_id_str
                 );
                 return std::ptr::null_mut();
@@ -2163,8 +2163,8 @@ mod broker_client {
         if cache_fd >= 0 {
             let mut cache = broker.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
-                eprintln!(
-                    "[slpn] broker resolve cache exceeded {} entries, dropping all cached fds",
+                tracing::error!(
+                    "broker resolve cache exceeded {} entries, dropping all cached fds",
                     MAX_RESOLVE_CACHE
                 );
                 cache.clear();
@@ -2211,8 +2211,8 @@ mod broker_client {
         _out_pool_id: *mut c_char,
         _pool_id_buf_len: u32,
     ) -> *mut SurfaceHandle {
-        eprintln!(
-            "[slpn] broker_acquire_surface: not supported on Linux; subprocess allocation must \
+        tracing::error!(
+            "broker_acquire_surface: not supported on Linux; subprocess allocation must \
              escalate to the host (acquire_pixel_buffer / acquire_texture over the stdio IPC) — \
              the subprocess then calls resolve_surface with the returned handle_id."
         );
@@ -2265,7 +2265,7 @@ mod broker_client {
         _xpc_service_name: *const c_char,
         _runtime_id: *const c_char,
     ) -> *mut c_void {
-        eprintln!("[slpn] Broker operations not supported on this platform");
+        tracing::error!("Broker operations not supported on this platform");
         std::ptr::null_mut()
     }
 

--- a/libs/streamlib-python/python/streamlib/_log_interceptors.py
+++ b/libs/streamlib-python/python/streamlib/_log_interceptors.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
+# streamlib:lint-logging:allow-file — installs the unified pathway; must touch sys.stdout/sys.stderr directly
 
 """Subprocess-side interceptors that route `print`, raw stdout/stderr
 writes, and `logging` records through `streamlib.log`.

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
+# streamlib:lint-logging:allow-file — subprocess bootstrap; writes to sys.stderr before the log pipeline is installed
 
 """Subprocess runner for Python processors (native FFI mode).
 

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -229,3 +229,6 @@ processors = [
 # name = "streamlib-mcp"
 # path = "src/bin/streamlib-mcp.rs"
 # required-features = ["mcp"]
+
+[lints]
+workspace = true

--- a/libs/streamlib/build.rs
+++ b/libs/streamlib/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // build.rs uses println! for `cargo:` directives
+
 fn main() {
     // Link Metal framework on macOS for MP4 writer
     #[cfg(target_os = "macos")]

--- a/libs/streamlib/src/bin/generate_openapi.rs
+++ b/libs/streamlib/src/bin/generate_openapi.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 #![allow(dead_code)] // Structs/functions are only used for schema generation
+#![allow(clippy::disallowed_macros)] // codegen binary: stdout is the output channel
 
 //! Generates OpenAPI specification for the StreamLib Runtime API.
 //!

--- a/libs/streamlib/src/bin/generate_schemas.rs
+++ b/libs/streamlib/src/bin/generate_schemas.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // codegen binary: stdout is the output channel
+
 //! Generates JSON Schema files for streamlib API responses.
 //!
 //! Run with: `cargo run --bin generate_schemas`

--- a/libs/streamlib/src/core/logging/init.rs
+++ b/libs/streamlib/src/core/logging/init.rs
@@ -142,11 +142,16 @@ fn build_components(
             ) {
                 Ok(w) => (Some(w), Some(path)),
                 Err(e) => {
-                    eprintln!(
-                        "streamlib::logging: failed to open JSONL file {}: {} — continuing with stdout only",
-                        path.display(),
-                        e
-                    );
+                    // Pre-init error path: the tracing subscriber we're trying to
+                    // build owns this error — emit via raw stderr before giving up.
+                    #[allow(clippy::disallowed_macros)]
+                    {
+                        eprintln!(
+                            "streamlib::logging: failed to open JSONL file {}: {} — continuing with stdout only",
+                            path.display(),
+                            e
+                        );
+                    }
                     (None, None)
                 }
             }
@@ -171,10 +176,14 @@ fn build_components(
                 (Some(pending), Some(files.real_stdout))
             }
             Err(e) => {
-                eprintln!(
-                    "streamlib::logging: failed to install stdio interceptor: {} — continuing without interception",
-                    e
-                );
+                // Pre-init error path: interceptor failed before the subscriber exists.
+                #[allow(clippy::disallowed_macros)]
+                {
+                    eprintln!(
+                        "streamlib::logging: failed to install stdio interceptor: {} — continuing without interception",
+                        e
+                    );
+                }
                 (None, None)
             }
         }

--- a/libs/streamlib/src/linux/processors/audio_capture.rs
+++ b/libs/streamlib/src/linux/processors/audio_capture.rs
@@ -175,7 +175,7 @@ impl LinuxAudioCaptureProcessor::Processor {
                     };
 
                     if let Err(e) = outputs_clone.write("audio", &ipc_frame) {
-                        eprintln!("[AudioCapture] Failed to write frame: {}", e);
+                        tracing::error!(error = %e, "AudioCapture: failed to write frame");
                     }
                 },
                 move |err| {

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -421,9 +421,10 @@ fn capture_thread_loop(
             include_bytes!("shaders/yuyv_to_rgba.spv"),
         ),
         _ => {
-            eprintln!(
-                "[Camera {}] Unsupported format {:?} — no GPU compute shader available",
-                camera_name, fourcc
+            tracing::error!(
+                camera = camera_name,
+                ?fourcc,
+                "unsupported format — no GPU compute shader available",
             );
             return;
         }
@@ -460,7 +461,7 @@ fn capture_thread_loop(
             match unsafe { allocator.create_buffer(input_buffer_info, &input_alloc_opts) } {
                 Ok(r) => r,
                 Err(e) => {
-                    eprintln!("[Camera {}] Failed to create input SSBO[{}]: {}", camera_name, i, e);
+                    tracing::error!(camera = camera_name, ssbo_index = i, error = %e, "failed to create input SSBO");
                     for j in 0..i {
                         if let Some(alloc) = input_allocations[j].take() {
                             unsafe { allocator.destroy_buffer(input_buffers[j], alloc) };
@@ -492,7 +493,7 @@ fn capture_thread_loop(
     let shader_module = match unsafe { device.create_shader_module(&shader_module_info, None) } {
         Ok(m) => m,
         Err(e) => {
-            eprintln!("[Camera {}] Failed to create shader module: {}", camera_name, e);
+            tracing::error!(camera = camera_name, error = %e, "failed to create shader module");
             unsafe {
                 for k in 0..2 {
                     if let Some(alloc) = input_allocations[k].take() {
@@ -527,7 +528,7 @@ fn capture_thread_loop(
         match unsafe { device.create_descriptor_set_layout(&descriptor_set_layout_info, None) } {
             Ok(l) => l,
             Err(e) => {
-                eprintln!("[Camera {}] Failed to create descriptor set layout: {}", camera_name, e);
+                tracing::error!(camera = camera_name, error = %e, "failed to create descriptor set layout");
                 unsafe {
                     device.destroy_shader_module(shader_module, None);
                     for k in 0..2 {
@@ -558,7 +559,7 @@ fn capture_thread_loop(
         match unsafe { device.create_pipeline_layout(&pipeline_layout_info, None) } {
             Ok(l) => l,
             Err(e) => {
-                eprintln!("[Camera {}] Failed to create pipeline layout: {}", camera_name, e);
+                tracing::error!(camera = camera_name, error = %e, "failed to create pipeline layout");
                 unsafe {
                     device.destroy_descriptor_set_layout(descriptor_set_layout, None);
                     device.destroy_shader_module(shader_module, None);
@@ -589,7 +590,7 @@ fn capture_thread_loop(
     } {
         Ok((pipelines, _)) => pipelines[0],
         Err(e) => {
-            eprintln!("[Camera {}] Failed to create compute pipeline: {}", camera_name, e);
+            tracing::error!(camera = camera_name, error = %e, "failed to create compute pipeline");
             unsafe {
                 device.destroy_pipeline_layout(pipeline_layout, None);
                 device.destroy_descriptor_set_layout(descriptor_set_layout, None);
@@ -625,7 +626,7 @@ fn capture_thread_loop(
         match unsafe { device.create_descriptor_pool(&descriptor_pool_info, None) } {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("[Camera {}] Failed to create descriptor pool: {}", camera_name, e);
+                tracing::error!(camera = camera_name, error = %e, "failed to create descriptor pool");
                 unsafe {
                     device.destroy_pipeline(compute_pipeline, None);
                     device.destroy_pipeline_layout(pipeline_layout, None);
@@ -650,7 +651,7 @@ fn capture_thread_loop(
     let descriptor_set = match unsafe { device.allocate_descriptor_sets(&alloc_info) } {
         Ok(sets) => sets[0],
         Err(e) => {
-            eprintln!("[Camera {}] Failed to allocate descriptor set: {}", camera_name, e);
+            tracing::error!(camera = camera_name, error = %e, "failed to allocate descriptor set");
             unsafe {
                 device.destroy_descriptor_pool(descriptor_pool, None);
                 device.destroy_pipeline(compute_pipeline, None);
@@ -678,7 +679,7 @@ fn capture_thread_loop(
     let compute_command_pool = match unsafe { device.create_command_pool(&pool_info, None) } {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("[Camera {}] Failed to create compute command pool: {}", camera_name, e);
+            tracing::error!(camera = camera_name, error = %e, "failed to create compute command pool");
             unsafe {
                 device.destroy_descriptor_pool(descriptor_pool, None);
                 device.destroy_pipeline(compute_pipeline, None);
@@ -705,7 +706,7 @@ fn capture_thread_loop(
         match unsafe { device.allocate_command_buffers(&cmd_alloc_info) } {
             Ok(bufs) => bufs[0],
             Err(e) => {
-                eprintln!("[Camera {}] Failed to allocate compute command buffer: {}", camera_name, e);
+                tracing::error!(camera = camera_name, error = %e, "failed to allocate compute command buffer");
                 unsafe {
                     device.destroy_command_pool(compute_command_pool, None);
                     device.destroy_descriptor_pool(descriptor_pool, None);
@@ -738,10 +739,7 @@ fn capture_thread_loop(
         match unsafe { device.create_semaphore(&timeline_semaphore_info, None) } {
             Ok(s) => s,
             Err(e) => {
-                eprintln!(
-                    "[Camera {}] Failed to create timeline semaphore: {}",
-                    camera_name, e
-                );
+                tracing::error!(camera = camera_name, error = %e, "failed to create timeline semaphore");
                 unsafe {
                     device.destroy_command_pool(compute_command_pool, None);
                     device.destroy_descriptor_pool(descriptor_pool, None);
@@ -785,9 +783,11 @@ fn capture_thread_loop(
         let vk_texture = match VulkanTexture::new(vulkan_device, &ring_texture_desc) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!(
-                    "[Camera {}] Failed to create ring texture[{}]: {}",
-                    camera_name, i, e
+                tracing::error!(
+                    camera = camera_name,
+                    ring_index = i,
+                    error = %e,
+                    "failed to create ring texture",
                 );
                 unsafe {
                     device.destroy_semaphore(camera_timeline_semaphore, None);
@@ -809,9 +809,11 @@ fn capture_thread_loop(
 
         // Create image view eagerly so we can fail fast
         if let Err(e) = vk_texture.image_view() {
-            eprintln!(
-                "[Camera {}] Failed to create ring texture[{}] image view: {}",
-                camera_name, i, e
+            tracing::error!(
+                camera = camera_name,
+                ring_index = i,
+                error = %e,
+                "failed to create ring texture image view",
             );
             unsafe {
                 device.destroy_semaphore(camera_timeline_semaphore, None);
@@ -838,10 +840,11 @@ fn capture_thread_loop(
             let surface_store = gpu_context.surface_store();
             if let Some(store) = surface_store {
                 if let Err(e) = store.register_texture(&texture_id, &stream_texture) {
-                    eprintln!(
-                        "[Camera {}] Failed to register ring texture[{}] with broker: {} \
-                         (cross-process GPU sharing unavailable, same-process still works)",
-                        camera_name, i, e
+                    tracing::warn!(
+                        camera = camera_name,
+                        ring_index = i,
+                        error = %e,
+                        "failed to register ring texture with broker — cross-process GPU sharing unavailable, same-process still works",
                     );
                 }
             }
@@ -852,9 +855,12 @@ fn capture_thread_loop(
         ring_textures.push(stream_texture);
     }
 
-    eprintln!(
-        "[Camera {}] Ring textures created: {} x {}x{} RGBA8 DEVICE_LOCAL DMA-BUF exportable (STORAGE | SAMPLED)",
-        camera_name, RING_TEXTURE_COUNT, width, height
+    tracing::info!(
+        camera = camera_name,
+        count = RING_TEXTURE_COUNT,
+        width,
+        height,
+        "ring textures created (RGBA8 DEVICE_LOCAL DMA-BUF exportable, STORAGE | SAMPLED)",
     );
 
     // Get ring texture image handles and views for compute dispatch
@@ -905,9 +911,14 @@ fn capture_thread_loop(
     let dispatch_y = (height + 15) / 16;
     let output_buffer_size = (width as vk::DeviceSize) * (height as vk::DeviceSize) * 4;
 
-    eprintln!(
-        "[Camera {}] GPU compute pipeline ready ({:?}, {}x{}, dispatch {}x{})",
-        camera_name, fourcc, width, height, dispatch_x, dispatch_y
+    tracing::info!(
+        camera = camera_name,
+        ?fourcc,
+        width,
+        height,
+        dispatch_x,
+        dispatch_y,
+        "GPU compute pipeline ready",
     );
 
     // -----------------------------------------------------------------------
@@ -962,10 +973,7 @@ fn capture_thread_loop(
             );
 
             if expbuf_result != 0 {
-                eprintln!(
-                    "[Camera {}] VIDIOC_EXPBUF not supported — using MMAP path",
-                    camera_name
-                );
+                tracing::info!(camera = camera_name, "VIDIOC_EXPBUF not supported — using MMAP path");
                 false
             } else {
                 let probe_fd = expbuf.fd;
@@ -996,9 +1004,10 @@ fn capture_thread_loop(
                                         true
                                     }
                                     Err(e) => {
-                                        eprintln!(
-                                            "[Camera {}] DMA-BUF bind failed: {} — using MMAP path",
-                                            camera_name, e
+                                        tracing::warn!(
+                                            camera = camera_name,
+                                            error = %e,
+                                            "DMA-BUF bind failed — using MMAP path",
                                         );
                                         vulkan_device.free_imported_memory(memory);
                                         device.destroy_buffer(buffer, None);
@@ -1111,9 +1120,10 @@ fn capture_thread_loop(
 
             if all_imported {
                 use_dmabuf = true;
-                eprintln!(
-                    "[Camera {}] DMA-BUF zero-copy enabled ({} buffers imported into Vulkan)",
-                    camera_name, V4L2_BUFFER_COUNT
+                tracing::info!(
+                    camera = camera_name,
+                    buffers_imported = V4L2_BUFFER_COUNT,
+                    "DMA-BUF zero-copy enabled",
                 );
             } else {
                 // Clean up any partially imported buffers
@@ -1133,10 +1143,7 @@ fn capture_thread_loop(
                         }
                     }
                 }
-                eprintln!(
-                    "[Camera {}] DMA-BUF partial import failed — using MMAP path",
-                    camera_name
-                );
+                tracing::warn!(camera = camera_name, "DMA-BUF partial import failed — using MMAP path");
             }
         }
     }
@@ -1193,7 +1200,7 @@ fn capture_thread_loop(
                 }
                 if poll_result < 0 {
                     if is_capturing.load(Ordering::Acquire) {
-                        eprintln!("[Camera {}] V4L2 poll error", camera_name);
+                        tracing::error!(camera = camera_name, "V4L2 poll error");
                     }
                     break;
                 }
@@ -1209,7 +1216,7 @@ fn capture_thread_loop(
                 ) != 0
                 {
                     if is_capturing.load(Ordering::Acquire) {
-                        eprintln!("[Camera {}] DQBUF failed", camera_name);
+                        tracing::error!(camera = camera_name, "DQBUF failed");
                     }
                     continue;
                 }
@@ -1250,7 +1257,7 @@ fn capture_thread_loop(
                 }
                 Err(e) => {
                     if is_capturing.load(Ordering::Acquire) {
-                        eprintln!("[Camera {}] V4L2 stream error: {}", camera_name, e);
+                        tracing::error!(camera = camera_name, error = %e, "V4L2 stream error");
                     }
                     break;
                 }
@@ -1304,10 +1311,7 @@ fn capture_thread_loop(
                 Ok(result) => result,
                 Err(e) => {
                     if frame_num == 0 {
-                        eprintln!(
-                            "[Camera {}] Failed to acquire pixel buffer: {}",
-                            camera_name, e
-                        );
+                        tracing::error!(camera = camera_name, error = %e, "failed to acquire pixel buffer");
                     }
                     if let Some(mut v4l2_buf) = v4l2_requeue_buf {
                         unsafe {
@@ -1600,10 +1604,7 @@ fn capture_thread_loop(
 
             if let Err(e) = vulkan_device.submit_to_queue(queue, &[submit], vk::Fence::null()) {
                 if frame_num == 0 {
-                    eprintln!(
-                        "[Camera {}] Failed to submit compute dispatch: {}",
-                        camera_name, e
-                    );
+                    tracing::error!(camera = camera_name, error = %e, "failed to submit compute dispatch");
                 }
                 if let Some(mut v4l2_buf) = v4l2_requeue_buf {
                     libc::ioctl(
@@ -1655,18 +1656,23 @@ fn capture_thread_loop(
         };
 
         if let Err(e) = outputs.write("video", &ipc_frame) {
-            eprintln!("[Camera {}] Failed to write frame: {}", camera_name, e);
+            tracing::error!(camera = camera_name, error = %e, "failed to write frame");
             continue;
         }
 
         if frame_num == 0 {
             let mode = if use_dmabuf { "DMA-BUF zero-copy" } else { "MMAP + memcpy" };
-            eprintln!(
-                "[Camera {}] First frame captured via GPU compute ({}, seq={}, {}x{} {:?})",
-                camera_name, mode, frame_sequence, width, height, fourcc
+            tracing::info!(
+                camera = camera_name,
+                mode,
+                seq = frame_sequence,
+                width,
+                height,
+                ?fourcc,
+                "first frame captured via GPU compute",
             );
         } else if frame_num % 300 == 0 {
-            eprintln!("[Camera {}] Frame #{}", camera_name, frame_num);
+            tracing::debug!(camera = camera_name, frame = frame_num, "frame milestone");
         }
 
         // Toggle ping-pong index for next frame (MMAP path only)

--- a/libs/vulkan-video/Cargo.toml
+++ b/libs/vulkan-video/Cargo.toml
@@ -42,3 +42,6 @@ path = "src/bin/video_demo.rs"
 [[bin]]
 name = "h265-caps"
 path = "src/bin/h265_caps.rs"
+
+[lints]
+workspace = true

--- a/libs/vulkan-video/build.rs
+++ b/libs/vulkan-video/build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // build.rs uses println!/eprintln! for `cargo:` directives and diagnostics
+
 //! Build script: compiles GLSL compute shaders to SPIR-V using glslc.
 
 use std::path::Path;

--- a/libs/vulkan-video/src/bin/decode_test.rs
+++ b/libs/vulkan-video/src/bin/decode_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // dev test binary: stdout is the output channel
+
 //! Standalone decode test binary.
 //!
 //! Exercises the ported bitstream parser components WITHOUT requiring a GPU.

--- a/libs/vulkan-video/src/bin/encode_test.rs
+++ b/libs/vulkan-video/src/bin/encode_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // dev test binary: stdout is the output channel
+
 //! Standalone encode test binary.
 //!
 //! Exercises the encoder configuration and parameter generation components

--- a/libs/vulkan-video/src/bin/h265_caps.rs
+++ b/libs/vulkan-video/src/bin/h265_caps.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // dev diagnostic binary: stdout is the output channel
+
 //! Diagnostic tool: dump ALL Vulkan Video H.265 encode capabilities.
 //!
 //! Creates a Vulkan 1.3 instance, finds the first physical device with

--- a/libs/vulkan-video/src/bin/pipeline_test.rs
+++ b/libs/vulkan-video/src/bin/pipeline_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // dev test binary: stdout is the output channel
+
 //! Full pipeline integration test: encode -> decode round-trip.
 //!
 //! Generates test fixture frames (SMPTE bars via ffmpeg or gradient pattern),

--- a/libs/vulkan-video/src/bin/video_demo.rs
+++ b/libs/vulkan-video/src/bin/video_demo.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+#![allow(clippy::disallowed_macros)] // dev demo binary: stdout is the output channel
+
 //! Video demo: encode NV12 fixture with SimpleEncoder, decode with SimpleDecoder,
 //! produce MP4 files for visual verification.
 

--- a/libs/vulkan-video/src/codec_utils/helpers.rs
+++ b/libs/vulkan-video/src/codec_utils/helpers.rs
@@ -657,6 +657,7 @@ impl DeviceUuidUtils {
 
     /// Format as the standard 8-4-4-4-12 hex string.
     /// Port of `DeviceUuidUtils::ToString`.
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         let mut s = String::with_capacity(36);
         for (i, byte) in self.device_uuid.iter().enumerate() {

--- a/libs/vulkan-video/src/codec_utils/vulkan_command_buffer_pool.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_command_buffer_pool.rs
@@ -233,9 +233,10 @@ impl PoolNode {
         );
 
         if result != vk::Result::SUCCESS {
-            eprintln!(
-                "\nERROR: wait_and_reset_fence() for {} with result: {:?}",
-                fence_name, result
+            tracing::error!(
+                fence = fence_name,
+                ?result,
+                "wait_and_reset_fence() failed",
             );
         }
 
@@ -593,11 +594,11 @@ pub unsafe fn wait_and_reset_fence(
                 break;
             }
             Ok(vk::SuccessCode::TIMEOUT) => {
-                eprintln!(
-                    "\t **** WARNING: fence {}({:?}) is not done after {} mSec ****",
-                    fence_name,
-                    fence,
-                    current_wait / (1000 * 1000)
+                tracing::warn!(
+                    fence = fence_name,
+                    fence_handle = ?fence,
+                    elapsed_ms = current_wait / (1000 * 1000),
+                    "fence not signaled",
                 );
                 result = vk::Result::TIMEOUT;
             }
@@ -613,12 +614,12 @@ pub unsafe fn wait_and_reset_fence(
     }
 
     if result != vk::Result::SUCCESS {
-        eprintln!(
-            "\t **** ERROR: fence {}({:?}) is not done after {} mSec with status {:?} ****",
-            fence_name,
-            fence,
-            fence_total_wait_timeout / (1000 * 1000),
-            device.get_fence_status(fence),
+        tracing::error!(
+            fence = fence_name,
+            fence_handle = ?fence,
+            total_wait_ms = fence_total_wait_timeout / (1000 * 1000),
+            status = ?device.get_fence_status(fence),
+            "fence wait exhausted without signal",
         );
         return result;
     }
@@ -940,6 +941,7 @@ impl PoolNodeHandle {
     /// The caller must not hold multiple mutable references to the same node.
     /// This is safe in practice because `PoolNodeHandle` has exclusive ownership
     /// of the node index (guaranteed by the bitmask).
+    #[allow(clippy::mut_from_ref)] // interior mutability via UnsafeCell; caller-guaranteed exclusivity
     pub unsafe fn node_mut(&self) -> &mut PoolNode {
         let nodes = &mut *self.pool.pool_nodes.get();
         &mut nodes[self.index as usize]

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -375,8 +375,15 @@ impl SimpleEncoder {
         self.encode_config = Some(config.clone());
         self.configured = true;
         self.effective_quality_level = effective_quality_level;
-        eprintln!("[ENCODER] configured: {}x{} codec={:?} quality={}->{} dpb={}",
-            aligned_w, aligned_h, self.codec_flag, config.quality_level, effective_quality_level, max_dpb);
+        tracing::info!(
+            width = aligned_w,
+            height = aligned_h,
+            codec = ?self.codec_flag,
+            quality_level = config.quality_level,
+            effective_quality_level,
+            max_dpb,
+            "encoder configured",
+        );
         self.frame_count = 0;
         self.poc_counter = 0;
         self.encode_order_count = 0;

--- a/libs/vulkan-video/src/nv_video_parser/vulkan_av1_decoder.rs
+++ b/libs/vulkan-video/src/nv_video_parser/vulkan_av1_decoder.rs
@@ -2174,7 +2174,10 @@ impl VulkanAv1Decoder {
         let subsampling_y = sps.color_config.subsampling_y;
 
         if film_grain_params_present && (self.pic_data.show_frame || self.showable_frame) {
-            self.pic_data.std_info.flags.delta_q_present = self.pic_data.std_info.flags.delta_q_present; // no-op, preserve
+            #[allow(clippy::self_assignment)] // intentional: documents preservation across this path
+            {
+                self.pic_data.std_info.flags.delta_q_present = self.pic_data.std_info.flags.delta_q_present;
+            }
             self.pic_data.film_grain.apply_grain = bs.u(1) != 0;
 
             if !self.pic_data.film_grain.apply_grain {
@@ -2310,7 +2313,9 @@ impl VulkanAv1Decoder {
         }
 
         // LAST_FRAME index = 0, GOLDEN_FRAME index = 3
-        self.ref_frame_idx[REFERENCE_NAME_LAST_FRAME - REFERENCE_NAME_LAST_FRAME] = last_frame_idx;
+        #[allow(clippy::eq_op)] // documents LAST_FRAME's relative slot in the reference frame table
+        let last_frame_slot = REFERENCE_NAME_LAST_FRAME - REFERENCE_NAME_LAST_FRAME;
+        self.ref_frame_idx[last_frame_slot] = last_frame_idx;
         self.ref_frame_idx[REFERENCE_NAME_GOLDEN_FRAME - REFERENCE_NAME_LAST_FRAME] = gold_frame_idx;
         if last_frame_idx >= 0 {
             used_frame[last_frame_idx as usize] = true;

--- a/libs/vulkan-video/src/vk_video_encoder/vk_video_gop_structure.rs
+++ b/libs/vulkan-video/src/vk_video_encoder/vk_video_gop_structure.rs
@@ -414,6 +414,7 @@ impl VkVideoGopStructure {
     /// Print the GOP structure for `num_frames` frames.
     ///
     /// Equivalent to the C++ `PrintGopStructure` virtual method.
+    #[allow(clippy::disallowed_macros)] // diagnostic dumper invoked from test bins; stdout is the output channel
     pub fn print_gop_structure(&self, num_frames: u64) {
         // Frame Index
         print!("\nFrame Index:   ");
@@ -492,6 +493,7 @@ impl VkVideoGopStructure {
     /// Dump a single frame's GOP structure info.
     ///
     /// Equivalent to the C++ `DumpFrameGopStructure` method.
+    #[allow(clippy::disallowed_macros)] // diagnostic dumper invoked from test bins; stdout is the output channel
     pub fn dump_frame_gop_structure(
         &self,
         gop_state: &mut GopState,
@@ -513,6 +515,7 @@ impl VkVideoGopStructure {
     /// Dump GOP structure for a range of frames.
     ///
     /// Equivalent to the C++ `DumpFramesGopStructure` method.
+    #[allow(clippy::disallowed_macros)] // diagnostic dumper invoked from test bins; stdout is the output channel
     pub fn dump_frames_gop_structure(
         &self,
         first_frame_num_in_input_order: u64,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,3 +23,9 @@ anyhow = "1.0"
 # Temp directory for jtd-codegen
 tempfile = "3.15"
 
+# Recursive file walk for lint-logging
+walkdir = "2.5"
+
+[dev-dependencies]
+tempfile = "3.15"
+

--- a/xtask/src/lint_logging.rs
+++ b/xtask/src/lint_logging.rs
@@ -1,0 +1,386 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Ripgrep-style string lint that bans ad-hoc logging patterns in the Python
+//! and TypeScript polyglot SDKs. The only sanctioned pathway is `streamlib.log.*`
+//! — see `docs/logging.md`. Rust violations are caught by clippy's
+//! `disallowed-macros` rule (see `clippy.toml`).
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub struct LintTarget {
+    pub name: &'static str,
+    pub root_relative: &'static str,
+    pub extension: &'static str,
+    pub exclude_path_segments: &'static [&'static str],
+    pub exclude_file_suffixes: &'static [&'static str],
+    pub comment_prefix: &'static str,
+    pub banned_substrings: &'static [&'static str],
+    pub allow_substring: &'static str,
+}
+
+pub const TARGETS: &[LintTarget] = &[
+    LintTarget {
+        name: "python",
+        root_relative: "libs/streamlib-python",
+        extension: "py",
+        exclude_path_segments: &["tests", "_generated_", "__pycache__", ".venv", "build", "dist"],
+        exclude_file_suffixes: &["_test.py"],
+        comment_prefix: "#",
+        banned_substrings: &["print(", "sys.stdout", "sys.stderr", "logging.basicConfig"],
+        allow_substring: "streamlib.log.",
+    },
+    LintTarget {
+        name: "typescript",
+        root_relative: "libs/streamlib-deno",
+        extension: "ts",
+        exclude_path_segments: &["_generated_", "tests", "node_modules"],
+        exclude_file_suffixes: &["_test.ts", ".test.ts"],
+        comment_prefix: "//",
+        banned_substrings: &[
+            "console.log",
+            "console.warn",
+            "console.error",
+            "console.info",
+            "console.debug",
+            "Deno.stdout.write",
+            "Deno.stderr.write",
+        ],
+        allow_substring: "streamlib.log.",
+    },
+];
+
+#[derive(Debug)]
+pub struct Violation {
+    pub path: PathBuf,
+    pub line_no: usize,
+    pub line_text: String,
+    pub matched_pattern: &'static str,
+    pub target: &'static str,
+}
+
+pub struct LintReport {
+    pub violations: Vec<Violation>,
+    pub files_scanned: usize,
+}
+
+pub fn run(project_root: &Path) -> Result<()> {
+    let report = scan_all(project_root)?;
+    for v in &report.violations {
+        eprintln!(
+            "{}:{}: [{}] banned `{}` — use streamlib.log.* / see docs/logging.md\n    {}",
+            v.path.display(),
+            v.line_no,
+            v.target,
+            v.matched_pattern,
+            v.line_text.trim_end(),
+        );
+    }
+    if report.violations.is_empty() {
+        println!(
+            "lint-logging: {} file(s) scanned across polyglot SDKs, no violations",
+            report.files_scanned,
+        );
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "lint-logging: {} violation(s) across {} file(s) scanned",
+            report.violations.len(),
+            report.files_scanned,
+        ))
+    }
+}
+
+pub fn scan_all(project_root: &Path) -> Result<LintReport> {
+    let mut violations = Vec::new();
+    let mut files_scanned = 0usize;
+    for target in TARGETS {
+        let root = project_root.join(target.root_relative);
+        if !root.exists() {
+            continue;
+        }
+        scan_target(&root, target, &mut violations, &mut files_scanned)?;
+    }
+    Ok(LintReport { violations, files_scanned })
+}
+
+fn scan_target(
+    root: &Path,
+    target: &'static LintTarget,
+    violations: &mut Vec<Violation>,
+    files_scanned: &mut usize,
+) -> Result<()> {
+    for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e != target.extension)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        if is_excluded(path, root, target) {
+            continue;
+        }
+        *files_scanned += 1;
+        scan_file(path, target, violations)?;
+    }
+    Ok(())
+}
+
+fn is_excluded(path: &Path, root: &Path, target: &LintTarget) -> bool {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    for component in rel.components() {
+        if let std::path::Component::Normal(seg) = component {
+            if let Some(seg_str) = seg.to_str() {
+                if target.exclude_path_segments.contains(&seg_str) {
+                    return true;
+                }
+            }
+        }
+    }
+    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+        for suffix in target.exclude_file_suffixes {
+            if name.ends_with(suffix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Marker comment that exempts an entire file. Used by the infrastructure
+/// files that *install* the unified pathway — `_log_interceptors.py`,
+/// `_log_interceptors.ts`, and the subprocess bootstrap runners that must
+/// emit diagnostics before the logging pipeline is wired.
+const ALLOW_FILE_PRAGMA: &str = "streamlib:lint-logging:allow-file";
+
+/// Marker comment that exempts a single line.
+const ALLOW_LINE_PRAGMA: &str = "streamlib:lint-logging:allow-line";
+
+fn scan_file(
+    path: &Path,
+    target: &'static LintTarget,
+    violations: &mut Vec<Violation>,
+) -> Result<()> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    if content.contains(ALLOW_FILE_PRAGMA) {
+        return Ok(());
+    }
+    for (idx, line) in content.lines().enumerate() {
+        if is_comment_line(line, target.comment_prefix) {
+            continue;
+        }
+        if line.contains(target.allow_substring) {
+            continue;
+        }
+        if line.contains(ALLOW_LINE_PRAGMA) {
+            continue;
+        }
+        for pattern in target.banned_substrings {
+            if line.contains(pattern) {
+                violations.push(Violation {
+                    path: path.to_path_buf(),
+                    line_no: idx + 1,
+                    line_text: line.to_string(),
+                    matched_pattern: pattern,
+                    target: target.name,
+                });
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_comment_line(line: &str, prefix: &str) -> bool {
+    line.trim_start().starts_with(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_fixture(dir: &Path, rel: &str, content: &str) -> PathBuf {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn scan_fixture_tree(target: &'static LintTarget, content: &str, rel_path: &str) -> Vec<Violation> {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        write_fixture(&root, rel_path, content);
+        let mut violations = Vec::new();
+        let mut files_scanned = 0usize;
+        scan_target(&root, target, &mut violations, &mut files_scanned).unwrap();
+        violations
+    }
+
+    const PYTHON_TARGET: &LintTarget = &TARGETS[0];
+    const TYPESCRIPT_TARGET: &LintTarget = &TARGETS[1];
+
+    #[test]
+    fn rejects_print_in_python_library() {
+        let v = scan_fixture_tree(PYTHON_TARGET, "print(\"hello\")\n", "src/app.py");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].matched_pattern, "print(");
+    }
+
+    #[test]
+    fn rejects_sys_stdout_in_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "import sys\nsys.stdout.write(\"hi\")\n",
+            "src/app.py",
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].matched_pattern, "sys.stdout");
+    }
+
+    #[test]
+    fn rejects_logging_basicconfig_in_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "import logging\nlogging.basicConfig(level=logging.INFO)\n",
+            "src/app.py",
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].matched_pattern, "logging.basicConfig");
+    }
+
+    #[test]
+    fn rejects_console_log_in_ts_library() {
+        let v = scan_fixture_tree(TYPESCRIPT_TARGET, "console.log(\"hello\");\n", "src/app.ts");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].matched_pattern, "console.log");
+    }
+
+    #[test]
+    fn rejects_deno_stdout_write_in_ts() {
+        let v = scan_fixture_tree(
+            TYPESCRIPT_TARGET,
+            "await Deno.stdout.write(new TextEncoder().encode(\"x\"));\n",
+            "src/app.ts",
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].matched_pattern, "Deno.stdout.write");
+    }
+
+    #[test]
+    fn rejects_every_console_method_variant() {
+        for method in ["log", "warn", "error", "info", "debug"] {
+            let src = format!("console.{}(\"x\");\n", method);
+            let v = scan_fixture_tree(TYPESCRIPT_TARGET, &src, "src/app.ts");
+            assert_eq!(v.len(), 1, "console.{} should be rejected", method);
+        }
+    }
+
+    #[test]
+    fn accepts_streamlib_log_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "import streamlib\nstreamlib.log.info(\"hi\")\n",
+            "src/app.py",
+        );
+        assert!(v.is_empty(), "streamlib.log.* should pass: {:?}", v);
+    }
+
+    #[test]
+    fn accepts_streamlib_log_ts() {
+        let v = scan_fixture_tree(
+            TYPESCRIPT_TARGET,
+            "import * as streamlib from \"./mod.ts\";\nstreamlib.log.info(\"hi\");\n",
+            "src/app.ts",
+        );
+        assert!(v.is_empty(), "streamlib.log.* should pass: {:?}", v);
+    }
+
+    #[test]
+    fn skips_comment_lines_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "# don't use print(\"x\") here\nstreamlib.log.info(\"ok\")\n",
+            "src/app.py",
+        );
+        assert!(v.is_empty(), "commented-out print should not flag: {:?}", v);
+    }
+
+    #[test]
+    fn skips_comment_lines_ts() {
+        let v = scan_fixture_tree(
+            TYPESCRIPT_TARGET,
+            "// don't use console.log here\nstreamlib.log.info(\"ok\");\n",
+            "src/app.ts",
+        );
+        assert!(v.is_empty(), "commented-out console.log should not flag: {:?}", v);
+    }
+
+    #[test]
+    fn excludes_tests_directory_python() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        write_fixture(&root, "tests/test_app.py", "print(\"hi\")\n");
+        write_fixture(&root, "src/app.py", "streamlib.log.info(\"ok\")\n");
+        let mut violations = Vec::new();
+        let mut files_scanned = 0usize;
+        scan_target(&root, PYTHON_TARGET, &mut violations, &mut files_scanned).unwrap();
+        assert!(violations.is_empty(), "tests/ should be excluded: {:?}", violations);
+    }
+
+    #[test]
+    fn allow_file_pragma_skips_entire_file_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "# streamlib:lint-logging:allow-file — this is the interceptor installer itself\nimport sys\nsys.stdout = MyInterceptor()\n",
+            "src/_log_interceptors.py",
+        );
+        assert!(v.is_empty(), "allow-file pragma should suppress entire file: {:?}", v);
+    }
+
+    #[test]
+    fn allow_file_pragma_skips_entire_file_ts() {
+        let v = scan_fixture_tree(
+            TYPESCRIPT_TARGET,
+            "// streamlib:lint-logging:allow-file — interceptor installer\nDeno.stdout.write(new Uint8Array());\n",
+            "src/_log_interceptors.ts",
+        );
+        assert!(v.is_empty(), "allow-file pragma should suppress entire file: {:?}", v);
+    }
+
+    #[test]
+    fn allow_line_pragma_skips_single_line_python() {
+        let v = scan_fixture_tree(
+            PYTHON_TARGET,
+            "sys.stderr.write(\"fallback\")  # streamlib:lint-logging:allow-line\nprint(\"bad\")\n",
+            "src/app.py",
+        );
+        assert_eq!(v.len(), 1, "only the non-allowed line should flag: {:?}", v);
+        assert_eq!(v[0].matched_pattern, "print(");
+    }
+
+    #[test]
+    fn excludes_test_suffix_ts() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        write_fixture(&root, "src/app_test.ts", "console.log(\"hi\");\n");
+        write_fixture(&root, "src/app.ts", "streamlib.log.info(\"ok\");\n");
+        let mut violations = Vec::new();
+        let mut files_scanned = 0usize;
+        scan_target(&root, TYPESCRIPT_TARGET, &mut violations, &mut files_scanned).unwrap();
+        assert!(violations.is_empty(), "*_test.ts should be excluded: {:?}", violations);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 mod generate_schemas;
+pub mod lint_logging;
 
 #[derive(Parser)]
 #[command(name = "xtask")]
@@ -52,6 +53,10 @@ enum Commands {
         #[arg(long, group = "input")]
         schema_dir: Option<PathBuf>,
     },
+
+    /// Ban ad-hoc logging in polyglot SDK library code (Python + TypeScript).
+    /// Paired with the workspace clippy.toml `disallowed-macros` rule for Rust.
+    LintLogging,
 }
 
 fn main() -> Result<()> {
@@ -65,6 +70,7 @@ fn main() -> Result<()> {
             schema_file,
             schema_dir,
         } => generate_schemas::run(runtime, output, project_file, schema_file, schema_dir)?,
+        Commands::LintLogging => lint_logging::run(&workspace_root()?)?,
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Three-layer lockout for the unified logging pathway landed in the logging milestone:

- **Rust (clippy)** — workspace `clippy.toml` denies `println!`/`eprintln!`/`print!`/`eprint!`/`dbg!`; library crates opt in via `[lints] workspace = true`. Binary-only crates (streamlib-cli, streamlib-runtime, xtask, examples) stay opt-out because stdout IS their user output channel.
- **Python + TypeScript (xtask)** — new `cargo xtask lint-logging` subcommand bans `print(`, `sys.stdout`, `sys.stderr`, `logging.basicConfig`, `console.{log,warn,error,info,debug}`, `Deno.stdout.{write,writeSync}`, `Deno.stderr.{write,writeSync}` in `libs/streamlib-python/**/*.py` + `libs/streamlib-deno/**/*.ts`. Allow-list pragmas (`streamlib:lint-logging:allow-file` / `-allow-line`) cover the interceptor installer files and subprocess bootstrap runners that must touch raw pipes.
- **CI** — `.github/workflows/lint-logging.yml` runs both checks on every PR + push to main (`cargo clippy --workspace` + `cargo xtask lint-logging` + xtask unit tests).

## Closes
Closes #441

## Exit criteria

- [x] Workspace `clippy.toml` configures `disallowed-macros` across all library crates
- [x] Overrides allowed only in `tests/`, `examples/`, `build.rs`, `xtask`, and binary crates (via `[lints]` opt-out or crate-level `#![allow]`)
- [x] `cargo clippy --workspace` passes on the repo at merge time (exit 0)
- [x] `cargo xtask lint-logging` subcommand rejects banned substrings in Python + TypeScript library paths
- [x] `streamlib.log.*` allow-list in xtask
- [x] Non-zero exit on violation with each offending file+line printed
- [x] `.github/workflows/lint-logging.yml` runs both as required checks on `main`
- [x] `docs/logging.md` documents single pathway + three enforcement layers + exception mechanism

## Audit of pre-existing first-party violations

Surfaced by the new rule — all fixed in this PR:

| Crate / area | Before | Approach |
| --- | --- | --- |
| `streamlib-python-native/src/lib.rs` | 50 `eprintln!("[slpn] …")` | Added `tracing` dep; converted all to `tracing::error!` / `warn!` / `info!` (prefix tag dropped — tracing span is the source). |
| `streamlib-deno-native/src/lib.rs` | 50 `eprintln!("[sldn] …")` | Same approach. |
| `streamlib/src/linux/processors/camera.rs` | 28 library-code `eprintln!` + `println!` | Converted to structured `tracing::*` with `camera = camera_name`, `error = %e`, etc. fields. |
| `streamlib/src/linux/processors/audio_capture.rs` | 1 `eprintln!` | Converted to `tracing::error!`. |
| `vulkan-video/src/codec_utils/vulkan_command_buffer_pool.rs` | 3 `eprintln!` (fence timeout/failure) | Converted to structured `tracing::warn!` / `tracing::error!`. |
| `vulkan-video/src/encode/session.rs` | 1 `eprintln!` (encoder configured log) | Converted to `tracing::info!`. |
| `vulkan-video/src/vk_video_encoder/vk_video_gop_structure.rs` | 18 `print!` / `println!` in `print_gop_structure` / `dump_frame_gop_structure` / `dump_frames_gop_structure` | Function-level `#[allow(clippy::disallowed_macros)]` — these are explicitly named dumpers called from test bins; stdout is the output channel. |
| `streamlib/src/core/logging/init.rs` | 2 `eprintln!` in pre-init error paths | Narrow call-site `#[allow]` — the tracing subscriber we're trying to build is what errored out, so raw stderr is the only channel. |
| `libs/streamlib/src/bin/*.rs`, `libs/vulkan-video/src/bin/*.rs`, `build.rs` (both crates) | Many | File-level `#![allow(clippy::disallowed_macros)]` — binaries and build scripts; stdout / `cargo:` directives are the output channel. |
| `vulkan-video` pre-existing non-disallowed-macro clippy errors (`inherent_to_string_shadow_display`, `mut_from_ref`, `self_assignment`, `eq_op`) | 4 errors pre-existing on `main` | Narrow allow attrs at each intentional call site. Required to land the gate green. |

## Allow-pragma mechanism (xtask)

Four library files legitimately bypass the pathway because they install it:

- `libs/streamlib-python/python/streamlib/_log_interceptors.py`
- `libs/streamlib-python/python/streamlib/subprocess_runner.py`
- `libs/streamlib-deno/_log_interceptors.ts`
- `libs/streamlib-deno/subprocess_runner.ts`

Each carries a single-line `streamlib:lint-logging:allow-file` pragma near the copyright header, with a justification on the same line. Per-line `streamlib:lint-logging:allow-line` also supported.

## Test plan

### Rust clippy

- [x] `cargo clippy --workspace --no-deps` → exit 0
- [x] Negative test — injected `println!` + `eprintln!` in `libs/streamlib-codegen-shared/src/lib.rs` → clippy exits with `use of a disallowed macro 'std::println'` + `'std::eprintln'`, reverted.

### xtask lint-logging

- [x] `cargo test -p xtask lint_logging` → 15/15 passing, covers:
  - `rejects_print_in_python_library`
  - `rejects_sys_stdout_in_python`
  - `rejects_logging_basicconfig_in_python`
  - `rejects_console_log_in_ts_library`
  - `rejects_deno_stdout_write_in_ts`
  - `rejects_every_console_method_variant` (log/warn/error/info/debug)
  - `accepts_streamlib_log_python`
  - `accepts_streamlib_log_ts`
  - `skips_comment_lines_python`
  - `skips_comment_lines_ts`
  - `excludes_tests_directory_python`
  - `excludes_test_suffix_ts`
  - `allow_file_pragma_skips_entire_file_python`
  - `allow_file_pragma_skips_entire_file_ts`
  - `allow_line_pragma_skips_single_line_python`
- [x] `cargo run -p xtask -- lint-logging` → `19 file(s) scanned across polyglot SDKs, no violations`
- [x] Negative test — injected `_lint_logging_probe.py` with `print(...)` + `sys.stdout.write(...)` → xtask exits 1 reporting both violations, reverted.

### Build health

- [x] `cargo check --workspace` → clean
- [x] `cargo test -p streamlib --lib --no-run` → compiles (23 pre-existing unrelated warnings)
- [x] `cargo test -p vulkan-video --lib --no-run` → compiles
- [x] `cargo test -p streamlib-python-native --lib --no-run` → compiles
- [x] `cargo test -p streamlib-deno-native --lib --no-run` → compiles

## CI evidence

Per `.claude/workflows/ci.md`:

- **Workflow file**: `.github/workflows/lint-logging.yml` in this branch
- **Green baseline run**: this PR's Actions run — the workflow file is new and will fire on this PR (link will populate once GHA picks it up)
- **Negative test run**: happy to push a throwaway sidecar branch (`probe/logging-lockout-regression`) with a deliberate violation so the red CI is visible — let me know and I'll open it
- **Environment validated**: `ubuntu-latest` runner, stable Rust toolchain via `dtolnay/rust-toolchain@stable`, cargo cache keyed on `Cargo.lock` / `xtask/Cargo.toml`

## Follow-ups

- None blocking. Potential future work: raise the severity to also deny disallowed-macros in binary crates by opting them into workspace lints and explicitly allowing at call sites where user-facing output is the intent. Not scoped here because the current binaries are heavy on CLI output and would require substantial per-call annotations for marginal benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)