### PR TITLE
fix(polyglot-python-native): one-shot cleanup via try/finally

### DIFF
--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -187,7 +187,15 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
 
 
 def _cleanup_native(native_lib, native_ctx_ptr, native_handle_ptr, state=None):
-    """Destroy native context and disconnect surface-share handle."""
+    """Destroy native context and disconnect surface-share handle exactly once.
+
+    The FFI calls (`slpn_surface_disconnect`, `slpn_context_destroy`) take the
+    pointer by value and run `Box::from_raw` internally — calling them twice on
+    the same pointer is a use-after-free that segfaults on the second call once
+    the heap allocator's metadata is touched (#469). Callers must invoke this
+    exactly once per (ctx_ptr, handle_ptr) pair; the `main()` loop guarantees
+    this via a single `finally` block.
+    """
     if state is not None:
         state.release_pool()
     if native_lib and native_handle_ptr:
@@ -422,10 +430,7 @@ def main():
                                 except Exception as e:
                                     log.error("teardown() error", error=str(e))
                             bridge_send_message(stdout, {"rpc": "done"})
-                            _cleanup_native(
-                                native_lib, native_ctx_ptr, native_handle_ptr, state,
-                            )
-                            sys.exit(0)
+                            return
                         elif lifecycle_cmd == "stop":
                             running = False
                             bridge_send_message(stdout, {"rpc": "stopped"})
@@ -455,10 +460,7 @@ def main():
                                 except Exception as e:
                                     log.error("teardown() error", error=str(e))
                             bridge_send_message(stdout, {"rpc": "done"})
-                            _cleanup_native(
-                                native_lib, native_ctx_ptr, native_handle_ptr, state,
-                            )
-                            sys.exit(0)
+                            return
                         elif lifecycle_cmd == "stop":
                             running = False
                             bridge_send_message(stdout, {"rpc": "stopped"})
@@ -479,8 +481,6 @@ def main():
                 except Exception as e:
                     traceback.print_exc(file=sys.stderr)
                 bridge_send_message(stdout, {"rpc": "done"})
-                if native_lib and native_ctx_ptr:
-                    _cleanup_native(native_lib, native_ctx_ptr, native_handle_ptr, state)
                 break
 
             elif cmd == "stop":
@@ -528,15 +528,14 @@ def main():
         log.info("stdin closed, shutting down")
     except Exception as e:
         log.error("Fatal error", error=str(e), traceback=traceback.format_exc())
+        # finally runs cleanup; exit code is set by sys.exit raising SystemExit
+        sys.exit(1)
+    finally:
+        # Single cleanup site — the FFI free is not idempotent (#469).
         if native_lib and native_ctx_ptr:
             _cleanup_native(native_lib, native_ctx_ptr, native_handle_ptr, state)
+        log.info("Subprocess runner exiting")
         log.shutdown()
-        sys.exit(1)
-
-    _cleanup_native(native_lib, native_ctx_ptr, native_handle_ptr, state)
-
-    log.info("Subprocess runner exiting")
-    log.shutdown()
 
 
 if __name__ == "__main__":

