### PR TITLE
feat(broker, rhi): multi-FD SCM_RIGHTS + Rust-side multi-plane import (closes #423)

### DIFF
--- a/libs/streamlib-broker-client/src/lib.rs
+++ b/libs/streamlib-broker-client/src/lib.rs
@@ -5,21 +5,26 @@
 //! SCM_RIGHTS protocol.
 //!
 //! This crate is the single shared home for the `connect_to_broker` /
-//! `send_request` / `send_message_with_fd` / `recv_message_with_fd` trio. It
-//! is deliberately tiny — `libc` + `serde_json` only — so the two polyglot
-//! cdylibs (`streamlib-python-native`, `streamlib-deno-native`) can depend
-//! on it without dragging the runtime's transitive closure (vulkanalia,
-//! tokio, winit, …) into their dep graphs. The runtime-internal service in
-//! `streamlib::linux::surface_broker` consumes the same helpers on its
-//! client-request path, so the wire format has exactly one source.
+//! `send_request_with_fds` / `send_message_with_fds` / `recv_message_with_fds`
+//! trio. It is deliberately tiny — `libc` + `serde_json` only — so the two
+//! polyglot cdylibs (`streamlib-python-native`, `streamlib-deno-native`) can
+//! depend on it without dragging the runtime's transitive closure
+//! (vulkanalia, tokio, winit, …) into their dep graphs. The runtime-internal
+//! service in `streamlib::linux::surface_broker` consumes the same helpers
+//! on its client-request path, so the wire format has exactly one source.
 //!
 //! The wire is: a 4-byte big-endian `u32` length prefix followed by a JSON
-//! payload, with an optional `SCM_RIGHTS` ancillary fd attached to the
-//! payload `sendmsg`. Fd ownership is unchanged by these helpers — callers
-//! that `close` their fd after send still do so.
+//! payload, with zero or more `SCM_RIGHTS` ancillary fds attached to the
+//! payload `sendmsg`. Multi-FD capacity covers DMA-BUFs with disjoint planes
+//! (e.g. NV12 under DRM format modifiers with separate Y and UV allocations);
+//! the ceiling is [`MAX_DMA_BUF_PLANES`]. Fd ownership is unchanged by these
+//! helpers — callers that `close` their fds after send still do so.
 
 #[cfg(target_os = "linux")]
 mod linux;
 
 #[cfg(target_os = "linux")]
-pub use linux::{connect_to_broker, recv_message_with_fd, send_message_with_fd, send_request};
+pub use linux::{
+    connect_to_broker, recv_message_with_fds, send_message_with_fds, send_request_with_fds,
+    MAX_DMA_BUF_PLANES,
+};

--- a/libs/streamlib-broker-client/src/linux.rs
+++ b/libs/streamlib-broker-client/src/linux.rs
@@ -5,17 +5,51 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 
+/// Maximum number of DMA-BUF plane fds carried in a single SCM_RIGHTS message.
+///
+/// Matches the DRM format-modifier plane ceiling for every format streamlib
+/// exchanges today — NV12 splits into Y/UV (2), YUV420 into Y/U/V (3), and a
+/// fourth slot covers RGBA-with-auxiliary / YUVA variants. The Linux kernel's
+/// SCM_MAX_FD is 253 so the wire itself is not the bottleneck; the cap exists
+/// to bound `cmsg` buffer sizing and to refuse obviously-bogus surfaces before
+/// they cost an fd table entry.
+pub const MAX_DMA_BUF_PLANES: usize = 4;
+
 /// Connect to the broker's Unix socket.
 pub fn connect_to_broker(socket_path: &Path) -> std::io::Result<UnixStream> {
     UnixStream::connect(socket_path)
 }
 
-/// Send a length-prefixed message with an optional SCM_RIGHTS fd.
-pub fn send_message_with_fd(
+/// `CMSG_SPACE(n * sizeof(RawFd))` at runtime.
+fn cmsg_space_for(n: usize) -> usize {
+    let bytes = (n * std::mem::size_of::<RawFd>()) as libc::c_uint;
+    unsafe { libc::CMSG_SPACE(bytes) as usize }
+}
+
+/// Send a length-prefixed message with zero or more SCM_RIGHTS fds attached.
+///
+/// The fds are packed into a single `cmsg` record of type `SCM_RIGHTS`. The
+/// kernel duplicates them into the receiver's fd table on successful
+/// `recvmsg`; the sender retains ownership of its copies (close after send).
+///
+/// Returns an error if `fds.len() > MAX_DMA_BUF_PLANES` without performing
+/// any syscalls — the caller still owns every fd in that case.
+pub fn send_message_with_fds(
     stream: &UnixStream,
     data: &[u8],
-    fd: Option<RawFd>,
+    fds: &[RawFd],
 ) -> std::io::Result<()> {
+    if fds.len() > MAX_DMA_BUF_PLANES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "SCM_RIGHTS fd count {} exceeds MAX_DMA_BUF_PLANES={}",
+                fds.len(),
+                MAX_DMA_BUF_PLANES
+            ),
+        ));
+    }
+
     // First send the length prefix
     let len_bytes = (data.len() as u32).to_be_bytes();
     let mut len_iov = libc::iovec {
@@ -31,7 +65,7 @@ pub fn send_message_with_fd(
         return Err(std::io::Error::last_os_error());
     }
 
-    // Then send the data payload with optional fd
+    // Then send the data payload with optional fds
     let mut iov = libc::iovec {
         iov_base: data.as_ptr() as *mut libc::c_void,
         iov_len: data.len(),
@@ -41,35 +75,32 @@ pub fn send_message_with_fd(
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
 
-    const CMSG_SPACE_SIZE: usize =
-        unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
+    // Size the control buffer for the worst case we allow, so a late-arriving
+    // receiver that probed a smaller cap still parses our messages.
+    let cmsg_space = cmsg_space_for(MAX_DMA_BUF_PLANES);
+    let mut cmsg_buf = vec![0u8; cmsg_space];
 
-    // Aligned control message buffer for SCM_RIGHTS (one fd)
-    #[repr(C)]
-    union CmsgBuf {
-        buf: [u8; CMSG_SPACE_SIZE],
-        _align: libc::cmsghdr,
-    }
-    let mut cmsg_buf = CmsgBuf {
-        buf: [0u8; CMSG_SPACE_SIZE],
-    };
-
-    if let Some(send_fd) = fd {
-        msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
-        msg.msg_controllen = CMSG_SPACE_SIZE;
+    if !fds.is_empty() {
+        let payload_space = cmsg_space_for(fds.len());
+        msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+        msg.msg_controllen = payload_space;
 
         let cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
-        if !cmsg_ptr.is_null() {
-            unsafe {
-                (*cmsg_ptr).cmsg_level = libc::SOL_SOCKET;
-                (*cmsg_ptr).cmsg_type = libc::SCM_RIGHTS;
-                (*cmsg_ptr).cmsg_len =
-                    libc::CMSG_LEN(std::mem::size_of::<RawFd>() as u32) as usize;
-                let fd_ptr = libc::CMSG_DATA(cmsg_ptr) as *mut RawFd;
-                *fd_ptr = send_fd;
-            }
-            msg.msg_controllen = CMSG_SPACE_SIZE;
+        if cmsg_ptr.is_null() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "CMSG_FIRSTHDR returned null",
+            ));
         }
+        let fd_bytes = (fds.len() * std::mem::size_of::<RawFd>()) as libc::c_uint;
+        unsafe {
+            (*cmsg_ptr).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg_ptr).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg_ptr).cmsg_len = libc::CMSG_LEN(fd_bytes) as usize;
+            let dst = libc::CMSG_DATA(cmsg_ptr) as *mut RawFd;
+            std::ptr::copy_nonoverlapping(fds.as_ptr(), dst, fds.len());
+        }
+        msg.msg_controllen = payload_space;
     }
 
     let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &msg, 0) };
@@ -80,27 +111,31 @@ pub fn send_message_with_fd(
     Ok(())
 }
 
-/// Receive a length-prefixed message payload with an optional SCM_RIGHTS fd.
+/// Receive a length-prefixed message payload with up to `max_fds` SCM_RIGHTS
+/// fds attached.
 ///
 /// `msg_len` is the payload byte count, which callers obtain from the 4-byte
-/// big-endian length prefix (read by `send_request` for the response, or
-/// directly by the server's connection loop for each request).
-pub fn recv_message_with_fd(
+/// big-endian length prefix (read by `send_request_with_fds` for the
+/// response, or directly by the server's connection loop for each request).
+///
+/// `max_fds` sizes the `cmsg` buffer allocated for the `recvmsg` call. It
+/// MUST be at least as large as the greatest plane count any peer will send
+/// on this connection — if the kernel delivers more fds than the buffer
+/// holds, `MSG_CTRUNC` is set and **the surplus fds are silently leaked into
+/// the peer's table**; this helper treats that condition as an error. Callers
+/// that expect single-plane traffic can pass `1`; callers that accept
+/// multi-plane should pass `MAX_DMA_BUF_PLANES`.
+///
+/// On any failure all received fds (if any) are closed before the error is
+/// returned.
+pub fn recv_message_with_fds(
     stream: &UnixStream,
     msg_len: usize,
-) -> std::io::Result<(Vec<u8>, Option<RawFd>)> {
-    const CMSG_SPACE_SIZE: usize =
-        unsafe { libc::CMSG_SPACE(std::mem::size_of::<RawFd>() as u32) } as usize;
-
-    // Aligned control message buffer for SCM_RIGHTS (one fd)
-    #[repr(C)]
-    union CmsgBuf {
-        buf: [u8; CMSG_SPACE_SIZE],
-        _align: libc::cmsghdr,
-    }
-    let mut cmsg_buf = CmsgBuf {
-        buf: [0u8; CMSG_SPACE_SIZE],
-    };
+    max_fds: usize,
+) -> std::io::Result<(Vec<u8>, Vec<RawFd>)> {
+    let cap = max_fds.min(MAX_DMA_BUF_PLANES);
+    let cmsg_space = cmsg_space_for(cap.max(1));
+    let mut cmsg_buf = vec![0u8; cmsg_space];
 
     let mut buf = vec![0u8; msg_len];
 
@@ -112,8 +147,8 @@ pub fn recv_message_with_fd(
     let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
-    msg.msg_control = unsafe { cmsg_buf.buf.as_mut_ptr() } as *mut libc::c_void;
-    msg.msg_controllen = CMSG_SPACE_SIZE;
+    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_space;
 
     let n = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut msg, 0) };
     if n < 0 {
@@ -126,11 +161,17 @@ pub fn recv_message_with_fd(
         ));
     }
 
-    // Check for truncated control message (fd silently lost)
+    let received_fds = extract_cmsg_fds(&msg);
+
+    // Check for truncated control message AFTER extracting whatever fds did
+    // fit, so we can close them instead of leaking them.
     if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+        for fd in &received_fds {
+            unsafe { libc::close(*fd) };
+        }
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "SCM_RIGHTS control message truncated",
+            "SCM_RIGHTS control message truncated (peer sent more fds than max_fds)",
         ));
     }
 
@@ -146,6 +187,9 @@ pub fn recv_message_with_fd(
             )
         };
         if n <= 0 {
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
+            }
             return Err(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "Connection closed during message read",
@@ -154,27 +198,45 @@ pub fn recv_message_with_fd(
         total_read += n as usize;
     }
 
-    // Extract fd from control message if present
-    let mut received_fd = None;
-    let mut cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    Ok((buf, received_fds))
+}
+
+/// Walk every `SCM_RIGHTS` cmsg in `msg` and flatten its fds into a single
+/// vec. A well-formed sender emits one record, but the kernel is free to
+/// split — handling both keeps us compatible.
+fn extract_cmsg_fds(msg: &libc::msghdr) -> Vec<RawFd> {
+    let mut out = Vec::new();
+    let mut cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(msg) };
     while !cmsg_ptr.is_null() {
         let cmsg = unsafe { &*cmsg_ptr };
         if cmsg.cmsg_level == libc::SOL_SOCKET && cmsg.cmsg_type == libc::SCM_RIGHTS {
-            let fd_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const RawFd;
-            received_fd = Some(unsafe { *fd_ptr });
+            let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const RawFd;
+            // cmsg_len covers header + payload; CMSG_LEN(0) is header alone.
+            let header_len = unsafe { libc::CMSG_LEN(0) } as usize;
+            let payload_bytes = cmsg.cmsg_len.saturating_sub(header_len);
+            let n_fds = payload_bytes / std::mem::size_of::<RawFd>();
+            for i in 0..n_fds {
+                out.push(unsafe { *data_ptr.add(i) });
+            }
         }
-        cmsg_ptr = unsafe { libc::CMSG_NXTHDR(&msg, cmsg_ptr) };
+        cmsg_ptr = unsafe { libc::CMSG_NXTHDR(msg, cmsg_ptr) };
     }
-
-    Ok((buf, received_fd))
+    out
 }
 
 /// Send a request and receive a response from the broker.
-pub fn send_request(
+///
+/// `fds` is the set of SCM_RIGHTS fds to attach to the request (empty for
+/// requests that don't transfer any, e.g. `check_out`, `release`).
+/// `max_response_fds` caps how many fds the helper is willing to receive on
+/// the response; `check_out` passes `MAX_DMA_BUF_PLANES`, `register` and
+/// `release` pass `0`.
+pub fn send_request_with_fds(
     stream: &UnixStream,
     request: &serde_json::Value,
-    fd: Option<RawFd>,
-) -> std::io::Result<(serde_json::Value, Option<RawFd>)> {
+    fds: &[RawFd],
+    max_response_fds: usize,
+) -> std::io::Result<(serde_json::Value, Vec<RawFd>)> {
     let request_bytes = serde_json::to_vec(request).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -182,8 +244,7 @@ pub fn send_request(
         )
     })?;
 
-    // Send request with optional fd
-    send_message_with_fd(stream, &request_bytes, fd)?;
+    send_message_with_fds(stream, &request_bytes, fds)?;
 
     // Read response length prefix
     let mut len_buf = [0u8; 4];
@@ -208,17 +269,22 @@ pub fn send_request(
     }
     let response_len = u32::from_be_bytes(len_buf) as usize;
 
-    // Read response with optional fd
-    let (response_bytes, response_fd) = recv_message_with_fd(stream, response_len)?;
+    let (response_bytes, response_fds) =
+        recv_message_with_fds(stream, response_len, max_response_fds)?;
 
     let response: serde_json::Value = serde_json::from_slice(&response_bytes).map_err(|e| {
+        // Close any fds that came with the malformed response so we don't
+        // leak them into the caller's table.
+        for fd in &response_fds {
+            unsafe { libc::close(*fd) };
+        }
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("Invalid JSON response: {}", e),
         )
     })?;
 
-    Ok((response, response_fd))
+    Ok((response, response_fds))
 }
 
 #[cfg(test)]
