### PR TITLE
feat(surface-share): EPOLLHUP watchdog for crashed-subprocess refcount cleanup

### DIFF
--- a/docs/architecture/surface-adapter.md
+++ b/docs/architecture/surface-adapter.md
@@ -144,12 +144,12 @@ runtime error.
 Polyglot subprocesses (Python, Deno) hold an `OwnedFd`-bound
 `StreamlibSurface`. When the subprocess exits cleanly, `Drop` runs
 the `streamlib-surface-client::release_surface` request. When the
-subprocess crashes mid-write, the kernel closes the inherited fd; the
-host's surface-share watchdog (tracked in
-[#520](https://github.com/tatolab/streamlib/issues/520)) observes
-`EPOLLHUP` on the per-subprocess Unix socket and decrements the
-backing's refcount. Until #520 lands, host-side cleanup of crashed
-subprocesses is manual.
+subprocess crashes mid-write, the kernel closes the per-subprocess
+Unix socket; the host's surface-share watchdog observes the
+disconnect (kernel-side equivalent of `EPOLLHUP`) and releases every
+surface registered under that subprocess's `runtime_id`. The
+double-release case is idempotent — a polite `release` followed by a
+crash leaves nothing for the watchdog to do.
 
 Subprocess Python/Deno code MUST NOT create its own `VkDevice` —
 dual `VkDevice` on NVIDIA Linux SIGSEGVs (see

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -161,6 +161,8 @@ serial_test = "3.2"  # Run tests sequentially to avoid global PUBSUB interferenc
 tempfile = "3.14"  # Temporary directories for config tests
 criterion = { version = "0.5", features = ["html_reports"] }  # Benches for logging hot path (#447)
 png = "0.17"  # PNG decoding for shader-output fixture comparisons
+# SubprocessCrashHarness for the EPOLLHUP watchdog integration test (#520)
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
 
 [[bench]]
 name = "logging"
@@ -171,6 +173,13 @@ name = "log_emit_1000"
 path = "tests/bin/log_emit_1000.rs"
 # Strace-backed no-syscalls test child. Built under `cargo test` via
 # the path dep; not needed for normal builds.
+
+[[bin]]
+name = "surface_share_crash_helper"
+path = "tests/bin/surface_share_crash_helper.rs"
+# Subprocess fixture for the EPOLLHUP watchdog integration test
+# (libs/streamlib/tests/surface_share_subprocess_crash.rs). Linux only.
+required-features = []
 
 # Build dependencies for protobuf compilation (surface-share service gRPC)
 [target.'cfg(target_os = "macos")'.build-dependencies]

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -162,6 +162,14 @@ pub use linux::{
     LinuxDisplayProcessor as DisplayProcessor,
 };
 
+/// Per-runtime surface-share service primitives. Exposed for adapter
+/// integration tests and 3rd-party tooling that needs to drive the
+/// service in isolation; production callers go through [`StreamRuntime`].
+#[cfg(target_os = "linux")]
+pub mod linux_surface_share {
+    pub use crate::linux::surface_share::{SurfaceShareState, UnixSocketSurfaceService};
+}
+
 // WebRTC streaming (cross-platform)
 pub use core::streaming::{WebRtcSession, WhepClient, WhepConfig, WhipClient, WhipConfig};
 

--- a/libs/streamlib/src/linux/surface_share/state.rs
+++ b/libs/streamlib/src/linux/surface_share/state.rs
@@ -133,6 +133,18 @@ impl SurfaceShareState {
     pub fn get_surfaces(&self) -> Vec<SurfaceMetadata> {
         self.inner.surfaces.read().values().cloned().collect()
     }
+
+    /// Surface ids registered by `runtime_id`. Used by the EPOLLHUP watchdog
+    /// to find what to release when a subprocess connection drops.
+    pub fn surface_ids_by_runtime(&self, runtime_id: &str) -> Vec<String> {
+        self.inner
+            .surfaces
+            .read()
+            .values()
+            .filter(|m| m.runtime_id == runtime_id)
+            .map(|m| m.surface_id.clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -181,28 +193,73 @@ mod tests {
         assert_eq!(rejected, vec![-1], "rejected fds returned to caller");
     }
 
+    /// The watchdog uses `surface_ids_by_runtime` to discover what to
+    /// release when a subprocess connection drops. The query must group by
+    /// `runtime_id` precisely — surfaces from sibling runtimes must not
+    /// appear in the result, or one crash would clean up another runtime's
+    /// state.
+    #[test]
+    fn surface_ids_by_runtime_groups_by_owner() {
+        let state = SurfaceShareState::new();
+        state
+            .register_surface(reg("a-1", "runtime-A", "pixel_buffer"))
+            .expect("a-1");
+        state
+            .register_surface(reg("a-2", "runtime-A", "pixel_buffer"))
+            .expect("a-2");
+        state
+            .register_surface(reg("b-1", "runtime-B", "pixel_buffer"))
+            .expect("b-1");
+
+        let mut for_a = state.surface_ids_by_runtime("runtime-A");
+        for_a.sort();
+        assert_eq!(for_a, vec!["a-1".to_string(), "a-2".to_string()]);
+
+        let for_b = state.surface_ids_by_runtime("runtime-B");
+        assert_eq!(for_b, vec!["b-1".to_string()]);
+
+        assert!(state.surface_ids_by_runtime("runtime-C").is_empty());
+
+        // After release, the owner's set shrinks and others are unaffected.
+        assert!(state.release_surface("a-1", "runtime-A"));
+        let mut for_a_after = state.surface_ids_by_runtime("runtime-A");
+        for_a_after.sort();
+        assert_eq!(for_a_after, vec!["a-2".to_string()]);
+        assert_eq!(
+            state.surface_ids_by_runtime("runtime-B"),
+            vec!["b-1".to_string()]
+        );
+    }
+
     /// Releasing a surface registered with multiple plane fds must close
     /// every fd — the state is the last owner of the table's fd dups and
-    /// leaking any plane would leak the whole DMA-BUF.
+    /// leaking any plane would leak the whole DMA-BUF. Verified via pipes:
+    /// register hands the write end to the table, and after release the
+    /// read end yields EOF on the next `read`. EOF is sticky and tied to
+    /// the pipe's underlying kernel object, so unlike `fcntl(F_GETFD)` on
+    /// a raw fd number, the assertion does not race against parallel
+    /// threads recycling fd-table slots.
     #[test]
     fn release_surface_closes_every_plane_fd() {
         let state = SurfaceShareState::new();
-        // Pair of real, independently-owned memfds so libc::close actually
-        // observable succeeds / fails per fd.
-        let plane_fds: Vec<RawFd> = (0..3)
-            .map(|i| {
-                let name = std::ffi::CString::new(format!("release-plane-{}", i)).unwrap();
-                let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
-                assert!(fd >= 0, "memfd {}: {}", i, std::io::Error::last_os_error());
-                fd
-            })
-            .collect();
+
+        // Three pipes; we keep the read ends, hand the write ends to the
+        // table.
+        let mut read_fds: Vec<RawFd> = Vec::with_capacity(3);
+        let mut write_fds: Vec<RawFd> = Vec::with_capacity(3);
+        for _ in 0..3 {
+            let mut fds = [0i32; 2];
+            let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+            assert_eq!(rc, 0, "pipe: {}", std::io::Error::last_os_error());
+            read_fds.push(fds[0]);
+            write_fds.push(fds[1]);
+        }
 
         state
             .register_surface(SurfaceRegistration {
                 surface_id: "multi",
                 runtime_id: "rt",
-                dma_buf_fds: plane_fds.clone(),
+                dma_buf_fds: write_fds,
                 plane_sizes: vec![8192, 2048, 2048],
                 plane_offsets: vec![0, 0, 0],
                 width: 640,
@@ -214,17 +271,20 @@ mod tests {
 
         assert!(state.release_surface("multi", "rt"));
 
-        // Each fd should be closed now. fcntl(F_GETFD) on a closed fd
-        // returns -1 with EBADF.
-        for fd in &plane_fds {
-            let ret = unsafe { libc::fcntl(*fd, libc::F_GETFD) };
+        // With the write ends closed, every read end now yields EOF (0
+        // bytes) on the next read — the kernel signals that no more data
+        // is coming and the pipe will never refill.
+        for fd in &read_fds {
+            let mut buf = [0u8; 1];
+            let n = unsafe {
+                libc::read(*fd, buf.as_mut_ptr() as *mut libc::c_void, 1)
+            };
             assert_eq!(
-                ret, -1,
-                "plane fd {} should be closed after release_surface",
+                n, 0,
+                "pipe read end {} should yield EOF after write end was closed by release_surface",
                 fd
             );
-            let errno = std::io::Error::last_os_error().raw_os_error();
-            assert_eq!(errno, Some(libc::EBADF));
+            unsafe { libc::close(*fd) };
         }
     }
 }

--- a/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
@@ -192,6 +192,19 @@ fn handle_client_connection(
         // knows whose surfaces to release on disconnect. Pure consumers
         // (check_out only) carry no runtime_id; a runtime that registers and
         // crashes is exactly the leak the watchdog cleans up.
+        //
+        // Invariant: one runtime_id per connection for the connection's
+        // lifetime. Subprocesses inherit STREAMLIB_RUNTIME_ID once at spawn
+        // and never multiplex sibling runtimes over a single socket. If
+        // that ever changes, the watchdog must move to a per-request scope
+        // (or per-surface ownership tag) — first-latched-then-frozen drops
+        // sibling runtimes' surfaces on the floor.
+        //
+        // The empty-string and `"unknown"` filter rejects the default
+        // sentinels every wire handler falls back to when no runtime_id
+        // is provided (`unwrap_or("unknown")` in `handle_register` /
+        // `handle_unregister` / `handle_check_in`). Keep these filters in
+        // sync if the handler defaults change.
         if observed_runtime_id.is_none() {
             let candidate = request
                 .get("runtime_id")

--- a/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
@@ -11,7 +11,7 @@
 //! for multi-plane DMA-BUFs (e.g. NV12 with separate Y and UV allocations).
 
 use std::io::Read;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -109,10 +109,34 @@ fn run_listener(
 
         match listener.accept() {
             Ok((stream, _addr)) => {
+                // SO_PEERCRED tells us the connecting process's pid. Connections
+                // from the host runtime's own process are diagnostic / test
+                // harnesses publishing surfaces over the wire — they intentionally
+                // disconnect after registering, and the surfaces must persist for
+                // subprocess consumers. The watchdog must skip these and only fire
+                // on out-of-process subprocess connections.
+                let is_subprocess_peer = is_out_of_process_peer(&stream);
                 let state = state.clone();
                 thread::spawn(move || {
-                    if let Err(e) = handle_client_connection(stream, state) {
+                    let mut connection_runtime_id: Option<String> = None;
+                    let conn_result = handle_client_connection(
+                        stream,
+                        state.clone(),
+                        &mut connection_runtime_id,
+                    );
+                    if let Err(e) = conn_result {
                         tracing::debug!("[Surface share] Client connection ended: {}", e);
+                    }
+                    // EPOLLHUP-equivalent watchdog: when the kernel closes the
+                    // socket (typical on subprocess SIGKILL), the per-connection
+                    // read loop above exits with `UnexpectedEof`. Release every
+                    // surface this client registered so a crashed subprocess
+                    // doesn't leak the backing. Same-process connections (host
+                    // runtime publishing to its own service) skip the watchdog
+                    // — those surfaces are intentionally long-lived.
+                    if let Some(runtime_id) = connection_runtime_id.filter(|_| is_subprocess_peer)
+                    {
+                        cleanup_runtime_surfaces(&state, &runtime_id);
                     }
                 });
             }
@@ -133,6 +157,7 @@ fn run_listener(
 fn handle_client_connection(
     mut stream: UnixStream,
     state: SurfaceShareState,
+    observed_runtime_id: &mut Option<String>,
 ) -> Result<(), std::io::Error> {
     stream.set_nonblocking(false)?;
 
@@ -162,6 +187,20 @@ fn handle_client_connection(
         })?;
 
         let op = request.get("op").and_then(|v| v.as_str()).unwrap_or("");
+
+        // Latch the first non-default runtime_id we observe so the watchdog
+        // knows whose surfaces to release on disconnect. Pure consumers
+        // (check_out only) carry no runtime_id; a runtime that registers and
+        // crashes is exactly the leak the watchdog cleans up.
+        if observed_runtime_id.is_none() {
+            let candidate = request
+                .get("runtime_id")
+                .and_then(|v| v.as_str())
+                .filter(|rid| !rid.is_empty() && *rid != "unknown");
+            if let Some(rid) = candidate {
+                *observed_runtime_id = Some(rid.to_string());
+            }
+        }
 
         let (response, reply_fds) = match op {
             "register" => handle_register(&state, &request, &received_fds),
@@ -492,6 +531,52 @@ fn handle_check_in(
     (serde_json::json!({"surface_id": surface_id}), Vec::new())
 }
 
+/// True if the peer of `stream` is a different process than the host
+/// running this service — i.e. a polyglot subprocess. Linux `SO_PEERCRED`
+/// returns the connecting process's pid; comparing against `getpid()` lets
+/// the watchdog distinguish "subprocess crashed mid-flight" from "host
+/// runtime opened a same-process diagnostic connection." On query failure
+/// we conservatively classify the peer as a subprocess so the watchdog
+/// does not silently skip a real cleanup.
+fn is_out_of_process_peer(stream: &UnixStream) -> bool {
+    let mut ucred: libc::ucred = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let ret = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut ucred as *mut libc::ucred as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if ret != 0 {
+        return true;
+    }
+    let host_pid = unsafe { libc::getpid() };
+    ucred.pid != host_pid
+}
+
+/// Release every surface registered by `runtime_id`. Called when a client
+/// connection drops (kernel-side equivalent of EPOLLHUP — typical when a
+/// polyglot subprocess SIGKILLs mid-flight). Idempotent: any surface the
+/// subprocess already released cleanly is simply absent from the table, and
+/// `release_surface` returns `false`.
+fn cleanup_runtime_surfaces(state: &SurfaceShareState, runtime_id: &str) {
+    let surface_ids = state.surface_ids_by_runtime(runtime_id);
+    if surface_ids.is_empty() {
+        return;
+    }
+    tracing::info!(
+        "[Surface share] Watchdog: releasing {} surface(s) registered by '{}' after disconnect",
+        surface_ids.len(),
+        runtime_id,
+    );
+    for surface_id in surface_ids {
+        let _ = state.release_surface(&surface_id, runtime_id);
+    }
+}
+
 unsafe impl Send for UnixSocketSurfaceService {}
 unsafe impl Sync for UnixSocketSurfaceService {}
 
@@ -710,6 +795,119 @@ mod tests {
 
         drop(stream);
         service.stop();
+    }
+
+    /// Same-process wire connections (the host runtime opening a diagnostic
+    /// connection to its own surface-share socket — used by tests like
+    /// `polyglot_linux_check_out` to publish surfaces) must NOT trigger the
+    /// watchdog. SO_PEERCRED reports the same pid, so the disconnect
+    /// classification rejects it as a subprocess and cleanup is skipped.
+    /// Wire-level coverage of the actual subprocess-crash path lives in the
+    /// `surface_share_subprocess_crash` integration test.
+    #[test]
+    fn same_process_disconnect_does_not_trigger_watchdog() {
+        let state = SurfaceShareState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+        let runtime_id = "host-publishes-then-disconnects";
+        let send_fd = make_memfd_with(b"host-published-fixture");
+        let (resp, _) = send_request_with_fds(
+            &stream,
+            &serde_json::json!({
+                "op": "check_in",
+                "runtime_id": runtime_id,
+                "width": 16,
+                "height": 16,
+                "format": "Bgra32",
+                "resource_type": "pixel_buffer",
+            }),
+            &[send_fd],
+            0,
+        )
+        .expect("check_in request");
+        unsafe { libc::close(send_fd) };
+        let surface_id = resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id")
+            .to_string();
+        assert_eq!(state.surface_ids_by_runtime(runtime_id).len(), 1);
+
+        drop(stream);
+
+        // Give the per-connection thread plenty of time to observe EOF and,
+        // if the watchdog were to misfire, run cleanup. The surface MUST
+        // survive: same-process publishers intentionally disconnect.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert_eq!(
+            state.surface_ids_by_runtime(runtime_id),
+            vec![surface_id],
+            "same-process disconnect must not release host-published surfaces",
+        );
+
+        service.stop();
+    }
+
+    /// Watchdog primitive (pure-function): given a state populated with
+    /// surfaces under multiple runtime_ids, `cleanup_runtime_surfaces`
+    /// releases only the targeted runtime's surfaces and is idempotent on
+    /// second call.
+    #[test]
+    fn cleanup_runtime_surfaces_is_scoped_and_idempotent() {
+        let state = SurfaceShareState::new();
+        // Use real memfds so release_surface's libc::close calls operate on
+        // valid fds (no fd-table corruption from -1 sentinels).
+        let mk = |label: &str| -> Vec<RawFd> {
+            let name = std::ffi::CString::new(label).unwrap();
+            let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+            assert!(fd >= 0);
+            vec![fd]
+        };
+        for (sid, rid, label) in [
+            ("victim-1", "victim-runtime", "v1"),
+            ("victim-2", "victim-runtime", "v2"),
+            ("survivor", "survivor-runtime", "s"),
+        ] {
+            state
+                .register_surface(SurfaceRegistration {
+                    surface_id: sid,
+                    runtime_id: rid,
+                    dma_buf_fds: mk(label),
+                    plane_sizes: vec![0],
+                    plane_offsets: vec![0],
+                    width: 1,
+                    height: 1,
+                    format: "Bgra32",
+                    resource_type: "pixel_buffer",
+                })
+                .expect("register");
+        }
+
+        cleanup_runtime_surfaces(&state, "victim-runtime");
+        assert!(state.surface_ids_by_runtime("victim-runtime").is_empty());
+        assert_eq!(
+            state.surface_ids_by_runtime("survivor-runtime"),
+            vec!["survivor".to_string()]
+        );
+
+        // Idempotent second call: nothing left for the victim, survivor
+        // unaffected. Nothing panics.
+        cleanup_runtime_surfaces(&state, "victim-runtime");
+        assert_eq!(
+            state.surface_ids_by_runtime("survivor-runtime"),
+            vec!["survivor".to_string()]
+        );
+
+        // Cleanup of a runtime with no registrations is a no-op.
+        cleanup_runtime_surfaces(&state, "never-registered");
+        assert_eq!(
+            state.surface_ids_by_runtime("survivor-runtime"),
+            vec!["survivor".to_string()]
+        );
     }
 
     /// The service must refuse a check_in whose fd count exceeds the plane

--- a/libs/streamlib/tests/bin/surface_share_crash_helper.rs
+++ b/libs/streamlib/tests/bin/surface_share_crash_helper.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Subprocess fixture for the surface-share EPOLLHUP watchdog integration test.
+//!
+//! Connects to the surface-share Unix socket, `check_in`s a memfd-backed
+//! surface, prints `SURFACE_ID=<uuid>` on stdout, then sleeps until SIGKILL.
+//! Communicates with the parent via stdout because tracing would route through
+//! the host's logging pathway, which the test doesn't want to interleave.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::disallowed_macros)]
+
+use std::io::Write;
+use std::os::unix::io::RawFd;
+
+use streamlib_surface_client::{connect_to_surface_share_socket, send_request_with_fds};
+
+fn make_memfd_with(contents: &[u8]) -> RawFd {
+    use std::io::{Seek, SeekFrom};
+    use std::os::unix::io::{FromRawFd, IntoRawFd};
+
+    let name = std::ffi::CString::new("streamlib-surface-share-crash-helper").unwrap();
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+    assert!(fd >= 0, "memfd_create failed: {}", std::io::Error::last_os_error());
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.write_all(contents).expect("memfd write");
+    file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+    file.into_raw_fd()
+}
+
+fn main() {
+    let socket_path = std::env::var_os("STREAMLIB_SURFACE_SOCKET")
+        .map(std::path::PathBuf::from)
+        .expect("STREAMLIB_SURFACE_SOCKET must be set");
+    let runtime_id = std::env::var("STREAMLIB_RUNTIME_ID")
+        .expect("STREAMLIB_RUNTIME_ID must be set");
+
+    let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+    let send_fd = make_memfd_with(b"crash-helper-fixture-payload");
+
+    let req = serde_json::json!({
+        "op": "check_in",
+        "runtime_id": runtime_id,
+        "width": 32,
+        "height": 32,
+        "format": "Bgra32",
+        "resource_type": "pixel_buffer",
+    });
+    let (resp, _) =
+        send_request_with_fds(&stream, &req, &[send_fd], 0).expect("check_in request");
+    unsafe { libc::close(send_fd) };
+    let surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("surface_id in check_in response")
+        .to_string();
+
+    println!("SURFACE_ID={}", surface_id);
+    std::io::stdout().flush().ok();
+
+    // Hold the connection open and idle until the parent SIGKILLs us.
+    // 60 s is generous — the harness kills well within a fraction of that.
+    std::thread::sleep(std::time::Duration::from_secs(60));
+}

--- a/libs/streamlib/tests/surface_share_subprocess_crash.rs
+++ b/libs/streamlib/tests/surface_share_subprocess_crash.rs
@@ -1,0 +1,225 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! End-to-end EPOLLHUP-watchdog integration test (#520).
+//!
+//! Wires the generic `SubprocessCrashHarness` against the real
+//! per-runtime surface-share service. Spawns the
+//! `surface_share_crash_helper` binary, waits for it to `check_in` a
+//! memfd-backed surface, SIGKILLs it, and asserts the host-side
+//! watchdog releases the surface within a short, bounded window —
+//! plus that the surface backing is immediately reusable and that
+//! `/proc/self/fd` returns to its pre-spawn baseline.
+
+#![cfg(target_os = "linux")]
+
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use streamlib::linux_surface_share::{SurfaceShareState, UnixSocketSurfaceService};
+use streamlib_adapter_abi::testing::{CrashTiming, SubprocessCrashHarness};
+use streamlib_surface_client::{connect_to_surface_share_socket, send_request_with_fds};
+
+/// Locate the test helper binary built by `cargo test` under `target/<profile>/`.
+fn locate_helper_binary() -> PathBuf {
+    // CARGO_MANIFEST_DIR is libs/streamlib; the binary lands in
+    // target/{debug,release}/surface_share_crash_helper. cargo sets
+    // CARGO_BIN_EXE_<name> automatically for tests in the same package
+    // — prefer that when present, fall back to a manual lookup.
+    if let Some(p) = option_env!("CARGO_BIN_EXE_surface_share_crash_helper") {
+        return PathBuf::from(p);
+    }
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    for profile in &["debug", "release"] {
+        let candidate = workspace
+            .join("target")
+            .join(profile)
+            .join("surface_share_crash_helper");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!("surface_share_crash_helper binary not built");
+}
+
+fn tmp_socket_path(label: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    p.push(format!(
+        "streamlib-surface-share-watchdog-{}-{}-{}.sock",
+        label,
+        std::process::id(),
+        nanos
+    ));
+    p
+}
+
+/// Live fd count for the current process — `/proc/self/fd` entries.
+/// The watchdog's correctness gate: any leak shows up as a baseline
+/// drift across the spawn/cleanup window.
+fn live_fd_count() -> usize {
+    std::fs::read_dir("/proc/self/fd")
+        .map(|d| d.count())
+        .unwrap_or(0)
+}
+
+fn make_memfd_with(contents: &[u8]) -> RawFd {
+    use std::io::{Seek, SeekFrom, Write};
+    use std::os::unix::io::{FromRawFd, IntoRawFd};
+
+    let name = std::ffi::CString::new("watchdog-test-memfd").unwrap();
+    let fd = unsafe { libc::memfd_create(name.as_ptr(), 0) };
+    assert!(fd >= 0, "memfd_create: {}", std::io::Error::last_os_error());
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    file.write_all(contents).expect("memfd write");
+    file.seek(SeekFrom::Start(0)).expect("memfd rewind");
+    file.into_raw_fd()
+}
+
+/// Subprocess crashes mid-flight after `check_in` — host watchdog must
+/// release the surface, and the runtime must remain healthy enough to
+/// accept a fresh registration immediately afterwards.
+#[test]
+fn watchdog_cleans_up_surface_after_subprocess_sigkill() {
+    let helper = locate_helper_binary();
+    assert!(helper.exists(), "helper binary missing: {:?}", helper);
+
+    let state = SurfaceShareState::new();
+    let socket_path = tmp_socket_path("crash");
+    let mut service = UnixSocketSurfaceService::new(state.clone(), socket_path.clone());
+    service.start().expect("service start");
+    // Give the listener thread a tick to bind before any subprocess connects.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let runtime_id = format!("watchdog-runtime-{}", std::process::id());
+    let baseline_fds = live_fd_count();
+
+    // Configure the harness's command — we don't pipe stdin/out/err because
+    // the test reads state directly. The helper's connection survives the
+    // post_spawn hook returning because the helper holds the OwnedFd, not
+    // the parent.
+    let mut command = Command::new(&helper);
+    command
+        .env("STREAMLIB_SURFACE_SOCKET", &socket_path)
+        .env("STREAMLIB_RUNTIME_ID", &runtime_id)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let runtime_id_for_observer = runtime_id.clone();
+    let state_for_observer = state.clone();
+    let runtime_id_for_post = runtime_id.clone();
+    let state_for_post = state.clone();
+
+    let outcome = SubprocessCrashHarness::new(command)
+        // 50 ms is enough for the helper to connect, send `check_in`, and
+        // print SURFACE_ID; we still verify it landed before kill via the
+        // post_spawn hook below, so a slow CI host won't false-pass.
+        .with_timing(CrashTiming::AfterDelay(Duration::from_millis(50)))
+        .with_cleanup_timeout(Duration::from_secs(2))
+        .with_post_spawn(move |_child| {
+            // Wait until the helper has actually registered its surface
+            // with the host. Without this, a sluggish spawn could see kill
+            // happen before check_in lands and the test would silently pass
+            // with nothing to clean up.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                let n = state_for_post.surface_ids_by_runtime(&runtime_id_for_post).len();
+                if n >= 1 {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "helper did not register a surface before kill window",
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        })
+        .run(move || {
+            if state_for_observer
+                .surface_ids_by_runtime(&runtime_id_for_observer)
+                .is_empty()
+            {
+                Ok(())
+            } else {
+                Err("watchdog has not yet released subprocess surfaces")
+            }
+        })
+        .expect("harness run");
+
+    // Per the issue's exit criteria: cleanup must complete within 1 s of
+    // SIGKILL. The harness reports cleanup_latency, which is wall-clock
+    // between kill and the observe_cleanup closure returning Ok.
+    assert!(
+        outcome.cleanup_latency < Duration::from_secs(1),
+        "watchdog cleanup_latency {:?} exceeds 1s budget",
+        outcome.cleanup_latency
+    );
+
+    // Surface really gone from the global table.
+    assert!(
+        state.surface_ids_by_runtime(&runtime_id).is_empty(),
+        "surfaces by runtime should be empty after watchdog cleanup",
+    );
+
+    // Backing immediately reusable: a fresh check_in under any runtime_id
+    // works (no leftover wedge in the service / state).
+    let stream = connect_to_surface_share_socket(&socket_path).expect("post-cleanup connect");
+    let send_fd = make_memfd_with(b"post-cleanup-fixture");
+    let (resp, _) = send_request_with_fds(
+        &stream,
+        &serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "post-cleanup",
+            "width": 16,
+            "height": 16,
+            "format": "Bgra32",
+            "resource_type": "pixel_buffer",
+        }),
+        &[send_fd],
+        0,
+    )
+    .expect("post-cleanup check_in");
+    unsafe { libc::close(send_fd) };
+    let new_surface_id = resp
+        .get("surface_id")
+        .and_then(|v| v.as_str())
+        .expect("post-cleanup surface_id")
+        .to_string();
+    assert!(!new_surface_id.is_empty());
+    let _ = send_request_with_fds(
+        &stream,
+        &serde_json::json!({
+            "op": "release",
+            "surface_id": new_surface_id,
+            "runtime_id": "post-cleanup",
+        }),
+        &[],
+        0,
+    )
+    .expect("post-cleanup release");
+    drop(stream);
+
+    service.stop();
+
+    // FD baseline: anything left allocated by the helper (the connection,
+    // the dup'd DMA-BUF fds the host kept) must be reaped. The service has
+    // closed its listener and its registered fds; the helper exited; the
+    // post-cleanup connection above was a roundtrip that closed cleanly.
+    // Allow a small slack — the test runner spawns its own threads and
+    // tracing layers can momentarily hold pipe fds.
+    let after_fds = live_fd_count();
+    assert!(
+        after_fds <= baseline_fds + 2,
+        "fd baseline drift after watchdog cleanup: baseline={}, after={}",
+        baseline_fds,
+        after_fds,
+    );
+}


### PR DESCRIPTION
## Summary

- Host-side watchdog releases surfaces a polyglot subprocess registered when the subprocess crashes mid-flight (kernel-side equivalent of `EPOLLHUP` on Linux Unix-stream sockets).
- `SO_PEERCRED` filters out same-process diagnostic connections (host runtime publishing to its own socket via wire — the `polyglot_linux_check_out` family of tests) so only out-of-process subprocess crashes trigger cleanup.
- Idempotent: a polite `release` followed by a crash leaves nothing for the watchdog to do.

## Closes
Closes #520

## Exit criteria

- [x] Per-connection cleanup hook in `unix_socket_service.rs` triggered on socket close
- [x] On socket close, watchdog walks the client's checked-out surfaces and calls `release_surface` for each
- [x] `SurfaceShareState::surface_ids_by_runtime(runtime_id) -> Vec<String>` query
- [x] Idempotent — no double-release if subprocess sent `release` before SIGKILL
- [x] `docs/architecture/surface-adapter.md`'s "Subprocess lifetime" section updated (planned caveat removed)

## Test plan

- [x] **Unit:** `state::tests::surface_ids_by_runtime_groups_by_owner` — query groups by `runtime_id` precisely
- [x] **Unit:** `unix_socket_service::tests::cleanup_runtime_surfaces_is_scoped_and_idempotent` — pure-function cleanup is scoped to the target runtime and no-ops on second call
- [x] **Unit:** `unix_socket_service::tests::same_process_disconnect_does_not_trigger_watchdog` — host's same-process publisher pattern survives disconnect
- [x] **Integration:** `tests/surface_share_subprocess_crash.rs::watchdog_cleans_up_surface_after_subprocess_sigkill` — spawns helper binary, helper `check_in`s a memfd-backed surface, harness SIGKILLs it, asserts:
  - `cleanup_latency < 1s` from kill
  - `surface_ids_by_runtime` is empty after watchdog
  - fresh `check_in` works immediately
  - `/proc/self/fd` baseline restored
- [x] All 249 lib tests green; 3 polyglot integration tests still green (host-publisher pattern preserved by SO_PEERCRED filter)

## Implementation notes

- The wire-level "EPOLLHUP" is the EOF the existing per-connection thread already gets from `read_exact` when the kernel closes the socket. No new event loop is needed; the watchdog runs at thread-end. Documented as the EPOLLHUP-equivalent in code comments.
- A narrow `pub mod streamlib::linux_surface_share { … }` re-export was added to expose `SurfaceShareState` and `UnixSocketSurfaceService` to the integration test (which needs to query state directly to verify cleanup).

## Out of scope / fixes pulled in for clean test gate

- Pre-existing parallel-only flake in `release_surface_closes_every_plane_fd`: the assertion checked `fcntl(F_GETFD)` on raw fd numbers, which raced with parallel-thread fd recycling. Rewrote to use pipes — register hands the write end to the table, after release the read end yields EOF (sticky kernel-level signal, immune to fd reuse). Confirmed flake exists on `main` without any of this PR's other changes; reproduced 5/5 clean runs in parallel after the redesign.

## Follow-ups

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)