### PR TITLE
feat(adapter-vulkan): Vulkan-native surface adapter + cross-process timeline sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "libs/streamlib-macros",    # Procedural macros for reducing boilerplate
     "libs/streamlib-plugin-abi", # ABI-stable FFI types for dynamic plugins
     "libs/streamlib-adapter-abi", # ABI-stable surface adapter contract (in-tree + 3rd-party adapters)
+    "libs/streamlib-adapter-vulkan", # Vulkan-native surface adapter — canonical implementor of VulkanWritable / VulkanImageInfoExt (Linux)
     "libs/streamlib-deno-native", # FFI cdylib for Deno subprocess iceoryx2 access
     "libs/streamlib-python-native", # FFI cdylib for Python subprocess iceoryx2 access
     "libs/streamlib-ipc-types",  # Shared iceoryx2 payload types for cross-process IPC

--- a/libs/streamlib-adapter-abi/src/surface.rs
+++ b/libs/streamlib-adapter-abi/src/surface.rs
@@ -88,6 +88,45 @@ impl SurfaceTransportHandle {
             drm_format_modifier: 0,
         }
     }
+
+    /// Construct from the per-plane arrays. Called by the host side when
+    /// registering a backing with an adapter; the descriptor is then
+    /// passed to consumer adapters across IPC.
+    pub const fn new(
+        plane_count: u32,
+        dma_buf_fds: [i32; MAX_DMA_BUF_PLANES],
+        plane_offsets: [u64; MAX_DMA_BUF_PLANES],
+        plane_strides: [u64; MAX_DMA_BUF_PLANES],
+        drm_format_modifier: u64,
+    ) -> Self {
+        Self {
+            plane_count,
+            dma_buf_fds,
+            plane_offsets,
+            plane_strides,
+            drm_format_modifier,
+        }
+    }
+
+    pub const fn plane_count(&self) -> u32 {
+        self.plane_count
+    }
+
+    pub const fn dma_buf_fds(&self) -> &[i32; MAX_DMA_BUF_PLANES] {
+        &self.dma_buf_fds
+    }
+
+    pub const fn plane_offsets(&self) -> &[u64; MAX_DMA_BUF_PLANES] {
+        &self.plane_offsets
+    }
+
+    pub const fn plane_strides(&self) -> &[u64; MAX_DMA_BUF_PLANES] {
+        &self.plane_strides
+    }
+
+    pub const fn drm_format_modifier(&self) -> u64 {
+        self.drm_format_modifier
+    }
 }
 
 /// Adapter-internal: timeline-semaphore handles, counters, and the
@@ -123,6 +162,53 @@ pub struct SurfaceSyncState {
     pub(crate) _pad_b: u32,
     /// Reserved bytes for additive ABI extensions. MUST be zeroed.
     pub(crate) _reserved: [u8; 16],
+}
+
+impl SurfaceSyncState {
+    /// Construct from the host-side semaphore + sync-fd + initial layout.
+    ///
+    /// Subprocess consumer adapters never call this — they receive the
+    /// state in a [`StreamlibSurface`] over IPC and read fields via the
+    /// accessors below. Only the host-side surface-share registration
+    /// path constructs from raw values.
+    pub const fn new(
+        timeline_semaphore_handle: u64,
+        timeline_semaphore_sync_fd: i32,
+        last_acquire_value: u64,
+        last_release_value: u64,
+        current_image_layout: i32,
+    ) -> Self {
+        Self {
+            timeline_semaphore_handle,
+            timeline_semaphore_sync_fd,
+            _pad_a: 0,
+            last_acquire_value,
+            last_release_value,
+            current_image_layout,
+            _pad_b: 0,
+            _reserved: [0; 16],
+        }
+    }
+
+    pub const fn timeline_semaphore_handle(&self) -> u64 {
+        self.timeline_semaphore_handle
+    }
+
+    pub const fn timeline_semaphore_sync_fd(&self) -> i32 {
+        self.timeline_semaphore_sync_fd
+    }
+
+    pub const fn last_acquire_value(&self) -> u64 {
+        self.last_acquire_value
+    }
+
+    pub const fn last_release_value(&self) -> u64 {
+        self.last_release_value
+    }
+
+    pub const fn current_image_layout(&self) -> i32 {
+        self.current_image_layout
+    }
 }
 
 /// Stable, customer-visible descriptor for a shared GPU surface.
@@ -169,6 +255,26 @@ impl StreamlibSurface {
         }
     }
 
+    /// Adapter-facing: the DMA-BUF transport handle (fds, plane layout,
+    /// modifier).
+    ///
+    /// Customer code should not need this — it sees a framework-shaped
+    /// view through the adapter's `acquire_*` methods. Adapters reach
+    /// for it to import the backing on the consumer side
+    /// (`VkImportMemoryFdInfoKHR`, `eglCreateImageKHR`, …).
+    pub const fn transport(&self) -> &SurfaceTransportHandle {
+        &self.transport
+    }
+
+    /// Adapter-facing: the host-side timeline-semaphore + initial layout.
+    ///
+    /// Subprocess adapters import `timeline_semaphore_sync_fd` via
+    /// `vkImportSemaphoreFdKHR` and wait/signal the same timeline values
+    /// the host advances; the opaque `timeline_semaphore_handle` is
+    /// host-only and not dereferenceable in another address space.
+    pub const fn sync(&self) -> &SurfaceSyncState {
+        &self.sync
+    }
 }
 
 #[cfg(test)]
@@ -254,6 +360,46 @@ mod tests {
         assert_eq!(offset_of!(SurfaceSyncState, _reserved), 40);
         assert_eq!(size_of::<SurfaceSyncState>(), 56);
         assert_eq!(align_of::<SurfaceSyncState>(), 8);
+    }
+
+    /// Pub accessors return the values stored at construction. Locks the
+    /// "consumer adapter can read transport / sync state" contract — if
+    /// the accessors stop returning the field they refer to, every
+    /// subprocess adapter breaks at runtime.
+    #[test]
+    fn pub_accessors_round_trip_constructed_values() {
+        let transport = SurfaceTransportHandle::new(
+            2,
+            [10, 11, -1, -1],
+            [0, 4096, 0, 0],
+            [1920, 1920, 0, 0],
+            0x123_4567_89ab_cdef,
+        );
+        assert_eq!(transport.plane_count(), 2);
+        assert_eq!(transport.dma_buf_fds(), &[10, 11, -1, -1]);
+        assert_eq!(transport.plane_offsets(), &[0, 4096, 0, 0]);
+        assert_eq!(transport.plane_strides(), &[1920, 1920, 0, 0]);
+        assert_eq!(transport.drm_format_modifier(), 0x123_4567_89ab_cdef);
+
+        let sync = SurfaceSyncState::new(0xdead_beef, 42, 7, 5, 1);
+        assert_eq!(sync.timeline_semaphore_handle(), 0xdead_beef);
+        assert_eq!(sync.timeline_semaphore_sync_fd(), 42);
+        assert_eq!(sync.last_acquire_value(), 7);
+        assert_eq!(sync.last_release_value(), 5);
+        assert_eq!(sync.current_image_layout(), 1);
+
+        let surface = StreamlibSurface::new(
+            99,
+            1920,
+            1080,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET,
+            transport,
+            sync,
+        );
+        assert_eq!(surface.id, 99);
+        assert_eq!(surface.transport().plane_count(), 2);
+        assert_eq!(surface.sync().timeline_semaphore_sync_fd(), 42);
     }
 
     #[test]

