### PR TITLE
perf(adapter-cpu-readback): per-submit fence wait instead of vkQueueWaitIdle

### DIFF
--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -46,8 +46,10 @@ use crate::view::{
     CpuReadbackPlaneView, CpuReadbackPlaneViewMut, CpuReadbackReadView, CpuReadbackWriteView,
 };
 
-/// Default per-acquire timeline-wait timeout.
-const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
+/// Default per-acquire GPU-wait timeout. Bounds both the prior-work
+/// timeline-semaphore wait and the per-submit `vk::Fence` wait that
+/// observe the image↔buffer copies.
+const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Explicit GPU→CPU [`SurfaceAdapter`] implementation.
 ///
@@ -71,11 +73,14 @@ impl CpuReadbackSurfaceAdapter {
         Self {
             device,
             surfaces: Mutex::new(HashMap::new()),
-            acquire_timeout: DEFAULT_TIMELINE_WAIT,
+            acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
         }
     }
 
-    /// Override the per-acquire timeline-wait timeout. Default 5 s.
+    /// Override the per-acquire GPU-wait timeout. Bounds both the
+    /// prior-work timeline-semaphore wait and the per-submit
+    /// `vk::Fence` wait that observe the image↔buffer copies. Default
+    /// 5 s.
     pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
         self.acquire_timeout = timeout;
         self

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -10,8 +10,9 @@
 //!  3. `vkCmdCopyImageToBuffer` into the per-plane staging buffer(s).
 //!     For multi-plane formats (NV12) one region per plane is recorded
 //!     with the corresponding `VK_IMAGE_ASPECT_PLANE_{0,1,…}_BIT`.
-//!  4. Block on `vkQueueWaitIdle` so the bytes are observable from the
-//!     CPU side once the call returns.
+//!  4. Wait on a per-submit `vk::Fence` so the bytes are observable from
+//!     the CPU side once the call returns. The wait is targeted to this
+//!     submit only — no `vkQueueWaitIdle` queue-wide drain.
 //!  5. Hand the customer per-plane `&[u8]` views over the mapped staging
 //!     buffers.
 //!
@@ -308,23 +309,13 @@ impl CpuReadbackSurfaceAdapter {
         }
     }
 
-    /// Submit a one-shot command buffer that:
-    ///   - transitions the image (`from` → `TRANSFER_SRC_OPTIMAL`) using
-    ///     the format-correct aspect mask
-    ///   - `vkCmdCopyImageToBuffer` into the per-plane staging buffers
-    ///     (one region per plane with the corresponding aspect mask)
-    ///   - transitions the image (`TRANSFER_SRC_OPTIMAL` → `GENERAL`)
-    /// then blocks via `vkQueueWaitIdle` so the host bytes are
-    /// observable.
-    ///
-    /// `vkQueueWaitIdle` is a **queue-wide** stall — every other
-    /// workload sharing this queue (encoder, decoder, camera) blocks
-    /// until the copy completes. That's correct for a v1
-    /// "GPU→CPU is the explicit slow exit" adapter, but the steady
-    /// state should switch to a per-submit fence + timeline wait so
-    /// only this surface's pipeline stalls. Tracked as part of the
-    /// adapter runtime-integration follow-up issues filed against
-    /// the Surface Adapter Architecture milestone.
+    /// Submit a one-shot command buffer that transitions the image to
+    /// `TRANSFER_SRC_OPTIMAL`, copies each plane into its staging
+    /// buffer, and transitions the image to `GENERAL`. Completion is
+    /// observed via a per-submit `vk::Fence` — the wait is targeted to
+    /// this submit only and composes correctly with concurrent activity
+    /// from other workloads sharing the queue (no `vkQueueWaitIdle`
+    /// drain).
     fn copy_image_to_buffer(&self, snap: &AcquireSnapshot) -> Result<(), AdapterError> {
         let device = self.device.device();
         let queue = self.device.queue();
@@ -433,36 +424,16 @@ impl CpuReadbackSurfaceAdapter {
             });
         }
 
-        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
-            .command_buffer(cmd)
-            .build()];
-        let submit = vk::SubmitInfo2::builder()
-            .command_buffer_infos(&cmd_infos)
-            .build();
-        if let Err(e) =
-            unsafe { self.device.submit_to_queue(queue, &[submit], vk::Fence::null()) }
-        {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
-                reason: format!("submit_to_queue: {e}"),
-            });
-        }
-
-        if let Err(e) = unsafe { device.queue_wait_idle(queue) } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
-                reason: format!("queue_wait_idle: {e}"),
-            });
-        }
-
+        let submit_result = self.submit_and_wait(queue, cmd);
         unsafe { device.destroy_command_pool(pool, None) };