@@ -288,7 +354,7 @@ mod tests {
 
         let client = UnixStream::connect(&socket_path).expect("connect");
         let payload = b"\x00hello\xff\x01wire\x7f";
-        send_message_with_fd(&client, payload, None).expect("send");
+        send_message_with_fds(&client, payload, &[]).expect("send");
         drop(client);
 
         let (len_buf, received) = server.join().expect("server thread");
@@ -298,9 +364,10 @@ mod tests {
         let _ = std::fs::remove_file(&socket_path);
     }
 
-    /// Round-trip an fd via SCM_RIGHTS: the receiving side must see a fd that
-    /// refers to the same kernel file object (memfd contents match byte for
-    /// byte). This is the core consumer-client guarantee.
+    /// Round-trip a single fd via SCM_RIGHTS: the receiving side must see a
+    /// fd that refers to the same kernel file object (memfd contents match
+    /// byte for byte). Single-plane is the common case — locking it here
+    /// protects the regression gate.
     #[test]
     fn send_recv_preserves_fd_content_via_scm_rights() {
         let socket_path = tmp_socket_path("fd-roundtrip");
@@ -308,7 +375,6 @@ mod tests {
 
         let server = std::thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept");
-            // Read the 4-byte length prefix first, then recv the payload + fd.
             let mut len_buf = [0u8; 4];
             let mut total = 0;
             while total < 4 {
@@ -323,38 +389,124 @@ mod tests {
                 total += n as usize;
             }
             let payload_len = u32::from_be_bytes(len_buf) as usize;
-            recv_message_with_fd(&stream, payload_len).expect("recv")
+            recv_message_with_fds(&stream, payload_len, 1).expect("recv")
         });
 
         let pattern = b"streamlib-broker-client-scm-rights-fixture-0123456789";
         let send_fd = make_memfd_with(pattern);
         let client = UnixStream::connect(&socket_path).expect("connect");
         let payload = br#"{"op":"noop"}"#;
-        send_message_with_fd(&client, payload, Some(send_fd)).expect("send");
+        send_message_with_fds(&client, payload, &[send_fd]).expect("send");
         unsafe { libc::close(send_fd) };
         drop(client);
 
-        let (received_payload, received_fd) = server.join().expect("server thread");
+        let (received_payload, received_fds) = server.join().expect("server thread");
         assert_eq!(received_payload, payload);
-        let received_fd = received_fd.expect("fd should be delivered");
+        assert_eq!(received_fds.len(), 1, "fd should be delivered");
+        let received_fd = received_fds[0];
         assert!(received_fd >= 0);
         assert_eq!(read_all_from_fd(received_fd), pattern);
 
         let _ = std::fs::remove_file(&socket_path);
     }
 
-    /// `send_request` composes send + length-prefixed recv into a JSON request
-    /// / JSON response round-trip. Lock the full request/response shape here
-    /// so the three consumers (broker proper, python-native, deno-native) all
+    /// Multi-plane round-trip: send `MAX_DMA_BUF_PLANES` distinct memfds in
+    /// one SCM_RIGHTS record, confirm every plane arrives with distinct
+    /// content and in order. Order matters — plane index is the only key the
+    /// consumer has to pair an fd with its `plane_sizes[i]`/`plane_offsets[i]`.
+    #[test]
+    fn send_recv_preserves_multi_fd_order_and_content_via_scm_rights() {
+        let socket_path = tmp_socket_path("multi-fd-roundtrip");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut len_buf = [0u8; 4];
+            let mut total = 0;
+            while total < 4 {
+                let n = unsafe {
+                    libc::read(
+                        stream.as_raw_fd(),
+                        len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                        4 - total,
+                    )
+                };
+                assert!(n > 0, "server read len");
+                total += n as usize;
+            }
+            let payload_len = u32::from_be_bytes(len_buf) as usize;
+            recv_message_with_fds(&stream, payload_len, MAX_DMA_BUF_PLANES).expect("recv")
+        });
+
+        let patterns: [&[u8]; MAX_DMA_BUF_PLANES] = [
+            b"plane-0-Y-plane-bytes-0000",
+            b"plane-1-U-plane-bytes-1111",
+            b"plane-2-V-plane-bytes-2222",
+            b"plane-3-A-plane-bytes-3333",
+        ];
+        let send_fds: Vec<RawFd> = patterns.iter().map(|p| make_memfd_with(p)).collect();
+        let client = UnixStream::connect(&socket_path).expect("connect");
+        let payload = br#"{"op":"check_out","surface_id":"multi"}"#;
+        send_message_with_fds(&client, payload, &send_fds).expect("send");
+        for fd in &send_fds {
+            unsafe { libc::close(*fd) };
+        }
+        drop(client);
+
+        let (received_payload, received_fds) = server.join().expect("server thread");
+        assert_eq!(received_payload, payload);
+        assert_eq!(received_fds.len(), MAX_DMA_BUF_PLANES, "all planes delivered");
+        for (i, fd) in received_fds.iter().enumerate() {
+            assert!(*fd >= 0);
+            assert_eq!(
+                read_all_from_fd(*fd),
+                patterns[i],
+                "plane {} content preserved",
+                i
+            );
+        }
+
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    /// Sending `MAX_DMA_BUF_PLANES + 1` fds returns an error and performs no
+    /// syscall — caller-owned fds are not closed under our feet.
+    #[test]
+    fn send_rejects_oversize_fd_vec_without_closing_caller_fds() {
+        let socket_path = tmp_socket_path("oversize");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let client = UnixStream::connect(&socket_path).expect("connect");
+        let _accepted = listener.accept().expect("accept");
+
+        let fds: Vec<RawFd> = (0..=MAX_DMA_BUF_PLANES)
+            .map(|i| make_memfd_with(format!("plane-{}", i).as_bytes()))
+            .collect();
+        let err = send_message_with_fds(&client, b"payload", &fds).expect_err("must reject");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        for fd in &fds {
+            // Still readable — the error path did not close caller-owned fds.
+            assert!(
+                unsafe { libc::fcntl(*fd, libc::F_GETFD) } >= 0,
+                "caller fd {} should still be valid after rejected send",
+                fd
+            );
+            unsafe { libc::close(*fd) };
+        }
+
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    /// `send_request_with_fds` composes send + length-prefixed recv into a
+    /// JSON request / JSON response round-trip. Lock the full shape here so
+    /// the three consumers (broker proper, python-native, deno-native) all
     /// see identical serialization + deserialization behavior.
     #[test]
-    fn send_request_round_trips_json_and_returns_response_fd() {
+    fn send_request_round_trips_json_and_returns_response_fds() {
         let socket_path = tmp_socket_path("send-request");
         let listener = UnixListener::bind(&socket_path).expect("bind");
 
         let server = std::thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept");
-            // Read request length + payload.
             let mut len_buf = [0u8; 4];
             let mut total = 0;
             while total < 4 {
@@ -369,28 +521,37 @@ mod tests {
                 total += n as usize;
             }
             let req_len = u32::from_be_bytes(len_buf) as usize;
-            let (req_bytes, req_fd) = recv_message_with_fd(&stream, req_len).expect("recv req");
-            assert!(req_fd.is_none(), "this test sends no fd");
+            let (req_bytes, req_fds) =
+                recv_message_with_fds(&stream, req_len, MAX_DMA_BUF_PLANES).expect("recv req");
+            assert!(req_fds.is_empty(), "this test sends no fd");
 
             let req: serde_json::Value = serde_json::from_slice(&req_bytes).expect("json");
             assert_eq!(req.get("op").and_then(|v| v.as_str()), Some("echo"));
 
-            // Reply with a JSON payload + an fd.
-            let reply_fd = make_memfd_with(b"reply-fd-contents");
+            // Reply with a JSON payload + two fds so the multi-plane path is
+            // exercised end-to-end at the send_request seam.
+            let reply_fds = [
+                make_memfd_with(b"reply-plane-0"),
+                make_memfd_with(b"reply-plane-1"),
+            ];
             let reply = serde_json::json!({"op": "echo", "ok": true, "echoed": req["payload"]});
             let reply_bytes = serde_json::to_vec(&reply).unwrap();
-            send_message_with_fd(&stream, &reply_bytes, Some(reply_fd)).expect("send reply");
-            unsafe { libc::close(reply_fd) };
+            send_message_with_fds(&stream, &reply_bytes, &reply_fds).expect("send reply");
+            for fd in &reply_fds {
+                unsafe { libc::close(*fd) };
+            }
         });
 
         let client = connect_to_broker(&socket_path).expect("connect");
         let request = serde_json::json!({"op": "echo", "payload": "hi"});
-        let (response, response_fd) =
-            send_request(&client, &request, None).expect("send_request");
+        let (response, response_fds) =
+            send_request_with_fds(&client, &request, &[], MAX_DMA_BUF_PLANES)
+                .expect("send_request_with_fds");
         assert_eq!(response.get("ok").and_then(|v| v.as_bool()), Some(true));
         assert_eq!(response.get("echoed").and_then(|v| v.as_str()), Some("hi"));
-        let response_fd = response_fd.expect("reply fd delivered");
-        assert_eq!(read_all_from_fd(response_fd), b"reply-fd-contents");
+        assert_eq!(response_fds.len(), 2, "both reply planes delivered");
+        assert_eq!(read_all_from_fd(response_fds[0]), b"reply-plane-0");
+        assert_eq!(read_all_from_fd(response_fds[1]), b"reply-plane-1");
 
         server.join().expect("server thread");
         let _ = std::fs::remove_file(&socket_path);

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -786,12 +786,23 @@ mod gpu_surface {
     pub const SURFACE_BACKEND_VULKAN: u32 = 2;
 
     pub struct SurfaceHandle {
-        pub fd: RawFd,
+        /// One fd per DMA-BUF plane. Multi-plane DMA-BUFs (e.g. NV12 under
+        /// DRM format modifiers with disjoint Y/UV allocations) carry one
+        /// per plane, keyed by plane index; single-plane surfaces carry a
+        /// one-element vec. Mirrors the Python-native twin.
+        pub fds: Vec<RawFd>,
+        pub plane_sizes: Vec<u64>,
+        pub plane_offsets: Vec<u64>,
         pub width: u32,
         pub height: u32,
         pub bytes_per_row: u32,
+        /// Total byte size across all planes — the sum of `plane_sizes`.
         pub size: u64,
+        /// Host-mapped base address of plane 0, populated by `lock` (Vulkan
+        /// path) or `plane_mmap` (CPU path). Multi-plane accessor reads
+        /// from [`Self::plane_mapped_ptrs`].
         pub mapped_ptr: *mut u8,
+        pub plane_mapped_ptrs: Vec<*mut u8>,
         pub is_locked: bool,
         /// Vulkan device attached by [`super::broker_client::sldn_broker_resolve_surface`].
         /// `None` means the broker could not create a Vulkan device and lock
@@ -805,21 +816,35 @@ mod gpu_surface {
         pub backend: u32,
     }
 
+    impl SurfaceHandle {
+        pub fn base_address(&self, plane_index: usize) -> *mut u8 {
+            if plane_index == 0 && !self.mapped_ptr.is_null() {
+                return self.mapped_ptr;
+            }
+            match self.plane_mapped_ptrs.get(plane_index) {
+                Some(&p) => p,
+                None => std::ptr::null_mut(),
+            }
+        }
+    }
+
     impl Drop for SurfaceHandle {
         fn drop(&mut self) {
-            // Tear down any outstanding Vulkan import (lock without unlock).
-            // `lock` imports a dup of `self.fd`; Vulkan owns that dup. Freeing
-            // the imported memory releases the dup, not `self.fd`.
             if self.is_locked {
                 if let Some(device) = self.vulkan_device.as_ref() {
                     device.destroy_imported(self.vulkan_buffer, self.vulkan_memory);
                 }
             }
-            // The original fd stays with the SurfaceHandle across lock/unlock
-            // cycles — close it last.
-            if self.fd >= 0 {
-                unsafe {
-                    libc::close(self.fd);
+            for (i, ptr) in self.plane_mapped_ptrs.iter().enumerate() {
+                if !ptr.is_null() {
+                    if let Some(size) = self.plane_sizes.get(i) {
+                        unsafe { libc::munmap(*ptr as *mut libc::c_void, *size as usize) };
+                    }
+                }
+            }
+            for fd in &self.fds {
+                if *fd >= 0 {
+                    unsafe { libc::close(*fd) };
                 }
             }
         }
@@ -843,7 +868,15 @@ mod gpu_surface {
         if handle.is_locked {
             return 0;
         }
-        if handle.size == 0 || handle.fd < 0 {
+        // Vulkan lock imports plane 0 only — multi-plane Vulkan producers
+        // do not exist in tree yet. Multi-plane consumers use
+        // `sldn_gpu_surface_plane_mmap` for CPU access to non-0 planes.
+        let fd0 = match handle.fds.first() {
+            Some(&fd) if fd >= 0 => fd,
+            _ => return -1,
+        };
+        let plane0_size = handle.plane_sizes.first().copied().unwrap_or(handle.size);
+        if plane0_size == 0 {
             return -1;
         }
         let device = match handle.vulkan_device.as_ref() {
@@ -856,10 +889,7 @@ mod gpu_surface {
                 return -1;
             }
         };
-        // Dup the fd before import: vkAllocateMemory takes ownership of the
-        // fd on success. Keeping the original fd on the SurfaceHandle lets
-        // the caller lock/unlock/lock again (each lock imports a fresh dup).
-        let dup_fd = unsafe { libc::dup(handle.fd) };
+        let dup_fd = unsafe { libc::dup(fd0) };
         if dup_fd < 0 {
             tracing::error!(
                 "gpu_surface_lock: dup fd failed: {}",
@@ -867,15 +897,13 @@ mod gpu_surface {
             );
             return -1;
         }
-        let imported = match device.import_dma_buf_fd(dup_fd, handle.size) {
+        let imported = match device.import_dma_buf_fd(dup_fd, plane0_size) {
             Ok(i) => i,
             Err(e) => {
                 tracing::error!(
                     "gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
-                    handle.fd, handle.size, e
+                    fd0, plane0_size, e
                 );
-                // On import failure Vulkan has not taken the fd — we must
-                // close the dup ourselves.
                 unsafe { libc::close(dup_fd) };
                 return -1;
             }
@@ -885,6 +913,59 @@ mod gpu_surface {
         handle.mapped_ptr = imported.mapped_ptr;
         handle.is_locked = true;
         handle.backend = SURFACE_BACKEND_VULKAN;
+        0
+    }
+
+    /// mmap a specific plane into user space. See the Python twin for the
+    /// full contract.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_mmap(
+        handle: *mut SurfaceHandle,
+        plane_index: u32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        let idx = plane_index as usize;
+        let fd = match handle.fds.get(idx) {
+            Some(&fd) if fd >= 0 => fd,
+            _ => return -1,
+        };
+        let size = match handle.plane_sizes.get(idx) {
+            Some(&s) if s > 0 => s as usize,
+            _ => return -1,
+        };
+        if handle
+            .plane_mapped_ptrs
+            .get(idx)
+            .map(|p| !p.is_null())
+            .unwrap_or(false)
+        {
+            return 0;
+        }
+        let offset = handle.plane_offsets.get(idx).copied().unwrap_or(0) as libc::off_t;
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                offset,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            tracing::error!(
+                "sldn_gpu_surface_plane_mmap: mmap failed for plane {} (fd {}, size {}): {}",
+                idx, fd, size, std::io::Error::last_os_error()
+            );
+            return -1;
+        }
+        handle.plane_mapped_ptrs[idx] = ptr as *mut u8;
+        if idx == 0 && handle.mapped_ptr.is_null() {
+            handle.mapped_ptr = ptr as *mut u8;
+        }
         0
     }
 
@@ -926,9 +1007,44 @@ mod gpu_surface {
         handle: *const SurfaceHandle,
     ) -> *mut u8 {
         match unsafe { handle.as_ref() } {
-            Some(h) => h.mapped_ptr,
+            Some(h) => h.base_address(0),
             None => std::ptr::null_mut(),
         }
+    }
+
+    /// Per-plane base address accessor. Returns null if the plane index is
+    /// out of range, if the plane is not mmap'd, or if the handle is null.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_base_address(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> *mut u8 {
+        match unsafe { handle.as_ref() } {
+            Some(h) => h.base_address(plane_index as usize),
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    /// Number of DMA-BUF planes on this surface (always >= 1).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_count(
+        handle: *const SurfaceHandle,
+    ) -> u32 {
+        unsafe { handle.as_ref() }
+            .map(|h| h.fds.len() as u32)
+            .unwrap_or(0)
+    }
+
+    /// Byte size of the given plane, or `0` if the plane index is out of
+    /// range or the handle is null.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_size(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_sizes.get(plane_index as usize).copied())
+            .unwrap_or(0)
     }
 
     #[unsafe(no_mangle)]
@@ -966,7 +1082,10 @@ mod gpu_surface {
         // Linux surface IDs are broker UUIDs (strings), not u32 IOSurfaceIDs;
         // return the fd as a best-effort numeric token. See the Python twin
         // in streamlib-python-native for the same behavior.
-        unsafe { handle.as_ref() }.map(|h| h.fd as u32).unwrap_or(0)
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.fds.first().copied())
+            .map(|fd| fd as u32)
+            .unwrap_or(0)
     }
 
     #[unsafe(no_mangle)]
@@ -1778,7 +1897,9 @@ mod broker_client {
     const MAX_RESOLVE_CACHE: usize = 128;
 
     struct CachedSurface {
-        fd: RawFd,
+        fds: Vec<RawFd>,
+        plane_sizes: Vec<u64>,
+        plane_offsets: Vec<u64>,
         width: u32,
         height: u32,
         bytes_per_row: u32,
@@ -1787,8 +1908,10 @@ mod broker_client {
 
     impl Drop for CachedSurface {
         fn drop(&mut self) {
-            if self.fd >= 0 {
-                unsafe { libc::close(self.fd) };
+            for fd in &self.fds {
+                if *fd >= 0 {
+                    unsafe { libc::close(*fd) };
+                }
             }
         }
     }
@@ -1939,22 +2062,38 @@ mod broker_client {
         {
             let cache = broker.resolve_cache.lock().expect("poisoned");
             if let Some(cached) = cache.get(&pool_id_str) {
-                let dup_fd = unsafe { libc::dup(cached.fd) };
-                if dup_fd < 0 {
-                    tracing::error!(
-                        "broker_resolve_surface: dup cached fd failed for '{}': {}",
-                        pool_id_str,
-                        std::io::Error::last_os_error()
-                    );
+                let mut dup_fds: Vec<RawFd> = Vec::with_capacity(cached.fds.len());
+                let mut dup_ok = true;
+                for fd in &cached.fds {
+                    let dup = unsafe { libc::dup(*fd) };
+                    if dup < 0 {
+                        tracing::error!(
+                            "broker_resolve_surface: dup cached fd failed for '{}': {}",
+                            pool_id_str,
+                            std::io::Error::last_os_error()
+                        );
+                        dup_ok = false;
+                        break;
+                    }
+                    dup_fds.push(dup);
+                }
+                if !dup_ok {
+                    for fd in &dup_fds {
+                        unsafe { libc::close(*fd) };
+                    }
                     return std::ptr::null_mut();
                 }
+                let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
-                    fd: dup_fd,
+                    fds: dup_fds,
+                    plane_sizes: cached.plane_sizes.clone(),
+                    plane_offsets: cached.plane_offsets.clone(),
                     width: cached.width,
                     height: cached.height,
                     bytes_per_row: cached.bytes_per_row,
                     size: cached.size,
                     mapped_ptr: std::ptr::null_mut(),
+                    plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
                     is_locked: false,
                     vulkan_device: Some(Arc::clone(&vulkan_device)),
                     vulkan_buffer: vk::Buffer::null(),
@@ -1982,7 +2121,12 @@ mod broker_client {
             "op": "check_out",
             "surface_id": pool_id_str,
         });
-        let (response, received_fd) = match wire::send_request(stream, &request, None) {
+        let (response, received_fds) = match wire::send_request_with_fds(
+            stream,
+            &request,
+            &[],
+            wire::MAX_DMA_BUF_PLANES,
+        ) {
             Ok(r) => r,
             Err(e) => {
                 tracing::error!(
@@ -1997,22 +2141,19 @@ mod broker_client {
                 "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, err
             );
-            if let Some(fd) = received_fd {
-                unsafe { libc::close(fd) };
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
             }
             return std::ptr::null_mut();
         }
 
-        let dma_buf_fd = match received_fd {
-            Some(fd) => fd,
-            None => {
-                tracing::error!(
-                    "broker_resolve_surface: no DMA-BUF fd for '{}'",
-                    pool_id_str
-                );
-                return std::ptr::null_mut();
-            }
-        };
+        if received_fds.is_empty() {
+            tracing::error!(
+                "broker_resolve_surface: no DMA-BUF fd for '{}'",
+                pool_id_str
+            );
+            return std::ptr::null_mut();
+        }
 
         let width = response.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
         let height = response.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -2022,10 +2163,42 @@ mod broker_client {
             .unwrap_or("Bgra32");
         let bpp = bytes_per_pixel_from_format(format_str);
         let bytes_per_row = width.saturating_mul(bpp);
-        let size = (height as u64).saturating_mul(bytes_per_row as u64);
 
-        let cache_fd = unsafe { libc::dup(dma_buf_fd) };
-        if cache_fd >= 0 {
+        // Zero size = "unknown" → use the width*bpp*height fallback so the
+        // Vulkan import path still has a byte count.
+        let fallback_total = (height as u64).saturating_mul(bytes_per_row as u64);
+        let plane_sizes: Vec<u64> = {
+            let raw: Option<Vec<u64>> = response
+                .get("plane_sizes")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect());
+            match raw {
+                Some(v) if v.len() == received_fds.len() => v
+                    .into_iter()
+                    .map(|s| if s == 0 { fallback_total } else { s })
+                    .collect(),
+                _ => vec![fallback_total; received_fds.len()],
+            }
+        };
+        let plane_offsets: Vec<u64> = response
+            .get("plane_offsets")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![0u64; received_fds.len()]);
+        let size: u64 = plane_sizes.iter().copied().sum();
+
+        let mut cache_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
+        let mut cache_dup_ok = true;
+        for fd in &received_fds {
+            let dup = unsafe { libc::dup(*fd) };
+            if dup < 0 {
+                cache_dup_ok = false;
+                break;
+            }
+            cache_fds.push(dup);
+        }
+        if cache_dup_ok {
             let mut cache = broker.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
                 tracing::error!(
@@ -2037,22 +2210,32 @@ mod broker_client {
             cache.insert(
                 pool_id_str.clone(),
                 CachedSurface {
-                    fd: cache_fd,
+                    fds: cache_fds,
+                    plane_sizes: plane_sizes.clone(),
+                    plane_offsets: plane_offsets.clone(),
                     width,
                     height,
                     bytes_per_row,
                     size,
                 },
             );
+        } else {
+            for fd in &cache_fds {
+                unsafe { libc::close(*fd) };
+            }
         }
 
+        let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
-            fd: dma_buf_fd,
+            fds: received_fds,
+            plane_sizes,
+            plane_offsets,
             width,
             height,
             bytes_per_row,
             size,
             mapped_ptr: std::ptr::null_mut(),
+            plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
             is_locked: false,
             vulkan_device: Some(vulkan_device),
             vulkan_buffer: vk::Buffer::null(),
@@ -2116,7 +2299,7 @@ mod broker_client {
                 "surface_id": pool_id_str,
                 "runtime_id": broker.runtime_id,
             });
-            let _ = wire::send_request(stream, &request, None);
+            let _ = wire::send_request_with_fds(stream, &request, &[], 0);
         }
     }
 }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -801,12 +801,28 @@ mod gpu_surface {
     pub const SURFACE_BACKEND_VULKAN: u32 = 2;
 
     pub struct SurfaceHandle {
-        pub fd: RawFd,
+        /// One fd per DMA-BUF plane. Single-plane surfaces carry a
+        /// one-element vec; multi-plane DMA-BUFs (e.g. NV12 under DRM format
+        /// modifiers with disjoint Y/UV allocations) carry one per plane,
+        /// keyed by plane index.
+        pub fds: Vec<RawFd>,
+        pub plane_sizes: Vec<u64>,
+        pub plane_offsets: Vec<u64>,
         pub width: u32,
         pub height: u32,
         pub bytes_per_row: u32,
+        /// Total byte size across all planes — the sum of `plane_sizes`,
+        /// kept cached so the Vulkan single-plane import path (`lock`) can
+        /// continue to pass it without recomputing.
         pub size: u64,
+        /// Host-mapped base address of plane 0, populated by `lock`. The
+        /// multi-plane accessor reads from [`Self::plane_mapped_ptrs`].
         pub mapped_ptr: *mut u8,
+        /// Per-plane mapped base addresses. Always the same length as
+        /// `fds`; `null` until a plane is mmap'd. The single-plane Vulkan
+        /// `lock` path populates index 0; `slpn_gpu_surface_plane_mmap`
+        /// mmaps a specific plane on demand.
+        pub plane_mapped_ptrs: Vec<*mut u8>,
         pub is_locked: bool,
         /// Vulkan device attached by [`super::broker_client::slpn_broker_resolve_surface`].
         /// `None` means the broker could not create a Vulkan device and lock
@@ -820,21 +836,47 @@ mod gpu_surface {
         pub backend: u32,
     }
 
+    impl SurfaceHandle {
+        /// Return the mapped base address for a given plane, or null if the
+        /// plane has not been mapped (or the index is out of range). Index
+        /// 0 on a single-plane surface that has been `lock`'d returns the
+        /// Vulkan-mapped pointer from `mapped_ptr`.
+        pub fn base_address(&self, plane_index: usize) -> *mut u8 {
+            if plane_index == 0 && !self.mapped_ptr.is_null() {
+                return self.mapped_ptr;
+            }
+            match self.plane_mapped_ptrs.get(plane_index) {
+                Some(&p) => p,
+                None => std::ptr::null_mut(),
+            }
+        }
+    }
+
     impl Drop for SurfaceHandle {
         fn drop(&mut self) {
             // Tear down any outstanding Vulkan import (lock without unlock).
-            // `lock` imports a dup of `self.fd`; Vulkan owns that dup. Freeing
-            // the imported memory releases the dup, not `self.fd`.
+            // `lock` imports a dup of `self.fds[0]`; Vulkan owns that dup.
+            // Freeing the imported memory releases the dup, not our fds.
             if self.is_locked {
                 if let Some(device) = self.vulkan_device.as_ref() {
                     device.destroy_imported(self.vulkan_buffer, self.vulkan_memory);
                 }
             }
-            // The original fd stays with the SurfaceHandle across lock/unlock
-            // cycles — close it last.
-            if self.fd >= 0 {
-                unsafe {
-                    libc::close(self.fd);
+            // Unmap any plane-specific mappings made via mmap. Plane 0's
+            // `mapped_ptr` (if populated by Vulkan `lock`) does not need an
+            // munmap — Vulkan manages its own backing memory.
+            for (i, ptr) in self.plane_mapped_ptrs.iter().enumerate() {
+                if !ptr.is_null() {
+                    if let Some(size) = self.plane_sizes.get(i) {
+                        unsafe { libc::munmap(*ptr as *mut libc::c_void, *size as usize) };
+                    }
+                }
+            }
+            // Every plane fd stays with the SurfaceHandle across lock/unlock
+            // cycles — close them last.
+            for fd in &self.fds {
+                if *fd >= 0 {
+                    unsafe { libc::close(*fd) };
                 }
             }
         }
@@ -858,7 +900,15 @@ mod gpu_surface {
         if handle.is_locked {
             return 0;
         }
-        if handle.size == 0 || handle.fd < 0 {
+        // Vulkan lock imports plane 0 only — there is no multi-plane Vulkan
+        // producer in tree yet. Multi-plane consumers can mmap individual
+        // planes via `slpn_gpu_surface_plane_mmap` without taking this path.
+        let fd0 = match handle.fds.first() {
+            Some(&fd) if fd >= 0 => fd,
+            _ => return -1,
+        };
+        let plane0_size = handle.plane_sizes.first().copied().unwrap_or(handle.size);
+        if plane0_size == 0 {
             return -1;
         }
         let device = match handle.vulkan_device.as_ref() {
@@ -874,7 +924,7 @@ mod gpu_surface {
         // Dup the fd before import: vkAllocateMemory takes ownership of the
         // fd on success. Keeping the original fd on the SurfaceHandle lets
         // the caller lock/unlock/lock again (each lock imports a fresh dup).
-        let dup_fd = unsafe { libc::dup(handle.fd) };
+        let dup_fd = unsafe { libc::dup(fd0) };
         if dup_fd < 0 {
             tracing::error!(
                 "gpu_surface_lock: dup fd failed: {}",
@@ -882,15 +932,13 @@ mod gpu_surface {
             );
             return -1;
         }
-        let imported = match device.import_dma_buf_fd(dup_fd, handle.size) {
+        let imported = match device.import_dma_buf_fd(dup_fd, plane0_size) {
             Ok(i) => i,
             Err(e) => {
                 tracing::error!(
                     "gpu_surface_lock: Vulkan DMA-BUF import failed for fd {} ({}B): {}",
-                    handle.fd, handle.size, e
+                    fd0, plane0_size, e
                 );
-                // On import failure Vulkan has not taken the fd — we must
-                // close the dup ourselves.
                 unsafe { libc::close(dup_fd) };
                 return -1;
             }
@@ -900,6 +948,65 @@ mod gpu_surface {
         handle.mapped_ptr = imported.mapped_ptr;
         handle.is_locked = true;
         handle.backend = SURFACE_BACKEND_VULKAN;
+        0
+    }
+
+    /// mmap a specific plane into user space. Intended for polyglot
+    /// consumers that need CPU-side access to a plane the Vulkan path did
+    /// not import (index > 0), or for tests that read back plane content
+    /// without requiring a Vulkan-capable device.
+    ///
+    /// Returns `0` on success, `-1` on failure. The mapping is torn down
+    /// when the [`SurfaceHandle`] is released.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_mmap(
+        handle: *mut SurfaceHandle,
+        plane_index: u32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_mut() } {
+            Some(h) => h,
+            None => return -1,
+        };
+        let idx = plane_index as usize;
+        let fd = match handle.fds.get(idx) {
+            Some(&fd) if fd >= 0 => fd,
+            _ => return -1,
+        };
+        let size = match handle.plane_sizes.get(idx) {
+            Some(&s) if s > 0 => s as usize,
+            _ => return -1,
+        };
+        if handle
+            .plane_mapped_ptrs
+            .get(idx)
+            .map(|p| !p.is_null())
+            .unwrap_or(false)
+        {
+            // Already mapped — idempotent.
+            return 0;
+        }
+        let offset = handle.plane_offsets.get(idx).copied().unwrap_or(0) as libc::off_t;
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                offset,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            tracing::error!(
+                "slpn_gpu_surface_plane_mmap: mmap failed for plane {} (fd {}, size {}): {}",
+                idx, fd, size, std::io::Error::last_os_error()
+            );
+            return -1;
+        }
+        handle.plane_mapped_ptrs[idx] = ptr as *mut u8;
+        if idx == 0 && handle.mapped_ptr.is_null() {
+            handle.mapped_ptr = ptr as *mut u8;
+        }
         0
     }
 
@@ -944,9 +1051,45 @@ mod gpu_surface {
         handle: *const SurfaceHandle,
     ) -> *mut u8 {
         match unsafe { handle.as_ref() } {
-            Some(h) => h.mapped_ptr,
+            Some(h) => h.base_address(0),
             None => std::ptr::null_mut(),
         }
+    }
+
+    /// Per-plane base address accessor. Returns null if the plane index is
+    /// out of range, if the plane is not mmap'd (call
+    /// [`slpn_gpu_surface_plane_mmap`] first), or if the handle is null.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_base_address(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> *mut u8 {
+        match unsafe { handle.as_ref() } {
+            Some(h) => h.base_address(plane_index as usize),
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    /// Number of DMA-BUF planes on this surface (always >= 1).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_count(
+        handle: *const SurfaceHandle,
+    ) -> u32 {
+        unsafe { handle.as_ref() }
+            .map(|h| h.fds.len() as u32)
+            .unwrap_or(0)
+    }
+
+    /// Byte size of the given plane, or `0` if the plane index is out of
+    /// range or the handle is null.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_size(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_sizes.get(plane_index as usize).copied())
+            .unwrap_or(0)
     }
 
     #[unsafe(no_mangle)]
@@ -986,7 +1129,10 @@ mod gpu_surface {
         // unconditionally calls this doesn't get a u32 collision with a real
         // IOSurface id. Callers that need the string surface_id should keep
         // the broker pool_id they already passed to resolve_surface.
-        unsafe { handle.as_ref() }.map(|h| h.fd as u32).unwrap_or(0)
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.fds.first().copied())
+            .map(|fd| fd as u32)
+            .unwrap_or(0)
     }
 
     #[unsafe(no_mangle)]
@@ -1893,7 +2039,9 @@ mod broker_client {
     const MAX_RESOLVE_CACHE: usize = 128;
 
     struct CachedSurface {
-        fd: RawFd,
+        fds: Vec<RawFd>,
+        plane_sizes: Vec<u64>,
+        plane_offsets: Vec<u64>,
         width: u32,
         height: u32,
         bytes_per_row: u32,
@@ -1902,8 +2050,10 @@ mod broker_client {
 
     impl Drop for CachedSurface {
         fn drop(&mut self) {
-            if self.fd >= 0 {
-                unsafe { libc::close(self.fd) };
+            for fd in &self.fds {
+                if *fd >= 0 {
+                    unsafe { libc::close(*fd) };
+                }
             }
         }
     }
@@ -2066,27 +2216,43 @@ mod broker_client {
             None => return std::ptr::null_mut(),
         };
 
-        // Cache hit — dup the stored fd so the returned SurfaceHandle owns
-        // an independent fd copy.
+        // Cache hit — dup each stored plane fd so the returned SurfaceHandle
+        // owns an independent set of fds.
         {
             let cache = broker.resolve_cache.lock().expect("poisoned");
             if let Some(cached) = cache.get(&pool_id_str) {
-                let dup_fd = unsafe { libc::dup(cached.fd) };
-                if dup_fd < 0 {
-                    tracing::error!(
-                        "broker_resolve_surface: dup cached fd failed for '{}': {}",
-                        pool_id_str,
-                        std::io::Error::last_os_error()
-                    );
+                let mut dup_fds: Vec<RawFd> = Vec::with_capacity(cached.fds.len());
+                let mut dup_ok = true;
+                for fd in &cached.fds {
+                    let dup = unsafe { libc::dup(*fd) };
+                    if dup < 0 {
+                        tracing::error!(
+                            "broker_resolve_surface: dup cached fd failed for '{}': {}",
+                            pool_id_str,
+                            std::io::Error::last_os_error()
+                        );
+                        dup_ok = false;
+                        break;
+                    }
+                    dup_fds.push(dup);
+                }
+                if !dup_ok {
+                    for fd in &dup_fds {
+                        unsafe { libc::close(*fd) };
+                    }
                     return std::ptr::null_mut();
                 }
+                let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
-                    fd: dup_fd,
+                    fds: dup_fds,
+                    plane_sizes: cached.plane_sizes.clone(),
+                    plane_offsets: cached.plane_offsets.clone(),
                     width: cached.width,
                     height: cached.height,
                     bytes_per_row: cached.bytes_per_row,
                     size: cached.size,
                     mapped_ptr: std::ptr::null_mut(),
+                    plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
                     is_locked: false,
                     vulkan_device: Some(Arc::clone(&vulkan_device)),
                     vulkan_buffer: vk::Buffer::null(),
@@ -2115,7 +2281,12 @@ mod broker_client {
             "op": "check_out",
             "surface_id": pool_id_str,
         });
-        let (response, received_fd) = match wire::send_request(stream, &request, None) {
+        let (response, received_fds) = match wire::send_request_with_fds(
+            stream,
+            &request,
+            &[],
+            wire::MAX_DMA_BUF_PLANES,
+        ) {
             Ok(r) => r,
             Err(e) => {
                 tracing::error!(
@@ -2130,22 +2301,19 @@ mod broker_client {
                 "broker_resolve_surface: broker error for '{}': {}",
                 pool_id_str, err
             );
-            if let Some(fd) = received_fd {
-                unsafe { libc::close(fd) };
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
             }
             return std::ptr::null_mut();
         }
 
-        let dma_buf_fd = match received_fd {
-            Some(fd) => fd,
-            None => {
-                tracing::error!(
-                    "broker_resolve_surface: no DMA-BUF fd for '{}'",
-                    pool_id_str
-                );
-                return std::ptr::null_mut();
-            }
-        };
+        if received_fds.is_empty() {
+            tracing::error!(
+                "broker_resolve_surface: no DMA-BUF fd for '{}'",
+                pool_id_str
+            );
+            return std::ptr::null_mut();
+        }
 
         let width = response.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
         let height = response.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -2155,12 +2323,48 @@ mod broker_client {
             .unwrap_or("Bgra32");
         let bpp = bytes_per_pixel_from_format(format_str);
         let bytes_per_row = width.saturating_mul(bpp);
-        let size = (height as u64).saturating_mul(bytes_per_row as u64);
 
-        // Cache: dup for the cache's own copy so the returned handle owns
-        // its own fd independently of the cache's fd.
-        let cache_fd = unsafe { libc::dup(dma_buf_fd) };
-        if cache_fd >= 0 {
+        // Pull plane sizes/offsets from the response. A zero size means
+        // "unknown" — the broker did not have per-plane layout at check-in
+        // time (e.g. legacy single-plane callers that don't emit
+        // `plane_sizes`). Substitute the width*bytes_per_row*height
+        // fallback so the Vulkan import path still has a byte count to
+        // allocate against.
+        let fallback_total = (height as u64).saturating_mul(bytes_per_row as u64);
+        let plane_sizes: Vec<u64> = {
+            let raw: Option<Vec<u64>> = response
+                .get("plane_sizes")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect());
+            match raw {
+                Some(v) if v.len() == received_fds.len() => v
+                    .into_iter()
+                    .map(|s| if s == 0 { fallback_total } else { s })
+                    .collect(),
+                _ => vec![fallback_total; received_fds.len()],
+            }
+        };
+        let plane_offsets: Vec<u64> = response
+            .get("plane_offsets")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![0u64; received_fds.len()]);
+        let size: u64 = plane_sizes.iter().copied().sum();
+
+        // Cache: dup every plane for the cache's own copy so the returned
+        // handle owns its own fds independently.
+        let mut cache_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
+        let mut cache_dup_ok = true;
+        for fd in &received_fds {
+            let dup = unsafe { libc::dup(*fd) };
+            if dup < 0 {
+                cache_dup_ok = false;
+                break;
+            }
+            cache_fds.push(dup);
+        }
+        if cache_dup_ok {
             let mut cache = broker.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
                 tracing::error!(
@@ -2172,22 +2376,32 @@ mod broker_client {
             cache.insert(
                 pool_id_str.clone(),
                 CachedSurface {
-                    fd: cache_fd,
+                    fds: cache_fds,
+                    plane_sizes: plane_sizes.clone(),
+                    plane_offsets: plane_offsets.clone(),
                     width,
                     height,
                     bytes_per_row,
                     size,
                 },
             );
+        } else {
+            for fd in &cache_fds {
+                unsafe { libc::close(*fd) };
+            }
         }
 
+        let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
-            fd: dma_buf_fd,
+            fds: received_fds,
+            plane_sizes,
+            plane_offsets,
             width,
             height,
             bytes_per_row,
             size,
             mapped_ptr: std::ptr::null_mut(),
+            plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
             is_locked: false,
             vulkan_device: Some(vulkan_device),
             vulkan_buffer: vk::Buffer::null(),
@@ -2250,7 +2464,7 @@ mod broker_client {
                 "surface_id": pool_id_str,
                 "runtime_id": broker.runtime_id,
             });
-            let _ = wire::send_request(stream, &request, None);
+            let _ = wire::send_request_with_fds(stream, &request, &[], 0);
         }
     }
 

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -855,19 +855,28 @@ impl SurfaceStore {
     pub fn check_in(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
         use crate::core::rhi::RhiPixelBufferExport;
 
-        // Export the DMA-BUF fd
-        let handle = pixel_buffer.export_handle()?;
-        let (fd, _size) = match handle {
-            crate::core::rhi::RhiExternalHandle::DmaBuf { fd, size } => (fd, size),
-        };
+        // Export every plane's fd. Single-plane pixel buffers return a
+        // one-element vec; multi-plane DMA-BUFs (e.g. NV12 under DRM format
+        // modifiers) return one fd per plane.
+        let planes = pixel_buffer.export_plane_handles()?;
+        let mut plane_fds: Vec<std::os::unix::io::RawFd> = Vec::with_capacity(planes.len());
+        let mut plane_sizes: Vec<u64> = Vec::with_capacity(planes.len());
+        let mut plane_offsets: Vec<u64> = Vec::with_capacity(planes.len());
+        for handle in planes {
+            let crate::core::rhi::RhiExternalHandle::DmaBuf { fd, size } = handle;
+            plane_fds.push(fd);
+            plane_sizes.push(size as u64);
+            plane_offsets.push(0);
+        }
 
-        // Send check_in request with fd
         let request = serde_json::json!({
             "op": "check_in",
             "runtime_id": self.inner.runtime_id,
             "width": pixel_buffer.width,
             "height": pixel_buffer.height,
             "format": format!("{:?}", pixel_buffer.format()),
+            "plane_sizes": plane_sizes,
+            "plane_offsets": plane_offsets,
         });
 
         let connection = self.inner.connection.lock();
@@ -875,16 +884,25 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, _response_fd): (serde_json::Value, _) =
-            streamlib_broker_client::send_request(stream, &request, Some(fd))
-                .map_err(|e| {
-                    StreamError::Configuration(format!("Unix socket check_in failed: {}", e))
-                })?;
+        let send_result =
+            streamlib_broker_client::send_request_with_fds(stream, &request, &plane_fds, 0);
 
-        // Close the exported fd (broker has its own dup)
-        unsafe { libc::close(fd) };
+        // Close the exported fds (broker has its own dups) regardless of
+        // the request outcome — the peer owns its kernel-delivered fds and
+        // we never keep ours.
+        for fd in &plane_fds {
+            unsafe { libc::close(*fd) };
+        }
 
-        // Extract surface_id from response
+        let (response, response_fds) = send_result.map_err(|e| {
+            StreamError::Configuration(format!("Unix socket check_in failed: {}", e))
+        })?;
+        // check_in never returns fds; close any the broker may have attached
+        // defensively so a future protocol drift doesn't leak them.
+        for fd in &response_fds {
+            unsafe { libc::close(*fd) };
+        }
+
         let surface_id = response
             .get("surface_id")
             .and_then(|v: &serde_json::Value| v.as_str())
@@ -893,7 +911,6 @@ impl SurfaceStore {
             })?
             .to_string();
 
-        // Cache locally
         self.inner
             .cache
             .lock()
@@ -937,29 +954,62 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, received_fd): (serde_json::Value, Option<std::os::unix::io::RawFd>) =
-            streamlib_broker_client::send_request(stream, &request, None).map_err(
-                |e| StreamError::Configuration(format!("Unix socket check_out failed: {}", e)),
-            )?;
+        let (response, received_fds) = streamlib_broker_client::send_request_with_fds(
+            stream,
+            &request,
+            &[],
+            streamlib_broker_client::MAX_DMA_BUF_PLANES,
+        )
+        .map_err(|e| {
+            StreamError::Configuration(format!("Unix socket check_out failed: {}", e))
+        })?;
 
-        // Check for error
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
+            }
             return Err(StreamError::Configuration(format!(
                 "check_out: {}",
                 error
             )));
         }
 
-        let dma_buf_fd = received_fd.ok_or_else(|| {
-            StreamError::Configuration("check_out: no DMA-BUF fd in response".into())
-        })?;
+        if received_fds.is_empty() {
+            return Err(StreamError::Configuration(
+                "check_out: no DMA-BUF fd in response".into(),
+            ));
+        }
+
+        // The Rust-side importer is single-plane today — no in-tree Rust
+        // consumer imports a multi-plane DMA-BUF. Take plane 0 as the
+        // primary and close the rest so a future multi-plane broker payload
+        // doesn't leak fds. The polyglot shims take the full vec.
+        let dma_buf_fd = received_fds[0];
+        if received_fds.len() > 1 {
+            tracing::warn!(
+                "SurfaceStore::check_out: broker returned {} plane fds; Rust importer \
+                 consumes plane 0 only, closing the rest. Multi-plane consumers belong \
+                 in the polyglot shims for now.",
+                received_fds.len()
+            );
+            for fd in &received_fds[1..] {
+                unsafe { libc::close(*fd) };
+            }
+        }
 
         // Import pixel buffer from DMA-BUF fd
         use crate::core::rhi::{PixelFormat, RhiExternalHandle, RhiPixelBufferImport};
 
+        let plane0_size = response
+            .get("plane_sizes")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
         let handle = RhiExternalHandle::DmaBuf {
             fd: dma_buf_fd,
-            size: 0,
+            size: plane0_size,
         };
         let pixel_buffer =
             RhiPixelBuffer::from_external_handle(handle, 0, 0, PixelFormat::default())?;
@@ -999,14 +1049,15 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, _): (serde_json::Value, _) =
-            streamlib_broker_client::send_request(stream, &request, Some(fd))
-                .map_err(|e| {
-                    StreamError::Configuration(format!("Unix socket register failed: {}", e))
-                })?;
-
-        // Close the exported fd
+        let send_result =
+            streamlib_broker_client::send_request_with_fds(stream, &request, &[fd], 0);
         unsafe { libc::close(fd) };
+        let (response, response_fds) = send_result.map_err(|e| {
+            StreamError::Configuration(format!("Unix socket register failed: {}", e))
+        })?;
+        for f in &response_fds {
+            unsafe { libc::close(*f) };
+        }
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
             return Err(StreamError::Configuration(format!(
@@ -1044,14 +1095,15 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, _): (serde_json::Value, _) =
-            streamlib_broker_client::send_request(stream, &request, Some(fd))
-                .map_err(|e| {
-                    StreamError::Configuration(format!("Unix socket register_texture failed: {}", e))
-                })?;
-
-        // Close the exported fd (broker has its own dup)
+        let send_result =
+            streamlib_broker_client::send_request_with_fds(stream, &request, &[fd], 0);
         unsafe { libc::close(fd) };
+        let (response, response_fds) = send_result.map_err(|e| {
+            StreamError::Configuration(format!("Unix socket register_texture failed: {}", e))
+        })?;
+        for f in &response_fds {
+            unsafe { libc::close(*f) };
+        }
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
             return Err(StreamError::Configuration(format!(
@@ -1077,27 +1129,48 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, received_fd): (serde_json::Value, Option<std::os::unix::io::RawFd>) =
-            streamlib_broker_client::send_request(stream, &request, None).map_err(
-                |e| StreamError::Configuration(format!("Unix socket lookup failed: {}", e)),
-            )?;
+        let (response, received_fds) = streamlib_broker_client::send_request_with_fds(
+            stream,
+            &request,
+            &[],
+            streamlib_broker_client::MAX_DMA_BUF_PLANES,
+        )
+        .map_err(|e| {
+            StreamError::Configuration(format!("Unix socket lookup failed: {}", e))
+        })?;
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
+            }
             return Err(StreamError::Configuration(format!(
                 "lookup: {}",
                 error
             )));
         }
 
-        let dma_buf_fd = received_fd.ok_or_else(|| {
-            StreamError::Configuration("lookup: no DMA-BUF fd in response".into())
-        })?;
+        if received_fds.is_empty() {
+            return Err(StreamError::Configuration(
+                "lookup: no DMA-BUF fd in response".into(),
+            ));
+        }
+        let dma_buf_fd = received_fds[0];
+        for fd in &received_fds[1..] {
+            unsafe { libc::close(*fd) };
+        }
 
         use crate::core::rhi::{PixelFormat, RhiExternalHandle, RhiPixelBufferImport};
 
+        let plane0_size = response
+            .get("plane_sizes")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
         let handle = RhiExternalHandle::DmaBuf {
             fd: dma_buf_fd,
-            size: 0,
+            size: plane0_size,
         };
         RhiPixelBuffer::from_external_handle(handle, 0, 0, PixelFormat::default())
     }
@@ -1115,21 +1188,35 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to broker".into())
         })?;
 
-        let (response, received_fd): (serde_json::Value, Option<std::os::unix::io::RawFd>) =
-            streamlib_broker_client::send_request(stream, &request, None).map_err(
-                |e| StreamError::Configuration(format!("Unix socket lookup_texture failed: {}", e)),
-            )?;
+        let (response, received_fds) = streamlib_broker_client::send_request_with_fds(
+            stream,
+            &request,
+            &[],
+            streamlib_broker_client::MAX_DMA_BUF_PLANES,
+        )
+        .map_err(|e| {
+            StreamError::Configuration(format!("Unix socket lookup_texture failed: {}", e))
+        })?;
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
+            for fd in &received_fds {
+                unsafe { libc::close(*fd) };
+            }
             return Err(StreamError::Configuration(format!(
                 "lookup_texture: {}",
                 error
             )));
         }
 
-        let dma_buf_fd = received_fd.ok_or_else(|| {
-            StreamError::Configuration("lookup_texture: no DMA-BUF fd in response".into())
-        })?;
+        if received_fds.is_empty() {
+            return Err(StreamError::Configuration(
+                "lookup_texture: no DMA-BUF fd in response".into(),
+            ));
+        }
+        let dma_buf_fd = received_fds[0];
+        for fd in &received_fds[1..] {
+            unsafe { libc::close(*fd) };
+        }
 
         // Extract width, height, format from the response
         let width = response
@@ -1209,7 +1296,7 @@ impl SurfaceStore {
             None => return Ok(()), // Already disconnected
         };
 
-        let _ = streamlib_broker_client::send_request(stream, &request, None);
+        let _ = streamlib_broker_client::send_request_with_fds(stream, &request, &[], 0);
         Ok(())
     }
 

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -980,39 +980,28 @@ impl SurfaceStore {
             ));
         }
 
-        // The Rust-side importer is single-plane today — no in-tree Rust
-        // consumer imports a multi-plane DMA-BUF. Take plane 0 as the
-        // primary and close the rest so a future multi-plane broker payload
-        // doesn't leak fds. The polyglot shims take the full vec.
-        let dma_buf_fd = received_fds[0];
-        if received_fds.len() > 1 {
-            tracing::warn!(
-                "SurfaceStore::check_out: broker returned {} plane fds; Rust importer \
-                 consumes plane 0 only, closing the rest. Multi-plane consumers belong \
-                 in the polyglot shims for now.",
-                received_fds.len()
-            );
-            for fd in &received_fds[1..] {
-                unsafe { libc::close(*fd) };
-            }
-        }
-
-        // Import pixel buffer from DMA-BUF fd
+        // Import every plane as a `RhiExternalHandle::DmaBuf`. The Rust
+        // importer now tracks the full vec symmetrically with the
+        // polyglot Python / Deno shims — no plane is dropped.
         use crate::core::rhi::{PixelFormat, RhiExternalHandle, RhiPixelBufferImport};
 
-        let plane0_size = response
+        let plane_sizes: Vec<u64> = response
             .get("plane_sizes")
             .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as usize;
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![0u64; received_fds.len()]);
 
-        let handle = RhiExternalHandle::DmaBuf {
-            fd: dma_buf_fd,
-            size: plane0_size,
-        };
+        let handles: Vec<RhiExternalHandle> = received_fds
+            .iter()
+            .zip(plane_sizes.iter())
+            .map(|(fd, size)| RhiExternalHandle::DmaBuf {
+                fd: *fd,
+                size: *size as usize,
+            })
+            .collect();
         let pixel_buffer =
-            RhiPixelBuffer::from_external_handle(handle, 0, 0, PixelFormat::default())?;
+            RhiPixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())?;
 
         // Cache for future use
         self.inner
@@ -1154,25 +1143,25 @@ impl SurfaceStore {
                 "lookup: no DMA-BUF fd in response".into(),
             ));
         }
-        let dma_buf_fd = received_fds[0];
-        for fd in &received_fds[1..] {
-            unsafe { libc::close(*fd) };
-        }
 
         use crate::core::rhi::{PixelFormat, RhiExternalHandle, RhiPixelBufferImport};
 
-        let plane0_size = response
+        let plane_sizes: Vec<u64> = response
             .get("plane_sizes")
             .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as usize;
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![0u64; received_fds.len()]);
 
-        let handle = RhiExternalHandle::DmaBuf {
-            fd: dma_buf_fd,
-            size: plane0_size,
-        };
-        RhiPixelBuffer::from_external_handle(handle, 0, 0, PixelFormat::default())
+        let handles: Vec<RhiExternalHandle> = received_fds
+            .iter()
+            .zip(plane_sizes.iter())
+            .map(|(fd, size)| RhiExternalHandle::DmaBuf {
+                fd: *fd,
+                size: *size as usize,
+            })
+            .collect();
+        RhiPixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())
     }
 
     /// Lookup a texture from the broker via Unix socket.

--- a/libs/streamlib/src/core/rhi/external_handle.rs
+++ b/libs/streamlib/src/core/rhi/external_handle.rs
@@ -56,6 +56,16 @@ impl RhiExternalHandle {
 pub trait RhiPixelBufferExport {
     /// Export the GPU buffer for sharing with another process.
     fn export_handle(&self) -> Result<RhiExternalHandle>;
+
+    /// Export one handle per plane for multi-plane DMA-BUFs. The default
+    /// implementation wraps [`Self::export_handle`] in a single-element vec
+    /// — correct for every single-allocation format in tree today (BGRA,
+    /// RGBA, NV12 contiguous). Backends that truly split planes across
+    /// separate allocations (e.g. NV12 under `VK_EXT_image_drm_format_modifier`
+    /// with disjoint Y and UV) must override.
+    fn export_plane_handles(&self) -> Result<Vec<RhiExternalHandle>> {
+        Ok(vec![self.export_handle()?])
+    }
 }
 
 /// Extension trait for importing RhiPixelBuffer from external handle.

--- a/libs/streamlib/src/core/rhi/external_handle.rs
+++ b/libs/streamlib/src/core/rhi/external_handle.rs
@@ -70,7 +70,7 @@ pub trait RhiPixelBufferExport {
 
 /// Extension trait for importing RhiPixelBuffer from external handle.
 pub trait RhiPixelBufferImport {
-    /// Import a GPU buffer from an external handle.
+    /// Import a GPU buffer from a single external handle.
     fn from_external_handle(
         handle: RhiExternalHandle,
         width: u32,
@@ -79,6 +79,33 @@ pub trait RhiPixelBufferImport {
     ) -> Result<Self>
     where
         Self: Sized;
+
+    /// Import a multi-plane GPU buffer from one external handle per plane.
+    ///
+    /// The default implementation only accepts a single-plane input —
+    /// backends that can't natively represent multiple planes still
+    /// compile and refuse multi-plane input at runtime. Linux overrides
+    /// with a real multi-plane import so the Rust surface-store path
+    /// keeps feature parity with the polyglot Python and Deno shims.
+    fn from_external_plane_handles(
+        handles: &[RhiExternalHandle],
+        width: u32,
+        height: u32,
+        format: super::PixelFormat,
+    ) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match handles {
+            [only] => Self::from_external_handle(only.clone(), width, height, format),
+            [] => Err(crate::core::StreamError::Configuration(
+                "from_external_plane_handles: empty plane vec".into(),
+            )),
+            _ => Err(crate::core::StreamError::NotSupported(
+                "multi-plane import is only implemented on Linux today".into(),
+            )),
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -98,7 +125,20 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
         height: u32,
         format: super::PixelFormat,
     ) -> Result<Self> {
-        let RhiExternalHandle::DmaBuf { fd, size } = handle;
+        Self::from_external_plane_handles(&[handle], width, height, format)
+    }
+
+    fn from_external_plane_handles(
+        handles: &[RhiExternalHandle],
+        width: u32,
+        height: u32,
+        format: super::PixelFormat,
+    ) -> Result<Self> {
+        if handles.is_empty() {
+            return Err(crate::core::StreamError::Configuration(
+                "DMA-BUF import: empty plane vec".into(),
+            ));
+        }
 
         let vulkan_device =
             crate::vulkan::rhi::vulkan_pixel_buffer::VULKAN_DEVICE_FOR_IMPORT
@@ -117,26 +157,38 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
             ));
         }
 
-        let allocation_size = if size > 0 {
-            size as u64
-        } else if width > 0 && height > 0 {
-            (width as u64) * (height as u64) * (bytes_per_pixel as u64)
-        } else {
-            return Err(crate::core::StreamError::Configuration(
-                "DMA-BUF import: cannot determine allocation size (size=0, width=0 or height=0)"
-                    .into(),
-            ));
-        };
+        // Unpack every plane's fd + size. Every handle must be a DmaBuf
+        // today — Windows / macOS handles would trip this and belong in a
+        // future widening when those backends grow multi-plane surfaces.
+        let mut fds: Vec<std::os::unix::io::RawFd> = Vec::with_capacity(handles.len());
+        let mut plane_sizes: Vec<vulkanalia::vk::DeviceSize> = Vec::with_capacity(handles.len());
+        for (idx, h) in handles.iter().enumerate() {
+            let RhiExternalHandle::DmaBuf { fd, size } = h.clone();
+            fds.push(fd);
+            let effective = if size > 0 {
+                size as vulkanalia::vk::DeviceSize
+            } else if idx == 0 && width > 0 && height > 0 {
+                // Plane 0 falls back to width*height*bpp (back-compat with
+                // legacy single-plane callers that don't pass a size).
+                (width as u64) * (height as u64) * (bytes_per_pixel as u64)
+            } else {
+                return Err(crate::core::StreamError::Configuration(format!(
+                    "DMA-BUF import: plane {} has size=0 and cannot be derived",
+                    idx
+                )));
+            };
+            plane_sizes.push(effective);
+        }
 
         let vulkan_pixel_buffer =
-            crate::vulkan::rhi::VulkanPixelBuffer::from_dma_buf_fd(
+            crate::vulkan::rhi::VulkanPixelBuffer::from_dma_buf_fds(
                 vulkan_device,
-                fd,
+                &fds,
+                &plane_sizes,
                 width,
                 height,
                 bytes_per_pixel,
                 format,
-                allocation_size,
             )?;
 
         let pixel_buffer_ref = super::RhiPixelBufferRef {

--- a/libs/streamlib/src/core/rhi/pixel_buffer.rs
+++ b/libs/streamlib/src/core/rhi/pixel_buffer.rs
@@ -52,6 +52,25 @@ impl RhiPixelBuffer {
         &self.ref_
     }
 
+    /// Number of DMA-BUF planes backing this pixel buffer. Always `>= 1`.
+    /// Mirror of `slpn_gpu_surface_plane_count` on the polyglot shims.
+    pub fn plane_count(&self) -> u32 {
+        self.ref_.plane_count()
+    }
+
+    /// Mapped base address for the given plane, or null if out of range.
+    /// Plane 0 on a VMA-allocated or single-plane-imported buffer points
+    /// at the same bytes as [`mapped_ptr`](RhiPixelBufferRef::plane_base_address)
+    /// with index 0.
+    pub fn plane_base_address(&self, plane_index: u32) -> *mut u8 {
+        self.ref_.plane_base_address(plane_index)
+    }
+
+    /// Byte size of the given plane, or `0` if out of range.
+    pub fn plane_size(&self, plane_index: u32) -> u64 {
+        self.ref_.plane_size(plane_index)
+    }
+
     /// Get the raw platform pointer (CVPixelBufferRef on macOS).
     #[cfg(target_os = "macos")]
     pub fn as_ptr(&self) -> *mut std::ffi::c_void {

--- a/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
@@ -74,6 +74,52 @@ impl RhiPixelBufferRef {
         }
     }
 
+    /// Number of DMA-BUF planes backing this pixel buffer.
+    ///
+    /// `1` for VMA-allocated buffers and single-plane DMA-BUF imports.
+    /// `N` for multi-plane imports — mirror of
+    /// `slpn_gpu_surface_plane_count` / `sldn_gpu_surface_plane_count`
+    /// on the polyglot shim side. On macOS and unsupported platforms
+    /// this always reports `1`.
+    pub fn plane_count(&self) -> u32 {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.plane_count()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            1
+        }
+    }
+
+    /// Mapped base address for `plane_index`, or null if the plane index
+    /// is out of range or the backend doesn't expose CPU-mapped planes.
+    pub fn plane_base_address(&self, plane_index: u32) -> *mut u8 {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.plane_mapped_ptr(plane_index)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = plane_index;
+            std::ptr::null_mut()
+        }
+    }
+
+    /// Byte size of `plane_index`, or `0` if the plane index is out of
+    /// range.
+    pub fn plane_size(&self, plane_index: u32) -> u64 {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.plane_size(plane_index) as u64
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = plane_index;
+            0
+        }
+    }
+
     /// Get the raw platform pointer (CVPixelBufferRef on macOS).
     #[cfg(target_os = "macos")]
     pub fn as_ptr(&self) -> *mut std::ffi::c_void {

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -1469,7 +1469,7 @@ mod tests {
     mod runtime_internal_broker {
         use super::*;
         use std::os::unix::net::UnixStream;
-        use streamlib_broker_client::send_request;
+        use streamlib_broker_client::{send_request_with_fds, MAX_DMA_BUF_PLANES};
 
         /// Replace XDG_RUNTIME_DIR with a fresh tempdir for the duration of the
         /// closure. Tests using this must be `#[serial]` so no other runtime
@@ -1517,8 +1517,10 @@ mod tests {
                     "op": "check_out",
                     "surface_id": "ping-no-such-surface",
                 });
-                let (resp, fd) = send_request(&stream, &req, None).expect("round-trip");
-                assert!(fd.is_none());
+                let (resp, fds) =
+                    send_request_with_fds(&stream, &req, &[], MAX_DMA_BUF_PLANES)
+                        .expect("round-trip");
+                assert!(fds.is_empty());
                 assert!(
                     resp.get("error").and_then(|v| v.as_str()).is_some(),
                     "expected error for missing surface, got {:?}",
@@ -1577,7 +1579,9 @@ mod tests {
                         "op": "check_out",
                         "surface_id": "no-such",
                     });
-                    let (resp, _) = send_request(&stream, &req, None).expect("round-trip");
+                    let (resp, _) =
+                        send_request_with_fds(&stream, &req, &[], MAX_DMA_BUF_PLANES)
+                            .expect("round-trip");
                     assert!(resp.get("error").is_some());
                 }
             });
@@ -1654,7 +1658,9 @@ mod tests {
                     "op": "check_out",
                     "surface_id": "no-such",
                 });
-                let (resp, _) = send_request(&stream, &req, None).expect("round-trip");
+                let (resp, _) =
+                    send_request_with_fds(&stream, &req, &[], MAX_DMA_BUF_PLANES)
+                        .expect("round-trip");
                 assert!(resp.get("error").is_some());
             });
         }

--- a/libs/streamlib/src/linux/surface_broker/state.rs
+++ b/libs/streamlib/src/linux/surface_broker/state.rs
@@ -4,6 +4,11 @@
 //! Per-runtime surface table backing the runtime-internal surface-sharing
 //! service. Stores DMA-BUF fds keyed by `surface_id` so polyglot
 //! subprocesses can `check_out` them via `SCM_RIGHTS`.
+//!
+//! Each surface may hold up to [`streamlib_broker_client::MAX_DMA_BUF_PLANES`]
+//! fds — one per plane for multi-plane DMA-BUFs under DRM format modifiers
+//! (e.g. NV12 with separate Y and UV allocations). Single-plane surfaces
+//! register a one-element vec; the multi-plane path is strictly additive.
 
 use std::collections::HashMap;
 use std::os::unix::io::RawFd;
@@ -16,7 +21,9 @@ use parking_lot::RwLock;
 pub struct SurfaceMetadata {
     pub surface_id: String,
     pub runtime_id: String,
-    pub dma_buf_fd: RawFd,
+    pub dma_buf_fds: Vec<RawFd>,
+    pub plane_sizes: Vec<u64>,
+    pub plane_offsets: Vec<u64>,
     pub width: u32,
     pub height: u32,
     pub format: String,
@@ -36,50 +43,76 @@ struct Inner {
     surface_counter: AtomicU64,
 }
 
+/// Arguments to [`SurfaceBrokerState::register_surface`]. Grouped so the
+/// signature stays legible as the per-plane fields grow.
+pub struct SurfaceRegistration<'a> {
+    pub surface_id: &'a str,
+    pub runtime_id: &'a str,
+    pub dma_buf_fds: Vec<RawFd>,
+    pub plane_sizes: Vec<u64>,
+    pub plane_offsets: Vec<u64>,
+    pub width: u32,
+    pub height: u32,
+    pub format: &'a str,
+    pub resource_type: &'a str,
+}
+
 impl SurfaceBrokerState {
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Insert a surface into the table.
+    ///
+    /// On rejection (duplicate surface_id), ownership of `dma_buf_fds` is
+    /// returned to the caller so it can decide whether to close them or hand
+    /// them to the next attempt. On success, the table owns the fds and
+    /// closes each on [`Self::release_surface`].
     pub fn register_surface(
         &self,
-        surface_id: &str,
-        runtime_id: &str,
-        dma_buf_fd: RawFd,
-        width: u32,
-        height: u32,
-        format: &str,
-        resource_type: &str,
-    ) -> bool {
+        reg: SurfaceRegistration<'_>,
+    ) -> Result<(), Vec<RawFd>> {
         let mut surfaces = self.inner.surfaces.write();
 
-        if surfaces.contains_key(surface_id) {
-            return false;
+        if surfaces.contains_key(reg.surface_id) {
+            return Err(reg.dma_buf_fds);
         }
 
         self.inner.surface_counter.fetch_add(1, Ordering::Relaxed);
 
         surfaces.insert(
-            surface_id.to_string(),
+            reg.surface_id.to_string(),
             SurfaceMetadata {
-                surface_id: surface_id.to_string(),
-                runtime_id: runtime_id.to_string(),
-                dma_buf_fd,
-                width,
-                height,
-                format: format.to_string(),
-                resource_type: resource_type.to_string(),
+                surface_id: reg.surface_id.to_string(),
+                runtime_id: reg.runtime_id.to_string(),
+                dma_buf_fds: reg.dma_buf_fds,
+                plane_sizes: reg.plane_sizes,
+                plane_offsets: reg.plane_offsets,
+                width: reg.width,
+                height: reg.height,
+                format: reg.format.to_string(),
+                resource_type: reg.resource_type.to_string(),
                 checkout_count: 0,
             },
         );
-        true
+        Ok(())
     }
 
-    pub fn get_surface_dma_buf_fd(&self, surface_id: &str) -> Option<RawFd> {
+    /// Return a clone of the surface's plane fd vec plus its plane-layout
+    /// arrays. The returned fds are the table's own — callers that hand them
+    /// out via SCM_RIGHTS must `dup` each fd first.
+    pub fn get_surface_planes(
+        &self,
+        surface_id: &str,
+    ) -> Option<(Vec<RawFd>, Vec<u64>, Vec<u64>)> {
         let mut surfaces = self.inner.surfaces.write();
         surfaces.get_mut(surface_id).map(|metadata| {
             metadata.checkout_count += 1;
-            metadata.dma_buf_fd
+            (
+                metadata.dma_buf_fds.clone(),
+                metadata.plane_sizes.clone(),
+                metadata.plane_offsets.clone(),
+            )
         })
     }
 
@@ -87,7 +120,9 @@ impl SurfaceBrokerState {
         let mut surfaces = self.inner.surfaces.write();
         if let Some(metadata) = surfaces.get(surface_id) {
             if metadata.runtime_id == runtime_id {
-                unsafe { libc::close(metadata.dma_buf_fd) };
+                for fd in &metadata.dma_buf_fds {
+                    unsafe { libc::close(*fd) };
+                }
                 surfaces.remove(surface_id);
                 return true;
             }
@@ -104,15 +139,29 @@ impl SurfaceBrokerState {
 mod tests {
     use super::*;
 
+    fn reg<'a>(surface_id: &'a str, runtime_id: &'a str, resource_type: &'a str) -> SurfaceRegistration<'a> {
+        SurfaceRegistration {
+            surface_id,
+            runtime_id,
+            dma_buf_fds: vec![-1],
+            plane_sizes: vec![0],
+            plane_offsets: vec![0],
+            width: 1920,
+            height: 1080,
+            format: "Rgba8Unorm",
+            resource_type,
+        }
+    }
+
     #[test]
     fn register_surface_with_resource_type() {
         let state = SurfaceBrokerState::new();
-        assert!(state.register_surface(
-            "buf-001", "runtime-1", -1, 1920, 1080, "Rgba8Unorm", "pixel_buffer"
-        ));
-        assert!(state.register_surface(
-            "tex-001", "runtime-1", -1, 1920, 1080, "Rgba8Unorm", "texture"
-        ));
+        assert!(state
+            .register_surface(reg("buf-001", "runtime-1", "pixel_buffer"))
+            .is_ok());
+        assert!(state
+            .register_surface(reg("tex-001", "runtime-1", "texture"))
+            .is_ok());
 
         let surfaces = state.get_surfaces();
         assert_eq!(surfaces.len(), 2);
@@ -125,7 +174,57 @@ mod tests {
     #[test]
     fn duplicate_surface_id_rejected() {
         let state = SurfaceBrokerState::new();
-        assert!(state.register_surface("dup", "rt", -1, 640, 480, "Rgba8Unorm", "texture"));
-        assert!(!state.register_surface("dup", "rt", -1, 640, 480, "Rgba8Unorm", "texture"));
+        assert!(state.register_surface(reg("dup", "rt", "texture")).is_ok());
+        let rejected = state
+            .register_surface(reg("dup", "rt", "texture"))
+            .expect_err("duplicate must be rejected");
+        assert_eq!(rejected, vec![-1], "rejected fds returned to caller");
+    }
+
+    /// Releasing a surface registered with multiple plane fds must close
+    /// every fd — the state is the last owner of the table's fd dups and
+    /// leaking any plane would leak the whole DMA-BUF.
+    #[test]
+    fn release_surface_closes_every_plane_fd() {
+        let state = SurfaceBrokerState::new();
+        // Pair of real, independently-owned memfds so libc::close actually
+        // observable succeeds / fails per fd.
+        let plane_fds: Vec<RawFd> = (0..3)
+            .map(|i| {
+                let name = std::ffi::CString::new(format!("release-plane-{}", i)).unwrap();
+                let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+                assert!(fd >= 0, "memfd {}: {}", i, std::io::Error::last_os_error());
+                fd
+            })
+            .collect();
+
+        state
+            .register_surface(SurfaceRegistration {
+                surface_id: "multi",
+                runtime_id: "rt",
+                dma_buf_fds: plane_fds.clone(),
+                plane_sizes: vec![8192, 2048, 2048],
+                plane_offsets: vec![0, 0, 0],
+                width: 640,
+                height: 480,
+                format: "Nv12VideoRange",
+                resource_type: "pixel_buffer",
+            })
+            .expect("register multi-plane");
+
+        assert!(state.release_surface("multi", "rt"));
+
+        // Each fd should be closed now. fcntl(F_GETFD) on a closed fd
+        // returns -1 with EBADF.
+        for fd in &plane_fds {
+            let ret = unsafe { libc::fcntl(*fd, libc::F_GETFD) };
+            assert_eq!(
+                ret, -1,
+                "plane fd {} should be closed after release_surface",
+                fd
+            );
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            assert_eq!(errno, Some(libc::EBADF));
+        }
     }
 }

--- a/libs/streamlib/src/linux/surface_broker/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_broker/unix_socket_service.rs
@@ -5,8 +5,10 @@
 //!
 //! Each `StreamRuntime` owns one of these listening on a unique socket under
 //! `$XDG_RUNTIME_DIR`. Polyglot subprocesses connect via `connect_to_broker`
-//! / `send_request` (from [`streamlib_broker_client`]) and exchange DMA-BUF
-//! fds over `SCM_RIGHTS`.
+//! / `send_request_with_fds` (from [`streamlib_broker_client`]) and exchange
+//! DMA-BUF fds over `SCM_RIGHTS`. Surfaces may carry up to
+//! [`streamlib_broker_client::MAX_DMA_BUF_PLANES`] plane fds — one per plane
+//! for multi-plane DMA-BUFs (e.g. NV12 with separate Y and UV allocations).
 
 use std::io::Read;
 use std::os::unix::io::RawFd;
@@ -15,9 +17,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 
-use streamlib_broker_client::{recv_message_with_fd, send_message_with_fd};
+use streamlib_broker_client::{
+    recv_message_with_fds, send_message_with_fds, MAX_DMA_BUF_PLANES,
+};
 
-use super::state::SurfaceBrokerState;
+use super::state::{SurfaceBrokerState, SurfaceRegistration};
 
 pub struct UnixSocketSurfaceService {
     state: SurfaceBrokerState,
@@ -150,7 +154,8 @@ fn handle_client_connection(
             ));
         }
 
-        let (json_bytes, received_fd) = recv_message_with_fd(&stream, msg_len)?;
+        let (json_bytes, received_fds) =
+            recv_message_with_fds(&stream, msg_len, MAX_DMA_BUF_PLANES)?;
 
         let request: serde_json::Value = serde_json::from_slice(&json_bytes).map_err(|e| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Invalid JSON: {}", e))
@@ -158,19 +163,21 @@ fn handle_client_connection(
 
         let op = request.get("op").and_then(|v| v.as_str()).unwrap_or("");
 
-        let (response, reply_fd) = match op {
-            "register" => handle_register(&state, &request, received_fd),
+        let (response, reply_fds) = match op {
+            "register" => handle_register(&state, &request, &received_fds),
             "lookup" | "check_out" => handle_lookup(&state, &request),
             "unregister" | "release" => handle_unregister(&state, &request),
-            "check_in" => handle_check_in(&state, &request, received_fd),
+            "check_in" => handle_check_in(&state, &request, &received_fds),
             _ => (
                 serde_json::json!({"error": format!("unknown operation: {}", op)}),
-                None,
+                Vec::new(),
             ),
         };
 
-        if let Some(fd) = received_fd {
-            unsafe { libc::close(fd) };
+        // Close every fd the peer sent us — handlers that wanted to keep
+        // ownership `dup`'d during registration.
+        for fd in &received_fds {
+            unsafe { libc::close(*fd) };
         }
 
         let response_bytes = serde_json::to_vec(&response).map_err(|e| {
@@ -180,22 +187,68 @@ fn handle_client_connection(
             )
         })?;
 
-        send_message_with_fd(&stream, &response_bytes, reply_fd)?;
+        send_message_with_fds(&stream, &response_bytes, &reply_fds)?;
 
-        if let Some(fd) = reply_fd {
-            unsafe { libc::close(fd) };
+        for fd in &reply_fds {
+            unsafe { libc::close(*fd) };
         }
     }
+}
+
+/// Extract `plane_sizes` and `plane_offsets` from a JSON request body.
+/// Returns `(plane_sizes, plane_offsets)` where each vec's length matches
+/// `expected_plane_count`, falling back to `[0]` and `[0]` when the peer
+/// sent no arrays (single-plane back-compat) or when a provided array has a
+/// different length than the fd set.
+///
+/// Returning `None` is an explicit wire-protocol violation (mismatched
+/// arrays, negative values); the handler should error out instead of
+/// guessing.
+fn parse_plane_arrays(
+    request: &serde_json::Value,
+    expected_plane_count: usize,
+) -> Option<(Vec<u64>, Vec<u64>)> {
+    let parse_arr = |key: &str| -> Option<Option<Vec<u64>>> {
+        match request.get(key) {
+            None => Some(None),
+            Some(v) => v
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .map(|el| el.as_u64())
+                        .collect::<Option<Vec<u64>>>()
+                })
+                .map(Some)
+                .unwrap_or(Some(None)),
+        }
+    };
+
+    let sizes_opt = parse_arr("plane_sizes")?;
+    let offsets_opt = parse_arr("plane_offsets")?;
+
+    let sizes = match sizes_opt {
+        Some(v) if v.len() == expected_plane_count => v,
+        Some(_) => return None,
+        None if expected_plane_count <= 1 => vec![0u64; expected_plane_count.max(1)],
+        None => return None,
+    };
+    let offsets = match offsets_opt {
+        Some(v) if v.len() == expected_plane_count => v,
+        Some(_) => return None,
+        None if expected_plane_count <= 1 => vec![0u64; expected_plane_count.max(1)],
+        None => return None,
+    };
+    Some((sizes, offsets))
 }
 
 fn handle_register(
     state: &SurfaceBrokerState,
     request: &serde_json::Value,
-    received_fd: Option<RawFd>,
-) -> (serde_json::Value, Option<RawFd>) {
+    received_fds: &[RawFd],
+) -> (serde_json::Value, Vec<RawFd>) {
     let surface_id = match request.get("surface_id").and_then(|v| v.as_str()) {
         Some(id) => id,
-        None => return (serde_json::json!({"error": "missing surface_id"}), None),
+        None => return (serde_json::json!({"error": "missing surface_id"}), Vec::new()),
     };
 
     let runtime_id = request
@@ -203,9 +256,32 @@ fn handle_register(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    let dma_buf_fd = match received_fd {
-        Some(fd) => fd,
-        None => return (serde_json::json!({"error": "missing DMA-BUF fd"}), None),
+    if received_fds.is_empty() {
+        return (
+            serde_json::json!({"error": "missing DMA-BUF fd(s)"}),
+            Vec::new(),
+        );
+    }
+    if received_fds.len() > MAX_DMA_BUF_PLANES {
+        return (
+            serde_json::json!({
+                "error": format!(
+                    "too many plane fds: {} > MAX_DMA_BUF_PLANES ({})",
+                    received_fds.len(), MAX_DMA_BUF_PLANES
+                )
+            }),
+            Vec::new(),
+        );
+    }
+
+    let (plane_sizes, plane_offsets) = match parse_plane_arrays(request, received_fds.len()) {
+        Some(arrays) => arrays,
+        None => {
+            return (
+                serde_json::json!({"error": "plane_sizes/plane_offsets length mismatch"}),
+                Vec::new(),
+            )
+        }
     };
 
     let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -216,81 +292,113 @@ fn handle_register(
         .and_then(|v| v.as_str())
         .unwrap_or("pixel_buffer");
 
-    let dup_fd = unsafe { libc::dup(dma_buf_fd) };
-    if dup_fd < 0 {
-        return (
-            serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
-            None,
-        );
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
+    for fd in received_fds {
+        let dup_fd = unsafe { libc::dup(*fd) };
+        if dup_fd < 0 {
+            for d in &dup_fds {
+                unsafe { libc::close(*d) };
+            }
+            return (
+                serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
+                Vec::new(),
+            );
+        }
+        dup_fds.push(dup_fd);
     }
 
-    let success =
-        state.register_surface(surface_id, runtime_id, dup_fd, width, height, format, resource_type);
-
-    if success {
-        tracing::debug!(
-            "[Runtime broker] register: surface '{}' for runtime '{}' (fd {})",
-            surface_id,
-            runtime_id,
-            dup_fd
-        );
-    } else {
-        unsafe { libc::close(dup_fd) };
-        tracing::warn!(
-            "[Runtime broker] register: surface '{}' already exists",
-            surface_id
-        );
+    match state.register_surface(SurfaceRegistration {
+        surface_id,
+        runtime_id,
+        dma_buf_fds: dup_fds,
+        plane_sizes,
+        plane_offsets,
+        width,
+        height,
+        format,
+        resource_type,
+    }) {
+        Ok(()) => {
+            tracing::debug!(
+                "[Runtime broker] register: surface '{}' for runtime '{}' ({} plane(s))",
+                surface_id,
+                runtime_id,
+                received_fds.len(),
+            );
+            (serde_json::json!({"success": true}), Vec::new())
+        }
+        Err(leftover) => {
+            for fd in &leftover {
+                unsafe { libc::close(*fd) };
+            }
+            tracing::warn!(
+                "[Runtime broker] register: surface '{}' already exists",
+                surface_id
+            );
+            (serde_json::json!({"success": false}), Vec::new())
+        }
     }
-
-    (serde_json::json!({"success": success}), None)
 }
 
 fn handle_lookup(
     state: &SurfaceBrokerState,
     request: &serde_json::Value,
-) -> (serde_json::Value, Option<RawFd>) {
+) -> (serde_json::Value, Vec<RawFd>) {
     let surface_id = match request.get("surface_id").and_then(|v| v.as_str()) {
         Some(id) => id,
-        None => return (serde_json::json!({"error": "missing surface_id"}), None),
+        None => return (serde_json::json!({"error": "missing surface_id"}), Vec::new()),
     };
 
-    match state.get_surface_dma_buf_fd(surface_id) {
-        Some(fd) => {
-            let dup_fd = unsafe { libc::dup(fd) };
-            if dup_fd < 0 {
-                return (
-                    serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
-                    None,
-                );
+    let (plane_fds, plane_sizes, plane_offsets) = match state.get_surface_planes(surface_id) {
+        Some(planes) => planes,
+        None => return (serde_json::json!({"error": "surface not found"}), Vec::new()),
+    };
+
+    // Dup each stored fd so the kernel-delivered fds in the peer's table are
+    // independent of the table's own copies. On partial failure, close every
+    // dup we already took.
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(plane_fds.len());
+    for fd in &plane_fds {
+        let dup = unsafe { libc::dup(*fd) };
+        if dup < 0 {
+            for d in &dup_fds {
+                unsafe { libc::close(*d) };
             }
-            let surfaces = state.get_surfaces();
-            let metadata = surfaces.iter().find(|s| s.surface_id == surface_id);
-            let (width, height, format, resource_type) = match metadata {
-                Some(m) => (m.width, m.height, m.format.as_str(), m.resource_type.as_str()),
-                None => (0, 0, "unknown", "pixel_buffer"),
-            };
-            (
-                serde_json::json!({
-                    "surface_id": surface_id,
-                    "width": width,
-                    "height": height,
-                    "format": format,
-                    "resource_type": resource_type,
-                }),
-                Some(dup_fd),
-            )
+            return (
+                serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
+                Vec::new(),
+            );
         }
-        None => (serde_json::json!({"error": "surface not found"}), None),
+        dup_fds.push(dup);
     }
+
+    let surfaces = state.get_surfaces();
+    let metadata = surfaces.iter().find(|s| s.surface_id == surface_id);
+    let (width, height, format, resource_type) = match metadata {
+        Some(m) => (m.width, m.height, m.format.as_str(), m.resource_type.as_str()),
+        None => (0, 0, "unknown", "pixel_buffer"),
+    };
+    (
+        serde_json::json!({
+            "surface_id": surface_id,
+            "width": width,
+            "height": height,
+            "format": format,
+            "resource_type": resource_type,
+            "plane_sizes": plane_sizes,
+            "plane_offsets": plane_offsets,
+        }),
+        dup_fds,
+    )
 }
 
 fn handle_unregister(
     state: &SurfaceBrokerState,
     request: &serde_json::Value,
-) -> (serde_json::Value, Option<RawFd>) {
+) -> (serde_json::Value, Vec<RawFd>) {
     let surface_id = match request.get("surface_id").and_then(|v| v.as_str()) {
         Some(id) => id,
-        None => return (serde_json::json!({"error": "missing surface_id"}), None),
+        None => return (serde_json::json!({"error": "missing surface_id"}), Vec::new()),
     };
 
     let runtime_id = request
@@ -299,22 +407,45 @@ fn handle_unregister(
         .unwrap_or("unknown");
 
     let released = state.release_surface(surface_id, runtime_id);
-    (serde_json::json!({"success": released}), None)
+    (serde_json::json!({"success": released}), Vec::new())
 }
 
 fn handle_check_in(
     state: &SurfaceBrokerState,
     request: &serde_json::Value,
-    received_fd: Option<RawFd>,
-) -> (serde_json::Value, Option<RawFd>) {
+    received_fds: &[RawFd],
+) -> (serde_json::Value, Vec<RawFd>) {
     let runtime_id = request
         .get("runtime_id")
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    let dma_buf_fd = match received_fd {
-        Some(fd) => fd,
-        None => return (serde_json::json!({"error": "missing DMA-BUF fd"}), None),
+    if received_fds.is_empty() {
+        return (
+            serde_json::json!({"error": "missing DMA-BUF fd(s)"}),
+            Vec::new(),
+        );
+    }
+    if received_fds.len() > MAX_DMA_BUF_PLANES {
+        return (
+            serde_json::json!({
+                "error": format!(
+                    "too many plane fds: {} > MAX_DMA_BUF_PLANES ({})",
+                    received_fds.len(), MAX_DMA_BUF_PLANES
+                )
+            }),
+            Vec::new(),
+        );
+    }
+
+    let (plane_sizes, plane_offsets) = match parse_plane_arrays(request, received_fds.len()) {
+        Some(arrays) => arrays,
+        None => {
+            return (
+                serde_json::json!({"error": "plane_sizes/plane_offsets length mismatch"}),
+                Vec::new(),
+            )
+        }
     };
 
     let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -327,22 +458,38 @@ fn handle_check_in(
 
     let surface_id = uuid::Uuid::new_v4().to_string();
 
-    let dup_fd = unsafe { libc::dup(dma_buf_fd) };
-    if dup_fd < 0 {
-        return (
-            serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
-            None,
-        );
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
+    for fd in received_fds {
+        let dup = unsafe { libc::dup(*fd) };
+        if dup < 0 {
+            for d in &dup_fds {
+                unsafe { libc::close(*d) };
+            }
+            return (
+                serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
+                Vec::new(),
+            );
+        }
+        dup_fds.push(dup);
     }
 
-    let success =
-        state.register_surface(&surface_id, runtime_id, dup_fd, width, height, format, resource_type);
-
-    if !success {
-        unsafe { libc::close(dup_fd) };
+    if let Err(leftover) = state.register_surface(SurfaceRegistration {
+        surface_id: &surface_id,
+        runtime_id,
+        dma_buf_fds: dup_fds,
+        plane_sizes,
+        plane_offsets,
+        width,
+        height,
+        format,
+        resource_type,
+    }) {
+        for fd in &leftover {
+            unsafe { libc::close(*fd) };
+        }
     }
 
-    (serde_json::json!({"surface_id": surface_id}), None)
+    (serde_json::json!({"surface_id": surface_id}), Vec::new())
 }
 
 unsafe impl Send for UnixSocketSurfaceService {}
@@ -352,7 +499,7 @@ unsafe impl Sync for UnixSocketSurfaceService {}
 mod tests {
     use super::*;
     use std::os::unix::io::FromRawFd;
-    use streamlib_broker_client::{connect_to_broker, send_request};
+    use streamlib_broker_client::{connect_to_broker, send_request_with_fds};
 
     fn make_memfd_with(contents: &[u8]) -> RawFd {
         use std::io::{Seek, SeekFrom, Write};
@@ -413,10 +560,10 @@ mod tests {
             "format": "Bgra32",
             "resource_type": "pixel_buffer",
         });
-        let (check_in_resp, check_in_fd) =
-            send_request(&stream, &check_in_req, Some(send_fd)).expect("check_in request");
+        let (check_in_resp, check_in_fds) =
+            send_request_with_fds(&stream, &check_in_req, &[send_fd], 0).expect("check_in request");
         unsafe { libc::close(send_fd) };
-        assert!(check_in_fd.is_none(), "check_in must not return an fd");
+        assert!(check_in_fds.is_empty(), "check_in must not return an fd");
         let surface_id = check_in_resp
             .get("surface_id")
             .and_then(|v| v.as_str())
@@ -428,12 +575,14 @@ mod tests {
             "op": "check_out",
             "surface_id": surface_id,
         });
-        let (check_out_resp, check_out_fd) =
-            send_request(&stream, &check_out_req, None).expect("check_out request");
+        let (check_out_resp, check_out_fds) =
+            send_request_with_fds(&stream, &check_out_req, &[], MAX_DMA_BUF_PLANES)
+                .expect("check_out request");
         assert_eq!(check_out_resp.get("width").and_then(|v| v.as_u64()), Some(640));
         assert_eq!(check_out_resp.get("height").and_then(|v| v.as_u64()), Some(480));
         assert_eq!(check_out_resp.get("format").and_then(|v| v.as_str()), Some("Bgra32"));
-        let received_fd = check_out_fd.expect("check_out must return an fd");
+        assert_eq!(check_out_fds.len(), 1, "single-plane: exactly one fd");
+        let received_fd = check_out_fds[0];
         assert!(received_fd >= 0);
         let received = read_all_from_fd(received_fd);
         assert_eq!(received, pattern);
@@ -443,7 +592,7 @@ mod tests {
             "surface_id": surface_id,
             "runtime_id": "test-runtime",
         });
-        let _ = send_request(&stream, &release_req, None).expect("release request");
+        let _ = send_request_with_fds(&stream, &release_req, &[], 0).expect("release request");
 
         drop(stream);
         service.stop();
@@ -462,9 +611,148 @@ mod tests {
             "op": "check_out",
             "surface_id": "never-registered",
         });
-        let (resp, fd) = send_request(&stream, &req, None).expect("check_out request");
-        assert!(fd.is_none());
+        let (resp, fds) = send_request_with_fds(&stream, &req, &[], MAX_DMA_BUF_PLANES)
+            .expect("check_out request");
+        assert!(fds.is_empty());
         assert!(resp.get("error").and_then(|v| v.as_str()).is_some());
+
+        drop(stream);
+        service.stop();
+    }
+
+    /// Two memfds with distinct content registered under one surface_id via
+    /// `check_in` must round-trip intact through `check_out`, including the
+    /// plane-layout metadata that lets the consumer mmap each plane at its
+    /// own size. This is the defining multi-plane DMA-BUF test.
+    #[test]
+    fn check_in_check_out_multi_fd_roundtrip() {
+        let state = SurfaceBrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_broker(&socket_path).expect("connect");
+
+        let pattern_y = b"plane-Y-bytes-A123456789";
+        let pattern_uv = b"plane-UV-bytes-Z987654321";
+        let fd_y = make_memfd_with(pattern_y);
+        let fd_uv = make_memfd_with(pattern_uv);
+
+        let check_in_req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "test-runtime",
+            "width": 1920,
+            "height": 1080,
+            "format": "Nv12VideoRange",
+            "resource_type": "pixel_buffer",
+            "plane_sizes": [pattern_y.len() as u64, pattern_uv.len() as u64],
+            "plane_offsets": [0u64, 0u64],
+        });
+        let (check_in_resp, check_in_fds) =
+            send_request_with_fds(&stream, &check_in_req, &[fd_y, fd_uv], 0)
+                .expect("check_in request");
+        unsafe {
+            libc::close(fd_y);
+            libc::close(fd_uv);
+        }
+        assert!(check_in_fds.is_empty(), "check_in must not return any fd");
+        let surface_id = check_in_resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id in response")
+            .to_string();
+
+        let check_out_req = serde_json::json!({
+            "op": "check_out",
+            "surface_id": surface_id,
+        });
+        let (check_out_resp, check_out_fds) =
+            send_request_with_fds(&stream, &check_out_req, &[], MAX_DMA_BUF_PLANES)
+                .expect("check_out request");
+        assert_eq!(
+            check_out_fds.len(),
+            2,
+            "both planes delivered via SCM_RIGHTS"
+        );
+        assert_eq!(
+            read_all_from_fd(check_out_fds[0]),
+            pattern_y,
+            "plane 0 content preserved"
+        );
+        assert_eq!(
+            read_all_from_fd(check_out_fds[1]),
+            pattern_uv,
+            "plane 1 content preserved"
+        );
+        let sizes = check_out_resp
+            .get("plane_sizes")
+            .and_then(|v| v.as_array())
+            .expect("plane_sizes array in response");
+        assert_eq!(
+            sizes
+                .iter()
+                .map(|v| v.as_u64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![pattern_y.len() as u64, pattern_uv.len() as u64],
+        );
+
+        let _ = send_request_with_fds(
+            &stream,
+            &serde_json::json!({
+                "op": "release",
+                "surface_id": surface_id,
+                "runtime_id": "test-runtime",
+            }),
+            &[],
+            0,
+        );
+
+        drop(stream);
+        service.stop();
+    }
+
+    /// The broker must refuse a check_in whose fd count exceeds the plane
+    /// cap instead of truncating silently. The check runs in the wire helper
+    /// before the handler, so this exercises the shared back-pressure path
+    /// every caller relies on.
+    #[test]
+    fn oversize_fd_vec_rejected() {
+        let state = SurfaceBrokerState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_broker(&socket_path).expect("connect");
+
+        // MAX_DMA_BUF_PLANES + 1 fds — one over the cap.
+        let fds: Vec<RawFd> = (0..=MAX_DMA_BUF_PLANES)
+            .map(|i| make_memfd_with(format!("plane-{}", i).as_bytes()))
+            .collect();
+
+        let check_in_req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "test-runtime",
+            "width": 640,
+            "height": 480,
+            "format": "Custom",
+            "plane_sizes": vec![0u64; fds.len()],
+            "plane_offsets": vec![0u64; fds.len()],
+        });
+
+        // The wire helper rejects with InvalidInput *before* any syscall,
+        // without closing the caller-owned fds.
+        let err = send_request_with_fds(&stream, &check_in_req, &fds, 0)
+            .expect_err("oversize vec must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+        // Every caller fd is still valid; no leaks, no double-closes.
+        for fd in &fds {
+            let rc = unsafe { libc::fcntl(*fd, libc::F_GETFD) };
+            assert!(rc >= 0, "caller fd {} must still be valid", fd);
+            unsafe { libc::close(*fd) };
+        }
 
         drop(stream);
         service.stop();

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -22,6 +22,20 @@ use super::VulkanDevice;
 pub(crate) static VULKAN_DEVICE_FOR_IMPORT: std::sync::OnceLock<Arc<VulkanDevice>> =
     std::sync::OnceLock::new();
 
+/// One extra plane of a multi-plane DMA-BUF import (planes 1..N on the
+/// Linux side). Plane 0 lives in [`VulkanPixelBuffer::buffer`] /
+/// `imported_memory` / `mapped_ptr` for back-compat with the
+/// single-plane accessors; additional planes are stored here so an
+/// exported multi-plane format (e.g. NV12 with disjoint Y and UV
+/// allocations) survives the round-trip.
+#[cfg(target_os = "linux")]
+struct VulkanImportedPlane {
+    buffer: vk::Buffer,
+    memory: vk::DeviceMemory,
+    mapped_ptr: *mut u8,
+    size: vk::DeviceSize,
+}
+
 /// CPU-visible staging buffer for pixel data upload/readback.
 pub struct VulkanPixelBuffer {
     /// VulkanDevice reference for tracked allocation/free through the RHI.
@@ -35,8 +49,12 @@ pub struct VulkanPixelBuffer {
     /// Whether this buffer was imported from a DMA-BUF fd.
     #[cfg(target_os = "linux")]
     imported_from_dma_buf: bool,
-    /// Persistently mapped CPU pointer.
+    /// Persistently mapped CPU pointer — plane 0 for multi-plane imports.
     mapped_ptr: *mut u8,
+    /// Planes 1..N for multi-plane DMA-BUF imports. Empty for single-plane
+    /// imports and for VMA-allocated buffers.
+    #[cfg(target_os = "linux")]
+    extra_imported_planes: Vec<VulkanImportedPlane>,
     width: u32,
     height: u32,
     bytes_per_pixel: u32,
@@ -127,6 +145,8 @@ impl VulkanPixelBuffer {
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
             mapped_ptr,
+            #[cfg(target_os = "linux")]
+            extra_imported_planes: Vec::new(),
             width,
             height,
             bytes_per_pixel,
@@ -135,9 +155,64 @@ impl VulkanPixelBuffer {
         })
     }
 
-    /// Persistently mapped pointer for CPU access.
+    /// Persistently mapped pointer for CPU access — plane 0 for
+    /// multi-plane imports. Use [`Self::plane_mapped_ptr`] for any plane
+    /// index.
     pub fn mapped_ptr(&self) -> *mut u8 {
         self.mapped_ptr
+    }
+
+    /// Number of DMA-BUF planes backing this pixel buffer. Always `>= 1`:
+    /// `1` for VMA-allocated buffers and single-plane imports, `N` for
+    /// multi-plane DMA-BUF imports.
+    pub fn plane_count(&self) -> u32 {
+        #[cfg(target_os = "linux")]
+        {
+            1 + self.extra_imported_planes.len() as u32
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            1
+        }
+    }
+
+    /// Mapped base address of a specific plane, or null if `plane_index`
+    /// is out of range. Plane 0 returns [`Self::mapped_ptr`]; planes 1..N
+    /// return the matching entry from the multi-plane import set.
+    pub fn plane_mapped_ptr(&self, plane_index: u32) -> *mut u8 {
+        if plane_index == 0 {
+            return self.mapped_ptr;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            self.extra_imported_planes
+                .get(plane_index as usize - 1)
+                .map(|p| p.mapped_ptr)
+                .unwrap_or(std::ptr::null_mut())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            std::ptr::null_mut()
+        }
+    }
+
+    /// Byte size of a specific plane, or `0` if `plane_index` is out of
+    /// range.
+    pub fn plane_size(&self, plane_index: u32) -> vk::DeviceSize {
+        if plane_index == 0 {
+            return self.size;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            self.extra_imported_planes
+                .get(plane_index as usize - 1)
+                .map(|p| p.size)
+                .unwrap_or(0)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            0
+        }
     }
 
     /// Buffer width in pixels.
@@ -200,7 +275,11 @@ impl VulkanPixelBuffer {
         Ok(fd)
     }
 
-    /// Import a buffer from a DMA-BUF file descriptor.
+    /// Import a buffer from a single-plane DMA-BUF file descriptor.
+    ///
+    /// Thin wrapper over [`Self::from_dma_buf_fds`] for back-compat with
+    /// existing single-plane callers — new code should prefer the
+    /// multi-plane signature even when there is only one plane.
     pub fn from_dma_buf_fd(
         vulkan_device: &Arc<VulkanDevice>,
         fd: std::os::unix::io::RawFd,
@@ -210,90 +289,203 @@ impl VulkanPixelBuffer {
         format: PixelFormat,
         allocation_size: vk::DeviceSize,
     ) -> Result<Self> {
-        let device = vulkan_device.device();
-        let size = (width as vk::DeviceSize)
-            * (height as vk::DeviceSize)
-            * (bytes_per_pixel as vk::DeviceSize);
-        let effective_size = if allocation_size > 0 { allocation_size } else { size };
-
-        let mut external_buffer_info = vk::ExternalMemoryBufferCreateInfo::builder()
-            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
-            .build();
-
-        let buffer_info = vk::BufferCreateInfo::builder()
-            .size(effective_size)
-            .usage(
-                vk::BufferUsageFlags::TRANSFER_SRC
-                    | vk::BufferUsageFlags::TRANSFER_DST
-                    | vk::BufferUsageFlags::STORAGE_BUFFER,
-            )
-            .sharing_mode(vk::SharingMode::EXCLUSIVE)
-            .push_next(&mut external_buffer_info)
-            .build();
-
-        let buffer = unsafe { device.create_buffer(&buffer_info, None) }
-            .map(|r| r)
-            .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create buffer for DMA-BUF import: {e}"))
-            })?;
-
-        let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
-        let alloc_size = effective_size.max(mem_requirements.size);
-
-        // VMA cannot import external memory — use raw import path in the RHI
-        let memory = vulkan_device
-            .import_dma_buf_memory(
-                fd,
-                alloc_size,
-                mem_requirements.memory_type_bits,
-                vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
-            )
-            .map_err(|e| {
-                unsafe { device.destroy_buffer(buffer, None) };
-                e
-            })?;
-
-        unsafe { device.bind_buffer_memory(buffer, memory, 0) }
-            .map(|_| ())
-            .map_err(|e| {
-                vulkan_device.free_imported_memory(memory);
-                unsafe { device.destroy_buffer(buffer, None) };
-                StreamError::GpuError(format!("Failed to bind imported memory: {e}"))
-            })?;
-
-        let mapped_ptr = vulkan_device
-            .map_imported_memory(memory, effective_size)
-            .map_err(|e| {
-                vulkan_device.free_imported_memory(memory);
-                unsafe { device.destroy_buffer(buffer, None) };
-                e
-            })?;
-
-        Ok(Self {
-            vulkan_device: Arc::clone(vulkan_device),
-            buffer,
-            allocation: None,
-            imported_memory: Some(memory),
-            imported_from_dma_buf: true,
-            mapped_ptr,
+        Self::from_dma_buf_fds(
+            vulkan_device,
+            &[fd],
+            &[allocation_size],
             width,
             height,
             bytes_per_pixel,
             format,
-            size: effective_size,
+        )
+    }
+
+    /// Import one `vk::Buffer` + `vk::DeviceMemory` pair per plane from
+    /// the given DMA-BUF fds. `plane_sizes[i]` must be the allocation
+    /// size of plane `i` (0 falls back to `width*height*bytes_per_pixel`
+    /// on plane 0, required for every other plane).
+    ///
+    /// Partial-failure semantics: if plane N fails to import, every
+    /// plane 0..N that already succeeded is torn down (buffer destroyed,
+    /// memory unmapped + freed) before the error is returned. The
+    /// caller retains ownership of the fds — each fd is consumed by
+    /// `vkAllocateMemory` only on success.
+    pub fn from_dma_buf_fds(
+        vulkan_device: &Arc<VulkanDevice>,
+        fds: &[std::os::unix::io::RawFd],
+        plane_sizes: &[vk::DeviceSize],
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: PixelFormat,
+    ) -> Result<Self> {
+        if fds.is_empty() {
+            return Err(StreamError::Configuration(
+                "DMA-BUF import: fd vec must be non-empty".into(),
+            ));
+        }
+        if fds.len() != plane_sizes.len() {
+            return Err(StreamError::Configuration(format!(
+                "DMA-BUF import: plane_sizes length ({}) must match fds length ({})",
+                plane_sizes.len(),
+                fds.len()
+            )));
+        }
+        if fds.len() > streamlib_broker_client::MAX_DMA_BUF_PLANES {
+            return Err(StreamError::Configuration(format!(
+                "DMA-BUF import: plane count {} exceeds MAX_DMA_BUF_PLANES ({})",
+                fds.len(),
+                streamlib_broker_client::MAX_DMA_BUF_PLANES
+            )));
+        }
+
+        let size = (width as vk::DeviceSize)
+            * (height as vk::DeviceSize)
+            * (bytes_per_pixel as vk::DeviceSize);
+
+        // Import every plane. Stash each successful import in a vec so we
+        // can unwind on partial failure.
+        let mut imported: Vec<VulkanImportedPlane> = Vec::with_capacity(fds.len());
+        for (idx, (&fd, &plane_size)) in fds.iter().zip(plane_sizes.iter()).enumerate() {
+            let effective_size = if plane_size > 0 {
+                plane_size
+            } else if idx == 0 {
+                size
+            } else {
+                // Planes 1..N need an explicit size — we can't derive it
+                // from width/height since subsampling and format
+                // modifiers vary per plane.
+                for plane in imported.into_iter() {
+                    teardown_imported_plane(vulkan_device, plane);
+                }
+                return Err(StreamError::Configuration(format!(
+                    "DMA-BUF import: plane {} has size=0 and cannot be derived from width*height",
+                    idx
+                )));
+            };
+
+            match import_single_plane(vulkan_device, fd, effective_size) {
+                Ok(plane) => imported.push(plane),
+                Err(e) => {
+                    for plane in imported.into_iter() {
+                        teardown_imported_plane(vulkan_device, plane);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        // Split plane 0 out into the existing back-compat fields; the
+        // rest become `extra_imported_planes`.
+        let plane0 = imported.remove(0);
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            buffer: plane0.buffer,
+            allocation: None,
+            imported_memory: Some(plane0.memory),
+            imported_from_dma_buf: true,
+            mapped_ptr: plane0.mapped_ptr,
+            extra_imported_planes: imported,
+            width,
+            height,
+            bytes_per_pixel,
+            format,
+            size: plane0.size,
         })
     }
+}
+
+/// Create one `VkBuffer` + bind one imported `VkDeviceMemory` + map it.
+/// Used by [`VulkanPixelBuffer::from_dma_buf_fds`] once per plane.
+#[cfg(target_os = "linux")]
+fn import_single_plane(
+    vulkan_device: &Arc<VulkanDevice>,
+    fd: std::os::unix::io::RawFd,
+    effective_size: vk::DeviceSize,
+) -> Result<VulkanImportedPlane> {
+    let device = vulkan_device.device();
+
+    let mut external_buffer_info = vk::ExternalMemoryBufferCreateInfo::builder()
+        .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+        .build();
+
+    let buffer_info = vk::BufferCreateInfo::builder()
+        .size(effective_size)
+        .usage(
+            vk::BufferUsageFlags::TRANSFER_SRC
+                | vk::BufferUsageFlags::TRANSFER_DST
+                | vk::BufferUsageFlags::STORAGE_BUFFER,
+        )
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .push_next(&mut external_buffer_info)
+        .build();
+
+    let buffer = unsafe { device.create_buffer(&buffer_info, None) }.map_err(|e| {
+        StreamError::GpuError(format!("Failed to create buffer for DMA-BUF import: {e}"))
+    })?;
+
+    let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
+    let alloc_size = effective_size.max(mem_requirements.size);
+
+    let memory = vulkan_device
+        .import_dma_buf_memory(
+            fd,
+            alloc_size,
+            mem_requirements.memory_type_bits,
+            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+        )
+        .map_err(|e| {
+            unsafe { device.destroy_buffer(buffer, None) };
+            e
+        })?;
+
+    unsafe { device.bind_buffer_memory(buffer, memory, 0) }.map_err(|e| {
+        vulkan_device.free_imported_memory(memory);
+        unsafe { device.destroy_buffer(buffer, None) };
+        StreamError::GpuError(format!("Failed to bind imported memory: {e}"))
+    })?;
+
+    let mapped_ptr = vulkan_device
+        .map_imported_memory(memory, effective_size)
+        .map_err(|e| {
+            vulkan_device.free_imported_memory(memory);
+            unsafe { device.destroy_buffer(buffer, None) };
+            e
+        })?;
+
+    Ok(VulkanImportedPlane {
+        buffer,
+        memory,
+        mapped_ptr: mapped_ptr,
+        size: effective_size,
+    })
+}
+
+/// Partial-unwind helper for [`VulkanPixelBuffer::from_dma_buf_fds`] —
+/// tears down one already-imported plane when a later plane fails.
+#[cfg(target_os = "linux")]
+fn teardown_imported_plane(vulkan_device: &Arc<VulkanDevice>, plane: VulkanImportedPlane) {
+    unsafe {
+        vulkan_device.device().destroy_buffer(plane.buffer, None);
+    }
+    vulkan_device.unmap_imported_memory(plane.memory);
+    vulkan_device.free_imported_memory(plane.memory);
 }
 
 impl Drop for VulkanPixelBuffer {
     fn drop(&mut self) {
         #[cfg(target_os = "linux")]
         if self.imported_from_dma_buf {
-            // DMA-BUF import path: raw DeviceMemory, not VMA
+            // DMA-BUF import path: raw DeviceMemory, not VMA.
             unsafe { self.vulkan_device.device().destroy_buffer(self.buffer, None) };
             if let Some(memory) = self.imported_memory.take() {
                 self.vulkan_device.unmap_imported_memory(memory);
                 self.vulkan_device.free_imported_memory(memory);
+            }
+            // Tear down every extra plane — each owns its own buffer +
+            // imported memory + mapping.
+            for plane in self.extra_imported_planes.drain(..) {
+                teardown_imported_plane(&self.vulkan_device, plane);
             }
             return;
         }
@@ -509,5 +701,138 @@ mod tests {
         }
 
         println!("DMA-BUF round-trip verified: {} bytes, fd={fd}", size);
+    }
+
+    /// Multi-plane `from_dma_buf_fds` round-trip: import two independently
+    /// allocated + pattern-written DMA-BUFs as the two planes of a single
+    /// `VulkanPixelBuffer`, confirm `plane_count()` reports 2, and each
+    /// plane's bytes survive intact. Mirrors the symmetry the polyglot
+    /// Python and Deno shims provide via `*_gpu_surface_plane_{count,size,mmap,base_address}`.
+    #[test]
+    fn test_dma_buf_import_multi_plane_round_trip() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+
+        let width = 64u32;
+        let height = 4u32;
+        let bpp = 4u32;
+        let plane_size = (width * height * bpp) as vk::DeviceSize;
+
+        // Two independent source buffers, each seeded with a distinct
+        // byte pattern so a cross-plane swap would be visible in the
+        // readback.
+        let src0 = VulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
+            .expect("source plane 0 creation failed");
+        let src1 = VulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
+            .expect("source plane 1 creation failed");
+        let pattern0: [u8; 4] = [0xA0, 0xA1, 0xA2, 0xA3];
+        let pattern1: [u8; 4] = [0xB0, 0xB1, 0xB2, 0xB3];
+        unsafe {
+            for i in (0..plane_size as usize).step_by(4) {
+                std::ptr::copy_nonoverlapping(pattern0.as_ptr(), src0.mapped_ptr().add(i), 4);
+                std::ptr::copy_nonoverlapping(pattern1.as_ptr(), src1.mapped_ptr().add(i), 4);
+            }
+        }
+
+        let fd0 = src0.export_dma_buf_fd().expect("plane 0 export failed");
+        let fd1 = src1.export_dma_buf_fd().expect("plane 1 export failed");
+
+        // Import both as planes of a single pixel buffer.
+        let imported = VulkanPixelBuffer::from_dma_buf_fds(
+            &device,
+            &[fd0, fd1],
+            &[plane_size, plane_size],
+            width,
+            height,
+            bpp,
+            PixelFormat::Bgra32,
+        )
+        .expect("multi-plane DMA-BUF import failed");
+
+        assert_eq!(imported.plane_count(), 2, "plane_count must report 2");
+        assert_eq!(imported.plane_size(0), plane_size);
+        assert_eq!(imported.plane_size(1), plane_size);
+        assert_eq!(imported.plane_size(2), 0, "out-of-range plane size must be 0");
+
+        let p0 = imported.plane_mapped_ptr(0);
+        let p1 = imported.plane_mapped_ptr(1);
+        assert!(!p0.is_null() && !p1.is_null());
+        assert_eq!(
+            imported.plane_mapped_ptr(2),
+            std::ptr::null_mut(),
+            "out-of-range plane ptr must be null"
+        );
+
+        // Content check: plane 0 matches pattern0, plane 1 matches
+        // pattern1. Byte-exact, no cross-contamination.
+        unsafe {
+            for i in (0..plane_size as usize).step_by(4) {
+                let b0 = [
+                    *p0.add(i),
+                    *p0.add(i + 1),
+                    *p0.add(i + 2),
+                    *p0.add(i + 3),
+                ];
+                let b1 = [
+                    *p1.add(i),
+                    *p1.add(i + 1),
+                    *p1.add(i + 2),
+                    *p1.add(i + 3),
+                ];
+                assert_eq!(b0, pattern0, "plane 0 mismatch at offset {i}");
+                assert_eq!(b1, pattern1, "plane 1 mismatch at offset {i}");
+            }
+        }
+
+        println!(
+            "Multi-plane DMA-BUF import round-trip verified: 2 planes × {} bytes",
+            plane_size
+        );
+    }
+
+    /// Oversize vec rejection: we refuse to import a pixel buffer with
+    /// more planes than the broker's `MAX_DMA_BUF_PLANES` cap (4 today).
+    /// Covers the Rust half of the consistency the wire helpers already
+    /// enforce on sends/receives.
+    #[test]
+    fn test_dma_buf_import_rejects_oversize_plane_vec() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+
+        // fds/sizes vecs with one more entry than the cap. Negative fds
+        // are fine — we expect the length check to fire before any
+        // syscall touches them.
+        let fds: Vec<std::os::unix::io::RawFd> =
+            (0..=streamlib_broker_client::MAX_DMA_BUF_PLANES as i32)
+                .map(|_| -1i32)
+                .collect();
+        let sizes: Vec<vk::DeviceSize> = vec![1024; fds.len()];
+
+        let result = VulkanPixelBuffer::from_dma_buf_fds(
+            &device,
+            &fds,
+            &sizes,
+            64,
+            4,
+            4,
+            PixelFormat::Bgra32,
+        );
+        match result {
+            Ok(_) => panic!("oversize plane vec must be rejected"),
+            Err(e) => assert!(
+                e.to_string().contains("MAX_DMA_BUF_PLANES"),
+                "error should name the cap, got: {e}"
+            ),
+        }
     }
 }

--- a/libs/streamlib/tests/polyglot_linux_check_out.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use streamlib::core::runtime::StreamRuntime;
-use streamlib_broker_client::{connect_to_broker, send_request};
+use streamlib_broker_client::{connect_to_broker, send_request_with_fds};
 
 #[path = "common/polyglot_dma_buf_producer.rs"]
 mod polyglot_dma_buf_producer;
@@ -252,7 +252,7 @@ fn python_subprocess_resolves_and_vulkan_imports_host_published_surface() {
         "resource_type": "pixel_buffer",
     });
     let (resp, _) =
-        send_request(&host_stream, &check_in_req, Some(fd)).expect("host check_in");
+        send_request_with_fds(&host_stream, &check_in_req, &[fd], 0).expect("host check_in");
     unsafe { libc::close(fd) };
     let surface_id = resp
         .get("surface_id")

--- a/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
+++ b/libs/streamlib/tests/polyglot_linux_check_out_deno.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use streamlib::core::runtime::StreamRuntime;
-use streamlib_broker_client::{connect_to_broker, send_request};
+use streamlib_broker_client::{connect_to_broker, send_request_with_fds};
 
 #[path = "common/polyglot_dma_buf_producer.rs"]
 mod polyglot_dma_buf_producer;
@@ -205,7 +205,8 @@ fn deno_subprocess_resolves_and_vulkan_imports_host_published_surface() {
         "format": "Bgra32",
         "resource_type": "pixel_buffer",
     });
-    let (resp, _) = send_request(&host_stream, &check_in_req, Some(fd)).expect("host check_in");
+    let (resp, _) =
+        send_request_with_fds(&host_stream, &check_in_req, &[fd], 0).expect("host check_in");
     unsafe { libc::close(fd) };
     let surface_id = resp
         .get("surface_id")

--- a/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
+++ b/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Multi-plane DMA-BUF round-trip through the polyglot consumer shims.
+//!
+//! This is the shim-level exit-criterion test for the multi-FD SCM_RIGHTS
+//! widening (#423). A real `StreamRuntime` runs the surface-sharing service;
+//! the host side `check_in`s a 2-plane surface built from two memfds seeded
+//! with distinct byte patterns; the shim's `*_broker_resolve_surface`
+//! resolves the surface_id, and `*_gpu_surface_plane_mmap` plus
+//! `*_gpu_surface_plane_base_address` expose each plane's bytes so the test
+//! can assert the patterns survived the wire.
+//!
+//! memfds stand in for real DMA-BUFs here. The shim never maps them as
+//! GPU memory (no Vulkan `lock` call in this test), so SCM_RIGHTS +
+//! `mmap(MAP_SHARED)` is enough to verify the wire + per-plane layout.
+//! The Vulkan `lock` path is covered by the existing
+//! `polyglot_linux_check_out*` tests with real DMA-BUFs.
+//!
+//! Skip conditions:
+//!   - `libstreamlib_{python,deno}_native.so` not under target/ → skip (as
+//!     with the existing polyglot tests).
+//!   - no Vulkan-capable device available to the shim → skip; the shim's
+//!     resolve_surface gates on `BrokerVulkanDevice::try_new()` even for
+//!     mmap-only consumers.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::{CString, c_void};
+use std::io::{Seek, SeekFrom, Write};
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::path::PathBuf;
+
+use streamlib::core::runtime::StreamRuntime;
+use streamlib_broker_client::{connect_to_broker, send_request_with_fds};
+
+fn locate_native_lib(basename: &str) -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    for profile in &["debug", "release"] {
+        let candidate = workspace.join("target").join(profile).join(basename);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn make_memfd_with(name: &str, contents: &[u8]) -> RawFd {
+    let name = CString::new(name).unwrap();
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+    assert!(
+        fd >= 0,
+        "memfd_create failed: {}",
+        std::io::Error::last_os_error()
+    );
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.write_all(contents).expect("memfd write");
+    file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+    file.into_raw_fd()
+}
+
+/// Shared bytes for each shim's test: the two planes (Y and UV for NV12).
+/// Distinct byte patterns so a cross-plane swap is visible.
+fn plane_patterns() -> (Vec<u8>, Vec<u8>) {
+    let plane_y: Vec<u8> = (0..(64 * 4))
+        .map(|i| (((i as u32) * 19 + 3) & 0xFF) as u8)
+        .collect();
+    let plane_uv: Vec<u8> = (0..(64 * 4))
+        .map(|i| (((i as u32) * 31 + 137) & 0xFF) as u8)
+        .collect();
+    (plane_y, plane_uv)
+}
+
+/// Check_in 2 memfds as planes of a single surface, return the surface_id.
+fn check_in_multi_plane(
+    socket_path: &std::path::Path,
+    runtime_id: &str,
+    plane_y: &[u8],
+    plane_uv: &[u8],
+) -> String {
+    let fd_y = make_memfd_with("multi-plane-test-y", plane_y);
+    let fd_uv = make_memfd_with("multi-plane-test-uv", plane_uv);
+
+    let stream = connect_to_broker(socket_path).expect("host connect");
+    let req = serde_json::json!({
+        "op": "check_in",
+        "runtime_id": runtime_id,
+        "width": 64u32,
+        "height": 4u32,
+        "format": "Nv12VideoRange",
+        "resource_type": "pixel_buffer",
+        "plane_sizes": [plane_y.len() as u64, plane_uv.len() as u64],
+        "plane_offsets": [0u64, 0u64],
+    });
+    let (resp, resp_fds) =
+        send_request_with_fds(&stream, &req, &[fd_y, fd_uv], 0).expect("host check_in");
+    assert!(resp_fds.is_empty());
+    unsafe {
+        libc::close(fd_y);
+        libc::close(fd_uv);
+    }
+    let surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("surface_id in check_in response")
+        .to_string();
+    drop(stream);
+    surface_id
+}
+
+/// How the shim's `broker_connect` is called. The Python shim takes
+/// `(socket_path, runtime_id)`; the Deno shim takes only `(socket_path)`.
+/// The two cdylibs are ABI-independent, so we resolve each signature
+/// exactly rather than gambling on x86_64 calling convention leniency.
+enum ConnectFlavor {
+    TwoArg, // Python: slpn_broker_connect(socket_path, runtime_id)
+    OneArg, // Deno:   sldn_broker_connect(socket_path)
+}
+
+/// Shared test body: load `lib_path` (a `libstreamlib_*_native.so`), call
+/// the per-shim FFI entry points (differing only by the `prefix`, e.g.
+/// `slpn_` or `sldn_`), and assert both plane contents round-trip through
+/// the shim intact.
+fn run_shim_test(lib_path: PathBuf, prefix: &str, flavor: ConnectFlavor) {
+    let runtime = StreamRuntime::new().expect("StreamRuntime::new");
+    let socket_path = runtime.surface_socket_path().to_path_buf();
+    let runtime_id = runtime.runtime_id().to_string();
+
+    let (plane_y, plane_uv) = plane_patterns();
+    let surface_id = check_in_multi_plane(&socket_path, &runtime_id, &plane_y, &plane_uv);
+
+    let lib = unsafe { libloading::Library::new(&lib_path) }.expect("load native lib");
+
+    let broker_disconnect: libloading::Symbol<unsafe extern "C" fn(*mut c_void)> =
+        unsafe { lib.get(format!("{}broker_disconnect", prefix).as_bytes()) }
+            .expect("broker_disconnect");
+    let broker_resolve_surface: libloading::Symbol<
+        unsafe extern "C" fn(*mut c_void, *const i8) -> *mut c_void,
+    > = unsafe { lib.get(format!("{}broker_resolve_surface", prefix).as_bytes()) }
+        .expect("broker_resolve_surface");
+    let gpu_surface_release: libloading::Symbol<unsafe extern "C" fn(*mut c_void)> =
+        unsafe { lib.get(format!("{}gpu_surface_release", prefix).as_bytes()) }
+            .expect("gpu_surface_release");
+    let gpu_surface_plane_count: libloading::Symbol<
+        unsafe extern "C" fn(*const c_void) -> u32,
+    > = unsafe { lib.get(format!("{}gpu_surface_plane_count", prefix).as_bytes()) }
+        .expect("gpu_surface_plane_count");
+    let gpu_surface_plane_size: libloading::Symbol<
+        unsafe extern "C" fn(*const c_void, u32) -> u64,
+    > = unsafe { lib.get(format!("{}gpu_surface_plane_size", prefix).as_bytes()) }
+        .expect("gpu_surface_plane_size");
+    let gpu_surface_plane_mmap: libloading::Symbol<
+        unsafe extern "C" fn(*mut c_void, u32) -> i32,
+    > = unsafe { lib.get(format!("{}gpu_surface_plane_mmap", prefix).as_bytes()) }
+        .expect("gpu_surface_plane_mmap");
+    let gpu_surface_plane_base_address: libloading::Symbol<
+        unsafe extern "C" fn(*const c_void, u32) -> *mut u8,
+    > = unsafe {
+        lib.get(format!("{}gpu_surface_plane_base_address", prefix).as_bytes())
+    }
+    .expect("gpu_surface_plane_base_address");
+
+    let socket_path_c = CString::new(socket_path.to_str().expect("path utf8")).unwrap();
+    let broker = match flavor {
+        ConnectFlavor::TwoArg => {
+            let broker_connect: libloading::Symbol<
+                unsafe extern "C" fn(*const i8, *const i8) -> *mut c_void,
+            > = unsafe { lib.get(format!("{}broker_connect", prefix).as_bytes()) }
+                .expect("broker_connect");
+            let runtime_id_c = CString::new("multi-plane-subprocess").unwrap();
+            unsafe { broker_connect(socket_path_c.as_ptr(), runtime_id_c.as_ptr()) }
+        }
+        ConnectFlavor::OneArg => {
+            let broker_connect: libloading::Symbol<
+                unsafe extern "C" fn(*const i8) -> *mut c_void,
+            > = unsafe { lib.get(format!("{}broker_connect", prefix).as_bytes()) }
+                .expect("broker_connect");
+            unsafe { broker_connect(socket_path_c.as_ptr()) }
+        }
+    };
+    if broker.is_null() {
+        eprintln!(
+            "{}resolve_surface_multi_plane: broker_connect returned null — skipping",
+            prefix
+        );
+        return;
+    }
+
+    let surface_id_c = CString::new(surface_id.as_str()).unwrap();
+    let surface = unsafe { broker_resolve_surface(broker, surface_id_c.as_ptr()) };
+    if surface.is_null() {
+        // resolve_surface gates on Vulkan device creation — skip cleanly
+        // rather than fail when the host has no Vulkan-capable driver.
+        eprintln!(
+            "{}resolve_surface_multi_plane: resolve_surface returned null — skipping (no Vulkan device?)",
+            prefix
+        );
+        unsafe { broker_disconnect(broker) };
+        return;
+    }
+
+    // Assert plane count and per-plane sizes match what we check_in'd.
+    let plane_count = unsafe { gpu_surface_plane_count(surface) };
+    assert_eq!(plane_count, 2, "{}: plane count should be 2", prefix);
+
+    let size0 = unsafe { gpu_surface_plane_size(surface, 0) };
+    let size1 = unsafe { gpu_surface_plane_size(surface, 1) };
+    assert_eq!(size0, plane_y.len() as u64, "{}: plane 0 size", prefix);
+    assert_eq!(size1, plane_uv.len() as u64, "{}: plane 1 size", prefix);
+
+    // mmap each plane and compare bytes to the source patterns.
+    let rc0 = unsafe { gpu_surface_plane_mmap(surface, 0) };
+    let rc1 = unsafe { gpu_surface_plane_mmap(surface, 1) };
+    assert_eq!(rc0, 0, "{}: plane 0 mmap", prefix);
+    assert_eq!(rc1, 0, "{}: plane 1 mmap", prefix);
+
+    let p0 = unsafe { gpu_surface_plane_base_address(surface, 0) };
+    let p1 = unsafe { gpu_surface_plane_base_address(surface, 1) };
+    assert!(!p0.is_null(), "{}: plane 0 base_address", prefix);
+    assert!(!p1.is_null(), "{}: plane 1 base_address", prefix);
+
+    let mapped_y = unsafe { std::slice::from_raw_parts(p0, size0 as usize) };
+    let mapped_uv = unsafe { std::slice::from_raw_parts(p1, size1 as usize) };
+    assert_eq!(mapped_y, plane_y.as_slice(), "{}: plane 0 content", prefix);
+    assert_eq!(
+        mapped_uv,
+        plane_uv.as_slice(),
+        "{}: plane 1 content",
+        prefix
+    );
+
+    // Out-of-range index returns 0 / null, never the wrong plane.
+    assert_eq!(unsafe { gpu_surface_plane_size(surface, 7) }, 0);
+    assert!(unsafe { gpu_surface_plane_base_address(surface, 7) }.is_null());
+
+    unsafe { gpu_surface_release(surface) };
+    unsafe { broker_disconnect(broker) };
+
+    // Best-effort release on the broker.
+    let stream = connect_to_broker(&socket_path).expect("host reconnect for release");
+    let release_req = serde_json::json!({
+        "op": "release",
+        "surface_id": surface_id,
+        "runtime_id": runtime_id,
+    });
+    let _ = send_request_with_fds(&stream, &release_req, &[], 0);
+}
+
+#[test]
+fn python_native_resolve_surface_multi_plane() {
+    let lib = match locate_native_lib("libstreamlib_python_native.so") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "python_native_resolve_surface_multi_plane: libstreamlib_python_native.so not \
+                 built — run `cargo build -p streamlib-python-native` first — skipping"
+            );
+            return;
+        }
+    };
+    run_shim_test(lib, "slpn_", ConnectFlavor::TwoArg);
+}
+
+#[test]
+fn deno_native_resolve_surface_multi_plane() {
+    let lib = match locate_native_lib("libstreamlib_deno_native.so") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "deno_native_resolve_surface_multi_plane: libstreamlib_deno_native.so not built \
+                 — run `cargo build -p streamlib-deno-native` first — skipping"
+            );
+            return;
+        }
+    };
+    run_shim_test(lib, "sldn_", ConnectFlavor::OneArg);
+}

--- a/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
+++ b/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
@@ -1,28 +1,30 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Multi-plane DMA-BUF round-trip through the polyglot consumer shims.
+//! Multi-plane DMA-BUF round-trip through the polyglot consumer shims and
+//! the Rust-side `SurfaceStore::check_out` path.
 //!
-//! This is the shim-level exit-criterion test for the multi-FD SCM_RIGHTS
-//! widening (#423). A real `StreamRuntime` runs the surface-sharing service;
-//! the host side `check_in`s a 2-plane surface built from two memfds seeded
-//! with distinct byte patterns; the shim's `*_broker_resolve_surface`
-//! resolves the surface_id, and `*_gpu_surface_plane_mmap` plus
-//! `*_gpu_surface_plane_base_address` expose each plane's bytes so the test
-//! can assert the patterns survived the wire.
+//! This is the shim + Rust-importer exit-criterion test for the multi-FD
+//! SCM_RIGHTS widening (#423). A real `StreamRuntime` runs the
+//! surface-sharing service; the host side `check_in`s a 2-plane surface,
+//! then each language consumer (Python, Deno, Rust) resolves that
+//! surface and verifies both planes' bytes survived the wire.
 //!
-//! memfds stand in for real DMA-BUFs here. The shim never maps them as
-//! GPU memory (no Vulkan `lock` call in this test), so SCM_RIGHTS +
-//! `mmap(MAP_SHARED)` is enough to verify the wire + per-plane layout.
-//! The Vulkan `lock` path is covered by the existing
-//! `polyglot_linux_check_out*` tests with real DMA-BUFs.
+//! The Python / Deno shim tests use memfds as stand-ins for real
+//! DMA-BUFs — the shim only `mmap`s them, never Vulkan-imports, so
+//! SCM_RIGHTS + `mmap(MAP_SHARED)` is enough.
+//!
+//! The Rust-side test goes through `VulkanPixelBuffer::from_dma_buf_fds`
+//! via `SurfaceStore::check_out`, which *does* Vulkan-import each plane.
+//! NVIDIA's driver rejects memfds as DMA_BUF_EXT handles, so the Rust
+//! case uses `TestDmaBufProducer` to mint two real Vulkan-exported
+//! DMA-BUFs (one per plane) — same helper the existing
+//! `polyglot_linux_check_out*` tests already rely on.
 //!
 //! Skip conditions:
-//!   - `libstreamlib_{python,deno}_native.so` not under target/ → skip (as
-//!     with the existing polyglot tests).
-//!   - no Vulkan-capable device available to the shim → skip; the shim's
-//!     resolve_surface gates on `BrokerVulkanDevice::try_new()` even for
-//!     mmap-only consumers.
+//!   - `libstreamlib_{python,deno}_native.so` not under target/ → skip
+//!     the Python/Deno shim case (Rust case is unaffected).
+//!   - no Vulkan-capable device available → skip every case.
 
 #![cfg(target_os = "linux")]
 
@@ -275,4 +277,166 @@ fn deno_native_resolve_surface_multi_plane() {
         }
     };
     run_shim_test(lib, "sldn_", ConnectFlavor::OneArg);
+}
+
+#[path = "common/polyglot_dma_buf_producer.rs"]
+mod polyglot_dma_buf_producer;
+
+/// Rust analogue of the Python / Deno shim tests: the host check_ins a
+/// 2-plane surface backed by real Vulkan-exported DMA-BUFs, then the
+/// Rust consumer calls `SurfaceStore::check_out` and confirms the
+/// returned `RhiPixelBuffer` carries two mapped planes whose bytes match
+/// the source patterns. This is the symmetry gate — if the Rust
+/// importer silently dropped a plane, this test fails.
+#[test]
+fn rust_surface_store_resolve_surface_multi_plane() {
+    use polyglot_dma_buf_producer::TestDmaBufProducer;
+    use streamlib::core::context::GpuContext;
+    use streamlib::core::context::SurfaceStore;
+
+    // Initialize the process-global `VulkanDevice` — `SurfaceStore::check_out`
+    // needs it for DMA-BUF import. `GpuContext::init_for_platform` wires up
+    // the global; duplicate calls across tests are accepted via
+    // `OnceLock::get_or_init`.
+    if GpuContext::init_for_platform_sync().is_err() {
+        eprintln!(
+            "rust_surface_store_resolve_surface_multi_plane: no Vulkan device — skipping"
+        );
+        return;
+    }
+
+    let producer = match TestDmaBufProducer::try_new() {
+        Ok(p) => p,
+        Err(reason) => {
+            eprintln!(
+                "rust_surface_store_resolve_surface_multi_plane: no Vulkan DMA-BUF \
+                 producer — skipping ({})",
+                reason
+            );
+            return;
+        }
+    };
+
+    let runtime = StreamRuntime::new().expect("StreamRuntime::new");
+    let socket_path = runtime.surface_socket_path().to_path_buf();
+    let runtime_id = runtime.runtime_id().to_string();
+
+    // Produce two independent DMA-BUFs with distinct byte patterns so
+    // any cross-plane swap would be visible on readback.
+    let plane_y: Vec<u8> = (0..(64 * 4))
+        .map(|i| (((i as u32) * 19 + 3) & 0xFF) as u8)
+        .collect();
+    let plane_uv: Vec<u8> = (0..(64 * 4))
+        .map(|i| (((i as u32) * 31 + 137) & 0xFF) as u8)
+        .collect();
+    let fd_y = match producer.produce(&plane_y) {
+        Ok(fd) => fd,
+        Err(reason) => {
+            eprintln!(
+                "rust_surface_store_resolve_surface_multi_plane: Vulkan producer plane 0 \
+                 failed — skipping ({})",
+                reason
+            );
+            return;
+        }
+    };
+    let fd_uv = match producer.produce(&plane_uv) {
+        Ok(fd) => fd,
+        Err(reason) => {
+            unsafe { libc::close(fd_y) };
+            eprintln!(
+                "rust_surface_store_resolve_surface_multi_plane: Vulkan producer plane 1 \
+                 failed — skipping ({})",
+                reason
+            );
+            return;
+        }
+    };
+
+    // Host-side: check_in both fds as planes of a single surface directly
+    // on the wire (no multi-plane Rust producer exists yet, so we
+    // synthesize the check_in instead of going through
+    // `SurfaceStore::check_in`). This exercises the SAME wire the
+    // polyglot shims consume.
+    let host_stream = connect_to_broker(&socket_path).expect("host connect");
+    let check_in_req = serde_json::json!({
+        "op": "check_in",
+        "runtime_id": runtime_id,
+        "width": 64u32,
+        "height": 4u32,
+        "format": "Nv12VideoRange",
+        "resource_type": "pixel_buffer",
+        "plane_sizes": [plane_y.len() as u64, plane_uv.len() as u64],
+        "plane_offsets": [0u64, 0u64],
+    });
+    let (resp, _) = send_request_with_fds(&host_stream, &check_in_req, &[fd_y, fd_uv], 0)
+        .expect("host check_in");
+    unsafe {
+        libc::close(fd_y);
+        libc::close(fd_uv);
+    }
+    let surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("surface_id in check_in response")
+        .to_string();
+    drop(host_stream);
+
+    // Consumer-side: build a SurfaceStore pointing at the same runtime
+    // socket, connect, call check_out. This is the critical symmetry
+    // check — the Rust consumer must see both planes, not just plane 0.
+    let store = SurfaceStore::new(
+        socket_path.to_string_lossy().to_string(),
+        runtime_id.clone(),
+    );
+    store.connect().expect("SurfaceStore connect");
+
+    let pixel_buffer = store
+        .check_out(&surface_id)
+        .expect("SurfaceStore::check_out");
+
+    assert_eq!(
+        pixel_buffer.plane_count(),
+        2,
+        "Rust importer must see 2 planes — symmetry with polyglot shims"
+    );
+    assert_eq!(
+        pixel_buffer.plane_size(0) as usize,
+        plane_y.len(),
+        "plane 0 size"
+    );
+    assert_eq!(
+        pixel_buffer.plane_size(1) as usize,
+        plane_uv.len(),
+        "plane 1 size"
+    );
+
+    let p0 = pixel_buffer.plane_base_address(0);
+    let p1 = pixel_buffer.plane_base_address(1);
+    assert!(!p0.is_null(), "plane 0 mapped");
+    assert!(!p1.is_null(), "plane 1 mapped");
+    let mapped0 = unsafe { std::slice::from_raw_parts(p0, plane_y.len()) };
+    let mapped1 = unsafe { std::slice::from_raw_parts(p1, plane_uv.len()) };
+    assert_eq!(mapped0, plane_y.as_slice(), "plane 0 content preserved");
+    assert_eq!(mapped1, plane_uv.as_slice(), "plane 1 content preserved");
+
+    // Out-of-range index returns 0 / null.
+    assert_eq!(pixel_buffer.plane_size(7), 0);
+    assert!(pixel_buffer.plane_base_address(7).is_null());
+
+    drop(pixel_buffer);
+    store.disconnect().ok();
+
+    // Best-effort release.
+    let stream = connect_to_broker(&socket_path).expect("reconnect for release");
+    let _ = send_request_with_fds(
+        &stream,
+        &serde_json::json!({
+            "op": "release",
+            "surface_id": surface_id,
+            "runtime_id": runtime_id,
+        }),
+        &[],
+        0,
+    );
 }


### PR DESCRIPTION
## Summary

Widens the surface-share wire, state, and every language consumer (Rust, Python, Deno) from one FD per SCM_RIGHTS message to a plane-indexed vec so multi-plane DMA-BUFs (e.g. NV12 under DRM format modifiers with disjoint Y/UV allocations) round-trip without silently losing planes in any runtime. Strictly additive: `MAX_DMA_BUF_PLANES = 4` cap, single-plane callers keep working, and the new trait default method keeps backends that can't yet represent multi-plane surfaces compiling cleanly.

## Closes

Closes #423

## Exit criteria

- [x] `send_message_with_fds` / `recv_message_with_fds` take/return `&[RawFd]`; `cmsg` buffer sized via `CMSG_SPACE(n * sizeof(RawFd))`.
- [x] `check_in` / `check_out` JSON response grows optional `plane_sizes: [u64]` / `plane_offsets: [u64]`; single-plane stays backwards-compatible.
- [x] `BrokerState` cache stores `Vec<RawFd>` per surface; dups + closes iterate the whole vec; partial-close on registration failure is tested.
- [x] `RhiPixelBufferExport::export_plane_handles()` sibling trait method with single-plane default; `SurfaceStore::check_in` ships every plane's fd.
- [x] Cap the plane count at 4 — matches `VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT` spec max; refuse more with a clear error at wire, broker, and Rust importer layers.
- [x] Python + Deno shim: `SurfaceHandle` carries `Vec<RawFd>` + plane arrays; `slpn_/sldn_gpu_surface_plane_{count,size,mmap,base_address}` FFI exposes per-plane access.
- [x] **Rust consumer symmetry**: `VulkanPixelBuffer` carries `extra_imported_planes: Vec<VulkanImportedPlane>` for planes 1..N; new `from_dma_buf_fds` multi-plane constructor with partial-failure unwind; `RhiPixelBufferImport::from_external_plane_handles` sibling trait method; `SurfaceStore::check_out` / `lookup_buffer` pass the full fd + size vec through to the importer; `RhiPixelBuffer::{plane_count, plane_size, plane_base_address}` mirror the shim FFI.
- [x] First-cut stays strictly additive — every existing single-plane caller compiles and runs unchanged (regression-gated).

## Test plan

Workspace baseline (`cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream`): **958 passed, 0 failed, 21 ignored**.

Focused gates:

- [x] `streamlib_broker_client::linux::tests::send_recv_preserves_multi_fd_order_and_content_via_scm_rights` — 4 distinct memfds round-trip in order.
- [x] `streamlib_broker_client::linux::tests::send_rejects_oversize_fd_vec_without_closing_caller_fds` — `MAX_DMA_BUF_PLANES + 1` fds rejected, caller fds still valid.
- [x] `streamlib_broker_client::linux::tests::send_request_round_trips_json_and_returns_response_fds` — 2-fd reply via full `send_request_with_fds` seam.
- [x] `streamlib::linux::surface_broker::…::check_in_check_out_multi_fd_roundtrip` — 2 memfds round-trip + `plane_sizes` matches on check-out.
- [x] `streamlib::linux::surface_broker::…::oversize_fd_vec_rejected` — wire-layer rejection with no leaks.
- [x] `streamlib::linux::surface_broker::…::release_surface_closes_every_plane_fd` — every plane fd reaches `close(2)`.
- [x] `vulkan_pixel_buffer::tests::test_dma_buf_import_multi_plane_round_trip` — two Vulkan DMA-BUFs import as two planes; content match.
- [x] `vulkan_pixel_buffer::tests::test_dma_buf_import_rejects_oversize_plane_vec` — Rust importer enforces `MAX_DMA_BUF_PLANES`.
- [x] `polyglot_linux_resolve_surface_multi_plane::python_native_resolve_surface_multi_plane` — Python shim.
- [x] `polyglot_linux_resolve_surface_multi_plane::deno_native_resolve_surface_multi_plane` — Deno shim.
- [x] `polyglot_linux_resolve_surface_multi_plane::rust_surface_store_resolve_surface_multi_plane` — Rust \`SurfaceStore::check_out\` sees both planes; byte-exact content match.
- [x] Single-plane regression gate: `polyglot_linux_check_out::python_subprocess_resolves_and_vulkan_imports_host_published_surface` and `polyglot_linux_check_out_deno::deno_subprocess_resolves_and_vulkan_imports_host_published_surface` still pass with a real Vulkan-exported DMA-BUF.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno (all three in sync, symmetric feature set)
- **Schema regenerated**: n/a (JSON schemas are inline `serde_json::json!` structs, not JTD)
- **E2E tests run**:
  - [x] Host-Rust: `check_in_check_out_multi_fd_roundtrip` + `rust_surface_store_resolve_surface_multi_plane` + single-plane regression via `SurfaceStore::check_in`
  - [x] Python subprocess: `python_native_resolve_surface_multi_plane` + existing `polyglot_linux_check_out`
  - [x] Deno subprocess: `deno_native_resolve_surface_multi_plane` + existing `polyglot_linux_check_out_deno`
- **FD-passing path**: DMA-BUF FD via SCM_RIGHTS, widened from 1 fd to up to `MAX_DMA_BUF_PLANES = 4` fds per message

## Follow-ups

None for the core symmetry story. Two genuinely future items filed-if-needed when a real multi-plane producer lands:
1. `RhiTextureImport` equivalent widening for `SurfaceStore::lookup_texture` (texture side, not pixel-buffer; no in-tree multi-plane texture producer today).
2. Multi-plane `VkImage` import via `VK_EXT_image_drm_format_modifier` for GPU-sampled multi-plane images. The current implementation binds one `VkBuffer` per plane — enough for CPU access and per-plane compute dispatch, but a future GPU sampler path wanting a single multi-plane `VkImage` would want this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)