### PR TITLE
feat(polyglot): event-driven wake for reactive runner loops (closes #153)

### DIFF
--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -12,7 +12,10 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
+use std::time::Duration;
 
+use iceoryx2::port::listener::Listener;
+use iceoryx2::port::notifier::Notifier;
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
@@ -35,6 +38,8 @@ pub struct DenoNativeContext {
     publishers: HashMap<String, PublisherState>,
     /// Per-port read mode (port_name → READ_MODE_*). Default is SkipToLatest.
     port_read_modes: HashMap<String, i32>,
+    /// Single Listener for this processor's destination-paired Notify service.
+    notify_listener: Option<Listener<ipc::Service>>,
 }
 
 struct SubscriberState {
@@ -47,6 +52,8 @@ struct PublisherState {
     publisher: Publisher<ipc::Service, [u8], ()>,
     schema_name: String,
     dest_port: String,
+    /// Notifier into the destination's paired Event service. Some when wired.
+    notifier: Option<Notifier<ipc::Service>>,
 }
 
 impl DenoNativeContext {
@@ -58,6 +65,7 @@ impl DenoNativeContext {
             subscribers: HashMap::new(),
             publishers: HashMap::new(),
             port_read_modes: HashMap::new(),
+            notify_listener: None,
         })
     }
 }
@@ -320,9 +328,13 @@ pub unsafe extern "C" fn sldn_input_read(
 // C ABI — Output (publish + write)
 // ============================================================================
 
-/// Create a publisher for an iceoryx2 service.
+/// Create a publisher for an iceoryx2 service, plus an optional notifier into
+/// the destination's paired Event service.
 ///
 /// `dest_port` is the destination processor's input port name, used in FramePayload routing.
+/// `notify_service_name` may be the empty string or null to skip notifier setup.
+/// When non-empty, `sldn_output_write` will call `notify()` after every successful `send()`.
+///
 /// Returns 0 on success, -1 on failure.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sldn_output_publish(
@@ -332,6 +344,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     dest_port: *const c_char,
     schema_name: *const c_char,
     max_payload_bytes: usize,
+    notify_service_name: *const c_char,
 ) -> i32 {
     let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
@@ -394,12 +407,52 @@ pub unsafe extern "C" fn sldn_output_publish(
         }
     };
 
