### PR TITLE
docs(polyglot): require Python+Deno coverage by default (closes #468)

### DIFF
--- a/.claude/workflows/polyglot.md
+++ b/.claude/workflows/polyglot.md
@@ -28,7 +28,16 @@ format.
    and must be regenerated via `cargo xtask generate-schemas`. All
    three runtimes (Rust, Python, Deno) must be rebuilt from the new
    schema in the same commit.
-3. **Which FD-passing story applies on Linux?** See the
+3. **Are Python AND Deno both covered?** Default answer: yes. Pipeline-
+   level work (new processor + scenario binary, new escalate op end-
+   to-end, new FD-passing story) ships in both runtimes together or
+   files paired tickets that block on each other and land in the same
+   milestone. "Python first, Deno deferred" is the failure mode this
+   workflow exists to prevent — see #468. The only legitimate split is
+   *schema-only / language-specific by construction* (e.g. a Python
+   ctypes ABI bug that doesn't exist in Deno's FFI binding); say so
+   explicitly in the issue body, don't just leave Deno off the list.
+4. **Which FD-passing story applies on Linux?** See the
    *Polyglot SDK Realignment* milestone's research issue —
    pool-IDs-over-JSON only works when the subprocess can resolve the
    pool locally. DMA-BUF FD passing is required for anything where the
@@ -72,6 +81,12 @@ blocked by it.
 - **Keep the three runtimes in sync.** Schema change → regenerate for
   all three → commit all three. PRs that update only one language are
   a merge hazard.
+- **Pipeline-level E2E covers Python AND Deno together.** A polyglot
+  ticket that ships a new processor + scenario binary in one runtime
+  must either (a) include the same processor + scenario in the other
+  runtime in the same PR, or (b) be paired with a sibling ticket that
+  blocks on this one and lands in the same milestone. Don't accept a
+  bare "Deno deferred" line — see #468.
 
 ## PR body additions
 
@@ -80,6 +95,7 @@ blocked by it.
 
 - **Runtimes affected**: rust | python | deno | all
 - **Schema regenerated**: yes | n/a
+- **Python and Deno both covered?** yes | paired ticket #N | schema-only / language-specific by construction (justify)
 - **E2E tests run**:
   - [ ] Host-Rust: <test name + result>
   - [ ] Python subprocess: <test name + result>

--- a/docs/issue-template.md
+++ b/docs/issue-template.md
@@ -90,6 +90,16 @@ also", "context from #N", etc.).
 7. **Cross-cutting concerns are labels, not milestones.** Linux-specific
    work goes in the relevant deliverable milestone with a `linux` label.
    "Linux support" is not a deliverable; "Pipeline Color & Resolution" is.
+8. **`polyglot`-labeled issues must answer: are Python AND Deno both
+   covered?** The default is yes — pipeline-level work (new processor +
+   scenario binary, new escalate op end-to-end, new FD-passing story)
+   ships both runtimes together or files paired tickets that block on
+   each other and land in the same milestone. The only legitimate split
+   is *schema-only / language-specific by construction* (e.g. a Python
+   ctypes ABI bug that doesn't exist in the Deno FFI binding); say so
+   explicitly in the issue body. "Python first, Deno deferred" is the
+   failure mode this rule exists to prevent — see #468 and
+   `.claude/workflows/polyglot.md`.
 
 ## What this means for CI
 


### PR DESCRIPTION
## Summary

- Codify the rule that pipeline-level polyglot work covers Python AND Deno together by default — instead of "Python first, Deno deferred" (the pattern PR #466 / #421 followed and that triggered the meta-issue).
- Edits two docs: `.claude/workflows/polyglot.md` (new decision-3 prompt + new "Pipeline-level E2E" rule + PR-body checkbox) and `docs/issue-template.md` (new agents-must-follow rule #8 cross-referencing #468 and the workflow file).
- Files #473 as the first paired-ticket follow-up: Deno twin of the Python DMA-BUF consumer E2E that shipped in PR #466. #473 is GitHub-natively `blocked by #468`.

## Closes

Closes #468

## Exit criteria

- [x] Audit existing open Polyglot SDK Realignment tickets and identify any that are Python-only or Deno-only by scope. **Result:** the milestone has 31 done and only #468 itself open at the time of this PR — there are no other open tickets in the milestone to re-scope. Future polyglot tickets are now subject to the codified rule.
- [x] Issue template for `polyglot`-labeled tickets explicitly asks "are Python and Deno both covered?" with no default. Added as agents-must-follow rule #8 in `docs/issue-template.md`, plus the matching decision/rule in `.claude/workflows/polyglot.md` and a PR-body checkbox.
- [x] File the Deno-twin follow-up for #421 / PR #466 (Deno DMA-BUF consumer scenario) — filed as #473, blocked by #468 via GitHub-native issue dependency.

## Test plan

No code change. Per the issue body, validation is "by inspection of the next batch of polyglot tickets that get filed — they should not be scoped per-language without an explicit *schema-only / language-specific by construction* justification." For this PR specifically:

- [x] `docs/issue-template.md` — rule #8 added, references #468 and the workflow file by path.
- [x] `.claude/workflows/polyglot.md` — decision #3 added (with the FD-passing question correctly renumbered to #4), rules section gets a new "Pipeline-level E2E" bullet, PR-body template gets the new "Python and Deno both covered?" row.
- [x] #473 filed in milestone *Polyglot SDK Realignment* with labels `polyglot, linux`, body modeled on #421/#466 and adapted for the Deno runtime, GitHub-native `blocked by #468` edge in place.

## Polyglot coverage

- **Runtimes affected**: n/a (process docs, no runtime code changes)
- **Schema regenerated**: n/a
- **Python and Deno both covered?** n/a — this PR establishes the rule; #473 is the paired Deno follow-up for the Python work that already shipped in #466.
- **E2E tests run**: n/a
- **FD-passing path**: n/a

## Follow-ups

- **#473** — Deno twin of the polyglot DMA-BUF consumer E2E (paired with #466). Blocked by #468 (this PR) so the rule lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)