### PR TITLE
docs: production-grade engine bias + #509 surface-adapter design plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,36 @@ Past models repeatedly created parallel abstractions without reading existing co
 
 Minor helpers within a single module, bug-fix-scoped private functions, and extensions to existing traits generally do not require this process — but still search first and default to the smallest change that works.
 
+### Production-grade by default
+
+StreamLib is an engine, not an application. The "ship the smallest thing that works, refactor when needed" defaults that suit application codebases are wrong-shaped here. Engine work biases toward production-grade by default; lighter alternatives are scope-cuts that need a reason, not the starting point.
+
+The principles:
+
+- **Core systems have many consumers.** Every adapter, platform, codec, and customer that hits a core trait will hit the same shape forever. Get it right at birth — the cost of breaking it later is multiplied across every downstream caller.
+- **Type-system enforcement beats convention.** A typestate, a marker trait, or a `!Clone` privileged type costs the same to write as a comment saying "don't" — and pushes the wrong way out of the easy path at compile time. **Make the right way easy and the wrong way hard.** "Hard" — not "impossible". Some escape hatches are legitimate (raw-handle accessors for power users, unsafe extension points for 3rd-party adapters). When you find you need an escape hatch, surface it and discuss before adding it — don't smuggle one in to make a tricky case compile.
+- **Bias toward supporting use-case classes, not single examples.** Real-time engines (Unreal, Bevy, Granite) serve classes — render targets, compute, video decode, audio, IPC. When designing or extending a core system, ask "what shape supports the *class* of use case this system is responsible for?", not "what's the smallest thing that makes the example in front of me work?".
+- **Observability is a design-time concern, not a retrofit.** `tracing::instrument` + metric hooks at trait birth is one line per method; added later it's a refactor across every implementor. Put hooks in when the trait is born.
+- **Concrete consumers are known requirements.** A future consumer is *hypothetical* only when unattested. A filed issue in the same milestone, a documented use case, an in-tree caller in a sibling file — these are *known*, and must be designed for now. The system-prompt's "don't design for hypothetical futures" rule still applies; it does *not* license under-shipping for known concrete futures.
+
+What this means concretely when designing or extending a core system (RHI, IPC, processor model, public ABI, surface adapters, escalate ops):
+
+- Comprehensive error taxonomy at trait birth — named `enum` variants with actionable context, no `()` errors, no panic-on-internal-bug.
+- `tracing` instrumentation on every public entrypoint.
+- ABI version constants on every cross-process / cross-crate / cross-language boundary.
+- Conformance / contract tests as first-class artifacts whenever a trait will have multiple implementors (in-tree or 3rd-party).
+- Layout regression tests for every `#[repr(C)]` type that crosses a language boundary, in every language that mirrors it.
+- Documentation per the autocomplete-focused doc rules below — terse, but every public type has one.
+
+What stays the same as the system-prompt defaults:
+
+- Don't fabricate consumers. "What if someone wants X" is hypothetical until X is filed, documented, or in-tree.
+- Don't add validation for impossibilities. Type-system invariants don't need runtime checks.
+- Don't keep half-finished implementations or `todo!()` in library code.
+- Don't introduce abstractions that solve no problem the engine is responsible for ("just in case") — but DO introduce abstractions that solve the *class* of problem a core system addresses, when the class is documented.
+
+When presenting design choices for engine work, recommend the production-grade option as **the right way** by default. Only present a lighter alternative when there's a specific reason to scope-cut (out-of-band time pressure, a research-gated unknown, etc.) — and call out the scope-cut explicitly so the user can confirm.
+
 ### Other Guardrails
 
 1. **No silent DRY refactors.** Duplicate code across unrelated call sites is fine. Extracting a helper is fine IF it replaces real duplication in a core system AND the extraction is mentioned in the PR. Don't refactor out of aesthetic preference alone.
@@ -60,6 +90,7 @@ Minor helpers within a single module, bug-fix-scoped private functions, and exte
    - Simple in-method fixes: allowed.
    - Rewriting a file or large section: summarize the plan first.
    - Adding new public API or changing existing signatures: get approval.
