### PR TITLE
perf(thread-runner): eventfd shutdown for truly-zero idle CPU

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler.rs
+++ b/libs/streamlib/src/core/compiler/compiler.rs
@@ -264,9 +264,10 @@ impl Compiler {
                         if let Some(state) = node.get::<StateComponent>() {
                             *state.0.lock() = ProcessorState::Stopping;
                         }
-                        // Send shutdown signal
+                        // Send shutdown signal — eventfd wakes reactive
+                        // mode's epoll, channel send wakes continuous/manual.
                         if let Some(channel) = node.get::<ShutdownChannelComponent>() {
-                            let _ = channel.sender.send(());
+                            channel.signal_shutdown();
                         }
                         // Extract thread and subprocess handles
                         let th = node.remove::<ThreadHandleComponent>();

--- a/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -3,6 +3,9 @@
 
 use std::sync::Arc;
 
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
+
 use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{scheduling_strategy_for_processor, SchedulingStrategy};
@@ -325,7 +328,7 @@ fn spawn_dedicated_thread(
             );
 
             // === PHASE 3: Extract components for setup and loop ===
-            let (state_arc, shutdown_rx, pause_gate_inner, exec_config) = {
+            let (state_arc, shutdown_rx, shutdown_eventfd, pause_gate_inner, exec_config) = {
                 let mut graph = graph_arc_clone.write();
                 let node = match graph.traversal_mut().v(&proc_id_clone).first_mut() {
                     Some(n) => n,
@@ -343,14 +346,23 @@ fn spawn_dedicated_thread(
                     }
                 };
 
-                let shutdown_rx = match node.get_mut::<ShutdownChannelComponent>() {
-                    Some(channel) => match channel.take_receiver() {
-                        Some(rx) => rx,
-                        None => {
-                            tracing::error!("[{}] Shutdown receiver already taken", proc_id_clone);
-                            return;
-                        }
-                    },
+                let (shutdown_rx, shutdown_eventfd) = match node
+                    .get_mut::<ShutdownChannelComponent>()
+                {
+                    Some(channel) => {
+                        let rx = match channel.take_receiver() {
+                            Some(rx) => rx,
+                            None => {
+                                tracing::error!(
+                                    "[{}] Shutdown receiver already taken",
+                                    proc_id_clone
+                                );
+                                return;
+                            }
+                        };
+                        let eventfd = clone_shutdown_eventfd(channel, &proc_id_clone);
+                        (rx, eventfd)
+                    }
                     None => {
                         tracing::error!("[{}] No ShutdownChannelComponent", proc_id_clone);
                         return;
@@ -367,7 +379,13 @@ fn spawn_dedicated_thread(
 
                 let exec_config = processor_arc_clone.lock().execution_config();
 
-                (state, shutdown_rx, pause_gate_inner, exec_config)
+                (
+                    state,
+                    shutdown_rx,
+                    shutdown_eventfd,
+                    pause_gate_inner,
+                    exec_config,
+                )
             }; // Lock released here
 
             // === PHASE 4: Setup (serialized across processors) ===
@@ -422,6 +440,7 @@ fn spawn_dedicated_thread(
                 proc_id_clone,
                 processor_arc_clone,
                 shutdown_rx,
+                shutdown_eventfd,
                 state_arc,
                 pause_gate_inner,
                 exec_config,
@@ -444,4 +463,31 @@ fn spawn_dedicated_thread(
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn clone_shutdown_eventfd(
+    channel: &ShutdownChannelComponent,
+    proc_id: &ProcessorUniqueId,
+) -> Option<OwnedFd> {
+    match channel.try_clone_shutdown_eventfd() {
+        Ok(fd) => Some(fd),
+        Err(e) => {
+            tracing::warn!(
+                "[{}] Failed to clone shutdown eventfd, reactive runner will fall back \
+                 to channel-only shutdown: {}",
+                proc_id,
+                e
+            );
+            None
+        }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn clone_shutdown_eventfd(
+    _channel: &ShutdownChannelComponent,
+    _proc_id: &ProcessorUniqueId,
+) -> Option<OwnedFd> {
+    None
 }

--- a/libs/streamlib/src/core/execution/thread_runner.rs
+++ b/libs/streamlib/src/core/execution/thread_runner.rs
@@ -150,6 +150,10 @@ fn run_reactive_mode(
     // Listener fd (any upstream Notifier::notify() wakes the loop) and the
     // shutdown eventfd (compiler signals teardown). epoll_wait blocks
     // indefinitely — idle CPU is truly zero until one of those fds fires.
+    //
+    // Processors with no Rust-side listener fd (subprocess host, audio-only,
+    // etc.) fall through to the channel-poll sleep loop so process() still
+    // ticks at NO_WAITER_FALLBACK_SLEEP cadence — same shape they had before.
     let listener_fd = {
         let mut guard = processor.lock();
         guard
@@ -158,20 +162,20 @@ fn run_reactive_mode(
     };
 
     #[cfg(target_os = "linux")]
-    let waiter = match ReactiveLoopFdWaiter::new(listener_fd, shutdown_eventfd) {
-        Ok(w) => Some(w),
-        Err(e) => {
-            tracing::warn!(
-                "[{}] Reactive epoll setup failed, falling back to channel-poll loop: {}",
-                id,
-                e
-            );
-            None
-        }
+    let waiter = match listener_fd {
+        Some(fd) => match ReactiveLoopFdWaiter::new(fd, shutdown_eventfd) {
+            Ok(w) => Some(w),
+            Err(e) => {
+                tracing::warn!(
+                    "[{}] Reactive epoll setup failed, falling back to channel-poll loop: {}",
+                    id,
+                    e
+                );
+                None
+            }
+        },
+        None => None,
     };
-
-    #[cfg(not(target_os = "linux"))]
-    let waiter: Option<ReactiveLoopFdWaiter> = None;
 
     let mut was_paused = false;
 
@@ -205,6 +209,7 @@ fn run_reactive_mode(
 
         // Block until an upstream notify, a shutdown signal, or (only in
         // the no-waiter fallback) the next channel-poll tick.
+        #[cfg(target_os = "linux")]
         match waiter.as_ref() {
             Some(w) => match w.wait() {
                 ReactiveLoopWakeOutcome::Notified => {
@@ -224,6 +229,8 @@ fn run_reactive_mode(
             },
             None => std::thread::sleep(NO_WAITER_FALLBACK_SLEEP),
         }
+        #[cfg(not(target_os = "linux"))]
+        std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
 
         {
             let limited_ctx = RuntimeContextLimitedAccess::new(runtime_ctx);
@@ -253,9 +260,8 @@ enum ReactiveLoopWakeOutcome {
 #[cfg(target_os = "linux")]
 const SHUTDOWN_EVENTFD_TAG: u64 = u64::MAX;
 
-/// Linux-only: epoll fd watching the iceoryx2 listener fd plus the shutdown
-/// eventfd, used by the reactive runner. Non-Linux constructor returns
-/// `Unsupported` so the runner falls back to channel-poll sleep.
+/// Linux-only: epoll fd watching the iceoryx2 listener fd plus an optional
+/// shutdown eventfd, used by the reactive runner.
 #[cfg(target_os = "linux")]
 struct ReactiveLoopFdWaiter {
     epoll_fd: i32,
@@ -267,10 +273,7 @@ struct ReactiveLoopFdWaiter {
 
 #[cfg(target_os = "linux")]
 impl ReactiveLoopFdWaiter {
-    fn new(
-        listener_fd: Option<i32>,
-        shutdown_eventfd: Option<OwnedFd>,
-    ) -> std::io::Result<Self> {
+    fn new(listener_fd: i32, shutdown_eventfd: Option<OwnedFd>) -> std::io::Result<Self> {
         use std::os::fd::AsRawFd;
 
         // SAFETY: epoll_create1 returns -1 on failure; checked below.
@@ -295,12 +298,10 @@ impl ReactiveLoopFdWaiter {
             }
         };
 
-        if let Some(fd) = listener_fd {
-            if let Err(e) = register(fd, 0) {
-                // SAFETY: epoll_fd is owned and unused after this point.
-                unsafe { libc::close(epoll_fd) };
-                return Err(e);
-            }
+        if let Err(e) = register(listener_fd, 0) {
+            // SAFETY: epoll_fd is owned and unused after this point.
+            unsafe { libc::close(epoll_fd) };
+            return Err(e);
         }
         if let Some(ref efd) = shutdown_eventfd {
             if let Err(e) = register(efd.as_raw_fd(), SHUTDOWN_EVENTFD_TAG) {
@@ -355,16 +356,6 @@ impl Drop for ReactiveLoopFdWaiter {
         // OwnedFd field drops after this; epoll_ctl(EPOLL_CTL_DEL) isn't
         // required because closing the epoll fd releases its registrations.
         unsafe { libc::close(self.epoll_fd) };
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-struct ReactiveLoopFdWaiter;
-
-#[cfg(not(target_os = "linux"))]
-impl ReactiveLoopFdWaiter {
-    fn wait(&self) -> ReactiveLoopWakeOutcome {
-        ReactiveLoopWakeOutcome::Error
     }
 }
 
@@ -528,8 +519,8 @@ mod tests {
         // only while listener stays alive (listener outlives the waiter
         // thread because we join it before this function returns).
         let listener_fd = unsafe { listener.file_descriptor().native_handle() };
-        let waiter =
-            ReactiveLoopFdWaiter::new(Some(listener_fd), Some(make_eventfd())).expect("epoll setup");
+        let waiter = ReactiveLoopFdWaiter::new(listener_fd, Some(make_eventfd()))
+            .expect("epoll setup");
 
         // Move the waiter to a worker thread, then fire notify() from this
         // thread. The worker reports the outcome and elapsed time back via
@@ -593,7 +584,7 @@ mod tests {
         let shutdown_eventfd = make_eventfd();
         let shutdown_raw = shutdown_eventfd.as_raw_fd();
 
-        let waiter = ReactiveLoopFdWaiter::new(Some(listener_fd), Some(shutdown_eventfd))
+        let waiter = ReactiveLoopFdWaiter::new(listener_fd, Some(shutdown_eventfd))
             .expect("epoll setup");
 
         let (tx, rx) = std::sync::mpsc::channel();

--- a/libs/streamlib/src/core/execution/thread_runner.rs
+++ b/libs/streamlib/src/core/execution/thread_runner.rs
@@ -8,6 +8,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
+
 use parking_lot::Mutex;
 
 use crate::core::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -18,12 +21,18 @@ use crate::core::RuntimeContext;
 /// Duration to sleep when paused (avoids busy-waiting).
 const PAUSE_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
+/// Sleep cadence for the no-fd-waiter fallback paths (non-Linux, or the
+/// rare case where epoll setup fails on Linux). Reactive mode on Linux
+/// with a working waiter uses `epoll_wait(-1)` and never sleeps.
+const NO_WAITER_FALLBACK_SLEEP: std::time::Duration = std::time::Duration::from_millis(100);
+
 /// Run the processor thread main loop based on execution mode.
-#[tracing::instrument(name = "processor.lifecycle", skip(processor, shutdown_rx, state, pause_gate, exec_config, runtime_ctx), fields(processor_id = %id))]
+#[tracing::instrument(name = "processor.lifecycle", skip(processor, shutdown_rx, shutdown_eventfd, state, pause_gate, exec_config, runtime_ctx), fields(processor_id = %id))]
 pub fn run_processor_loop(
     id: ProcessorUniqueId,
     processor: Arc<Mutex<ProcessorInstance>>,
     shutdown_rx: crossbeam_channel::Receiver<()>,
+    #[cfg(unix)] shutdown_eventfd: Option<OwnedFd>,
     state: Arc<Mutex<ProcessorState>>,
     pause_gate: Arc<AtomicBool>,
     exec_config: ExecutionConfig,
@@ -47,8 +56,15 @@ pub fn run_processor_loop(
             );
         }
         ProcessExecution::Reactive => {
-            // With iceoryx2, reactive mode polls mailboxes at a fixed interval
-            run_reactive_mode(&id, &processor, &shutdown_rx, &pause_gate, &runtime_ctx);
+            run_reactive_mode(
+                &id,
+                &processor,
+                &shutdown_rx,
+                #[cfg(unix)]
+                shutdown_eventfd,
+                &pause_gate,
+                &runtime_ctx,
+            );
         }
         ProcessExecution::Manual => {
             run_manual_mode(&id, &processor, &shutdown_rx, &pause_gate, &runtime_ctx);
@@ -126,19 +142,14 @@ fn run_reactive_mode(
     id: &ProcessorUniqueId,
     processor: &Arc<Mutex<ProcessorInstance>>,
     shutdown_rx: &crossbeam_channel::Receiver<()>,
+    #[cfg(unix)] shutdown_eventfd: Option<OwnedFd>,
     pause_gate: &Arc<AtomicBool>,
     runtime_ctx: &RuntimeContext,
 ) {
-    // Reactive mode waits on the destination's iceoryx2 Listener fd via epoll —
-    // any upstream Notifier::notify() (paired 1:1 with publisher.send() in
-    // OutputWriter) wakes the loop. The 100 ms timeout caps shutdown-signal
-    // latency without burning idle CPU; the previous 100 µs poll interval ran
-    // ~10 000 wakeups/sec/processor regardless of pipeline activity.
-    const SHUTDOWN_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
-
-    // Pull the listener fd up-front. None means the processor has no Rust-side
-    // inputs wired (subprocess host, audio-only, etc.) — fall back to a coarse
-    // sleep so shutdown still responds.
+    // Reactive mode waits on two fds via epoll: the destination's iceoryx2
+    // Listener fd (any upstream Notifier::notify() wakes the loop) and the
+    // shutdown eventfd (compiler signals teardown). epoll_wait blocks
+    // indefinitely — idle CPU is truly zero until one of those fds fires.
     let listener_fd = {
         let mut guard = processor.lock();
         guard
@@ -146,21 +157,30 @@ fn run_reactive_mode(
             .and_then(|m| m.listener_fd())
     };
 
-    let waiter = listener_fd.and_then(|fd| match ListenerFdWaiter::new(fd) {
+    #[cfg(target_os = "linux")]
+    let waiter = match ReactiveLoopFdWaiter::new(listener_fd, shutdown_eventfd) {
         Ok(w) => Some(w),
         Err(e) => {
             tracing::warn!(
-                "[{}] Failed to set up listener-fd waiter, falling back to sleep: {}",
+                "[{}] Reactive epoll setup failed, falling back to channel-poll loop: {}",
                 id,
                 e
             );
             None
         }
-    });
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let waiter: Option<ReactiveLoopFdWaiter> = None;
 
     let mut was_paused = false;
 
     loop {
+        // Channel-side shutdown check covers two paths:
+        //   1. The fallback sleep loop (no waiter — non-Linux or epoll setup
+        //      failure), which has no way to wake on shutdown otherwise.
+        //   2. A race where signal_shutdown() landed between the previous
+        //      epoll_wait return and reading the eventfd-side outcome.
         if shutdown_rx.try_recv().is_ok() {
             tracing::info!("[{}] Received shutdown signal", id);
             break;
@@ -177,25 +197,32 @@ fn run_reactive_mode(
         }
 
         if is_paused {
+            // While paused we deliberately poll: the pause_gate is an
+            // AtomicBool with no fd, so on_resume can't fire from epoll.
             std::thread::sleep(PAUSE_CHECK_INTERVAL);
             continue;
         }
 
-        // Wait for an upstream notify or the shutdown-check timeout. Always
-        // call process() afterward — it drains any available frames itself
-        // (receive_pending is cheap when nothing arrived).
+        // Block until an upstream notify, a shutdown signal, or (only in
+        // the no-waiter fallback) the next channel-poll tick.
         match waiter.as_ref() {
-            Some(w) => match w.wait(SHUTDOWN_CHECK_TIMEOUT) {
-                ListenerWaitOutcome::Notified => {
+            Some(w) => match w.wait() {
+                ReactiveLoopWakeOutcome::Notified => {
                     let mut guard = processor.lock();
                     if let Some(mailboxes) = guard.get_iceoryx2_input_mailboxes() {
                         mailboxes.drain_listener();
                     }
                 }
-                ListenerWaitOutcome::Timeout => {}
-                ListenerWaitOutcome::Error => std::thread::sleep(SHUTDOWN_CHECK_TIMEOUT),
+                ReactiveLoopWakeOutcome::Shutdown => {
+                    tracing::info!("[{}] Received shutdown via eventfd", id);
+                    break;
+                }
+                ReactiveLoopWakeOutcome::Interrupted => continue,
+                ReactiveLoopWakeOutcome::Error => {
+                    std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
+                }
             },
-            None => std::thread::sleep(SHUTDOWN_CHECK_TIMEOUT),
+            None => std::thread::sleep(NO_WAITER_FALLBACK_SLEEP),
         }
 
         {
@@ -208,94 +235,136 @@ fn run_reactive_mode(
     }
 }
 
-/// Outcome of one [`ListenerFdWaiter::wait`] call.
+/// Outcome of one [`ReactiveLoopFdWaiter::wait`] call.
 #[derive(Debug, Clone, Copy)]
-enum ListenerWaitOutcome {
+enum ReactiveLoopWakeOutcome {
     /// Listener fd became readable — at least one upstream notify arrived.
     Notified,
-    /// Wait timed out — no notify in this window.
-    Timeout,
-    /// epoll_wait returned an unrecoverable error.
+    /// Shutdown eventfd became readable — runner should exit.
+    Shutdown,
+    /// `epoll_wait` was interrupted by a signal (`EINTR`); caller should retry.
+    Interrupted,
+    /// `epoll_wait` returned an unrecoverable error.
     Error,
 }
 
-/// Owned epoll fd registered with a single listener fd. Linux-only; the
-/// non-Linux constructor returns an error so the runner falls back to sleep
-/// (kqueue/macOS support can be added when streamlib runs reactive
-/// processors on macOS — currently they're host-callback driven).
+/// Tag stored in `epoll_event.u64` for the shutdown eventfd; chosen so it
+/// can never collide with a listener-fd tag (which we set to 0).
 #[cfg(target_os = "linux")]
-struct ListenerFdWaiter {
+const SHUTDOWN_EVENTFD_TAG: u64 = u64::MAX;
+
+/// Linux-only: epoll fd watching the iceoryx2 listener fd plus the shutdown
+/// eventfd, used by the reactive runner. Non-Linux constructor returns
+/// `Unsupported` so the runner falls back to channel-poll sleep.
+#[cfg(target_os = "linux")]
+struct ReactiveLoopFdWaiter {
     epoll_fd: i32,
+    /// Stored to keep the kernel-side eventfd alive for the lifetime of the
+    /// epoll registration. Closing the fd before the epoll fd would leave a
+    /// dangling registration that never fires.
+    _shutdown_eventfd: Option<OwnedFd>,
 }
 
 #[cfg(target_os = "linux")]
-impl ListenerFdWaiter {
-    fn new(listener_fd: i32) -> std::io::Result<Self> {
+impl ReactiveLoopFdWaiter {
+    fn new(
+        listener_fd: Option<i32>,
+        shutdown_eventfd: Option<OwnedFd>,
+    ) -> std::io::Result<Self> {
+        use std::os::fd::AsRawFd;
+
         // SAFETY: epoll_create1 returns -1 on failure; checked below.
         let epoll_fd = unsafe { libc::epoll_create1(libc::EPOLL_CLOEXEC) };
         if epoll_fd < 0 {
             return Err(std::io::Error::last_os_error());
         }
-        let mut event = libc::epoll_event {
-            events: libc::EPOLLIN as u32,
-            u64: 0,
+
+        let register = |fd: i32, tag: u64| -> std::io::Result<()> {
+            let mut event = libc::epoll_event {
+                events: libc::EPOLLIN as u32,
+                u64: tag,
+            };
+            // SAFETY: epoll_ctl with EPOLL_CTL_ADD takes a pointer to a
+            // valid epoll_event for the duration of the call.
+            let r =
+                unsafe { libc::epoll_ctl(epoll_fd, libc::EPOLL_CTL_ADD, fd, &mut event) };
+            if r < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
         };
-        // SAFETY: epoll_ctl with EPOLL_CTL_ADD takes a pointer to a valid
-        // epoll_event for the duration of the call.
-        let ctl =
-            unsafe { libc::epoll_ctl(epoll_fd, libc::EPOLL_CTL_ADD, listener_fd, &mut event) };
-        if ctl < 0 {
-            let err = std::io::Error::last_os_error();
-            // SAFETY: epoll_fd is owned and unused after this point.
-            unsafe { libc::close(epoll_fd) };
-            return Err(err);
+
+        if let Some(fd) = listener_fd {
+            if let Err(e) = register(fd, 0) {
+                // SAFETY: epoll_fd is owned and unused after this point.
+                unsafe { libc::close(epoll_fd) };
+                return Err(e);
+            }
         }
-        Ok(Self { epoll_fd })
+        if let Some(ref efd) = shutdown_eventfd {
+            if let Err(e) = register(efd.as_raw_fd(), SHUTDOWN_EVENTFD_TAG) {
+                unsafe { libc::close(epoll_fd) };
+                return Err(e);
+            }
+        }
+
+        Ok(Self {
+            epoll_fd,
+            _shutdown_eventfd: shutdown_eventfd,
+        })
     }
 
-    fn wait(&self, timeout: std::time::Duration) -> ListenerWaitOutcome {
-        let mut events = [libc::epoll_event { events: 0, u64: 0 }; 1];
-        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+    fn wait(&self) -> ReactiveLoopWakeOutcome {
+        let mut events = [libc::epoll_event { events: 0, u64: 0 }; 2];
+        // -1 = block forever. Wakes only when one of the registered fds is
+        // actually readable, or a signal interrupts the call.
         // SAFETY: epoll_wait writes up to events.len() events into the buffer.
-        let n = unsafe { libc::epoll_wait(self.epoll_fd, events.as_mut_ptr(), 1, timeout_ms) };
-        if n > 0 {
-            ListenerWaitOutcome::Notified
-        } else if n == 0 {
-            ListenerWaitOutcome::Timeout
-        } else {
+        let n = unsafe { libc::epoll_wait(self.epoll_fd, events.as_mut_ptr(), 2, -1) };
+        if n < 0 {
             let err = std::io::Error::last_os_error();
             if err.kind() == std::io::ErrorKind::Interrupted {
-                ListenerWaitOutcome::Timeout
-            } else {
-                tracing::warn!("epoll_wait failed on listener fd: {}", err);
-                ListenerWaitOutcome::Error
+                return ReactiveLoopWakeOutcome::Interrupted;
             }
+            tracing::warn!("epoll_wait failed in reactive runner: {}", err);
+            return ReactiveLoopWakeOutcome::Error;
+        }
+
+        // Shutdown takes priority over notify when both fired in the same
+        // wait — let the runner exit instead of draining one more frame.
+        let mut notified = false;
+        for ev in &events[..n as usize] {
+            if ev.u64 == SHUTDOWN_EVENTFD_TAG {
+                return ReactiveLoopWakeOutcome::Shutdown;
+            }
+            notified = true;
+        }
+        if notified {
+            ReactiveLoopWakeOutcome::Notified
+        } else {
+            // n > 0 but no events matched — shouldn't happen.
+            ReactiveLoopWakeOutcome::Error
         }
     }
 }
 
 #[cfg(target_os = "linux")]
-impl Drop for ListenerFdWaiter {
+impl Drop for ReactiveLoopFdWaiter {
     fn drop(&mut self) {
-        // SAFETY: epoll_fd is owned by Self and closed at most once.
+        // SAFETY: epoll_fd is owned by Self and closed at most once. The
+        // OwnedFd field drops after this; epoll_ctl(EPOLL_CTL_DEL) isn't
+        // required because closing the epoll fd releases its registrations.
         unsafe { libc::close(self.epoll_fd) };
     }
 }
 
 #[cfg(not(target_os = "linux"))]
-struct ListenerFdWaiter;
+struct ReactiveLoopFdWaiter;
 
 #[cfg(not(target_os = "linux"))]
-impl ListenerFdWaiter {
-    fn new(_listener_fd: i32) -> std::io::Result<Self> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "ListenerFdWaiter not implemented for this platform",
-        ))
-    }
-
-    fn wait(&self, _timeout: std::time::Duration) -> ListenerWaitOutcome {
-        ListenerWaitOutcome::Timeout
+impl ReactiveLoopFdWaiter {
+    fn wait(&self) -> ReactiveLoopWakeOutcome {
+        ReactiveLoopWakeOutcome::Error
     }
 }
 
@@ -401,6 +470,7 @@ fn dispatch_on_resume(
 mod tests {
     use super::*;
     use iceoryx2::prelude::*;
+    use std::os::fd::{AsRawFd, FromRawFd};
 
     fn unique_suffix(tag: &str) -> String {
         format!(
@@ -414,13 +484,32 @@ mod tests {
         )
     }
 
+    fn make_eventfd() -> OwnedFd {
+        // SAFETY: eventfd returns -1 on failure; checked below. Initial
+        // counter is 0; EFD_CLOEXEC matches production.
+        let raw = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC) };
+        assert!(raw >= 0, "eventfd failed: {}", std::io::Error::last_os_error());
+        // SAFETY: raw is a fresh, owned fd from a successful eventfd() call.
+        unsafe { OwnedFd::from_raw_fd(raw) }
+    }
+
+    fn write_eventfd(fd: i32) {
+        let buf = 1u64.to_ne_bytes();
+        // SAFETY: fd is a valid eventfd; eventfd accepts 8-byte writes.
+        let n = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
+        assert!(
+            n == buf.len() as isize,
+            "eventfd write failed: n={n}, err={}",
+            std::io::Error::last_os_error()
+        );
+    }
+
     /// The reactive runner's wake primitive: a notify() from another thread
-    /// must transition `ListenerFdWaiter::wait` from Timeout to Notified
-    /// well within the issue's "process() called within 1 ms" exit-criterion
-    /// budget. iceoryx2's `ipc::Service` Notifier is `!Send` (Rc-backed
-    /// SingleThreaded threadsafety policy), so the test keeps notifier on
-    /// the main thread and ships the `ListenerFdWaiter` (which is just an
-    /// `i32` + Drop) to the waiter thread.
+    /// must transition `ReactiveLoopFdWaiter::wait` to Notified well within
+    /// the runner's wake-latency budget. iceoryx2's `ipc::Service` Notifier
+    /// is `!Send` (Rc-backed SingleThreaded threadsafety policy), so the
+    /// test keeps notifier on the main thread and ships the waiter to the
+    /// waiter thread.
     #[test]
     fn reactive_loop_wakes_on_notify() {
         let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
@@ -438,17 +527,9 @@ mod tests {
         // SAFETY: same lifetime contract as production code — fd is used
         // only while listener stays alive (listener outlives the waiter
         // thread because we join it before this function returns).
-        let fd = unsafe { listener.file_descriptor().native_handle() };
-        let waiter = ListenerFdWaiter::new(fd).expect("epoll setup");
-
-        // Pre-flight: with no notify pending, wait hits the timeout.
-        assert!(
-            matches!(
-                waiter.wait(std::time::Duration::from_millis(20)),
-                ListenerWaitOutcome::Timeout
-            ),
-            "expected Timeout before notify"
-        );
+        let listener_fd = unsafe { listener.file_descriptor().native_handle() };
+        let waiter =
+            ReactiveLoopFdWaiter::new(Some(listener_fd), Some(make_eventfd())).expect("epoll setup");
 
         // Move the waiter to a worker thread, then fire notify() from this
         // thread. The worker reports the outcome and elapsed time back via
@@ -456,7 +537,7 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         let worker = std::thread::spawn(move || {
             let started = std::time::Instant::now();
-            let outcome = waiter.wait(std::time::Duration::from_millis(500));
+            let outcome = waiter.wait();
             tx.send((outcome, started.elapsed())).unwrap();
             waiter
         });
@@ -467,10 +548,10 @@ mod tests {
         let (outcome, elapsed) = rx
             .recv_timeout(std::time::Duration::from_millis(800))
             .expect("worker did not respond — wait did not wake");
-        let waiter = worker.join().expect("worker panicked");
+        let _waiter = worker.join().expect("worker panicked");
 
         assert!(
-            matches!(outcome, ListenerWaitOutcome::Notified),
+            matches!(outcome, ReactiveLoopWakeOutcome::Notified),
             "expected Notified, got {:?}",
             outcome
         );
@@ -480,14 +561,67 @@ mod tests {
             elapsed
         );
 
-        // Drain so the next wait blocks again.
+        // Drain so the next wait would block again — done implicitly by
+        // dropping references; not asserted because there's no second wait
+        // here (a second wait without re-notify would block until shutdown).
         listener.try_wait_all(|_| {}).unwrap();
+    }
+
+    /// Writing to the shutdown eventfd must transition `wait` to Shutdown
+    /// within milliseconds, even when no listener-fd activity occurs. This
+    /// is the runner's exit primitive — the runner breaks its loop the
+    /// moment `wait` returns Shutdown, so wake latency here is exit latency.
+    #[test]
+    fn reactive_loop_exits_on_shutdown_signal() {
+        // Build a real iceoryx2 listener fd so the waiter exercises the
+        // production two-fd shape (listener + shutdown eventfd). The
+        // listener never sees a notify in this test — only the shutdown
+        // eventfd should fire.
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let name = unique_suffix("shutdown");
+        let svc = node
+            .service_builder(&ServiceName::new(&name).unwrap())
+            .event()
+            .max_notifiers(1)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+        let listener = svc.listener_builder().create().unwrap();
+        // SAFETY: listener outlives the worker thread (joined below).
+        let listener_fd = unsafe { listener.file_descriptor().native_handle() };
+
+        let shutdown_eventfd = make_eventfd();
+        let shutdown_raw = shutdown_eventfd.as_raw_fd();
+
+        let waiter = ReactiveLoopFdWaiter::new(Some(listener_fd), Some(shutdown_eventfd))
+            .expect("epoll setup");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let outcome = waiter.wait();
+            tx.send((outcome, started.elapsed())).unwrap();
+            waiter
+        });
+
+        // Give the worker a moment to enter epoll_wait, then fire shutdown.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        write_eventfd(shutdown_raw);
+
+        let (outcome, elapsed) = rx
+            .recv_timeout(std::time::Duration::from_millis(800))
+            .expect("worker did not respond — shutdown did not wake the waiter");
+        let _waiter = worker.join().expect("worker panicked");
+
         assert!(
-            matches!(
-                waiter.wait(std::time::Duration::from_millis(20)),
-                ListenerWaitOutcome::Timeout
-            ),
-            "expected Timeout after drain"
+            matches!(outcome, ReactiveLoopWakeOutcome::Shutdown),
+            "expected Shutdown, got {:?}",
+            outcome
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(50),
+            "shutdown wake latency too high: {:?} (eventfd write scheduled 5 ms in)",
+            elapsed
         );
     }
 }

--- a/libs/streamlib/src/core/graph/components/shutdown_channel_component.rs
+++ b/libs/streamlib/src/core/graph/components/shutdown_channel_component.rs
@@ -4,21 +4,31 @@
 use crossbeam_channel::{Receiver, Sender};
 use serde_json::Value as JsonValue;
 
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, OwnedFd};
+
 use super::JsonSerializableComponent;
 
 /// Channel to signal processor shutdown.
 pub struct ShutdownChannelComponent {
     pub sender: Sender<()>,
     pub receiver: Option<Receiver<()>>,
+    /// Linux-only: eventfd that mirrors the shutdown signal. The reactive
+    /// thread runner registers this fd in its epoll set so it can wake on
+    /// shutdown without polling. Continuous and manual modes still use the
+    /// crossbeam channel via [`Self::sender`] / [`Self::receiver`].
+    #[cfg(target_os = "linux")]
+    shutdown_eventfd: OwnedFd,
 }
 
 impl ShutdownChannelComponent {
-    /// Create a new shutdown channel.
     pub fn new() -> Self {
         let (sender, receiver) = crossbeam_channel::bounded(1);
         Self {
             sender,
             receiver: Some(receiver),
+            #[cfg(target_os = "linux")]
+            shutdown_eventfd: create_shutdown_eventfd(),
         }
     }
 
@@ -26,6 +36,60 @@ impl ShutdownChannelComponent {
     pub fn take_receiver(&mut self) -> Option<Receiver<()>> {
         self.receiver.take()
     }
+
+    /// Signal shutdown to every waiting consumer: writes to the Linux
+    /// eventfd (wakes the reactive epoll-wait) and sends on the crossbeam
+    /// channel (poll-based continuous/manual modes).
+    pub fn signal_shutdown(&self) {
+        #[cfg(target_os = "linux")]
+        {
+            let buf = 1u64.to_ne_bytes();
+            // SAFETY: shutdown_eventfd is a valid eventfd owned by Self for
+            // the duration of this call. eventfd accepts an 8-byte write.
+            let n = unsafe {
+                libc::write(
+                    self.shutdown_eventfd.as_raw_fd(),
+                    buf.as_ptr().cast(),
+                    buf.len(),
+                )
+            };
+            if n < 0 {
+                tracing::warn!(
+                    "shutdown eventfd write failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+        let _ = self.sender.send(());
+    }
+
+    /// Linux-only: duplicate the shutdown eventfd for a consumer that
+    /// wants to register it in its own epoll set. Returns an [`OwnedFd`]
+    /// the caller closes when done.
+    #[cfg(target_os = "linux")]
+    pub fn try_clone_shutdown_eventfd(&self) -> std::io::Result<OwnedFd> {
+        self.shutdown_eventfd.try_clone()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn create_shutdown_eventfd() -> OwnedFd {
+    use std::os::fd::FromRawFd;
+    // SAFETY: eventfd returns -1 on failure; checked below. Initial counter
+    // is 0; EFD_CLOEXEC prevents fork-inherited duplicates from leaking
+    // into subprocesses.
+    let raw = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC) };
+    if raw < 0 {
+        // eventfd failure here is unrecoverable — the runtime can't shutdown
+        // reactive processors without it. Panicking surfaces the misconfig
+        // immediately instead of silently degrading to the old polling shape.
+        panic!(
+            "eventfd(EFD_CLOEXEC) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // SAFETY: raw is a fresh, owned fd from a successful eventfd() call.
+    unsafe { OwnedFd::from_raw_fd(raw) }
 }
 
 impl Default for ShutdownChannelComponent {


### PR DESCRIPTION
## Summary

- Wires an `eventfd(EFD_CLOEXEC)` alongside the iceoryx2 listener fd in the reactive runner's epoll set so `epoll_wait` blocks indefinitely until either an upstream `Notifier::notify()` or a shutdown signal arrives. Idle CPU on running reactive processors is now truly zero — eliminates the 100 ms / ~10 wake-per-sec floor from PR #488.
- Adds `signal_shutdown()` to `ShutdownChannelComponent` that writes to BOTH the eventfd (wakes the reactive epoll) and the crossbeam channel (continuous + manual modes still poll the channel via `try_recv`). Shutdown latency for reactive mode drops from up to 100 ms to sub-millisecond on Linux.
- Reactive processors with no Rust-side iceoryx2 input (subprocess host, audio-only) keep the prior `sleep(100 ms) + process()` cadence — they fall through to `NO_WAITER_FALLBACK_SLEEP` since there's no listener fd to register. Non-Linux paths unchanged.

## Closes

Closes #490

## Exit criteria

- [x] `eventfd(EFD_CLOEXEC)` registered alongside the listener fd in the runner's epoll set
- [x] Shutdown handler writes to the eventfd from the existing shutdown-signal site (paralleling the `crossbeam_channel` send via `signal_shutdown()`)
- [x] `run_reactive_mode` calls `epoll_wait` with `-1` (block forever) and dispatches based on which fd fired
- [x] `SHUTDOWN_CHECK_TIMEOUT` constant and the timeout-based fallback removed from the Linux code path
- [x] Non-Linux fallback (sleep loop) still works unchanged

## Test plan

- [x] `core::execution::thread_runner::tests::reactive_loop_exits_on_shutdown_signal` — new; writes to the shutdown eventfd from the main thread, asserts `wait()` returns `Shutdown` within 50 ms on a worker thread (real iceoryx2 listener registered alongside, never notified).
- [x] `core::execution::thread_runner::tests::reactive_loop_wakes_on_notify` — kept passing; uses the new two-fd `ReactiveLoopFdWaiter` API directly, asserts a `Notified` outcome with <100 ms wake latency.
- [x] `cargo check -p streamlib` — clean (only pre-existing warnings).
- [x] `cargo test -p streamlib --lib core::execution::` (2/2), `core::compiler::` (39/39), `core::graph::` (33/33).

## Pre-open review

Ran `pr-review-gate` twice. First pass returned DISCUSS on (a) the no-listener-fd Linux case becoming `epoll_wait(-1)` forever — `process()` would never tick for subprocess-host / audio-only processors — and (b) a dead non-Linux waiter stub. Both addressed in commit `f1161d1`: `ReactiveLoopFdWaiter::new` now requires `listener_fd: i32`; the Linux path falls through to `NO_WAITER_FALLBACK_SLEEP` when listener_fd is None; the non-Linux stub is gone (the wait dispatch is `cfg(target_os = "linux")`-gated). Second pass returned PASS.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)