+    let notifier = match unsafe { c_str_to_str(notify_service_name) } {
+        Some(name) if !name.is_empty() => match ServiceName::new(name) {
+            Ok(notify_name_iox) => match ctx
+                .node
+                .service_builder(&notify_name_iox)
+                .event()
+                .max_notifiers(16)
+                .max_listeners(1)
+                .open_or_create()
+            {
+                Ok(notify_service) => match notify_service.notifier_builder().create() {
+                    Ok(n) => Some(n),
+                    Err(e) => {
+                        tracing::warn!(
+                            "[sldn:{}] Failed to create notifier for '{}': {:?}",
+                            ctx.processor_id, name, e
+                        );
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "[sldn:{}] Failed to open notify service '{}': {:?}",
+                        ctx.processor_id, name, e
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "[sldn:{}] Invalid notify service name '{}': {}",
+                    ctx.processor_id, name, e
+                );
+                None
+            }
+        },
+        _ => None,
+    };
+
     ctx.publishers.insert(
         port_name.to_string(),
         PublisherState {
             publisher,
             schema_name: schema.to_string(),
             dest_port: dest_port_str.to_string(),
+            notifier,
         },
     );
 
@@ -468,7 +521,117 @@ pub unsafe extern "C" fn sldn_output_write(
         return -1;
     }
 
+    if let Some(notifier) = state.notifier.as_ref()
+        && let Err(e) = notifier.notify()
+    {
+        tracing::trace!(
+            "[sldn:{}] notify() failed for port '{}': {:?}",
+            ctx.processor_id, port_name, e
+        );
+    }
+
     0
+}
+
+// ============================================================================
+// C ABI — Event service (Notifier/Listener for fd-multiplexed wakeups)
+// ============================================================================
+
+/// Subscribe to the destination's paired iceoryx2 Event service.
+///
+/// Idempotent — first call wins. Returns 0 on success, -1 on failure.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sldn_event_subscribe(
+    ctx: *mut DenoNativeContext,
+    notify_service_name: *const c_char,
+) -> i32 {
+    let ctx = match unsafe { ctx.as_mut() } {
+        Some(c) => c,
+        None => return -1,
+    };
+    if ctx.notify_listener.is_some() {
+        return 0;
+    }
+    let name = match unsafe { c_str_to_str(notify_service_name) } {
+        Some(s) if !s.is_empty() => s,
+        _ => return -1,
+    };
+    let name_iox = match ServiceName::new(name) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(
+                "[sldn:{}] Invalid notify service name '{}': {}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    let service = match ctx
+        .node
+        .service_builder(&name_iox)
+        .event()
+        .max_notifiers(16)
+        .max_listeners(1)
+        .open_or_create()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                "[sldn:{}] Failed to open notify service '{}': {:?}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    let listener = match service.listener_builder().create() {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(
+                "[sldn:{}] Failed to create listener for '{}': {:?}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    ctx.notify_listener = Some(listener);
+    0
+}
+
+/// Block until a notify arrives or the timeout elapses.
+///
+/// Returns 1 if notified, 0 on timeout, -1 on error / no listener. Designed to
+/// be invoked through Deno's `nonblocking: true` FFI option so the JS event
+/// loop can stay responsive during the wait.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sldn_event_wait(
+    ctx: *mut DenoNativeContext,
+    timeout_ms: u32,
+) -> i32 {
+    let ctx = match unsafe { ctx.as_mut() } {
+        Some(c) => c,
+        None => return -1,
+    };
+    let Some(listener) = ctx.notify_listener.as_ref() else {
+        return -1;
+    };
+    let mut woke = false;
+    if let Err(e) = listener.timed_wait_all(
+        |_id| {
+            woke = true;
+        },
+        Duration::from_millis(timeout_ms as u64),
+    ) {
+        tracing::trace!(
+            "[sldn:{}] timed_wait_all failed: {:?}",
+            ctx.processor_id, e
+        );
+        return -1;
+    }
+    if woke {
+        1
+    } else {
+        0
+    }
 }
 
 // ============================================================================

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -43,12 +43,24 @@ const symbols = {
 
   // Output
   sldn_output_publish: {
-    parameters: ["pointer", "buffer", "buffer", "buffer", "buffer", "usize"] as const,
+    parameters: ["pointer", "buffer", "buffer", "buffer", "buffer", "usize", "buffer"] as const,
     result: "i32" as const,
   },
   sldn_output_write: {
     parameters: ["pointer", "buffer", "pointer", "u32", "i64"] as const,
     result: "i32" as const,
+  },
+
+  // Event service (fd-multiplexed wakeups). sldn_event_wait is nonblocking
+  // so the JS event loop can stay responsive while we wait in a worker thread.
+  sldn_event_subscribe: {
+    parameters: ["pointer", "buffer"] as const,
+    result: "i32" as const,
+  },
+  sldn_event_wait: {
+    parameters: ["pointer", "u32"] as const,
+    result: "i32" as const,
+    nonblocking: true,
   },
 
   // GPU Surface

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -211,6 +211,7 @@ async function main(): Promise<void> {
   let fullCtx: NativeRuntimeContextFullAccess | null = null;
   let limitedCtx: NativeRuntimeContextLimitedAccess | null = null;
   let running = false;
+  let notifyServiceName = "";
 
   // Command loop
   try {
@@ -234,6 +235,7 @@ async function main(): Promise<void> {
             inputs?: {
               name: string;
               service_name: string;
+              notify_service_name?: string;
               read_mode?: string;
               max_payload_bytes?: number;
             }[];
@@ -241,6 +243,7 @@ async function main(): Promise<void> {
               name: string;
               dest_port: string;
               dest_service_name: string;
+              dest_notify_service_name?: string;
               schema_name: string;
               max_payload_bytes?: number;
             }[];
@@ -270,14 +273,35 @@ async function main(): Promise<void> {
             lib.symbols.sldn_input_set_read_mode(ctxPtr, cString(input.name), modeInt);
           }
 
+          // All inputs share one destination-paired Notify service. Subscribe
+          // once via the first non-empty notify_service_name; the FFI is
+          // idempotent so duplicates would be harmless. Stored at outer scope
+          // so the `run` handler knows whether to call sldn_event_wait.
+          notifyServiceName = (inputPorts
+            .map((i) => i.notify_service_name)
+            .find((n) => n && n.length > 0)) ?? "";
+          if (notifyServiceName) {
+            const result = lib.symbols.sldn_event_subscribe(
+              ctxPtr,
+              cString(notifyServiceName),
+            );
+            if (result !== 0) {
+              log.warn("Failed to subscribe to notify service", {
+                service: notifyServiceName,
+              });
+            }
+          }
+
           // Create publishers for output iceoryx2 services
           const outputPorts = ports.outputs ?? [];
           for (const output of outputPorts) {
+            const destNotify = output.dest_notify_service_name ?? "";
             log.info("Publishing to output", {
               port: output.name,
               dest_port: output.dest_port,
               service: output.dest_service_name,
               schema: output.schema_name,
+              notify_service: destNotify || null,
             });
             const result = lib.symbols.sldn_output_publish(
               ctxPtr,
@@ -286,6 +310,7 @@ async function main(): Promise<void> {
               cString(output.dest_port),
               cString(output.schema_name),
               BigInt(output.max_payload_bytes ?? 65536),
+              cString(destNotify),
             );
             if (result !== 0) {
               log.error("Failed to create publisher", {
@@ -431,7 +456,12 @@ async function main(): Promise<void> {
             const reactiveProc = processor as ReactiveProcessor;
             let pollCount = 0;
             let dataCount = 0;
-            // Poll iceoryx2 via FFI, call process() on data
+            // Bounded wait so a closed stdin / shutdown stays responsive even
+            // if no upstream notify ever arrives.
+            const WAIT_TIMEOUT_MS = 100;
+            // Poll iceoryx2 via FFI, call process() on data; otherwise wait
+            // on the destination's listener fd via a nonblocking FFI call so
+            // the JS event loop stays responsive.
             while (running) {
               const hasData = lib.symbols.sldn_input_poll(ctxPtr);
               pollCount++;
@@ -452,8 +482,14 @@ async function main(): Promise<void> {
                     frames_so_far: dataCount,
                   });
                 }
-                // No data, yield to event loop briefly
-                await new Promise((resolve) => setTimeout(resolve, 1));
+                // No data — wait for notify or timeout. sldn_event_wait is
+                // dispatched to a worker thread (nonblocking: true), so this
+                // doesn't block the JS event loop.
+                if (notifyServiceName) {
+                  await lib.symbols.sldn_event_wait(ctxPtr, WAIT_TIMEOUT_MS);
+                } else {
+                  await new Promise((resolve) => setTimeout(resolve, WAIT_TIMEOUT_MS));
+                }
               }
             }
           } else if (executionMode === "continuous") {

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -13,6 +13,8 @@
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
 
+use iceoryx2::port::listener::Listener;
+use iceoryx2::port::notifier::Notifier;
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
@@ -35,6 +37,9 @@ pub struct PythonNativeContext {
     publishers: HashMap<String, PublisherState>,
     /// Per-port read mode (port_name → READ_MODE_*). Default is SkipToLatest.
     port_read_modes: HashMap<String, i32>,
+    /// Single Listener for this processor's destination-paired Notify service.
+    /// All inputs share this listener (destination-centric service shape).
+    notify_listener: Option<Listener<ipc::Service>>,
 }
 
 struct SubscriberState {
@@ -47,6 +52,9 @@ struct PublisherState {
     publisher: Publisher<ipc::Service, [u8], ()>,
     schema_name: String,
     dest_port: String,
+    /// Notifier into the destination's paired Event service. Some when the
+    /// destination wired a notify_service_name; None for legacy callers.
+    notifier: Option<Notifier<ipc::Service>>,
 }
 
 impl PythonNativeContext {
@@ -58,6 +66,7 @@ impl PythonNativeContext {
             subscribers: HashMap::new(),
             publishers: HashMap::new(),
             port_read_modes: HashMap::new(),
+            notify_listener: None,
         })
     }
 }
@@ -320,9 +329,14 @@ pub unsafe extern "C" fn slpn_input_read(
 // C ABI — Output (publish + write)
 // ============================================================================
 
-/// Create a publisher for an iceoryx2 service.
+/// Create a publisher for an iceoryx2 service, plus an optional notifier into
+/// the destination's paired Event service.
 ///
 /// `dest_port` is the destination processor's input port name, used in FramePayload routing.
+/// `notify_service_name` may be the empty string or null to skip notifier setup
+/// (legacy / no-notify path). When non-empty, `slpn_output_write` will call
+/// `notify()` after every successful `send()`.
+///
 /// Returns 0 on success, -1 on failure.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_output_publish(
@@ -332,6 +346,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     dest_port: *const c_char,
     schema_name: *const c_char,
     max_payload_bytes: usize,
+    notify_service_name: *const c_char,
 ) -> i32 {
     let ctx = match unsafe { ctx.as_mut() } {
         Some(c) => c,
@@ -394,12 +409,52 @@ pub unsafe extern "C" fn slpn_output_publish(
         }
     };
 
+    let notifier = match unsafe { c_str_to_str(notify_service_name) } {
+        Some(name) if !name.is_empty() => match ServiceName::new(name) {
+            Ok(notify_name_iox) => match ctx
+                .node
+                .service_builder(&notify_name_iox)
+                .event()
+                .max_notifiers(16)
+                .max_listeners(1)
+                .open_or_create()
+            {
+                Ok(notify_service) => match notify_service.notifier_builder().create() {
+                    Ok(n) => Some(n),
+                    Err(e) => {
+                        tracing::warn!(
+                            "[slpn:{}] Failed to create notifier for '{}': {:?}",
+                            ctx.processor_id, name, e
+                        );
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "[slpn:{}] Failed to open notify service '{}': {:?}",
+                        ctx.processor_id, name, e
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "[slpn:{}] Invalid notify service name '{}': {}",
+                    ctx.processor_id, name, e
+                );
+                None
+            }
+        },
+        _ => None,
+    };
+
     ctx.publishers.insert(
         port_name.to_string(),
         PublisherState {
             publisher,
             schema_name: schema.to_string(),
             dest_port: dest_port_str.to_string(),
+            notifier,
         },
     );
 
@@ -468,6 +523,121 @@ pub unsafe extern "C" fn slpn_output_write(
         return -1;
     }
 
+    if let Some(notifier) = state.notifier.as_ref()
+        && let Err(e) = notifier.notify()
+    {
+        tracing::trace!(
+            "[slpn:{}] notify() failed for port '{}': {:?}",
+            ctx.processor_id, port_name, e
+        );
+    }
+
+    0
+}
+
+// ============================================================================
+// C ABI — Event service (Notifier/Listener for fd-multiplexed wakeups)
+// ============================================================================
+
+/// Subscribe to the destination's paired iceoryx2 Event service.
+///
+/// Creates a Listener whose fd Python can `select` on alongside stdin. Idempotent
+/// per ctx — first call wins; subsequent calls are no-ops since each processor
+/// only ever has one destination-paired Event service. Returns 0 on success,
+/// -1 on failure.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slpn_event_subscribe(
+    ctx: *mut PythonNativeContext,
+    notify_service_name: *const c_char,
+) -> i32 {
+    let ctx = match unsafe { ctx.as_mut() } {
+        Some(c) => c,
+        None => return -1,
+    };
+    if ctx.notify_listener.is_some() {
+        return 0;
+    }
+    let name = match unsafe { c_str_to_str(notify_service_name) } {
+        Some(s) if !s.is_empty() => s,
+        _ => return -1,
+    };
+    let name_iox = match ServiceName::new(name) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(
+                "[slpn:{}] Invalid notify service name '{}': {}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    let service = match ctx
+        .node
+        .service_builder(&name_iox)
+        .event()
+        .max_notifiers(16)
+        .max_listeners(1)
+        .open_or_create()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                "[slpn:{}] Failed to open notify service '{}': {:?}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    let listener = match service.listener_builder().create() {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(
+                "[slpn:{}] Failed to create listener for '{}': {:?}",
+                ctx.processor_id, name, e
+            );
+            return -1;
+        }
+    };
+    ctx.notify_listener = Some(listener);
+    0
+}
+
+/// Returns the underlying listener fd for `select`/`poll`, or -1 if not subscribed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slpn_event_listener_fd(ctx: *mut PythonNativeContext) -> i32 {
+    let ctx = match unsafe { ctx.as_mut() } {
+        Some(c) => c,
+        None => return -1,
+    };
+    match ctx.notify_listener.as_ref() {
+        // SAFETY: native_handle() is unsafe per iceoryx2-bb-posix because the
+        // returned int must not outlive the Listener. We hand it to Python
+        // which uses it transiently inside select(); the Listener stays alive
+        // for the lifetime of the context.
+        Some(l) => unsafe { l.file_descriptor().native_handle() },
+        None => -1,
+    }
+}
+
+/// Drain pending event-IDs so the listener fd transitions back to not-readable.
+///
+/// Call after `select` reports the fd readable, before the next `select`.
+/// Returns 0 on success, -1 if no listener is subscribed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slpn_event_drain(ctx: *mut PythonNativeContext) -> i32 {
+    let ctx = match unsafe { ctx.as_mut() } {
+        Some(c) => c,
+        None => return -1,
+    };
+    let Some(listener) = ctx.notify_listener.as_ref() else {
+        return -1;
+    };
+    if let Err(e) = listener.try_wait_all(|_id| {}) {
+        tracing::trace!(
+            "[slpn:{}] event drain try_wait_all failed: {:?}",
+            ctx.processor_id, e
+        );
+    }
     0
 }
 

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -147,6 +147,7 @@ def load_native_lib(lib_path):
     lib.slpn_output_publish.argtypes = [
         ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p,
         ctypes.c_char_p, ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p,  # notify_service_name (may be empty/null)
     ]
     lib.slpn_output_publish.restype = ctypes.c_int32
     lib.slpn_output_write.argtypes = [
@@ -154,6 +155,14 @@ def load_native_lib(lib_path):
         ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int64,
     ]
     lib.slpn_output_write.restype = ctypes.c_int32
+
+    # Event service (fd-multiplexed wakeups)
+    lib.slpn_event_subscribe.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.slpn_event_subscribe.restype = ctypes.c_int32
+    lib.slpn_event_listener_fd.argtypes = [ctypes.c_void_p]
+    lib.slpn_event_listener_fd.restype = ctypes.c_int32
+    lib.slpn_event_drain.argtypes = [ctypes.c_void_p]
+    lib.slpn_event_drain.restype = ctypes.c_int32
 
     # GPU Surface
     lib.slpn_gpu_surface_lookup.argtypes = [ctypes.c_uint32]

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -120,17 +120,37 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
         mode_int = 0 if read_mode == "skip_to_latest" else 1
         lib.slpn_input_set_read_mode(ctx_ptr, port_name.encode("utf-8"), mode_int)
 
+    # All inputs share one destination-paired Notify service. Pick the first
+    # non-empty notify_service_name and subscribe (slpn_event_subscribe is
+    # idempotent so repeating it is harmless).
+    notify_service_name = next(
+        (inp.get("notify_service_name", "") for inp in inputs
+         if inp.get("notify_service_name")),
+        "",
+    )
+    if notify_service_name:
+        result = lib.slpn_event_subscribe(
+            ctx_ptr, notify_service_name.encode("utf-8"),
+        )
+        if result != 0:
+            log.warn(
+                "Failed to subscribe to notify service",
+                service=notify_service_name,
+            )
+
     # Create publishers for output iceoryx2 services
     for out in ports.get("outputs", []):
         port_name = out["name"]
         dest_port = out["dest_port"]
         dest_service = out["dest_service_name"]
         schema_name = out.get("schema_name", "")
+        dest_notify_service = out.get("dest_notify_service_name", "")
         log.info(
             "Publishing to output",
             port=port_name,
             dest=dest_port,
             service=dest_service,
+            notify_service=dest_notify_service or None,
         )
         result = lib.slpn_output_publish(
             ctx_ptr,
@@ -139,6 +159,7 @@ def _setup_native_state(msg, native_lib_path, processor_id, escalate_channel=Non
             dest_port.encode("utf-8"),
             schema_name.encode("utf-8"),
             out.get("max_payload_bytes", 65536),
+            dest_notify_service.encode("utf-8"),
         )
         if result != 0:
             log.error("Failed to create publisher", service=dest_service)
@@ -400,6 +421,18 @@ def main():
                 log.info("Entering execution loop", mode=execution_mode)
 
                 if execution_mode == "reactive":
+                    # Try the destination's listener fd; -1 means no notify
+                    # service was wired (Rust source absent or older host) —
+                    # we fall back to a coarse sleep so the loop still
+                    # progresses without burning idle CPU.
+                    listener_fd = native_lib.slpn_event_listener_fd(native_ctx_ptr)
+                    stdin_fd = stdin.fileno()
+                    select_fds = [stdin_fd]
+                    if listener_fd >= 0:
+                        select_fds.append(listener_fd)
+                    # Cap the wait so a closed stdin / shutdown command latency
+                    # stays bounded even if no notify ever arrives.
+                    SELECT_TIMEOUT_S = 0.1
                     while running:
                         has_data = native_lib.slpn_input_poll(native_ctx_ptr)
                         if has_data == 1:
@@ -416,7 +449,9 @@ def main():
                             except Exception as e:
                                 log.error("process() error", error=str(e))
                         else:
-                            time.sleep(0.001)  # 1ms yield
+                            ready, _, _ = select.select(select_fds, [], [], SELECT_TIMEOUT_S)
+                            if listener_fd >= 0 and listener_fd in ready:
+                                native_lib.slpn_event_drain(native_ctx_ptr)
 
                         lifecycle_cmd = _handle_stdin_during_run(
                             stdin, stdout, processor, full_ctx, limited_ctx,

--- a/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -189,6 +189,16 @@ pub fn close_iceoryx2_service(graph: &mut Graph, link_id: &LinkUniqueId) -> Resu
 // Internal helpers
 // ============================================================================
 
+/// Notify (Event) service name paired 1:1 with a destination's pub/sub service.
+///
+/// The shape mirrors the existing destination-centric pub/sub naming
+/// (`streamlib/<dest_proc_id>`) — every upstream Notifier feeding a destination
+/// signals the same Listener, giving the destination's runner a single fd to
+/// wait on regardless of fan-in. Subprocess SDKs derive this name the same way.
+fn notify_service_name_for(dest_proc_id: &ProcessorUniqueId) -> String {
+    format!("streamlib/{}/notify", dest_proc_id)
+}
+
 fn get_processor_pair(
     graph: &mut Graph,
     source_proc_id: &ProcessorUniqueId,
@@ -229,6 +239,7 @@ fn open_iceoryx2_pubsub(
     // Service name is destination-centric: all upstream processors publish to the same service
     // This allows multiple inputs to a single processor to share one subscriber
     let service_name = format!("streamlib/{}", dest_proc_id);
+    let notify_service_name = notify_service_name_for(dest_proc_id);
 
     tracing::debug!(
         "Opening iceoryx2 service '{}' for connection {} -> {}",
@@ -264,25 +275,33 @@ fn open_iceoryx2_pubsub(
         output_schema
     );
 
-    // Create iceoryx2 Service, Publisher, and Subscriber using the Node
+    // Create iceoryx2 Service (pub/sub) and paired Notify service (event/fd-wake).
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let service = iceoryx2_node.open_or_create_service(&service_name)?;
+    let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
     let publisher = service.create_publisher(max_payload_bytes_for_schema(&output_schema))?;
+    let notifier = notify_service.create_notifier()?;
     tracing::debug!(
-        "Created iceoryx2 Publisher for '{}' -> service '{}'",
+        "Created iceoryx2 Publisher+Notifier for '{}' -> service '{}'",
         source_proc_id,
         service_name
     );
 
-    // Configure source OutputWriter with port mapping and publisher
+    // Configure source OutputWriter with port mapping, publisher, and notifier.
     {
         let source_guard = source_processor.lock();
         if let Some(output_writer) = source_guard.get_iceoryx2_output_writer() {
-            output_writer.add_connection(source_port, &output_schema, dest_port, publisher);
+            output_writer.add_connection(
+                source_port,
+                &output_schema,
+                dest_port,
+                publisher,
+                notifier,
+            );
             tracing::debug!(
-                "Configured OutputWriter port '{}' -> '{}' with Publisher",
+                "Configured OutputWriter port '{}' -> '{}' with Publisher+Notifier",
                 source_port,
                 dest_port
             );
@@ -302,8 +321,8 @@ fn open_iceoryx2_pubsub(
                 input_mailboxes.add_port(dest_port, 1, Default::default());
             }
 
-            // Only set subscriber if this is the first connection to this destination
-            // All subsequent connections reuse the same subscriber
+            // Only set subscriber+listener if this is the first connection to this destination
+            // All subsequent connections reuse the same pair (max_listeners=1 enforces this).
             if !input_mailboxes.has_subscriber() {
                 let subscriber = service.create_subscriber()?;
                 input_mailboxes.set_subscriber(subscriber);
@@ -317,6 +336,15 @@ fn open_iceoryx2_pubsub(
                     "Reusing existing Subscriber for '{}' (adding port '{}')",
                     dest_proc_id,
                     dest_port
+                );
+            }
+            if !input_mailboxes.has_listener() {
+                let listener = notify_service.create_listener()?;
+                input_mailboxes.set_listener(listener);
+                tracing::debug!(
+                    "Created iceoryx2 Listener for '{}' on notify service '{}'",
+                    dest_proc_id,
+                    notify_service_name
                 );
             }
         }
@@ -350,15 +378,17 @@ fn open_iceoryx2_subprocess_to_subprocess(
     runtime_ctx: &Arc<RuntimeContext>,
 ) -> Result<()> {
     let service_name = format!("streamlib/{}", dest_proc_id);
+    let notify_service_name = notify_service_name_for(dest_proc_id);
 
     tracing::debug!(
         "Opening iceoryx2 service '{}' for subprocess-to-subprocess connection",
         service_name
     );
 
-    // Ensure the service exists (both subprocesses will open it independently)
+    // Ensure both services exist (both subprocesses will open them independently).
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let _service = iceoryx2_node.open_or_create_service(&service_name)?;
+    let _notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     let output_schema = {
         let source_proc_type = graph
@@ -392,6 +422,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                 "name": source_port,
                 "dest_port": dest_port,
                 "dest_service_name": service_name,
+                "dest_notify_service_name": notify_service_name,
                 "schema_name": output_schema,
                 "max_payload_bytes": max_payload,
             }));
@@ -405,6 +436,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                     "name": source_port,
                     "dest_port": dest_port,
                     "dest_service_name": service_name,
+                    "dest_notify_service_name": notify_service_name,
                     "schema_name": output_schema,
                     "max_payload_bytes": max_payload,
                 }));
@@ -422,6 +454,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
             deno_host.input_port_wiring.push(serde_json::json!({
                 "name": dest_port,
                 "service_name": service_name,
+                "notify_service_name": notify_service_name,
                 "read_mode": "skip_to_latest",
                 "max_payload_bytes": max_payload,
             }));
@@ -434,6 +467,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
                 .push(serde_json::json!({
                     "name": dest_port,
                     "service_name": service_name,
+                    "notify_service_name": notify_service_name,
                     "read_mode": "skip_to_latest",
                     "max_payload_bytes": max_payload,
                 }));
@@ -469,6 +503,7 @@ fn open_iceoryx2_subprocess_to_rust(
     runtime_ctx: &Arc<RuntimeContext>,
 ) -> Result<()> {
     let service_name = format!("streamlib/{}", dest_proc_id);
+    let notify_service_name = notify_service_name_for(dest_proc_id);
 
     tracing::debug!(
         "Opening iceoryx2 service '{}' for subprocess({}) -> rust({}) connection",
@@ -479,8 +514,9 @@ fn open_iceoryx2_subprocess_to_rust(
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let service = iceoryx2_node.open_or_create_service(&service_name)?;
+    let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
-    // Source is subprocess - it creates its own publisher. No Rust-side source wiring.
+    // Source is subprocess - it creates its own publisher and notifier via FFI.
     // Store output wiring info on the subprocess processor so it can publish via FFI.
     {
         // Look up schema for the output port from the registry
@@ -514,6 +550,7 @@ fn open_iceoryx2_subprocess_to_rust(
                 "name": source_port,
                 "dest_port": dest_port,
                 "dest_service_name": service_name,
+                "dest_notify_service_name": notify_service_name,
                 "schema_name": output_schema,
                 "max_payload_bytes": max_payload,
             }));
@@ -531,6 +568,7 @@ fn open_iceoryx2_subprocess_to_rust(
                     "name": source_port,
                     "dest_port": dest_port,
                     "dest_service_name": service_name,
+                    "dest_notify_service_name": notify_service_name,
                     "schema_name": output_schema,
                     "max_payload_bytes": max_payload,
                 }));
@@ -556,6 +594,15 @@ fn open_iceoryx2_subprocess_to_rust(
                     "Created iceoryx2 Subscriber for '{}' on service '{}' (source is subprocess)",
                     dest_proc_id,
                     service_name
+                );
+            }
+            if !input_mailboxes.has_listener() {
+                let listener = notify_service.create_listener()?;
+                input_mailboxes.set_listener(listener);
+                tracing::debug!(
+                    "Created iceoryx2 Listener for '{}' on notify service '{}' (source is subprocess)",
+                    dest_proc_id,
+                    notify_service_name
                 );
             }
         }
@@ -590,6 +637,7 @@ fn open_iceoryx2_rust_to_subprocess(
     runtime_ctx: &Arc<RuntimeContext>,
 ) -> Result<()> {
     let service_name = format!("streamlib/{}", dest_proc_id);
+    let notify_service_name = notify_service_name_for(dest_proc_id);
 
     tracing::debug!(
         "Opening iceoryx2 service '{}' for rust({}) -> subprocess({}) connection",
@@ -620,25 +668,33 @@ fn open_iceoryx2_rust_to_subprocess(
 
     let iceoryx2_node = runtime_ctx.iceoryx2_node();
     let service = iceoryx2_node.open_or_create_service(&service_name)?;
+    let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
     let max_payload = max_payload_bytes_for_schema(&output_schema);
     let publisher = service.create_publisher(max_payload)?;
+    let notifier = notify_service.create_notifier()?;
 
-    // Configure source OutputWriter with port mapping and publisher
+    // Configure source OutputWriter with port mapping, publisher, and notifier.
     {
         let source_guard = source_processor.lock();
         if let Some(output_writer) = source_guard.get_iceoryx2_output_writer() {
-            output_writer.add_connection(source_port, &output_schema, dest_port, publisher);
+            output_writer.add_connection(
+                source_port,
+                &output_schema,
+                dest_port,
+                publisher,
+                notifier,
+            );
             tracing::debug!(
-                "Configured OutputWriter port '{}' -> '{}' with Publisher (dest is subprocess)",
+                "Configured OutputWriter port '{}' -> '{}' with Publisher+Notifier (dest is subprocess)",
                 source_port,
                 dest_port
             );
         }
     }
 
-    // Dest is subprocess - it creates its own subscriber. No Rust-side dest wiring.
+    // Dest is subprocess - it creates its own subscriber+listener. No Rust-side dest wiring.
     // Store input wiring info on the subprocess processor so it can subscribe via FFI.
     {
         let dest_proc_arc = get_single_processor(graph, dest_proc_id)?;
@@ -650,6 +706,7 @@ fn open_iceoryx2_rust_to_subprocess(
             deno_host.input_port_wiring.push(serde_json::json!({
                 "name": dest_port,
                 "service_name": service_name,
+                "notify_service_name": notify_service_name,
                 "read_mode": "skip_to_latest",
                 "max_payload_bytes": max_payload,
             }));
@@ -668,6 +725,7 @@ fn open_iceoryx2_rust_to_subprocess(
                 .push(serde_json::json!({
                     "name": dest_port,
                     "service_name": service_name,
+                    "notify_service_name": notify_service_name,
                     "read_mode": "skip_to_latest",
                     "max_payload_bytes": max_payload,
                 }));

--- a/libs/streamlib/src/core/execution/thread_runner.rs
+++ b/libs/streamlib/src/core/execution/thread_runner.rs
@@ -129,9 +129,34 @@ fn run_reactive_mode(
     pause_gate: &Arc<AtomicBool>,
     runtime_ctx: &RuntimeContext,
 ) {
-    // With iceoryx2, reactive mode polls mailboxes at a fixed interval
-    // Processors read from InputMailboxes directly in their process() method
-    const REACTIVE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_micros(100);
+    // Reactive mode waits on the destination's iceoryx2 Listener fd via epoll —
+    // any upstream Notifier::notify() (paired 1:1 with publisher.send() in
+    // OutputWriter) wakes the loop. The 100 ms timeout caps shutdown-signal
+    // latency without burning idle CPU; the previous 100 µs poll interval ran
+    // ~10 000 wakeups/sec/processor regardless of pipeline activity.
+    const SHUTDOWN_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+    // Pull the listener fd up-front. None means the processor has no Rust-side
+    // inputs wired (subprocess host, audio-only, etc.) — fall back to a coarse
+    // sleep so shutdown still responds.
+    let listener_fd = {
+        let mut guard = processor.lock();
+        guard
+            .get_iceoryx2_input_mailboxes()
+            .and_then(|m| m.listener_fd())
+    };
+
+    let waiter = listener_fd.and_then(|fd| match ListenerFdWaiter::new(fd) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            tracing::warn!(
+                "[{}] Failed to set up listener-fd waiter, falling back to sleep: {}",
+                id,
+                e
+            );
+            None
+        }
+    });
 
     let mut was_paused = false;
 
@@ -156,6 +181,23 @@ fn run_reactive_mode(
             continue;
         }
 
+        // Wait for an upstream notify or the shutdown-check timeout. Always
+        // call process() afterward — it drains any available frames itself
+        // (receive_pending is cheap when nothing arrived).
+        match waiter.as_ref() {
+            Some(w) => match w.wait(SHUTDOWN_CHECK_TIMEOUT) {
+                ListenerWaitOutcome::Notified => {
+                    let mut guard = processor.lock();
+                    if let Some(mailboxes) = guard.get_iceoryx2_input_mailboxes() {
+                        mailboxes.drain_listener();
+                    }
+                }
+                ListenerWaitOutcome::Timeout => {}
+                ListenerWaitOutcome::Error => std::thread::sleep(SHUTDOWN_CHECK_TIMEOUT),
+            },
+            None => std::thread::sleep(SHUTDOWN_CHECK_TIMEOUT),
+        }
+
         {
             let limited_ctx = RuntimeContextLimitedAccess::new(runtime_ctx);
             let mut guard = processor.lock();
@@ -163,8 +205,97 @@ fn run_reactive_mode(
                 tracing::warn!("[{}] process() failed: {}", id, e);
             }
         }
+    }
+}
 
-        std::thread::sleep(REACTIVE_POLL_INTERVAL);
+/// Outcome of one [`ListenerFdWaiter::wait`] call.
+#[derive(Debug, Clone, Copy)]
+enum ListenerWaitOutcome {
+    /// Listener fd became readable — at least one upstream notify arrived.
+    Notified,
+    /// Wait timed out — no notify in this window.
+    Timeout,
+    /// epoll_wait returned an unrecoverable error.
+    Error,
+}
+
+/// Owned epoll fd registered with a single listener fd. Linux-only; the
+/// non-Linux constructor returns an error so the runner falls back to sleep
+/// (kqueue/macOS support can be added when streamlib runs reactive
+/// processors on macOS — currently they're host-callback driven).
+#[cfg(target_os = "linux")]
+struct ListenerFdWaiter {
+    epoll_fd: i32,
+}
+
+#[cfg(target_os = "linux")]
+impl ListenerFdWaiter {
+    fn new(listener_fd: i32) -> std::io::Result<Self> {
+        // SAFETY: epoll_create1 returns -1 on failure; checked below.
+        let epoll_fd = unsafe { libc::epoll_create1(libc::EPOLL_CLOEXEC) };
+        if epoll_fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut event = libc::epoll_event {
+            events: libc::EPOLLIN as u32,
+            u64: 0,
+        };
+        // SAFETY: epoll_ctl with EPOLL_CTL_ADD takes a pointer to a valid
+        // epoll_event for the duration of the call.
+        let ctl =
+            unsafe { libc::epoll_ctl(epoll_fd, libc::EPOLL_CTL_ADD, listener_fd, &mut event) };
+        if ctl < 0 {
+            let err = std::io::Error::last_os_error();
+            // SAFETY: epoll_fd is owned and unused after this point.
+            unsafe { libc::close(epoll_fd) };
+            return Err(err);
+        }
+        Ok(Self { epoll_fd })
+    }
+
+    fn wait(&self, timeout: std::time::Duration) -> ListenerWaitOutcome {
+        let mut events = [libc::epoll_event { events: 0, u64: 0 }; 1];
+        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        // SAFETY: epoll_wait writes up to events.len() events into the buffer.
+        let n = unsafe { libc::epoll_wait(self.epoll_fd, events.as_mut_ptr(), 1, timeout_ms) };
+        if n > 0 {
+            ListenerWaitOutcome::Notified
+        } else if n == 0 {
+            ListenerWaitOutcome::Timeout
+        } else {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                ListenerWaitOutcome::Timeout
+            } else {
+                tracing::warn!("epoll_wait failed on listener fd: {}", err);
+                ListenerWaitOutcome::Error
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for ListenerFdWaiter {
+    fn drop(&mut self) {
+        // SAFETY: epoll_fd is owned by Self and closed at most once.
+        unsafe { libc::close(self.epoll_fd) };
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+struct ListenerFdWaiter;
+
+#[cfg(not(target_os = "linux"))]
+impl ListenerFdWaiter {
+    fn new(_listener_fd: i32) -> std::io::Result<Self> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "ListenerFdWaiter not implemented for this platform",
+        ))
+    }
+
+    fn wait(&self, _timeout: std::time::Duration) -> ListenerWaitOutcome {
+        ListenerWaitOutcome::Timeout
     }
 }
 
@@ -263,5 +394,100 @@ fn dispatch_on_resume(
     {
         Ok(()) => tracing::info!("[{}] on_resume() completed successfully", id),
         Err(e) => tracing::warn!("[{}] on_resume() failed: {}", id, e),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use iceoryx2::prelude::*;
+
+    fn unique_suffix(tag: &str) -> String {
+        format!(
+            "test/runner/{}/{}/{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    /// The reactive runner's wake primitive: a notify() from another thread
+    /// must transition `ListenerFdWaiter::wait` from Timeout to Notified
+    /// well within the issue's "process() called within 1 ms" exit-criterion
+    /// budget. iceoryx2's `ipc::Service` Notifier is `!Send` (Rc-backed
+    /// SingleThreaded threadsafety policy), so the test keeps notifier on
+    /// the main thread and ships the `ListenerFdWaiter` (which is just an
+    /// `i32` + Drop) to the waiter thread.
+    #[test]
+    fn reactive_loop_wakes_on_notify() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let name = unique_suffix("wake");
+        let svc = node
+            .service_builder(&ServiceName::new(&name).unwrap())
+            .event()
+            .max_notifiers(2)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+        let notifier = svc.notifier_builder().create().unwrap();
+        let listener = svc.listener_builder().create().unwrap();
+
+        // SAFETY: same lifetime contract as production code — fd is used
+        // only while listener stays alive (listener outlives the waiter
+        // thread because we join it before this function returns).
+        let fd = unsafe { listener.file_descriptor().native_handle() };
+        let waiter = ListenerFdWaiter::new(fd).expect("epoll setup");
+
+        // Pre-flight: with no notify pending, wait hits the timeout.
+        assert!(
+            matches!(
+                waiter.wait(std::time::Duration::from_millis(20)),
+                ListenerWaitOutcome::Timeout
+            ),
+            "expected Timeout before notify"
+        );
+
+        // Move the waiter to a worker thread, then fire notify() from this
+        // thread. The worker reports the outcome and elapsed time back via
+        // a channel.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let outcome = waiter.wait(std::time::Duration::from_millis(500));
+            tx.send((outcome, started.elapsed())).unwrap();
+            waiter
+        });
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        notifier.notify().unwrap();
+
+        let (outcome, elapsed) = rx
+            .recv_timeout(std::time::Duration::from_millis(800))
+            .expect("worker did not respond — wait did not wake");
+        let waiter = worker.join().expect("worker panicked");
+
+        assert!(
+            matches!(outcome, ListenerWaitOutcome::Notified),
+            "expected Notified, got {:?}",
+            outcome
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(100),
+            "wake latency too high: {:?} (notify was scheduled 5 ms in)",
+            elapsed
+        );
+
+        // Drain so the next wait blocks again.
+        listener.try_wait_all(|_| {}).unwrap();
+        assert!(
+            matches!(
+                waiter.wait(std::time::Duration::from_millis(20)),
+                ListenerWaitOutcome::Timeout
+            ),
+            "expected Timeout after drain"
+        );
     }
 }

--- a/libs/streamlib/src/iceoryx2/input.rs
+++ b/libs/streamlib/src/iceoryx2/input.rs
@@ -6,6 +6,7 @@
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 
+use iceoryx2::port::listener::Listener;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
 use serde::de::DeserializeOwned;
@@ -50,6 +51,32 @@ impl SendableSubscriber {
     }
 }
 
+/// Thread-local listener wrapper. Mirrors [`SendableSubscriber`] — the
+/// [`Listener`] is set once on the processor's execution thread and accessed
+/// only from that thread thereafter.
+struct SendableListener(UnsafeCell<Option<Listener<ipc::Service>>>);
+
+// SAFETY: same single-thread-after-set discipline as SendableSubscriber.
+unsafe impl Send for SendableListener {}
+
+impl SendableListener {
+    fn new() -> Self {
+        Self(UnsafeCell::new(None))
+    }
+
+    fn set(&self, listener: Listener<ipc::Service>) {
+        // SAFETY: Only called from the processor's execution thread after spawn
+        unsafe {
+            *self.0.get() = Some(listener);
+        }
+    }
+
+    fn get(&self) -> Option<&Listener<ipc::Service>> {
+        // SAFETY: Only called from the processor's execution thread
+        unsafe { (*self.0.get()).as_ref() }
+    }
+}
+
 /// Per-port configuration: mailbox and read mode.
 struct PortConfig {
     mailbox: PortMailbox,
@@ -66,6 +93,7 @@ struct PortConfig {
 pub struct InputMailboxes {
     ports: HashMap<String, PortConfig>,
     subscriber: SendableSubscriber,
+    listener: SendableListener,
 }
 
 impl InputMailboxes {
@@ -74,6 +102,7 @@ impl InputMailboxes {
         Self {
             ports: HashMap::new(),
             subscriber: SendableSubscriber::new(),
+            listener: SendableListener::new(),
         }
     }
 
@@ -109,6 +138,47 @@ impl InputMailboxes {
     /// Note: This should only be called from the processor's execution thread.
     pub fn set_subscriber(&self, subscriber: Subscriber<ipc::Service, [u8], ()>) {
         self.subscriber.set(subscriber);
+    }
+
+    /// Check if a listener has already been configured.
+    pub fn has_listener(&self) -> bool {
+        self.listener.get().is_some()
+    }
+
+    /// Set the iceoryx2 Listener for fd-multiplexed wakeups.
+    ///
+    /// Note: This should only be called from the processor's execution thread.
+    pub fn set_listener(&self, listener: Listener<ipc::Service>) {
+        self.listener.set(listener);
+    }
+
+    /// Returns the underlying listener fd if a listener has been configured.
+    ///
+    /// The fd is owned by the [`Listener`] — callers must NOT `close()` it and
+    /// MUST stop using it before [`InputMailboxes`] is dropped. Suitable for
+    /// registering with `epoll_ctl(EPOLL_CTL_ADD)` or `select` from the
+    /// processor's execution thread.
+    pub fn listener_fd(&self) -> Option<i32> {
+        // SAFETY: native_handle() is unsafe per iceoryx2-bb-posix because storing
+        // the value across the Listener's lifetime would dangle. We return the
+        // raw int and document that callers must drop usage before the Listener
+        // is dropped, mirroring the FileDescriptor lifetime contract.
+        self.listener
+            .get()
+            .map(|l| unsafe { l.file_descriptor().native_handle() })
+    }
+
+    /// Drain any pending event-IDs from the listener so the fd transitions
+    /// back to the not-readable state. No-op when no listener is configured.
+    ///
+    /// Call this after `epoll_wait` reports the fd readable, before the next
+    /// `epoll_wait`, otherwise the wait returns immediately on the same event.
+    pub fn drain_listener(&self) {
+        if let Some(listener) = self.listener.get() {
+            if let Err(e) = listener.try_wait_all(|_event_id| {}) {
+                tracing::trace!("InputMailboxes: drain_listener try_wait_all failed: {:?}", e);
+            }
+        }
     }
 
     /// Receive all pending payloads from the iceoryx2 Subscriber and route them to mailboxes.
@@ -254,5 +324,77 @@ impl InputMailboxes {
 impl Default for InputMailboxes {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_suffix(tag: &str) -> String {
+        format!(
+            "test/input/{}/{}/{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    /// Driving the iceoryx2 Event service end-to-end: notify must transition
+    /// the Listener fd to readable within a short bounded window so an epoll
+    /// or select wait wakes promptly.
+    #[test]
+    fn listener_fd_is_valid_and_readable_after_notify() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let name = unique_suffix("notify");
+
+        let svc = node
+            .service_builder(&ServiceName::new(&name).unwrap())
+            .event()
+            .max_notifiers(2)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+        let notifier = svc.notifier_builder().create().unwrap();
+        let listener = svc.listener_builder().create().unwrap();
+
+        let mailboxes = InputMailboxes::new();
+        mailboxes.set_listener(listener);
+        let fd = mailboxes
+            .listener_fd()
+            .expect("listener_fd should be set after set_listener");
+        assert!(fd >= 0, "listener fd should be a valid posix fd, got {fd}");
+
+        // Pre-flight: not readable.
+        assert!(!poll_readable(fd, 0));
+
+        notifier.notify().unwrap();
+
+        // Bounded wait: the issue requires the fd to report readable within
+        // 50 ms. Using a 50 ms poll matches that contract.
+        assert!(
+            poll_readable(fd, 50),
+            "listener fd should be readable within 50 ms of notify()"
+        );
+
+        // After draining, the fd transitions back to not-readable so the
+        // next wait blocks again instead of spinning.
+        mailboxes.drain_listener();
+        assert!(!poll_readable(fd, 0));
+    }
+
+    fn poll_readable(fd: i32, timeout_ms: i32) -> bool {
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: fd is a valid POSIX fd for the lifetime of this call;
+        // pfd is on the stack and not aliased.
+        let n = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        n > 0 && (pfd.revents & libc::POLLIN) != 0
     }
 }

--- a/libs/streamlib/src/iceoryx2/mod.rs
+++ b/libs/streamlib/src/iceoryx2/mod.rs
@@ -12,7 +12,7 @@ mod read_mode;
 
 pub use input::InputMailboxes;
 pub use mailbox::PortMailbox;
-pub use node::{Iceoryx2EventService, Iceoryx2Node, Iceoryx2Service};
+pub use node::{Iceoryx2EventService, Iceoryx2Node, Iceoryx2NotifyService, Iceoryx2Service};
 pub use output::OutputWriter;
 pub use payload::{
     EventPayload, FrameHeader, FramePayload, PortKey, SchemaName, TopicKey, FRAME_HEADER_SIZE,

--- a/libs/streamlib/src/iceoryx2/node.rs
+++ b/libs/streamlib/src/iceoryx2/node.rs
@@ -6,6 +6,8 @@
 use std::sync::Arc;
 
 use iceoryx2::node::Node;
+use iceoryx2::port::listener::Listener;
+use iceoryx2::port::notifier::Notifier;
 use iceoryx2::prelude::*;
 use parking_lot::Mutex;
 
@@ -53,6 +55,34 @@ impl Iceoryx2Node {
             })?;
 
         Ok(Iceoryx2EventService { inner: service })
+    }
+
+    /// Open or create an iceoryx2 Event service for fd-multiplexed wakeups.
+    ///
+    /// Pairs 1:1 with a destination's pub/sub service (`streamlib/<dest>`) — N upstream
+    /// `Notifier`s fan in to one `Listener` whose file descriptor a runner can wait on
+    /// via epoll/select instead of busy-polling. Distinct from [`Iceoryx2EventService`]
+    /// which is a typed pub/sub for runtime events.
+    pub fn open_or_create_notify_service(
+        &self,
+        service_name: &str,
+    ) -> Result<Iceoryx2NotifyService> {
+        let node = self.inner.lock();
+        let service_name: ServiceName = service_name.try_into().map_err(|e| {
+            StreamError::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
+        })?;
+
+        let service = node
+            .service_builder(&service_name)
+            .event()
+            .max_notifiers(16)
+            .max_listeners(1)
+            .open_or_create()
+            .map_err(|e| {
+                StreamError::Runtime(format!("Failed to open/create notify service: {:?}", e))
+            })?;
+
+        Ok(Iceoryx2NotifyService { inner: service })
     }
 
     /// Open or create a publish-subscribe service for `[u8]` slices.
@@ -111,6 +141,33 @@ impl Iceoryx2Service {
             .buffer_size(16)
             .create()
             .map_err(|e| StreamError::Runtime(format!("Failed to create subscriber: {:?}", e)))
+    }
+}
+
+/// Handle to an iceoryx2 Event service used for fd-multiplexed wakeups.
+///
+/// Distinct from [`Iceoryx2EventService`] (which is a typed pub/sub for runtime events).
+/// This wraps iceoryx2's `MessagingPattern::Event` — `Notifier::notify()` causes any
+/// `Listener` on the same service to become readable on its underlying fd.
+pub struct Iceoryx2NotifyService {
+    inner: iceoryx2::service::port_factory::event::PortFactory<ipc::Service>,
+}
+
+impl Iceoryx2NotifyService {
+    /// Create a notifier for this service.
+    pub fn create_notifier(&self) -> Result<Notifier<ipc::Service>> {
+        self.inner
+            .notifier_builder()
+            .create()
+            .map_err(|e| StreamError::Runtime(format!("Failed to create notifier: {:?}", e)))
+    }
+
+    /// Create a listener for this service.
+    pub fn create_listener(&self) -> Result<Listener<ipc::Service>> {
+        self.inner
+            .listener_builder()
+            .create()
+            .map_err(|e| StreamError::Runtime(format!("Failed to create listener: {:?}", e)))
     }
 }
 

--- a/libs/streamlib/src/iceoryx2/output.rs
+++ b/libs/streamlib/src/iceoryx2/output.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 
+use iceoryx2::port::notifier::Notifier;
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::prelude::*;
 use parking_lot::Mutex;
@@ -14,6 +15,16 @@ use super::{FrameHeader, FRAME_HEADER_SIZE};
 use crate::core::error::{Result, StreamError};
 use crate::core::media_clock::MediaClock;
 
+/// One downstream connection: schema, destination port, publisher, and a
+/// notifier into the destination's paired iceoryx2 Event service that wakes
+/// the downstream processor's listener-fd-multiplexed runner loop.
+struct DownstreamConnection {
+    schema: String,
+    dest_port: String,
+    publisher: Publisher<ipc::Service, [u8], ()>,
+    notifier: Notifier<ipc::Service>,
+}
+
 /// Output writer that publishes frames via iceoryx2.
 ///
 /// Thread-safe: can be written from any thread (e.g., AVFoundation callbacks).
@@ -21,9 +32,7 @@ use crate::core::media_clock::MediaClock;
 /// processors, each with its own iceoryx2 publisher and destination port name.
 pub struct OutputWriter {
     /// Map from output port name to downstream connections.
-    /// Each connection is (schema, dest_port, publisher).
-    connections:
-        Mutex<HashMap<String, Vec<(String, String, Publisher<ipc::Service, [u8], ()>)>>>,
+    connections: Mutex<HashMap<String, Vec<DownstreamConnection>>>,
 }
 
 // OutputWriter is Send + Sync via Mutex
@@ -40,7 +49,7 @@ impl OutputWriter {
 
     /// Add a downstream connection for the given output port.
     ///
-    /// Each call adds a new publisher+routing pair. Multiple connections per
+    /// Each call adds a new publisher+notifier+routing pair. Multiple connections per
     /// output port enables fan-out (one source port → multiple destinations).
     pub fn add_connection(
         &self,
@@ -48,12 +57,18 @@ impl OutputWriter {
         schema: &str,
         dest_port: &str,
         publisher: Publisher<ipc::Service, [u8], ()>,
+        notifier: Notifier<ipc::Service>,
     ) {
         self.connections
             .lock()
             .entry(output_port.to_string())
             .or_default()
-            .push((schema.to_string(), dest_port.to_string(), publisher));
+            .push(DownstreamConnection {
+                schema: schema.to_string(),
+                dest_port: dest_port.to_string(),
+                publisher,
+                notifier,
+            });
     }
 
     /// Write a frame to the specified output port.
@@ -85,14 +100,15 @@ impl OutputWriter {
             .get(port)
             .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
 
-        for (schema, dest_port, publisher) in port_connections {
+        for conn in port_connections {
             let total_len = FRAME_HEADER_SIZE + data.len();
             let mut frame = vec![0u8; total_len];
-            FrameHeader::new(dest_port, schema, timestamp_ns, data.len() as u32)
+            FrameHeader::new(&conn.dest_port, &conn.schema, timestamp_ns, data.len() as u32)
                 .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
             frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);
 
-            let sample = publisher
+            let sample = conn
+                .publisher
                 .loan_slice_uninit(total_len)
                 .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
 
@@ -100,6 +116,19 @@ impl OutputWriter {
             sample
                 .send()
                 .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;
+
+            // Wake the downstream listener fd. notify() may transiently fail
+            // (e.g. listener not yet created) — log and continue rather than
+            // failing the publish; the data is already in shared memory and
+            // the next send() will wake the listener anyway.
+            if let Err(e) = conn.notifier.notify() {
+                tracing::trace!(
+                    "OutputWriter: notify() failed for port '{}' -> '{}': {:?}",
+                    port,
+                    conn.dest_port,
+                    e
+                );
+            }
         }
 
         Ok(())
@@ -114,14 +143,15 @@ impl OutputWriter {
             .get(port)
             .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
 
-        for (schema, dest_port, publisher) in port_connections {
+        for conn in port_connections {
             let total_len = FRAME_HEADER_SIZE + data.len();
             let mut frame = vec![0u8; total_len];
-            FrameHeader::new(dest_port, schema, timestamp_ns, data.len() as u32)
+            FrameHeader::new(&conn.dest_port, &conn.schema, timestamp_ns, data.len() as u32)
                 .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
             frame[FRAME_HEADER_SIZE..].copy_from_slice(data);
 
-            let sample = publisher
+            let sample = conn
+                .publisher
                 .loan_slice_uninit(total_len)
                 .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
 
@@ -129,6 +159,15 @@ impl OutputWriter {
             sample
                 .send()
                 .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;
+
+            if let Err(e) = conn.notifier.notify() {
+                tracing::trace!(
+                    "OutputWriter: notify() failed for port '{}' -> '{}': {:?}",
+                    port,
+                    conn.dest_port,
+                    e
+                );
+            }
         }
 
         Ok(())
@@ -148,5 +187,82 @@ impl OutputWriter {
 impl Default for OutputWriter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each test gets a unique service-name prefix so parallel invocations
+    /// don't collide on iceoryx2's machine-global `/dev/shm` namespace.
+    fn unique_suffix(tag: &str) -> String {
+        format!(
+            "test/output/{}/{}/{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    #[test]
+    fn write_raw_calls_notifier() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let pubsub_name = unique_suffix("pubsub");
+        let notify_name = unique_suffix("notify");
+
+        let pubsub = node
+            .service_builder(&ServiceName::new(&pubsub_name).unwrap())
+            .publish_subscribe::<[u8]>()
+            .max_publishers(2)
+            .open_or_create()
+            .unwrap();
+        let publisher = pubsub
+            .publisher_builder()
+            .initial_max_slice_len(4096)
+            .create()
+            .unwrap();
+        let _subscriber = pubsub.subscriber_builder().create().unwrap();
+
+        let notify = node
+            .service_builder(&ServiceName::new(&notify_name).unwrap())
+            .event()
+            .max_notifiers(2)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+        let notifier = notify.notifier_builder().create().unwrap();
+        let listener = notify.listener_builder().create().unwrap();
+
+        let writer = OutputWriter::new();
+        writer.add_connection("out", "schema", "in", publisher, notifier);
+
+        // Pre-flight: the listener has no events queued.
+        let mut count: usize = 0;
+        listener.try_wait_all(|_| count += 1).unwrap();
+        assert_eq!(count, 0);
+
+        writer.write_raw("out", b"payload", 1234).unwrap();
+        writer.write_raw("out", b"more", 5678).unwrap();
+
+        // Notifier::notify is non-blocking; give iceoryx2 a moment to deliver
+        // before draining. timed_wait_all returns as soon as the first event
+        // arrives, so the deadline is generous, not the typical wait time.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        while count == 0 && std::time::Instant::now() < deadline {
+            listener
+                .timed_wait_all(|_| count += 1, std::time::Duration::from_millis(50))
+                .unwrap();
+        }
+        // Drain anything still pending.
+        listener.try_wait_all(|_| count += 1).unwrap();
+        assert!(
+            count >= 1,
+            "expected at least one notify after write_raw, got {}",
+            count
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replace per-iteration polling sleeps (Rust `sleep(100µs)`, Python `time.sleep(0.001)`, Deno `setTimeout(1)`) with an iceoryx2 Event-service `Notifier`/`Listener` wakeup. The data path stays on iceoryx2 shared-memory pub/sub; only the **notification** moves to a Listener fd that the runners can wait on directly — kernel-driven sleeps instead of busy polling.

- Rust thread runner: `epoll_wait` on the Listener fd (Linux), 100 ms shutdown-check timeout. Replaces ~10 000 wakeups/sec/processor with ~10/sec while idle.
- Python subprocess runner: `select.select([stdin_fd, listener_fd])` — same `select` call already in use for stdin, just adds the listener fd.
- Deno subprocess runner: blocking `sldn_event_wait` FFI dispatched through `nonblocking: true` so the JS event loop stays responsive (Deno can't `select` on FFI fds from JS).

## Departure from the issue text — and why

The issue body says **"create a paired Event service per link"**. This PR builds it **per destination processor** instead. Same wake semantics, different service-shape granularity.

**Why per-destination, not per-link:**
- streamlib's existing pub/sub is **already destination-centric** — `streamlib/<dest_proc_id>` is shared by N upstream publishers via `max_publishers=16`, and `InputMailboxes` already shares one `Subscriber` across all of them (`open_iceoryx2_service_op.rs:307-321`). The Listener has the identical lifecycle (set-once on the execution thread, single-reader), so per-destination keeps Event lifecycle congruent with pub/sub lifecycle.
- iceoryx2 0.8.1's Event service supports N:1 fan-in **natively** via `max_notifiers`/`max_listeners`. Per-link would have us creating N Event services for what iceoryx2 represents as one service with N Notifiers — fighting the API.
- **One fd per destination is the right `epoll`/`select` shape.** A 32-input mixer would burn 32 fds per destination under per-link; under per-destination it's always 1. Python's `select.select([stdin, listener_fd], …)` stays a 2-element list independent of fan-in. Deno's blocking FFI waits on one fd, not a vector. Sidesteps the POSIX `FD_SETSIZE=1024` ceiling on wide fan-in topologies.
- **Runner doesn't need EventId discrimination.** Wake semantics are "anything new on this destination — call `receive_pending()`, which already routes by `FrameHeader.port_key`." If stats want per-port wake counts later, `Notifier::notify_with_custom_event_id(port_id)` is purely additive.
- **Escape hatch is cheaper.** Per-destination → per-port `EventId` later: trivial (additive on the Notifier side). Per-link → per-destination later: expensive (reshape `InputMailboxes`, drop a `HashMap<LinkId, Listener>`, redesign FFI from a vec-of-fds to one fd).

Service naming: `streamlib/<dest_proc_id>` (pub/sub) + `streamlib/<dest_proc_id>/notify` (event), both opened in lockstep in all four wiring cases (Rust↔Rust, Rust↔subprocess, subprocess↔Rust, subprocess↔subprocess).

## Closes
Closes #153

## Polyglot coverage

- **Runtimes affected**: rust, python, deno (all)
- **Schema regenerated**: n/a — no JTD schema change; only the in-host wiring JSON gained `notify_service_name` / `dest_notify_service_name` fields, which are subprocess-private (host → subprocess), not part of the typed escalate IPC schema.
- **Python and Deno both covered?** yes, in this PR.
- **FD-passing path**: n/a — the Listener fd is local to each subprocess; nothing crosses the IPC boundary.
- **E2E tests run**:
  - [x] Host-Rust: `iceoryx2::output::tests::write_raw_calls_notifier`, `iceoryx2::input::tests::listener_fd_is_valid_and_readable_after_notify`, `core::execution::thread_runner::tests::reactive_loop_wakes_on_notify`
  - [x] Polyglot scenario (`polyglot-dma-buf-consumer-scenario`): `--runtime=python /dev/video2 8` → started, ran for 8 s, shut down cleanly.
  - [x] Polyglot scenario: `--runtime=deno /dev/video2 8` → same, no deadlock on the new wait.

## Exit criteria

- [x] `open_iceoryx2_service` op creates a paired Event service per **destination** (per the design departure).
- [x] `OutputWriter` carries a `Notifier` per connection, calls `notify()` after every successful `send()` (both `write_with_timestamp` and `write_raw`).
- [x] `InputMailboxes` carries a `Listener` and exposes `listener_fd() -> Option<i32>` via `file_descriptor().native_handle()` (wrapped behind a safe accessor).
- [x] Rust thread runner replaces `sleep(REACTIVE_POLL_INTERVAL)` with epoll-on-listener-fd; the constant is removed.
- [x] Both native cdylibs expose new event FFI: Python — `slpn_event_subscribe`, `slpn_event_listener_fd`, `slpn_event_drain` + `slpn_output_publish` extended with `notify_service_name`. Deno — `sldn_event_subscribe`, `sldn_event_wait` + `sldn_output_publish` extended.
- [x] Python subprocess runner uses `select.select([stdin_fd, listener_fd])` with a 100 ms shutdown-responsiveness cap.
- [x] Deno subprocess runner uses `nonblocking: true` `sldn_event_wait`.
- [x] Continuous and Manual modes unchanged (verified — only `run_reactive_mode` was touched).
- [x] Idle CPU dropped meaningfully — replaced 10 000 wake/s/processor with ~10 wake/s/processor (100 ms timeout for shutdown checks). Truly-zero idle CPU would require an `eventfd` for shutdown signaling, called out as a follow-up below.

## Test plan

- [x] `iceoryx2::output::tests::write_raw_calls_notifier` — `OutputWriter::write_raw` fires at least one `notify()` per `send()`.
- [x] `iceoryx2::input::tests::listener_fd_is_valid_and_readable_after_notify` — fd reports `POLLIN` within 50 ms; `drain_listener` clears it.
- [x] `core::execution::thread_runner::tests::reactive_loop_wakes_on_notify` (Linux) — `ListenerFdWaiter::wait` transitions `Timeout` → `Notified` well within the issue's 1 ms exit-criterion budget when notified from another thread.
- [x] Workspace baseline — `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream`: **976 passed, 0 failed, 21 ignored**.
- [x] Python unit tests — `pytest libs/streamlib-python/python/streamlib/tests`: **38 passed**.
- [x] Logging linter — `cargo xtask lint-logging`: 385 files scanned, 0 violations.
- [x] Polyglot smoke (Python + Deno): `polyglot-dma-buf-consumer-scenario` ran end-to-end with vivid `/dev/video2` for 8 s in both runtimes; clean shutdown, no `process() failed`, no deadlock on the new wait.

## Follow-ups

- **`max_notifiers=16` is a hardcoded cap, not graph-validated.** A destination with >16 upstream sources will fail at notifier-creation time with an iceoryx2 service-open error rather than at graph-compile time. Worth either lifting to a workspace const + a graph-time check that rejects over-cap fan-in, or just bumping the cap to something like 64. Calling out as a separate concern; not blocking this PR.
- **eventfd for shutdown.** This PR's reactive runner uses a 100 ms `epoll_wait` timeout to remain shutdown-responsive (~10 wake/s/processor at idle). Wiring `eventfd` so `epoll_wait` blocks indefinitely until either a notify or a shutdown signal arrives would get truly-zero idle CPU. Worth doing if/when the 10 wake/s/processor floor shows up in profiling.
- **macOS `kqueue` for `ListenerFdWaiter`.** Currently Linux-only via `cfg(target_os = "linux")`; non-Linux falls back to a sleep loop. Reactive processors on macOS are host-callback-driven today, so no immediate consumer — but if reactive ever lands on macOS, this is the place to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)