### PR TITLE
chore(adapter-vulkan): remove CpuReadable impl on VulkanReadView

### DIFF
--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -446,7 +446,6 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
                 image,
                 layout,
                 info,
-                cpu_bytes: None,
                 _marker: PhantomData,
             },
         ))
@@ -505,7 +504,6 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
                 image,
                 layout,
                 info,
-                cpu_bytes: None,
                 _marker: PhantomData,
             },
         )))

--- a/libs/streamlib-adapter-vulkan/src/view.rs
+++ b/libs/streamlib-adapter-vulkan/src/view.rs
@@ -12,8 +12,7 @@
 use std::marker::PhantomData;
 
 use streamlib_adapter_abi::{
-    CpuReadable, VkImageHandle, VkImageInfo, VkImageLayoutValue, VulkanImageInfoExt,
-    VulkanWritable,
+    VkImageHandle, VkImageInfo, VkImageLayoutValue, VulkanImageInfoExt, VulkanWritable,
 };
 use vulkanalia::vk;
 use vulkanalia::vk::Handle as _;
@@ -25,12 +24,6 @@ pub struct VulkanReadView<'g> {
     pub(crate) image: vk::Image,
     pub(crate) layout: vk::ImageLayout,
     pub(crate) info: VkImageInfo,
-    /// Optional CPU-side staging slice. Some adapter consumers (the
-    /// in-process round-trip tests, debug snapshotters) want a byte
-    /// view of the surface in addition to the `VkImage`. The adapter
-    /// fills this when the consumer asks for it; the default is
-    /// `None`.
-    pub(crate) cpu_bytes: Option<&'g [u8]>,
     pub(crate) _marker: PhantomData<&'g ()>,
 }
 
@@ -47,12 +40,6 @@ impl VulkanWritable for VulkanReadView<'_> {
 impl VulkanImageInfoExt for VulkanReadView<'_> {
     fn vk_image_info(&self) -> VkImageInfo {
         self.info
-    }
-}
-
-impl CpuReadable for VulkanReadView<'_> {
-    fn read_bytes(&self) -> &[u8] {
-        self.cpu_bytes.unwrap_or(&[])
     }
 }
 
@@ -80,4 +67,27 @@ impl VulkanImageInfoExt for VulkanWriteView<'_> {
     fn vk_image_info(&self) -> VkImageInfo {
         self.info
     }
+}
+
+// GPU surface views must not implement `CpuReadable`. Switching to the
+// `streamlib-adapter-cpu-readback` adapter is the contractual signal for
+// "I want CPU bytes" — see #514. Adding the impl back, even returning an
+// empty slice "for symmetry," would re-introduce the asymmetry that PR
+// #527 deliberately removed and would make every Vulkan consumer
+// silently appear CPU-readable.
+mod _assert_vulkan_read_view_not_cpu_readable {
+    use super::VulkanReadView;
+    use streamlib_adapter_abi::CpuReadable;
+
+    trait AmbiguousIfImpl<A> {
+        fn some_item() {}
+    }
+    impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+    #[allow(dead_code)]
+    struct Invalid;
+    impl<T: ?Sized + CpuReadable> AmbiguousIfImpl<Invalid> for T {}
+
+    const _: fn() = || {
+        let _ = <VulkanReadView<'static> as AmbiguousIfImpl<_>>::some_item;
+    };
 }


### PR DESCRIPTION
## Summary

- Removes the dead `impl CpuReadable for VulkanReadView<'_>` (returned `&[]` from a `cpu_bytes: Option<&[u8]>` field that no in-tree code populated) and the field itself, plus the two `cpu_bytes: None` populations in `adapter.rs`.
- Locks the architectural invariant from #514 / PR #527 — only `streamlib-adapter-cpu-readback` exposes `CpuReadable` / `CpuWritable`; switching to that adapter is the contractual signal for "I want CPU bytes" — with a hand-rolled compile-time assertion (the `static_assertions::assert_not_impl_all!` ambiguous-impl pattern, no new dep).
- Sibling check (per issue's AI Notes): `streamlib-adapter-opengl` has zero `CpuReadable` matches; `streamlib-adapter-skia` doesn't exist yet. No scope expansion needed.

## Closes
Closes #534

## Exit criteria

- [x] `impl CpuReadable for VulkanReadView<'_>` block removed from `libs/streamlib-adapter-vulkan/src/view.rs`.
- [x] `cpu_bytes` field removed from `VulkanReadView`.
- [x] All call sites in `streamlib-adapter-vulkan` updated (both `cpu_bytes: None` populations in `adapter.rs` removed).
- [x] `cargo test -p streamlib-adapter-vulkan` still green.

## Test plan

- [x] **Existing tests**: `cargo test -p streamlib-adapter-vulkan` — 6 integration tests + 1 conformance test pass:
  - `vulkan_adapter_passes_run_conformance` ✅
  - `host_writes_subprocess_reads_round_trip` ✅
  - `subprocess_writes_host_reads_round_trip` ✅
  - `subprocess_crash_mid_write_does_not_break_host_adapter` ✅
  - `timeline_counter_advances_on_release_and_is_observable_by_next_acquire` ✅
  - `live_write_guard_blocks_acquire_read_until_dropped` ✅
- [x] **Compile-time invariant**: a `mod _assert_vulkan_read_view_not_cpu_readable` block in `view.rs` uses the ambiguous-impl trick to make `VulkanReadView<'_>: CpuReadable` un-compilable. Sanity-checked by temporarily re-adding `impl CpuReadable for VulkanReadView<'_>` — produces `E0283: type annotations needed` exactly as designed; reverted before commit.

## Follow-ups

None. Symmetric assertion for `VulkanWriteView<'_>: !CpuWritable` was deliberately scoped out — the issue specified `VulkanReadView<'_>: !CpuReadable` only. Can be added in a follow-up if the broader architecture-lock is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)