### PR TITLE
feat(adapter-cpu-readback): NV12 + multi-plane format support

### DIFF
--- a/libs/streamlib-adapter-abi/src/surface.rs
+++ b/libs/streamlib-adapter-abi/src/surface.rs
@@ -22,6 +22,67 @@ pub enum SurfaceFormat {
     Nv12 = 2,
 }
 
+impl SurfaceFormat {
+    /// Number of planes for this format.
+    pub const fn plane_count(&self) -> u32 {
+        match self {
+            Self::Bgra8 | Self::Rgba8 => 1,
+            Self::Nv12 => 2,
+        }
+    }
+
+    /// Bytes per texel of `plane`. NV12: Y plane = 1, UV plane = 2 (interleaved Cb/Cr).
+    ///
+    /// Panics if `plane >= self.plane_count()`.
+    pub const fn plane_bytes_per_pixel(&self, plane: u32) -> u32 {
+        match (self, plane) {
+            (Self::Bgra8 | Self::Rgba8, 0) => 4,
+            (Self::Nv12, 0) => 1,
+            (Self::Nv12, 1) => 2,
+            _ => panic!("plane index out of range for SurfaceFormat"),
+        }
+    }
+
+    /// Plane width in texels at `surface_width`. NV12: Y = full width, UV = `surface_width / 2`.
+    ///
+    /// Panics if `plane >= self.plane_count()`.
+    pub const fn plane_width(&self, surface_width: u32, plane: u32) -> u32 {
+        match (self, plane) {
+            (Self::Bgra8 | Self::Rgba8, 0) => surface_width,
+            (Self::Nv12, 0) => surface_width,
+            (Self::Nv12, 1) => surface_width / 2,
+            _ => panic!("plane index out of range for SurfaceFormat"),
+        }
+    }
+
+    /// Plane height in texels at `surface_height`. NV12: Y = full height, UV = `surface_height / 2`.
+    ///
+    /// Panics if `plane >= self.plane_count()`.
+    pub const fn plane_height(&self, surface_height: u32, plane: u32) -> u32 {
+        match (self, plane) {
+            (Self::Bgra8 | Self::Rgba8, 0) => surface_height,
+            (Self::Nv12, 0) => surface_height,
+            (Self::Nv12, 1) => surface_height / 2,
+            _ => panic!("plane index out of range for SurfaceFormat"),
+        }
+    }
+
+    /// Tightly-packed plane size in bytes for a `surface_width x surface_height` surface.
+    ///
+    /// Panics if `plane >= self.plane_count()`.
+    pub const fn plane_byte_size(
+        &self,
+        surface_width: u32,
+        surface_height: u32,
+        plane: u32,
+    ) -> u64 {
+        let w = self.plane_width(surface_width, plane) as u64;
+        let h = self.plane_height(surface_height, plane) as u64;
+        let bpp = self.plane_bytes_per_pixel(plane) as u64;
+        w * h * bpp
+    }
+}
+
 bitflags! {
     /// What a surface may be used for.
     #[repr(transparent)]
@@ -295,6 +356,48 @@ mod tests {
     fn surface_format_is_u32() {
         assert_eq!(size_of::<SurfaceFormat>(), 4);
         assert_eq!(align_of::<SurfaceFormat>(), 4);
+    }
+
+    #[test]
+    fn surface_format_plane_count_matches_format_shape() {
+        assert_eq!(SurfaceFormat::Bgra8.plane_count(), 1);
+        assert_eq!(SurfaceFormat::Rgba8.plane_count(), 1);
+        assert_eq!(SurfaceFormat::Nv12.plane_count(), 2);
+    }
+
+    #[test]
+    fn surface_format_plane_geometry_for_bgra() {
+        // BGRA8: 1 plane, 4 bpp, full surface dimensions.
+        assert_eq!(SurfaceFormat::Bgra8.plane_bytes_per_pixel(0), 4);
+        assert_eq!(SurfaceFormat::Bgra8.plane_width(64, 0), 64);
+        assert_eq!(SurfaceFormat::Bgra8.plane_height(48, 0), 48);
+        assert_eq!(SurfaceFormat::Bgra8.plane_byte_size(64, 48, 0), 64 * 48 * 4);
+    }
+
+    #[test]
+    fn surface_format_plane_geometry_for_nv12() {
+        // NV12 plane 0 (Y): 1 bpp, full width × full height.
+        assert_eq!(SurfaceFormat::Nv12.plane_bytes_per_pixel(0), 1);
+        assert_eq!(SurfaceFormat::Nv12.plane_width(64, 0), 64);
+        assert_eq!(SurfaceFormat::Nv12.plane_height(48, 0), 48);
+        assert_eq!(SurfaceFormat::Nv12.plane_byte_size(64, 48, 0), 64 * 48);
+
+        // NV12 plane 1 (UV interleaved): 2 bpp, half width × half height.
+        assert_eq!(SurfaceFormat::Nv12.plane_bytes_per_pixel(1), 2);
+        assert_eq!(SurfaceFormat::Nv12.plane_width(64, 1), 32);
+        assert_eq!(SurfaceFormat::Nv12.plane_height(48, 1), 24);
+        assert_eq!(SurfaceFormat::Nv12.plane_byte_size(64, 48, 1), 32 * 24 * 2);
+
+        // Total NV12 footprint = 1.5× the surface pixel count (12 bpp average).
+        let total = SurfaceFormat::Nv12.plane_byte_size(64, 48, 0)
+            + SurfaceFormat::Nv12.plane_byte_size(64, 48, 1);
+        assert_eq!(total, 64 * 48 * 3 / 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "plane index out of range")]
+    fn surface_format_plane_out_of_range_panics() {
+        let _ = SurfaceFormat::Bgra8.plane_bytes_per_pixel(1);
     }
 
     #[test]

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -125,15 +125,20 @@ impl CpuReadbackSurfaceAdapter {
             let pw = format.plane_width(width, plane_idx);
             let ph = format.plane_height(height, plane_idx);
             let pbpp = format.plane_bytes_per_pixel(plane_idx);
-            let staging_pixel_format = pixel_format_for_bpp(pbpp);
 
             // Allocate a *dedicated* HOST_VISIBLE linear staging buffer per
             // plane. Going through `GpuContext::acquire_pixel_buffer` would
             // draw from the shared (w,h,format) pool and cap at 4 surfaces
             // of identical dimensions — wrong shape for an adapter that
             // needs one buffer per registered surface plane.
+            //
+            // The `PixelFormat` argument to `VulkanPixelBuffer::new` is
+            // opaque metadata only — `bytes_per_pixel` drives the
+            // allocation size. We pass `Bgra32` uniformly so the
+            // staging buffer's recorded format isn't claiming a specific
+            // pixel layout (Y/UV/RGB) the adapter never interprets.
             let staging = Arc::new(
-                VulkanPixelBuffer::new(&self.device, pw, ph, pbpp, staging_pixel_format).map_err(
+                VulkanPixelBuffer::new(&self.device, pw, ph, pbpp, PixelFormat::Bgra32).map_err(
                     |e| AdapterError::IpcDisconnected {
                         reason: format!(
                             "VulkanPixelBuffer::new for cpu-readback staging plane {plane_idx}: {e}"
@@ -689,30 +694,6 @@ fn combined_aspect_mask(format: SurfaceFormat) -> vk::ImageAspectFlags {
     match format {
         SurfaceFormat::Bgra8 | SurfaceFormat::Rgba8 => vk::ImageAspectFlags::COLOR,
         SurfaceFormat::Nv12 => vk::ImageAspectFlags::PLANE_0 | vk::ImageAspectFlags::PLANE_1,
-    }
-}
-
-/// Pick the [`PixelFormat`] enumerant for a HOST_VISIBLE staging
-/// `VulkanPixelBuffer` whose only role is "linear bytes the customer
-/// will memcpy out of / into". The buffer never gets sampled or rendered
-/// from, so the choice only governs allocation sizing — the bytes-per-
-/// pixel passed alongside is the load-bearing input.
-fn pixel_format_for_bpp(bpp: u32) -> PixelFormat {
-    match bpp {
-        // BGRA32 / RGBA32 are interchangeable for staging; both are 4 bpp.
-        4 => PixelFormat::Bgra32,
-        // NV12 UV plane is 2 bytes per texel — Uyvy422 is the closest
-        // 2-bpp enumerant in PixelFormat. Buffer is opaque bytes either
-        // way; the bpp parameter to VulkanPixelBuffer::new is what
-        // actually drives the allocation size.
-        2 => PixelFormat::Uyvy422,
-        // NV12 Y plane is 1 byte per texel.
-        1 => PixelFormat::Gray8,
-        // 16 bpp (Rgba64) etc. — fall back to Rgba32 for an oversized
-        // stage; this branch is currently unreachable for SurfaceFormat
-        // {Bgra8, Rgba8, Nv12} but documents the intent if the format
-        // set widens.
-        _ => PixelFormat::Bgra32,
     }
 }
 

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -7,14 +7,17 @@
 //! On `acquire_*`:
 //!  1. Wait for prior GPU work to drain (timeline semaphore wait).
 //!  2. Transition the host's `VkImage` into `TRANSFER_SRC_OPTIMAL`.
-//!  3. `vkCmdCopyImageToBuffer` into the per-surface staging buffer.
+//!  3. `vkCmdCopyImageToBuffer` into the per-plane staging buffer(s).
+//!     For multi-plane formats (NV12) one region per plane is recorded
+//!     with the corresponding `VK_IMAGE_ASPECT_PLANE_{0,1,…}_BIT`.
 //!  4. Block on `vkQueueWaitIdle` so the bytes are observable from the
 //!     CPU side once the call returns.
-//!  5. Hand the customer a `&[u8]` view over the mapped staging buffer.
+//!  5. Hand the customer per-plane `&[u8]` views over the mapped staging
+//!     buffers.
 //!
 //! On WRITE guard `Drop`:
-//!  1. `vkCmdCopyBufferToImage` to flush CPU edits back into the host
-//!     `VkImage`.
+//!  1. `vkCmdCopyBufferToImage` per plane to flush CPU edits back into
+//!     the host `VkImage`.
 //!  2. Transition the image to `GENERAL` so the next consumer sees a
 //!     deterministic layout.
 //!  3. Signal the next timeline release-value.
@@ -31,14 +34,16 @@ use parking_lot::Mutex;
 use streamlib::adapter_support::{VulkanDevice, VulkanPixelBuffer, VulkanTimelineSemaphore};
 use streamlib::core::rhi::PixelFormat;
 use streamlib_adapter_abi::{
-    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceId, WriteGuard,
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, WriteGuard,
 };
 use tracing::instrument;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use crate::state::{HostSurfaceRegistration, SurfaceState, VulkanLayout};
-use crate::view::{CpuReadbackReadView, CpuReadbackWriteView};
+use crate::state::{HostSurfaceRegistration, PlaneSlot, SurfaceState, VulkanLayout};
+use crate::view::{
+    CpuReadbackPlaneView, CpuReadbackPlaneViewMut, CpuReadbackReadView, CpuReadbackWriteView,
+};
 
 /// Default per-acquire timeline-wait timeout.
 const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
@@ -47,9 +52,9 @@ const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
 ///
 /// Construct with [`Self::new`] passing the host's [`VulkanDevice`].
 /// Register host-allocated surfaces with [`Self::register_host_surface`];
-/// each registration allocates a dedicated [`VulkanPixelBuffer`]
-/// (HOST_VISIBLE/HOST_COHERENT linear buffer, sized exactly to the
-/// surface's pixel footprint) used as the staging area for image↔buffer
+/// each registration allocates one dedicated [`VulkanPixelBuffer`] per
+/// plane (HOST_VISIBLE/HOST_COHERENT linear buffer, sized exactly to the
+/// plane's pixel footprint) used as the staging area for image↔buffer
 /// copies. Consumers acquire scoped access through the standard
 /// [`SurfaceAdapter::acquire_read`] / [`SurfaceAdapter::acquire_write`]
 /// API or via the [`crate::CpuReadbackContext`] convenience.
@@ -82,10 +87,10 @@ impl CpuReadbackSurfaceAdapter {
 
     /// Register a host-allocated surface with this adapter.
     ///
-    /// Allocates a dedicated `VulkanPixelBuffer` (HOST_VISIBLE,
-    /// HOST_COHERENT, linear) sized to
-    /// `width * height * bytes_per_pixel` to serve as the staging area
-    /// for image↔buffer copies on every acquire/release.
+    /// Allocates one dedicated `VulkanPixelBuffer` per plane (HOST_VISIBLE,
+    /// HOST_COHERENT, linear). Plane geometry is derived from
+    /// [`HostSurfaceRegistration::format`] via [`SurfaceFormat::plane_count`]
+    /// and [`SurfaceFormat::plane_byte_size`].
     #[instrument(level = "debug", skip(self, registration), fields(surface_id = id))]
     pub fn register_host_surface(
         &self,
@@ -99,55 +104,65 @@ impl CpuReadbackSurfaceAdapter {
 
         let width = registration.texture.width();
         let height = registration.texture.height();
-        let bpp = registration.bytes_per_pixel;
+        let format = registration.format;
 
-        // Pick a PixelFormat for the staging buffer based on bpp. The
-        // buffer is just bytes; the adapter never interprets it as a
-        // typed format. Multi-plane formats (NV12, YUV420p, …) need a
-        // separate plane-aware copy path and are out of scope for v1
-        // — reject explicitly with `UnsupportedFormat` so callers can
-        // branch.
-        let staging_format = match bpp {
-            4 => PixelFormat::Bgra32,
-            other => {
-                tracing::warn!(
-                    bytes_per_pixel = other,
-                    "cpu-readback adapter: unsupported bytes_per_pixel; rejecting"
-                );
-                return Err(AdapterError::UnsupportedFormat {
-                    surface_id: id,
-                    reason: format!("bytes_per_pixel = {other}, only 4 (BGRA8/RGBA8) supported in v1"),
-                });
-            }
-        };
+        // Validate dimensions are compatible with the format's chroma
+        // subsampling. NV12's UV plane is at half-resolution, so the
+        // surface must be even-sized to round-trip exactly. Odd sizes
+        // would silently lose the trailing column / row.
+        if format.plane_count() > 1 && (width % 2 != 0 || height % 2 != 0) {
+            return Err(AdapterError::UnsupportedFormat {
+                surface_id: id,
+                reason: format!(
+                    "{format:?} requires even surface dimensions for chroma subsampling, got {width}x{height}"
+                ),
+            });
+        }
 
-        // Allocate a *dedicated* HOST_VISIBLE linear staging buffer per
-        // surface. Going through `GpuContext::acquire_pixel_buffer`
-        // would draw from the shared (w,h,format) pool and cap at 4
-        // surfaces of identical dimensions — wrong shape for an
-        // adapter that needs one buffer per registered surface.
-        let staging = Arc::new(
-            VulkanPixelBuffer::new(&self.device, width, height, bpp, staging_format).map_err(|e| {
-                AdapterError::IpcDisconnected {
-                    reason: format!("VulkanPixelBuffer::new for cpu-readback staging: {e}"),
-                }
-            })?,
-        );
+        let plane_count = format.plane_count();
+        let mut planes = Vec::with_capacity(plane_count as usize);
+        for plane_idx in 0..plane_count {
+            let pw = format.plane_width(width, plane_idx);
+            let ph = format.plane_height(height, plane_idx);
+            let pbpp = format.plane_bytes_per_pixel(plane_idx);
+            let staging_pixel_format = pixel_format_for_bpp(pbpp);
+
+            // Allocate a *dedicated* HOST_VISIBLE linear staging buffer per
+            // plane. Going through `GpuContext::acquire_pixel_buffer` would
+            // draw from the shared (w,h,format) pool and cap at 4 surfaces
+            // of identical dimensions — wrong shape for an adapter that
+            // needs one buffer per registered surface plane.
+            let staging = Arc::new(
+                VulkanPixelBuffer::new(&self.device, pw, ph, pbpp, staging_pixel_format).map_err(
+                    |e| AdapterError::IpcDisconnected {
+                        reason: format!(
+                            "VulkanPixelBuffer::new for cpu-readback staging plane {plane_idx}: {e}"
+                        ),
+                    },
+                )?,
+            );
+            planes.push(PlaneSlot {
+                staging,
+                width: pw,
+                height: ph,
+                bytes_per_pixel: pbpp,
+            });
+        }
 
         map.insert(
             id,
             SurfaceState {
                 surface_id: id,
                 texture: registration.texture,
-                staging,
+                planes,
                 timeline: registration.timeline,
                 current_layout: VulkanLayout(registration.initial_image_layout),
                 read_holders: 0,
                 write_held: false,
                 current_release_value: 0,
+                format,
                 width,
                 height,
-                bytes_per_pixel: bpp,
             },
         );
         Ok(())
@@ -164,7 +179,7 @@ impl CpuReadbackSurfaceAdapter {
     }
 
     /// Common acquire path: wait timeline, then issue
-    /// `vkCmdCopyImageToBuffer` into the per-surface staging buffer.
+    /// `vkCmdCopyImageToBuffer` into the per-plane staging buffers.
     /// Returns the snapshot needed to build a view, with state's
     /// `read_holders` / `write_held` already incremented.
     fn try_begin(
@@ -192,12 +207,21 @@ impl CpuReadbackSurfaceAdapter {
             .image()
             .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
         let from = state.current_layout;
-        let buffer = state.staging.buffer();
-        let mapped_ptr = state.staging.mapped_ptr();
-        let byte_size = state.buffer_byte_size();
+        let format = state.format;
         let width = state.width;
         let height = state.height;
-        let bpp = state.bytes_per_pixel;
+        let plane_snaps: Vec<PlaneAcquireSlot> = state
+            .planes
+            .iter()
+            .map(|p| PlaneAcquireSlot {
+                buffer: p.staging.buffer(),
+                mapped_ptr: p.staging.mapped_ptr(),
+                width: p.width,
+                height: p.height,
+                bytes_per_pixel: p.bytes_per_pixel,
+                byte_size: p.byte_size(),
+            })
+            .collect();
 
         if write {
             state.write_held = true;
@@ -210,12 +234,10 @@ impl CpuReadbackSurfaceAdapter {
             wait_value,
             image,
             from,
-            buffer,
-            mapped_ptr,
-            byte_size,
+            format,
             width,
             height,
-            bytes_per_pixel: bpp,
+            planes: plane_snaps,
         }))
     }
 
@@ -238,23 +260,26 @@ impl CpuReadbackSurfaceAdapter {
         }
 
         // Acquire-time logging — customers know they paid for this.
+        let total_bytes: u64 = snap.planes.iter().map(|p| p.byte_size).sum();
         tracing::info!(
             surface_id = surface_id,
             width = snap.width,
             height = snap.height,
-            bytes = snap.byte_size,
+            format = ?snap.format,
+            plane_count = snap.planes.len(),
+            bytes = total_bytes,
             mode = if write { "write" } else { "read" },
-            "cpu-readback: GPU→CPU copy of {}x{} surface, {} bytes",
+            "cpu-readback: GPU→CPU copy of {}x{} {:?} surface, {} bytes total ({} planes)",
             snap.width,
             snap.height,
-            snap.byte_size,
+            snap.format,
+            total_bytes,
+            snap.planes.len(),
         );
 
         // Issue: image (current layout) → TRANSFER_SRC_OPTIMAL → copy
         //        → image (TRANSFER_SRC_OPTIMAL → GENERAL).
-        if let Err(err) =
-            self.copy_image_to_buffer(snap.image, snap.from.vk(), snap.buffer, snap.width, snap.height)
-        {
+        if let Err(err) = self.copy_image_to_buffer(snap) {
             self.rollback(surface_id, write);
             return Err(err);
         }
@@ -279,9 +304,11 @@ impl CpuReadbackSurfaceAdapter {
     }
 
     /// Submit a one-shot command buffer that:
-    ///   - transitions `image` (`from` → `TRANSFER_SRC_OPTIMAL`)
-    ///   - `vkCmdCopyImageToBuffer` into `dst` (tightly packed)
-    ///   - transitions `image` (`TRANSFER_SRC_OPTIMAL` → `GENERAL`)
+    ///   - transitions the image (`from` → `TRANSFER_SRC_OPTIMAL`) using
+    ///     the format-correct aspect mask
+    ///   - `vkCmdCopyImageToBuffer` into the per-plane staging buffers
+    ///     (one region per plane with the corresponding aspect mask)
+    ///   - transitions the image (`TRANSFER_SRC_OPTIMAL` → `GENERAL`)
     /// then blocks via `vkQueueWaitIdle` so the host bytes are
     /// observable.
     ///
@@ -293,17 +320,11 @@ impl CpuReadbackSurfaceAdapter {
     /// only this surface's pipeline stalls. Tracked as part of the
     /// adapter runtime-integration follow-up issues filed against
     /// the Surface Adapter Architecture milestone.
-    fn copy_image_to_buffer(
-        &self,
-        image: vk::Image,
-        from: vk::ImageLayout,
-        dst: vk::Buffer,
-        width: u32,
-        height: u32,
-    ) -> Result<(), AdapterError> {
+    fn copy_image_to_buffer(&self, snap: &AcquireSnapshot) -> Result<(), AdapterError> {
         let device = self.device.device();
         let queue = self.device.queue();
         let qf = self.device.queue_family_index();
+        let combined_aspect = combined_aspect_mask(snap.format);
 
         let (pool, cmd) = create_one_shot_command_buffer(device, qf)?;
 
@@ -317,64 +338,83 @@ impl CpuReadbackSurfaceAdapter {
             });
         }
 
-        let pre_barrier = build_image_barrier(image, qf, from, vk::ImageLayout::TRANSFER_SRC_OPTIMAL);
+        let pre_barrier = build_image_barrier(
+            snap.image,
+            qf,
+            snap.from.vk(),
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            combined_aspect,
+        );
         let pre_barriers = [pre_barrier];
         let pre_dep = vk::DependencyInfo::builder()
             .image_memory_barriers(&pre_barriers)
             .build();
         unsafe { device.cmd_pipeline_barrier2(cmd, &pre_dep) };
 
-        let copy_region = vk::BufferImageCopy::builder()
-            .buffer_offset(0)
-            // Tight packing: row length = width pixels, image height = height rows.
-            .buffer_row_length(width)
-            .buffer_image_height(height)
-            .image_subresource(
-                vk::ImageSubresourceLayers::builder()
-                    .aspect_mask(vk::ImageAspectFlags::COLOR)
-                    .mip_level(0)
-                    .base_array_layer(0)
-                    .layer_count(1)
-                    .build(),
-            )
-            .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-            .image_extent(vk::Extent3D {
-                width,
-                height,
-                depth: 1,
-            })
-            .build();
-
-        unsafe {
-            device.cmd_copy_image_to_buffer(
-                cmd,
-                image,
-                vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-                dst,
-                &[copy_region],
-            )
-        };
+        // One copy per plane. NV12 issues two regions (Y → plane-0
+        // staging buffer with PLANE_0 aspect; UV → plane-1 staging buffer
+        // with PLANE_1 aspect). Single-plane formats issue one region
+        // with the COLOR aspect.
+        for (plane_idx, plane) in snap.planes.iter().enumerate() {
+            let aspect = plane_aspect_mask(snap.format, plane_idx as u32);
+            let copy_region = vk::BufferImageCopy::builder()
+                .buffer_offset(0)
+                // Tight packing: row length = plane width texels,
+                // image height = plane height rows.
+                .buffer_row_length(plane.width)
+                .buffer_image_height(plane.height)
+                .image_subresource(
+                    vk::ImageSubresourceLayers::builder()
+                        .aspect_mask(aspect)
+                        .mip_level(0)
+                        .base_array_layer(0)
+                        .layer_count(1)
+                        .build(),
+                )
+                .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+                .image_extent(vk::Extent3D {
+                    width: plane.width,
+                    height: plane.height,
+                    depth: 1,
+                })
+                .build();
+            unsafe {
+                device.cmd_copy_image_to_buffer(
+                    cmd,
+                    snap.image,
+                    vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+                    plane.buffer,
+                    &[copy_region],
+                )
+            };
+        }
 
         // Image: TRANSFER_SRC_OPTIMAL → GENERAL (deterministic post-state).
-        // Buffer: TRANSFER_WRITE → HOST_READ so the unmapped bytes are
-        // host-coherent after the wait.
+        // Each per-plane staging VkBuffer: TRANSFER_WRITE → HOST_READ so
+        // the unmapped bytes are host-coherent after the wait.
         let post_barrier = build_image_barrier(
-            image,
+            snap.image,
             qf,
             vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
             vk::ImageLayout::GENERAL,
+            combined_aspect,
         );
         let post_barriers = [post_barrier];
-        let host_buf_barrier = vk::BufferMemoryBarrier2::builder()
-            .src_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
-            .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
-            .dst_stage_mask(vk::PipelineStageFlags2::HOST)
-            .dst_access_mask(vk::AccessFlags2::HOST_READ)
-            .buffer(dst)
-            .offset(0)
-            .size(vk::WHOLE_SIZE)
-            .build();
-        let post_buf_barriers = [host_buf_barrier];
+        let post_buf_barriers: Vec<vk::BufferMemoryBarrier2> = snap
+            .planes
+            .iter()
+            .map(|p| {
+                vk::BufferMemoryBarrier2::builder()
+                    .src_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+                    .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                    .dst_stage_mask(vk::PipelineStageFlags2::HOST)
+                    .dst_access_mask(vk::AccessFlags2::HOST_READ)
+                    .buffer(p.buffer)
+                    .offset(0)
+                    .size(vk::WHOLE_SIZE)
+                    .build()
+            })
+            .collect();
         let post_dep = vk::DependencyInfo::builder()
             .image_memory_barriers(&post_barriers)
             .buffer_memory_barriers(&post_buf_barriers)
@@ -415,19 +455,14 @@ impl CpuReadbackSurfaceAdapter {
     }
 
     /// Symmetric counterpart of [`Self::copy_image_to_buffer`] — flushes
-    /// `src` (linear buffer) into `image` and leaves the image in
-    /// `GENERAL`. Called from the WRITE guard's release path.
-    fn copy_buffer_to_image(
-        &self,
-        src: vk::Buffer,
-        image: vk::Image,
-        from: vk::ImageLayout,
-        width: u32,
-        height: u32,
-    ) -> Result<(), AdapterError> {
+    /// each plane's linear staging buffer back into the corresponding
+    /// image plane and leaves the image in `GENERAL`. Called from the
+    /// WRITE guard's release path.
+    fn copy_buffer_to_image(&self, snap: &FlushSnapshot) -> Result<(), AdapterError> {
         let device = self.device.device();
         let queue = self.device.queue();
         let qf = self.device.queue_family_index();
+        let combined_aspect = combined_aspect_mask(snap.format);
 
         let (pool, cmd) = create_one_shot_command_buffer(device, qf)?;
 
@@ -441,48 +476,57 @@ impl CpuReadbackSurfaceAdapter {
             });
         }
 
-        let pre_barrier = build_image_barrier(image, qf, from, vk::ImageLayout::TRANSFER_DST_OPTIMAL);
+        let pre_barrier = build_image_barrier(
+            snap.image,
+            qf,
+            snap.from.vk(),
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            combined_aspect,
+        );
         let pre_barriers = [pre_barrier];
         let pre_dep = vk::DependencyInfo::builder()
             .image_memory_barriers(&pre_barriers)
             .build();
         unsafe { device.cmd_pipeline_barrier2(cmd, &pre_dep) };
 
-        let copy_region = vk::BufferImageCopy::builder()
-            .buffer_offset(0)
-            .buffer_row_length(width)
-            .buffer_image_height(height)
-            .image_subresource(
-                vk::ImageSubresourceLayers::builder()
-                    .aspect_mask(vk::ImageAspectFlags::COLOR)
-                    .mip_level(0)
-                    .base_array_layer(0)
-                    .layer_count(1)
-                    .build(),
-            )
-            .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-            .image_extent(vk::Extent3D {
-                width,
-                height,
-                depth: 1,
-            })
-            .build();
-
-        unsafe {
-            device.cmd_copy_buffer_to_image(
-                cmd,
-                src,
-                image,
-                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-                &[copy_region],
-            )
-        };
+        for (plane_idx, plane) in snap.planes.iter().enumerate() {
+            let aspect = plane_aspect_mask(snap.format, plane_idx as u32);
+            let copy_region = vk::BufferImageCopy::builder()
+                .buffer_offset(0)
+                .buffer_row_length(plane.width)
+                .buffer_image_height(plane.height)
+                .image_subresource(
+                    vk::ImageSubresourceLayers::builder()
+                        .aspect_mask(aspect)
+                        .mip_level(0)
+                        .base_array_layer(0)
+                        .layer_count(1)
+                        .build(),
+                )
+                .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+                .image_extent(vk::Extent3D {
+                    width: plane.width,
+                    height: plane.height,
+                    depth: 1,
+                })
+                .build();
+            unsafe {
+                device.cmd_copy_buffer_to_image(
+                    cmd,
+                    plane.buffer,
+                    snap.image,
+                    vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                    &[copy_region],
+                )
+            };
+        }
 
         let post_barrier = build_image_barrier(
-            image,
+            snap.image,
             qf,
             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
             vk::ImageLayout::GENERAL,
+            combined_aspect,
         );
         let post_barriers = [post_barrier];
         let post_dep = vk::DependencyInfo::builder()
@@ -524,6 +568,17 @@ impl CpuReadbackSurfaceAdapter {
     }
 }
 
+/// Per-plane snapshot taken under the registry lock.
+#[derive(Clone, Copy)]
+struct PlaneAcquireSlot {
+    buffer: vk::Buffer,
+    mapped_ptr: *mut u8,
+    width: u32,
+    height: u32,
+    bytes_per_pixel: u32,
+    byte_size: u64,
+}
+
 /// Snapshot taken under the registry lock so the timeline wait + GPU
 /// copy can run unlocked. `read_holders` / `write_held` are already
 /// incremented; rollback paths decrement them on failure.
@@ -532,19 +587,27 @@ struct AcquireSnapshot {
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,
-    buffer: vk::Buffer,
-    mapped_ptr: *mut u8,
-    byte_size: u64,
+    format: SurfaceFormat,
     width: u32,
     height: u32,
-    bytes_per_pixel: u32,
+    planes: Vec<PlaneAcquireSlot>,
 }
 
-// Safe: raw pointer points into a HOST_VISIBLE/HOST_COHERENT mapped
-// allocation that outlives the snapshot, and is only ever touched by
+// Safe: raw pointers point into HOST_VISIBLE/HOST_COHERENT mapped
+// allocations that outlive the snapshot, and are only ever touched by
 // the thread that owns the active acquire scope.
 unsafe impl Send for AcquireSnapshot {}
 unsafe impl Sync for AcquireSnapshot {}
+
+struct FlushSnapshot {
+    image: vk::Image,
+    from: VulkanLayout,
+    format: SurfaceFormat,
+    planes: Vec<PlaneAcquireSlot>,
+}
+
+unsafe impl Send for FlushSnapshot {}
+unsafe impl Sync for FlushSnapshot {}
 
 fn create_one_shot_command_buffer(
     device: &vulkanalia::Device,
@@ -583,6 +646,7 @@ fn build_image_barrier(
     qf: u32,
     from: vk::ImageLayout,
     to: vk::ImageLayout,
+    aspect_mask: vk::ImageAspectFlags,
 ) -> vk::ImageMemoryBarrier2 {
     vk::ImageMemoryBarrier2::builder()
         .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
@@ -596,7 +660,7 @@ fn build_image_barrier(
         .image(image)
         .subresource_range(
             vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .aspect_mask(aspect_mask)
                 .base_mip_level(0)
                 .level_count(1)
                 .base_array_layer(0)
@@ -604,6 +668,52 @@ fn build_image_barrier(
                 .build(),
         )
         .build()
+}
+
+/// Vulkan aspect mask for the given plane of a [`SurfaceFormat`], suitable
+/// for `VkImageSubresourceLayers` when issuing image↔buffer copies.
+fn plane_aspect_mask(format: SurfaceFormat, plane: u32) -> vk::ImageAspectFlags {
+    match (format, plane) {
+        (SurfaceFormat::Bgra8 | SurfaceFormat::Rgba8, 0) => vk::ImageAspectFlags::COLOR,
+        (SurfaceFormat::Nv12, 0) => vk::ImageAspectFlags::PLANE_0,
+        (SurfaceFormat::Nv12, 1) => vk::ImageAspectFlags::PLANE_1,
+        _ => unreachable!("plane_aspect_mask: plane {plane} out of range for {format:?}"),
+    }
+}
+
+/// Aspect mask covering every plane of a [`SurfaceFormat`], for
+/// `VkImageMemoryBarrier::subresourceRange`. Vulkan requires the barrier
+/// to cover all aspects the image possesses; for multi-plane images that
+/// is `PLANE_0 | PLANE_1 | …`, not `COLOR`.
+fn combined_aspect_mask(format: SurfaceFormat) -> vk::ImageAspectFlags {
+    match format {
+        SurfaceFormat::Bgra8 | SurfaceFormat::Rgba8 => vk::ImageAspectFlags::COLOR,
+        SurfaceFormat::Nv12 => vk::ImageAspectFlags::PLANE_0 | vk::ImageAspectFlags::PLANE_1,
+    }
+}
+
+/// Pick the [`PixelFormat`] enumerant for a HOST_VISIBLE staging
+/// `VulkanPixelBuffer` whose only role is "linear bytes the customer
+/// will memcpy out of / into". The buffer never gets sampled or rendered
+/// from, so the choice only governs allocation sizing — the bytes-per-
+/// pixel passed alongside is the load-bearing input.
+fn pixel_format_for_bpp(bpp: u32) -> PixelFormat {
+    match bpp {
+        // BGRA32 / RGBA32 are interchangeable for staging; both are 4 bpp.
+        4 => PixelFormat::Bgra32,
+        // NV12 UV plane is 2 bytes per texel — Uyvy422 is the closest
+        // 2-bpp enumerant in PixelFormat. Buffer is opaque bytes either
+        // way; the bpp parameter to VulkanPixelBuffer::new is what
+        // actually drives the allocation size.
+        2 => PixelFormat::Uyvy422,
+        // NV12 Y plane is 1 byte per texel.
+        1 => PixelFormat::Gray8,
+        // 16 bpp (Rgba64) etc. — fall back to Rgba32 for an oversized
+        // stage; this branch is currently unreachable for SurfaceFormat
+        // {Bgra8, Rgba8, Nv12} but documents the intent if the format
+        // set widens.
+        _ => PixelFormat::Bgra32,
+    }
 }
 
 impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
@@ -624,19 +734,7 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
             }
         };
         self.finalize_acquire(surface.id, false, &snap)?;
-        Ok(ReadGuard::new(
-            self,
-            surface.id,
-            CpuReadbackReadView {
-                bytes: unsafe {
-                    std::slice::from_raw_parts(snap.mapped_ptr, snap.byte_size as usize)
-                },
-                width: snap.width,
-                height: snap.height,
-                bytes_per_pixel: snap.bytes_per_pixel,
-                _marker: PhantomData,
-            },
-        ))
+        Ok(ReadGuard::new(self, surface.id, build_read_view(&snap)))
     }
 
     fn acquire_write<'g>(
@@ -660,19 +758,7 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
             }
         };
         self.finalize_acquire(surface.id, true, &snap)?;
-        Ok(WriteGuard::new(
-            self,
-            surface.id,
-            CpuReadbackWriteView {
-                bytes: unsafe {
-                    std::slice::from_raw_parts_mut(snap.mapped_ptr, snap.byte_size as usize)
-                },
-                width: snap.width,
-                height: snap.height,
-                bytes_per_pixel: snap.bytes_per_pixel,
-                _marker: PhantomData,
-            },
-        ))
+        Ok(WriteGuard::new(self, surface.id, build_write_view(&snap)))
     }
 
     fn try_acquire_read<'g>(
@@ -684,19 +770,7 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
             None => return Ok(None),
         };
         self.finalize_acquire(surface.id, false, &snap)?;
-        Ok(Some(ReadGuard::new(
-            self,
-            surface.id,
-            CpuReadbackReadView {
-                bytes: unsafe {
-                    std::slice::from_raw_parts(snap.mapped_ptr, snap.byte_size as usize)
-                },
-                width: snap.width,
-                height: snap.height,
-                bytes_per_pixel: snap.bytes_per_pixel,
-                _marker: PhantomData,
-            },
-        )))
+        Ok(Some(ReadGuard::new(self, surface.id, build_read_view(&snap))))
     }
 
     fn try_acquire_write<'g>(
@@ -711,15 +785,7 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
         Ok(Some(WriteGuard::new(
             self,
             surface.id,
-            CpuReadbackWriteView {
-                bytes: unsafe {
-                    std::slice::from_raw_parts_mut(snap.mapped_ptr, snap.byte_size as usize)
-                },
-                width: snap.width,
-                height: snap.height,
-                bytes_per_pixel: snap.bytes_per_pixel,
-                _marker: PhantomData,
-            },
+            build_write_view(&snap),
         )))
     }
 
@@ -766,7 +832,6 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
                 }
             };
             debug_assert!(state.write_held, "write release without acquire");
-            let buffer = state.staging.buffer();
             let image = match state.texture.vulkan_inner().image() {
                 Some(i) => i,
                 None => {
@@ -775,25 +840,27 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
                     return;
                 }
             };
-            let from = state.current_layout;
-            let width = state.width;
-            let height = state.height;
+            let planes: Vec<PlaneAcquireSlot> = state
+                .planes
+                .iter()
+                .map(|p| PlaneAcquireSlot {
+                    buffer: p.staging.buffer(),
+                    mapped_ptr: p.staging.mapped_ptr(),
+                    width: p.width,
+                    height: p.height,
+                    bytes_per_pixel: p.bytes_per_pixel,
+                    byte_size: p.byte_size(),
+                })
+                .collect();
             FlushSnapshot {
-                buffer,
                 image,
-                from,
-                width,
-                height,
+                from: state.current_layout,
+                format: state.format,
+                planes,
             }
         };
 
-        if let Err(e) = self.copy_buffer_to_image(
-            snap.buffer,
-            snap.image,
-            snap.from.vk(),
-            snap.width,
-            snap.height,
-        ) {
+        if let Err(e) = self.copy_buffer_to_image(&snap) {
             tracing::error!(
                 ?surface_id,
                 error = %e,
@@ -826,11 +893,44 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
     }
 }
 
-struct FlushSnapshot {
-    buffer: vk::Buffer,
-    image: vk::Image,
-    from: VulkanLayout,
-    width: u32,
-    height: u32,
+fn build_read_view<'g>(snap: &AcquireSnapshot) -> CpuReadbackReadView<'g> {
+    let planes = snap
+        .planes
+        .iter()
+        .map(|p| CpuReadbackPlaneView {
+            bytes: unsafe { std::slice::from_raw_parts(p.mapped_ptr, p.byte_size as usize) },
+            width: p.width,
+            height: p.height,
+            bytes_per_pixel: p.bytes_per_pixel,
+            _marker: PhantomData,
+        })
+        .collect();
+    CpuReadbackReadView {
+        format: snap.format,
+        width: snap.width,
+        height: snap.height,
+        planes,
+    }
 }
 
+fn build_write_view<'g>(snap: &AcquireSnapshot) -> CpuReadbackWriteView<'g> {
+    let planes = snap
+        .planes
+        .iter()
+        .map(|p| CpuReadbackPlaneViewMut {
+            bytes: unsafe {
+                std::slice::from_raw_parts_mut(p.mapped_ptr, p.byte_size as usize)
+            },
+            width: p.width,
+            height: p.height,
+            bytes_per_pixel: p.bytes_per_pixel,
+            _marker: PhantomData,
+        })
+        .collect();
+    CpuReadbackWriteView {
+        format: snap.format,
+        width: snap.width,
+        height: snap.height,
+        planes,
+    }
+}

--- a/libs/streamlib-adapter-cpu-readback/src/context.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/context.rs
@@ -7,9 +7,12 @@
 //! let ctx = streamlib_adapter_cpu_readback::CpuReadbackContext::new(adapter);
 //! {
 //!     let mut guard = ctx.acquire_write(&surface)?;
-//!     // guard.view().bytes() / view_mut().bytes_mut() are the
-//!     // tightly-packed BGRA bytes; mutate freely. On guard drop the
-//!     // adapter flushes them back to the host VkImage.
+//!     // guard.view().plane(i).bytes() (read) /
+//!     // guard.view_mut().plane_mut(i).bytes_mut() (write) are the
+//!     // tightly-packed bytes for plane i. Single-plane formats
+//!     // (BGRA8/RGBA8) report plane_count() == 1; multi-plane (NV12)
+//!     // reports 2 (Y at 0, UV at 1). On guard drop the adapter
+//!     // flushes every plane back to the host VkImage.
 //! }
 //! ```
 
@@ -36,10 +39,11 @@ impl CpuReadbackContext {
         &self.adapter
     }
 
-    /// Blocking read acquire. The guard's view exposes the pixel bytes
-    /// as `&[u8]` (tightly packed, `width * height * bytes_per_pixel`).
-    /// The GPU→CPU copy is performed before this call returns; release
-    /// is a no-op flush plus timeline signal.
+    /// Blocking read acquire. The guard's view exposes per-plane byte
+    /// slices via `view.plane(i).bytes()` (tightly packed,
+    /// `plane_width * plane_height * plane_bytes_per_pixel`). The
+    /// GPU→CPU copy is performed before this call returns; release is a
+    /// no-op flush plus timeline signal.
     pub fn acquire_read<'a>(
         &'a self,
         surface: &StreamlibSurface,
@@ -47,10 +51,11 @@ impl CpuReadbackContext {
         self.adapter.acquire_read(surface)
     }
 
-    /// Blocking write acquire. The guard's view exposes the pixel bytes
-    /// as `&mut [u8]`. On guard drop, the modified bytes are flushed
-    /// back to the host `VkImage` via `vkCmdCopyBufferToImage` before
-    /// the timeline release-value signals.
+    /// Blocking write acquire. The guard's view exposes mutable per-
+    /// plane byte slices via `view_mut().plane_mut(i).bytes_mut()`. On
+    /// guard drop, every plane's modified bytes are flushed back to the
+    /// host `VkImage` via per-plane `vkCmdCopyBufferToImage` before the
+    /// timeline release-value signals.
     pub fn acquire_write<'a>(
         &'a self,
         surface: &StreamlibSurface,

--- a/libs/streamlib-adapter-cpu-readback/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/lib.rs
@@ -11,13 +11,17 @@
 //! deliberately do not implement these — that asymmetry is the
 //! architectural enforcement of "switch adapter to opt into CPU".
 //!
-//! Implementation rides on `VulkanPixelBuffer` (a HOST_VISIBLE,
-//! HOST_COHERENT linear `VkBuffer`); each acquire issues a
-//! `vkCmdCopyImageToBuffer` from the host's `VkImage` into that staging
-//! buffer, blocks until the copy is observable on the host, and hands
-//! the customer a `&[u8]` view over the mapped bytes. On WRITE release,
-//! the staging bytes are flushed back via `vkCmdCopyBufferToImage`
-//! before the timeline release-value is signaled.
+//! Implementation rides on one [`streamlib::adapter_support::VulkanPixelBuffer`]
+//! (a HOST_VISIBLE, HOST_COHERENT linear `VkBuffer`) **per plane**.
+//! Single-plane formats (BGRA8/RGBA8) allocate one staging buffer;
+//! multi-plane formats (NV12) allocate one per logical plane (Y + UV).
+//! Each acquire issues a per-plane `vkCmdCopyImageToBuffer` from the
+//! host's `VkImage` (with the matching `VK_IMAGE_ASPECT_*_BIT` aspect)
+//! into the corresponding staging buffer, blocks until the copies are
+//! observable on the host, and hands the customer per-plane `&[u8]`
+//! views over the mapped bytes. On WRITE release, every plane's staging
+//! bytes are flushed back via per-plane `vkCmdCopyBufferToImage` before
+//! the timeline release-value is signaled.
 //!
 //! See `docs/architecture/surface-adapter.md` for the architecture
 //! brief.
@@ -32,4 +36,6 @@ mod view;
 pub use adapter::CpuReadbackSurfaceAdapter;
 pub use context::CpuReadbackContext;
 pub use state::HostSurfaceRegistration;
-pub use view::{CpuReadbackReadView, CpuReadbackWriteView};
+pub use view::{
+    CpuReadbackPlaneView, CpuReadbackPlaneViewMut, CpuReadbackReadView, CpuReadbackWriteView,
+};

--- a/libs/streamlib-adapter-cpu-readback/src/state.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/state.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Per-surface adapter state: host `VkImage`, dedicated linear staging
-//! `VkBuffer`, timeline semaphore, and acquire/release counters.
+//! `VkBuffer`s (one per plane), timeline semaphore, and acquire/release
+//! counters.
 
 use std::sync::Arc;
 
 use streamlib::adapter_support::{VulkanPixelBuffer, VulkanTimelineSemaphore};
 use streamlib::core::rhi::StreamTexture;
-use streamlib_adapter_abi::SurfaceId;
+use streamlib_adapter_abi::{SurfaceFormat, SurfaceId};
 use vulkanalia::vk;
 
 /// `VkImageLayout` enumerant. Stored as `i32` per the Vulkan spec.
@@ -32,8 +33,8 @@ impl VulkanLayout {
 /// `GpuContext::acquire_render_target_dma_buf_image`) and an exportable
 /// timeline semaphore (via `VulkanTimelineSemaphore::new_exportable`),
 /// then registers them here. The adapter takes joint ownership and
-/// allocates its own dedicated linear staging buffer sized to the
-/// texture's pixel footprint.
+/// allocates one dedicated linear staging buffer per plane sized to the
+/// plane's pixel footprint.
 pub struct HostSurfaceRegistration {
     pub texture: StreamTexture,
     pub timeline: Arc<VulkanTimelineSemaphore>,
@@ -41,43 +42,53 @@ pub struct HostSurfaceRegistration {
     /// For freshly-allocated images this is typically
     /// `vk::ImageLayout::UNDEFINED` (raw value 0).
     pub initial_image_layout: i32,
-    /// Bytes per pixel of the staging buffer. The adapter copies
-    /// `width * height * bytes_per_pixel` bytes through the staging
-    /// buffer; the customer receives a `&[u8]` of that length.
-    /// BGRA8/RGBA8 → 4. NV12 / multi-plane formats are not supported
-    /// in v1.
-    pub bytes_per_pixel: u32,
+    /// Pixel format of the surface. Determines plane count and per-plane
+    /// dimensions of the staging buffers (see [`SurfaceFormat::plane_count`]).
+    pub format: SurfaceFormat,
 }
 
-/// Per-surface state held inside the adapter's
-/// `Mutex<HashMap<SurfaceId, _>>`.
-///
-/// Each entry owns a dedicated `VulkanPixelBuffer` (a
-/// HOST_VISIBLE/HOST_COHERENT linear `VkBuffer`) sized once at
-/// registration. The same staging buffer is reused on every acquire —
-/// per-acquire allocation would be far too expensive on the hot path,
-/// and the surface's dimensions are immutable for its lifetime.
-pub(crate) struct SurfaceState {
-    #[allow(dead_code)] // surface_id is kept for tracing / debug output
-    pub(crate) surface_id: SurfaceId,
-    pub(crate) texture: StreamTexture,
+/// Per-plane staging slot. One [`VulkanPixelBuffer`] per plane, with the
+/// plane's tightly-packed `(width, height, bytes_per_pixel)` geometry
+/// recorded so the copy paths and the customer-facing view can compute
+/// strides without re-deriving from `format` on every access.
+pub(crate) struct PlaneSlot {
     pub(crate) staging: Arc<VulkanPixelBuffer>,
-    pub(crate) timeline: Arc<VulkanTimelineSemaphore>,
-    pub(crate) current_layout: VulkanLayout,
-    pub(crate) read_holders: u64,
-    pub(crate) write_held: bool,
-    pub(crate) current_release_value: u64,
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) bytes_per_pixel: u32,
 }
 
+impl PlaneSlot {
+    pub(crate) fn byte_size(&self) -> u64 {
+        (self.width as u64) * (self.height as u64) * (self.bytes_per_pixel as u64)
+    }
+}
+
+/// Per-surface state held inside the adapter's
+/// `Mutex<HashMap<SurfaceId, _>>`.
+///
+/// Each entry owns one dedicated `VulkanPixelBuffer` per plane (a
+/// HOST_VISIBLE/HOST_COHERENT linear `VkBuffer`) sized once at
+/// registration. The staging buffers are reused on every acquire — per-
+/// acquire allocation would be far too expensive on the hot path, and
+/// the surface's dimensions are immutable for its lifetime.
+pub(crate) struct SurfaceState {
+    #[allow(dead_code)] // surface_id is kept for tracing / debug output
+    pub(crate) surface_id: SurfaceId,
+    pub(crate) texture: StreamTexture,
+    pub(crate) planes: Vec<PlaneSlot>,
+    pub(crate) timeline: Arc<VulkanTimelineSemaphore>,
+    pub(crate) current_layout: VulkanLayout,
+    pub(crate) read_holders: u64,
+    pub(crate) write_held: bool,
+    pub(crate) current_release_value: u64,
+    pub(crate) format: SurfaceFormat,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
 impl SurfaceState {
     pub(crate) fn next_release_value(&self) -> u64 {
         self.current_release_value + 1
-    }
-
-    pub(crate) fn buffer_byte_size(&self) -> u64 {
-        (self.width as u64) * (self.height as u64) * (self.bytes_per_pixel as u64)
     }
 }

--- a/libs/streamlib-adapter-cpu-readback/src/view.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/view.rs
@@ -3,10 +3,10 @@
 
 //! Read and write views handed back to consumers inside an acquire scope.
 //!
-//! Both views are short-lived (lifetime-bound to the guard) and expose
-//! only what a CPU consumer needs: a byte slice (`&[u8]` or
-//! `&mut [u8]`) sized to `width * height * bytes_per_pixel`. Stride is
-//! always tightly packed.
+//! Both views expose the surface as a sequence of planes — single-plane
+//! formats (BGRA/RGBA) report one plane, multi-plane formats (NV12)
+//! report one plane per logical plane (Y + UV for NV12). Each plane is a
+//! tightly-packed byte slice (`width * bytes_per_pixel` per row).
 //!
 //! These are the only [`streamlib_adapter_abi::SurfaceAdapter`] views
 //! in-tree that implement [`streamlib_adapter_abi::CpuReadable`] /
@@ -17,12 +17,12 @@
 
 use std::marker::PhantomData;
 
-use streamlib_adapter_abi::{CpuReadable, CpuWritable};
+use streamlib_adapter_abi::{CpuReadable, CpuWritable, SurfaceFormat};
 
-/// Read view of an acquired surface — a tightly-packed byte slice with
-/// the surface's current pixel content (already copied from GPU at
-/// `acquire_read` time).
-pub struct CpuReadbackReadView<'g> {
+/// Read-only view of one plane of an acquired surface — tightly-packed
+/// pixel content, dimensions in plane texels (NV12 UV: half width × half
+/// height), and bytes-per-texel.
+pub struct CpuReadbackPlaneView<'g> {
     pub(crate) bytes: &'g [u8],
     pub(crate) width: u32,
     pub(crate) height: u32,
@@ -30,18 +30,18 @@ pub struct CpuReadbackReadView<'g> {
     pub(crate) _marker: PhantomData<&'g ()>,
 }
 
-impl<'g> CpuReadbackReadView<'g> {
-    /// Width in pixels.
+impl<'g> CpuReadbackPlaneView<'g> {
+    /// Plane width in texels.
     pub fn width(&self) -> u32 {
         self.width
     }
 
-    /// Height in pixels.
+    /// Plane height in texels.
     pub fn height(&self) -> u32 {
         self.height
     }
 
-    /// Bytes per pixel (4 for BGRA8 / RGBA8).
+    /// Bytes per texel of this plane (BGRA: 4, NV12 Y: 1, NV12 UV: 2).
     pub fn bytes_per_pixel(&self) -> u32 {
         self.bytes_per_pixel
     }
@@ -51,24 +51,15 @@ impl<'g> CpuReadbackReadView<'g> {
         self.width * self.bytes_per_pixel
     }
 
-    /// Tightly-packed pixel bytes — `(height, width, bytes_per_pixel)`
-    /// in row-major order.
+    /// Tightly-packed pixel bytes, row-major, no padding.
     pub fn bytes(&self) -> &[u8] {
         self.bytes
     }
 }
 
-impl CpuReadable for CpuReadbackReadView<'_> {
-    fn read_bytes(&self) -> &[u8] {
-        self.bytes
-    }
-}
-
-/// Write view of an acquired surface — a tightly-packed mutable byte
-/// slice initialized with the current pixel content. Customer mutations
-/// are flushed back to the host's `VkImage` on guard drop via
-/// `vkCmdCopyBufferToImage` before the timeline release-value signals.
-pub struct CpuReadbackWriteView<'g> {
+/// Mutable view of one plane of an acquired surface. Returned only from
+/// a [`CpuReadbackWriteView`] inside a write guard scope.
+pub struct CpuReadbackPlaneViewMut<'g> {
     pub(crate) bytes: &'g mut [u8],
     pub(crate) width: u32,
     pub(crate) height: u32,
@@ -76,7 +67,7 @@ pub struct CpuReadbackWriteView<'g> {
     pub(crate) _marker: PhantomData<&'g mut ()>,
 }
 
-impl<'g> CpuReadbackWriteView<'g> {
+impl<'g> CpuReadbackPlaneViewMut<'g> {
     pub fn width(&self) -> u32 {
         self.width
     }
@@ -102,14 +93,120 @@ impl<'g> CpuReadbackWriteView<'g> {
     }
 }
 
+/// Read view of an acquired surface — surface-level metadata plus the
+/// list of planes (already copied from GPU at `acquire_read` time).
+///
+/// For BGRA/RGBA the view reports a single plane; for NV12 it reports
+/// two (Y at index 0, UV at index 1). [`Self::plane_count`] reflects the
+/// surface's [`SurfaceFormat`].
+pub struct CpuReadbackReadView<'g> {
+    pub(crate) format: SurfaceFormat,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) planes: Vec<CpuReadbackPlaneView<'g>>,
+}
+
+impl<'g> CpuReadbackReadView<'g> {
+    /// Surface pixel format.
+    pub fn format(&self) -> SurfaceFormat {
+        self.format
+    }
+
+    /// Surface width in pixels (= plane 0 width).
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Surface height in pixels (= plane 0 height).
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Number of planes in this surface (1 for BGRA/RGBA, 2 for NV12).
+    pub fn plane_count(&self) -> u32 {
+        self.planes.len() as u32
+    }
+
+    /// Borrow plane `index`. Panics if `index >= plane_count()`.
+    pub fn plane(&self, index: u32) -> &CpuReadbackPlaneView<'g> {
+        &self.planes[index as usize]
+    }
+
+    /// All planes in declaration order (plane 0 first). For NV12: `[Y, UV]`.
+    pub fn planes(&self) -> &[CpuReadbackPlaneView<'g>] {
+        &self.planes
+    }
+}
+
+impl CpuReadable for CpuReadbackReadView<'_> {
+    /// Returns the **primary plane**'s bytes (plane 0). For single-plane
+    /// formats this is the entire image; for multi-plane formats (NV12)
+    /// it is the Y/luma plane. Use [`Self::plane`] to reach chroma planes.
+    fn read_bytes(&self) -> &[u8] {
+        self.planes[0].bytes
+    }
+}
+
+/// Write view of an acquired surface. Edits to any plane's bytes are
+/// flushed back to the host's `VkImage` (per-plane
+/// `vkCmdCopyBufferToImage`) on guard drop, before the timeline release-
+/// value signals.
+pub struct CpuReadbackWriteView<'g> {
+    pub(crate) format: SurfaceFormat,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) planes: Vec<CpuReadbackPlaneViewMut<'g>>,
+}
+
+impl<'g> CpuReadbackWriteView<'g> {
+    pub fn format(&self) -> SurfaceFormat {
+        self.format
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    pub fn plane_count(&self) -> u32 {
+        self.planes.len() as u32
+    }
+
+    /// Borrow plane `index` immutably. Panics if `index >= plane_count()`.
+    pub fn plane(&self, index: u32) -> &CpuReadbackPlaneViewMut<'g> {
+        &self.planes[index as usize]
+    }
+
+    /// Borrow plane `index` mutably. Panics if `index >= plane_count()`.
+    pub fn plane_mut(&mut self, index: u32) -> &mut CpuReadbackPlaneViewMut<'g> {
+        &mut self.planes[index as usize]
+    }
+
+    /// All planes in declaration order, immutable.
+    pub fn planes(&self) -> &[CpuReadbackPlaneViewMut<'g>] {
+        &self.planes
+    }
+
+    /// All planes in declaration order, mutable.
+    pub fn planes_mut(&mut self) -> &mut [CpuReadbackPlaneViewMut<'g>] {
+        &mut self.planes
+    }
+}
+
 impl CpuReadable for CpuReadbackWriteView<'_> {
     fn read_bytes(&self) -> &[u8] {
-        self.bytes
+        self.planes[0].bytes
     }
 }
 
 impl CpuWritable for CpuReadbackWriteView<'_> {