--- a/libs/streamlib-python/python/streamlib/tests/test_subprocess_runner_cleanup.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_subprocess_runner_cleanup.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Regression tests for `subprocess_runner.main()` cleanup-once invariant (#469).
+
+Pre-fix, the outer `cmd == "teardown"` branch called `_cleanup_native()` and
+then `break`, which fell through to a redundant trailing `_cleanup_native()`
+at the end of `main()`. The second call invoked `slpn_surface_disconnect` /
+`slpn_context_destroy` on already-freed pointers, segfaulting the subprocess
+on every teardown.
+
+These tests script the lifecycle messages the host would send (setup → stop →
+teardown), mock the FFI lib so the cleanup symbols are countable, and assert
+each FFI cleanup symbol is called *exactly once*. Reverting the fix (re-adding
+the inline `_cleanup_native(...)` in the outer teardown branch) makes both
+counts equal 2 and these tests fail.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from streamlib import subprocess_runner
+
+
+# ============================================================================
+# Mock FFI lib — counts the cleanup symbols
+# ============================================================================
+
+
+class _MockNativeLib:
+    """Stand-in for `ctypes.CDLL(libstreamlib_python_native.so)` in tests.
+
+    Records every cleanup call so the test can assert exactly-once semantics.
+    Returns sentinel non-zero pointers from create/connect so the runner's
+    `if native_lib and native_ctx_ptr` guards behave like the real flow.
+    """
+
+    CTX_PTR = 0xC0FFEE_CAFE
+    HANDLE_PTR = 0xBEEF_DEAD
+
+    def __init__(self) -> None:
+        self.disconnect_calls: list[int] = []
+        self.destroy_calls: list[int] = []
+
+    # Lifecycle
+    def slpn_context_create(self, _processor_id: bytes) -> int:
+        return self.CTX_PTR
+
+    def slpn_context_destroy(self, ctx: int) -> None:
+        self.destroy_calls.append(ctx)
+
+    def slpn_surface_connect(self, _endpoint: bytes, _runtime_id: bytes) -> int:
+        return self.HANDLE_PTR
+
+    def slpn_surface_disconnect(self, handle: int) -> None:
+        self.disconnect_calls.append(handle)
+
+    # I/O wiring (the runner's setup walks input/output port lists)
+    def slpn_input_subscribe(self, _ctx: int, _service: bytes) -> int:
+        return 0
+
+    def slpn_input_set_read_mode(self, _ctx: int, _port: bytes, _mode: int) -> None:
+        pass
+
+    def slpn_output_publish(self, *_args: Any) -> int:
+        return 0
+
+
+class _NoopProcessor:
+    """Processor stub — every lifecycle hook is a no-op so the test exercises
+    only the runner's dispatch logic."""
+
+    def setup(self, _ctx: Any) -> None:
+        pass
+
+    def stop(self, _ctx: Any) -> None:
+        pass
+
+    def teardown(self, _ctx: Any) -> None:
+        pass
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the env vars `main()` reads before it dispatches."""
+    monkeypatch.setenv("STREAMLIB_ENTRYPOINT", "tests.fake:Fake")
+    monkeypatch.setenv("STREAMLIB_PROJECT_PATH", "")
+    monkeypatch.setenv("STREAMLIB_PYTHON_NATIVE_LIB", "/tmp/fake-libstreamlib_python_native.so")
+    monkeypatch.setenv("STREAMLIB_PROCESSOR_ID", "test-469")
+    monkeypatch.setenv("STREAMLIB_EXECUTION_MODE", "reactive")
+    monkeypatch.setenv("STREAMLIB_RUNTIME_ID", "runtime-469")
+    monkeypatch.setenv("STREAMLIB_ESCALATE_FD", "999")  # never actually opened
+    # Force the surface-share connect path so handle_ptr is populated.
+    monkeypatch.setenv("STREAMLIB_SURFACE_SOCKET", "/tmp/fake-surface.sock")
+
+
+def _patch_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_lib: _MockNativeLib,
+    scripted_messages: list[dict[str, Any]],
+) -> None:
+    """Replace every external dependency of `main()` so it dispatches the
+    scripted messages against the mock FFI without touching real fds."""
+
+    # Stub the escalate fd / channel — the runner never actually reads from
+    # them in this test because we replace `bridge_read_message` below.
+    class _DummyStream:
+        def write(self, _b: bytes) -> int:
+            return 0
+
+        def flush(self) -> None:
+            pass
+
+        def read(self, _n: int) -> bytes:
+            return b""
+
+    class _DummySocket:
+        def close(self) -> None:
+            pass
+
+    def _fake_open_escalate_fd_stream() -> tuple[Any, Any, Any]:
+        return _DummyStream(), _DummyStream(), _DummySocket()
+
+    monkeypatch.setattr(
+        subprocess_runner, "_open_escalate_fd_stream", _fake_open_escalate_fd_stream
+    )
+
+    class _DummyChannel:
+        def __init__(self, *_a: Any, **_kw: Any) -> None:
+            pass
+
+        def has_deferred_lifecycle_messages(self) -> bool:
+            return False
+
+    monkeypatch.setattr(subprocess_runner, "EscalateChannel", _DummyChannel)
+    monkeypatch.setattr(subprocess_runner, "install_channel", lambda _c: None)
+
+    # Logging — the runner installs interceptors that hijack stdout. Skip them.
+    monkeypatch.setattr(subprocess_runner.log, "set_processor_id", lambda _p: None)
+    monkeypatch.setattr(subprocess_runner.log, "install", lambda _c: None)
+    monkeypatch.setattr(subprocess_runner.log, "shutdown", lambda: None)
+
+    monkeypatch.setattr(
+        subprocess_runner, "_load_processor_class", lambda _e, _p: _NoopProcessor
+    )
+    # `_setup_native_state` calls `load_native_lib` from the
+    # `processor_context` module — patch the import the runner re-exported
+    # *and* the symbol on the source module so both lookups resolve to the
+    # mock.
+    import streamlib.processor_context as pc
+
+    monkeypatch.setattr(subprocess_runner, "load_native_lib", lambda _path: mock_lib)
+    monkeypatch.setattr(pc, "load_native_lib", lambda _path: mock_lib)
+
+    # Script the bridge message sequence.
+    msg_iter = iter(scripted_messages)
+
+    def _fake_read(_stdin: Any) -> dict[str, Any]:
+        try:
+            return next(msg_iter)
+        except StopIteration as e:
+            # Loop is supposed to exit before we run out — surfacing as
+            # EOFError mimics the host closing stdin.
+            raise EOFError("scripted messages exhausted") from e
+
+    sent: list[dict[str, Any]] = []
+
+    def _fake_send(_stdout: Any, msg: dict[str, Any]) -> None:
+        sent.append(msg)
+
+    monkeypatch.setattr(subprocess_runner, "bridge_read_message", _fake_read)
+    monkeypatch.setattr(subprocess_runner, "bridge_send_message", _fake_send)
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+def test_cleanup_called_once_on_setup_then_teardown(
+    env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Outer-loop teardown path: cleanup runs in the `finally` block exactly
+    once. Pre-fix this branch called cleanup inline AND fell through to a
+    second cleanup call after the loop, double-freeing both pointers."""
+    mock_lib = _MockNativeLib()
+    _patch_runner(
+        monkeypatch,
+        mock_lib,
+        scripted_messages=[
+            {
+                "cmd": "setup",
+                "capability": "full",
+                "config": {},
+                "ports": {"inputs": [], "outputs": []},
+            },
+            {"cmd": "teardown", "capability": "full"},
+        ],
+    )
+
+    # main() returns normally on a clean teardown — no SystemExit expected.
+    subprocess_runner.main()
+
+    assert mock_lib.disconnect_calls == [
+        _MockNativeLib.HANDLE_PTR
+    ], "slpn_surface_disconnect must be called exactly once"
+    assert mock_lib.destroy_calls == [
+        _MockNativeLib.CTX_PTR
+    ], "slpn_context_destroy must be called exactly once"
+
+
+def test_cleanup_called_once_on_setup_stop_teardown(
+    env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact host-issued sequence the live scenario triggers: stop is
+    sent first, then teardown. Pre-fix this hit the same fall-through bug
+    because stop didn't enter (or had already exited) the run loop and
+    teardown was processed by the outer dispatch."""
+    mock_lib = _MockNativeLib()
+    _patch_runner(
+        monkeypatch,
+        mock_lib,
+        scripted_messages=[
+            {
+                "cmd": "setup",
+                "capability": "full",
+                "config": {},
+                "ports": {"inputs": [], "outputs": []},
+            },
+            {"cmd": "stop", "capability": "full"},
+            {"cmd": "teardown", "capability": "full"},
+        ],
+    )
+
+    subprocess_runner.main()
+
+    assert mock_lib.disconnect_calls == [_MockNativeLib.HANDLE_PTR]
+    assert mock_lib.destroy_calls == [_MockNativeLib.CTX_PTR]
+
+
+def test_cleanup_skipped_when_setup_never_ran(
+    env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the host closes stdin before sending `setup`, no FFI handles were
+    ever allocated — cleanup must be a no-op rather than calling
+    `slpn_*_destroy(NULL)` (which the FFI tolerates, but the runner avoids)."""
+    mock_lib = _MockNativeLib()
+    _patch_runner(
+        monkeypatch,
+        mock_lib,
+        scripted_messages=[],  # immediate EOF
+    )
+
+    subprocess_runner.main()
+
+    assert mock_lib.disconnect_calls == []
+    assert mock_lib.destroy_calls == []


### PR DESCRIPTION
## Summary

- Linux Python polyglot subprocesses SIGSEGVed every teardown because `subprocess_runner.py` called `_cleanup_native(...)` inline in the outer `cmd == "teardown"` branch AND fell through to a redundant trailing `_cleanup_native(...)` after the dispatch loop. The second `slpn_surface_disconnect` ran `Box::from_raw` on a dangling pointer; SIGSEGV fired the moment String field drops touched heap allocator metadata.
- Consolidate cleanup into a single `finally` block. In-loop teardown returns instead of `_cleanup_native + sys.exit(0)`; outer teardown branch just sends "done" and breaks; the `except Exception:` handler delegates cleanup to `finally` and just sets the exit code via `sys.exit(1)`.
- FFI side stays as-is — `slpn_*_destroy` is contractually single-call. The right place to enforce "once" is the caller, not a band-aid in the cdylib.

## Closes

Closes #469

## Exit criteria

- [x] Identify the offending pointer/drop in `streamlib-python-native` — bisected via `eprintln!` markers in `SurfaceShareHandle::drop` / `SurfaceShareVulkanDevice::drop` / `slpn_surface_disconnect`. Output proved `slpn_surface_disconnect` was called twice; the second call segfaulted at the first String drop on the freed Box.
- [x] Subprocess exits with status 0 in normal teardown — no SIGSEGV in the host log.
- [x] Existing test `polyglot_linux_check_out` continues to pass (workspace baseline green).

## Test plan

- [x] `target/release/polyglot-dma-buf-consumer-scenario /dev/video0 16` — 3 consecutive cold runs, all show `Python native subprocess exited: exit status: 0` (was `signal: 11 (SIGSEGV) (core dumped)` pre-fix), zero `signal: 11` entries.
- [⏭] `camera-python-subprocess` example — skipped per #468 scoping (separate breakage in that example).
- [x] Workspace baseline (`cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream`): 972 passed, 0 failed, 21 ignored.
- [x] New `python/streamlib/tests/test_subprocess_runner_cleanup.py`: 3 tests passing. Empirically verified by reverting the fix that the two main tests fail with `disconnect_calls == [HANDLE_PTR, HANDLE_PTR]` (length 2) instead of length 1.
- [x] Existing `pytest python/streamlib/tests/`: 38 passed.

## Polyglot coverage

- **Runtimes affected**: python
- **Schema regenerated**: n/a
- **E2E tests run**:
  - [x] Host-Rust: workspace baseline incl. `polyglot_linux_check_out` — 972 passed, 0 failed
  - [x] Python subprocess: `polyglot-dma-buf-consumer-scenario /dev/video0 16` x3 cold runs — all exit 0
  - [x] Deno subprocess: not applicable — Deno's `subprocess_runner.ts` uses `Deno.exit(0)` directly in both teardown branches; the fall-through pattern that triggered #469 in Python doesn't exist there. Verified by inspection.
- **FD-passing path**: n/a (FFI cleanup, not data-plane)

## Follow-ups

- The `[DmaBufConsumer] teardown resolves=…` print not appearing in the host log is the adjacent #467 (bridge log-fwd regression), not part of this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)