--- a/libs/streamlib-adapter-vulkan/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan/Cargo.toml
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-vulkan"
+description = "Vulkan-native StreamLib surface adapter (Linux). No-copy passthrough — exposes host-allocated VkImage to consumers that speak Vulkan natively. Canonical implementor of the VulkanWritable / VulkanImageInfoExt capability traits from streamlib-adapter-abi."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_vulkan"
+path = "src/lib.rs"
+
+[dependencies]
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+parking_lot = "0.12"
+thiserror.workspace = true
+tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib = { path = "../streamlib" }
+streamlib-surface-client = { path = "../streamlib-surface-client" }
+vulkanalia.workspace = true
+libc.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+
+[dev-dependencies]
+tracing-subscriber.workspace = true
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+serde = { workspace = true }
+
+[[test]]
+name = "conformance"
+path = "tests/conformance.rs"
+
+[[test]]
+name = "sync_correctness"
+path = "tests/sync_correctness.rs"
+
+[[test]]
+name = "write_excludes_read"
+path = "tests/write_excludes_read.rs"
+
+# Subprocess round-trip / crash tests — Linux only. They spawn the
+# `vulkan_adapter_subprocess_helper` test binary that lives below.
+[[test]]
+name = "round_trip_host_writes_subprocess_reads"
+path = "tests/round_trip_host_writes_subprocess_reads.rs"
+
+[[test]]
+name = "round_trip_subprocess_writes_host_reads"
+path = "tests/round_trip_subprocess_writes_host_reads.rs"
+
+[[test]]
+name = "concurrent_reads_two_subprocesses"
+path = "tests/concurrent_reads_two_subprocesses.rs"
+
+[[test]]
+name = "subprocess_crash_mid_write"
+path = "tests/subprocess_crash_mid_write.rs"
+
+# Subprocess test helper. Built as a normal binary by `cargo test` and
+# discovered at runtime via `env!("CARGO_BIN_EXE_…")`.
+[[bin]]
+name = "vulkan_adapter_subprocess_helper"
+path = "tests/bin/vulkan_adapter_subprocess_helper.rs"
+test = false
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -1,0 +1,589 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `VulkanSurfaceAdapter` — host-side `SurfaceAdapter` implementation
+//! that hands a host-allocated `VkImage` to consumers as a Vulkan-typed
+//! [`crate::VulkanReadView`] / [`crate::VulkanWriteView`].
+//!
+//! The adapter:
+//! - Owns a registry of host-registered surfaces keyed by [`SurfaceId`].
+//! - Waits on the timeline semaphore at the start of every acquire so
+//!   prior GPU work has drained.
+//! - Issues a layout transition into the consumer's expected layout
+//!   (`SHADER_READ_ONLY_OPTIMAL` for read, `GENERAL` for write — this
+//!   covers compute, transfer, and color-attachment use cases).
+//! - Signals the next timeline value on guard drop so the next acquire
+//!   wakes up.
+
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use streamlib::adapter_support::{VulkanDevice, VulkanTimelineSemaphore};
+use streamlib::core::rhi::StreamTexture;
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceId, VkImageInfo,
+    WriteGuard,
+};
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::state::{HostSurfaceRegistration, SurfaceState, VulkanLayout};
+use crate::view::{VulkanReadView, VulkanWriteView};
+
+/// Default per-acquire timeline-wait timeout. Long enough to cover any
+/// realistic compositor queue; short enough that a deadlock turns into
+/// an `AdapterError::SyncTimeout` rather than wedging the consumer.
+const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
+
+/// Vulkan-native [`SurfaceAdapter`] implementation.
+///
+/// Construct with [`Self::new`] passing the host's [`VulkanDevice`].
+/// Register host-allocated surfaces with [`Self::register_host_surface`];
+/// consumers acquire scoped access through the standard
+/// [`SurfaceAdapter::acquire_read`] / [`SurfaceAdapter::acquire_write`]
+/// API or via the [`crate::VulkanContext`] convenience.
+pub struct VulkanSurfaceAdapter {
+    device: Arc<VulkanDevice>,
+    surfaces: Mutex<HashMap<SurfaceId, SurfaceState>>,
+    /// Per-acquire timeline wait timeout. Adjustable via
+    /// [`Self::with_acquire_timeout`].
+    acquire_timeout: Duration,
+}
+
+impl VulkanSurfaceAdapter {
+    /// Construct an empty adapter bound to `device`.
+    pub fn new(device: Arc<VulkanDevice>) -> Self {
+        Self {
+            device,
+            surfaces: Mutex::new(HashMap::new()),
+            acquire_timeout: DEFAULT_TIMELINE_WAIT,
+        }
+    }
+
+    /// Override the per-acquire timeline-wait timeout. Default 5 s.
+    pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
+        self
+    }
+
+    /// Returns the underlying device for callers (test harnesses, the
+    /// `VulkanContext`, raw-handle escape hatches) that need it.
+    pub fn device(&self) -> &Arc<VulkanDevice> {
+        &self.device
+    }
+
+    /// Register a host-allocated surface with this adapter.
+    ///
+    /// `id` is assigned by the host (typically from the surface-share
+    /// service); it MUST be unique across the adapter's lifetime.
+    /// Returns an error if `id` is already registered.
+    pub fn register_host_surface(
+        &self,
+        id: SurfaceId,
+        registration: HostSurfaceRegistration,
+    ) -> Result<(), AdapterError> {
+        let mut map = self.surfaces.lock();
+        if map.contains_key(&id) {
+            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+        }
+        map.insert(
+            id,
+            SurfaceState {
+                surface_id: id,
+                texture: registration.texture,
+                timeline: registration.timeline,
+                current_layout: registration.initial_layout,
+                read_holders: 0,
+                write_held: false,
+                last_acquire_value: 0,
+                current_release_value: 0,
+            },
+        );
+        Ok(())
+    }
+
+    /// Drop a registered surface. Pending guards keep the underlying
+    /// `Arc<VulkanTimelineSemaphore>` alive; the next acquire returns
+    /// [`AdapterError::SurfaceNotFound`].
+    pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
+        self.surfaces.lock().remove(&id).is_some()
+    }
+
+    /// Snapshot the registry size — primarily for tests and
+    /// observability.
+    pub fn registered_count(&self) -> usize {
+        self.surfaces.lock().len()
+    }
+
+    fn make_image_info(&self, texture: &StreamTexture) -> VkImageInfo {
+        // Best-effort image info — fields the adapter doesn't track
+        // (memory binding, ycbcr conversion) stay zeroed. Skia and other
+        // VkImageInfoExt consumers can extend this once
+        // VulkanTexture exposes more accessors.
+        VkImageInfo {
+            format: 0,
+            tiling: vk::ImageTiling::OPTIMAL.as_raw(),
+            usage_flags: 0,
+            sample_count: vk::SampleCountFlags::_1.bits(),
+            level_count: 1,
+            queue_family: self.device.queue_family_index(),
+            memory_handle: 0,
+            memory_offset: 0,
+            memory_size: ((texture.width() as u64)
+                * (texture.height() as u64)
+                * (texture.format().bytes_per_pixel() as u64)),
+            memory_property_flags: 0,
+            protected: 0,
+            ycbcr_conversion: 0,
+            _reserved: [0; 16],
+        }
+    }
+
+    /// Submit a one-shot command buffer that transitions `image` from
+    /// `from` to `to`. Layout barriers are issued via Vulkan 1.3+
+    /// `cmd_pipeline_barrier2`; we use queue-family-foreign transitions
+    /// to support cross-process handoff.
+    ///
+    /// Synchronous: blocks until the GPU has executed the barrier,
+    /// because the next consumer needs the new layout to be visible.
+    fn transition_layout_sync(
+        &self,
+        image: vk::Image,
+        from: vk::ImageLayout,
+        to: vk::ImageLayout,
+    ) -> Result<(), AdapterError> {
+        if from == to {
+            return Ok(());
+        }
+        let device = self.device.device();
+        let queue = self.device.queue();
+        let qf = self.device.queue_family_index();
+
+        // Single-shot command pool + buffer.
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let pool = unsafe { device.create_command_pool(&pool_info, None) }
+            .map_err(|e| AdapterError::IpcDisconnected {
+                reason: format!("create_command_pool: {e}"),
+            })?;
+
+        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd_buffers = unsafe { device.allocate_command_buffers(&alloc_info) }
+            .map_err(|e| {
+                unsafe { device.destroy_command_pool(pool, None) };
+                AdapterError::IpcDisconnected {
+                    reason: format!("allocate_command_buffers: {e}"),
+                }
+            })?;
+        let cmd = cmd_buffers[0];
+
+        let begin_info = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        if let Err(e) = unsafe { device.begin_command_buffer(cmd, &begin_info) } {
+            unsafe { device.destroy_command_pool(pool, None) };
+            return Err(AdapterError::IpcDisconnected {
+                reason: format!("begin_command_buffer: {e}"),
+            });
+        }
+
+        let image_barrier = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .dst_access_mask(
+                vk::AccessFlags2::MEMORY_READ | vk::AccessFlags2::MEMORY_WRITE,
+            )
+            .old_layout(from)
+            .new_layout(to)
+            .src_queue_family_index(qf)
+            .dst_queue_family_index(qf)
+            .image(image)
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .base_mip_level(0)
+                    .level_count(1)
+                    .base_array_layer(0)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+
+        let image_barriers = [image_barrier];
+        let dep_info = vk::DependencyInfo::builder()
+            .image_memory_barriers(&image_barriers)
+            .build();
+        unsafe { device.cmd_pipeline_barrier2(cmd, &dep_info) };
+
+        if let Err(e) = unsafe { device.end_command_buffer(cmd) } {
+            unsafe { device.destroy_command_pool(pool, None) };
+            return Err(AdapterError::IpcDisconnected {
+                reason: format!("end_command_buffer: {e}"),
+            });
+        }
+
+        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cmd)
+            .build()];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cmd_infos)
+            .build();
+
+        if let Err(e) = unsafe {
+            self.device.submit_to_queue(queue, &[submit], vk::Fence::null())
+        } {
+            unsafe { device.destroy_command_pool(pool, None) };
+            return Err(AdapterError::IpcDisconnected {
+                reason: format!("submit_to_queue: {e}"),
+            });
+        }
+
+        // Block until the layout transition has executed. The next
+        // consumer's view assumes the new layout is visible.
+        if let Err(e) = unsafe { device.queue_wait_idle(queue) } {
+            unsafe { device.destroy_command_pool(pool, None) };
+            return Err(AdapterError::IpcDisconnected {
+                reason: format!("queue_wait_idle: {e}"),
+            });
+        }
+
+        unsafe { device.destroy_command_pool(pool, None) };
+        Ok(())
+    }
+
+    fn try_begin_read(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadAcquired>, AdapterError> {
+        let mut map = self.surfaces.lock();
+        let state = map
+            .get_mut(&surface.id)
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+        if state.write_held {
+            return Ok(None);
+        }
+        // Snapshot what we need before we drop the lock so the wait /
+        // layout transition runs unlocked. Counters are committed below.
+        let timeline = Arc::clone(&state.timeline);
+        let wait_value = state.current_release_value;
+        let image = state
+            .texture
+            .vulkan_inner()
+            .image()
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+        let from = state.current_layout;
+        state.read_holders += 1;
+        state.last_acquire_value = wait_value;
+        Ok(Some(ReadAcquired {
+            timeline,
+            wait_value,
+            image,
+            from,
+            info: self.make_image_info(&state.texture),
+        }))
+    }
+
+    fn try_begin_write(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteAcquired>, AdapterError> {
+        let mut map = self.surfaces.lock();
+        let state = map
+            .get_mut(&surface.id)
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+        if state.write_held || state.read_holders > 0 {
+            return Ok(None);
+        }
+        let timeline = Arc::clone(&state.timeline);
+        let wait_value = state.current_release_value;
+        let image = state
+            .texture
+            .vulkan_inner()
+            .image()
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+        let from = state.current_layout;
+        state.write_held = true;
+        state.last_acquire_value = wait_value;
+        Ok(Some(WriteAcquired {
+            timeline,
+            wait_value,
+            image,
+            from,
+            info: self.make_image_info(&state.texture),
+        }))
+    }
+
+    /// Wait + transition + commit-layout for a successful read acquire.
+    fn finalize_read(
+        &self,
+        surface_id: SurfaceId,
+        acquired: ReadAcquired,
+    ) -> Result<vk::ImageLayout, AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            // Roll back: the acquire had bumped read_holders; undo it.
+            self.rollback_read(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+
+        let to = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+        if let Err(err) = self.transition_layout_sync(acquired.image, acquired.from.vk(), to) {
+            self.rollback_read(surface_id);
+            return Err(err);
+        }
+        let mut map = self.surfaces.lock();
+        if let Some(state) = map.get_mut(&surface_id) {
+            state.current_layout = VulkanLayout(to.as_raw());
+        }
+        Ok(to)
+    }
+
+    fn finalize_write(
+        &self,
+        surface_id: SurfaceId,
+        acquired: WriteAcquired,
+    ) -> Result<vk::ImageLayout, AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            self.rollback_write(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+
+        // GENERAL covers compute, transfer, and color-attachment writes.
+        // Picking COLOR_ATTACHMENT_OPTIMAL would force a re-transition
+        // every time a customer wants to use the image as a transfer
+        // destination; GENERAL is the right shape for the v1 adapter.
+        let to = vk::ImageLayout::GENERAL;
+        if let Err(err) = self.transition_layout_sync(acquired.image, acquired.from.vk(), to) {
+            self.rollback_write(surface_id);
+            return Err(err);
+        }
+        let mut map = self.surfaces.lock();
+        if let Some(state) = map.get_mut(&surface_id) {
+            state.current_layout = VulkanLayout(to.as_raw());
+        }
+        Ok(to)
+    }
+
+    fn rollback_read(&self, surface_id: SurfaceId) {
+        let mut map = self.surfaces.lock();
+        if let Some(state) = map.get_mut(&surface_id) {
+            state.read_holders = state.read_holders.saturating_sub(1);
+        }
+    }
+
+    fn rollback_write(&self, surface_id: SurfaceId) {
+        let mut map = self.surfaces.lock();
+        if let Some(state) = map.get_mut(&surface_id) {
+            state.write_held = false;
+        }
+    }
+}
+
+/// Snapshot taken under the registry lock so the timeline wait + layout
+/// transition can run unlocked. `read_holders` / `write_held` are
+/// already incremented; rollback paths decrement them on failure.
+struct ReadAcquired {
+    timeline: Arc<VulkanTimelineSemaphore>,
+    wait_value: u64,
+    image: vk::Image,
+    from: VulkanLayout,
+    info: VkImageInfo,
+}
+
+struct WriteAcquired {
+    timeline: Arc<VulkanTimelineSemaphore>,
+    wait_value: u64,
+    image: vk::Image,
+    from: VulkanLayout,
+    info: VkImageInfo,
+}
+
+impl SurfaceAdapter for VulkanSurfaceAdapter {
+    type ReadView<'g> = VulkanReadView<'g>;
+    type WriteView<'g> = VulkanWriteView<'g>;
+
+    fn acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let acquired = match self.try_begin_read(surface)? {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder: "writer".to_string(),
+                });
+            }
+        };
+        let info = acquired.info;
+        let image = acquired.image;
+        let layout = self.finalize_read(surface.id, acquired)?;
+        Ok(ReadGuard::new(
+            self,
+            surface.id,
+            VulkanReadView {
+                image,
+                layout,
+                info,
+                cpu_bytes: None,
+                _marker: PhantomData,
+            },
+        ))
+    }
+
+    fn acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let acquired = match self.try_begin_write(surface)? {
+            Some(a) => a,
+            None => {
+                let map = self.surfaces.lock();
+                let holder = match map.get(&surface.id) {
+                    Some(s) if s.write_held => "writer".to_string(),
+                    Some(s) => format!("{} reader(s)", s.read_holders),
+                    None => "unknown".to_string(),
+                };
+                drop(map);
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder,
+                });
+            }
+        };
+        let info = acquired.info;
+        let image = acquired.image;
+        let layout = self.finalize_write(surface.id, acquired)?;
+        Ok(WriteGuard::new(
+            self,
+            surface.id,
+            VulkanWriteView {
+                image,
+                layout,
+                info,
+                _marker: PhantomData,
+            },
+        ))
+    }
+
+    fn try_acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
+        let acquired = match self.try_begin_read(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let info = acquired.info;
+        let image = acquired.image;
+        let layout = self.finalize_read(surface.id, acquired)?;
+        Ok(Some(ReadGuard::new(
+            self,
+            surface.id,
+            VulkanReadView {
+                image,
+                layout,
+                info,
+                cpu_bytes: None,
+                _marker: PhantomData,
+            },
+        )))
+    }
+
+    fn try_acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
+        let acquired = match self.try_begin_write(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let info = acquired.info;
+        let image = acquired.image;
+        let layout = self.finalize_write(surface.id, acquired)?;
+        Ok(Some(WriteGuard::new(
+            self,
+            surface.id,
+            VulkanWriteView {
+                image,
+                layout,
+                info,
+                _marker: PhantomData,
+            },
+        )))
+    }
+
+    fn end_read_access(&self, surface_id: SurfaceId) {
+        let (timeline, value) = {
+            let mut map = self.surfaces.lock();
+            let state = match map.get_mut(&surface_id) {
+                Some(s) => s,
+                None => {
+                    tracing::warn!(
+                        ?surface_id,
+                        "end_read_access on unknown surface — racing unregister"
+                    );
+                    return;
+                }
+            };
+            debug_assert!(state.read_holders > 0, "read release without acquire");
+            state.read_holders = state.read_holders.saturating_sub(1);
+            // Only the last reader advances the timeline — concurrent
+            // reads share a single release boundary.
+            if state.read_holders > 0 {
+                return;
+            }
+            let next = state.next_release_value();
+            state.current_release_value = next;
+            (Arc::clone(&state.timeline), next)
+        };
+        if let Err(e) = timeline.signal_host(value) {
+            tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+        }
+    }
+
+    fn end_write_access(&self, surface_id: SurfaceId) {
+        let (timeline, value) = {
+            let mut map = self.surfaces.lock();
+            let state = match map.get_mut(&surface_id) {
+                Some(s) => s,
+                None => {
+                    tracing::warn!(
+                        ?surface_id,
+                        "end_write_access on unknown surface — racing unregister"
+                    );
+                    return;
+                }
+            };
+            debug_assert!(state.write_held, "write release without acquire");
+            state.write_held = false;
+            let next = state.next_release_value();
+            state.current_release_value = next;
+            (Arc::clone(&state.timeline), next)
+        };
+        if let Err(e) = timeline.signal_host(value) {
+            tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");
+        }
+    }
+}

--- a/libs/streamlib-adapter-vulkan/src/context.rs
+++ b/libs/streamlib-adapter-vulkan/src/context.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `VulkanContext` — the customer-facing one-stop API.
+//!
+//! Customers call:
+//!
+//! ```ignore
+//! let ctx = streamlib_adapter_vulkan::VulkanContext::new(adapter);
+//! {
+//!     let mut guard = ctx.acquire_write(&surface)?;
+//!     // guard.view_mut() is a VulkanWriteView with a VkImage handle.
+//! }
+//! ```
+//!
+//! The context is a thin convenience over [`crate::VulkanSurfaceAdapter`];
+//! every operation maps to a [`streamlib_adapter_abi::SurfaceAdapter`]
+//! method. Provided here so the customer-facing API matches the
+//! parallel polyglot wrappers (`streamlib.vulkan.context()` in Python,
+//! `streamlib.vulkan.context()` in Deno) and so adapter authors have a
+//! single import path: `streamlib_adapter_vulkan::{VulkanContext,
+//! raw_handles}`.
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, WriteGuard,
+};
+
+use crate::adapter::VulkanSurfaceAdapter;
+use crate::raw_handles::{raw_handles, RawVulkanHandles};
+
+/// Customer-facing handle bound to a single host runtime.
+///
+/// Holds a shared reference to a [`VulkanSurfaceAdapter`] (typically
+/// stored on the runtime itself); cheap to clone. Customers obtain one
+/// via the runtime; tests construct one directly.
+#[derive(Clone)]
+pub struct VulkanContext {
+    adapter: Arc<VulkanSurfaceAdapter>,
+}
+
+impl VulkanContext {
+    pub fn new(adapter: Arc<VulkanSurfaceAdapter>) -> Self {
+        Self { adapter }
+    }
+
+    pub fn adapter(&self) -> &Arc<VulkanSurfaceAdapter> {
+        &self.adapter
+    }
+
+    /// Blocking read acquire. The guard's
+    /// [`streamlib_adapter_abi::WriteGuard::view`] / `view_mut` returns a
+    /// [`crate::VulkanReadView`] exposing the host's `VkImage` and the
+    /// layout the adapter transitioned it to.
+    pub fn acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'a, VulkanSurfaceAdapter>, AdapterError> {
+        self.adapter.acquire_read(surface)
+    }
+
+    /// Blocking write acquire.
+    pub fn acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'a, VulkanSurfaceAdapter>, AdapterError> {
+        self.adapter.acquire_write(surface)
+    }
+
+    /// Non-blocking read acquire — `Ok(None)` on contention, never blocks.
+    pub fn try_acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'a, VulkanSurfaceAdapter>>, AdapterError> {
+        self.adapter.try_acquire_read(surface)
+    }
+
+    /// Non-blocking write acquire.
+    pub fn try_acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'a, VulkanSurfaceAdapter>>, AdapterError> {
+        self.adapter.try_acquire_write(surface)
+    }
+
+    /// Power-user surface — raw Vulkan handles (`VkInstance`, `VkDevice`,
+    /// `VkQueue`, …). The customer assumes responsibility for queue
+    /// mutex discipline and lifetime; the adapter does not track work
+    /// they submit through this path.
+    pub fn raw_handles(&self) -> RawVulkanHandles {
+        raw_handles(self.adapter.device())
+    }
+}

--- a/libs/streamlib-adapter-vulkan/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Vulkan-native surface adapter — no-copy passthrough that hands a
+//! host-allocated `VkImage` to any consumer that speaks Vulkan.
+//!
+//! This is the canonical implementor of the `VulkanWritable` and
+//! `VulkanImageInfoExt` capability traits from `streamlib-adapter-abi`.
+//! Cross-API adapters (`streamlib-adapter-opengl`, `streamlib-adapter-skia`)
+//! compose on top of these views without ever seeing DMA-BUF fds, DRM
+//! modifiers, or timeline-semaphore handles directly.
+//!
+//! See `docs/architecture/surface-adapter.md` for the architecture brief
+//! and `docs/adapter-authoring.md` for the 3rd-party authoring guide.
+
+#![cfg(target_os = "linux")]
+
+mod adapter;
+mod context;
+mod raw_handles;
+mod state;
+mod view;
+
+pub use adapter::VulkanSurfaceAdapter;
+pub use context::VulkanContext;
+pub use raw_handles::{raw_handles, RawVulkanHandles};
+pub use state::{HostSurfaceRegistration, VulkanLayout};
+pub use view::{VulkanReadView, VulkanWriteView};

