### PR TITLE
feat(rhi): host VkImage pool with DMA-BUF export and RT-capable DRM modifier (#510)

### DIFF
--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -8,7 +8,42 @@
 /**
  * Polyglot subprocess escalate-on-behalf request (subprocess → host)
  */
-export type EscalateRequest = EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestReleaseHandle;
+export type EscalateRequest = EscalateRequestAcquireImage | EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestReleaseHandle;
+
+export interface EscalateRequestAcquireImage {
+  op: "acquire_image";
+
+  /**
+   * Texture format identifier. Lowercase snake-case names: bgra8_unorm,
+   * bgra8_unorm_srgb, rgba8_unorm, rgba8_unorm_srgb. The host
+   * backs this with a render-target-capable VkImage allocated via
+   * VK_EXT_image_drm_format_modifier and a tiled DRM modifier picked from the
+   * EGL `external_only=FALSE` list — the resulting DMA-BUF can be imported by
+   * the consumer as a GL_TEXTURE_2D color attachment. Returns an error when
+   * the EGL probe didn't find an RT-capable modifier for `format` (no fallback
+   * to LINEAR — sampler-only on NVIDIA, see docs/learnings/nvidia-egl-dmabuf-
+   * render-target.md).
+   * Internal host primitive — surface adapters (streamlib-adapter-vulkan /
+   * -opengl / -skia) use this on customers' behalf; customers never invoke
+   * acquire_image directly.
+   */
+  format: string;
+
+  /**
+   * Pixel height of the image.
+   */
+  height: number;
+
+  /**
+   * Correlates request with response. UUID string.
+   */
+  request_id: string;
+
+  /**
+   * Pixel width of the image.
+   */
+  width: number;
+}
 
 export interface EscalateRequestAcquirePixelBuffer {
   op: "acquire_pixel_buffer";

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -23,6 +23,7 @@ class EscalateRequest:
     @classmethod
     def from_json_data(cls, data: Any) -> 'EscalateRequest':
         variants: Dict[str, Type[EscalateRequest]] = {
+            "acquire_image": EscalateRequestAcquireImage,
             "acquire_pixel_buffer": EscalateRequestAcquirePixelBuffer,
             "acquire_texture": EscalateRequestAcquireTexture,
             "log": EscalateRequestLog,
@@ -33,6 +34,57 @@ class EscalateRequest:
 
     def to_json_data(self) -> Any:
         pass
+
+@dataclass
+class EscalateRequestAcquireImage(EscalateRequest):
+    format: 'str'
+    """
+    Texture format identifier. Lowercase snake-case names: bgra8_unorm,
+    bgra8_unorm_srgb, rgba8_unorm, rgba8_unorm_srgb. The host backs this with a
+    render-target-capable VkImage allocated via VK_EXT_image_drm_format_modifier
+    and a tiled DRM modifier picked from the EGL `external_only=FALSE` list —
+    the resulting DMA-BUF can be imported by the consumer as a GL_TEXTURE_2D
+    color attachment. Returns an error when the EGL probe didn't find an RT-
+    capable modifier for `format` (no fallback to LINEAR — sampler-only on
+    NVIDIA, see docs/learnings/nvidia-egl-dmabuf-render-target.md).
+    Internal host primitive — surface adapters (streamlib-adapter-vulkan /
+    -opengl / -skia) use this on customers' behalf; customers never invoke
+    acquire_image directly.
+    """
+
+    height: 'int'
+    """
+    Pixel height of the image.
+    """
+
+    request_id: 'str'
+    """
+    Correlates request with response. UUID string.
+    """
+
+    width: 'int'
+    """
+    Pixel width of the image.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestAcquireImage':
+        return cls(
+            "acquire_image",
+            _from_json_data(str, data.get("format")),
+            _from_json_data(int, data.get("height")),
+            _from_json_data(str, data.get("request_id")),
+            _from_json_data(int, data.get("width")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "acquire_image" }
+        data["format"] = _to_json_data(self.format)
+        data["height"] = _to_json_data(self.height)
+        data["request_id"] = _to_json_data(self.request_id)
+        data["width"] = _to_json_data(self.width)
+        return data
 
 @dataclass
 class EscalateRequestAcquirePixelBuffer(EscalateRequest):

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -66,6 +66,39 @@ mapping:
             tokens return an error response.
         elements:
           type: string
+  acquire_image:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      width:
+        metadata:
+          description: "Pixel width of the image."
+        type: uint32
+      height:
+        metadata:
+          description: "Pixel height of the image."
+        type: uint32
+      format:
+        metadata:
+          description: >
+            Texture format identifier. Lowercase snake-case names:
+            bgra8_unorm, bgra8_unorm_srgb, rgba8_unorm, rgba8_unorm_srgb.
+            The host backs this with a render-target-capable VkImage
+            allocated via VK_EXT_image_drm_format_modifier and a tiled
+            DRM modifier picked from the EGL `external_only=FALSE` list
+            — the resulting DMA-BUF can be imported by the consumer as
+            a GL_TEXTURE_2D color attachment. Returns an error when the
+            EGL probe didn't find an RT-capable modifier for `format`
+            (no fallback to LINEAR — sampler-only on NVIDIA, see
+            docs/learnings/nvidia-egl-dmabuf-render-target.md).
+
+            Internal host primitive — surface adapters
+            (streamlib-adapter-vulkan / -opengl / -skia) use this on
+            customers' behalf; customers never invoke acquire_image
+            directly.
+        type: string
   release_handle:
     properties:
       request_id:

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op")]
 pub enum EscalateRequest {
+    #[serde(rename = "acquire_image")]
+    AcquireImage(EscalateRequestAcquireImage),
+
     #[serde(rename = "acquire_pixel_buffer")]
     AcquirePixelBuffer(EscalateRequestAcquirePixelBuffer),
 
@@ -23,6 +26,37 @@ pub enum EscalateRequest {
 
     #[serde(rename = "release_handle")]
     ReleaseHandle(EscalateRequestReleaseHandle),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestAcquireImage {
+    /// Texture format identifier. Lowercase snake-case names: bgra8_unorm,
+    /// bgra8_unorm_srgb, rgba8_unorm, rgba8_unorm_srgb. The host
+    /// backs this with a render-target-capable VkImage allocated via
+    /// VK_EXT_image_drm_format_modifier and a tiled DRM modifier picked
+    /// from the EGL `external_only=FALSE` list — the resulting DMA-BUF can
+    /// be imported by the consumer as a GL_TEXTURE_2D color attachment.
+    /// Returns an error when the EGL probe didn't find an RT-capable modifier
+    /// for `format` (no fallback to LINEAR — sampler-only on NVIDIA, see
+    /// docs/learnings/nvidia-egl-dmabuf-render-target.md).
+    /// Internal host primitive — surface adapters (streamlib-adapter-vulkan /
+    /// -opengl / -skia) use this on customers' behalf; customers never invoke
+    /// acquire_image directly.
+    #[serde(rename = "format")]
+    pub format: String,
+
+    /// Pixel height of the image.
+    #[serde(rename = "height")]
+    pub height: u32,
+
+    /// Correlates request with response. UUID string.
+    #[serde(rename = "request_id")]
+    pub request_id: String,
+
+    /// Pixel width of the image.
+    #[serde(rename = "width")]
+    pub width: u32,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -21,8 +21,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::_generated_::com_streamlib_escalate_request::{
-    EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture, EscalateRequestLog,
-    EscalateRequestLogLevel, EscalateRequestLogSource, EscalateRequestReleaseHandle,
+    EscalateRequestAcquireImage, EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
+    EscalateRequestLog, EscalateRequestLogLevel, EscalateRequestLogSource,
+    EscalateRequestReleaseHandle,
 };
 use crate::_generated_::com_streamlib_escalate_response::{
     EscalateResponseErr, EscalateResponseOk,
@@ -50,6 +51,7 @@ fn request_id(op: &EscalateRequest) -> Option<&str> {
     match op {
         EscalateRequest::AcquirePixelBuffer(p) => Some(&p.request_id),
         EscalateRequest::AcquireTexture(p) => Some(&p.request_id),
+        EscalateRequest::AcquireImage(p) => Some(&p.request_id),
         EscalateRequest::ReleaseHandle(p) => Some(&p.request_id),
         EscalateRequest::Log(_) => None,
     }
@@ -215,6 +217,65 @@ pub(crate) fn handle_escalate_op(
                 }),
             })
         }
+        EscalateRequest::AcquireImage(EscalateRequestAcquireImage {
+            request_id: _,
+            width,
+            height,
+            format,
+        }) => {
+            #[cfg(target_os = "linux")]
+            {
+                let parsed_format = match parse_texture_format(&format) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        return Some(EscalateResponse::Err(EscalateResponseErr {
+                            request_id: rid,
+                            message: e,
+                        }));
+                    }
+                };
+                // Render-target images carry their own usage signature —
+                // they can be sampled, copied, AND used as render attachments.
+                // The wire op deliberately does not take a usage list (that's
+                // an acquire_texture concern); here the host knows the exact
+                // set because the consumer is always a render-target adapter.
+                let acquired = sandbox.escalate(|full| {
+                    let texture = full.acquire_render_target_dma_buf_image(
+                        width,
+                        height,
+                        parsed_format,
+                    )?;
+                    let handle_id = assign_image_handle_id(full, &texture)?;
+                    Ok((handle_id, texture))
+                });
+                Some(match acquired {
+                    Ok((handle_id, _texture)) => EscalateResponse::Ok(EscalateResponseOk {
+                        request_id: rid,
+                        handle_id,
+                        width: Some(width),
+                        height: Some(height),
+                        format: Some(texture_format_to_wire(parsed_format).to_string()),
+                        usage: Some(vec![
+                            "render_attachment".to_string(),
+                            "texture_binding".to_string(),
+                            "copy_src".to_string(),
+                        ]),
+                    }),
+                    Err(e) => EscalateResponse::Err(EscalateResponseErr {
+                        request_id: rid,
+                        message: format!("acquire_image failed: {e}"),
+                    }),
+                })
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = (width, height, format);
+                Some(EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: "acquire_image is only available on Linux (DMA-BUF render-target path)".to_string(),
+                }))
+            }
+        }
         EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
             request_id: _,
             handle_id,
@@ -335,6 +396,24 @@ fn assign_texture_handle_id(
         if let Some(store) = full.surface_store() {
             store.register_texture(&handle_id, texture.texture())?;
         }
+    }
+    Ok(handle_id)
+}
+
+/// Resolve the `handle_id` for a render-target DMA-BUF image.
+///
+/// On Linux, register the image's DMA-BUF (with the chosen DRM modifier and
+/// per-plane row pitches) with the surface-share service under a fresh UUID
+/// so the subprocess can `check_out` it; the surface-share registration
+/// carries the modifier and strides the consumer-side EGL import requires.
+#[cfg(target_os = "linux")]
+fn assign_image_handle_id(
+    full: &crate::core::context::GpuContextFullAccess,
+    texture: &crate::core::rhi::StreamTexture,
+) -> crate::core::error::Result<String> {
+    let handle_id = Uuid::new_v4().to_string();
+    if let Some(store) = full.surface_store() {
+        store.register_texture(&handle_id, texture)?;
     }
     Ok(handle_id)
 }

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -779,6 +779,121 @@ impl GpuContext {
         self.command_queue().create_command_buffer()
     }
 
+    /// Allocate a render-target-capable DMA-BUF VkImage backed by the device's
+    /// tiled-modifier VMA pool.
+    ///
+    /// The driver picks one of the EGL-advertised render-target modifiers
+    /// from [`VulkanDevice::drm_modifier_table`]. The resulting
+    /// `StreamTexture` carries the chosen modifier on its inner
+    /// [`VulkanTexture`] (see [`VulkanTexture::chosen_drm_format_modifier`]),
+    /// ready to be carried in a `SurfaceTransportHandle` when the host
+    /// surface-share service registers the surface.
+    ///
+    /// Errors when the EGL probe didn't find an RT-capable modifier for
+    /// `format` — there is no silent fallback to LINEAR (sampler-only on
+    /// NVIDIA — see `docs/learnings/nvidia-egl-dmabuf-render-target.md`).
+    /// Callers that want a CPU-readable linear allocation should use
+    /// [`Self::acquire_pixel_buffer`] instead.
+    #[cfg(target_os = "linux")]
+    pub fn acquire_render_target_dma_buf_image(
+        &self,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) -> Result<StreamTexture> {
+        use crate::vulkan::rhi::drm_modifier_probe::fourcc;
+
+        tracing::debug!(
+            rhi_op = "acquire_render_target_dma_buf_image",
+            width,
+            height,
+            format = ?format,
+            "GpuContext::acquire_render_target_dma_buf_image"
+        );
+
+        let fourcc = match format {
+            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => {
+                fourcc::DRM_FORMAT_ARGB8888
+            }
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => {
+                fourcc::DRM_FORMAT_ABGR8888
+            }
+            TextureFormat::Nv12 => fourcc::DRM_FORMAT_NV12,
+            other => {
+                return Err(StreamError::GpuError(format!(
+                    "acquire_render_target_dma_buf_image: format {other:?} has no DRM FOURCC mapping"
+                )));
+            }
+        };
+
+        let vulkan_device = &self.device.inner;
+        let modifiers: Vec<u64> = vulkan_device
+            .drm_modifier_table()
+            .rt_modifiers(fourcc)
+            .to_vec();
+
+        if modifiers.is_empty() {
+            return Err(StreamError::GpuError(format!(
+                "acquire_render_target_dma_buf_image: no RT-capable DRM modifier for {format:?} (fourcc=0x{fourcc:08x}); EGL probe returned empty list"
+            )));
+        }
+
+        let desc = TextureDescriptor::new(width, height, format).with_usage(
+            TextureUsages::RENDER_ATTACHMENT
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+        );
+        let texture = crate::vulkan::rhi::VulkanTexture::new_render_target_dma_buf(
+            vulkan_device,
+            &desc,
+            &modifiers,
+        )?;
+        Ok(StreamTexture::from_vulkan(texture))
+    }
+
+    /// Pre-warm the tiled DMA-BUF VMA pool so the first VMA block lands
+    /// before the display swapchain creates the NVIDIA DMA-BUF cap pressure.
+    ///
+    /// Mirrors [`acquire_pixel_buffer`]'s pre-warm pattern in
+    /// `LinuxCameraProcessor::start()` — allocate a small probe image and
+    /// drop it. Subsequent allocations reuse the pool block.
+    ///
+    /// No-op (returns `Ok(())`) when the EGL probe has no RT modifiers for
+    /// `format` — there's nothing to pre-warm in that case.
+    #[cfg(target_os = "linux")]
+    pub fn pre_warm_render_target_dma_buf_pool(
+        &self,
+        format: TextureFormat,
+    ) -> Result<()> {
+        use crate::vulkan::rhi::drm_modifier_probe::fourcc;
+        let fourcc = match format {
+            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => {
+                fourcc::DRM_FORMAT_ARGB8888
+            }
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => {
+                fourcc::DRM_FORMAT_ABGR8888
+            }
+            _ => return Ok(()),
+        };
+        let vulkan_device = &self.device.inner;
+        if vulkan_device
+            .drm_modifier_table()
+            .rt_modifiers(fourcc)
+            .is_empty()
+        {
+            tracing::info!(
+                "pre_warm_render_target_dma_buf_pool: skipping {format:?} — no RT modifiers"
+            );
+            return Ok(());
+        }
+        let probe = self.acquire_render_target_dma_buf_image(64, 64, format)?;
+        drop(probe);
+        tracing::info!(
+            "pre_warm_render_target_dma_buf_pool: {format:?} pool warmed"
+        );
+        Ok(())
+    }
+
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
     ///
     /// Reflects the SPIR-V at creation time and validates that the declared
@@ -1224,6 +1339,30 @@ impl GpuContextLimitedAccess {
     /// Acquire a texture from a pre-reserved pool (Split: fast path).
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
         self.inner.acquire_texture(desc)
+    }
+
+    /// Allocate a render-target-capable DMA-BUF VkImage (privileged path —
+    /// host-only adapter primitive, customers never see this directly).
+    /// See [`GpuContext::acquire_render_target_dma_buf_image`].
+    #[cfg(target_os = "linux")]
+    pub fn acquire_render_target_dma_buf_image(
+        &self,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) -> Result<StreamTexture> {
+        self.inner
+            .acquire_render_target_dma_buf_image(width, height, format)
+    }
+
+    /// Pre-warm the tiled DMA-BUF VMA pool. See
+    /// [`GpuContext::pre_warm_render_target_dma_buf_pool`].
+    #[cfg(target_os = "linux")]
+    pub fn pre_warm_render_target_dma_buf_pool(
+        &self,
+        format: TextureFormat,
+    ) -> Result<()> {
+        self.inner.pre_warm_render_target_dma_buf_pool(format)
     }
 
     /// Get the shared command queue.

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -752,7 +752,13 @@ impl GpuContext {
         &self.texture_pool
     }
 
-    /// Acquire a texture from the pool.
+    /// Acquire a pooled texture for in-process GPU work.
+    ///
+    /// Uses `VK_IMAGE_TILING_OPTIMAL` and is **not** safe to share with
+    /// another process as a render target on NVIDIA Linux — the resulting
+    /// DMA-BUF (if exported) is sampler-only there. For cross-process
+    /// surfaces a consumer adapter will render INTO, use
+    /// [`Self::acquire_render_target_dma_buf_image`] (Linux) instead.
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
         tracing::debug!(
             rhi_op = "acquire_texture",
@@ -792,8 +798,16 @@ impl GpuContext {
     /// Errors when the EGL probe didn't find an RT-capable modifier for
     /// `format` — there is no silent fallback to LINEAR (sampler-only on
     /// NVIDIA — see `docs/learnings/nvidia-egl-dmabuf-render-target.md`).
-    /// Callers that want a CPU-readable linear allocation should use
-    /// [`Self::acquire_pixel_buffer`] instead.
+    ///
+    /// Picking the right acquire method:
+    /// - **In-process texture for sampling/compute**: use
+    ///   [`Self::acquire_texture`] (`VK_IMAGE_TILING_OPTIMAL`, no
+    ///   DMA-BUF export pressure).
+    /// - **CPU-readable buffer (mmap/PNG sample/MMAP fallback)**: use
+    ///   [`Self::acquire_pixel_buffer`] (`VkBuffer`, linear).
+    /// - **Cross-process surface a consumer adapter renders into**:
+    ///   this method (tiled DRM modifier, DMA-BUF exportable, FBO-completable
+    ///   on the consumer side).
     #[cfg(target_os = "linux")]
     pub fn acquire_render_target_dma_buf_image(
         &self,
@@ -1336,7 +1350,13 @@ impl GpuContextLimitedAccess {
         self.inner.camera_timeline_semaphore()
     }
 
-    /// Acquire a texture from a pre-reserved pool (Split: fast path).
+    /// Acquire a pooled texture from a pre-reserved pool (Split: fast path).
+    ///
+    /// `VK_IMAGE_TILING_OPTIMAL`, in-process use only. For cross-process
+    /// render targets, see [`GpuContextFullAccess::acquire_render_target_dma_buf_image`]
+    /// (Linux) — Sandbox callers don't have a render-target alloc path
+    /// because allocating a new RT-capable image is a privileged op
+    /// that goes through escalate.
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
         self.inner.acquire_texture(desc)
     }
@@ -1495,7 +1515,10 @@ impl GpuContextFullAccess {
         self.inner.texture_pool()
     }
 
-    /// Acquire a texture from the pool.
+    /// Acquire a pooled texture for in-process GPU work
+    /// (`VK_IMAGE_TILING_OPTIMAL`). For cross-process render targets the
+    /// host adapter layer wants on Linux, see
+    /// [`Self::acquire_render_target_dma_buf_image`].
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
         self.inner.acquire_texture(desc)
     }

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -1341,30 +1341,6 @@ impl GpuContextLimitedAccess {
         self.inner.acquire_texture(desc)
     }
 
-    /// Allocate a render-target-capable DMA-BUF VkImage (privileged path —
-    /// host-only adapter primitive, customers never see this directly).
-    /// See [`GpuContext::acquire_render_target_dma_buf_image`].
-    #[cfg(target_os = "linux")]
-    pub fn acquire_render_target_dma_buf_image(
-        &self,
-        width: u32,
-        height: u32,
-        format: TextureFormat,
-    ) -> Result<StreamTexture> {
-        self.inner
-            .acquire_render_target_dma_buf_image(width, height, format)
-    }
-
-    /// Pre-warm the tiled DMA-BUF VMA pool. See
-    /// [`GpuContext::pre_warm_render_target_dma_buf_pool`].
-    #[cfg(target_os = "linux")]
-    pub fn pre_warm_render_target_dma_buf_pool(
-        &self,
-        format: TextureFormat,
-    ) -> Result<()> {
-        self.inner.pre_warm_render_target_dma_buf_pool(format)
-    }
-
     /// Get the shared command queue.
     ///
     /// Submitting recorded command buffers from `process()` is safe: the
@@ -1430,6 +1406,30 @@ impl GpuContextFullAccess {
         format: PixelFormat,
     ) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
         self.inner.acquire_pixel_buffer(width, height, format)
+    }
+
+    /// Allocate a render-target-capable DMA-BUF VkImage (privileged path —
+    /// host-only adapter primitive, customers never see this directly).
+    /// See [`GpuContext::acquire_render_target_dma_buf_image`].
+    #[cfg(target_os = "linux")]
+    pub fn acquire_render_target_dma_buf_image(
+        &self,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) -> Result<StreamTexture> {
+        self.inner
+            .acquire_render_target_dma_buf_image(width, height, format)
+    }
+
+    /// Pre-warm the tiled DMA-BUF VMA pool. See
+    /// [`GpuContext::pre_warm_render_target_dma_buf_pool`].
+    #[cfg(target_os = "linux")]
+    pub fn pre_warm_render_target_dma_buf_pool(
+        &self,
+        format: TextureFormat,
+    ) -> Result<()> {
+        self.inner.pre_warm_render_target_dma_buf_pool(format)
     }
 
     /// Get a pixel buffer by its pool id.

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -1069,6 +1069,21 @@ impl SurfaceStore {
         // Export the DMA-BUF fd from the texture
         let fd = texture.inner.export_dma_buf_fd()?;
 
+        // Carry the DRM format modifier and per-plane row pitch so the
+        // consumer-side EGL or Vulkan import can pass them via
+        // EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT and EGL_DMA_BUF_PLANE{N}_PITCH_EXT
+        // (or VkImageDrmFormatModifierExplicitCreateInfoEXT). Zero modifier
+        // means LINEAR / not applicable; render-target consumers must refuse
+        // such surfaces because LINEAR DMA-BUFs are sampler-only on NVIDIA
+        // (see docs/learnings/nvidia-egl-dmabuf-render-target.md).
+        let drm_format_modifier = texture.inner.chosen_drm_format_modifier();
+        let plane_layout = texture
+            .inner
+            .dma_buf_plane_layout()
+            .unwrap_or_else(|_| vec![(0, 0)]);
+        let plane_offsets: Vec<u64> = plane_layout.iter().map(|(o, _)| *o).collect();
+        let plane_strides: Vec<u64> = plane_layout.iter().map(|(_, s)| *s).collect();
+
         let request = serde_json::json!({
             "op": "register",
             "surface_id": surface_id,
@@ -1077,6 +1092,9 @@ impl SurfaceStore {
             "height": texture.height(),
             "format": format!("{:?}", texture.format()),
             "resource_type": "texture",
+            "plane_offsets": plane_offsets,
+            "plane_strides": plane_strides,
+            "drm_format_modifier": drm_format_modifier,
         });
 
         let connection = self.inner.connection.lock();

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -128,7 +128,8 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
         // which case render-target adapters will fail loudly with a clear
         // message at acquire time rather than silently fall back to
         // sampler-only LINEAR.
-        if let Err(e) = gpu_context
+        if let Err(e) = ctx
+            .gpu_full_access()
             .pre_warm_render_target_dma_buf_pool(crate::core::rhi::TextureFormat::Bgra8Unorm)
         {
             tracing::warn!(

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -116,6 +116,28 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
             .clone()
             .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
 
+        // Pre-warm the tiled DMA-BUF VMA pool BEFORE spawning the render
+        // thread that creates the swapchain. NVIDIA caps DMA-BUF
+        // exportable allocations after swapchain creation; pre-warming the
+        // pool now ensures the first VMA block lands while DMA-BUF
+        // allocations are still freely available.
+        // See `docs/learnings/nvidia-dma-buf-after-swapchain.md` and
+        // `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
+        // Failure here is non-fatal: the EGL probe may have returned no
+        // RT-capable modifiers in headless / no-display environments, in
+        // which case render-target adapters will fail loudly with a clear
+        // message at acquire time rather than silently fall back to
+        // sampler-only LINEAR.
+        if let Err(e) = gpu_context
+            .pre_warm_render_target_dma_buf_pool(crate::core::rhi::TextureFormat::Bgra8Unorm)
+        {
+            tracing::warn!(
+                "Display {}: render-target DMA-BUF pool pre-warm failed: {} \
+                 — surface adapter consumers will see allocation errors",
+                self.window_id.0, e
+            );
+        }
+
         // Pull the Vulkan device handle from the FullAccess lifecycle ctx.
         // The render thread uses it to build its swapchain and rendering
         // pipeline at startup; the Sandbox clone is what the thread keeps

--- a/libs/streamlib/src/linux/surface_share/state.rs
+++ b/libs/streamlib/src/linux/surface_share/state.rs
@@ -24,10 +24,23 @@ pub struct SurfaceMetadata {
     pub dma_buf_fds: Vec<RawFd>,
     pub plane_sizes: Vec<u64>,
     pub plane_offsets: Vec<u64>,
+    /// Per-plane row pitch in bytes — what the consumer-side EGL or
+    /// Vulkan import passes via `EGL_DMA_BUF_PLANE{N}_PITCH_EXT` /
+    /// `VkSubresourceLayout::rowPitch`. One entry per plane fd; defaults
+    /// to a vec of zeros for legacy registrations that didn't supply it.
+    pub plane_strides: Vec<u64>,
     pub width: u32,
     pub height: u32,
     pub format: String,
     pub resource_type: String,
+    /// DRM format modifier of the underlying VkImage. Zero means
+    /// `DRM_FORMAT_MOD_LINEAR` (sampler-only on NVIDIA — see
+    /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`) or "not set"
+    /// for legacy `VkBuffer`-backed surfaces (CPU-readable pixel buffers).
+    /// Render-target adapters MUST receive a non-zero modifier picked
+    /// from the EGL `external_only=FALSE` set; otherwise consumer-side
+    /// FBO completeness will fail on NVIDIA.
+    pub drm_format_modifier: u64,
     pub checkout_count: u64,
 }
 
@@ -43,6 +56,17 @@ struct Inner {
     surface_counter: AtomicU64,
 }
 
+/// Result of [`SurfaceShareState::get_surface_planes`] — everything a
+/// consumer needs to import the DMA-BUF as a Vulkan or EGL image.
+#[derive(Clone, Debug)]
+pub struct SurfacePlaneCheckout {
+    pub dma_buf_fds: Vec<RawFd>,
+    pub plane_sizes: Vec<u64>,
+    pub plane_offsets: Vec<u64>,
+    pub plane_strides: Vec<u64>,
+    pub drm_format_modifier: u64,
+}
+
 /// Arguments to [`SurfaceShareState::register_surface`]. Grouped so the
 /// signature stays legible as the per-plane fields grow.
 pub struct SurfaceRegistration<'a> {
@@ -51,10 +75,15 @@ pub struct SurfaceRegistration<'a> {
     pub dma_buf_fds: Vec<RawFd>,
     pub plane_sizes: Vec<u64>,
     pub plane_offsets: Vec<u64>,
+    /// Per-plane row pitch in bytes. Length must match `dma_buf_fds`.
+    pub plane_strides: Vec<u64>,
     pub width: u32,
     pub height: u32,
     pub format: &'a str,
     pub resource_type: &'a str,
+    /// DRM format modifier of the underlying VkImage. See
+    /// [`SurfaceMetadata::drm_format_modifier`].
+    pub drm_format_modifier: u64,
 }
 
 impl SurfaceShareState {
@@ -88,10 +117,12 @@ impl SurfaceShareState {
                 dma_buf_fds: reg.dma_buf_fds,
                 plane_sizes: reg.plane_sizes,
                 plane_offsets: reg.plane_offsets,
+                plane_strides: reg.plane_strides,
                 width: reg.width,
                 height: reg.height,
                 format: reg.format.to_string(),
                 resource_type: reg.resource_type.to_string(),
+                drm_format_modifier: reg.drm_format_modifier,
                 checkout_count: 0,
             },
         );
@@ -99,20 +130,23 @@ impl SurfaceShareState {
     }
 
     /// Return a clone of the surface's plane fd vec plus its plane-layout
-    /// arrays. The returned fds are the table's own — callers that hand them
-    /// out via SCM_RIGHTS must `dup` each fd first.
+    /// arrays and the underlying VkImage's DRM format modifier. The
+    /// returned fds are the table's own — callers that hand them out via
+    /// SCM_RIGHTS must `dup` each fd first.
     pub fn get_surface_planes(
         &self,
         surface_id: &str,
-    ) -> Option<(Vec<RawFd>, Vec<u64>, Vec<u64>)> {
+    ) -> Option<SurfacePlaneCheckout> {
         let mut surfaces = self.inner.surfaces.write();
         surfaces.get_mut(surface_id).map(|metadata| {
             metadata.checkout_count += 1;
-            (
-                metadata.dma_buf_fds.clone(),
-                metadata.plane_sizes.clone(),
-                metadata.plane_offsets.clone(),
-            )
+            SurfacePlaneCheckout {
+                dma_buf_fds: metadata.dma_buf_fds.clone(),
+                plane_sizes: metadata.plane_sizes.clone(),
+                plane_offsets: metadata.plane_offsets.clone(),
+                plane_strides: metadata.plane_strides.clone(),
+                drm_format_modifier: metadata.drm_format_modifier,
+            }
         })
     }
 
@@ -158,10 +192,12 @@ mod tests {
             dma_buf_fds: vec![-1],
             plane_sizes: vec![0],
             plane_offsets: vec![0],
+            plane_strides: vec![0],
             width: 1920,
             height: 1080,
             format: "Rgba8Unorm",
             resource_type,
+            drm_format_modifier: 0,
         }
     }
 
@@ -262,10 +298,12 @@ mod tests {
                 dma_buf_fds: write_fds,
                 plane_sizes: vec![8192, 2048, 2048],
                 plane_offsets: vec![0, 0, 0],
+                plane_strides: vec![64, 32, 32],
                 width: 640,
                 height: 480,
                 format: "Nv12VideoRange",
                 resource_type: "pixel_buffer",
+                drm_format_modifier: 0,
             })
             .expect("register multi-plane");
 

--- a/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
@@ -247,11 +247,9 @@ fn handle_client_connection(
     }
 }
 
-/// Extract `plane_sizes` and `plane_offsets` from a JSON request body.
-/// Returns `(plane_sizes, plane_offsets)` where each vec's length matches
-/// `expected_plane_count`, falling back to `[0]` and `[0]` when the peer
-/// sent no arrays (single-plane back-compat) or when a provided array has a
-/// different length than the fd set.
+/// Extract `plane_sizes`, `plane_offsets`, and `plane_strides` from a JSON
+/// request body. Returns vecs whose length matches `expected_plane_count`,
+/// falling back to `[0]` for single-plane registrations that omit the arrays.
 ///
 /// Returning `None` is an explicit wire-protocol violation (mismatched
 /// arrays, negative values); the handler should error out instead of
@@ -259,7 +257,7 @@ fn handle_client_connection(
 fn parse_plane_arrays(
     request: &serde_json::Value,
     expected_plane_count: usize,
-) -> Option<(Vec<u64>, Vec<u64>)> {
+) -> Option<(Vec<u64>, Vec<u64>, Vec<u64>)> {
     let parse_arr = |key: &str| -> Option<Option<Vec<u64>>> {
         match request.get(key) {
             None => Some(None),
@@ -275,22 +273,19 @@ fn parse_plane_arrays(
         }
     };
 
-    let sizes_opt = parse_arr("plane_sizes")?;
-    let offsets_opt = parse_arr("plane_offsets")?;
+    let resolve = |opt: Option<Vec<u64>>| -> Option<Vec<u64>> {
+        match opt {
+            Some(v) if v.len() == expected_plane_count => Some(v),
+            Some(_) => None,
+            None if expected_plane_count <= 1 => Some(vec![0u64; expected_plane_count.max(1)]),
+            None => None,
+        }
+    };
 
-    let sizes = match sizes_opt {
-        Some(v) if v.len() == expected_plane_count => v,
-        Some(_) => return None,
-        None if expected_plane_count <= 1 => vec![0u64; expected_plane_count.max(1)],
-        None => return None,
-    };
-    let offsets = match offsets_opt {
-        Some(v) if v.len() == expected_plane_count => v,
-        Some(_) => return None,
-        None if expected_plane_count <= 1 => vec![0u64; expected_plane_count.max(1)],
-        None => return None,
-    };
-    Some((sizes, offsets))
+    let sizes = resolve(parse_arr("plane_sizes")?)?;
+    let offsets = resolve(parse_arr("plane_offsets")?)?;
+    let strides = resolve(parse_arr("plane_strides")?)?;
+    Some((sizes, offsets, strides))
 }
 
 fn handle_register(
@@ -326,15 +321,22 @@ fn handle_register(
         );
     }
 
-    let (plane_sizes, plane_offsets) = match parse_plane_arrays(request, received_fds.len()) {
-        Some(arrays) => arrays,
-        None => {
-            return (
-                serde_json::json!({"error": "plane_sizes/plane_offsets length mismatch"}),
-                Vec::new(),
-            )
-        }
-    };
+    let (plane_sizes, plane_offsets, plane_strides) =
+        match parse_plane_arrays(request, received_fds.len()) {
+            Some(arrays) => arrays,
+            None => {
+                return (
+                    serde_json::json!({
+                        "error": "plane_sizes/plane_offsets/plane_strides length mismatch"
+                    }),
+                    Vec::new(),
+                )
+            }
+        };
+    let drm_format_modifier = request
+        .get("drm_format_modifier")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
 
     let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let height = request.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -365,10 +367,12 @@ fn handle_register(
         dma_buf_fds: dup_fds,
         plane_sizes,
         plane_offsets,
+        plane_strides,
         width,
         height,
         format,
         resource_type,
+        drm_format_modifier,
     }) {
         Ok(()) => {
             tracing::debug!(
@@ -401,7 +405,7 @@ fn handle_lookup(
         None => return (serde_json::json!({"error": "missing surface_id"}), Vec::new()),
     };
 
-    let (plane_fds, plane_sizes, plane_offsets) = match state.get_surface_planes(surface_id) {
+    let checkout = match state.get_surface_planes(surface_id) {
         Some(planes) => planes,
         None => return (serde_json::json!({"error": "surface not found"}), Vec::new()),
     };
@@ -409,8 +413,8 @@ fn handle_lookup(
     // Dup each stored fd so the kernel-delivered fds in the peer's table are
     // independent of the table's own copies. On partial failure, close every
     // dup we already took.
-    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(plane_fds.len());
-    for fd in &plane_fds {
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(checkout.dma_buf_fds.len());
+    for fd in &checkout.dma_buf_fds {
         let dup = unsafe { libc::dup(*fd) };
         if dup < 0 {
             for d in &dup_fds {
@@ -437,8 +441,10 @@ fn handle_lookup(
             "height": height,
             "format": format,
             "resource_type": resource_type,
-            "plane_sizes": plane_sizes,
-            "plane_offsets": plane_offsets,
+            "plane_sizes": checkout.plane_sizes,
+            "plane_offsets": checkout.plane_offsets,
+            "plane_strides": checkout.plane_strides,
+            "drm_format_modifier": checkout.drm_format_modifier,
         }),
         dup_fds,
     )
@@ -490,15 +496,22 @@ fn handle_check_in(
         );
     }
 
-    let (plane_sizes, plane_offsets) = match parse_plane_arrays(request, received_fds.len()) {
-        Some(arrays) => arrays,
-        None => {
-            return (
-                serde_json::json!({"error": "plane_sizes/plane_offsets length mismatch"}),
-                Vec::new(),
-            )
-        }
-    };
+    let (plane_sizes, plane_offsets, plane_strides) =
+        match parse_plane_arrays(request, received_fds.len()) {
+            Some(arrays) => arrays,
+            None => {
+                return (
+                    serde_json::json!({
+                        "error": "plane_sizes/plane_offsets/plane_strides length mismatch"
+                    }),
+                    Vec::new(),
+                )
+            }
+        };
+    let drm_format_modifier = request
+        .get("drm_format_modifier")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
 
     let width = request.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let height = request.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
@@ -531,10 +544,12 @@ fn handle_check_in(
         dma_buf_fds: dup_fds,
         plane_sizes,
         plane_offsets,
+        plane_strides,
         width,
         height,
         format,
         resource_type,
+        drm_format_modifier,
     }) {
         for fd in &leftover {
             unsafe { libc::close(*fd) };
@@ -746,6 +761,8 @@ mod tests {
             "resource_type": "pixel_buffer",
             "plane_sizes": [pattern_y.len() as u64, pattern_uv.len() as u64],
             "plane_offsets": [0u64, 0u64],
+            "plane_strides": [1920u64, 1920u64],
+            "drm_format_modifier": 0u64,
         });
         let (check_in_resp, check_in_fds) =
             send_request_with_fds(&stream, &check_in_req, &[fd_y, fd_uv], 0)
@@ -806,6 +823,88 @@ mod tests {
             0,
         );
 
+        drop(stream);
+        service.stop();
+    }
+
+    /// `drm_format_modifier` and `plane_strides` ride along through the
+    /// register/lookup path. The host adapter writes the modifier into the
+    /// `SurfaceTransportHandle` field defined in `streamlib-adapter-abi`; the
+    /// consumer reads it from the lookup response and passes it to
+    /// `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT` (or the Vulkan equivalent).
+    /// A round-trip through the wire is the test that locks the contract.
+    #[test]
+    fn drm_format_modifier_and_strides_round_trip() {
+        let state = SurfaceShareState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+
+        let send_fd = make_memfd_with(b"rt-render-target-payload");
+        // An NVIDIA-tiled modifier from the live probe (one of the values
+        // documented in docs/learnings/nvidia-egl-dmabuf-render-target.md).
+        // The wire treats it opaquely — no need to validate the exact bits.
+        let chosen_modifier: u64 = 0x0300_0000_0060_6014;
+        let pitch: u64 = 1920 * 4;
+        let req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "test-runtime",
+            "width": 1920,
+            "height": 1080,
+            "format": "Bgra8Unorm",
+            "resource_type": "texture",
+            "plane_sizes": [pitch * 1080],
+            "plane_offsets": [0u64],
+            "plane_strides": [pitch],
+            "drm_format_modifier": chosen_modifier,
+        });
+        let (resp, _) = send_request_with_fds(&stream, &req, &[send_fd], 0)
+            .expect("check_in request");
+        unsafe { libc::close(send_fd) };
+        let surface_id = resp
+            .get("surface_id")
+            .and_then(|v| v.as_str())
+            .expect("surface_id in response")
+            .to_string();
+
+        let lookup_req = serde_json::json!({
+            "op": "check_out",
+            "surface_id": surface_id,
+        });
+        let (lookup_resp, lookup_fds) =
+            send_request_with_fds(&stream, &lookup_req, &[], MAX_DMA_BUF_PLANES)
+                .expect("check_out request");
+        for fd in &lookup_fds {
+            unsafe { libc::close(*fd) };
+        }
+
+        assert_eq!(
+            lookup_resp.get("drm_format_modifier").and_then(|v| v.as_u64()),
+            Some(chosen_modifier),
+            "modifier round-trip: lookup must echo the registered value verbatim",
+        );
+        assert_eq!(
+            lookup_resp
+                .get("plane_strides")
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|v| v.as_u64()).collect::<Vec<_>>()),
+            Some(vec![pitch]),
+            "plane_strides round-trip: lookup must echo registered values verbatim",
+        );
+
+        let _ = send_request_with_fds(
+            &stream,
+            &serde_json::json!({
+                "op": "release",
+                "surface_id": surface_id,
+                "runtime_id": "test-runtime",
+            }),
+            &[],
+            0,
+        );
         drop(stream);
         service.stop();
     }
@@ -892,10 +991,12 @@ mod tests {
                     dma_buf_fds: mk(label),
                     plane_sizes: vec![0],
                     plane_offsets: vec![0],
+                    plane_strides: vec![0],
                     width: 1,
                     height: 1,
                     format: "Bgra32",
                     resource_type: "pixel_buffer",
+                    drm_format_modifier: 0,
                 })
                 .expect("register");
         }

--- a/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
+++ b/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
@@ -1,0 +1,425 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! EGL probe for render-target-capable DRM format modifiers.
+//!
+//! Queries `eglQueryDmaBufModifiersEXT` on a host EGL display and filters out
+//! `external_only=TRUE` modifiers. Returned modifiers are safe to pass to a
+//! consumer-side EGL `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT` import for use as
+//! a `GL_TEXTURE_2D` color attachment.
+//!
+//! See `docs/learnings/nvidia-egl-dmabuf-render-target.md` — linear DMA-BUFs
+//! are sampler-only on NVIDIA Linux; tiled modifiers picked from this probe
+//! are render-target-capable.
+//!
+//! `libEGL.so.1` is loaded dynamically. When EGL is unavailable (headless CI,
+//! systems without `libEGL`, or display servers that decline to initialize),
+//! the probe returns an empty table and the caller is responsible for picking
+//! a fallback path (typically: refuse to allocate a render-target image and
+//! surface a `GpuError`).
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::sync::Arc;
+
+use libloading::Library;
+use thiserror::Error;
+
+/// DRM FOURCC codes for the surface formats the runtime cares about.
+///
+/// `fourcc::DRM_FORMAT_*` values from `<drm/drm_fourcc.h>` — packed little-
+/// endian ASCII so e.g. `'A'|'R'<<8|'2'<<16|'4'<<24` = `AR24` = `ARGB8888`.
+/// We list the constants here rather than depending on a `drm-fourcc` crate
+/// because the set is small and stable.
+pub mod fourcc {
+    /// `'A'|'R'<<8|'2'<<16|'4'<<24` — `XRGB8888` packed.
+    pub const DRM_FORMAT_ARGB8888: u32 = 0x3432_5241;
+    /// `'A'|'B'<<8|'2'<<16|'4'<<24` — `ABGR8888` packed.
+    pub const DRM_FORMAT_ABGR8888: u32 = 0x3432_4241;
+    /// `'N'|'V'<<8|'1'<<16|'2'<<24` — NV12 (Y plane + interleaved UV).
+    pub const DRM_FORMAT_NV12: u32 = 0x3231_564E;
+}
+
+/// `DRM_FORMAT_MOD_LINEAR` — sampler-only on NVIDIA Linux; included as the
+/// universally-supported but non-render-target fallback.
+pub const DRM_FORMAT_MOD_LINEAR: u64 = 0;
+
+/// Reasons the EGL probe couldn't enumerate render-target modifiers.
+///
+/// All variants are fall-back-to-linear conditions, not hard failures —
+/// the runtime keeps booting even when EGL is missing.
+#[derive(Debug, Error)]
+pub enum ProbeError {
+    #[error("libEGL.so.1 not loadable: {0}")]
+    LibraryNotFound(String),
+    #[error("required EGL symbol '{0}' missing")]
+    SymbolMissing(&'static str),
+    #[error("eglGetDisplay returned EGL_NO_DISPLAY")]
+    NoDisplay,
+    #[error("eglInitialize failed (EGL error 0x{0:04x})")]
+    InitFailed(u32),
+    #[error("EGL_EXT_image_dma_buf_import_modifiers extension not advertised")]
+    ExtensionMissing,
+    #[error("eglQueryDmaBufModifiersEXT failed for fourcc 0x{0:08x} (EGL error 0x{1:04x})")]
+    QueryFailed(u32, u32),
+}
+
+/// Render-target-capable DRM modifiers for each probed format.
+///
+/// Empty for formats EGL didn't return any `external_only=FALSE` modifier
+/// for. Callers asking for a format that isn't in the table get an empty
+/// slice — the convention is: empty list ⇒ no render-target path is
+/// available for this format on this driver, fall back to linear with a
+/// `tracing::warn!`.
+#[derive(Debug, Clone, Default)]
+pub struct DrmModifierTable {
+    rt_modifiers: HashMap<u32, Vec<u64>>,
+}
+
+impl DrmModifierTable {
+    /// Empty table — used when EGL probing failed and the caller falls back
+    /// to linear-only allocation.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Render-target-capable modifiers for a DRM FOURCC, in the order EGL
+    /// returned them. Vulkan's `VkImageDrmFormatModifierListCreateInfoEXT`
+    /// will pick from this list at image-create time.
+    pub fn rt_modifiers(&self, fourcc: u32) -> &[u64] {
+        self.rt_modifiers
+            .get(&fourcc)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Whether the probe found at least one RT-capable modifier for `fourcc`.
+    pub fn has_rt_modifier(&self, fourcc: u32) -> bool {
+        !self.rt_modifiers(fourcc).is_empty()
+    }
+
+    /// Number of probed formats with at least one RT-capable modifier.
+    pub fn formats_with_rt_modifier(&self) -> usize {
+        self.rt_modifiers
+            .values()
+            .filter(|v| !v.is_empty())
+            .count()
+    }
+}
+
+/// EGL constants and types the probe needs.
+///
+/// We dlopen libEGL and call extension functions via `eglGetProcAddress`, so
+/// no `khronos-egl` dep is required and a missing libEGL becomes a graceful
+/// `ProbeError::LibraryNotFound` rather than a link-time failure.
+#[allow(non_camel_case_types, dead_code)]
+mod egl {
+    use std::ffi::c_void;
+
+    pub type EGLDisplay = *mut c_void;
+    pub type EGLBoolean = u32;
+    pub type EGLint = i32;
+    pub type EGLuint64KHR = u64;
+    pub type EGLNativeDisplayType = *mut c_void;
+
+    pub const EGL_NO_DISPLAY: EGLDisplay = std::ptr::null_mut();
+    pub const EGL_DEFAULT_DISPLAY: EGLNativeDisplayType = std::ptr::null_mut();
+    pub const EGL_TRUE: EGLBoolean = 1;
+    pub const EGL_FALSE: EGLBoolean = 0;
+    pub const EGL_EXTENSIONS: EGLint = 0x3055;
+}
+
+/// Probed EGL function pointers.
+///
+/// Held inside `Probe` for the duration of the probe; dropped before the
+/// table is returned so libEGL can be unloaded without leaving dangling
+/// symbol pointers.
+struct EglFns {
+    _lib: Arc<Library>,
+    egl_get_display: unsafe extern "C" fn(egl::EGLNativeDisplayType) -> egl::EGLDisplay,
+    egl_initialize: unsafe extern "C" fn(egl::EGLDisplay, *mut egl::EGLint, *mut egl::EGLint) -> egl::EGLBoolean,
+    egl_terminate: unsafe extern "C" fn(egl::EGLDisplay) -> egl::EGLBoolean,
+    egl_query_string: unsafe extern "C" fn(egl::EGLDisplay, egl::EGLint) -> *const c_char,
+    egl_get_proc_address: unsafe extern "C" fn(*const c_char) -> *mut c_void,
+    egl_get_error: unsafe extern "C" fn() -> egl::EGLint,
+    /// Loaded via `eglGetProcAddress`. `None` when the
+    /// `EGL_EXT_image_dma_buf_import_modifiers` extension is not advertised.
+    egl_query_dma_buf_modifiers: Option<
+        unsafe extern "C" fn(
+            egl::EGLDisplay,
+            egl::EGLint,                  // format (DRM FOURCC)
+            egl::EGLint,                  // max_modifiers (0 to query count)
+            *mut egl::EGLuint64KHR,       // modifiers out
+            *mut egl::EGLBoolean,         // external_only out (per-modifier)
+            *mut egl::EGLint,             // num_modifiers out
+        ) -> egl::EGLBoolean,
+    >,
+}
+
+impl EglFns {
+    fn load() -> Result<Self, ProbeError> {
+        let lib = unsafe { Library::new("libEGL.so.1") }
+            .or_else(|_| unsafe { Library::new("libEGL.so") })
+            .map_err(|e| ProbeError::LibraryNotFound(e.to_string()))?;
+        let lib = Arc::new(lib);
+
+        unsafe fn sym<T: Copy>(lib: &Library, name: &'static [u8]) -> Result<T, ProbeError> {
+            let symbol: libloading::Symbol<T> = unsafe { lib.get(name) }
+                .map_err(|_| ProbeError::SymbolMissing(
+                    std::str::from_utf8(&name[..name.len().saturating_sub(1)]).unwrap_or("?"),
+                ))?;
+            Ok(*symbol)
+        }
+
+        let egl_get_display = unsafe { sym(&lib, b"eglGetDisplay\0")? };
+        let egl_initialize = unsafe { sym(&lib, b"eglInitialize\0")? };
+        let egl_terminate = unsafe { sym(&lib, b"eglTerminate\0")? };
+        let egl_query_string = unsafe { sym(&lib, b"eglQueryString\0")? };
+        let egl_get_proc_address = unsafe { sym(&lib, b"eglGetProcAddress\0")? };
+        let egl_get_error = unsafe { sym(&lib, b"eglGetError\0")? };
+
+        Ok(Self {
+            _lib: lib,
+            egl_get_display,
+            egl_initialize,
+            egl_terminate,
+            egl_query_string,
+            egl_get_proc_address,
+            egl_get_error,
+            egl_query_dma_buf_modifiers: None,
+        })
+    }
+
+    /// Resolve `eglQueryDmaBufModifiersEXT` after `eglInitialize`. The
+    /// extension function is only valid once a display is initialized.
+    fn resolve_modifier_query(&mut self, _display: egl::EGLDisplay) -> Result<(), ProbeError> {
+        let name = CString::new("eglQueryDmaBufModifiersEXT").unwrap();
+        let raw = unsafe { (self.egl_get_proc_address)(name.as_ptr()) };
+        if raw.is_null() {
+            return Err(ProbeError::ExtensionMissing);
+        }
+        // eglGetProcAddress returns a `void(*)()` cast — extension fn is
+        // `EGLBoolean(EGLDisplay, EGLint, EGLint, EGLuint64KHR*, EGLBoolean*, EGLint*)`.
+        let typed: unsafe extern "C" fn(
+            egl::EGLDisplay,
+            egl::EGLint,
+            egl::EGLint,
+            *mut egl::EGLuint64KHR,
+            *mut egl::EGLBoolean,
+            *mut egl::EGLint,
+        ) -> egl::EGLBoolean = unsafe { std::mem::transmute(raw) };
+        self.egl_query_dma_buf_modifiers = Some(typed);
+        Ok(())
+    }
+}
+
+/// FOURCC formats the probe interrogates by default. Mirrors the
+/// `SurfaceFormat` set carried over the surface-adapter ABI (BGRA, RGBA,
+/// NV12).
+const DEFAULT_PROBE_FORMATS: &[u32] = &[
+    fourcc::DRM_FORMAT_ABGR8888,
+    fourcc::DRM_FORMAT_ARGB8888,
+    fourcc::DRM_FORMAT_NV12,
+];
+
+/// Run the EGL probe on `EGL_DEFAULT_DISPLAY` and return a populated
+/// [`DrmModifierTable`].
+///
+/// On any failure (missing libEGL, no display server, extension not
+/// advertised), returns the error and the caller decides whether to
+/// degrade to [`DrmModifierTable::empty`] or surface the failure.
+#[tracing::instrument(level = "info", name = "drm_modifier_probe", skip_all)]
+pub fn probe_default_display() -> Result<DrmModifierTable, ProbeError> {
+    probe_with_formats(DEFAULT_PROBE_FORMATS)
+}
+
+/// Run the EGL probe with an explicit FOURCC list. Exposed for tests that
+/// want to interrogate a single format.
+pub fn probe_with_formats(formats: &[u32]) -> Result<DrmModifierTable, ProbeError> {
+    let mut fns = EglFns::load()?;
+
+    let display = unsafe { (fns.egl_get_display)(egl::EGL_DEFAULT_DISPLAY) };
+    if display == egl::EGL_NO_DISPLAY {
+        return Err(ProbeError::NoDisplay);
+    }
+
+    let mut major = 0;
+    let mut minor = 0;
+    let init_ok = unsafe { (fns.egl_initialize)(display, &mut major, &mut minor) };
+    if init_ok != egl::EGL_TRUE {
+        let err = unsafe { (fns.egl_get_error)() } as u32;
+        return Err(ProbeError::InitFailed(err));
+    }
+
+    // Use a guard so eglTerminate runs even on early-return. The guard
+    // holds a copied function pointer (fn pointers are Copy) plus the
+    // display handle, so it doesn't borrow `fns` and the extension
+    // resolve below can take `&mut fns` freely.
+    struct DisplayGuard {
+        terminate: unsafe extern "C" fn(egl::EGLDisplay) -> egl::EGLBoolean,
+        display: egl::EGLDisplay,
+    }
+    impl Drop for DisplayGuard {
+        fn drop(&mut self) {
+            unsafe { (self.terminate)(self.display) };
+        }
+    }
+    let _guard = DisplayGuard {
+        terminate: fns.egl_terminate,
+        display,
+    };
+
+    // Verify the extension is advertised on this display before chasing the
+    // proc address.
+    let exts_ptr = unsafe { (fns.egl_query_string)(display, egl::EGL_EXTENSIONS) };
+    if exts_ptr.is_null() {
+        return Err(ProbeError::ExtensionMissing);
+    }
+    let exts = unsafe { CStr::from_ptr(exts_ptr) }
+        .to_str()
+        .unwrap_or("");
+    if !exts.split_whitespace().any(|tok| tok == "EGL_EXT_image_dma_buf_import_modifiers") {
+        return Err(ProbeError::ExtensionMissing);
+    }
+
+    fns.resolve_modifier_query(display)?;
+
+    let query = fns
+        .egl_query_dma_buf_modifiers
+        .expect("resolve_modifier_query set this");
+
+    let mut table = DrmModifierTable::default();
+
+    for &fourcc in formats {
+        // First call with max=0, NULLs out, gets the count.
+        let mut count: egl::EGLint = 0;
+        let ok = unsafe {
+            query(
+                display,
+                fourcc as egl::EGLint,
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut count,
+            )
+        };
+        if ok != egl::EGL_TRUE {
+            let err = unsafe { (fns.egl_get_error)() } as u32;
+            tracing::warn!(
+                "drm_modifier_probe: eglQueryDmaBufModifiersEXT count for fourcc 0x{:08x} failed (EGL 0x{:04x})",
+                fourcc,
+                err
+            );
+            continue;
+        }
+        if count == 0 {
+            tracing::debug!(
+                "drm_modifier_probe: no modifiers advertised for fourcc 0x{:08x}",
+                fourcc
+            );
+            continue;
+        }
+
+        let mut modifiers = vec![0u64; count as usize];
+        let mut external_only = vec![egl::EGL_FALSE; count as usize];
+        let mut returned: egl::EGLint = 0;
+        let ok = unsafe {
+            query(
+                display,
+                fourcc as egl::EGLint,
+                count,
+                modifiers.as_mut_ptr(),
+                external_only.as_mut_ptr(),
+                &mut returned,
+            )
+        };
+        if ok != egl::EGL_TRUE {
+            let err = unsafe { (fns.egl_get_error)() } as u32;
+            return Err(ProbeError::QueryFailed(fourcc, err));
+        }
+
+        // Filter to render-target-capable: external_only must be EGL_FALSE.
+        let rt: Vec<u64> = modifiers
+            .iter()
+            .zip(external_only.iter())
+            .take(returned as usize)
+            .filter_map(|(m, ext)| if *ext == egl::EGL_FALSE { Some(*m) } else { None })
+            .collect();
+
+        tracing::info!(
+            "drm_modifier_probe: fourcc 0x{:08x} → {} modifier(s) total, {} render-target-capable",
+            fourcc,
+            returned,
+            rt.len(),
+        );
+
+        if !rt.is_empty() {
+            table.rt_modifiers.insert(fourcc, rt);
+        }
+    }
+
+    tracing::info!(
+        "drm_modifier_probe: EGL {}.{}, {} format(s) with render-target-capable modifiers",
+        major,
+        minor,
+        table.formats_with_rt_modifier(),
+    );
+
+    Ok(table)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Empty table reports zero RT modifiers for any format and an empty
+    /// slice on lookup — the no-EGL fallback shape.
+    #[test]
+    fn empty_table_reports_no_rt_modifiers() {
+        let table = DrmModifierTable::empty();
+        assert_eq!(table.formats_with_rt_modifier(), 0);
+        assert!(!table.has_rt_modifier(fourcc::DRM_FORMAT_ABGR8888));
+        assert!(table.rt_modifiers(fourcc::DRM_FORMAT_ABGR8888).is_empty());
+    }
+
+    /// Live EGL probe — best-effort, skips when no EGL is available.
+    /// On NVIDIA Linux this should report ≥12 RT-capable modifiers for
+    /// `DRM_FORMAT_ABGR8888` (the tiled NVIDIA modifiers documented in
+    /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`); on Mesa the
+    /// count is driver-dependent. We assert only that the probe ran and
+    /// either returned a known error or a sane table.
+    #[test]
+    fn probe_default_display_runs_or_skips_cleanly() {
+        match probe_default_display() {
+            Ok(table) => {
+                let n = table.formats_with_rt_modifier();
+                println!(
+                    "EGL probe ok: {} format(s) with RT modifiers",
+                    n
+                );
+                // Don't assert n>0 — vivid-only / headless CI may legitimately
+                // return zero formats. The probe ran without panic; that is
+                // the assertion.
+            }
+            Err(e) => {
+                println!("EGL probe skipped: {e}");
+            }
+        }
+    }
+
+    /// FOURCC packing is little-endian ASCII per `<drm/drm_fourcc.h>`.
+    /// Locking the constants here prevents the silent drift that would
+    /// otherwise corrupt every modifier query for the affected format.
+    #[test]
+    fn fourcc_constants_are_ascii_packed() {
+        assert_eq!(
+            &fourcc::DRM_FORMAT_ARGB8888.to_le_bytes(),
+            b"AR24",
+        );
+        assert_eq!(
+            &fourcc::DRM_FORMAT_ABGR8888.to_le_bytes(),
+            b"AB24",
+        );
+        assert_eq!(&fourcc::DRM_FORMAT_NV12.to_le_bytes(), b"NV12");
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -37,5 +37,8 @@ pub use vulkan_compute_kernel::VulkanComputeKernel;
 mod vulkan_format_converter;
 pub use vulkan_format_converter::VulkanFormatConverter;
 
+#[cfg(target_os = "linux")]
+pub mod drm_modifier_probe;
+
 #[cfg(all(test, target_os = "linux"))]
 mod vulkan_swapchain_alloc_repro_test;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -16,6 +16,8 @@ use vma::Alloc as _;
 use crate::core::rhi::TextureDescriptor;
 use crate::core::{Result, StreamError};
 
+#[cfg(target_os = "linux")]
+use super::drm_modifier_probe::{self, DrmModifierTable};
 use super::{VulkanCommandQueue, VulkanTexture};
 
 /// Vulkan GPU device.
@@ -56,6 +58,15 @@ pub struct VulkanDevice {
     /// VMA pool for DMA-BUF exportable DEVICE_LOCAL images (textures for IPC).
     #[cfg(target_os = "linux")]
     dma_buf_image_pool: Option<vma::Pool>,
+    /// VMA pool for DMA-BUF exportable images created with
+    /// `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT` and a render-target-capable
+    /// DRM modifier from [`Self::drm_modifier_table`]. Separate from
+    /// [`Self::dma_buf_image_pool`] because the memory type index for tiled
+    /// DRM-modifier images may differ from the OPTIMAL pool's, and because
+    /// callers should never get a sampler-only LINEAR image when they asked
+    /// for an RT-capable one.
+    #[cfg(target_os = "linux")]
+    dma_buf_image_pool_tiled: Option<vma::Pool>,
     /// Backing storage for the buffer pool's VkExportMemoryAllocateInfo. VMA stores
     /// a raw pointer to this struct via pMemoryAllocateNext, so we must keep it
     /// alive for the pool's entire lifetime.
@@ -64,6 +75,15 @@ pub struct VulkanDevice {
     /// Backing storage for the image pool's VkExportMemoryAllocateInfo.
     #[cfg(target_os = "linux")]
     _dma_buf_image_export_info: Option<Box<vk::ExportMemoryAllocateInfo>>,
+    /// Backing storage for the tiled image pool's VkExportMemoryAllocateInfo.
+    #[cfg(target_os = "linux")]
+    _dma_buf_image_tiled_export_info: Option<Box<vk::ExportMemoryAllocateInfo>>,
+    /// Render-target-capable DRM modifiers per format from the EGL probe at
+    /// device init. Empty when libEGL is unavailable or the probe failed.
+    /// Callers consult this before requesting
+    /// [`VulkanTexture::new_render_target_dma_buf`].
+    #[cfg(target_os = "linux")]
+    drm_modifier_table: Arc<DrmModifierTable>,
     /// Tracks DMA-BUF import-path allocations (raw vkAllocateMemory for import only).
     live_allocation_count: AtomicUsize,
     /// Per-queue mutex for thread-safe queue submission (Vulkan spec requirement).
@@ -646,27 +666,60 @@ impl VulkanDevice {
                 .map_err(|e| StreamError::GpuError(format!("Failed to create VMA allocator: {e}")))?,
         );
 
+        // Run the EGL probe BEFORE creating pools — the tiled pool needs the
+        // modifier list. Probe failure (no libEGL, no display, extension
+        // missing) is non-fatal: the table stays empty and the tiled pool
+        // is skipped, which makes render-target DMA-BUF allocations refuse
+        // with an error rather than silently picking a sampler-only modifier.
+        // See `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
+        #[cfg(target_os = "linux")]
+        let drm_modifier_table = match drm_modifier_probe::probe_default_display() {
+            Ok(t) => Arc::new(t),
+            Err(e) => {
+                tracing::warn!(
+                    "EGL DRM modifier probe failed: {e} — render-target DMA-BUF \
+                     pool will be unavailable; only sampler-only / linear DMA-BUF \
+                     allocations will succeed"
+                );
+                Arc::new(DrmModifierTable::empty())
+            }
+        };
+
         // Build DMA-BUF export pools on Linux when external memory is supported.
+        // The tiled pool is built only when the EGL probe found at least one
+        // RT-capable modifier for BGRA — that's the probe shape.
         #[cfg(target_os = "linux")]
         let (
             dma_buf_buffer_pool,
             dma_buf_image_pool,
+            dma_buf_image_pool_tiled,
             dma_buf_buffer_export_info,
             dma_buf_image_export_info,
+            dma_buf_image_tiled_export_info,
         ) = if supports_external_memory {
-            match Self::create_dma_buf_pools(&allocator) {
-                Ok((bp, ip, bi, ii)) => (Some(bp), Some(ip), Some(bi), Some(ii)),
+            // BGRA8_UNORM in Vulkan = ARGB8888 in DRM.
+            let bgra_modifiers = drm_modifier_table
+                .rt_modifiers(drm_modifier_probe::fourcc::DRM_FORMAT_ARGB8888);
+            match Self::create_dma_buf_pools(
+                &allocator,
+                &device,
+                &memory_properties,
+                bgra_modifiers,
+            ) {
+                Ok((bp, ip, tp, bi, ii, ti)) => {
+                    (Some(bp), Some(ip), tp, Some(bi), Some(ii), ti)
+                }
                 Err(e) => {
                     tracing::warn!(
                         "DMA-BUF export pools could not be created — falling back to \
                          default pool for exportable allocations (may fail on NVIDIA \
                          after swapchain creation): {e}"
                     );
-                    (None, None, None, None)
+                    (None, None, None, None, None, None)
                 }
             }
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None, None)
         };
 
         tracing::info!(
@@ -709,9 +762,15 @@ impl VulkanDevice {
             #[cfg(target_os = "linux")]
             dma_buf_image_pool,
             #[cfg(target_os = "linux")]
+            dma_buf_image_pool_tiled,
+            #[cfg(target_os = "linux")]
             _dma_buf_buffer_export_info: dma_buf_buffer_export_info,
             #[cfg(target_os = "linux")]
             _dma_buf_image_export_info: dma_buf_image_export_info,
+            #[cfg(target_os = "linux")]
+            _dma_buf_image_tiled_export_info: dma_buf_image_tiled_export_info,
+            #[cfg(target_os = "linux")]
+            drm_modifier_table,
             live_allocation_count: AtomicUsize::new(0),
             graphics_queue_mutex: Mutex::new(()),
             transfer_queue_mutex: Mutex::new(()),
@@ -722,6 +781,78 @@ impl VulkanDevice {
         })
     }
 
+}
+
+/// Pick a DEVICE_LOCAL memory type for a tiled DMA-BUF VkImage.
+///
+/// VMA's `find_memory_type_index_for_image_info` cannot probe images with
+/// `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT` (it asserts on the missing
+/// plane aspect for multi-plane modifiers), so we create a real probe
+/// image, query its memory requirements, and find a matching DEVICE_LOCAL
+/// type ourselves. The probe image is destroyed before the function returns.
+#[cfg(target_os = "linux")]
+fn probe_tiled_dma_buf_memory_type(
+    device: &vulkanalia::Device,
+    memory_properties: &vk::PhysicalDeviceMemoryProperties,
+    tiled_modifiers: &[u64],
+) -> Result<u32> {
+    let mut probe_modifier_info = vk::ImageDrmFormatModifierListCreateInfoEXT::builder()
+        .drm_format_modifiers(tiled_modifiers);
+    let mut probe_external_info = vk::ExternalMemoryImageCreateInfo::builder()
+        .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+    let probe_image_info = vk::ImageCreateInfo::builder()
+        .image_type(vk::ImageType::_2D)
+        .format(vk::Format::B8G8R8A8_UNORM)
+        .extent(vk::Extent3D { width: 64, height: 64, depth: 1 })
+        .mip_levels(1)
+        .array_layers(1)
+        .samples(vk::SampleCountFlags::_1)
+        .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+        .usage(
+            vk::ImageUsageFlags::COLOR_ATTACHMENT
+                | vk::ImageUsageFlags::SAMPLED
+                | vk::ImageUsageFlags::TRANSFER_SRC
+                | vk::ImageUsageFlags::TRANSFER_DST,
+        )
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .initial_layout(vk::ImageLayout::UNDEFINED)
+        .push_next(&mut probe_modifier_info)
+        .push_next(&mut probe_external_info);
+
+    let probe_image = unsafe { device.create_image(&probe_image_info, None) }
+        .map_err(|e| {
+            StreamError::GpuError(format!(
+                "tiled-DMA-BUF probe vkCreateImage failed: {e}"
+            ))
+        })?;
+
+    let mem_reqs = unsafe { device.get_image_memory_requirements(probe_image) };
+    unsafe { device.destroy_image(probe_image, None) };
+
+    // First DEVICE_LOCAL type that satisfies memory_type_bits, preferring
+    // one without HOST_VISIBLE (main VRAM heap) on discrete GPUs.
+    for pass in 0..2 {
+        for i in 0..memory_properties.memory_type_count {
+            if (mem_reqs.memory_type_bits & (1 << i)) == 0 {
+                continue;
+            }
+            let flags = memory_properties.memory_types[i as usize].property_flags;
+            if !flags.contains(vk::MemoryPropertyFlags::DEVICE_LOCAL) {
+                continue;
+            }
+            if pass == 0 && flags.contains(vk::MemoryPropertyFlags::HOST_VISIBLE) {
+                continue;
+            }
+            return Ok(i);
+        }
+    }
+    Err(StreamError::GpuError(format!(
+        "no DEVICE_LOCAL memory type accepts tiled DMA-BUF probe image (memory_type_bits=0x{:x})",
+        mem_reqs.memory_type_bits
+    )))
+}
+
+impl VulkanDevice {
     /// Build VMA pools dedicated to DMA-BUF exportable allocations.
     ///
     /// Each pool is pinned to a memory type that supports the relevant property
@@ -729,14 +860,26 @@ impl VulkanDevice {
     /// pMemoryAllocateNext. The export info structs are heap-boxed and returned
     /// alongside the pools — the caller must keep them alive for the pool's
     /// lifetime (VMA stores raw pointers to them).
+    ///
+    /// The third pool (tiled) is conditional on `tiled_modifiers` being
+    /// non-empty — we need at least one render-target-capable DRM modifier to
+    /// create the probe image. When the EGL probe returned no modifiers (no
+    /// libEGL, no display, extension missing) the tiled pool is `None` and
+    /// callers fall back to refusing render-target allocations.
     #[cfg(target_os = "linux")]
+    #[allow(clippy::too_many_arguments)]
     fn create_dma_buf_pools(
         allocator: &Arc<vma::Allocator>,
+        device: &vulkanalia::Device,
+        memory_properties: &vk::PhysicalDeviceMemoryProperties,
+        tiled_modifiers: &[u64],
     ) -> Result<(
         vma::Pool,
         vma::Pool,
+        Option<vma::Pool>,
         Box<vk::ExportMemoryAllocateInfo>,
         Box<vk::ExportMemoryAllocateInfo>,
+        Option<Box<vk::ExportMemoryAllocateInfo>>,
     )> {
         // ── Find memory type for HOST_VISIBLE DMA-BUF exportable buffers ──
         // The probe must mirror the real buffer create info used by
@@ -846,13 +989,70 @@ impl VulkanDevice {
             .create_pool(&image_pool_options)
             .map_err(|e| StreamError::GpuError(format!("create DMA-BUF image pool: {e}")))?;
 
+        // ── Tiled (DRM_FORMAT_MODIFIER) image pool ────────────────────────
+        // Only created when the EGL probe returned at least one
+        // render-target-capable modifier. VMA's
+        // `find_memory_type_index_for_image_info` asserts on
+        // `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT` (it can't infer the plane
+        // aspect for multi-plane modifiers), so we probe via raw
+        // `vkCreateImage` + `vkGetImageMemoryRequirements` and pick a
+        // DEVICE_LOCAL type ourselves. The probe image is destroyed before
+        // the pool is created — VMA only needs the memory type index.
+        let (tiled_pool, tiled_export_info) = if tiled_modifiers.is_empty() {
+            (None, None)
+        } else {
+            match probe_tiled_dma_buf_memory_type(device, memory_properties, tiled_modifiers) {
+                Ok(tiled_mem_type_idx) => {
+                    let mut tiled_export_info = Box::new(
+                        vk::ExportMemoryAllocateInfo::builder()
+                            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+                            .build(),
+                    );
+                    let mut tiled_pool_options = vma::PoolOptions::default();
+                    tiled_pool_options = tiled_pool_options.push_next(tiled_export_info.as_mut());
+                    tiled_pool_options.memory_type_index = tiled_mem_type_idx;
+                    match allocator.create_pool(&tiled_pool_options) {
+                        Ok(tiled_pool) => {
+                            tracing::info!(
+                                "DMA-BUF VMA tiled image pool created — mem_type={}, modifiers_probed={}",
+                                tiled_mem_type_idx,
+                                tiled_modifiers.len(),
+                            );
+                            (Some(tiled_pool), Some(tiled_export_info))
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "DMA-BUF VMA tiled image pool creation failed (mem_type={}): {e} — render-target DMA-BUF allocations will be unavailable",
+                                tiled_mem_type_idx,
+                            );
+                            (None, None)
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Tiled DMA-BUF memory-type probe failed: {e} — render-target DMA-BUF allocations will be unavailable",
+                    );
+                    (None, None)
+                }
+            }
+        };
+
         tracing::info!(
-            "DMA-BUF VMA pools created — buffer mem_type={}, image mem_type={}",
+            "DMA-BUF VMA pools created — buffer mem_type={}, image mem_type={}, tiled={}",
             buffer_mem_type_idx,
-            image_mem_type_idx
+            image_mem_type_idx,
+            tiled_pool.is_some(),
         );
 
-        Ok((buffer_pool, image_pool, buffer_export_info, image_export_info))
+        Ok((
+            buffer_pool,
+            image_pool,
+            tiled_pool,
+            buffer_export_info,
+            image_export_info,
+            tiled_export_info,
+        ))
     }
 
     /// Find a memory type that satisfies both the type filter and required properties.
@@ -1295,6 +1495,28 @@ impl VulkanDevice {
         self.dma_buf_image_pool.as_ref()
     }
 
+    /// Get the VMA pool for DMA-BUF exportable images created with
+    /// `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`.
+    ///
+    /// Returns `None` when the EGL probe didn't find any RT-capable modifier
+    /// (no libEGL, no display, extension missing, or driver doesn't expose
+    /// `external_only=FALSE` modifiers for BGRA). Callers must refuse the
+    /// allocation in that case rather than fall back to LINEAR — LINEAR is
+    /// sampler-only on NVIDIA.
+    #[cfg(target_os = "linux")]
+    pub fn dma_buf_image_pool_tiled(&self) -> Option<&vma::Pool> {
+        self.dma_buf_image_pool_tiled.as_ref()
+    }
+
+    /// Render-target-capable DRM format modifiers, by DRM FOURCC, from the
+    /// EGL probe at device init. Empty when the probe failed. Callers
+    /// pass [`DrmModifierTable::rt_modifiers`] into
+    /// [`VulkanTexture::new_render_target_dma_buf`].
+    #[cfg(target_os = "linux")]
+    pub fn drm_modifier_table(&self) -> &Arc<DrmModifierTable> {
+        &self.drm_modifier_table
+    }
+
     /// Free device memory allocated via raw vkAllocateMemory (import path only).
     ///
     /// VMA-managed allocations are freed via [`vma::Allocator::destroy_image`] or
@@ -1351,6 +1573,7 @@ impl Drop for VulkanDevice {
         {
             drop(self.dma_buf_buffer_pool.take());
             drop(self.dma_buf_image_pool.take());
+            drop(self.dma_buf_image_pool_tiled.take());
         }
 
         drop(self.allocator.take());
@@ -1359,6 +1582,7 @@ impl Drop for VulkanDevice {
         {
             drop(self._dma_buf_buffer_export_info.take());
             drop(self._dma_buf_image_export_info.take());
+            drop(self._dma_buf_image_tiled_export_info.take());
         }
 
         unsafe {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -15,6 +15,30 @@ use crate::core::{Result, StreamError};
 
 use super::VulkanDevice;
 
+#[cfg(target_os = "linux")]
+use super::drm_modifier_probe::fourcc;
+
+/// Map a `TextureFormat` to the DRM FOURCC the EGL probe uses to look up
+/// render-target-capable modifiers. Returns `None` for formats that aren't
+/// part of the cross-language surface ABI (the ones the modifier probe
+/// doesn't interrogate).
+#[cfg(target_os = "linux")]
+fn texture_format_to_fourcc(format: TextureFormat) -> Option<u32> {
+    match format {
+        // BGRA8_UNORM in Vulkan = ARGB8888 in DRM (channel order matches once
+        // little-endian byte layout is taken into account).
+        TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => {
+            Some(fourcc::DRM_FORMAT_ARGB8888)
+        }
+        // RGBA8_UNORM in Vulkan = ABGR8888 in DRM.
+        TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => {
+            Some(fourcc::DRM_FORMAT_ABGR8888)
+        }
+        TextureFormat::Nv12 => Some(fourcc::DRM_FORMAT_NV12),
+        TextureFormat::Rgba16Float | TextureFormat::Rgba32Float => None,
+    }
+}
+
 /// Convert RHI TextureFormat to Vulkan format.
 fn texture_format_to_vk(format: TextureFormat) -> vk::Format {
     match format {
@@ -79,6 +103,14 @@ pub struct VulkanTexture {
     /// Whether this texture was imported from a DMA-BUF fd (uses imported_memory path).
     #[cfg(target_os = "linux")]
     imported_from_dma_buf: bool,
+    /// DRM format modifier the driver picked for this image. Zero means
+    /// `DRM_FORMAT_MOD_LINEAR` or "not applicable" (image was not created
+    /// with [`vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT`]). Render-target
+    /// adapters propagate this through `SurfaceTransportHandle` so the
+    /// consumer's EGL import can pass it via
+    /// `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT`.
+    #[cfg(target_os = "linux")]
+    chosen_drm_format_modifier: u64,
     width: u32,
     height: u32,
     format: TextureFormat,
@@ -159,6 +191,8 @@ impl VulkanTexture {
             imported_from_iosurface: false,
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
+            #[cfg(target_os = "linux")]
+            chosen_drm_format_modifier: 0,
             width: desc.width,
             height: desc.height,
             format: desc.format,
@@ -216,6 +250,143 @@ impl VulkanTexture {
             imported_from_iosurface: false,
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
+            #[cfg(target_os = "linux")]
+            chosen_drm_format_modifier: 0,
+            width: desc.width,
+            height: desc.height,
+            format: desc.format,
+        })
+    }
+
+    /// Create a render-target-capable DMA-BUF exportable texture using
+    /// `VK_EXT_image_drm_format_modifier`.
+    ///
+    /// `modifier_candidates` MUST come from
+    /// [`crate::vulkan::rhi::drm_modifier_probe::DrmModifierTable::rt_modifiers`]
+    /// — every entry has `external_only=FALSE` per the EGL probe, so the
+    /// exported FD can be imported on the consumer side as a
+    /// `GL_TEXTURE_2D` and bound as an FBO color attachment. The driver
+    /// picks one modifier from the list at allocation time; the choice is
+    /// available via [`Self::chosen_drm_format_modifier`] after
+    /// construction.
+    ///
+    /// Empty `modifier_candidates` ⇒ `Err` — there is no fallback to
+    /// linear at this entry point because linear DMA-BUFs are sampler-only
+    /// on NVIDIA Linux (see
+    /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`). Callers that
+    /// want a linear allocation should use [`Self::new`].
+    #[cfg(target_os = "linux")]
+    pub fn new_render_target_dma_buf(
+        vulkan_device: &Arc<VulkanDevice>,
+        desc: &TextureDescriptor,
+        modifier_candidates: &[u64],
+    ) -> Result<Self> {
+        if modifier_candidates.is_empty() {
+            return Err(StreamError::GpuError(
+                "new_render_target_dma_buf: empty modifier list — EGL did not advertise an external_only=FALSE modifier for this format. Linear DMA-BUF is sampler-only on NVIDIA; refusing to allocate.".into(),
+            ));
+        }
+
+        let vk_format = texture_format_to_vk(desc.format);
+        let usage_flags = texture_usages_to_vk(desc.usage);
+
+        // VK_EXT_image_drm_format_modifier requires the modifier list to
+        // outlive the ImageCreateInfo. Hold the slice in a local — the
+        // builder borrows from it via the pNext chain pointer, and the
+        // chain is consumed by create_image before this function returns.
+        let mut modifier_list_info = vk::ImageDrmFormatModifierListCreateInfoEXT::builder()
+            .drm_format_modifiers(modifier_candidates);
+
+        let mut external_image_info = vk::ExternalMemoryImageCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let image_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D {
+                width: desc.width,
+                height: desc.height,
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::_1)
+            .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+            .usage(usage_flags)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push_next(&mut modifier_list_info)
+            .push_next(&mut external_image_info);
+
+        let alloc_opts = vma::AllocationOptions {
+            flags: vma::AllocationCreateFlags::DEDICATED_MEMORY,
+            required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            ..Default::default()
+        };
+
+        // Prefer the dedicated tiled DMA-BUF image pool; fall back to the
+        // default allocator (still with the export-info pNext chain) only
+        // when external memory isn't supported. The fallback path may fail
+        // on NVIDIA after swapchain creation — caller is expected to have
+        // pre-warmed the pool to avoid that.
+        let (image, allocation) = if let Some(pool) =
+            vulkan_device.dma_buf_image_pool_tiled()
+        {
+            unsafe { pool.create_image(image_info, &alloc_opts) }
+        } else {
+            let allocator = vulkan_device.allocator();
+            unsafe { allocator.create_image(image_info, &alloc_opts) }
+        }
+        .map_err(|e| {
+            StreamError::GpuError(format!(
+                "Failed to create render-target DMA-BUF image (modifiers={:?}): {e}",
+                modifier_candidates
+            ))
+        })?;
+
+        // Read back which modifier the driver actually chose.
+        let chosen = {
+            use vulkanalia::vk::ExtImageDrmFormatModifierExtensionDeviceCommands;
+            let mut props = vk::ImageDrmFormatModifierPropertiesEXT::default();
+            let device = vulkan_device.device();
+            unsafe { device.get_image_drm_format_modifier_properties_ext(image, &mut props) }
+                .map_err(|e| {
+                    // Image leaks on this branch — the allocator owns it. We
+                    // destroy it explicitly so the caller doesn't need to.
+                    unsafe { vulkan_device.allocator().destroy_image(image, allocation) };
+                    StreamError::GpuError(format!(
+                        "vkGetImageDrmFormatModifierPropertiesEXT failed: {e}"
+                    ))
+                })?;
+            props.drm_format_modifier
+        };
+
+        if !modifier_candidates.contains(&chosen) {
+            unsafe { vulkan_device.allocator().destroy_image(image, allocation) };
+            return Err(StreamError::GpuError(format!(
+                "Driver picked modifier 0x{:016x} that wasn't in our candidate list {:?} — VUID violation",
+                chosen, modifier_candidates
+            )));
+        }
+
+        tracing::info!(
+            "VulkanTexture render-target DMA-BUF: {}x{} {:?} → modifier 0x{:016x}",
+            desc.width,
+            desc.height,
+            desc.format,
+            chosen
+        );
+
+        Ok(Self {
+            vulkan_device: Some(Arc::clone(vulkan_device)),
+            image: Some(image),
+            allocation: Some(allocation),
+            imported_memory: None,
+            cached_dma_buf_fd: OnceLock::new(),
+            cached_image_view: OnceLock::new(),
+            imported_from_iosurface: false,
+            imported_from_dma_buf: false,
+            chosen_drm_format_modifier: chosen,
             width: desc.width,
             height: desc.height,
             format: desc.format,
@@ -316,6 +487,8 @@ impl VulkanTexture {
             imported_from_iosurface: false,
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
+            #[cfg(target_os = "linux")]
+            chosen_drm_format_modifier: 0,
             width: 0,
             height: 0,
             format: TextureFormat::Rgba8Unorm,
@@ -385,6 +558,83 @@ impl VulkanTexture {
 
 #[cfg(target_os = "linux")]
 impl VulkanTexture {
+    /// DRM format modifier the driver picked at allocation time.
+    ///
+    /// Zero for textures created via [`Self::new`] / [`Self::new_device_local`]
+    /// or imported via [`Self::from_dma_buf_fd`] — those paths do not go
+    /// through `VK_EXT_image_drm_format_modifier`. Render-target textures
+    /// allocated via [`Self::new_render_target_dma_buf`] return the modifier
+    /// the driver chose from the candidate list.
+    pub fn chosen_drm_format_modifier(&self) -> u64 {
+        self.chosen_drm_format_modifier
+    }
+
+    /// Per-plane DMA-BUF layout for this texture, in plane index order.
+    ///
+    /// Each entry is `(offset_bytes, row_pitch_bytes)` from
+    /// `vkGetImageSubresourceLayout` — the values consumer-side EGL imports
+    /// must pass in `EGL_DMA_BUF_PLANE{N}_OFFSET_EXT` /
+    /// `EGL_DMA_BUF_PLANE{N}_PITCH_EXT`.
+    ///
+    /// For single-plane formats (BGRA/RGBA) returns one entry. NV12 returns
+    /// two (Y plane, then UV). Returns `Err` for textures without a backing
+    /// image or when the format's plane count isn't supported by this RHI
+    /// build.
+    pub fn dma_buf_plane_layout(&self) -> Result<Vec<(u64, u64)>> {
+        let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
+            StreamError::GpuError("dma_buf_plane_layout: no VulkanDevice".into())
+        })?;
+        let image = self.image.ok_or_else(|| {
+            StreamError::GpuError("dma_buf_plane_layout: no image".into())
+        })?;
+
+        let plane_count = match self.format {
+            TextureFormat::Nv12 => 2,
+            _ => 1,
+        };
+
+        let mut planes = Vec::with_capacity(plane_count);
+        for plane_idx in 0..plane_count {
+            // For DRM_FORMAT_MODIFIER_EXT images use the MEMORY_PLANE aspect;
+            // for OPTIMAL/LINEAR images use COLOR (or PLANE_0/_1 for NV12).
+            let aspect_mask = if self.chosen_drm_format_modifier != 0 {
+                match plane_idx {
+                    0 => vk::ImageAspectFlags::MEMORY_PLANE_0_EXT,
+                    1 => vk::ImageAspectFlags::MEMORY_PLANE_1_EXT,
+                    2 => vk::ImageAspectFlags::MEMORY_PLANE_2_EXT,
+                    3 => vk::ImageAspectFlags::MEMORY_PLANE_3_EXT,
+                    _ => return Err(StreamError::GpuError(format!(
+                        "dma_buf_plane_layout: plane index {plane_idx} out of range"
+                    ))),
+                }
+            } else if matches!(self.format, TextureFormat::Nv12) {
+                match plane_idx {
+                    0 => vk::ImageAspectFlags::PLANE_0,
+                    1 => vk::ImageAspectFlags::PLANE_1,
+                    _ => return Err(StreamError::GpuError(format!(
+                        "dma_buf_plane_layout: NV12 plane {plane_idx} out of range"
+                    ))),
+                }
+            } else {
+                vk::ImageAspectFlags::COLOR
+            };
+
+            let subres = vk::ImageSubresource::builder()
+                .aspect_mask(aspect_mask)
+                .mip_level(0)
+                .array_layer(0)
+                .build();
+            let layout = unsafe {
+                vk_dev
+                    .device()
+                    .get_image_subresource_layout(image, &subres)
+            };
+            planes.push((layout.offset, layout.row_pitch));
+        }
+
+        Ok(planes)
+    }
+
     /// Export the texture's memory as a DMA-BUF file descriptor.
     pub fn export_dma_buf_fd(&self) -> Result<std::os::unix::io::RawFd> {
         if let Some(&fd) = self.cached_dma_buf_fd.get() {
@@ -493,6 +743,7 @@ impl VulkanTexture {
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
             imported_from_dma_buf: true,
+            chosen_drm_format_modifier: 0,
             width,
             height,
             format,
@@ -514,6 +765,8 @@ impl Clone for VulkanTexture {
             imported_from_iosurface: false,
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
+            #[cfg(target_os = "linux")]
+            chosen_drm_format_modifier: 0,
             width: self.width,
             height: self.height,
             format: self.format,
@@ -898,6 +1151,107 @@ mod tests {
         assert_eq!(view1, view2, "image_view() should return the same cached view");
 
         println!("Lazy image view: created and cached successfully");
+    }
+
+    /// Round-trip test for the render-target DMA-BUF path:
+    /// 1. Pull RT-capable modifiers for ARGB8888 from the device's EGL probe.
+    /// 2. Skip if none — vivid CI / headless boxes have no modifiers.
+    /// 3. Allocate a 1920x1080 BGRA render-target VkImage with the candidate list.
+    /// 4. Assert the driver-chosen modifier is in the candidate list.
+    /// 5. Export the DMA-BUF fd and read back the per-plane layout.
+    /// 6. Assert plane[0].row_pitch >= 1920 * 4 (BGRA stride is at least
+    ///    pixel-tight, possibly aligned up by tiling).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_render_target_dma_buf_round_trip() {
+        use crate::vulkan::rhi::drm_modifier_probe::fourcc;
+
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                println!("Skipping — no Vulkan device: {e}");
+                return;
+            }
+        };
+        let table = device.drm_modifier_table();
+        let modifiers = table.rt_modifiers(fourcc::DRM_FORMAT_ARGB8888);
+        if modifiers.is_empty() {
+            println!("Skipping — EGL probe returned no RT-capable modifiers for ARGB8888");
+            return;
+        }
+        if device.dma_buf_image_pool_tiled().is_none() {
+            println!("Skipping — tiled DMA-BUF pool not created");
+            return;
+        }
+
+        let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Bgra8Unorm).with_usage(
+            TextureUsages::RENDER_ATTACHMENT
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+        );
+        let texture = VulkanTexture::new_render_target_dma_buf(&device, &desc, modifiers)
+            .expect("RT DMA-BUF allocation must succeed when modifiers exist");
+
+        assert!(texture.image().is_some());
+        let chosen = texture.chosen_drm_format_modifier();
+        assert!(
+            modifiers.contains(&chosen),
+            "driver picked modifier 0x{:016x} not in candidate list {:?}",
+            chosen,
+            modifiers
+        );
+        // Modifier 0 is DRM_FORMAT_MOD_LINEAR; the EGL probe's RT-capable
+        // list is supposed to be tiled-only.
+        assert_ne!(
+            chosen, 0,
+            "RT-capable modifier must not be DRM_FORMAT_MOD_LINEAR"
+        );
+
+        let layout = texture
+            .dma_buf_plane_layout()
+            .expect("plane layout must be queryable");
+        assert_eq!(layout.len(), 1, "BGRA is single-plane");
+        let (offset, row_pitch) = layout[0];
+        assert!(
+            row_pitch >= 1920 * 4,
+            "row_pitch {row_pitch} must be at least pixel-tight 1920*4"
+        );
+        println!(
+            "RT DMA-BUF: chosen modifier=0x{:016x}, plane[0]: offset={}, row_pitch={}",
+            chosen, offset, row_pitch
+        );
+
+        let fd = texture
+            .export_dma_buf_fd()
+            .expect("DMA-BUF export must succeed");
+        assert!(fd >= 0, "DMA-BUF fd must be non-negative");
+    }
+
+    /// `new_render_target_dma_buf` with an empty modifier list must fail
+    /// loudly rather than silently fall back to LINEAR (which is sampler-
+    /// only on NVIDIA — see docs/learnings/nvidia-egl-dmabuf-render-target.md).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_render_target_dma_buf_empty_modifiers_rejected() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                println!("Skipping — no Vulkan device: {e}");
+                return;
+            }
+        };
+        let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm)
+            .with_usage(TextureUsages::RENDER_ATTACHMENT);
+        let result = VulkanTexture::new_render_target_dma_buf(&device, &desc, &[]);
+        let err = match result {
+            Ok(_) => panic!("empty modifier list must reject, but allocation succeeded"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("empty modifier list") || msg.contains("EGL"),
+            "error must explain the missing-EGL-modifier root cause: {msg}"
+        );
     }
 
     #[test]

--- a/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
+++ b/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
@@ -94,6 +94,8 @@ fn check_in_multi_plane(
         "resource_type": "pixel_buffer",
         "plane_sizes": [plane_y.len() as u64, plane_uv.len() as u64],
         "plane_offsets": [0u64, 0u64],
+        "plane_strides": [64u64, 64u64],
+        "drm_format_modifier": 0u64,
     });
     let (resp, resp_fds) =
         send_request_with_fds(&stream, &req, &[fd_y, fd_uv], 0).expect("host check_in");
@@ -368,6 +370,8 @@ fn rust_surface_store_resolve_surface_multi_plane() {
         "resource_type": "pixel_buffer",
         "plane_sizes": [plane_y.len() as u64, plane_uv.len() as u64],
         "plane_offsets": [0u64, 0u64],
+        "plane_strides": [64u64, 64u64],
+        "drm_format_modifier": 0u64,
     });
     let (resp, _) = send_request_with_fds(&host_stream, &check_in_req, &[fd_y, fd_uv], 0)
         .expect("host check_in");


### PR DESCRIPTION
## Summary

- EGL probe (libEGL via libloading) enumerates RT-capable DRM modifiers per FOURCC; live verified on NVIDIA RTX 3090 (570.211.01) — 12 `external_only=FALSE` modifiers for ARGB8888 + ABGR8888, 0 for NV12 (decode-only path on this driver).
- New `VulkanTexture::new_render_target_dma_buf` allocates via `VK_EXT_image_drm_format_modifier` from a dedicated tiled VMA pool; the chosen modifier is read back via `vkGetImageDrmFormatModifierPropertiesEXT` and surfaced through `chosen_drm_format_modifier()` + `dma_buf_plane_layout()`.
- `SurfaceShareState` / `SurfaceRegistration` / unix-socket wire / `surface_store::register_texture` now carry `plane_strides: Vec<u64>` and `drm_format_modifier: u64`. `SurfacePlaneCheckout` returns the same on lookup.
- New `escalate_acquire_image` op (schemas regenerated for Rust + Python + Deno) routes subprocess RT-image acquisition through `GpuContextFullAccess::acquire_render_target_dma_buf_image`. Customers never invoke it directly — it's a host-side primitive for the forthcoming surface adapters.
- Display processor pre-warms the BGRA tiled pool in `start()` before swapchain creation, mirroring the camera-processor `VkBuffer` pattern; non-fatal warn when EGL probe returned no modifiers (headless CI / missing libEGL).

## Closes

Closes #510

## Exit criteria

- [x] `VulkanTexture` supports DMA-BUF export with `VK_EXT_image_drm_format_modifier`.
- [x] Host queries `eglQueryDmaBufModifiersEXT` at startup, picks `external_only=FALSE` modifiers per format; cached in `DrmModifierTable` on `VulkanDevice`.
- [x] Pool pre-warm at startup (display-processor `start()` allocates-then-releases a 64x64 BGRA RT image before the render thread spawns).
- [x] `SurfaceTransportHandle` already carried `drm_format_modifier` from #509; `surface_share` register+lookup now thread the modifier and per-plane strides through.
- [x] `streamlib-ipc-types` extended with `escalate_acquire_image` op.
- [x] `surface_share` registration carries the modifier + per-plane strides alongside each DMA-BUF FD.
- [x] No regressions in CPU-readable `VulkanPixelBuffer` paths — `VulkanPixelBuffer::new` is untouched, all existing pixel-buffer tests pass.

## Test plan

### Workspace baseline

`cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — **all green**, zero failures across every test binary.

### Focused new tests

- `vulkan::rhi::vulkan_texture::tests::test_render_target_dma_buf_round_trip` — allocates 1920x1080 BGRA RT image via the new path, asserts driver-chosen modifier is in the candidate list and != 0 (LINEAR), asserts plane[0] row pitch ≥ 1920*4. Pass on NVIDIA: chosen modifier = 0x0300000000606014, row_pitch = 7680.
- `vulkan::rhi::vulkan_texture::tests::test_render_target_dma_buf_empty_modifiers_rejected` — locks the no-LINEAR-fallback rule.
- `vulkan::rhi::drm_modifier_probe::tests::probe_default_display_runs_or_skips_cleanly` — runs probe on default display, accepts headless skip.
- `linux::surface_share::unix_socket_service::tests::drm_format_modifier_and_strides_round_trip` — register → lookup → assert both fields echo verbatim.
- 28 escalate handler tests still green.

### E2E Test Reports

#### Scenario 1 — vivid h264 roundtrip

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`
- **Build profile**: debug
- **Command**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-510-h264/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=300 \
    timeout --kill-after=3 30 cargo run -q -p vulkan-video-roundtrip -- h264 /dev/video0 15
    ```

##### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame encoded` / `First frame decoded`: 23:15:03.845 / 23:15:03.934
- `drm_modifier_probe` output: 12 RT modifiers for ARGB, 12 for ABGR, 0 for NV12 (NVIDIA-expected)
- `DMA-BUF VMA tiled image pool created — mem_type=1, modifiers_probed=12`
- `VulkanTexture render-target DMA-BUF: 64x64 Bgra8Unorm → modifier 0x0300000000606013` (display pre-warm)

##### PNG samples

- Directory: `/tmp/e2e-510-h264/png_samples/`
- Sample count: 3
- PNGs read: `display_001_frame_000060_input_000063.png`
- What was in the image: vivid 1920x1080 test pattern — green vertical gradient bars on the right; metadata text overlay top-left including `1920x1080, input 0`, `brightness 128, contrast 128, saturation 128, hue 0`, `volume 200, mute 0`, and various `int32 / int64 / boolean / menu` parameter readouts. Exactly what vivid emits.
- Anomalies: none

##### PSNR

- Reference frame: n/a — vivid synthetic source without a checked-in reference (PSNR rig is fixture-only).
- Y / U / V PSNR: n/a

##### Outcome

- **Pass**

#### Scenario 2 — vivid h265 roundtrip

Same setup with `h265` codec. Identical log-signal pass profile (0 errors, 12 RT modifiers, tiled pool created, first encode+decode at 23:15:49). PNG sample shows the same vivid pattern with timecode `00:00:12.683 63` clearly readable. **Pass**.

## Follow-ups

- **#512 (OpenGL adapter)** owns the FBO completeness round-trip test the issue body lists in exit criteria — implementing it requires GL/EGL context infrastructure that doesn't exist on Linux yet. The host-side allocation invariant (modifier picked from EGL `external_only=FALSE` list, threaded through `SurfaceTransportHandle`) is locked by the round-trip and wire tests in this PR; the consumer-side FBO check is the natural test of #512.
- Cam Link 4K / real UVC camera scenario skipped — vivid covers the camera→encoder→decoder→display path the new pool sits inside; real-hardware coverage belongs to scenarios that exercise driver-quirk paths the new pool doesn't touch (#288/#289/#292 territory).

## Polyglot coverage

- **Runtimes affected**: rust + python + deno (schema regenerated)
- **Schema regenerated**: yes
- **Python and Deno both covered?** yes — generated `EscalateRequestAcquireImage` types land in all three runtimes; SDK-side convenience wrappers (e.g. `streamlib.escalate.acquire_image`) ship with the consumer adapter PRs (#511 / #512), since this PR only ships the host-side primitive.
- **E2E tests run**:
  - [x] Host-Rust: 28 escalate handler tests pass; `drm_format_modifier_and_strides_round_trip` locks the wire contract
  - [x] Python subprocess: `polyglot_linux_resolve_surface_multi_plane::python_native_resolve_surface_multi_plane` pass
  - [x] Deno subprocess: `polyglot_linux_resolve_surface_multi_plane::deno_native_resolve_surface_multi_plane` pass
- **FD-passing path**: DMA-BUF FD (with modifier + per-plane strides via SCM_RIGHTS surface-share)

🤖 Generated with [Claude Code](https://claude.com/claude-code)