+    /// Returns mutable access to the **primary plane**'s bytes (plane 0).
+    /// For NV12 surfaces, callers wanting to write chroma must use
+    /// [`CpuReadbackWriteView::plane_mut`].
     fn write_bytes(&mut self) -> &mut [u8] {
-        self.bytes
+        self.planes[0].bytes
     }
 }

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, OnceLock};
 
 use streamlib::adapter_support::VulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
+use streamlib::core::error::StreamError;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::{
     StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
@@ -57,8 +58,8 @@ impl HostFixture {
         Some(Self { gpu, adapter, ctx })
     }
 
-    /// Allocate a host `VkImage` + exportable timeline, register them
-    /// with the adapter under `surface_id`, and return a
+    /// Allocate a host BGRA8 `VkImage` + exportable timeline, register
+    /// them with the adapter under `surface_id`, and return a
     /// [`StreamlibSurface`] descriptor pointing at the registration.
     pub fn register_surface(
         &self,
@@ -66,13 +67,57 @@ impl HostFixture {
         width: u32,
         height: u32,
     ) -> StreamlibSurface {
+        self.register_surface_with_format(
+            surface_id,
+            width,
+            height,
+            SurfaceFormat::Bgra8,
+            TextureFormat::Bgra8Unorm,
+        )
+    }
+
+    /// General-purpose surface registration used by single- and multi-
+    /// plane tests. `surface_format` is the customer-facing pixel
+    /// format; `texture_format` is the RHI-level texture allocation
+    /// format. They must agree (e.g. `Nv12` ↔ `TextureFormat::Nv12`).
+    pub fn register_surface_with_format(
+        &self,
+        surface_id: SurfaceId,
+        width: u32,
+        height: u32,
+        surface_format: SurfaceFormat,
+        texture_format: TextureFormat,
+    ) -> StreamlibSurface {
+        self.try_register_surface_with_format(
+            surface_id,
+            width,
+            height,
+            surface_format,
+            texture_format,
+        )
+        .expect("register_surface_with_format")
+    }
+
+    /// Fallible variant. Returns `Err(StreamError)` when the host can't
+    /// allocate a render-target DMA-BUF in `texture_format` on this
+    /// driver — typically because the EGL probe didn't advertise an
+    /// RT-capable DRM modifier for the format. Multi-plane tests use
+    /// this so they can skip cleanly on drivers without NV12 RT modifier
+    /// support, instead of failing.
+    pub fn try_register_surface_with_format(
+        &self,
+        surface_id: SurfaceId,
+        width: u32,
+        height: u32,
+        surface_format: SurfaceFormat,
+        texture_format: TextureFormat,
+    ) -> Result<StreamlibSurface, StreamError> {
         let texture = self
             .gpu
-            .acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)
-            .expect("acquire_render_target_dma_buf_image");
+            .acquire_render_target_dma_buf_image(width, height, texture_format)?;
         let timeline = Arc::new(
             VulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
-                .expect("create timeline"),
+                .map_err(|e| StreamError::GpuError(format!("create timeline: {e}")))?,
         );
         self.adapter
             .register_host_surface(
@@ -81,18 +126,18 @@ impl HostFixture {
                     texture,
                     timeline,
                     initial_image_layout: vk::ImageLayout::UNDEFINED.as_raw(),
-                    bytes_per_pixel: 4,
+                    format: surface_format,
                 },
             )
-            .expect("register_host_surface");
-        StreamlibSurface::new(
+            .map_err(|e| StreamError::GpuError(format!("register_host_surface: {e}")))?;
+        Ok(StreamlibSurface::new(
             surface_id,
             width,
             height,
-            SurfaceFormat::Bgra8,
+            surface_format,
             SurfaceUsage::CPU_READBACK,
             SurfaceTransportHandle::empty(),
             SurfaceSyncState::default(),
-        )
+        ))
     }
 }