-        Ok(())
+        submit_result
     }
 
     /// Symmetric counterpart of [`Self::copy_image_to_buffer`] — flushes
     /// each plane's linear staging buffer back into the corresponding
     /// image plane and leaves the image in `GENERAL`. Called from the
-    /// WRITE guard's release path.
+    /// WRITE guard's release path. Like the readback path, completion is
+    /// observed via a per-submit `vk::Fence`, not `vkQueueWaitIdle`.
     fn copy_buffer_to_image(&self, snap: &FlushSnapshot) -> Result<(), AdapterError> {
         let device = self.device.device();
         let queue = self.device.queue();
@@ -546,30 +517,63 @@ impl CpuReadbackSurfaceAdapter {
             });
         }
 
+        let submit_result = self.submit_and_wait(queue, cmd);
+        unsafe { device.destroy_command_pool(pool, None) };
+        submit_result
+    }
+
+    /// Submit `cmd` to `queue` with a per-call `vk::Fence` and wait for
+    /// it to signal. Bounded by [`Self::acquire_timeout`]; on timeout
+    /// returns [`AdapterError::SyncTimeout`].
+    ///
+    /// The fence is created unsignaled, attached to a single-submit
+    /// `VkSubmitInfo2`, and destroyed before this returns. Does NOT call
+    /// `vkQueueWaitIdle` — the wait is targeted to this submit only and
+    /// composes correctly with concurrent activity from other workloads
+    /// sharing the queue.
+    fn submit_and_wait(
+        &self,
+        queue: vk::Queue,
+        cmd: vk::CommandBuffer,
+    ) -> Result<(), AdapterError> {
+        let device = self.device.device();
+
+        let fence_info = vk::FenceCreateInfo::builder().build();
+        let fence = unsafe { device.create_fence(&fence_info, None) }.map_err(|e| {
+            AdapterError::IpcDisconnected {
+                reason: format!("create_fence: {e}"),
+            }
+        })?;
+
         let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
             .command_buffer(cmd)
             .build()];
         let submit = vk::SubmitInfo2::builder()
             .command_buffer_infos(&cmd_infos)
             .build();
-        if let Err(e) =
-            unsafe { self.device.submit_to_queue(queue, &[submit], vk::Fence::null()) }
-        {
-            unsafe { device.destroy_command_pool(pool, None) };
+        if let Err(e) = unsafe { self.device.submit_to_queue(queue, &[submit], fence) } {
+            unsafe { device.destroy_fence(fence, None) };
             return Err(AdapterError::IpcDisconnected {
                 reason: format!("submit_to_queue: {e}"),
             });
         }
 
-        if let Err(e) = unsafe { device.queue_wait_idle(queue) } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
-                reason: format!("queue_wait_idle: {e}"),
-            });
-        }
+        let timeout_ns = self.acquire_timeout.as_nanos() as u64;
+        let wait_result = unsafe { device.wait_for_fences(&[fence], true, timeout_ns) };
+        unsafe { device.destroy_fence(fence, None) };
 
-        unsafe { device.destroy_command_pool(pool, None) };
-        Ok(())
+        match wait_result {
+            Ok(vk::SuccessCode::SUCCESS) => Ok(()),
+            Ok(vk::SuccessCode::TIMEOUT) => Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            }),
+            Ok(other) => Err(AdapterError::IpcDisconnected {
+                reason: format!("wait_for_fences unexpected success: {other:?}"),
+            }),
+            Err(e) => Err(AdapterError::IpcDisconnected {
+                reason: format!("wait_for_fences: {e}"),
+            }),
+        }
     }
 }
 

