### PR TITLE
test(polyglot): E2E DMA-BUF consumer Deno twin

### DIFF
--- a/examples/polyglot-dma-buf-consumer/deno/deno.json
+++ b/examples/polyglot-dma-buf-consumer/deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+  }
+}

--- a/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
+++ b/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Linux polyglot DMA-BUF consumer processor — Deno twin of
+ * `examples/polyglot-dma-buf-consumer/python/dma_buf_consumer.py`.
+ *
+ * Subscribes to a video input port, resolves the upstream surface_id through
+ * the surface-share service (DMA-BUF FD via SCM_RIGHTS, Vulkan-imported into
+ * the subprocess), locks the resulting handle for read, and probes the first
+ * byte of the imported buffer to confirm the cross-process import worked
+ * end-to-end. Then forwards the frame unmodified to the downstream output so
+ * the rest of the pipeline (e.g. display) keeps moving.
+ *
+ * Stays dep-light on purpose — only the SDK and `Deno.UnsafePointerView` for
+ * the byte probe. The point is to exercise the control plane and CPU-mapped
+ * readback, not to do anything with the pixels.
+ *
+ * Config keys (all optional):
+ *     force_bad_surface_id (bool, default false)
+ *         Negative test mode. Replaces the upstream surface_id with a synthetic
+ *         UUID that the surface-share service won't resolve, exercising the
+ *         consumer's failure-handling path. Frames still propagate downstream
+ *         so the rest of the pipeline doesn't deadlock.
+ *     log_every (number, default 60)
+ *         Throttle for periodic resolve-success / resolve-failure log lines.
+ */
+
+import type {
+  ReactiveProcessor,
+  RuntimeContextFullAccess,
+  RuntimeContextLimitedAccess,
+} from "../../../libs/streamlib-deno/mod.ts";
+import type { Videoframe } from "../../../libs/streamlib-deno/_generated_/com_tatolab_videoframe.ts";
+
+const BOGUS_SURFACE_ID = "00000000-0000-0000-0000-000000000000";
+
+export default class DmaBufConsumer implements ReactiveProcessor {
+  private forceBadId = false;
+  private logEvery = 60;
+  private resolveCount = 0;
+  private errorCount = 0;
+  private firstByte: number | null = null;
+
+  setup(ctx: RuntimeContextFullAccess): void {
+    this.forceBadId = Boolean(ctx.config["force_bad_surface_id"] ?? false);
+    const rawLogEvery = ctx.config["log_every"];
+    this.logEvery = typeof rawLogEvery === "number" && rawLogEvery > 0
+      ? Math.floor(rawLogEvery)
+      : 60;
+    const mode = this.forceBadId ? "negative (force_bad_surface_id)" : "normal";
+    console.error(
+      `[DmaBufConsumer] setup mode=${mode} log_every=${this.logEvery}`,
+    );
+  }
+
+  process(ctx: RuntimeContextLimitedAccess): void {
+    const result = ctx.inputs.read<Videoframe>("video_in");
+    if (!result) return;
+    const { value: frame, timestampNs } = result;
+
+    const upstreamId = frame.surface_id;
+    if (!upstreamId) return;
+
+    const surfaceId = this.forceBadId ? BOGUS_SURFACE_ID : upstreamId;
+
+    try {
+      const handle = ctx.gpuLimitedAccess.resolveSurface(surfaceId);
+      handle.lock(true);
+      try {
+        const buffer = handle.asBuffer();
+        if (buffer.byteLength === 0) {
+          throw new Error("base address mapped a zero-length buffer");
+        }
+        this.firstByte = new Uint8Array(buffer)[0];
+        this.resolveCount += 1;
+        if (
+          this.resolveCount <= 3 ||
+          this.resolveCount % this.logEvery === 0
+        ) {
+          const hex = this.firstByte.toString(16).padStart(2, "0");
+          console.error(
+            `[DmaBufConsumer] resolved surface ${handle.width}x${handle.height} ` +
+              `stride=${handle.bytesPerRow} first_byte=0x${hex} ` +
+              `count=${this.resolveCount}`,
+          );
+        }
+      } finally {
+        handle.unlock(true);
+        handle.release();
+      }
+    } catch (e) {
+      this.errorCount += 1;
+      if (
+        this.errorCount <= 3 ||
+        this.errorCount % this.logEvery === 0
+      ) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(
+          `[DmaBufConsumer] resolve_surface failed for ` +
+            `surface_id=${JSON.stringify(surfaceId)}: ${msg} ` +
+            `count=${this.errorCount}`,
+        );
+      }
+    }
+
+    ctx.outputs.write("video_out", frame, timestampNs);
+  }
+
+  teardown(_ctx: RuntimeContextFullAccess): void {
+    console.error(
+      `[DmaBufConsumer] teardown resolves=${this.resolveCount} ` +
+        `errors=${this.errorCount} last_first_byte=${this.firstByte}`,
+    );
+  }
+}