--- a/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
@@ -55,7 +55,7 @@ fn register_one(
                 texture,
                 timeline,
                 initial_image_layout: vk::ImageLayout::UNDEFINED.as_raw(),
-                bytes_per_pixel: 4,
+                format: SurfaceFormat::Bgra8,
             },
         )
         .expect("register_host_surface");

--- a/libs/streamlib-adapter-cpu-readback/tests/multi_plane_round_trip.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/multi_plane_round_trip.rs
@@ -1,0 +1,275 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cpu_readback::tests::multi_plane_round_trip` —
+//! the cpu-readback adapter must round-trip multi-plane formats (NV12)
+//! plane-by-plane: customer writes a known pattern into each plane,
+//! release flushes back, next acquire's read view observes the same
+//! pattern in the same plane. Validates:
+//!
+//!  - Per-plane staging allocation (Y plane and UV plane each get their
+//!    own `VulkanPixelBuffer`).
+//!  - Per-plane `vkCmdCopyImageToBuffer` regions with the right
+//!    `VK_IMAGE_ASPECT_PLANE_{0,1}_BIT` aspect — wrong aspect or wrong
+//!    extent would scramble the read-back.
+//!  - Plane geometry: Y at full resolution, UV at half resolution
+//!    (NV12 4:2:0 chroma subsampling).
+//!
+//! The fresh-allocation NV12 path goes through the host's
+//! `acquire_render_target_dma_buf_image(_, _, TextureFormat::Nv12)`
+//! which only succeeds when the EGL probe advertised an NV12 modifier
+//! that's render-target-capable. Drivers without that modifier (e.g.
+//! pre-570 NVIDIA, llvmpipe-only) skip the test cleanly via the
+//! fallible registration path.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{StreamlibSurface, SurfaceFormat};
+
+use crate::common::HostFixture;
+
+/// Distinct, non-trivial bytes per plane so any aspect-mask swap
+/// (Y ↔ UV) shows up as a byte-exact mismatch instead of looking
+/// "almost right."
+const Y_BYTE: u8 = 0x42;
+const UV_BYTES: [u8; 2] = [0x80, 0xC0]; // U = 0x80 (neutral), V = 0xC0 (red shift)
+
+/// Try to register an NV12 surface; return `None` (and log) if the
+/// driver doesn't support an NV12 render-target DRM modifier.
+fn register_nv12_or_skip(
+    fixture: &HostFixture,
+    id: u64,
+    width: u32,
+    height: u32,
+    test_name: &str,
+) -> Option<StreamlibSurface> {
+    match fixture.try_register_surface_with_format(
+        id,
+        width,
+        height,
+        SurfaceFormat::Nv12,
+        TextureFormat::Nv12,
+    ) {
+        Ok(d) => Some(d),
+        Err(e) => {
+            println!(
+                "{test_name}: skipping — host can't allocate NV12 \
+                 render-target DMA-BUF on this driver ({e})"
+            );
+            None
+        }
+    }
+}
+
+#[test]
+fn nv12_multi_plane_write_round_trips_to_read() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!("nv12_multi_plane_write_round_trips_to_read: skipping — no Vulkan device available");
+            return;
+        }
+    };
+
+    // NV12 dims must be even (UV plane is half-resolution). Pick a
+    // width that's not a power of 2 so plane-1 stride ≠ a friendly
+    // alignment — catches a buffer_row_length misuse on the UV plane.
+    let width = 36u32;
+    let height = 8u32;
+
+    let descriptor = match register_nv12_or_skip(
+        &fixture,
+        1,
+        width,
+        height,
+        "nv12_multi_plane_write_round_trips_to_read",
+    ) {
+        Some(d) => d,
+        None => return,
+    };
+
+    // Surface-level metadata reflects the format.
+    assert_eq!(descriptor.format, SurfaceFormat::Nv12);
+    assert_eq!(descriptor.width, width);
+    assert_eq!(descriptor.height, height);
+
+    // First WRITE round: stamp a known per-plane pattern.
+    {
+        let mut guard = fixture
+            .ctx
+            .acquire_write(&descriptor)
+            .expect("acquire_write 1");
+
+        // Per-plane geometry assertions: Y at full resolution
+        // (1 byte per texel), UV at half resolution (2 bytes per
+        // texel, interleaved Cb/Cr).
+        let view = guard.view();
+        assert_eq!(view.format(), SurfaceFormat::Nv12);
+        assert_eq!(view.plane_count(), 2);
+        assert_eq!(view.width(), width);
+        assert_eq!(view.height(), height);
+
+        let y = view.plane(0);
+        assert_eq!(y.width(), width);
+        assert_eq!(y.height(), height);
+        assert_eq!(y.bytes_per_pixel(), 1);
+        assert_eq!(y.row_stride(), width);
+        assert_eq!(y.bytes().len() as u32, width * height);
+
+        let uv = view.plane(1);
+        assert_eq!(uv.width(), width / 2);
+        assert_eq!(uv.height(), height / 2);
+        assert_eq!(uv.bytes_per_pixel(), 2);
+        assert_eq!(uv.row_stride(), (width / 2) * 2);
+        assert_eq!(uv.bytes().len() as u32, (width / 2) * (height / 2) * 2);
+
+        // Stamp Y plane uniform.
+        for byte in guard.view_mut().plane_mut(0).bytes_mut().iter_mut() {
+            *byte = Y_BYTE;
+        }
+        // Stamp UV plane interleaved [U, V, U, V, …].
+        for chunk in guard
+            .view_mut()
+            .plane_mut(1)
+            .bytes_mut()
+            .chunks_exact_mut(2)
+        {
+            chunk.copy_from_slice(&UV_BYTES);
+        }
+    }
+
+    // READ acquire after release re-runs the GPU→CPU copy — observed
+    // bytes must match what we stamped.
+    let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
+    let view = guard.view();
+
+    let y = view.plane(0);
+    let y_bytes = y.bytes();
+    assert_eq!(y_bytes.len() as u32, width * height);
+    for (i, &b) in y_bytes.iter().enumerate() {
+        assert_eq!(b, Y_BYTE, "Y plane byte {i} mismatch: {b:02x}");
+    }
+
+    let uv = view.plane(1);
+    let uv_bytes = uv.bytes();
+    assert_eq!(uv_bytes.len() as u32, (width / 2) * (height / 2) * 2);
+    for (i, chunk) in uv_bytes.chunks_exact(2).enumerate() {
+        assert_eq!(
+            chunk, &UV_BYTES,
+            "UV pair {i} mismatch: {chunk:02x?}"
+        );
+    }
+}
+
+#[test]
+fn nv12_per_plane_distinct_patterns_lands_unscrambled() {
+    // Distinct bytes per row of each plane catch column-vs-row swaps
+    // and aspect-mask swaps simultaneously — a test where both planes
+    // hold uniform bytes can pass even when Y and UV are swapped.
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!("nv12_per_plane_distinct_patterns: skipping — no Vulkan device available");
+            return;
+        }
+    };
+
+    let width = 16u32;
+    let height = 8u32;
+    let descriptor = match register_nv12_or_skip(
+        &fixture,
+        2,
+        width,
+        height,
+        "nv12_per_plane_distinct_patterns",
+    ) {
+        Some(d) => d,
+        None => return,
+    };
+
+    // Prime: Y row N := byte (N + 0x10), UV row M := pair
+    // (M + 0x40, M + 0x80).
+    {
+        let mut guard = fixture
+            .ctx
+            .acquire_write(&descriptor)
+            .expect("acquire_write");
+        let view_mut = guard.view_mut();
+
+        // Y plane.
+        {
+            let y = view_mut.plane_mut(0);
+            let yw = y.width() as usize;
+            let yh = y.height() as usize;
+            let bytes = y.bytes_mut();
+            for row in 0..yh {
+                let v = row as u8 + 0x10;
+                let start = row * yw;
+                for byte in &mut bytes[start..start + yw] {
+                    *byte = v;
+                }
+            }
+        }
+
+        // UV plane (half resolution, 2 bytes per texel).
+        {
+            let uv = view_mut.plane_mut(1);
+            let uvw = uv.width() as usize;
+            let uvh = uv.height() as usize;
+            let bytes = uv.bytes_mut();
+            for row in 0..uvh {
+                let u = row as u8 + 0x40;
+                let v = row as u8 + 0x80;
+                let row_start = row * uvw * 2;
+                for col in 0..uvw {
+                    let off = row_start + col * 2;
+                    bytes[off] = u;
+                    bytes[off + 1] = v;
+                }
+            }
+        }
+    }
+
+    // Read back and assert per-row patterns.
+    let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
+    let view = guard.view();
+
+    let y = view.plane(0);
+    let yw = y.width() as usize;
+    let yh = y.height() as usize;
+    let y_bytes = y.bytes();
+    for row in 0..yh {
+        let expected = row as u8 + 0x10;
+        for col in 0..yw {
+            assert_eq!(
+                y_bytes[row * yw + col],
+                expected,
+                "Y plane row {row} col {col} mismatch"
+            );
+        }
+    }
+
+    let uv = view.plane(1);
+    let uvw = uv.width() as usize;
+    let uvh = uv.height() as usize;
+    let uv_bytes = uv.bytes();
+    for row in 0..uvh {
+        let expected_u = row as u8 + 0x40;
+        let expected_v = row as u8 + 0x80;
+        for col in 0..uvw {
+            let off = row * uvw * 2 + col * 2;
+            assert_eq!(
+                uv_bytes[off], expected_u,
+                "UV plane row {row} col {col} U mismatch"
+            );
+            assert_eq!(
+                uv_bytes[off + 1], expected_v,
+                "UV plane row {row} col {col} V mismatch"
+            );
+        }
+    }
+}

--- a/libs/streamlib-adapter-cpu-readback/tests/round_trip_read.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/round_trip_read.rs
@@ -28,7 +28,7 @@ fn prime_with_pattern(
         .ctx
         .acquire_write(descriptor)
         .expect("prime: acquire_write");
-    let bytes = guard.view_mut().bytes_mut();
+    let bytes = guard.view_mut().plane_mut(0).bytes_mut();
     for chunk in bytes.chunks_exact_mut(4) {
         chunk.copy_from_slice(&pattern);
     }
@@ -52,12 +52,14 @@ fn round_trip_read_observes_host_pattern() {
     let view = guard.view();
     assert_eq!(view.width(), 32);
     assert_eq!(view.height(), 16);
-    assert_eq!(view.bytes_per_pixel(), 4);
-    assert_eq!(view.row_stride(), 32 * 4);
-    assert_eq!(view.bytes().len(), 32 * 16 * 4);
+    assert_eq!(view.plane_count(), 1);
+    let plane = view.plane(0);
+    assert_eq!(plane.bytes_per_pixel(), 4);
+    assert_eq!(plane.row_stride(), 32 * 4);
+    assert_eq!(plane.bytes().len(), 32 * 16 * 4);
     assert_eq!(view.read_bytes().len(), 32 * 16 * 4);
 
-    for (i, chunk) in view.bytes().chunks_exact(4).enumerate() {
+    for (i, chunk) in plane.bytes().chunks_exact(4).enumerate() {
         assert_eq!(chunk, &pattern, "pixel {i} mismatch: {chunk:02x?}");
     }
 }
@@ -86,7 +88,7 @@ fn round_trip_read_per_row_pattern_lands_unscrambled() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write");
-        let bytes = guard.view_mut().bytes_mut();
+        let bytes = guard.view_mut().plane_mut(0).bytes_mut();
         for y in 0..height as usize {
             for x in 0..width as usize {
                 let byte = y as u8 + 0x10;
@@ -99,7 +101,7 @@ fn round_trip_read_per_row_pattern_lands_unscrambled() {
     // Read back and assert row N is full of [byte, …].
     let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
     let view = guard.view();
-    let bytes = view.bytes();
+    let bytes = view.plane(0).bytes();
     for y in 0..height as usize {
         for x in 0..width as usize {
             let expected = y as u8 + 0x10;

--- a/libs/streamlib-adapter-cpu-readback/tests/round_trip_write.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/round_trip_write.rs
@@ -34,7 +34,12 @@ fn round_trip_write_persists_modifications() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write 1");
-        for chunk in guard.view_mut().bytes_mut().chunks_exact_mut(4) {
+        for chunk in guard
+            .view_mut()
+            .plane_mut(0)
+            .bytes_mut()
+            .chunks_exact_mut(4)
+        {
             chunk.copy_from_slice(&pattern_a);
         }
     }
@@ -46,20 +51,25 @@ fn round_trip_write_persists_modifications() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write 2");
-        for chunk in guard.view().bytes().chunks_exact(4) {
+        for chunk in guard.view().plane(0).bytes().chunks_exact(4) {
             assert_eq!(
                 chunk, &pattern_a,
                 "second-acquire view should reflect first-release pattern"
             );
         }
-        for chunk in guard.view_mut().bytes_mut().chunks_exact_mut(4) {
+        for chunk in guard
+            .view_mut()
+            .plane_mut(0)
+            .bytes_mut()
+            .chunks_exact_mut(4)
+        {
             chunk.copy_from_slice(&pattern_b);
         }
     }
 
     // READ round: confirm pattern_b made it.
     let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
-    for chunk in guard.view().bytes().chunks_exact(4) {
+    for chunk in guard.view().plane(0).bytes().chunks_exact(4) {
         assert_eq!(chunk, &pattern_b, "post-write read should observe pattern_b");
     }
 }
@@ -88,7 +98,12 @@ fn round_trip_write_partial_modification_leaves_rest_untouched() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write prime");
-        for chunk in guard.view_mut().bytes_mut().chunks_exact_mut(4) {
+        for chunk in guard
+            .view_mut()
+            .plane_mut(0)
+            .bytes_mut()
+            .chunks_exact_mut(4)
+        {
             chunk.copy_from_slice(&base);
         }
     }
@@ -99,7 +114,7 @@ fn round_trip_write_partial_modification_leaves_rest_untouched() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write edit");
-        let bytes = guard.view_mut().bytes_mut();
+        let bytes = guard.view_mut().plane_mut(0).bytes_mut();
         let row_bytes = (width as usize) * 4;
         for chunk in bytes[..row_bytes].chunks_exact_mut(4) {
             chunk.copy_from_slice(&edit);
@@ -108,7 +123,7 @@ fn round_trip_write_partial_modification_leaves_rest_untouched() {
 
     // Read: row 0 == edit, rows 1..H == base.
     let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
-    let bytes = guard.view().bytes();
+    let bytes = guard.view().plane(0).bytes();
     let row_bytes = (width as usize) * 4;
     for chunk in bytes[..row_bytes].chunks_exact(4) {
         assert_eq!(chunk, &edit, "row 0 should hold edit pattern");

--- a/libs/streamlib-adapter-cpu-readback/tests/stride_offset_handling.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/stride_offset_handling.rs
@@ -32,9 +32,10 @@ fn stride_is_tightly_packed_width_times_bpp() {
     // Pick a width that is NOT a power of 2 — common driver stride-
     // alignment requirements (256-byte rows, 64-pixel rows on NVIDIA)
     // would surface here if the staging buffer accidentally inherited
-    // them.
-    let width = 38u32;
-    let height = 6u32;
+    // them. Prime / odd dims are deliberate; this is a single-plane
+    // BGRA test and is not subject to NV12's even-dimension rule.
+    let width = 37u32;
+    let height = 5u32;
     let bpp = 4u32;
 
     let descriptor = fixture.register_surface(1, width, height);
@@ -68,14 +69,13 @@ fn unaligned_widths_round_trip_byte_exact() {
         }
     };
 
-    // Width = 18 (not aligned to 16/64). If the image-to-buffer copy is
-    // using the wrong row pitch on the buffer side, every other row will
-    // be shifted by the alignment delta and this byte-exact comparison
-    // will diverge. Surface dims are even because NV12 elsewhere
-    // requires it; using even dims here keeps the BGRA path consistent
-    // with the multi-plane round-trip's geometry assumptions.
-    let width = 18u32;
-    let height = 10u32;
+    // Width = 17 (prime, not aligned to 4/16/64). If the image-to-
+    // buffer copy is using the wrong row pitch on the buffer side,
+    // every other row will be shifted by the alignment delta and this
+    // byte-exact comparison will diverge. Single-plane BGRA: not
+    // subject to NV12's even-dimension rule.
+    let width = 17u32;
+    let height = 9u32;
     let descriptor = fixture.register_surface(1, width, height);
 
     // Prime: each pixel's value encodes (y * width + x) mod 256 in all

--- a/libs/streamlib-adapter-cpu-readback/tests/stride_offset_handling.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/stride_offset_handling.rs
@@ -33,8 +33,8 @@ fn stride_is_tightly_packed_width_times_bpp() {
     // alignment requirements (256-byte rows, 64-pixel rows on NVIDIA)
     // would surface here if the staging buffer accidentally inherited
     // them.
-    let width = 37u32;
-    let height = 5u32;
+    let width = 38u32;
+    let height = 6u32;
     let bpp = 4u32;
 
     let descriptor = fixture.register_surface(1, width, height);
@@ -43,13 +43,15 @@ fn stride_is_tightly_packed_width_times_bpp() {
 
     assert_eq!(view.width(), width);
     assert_eq!(view.height(), height);
-    assert_eq!(view.bytes_per_pixel(), bpp);
+    assert_eq!(view.plane_count(), 1);
+    let plane = view.plane(0);
+    assert_eq!(plane.bytes_per_pixel(), bpp);
     // Adapter's contract: row stride is exactly width * bpp.
-    assert_eq!(view.row_stride(), width * bpp);
+    assert_eq!(plane.row_stride(), width * bpp);
     // Total slice length is height * row_stride.
     assert_eq!(
-        view.bytes().len() as u32,
-        height * view.row_stride(),
+        plane.bytes().len() as u32,
+        height * plane.row_stride(),
         "tightly-packed contract: bytes.len() == height * row_stride"
     );
 }
@@ -66,12 +68,14 @@ fn unaligned_widths_round_trip_byte_exact() {
         }
     };
 
-    // Width = 17 (prime, not aligned to 4/16/64). If the
-    // image-to-buffer copy is using the wrong row pitch on the buffer
-    // side, every other row will be shifted by the alignment delta and
-    // this byte-exact comparison will diverge.
-    let width = 17u32;
-    let height = 9u32;
+    // Width = 18 (not aligned to 16/64). If the image-to-buffer copy is
+    // using the wrong row pitch on the buffer side, every other row will
+    // be shifted by the alignment delta and this byte-exact comparison
+    // will diverge. Surface dims are even because NV12 elsewhere
+    // requires it; using even dims here keeps the BGRA path consistent
+    // with the multi-plane round-trip's geometry assumptions.
+    let width = 18u32;
+    let height = 10u32;
     let descriptor = fixture.register_surface(1, width, height);
 
     // Prime: each pixel's value encodes (y * width + x) mod 256 in all
@@ -82,7 +86,7 @@ fn unaligned_widths_round_trip_byte_exact() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write prime");
-        let bytes = guard.view_mut().bytes_mut();
+        let bytes = guard.view_mut().plane_mut(0).bytes_mut();
         for y in 0..height as usize {
             for x in 0..width as usize {
                 let v = ((y * width as usize + x) & 0xFF) as u8;
@@ -94,7 +98,7 @@ fn unaligned_widths_round_trip_byte_exact() {
 
     // Read and assert byte-exact match.
     let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
-    let bytes = guard.view().bytes();
+    let bytes = guard.view().plane(0).bytes();
     for y in 0..height as usize {
         for x in 0..width as usize {
             let v = ((y * width as usize + x) & 0xFF) as u8;

--- a/libs/streamlib-adapter-cpu-readback/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/subprocess_crash_mid_write.rs
@@ -52,8 +52,8 @@ fn panic_mid_write_releases_lock_for_next_acquire() {
             .ctx
             .acquire_write(&descriptor)
             .expect("acquire_write before panic");
-        // Touch the bytes so bytes_mut isn't optimized out.
-        guard.view_mut().bytes_mut()[0] = 0xAB;
+        // Touch the bytes so the write isn't optimized out.
+        guard.view_mut().plane_mut(0).bytes_mut()[0] = 0xAB;
         panic!("simulated customer panic mid-write");
     }));
     assert!(result.is_err(), "the closure must have panicked");
@@ -64,7 +64,7 @@ fn panic_mid_write_releases_lock_for_next_acquire() {
             .ctx
             .acquire_write(&descriptor)
             .expect("post-panic acquire_write must succeed");
-        assert_eq!(guard.view().bytes().len(), 32 * 32 * 4);
+        assert_eq!(guard.view().plane(0).bytes().len(), 32 * 32 * 4);
     }
     {
         let _g = fixture

--- a/libs/streamlib-deno/adapters/cpu_readback.ts
+++ b/libs/streamlib-deno/adapters/cpu_readback.ts
@@ -4,17 +4,19 @@
 /**
  * Explicit GPU→CPU surface adapter — Deno customer-facing API.
  *
- * Mirrors the Rust crate `streamlib-adapter-cpu-readback` (#514).
+ * Mirrors the Rust crate `streamlib-adapter-cpu-readback` (#514, #533).
  * The subprocess's actual GPU→CPU copy is performed by the host
- * adapter via `vkCmdCopyImageToBuffer` against a HOST_VISIBLE
- * staging buffer; this module declares the type shapes a Deno
- * customer programs against.
+ * adapter via per-plane `vkCmdCopyImageToBuffer` against per-plane
+ * HOST_VISIBLE staging buffers; this module declares the type shapes
+ * a Deno customer programs against.
  *
- *  - `CpuReadbackReadView` / `CpuReadbackWriteView` — typed views
- *    inside `acquireRead` / `acquireWrite` scopes. Both expose
- *    `bytes` as a tightly-packed `Uint8Array` (read-only on the
- *    read side, mutable on the write side). Length is exactly
- *    `width * height * bytesPerPixel`.
+ *  - `CpuReadbackPlaneView` / `CpuReadbackPlaneViewMut` — per-plane
+ *    byte slices (`Uint8Array`) and dimensions in plane texels. NV12
+ *    UV plane has half the surface width × half the surface height.
+ *  - `CpuReadbackReadView` / `CpuReadbackWriteView` — surface-level
+ *    metadata plus the array of plane views inside `acquireRead` /
+ *    `acquireWrite` scopes. `planeCount` reflects the surface's
+ *    `SurfaceFormat`: 1 for BGRA8/RGBA8, 2 for NV12.
  *  - `CpuReadbackContext` interface — runtime hands one out;
  *    customers use TC39 `using` blocks for scoped acquire/release.
  *
@@ -31,32 +33,58 @@ import {
   STREAMLIB_ADAPTER_ABI_VERSION,
   type StreamlibSurface,
   type SurfaceAccessGuard,
+  type SurfaceFormat,
 } from "../surface_adapter.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };
+
+/** Read-only view of a single plane of an acquired surface. */
+export interface CpuReadbackPlaneView {
+  /** Plane width in texels. */
+  readonly width: number;
+  /** Plane height in texels. */
+  readonly height: number;
+  /** Bytes per texel of this plane (BGRA: 4, NV12 Y: 1, NV12 UV: 2). */
+  readonly bytesPerPixel: number;
+  /** Tightly-packed row stride in bytes (`width * bytesPerPixel`). */
+  readonly rowStride: number;
+  /** Read-only view of this plane's staging buffer. */
+  readonly bytes: Uint8Array;
+}
+
+/** Mutable view of a single plane of an acquired surface. */
+export interface CpuReadbackPlaneViewMut {
+  readonly width: number;
+  readonly height: number;
+  readonly bytesPerPixel: number;
+  readonly rowStride: number;
+  /** Mutable view of this plane's staging buffer. */
+  readonly bytes: Uint8Array;
+}
 
 /** Read-side view inside an `acquireRead` scope. */
 export interface CpuReadbackReadView {
   readonly width: number;
   readonly height: number;
-  readonly bytesPerPixel: number;
-  /** Tightly-packed row stride in bytes
-   * (`width * bytesPerPixel`). */
-  readonly rowStride: number;
-  /** Read-only view of the staging buffer. The GPU→CPU copy already
-   * happened at acquire time; reading is O(1). */
-  readonly bytes: Uint8Array;
+  readonly format: SurfaceFormat;
+  /** Number of planes (1 for BGRA/RGBA, 2 for NV12). */
+  readonly planeCount: number;
+  /** All planes in declaration order — for NV12, `[Y, UV]`. */
+  readonly planes: readonly CpuReadbackPlaneView[];
+  /** Borrow plane `index`. Throws `RangeError` on out-of-range. */
+  plane(index: number): CpuReadbackPlaneView;
 }
 
-/** Write-side view inside an `acquireWrite` scope. */
+/** Write-side view inside an `acquireWrite` scope. Edits to any
+ * plane's `bytes` are flushed back to the host `VkImage` via per-
+ * plane `vkCmdCopyBufferToImage` on guard drop. */
 export interface CpuReadbackWriteView {
   readonly width: number;
   readonly height: number;
-  readonly bytesPerPixel: number;
-  readonly rowStride: number;
-  /** Mutable view of the staging buffer. Edits are flushed back to
-   * the host `VkImage` via `vkCmdCopyBufferToImage` on guard drop. */
-  readonly bytes: Uint8Array;
+  readonly format: SurfaceFormat;
+  readonly planeCount: number;
+  readonly planes: readonly CpuReadbackPlaneViewMut[];
+  plane(index: number): CpuReadbackPlaneViewMut;
 }
 
 /** Public cpu-readback adapter contract. */

--- a/libs/streamlib-deno/surface_adapter.ts
+++ b/libs/streamlib-deno/surface_adapter.ts
@@ -25,6 +25,92 @@ export const SurfaceFormat = {
 } as const;
 export type SurfaceFormat = (typeof SurfaceFormat)[keyof typeof SurfaceFormat];
 
+/**
+ * Number of planes for `format`. Mirrors Rust
+ * `SurfaceFormat::plane_count`.
+ */
+export function surfaceFormatPlaneCount(format: SurfaceFormat): number {
+  switch (format) {
+    case SurfaceFormat.Bgra8:
+    case SurfaceFormat.Rgba8:
+      return 1;
+    case SurfaceFormat.Nv12:
+      return 2;
+  }
+  throw new RangeError(`unknown SurfaceFormat: ${format}`);
+}
+
+/**
+ * Bytes per texel of `plane`. NV12: Y = 1, UV = 2 (interleaved).
+ *
+ * Throws `RangeError` if `plane >= surfaceFormatPlaneCount(format)`.
+ */
+export function surfaceFormatPlaneBytesPerPixel(
+  format: SurfaceFormat,
+  plane: number,
+): number {
+  if (plane === 0) {
+    if (format === SurfaceFormat.Bgra8 || format === SurfaceFormat.Rgba8) {
+      return 4;
+    }
+    if (format === SurfaceFormat.Nv12) return 1;
+  }
+  if (plane === 1 && format === SurfaceFormat.Nv12) return 2;
+  throw new RangeError(
+    `plane index ${plane} out of range for SurfaceFormat ${format}`,
+  );
+}
+
+/**
+ * Plane width in texels. NV12 UV plane is half-width.
+ */
+export function surfaceFormatPlaneWidth(
+  format: SurfaceFormat,
+  surfaceWidth: number,
+  plane: number,
+): number {
+  if (plane === 0) {
+    if (
+      format === SurfaceFormat.Bgra8 ||
+      format === SurfaceFormat.Rgba8 ||
+      format === SurfaceFormat.Nv12
+    ) {
+      return surfaceWidth;
+    }
+  }
+  if (plane === 1 && format === SurfaceFormat.Nv12) {
+    return Math.floor(surfaceWidth / 2);
+  }
+  throw new RangeError(
+    `plane index ${plane} out of range for SurfaceFormat ${format}`,
+  );
+}
+
+/**
+ * Plane height in texels. NV12 UV plane is half-height.
+ */
+export function surfaceFormatPlaneHeight(
+  format: SurfaceFormat,
+  surfaceHeight: number,
+  plane: number,
+): number {
+  if (plane === 0) {
+    if (
+      format === SurfaceFormat.Bgra8 ||
+      format === SurfaceFormat.Rgba8 ||
+      format === SurfaceFormat.Nv12
+    ) {
+      return surfaceHeight;
+    }
+  }
+  if (plane === 1 && format === SurfaceFormat.Nv12) {
+    return Math.floor(surfaceHeight / 2);
+  }
+  throw new RangeError(
+    `plane index ${plane} out of range for SurfaceFormat ${format}`,
+  );
+}
+
 /** Mirror of Rust `SurfaceUsage` bitflags. */
 export const SurfaceUsage = {
   RenderTarget: 1 << 0,

--- a/libs/streamlib-deno/surface_adapter_test.ts
+++ b/libs/streamlib-deno/surface_adapter_test.ts
@@ -14,12 +14,16 @@
  * When this file changes, update both other mirrors in the same commit.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
   AccessMode,
   MAX_DMA_BUF_PLANES,
   STREAMLIB_ADAPTER_ABI_VERSION,
   SurfaceFormat,
+  surfaceFormatPlaneBytesPerPixel,
+  surfaceFormatPlaneCount,
+  surfaceFormatPlaneHeight,
+  surfaceFormatPlaneWidth,
   SurfaceLayout,
   SurfaceUsage,
 } from "./surface_adapter.ts";
@@ -36,6 +40,40 @@ Deno.test("SurfaceFormat values match Rust #[repr(u32)] layout", () => {
   assertEquals(SurfaceFormat.Bgra8, 0);
   assertEquals(SurfaceFormat.Rgba8, 1);
   assertEquals(SurfaceFormat.Nv12, 2);
+});
+
+Deno.test("SurfaceFormat plane_count matches Rust", () => {
+  assertEquals(surfaceFormatPlaneCount(SurfaceFormat.Bgra8), 1);
+  assertEquals(surfaceFormatPlaneCount(SurfaceFormat.Rgba8), 1);
+  assertEquals(surfaceFormatPlaneCount(SurfaceFormat.Nv12), 2);
+});
+
+Deno.test("SurfaceFormat plane geometry matches Rust", () => {
+  // BGRA: 1 plane, 4 bpp, full size.
+  assertEquals(surfaceFormatPlaneBytesPerPixel(SurfaceFormat.Bgra8, 0), 4);
+  assertEquals(surfaceFormatPlaneWidth(SurfaceFormat.Bgra8, 64, 0), 64);
+  assertEquals(surfaceFormatPlaneHeight(SurfaceFormat.Bgra8, 48, 0), 48);
+
+  // NV12 plane 0 (Y) — full resolution, 1 byte per texel.
+  assertEquals(surfaceFormatPlaneBytesPerPixel(SurfaceFormat.Nv12, 0), 1);
+  assertEquals(surfaceFormatPlaneWidth(SurfaceFormat.Nv12, 64, 0), 64);
+  assertEquals(surfaceFormatPlaneHeight(SurfaceFormat.Nv12, 48, 0), 48);
+
+  // NV12 plane 1 (UV interleaved) — half resolution, 2 bytes per texel.
+  assertEquals(surfaceFormatPlaneBytesPerPixel(SurfaceFormat.Nv12, 1), 2);
+  assertEquals(surfaceFormatPlaneWidth(SurfaceFormat.Nv12, 64, 1), 32);
+  assertEquals(surfaceFormatPlaneHeight(SurfaceFormat.Nv12, 48, 1), 24);
+});
+
+Deno.test("SurfaceFormat plane out-of-range throws RangeError", () => {
+  assertThrows(
+    () => surfaceFormatPlaneBytesPerPixel(SurfaceFormat.Bgra8, 1),
+    RangeError,
+  );
+  assertThrows(
+    () => surfaceFormatPlaneBytesPerPixel(SurfaceFormat.Nv12, 2),
+    RangeError,
+  );
 });
 
 Deno.test("SurfaceUsage flag bits match Rust bitflags", () => {

--- a/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
@@ -3,25 +3,26 @@
 
 """Explicit GPU→CPU surface adapter — Python customer-facing API.
 
-Mirrors the Rust crate ``streamlib-adapter-cpu-readback`` (#514). The
-subprocess's actual GPU→CPU copy is performed by the host (the
+Mirrors the Rust crate ``streamlib-adapter-cpu-readback`` (#514, #533).
+The subprocess's actual GPU→CPU copy is performed by the host (the
 adapter runs in-process on the host and issues
-``vkCmdCopyImageToBuffer`` against a HOST_VISIBLE staging buffer).
-This module provides the type shapes a Python customer programs
-against:
+``vkCmdCopyImageToBuffer`` against per-plane HOST_VISIBLE staging
+buffers). This module provides the type shapes a Python customer
+programs against:
 
-  * ``CpuReadbackReadView`` / ``CpuReadbackWriteView`` — views the
-    customer sees inside ``acquire_read`` / ``acquire_write`` scopes.
-    Both expose ``bytes`` (a tightly-packed ``bytes`` slice or
-    ``memoryview``) and ``numpy`` (a ``numpy.ndarray`` view of the
-    same memory, shape ``(height, width, bytes_per_pixel)``, dtype
-    ``numpy.uint8``). Reads on either property are O(1) — the GPU→CPU
-    copy already happened at acquire time.
+  * ``CpuReadbackPlaneView`` / ``CpuReadbackPlaneViewMut`` — per-plane
+    byte slices and dimensions. For BGRA/RGBA there's exactly one
+    plane; for NV12 there are two (Y at index 0, UV at index 1).
+  * ``CpuReadbackReadView`` / ``CpuReadbackWriteView`` — surface-level
+    metadata plus the tuple of plane views the customer sees inside
+    ``acquire_read`` / ``acquire_write`` scopes. Each plane view
+    exposes ``bytes`` (a ``bytes`` slice or ``memoryview``) and
+    ``numpy`` (a ``numpy.ndarray`` aliasing the same memory).
   * ``CpuReadbackContext`` Protocol — the subprocess runtime
     implements this and hands a customer-facing context out.
   * Acquire-time logging line ``cpu-readback: GPU→CPU copy of NxN
-    surface, M bytes`` — emitted by the host adapter so customers see
-    they paid for the copy.
+    {format} surface, M bytes total (P planes)`` — emitted by the host
+    adapter so customers see they paid for the copy.
 
 This is the **single sanctioned CPU exit** in the surface-adapter
 architecture. GPU adapters (``streamlib.adapters.vulkan`` /
@@ -36,11 +37,12 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, Tuple, runtime_checkable
 
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
     StreamlibSurface,
+    SurfaceFormat,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import
@@ -48,6 +50,8 @@ if TYPE_CHECKING:  # pragma: no cover - type-only import
 
 __all__ = [
     "STREAMLIB_ADAPTER_ABI_VERSION",
+    "CpuReadbackPlaneView",
+    "CpuReadbackPlaneViewMut",
     "CpuReadbackReadView",
     "CpuReadbackWriteView",
     "CpuReadbackSurfaceAdapter",
@@ -56,13 +60,14 @@ __all__ = [
 
 
 @dataclass(frozen=True)
-class CpuReadbackReadView:
-    """View handed back inside an ``acquire_read`` scope.
+class CpuReadbackPlaneView:
+    """Read-only view of a single plane of an acquired surface.
 
-    ``bytes`` is a read-only ``memoryview`` over the
-    ``width * height * bytes_per_pixel`` staging buffer. ``numpy`` is a
-    ``numpy.ndarray`` aliasing the same memory (no extra copy); shape
-    ``(height, width, bytes_per_pixel)``, dtype ``numpy.uint8``.
+    Exposes ``bytes`` (a read-only ``memoryview``) and ``numpy`` (a
+    ``numpy.ndarray`` aliasing the same memory; shape
+    ``(height, width, bytes_per_pixel)``, dtype ``numpy.uint8``).
+    Plane dimensions are in plane texels — for NV12's UV plane that
+    means half the surface width × half the surface height.
     """
 
     width: int
@@ -73,30 +78,77 @@ class CpuReadbackReadView:
 
     @property
     def row_stride(self) -> int:
-        """Row stride in bytes — always tightly packed
+        """Tightly-packed row stride in bytes
         (``width * bytes_per_pixel``)."""
         return self.width * self.bytes_per_pixel
+
+
+@dataclass(frozen=True)
+class CpuReadbackPlaneViewMut:
+    """Mutable view of a single plane of an acquired surface.
+
+    ``bytes`` is a writable ``memoryview``; ``numpy`` is a
+    ``numpy.ndarray`` aliasing the same memory. Edits to any plane are
+    flushed back to the host ``VkImage`` via per-plane
+    ``vkCmdCopyBufferToImage`` on guard drop.
+    """
+
+    width: int
+    height: int
+    bytes_per_pixel: int
+    bytes: memoryview
+    numpy: "np.ndarray"
+
+    @property
+    def row_stride(self) -> int:
+        return self.width * self.bytes_per_pixel
+
+
+@dataclass(frozen=True)
+class CpuReadbackReadView:
+    """View handed back inside an ``acquire_read`` scope.
+
+    ``planes`` is a tuple of [`CpuReadbackPlaneView`] in declaration
+    order — for NV12 that's ``(Y, UV)``. ``plane_count`` reflects the
+    surface's [`SurfaceFormat`]: 1 for BGRA8/RGBA8, 2 for NV12.
+    """
+
+    width: int
+    height: int
+    format: SurfaceFormat
+    planes: Tuple[CpuReadbackPlaneView, ...]
+
+    @property
+    def plane_count(self) -> int:
+        return len(self.planes)
+
+    def plane(self, index: int) -> CpuReadbackPlaneView:
+        """Borrow plane ``index``. Raises ``IndexError`` on out-of-range."""
+        return self.planes[index]
 
 
 @dataclass(frozen=True)
 class CpuReadbackWriteView:
     """View handed back inside an ``acquire_write`` scope.
 
-    ``bytes`` is a writable ``memoryview``; ``numpy`` is a
-    ``numpy.ndarray`` aliasing the same memory. Edits are flushed back
-    to the host ``VkImage`` via ``vkCmdCopyBufferToImage`` on guard
-    drop.
+    Same shape as [`CpuReadbackReadView`] but each plane's ``bytes`` /
+    ``numpy`` are mutable; on guard drop the modified bytes are
+    flushed back to the host ``VkImage`` via per-plane
+    ``vkCmdCopyBufferToImage``.
     """
 
     width: int
     height: int
-    bytes_per_pixel: int
-    bytes: memoryview
-    numpy: "np.ndarray"
+    format: SurfaceFormat
+    planes: Tuple[CpuReadbackPlaneViewMut, ...]
 
     @property
-    def row_stride(self) -> int:
-        return self.width * self.bytes_per_pixel
+    def plane_count(self) -> int:
+        return len(self.planes)
+
+    def plane(self, index: int) -> CpuReadbackPlaneViewMut:
+        """Borrow plane ``index``. Raises ``IndexError`` on out-of-range."""
+        return self.planes[index]
 
 
 @runtime_checkable
@@ -128,8 +180,16 @@ class CpuReadbackContext(Protocol):
     over a ``CpuReadbackSurfaceAdapter`` so customer code can write::
 
         with ctx.acquire_write(surface) as view:
-            arr = view.numpy  # shape (H, W, 4), dtype uint8
-            arr[..., :] = my_image  # mutate in-place; flushed on exit
+            # Single-plane (BGRA): one entry in view.planes.
+            arr = view.plane(0).numpy  # shape (H, W, 4), dtype uint8
+            arr[..., :] = my_image     # mutate in-place; flushed on exit
+
+        with ctx.acquire_write(nv12_surface) as view:
+            # Multi-plane (NV12): view.plane_count == 2.
+            y  = view.plane(0).numpy   # shape (H, W,   1)
+            uv = view.plane(1).numpy   # shape (H/2, W/2, 2)
+            y[...] = luma
+            uv[...] = chroma_uv
     """
 
     def acquire_read(

--- a/libs/streamlib-python/python/streamlib/surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/surface_adapter.py
@@ -41,6 +41,53 @@ class SurfaceFormat(enum.IntEnum):
     RGBA8 = 1
     NV12 = 2
 
+    def plane_count(self) -> int:
+        """Number of planes for this format. Mirrors Rust
+        `SurfaceFormat::plane_count`."""
+        if self in (SurfaceFormat.BGRA8, SurfaceFormat.RGBA8):
+            return 1
+        if self is SurfaceFormat.NV12:
+            return 2
+        raise ValueError(f"unknown SurfaceFormat: {self!r}")
+
+    def plane_bytes_per_pixel(self, plane: int) -> int:
+        """Bytes per texel of `plane`. NV12: Y=1, UV=2 (interleaved)."""
+        if self in (SurfaceFormat.BGRA8, SurfaceFormat.RGBA8) and plane == 0:
+            return 4
+        if self is SurfaceFormat.NV12 and plane == 0:
+            return 1
+        if self is SurfaceFormat.NV12 and plane == 1:
+            return 2
+        raise IndexError(
+            f"plane index {plane} out of range for SurfaceFormat {self!r}"
+        )
+
+    def plane_width(self, surface_width: int, plane: int) -> int:
+        """Plane width in texels at `surface_width`. NV12 UV plane is
+        half-width."""
+        if self in (SurfaceFormat.BGRA8, SurfaceFormat.RGBA8) and plane == 0:
+            return surface_width
+        if self is SurfaceFormat.NV12 and plane == 0:
+            return surface_width
+        if self is SurfaceFormat.NV12 and plane == 1:
+            return surface_width // 2
+        raise IndexError(
+            f"plane index {plane} out of range for SurfaceFormat {self!r}"
+        )
+
+    def plane_height(self, surface_height: int, plane: int) -> int:
+        """Plane height in texels at `surface_height`. NV12 UV plane is
+        half-height."""
+        if self in (SurfaceFormat.BGRA8, SurfaceFormat.RGBA8) and plane == 0:
+            return surface_height
+        if self is SurfaceFormat.NV12 and plane == 0:
+            return surface_height
+        if self is SurfaceFormat.NV12 and plane == 1:
+            return surface_height // 2
+        raise IndexError(
+            f"plane index {plane} out of range for SurfaceFormat {self!r}"
+        )
+
 
 class SurfaceUsage(enum.IntFlag):
     """Mirror of Rust `SurfaceUsage` (`bitflags!` `#[repr(transparent)] u32`)."""