+   - **Engine-core changes** (RHI, IPC wire format, processor model, public ABI crates, escalate ops): a written plan is required, not optional. The plan covers trait shape, error taxonomy, observability hooks, polyglot mirrors, and tests, before any code lands.
 
 ### Work Tracking
 
@@ -369,6 +400,10 @@ make sense if the surrounding files were renamed or restructured.
 - @docs/learnings/nvidia-dma-buf-after-swapchain.md — `VK_ERROR_OUT_OF_DEVICE_MEMORY`
   from `vmaCreateImage`/`vkAllocateMemory` on NVIDIA Linux when a swapchain
   has been created. NOT real OOM.
+- @docs/learnings/nvidia-egl-dmabuf-render-target.md — Linear DMA-BUFs on
+  NVIDIA Linux are sampler-only (EGL `external_only=TRUE`); FBO color
+  attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`.
+  Read before importing a DMA-BUF as a GL render target.
 - @docs/learnings/vma-export-pools.md — Mixing DMA-BUF exportable and
   non-exportable VMA allocations. Read before adding/changing
   `pTypeExternalMemoryHandleTypes` or any export memory configuration.

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -47,6 +47,8 @@ Avoid the two failure modes:
 - [@docs/learnings/nvidia-dma-buf-after-swapchain.md](nvidia-dma-buf-after-swapchain.md) —
   `VK_ERROR_OUT_OF_DEVICE_MEMORY` from `vmaCreateImage`/`vkAllocateMemory`
   on NVIDIA Linux when a swapchain exists
+- [@docs/learnings/nvidia-egl-dmabuf-render-target.md](nvidia-egl-dmabuf-render-target.md) —
+  Linear DMA-BUFs on NVIDIA are EGL `external_only=TRUE` (sampler-only); FBO color attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`
 - [@docs/learnings/vma-export-pools.md](vma-export-pools.md) —
   Pattern for mixing DMA-BUF exportable and non-exportable allocations via VMA pools
 - [@docs/learnings/vulkan-frames-in-flight.md](vulkan-frames-in-flight.md) —

