### PR TITLE
refactor(adapter-abi): make CpuReadable plane-aware

### DIFF
--- a/libs/streamlib-adapter-abi/src/adapter.rs
+++ b/libs/streamlib-adapter-abi/src/adapter.rs
@@ -204,12 +204,61 @@ pub trait GlWritable {
     fn gl_texture_id(&self) -> u32;
 }
 
-/// Capability marker for views that expose a CPU-readable byte slice.
+/// Capability marker for views that expose CPU-readable bytes.
+///
+/// Strict capability marker — only `streamlib-adapter-cpu-readback`
+/// implements this trait. Switching to that adapter is the contractual
+/// signal that the customer has opted into a host-side GPU→CPU copy;
+/// GPU adapters (`-vulkan`, `-opengl`, `-skia`) deliberately do not
+/// satisfy it (enforced at compile time via `assert_not_impl_all!`).
+///
+/// Plane-aware shape: trait-generic callers iterating bytes through
+/// `&dyn CpuReadable` should use [`Self::plane_count`] +
+/// [`Self::plane_bytes`] to cover every plane of multi-plane formats
+/// (NV12). [`Self::read_bytes`] returns plane 0 only — fine for
+/// single-plane formats (BGRA/RGBA), silently drops chroma on NV12.
 pub trait CpuReadable {
+    /// Bytes of plane 0. Plane-0-only by design; use
+    /// [`Self::plane_bytes`] for full multi-plane coverage.
     fn read_bytes(&self) -> &[u8];
+
+    /// Number of planes in this view. Defaults to 1; multi-plane impls
+    /// override.
+    fn plane_count(&self) -> u32 {
+        1
+    }
+
+    /// Bytes of plane `index`, row-major, tightly packed. Default impl
+    /// preserves single-plane semantics: index `0` returns
+    /// [`Self::read_bytes`] and any other index panics.
+    fn plane_bytes(&self, index: u32) -> &[u8] {
+        assert_eq!(
+            index, 0,
+            "plane_bytes: default impl only serves plane 0 (got {index})"
+        );
+        self.read_bytes()
+    }
 }
 
-/// Capability marker for views that expose a CPU-writable byte slice.
+/// Capability marker for views that expose CPU-writable bytes.
+///
+/// Strict capability marker — see [`CpuReadable`] for the architectural
+/// invariant. Plane-aware shape: trait-generic callers writing bytes
+/// through `&mut dyn CpuWritable` should use [`Self::plane_bytes_mut`]
+/// to cover every plane. [`Self::write_bytes`] is plane-0-only legacy.
 pub trait CpuWritable {
+    /// Mutable bytes of plane 0. Plane-0-only by design; use
+    /// [`Self::plane_bytes_mut`] for full multi-plane coverage.
     fn write_bytes(&mut self) -> &mut [u8];
+
+    /// Mutable bytes of plane `index`. Default impl preserves single-
+    /// plane semantics: index `0` returns [`Self::write_bytes`] and any
+    /// other index panics.
+    fn plane_bytes_mut(&mut self, index: u32) -> &mut [u8] {
+        assert_eq!(
+            index, 0,
+            "plane_bytes_mut: default impl only serves plane 0 (got {index})"
+        );
+        self.write_bytes()
+    }
 }

--- a/libs/streamlib-adapter-cpu-readback/src/view.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/view.rs
@@ -141,9 +141,18 @@ impl<'g> CpuReadbackReadView<'g> {
 impl CpuReadable for CpuReadbackReadView<'_> {
     /// Returns the **primary plane**'s bytes (plane 0). For single-plane
     /// formats this is the entire image; for multi-plane formats (NV12)
-    /// it is the Y/luma plane. Use [`Self::plane`] to reach chroma planes.
+    /// it is the Y/luma plane. Use [`CpuReadable::plane_bytes`] to reach
+    /// chroma planes.
     fn read_bytes(&self) -> &[u8] {
         self.planes[0].bytes
+    }
+
+    fn plane_count(&self) -> u32 {
+        self.planes.len() as u32
+    }
+
+    fn plane_bytes(&self, index: u32) -> &[u8] {
+        self.planes[index as usize].bytes
     }
 }
 
@@ -197,16 +206,29 @@ impl<'g> CpuReadbackWriteView<'g> {
 }
 
 impl CpuReadable for CpuReadbackWriteView<'_> {