--- a/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
@@ -43,6 +43,40 @@ def test_surface_format_is_4_bytes():
     assert int(SurfaceFormat.NV12) == 2
 
 
+def test_surface_format_plane_count_matches_rust():
+    """Locks parity with Rust `SurfaceFormat::plane_count`."""
+    assert SurfaceFormat.BGRA8.plane_count() == 1
+    assert SurfaceFormat.RGBA8.plane_count() == 1
+    assert SurfaceFormat.NV12.plane_count() == 2
+
+
+def test_surface_format_plane_geometry_matches_rust():
+    """NV12 chroma subsampling: Y at full resolution, UV at half."""
+    # BGRA: 1 plane, 4 bpp, full size.
+    assert SurfaceFormat.BGRA8.plane_bytes_per_pixel(0) == 4
+    assert SurfaceFormat.BGRA8.plane_width(64, 0) == 64
+    assert SurfaceFormat.BGRA8.plane_height(48, 0) == 48
+
+    # NV12 plane 0 (Y).
+    assert SurfaceFormat.NV12.plane_bytes_per_pixel(0) == 1
+    assert SurfaceFormat.NV12.plane_width(64, 0) == 64
+    assert SurfaceFormat.NV12.plane_height(48, 0) == 48
+
+    # NV12 plane 1 (UV interleaved, half resolution).
+    assert SurfaceFormat.NV12.plane_bytes_per_pixel(1) == 2
+    assert SurfaceFormat.NV12.plane_width(64, 1) == 32
+    assert SurfaceFormat.NV12.plane_height(48, 1) == 24
+
+
+def test_surface_format_plane_out_of_range_raises():
+    import pytest
+
+    with pytest.raises(IndexError):
+        SurfaceFormat.BGRA8.plane_bytes_per_pixel(1)
+    with pytest.raises(IndexError):
+        SurfaceFormat.NV12.plane_bytes_per_pixel(2)
+
+
 def test_surface_usage_flag_values():
     assert int(SurfaceUsage.RENDER_TARGET) == 1
     assert int(SurfaceUsage.SAMPLED) == 2