--- a/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
@@ -1,0 +1,18 @@
+package:
+  name: polyglot-dma-buf-consumer-deno
+  version: "0.1.0"
+  description: "Linux DMA-BUF consumer — Deno twin of the Python polyglot E2E"
+
+processors:
+  - name: com.tatolab.dma_buf_consumer_deno
+    version: "1.0.0"
+    description: "Resolves an upstream surface_id to a DMA-BUF, locks/reads it, and forwards the frame downstream"
+    runtime: deno
+    execution: reactive
+    entrypoint: "dma_buf_consumer.ts:default"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0
+    outputs:
+      - name: video_out
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-dma-buf-consumer/src/main.rs
+++ b/examples/polyglot-dma-buf-consumer/src/main.rs
@@ -1,26 +1,30 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Camera → Python DMA-BUF consumer → Display pipeline (Linux).
+//! Camera → polyglot DMA-BUF consumer → Display pipeline (Linux).
 //!
 //! Pipeline-level gate for the polyglot consumer DMA-BUF FD path shipped in
-//! #394 / #420. The Python subprocess receives camera frames over IPC,
-//! calls `ctx.gpu_limited_access.resolve_surface(frame.surface_id)` to import
-//! the host-allocated DMA-BUF, locks it, reads a probe byte, then forwards
-//! the frame unmodified to the display.
+//! #394 / #420. The Python or Deno subprocess receives camera frames over
+//! IPC, calls `ctx.gpu_limited_access.resolve_surface(frame.surface_id)` to
+//! import the host-allocated DMA-BUF, locks it, reads a probe byte, then
+//! forwards the frame unmodified to the display.
 //!
 //! Usage:
-//!   cargo run -p polyglot-dma-buf-consumer-scenario -- [device] [seconds] [--negative]
+//!   cargo run -p polyglot-dma-buf-consumer-scenario -- \
+//!       [--runtime=python|deno] [device] [seconds] [--negative]
 //!
-//! Defaults to `/dev/video2` (the canonical vivid index in `docs/testing.md`)
-//! for 15 seconds. On hosts where vivid landed at a different index (e.g.
-//! `/dev/video0` after a UVC device unplug) pass the device path explicitly.
-//! The `--negative` flag sets the consumer's `force_bad_surface_id` config so
-//! resolve_surface fails deterministically on every frame — the pipeline
-//! must still shut down cleanly.
+//! Defaults to `--runtime=python` and `/dev/video2` (the canonical vivid index
+//! in `docs/testing.md`) for 15 seconds. On hosts where vivid landed at a
+//! different index (e.g. `/dev/video0` after a UVC device unplug) pass the
+//! device path explicitly. The `--negative` flag sets the consumer's
+//! `force_bad_surface_id` config so resolve_surface fails deterministically on
+//! every frame — the pipeline must still shut down cleanly.
 //!
-//! Build the .slpkg first (or it will not be found):
+//! Build the Python .slpkg first when running --runtime=python (or it will
+//! not be found):
 //!   cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python
+//!
+//! The Deno project loads its `streamlib.yaml` directly — no pack step.
 
 use std::path::PathBuf;
 
@@ -29,17 +33,54 @@ use streamlib::{
     CameraProcessor, DisplayProcessor, ProcessorSpec, Result, StreamRuntime,
 };
 
