### PR TITLE
docs(architecture): adapter runtime integration design (#528)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,9 @@ When presenting design choices for engine work, recommend the production-grade o
 
 **Picking up the next task:** invoke the `/amos:next` skill (or just say "continue" / "next task" / "what's next"). It finds the next ready issue in the focused milestone, pulls the issue body from GitHub, auto-loads any matching `.claude/workflows/<label>.md` for the issue's labels, and walks the execution protocol. To set the focused milestone, run `/amos:focus <title>` — `amos milestones` lists candidates.
 
-**Writing issues:** every new issue follows the template in @docs/issue-template.md — Description / Context / Exit criteria / Tests or validation / Related / AI Agent Notes. Cross-cutting concerns (linux, macos, polyglot, ci, frozen) are labels, not milestones. Test harnesses are their own issues. Dependency edges (`blocked by` / `blocks` / `parent`) are native GitHub relationships, not text. Use the `/amos-file` skill to draft new issues — it handles the template, milestone inference, and relationships in one pass.
+**Issues are goals, not specs.** An issue captures the *intent* of the work — the problem to solve, why it matters, and roughly how done looks. The specific exit-criteria checkboxes, file paths, suggested orderings, and AI Agent Notes inside an issue body are the best understanding *as of when the issue was filed*; they go stale fast as code lands, dependencies close, or the surrounding architecture shifts. **When you pick up a task, treat the issue as the goal but research current state before locking the plan.** Re-read the referenced files, check whether referenced code still exists in the shape claimed, verify whether listed follow-ups have already been filed, confirm whether flagged "defects" are still defects. Then announce a *fresh* task plan that supersedes the issue body where evidence has shifted — and update the issue body in place per the markdown-editing rules below (strike through stale items with reasoning, don't silently rewrite). Don't be dogmatic about checking off every original criterion if the world has moved; do hit the goal.
+
+**Writing issues:** every new issue follows the template in @docs/issue-template.md — Description / Context / Exit criteria / Tests or validation / Related / AI Agent Notes. **Keep issues low-resolution by default.** State the goal, the constraints, and what "done" looks like in broad strokes; do *not* try to capture every file path, exact test name, suggested implementation order, or detailed plan in the issue body. That high-resolution detail decays as code shifts, and a future agent picking up the issue will re-derive it anyway. The picker's job is to research current state and produce the implementation plan; the filer's job is to capture the goal cleanly. Cross-cutting concerns (linux, macos, polyglot, ci, frozen) are labels, not milestones. Test harnesses are their own issues. Dependency edges (`blocked by` / `blocks` / `parent`) are native GitHub relationships, not text. Use the `/amos-file` skill to draft new issues — it handles the template, milestone inference, and relationships in one pass.
 
 **Specialty workflows** live at `.claude/workflows/<label>.md`. Add a new one by dropping a file there and labeling relevant issues. `/amos:next` loads every matching file into context before starting work. Current workflows:
 - `.claude/workflows/ci.md` — for `ci`-labeled issues (negative test + green baseline evidence required)
@@ -348,6 +350,47 @@ for the full recipe.
 
 ---
 
+## Editing markdown documentation
+
+All markdown in this repo — CLAUDE.md, `docs/learnings/`,
+`docs/architecture/`, workflow files under `.claude/workflows/`,
+research docs — is **living documentation**. Future agents are
+encouraged to validate, update, critique, and prune as evidence
+shifts. Treat these files academically, not dogmatically: older
+content was true at the time it was written, and reality may have
+moved on.
+
+When editing any `*.md`:
+
+1. **Use Opus.** Markdown edits are research work — Sonnet or Haiku
+   may not hold enough context to weigh the trade-offs and
+   preserve nuance.
+2. **Show your work.** PR description / commit body must include
+   the evidence that drove the change: command output, file paths,
+   spec references, observations. "I think this is wrong" without
+   evidence is not enough.
+3. **Preserve disagreement, don't silently overwrite.** When you
+   supersede content, annotate it rather than removing it cleanly:
+
+   ```markdown
+   > ~~Original claim that X holds.~~ — Superseded YYYY-MM-DD by
+   > <evidence>. <One or two sentences on why the original is no
+   > longer right>.
+   ```
+
+   Outright deletion is allowed when content is provably wrong or
+   no longer relevant; in that case, leave a one-line marker in
+   the surrounding text ("section on X removed YYYY-MM-DD —
+   <reason>") so a future reader doesn't re-derive the same dead
+   end. Crossed-out content carries learnings of its own ("don't
+   go down this path; an agent tried it and it didn't work because
+   Y") — those are valuable and should be preserved.
+4. **Don't be dogmatic.** Re-derive conclusions when the stakes
+   are non-trivial. A doc that says "do X" is a hypothesis for
+   your current situation, not a command.
+
+These rules apply to every doc in this repo, including this one.
+
 ## Hard-won learnings (look these up when triggered)
 
 These docs capture surprising, non-obvious behavior — driver bugs,
@@ -356,7 +399,10 @@ condition matches what you're seeing.
 
 ### How to treat them
 
-Learnings are **notes from past-me to current-me** — a conversation
+Learnings follow the general
+[Editing markdown documentation](#editing-markdown-documentation)
+rules above; this subsection is a learnings-flavored restatement.
+They are **notes from past-me to current-me** — a conversation
 across sessions, not a spec. Treat them the way any engineer treats
 their own older notes: useful prior context, **not authority**.
 
@@ -367,11 +413,12 @@ their own older notes: useful prior context, **not authority**.
   missed, realize the problem was framed wrong, or find a simpler /
   better fix. Prefer the current understanding over the recorded one
   when they conflict.
-- **Edit freely.** A learning can be updated, rewritten, split, merged,
-  or deleted whenever you have evidence it's out of date, wrong,
-  incomplete, too narrow, too broad, or simply no longer relevant.
-  These edits don't need approval beyond the normal PR review — treat
-  them like any other doc change.
+- **Edit freely, preserve disagreement.** A learning can be updated,
+  rewritten, split, merged, or deleted whenever you have evidence
+  it's out of date, wrong, incomplete, too narrow, too broad, or
+  simply no longer relevant. When you do, follow the general rules
+  above — annotate superseded content, leave deletion markers
+  explaining why, preserve the dead-end as its own learning.
 - **Don't follow them blindly.** A learning telling you "do X" is a
   hypothesis for your current situation, not a command. Verify the
   trigger still matches, verify the prescribed fix still applies,
@@ -426,5 +473,14 @@ make sense if the surrounding files were renamed or restructured.
   buffers, publish drops) without `init()`. Read before writing any test
   that uses PUBSUB events (shutdown, reconfigure) outside a full
   `StreamRuntime`.
+- @docs/architecture/adapter-runtime-integration.md — Two IPC seams
+  (surface-share FD lookup, escalate IPC) already exist for handing
+  host-allocated adapter resources to subprocess customers. The doc
+  records which adapter rides which today and why. To the best of our
+  current knowledge GPU adapters (Vulkan / OpenGL / Skia) fit one-shot
+  FD passing and cpu-readback fits per-acquire escalate, but the
+  trade-offs may shift as new adapters arrive — verify against current
+  code before generalizing. Read before adding a new surface adapter
+  or wondering why one path was picked over another.
 
 Index: @docs/learnings/README.md

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -86,6 +86,7 @@ pub enum EscalateRequest {
     AcquirePixelBuffer(EscalateRequestAcquirePixelBuffer),
     AcquireTexture(EscalateRequestAcquireTexture),
     Log(EscalateRequestLog),
+    ReleaseHandle(EscalateRequestReleaseHandle),
 }
 ```
 

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -1,0 +1,355 @@
+# Adapter runtime integration
+
+> **Living document.** Validate, update, and critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation):
+> use Opus, show your work, preserve disagreed-with content with
+> reasoning rather than silently deleting. Treat this academically,
+> not dogmatically. The recommendations below reflect the best
+> understanding of the codebase as of 2026-04-27; trade-offs may
+> shift as new adapters arrive or as existing seams evolve.
+
+## Question
+
+How does a subprocess customer (Python, Deno, future others) obtain
+a usable `VulkanContext` / `OpenGlContext` / `SkiaContext` /
+`CpuReadbackContext` instance against StreamLib's host-side surface
+adapters, without re-implementing host RHI patterns and without
+breaking the [`LimitedAccess` / `FullAccess` capability
+typestate](../../libs/streamlib/src/core/context/)?
+
+## Context
+
+After the Surface Adapter Architecture milestone shipped four
+adapter crates — `streamlib-adapter-vulkan` (#511),
+`streamlib-adapter-opengl` (#512), `streamlib-adapter-skia` (#513,
+host crate still in flight), `streamlib-adapter-cpu-readback`
+(#514) — the customer-facing trait is in place but no subprocess
+runtime constructs a usable instance. The polyglot wrappers in
+`streamlib-python` and `streamlib-deno` carry only Protocol /
+interface type stubs.
+
+The bar this design must clear (paraphrased from the PR #527 review
+of #514): *"the milestone is complete only if a downstream issue
+can use the adapter from day one."* That means a Python customer
+writing
+
+```python
+with skia_adapter.acquire_write(surface) as guard:
+    sk_surface = guard.view
+    # draw stuff
+```
+
+must work the same way it works in-process Rust — same trait shape,
+same resource semantics, same scope-bound synchronization.
+
+## What's already shipped (so the doc isn't speculating)
+
+Two IPC seams already exist in tree, both wired through
+`GpuContextLimitedAccess` so subprocess code never crosses into
+`FullAccess`:
+
+### Seam 1 — surface-share registry
+
+`libs/streamlib/src/linux/surface_share/` plus client at
+`libs/streamlib-surface-client/src/linux.rs`. One-shot
+length-prefixed JSON request/response over Unix socket with
+`SCM_RIGHTS` ancillary FD passing. Operations:
+
+| op | direction | payload |
+|---|---|---|
+| `register` / `check_in` | client → host | metadata + FDs (one per plane) |
+| `lookup` / `check_out` | client → host | `surface_id` → metadata + FDs |
+| `unregister` / `release` | client → host | `surface_id` (idempotent) |
+
+Metadata travels alongside FDs: `width`, `height`, `format`,
+`plane_sizes`, `plane_offsets`, `plane_strides`, `drm_format_modifier`,
+`resource_type` (`pixel_buffer` | `texture`). The wire format is
+extensible — additional JSON fields can be added without breaking
+existing clients.
+
+Already used by `examples/polyglot-dma-buf-consumer/` from both
+Python and Deno via `ctx.gpu_limited_access.resolve_surface(id)`,
+which under the hood does a `check_out` and hands back a handle
+the subprocess can `lock` / read / `unlock` / `release`.
+
+### Seam 2 — escalate IPC
+
+`libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs`,
+typed by JTD schemas at
+`libs/streamlib/schemas/com.streamlib.escalate_{request,response}@1.0.0.yaml`.
+Length-prefixed JSON request/response over the subprocess's
+stdin/stdout pipes, with discriminator-tagged op enum:
+
+```rust
+pub enum EscalateRequest {
+    AcquireImage(EscalateRequestAcquireImage),
+    AcquirePixelBuffer(EscalateRequestAcquirePixelBuffer),
+    AcquireTexture(EscalateRequestAcquireTexture),
+    Log(EscalateRequestLog),
+}
+```
+
+Each request carries a UUID `request_id`; responses echo it.
+Adding a new op is a schema change → `cargo xtask generate-schemas`
+→ rebuild all three runtimes (Rust, Python, Deno). The host side
+holds resources alive on behalf of the subprocess via
+`EscalateHandleRegistry`; subprocess crash drops them.
+
+The current acquire-style ops (`AcquireImage`, etc.) are how the
+surface-share registry gets populated in the first place — host
+allocates a backing, registers it under a UUID, returns the UUID
+to the subprocess, which then `check_out`s the FDs from
+surface-share.
+
+## Three architectural directions considered
+
+### Option A — escalate IPC op per adapter
+
+Subprocess JSON-RPCs the host on every `acquire_*` call. Host
+runs the adapter's `acquire_*` against its in-tree implementation,
+blocks on the per-surface timeline, and returns the framework-native
+handle metadata (or, for cpu-readback, a freshly-populated staging
+FD).
+
+- **Pros** — All synchronization, layout transitions, and
+  adapter-specific state stays on the host. Bug fixes land once.
+  Polyglot SDKs stay tiny. Host's queue mutex / fence pool /
+  submit instrumentation cover every dispatch.
+- **Cons** — IPC roundtrip latency on every acquire. Per-adapter
+  JTD schema regen + 3-runtime rebuild. The escalate seam wasn't
+  designed for hot-path acquire/release traffic.
+
+### Option B — surface-share registry extension
+
+Extend the surface-share registry so a registered surface also
+carries an "adapter handle" entry. Subprocess SDK looks up the
+entry and constructs the right `*Context` from the looked-up data.
+cpu-readback's staging buffer becomes a separately-registered
+surface in the same registry; vulkan/opengl/skia just use the
+existing FD.
+
+- **Pros** — Reuses the `polyglot-dma-buf-consumer` plumbing.
+  One IPC seam, not per-op. No per-acquire roundtrip for GPU
+  adapters.
+- **Cons** — cpu-readback semantically wants a host-driven copy
+  on every `acquire_read` (`vkCmdCopyImageToBuffer`), not a
+  one-shot FD handoff. Forcing it through the registry means
+  re-registering on every acquire — that's an escalate op in
+  registry clothing.
+
+### Option C — hybrid
+
+GPU adapters (Vulkan, OpenGL, Skia) ride the surface-share
+registry path: host pre-allocates the backing with the right
+DRM modifier (NVIDIA EGL trap solved once, on host); subprocess
+does a one-shot FD lookup and wraps it as the framework-native
+handle. cpu-readback rides the escalate-IPC path: each
+`acquire_read` is a JSON-RPC ping that triggers the host's
+`vkCmdCopyImageToBuffer`, after which the subprocess mmaps the
+freshly-populated staging FD.
+
+- **Pros** — Each adapter takes the seam that matches its
+  data-flow shape. No per-acquire IPC roundtrip for GPU adapters.
+  Host-driven copy semantics preserved for cpu-readback.
+- **Cons** — Two integration paths to understand instead of one.
+  Future adapter authors must consciously pick which seam fits.
+
+## Recommendation
+
+**Option C — hybrid.** The data-flow shapes are genuinely
+different and forcing one seam on both buckets re-creates work
+that already exists. Specifically:
+
+| Adapter | Seam | Why |
+|---|---|---|
+| `streamlib-adapter-vulkan` | surface-share registry | Imported `VkImage`/`VkBuffer` is a static handle for the surface's lifetime. Once the FD is bound, every acquire is a layout-transition + sync wait — no fresh host work. |
+| `streamlib-adapter-opengl` | surface-share registry | Same shape as Vulkan. The DRM-modifier import path already exists in `polyglot-dma-buf-consumer` and `nvidia-egl-dmabuf-render-target.md` documents the modifier-vs-`external_only` constraint that must be solved at allocation time on host. |
+| `streamlib-adapter-skia` | surface-share registry | Skia composes on Vulkan via `VulkanImageInfoExt` (per `surface-adapter.md`), so it inherits Vulkan's seam transitively. |
+| `streamlib-adapter-cpu-readback` | escalate IPC | Each `acquire_read` requires a fresh `vkCmdCopyImageToBuffer` on the host VkDevice/queue (the readback is a snapshot, not a static handle). The host-driven copy is exactly the kind of "small request, host does the privileged work" operation escalate IPC was built for. |
+
+This recommendation is the working hypothesis; the trip-wires
+section below names the conditions that would shift it.
+
+## Customer-facing surface — unchanged
+
+The seam choice is **internal to the adapter implementation**.
+From the customer's perspective the API is identical regardless
+of where they're running and which seam the runtime picks:
+
+```rust
+// Rust, in-process
+let mut guard = adapter.acquire_write(&surface)?;
+let view = guard.view_mut();
+```
+
+```python
+# Python subprocess
+with adapter.acquire_write(surface) as guard:
+    view = guard.view
+```
+
+```typescript
+// Deno subprocess
+{
+  using guard = adapter.acquireWrite(surface);
+  const view = guard.view;
+}
+```
+
+The customer never sees DMA-BUF FDs, DRM modifiers, timeline
+semaphores, queue family ownership transitions, or escalate
+request IDs. That's the whole point of the adapter pattern, and
+this design preserves it.
+
+## Layered architecture
+
+```
+Customer code (Rust processor / Python script / Deno script)
+  └── adapter.acquire_write(surface)              ← public API, unchanged
+      └── streamlib-{python,deno} adapter Protocol ← type stub
+          └── streamlib-{python,deno}-native FFI   ← runtime impl
+              └── ONE OF:
+                  ├── surface-share registry      ← Vulkan / OpenGL / Skia
+                  └── escalate IPC                ← cpu-readback
+                      └── host RHI                ← FullAccess, only here
+```
+
+Above the bottom line, the seam choice is invisible.
+
+## Capability sandbox preservation
+
+The `RuntimeContextLimitedAccess` / `RuntimeContextFullAccess`
+typestate (and the parallel `GpuContextLimitedAccess` /
+`GpuContextFullAccess` split) exist to make a class of bugs
+unreachable at compile time: subprocess code cannot accidentally
+allocate exportable memory, cannot configure modifiers, cannot
+construct compute pipelines. The two seams preserve this
+guarantee differently:
+
+### Surface-share path (Vulkan / OpenGL / Skia)
+
+The privileged operation — allocating a `VkImage` with a
+render-target-capable DRM modifier — happens on the host at
+backing creation time, far upstream of the customer's `acquire_*`
+call. By the time the subprocess does its `check_out` lookup,
+the FD is already an artifact; what the subprocess does with it
+is bounded:
+
+1. `VkImportMemoryFdInfoKHR` (the import-side carve-out from
+   `.claude/workflows/polyglot.md`)
+2. `vkBindImageMemory` / `vkBindBufferMemory`
+3. Layout transitions + sync wait/signal on imported handles
+4. Render or compute against the imported handle
+
+None of those touch `vkAllocateMemory`, no modifier discovery,
+no pool management. The subprocess `VkDevice` (consumer-only by
+construction) holds the imported handles; the host `VkDevice`
+(`FullAccess`) is never directly referenced from subprocess
+address space.
+
+### Escalate-IPC path (cpu-readback)
+
+The crossing **is** the IPC wire. Subprocess holds
+`LimitedAccess`, sends a JSON-RPC request with a `surface_id`
+and `mode=read`. Host receives it on a worker holding
+`FullAccess`, runs `vkCmdCopyImageToBuffer` on the host VkDevice
++ queue (queue mutex, fence pool, submit instrumentation all
+covered), exports the resulting staging-buffer FD via
+surface-share, returns the FD reference. Subprocess mmaps and
+reads bytes.
+
+There is no in-process `LimitedAccess → FullAccess` upgrade ever.
+The typestate split is enforced by the IPC boundary itself, the
+same way it's enforced for every other escalate op.
+
+### Customer's view
+
+`adapter.acquire_write(surface)` — at the API surface — is a
+`LimitedAccess` operation in subprocess code and a `FullAccess`
+operation in in-process Rust code. The trait shape is identical;
+the underlying typestate is whichever the surrounding context
+carries. A customer writing processor code never sees `FullAccess`
+unless their processor itself is wired to receive it.
+
+## Trip-wires for future adapters
+
+If any of the following becomes true for a new adapter, revisit
+this design — the working hypothesis may not fit:
+
+1. **Subprocess wants to allocate.** A new adapter that needs a
+   subprocess-side staging buffer larger than what import + bind
+   covers would break the import-side carve-out. Escalate the
+   allocation to host instead.
+2. **Subprocess wants its own `VkPipeline` / compute kernel.**
+   That re-introduces the SPIR-V reflection / descriptor-set
+   layout / pipeline cache problems
+   `core::rhi::ComputeKernelDescriptor` solved once on host. If
+   a future adapter needs subprocess-local compute, prefer
+   escalating the dispatch as a single "run kernel K with bindings
+   B" op rather than building a parallel kernel cache.
+3. **Per-acquire host work for what looks like a GPU adapter.**
+   If a Vulkan/OpenGL adapter discovers it needs fresh host work
+   on every `acquire_*` (e.g. dynamic format negotiation), it's
+   probably better routed as an escalate op even though it's a
+   GPU adapter. The bucketing isn't framework-agnostic — it
+   tracks data-flow shape.
+4. **Hot-path acquire/release.** If an escalate-IPC adapter
+   starts being called at frame rate and the JSON-RPC roundtrip
+   shows up in profiles, the answer is probably to batch
+   acquires (one escalate op covering N frames) before reaching
+   for shared memory or a third seam.
+
+## Open questions for the user
+
+- **Hot-path cpu-readback.** If a future scenario reads back
+  every frame at 60fps, is per-acquire JSON-RPC acceptable, or
+  do we want a "subscribe to readbacks" escalate op that
+  populates a shared-memory ring? Filing as a follow-up if/when
+  it becomes load-bearing; not blocking the initial
+  cpu-readback runtime.
+- **Skia (#513) is still in flight.** This doc specifies the
+  seam Skia should ride (surface-share, transitively via
+  Vulkan). If #513's host-side implementation lands with a
+  different shape, this section needs updating. Marked as a
+  trip-wire above.
+
+## Implementation issues
+
+The subprocess runtimes for the three already-shipped adapters
+inherit this design:
+
+- `#529` — `feat(adapter-cpu-readback): subprocess
+  CpuReadbackContext runtime + cv2 fixture` — escalate IPC seam
+- `#530` — `feat(adapter-opengl): subprocess OpenGlContext
+  runtime + scenario binary` — surface-share seam
+- `#531` — `feat(adapter-vulkan): subprocess VulkanContext
+  runtime + scenario binary` — surface-share seam
+
+Suggested implementation order: cpu-readback first (smallest
+data shape; escalate-IPC seam is well-trodden), opengl second
+(DRM-modifier import path already exists in
+`polyglot-dma-buf-consumer`), vulkan third (most plumbing,
+biggest blast radius if any of the others surfaces a design
+gap).
+
+`#513` (Skia host crate) is not yet implemented; its subprocess
+runtime issue should be filed once #513 lands and inherits this
+doc's recommendation.
+
+## Related
+
+- `docs/architecture/surface-adapter.md` — the customer-facing
+  brief for the adapter trait shape
+- `.claude/workflows/polyglot.md` — the polyglot rule, including
+  the import-side carve-out
+- `docs/learnings/nvidia-egl-dmabuf-render-target.md` —
+  modifier-vs-`external_only` constraint that must be solved on
+  host
+- `docs/learnings/nvidia-dual-vulkan-device-crash.md` — why
+  subprocess Vulkan code stays consumer-only
+- `#525` — separate research on subprocess-side RHI pattern
+  parity (escalate vs per-language). Orthogonal to this doc:
+  #525 is about *implementation parity* (does the subprocess
+  reimplement RHI patterns), this doc is about *integration
+  shape* (how does the subprocess obtain a usable adapter
+  context).

--- a/docs/issue-template.md
+++ b/docs/issue-template.md
@@ -4,58 +4,99 @@ GitHub is the source of truth for work in this repo. Milestones group deliverabl
 
 This doc is the template every new issue should follow, and the contract agents (and humans) are expected to honor.
 
+## Keep issues low-resolution
+
+An issue captures the *goal* of a piece of work — the problem to
+solve, why it matters, and roughly how done looks. The high-resolution
+plan (specific file paths, exact test names, suggested implementation
+ordering, ruled-out approaches) decays as the surrounding code shifts,
+so capturing it in the issue body just creates staleness for the next
+agent to clean up. Resist the urge to be exhaustive.
+
+The picker's job is to research current state at pickup time and
+produce a fresh implementation plan; the filer's job is to capture
+the goal cleanly enough that a competent agent can pick it up cold
+and figure the rest out.
+
+What this means in practice:
+
+- **Description** is a short paragraph stating the goal, not a
+  pre-implementation plan.
+- **Context** explains *why* the work matters and what constraints
+  bound it. It does not summarize an investigation that the picker
+  could redo themselves.
+- **Exit criteria** are 2–4 high-level deliverables that define
+  "done," not a checklist of file edits.
+- **Tests / validation** describes the *shape* of validation needed
+  (unit test, E2E scenario, harness reference), not the exact test
+  function names.
+- **AI Agent Notes** are reserved for things the picker genuinely
+  cannot derive from current code (a hidden invariant, a ruled-out
+  approach with a reason). When in doubt, leave it as "None."
+- **Phrase claims as "to the best of our current knowledge"** when
+  the issue body must reference specific code or behavior. This
+  signals to the picker that the claim deserves verification.
+
+The picker is required (per CLAUDE.md → Work Tracking → "Issues are
+goals, not specs") to verify the issue body against current code
+before announcing a plan, and to update the body in place when
+something has gone stale. Plan for that loop; don't try to make the
+issue body authoritative forever.
+
 ## Template
 
 ```markdown
 ## Description
 
-One short paragraph, written for an AI agent with no prior context. Say *what*
-this issue delivers in plain terms. Avoid "as discussed in slack" — link or
-quote.
+One short paragraph stating the goal — *what* this issue delivers and
+roughly *how* done looks. Written for a future agent picking this up
+cold. No ruled-out approaches, no file paths, no implementation
+ordering.
 
 ## Context
 
-Why this matters. Architectural constraints, prior work, adjacent milestones,
-anything a reader needs to understand *before* deciding the scope is right.
+Why this matters and what constraints bound the work — adjacent
+milestones, prior work, the architectural commitment that makes this
+the right shape. Phrase specific claims as "to the best of our
+current knowledge" so the picker knows to verify.
 
 ## Exit criteria
 
-Concrete, checkable deliverables. An agent or reviewer should be able to
-tick each item and know the issue is done.
+2–4 high-level deliverables that define "done." Resist breaking
+each one down further; the picker will produce the detailed plan.
 
-- [ ] <deliverable 1>
-- [ ] <deliverable 2>
+- [ ] <high-level deliverable 1>
+- [ ] <high-level deliverable 2>
 
 ## Tests / validation
 
-What proves this works? Every non-trivial issue answers this section. Either:
+The *shape* of validation needed, not exact test names. Either:
 
-- **Inline test cases** — unit tests, integration tests, or E2E scenarios to
-  write as part of this issue. Each listed as a bullet so reviewers can check
-  them off:
-  - [ ] `<module>::<test_name>` — <what it exercises>
-  - [ ] E2E: <scenario description>
+- **Inline scope** — the kinds of tests this issue should add:
+  - [ ] Unit test(s) covering <what behavior>
+  - [ ] E2E scenario: <one-line description>
 
-- **OR** a reference to a test-harness issue: if the tests need scaffolding
-  that doesn't exist yet, file that scaffolding as its own issue and mark
-  this one blocked on it.
+- **OR** a reference to a test-harness issue:
   - Blocked by #N (test harness for <area>)
 
-The intent: once CI exists, a PR merging this issue is only reviewable if the
-listed tests pass. See `docs/testing.md` for which test types apply when.
+The picker fills in the specifics during plan-out.
 
 ## Related
 
 - Milestone: <name>
-- See also: #N
+- See also: #N (free-text context only — dependency edges go through
+  GitHub's `Blocked by` / `Blocks` / `Parent`, not text).
 
 <!-- amos:ai-notes-begin -->
 ## AI Agent Notes
 
-Agent-facing context that doesn't belong in the human-readable sections
-above — exact error strings, VUIDs, file paths, ruled-out approaches,
-hidden invariants. "None." is valid when there's nothing agent-specific
-to add; absence must be deliberate, not forgotten.
+None.
+
+(Or: things the picker genuinely cannot derive from current code — a
+hidden invariant, a ruled-out approach with reasoning, a non-obvious
+gotcha. Default to "None." — absence must be deliberate, not
+forgotten, but adding low-value content that will go stale is worse
+than leaving the section empty.)
 <!-- amos:ai-notes-end -->
 ```
 
@@ -70,27 +111,32 @@ also", "context from #N", etc.).
 1. **GitHub is the source of truth.** Every issue — description, exit
    criteria, tests, dependency edges, AI-agent notes — lives in the
    issue itself. Local plan files are deprecated; don't create new ones.
-2. **Every issue includes an AI Agent Notes section** (wrapped in the
+2. **Keep it low-resolution.** When in doubt, leave detail out. The
+   picker will research current state and produce the high-resolution
+   plan; specifics in the issue body just create staleness.
+3. **Every issue includes an AI Agent Notes section** (wrapped in the
    `<!-- amos:ai-notes-begin -->` / `<!-- amos:ai-notes-end -->` markers
-   so tooling can update it safely). The section can be "None." when
-   there's no agent-specific context, but it must be present.
-3. **Every issue has exit criteria.** No exit criteria = scope is unclear.
-   Push back and refine before starting work.
-4. **Every non-trivial issue has a Tests / validation section**, even if
+   so tooling can update it safely). Default to "None."; only add
+   content that's genuinely non-derivable from current code.
+4. **Every issue has exit criteria.** No exit criteria = scope is unclear.
+   Push back and refine before starting work. But keep the criteria
+   high-level — 2–4 items, not a 12-item checklist.
+5. **Every non-trivial issue has a Tests / validation section**, even if
    the answer is "no tests — pure doc change" (write that explicitly so
-   reviewers know it was considered, not forgotten).
-5. **Test harnesses are their own issues.** If validating an issue requires
+   reviewers know it was considered, not forgotten). Describe shape,
+   not specifics.
+6. **Test harnesses are their own issues.** If validating an issue requires
    building new test infrastructure, that infrastructure is its own issue
    with its own exit criteria (the harness exists and works) and its own
    test cases (the harness catches the scenarios it's supposed to catch).
-6. **Milestone assignment is required.** Every issue belongs to a milestone.
+7. **Milestone assignment is required.** Every issue belongs to a milestone.
    If it doesn't fit any existing milestone, either the milestone's scope
    is wrong or a new milestone is warranted — raise it before filing the
    issue.
-7. **Cross-cutting concerns are labels, not milestones.** Linux-specific
+8. **Cross-cutting concerns are labels, not milestones.** Linux-specific
    work goes in the relevant deliverable milestone with a `linux` label.
    "Linux support" is not a deliverable; "Pipeline Color & Resolution" is.
-8. **`polyglot`-labeled issues must answer: are Python AND Deno both
+9. **`polyglot`-labeled issues must answer: are Python AND Deno both
    covered?** The default is yes — pipeline-level work (new processor +
    scenario binary, new escalate op end-to-end, new FD-passing story)
    ships both runtimes together or files paired tickets that block on
@@ -104,44 +150,44 @@ also", "context from #N", etc.).
 ## What this means for CI
 
 Once CI is wired (see the *CI & Test Infrastructure* milestone), the
-"Tests / validation" section becomes the gate: the tests listed must pass
-in CI before an issue can be considered merge-ready. Test harnesses land
-first, tests land inside the issue that drives them, and the merge signal
-is automatic.
+"Tests / validation" section becomes the gate: the tests the picker
+ends up writing must pass in CI before the PR can merge. Test
+harnesses land first, tests land inside the issue that drives them,
+and the merge signal is automatic.
 
-## Example — a well-formed issue
+## Example — a well-formed (low-resolution) issue
 
 ```markdown
 ## Description
 
-Route `SimpleEncoder::queue_submit()` calls through `VulkanDevice`'s
-mutex-protected `submit_to_queue()` method so concurrent processor threads
-can't race on `vkQueueSubmit`. Fixes the release-build SIGSEGV seen when
-encoder and decoder submit from different threads.
+Route encoder/decoder Vulkan submissions through `VulkanDevice`'s
+mutex-protected submit path so concurrent processor threads can't
+race on `vkQueueSubmit`. Goal: release-build encode/decode pipeline
+runs without the cross-thread SIGSEGV currently observed.
 
 ## Context
 
-#273 added the per-queue mutex on `VulkanDevice`. This issue makes the
-encoder actually use it. Without this, the mutex exists but the encoder
-still submits directly via `ash::Device`, defeating the guard.
+The per-queue mutex exists on `VulkanDevice` but the codec processors
+appear to bypass it, defeating the guard. To the best of our current
+knowledge this is the cause of the release-build SIGSEGV seen when
+encoder and decoder submit from different threads — verify against
+current code at pickup, the structure may have shifted.
 
 ## Exit criteria
 
-- [ ] `SimpleEncoder::queue_submit` calls `VulkanDevice::submit_to_queue`
-- [ ] Same change applied to `SimpleDecoder::queue_submit`
-- [ ] Release build runs `vulkan-video-roundtrip h264 /dev/video2 30` without
-      SIGSEGV for ≥3 consecutive cold runs
+- [ ] Codec processors no longer submit to the queue outside the
+      RHI's mutex-protected path.
+- [ ] Release build runs the encoder/decoder roundtrip end-to-end
+      without crashing across multiple cold runs.
 
 ## Tests / validation
 
-- [ ] `vulkan_video::tests::concurrent_encode_decode_no_race` — new unit
-      test that spawns two threads submitting simultaneously and asserts
-      no double-submit
-- [ ] E2E: encoder/decoder scenario from docs/testing.md, release build,
-      30s duration × 3 cold runs — see the standardized E2E template
+- [ ] Unit test exercising concurrent submission across two threads
+      and asserting no race.
+- [ ] E2E: encoder/decoder roundtrip per `docs/testing.md`, release
+      build, multiple cold runs.
 
 ## Related
 
 - Milestone: Vulkan Video RHI Coupling
-- Blocked by: #273
 ```


### PR DESCRIPTION
## Summary

- Picks the integration shape between host-side surface adapters and subprocess customers: **hybrid (Option C)** — GPU adapters (Vulkan/OpenGL/Skia) ride the existing surface-share registry one-shot FD lookup; cpu-readback rides escalate IPC for per-acquire host-driven copies. Both seams already exist in the runtime and preserve the `LimitedAccess`/`FullAccess` capability typestate by construction.
- Tightens the broader documentation discipline this issue surfaced: a new "Editing markdown documentation" section in CLAUDE.md establishes project-wide rules for editing `*.md` files (use Opus, show your work, preserve disagreement with strike-throughs, treat docs academically not dogmatically).
- Reframes "Work Tracking" so issues represent goals not specs, and require pickers to research current state before locking the plan; rewrites `docs/issue-template.md` to be lower-resolution by default. The matching pickup-research-and-supersede flow lands in the `amos-next` skill (out-of-tree) and the `amos-file` skill is updated to default to "None." in AI Agent Notes.

## Closes

Closes #528

## Exit criteria (from issue body, refined per current state)

- [x] Architecture doc at `docs/architecture/adapter-runtime-integration.md` listing each adapter, the integration shape it uses, and why.
- [x] Three implementation issues already filed (#529 cpu-readback, #530 opengl, #531 vulkan) — all `blocked_by: #528`. Lifecycle criterion already met without new filings; verified during pickup-time staleness audit.
- [x] Adapter issues #511/#512/#514 cross-referenced from impl issues #531/#530/#529 (in `Related` sections of the impl issue bodies). #513 (skia host crate) correctly unpaired until it ships.
- [x] CLAUDE.md updated to reference the new doc (learning-style pointer in Hard-won learnings index) plus the broader markdown-editing and issue-as-goal framing.

## Staleness audit (against original issue AI Agent Notes)

Three of the original AI Agent Notes were superseded by current state and have been struck through in #528 with reasoning preserved per the new markdown-editing rules:

- "File three implementation issues sequentially" — already filed as #529/#530/#531.
- "#513 should gain a `blocked-by` edge to #528" — edge already exists.
- "Pre-existing defect: VulkanReadView impls CpuReadable" — was deliberately removed in PR #527/#538; current code at `libs/streamlib-adapter-vulkan/src/view.rs:76–93` contains a compile-time assertion that *prevents* the impl. Not a defect.

## Test plan

- [x] Doc compiles, no broken intra-doc links — every cited file path verified to exist.
- [x] Doc reviewed against `.claude/workflows/polyglot.md` and #525 — recommendations consistent (this doc covers integration shape; #525 covers implementation parity).
- [x] `pr-review-gate` PASS verdict.

No code changes; no cargo/test gate to run.

## Follow-ups

- Skia subprocess runtime issue should be filed once the host adapter (#513) ships, inheriting this doc's recommendation.
- Hot-path cpu-readback (60fps readback every frame) is flagged as an open question in the doc; not blocking the initial cpu-readback runtime but worth filing as a research follow-up if/when it becomes load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)