### PR DESCRIPTION
## Summary

- Adds NV12 / multi-plane format support to `streamlib-adapter-cpu-readback`. The host's `VkImage` now round-trips through one HOST_VISIBLE staging `VkBuffer` **per plane** (Y at full resolution, UV interleaved at half resolution); per-plane `vkCmdCopyImageToBuffer` regions use the matching `VK_IMAGE_ASPECT_PLANE_{0,1}_BIT`.
- Reshapes the customer-facing view as a sequence of `CpuReadbackPlaneView` / `CpuReadbackPlaneViewMut`. `view.plane(i).bytes()` for read, `view.plane_mut(i).bytes_mut()` for write. `HostSurfaceRegistration` takes `format: SurfaceFormat` instead of `bytes_per_pixel: u32` (pre-1.0 clean rename, no shim).
- Mirrors `SurfaceFormat` plane geometry on the Python (`IntEnum` methods) and Deno (free helpers) sides with parity tests.

## Closes
Closes #533

## Exit criteria

- [x] Multi-plane staging buffer allocation in `register_host_surface`.
- [x] Per-plane copy paths in `copy_image_to_buffer` and `copy_buffer_to_image`.
- [x] `CpuReadbackReadView` / `CpuReadbackWriteView` extended with per-plane accessors. **Picked separate plane slices** (one `CpuReadbackPlaneView` per plane) — staging buffers are independent allocations under the per-plane allocation strategy, so there's no contiguous backing to expose; per-plane is also what the Python ecosystem (`av`, `pyav`, OpenCV) expects for NV12.
- [x] Python wrapper updated: `view.planes` is a tuple of per-plane dataclasses, each with its own `bytes` / `numpy` view.
- [x] Deno wrapper updated equivalently: `view.planes` is an array of per-plane interfaces, each with its own `Uint8Array`.
- [x] Customer-facing API documented as a one-line note in the module docstring (Rust `lib.rs`, Python `cpu_readback.py`, Deno `cpu_readback.ts`).