--- a/libs/streamlib-adapter-cpu-readback/tests/queue_isolation.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/queue_isolation.rs
@@ -1,0 +1,201 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cpu_readback::tests::queue_isolation` — exercises
+//! the per-submit `vk::Fence` path under concurrent queue activity.
+//!
+//! Background: the cpu-readback adapter previously used
+//! `vkQueueWaitIdle` to observe completion of its image↔buffer copies.
+//! `vkQueueWaitIdle` is queue-wide — its wait set covers every prior
+//! submission on the queue at the time of the call. Issue #532 replaced
+//! it with a per-submit `vk::Fence` so the wait is targeted to the
+//! cpu-readback's own copy and composes correctly with concurrent
+//! activity from other workloads sharing the queue.
+//!
+//! What this test asserts: with a worker thread continuously submitting
+//! unrelated command buffers to the same queue, repeated cpu-readback
+//! acquire/release cycles all complete correctly within a sane bound,
+//! and the round-tripped pixel data still matches the host-written
+//! pattern. That demonstrates the fence-based path is robust under
+//! contention and free of `vkQueueWaitIdle`-style queue-wide drain.
+//!
+//! What this test deliberately does NOT assert: a literal "acquire
+//! returns before a prior unrelated submit finishes" timing claim.
+//! Vulkan submission ordering forces our submit to wait for any prior
+//! submit on the same queue, regardless of whether the wait primitive
+//! is `vkQueueWaitIdle` or `vk::Fence`. A strictly-isolated timing
+//! assertion would require multi-queue parallelism (separate
+//! graphics/compute queues), which is out of scope here. See issue
+//! #532's `Tests / validation` section for the full caveat.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use streamlib::adapter_support::VulkanDevice;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::common::HostFixture;
+
+/// Submit a single empty (begin/end only) command buffer to `queue`
+/// with a per-call fence and wait for it. Used by the worker thread to
+/// keep the queue busy with unrelated submits while the main thread is
+/// running cpu-readback acquires.
+fn submit_noop_and_wait(device: &VulkanDevice) -> Result<(), String> {
+    let raw = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool_info = vk::CommandPoolCreateInfo::builder()
+        .queue_family_index(qf)
+        .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+        .build();
+    let pool = unsafe { raw.create_command_pool(&pool_info, None) }
+        .map_err(|e| format!("create_command_pool: {e}"))?;
+
+    let alloc_info = vk::CommandBufferAllocateInfo::builder()
+        .command_pool(pool)
+        .level(vk::CommandBufferLevel::PRIMARY)
+        .command_buffer_count(1)
+        .build();
+    let cmd = match unsafe { raw.allocate_command_buffers(&alloc_info) } {
+        Ok(v) => v[0],
+        Err(e) => {
+            unsafe { raw.destroy_command_pool(pool, None) };
+            return Err(format!("allocate_command_buffers: {e}"));
+        }
+    };
+
+    let begin_info = vk::CommandBufferBeginInfo::builder()
+        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+        .build();
+    unsafe { raw.begin_command_buffer(cmd, &begin_info) }
+        .map_err(|e| format!("begin_command_buffer: {e}"))?;
+    unsafe { raw.end_command_buffer(cmd) }
+        .map_err(|e| format!("end_command_buffer: {e}"))?;
+
+    let fence_info = vk::FenceCreateInfo::builder().build();
+    let fence = unsafe { raw.create_fence(&fence_info, None) }
+        .map_err(|e| format!("create_fence: {e}"))?;
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    let submit_result =
+        unsafe { device.submit_to_queue(queue, &[submit], fence) }.map_err(|e| format!("{e}"));
+
+    let wait_result = match submit_result {
+        Ok(_) => unsafe { raw.wait_for_fences(&[fence], true, 5_000_000_000) }
+            .map(|_| ())
+            .map_err(|e| format!("wait_for_fences: {e}")),
+        Err(e) => Err(e),
+    };
+
+    unsafe {
+        raw.destroy_fence(fence, None);
+        raw.destroy_command_pool(pool, None);
+    }
+
+    wait_result
+}
+
+#[test]
+fn acquire_release_cycles_robust_under_concurrent_queue_submits() {
+    let Some(fixture) = HostFixture::try_new() else {
+        // No Vulkan device available — skip silently, matching the
+        // behavior of every other test in this crate.
+        return;
+    };
+
+    let descriptor = fixture.register_surface(1, 64, 32);
+
+    // Worker thread: keep the queue busy with unrelated noop submits
+    // until the main thread tells it to stop. Each iteration goes
+    // through `VulkanDevice::submit_to_queue`, the same per-queue-
+    // mutex-protected entrypoint the cpu-readback adapter uses, so we
+    // exercise the same submission path under contention.
+    let stop = Arc::new(AtomicBool::new(false));
+    let worker_device = Arc::clone(fixture.adapter.device());
+    let worker_stop = Arc::clone(&stop);
+    let worker_iters = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let worker_iters_clone = Arc::clone(&worker_iters);
+    let worker = std::thread::spawn(move || -> Result<(), String> {
+        while !worker_stop.load(Ordering::Relaxed) {
+            submit_noop_and_wait(&worker_device)?;
+            worker_iters_clone.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    });
+
+    // Main thread: run a meaningful number of acquire/release cycles
+    // and assert each one round-trips the pixel pattern correctly.
+    // Each iteration writes a per-iteration distinct pattern so a
+    // stale-data bug in the fence-wait path would surface as a
+    // mismatch.
+    let cycles = 24;
+    let started = Instant::now();
+    for i in 0..cycles {
+        let pattern: [u8; 4] = [i as u8, (i + 1) as u8, (i + 2) as u8, (i + 3) as u8];
+        {
+            let mut wg = fixture
+                .ctx
+                .acquire_write(&descriptor)
+                .expect("acquire_write under contention");
+            let bytes = wg.view_mut().plane_mut(0).bytes_mut();
+            for chunk in bytes.chunks_exact_mut(4) {
+                chunk.copy_from_slice(&pattern);
+            }
+        }
+        let rg = fixture
+            .ctx
+            .acquire_read(&descriptor)
+            .expect("acquire_read under contention");
+        let view = rg.view();
+        let bytes = view.plane(0).bytes();
+        for chunk in bytes.chunks_exact(4) {
+            assert_eq!(
+                chunk, &pattern,
+                "iteration {i}: round-tripped bytes do not match host pattern"
+            );
+        }
+    }
+    let elapsed = started.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    worker
+        .join()
+        .expect("worker thread panicked")
+        .expect("worker submit_noop_and_wait failed");
+
+    // Sanity bound: 24 acquire/write + acquire/read cycles plus the
+    // worker's noop submits should comfortably finish in well under a
+    // minute on any reasonable setup. The bound exists to flag a
+    // pathological queue-wide stall regression — if the fence wait
+    // accidentally degrades back to `vkQueueWaitIdle`-style behavior
+    // and the worker hammers the queue hard enough, this could blow
+    // the bound. The assertion is intentionally loose to stay stable
+    // across hardware.
+    assert!(
+        elapsed < Duration::from_secs(60),
+        "{cycles} cpu-readback round-trip cycles took {elapsed:?} under \
+         concurrent queue activity — suspect queue-wide drain regression"
+    );
+
+    // Confirm the worker actually got onto the queue (otherwise this
+    // is just a single-threaded test with no contention). One iter is
+    // the floor; in practice the worker lands many.
+    let iters = worker_iters.load(Ordering::Relaxed);
+    assert!(
+        iters >= 1,
+        "worker thread didn't land any noop submits — test isn't actually exercising contention"
+    );
+}


### PR DESCRIPTION
## Summary
- Replaces the queue-wide `vkQueueWaitIdle` drain in the cpu-readback adapter's `copy_image_to_buffer` / `copy_buffer_to_image` with a per-submit `vk::Fence` + `wait_for_fences`. Wait is now targeted to this submit only.
- Centralises create-fence → submit → wait → destroy-fence in a single `submit_and_wait` helper shared by both copy paths. Fence wait is bounded by the existing `acquire_timeout`; `vk::SuccessCode::TIMEOUT` maps to `AdapterError::SyncTimeout`.
- Updates `acquire_timeout` / `with_acquire_timeout` docs (and renames the internal `DEFAULT_TIMELINE_WAIT` to `DEFAULT_ACQUIRE_TIMEOUT`) to reflect that the timeout now bounds both the prior-work timeline-semaphore wait and the per-submit fence wait.
- Adds `tests/queue_isolation.rs` exercising the fence path with a worker thread continuously submitting unrelated noop command buffers to the same queue while the main thread runs cpu-readback acquire/release cycles.

## Closes
Closes #532

## Exit criteria
- [x] `copy_image_to_buffer` and `copy_buffer_to_image` switched to per-submit `vk::Fence` (or timeline-semaphore signal + wait) for completion observation. No `vkQueueWaitIdle`.
- [x] Existing 9 cpu-readback tests still pass.
- [x] New test that exercises the fence-based path under concurrent queue activity.

## Test plan
Ran `cargo test -p streamlib-adapter-cpu-readback --tests`:
- `conformance` (1) — pass
- `cpu_readable_plane_aware` (2) — pass
- `multi_plane_round_trip` (2) — pass
- `queue_isolation` (1, new) — pass
- `round_trip_read` (2) — pass
- `round_trip_write` (2) — pass
- `stride_offset_handling` (2) — pass
- `subprocess_crash_mid_write` (2) — pass

Total: 14 tests, all green. Also `cargo check -p streamlib-adapter-cpu-readback --tests` clean (only pre-existing dead-code warnings in unrelated crates).

`cargo clippy -p streamlib-adapter-cpu-readback --test queue_isolation` clean for the touched files (the wider workspace has pre-existing clippy issues outside scope).

### Test note (per issue #532 caveat)
The new `queue_isolation` test is intentionally a correctness-under-contention test, not a strict "acquire returns before prior unrelated submit finishes" timing test. The latter is impossible to assert on a single Vulkan queue — submission ordering forces our submit to wait for any prior submit on the same queue regardless of whether the wait primitive is `vkQueueWaitIdle` or `vk::Fence`. A strictly-isolated timing assertion would require multi-queue parallelism, which is out of scope here. The issue body and AI Agent Notes call this caveat out so future agents working on related tickets don't try to write the impossible assertion.

## Follow-ups
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