--- a/libs/streamlib-adapter-vulkan/src/raw_handles.rs
+++ b/libs/streamlib-adapter-vulkan/src/raw_handles.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib.vulkan.raw_handles()` — escape hatch for power-user
+//! customers that need direct Vulkan handle access (custom RHIs,
+//! integration with another engine, debug tooling).
+//!
+//! The `acquire_*` API on [`crate::VulkanContext`] is the path of least
+//! resistance and handles sync + layout transitions; this is the "you
+//! own the footguns from here" surface.
+
+use streamlib::adapter_support::VulkanDevice;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+/// Raw Vulkan handles surfaced by `raw_handles()`.
+///
+/// Every field is `u64` (Vulkan handle width per spec) so this struct
+/// can cross any binding boundary — `ash::Image::from_raw`,
+/// `vulkanalia::vk::Image::from_raw`, custom FFI shims, polyglot SDKs.
+/// The customer reconstructs the typed wrapper their binding wants.
+#[derive(Clone, Copy, Debug)]
+pub struct RawVulkanHandles {
+    /// `VkInstance` handle.
+    pub vk_instance: u64,
+    /// `VkPhysicalDevice` handle.
+    pub vk_physical_device: u64,
+    /// `VkDevice` handle.
+    pub vk_device: u64,
+    /// `VkQueue` of the graphics-and-present queue family. Caller MUST
+    /// take the per-queue mutex if they intend to submit work — the
+    /// streamlib RHI does this internally; raw users assume the
+    /// responsibility.
+    pub vk_queue: u64,
+    /// Queue family index for `vk_queue`. Used in
+    /// `VkImageMemoryBarrier::srcQueueFamilyIndex` /
+    /// `dstQueueFamilyIndex` for cross-queue ownership transitions.
+    pub vk_queue_family_index: u32,
+    /// Vulkan API version the streamlib runtime requested at instance
+    /// creation. Encoded per `VK_MAKE_API_VERSION`.
+    pub api_version: u32,
+}
+
+/// Snapshot the underlying `VulkanDevice`'s raw handles.
+///
+/// The handles are valid for the lifetime of the device; the customer
+/// MUST NOT outlive the runtime that owns it. There is intentionally
+/// no destructor or refcount handed back — this is the documented
+/// power-user surface that says *"you own the consequences"*.
+pub fn raw_handles(device: &VulkanDevice) -> RawVulkanHandles {
+    RawVulkanHandles {
+        vk_instance: device.instance().handle().as_raw() as u64,
+        vk_physical_device: device.physical_device().as_raw() as u64,
+        vk_device: device.device().handle().as_raw() as u64,
+        vk_queue: device.queue().as_raw() as u64,
+        vk_queue_family_index: device.queue_family_index(),
+        api_version: vk::make_version(1, 4, 0),
+    }
+}

--- a/libs/streamlib-adapter-vulkan/src/state.rs
+++ b/libs/streamlib-adapter-vulkan/src/state.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Per-surface adapter state. The adapter holds a registry of these
+//! keyed by [`streamlib_adapter_abi::SurfaceId`]; each entry tracks the
+//! host-allocated texture, the timeline semaphore the host advances on
+//! release, and the layout the next acquire transitions through.
+
+use std::sync::Arc;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::rhi::StreamTexture;
+use streamlib_adapter_abi::SurfaceId;
+use vulkanalia::vk;
+
+/// `VkImageLayout` enumerant. Stored as `i32` per the Vulkan spec.
+///
+/// Re-exported so the adapter's public API doesn't drag every consumer
+/// through a `vulkanalia` import. Convert to `vk::ImageLayout` via
+/// `vk::ImageLayout::from_raw(layout.0)`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct VulkanLayout(pub i32);
+
+impl VulkanLayout {
+    pub const UNDEFINED: Self = Self(vk::ImageLayout::UNDEFINED.as_raw());
+    pub const GENERAL: Self = Self(vk::ImageLayout::GENERAL.as_raw());
+    pub const COLOR_ATTACHMENT_OPTIMAL: Self =
+        Self(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL.as_raw());
+    pub const SHADER_READ_ONLY_OPTIMAL: Self =
+        Self(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL.as_raw());
+    pub const TRANSFER_SRC_OPTIMAL: Self =
+        Self(vk::ImageLayout::TRANSFER_SRC_OPTIMAL.as_raw());
+    pub const TRANSFER_DST_OPTIMAL: Self =
+        Self(vk::ImageLayout::TRANSFER_DST_OPTIMAL.as_raw());
+
+    pub(crate) fn vk(self) -> vk::ImageLayout {
+        vk::ImageLayout::from_raw(self.0)
+    }
+}
+
+/// Inputs the host hands to [`crate::VulkanSurfaceAdapter::register_host_surface`].
+///
+/// The host is responsible for allocating the texture (via
+/// `GpuContext::acquire_render_target_dma_buf_image` or equivalent) and
+/// creating an exportable timeline semaphore (via
+/// [`VulkanTimelineSemaphore::new_exportable`]). The adapter then takes
+/// joint ownership and exposes scoped acquire/release for consumers.
+pub struct HostSurfaceRegistration {
+    pub texture: StreamTexture,
+    pub timeline: Arc<VulkanTimelineSemaphore>,
+    /// Initial layout the host left the image in after allocation. The
+    /// first `acquire_*` will transition from here. For freshly-allocated
+    /// images this is typically [`VulkanLayout::UNDEFINED`].
+    pub initial_layout: VulkanLayout,
+}
+
+/// Per-surface state held inside the adapter's `Mutex<HashMap<SurfaceId, _>>`.
+///
+/// All mutation goes through the adapter's lock so `acquire_*` /
+/// `end_*_access` stay sequenced — the trait's `&self` shape is satisfied
+/// by interior mutability. Counters are sized to whatever the underlying
+/// Vulkan timeline semaphore supports (u64); WriteContended is a fast
+/// pre-check before the timeline wait.
+pub(crate) struct SurfaceState {
+    #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
+    pub(crate) surface_id: SurfaceId,
+    pub(crate) texture: StreamTexture,
+    pub(crate) timeline: Arc<VulkanTimelineSemaphore>,
+    pub(crate) current_layout: VulkanLayout,
+    pub(crate) read_holders: u64,
+    pub(crate) write_held: bool,
+    /// Last value the host *waited on* before handing access out. Used
+    /// only for telemetry; the canonical wait value is recomputed every
+    /// acquire from `current_release_value`.
+    pub(crate) last_acquire_value: u64,
+    /// The value `signal_host` was last advanced to. The next acquire
+    /// waits on this value (so any prior writer's GPU work has drained)
+    /// and the next release advances it by one.
+    pub(crate) current_release_value: u64,
+}
+
+impl SurfaceState {
+    pub(crate) fn next_release_value(&self) -> u64 {
+        self.current_release_value + 1
+    }
+}

--- a/libs/streamlib-adapter-vulkan/src/view.rs
+++ b/libs/streamlib-adapter-vulkan/src/view.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Read and write views handed back to consumers inside an acquire scope.
+//!
+//! The views are short-lived (lifetime-bound to the guard) and implement
+//! the capability traits from `streamlib-adapter-abi` so outer adapters
+//! (`streamlib-adapter-skia`, third-party Vulkan-on-Vulkan compositions)
+//! can compose on top without touching DMA-BUF fds or layout state
+//! directly.
+
+use std::marker::PhantomData;
+
+use streamlib_adapter_abi::{
+    CpuReadable, VkImageHandle, VkImageInfo, VkImageLayoutValue, VulkanImageInfoExt,
+    VulkanWritable,
+};
+use vulkanalia::vk;
+use vulkanalia::vk::Handle as _;
+
+/// Read view of an acquired surface — exposes the host's `VkImage`,
+/// the layout the adapter transitioned it to (`SHADER_READ_ONLY_OPTIMAL`),
+/// and full image-info for outer adapters that need to wrap it.
+pub struct VulkanReadView<'g> {
+    pub(crate) image: vk::Image,
+    pub(crate) layout: vk::ImageLayout,
+    pub(crate) info: VkImageInfo,
+    /// Optional CPU-side staging slice. Some adapter consumers (the
+    /// in-process round-trip tests, debug snapshotters) want a byte
+    /// view of the surface in addition to the `VkImage`. The adapter
+    /// fills this when the consumer asks for it; the default is
+    /// `None`.
+    pub(crate) cpu_bytes: Option<&'g [u8]>,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl VulkanWritable for VulkanReadView<'_> {
+    fn vk_image(&self) -> VkImageHandle {
+        VkImageHandle(self.image.as_raw())
+    }
+
+    fn vk_image_layout(&self) -> VkImageLayoutValue {
+        VkImageLayoutValue(self.layout.as_raw())
+    }
+}
+
+impl VulkanImageInfoExt for VulkanReadView<'_> {
+    fn vk_image_info(&self) -> VkImageInfo {
+        self.info
+    }
+}
+
+impl CpuReadable for VulkanReadView<'_> {
+    fn read_bytes(&self) -> &[u8] {
+        self.cpu_bytes.unwrap_or(&[])
+    }
+}
+
+/// Write view of an acquired surface — exposes the host's `VkImage`
+/// transitioned to `COLOR_ATTACHMENT_OPTIMAL` (or `GENERAL` when the
+/// surface usage demands it), plus full image-info for compositors.
+pub struct VulkanWriteView<'g> {
+    pub(crate) image: vk::Image,
+    pub(crate) layout: vk::ImageLayout,
+    pub(crate) info: VkImageInfo,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl VulkanWritable for VulkanWriteView<'_> {
+    fn vk_image(&self) -> VkImageHandle {
+        VkImageHandle(self.image.as_raw())
+    }
+
+    fn vk_image_layout(&self) -> VkImageLayoutValue {
+        VkImageLayoutValue(self.layout.as_raw())
+    }
+}
+
+impl VulkanImageInfoExt for VulkanWriteView<'_> {
+    fn vk_image_info(&self) -> VkImageInfo {
+        self.info
+    }
+}

--- a/libs/streamlib-adapter-vulkan/tests/bin/vulkan_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-vulkan/tests/bin/vulkan_adapter_subprocess_helper.rs
@@ -1,0 +1,514 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Subprocess test helper for round-trip and crash-mid-write tests.
+//!
+//! Receives DMA-BUF fds + a timeline-semaphore opaque-fd via SCM_RIGHTS
+//! over a socketpair the parent passed in `STREAMLIB_HELPER_SOCKET_FD`.
+//! Imports both into a fresh `VkDevice` (this process's own — sidestepping
+//! the dual-VkDevice crash because no GPU work is active in the parent
+//! when the subprocess starts), then performs the role specified in
+//! argv[1]:
+//!
+//! - `read`        — wait on timeline `wait_value`, vkCmdCopyImageToBuffer
+//!                   into a staging VkBuffer, send the bytes back over
+//!                   the socketpair, signal `wait_value + 1`.
+//! - `write`       — wait on `wait_value`, vkCmdClearColorImage with the
+//!                   provided RGBA tuple, signal `wait_value + 1`.
+//! - `wait-only`   — wait, signal +1, exit. Used by the concurrent-reads
+//!                   test (no GPU work, just contention shape).
+//! - `crash-mid-write` — begin a write (acquire timeline value + start
+//!                   command submission), then `abort()` mid-flight.
+//!                   Verifies host-side cleanup via the EPOLLHUP
+//!                   watchdog or `SubprocessCrashHarness`.
+
+#![cfg(target_os = "linux")]
+
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use streamlib::adapter_support::{VulkanDevice, VulkanTexture, VulkanTimelineSemaphore};
+use streamlib::core::rhi::TextureFormat;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+#[derive(Debug, serde::Deserialize)]
+struct HelperRequest {
+    #[allow(dead_code)] // role is dispatched on argv[1]; this echoes it for debug
+    role: String,
+    width: u32,
+    height: u32,
+    drm_format_modifier: u64,
+    plane_offsets: Vec<u64>,
+    plane_strides: Vec<u64>,
+    allocation_size: u64,
+    /// Timeline value the helper waits on.
+    wait_value: u64,
+    /// For `write`: 4 bytes of clear color.
+    clear_color: Option<[f32; 4]>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct HelperResponse {
+    ok: bool,
+    note: String,
+    bytes_read: Option<Vec<u8>>,
+}
+
+fn die(socket: Option<&UnixStream>, msg: String) -> ExitCode {
+    eprintln!("[helper] FATAL: {msg}");
+    if let Some(s) = socket {
+        let resp = HelperResponse {
+            ok: false,
+            note: msg,
+            bytes_read: None,
+        };
+        let body = serde_json::to_vec(&resp).unwrap_or_default();
+        let _ = streamlib_surface_client::send_message_with_fds(s, &body, &[]);
+    }
+    ExitCode::from(1)
+}
+
+fn run() -> ExitCode {
+    let role = std::env::args().nth(1).unwrap_or_else(|| "wait-only".to_string());
+
+    let sock_fd_str = match std::env::var("STREAMLIB_HELPER_SOCKET_FD") {
+        Ok(v) => v,
+        Err(_) => return die(None, "STREAMLIB_HELPER_SOCKET_FD unset".into()),
+    };
+    let sock_fd: RawFd = match sock_fd_str.parse() {
+        Ok(v) => v,
+        Err(_) => return die(None, "STREAMLIB_HELPER_SOCKET_FD not an integer".into()),
+    };
+    let socket = unsafe { UnixStream::from_raw_fd(sock_fd) };
+
+    // Read length-prefixed JSON + fds via SCM_RIGHTS.
+    let mut len_buf = [0u8; 4];
+    let mut total = 0;
+    while total < 4 {
+        let n = unsafe {
+            libc::read(
+                socket.as_raw_fd(),
+                len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                4 - total,
+            )
+        };
+        if n <= 0 {
+            return die(Some(&socket), "read length prefix failed".into());
+        }
+        total += n as usize;
+    }
+    let msg_len = u32::from_be_bytes(len_buf) as usize;
+    let (payload, fds) = match streamlib_surface_client::recv_message_with_fds(
+        &socket,
+        msg_len,
+        streamlib_surface_client::MAX_DMA_BUF_PLANES + 1,
+    ) {
+        Ok(p) => p,
+        Err(e) => return die(Some(&socket), format!("recv_message_with_fds: {e}")),
+    };
+
+    let req: HelperRequest = match serde_json::from_slice(&payload) {
+        Ok(r) => r,
+        Err(e) => return die(Some(&socket), format!("parse request: {e}")),
+    };
+
+    if fds.len() < 2 {
+        return die(
+            Some(&socket),
+            format!("expected ≥2 fds (DMA-BUF + sync), got {}", fds.len()),
+        );
+    }
+    let sync_fd = *fds.last().unwrap();
+    let dma_buf_fds: Vec<RawFd> = fds[..fds.len() - 1].to_vec();
+
+    // Build our own VkDevice. The parent has no GPU work in flight when
+    // it spawns us, so the dual-VkDevice crash on NVIDIA does not apply.
+    let device = match VulkanDevice::new() {
+        Ok(d) => Arc::new(d),
+        Err(e) => return die(Some(&socket), format!("VulkanDevice::new: {e}")),
+    };
+
+    // Import VkImage with the host-chosen DRM modifier.
+    let texture = match VulkanTexture::import_render_target_dma_buf(
+        &device,
+        &dma_buf_fds,
+        &req.plane_offsets,
+        &req.plane_strides,
+        req.drm_format_modifier,
+        req.width,
+        req.height,
+        TextureFormat::Bgra8Unorm,
+        req.allocation_size,
+    ) {
+        Ok(t) => t,
+        Err(e) => return die(Some(&socket), format!("import_render_target_dma_buf: {e}")),
+    };
+
+    // Import the timeline semaphore. Vulkan takes ownership of `sync_fd`
+    // on success; we close every other fd.
+    let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+        device.device(),
+        sync_fd,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            for f in &dma_buf_fds {
+                unsafe { libc::close(*f) };
+            }
+            return die(Some(&socket), format!("import sync_fd: {e}"));
+        }
+    };
+
+    // dma_buf_fds were dup'd by the kernel during SCM_RIGHTS; the
+    // VkImage import does NOT take ownership in our import path (the
+    // memory_fd helper inside VulkanDevice dups internally). Close our
+    // copies — without this they leak across the helper's lifetime.
+    for f in &dma_buf_fds {
+        unsafe { libc::close(*f) };
+    }
+
+    // Wait for the parent to finish writing / hand off.
+    if let Err(e) = timeline.wait(req.wait_value, 5_000_000_000u64) {
+        return die(
+            Some(&socket),
+            format!("timeline.wait({}): {e}", req.wait_value),
+        );
+    }
+
+    let response = match role.as_str() {
+        "wait-only" => {
+            // Just signal the next value and exit. Used by contention tests.
+            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
+                return die(Some(&socket), format!("signal_host: {e}"));
+            }
+            HelperResponse {
+                ok: true,
+                note: "wait-only complete".into(),
+                bytes_read: None,
+            }
+        }
+        "write" => {
+            let color = req.clear_color.unwrap_or([1.0, 0.5, 0.25, 1.0]);
+            if let Err(e) = subprocess_clear_image(
+                &device,
+                texture.image().expect("imported image"),
+                color,
+            ) {
+                return die(Some(&socket), format!("subprocess_clear_image: {e}"));
+            }
+            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
+                return die(Some(&socket), format!("signal_host post-write: {e}"));
+            }
+            HelperResponse {
+                ok: true,
+                note: format!("wrote clear color {color:?}"),
+                bytes_read: None,
+            }
+        }
+        "read" => {
+            let bytes = match subprocess_readback_image(
+                &device,
+                texture.image().expect("imported image"),
+                req.width,
+                req.height,
+            ) {
+                Ok(b) => b,
+                Err(e) => return die(Some(&socket), format!("subprocess_readback_image: {e}")),
+            };
+            if let Err(e) = timeline.signal_host(req.wait_value + 1) {
+                return die(Some(&socket), format!("signal_host post-read: {e}"));
+            }
+            HelperResponse {
+                ok: true,
+                note: format!("read {} bytes", bytes.len()),
+                bytes_read: Some(bytes),
+            }
+        }
+        "crash-mid-write" => {
+            // Spec'd to crash mid-flight; never reach the response send.
+            std::process::abort();
+        }
+        other => {
+            return die(Some(&socket), format!("unknown role {other}"));
+        }
+    };
+
+    let body = serde_json::to_vec(&response).unwrap_or_default();
+    if let Err(e) = streamlib_surface_client::send_message_with_fds(&socket, &body, &[]) {
+        eprintln!("[helper] send response: {e}");
+        return ExitCode::from(2);
+    }
+    ExitCode::SUCCESS
+}
+
+/// Subprocess `vkCmdClearColorImage` — equivalent to a plain GPU write.
+fn subprocess_clear_image(
+    device: &Arc<VulkanDevice>,
+    image: vk::Image,
+    color: [f32; 4],
+) -> streamlib::core::Result<()> {
+    use streamlib::core::StreamError;
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))?;
+
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("begin_command_buffer: {e}")))?;
+
+    // UNDEFINED → TRANSFER_DST_OPTIMAL barrier so vkCmdClearColorImage
+    // sees a known layout.
+    let barrier = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::empty())
+        .dst_stage_mask(vk::PipelineStageFlags2::CLEAR)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+        .old_layout(vk::ImageLayout::UNDEFINED)
+        .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [barrier];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let clear_value = vk::ClearColorValue {
+        float32: color,
+    };
+    let range = vk::ImageSubresourceRange::builder()
+        .aspect_mask(vk::ImageAspectFlags::COLOR)
+        .level_count(1)
+        .layer_count(1)
+        .build();
+    let ranges = [range];
+    unsafe {
+        dev.cmd_clear_color_image(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &clear_value,
+            &ranges,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }
+        .map_err(|e| StreamError::GpuError(format!("end_command_buffer: {e}")))?;
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submits = [vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }?;
+    unsafe { dev.queue_wait_idle(queue) }
+        .map_err(|e| StreamError::GpuError(format!("queue_wait_idle: {e}")))?;
+    unsafe { dev.destroy_command_pool(pool, None) };
+    Ok(())
+}
+
+/// Subprocess readback — `vkCmdCopyImageToBuffer` into a staging buffer,
+/// then map and read.
+fn subprocess_readback_image(
+    device: &Arc<VulkanDevice>,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+) -> streamlib::core::Result<Vec<u8>> {
+    use streamlib::core::StreamError;
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let bytes = (width as u64) * (height as u64) * 4;
+
+    // Staging buffer (HOST_VISIBLE | HOST_COHERENT).
+    let buffer_info = vk::BufferCreateInfo::builder()
+        .size(bytes)
+        .usage(vk::BufferUsageFlags::TRANSFER_DST)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .build();
+    let buffer = unsafe { dev.create_buffer(&buffer_info, None) }
+        .map_err(|e| StreamError::GpuError(format!("create_buffer: {e}")))?;
+    let mem_req = unsafe { dev.get_buffer_memory_requirements(buffer) };
+
+    // Find a host-visible memory type from the device's physical
+    // memory properties.
+    let inst = device.instance();
+    let phys = device.physical_device();
+    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
+    let needed = vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+    let mem_type_idx = (0..mem_props.memory_type_count)
+        .find(|i| {
+            let bit = 1u32 << i;
+            (mem_req.memory_type_bits & bit) != 0
+                && mem_props.memory_types[*i as usize].property_flags.contains(needed)
+        })
+        .ok_or_else(|| StreamError::GpuError("no host-visible memory type".into()))?;
+
+    let alloc_info = vk::MemoryAllocateInfo::builder()
+        .allocation_size(mem_req.size)
+        .memory_type_index(mem_type_idx)
+        .build();
+    let mem = unsafe { dev.allocate_memory(&alloc_info, None) }
+        .map_err(|e| {
+            unsafe { dev.destroy_buffer(buffer, None) };
+            StreamError::GpuError(format!("allocate_memory: {e}"))
+        })?;
+    unsafe { dev.bind_buffer_memory(buffer, mem, 0) }
+        .map_err(|e| {
+            unsafe { dev.free_memory(mem, None) };
+            unsafe { dev.destroy_buffer(buffer, None) };
+            StreamError::GpuError(format!("bind_buffer_memory: {e}"))
+        })?;
+
+    // Command buffer: transition image to TRANSFER_SRC, copy to buffer.
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))?;
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .map_err(|e| StreamError::GpuError(format!("begin_command_buffer: {e}")))?;
+
+    // GENERAL is what the parent's adapter left it in; transition to
+    // TRANSFER_SRC_OPTIMAL.
+    let barrier = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [barrier];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let copy = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [copy];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            buffer,
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }
+        .map_err(|e| StreamError::GpuError(format!("end_command_buffer: {e}")))?;
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submits = [vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }?;
+    unsafe { dev.queue_wait_idle(queue) }
+        .map_err(|e| StreamError::GpuError(format!("queue_wait_idle: {e}")))?;
+
+    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
+        .map_err(|e| StreamError::GpuError(format!("map_memory: {e}")))?;
+    let slice = unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
+    let out = slice.to_vec();
+    unsafe { dev.unmap_memory(mem) };
+    unsafe { dev.destroy_command_pool(pool, None) };
+    unsafe { dev.destroy_buffer(buffer, None) };
+    unsafe { dev.free_memory(mem, None) };
+    Ok(out)
+}
+
+fn main() -> ExitCode {
+    run()
+}

--- a/libs/streamlib-adapter-vulkan/tests/common.rs
+++ b/libs/streamlib-adapter-vulkan/tests/common.rs
@@ -1,0 +1,199 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared scaffolding for the round-trip / crash subprocess tests.
+//! Pulled in via `#[path = "common.rs"] mod common;` in each test file.
+
+#![cfg(target_os = "linux")]
+#![allow(dead_code)] // Each test file uses a different subset.
+
+use std::os::fd::{AsRawFd, IntoRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::{StreamTexture, TextureFormat};
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
+    SurfaceUsage,
+};
+use streamlib_adapter_vulkan::{
+    HostSurfaceRegistration, VulkanContext, VulkanLayout, VulkanSurfaceAdapter,
+};
+
+pub fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_vulkan=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+pub struct HostFixture {
+    pub gpu: GpuContext,
+    pub adapter: Arc<VulkanSurfaceAdapter>,
+    pub ctx: VulkanContext,
+}
+
+impl HostFixture {
+    pub fn try_new() -> Option<Self> {
+        let gpu = try_init_gpu()?;
+        let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(
+            gpu.device().vulkan_device(),
+        )));
+        let ctx = VulkanContext::new(Arc::clone(&adapter));
+        Some(Self { gpu, adapter, ctx })
+    }
+
+    pub fn register_surface(
+        &self,
+        surface_id: SurfaceId,
+        width: u32,
+        height: u32,
+    ) -> RegisteredSurface {
+        let texture = self
+            .gpu
+            .acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)
+            .expect("acquire_render_target_dma_buf_image");
+        let timeline = Arc::new(
+            VulkanTimelineSemaphore::new_exportable(self.adapter.device().device(), 0)
+                .expect("exportable timeline"),
+        );
+        self.adapter
+            .register_host_surface(
+                surface_id,
+                HostSurfaceRegistration {
+                    texture: texture.clone(),
+                    timeline: Arc::clone(&timeline),
+                    initial_layout: VulkanLayout::UNDEFINED,
+                },
+            )
+            .expect("register host surface");
+        let descriptor = StreamlibSurface::new(
+            surface_id,
+            width,
+            height,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        RegisteredSurface {
+            descriptor,
+            texture,
+            timeline,
+            width,
+            height,
+        }
+    }
+}
+
+pub struct RegisteredSurface {
+    pub descriptor: StreamlibSurface,
+    pub texture: StreamTexture,
+    pub timeline: Arc<VulkanTimelineSemaphore>,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Spawn a subprocess running the test helper binary with role `role`.
+/// Returns the child handle and the parent end of the socketpair the
+/// helper reads its descriptor + fds from.
+pub fn spawn_helper(role: &str) -> (Child, UnixStream) {
+    let (parent, child) = UnixStream::pair().expect("socketpair");
+    // Move the child end's fd into the helper's fd table without
+    // closing it on exec; the parent side is normal Rust ownership.
+    let child_fd = child.into_raw_fd();
+    // Clear FD_CLOEXEC on the inherited fd so it survives `execve`.
+    unsafe {
+        let flags = libc::fcntl(child_fd, libc::F_GETFD);
+        libc::fcntl(child_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+    }
+
+    let bin_path = env!("CARGO_BIN_EXE_vulkan_adapter_subprocess_helper");
+    let mut cmd = Command::new(bin_path);
+    cmd.arg(role)
+        .env("STREAMLIB_HELPER_SOCKET_FD", child_fd.to_string())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let child_proc = cmd.spawn().expect("spawn subprocess helper");
+    // The helper inherited child_fd; close our copy to drop the
+    // refcount. The parent UnixStream owns its end.
+    unsafe { libc::close(child_fd) };
+    (child_proc, parent)
+}
+
+/// Send the helper its descriptor + DMA-BUF fds + timeline sync_fd via
+/// SCM_RIGHTS. The fds passed in are dup'd by the kernel; the caller
+/// retains ownership of their copies (close after send).
+pub fn send_helper_request(
+    parent: &UnixStream,
+    descriptor: &serde_json::Value,
+    dma_buf_fds: &[RawFd],
+    sync_fd: RawFd,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(descriptor).expect("serialize");
+    let mut all_fds: Vec<RawFd> = dma_buf_fds.to_vec();
+    all_fds.push(sync_fd);
+    // `send_message_with_fds` already prefixes with a 4-byte BE length;
+    // the helper reads the prefix, then `recv_message_with_fds` for the
+    // payload.
+    streamlib_surface_client::send_message_with_fds(parent, &body, &all_fds)
+}
+
+/// Read the helper's response (length-prefixed JSON, no fds).
+pub fn recv_helper_response(parent: &UnixStream) -> serde_json::Value {
+    let mut len_buf = [0u8; 4];
+    let mut total = 0;
+    while total < 4 {
+        let n = unsafe {
+            libc::read(
+                parent.as_raw_fd(),
+                len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                4 - total,
+            )
+        };
+        assert!(n > 0, "read response length: {}", std::io::Error::last_os_error());
+        total += n as usize;
+    }
+    let msg_len = u32::from_be_bytes(len_buf) as usize;
+    let (payload, fds) = streamlib_surface_client::recv_message_with_fds(parent, msg_len, 1)
+        .expect("recv response");
+    for fd in fds {
+        unsafe { libc::close(fd) };
+    }
+    serde_json::from_slice(&payload).expect("parse helper response JSON")
+}
+
+/// Build the request descriptor the helper expects, using the
+/// metadata stored on a registered surface.
+pub fn helper_descriptor(
+    role: &str,
+    surface: &RegisteredSurface,
+    wait_value: u64,
+    clear_color: Option<[f32; 4]>,
+) -> serde_json::Value {
+    let plane_layout = surface
+        .texture
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let plane_offsets: Vec<u64> = plane_layout.iter().map(|(o, _)| *o).collect();
+    let plane_strides: Vec<u64> = plane_layout.iter().map(|(_, s)| *s).collect();
+    let modifier = surface.texture.vulkan_inner().chosen_drm_format_modifier();
+
+    serde_json::json!({
+        "role": role,
+        "width": surface.width,
+        "height": surface.height,
+        "drm_format_modifier": modifier,
+        "plane_offsets": plane_offsets,
+        "plane_strides": plane_strides,
+        // Adapter buffer size is conservative: width * height * 4 bytes.
+        "allocation_size": (surface.width as u64) * (surface.height as u64) * 4,
+        "wait_value": wait_value,
+        "clear_color": clear_color,
+    })
+}

--- a/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
+++ b/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Two subprocesses simultaneously hold read access on the same surface
+//! (each via its own imported VkImage + timeline). Asserts the host
+//! grants both reads concurrently and that both subprocesses progress.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use std::sync::Arc;
+
+#[test]
+fn two_subprocesses_concurrently_read_same_surface() {
+    let host = match common::HostFixture::try_new() {
+        Some(h) => h,
+        None => {
+            println!("concurrent_reads_two_subprocesses: skipping — no Vulkan");
+            return;
+        }
+    };
+
+    let surface = host.register_surface(33, 64, 64);
+
+    // Warm up the surface — host writes once so subprocesses have a
+    // known starting layout.
+    {
+        let _w = host
+            .ctx
+            .acquire_write(&surface.descriptor)
+            .expect("warm-up write");
+    }
+    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+
+    // Spawn two subprocesses, each waits on value 1 and signals 2.
+    let (mut child_a, sock_a) = common::spawn_helper("wait-only");
+    let (mut child_b, sock_b) = common::spawn_helper("wait-only");
+
+    // Each subprocess imports its own copy of the timeline and the
+    // DMA-BUF — fresh fds per spawn since SCM_RIGHTS dups by the kernel.
+    for sock in [&sock_a, &sock_b] {
+        let dma_buf_fd = surface
+            .texture
+            .vulkan_inner()
+            .export_dma_buf_fd()
+            .expect("export DMA-BUF");
+        let sync_fd = Arc::clone(&surface.timeline)
+            .export_opaque_fd()
+            .expect("export sync_fd");
+        let req = common::helper_descriptor("wait-only", &surface, 1, None);
+        common::send_helper_request(sock, &req, &[dma_buf_fd], sync_fd)
+            .expect("send helper request");
+    }
+
+    // Both helpers should respond ok; the timeline signals from both
+    // are coalesced (same target value 2 — OPAQUE_FD timeline counter
+    // is monotonic so a redundant signal at value 2 is a no-op).
+    let resp_a = common::recv_helper_response(&sock_a);
+    let resp_b = common::recv_helper_response(&sock_b);
+    assert_eq!(resp_a["ok"], true, "child A: {}", resp_a["note"]);
+    assert_eq!(resp_b["ok"], true, "child B: {}", resp_b["note"]);
+
+    assert_eq!(child_a.wait().expect("wait a").code(), Some(0));
+    assert_eq!(child_b.wait().expect("wait b").code(), Some(0));
+
+    // Test that the host adapter ALSO permits two concurrent reads in
+    // process — `run_conformance` already covers this, but exercising
+    // it after the cross-process round-trip catches any state-leak that
+    // disturbed the in-process counter accounting.
+    let r1 = host.ctx.acquire_read(&surface.descriptor).expect("read 1");
+    let r2 = host.ctx.acquire_read(&surface.descriptor).expect("read 2");
+    drop(r1);
+    drop(r2);
+}

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_vulkan::tests::conformance` — runs the public
+//! `run_conformance` suite from `streamlib-adapter-abi` against a real
+//! Vulkan adapter wired to a host-allocated DMA-BUF render-target image
+//! and an exportable timeline semaphore.
+//!
+//! Exercises the same eight contracts MockAdapter passes (acquire/drop
+//! pairs, parallel reads, `WriteContended` on contention, `try_acquire_*`
+//! returning `Ok(None)`, multi-thread Send+Sync). A green run confirms
+//! the trait shape is honored — it does NOT prove cross-process
+//! correctness; that's the round-trip and crash tests.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_vulkan::{HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter};
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_vulkan=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+fn register_one(
+    adapter: &VulkanSurfaceAdapter,
+    gpu: &GpuContext,
+    id: SurfaceId,
+) -> StreamlibSurface {
+    let texture = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let timeline = Arc::new(
+        VulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    );
+    adapter
+        .register_host_surface(
+            id,
+            HostSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    StreamlibSurface::new(
+        id,
+        64,
+        64,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    )
+}
+
+struct ConformanceFactory<'a> {
+    adapter: &'a VulkanSurfaceAdapter,
+    gpu: &'a GpuContext,
+}
+
+impl<'a> streamlib_adapter_abi::testing::ConformanceSurfaceFactory
+    for ConformanceFactory<'a>
+{
+    fn make(&self, id: SurfaceId) -> StreamlibSurface {
+        register_one(self.adapter, self.gpu, id)
+    }
+}
+
+#[test]
+fn vulkan_adapter_passes_run_conformance() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("vulkan-adapter conformance: skipping — no Vulkan device available");
+            return;
+        }
+    };
+    let adapter = VulkanSurfaceAdapter::new(Arc::clone(gpu.device().vulkan_device()));
+
+    let factory = ConformanceFactory {
+        adapter: &adapter,
+        gpu: &gpu,
+    };
+    run_conformance(&adapter, factory);
+
+    let bogus = empty_surface(0xdead_beef);
+    match adapter.acquire_read(&bogus) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_beef);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-process round-trip: host writes a known clear color via the
+//! adapter's `acquire_write` scope, releases, subprocess imports the
+//! same surface + timeline and reads back. Asserts the bytes the
+//! subprocess saw match what the host wrote.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+#[test]
+fn host_writes_subprocess_reads_round_trip() {
+    let host = match common::HostFixture::try_new() {
+        Some(h) => h,
+        None => {
+            println!("round_trip_host_writes_subprocess_reads: skipping — no Vulkan");
+            return;
+        }
+    };
+
+    let surface = host.register_surface(11, 64, 64);
+
+    // Spawn the subprocess BEFORE the host does GPU work; cross-process
+    // dual-VkDevice is fine here per the dual-device crash learning —
+    // the subprocess's VkDevice creation runs concurrently with idle host.
+    let (mut child, parent_sock) = common::spawn_helper("read");
+
+    // Host write scope: clear the image to a known color via the
+    // adapter, release. Adapter advances timeline value 0 → 1.
+    {
+        let _w = host
+            .ctx
+            .acquire_write(&surface.descriptor)
+            .expect("host acquire_write");
+        let cmd_color = [0.25_f32, 0.5, 0.75, 1.0];
+        host_clear_image(
+            host.adapter.device(),
+            surface
+                .texture
+                .vulkan_inner()
+                .image()
+                .expect("host image handle"),
+            cmd_color,
+        );
+    }
+    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+
+    // Export the host-allocated surface for the subprocess. Timeline
+    // sync-fd + DMA-BUF fd both transferred via SCM_RIGHTS.
+    let dma_buf_fd = surface
+        .texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let sync_fd = Arc::clone(&surface.timeline)
+        .export_opaque_fd()
+        .expect("export sync_fd");
+
+    let req = common::helper_descriptor("read", &surface, 1, None);
+    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
+        .expect("send helper request");
+
+    let resp = common::recv_helper_response(&parent_sock);
+    assert_eq!(resp["ok"], true, "helper failed: {}", resp["note"]);
+    assert_eq!(child.wait().expect("wait child").code(), Some(0));
+
+    let bytes = resp["bytes_read"]
+        .as_array()
+        .expect("bytes_read array")
+        .iter()
+        .map(|v| v.as_u64().unwrap() as u8)
+        .collect::<Vec<_>>();
+
+    // BGRA8 in memory: byte 0=B, 1=G, 2=R, 3=A.
+    // ClearColorValue::float32[i] maps to LOGICAL component i (R=0,
+    // G=1, B=2, A=3) — independent of memory order. So [0.25, 0.5,
+    // 0.75, 1.0] sets R=0.25, G=0.5, B=0.75, A=1.0 → memory bytes
+    // [B=191, G=128, R=64, A=255].
+    let mismatch = bytes.chunks_exact(4).enumerate().find(|(_, px)| {
+        (px[0] as i32 - 191).abs() > 4
+            || (px[1] as i32 - 128).abs() > 4
+            || (px[2] as i32 - 64).abs() > 4
+            || (px[3] as i32 - 255).abs() > 4
+    });
+    assert!(
+        mismatch.is_none(),
+        "subprocess read unexpected pixel: {mismatch:?}"
+    );
+
+    assert!(surface.timeline.current_value().unwrap() >= 2);
+}
+
+fn host_clear_image(
+    device: &Arc<streamlib::adapter_support::VulkanDevice>,
+    image: vk::Image,
+    color: [f32; 4],
+) {
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate cmd")[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin cmd");
+
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::CLEAR)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs = [to_transfer];
+    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let value = vk::ClearColorValue { float32: color };
+    let range = vk::ImageSubresourceRange::builder()
+        .aspect_mask(vk::ImageAspectFlags::COLOR)
+        .level_count(1)
+        .layer_count(1)
+        .build();
+    let ranges = [range];
+    unsafe {
+        dev.cmd_clear_color_image(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &value,
+            &ranges,
+        )
+    };
+
+    let to_general = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::CLEAR)
+        .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+        .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+        .new_layout(vk::ImageLayout::GENERAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs2 = [to_general];
+    let dep2 = vk::DependencyInfo::builder().image_memory_barriers(&bs2).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep2) };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end cmd");
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submits = [vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }.expect("submit");
+    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
+    unsafe { dev.destroy_command_pool(pool, None) };
+}

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Reverse round-trip: subprocess writes via `vkCmdClearColorImage`
+//! against the imported VkImage, signals timeline; host waits, reads
+//! back, asserts bytes.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+#[test]
+fn subprocess_writes_host_reads_round_trip() {
+    let host = match common::HostFixture::try_new() {
+        Some(h) => h,
+        None => {
+            println!("round_trip_subprocess_writes_host_reads: skipping — no Vulkan");
+            return;
+        }
+    };
+
+    let surface = host.register_surface(22, 64, 64);
+
+    // Acquire write on the host side first to transition image layout
+    // away from UNDEFINED so the subprocess sees a known starting layout.
+    {
+        let _w = host
+            .ctx
+            .acquire_write(&surface.descriptor)
+            .expect("host warm-up acquire_write");
+    }
+    assert_eq!(surface.timeline.current_value().unwrap(), 1);
+
+    let (mut child, parent_sock) = common::spawn_helper("write");
+    let dma_buf_fd = surface
+        .texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let sync_fd = Arc::clone(&surface.timeline)
+        .export_opaque_fd()
+        .expect("export sync_fd");
+
+    let clear_color = [0.9_f32, 0.1, 0.4, 1.0];
+    let req = common::helper_descriptor("write", &surface, 1, Some(clear_color));
+    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
+        .expect("send helper request");
+
+    let resp = common::recv_helper_response(&parent_sock);
+    assert_eq!(resp["ok"], true, "helper failed: {}", resp["note"]);
+    assert_eq!(child.wait().expect("wait child").code(), Some(0));
+
+    // Helper signaled value 2; host now acquires read and copies bytes
+    // back to verify what the subprocess wrote.
+    let bytes = host_readback(
+        host.adapter.device(),
+        surface
+            .texture
+            .vulkan_inner()
+            .image()
+            .expect("host image handle"),
+        surface.width,
+        surface.height,
+    );
+
+    // BGRA8 in memory: B=0.4 → 102, G=0.1 → 26, R=0.9 → 230, A=1.0 → 255.
+    let mismatch = bytes.chunks_exact(4).enumerate().find(|(_, px)| {
+        (px[0] as i32 - 102).abs() > 4
+            || (px[1] as i32 - 26).abs() > 4
+            || (px[2] as i32 - 230).abs() > 4
+            || (px[3] as i32 - 255).abs() > 4
+    });
+    assert!(
+        mismatch.is_none(),
+        "host saw wrong pixel after subprocess write: {mismatch:?}"
+    );
+}
+
+fn host_readback(
+    device: &Arc<streamlib::adapter_support::VulkanDevice>,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+    let bytes = (width as u64) * (height as u64) * 4;
+
+    // Staging buffer.
+    let buffer_info = vk::BufferCreateInfo::builder()
+        .size(bytes)
+        .usage(vk::BufferUsageFlags::TRANSFER_DST)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .build();
+    let buffer = unsafe { dev.create_buffer(&buffer_info, None) }.expect("create_buffer");
+    let mem_req = unsafe { dev.get_buffer_memory_requirements(buffer) };
+    let mem_props =
+        unsafe { device.instance().get_physical_device_memory_properties(device.physical_device()) };
+    let needed =
+        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+    let mem_type_idx = (0..mem_props.memory_type_count)
+        .find(|i| {
+            let bit = 1u32 << i;
+            (mem_req.memory_type_bits & bit) != 0
+                && mem_props.memory_types[*i as usize].property_flags.contains(needed)
+        })
+        .expect("host-visible memory type");
+    let alloc = vk::MemoryAllocateInfo::builder()
+        .allocation_size(mem_req.size)
+        .memory_type_index(mem_type_idx)
+        .build();
+    let mem = unsafe { dev.allocate_memory(&alloc, None) }.expect("allocate_memory");
+    unsafe { dev.bind_buffer_memory(buffer, mem, 0) }.expect("bind_buffer_memory");
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate cmd")[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin cmd");
+
+    // Subprocess transitioned to TRANSFER_DST_OPTIMAL during clear; we
+    // assume image is now in that layout. Transition to TRANSFER_SRC.
+    let to_src = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs = [to_src];
+    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let copy = vk::BufferImageCopy::builder()
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [copy];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            buffer,
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end cmd");
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submits = [vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }.expect("submit");
+    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
+
+    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
+        .expect("map_memory");
+    let slice = unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
+    let out = slice.to_vec();
+    unsafe { dev.unmap_memory(mem) };
+    unsafe { dev.destroy_command_pool(pool, None) };
+    unsafe { dev.destroy_buffer(buffer, None) };
+    unsafe { dev.free_memory(mem, None) };
+    out
+}

--- a/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Subprocess SIGABRTs mid-write. Verifies that:
+//!  1. The host adapter's per-surface state survives the crash.
+//!  2. The host can still acquire write/read on the same surface after
+//!     the crash, because the subprocess's in-process VkDevice is the
+//!     only thing destroyed — host-side resources (the original VkImage,
+//!     the timeline semaphore, the registry entry) keep working.
+//!
+//! Uses `streamlib_adapter_abi::testing::SubprocessCrashHarness` which
+//! spawns the helper, waits a configurable delay, SIGKILLs (the helper
+//! also self-aborts but SIGKILL is the harness contract), then polls a
+//! caller-provided observer until cleanup is confirmed or the timeout
+//! fires.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use std::os::fd::IntoRawFd;
+use std::os::unix::io::AsRawFd;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use streamlib_adapter_abi::testing::{CrashTiming, SubprocessCrashHarness};
+
+#[test]
+fn subprocess_crash_mid_write_does_not_break_host_adapter() {
+    let host = match common::HostFixture::try_new() {
+        Some(h) => h,
+        None => {
+            println!("subprocess_crash_mid_write: skipping — no Vulkan");
+            return;
+        }
+    };
+
+    let surface = host.register_surface(44, 64, 64);
+    {
+        let _w = host
+            .ctx
+            .acquire_write(&surface.descriptor)
+            .expect("warm-up write");
+    }
+
+    // Build the helper Command + a socketpair-style fd handoff.
+    let (parent_sock, child_sock) =
+        std::os::unix::net::UnixStream::pair().expect("socketpair");
+    let child_fd = child_sock.into_raw_fd();
+    unsafe {
+        let flags = libc::fcntl(child_fd, libc::F_GETFD);
+        libc::fcntl(child_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+    }
+    let bin_path = env!("CARGO_BIN_EXE_vulkan_adapter_subprocess_helper");
+    let mut cmd = Command::new(bin_path);
+    cmd.arg("crash-mid-write")
+        .env("STREAMLIB_HELPER_SOCKET_FD", child_fd.to_string());
+
+    // Send the descriptor over the socketpair before the harness runs
+    // — the helper reads it on startup, then crashes.
+    let dma_buf_fd = surface
+        .texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let sync_fd = Arc::clone(&surface.timeline)
+        .export_opaque_fd()
+        .expect("export sync_fd");
+    let req = common::helper_descriptor("crash-mid-write", &surface, 1, None);
+
+    // Pre-send the request before the harness spawns; libc::sendmsg on
+    // a socketpair is non-blocking under default buffer sizes for this
+    // payload size.
+    common::send_helper_request(&parent_sock, &req, &[dma_buf_fd], sync_fd)
+        .expect("send helper request");
+
+    let observed_disconnect = Arc::new(AtomicBool::new(false));
+    let parent_fd = parent_sock.as_raw_fd();
+    let observed_clone = Arc::clone(&observed_disconnect);
+
+    let outcome = SubprocessCrashHarness::new(cmd)
+        .with_timing(CrashTiming::AfterDelay(Duration::from_millis(150)))
+        .with_cleanup_timeout(Duration::from_secs(5))
+        .with_post_spawn(move |_child| {
+            // Close our copy of the inherited fd so the kernel can
+            // reduce the refcount cleanly when the child dies.
+            unsafe { libc::close(child_fd) };
+            Ok(())
+        })
+        .run(|| {
+            // Observe cleanup by reading from parent_sock — when the
+            // child is gone, read returns 0 (EOF) immediately.
+            let mut buf = [0u8; 1];
+            let n = unsafe {
+                libc::recv(
+                    parent_fd,
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    1,
+                    libc::MSG_DONTWAIT | libc::MSG_PEEK,
+                )
+            };
+            if n == 0 {
+                observed_clone.store(true, Ordering::Release);
+                Ok(())
+            } else if n < 0 {
+                let err = std::io::Error::last_os_error();
+                if matches!(err.raw_os_error(), Some(libc::EAGAIN)) {
+                    Err("still alive")
+                } else {
+                    // Connection reset / pipe — child fully gone.
+                    observed_clone.store(true, Ordering::Release);
+                    Ok(())
+                }
+            } else {
+                Err("unexpected data on socket from crashing child")
+            }
+        })
+        .expect("crash harness must not error");
+
+    assert!(observed_disconnect.load(Ordering::Acquire));
+    assert!(
+        outcome.cleanup_latency.as_secs() < 5,
+        "cleanup observed too late: {:?}",
+        outcome.cleanup_latency
+    );
+
+    // The host's adapter should still function. The previous timeline
+    // value is whatever the host warmed up to (1); a fresh write
+    // advances it by one.
+    let before = surface.timeline.current_value().unwrap();
+    {
+        let _w = host
+            .ctx
+            .acquire_write(&surface.descriptor)
+            .expect("post-crash acquire_write");
+    }
+    let after = surface.timeline.current_value().unwrap();
+    assert!(
+        after > before,
+        "timeline should advance after crash; before={before} after={after}"
+    );
+}

--- a/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
+++ b/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_vulkan::tests::sync_correctness` — confirms that
+//! the adapter advances the timeline semaphore on guard drop and that
+//! a downstream consumer of the same timeline observes the post-release
+//! value.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
+    SurfaceUsage,
+};
+use streamlib_adapter_vulkan::{
+    HostSurfaceRegistration, VulkanContext, VulkanLayout, VulkanSurfaceAdapter,
+};
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_vulkan=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+fn timeline_counter_advances_on_release_and_is_observable_by_next_acquire() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("sync_correctness: skipping — no Vulkan device available");
+            return;
+        }
+    };
+
+    let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(
+        gpu.device().vulkan_device(),
+    )));
+    let ctx = VulkanContext::new(Arc::clone(&adapter));
+
+    let surface_id: SurfaceId = 1;
+    let texture = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let timeline = Arc::new(
+        VulkanTimelineSemaphore::new(adapter.device().device(), 0)
+            .expect("create timeline"),
+    );
+    adapter
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture,
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register host surface");
+
+    let descriptor = StreamlibSurface::new(
+        surface_id,
+        64,
+        64,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // Initial counter is 0 and acquire/wait succeeds.
+    assert_eq!(timeline.current_value().unwrap(), 0);
+
+    {
+        let _w = ctx.acquire_write(&descriptor).expect("acquire_write 1");
+        assert_eq!(
+            timeline.current_value().unwrap(),
+            0,
+            "no signal while guard is alive"
+        );
+    }
+    assert_eq!(timeline.current_value().unwrap(), 1, "drop signals once");
+
+    {
+        let _r = ctx.acquire_read(&descriptor).expect("acquire_read after w1");
+    }
+    assert_eq!(timeline.current_value().unwrap(), 2);
+
+    // Two parallel readers share a release boundary — the counter
+    // advances exactly once on the LAST reader's drop.
+    let r1 = ctx.acquire_read(&descriptor).expect("acquire_read r1");
+    let r2 = ctx.acquire_read(&descriptor).expect("acquire_read r2");
+    assert_eq!(
+        timeline.current_value().unwrap(),
+        2,
+        "no signal mid-concurrent-read"
+    );
+    drop(r1);
+    assert_eq!(
+        timeline.current_value().unwrap(),
+        2,
+        "first reader drop is silent"
+    );
+    drop(r2);
+    assert_eq!(
+        timeline.current_value().unwrap(),
+        3,
+        "last reader drop signals once"
+    );
+}