## Design choices made during implementation

- **Per-plane VkBuffers, not multi-plane fresh allocation.** `VulkanPixelBuffer::new` is single-plane (multi-plane DMA-BUF is import-only via `from_dma_buf_fds`). Rather than extend that RHI surface, the adapter allocates one staging `VulkanPixelBuffer` per plane and issues one `vkCmdCopyImageToBuffer` region per plane. Engine-model preserved (everything goes through RHI), RHI surface stays small.
- **Plane geometry centralized on `SurfaceFormat`.** Added `plane_count`, `plane_width`, `plane_height`, `plane_bytes_per_pixel`, `plane_byte_size` on `streamlib_adapter_abi::SurfaceFormat`, mirrored in Python+Deno. Future adapters needing plane info don't reinvent.
- **Polyglot label added** to the issue (was `linux` only). Exit criteria require Python AND Deno wrapper updates; this is polyglot work by definition.

## Test plan

- [x] `cargo test -p streamlib-adapter-abi --lib` — 12 passed (incl. 4 new `surface_format_plane_*` tests covering BGRA single-plane, NV12 Y/UV geometry, and out-of-range panic)
- [x] `cargo test -p streamlib-adapter-cpu-readback` — all 11 integration tests pass on the local Vulkan device:
  - `multi_plane_round_trip::nv12_multi_plane_write_round_trips_to_read` (new) — Y_BYTE=0x42 + UV_BYTES=[0x80,0xC0] round-trip; geometry assertions on both planes.
  - `multi_plane_round_trip::nv12_per_plane_distinct_patterns_lands_unscrambled` (new) — distinct per-row Y and UV patterns, catches Y↔UV aspect-mask swaps.
  - Existing `round_trip_read`, `round_trip_write`, `stride_offset_handling`, `conformance`, `subprocess_crash_mid_write` migrated to `view.plane(0).bytes()` shape; all pass.