--- a/docs/learnings/nvidia-egl-dmabuf-render-target.md
+++ b/docs/learnings/nvidia-egl-dmabuf-render-target.md
@@ -1,0 +1,115 @@
+# NVIDIA EGL DMA-BUF render-target: linear modifier is sampler-only, tiled modifiers are render-target-capable
+
+## Symptom
+
+Importing a DMA-BUF as an EGLImage via `EGL_LINUX_DMA_BUF_EXT` and
+binding it to a `GL_TEXTURE_2D` on NVIDIA Linux:
+
+- `glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image)` returns
+  `GL_INVALID_OPERATION` (`0x0502`) via `glGetError`. The call does
+  not raise an exception in ctypes; the error is asynchronous.
+- Attaching that texture to an FBO via
+  `glFramebufferTexture2D(... GL_COLOR_ATTACHMENT0 ...)` does not
+  error, but `glCheckFramebufferStatus(GL_FRAMEBUFFER)` returns
+  `GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT` (`0x8CD6`).
+- The same texture *can* be sampled fine via a `samplerExternalOES`
+  in a fragment shader — sampling works, rendering doesn't.
+
+## Root cause
+
+NVIDIA's EGL implementation classifies DMA-BUF imports per
+*format×modifier* pair. Query
+`eglQueryDmaBufModifiersEXT(display, fourcc, …)` and you get an
+`external_only` flag for each supported modifier. On
+`570.211.01` / RTX 3090 for `DRM_FORMAT_ABGR8888` (fourcc `'AB24'`):
+
+| modifier | external_only | meaning |
+|---|---|---|
+| `0x0` (DRM_FORMAT_MOD_LINEAR) | `TRUE` | sampler-only |
+| `0x300000000606010..15` (NVIDIA tiled) | `FALSE` | full GL_TEXTURE_2D, render-target-capable |
+| `0x300000000e08010..15` (NVIDIA tiled) | `FALSE` | full GL_TEXTURE_2D, render-target-capable |
+
+`external_only=TRUE` means the imported EGLImage has
+`GL_TEXTURE_EXTERNAL_OES` semantics: it can only be bound via
+`glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, image)`, sampled
+in shaders via `samplerExternalOES`, and **cannot** be a color
+attachment. Binding it to `GL_TEXTURE_2D` triggers the
+`GL_INVALID_OPERATION` above.
+
+This is **not** a bug or a missing extension. NVIDIA does not publish
+an OS-side path that exposes a linearly-laid-out DMA-BUF as a
+render-target-capable `GL_TEXTURE_2D`. Linear DMA-BUFs are
+sampler-only on this driver family; tiled ones are full textures.
+
+Mesa drivers (Intel / AMD via `iris` / `radeonsi`) generally mark
+LINEAR `external_only=FALSE`, which is why this is invisible until
+you try the path on NVIDIA.
+
+## What this rules out
+
+- **Passing `DRM_FORMAT_MOD_LINEAR` explicitly** — same result. The
+  attribute is correctly accepted; the import succeeds; the resulting
+  texture is still external-only.
+- **Choosing a different format** (`ARGB8888`, `XRGB8888`, etc.) —
+  the `external_only` distinction tracks the modifier, not the
+  format. Linear is sampler-only across formats on NVIDIA.
+- **Adding `EGL_IMAGE_PRESERVED_KHR`** or similar attribute hints —
+  these don't change render-target capability for an external-only
+  modifier.
+
+## What works
+
+**Allocate the DMA-BUF as a tiled VkImage instead of a linear
+VkBuffer.** A `VkImage` created with `VK_IMAGE_TILING_OPTIMAL` (or,
+better, `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT` from
+`VK_EXT_image_drm_format_modifier` with one of the modifiers the
+EGL query reports as `external_only=FALSE`) and exported via
+`VkExportMemoryAllocateInfo` lands a DMA-BUF FD that EGL imports as
+a real `GL_TEXTURE_2D` — no `GL_INVALID_OPERATION`, FBO completes,
+shader can render to it.
+
+The streamlib RHI already has `VulkanTexture` (a `VkImage`) for
+render-target use; the gap is escalate-IPC plumbing for subprocess
+processors to acquire one. The host-side allocation already needs to
+happen pre-swapchain to avoid NVIDIA's per-process DMA-BUF cap (see
+`docs/learnings/nvidia-dma-buf-after-swapchain.md`) — same pattern
+the camera processor already uses for its buffer pool.
+
+`VulkanPixelBuffer` (a `VkBuffer`, linear by definition) is the
+right shape for CPU-touchable / MMAP / readback paths — but it is
+not the right shape for "GL renders into it." Treat the buffer
+vs. image distinction as a load-bearing one for cross-API
+interop, not a freely-substitutable detail.
+
+## How to detect this in the field
+
+Before assuming a DMA-BUF will work as a GL render target on Linux,
+query supported modifiers and inspect `external_only`:
+
+```c
+/* PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;
+   resolve via eglGetProcAddress("eglQueryDmaBufModifiersEXT"). */
+EGLint count = 0;
+eglQueryDmaBufModifiersEXT(display, fourcc, 0, NULL, NULL, &count);
+EGLuint64KHR mods[count];
+EGLBoolean external_only[count];
+eglQueryDmaBufModifiersEXT(display, fourcc, count, mods, external_only, &count);
+/* external_only[i] == EGL_TRUE  →  modifier mods[i] is sampler-only.
+   external_only[i] == EGL_FALSE →  modifier mods[i] is full GL_TEXTURE_2D. */
+```
+
+Pair this with `glCheckFramebufferStatus` after attaching — a
+`0x8CD6` (`GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT`) on a successfully-
+imported EGL DMA-BUF texture is the red flag for this exact
+mismatch.
+
+## Reference
+
+- NVIDIA driver: `570.211.01`, RTX 3090.
+- Probe captured during issue #481 PR review (see PR body for the
+  research run that established the `external_only` table).
+- Spec: `EGL_EXT_image_dma_buf_import_modifiers`, in particular the
+  `external_only` semantics —
+  https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
+- Spec: `GL_OES_EGL_image_external` for the texture-external
+  semantics that `external_only=TRUE` opts the import into.