-fn main() -> Result<()> {
-    let mut args = std::env::args().skip(1).peekable();
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeKind {
+    Python,
+    Deno,
+}
 
+impl RuntimeKind {
+    fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "python" => Ok(Self::Python),
+            "deno" => Ok(Self::Deno),
+            other => Err(format!(
+                "unknown --runtime value '{other}' (expected 'python' or 'deno')"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Deno => "deno",
+        }
+    }
+
+    fn processor_name(self) -> &'static str {
+        match self {
+            Self::Python => "com.tatolab.dma_buf_consumer",
+            Self::Deno => "com.tatolab.dma_buf_consumer_deno",
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1);
+
+    let mut runtime_kind = RuntimeKind::Python;
     let mut device = "/dev/video2".to_string();
     let mut duration_secs: u64 = 15;
     let mut negative = false;
     let mut positional: Vec<String> = Vec::new();
 
-    while let Some(a) = args.next() {
+    for a in args {
         if a == "--negative" {
             negative = true;
+        } else if let Some(value) = a.strip_prefix("--runtime=") {
+            runtime_kind = RuntimeKind::parse(value).map_err(|e| {
+                streamlib::core::StreamError::Configuration(e)
+            })?;
         } else {
             positional.push(a);
         }
@@ -52,22 +93,45 @@ fn main() -> Result<()> {
     }
 
     println!("=== Polyglot DMA-BUF Consumer Scenario ===");
+    println!("Runtime:  {}", runtime_kind.as_str());
     println!("Camera:   {device}");
     println!("Duration: {duration_secs}s");
-    println!("Mode:     {}", if negative { "negative (force_bad_surface_id)" } else { "normal" });
+    println!(
+        "Mode:     {}",
+        if negative {
+            "negative (force_bad_surface_id)"
+        } else {
+            "normal"
+        }
+    );
     println!();
 
     let runtime = StreamRuntime::new()?;
 
-    let slpkg_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("python/polyglot-dma-buf-consumer-0.1.0.slpkg");
-    if !slpkg_path.exists() {
-        return Err(streamlib::core::StreamError::Configuration(format!(
-            "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python",
-            slpkg_path.display()
-        )));
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match runtime_kind {
+        RuntimeKind::Python => {
+            let slpkg_path =
+                manifest_dir.join("python/polyglot-dma-buf-consumer-0.1.0.slpkg");
+            if !slpkg_path.exists() {
+                return Err(streamlib::core::StreamError::Configuration(format!(
+                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python",
+                    slpkg_path.display()
+                )));
+            }
+            runtime.load_package(&slpkg_path)?;
+        }
+        RuntimeKind::Deno => {
+            let project_path = manifest_dir.join("deno");
+            if !project_path.join("streamlib.yaml").exists() {
+                return Err(streamlib::core::StreamError::Configuration(format!(
+                    "Deno project not found: {}",
+                    project_path.display()
+                )));
+            }
+            runtime.load_project(&project_path)?;
+        }
     }
-    runtime.load_package(&slpkg_path)?;
 
     let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
         device_id: Some(device.clone()),
@@ -79,7 +143,7 @@ fn main() -> Result<()> {
         "force_bad_surface_id": negative,
     });
     let consumer = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.dma_buf_consumer",
+        runtime_kind.processor_name(),
         consumer_config,
     ))?;
     println!("+ Consumer: {consumer}");
@@ -87,7 +151,10 @@ fn main() -> Result<()> {
     let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
         width: 1920,
         height: 1080,
-        title: Some("streamlib polyglot DMA-BUF consumer".to_string()),
+        title: Some(format!(
+            "streamlib polyglot DMA-BUF consumer ({})",
+            runtime_kind.as_str()
+        )),
         ..Default::default()
     }))?;
     println!("+ Display: {display}");
@@ -100,7 +167,10 @@ fn main() -> Result<()> {
         OutputLinkPortRef::new(&consumer, "video_out"),
         InputLinkPortRef::new(&display, "video"),
     )?;
-    println!("\nPipeline: camera -> python consumer -> display");
+    println!(
+        "\nPipeline: camera -> {} consumer -> display",
+        runtime_kind.as_str()
+    );
 
     println!("Starting pipeline for {duration_secs}s...\n");
     runtime.start()?;


### PR DESCRIPTION
## Summary

- Adds the Deno twin of the Python DMA-BUF consumer E2E shipped in #466. New `examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts` mirrors the Python processor contract — resolve `frame.surface_id` through the surface-share service, lock the imported handle read-only, probe the first byte, throttled-log success/failure (counts 1, 2, 3, then every `log_every`), forward the frame unmodified.
- Extends the scenario binary with a `--runtime=python|deno` selector so one binary spawns either subprocess. Defaults to `python` so the existing invocation shape is preserved; `deno` loads `streamlib.yaml` directly via `runtime.load_project` (no `.slpkg` build step).
- Closes the Python/Deno gap from #466 under the pairing rule codified in #468 / `.claude/workflows/polyglot.md`.

## Closes

Closes #473

## Polyglot coverage

- **Runtimes affected**: deno (new), rust (scenario binary refactor); python untouched
- **Schema regenerated**: n/a — uses the existing `com.tatolab.videoframe@1.0.0` schema
- **Python and Deno both covered?** yes — Python shipped in #466, Deno lands here
- **E2E tests run**:
  - [x] Host-Rust: `cargo test --workspace` — 973 passed, 0 failed, 21 ignored
  - [x] Python subprocess: smoke run via `--runtime=python /dev/video0 8` confirms the runtime selector didn't regress the existing path
  - [x] Deno subprocess: see E2E reports below