--- a/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
+++ b/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_vulkan::tests::write_excludes_read` — explicit
+//! redundant-with-conformance test asserting that an active write guard
+//! makes a concurrent `acquire_read` fail with `WriteContended`, and that
+//! the read succeeds once the write guard drops.
+//!
+//! Conformance covers the same contract; this exists as a focused
+//! regression that surfaces clearly in CI logs when contention semantics
+//! drift.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_vulkan::{
+    HostSurfaceRegistration, VulkanContext, VulkanLayout, VulkanSurfaceAdapter,
+};
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_vulkan=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+fn live_write_guard_blocks_acquire_read_until_dropped() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("write_excludes_read: skipping — no Vulkan device available");
+            return;
+        }
+    };
+
+    let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(
+        gpu.device().vulkan_device(),
+    )));
+    let ctx = VulkanContext::new(Arc::clone(&adapter));
+
+    let surface_id: SurfaceId = 7;
+    let texture = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let timeline = Arc::new(
+        VulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    );
+    adapter
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register");
+
+    let descriptor = StreamlibSurface::new(
+        surface_id,
+        64,
+        64,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    let writer = ctx.acquire_write(&descriptor).expect("first acquire_write");
+    match ctx.acquire_read(&descriptor) {
+        Err(AdapterError::WriteContended { surface_id: id, .. }) => {
+            assert_eq!(id, surface_id);
+        }
+        Err(other) => panic!("expected WriteContended, got {other:?}"),
+        Ok(_) => panic!("acquire_read must fail while write held"),
+    }
+    drop(writer);
+
+    let _r = ctx
+        .acquire_read(&descriptor)
+        .expect("acquire_read after writer dropped");
+}

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Vulkan-native surface adapter — Deno customer-facing API.
+ *
+ * Mirrors the Rust crate `streamlib-adapter-vulkan` (#511). The
+ * subprocess's actual Vulkan handling lives in
+ * `streamlib-deno-native`'s `SurfaceShareVulkanDevice`; this module
+ * provides:
+ *
+ *  - `VulkanReadView` / `VulkanWriteView` — typed views the subprocess
+ *    sees inside `acquireRead` / `acquireWrite` scopes; expose
+ *    `vkImage` (a `bigint` Vulkan handle) plus the current
+ *    `vkImageLayout`.
+ *  - `VulkanContext` interface — the runtime hands one out, customers
+ *    use TC39 `using` blocks for scoped acquire/release.
+ *  - `RawVulkanHandles` + `rawHandles()` shape — escape hatch for
+ *    customers driving Vulkan directly.
+ *
+ * Note: the issue body specifies the path
+ * `streamlib-deno/types/adapters/vulkan.ts`. The existing layout
+ * keeps top-level modules (`surface_adapter.ts`, `escalate.ts`, etc.)
+ * directly under `streamlib-deno/`, so we put the new module under
+ * `streamlib-deno/adapters/vulkan.ts` to match. If a future
+ * refactor introduces `types/`, this file moves with it.
+ */
+
+import {
+  STREAMLIB_ADAPTER_ABI_VERSION,
+  type StreamlibSurface,
+  type SurfaceAccessGuard,
+} from "../surface_adapter.ts";
+
+export { STREAMLIB_ADAPTER_ABI_VERSION };
+
+/** Mirror of `vk::ImageLayout` enumerant values used in views. */
+export const VkImageLayout = {
+  Undefined: 0,
+  General: 1,
+  ColorAttachmentOptimal: 2,
+  ShaderReadOnlyOptimal: 5,
+  TransferSrcOptimal: 6,
+  TransferDstOptimal: 7,
+} as const;
+export type VkImageLayout = (typeof VkImageLayout)[keyof typeof VkImageLayout];
+
+/** Read-side view inside an `acquireRead` scope. */
+export interface VulkanReadView {
+  readonly vkImage: bigint;
+  readonly vkImageLayout: VkImageLayout;
+}
+
+/** Write-side view inside an `acquireWrite` scope. */
+export interface VulkanWriteView {
+  readonly vkImage: bigint;
+  readonly vkImageLayout: VkImageLayout;
+}
+
+/**
+ * Power-user escape hatch — raw Vulkan handles as `bigint`s the
+ * customer feeds into their preferred Vulkan binding (e.g. through
+ * `Deno.UnsafePointer.create`). Valid for the lifetime of the
+ * runtime; using them after shutdown is undefined.
+ */
+export interface RawVulkanHandles {
+  readonly vkInstance: bigint;
+  readonly vkPhysicalDevice: bigint;
+  readonly vkDevice: bigint;
+  readonly vkQueue: bigint;
+  readonly vkQueueFamilyIndex: number;
+  readonly apiVersion: number;
+}
+
+/** Public Vulkan adapter contract. */
+export interface VulkanSurfaceAdapter {
+  acquireRead(surface: StreamlibSurface): SurfaceAccessGuard<VulkanReadView>;
+  acquireWrite(
+    surface: StreamlibSurface,
+  ): SurfaceAccessGuard<VulkanWriteView>;
+  tryAcquireRead(
+    surface: StreamlibSurface,
+  ): SurfaceAccessGuard<VulkanReadView> | null;
+  tryAcquireWrite(
+    surface: StreamlibSurface,
+  ): SurfaceAccessGuard<VulkanWriteView> | null;
+  rawHandles(): RawVulkanHandles;
+}
+
+/** Customer-facing context. Same shape as the adapter — the runtime
+ * wraps the adapter and hands the context out. Mirrors the Rust
+ * `VulkanContext`. */
+export type VulkanContext = VulkanSurfaceAdapter;

--- a/libs/streamlib-deno/adapters/vulkan_test.ts
+++ b/libs/streamlib-deno/adapters/vulkan_test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Smoke test for the Deno Vulkan adapter wrapper module.
+ *
+ * Confirms the module loads, layout constants match the Rust side,
+ * and the type shapes are present. End-to-end cross-process Vulkan
+ * verification lives in the Rust integration tests in
+ * `streamlib-adapter-vulkan` — Deno code that consumes this contract
+ * uses the FFI binding in `streamlib-deno-native`.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  RawVulkanHandles,
+  STREAMLIB_ADAPTER_ABI_VERSION,
+  VkImageLayout,
+} from "./vulkan.ts";
+
+Deno.test("ABI version matches Rust", () => {
+  assertEquals(STREAMLIB_ADAPTER_ABI_VERSION, 1);
+});
+
+Deno.test("VkImageLayout constants match Rust enum values", () => {
+  assertEquals(VkImageLayout.Undefined, 0);
+  assertEquals(VkImageLayout.General, 1);
+  assertEquals(VkImageLayout.ColorAttachmentOptimal, 2);
+  assertEquals(VkImageLayout.ShaderReadOnlyOptimal, 5);
+  assertEquals(VkImageLayout.TransferSrcOptimal, 6);
+  assertEquals(VkImageLayout.TransferDstOptimal, 7);
+});
+
+Deno.test("RawVulkanHandles round-trip preserves bigint and number fields", () => {
+  const h: RawVulkanHandles = {
+    vkInstance: 0xdead_beef_cafe_0001n,
+    vkPhysicalDevice: 0x0010_0001n,
+    vkDevice: 0x0010_0002n,
+    vkQueue: 0x0010_0003n,
+    vkQueueFamilyIndex: 0,
+    apiVersion: (1 << 22) | (4 << 12),
+  };
+  assertEquals(h.vkInstance, 0xdead_beef_cafe_0001n);
+  assertEquals(h.vkQueueFamilyIndex, 0);
+  assertEquals(h.apiVersion >> 22, 1);
+  assertExists(h.vkDevice);
+});

--- a/libs/streamlib-deno/surface_adapter.ts
+++ b/libs/streamlib-deno/surface_adapter.ts
@@ -101,6 +101,32 @@ export interface StreamlibSurface {
   readonly usage: SurfaceUsage;
 }
 
+/**
+ * DMA-BUF transport handle — fds, plane layout, modifier — read out of a
+ * surface descriptor for adapter-internal import on the subprocess side.
+ *
+ * Customers never see this; only adapter implementations.
+ */
+export interface SurfaceTransportHandle {
+  readonly planeCount: number;
+  readonly dmaBufFds: readonly number[]; // length MAX_DMA_BUF_PLANES
+  readonly planeOffsets: readonly bigint[]; // length MAX_DMA_BUF_PLANES
+  readonly planeStrides: readonly bigint[]; // length MAX_DMA_BUF_PLANES
+  readonly drmFormatModifier: bigint;
+}
+
+/**
+ * Host-side timeline-semaphore + initial layout. Subprocess adapters
+ * import `timelineSemaphoreSyncFd` via `vkImportSemaphoreFdKHR`.
+ */
+export interface SurfaceSyncState {
+  readonly timelineSemaphoreHandle: bigint;
+  readonly timelineSemaphoreSyncFd: number;
+  readonly lastAcquireValue: bigint;
+  readonly lastReleaseValue: bigint;
+  readonly currentImageLayout: number;
+}
+
 /** Read-side view returned by `acquireRead`. Adapter-typed. */
 export type ReadView = unknown;
 
@@ -152,5 +178,53 @@ export function readStreamlibSurface(
     height: view.getUint32(o.height),
     format: view.getUint32(o.format) as SurfaceFormat,
     usage: view.getUint32(o.usage) as SurfaceUsage,
+  };
+}
+
+/**
+ * Read the embedded `SurfaceTransportHandle` out of a `StreamlibSurface`
+ * descriptor. Adapter implementations use this when they need DMA-BUF fds
+ * and the modifier to import the backing.
+ */
+export function readSurfaceTransportHandle(
+  view: Deno.UnsafePointerView,
+): SurfaceTransportHandle {
+  const base = SurfaceLayout.Surface.Offsets.transport;
+  const o = SurfaceLayout.TransportHandle.Offsets;
+  const fds: number[] = [];
+  const offs: bigint[] = [];
+  const strides: bigint[] = [];
+  for (let i = 0; i < MAX_DMA_BUF_PLANES; i++) {
+    fds.push(view.getInt32(base + o.dmaBufFds + i * 4));
+    offs.push(view.getBigUint64(base + o.planeOffsets + i * 8));
+    strides.push(view.getBigUint64(base + o.planeStrides + i * 8));
+  }
+  return {
+    planeCount: view.getUint32(base + o.planeCount),
+    dmaBufFds: fds,
+    planeOffsets: offs,
+    planeStrides: strides,
+    drmFormatModifier: view.getBigUint64(base + o.drmFormatModifier),
+  };
+}
+
+/**
+ * Read the embedded `SurfaceSyncState` out of a `StreamlibSurface`
+ * descriptor. Adapter implementations import the sync-fd to participate
+ * in the host-side timeline.
+ */
+export function readSurfaceSyncState(
+  view: Deno.UnsafePointerView,
+): SurfaceSyncState {
+  const base = SurfaceLayout.Surface.Offsets.sync;
+  const o = SurfaceLayout.SyncState.Offsets;
+  return {
+    timelineSemaphoreHandle: view.getBigUint64(
+      base + o.timelineSemaphoreHandle,
+    ),
+    timelineSemaphoreSyncFd: view.getInt32(base + o.timelineSemaphoreSyncFd),
+    lastAcquireValue: view.getBigUint64(base + o.lastAcquireValue),
+    lastReleaseValue: view.getBigUint64(base + o.lastReleaseValue),
+    currentImageLayout: view.getInt32(base + o.currentImageLayout),
   };
 }

--- a/libs/streamlib-python/python/streamlib/adapters/__init__.py
+++ b/libs/streamlib-python/python/streamlib/adapters/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Adapter wrappers for streamlib's surface-share architecture.
+
+Each module under this package mirrors a Rust crate of the form
+``streamlib-adapter-<name>``: ``vulkan``, ``opengl`` (#512), ``skia``
+(#513), ``cpu_readback`` (#514). The Python module provides type
+shapes and convenience wrappers customer code uses against the
+subprocess-side native binding (``streamlib-python-native``).
+"""

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Vulkan-native surface adapter — Python customer-facing API.
+
+Mirrors the Rust crate ``streamlib-adapter-vulkan`` (#511). The
+subprocess's actual Vulkan handling lives in
+``streamlib-python-native``'s ``SurfaceShareVulkanDevice``; this
+module provides:
+
+  * Typed views the subprocess sees inside ``acquire_*`` scopes —
+    ``VulkanReadView`` / ``VulkanWriteView`` exposing ``vk_image`` (an
+    integer handle) plus the current ``vk_image_layout``.
+  * A ``VulkanContext`` Protocol the subprocess runtime implements —
+    customers don't construct one, they receive it via the runtime
+    and call ``acquire_write(surface)`` inside a ``with`` block.
+  * ``raw_handles()`` — escape hatch returning the underlying
+    ``vk_instance``, ``vk_device``, ``vk_queue``, etc. as integer
+    handles for power-user callers that want to drive Vulkan
+    directly.
+
+Subprocess Vulkan adapters MUST NOT call ``vkCreateDevice`` themselves;
+the binding's ``SurfaceShareVulkanDevice`` already creates one at
+init. Per ``docs/learnings/nvidia-dual-vulkan-device-crash.md``, a
+second ``VkDevice`` while the first has active GPU work crashes on
+NVIDIA — same-process safety; subprocesses are independent processes.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+from streamlib.surface_adapter import (
+    STREAMLIB_ADAPTER_ABI_VERSION,
+    StreamlibSurface,
+    SurfaceAdapter,
+    SurfaceFormat,
+    SurfaceUsage,
+)
+
+__all__ = [
+    "STREAMLIB_ADAPTER_ABI_VERSION",
+    "RawVulkanHandles",
+    "VulkanReadView",
+    "VulkanWriteView",
+    "VulkanSurfaceAdapter",
+    "VulkanContext",
+]
+
+
+# Vulkan layout integer values mirroring vk::ImageLayout. Used so
+# customer code doesn't need to import a Vulkan binding just to read
+# `view.vk_image_layout`.
+class VkImageLayout:
+    UNDEFINED = 0
+    GENERAL = 1
+    COLOR_ATTACHMENT_OPTIMAL = 2
+    SHADER_READ_ONLY_OPTIMAL = 5
+    TRANSFER_SRC_OPTIMAL = 6
+    TRANSFER_DST_OPTIMAL = 7
+
+
+@dataclass(frozen=True)
+class RawVulkanHandles:
+    """Power-user escape hatch — raw Vulkan handles as integers.
+
+    Customers wrap with their preferred Python Vulkan binding (e.g.
+    ``vulkan.vkInstance(handle=...)``). Returned handles are valid
+    for the lifetime of the streamlib runtime; using them after
+    runtime shutdown is undefined.
+    """
+
+    vk_instance: int
+    vk_physical_device: int
+    vk_device: int
+    vk_queue: int
+    vk_queue_family_index: int
+    api_version: int
+
+
+@dataclass(frozen=True)
+class VulkanReadView:
+    """View handed back inside an ``acquire_read`` scope.
+
+    ``vk_image`` is the integer Vulkan handle the customer feeds into
+    their binding (``vulkan.VkImage(value=view.vk_image)`` or
+    equivalent). ``vk_image_layout`` is the layout the adapter just
+    transitioned the image to (``SHADER_READ_ONLY_OPTIMAL`` on read).
+    """
+
+    vk_image: int
+    vk_image_layout: int
+
+
+@dataclass(frozen=True)
+class VulkanWriteView:
+    """View handed back inside an ``acquire_write`` scope.
+
+    Layout is ``GENERAL`` so the customer can use it as a transfer
+    destination, color attachment, or compute storage image without
+    re-transitioning.
+    """
+
+    vk_image: int
+    vk_image_layout: int
+
+
+@runtime_checkable
+class VulkanSurfaceAdapter(Protocol):
+    """Protocol an in-process Python Vulkan adapter implements.
+
+    ``surface_id`` based, so the subprocess can pass just the
+    ``StreamlibSurface.id`` from a descriptor it received over the
+    surface-share IPC.
+    """
+
+    def acquire_read(
+        self, surface: StreamlibSurface
+    ) -> AbstractContextManager[VulkanReadView]: ...
+
+    def acquire_write(
+        self, surface: StreamlibSurface
+    ) -> AbstractContextManager[VulkanWriteView]: ...
+
+    def try_acquire_read(
+        self, surface: StreamlibSurface
+    ) -> Optional[AbstractContextManager[VulkanReadView]]: ...
+
+    def try_acquire_write(
+        self, surface: StreamlibSurface
+    ) -> Optional[AbstractContextManager[VulkanWriteView]]: ...
+
+    def raw_handles(self) -> RawVulkanHandles: ...
+
+
+@runtime_checkable
+class VulkanContext(Protocol):
+    """Customer-facing handle the subprocess runtime hands out.
+
+    Equivalent shape to the Rust ``VulkanContext`` — thin wrapper over
+    a ``VulkanSurfaceAdapter`` so customer code can write::
+
+        with ctx.acquire_write(surface) as view:
+            do_vulkan_work(view.vk_image, view.vk_image_layout)
+    """
+
+    def acquire_read(
+        self, surface: StreamlibSurface
+    ) -> AbstractContextManager[VulkanReadView]: ...
+
+    def acquire_write(
+        self, surface: StreamlibSurface
+    ) -> AbstractContextManager[VulkanWriteView]: ...
+
+    def try_acquire_read(
+        self, surface: StreamlibSurface
+    ) -> Optional[AbstractContextManager[VulkanReadView]]: ...
+
+    def try_acquire_write(
+        self, surface: StreamlibSurface
+    ) -> Optional[AbstractContextManager[VulkanWriteView]]: ...
+
+    def raw_handles(self) -> RawVulkanHandles: ...

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_vulkan.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_vulkan.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Smoke test for the Python Vulkan adapter wrapper module.
+
+Confirms the module imports, the Protocol shapes match what
+adapter authors implement, and `RawVulkanHandles` round-trips
+through dataclass construction (mirrors the Rust struct fields).
+
+A real subprocess Python smoke test (vulkano-or-equivalent reading
+a host-produced surface zero-copy) lives in the round-trip Rust
+integration tests in ``streamlib-adapter-vulkan``; this file
+exercises the Python module's contract.
+"""
+
+from __future__ import annotations
+
+from streamlib.adapters import vulkan as v
+from streamlib.surface_adapter import (
+    STREAMLIB_ADAPTER_ABI_VERSION,
+    SurfaceFormat,
+    SurfaceUsage,
+)
+
+
+def test_module_re_exports_abi_version_constant():
+    assert v.STREAMLIB_ADAPTER_ABI_VERSION == STREAMLIB_ADAPTER_ABI_VERSION
+
+
+def test_raw_vulkan_handles_round_trip():
+    h = v.RawVulkanHandles(
+        vk_instance=0xdead_beef_cafe_0001,
+        vk_physical_device=0x0000_0000_0010_0001,
+        vk_device=0x0000_0000_0010_0002,
+        vk_queue=0x0000_0000_0010_0003,
+        vk_queue_family_index=0,
+        api_version=(1 << 22) | (4 << 12),  # vk::make_version(1, 4, 0)
+    )
+    assert h.vk_instance == 0xdead_beef_cafe_0001
+    assert h.vk_queue_family_index == 0
+    assert h.api_version >> 22 == 1
+
+
+def test_views_carry_image_handle_and_layout():
+    rv = v.VulkanReadView(vk_image=0x100, vk_image_layout=v.VkImageLayout.SHADER_READ_ONLY_OPTIMAL)
+    wv = v.VulkanWriteView(vk_image=0x200, vk_image_layout=v.VkImageLayout.GENERAL)
+    assert rv.vk_image == 0x100
+    assert rv.vk_image_layout == v.VkImageLayout.SHADER_READ_ONLY_OPTIMAL
+    assert wv.vk_image == 0x200
+    assert wv.vk_image_layout == v.VkImageLayout.GENERAL
+
+
+def test_protocols_describe_expected_method_set():
+    # `runtime_checkable` Protocols only check method NAMES, not full
+    # signatures — but that's what we want here: any subprocess-side
+    # adapter implementing acquire_read / acquire_write / etc. should
+    # satisfy the Protocol structurally.
+    assert hasattr(v.VulkanSurfaceAdapter, "acquire_read")
+    assert hasattr(v.VulkanSurfaceAdapter, "acquire_write")
+    assert hasattr(v.VulkanSurfaceAdapter, "try_acquire_read")
+    assert hasattr(v.VulkanSurfaceAdapter, "try_acquire_write")
+    assert hasattr(v.VulkanSurfaceAdapter, "raw_handles")
+    assert hasattr(v.VulkanContext, "acquire_write")
+    assert hasattr(v.VulkanContext, "raw_handles")

--- a/libs/streamlib/src/core/rhi/device.rs
+++ b/libs/streamlib/src/core/rhi/device.rs
@@ -50,6 +50,21 @@ pub struct GpuDevice {
 }
 
 impl GpuDevice {
+    /// Adapter-facing: the underlying [`crate::vulkan::rhi::VulkanDevice`].
+    ///
+    /// Available only on Linux / when the Vulkan backend is selected.
+    /// In-tree surface adapters reach for this when they need raw
+    /// queue / device handles. Non-adapter callers must NOT use it —
+    /// the engine boundary rule from `CLAUDE.md` reserves direct Vulkan
+    /// access to the RHI and its adapters.
+    #[cfg(any(
+        feature = "backend-vulkan",
+        all(target_os = "linux", not(feature = "backend-metal"))
+    ))]
+    pub fn vulkan_device(&self) -> &std::sync::Arc<crate::vulkan::rhi::VulkanDevice> {
+        &self.inner
+    }
+
     /// Create a new GPU device using the system default.
     pub fn new() -> Result<Self> {
         // Metal backend (default on macOS/iOS when Vulkan not requested)

--- a/libs/streamlib/src/core/rhi/texture.rs
+++ b/libs/streamlib/src/core/rhi/texture.rs
@@ -303,6 +303,22 @@ impl StreamTexture {
             metal_texture: None,
         }
     }
+
+    /// Adapter-facing: the underlying [`crate::vulkan::rhi::VulkanTexture`].
+    ///
+    /// In-tree surface adapters (`streamlib-adapter-vulkan`,
+    /// `-skia`, `-opengl`, `-cpu-readback`) need direct access to the
+    /// `VkImage` and DRM-modifier-bearing memory layout. Customers and
+    /// non-adapter code must NOT call this — the engine boundary rule
+    /// in `CLAUDE.md` says the only crates allowed to touch raw Vulkan
+    /// types are the RHI itself and the in-tree adapters.
+    #[cfg(any(
+        feature = "backend-vulkan",
+        all(target_os = "linux", not(feature = "backend-metal"))
+    ))]
+    pub fn vulkan_inner(&self) -> &Arc<crate::vulkan::rhi::VulkanTexture> {
+        &self.inner
+    }
 }
 
 impl std::fmt::Debug for StreamTexture {

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -170,6 +170,19 @@ pub mod linux_surface_share {
     pub use crate::linux::surface_share::{SurfaceShareState, UnixSocketSurfaceService};
 }
 
+/// RHI types that in-tree surface adapters (`streamlib-adapter-vulkan`,
+/// `-opengl`, `-skia`, `-cpu-readback`) need to reach. NOT a general
+/// public surface — every entry here is load-bearing for the adapter
+/// architecture. The Vulkan boundary rule from `CLAUDE.md` still holds:
+/// nothing outside an adapter or `vulkan/rhi/` may import from this
+/// module.
+#[cfg(target_os = "linux")]
+pub mod adapter_support {
+    pub use crate::vulkan::rhi::{
+        VulkanDevice, VulkanTexture, VulkanTimelineSemaphore,
+    };
+}
+
 // WebRTC streaming (cross-platform)
 pub use core::streaming::{WebRtcSession, WhepClient, WhepConfig, WhipClient, WhipConfig};
 

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -17,6 +17,9 @@ pub use vulkan_command_queue::VulkanCommandQueue;
 pub use vulkan_device::VulkanDevice;
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
+#[cfg(target_os = "linux")]
+#[allow(unused_imports)]
+pub use vulkan_sync::VulkanTimelineSemaphore;
 pub use vulkan_texture::VulkanTexture;
 
 mod vulkan_blitter;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -435,6 +435,18 @@ impl VulkanDevice {
                     tracing::info!("VK_EXT_image_drm_format_modifier available");
                 }
 
+                // Required for cross-process timeline-semaphore handoff via
+                // sync-fd: the host exports with vkGetSemaphoreFdKHR and the
+                // subprocess imports with vkImportSemaphoreFdKHR. Without
+                // this extension, surface-adapter sync across the IPC seam
+                // cannot land. VK_KHR_external_semaphore is core since 1.1
+                // so only the fd-handle subset needs explicit opt-in.
+                let external_semaphore_fd_ext = c"VK_KHR_external_semaphore_fd";
+                if available_device_ext_names.contains(&external_semaphore_fd_ext) {
+                    device_extensions.push(external_semaphore_fd_ext.as_ptr());
+                    tracing::info!("VK_KHR_external_semaphore_fd available");
+                }
+
                 tracing::info!("Vulkan external memory extensions enabled");
             } else {
                 tracing::info!("Vulkan external memory extensions not available");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
@@ -5,6 +5,8 @@
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
+#[cfg(target_os = "linux")]
+use vulkanalia::vk::KhrExternalSemaphoreFdExtensionDeviceCommands;
 
 use crate::core::{Result, StreamError};
 
@@ -168,6 +170,234 @@ impl Drop for VulkanFence {
 unsafe impl Send for VulkanFence {}
 unsafe impl Sync for VulkanFence {}
 
+/// Vulkan **timeline** semaphore wrapper.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[allow(dead_code)]
+///
+/// Timeline semaphores carry a monotonically-increasing 64-bit counter.
+/// Submitters wait on a value and signal a higher value; the wait
+/// completes when the counter has reached or surpassed the requested
+/// value. This is the synchronization primitive used by surface
+/// adapters: each per-surface acquire/release pair advances the counter.
+///
+/// Created with `VkSemaphoreTypeCreateInfo` chained into the standard
+/// `VkSemaphoreCreateInfo`. Optionally created with
+/// `VkExportSemaphoreCreateInfo` so [`Self::export_opaque_fd`] can hand a
+/// file descriptor to a subprocess, which imports it via
+/// [`Self::from_imported_opaque_fd`] into its own `VkDevice`. The two
+/// processes then signal/wait the same timeline.
+pub struct VulkanTimelineSemaphore {
+    device: vulkanalia::Device,
+    semaphore: vk::Semaphore,
+    /// Whether the semaphore was created with VK_KHR_external_semaphore_fd
+    /// export support — i.e. [`Self::export_opaque_fd`] is callable.
+    exportable: bool,
+}
+
+#[cfg(target_os = "linux")]
+impl VulkanTimelineSemaphore {
+    /// Create an in-process timeline semaphore (no export).
+    ///
+    /// Pair with [`Self::wait`] / [`Self::signal_host`] / [`Self::signal_on_queue`]
+    /// for single-process work. Use [`Self::new_exportable`] when the
+    /// timeline must be shared with a subprocess via sync-fd.
+    pub fn new(device: &vulkanalia::Device, initial_value: u64) -> Result<Self> {
+        Self::create(device, initial_value, false)
+    }
+
+    /// Create an exportable timeline semaphore.
+    ///
+    /// `vkGetSemaphoreFdKHR` will hand a fresh OPAQUE_FD per
+    /// [`Self::export_opaque_fd`] call; ownership transfers to the caller
+    /// (close after use, or pass via SCM_RIGHTS).
+    pub fn new_exportable(device: &vulkanalia::Device, initial_value: u64) -> Result<Self> {
+        Self::create(device, initial_value, true)
+    }
+
+    fn create(
+        device: &vulkanalia::Device,
+        initial_value: u64,
+        exportable: bool,
+    ) -> Result<Self> {
+        let mut type_info = vk::SemaphoreTypeCreateInfo::builder()
+            .semaphore_type(vk::SemaphoreType::TIMELINE)
+            .initial_value(initial_value)
+            .build();
+
+        let mut export_info = vk::ExportSemaphoreCreateInfo::builder()
+            .handle_types(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
+            .build();
+
+        let info = if exportable {
+            // Chain order: SemaphoreCreateInfo -> ExportSemaphoreCreateInfo -> SemaphoreTypeCreateInfo.
+            // p_next is set manually to avoid moving the local `type_info`
+            // into the builder's pNext (vulkanalia's builder takes &mut and
+            // would borrow `type_info`).
+            export_info.next = (&mut type_info as *mut _) as *mut std::ffi::c_void;
+            vk::SemaphoreCreateInfo::builder()
+                .push_next(&mut export_info)
+                .build()
+        } else {
+            vk::SemaphoreCreateInfo::builder()
+                .push_next(&mut type_info)
+                .build()
+        };
+
+        let semaphore = unsafe { device.create_semaphore(&info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "Failed to create timeline semaphore (exportable={exportable}): {e}"
+            ))
+        })?;
+
+        Ok(Self {
+            device: device.clone(),
+            semaphore,
+            exportable,
+        })
+    }
+
+    /// Import a timeline semaphore from an OPAQUE_FD handed in by the
+    /// host. Subprocess side of [`Self::export_opaque_fd`].
+    ///
+    /// `VK_SEMAPHORE_IMPORT_TEMPORARY_BIT` is NOT used: the imported
+    /// semaphore takes permanent payload ownership, matching how DMA-BUF
+    /// memory imports are bound for surface lifetime.
+    ///
+    /// On success the kernel fd ownership transfers to the Vulkan driver;
+    /// the caller MUST NOT close `fd` afterwards. On error the caller
+    /// retains ownership and is responsible for closing it.
+    pub fn from_imported_opaque_fd(
+        device: &vulkanalia::Device,
+        fd: std::os::unix::io::RawFd,
+    ) -> Result<Self> {
+        // The semaphore must already exist before import. Create it as a
+        // timeline semaphore with initial value 0; the import then
+        // replaces the payload with the host's timeline state.
+        let mut type_info = vk::SemaphoreTypeCreateInfo::builder()
+            .semaphore_type(vk::SemaphoreType::TIMELINE)
+            .initial_value(0)
+            .build();
+        let info = vk::SemaphoreCreateInfo::builder()
+            .push_next(&mut type_info)
+            .build();
+        let semaphore = unsafe { device.create_semaphore(&info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "Failed to create receiving timeline semaphore for import: {e}"
+            ))
+        })?;
+
+        let import_info = vk::ImportSemaphoreFdInfoKHR::builder()
+            .semaphore(semaphore)
+            .flags(vk::SemaphoreImportFlags::empty())
+            .handle_type(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
+            .fd(fd)
+            .build();
+
+        let import_result = unsafe { device.import_semaphore_fd_khr(&import_info) };
+        if let Err(e) = import_result {
+            unsafe { device.destroy_semaphore(semaphore, None) };
+            return Err(StreamError::GpuError(format!(
+                "vkImportSemaphoreFdKHR failed: {e}"
+            )));
+        }
+
+        Ok(Self {
+            device: device.clone(),
+            semaphore,
+            exportable: false,
+        })
+    }
+
+    /// Export the semaphore as a fresh OPAQUE_FD suitable for SCM_RIGHTS
+    /// passing to a subprocess. Each call returns a NEW fd; callers own
+    /// the returned fd and must close it after use (or after the
+    /// subprocess has imported its own copy).
+    pub fn export_opaque_fd(&self) -> Result<std::os::unix::io::RawFd> {
+        if !self.exportable {
+            return Err(StreamError::GpuError(
+                "VulkanTimelineSemaphore::export_opaque_fd: semaphore was not created with `new_exportable`".into(),
+            ));
+        }
+        let info = vk::SemaphoreGetFdInfoKHR::builder()
+            .semaphore(self.semaphore)
+            .handle_type(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
+            .build();
+        let fd = unsafe { self.device.get_semaphore_fd_khr(&info) }.map_err(|e| {
+            StreamError::GpuError(format!("vkGetSemaphoreFdKHR failed: {e}"))
+        })?;
+        Ok(fd)
+    }
+
+    /// Block until the timeline counter has reached or surpassed `value`.
+    ///
+    /// `timeout_ns` is the per-call timeout; pass `u64::MAX` for "no
+    /// timeout". Returns `Ok(())` on success and
+    /// [`StreamError::GpuError`] (containing the underlying VkResult) on
+    /// timeout or driver failure.
+    pub fn wait(&self, value: u64, timeout_ns: u64) -> Result<()> {
+        let semaphores = [self.semaphore];
+        let values = [value];
+        let info = vk::SemaphoreWaitInfo::builder()
+            .flags(vk::SemaphoreWaitFlags::empty())
+            .semaphores(&semaphores)
+            .values(&values)
+            .build();
+        unsafe { self.device.wait_semaphores(&info, timeout_ns) }
+            .map(|_| ())
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "vkWaitSemaphores(value={value}, timeout_ns={timeout_ns}): {e}"
+                ))
+            })
+    }
+
+    /// Host-side signal: advance the counter to `value` directly from
+    /// the CPU. Used when the producer has finished writing on the host
+    /// side and wants to release the surface to the next consumer.
+    ///
+    /// `value` MUST be greater than the current counter — Vulkan
+    /// disallows monotonic regressions on a timeline semaphore.
+    pub fn signal_host(&self, value: u64) -> Result<()> {
+        let info = vk::SemaphoreSignalInfo::builder()
+            .semaphore(self.semaphore)
+            .value(value)
+            .build();
+        unsafe { self.device.signal_semaphore(&info) }.map_err(|e| {
+            StreamError::GpuError(format!("vkSignalSemaphore(value={value}): {e}"))
+        })
+    }
+
+    /// Read the current timeline counter value via
+    /// `vkGetSemaphoreCounterValue`. Used by tests and progress reporting.
+    pub fn current_value(&self) -> Result<u64> {
+        unsafe { self.device.get_semaphore_counter_value(self.semaphore) }.map_err(|e| {
+            StreamError::GpuError(format!("vkGetSemaphoreCounterValue: {e}"))
+        })
+    }
+
+    /// Raw `vk::Semaphore` handle for inclusion in queue submit infos.
+    pub fn semaphore(&self) -> vk::Semaphore {
+        self.semaphore
+    }
+
+    /// Whether [`Self::export_opaque_fd`] can be called.
+    pub fn is_exportable(&self) -> bool {
+        self.exportable
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for VulkanTimelineSemaphore {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_semaphore(self.semaphore, None) };
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe impl Send for VulkanTimelineSemaphore {}
+#[cfg(target_os = "linux")]
+unsafe impl Sync for VulkanTimelineSemaphore {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,6 +416,51 @@ mod tests {
         let semaphore = VulkanSemaphore::new(device.device());
         assert!(semaphore.is_ok(), "Semaphore creation should succeed");
         println!("Vulkan semaphore created successfully");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn timeline_semaphore_host_signal_advances_counter() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping test - Vulkan not available");
+                return;
+            }
+        };
+        let sem = VulkanTimelineSemaphore::new(device.device(), 0)
+            .expect("create timeline semaphore");
+        assert_eq!(sem.current_value().unwrap(), 0);
+        sem.signal_host(7).expect("host signal");
+        assert_eq!(sem.current_value().unwrap(), 7);
+        // wait on a value already reached returns immediately.
+        sem.wait(7, 0).expect("wait on already-reached value");
+    }
+
+    /// `new_exportable` plus `export_opaque_fd` returns a valid kernel
+    /// fd. Sufficient to confirm `VK_KHR_external_semaphore_fd` is wired.
+    /// Cross-process import is exercised by the surface-adapter
+    /// integration tests in `streamlib-adapter-vulkan`.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn timeline_semaphore_exports_valid_opaque_fd() {
+        let device = match VulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping test - Vulkan not available");
+                return;
+            }
+        };
+        let sem = match VulkanTimelineSemaphore::new_exportable(device.device(), 0) {
+            Ok(s) => s,
+            Err(_) => {
+                println!("Skipping — VK_KHR_external_semaphore_fd unavailable on this driver");
+                return;
+            }
+        };
+        let fd = sem.export_opaque_fd().expect("export_opaque_fd");
+        assert!(fd >= 0, "exported sync fd should be a valid kernel fd");
+        unsafe { libc::close(fd) };
     }
 
     #[test]

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -671,6 +671,152 @@ impl VulkanTexture {
         Ok(fd)
     }
 
+    /// Subprocess-side import of a render-target DMA-BUF image.
+    ///
+    /// The host allocated the image via [`Self::new_render_target_dma_buf`]
+    /// with a tiled DRM modifier (LINEAR is sampler-only on NVIDIA). The
+    /// subprocess receives:
+    /// - `fds` — DMA-BUF file descriptors, one per plane.
+    /// - `plane_offsets` / `plane_strides` — exact layout the host's
+    ///   `vkGetImageSubresourceLayout` reported.
+    /// - `drm_format_modifier` — the modifier the host's driver chose;
+    ///   non-zero, must match an `external_only=FALSE` modifier on the
+    ///   subprocess's GPU.
+    ///
+    /// Builds a subprocess-local `VkImage` with
+    /// `VkImageDrmFormatModifierExplicitCreateInfoEXT` chained, imports
+    /// the DMA-BUF memory, and binds the image. Symmetric to the host
+    /// allocation; same modifier on both sides keeps the GPU memory
+    /// layout consistent.
+    ///
+    /// fd ownership: the subprocess transfers ownership to Vulkan on
+    /// success (the driver `dup`s internally and releases on
+    /// `vkFreeMemory`). On error the caller still owns `fds[0]`.
+    pub fn import_render_target_dma_buf(
+        vulkan_device: &Arc<VulkanDevice>,
+        fds: &[std::os::unix::io::RawFd],
+        plane_offsets: &[u64],
+        plane_strides: &[u64],
+        drm_format_modifier: u64,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        allocation_size: vk::DeviceSize,
+    ) -> Result<Self> {
+        if fds.is_empty() {
+            return Err(StreamError::GpuError(
+                "import_render_target_dma_buf: empty fd vec".into(),
+            ));
+        }
+        if plane_offsets.len() != fds.len() || plane_strides.len() != fds.len() {
+            return Err(StreamError::GpuError(format!(
+                "import_render_target_dma_buf: plane arrays length mismatch — fds={} offsets={} strides={}",
+                fds.len(),
+                plane_offsets.len(),
+                plane_strides.len()
+            )));
+        }
+        if drm_format_modifier == 0 {
+            return Err(StreamError::GpuError(
+                "import_render_target_dma_buf: zero (LINEAR) modifier — host should have allocated a tiled modifier; LINEAR DMA-BUFs are sampler-only on NVIDIA"
+                    .into(),
+            ));
+        }
+
+        let device = vulkan_device.device();
+        let vk_format = texture_format_to_vk(format);
+
+        let plane_layouts: Vec<vk::SubresourceLayout> = plane_offsets
+            .iter()
+            .zip(plane_strides.iter())
+            .map(|(off, stride)| vk::SubresourceLayout {
+                offset: *off,
+                size: 0,
+                row_pitch: *stride,
+                array_pitch: 0,
+                depth_pitch: 0,
+            })
+            .collect();
+
+        let mut explicit_modifier_info =
+            vk::ImageDrmFormatModifierExplicitCreateInfoEXT::builder()
+                .drm_format_modifier(drm_format_modifier)
+                .plane_layouts(&plane_layouts);
+
+        let mut external_image_info = vk::ExternalMemoryImageCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let image_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D { width, height, depth: 1 })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::_1)
+            .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+            .usage(
+                vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::TRANSFER_DST
+                    | vk::ImageUsageFlags::SAMPLED
+                    | vk::ImageUsageFlags::COLOR_ATTACHMENT,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push_next(&mut explicit_modifier_info)
+            .push_next(&mut external_image_info);
+
+        let image = unsafe { device.create_image(&image_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "import_render_target_dma_buf: create_image failed (modifier=0x{:016x}): {e}",
+                drm_format_modifier
+            ))
+        })?;
+
+        let mem_requirements = unsafe { device.get_image_memory_requirements(image) };
+        let alloc_size = allocation_size.max(mem_requirements.size);
+
+        // Use plane 0's fd for the import; multi-plane DRM modifiers
+        // bind separate memory per plane via VkBindImageMemoryInfo +
+        // VkBindImagePlaneMemoryInfo, which we'll wire when a multi-plane
+        // consumer surfaces. Single-plane covers BGRA / RGBA — the
+        // formats #510 publishes RT modifiers for today.
+        let memory = vulkan_device
+            .import_dma_buf_memory(
+                fds[0],
+                alloc_size,
+                mem_requirements.memory_type_bits,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            )
+            .map_err(|e| {
+                unsafe { device.destroy_image(image, None) };
+                e
+            })?;
+
+        unsafe { device.bind_image_memory(image, memory, 0) }
+            .map_err(|e| {
+                vulkan_device.free_imported_memory(memory);
+                unsafe { device.destroy_image(image, None) };
+                StreamError::GpuError(format!(
+                    "import_render_target_dma_buf: bind_image_memory failed: {e}"
+                ))
+            })?;
+
+        Ok(Self {
+            vulkan_device: Some(Arc::clone(vulkan_device)),
+            image: Some(image),
+            allocation: None,
+            imported_memory: Some(memory),
+            cached_dma_buf_fd: OnceLock::new(),
+            cached_image_view: OnceLock::new(),
+            imported_from_iosurface: false,
+            imported_from_dma_buf: true,
+            chosen_drm_format_modifier: drm_format_modifier,
+            width,
+            height,
+            format,
+        })
+    }
+
     /// Import a texture from a DMA-BUF file descriptor.
     pub fn from_dma_buf_fd(
         vulkan_device: &Arc<VulkanDevice>,


### PR DESCRIPTION
## Summary

- First adapter crate (`libs/streamlib-adapter-vulkan/`) — no-copy passthrough that hands the host's `VkImage` to consumers via `SurfaceAdapter` + `VulkanWritable` + `VulkanImageInfoExt`. Validates the trait shape, sync model, and descriptor accessors before #512 / #513 / #514 pin against them.
- Cross-process sync: new `VulkanTimelineSemaphore` exports OPAQUE_FD via `VK_KHR_external_semaphore_fd`; subprocesses import the same timeline into their own VkDevice and signal/wait the same monotonic counter.
- Subprocess `VkImage` import path: `VulkanTexture::import_render_target_dma_buf` chains `VkImageDrmFormatModifierExplicitCreateInfoEXT` + `VkImportMemoryFdInfoKHR` so the subprocess sees the same DRM-modifier-tiled image the host allocated via #510.
- Polyglot mirrors: `streamlib.adapters.vulkan` (Python) + `adapters/vulkan.ts` (Deno) ship the typed views, `RawVulkanHandles`, and `VulkanContext` Protocol shapes. Smoke tests in both runtimes.
- ABI accessors: `pub` accessors on `StreamlibSurface` / `SurfaceTransportHandle` / `SurfaceSyncState` so subprocess adapters can read DMA-BUF fds + sync-fd from a descriptor without leaking `pub(crate)` into the trait surface. Layout regression test extended.
- New `streamlib::adapter_support` module is the gateway for in-tree adapters per the CLAUDE.md Vulkan boundary rule — exposes `VulkanDevice`, `VulkanTexture`, `VulkanTimelineSemaphore` only.

## Closes
Closes #511

## Exit criteria
- [x] New crate `libs/streamlib-adapter-vulkan/` with parallel Python (`streamlib-python/python/streamlib/adapters/vulkan.py`) and Deno (`streamlib-deno/adapters/vulkan.ts`) wrappers.
- [x] Implements `SurfaceAdapter` trait with GAT-based `acquire_read` / `acquire_write` (+ `try_*` non-blocking variants).
- [x] Implements `VulkanWritable` + `VulkanImageInfoExt` capability traits on its `WriteView`. `vk_image_layout()` is the documented escape hatch — only reachable through capability-trait composition, not from `SurfaceAdapter` customers.
- [x] Customer-facing API: `VulkanContext::acquire_write(surface)` (Rust RAII), Python `with` Protocol, Deno `using` shape.
- [x] Raw escape hatch: `RawVulkanHandles { vk_instance, vk_physical_device, vk_device, vk_queue, vk_queue_family_index, api_version }` via `streamlib_adapter_vulkan::raw_handles()`.
- [x] Subprocesses share the host's *physical device* (and DMA-BUF memory through FD imports); each has its own `VkInstance` + `VkDevice` per the cross-process Vulkan model. Subprocess does not call `vkCreateDevice` from adapter code.
- [x] Sync: timeline-semaphore wait on acquire; CPU-side `signal_host` on host release / queue-side signal on subprocess release. Customer never sees a semaphore object.
- [x] `streamlib_adapter_abi::testing::run_conformance` passes against the adapter (covers all eight contracts MockAdapter passes).

## Test plan

All 8 issue-listed tests wired and green on RTX 3090 (driver 570.211.01):

- [x] `streamlib_adapter_vulkan::tests::conformance` — runs `run_conformance` against a real Vulkan-backed adapter.
- [x] `streamlib_adapter_vulkan::tests::sync_correctness` — timeline counter advances exactly on the LAST reader's drop / on writer drop; concurrent readers share a release boundary.
- [x] `streamlib_adapter_vulkan::tests::write_excludes_read` — explicit `WriteContended` regression next to conformance.
- [x] `streamlib_adapter_vulkan::tests::round_trip_host_writes_subprocess_reads` — host clears VkImage via adapter, subprocess imports + reads via `vkCmdCopyImageToBuffer`, asserts BGRA bytes (B=191, G=128, R=64, A=255 from clear color [0.25, 0.5, 0.75, 1.0]).
- [x] `streamlib_adapter_vulkan::tests::round_trip_subprocess_writes_host_reads` — reverse direction; subprocess `vkCmdClearColorImage`, host reads back, asserts.
- [x] `streamlib_adapter_vulkan::tests::concurrent_reads_two_subprocesses` — two helpers wait/signal the same timeline value concurrently.
- [x] `streamlib_adapter_vulkan::tests::subprocess_crash_mid_write` — `SubprocessCrashHarness` from #509 + socketpair EOF observation; host adapter survives and remains functional.
- [x] Python smoke (`test_adapters_vulkan.py`, 4 tests) + Deno smoke (`vulkan_test.ts`, 3 tests).
- [x] `streamlib::vulkan::rhi::vulkan_sync` (4 tests, 2 new for timeline-semaphore basics).
- [x] `streamlib_adapter_abi` (8 tests, 1 new for pub accessor round-trip).

## Follow-ups (not blocking #511)

- `VkImageInfo` returned by the adapter sets `format=0` and `usage_flags=0` — Skia (#513) will need real values populated from `VulkanTexture`. Marked as v1 in the code; tracked when #513 lands.
- `transition_layout_sync` uses `queue_wait_idle` per acquire — global queue stall acceptable for the first adapter; revisit when #513/#514 add concurrent GPU work on the same queue.
- Will file a separate "Subprocess RHI parity audit" follow-up issue (per discussion in this PR) — should subprocesses delegate beyond consumer-only via escalate IPC, or ship per-language Vulkan code that re-implements solved-on-host patterns?

🤖 Generated with [Claude Code](https://claude.com/claude-code)