### PR TITLE
test(logging): cross-language merged-stream host_ts/source_seq monotonicity

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -1105,6 +1105,139 @@ mod tests {
                 );
             }
         }
+
+        /// Rust + Python + Deno emit interleaved records into the unified
+        /// JSONL pathway. Verifies the architectural contract from #430:
+        /// `host_ts` is the authoritative sort key across the merged
+        /// stream (monotonically non-decreasing) and `source_seq` is
+        /// preserved within each subprocess source (monotonically
+        /// increasing). Rust records carry no `source_seq` because the
+        /// host-local tracing layer has no need for one — host receipt
+        /// IS the local order.
+        #[test]
+        #[serial]
+        fn cross_language_source_seq_monotonic_within_source() {
+            let (_tmp, guard) = install_logging("RxLang");
+            let path = guard.jsonl_path().unwrap().to_path_buf();
+
+            // Round-robin emit Rust / Python / Deno. Each subprocess
+            // source carries a monotonic `source_seq`; Rust records do
+            // not. A 50µs nap between emissions guarantees `host_ts`
+            // strictly increases, which is the stronger property — the
+            // contract only requires non-decreasing.
+            const ROUNDS: u64 = 16;
+            let mut py_seq = 0u64;
+            let mut deno_seq = 0u64;
+            for _ in 0..ROUNDS {
+                tracing::info!(round = py_seq, "rust-merged");
+                std::thread::sleep(Duration::from_micros(50));
+
+                let py_log = EscalateRequestLog {
+                    source: EscalateRequestLogSource::Python,
+                    source_seq: py_seq.to_string(),
+                    source_ts: "2026-04-25T12:00:00Z".into(),
+                    level: EscalateRequestLogLevel::Info,
+                    message: format!("py-merged-{py_seq}"),
+                    intercepted: false,
+                    channel: None,
+                    pipeline_id: Some("pl-merge".into()),
+                    processor_id: Some("pr-merge".into()),
+                    attrs: HashMap::new(),
+                };
+                dispatch_log(py_log);
+                py_seq += 1;
+                std::thread::sleep(Duration::from_micros(50));
+
+                let deno_log = EscalateRequestLog {
+                    source: EscalateRequestLogSource::Deno,
+                    source_seq: deno_seq.to_string(),
+                    source_ts: "2026-04-25T12:00:00Z".into(),
+                    level: EscalateRequestLogLevel::Info,
+                    message: format!("deno-merged-{deno_seq}"),
+                    intercepted: false,
+                    channel: None,
+                    pipeline_id: Some("pl-merge".into()),
+                    processor_id: Some("pr-merge".into()),
+                    attrs: HashMap::new(),
+                };
+                dispatch_log(deno_log);
+                deno_seq += 1;
+                std::thread::sleep(Duration::from_micros(50));
+            }
+
+            drop(guard);
+
+            let events = read_jsonl(&path);
+
+            let merged: Vec<&RuntimeLogEvent> = events
+                .iter()
+                .filter(|e| {
+                    e.message.starts_with("rust-merged")
+                        || e.message.starts_with("py-merged-")
+                        || e.message.starts_with("deno-merged-")
+                })
+                .collect();
+            assert_eq!(
+                merged.len(),
+                (ROUNDS * 3) as usize,
+                "expected {} merged-stream records, got {}: {merged:#?}",
+                ROUNDS * 3,
+                merged.len()
+            );
+
+            // host_ts is the authoritative cross-source order.
+            for pair in merged.windows(2) {
+                assert!(
+                    pair[1].host_ts >= pair[0].host_ts,
+                    "host_ts must be monotonic across merged stream: \
+                     {} ({:?}) precedes {} ({:?})",
+                    pair[0].message,
+                    pair[0].host_ts,
+                    pair[1].message,
+                    pair[1].host_ts,
+                );
+            }
+
+            // source_seq is monotonic within each subprocess source and
+            // covers exactly [0, ROUNDS).
+            let py_seqs: Vec<u64> = merged
+                .iter()
+                .filter(|e| e.source == Source::Python)
+                .filter_map(|e| e.source_seq)
+                .collect();
+            assert_eq!(
+                py_seqs,
+                (0..ROUNDS).collect::<Vec<u64>>(),
+                "python source_seq must be monotonic and contiguous"
+            );
+            let deno_seqs: Vec<u64> = merged
+                .iter()
+                .filter(|e| e.source == Source::Deno)
+                .filter_map(|e| e.source_seq)
+                .collect();
+            assert_eq!(
+                deno_seqs,
+                (0..ROUNDS).collect::<Vec<u64>>(),
+                "deno source_seq must be monotonic and contiguous"
+            );
+
+            // Rust records carry no source_seq — host-local tracing has
+            // no use for one.
+            let rust_records: Vec<&RuntimeLogEvent> = merged
+                .iter()
+                .copied()
+                .filter(|e| e.source == Source::Rust)
+                .collect();
+            assert_eq!(rust_records.len(), ROUNDS as usize);
+            for record in &rust_records {
+                assert!(
+                    record.source_seq.is_none(),
+                    "rust records must not carry source_seq; got {:?}",
+                    record.source_seq,
+                );
+                assert_eq!(record.level, LogLevel::Info);
+            }
+        }
     }
 
     /// End-to-end tests that spawn a real Python 3 subprocess, have it