+    /// Returns the **primary plane**'s bytes (plane 0). Use
+    /// [`CpuReadable::plane_bytes`] to reach chroma planes.
     fn read_bytes(&self) -> &[u8] {
         self.planes[0].bytes
+    }
+
+    fn plane_count(&self) -> u32 {
+        self.planes.len() as u32
+    }
+
+    fn plane_bytes(&self, index: u32) -> &[u8] {
+        self.planes[index as usize].bytes
     }
 }
 
 impl CpuWritable for CpuReadbackWriteView<'_> {
     /// Returns mutable access to the **primary plane**'s bytes (plane 0).
-    /// For NV12 surfaces, callers wanting to write chroma must use
-    /// [`CpuReadbackWriteView::plane_mut`].
+    /// Use [`CpuWritable::plane_bytes_mut`] to reach chroma planes.
     fn write_bytes(&mut self) -> &mut [u8] {
         self.planes[0].bytes
+    }
+
+    fn plane_bytes_mut(&mut self, index: u32) -> &mut [u8] {
+        self.planes[index as usize].bytes
     }
 }

--- a/libs/streamlib-adapter-cpu-readback/tests/cpu_readable_plane_aware.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/cpu_readable_plane_aware.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cpu_readback::tests::cpu_readable_plane_aware` —
+//! exercises the plane-aware shape of [`CpuReadable`] through a
+//! `&dyn CpuReadable` so trait-generic callers iterate every plane on
+//! multi-plane surfaces (NV12) and observe single-plane semantics on
+//! BGRA/RGBA via the trait's defaults.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{CpuReadable, StreamlibSurface, SurfaceFormat};
+
+use crate::common::HostFixture;
+
+const Y_BYTE: u8 = 0x42;
+const UV_BYTES: [u8; 2] = [0x80, 0xC0];
+
+fn register_nv12_or_skip(
+    fixture: &HostFixture,
+    id: u64,
+    width: u32,
+    height: u32,
+    test_name: &str,
+) -> Option<StreamlibSurface> {
+    match fixture.try_register_surface_with_format(
+        id,
+        width,
+        height,
+        SurfaceFormat::Nv12,
+        TextureFormat::Nv12,
+    ) {
+        Ok(d) => Some(d),
+        Err(e) => {
+            println!(
+                "{test_name}: skipping — host can't allocate NV12 \
+                 render-target DMA-BUF on this driver ({e})"
+            );
+            None
+        }
+    }
+}
+
+#[test]
+fn cpu_readable_default_plane_count_is_one() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "cpu_readable_default_plane_count_is_one: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+
+    let descriptor = fixture.register_surface(1, 32, 16);
+    let pattern: [u8; 4] = [0xAA, 0xBB, 0xCC, 0xDD];
+    {
+        let mut guard = fixture
+            .ctx
+            .acquire_write(&descriptor)
+            .expect("acquire_write");
+        let bytes = guard.view_mut().plane_mut(0).bytes_mut();
+        for chunk in bytes.chunks_exact_mut(4) {
+            chunk.copy_from_slice(&pattern);
+        }
+    }
+
+    let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
+    let view = guard.view();
+    let dyn_view: &dyn CpuReadable = view;
+
+    assert_eq!(
+        dyn_view.plane_count(),
+        1,
+        "BGRA single-plane surface must report plane_count()=1 through &dyn CpuReadable"
+    );
+    assert_eq!(
+        dyn_view.plane_bytes(0),
+        dyn_view.read_bytes(),
+        "plane_bytes(0) must alias read_bytes() for single-plane formats"
+    );
+    assert_eq!(dyn_view.plane_bytes(0).len(), 32 * 16 * 4);
+    for chunk in dyn_view.plane_bytes(0).chunks_exact(4) {
+        assert_eq!(chunk, &pattern);
+    }
+}
+
+#[test]
+fn cpu_readable_walks_all_planes_for_nv12() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "cpu_readable_walks_all_planes_for_nv12: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+
+    let width = 32u32;
+    let height = 16u32;
+    let descriptor = match register_nv12_or_skip(
+        &fixture,
+        2,
+        width,
+        height,
+        "cpu_readable_walks_all_planes_for_nv12",
+    ) {
+        Some(d) => d,
+        None => return,
+    };
+
+    {
+        let mut guard = fixture
+            .ctx
+            .acquire_write(&descriptor)
+            .expect("acquire_write");
+        for byte in guard.view_mut().plane_mut(0).bytes_mut().iter_mut() {
+            *byte = Y_BYTE;
+        }
+        for chunk in guard
+            .view_mut()
+            .plane_mut(1)
+            .bytes_mut()
+            .chunks_exact_mut(2)
+        {
+            chunk.copy_from_slice(&UV_BYTES);
+        }
+    }
+
+    let guard = fixture.ctx.acquire_read(&descriptor).expect("acquire_read");
+    let view = guard.view();
+    let dyn_view: &dyn CpuReadable = view;
+
+    assert_eq!(
+        dyn_view.plane_count(),
+        2,
+        "NV12 surface must expose 2 planes through &dyn CpuReadable"
+    );
+
+    let mut total_bytes_seen = 0usize;
+    for plane_index in 0..dyn_view.plane_count() {
+        let bytes = dyn_view.plane_bytes(plane_index);
+        total_bytes_seen += bytes.len();
+        match plane_index {
+            0 => {
+                assert_eq!(bytes.len() as u32, width * height, "Y plane size");
+                for (i, &b) in bytes.iter().enumerate() {
+                    assert_eq!(b, Y_BYTE, "Y plane byte {i}: {b:02x}");
+                }
+            }
+            1 => {
+                assert_eq!(
+                    bytes.len() as u32,
+                    (width / 2) * (height / 2) * 2,
+                    "UV plane size"
+                );
+                for (i, chunk) in bytes.chunks_exact(2).enumerate() {
+                    assert_eq!(chunk, &UV_BYTES, "UV pair {i}: {chunk:02x?}");
+                }
+            }
+            other => panic!("unexpected plane index {other}"),
+        }
+    }
+
+    let expected_total = (width * height) + (width / 2) * (height / 2) * 2;
+    assert_eq!(
+        total_bytes_seen as u32, expected_total,
+        "trait-generic walker must visit every plane of an NV12 surface"
+    );
+
+    assert_eq!(
+        dyn_view.read_bytes(),
+        dyn_view.plane_bytes(0),
+        "read_bytes() must keep returning plane 0 for back-compat"
+    );
+}


### PR DESCRIPTION
## Summary

- `CpuReadable::read_bytes()` / `CpuWritable::write_bytes()` returned plane 0 only — silently dropped chroma for any caller iterating through `&dyn CpuReadable` on multi-plane (NV12) cpu-readback surfaces.
- Extends both traits with plane-aware default methods (`plane_count()` + `plane_bytes(i)` on the reader, `plane_bytes_mut(i)` on the writer). Defaults preserve single-plane semantics: index 0 delegates to the legacy slice method, any other index panics.
- The cpu-readback views (`CpuReadbackReadView`, `CpuReadbackWriteView`) override the new methods to expose every plane; `read_bytes()` / `write_bytes()` keep plane-0 legacy semantics so existing single-plane callers compile unchanged.
- PR #535's `assert_not_impl_all!` invariant — only `streamlib-adapter-cpu-readback` implements the marker traits — is preserved; the only knob this PR turns is the trait shape.

## Closes
Closes #537

## Exit criteria

- [x] `CpuReadable` gains `plane_count()` + `plane_bytes(i)` with safe defaults.
- [x] `CpuWritable` gains `plane_bytes_mut(i)` symmetrically.
- [x] `CpuReadbackReadView` / `CpuReadbackWriteView` override the new methods to return real plane data; `read_bytes()` keeps plane-0 legacy.
- [x] Existing single-plane callers of `read_bytes()` / `write_bytes()` compile and pass unchanged.
- [x] Module docs on `CpuReadable` / `CpuWritable` updated to point callers at `plane_bytes` for full coverage and explain the plane-0-only legacy of `read_bytes`.

## Test plan

- [x] `cpu_readback::cpu_readable_plane_aware::cpu_readable_walks_all_planes_for_nv12` — NEW. Builds an NV12 surface, primes distinct Y / UV patterns, iterates the read view through `&dyn CpuReadable` using `plane_count()` + `plane_bytes(i)`, asserts both planes' bytes observed and total byte count matches `Y + UV` for the surface's geometry.
- [x] `cpu_readback::cpu_readable_plane_aware::cpu_readable_default_plane_count_is_one` — NEW. BGRA surface through `&dyn CpuReadable`, asserts `plane_count() == 1` and `plane_bytes(0) == read_bytes()`.
- [x] Existing `streamlib-adapter-cpu-readback` integration tests stay green: `multi_plane_round_trip` (×2), `round_trip_read` (×2), `round_trip_write` (×2), `stride_offset_handling` (×2), `subprocess_crash_mid_write` (×2), `conformance` — all pass.
- [x] `cargo check -p streamlib-adapter-vulkan -p streamlib-adapter-opengl --tests` — confirms the GPU-adapter `assert_not_impl_all!` capability assertions still hold (default-method additions to the trait don't change implementor status).

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)