--- a/docs/plans/509-surface-adapter-trait.md
+++ b/docs/plans/509-surface-adapter-trait.md
@@ -1,0 +1,302 @@
+# Plan — #509: SurfaceAdapter trait + StreamlibSurface descriptor
+
+Foundation ABI for the Surface Adapter Architecture milestone. Lands the
+trait, descriptor, scope ABI, polyglot mirrors, conformance suite, and
+docs. #510 (host VkImage pool), #511 (Vulkan adapter), #512 (OpenGL),
+#513 (Skia), #514 (CPU readback), and #515 (polyglot rewrite) build on
+top.
+
+Production-grade by default per CLAUDE.md → "Production-grade by default".
+
+## Crate placement
+
+**New crate `libs/streamlib-adapter-abi/`.** Companion to
+`streamlib-plugin-abi` — tiny, dependency-light, the contract that
+adapter authors (in-tree and 3rd-party) implement against. Existing
+`core::rhi` (compute kernels, GpuContext, RhiPixelBuffer, textures)
+stays in `libs/streamlib/src/core/rhi/` untouched.
+
+Why not `streamlib-rhi`: would collide with the existing
+`streamlib::core::rhi` runtime-internal module name. `-adapter-abi`
+mirrors the existing `-plugin-abi` pattern unambiguously.
+
+Three-crate split for surface concerns:
+
+| Crate | Role |
+|---|---|
+| `streamlib-adapter-abi` | **New** — surface adapter contract |
+| `streamlib-surface-client` | Existing — SCM_RIGHTS Linux wire helper (sits below the trait) |
+| `streamlib::core::rhi` | Existing — runtime-internal hardware abstraction |
+
+## Trait shape
+
+### 1. `StreamlibSurface` — `#[repr(C)]` descriptor
+
+```rust
+#[repr(C)]
+pub struct StreamlibSurface {
+    pub id: SurfaceId,            // u64 host-assigned
+    pub width: u32,
+    pub height: u32,
+    pub format: SurfaceFormat,    // #[repr(u32)] enum
+    pub usage: SurfaceUsage,      // #[repr(transparent)] bitflags
+    transport: SurfaceTransportHandle,  // pub(crate) — DMA-BUF fd + DRM modifier
+    sync: SurfaceSyncState,             // pub(crate) — timeline semaphore values, current layout
+}
+
+pub type SurfaceId = u64;
+
+#[repr(u32)] pub enum SurfaceFormat { Bgra8 = 0, Rgba8 = 1, Nv12 = 2, /* … */ }
+
+bitflags! {
+    #[repr(transparent)] pub struct SurfaceUsage: u32 {
+        const RENDER_TARGET = 1 << 0;
+        const SAMPLED       = 1 << 1;
+        const CPU_READBACK  = 1 << 2;
+    }
+}
+```
+
+Customer-visible fields are `pub`; transport + sync are `pub(crate)`,
+exposed only to adapter implementations through `pub(crate)` accessor
+methods.
+
+### 2. `SurfaceAdapter` — the trait (GATs, two methods)
+
+```rust
+pub trait SurfaceAdapter: Send + Sync {
+    type ReadView<'g>  where Self: 'g;
+    type WriteView<'g> where Self: 'g;
+
+    fn acquire_read<'g>(&'g self, surface: &StreamlibSurface)
+        -> Result<ReadGuard<'g, Self>, AdapterError>;
+    fn acquire_write<'g>(&'g self, surface: &StreamlibSurface)
+        -> Result<WriteGuard<'g, Self>, AdapterError>;
+
+    fn trait_version(&self) -> u32 { STREAMLIB_ADAPTER_ABI_VERSION }
+}
+
+pub const STREAMLIB_ADAPTER_ABI_VERSION: u32 = 1;
+```
+
+Two methods (`acquire_read` / `acquire_write`) — type-system enforces
+R/W asymmetry the way `RwLock::read()`/`write()` does. `AccessMode`
+enum still exists for the IPC wire format and the Python/Deno mirrors
+(typestate doesn't translate ergonomically across language boundaries).
+
+GATs — `type ReadView<'g>` — let the view borrow from the adapter for
+the guard's lifetime without heap allocation. Stable since Rust 1.65;
+workspace MSRV is far past.
+
+### 3. RAII guards
+
+```rust
+pub struct ReadGuard<'g, A: SurfaceAdapter + ?Sized> {
+    adapter: &'g A,
+    surface_id: SurfaceId,
+    view: A::ReadView<'g>,
+}
+impl<'g, A: SurfaceAdapter + ?Sized> ReadGuard<'g, A> {
+    pub fn view(&self) -> &A::ReadView<'g> { &self.view }
+}
+impl<'g, A: SurfaceAdapter + ?Sized> Drop for ReadGuard<'g, A> {
+    fn drop(&mut self) { self.adapter.end_read_access(self.surface_id); }
+}
+
+// WriteGuard mirrors ReadGuard with `view_mut()` and exclusive-access
+// enforcement inside the adapter.
+```
+
+Drop signals the release-side timeline semaphore via the adapter's
+`end_read_access` / `end_write_access` (sealed trait methods, not
+overridable). Customer never types "semaphore."
+
+### 4. Capability marker traits (composition)
+
+```rust
+pub trait VulkanWritable {
+    fn vk_image(&self) -> ash::vk::Image;
+    fn vk_image_layout(&self) -> ash::vk::ImageLayout;
+}
+pub trait GlWritable { fn gl_texture_id(&self) -> u32; }
+pub trait CpuReadable { fn read_bytes(&self) -> &[u8]; }   // forward-compat for #514
+pub trait CpuWritable { fn write_bytes(&mut self) -> &mut [u8]; }
+```
+
+The Skia adapter can constrain its inner adapter via these:
+
+```rust
+impl<Inner> SurfaceAdapter for SkiaAdapter<Inner>
+where
+    Inner: SurfaceAdapter,
+    for<'g> Inner::WriteView<'g>: VulkanWritable,
+{
+    type WriteView<'g> = SkiaWriteView<'g, Inner>;
+    /* SkiaWriteView holds the inner WriteGuard; customer sees only skia::Surface */
+}
+```
+
+Customer never sees the inner view — it lives inside the outer adapter's
+`WriteView` type, used only to construct the framework-idiomatic handle.
+
+`VulkanWritable::vk_image_layout()` is the **deliberate escape hatch**
+for the Skia adapter (Skia's `GrVkImageInfo` requires the current layout
+to build a backend context). Customers of `SurfaceAdapter` never see it;
+only adapter authors composing on Vulkan do. Per CLAUDE.md, this is the
+"escape hatch surfaced and discussed" pattern.
+
+## Observability + ABI hygiene
+
+Per CLAUDE.md "Production-grade by default":
+
+- **`tracing::instrument`** on every public method: `acquire_read`,
+  `acquire_write`, guard drops. Fields: `surface_id`, `mode`,
+  `duration_us`, `adapter_kind`.
+- **`AdapterError`** enum with named variants:
+  `WriteContended { surface_id, holder }`, `SurfaceNotFound { surface_id }`,
+  `IpcDisconnected { reason }`, `SyncTimeout { duration }`,
+  `IncompatibleAdapter { trait_version, runtime_version }`,
+  `BackingDestroyed { surface_id }`. `thiserror`-derived `Display`,
+  no `()` errors, no panic-on-internal-bug.
+- **`STREAMLIB_ADAPTER_ABI_VERSION`** u32 constant; `trait_version()`
+  default. Runtime can refuse adapters from a future major.
+- **Documented stability contract** — what's SemVer-stable, what's an
+  extension point.
+
+## Subprocess lifetime — kernel-FD watchdog (option A)
+
+- Host's `SurfaceShareState` (#420) refcounts via `checkout_count`.
+- Subprocess holds an `OwnedFd`-bound `StreamlibSurface`; `Drop` runs
+  `streamlib-surface-client::release_surface`.
+- Subprocess crash mid-write: kernel closes the FD; host's existing
+  `epoll(EPOLLHUP)` decrement triggers refcount cleanup. **#509 only
+  ships the integration test, not a re-implementation of the watchdog.**
+- Heartbeat-style watchdog (catches "alive but wedged") is a separate
+  failure class — file as research issue if production observes wedge
+  cases. Not preemptive.
+
+## Polyglot mirrors
+
+### Python — `streamlib-python/python/streamlib/surface_adapter.py`
+
+```python
+class StreamlibSurface(Protocol):
+    id: int
+    width: int
+    height: int
+    format: int
+    usage: int
+
+class _StreamlibSurfaceC(ctypes.Structure):
+    """Mirror of streamlib_adapter_abi::StreamlibSurface for ctypes drift testing."""
+    _fields_ = [
+        ("id", ctypes.c_uint64),
+        ("width", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("format", ctypes.c_uint32),
+        ("usage", ctypes.c_uint32),
+        ("transport", _SurfaceTransportHandleC),
+        ("sync", _SurfaceSyncStateC),
+    ]
+
+class SurfaceAdapter(Protocol):
+    def acquire_read(self, surface: StreamlibSurface) -> ContextManager[ReadView]: ...
+    def acquire_write(self, surface: StreamlibSurface) -> ContextManager[WriteView]: ...
+```
+
+`with adapter.acquire_write(surface) as view:` — context-manager exit
+signals release. `AccessMode` enum mirrored separately for IPC wire.
+
+Test follows `test_vulkan_context.py::test_vulkan_handles_struct_layout_matches_rust_repr_c`
+shape: size + per-field offset locked.
+
+### Deno — `streamlib-deno/types/surface_adapter.ts`
+
+```typescript
+export interface SurfaceAdapter<RView, WView> {
+  acquireRead(surface: StreamlibSurface): { view: RView; [Symbol.dispose](): void };
+  acquireWrite(surface: StreamlibSurface): { view: WView; [Symbol.dispose](): void };
+}
+```
+
+`using guard = adapter.acquireWrite(surface);` — TC39 `using` block
+runs `[Symbol.dispose]` at scope end. Layout offsets locked via
+`Deno.UnsafePointerView` reads.
+
+### Polyglot conformance
+
+`streamlib_adapter_abi::testing::run_conformance(&adapter)` in Rust;
+`streamlib.adapter_abi.testing.run_conformance(adapter)` in Python;
+Deno equivalent. Adapter authors in any language can validate against
+the same gate.
+
+## Tests
+
+1. **`tests::surface_adapter_conformance`** — generic fixture parameterized
+   over `<A: SurfaceAdapter>`. Covers acquire/release ordering,
+   double-acquire-write rejection, concurrent-read permission, scope-drop
+   sync emission. Run against `MockAdapter`.
+2. **`tests::descriptor_repr_c_layout`** — `mem::size_of::<StreamlibSurface>()`
+   + per-field `offset_of!` assertions. Twin Python and Deno tests.
+3. **`MockAdapter`** — pure-Rust, tracks acquire/release in atomics. Runs
+   the conformance suite. Reference for 3rd-party adapter authors.
+4. **`SubprocessCrashHarness`** — public test helper. Spawns a
+   Python/Deno subprocess, runs a closure, SIGKILLs at a configurable
+   point. Reused by #511–#514 for their own crash tests.
+5. **Subprocess-crash-mid-write** integration test — uses the harness +
+   the existing #420 surface-share service. Asserts host refcount drops
+   to zero within 1 s of kill, surface becomes available for new write.
+
+## Files this issue touches
+
+**New (Rust):**
+- `libs/streamlib-adapter-abi/Cargo.toml`
+- `libs/streamlib-adapter-abi/src/lib.rs`
+- `libs/streamlib-adapter-abi/src/surface.rs`
+- `libs/streamlib-adapter-abi/src/adapter.rs`
+- `libs/streamlib-adapter-abi/src/guard.rs`
+- `libs/streamlib-adapter-abi/src/error.rs`
+- `libs/streamlib-adapter-abi/src/mock.rs`
+- `libs/streamlib-adapter-abi/src/conformance.rs`
+- `libs/streamlib-adapter-abi/src/testing.rs`
+- `libs/streamlib-adapter-abi/tests/conformance_run.rs`
+- `libs/streamlib-adapter-abi/tests/repr_c_layout.rs`
+- `libs/streamlib-adapter-abi/tests/subprocess_crash.rs`
+
+**New (polyglot):**
+- `libs/streamlib-python/python/streamlib/surface_adapter.py`
+- `libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py`
+- `libs/streamlib-deno/types/surface_adapter.ts`
+- `libs/streamlib-deno/tests/surface_adapter_test.ts`
+
+**New (docs):**
+- `docs/architecture/surface-adapter.md`
+- `docs/adapter-authoring.md`
+
+**Modified:**
+- `Cargo.toml` (workspace member entry)
+- `libs/streamlib/Cargo.toml` (depend on `streamlib-adapter-abi`,
+  re-export through `core::rhi::surface`)
+
+## Out of scope
+
+- Concrete adapter implementations (#511–#514).
+- Host VkImage pool with DRM-modifier export (#510).
+- Surface-share service protocol changes (#420 already shipped; trait
+  consumes existing API).
+- macOS support (milestone description: Linux first).
+- Removing `vulkan_context.py` (#515).
+- Heartbeat watchdog (file as research issue if observed in production).
+
+## Follow-up issues to file alongside #509
+
+Both independent of #509, both `research`-labeled, target *Stability &
+Debuggability Uplift* milestone:
+
+1. **Audit `streamlib-runtime` crate** — what depends on it, can it be
+   deleted, who's the consumer? User suspects it's vestige from the
+   old CLI/broker design serving a niche web-UI use case.
+2. **Crate layout: `streamlib` umbrella + `streamlib-engine`?** —
+   research whether the bevy-style umbrella pattern applies (thin
+   `streamlib` re-exports `streamlib-engine` + subsystem crates).
+   No decision yet; research-gated.


### PR DESCRIPTION
## Summary

Pre-implementation docs for the Surface Adapter Architecture milestone. No code changes — just gets the docs straight before #509 implementation starts in a fresh session.

- **CLAUDE.md** — adds "Production-grade by default" section: the engine-not-application bias, type-system-over-convention principle ("right way easy, wrong way hard"), use-case-class framing (Unreal/Bevy/Granite), observability as design-time concern, concrete-vs-hypothetical-consumer distinction. Tightens Scope discipline to require written plans for engine-core changes.
- **docs/learnings/nvidia-egl-dmabuf-render-target.md** — commits the orphan learning doc that was sitting uncommitted in the working tree. #509's issue body links to it; was a dangling reference on main until now. Plus the matching index entry in CLAUDE.md and docs/learnings/README.md.
- **docs/plans/509-surface-adapter-trait.md** — full design plan for #509: crate placement (`streamlib-adapter-abi`, companion to `streamlib-plugin-abi`), trait shape with GATs and capability marker traits, kernel-FD watchdog (option A) with #420 integration test, polyglot mirrors with layout regression tests, production-grade additions (error taxonomy, tracing, ABI version constant, public conformance suite, `SubprocessCrashHarness`).

## Closes

(no issues — this PR is the brief for #509, doesn't close it)

## Test plan

Docs-only — no code, no tests.

- [x] CLAUDE.md renders correctly (markdown lint via render in GitHub UI)
- [x] Cross-references resolve (`@docs/learnings/nvidia-egl-dmabuf-render-target.md` link in CLAUDE.md and #509's issue body now points to a real file)
- [x] Plan doc is self-contained — a fresh session can pick it up as the brief for #509 without needing this conversation's context

## Follow-ups

- #509 implementation (next session, fresh context)
- #517 — research: audit `streamlib-runtime` crate
- #518 — research: `streamlib` umbrella vs engine split

🤖 Generated with [Claude Code](https://claude.com/claude-code)