### PR DESCRIPTION
## Summary

- Adds the final missing exit-criteria test from #430: `cross_language_source_seq_monotonic_within_source`.
- Pins the architectural ordering contract for the unified logging pathway: `host_ts` is the authoritative cross-source key (non-decreasing across the merged Rust+Python+Deno stream), `source_seq` is per-source monotonic (subprocess-local fidelity), and Rust records carry no `source_seq`.
- Test lives alongside `within_source_fifo_preserved` in `subprocess_escalate.rs::tests::log_op`. Subprocess sources are simulated through the production wire path (`log_record_from_wire` → `push_polyglot_record`); real-subprocess coverage already lives in `python_log_surfaces_in_host_jsonl` and `deno_log_surfaces_in_host_jsonl`.

## Closes

Closes #430

## Context — what was already shipped

The 9 sub-issues #437–#447 delivered the entire implementation: JSONL producer + batched writer (#437), Rust fd-level interceptor (#438), release-build trace-strip (#439), `streamlib-cli logs` reader (#440), clippy + xtask lint-logging + CI gate (#441), escalate-IPC `{op:"log"}` wire format (#442), Python `streamlib.log` + interceptors (#443), Deno `streamlib.log` + interceptors (#444), and the criterion bench harness (#447). Per-source tests (`python_log_surfaces_in_host_jsonl`, `deno_log_surfaces_in_host_jsonl`, `python_os_write_fd1_intercepted`, `python_stderr_fd2_intercepted_on_dedicated_fd_transport`, `python_log_burst_preserves_order`) and the schema doctest (`event::tests::docs_example_line_parses`) all already existed.

The single missing test was the cross-language merge invariant — proof that the three runtimes converge into one ordered JSONL stream. That is now in place.

## Test plan

- [x] `cargo check -p streamlib --tests` clean.
- [x] `cargo test -p streamlib --lib core::compiler::compiler_ops::subprocess_escalate::tests::log_op::` — 6 passed (including the new test).
- [x] `cargo test -p streamlib --lib core::logging::` — 29 passed, no regressions.
- [x] `cargo test -p streamlib --lib core::compiler::compiler_ops::subprocess_escalate::` — 28 passed (including all polyglot-subprocess spawn tests for Python and Deno).
- [x] pr-review-gate: PASS.

## Polyglot coverage

- **Runtimes affected**: rust (test simulates Python and Deno via the wire path)
- **Schema regenerated**: n/a (no schema change)
- **E2E tests run**:
  - [x] Host-Rust: `cross_language_source_seq_monotonic_within_source` — passed
  - [x] Python subprocess: `python_log_surfaces_in_host_jsonl` (pre-existing) — passed
  - [x] Deno subprocess: `deno_log_surfaces_in_host_jsonl` (pre-existing) — passed
- **FD-passing path**: n/a

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)