### PR TITLE
feat(logging): release-build trace-strip + opt-in strip_debug_logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ disallowed_macros = "deny"
 # Core dependencies
 thiserror = "2.0.17"
 anyhow = "1.0.100"
-tracing = "0.1.41"
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tokio = { version = "1.48.0", features = ["full"] }
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -63,6 +63,20 @@ Binary-only crates (`streamlib-cli`, `streamlib-runtime`, `xtask`, examples)
 do NOT opt into the workspace `[lints]` block because stdout IS their user
 output channel. The rule only applies to library crates.
 
+### Test code
+
+`#[cfg(test)]` modules inside library crates and integration tests under
+`libs/*/tests/` are allow-listed — `println!` / `eprintln!` there are
+fine. This matches the original lockout design (#441): "Overrides
+allowed only in `tests/`, `examples/`, `build.rs`, and `xtask`." CI
+enforces this naturally — `cargo clippy --workspace --no-deps` compiles
+only lib + bin targets, so `#[cfg(test)]` code isn't linted.
+
+If you run `cargo clippy --workspace --all-targets` or `--tests` locally
+you'll see disallowed-macro errors from this test-side code. They are
+NOT regressions and do NOT need fixing — the CI gate intentionally
+doesn't include `--tests`.
+
 ### Individual files
 
 Two kinds of files legitimately bypass the unified pathway, because they
@@ -111,11 +125,42 @@ records `intercepted=true channel=stdout|stderr`. You don't need to do
 anything. If the noise is genuinely unhelpful, consider filtering it in
 the subscriber rather than suppressing at the source.
 
+## Release-build level stripping
+
+`tracing` supports compile-time level filtering — call sites above the
+configured maximum are codegen'd to `{}` and have zero runtime cost.
+Streamlib pins two behaviors:
+
+| Build | `trace!` | `debug!` | `info!` / `warn!` / `error!` |
+| --- | --- | --- | --- |
+| debug | live | live | live |
+| release (default) | **stripped** | live | live |
+| release + `--features streamlib/strip_debug_logging` | **stripped** | **stripped** | live |
+
+- **Workspace default** enables `tracing/release_max_level_debug` — every
+  release build strips `trace!` so per-frame / per-RHI-op tracing is
+  safe to sprinkle on hot paths without runtime cost.
+- **Opt-in `strip_debug_logging`** on the `streamlib` crate activates
+  `tracing/release_max_level_info`, which additionally strips `debug!`.
+  Production images that want a smaller release output enable this
+  explicitly: `cargo build --release --features streamlib/strip_debug_logging`.
+- **`warn!` / `error!` are never stripped.** Production JSONL must
+  capture failure modes under every config. `release_max_level_off`,
+  `release_max_level_error`, and `release_max_level_warn` are NOT
+  exposed as streamlib features.
+- **`debug!` stays live in release by default** — on-site diagnostics
+  rely on it. Don't bump the workspace default to `release_max_level_info`.
+
+Verify the effective level at compile time via
+`tracing::level_filters::STATIC_MAX_LEVEL`.
+
 ## Recap
 
 - One API per language: `tracing::*!` (Rust) / `streamlib.log.*` (Python,
   Deno).
 - Three enforcement layers: clippy, xtask lint, runtime interceptors.
+- `trace!` is zero-cost in release; `debug!` is opt-out via
+  `strip_debug_logging`; `warn!` / `error!` are never stripped.
 - Binary crates and installer/bootstrap files are the only acceptable
   exceptions.
 - CI fails fast on regressions; don't try to bypass it — extend the

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -20,6 +20,9 @@ backend-metal = []
 backend-vulkan = ["dep:vulkanalia"]
 # MoQ (Media over QUIC) transport layer for network-transparent IPC
 moq = ["dep:moq-transport", "dep:web-transport", "dep:quinn", "dep:url", "dep:rustls-native-certs"]
+# Strip `debug!` (and `trace!`) from release builds. Opt-in per deployment
+# image. `warn!` / `error!` / `info!` are never stripped. See docs/logging.md.
+strip_debug_logging = ["tracing/release_max_level_info"]
 
 [dependencies]
 # Execution types (shared with macros for code generation)

--- a/libs/streamlib/src/core/logging/tests.rs
+++ b/libs/streamlib/src/core/logging/tests.rs
@@ -639,6 +639,200 @@ fn reader_thread_shuts_down_on_runtime_drop() {
     clear_xdg_state_home();
 }
 
+/// Workspace default pins `tracing/release_max_level_debug`. Verify the
+/// compile-time constant reflects that (TRACE in debug builds, DEBUG in
+/// release builds with no `strip_debug_logging`) and that a `trace!`
+/// call emits zero records in release while `debug!` survives.
+#[test]
+#[serial]
+#[cfg(not(feature = "strip_debug_logging"))]
+fn trace_compiled_out_in_release() {
+    reset_for_test();
+    // Open the subscriber filter as wide as possible so any record that
+    // survives the compile-time strip reaches the JSONL.
+    unsafe { std::env::set_var("RUST_LOG", "trace") };
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RtestTraceStrip"));
+    let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+    let guard = init_for_tests(config).unwrap();
+
+    tracing::trace!("trace-release-stripped-token");
+    tracing::debug!("debug-release-default-token");
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    let trace_count = events
+        .iter()
+        .filter(|e| e.message == "trace-release-stripped-token")
+        .count();
+    let debug_count = events
+        .iter()
+        .filter(|e| e.message == "debug-release-default-token")
+        .count();
+
+    if cfg!(debug_assertions) {
+        assert_eq!(
+            tracing::level_filters::STATIC_MAX_LEVEL,
+            tracing::level_filters::LevelFilter::TRACE,
+            "debug builds must keep every level live"
+        );
+        assert_eq!(trace_count, 1, "trace! must emit in debug builds");
+        assert_eq!(debug_count, 1, "debug! must emit in debug builds");
+    } else {
+        assert_eq!(
+            tracing::level_filters::STATIC_MAX_LEVEL,
+            tracing::level_filters::LevelFilter::DEBUG,
+            "release builds must strip trace! via release_max_level_debug"
+        );
+        assert_eq!(
+            trace_count, 0,
+            "trace! must be compiled out in release (workspace default)"
+        );
+        assert_eq!(
+            debug_count, 1,
+            "debug! must stay live in release without strip_debug_logging"
+        );
+    }
+
+    clear_xdg_state_home();
+}
+
+/// Without the opt-in feature, `debug!` produces a JSONL record under
+/// every profile.
+#[test]
+#[serial]
+#[cfg(not(feature = "strip_debug_logging"))]
+fn debug_lives_in_release_default() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RtestDebugLive"));
+    let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+    let guard = init_for_tests(config).unwrap();
+
+    tracing::debug!("debug-default-must-survive");
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        events
+            .iter()
+            .any(|e| e.message == "debug-default-must-survive" && e.level == LogLevel::Debug),
+        "expected debug! record in JSONL; got {:#?}",
+        events
+    );
+
+    clear_xdg_state_home();
+}
+
+/// With `--features streamlib/strip_debug_logging`, release builds
+/// additionally strip `debug!` (STATIC_MAX_LEVEL = INFO) while `info!`
+/// stays live.
+#[test]
+#[serial]
+#[cfg(feature = "strip_debug_logging")]
+fn strip_debug_logging_feature_strips_debug() {
+    reset_for_test();
+    unsafe { std::env::set_var("RUST_LOG", "trace") };
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RtestDebugStrip"));
+    let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+    let guard = init_for_tests(config).unwrap();
+
+    tracing::debug!("debug-feature-stripped-token");
+    tracing::info!("info-feature-keeps-token");
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    let debug_count = events
+        .iter()
+        .filter(|e| e.message == "debug-feature-stripped-token")
+        .count();
+    let info_count = events
+        .iter()
+        .filter(|e| e.message == "info-feature-keeps-token")
+        .count();
+
+    if cfg!(debug_assertions) {
+        // `release_max_level_*` features only apply in release.
+        assert_eq!(
+            tracing::level_filters::STATIC_MAX_LEVEL,
+            tracing::level_filters::LevelFilter::TRACE,
+            "debug builds ignore release_max_level_info"
+        );
+        assert_eq!(debug_count, 1);
+        assert_eq!(info_count, 1);
+    } else {
+        assert_eq!(
+            tracing::level_filters::STATIC_MAX_LEVEL,
+            tracing::level_filters::LevelFilter::INFO,
+            "release builds with strip_debug_logging must raise the cap to INFO"
+        );
+        assert_eq!(
+            debug_count, 0,
+            "debug! must be compiled out with strip_debug_logging"
+        );
+        assert_eq!(info_count, 1, "info! must survive strip_debug_logging");
+    }
+
+    clear_xdg_state_home();
+}
+
+/// `warn!` and `error!` must always reach the JSONL. No feature combo
+/// may strip them — production diagnostics depend on it.
+#[test]
+#[serial]
+fn warn_and_error_never_stripped() {
+    reset_for_test();
+    let tmp = TempDir::new().unwrap();
+    set_xdg_state_home(&tmp);
+
+    let runtime_id = Arc::new(RuntimeUniqueId::from("RtestWarnErr"));
+    let config = StreamlibLoggingConfig::for_runtime("test", runtime_id);
+    let guard = init_for_tests(config).unwrap();
+
+    tracing::warn!("warn-never-stripped-token");
+    tracing::error!("error-never-stripped-token");
+
+    let path = guard.jsonl_path().unwrap().to_path_buf();
+    drop(guard);
+
+    let events = read_jsonl(&path);
+    assert!(
+        events
+            .iter()
+            .any(|e| e.message == "warn-never-stripped-token" && e.level == LogLevel::Warn),
+        "expected warn! record in JSONL; got {:#?}",
+        events
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| e.message == "error-never-stripped-token" && e.level == LogLevel::Error),
+        "expected error! record in JSONL; got {:#?}",
+        events
+    );
+    assert!(
+        tracing::level_filters::STATIC_MAX_LEVEL
+            >= tracing::level_filters::LevelFilter::INFO,
+        "STATIC_MAX_LEVEL must always admit warn!/error!; got {:?}",
+        tracing::level_filters::STATIC_MAX_LEVEL
+    );
+
+    clear_xdg_state_home();
+}
+
 #[test]
 #[serial]
 fn burst_surfaces_dropped_counter_record() {


### PR DESCRIPTION
## Summary

- Workspace `tracing` pinned with `release_max_level_debug` — `tracing::trace!` is codegen'd to `{}` in release, safe to sprinkle on per-frame / per-RHI-op hot paths.
- New opt-in `streamlib` feature `strip_debug_logging = ["tracing/release_max_level_info"]` — deployment images that want `debug!` stripped too enable it explicitly; `warn!` / `error!` / `info!` are never stripped.
- `docs/logging.md` documents the new feature + verifies the pre-existing `#[cfg(test)]` allow-list from the #441 lockout (CI's `cargo clippy --workspace --no-deps` intentionally omits `--tests`).

## Closes
Closes #439

## Exit criteria

- [x] Workspace `Cargo.toml` pins `tracing` with `release_max_level_debug`.
- [x] Optional `streamlib` crate feature `strip_debug_logging` activates `tracing/release_max_level_info`.
- [x] `warn!` / `error!` remain live in every supported config; `release_max_level_off` / `release_max_level_error` are NOT exposed.
- [x] `docs/logging.md` documents the feature and when to enable it.

## Test plan

Four new tests in `core::logging::tests`, validated across all four build matrix cells:

- [x] `trace_compiled_out_in_release` — `STATIC_MAX_LEVEL` assertion per profile + verifies zero JSONL records from `trace!` under release default.
- [x] `debug_lives_in_release_default` — `debug!` reaches JSONL under workspace default (debug + release).
- [x] `strip_debug_logging_feature_strips_debug` — feature-gated test; in release with feature on, `debug!` is stripped while `info!` survives.
- [x] `warn_and_error_never_stripped` — `warn!` / `error!` always reach JSONL; also asserts `STATIC_MAX_LEVEL >= INFO`.

Matrix runs locally:

- `cargo test -p streamlib --lib core::logging::tests` (debug default) → 18 pass
- `cargo test --release -p streamlib --lib core::logging::tests` (release default) → 18 pass, stdout shows only `debug-release-default-token` — `trace-release-stripped-token` was compiled out.
- `cargo test -p streamlib --lib --features strip_debug_logging core::logging::tests::strip_debug_logging_feature_strips_debug` (debug + feature) → 1 pass
- `cargo test --release -p streamlib --lib --features strip_debug_logging core::logging::tests` (release + feature) → 17 pass, stdout shows only `info-feature-keeps-token` — `debug-feature-stripped-token` was compiled out.

`cargo clippy -p streamlib --lib --no-deps` → no new errors. (`--tests` surfaces pre-existing test-side `println!`/`eprintln!`, which is allow-listed by #441 design — documented in `docs/logging.md`.)

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)