- **FD-passing path**: DMA-BUF FD via `sldn_surface_resolve_surface` (already shipped in #420)

## E2E Test Report — normal mode (debug build)

- **Scenario**: camera+display-only (with consumer in the middle)
- **Example**: `polyglot-dma-buf-consumer-scenario --runtime=deno`
- **Codec**: n/a
- **Camera device**: `/dev/video0` (vivid — `/dev/video2` listed in `docs/testing.md` is a VBI/output endpoint on this host; `v4l2-ctl --get-fmt-video` confirms `/dev/video0` is the live capture device)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 15 s
- **Build profile**: debug
- **Command**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-deno-normal/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
    timeout --kill-after=3 30 \
        cargo run -q -p polyglot-dma-buf-consumer-scenario -- --runtime=deno /dev/video0 15
    ```

### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `[DmaBufConsumer] setup mode=normal log_every=60`: present
- Throttled resolves: counts 1, 2, 3, 60 — `1920x1080 stride=7680 first_byte=0xff`
- Subprocess exit: `Deno subprocess exited: exit status: 0`

### PNG samples

- Directory: `/tmp/e2e-deno-normal/png_samples/`
- Sample count: 3
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30`
- PNG read with Read tool: `display_001_frame_000030_input_000034.png`
- **What was in the image**: vivid test pattern — green vertical bars across the full frame with the standard vivid info overlay in the upper-left corner showing timecode `00:00:06.607` and frame counter `33`, `1920x1080, input 0`, brightness/contrast/saturation values, autogain/gain/alpha, volume/mute, plus the typed parameter readouts vivid renders for testing (int32, ro int32, int64, bitmask, boolean, menu/string, integer menu). Horizontal scanline interlacing characteristic of vivid is visible. Frame matches expected vivid content cleanly.
- Anomalies: none

### PSNR

- Reference frame: n/a — vivid content is procedurally generated and the consumer pipeline is camera→consumer→display (no encode/decode); the Read-tool visual check is the gate.

### Outcome

- **Pass**

## E2E Test Report — release × 3 cold runs

- **Build profile**: release (`./target/release/polyglot-dma-buf-consumer-scenario --runtime=deno /dev/video0 15`)
- **Frame limit**: 600
- **Sample interval**: 60

| Run | rc | OOM | DEVICE_LOST | process() failed | SIGSEGV | resolves logged | PNGs |
|-----|----|----|-------------|------------------|---------|-----------------|------|
| 1   | 0  | 0  | 0           | 0                | 0       | 4 (counts 1,2,3,60) | 2 |
| 2   | 0  | 0  | 0           | 0                | 0       | 4 (counts 1,2,3,60) | 2 |
| 3   | 0  | 0  | 0           | 0                | 0       | 4 (counts 1,2,3,60) | 2 |

- **Outcome**: **Pass**

## E2E Test Report — negative mode (`--negative`)

- **Build profile**: release
- **Command**: `./target/release/polyglot-dma-buf-consumer-scenario --runtime=deno /dev/video0 15 --negative`
- **rc**: 0
- **Log signals**: 0 OOM, 0 DEVICE_LOST, 0 process() failed, 0 SIGSEGV
- **Setup log**: `[DmaBufConsumer] setup mode=negative (force_bad_surface_id) log_every=60`
- **Throttled errors** (counts 1, 2, 3, 60):
  ```
  [DmaBufConsumer] resolve_surface failed for surface_id="00000000-0000-0000-0000-000000000000": Surface-share service failed to resolve surface: 00000000-0000-0000-0000-000000000000 count=N
  ```
  — exact "Surface-share service failed to resolve surface" string per the issue's negative-test contract.
- **Shutdown**: `[stop] Graceful shutdown complete` after the 15 s sleep — pipeline did not deadlock.
- **Outcome**: **Pass**

## Workspace baseline

```
cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess \
    --exclude camera-python-subprocess --exclude camera-rust-plugin \
    --exclude webrtc-cloudflare-stream --no-fail-fast
```
- **Result**: 973 passed, 0 failed, 21 ignored, exit 0.

## Exit criteria

- [x] `examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts` mirrors the Python contract (subscribe → `resolveSurface` → `lock` → first-byte read → forward → `unlock` → `release`); same `force_bad_surface_id` and `log_every` config keys; same throttled cadence; same setup/error/teardown log strings.
- [x] Scenario wiring: `--runtime=python|deno` selector on the existing `polyglot-dma-buf-consumer-scenario` binary.
- [x] Fixture: vivid (`/dev/video0` on this workstation; see note above).
- [x] PNG sampling enabled, agent read and described `display_001_frame_000030_input_000034.png`.
- [x] Logs: zero `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed` across normal and negative runs.
- [x] Release-build × 3 cold runs (≥15 s each), all rc=0, no SIGSEGV.
- [x] Negative: bogus `surface_id` → "Surface-share service failed to resolve surface", graceful shutdown.

## Follow-ups

- Pre-existing surface-share teardown SIGSEGV during subprocess shutdown (noted as a follow-up in PR #466) — did not reproduce in any of the 3 release runs in this PR; no new tracking needed unless it surfaces.
- `docs/testing.md` says vivid is at `/dev/video2`; on this workstation only `/dev/video0` is the actual capture endpoint (the others are VBI/output). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)