- [x] `python3 -m pytest libs/streamlib-python/python/streamlib/tests/` — 59 passed (incl. 3 new `surface_format_plane_*` parity tests).
- [x] `deno test libs/streamlib-deno/surface_adapter_test.ts` — 11 passed (incl. 3 new `SurfaceFormat plane_*` parity tests).
- [x] `cargo check --workspace` — clean (29 pre-existing warnings, all unrelated to this PR).

## Polyglot coverage

- **Runtimes affected**: rust, python, deno
- **Schema regenerated**: n/a (no escalate-IPC schema change; types are in-process)
- **Python and Deno both covered?** yes — each ships parallel additions in this PR
- **E2E tests run**:
  - [x] Host-Rust: `multi_plane_round_trip::*` (NV12 byte-exact round-trip on real GPU)
  - [x] Python parity: `test_surface_format_plane_count_matches_rust` + plane geometry
  - [x] Deno parity: `SurfaceFormat plane_count matches Rust` + plane geometry
- **FD-passing path**: n/a (cpu-readback is intra-process; no DMA-BUF FD passing)

## Follow-ups

- `CpuReadable::read_bytes()` returns plane 0 only on multi-plane views — documented as a foot-gun. Trait-generic code that consumes `CpuReadable` will silently process Y-only on NV12. Fine for v1 since the trait is the legacy single-slice contract; worth a tracking issue if NV12 starts being used through it.
- The fresh-allocation path for NV12 textures comes from the host via `acquire_render_target_dma_buf_image(_, _, TextureFormat::Nv12)` — the test skips cleanly if the EGL probe doesn't advertise an RT-capable NV12 modifier. Validated locally on NVIDIA 570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)