### PR TITLE
feat(adapter-cpu-readback): subprocess CpuReadbackContext runtime + cv2 fixture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "examples/camera-python-subprocess",  # Example: Camera → Python subprocess → Display pipeline
     "examples/camera-deno-subprocess",   # Example: Camera → Deno subprocess → Display pipeline
     "examples/polyglot-dma-buf-consumer", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
+    "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -356,8 +356,62 @@ that need pre-start GpuContext access should use it; adapters that
 need per-acquire host work should also expose a `set_*_bridge` setter
 on `GpuContext` mirroring `set_cpu_readback_bridge`. Application
 authors call `install_setup_hook` exactly once per adapter they want
-to expose to subprocesses — explicit, greppable, no ambient
-"Cargo-feature-pulls-everything-in" surprises.
+to expose to subprocesses.
+
+### Trade-off — explicit registration vs. Cargo-feature ambient availability
+
+The pre-#529 mental model was implicit: a Cargo feature like
+`streamlib/adapter-cpu-readback` would compile the adapter in and
+the runtime would discover it ambiently (via `inventory` registration
+or similar). That's not how this works anymore. With
+`install_setup_hook` the model is:
+
+1. Add the adapter crate as a Cargo dep.
+2. Call `runtime.install_setup_hook(...)` exactly once at app
+   startup, doing the adapter's required pre-start work (allocate
+   host surfaces, register in surface-share, set bridge if needed).
+
+The cost: one extra line of wiring per adapter at the application's
+`main.rs`. Compile-time presence is no longer enough — you have to
+explicitly hand the adapter the resources it manages. Embedded /
+headless deployments that just want "everything that compiled in to
+be available" pay a real, if small, ergonomic cost here.
+
+What we get for that cost (and why it was the right call):
+
+- **Explicit and greppable.** `git grep install_setup_hook` tells
+  you exactly which adapters this runtime exposes to subprocesses
+  and what host surfaces it pre-allocates. No ambient surprises
+  ("wait, why is cpu-readback available, I didn't enable it?").
+- **Lifetime control.** The hook captures the adapter `Arc`, so the
+  application owns when the adapter is destroyed. A Cargo feature
+  can't express lifetime — it'd either leak per-process state for
+  the whole binary's life, or hand-roll a separate teardown path.
+- **Per-runtime configuration.** Multiple `StreamRuntime` instances
+  in the same process can wire different adapter sets, or wire the
+  same adapter against different surface dimensions / DRM modifiers
+  / quality knobs. Cargo features are per-binary; this is per-runtime.
+- **No magic about required setup.** Every adapter has *some*
+  pre-start work — at minimum allocating one or more host surfaces
+  and registering them. A Cargo feature flag can't do that work; it
+  can only flip a compile-time bit. The hook makes the work the
+  application has to do for that adapter visible at the call site,
+  next to the surface-allocation arguments.
+- **Type safety on bridge wiring.** `gpu.set_cpu_readback_bridge(...)`
+  takes a typed `Arc<dyn CpuReadbackBridge>` — wrong-type bridges
+  are a compile error. A feature-flag-driven registration would
+  funnel everything through a generic registry and lose that.
+
+When this trade-off becomes painful and what to do about it: if
+applications start writing the same five-line adapter setup
+boilerplate over and over, the right answer is a per-adapter
+`install_default` convenience helper (e.g.
+`streamlib_adapter_cpu_readback::install_default(&runtime, surface_size)`)
+that internally calls `install_setup_hook` with sensible defaults.
+The convenience helper is opt-in and additive; the underlying
+explicit API stays as the escape hatch. Don't replace explicit
+registration with implicit feature-flag discovery — the auditability
+property is load-bearing.
 
 ## Implementation issues
 

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -314,6 +314,51 @@ this design — the working hypothesis may not fit:
   different shape, this section needs updating. Marked as a
   trip-wire above.
 
+## Runtime wiring — `install_setup_hook`
+
+> Added 2026-04-27 (#529). All adapter integrations register their
+> host-side state through this single API.
+
+Every surface adapter's host-side wiring runs through
+[`StreamRuntime::install_setup_hook`][hook]. The hook fires exactly
+once per `start()`, after `GpuContext::init_for_platform_sync` has
+created the live `GpuContext` but before any processor's `setup()`
+runs — the window where adapter bridges and pre-allocated host
+surfaces have to be in place.
+
+[hook]: ../../libs/streamlib/src/core/runtime/runtime.rs
+
+The shape of what the hook does varies by seam:
+
+- **Surface-share seam** (Vulkan, OpenGL, Skia). The hook allocates
+  the host's `StreamTexture` (via
+  `gpu.acquire_render_target_dma_buf_image` for render-target-capable
+  DMA-BUF), registers it in surface-share with a known UUID via
+  `gpu.surface_store().register_texture(uuid, &texture)`, and stashes
+  any per-runtime sync state the adapter needs (timeline semaphores,
+  DRM modifier records). No bridge — every subprocess acquire is a
+  one-shot `check_out`.
+- **Escalate-IPC seam** (cpu-readback). The hook constructs the
+  `CpuReadbackSurfaceAdapter`, allocates + registers the host
+  surface(s) it serves, and registers a `CpuReadbackBridge`
+  implementation on the GpuContext via
+  `gpu.set_cpu_readback_bridge(...)`. The bridge is the dispatch
+  target the escalate handler reaches when a subprocess sends
+  `acquire_cpu_readback`.
+
+Reference implementation:
+`examples/polyglot-cpu-readback-blur/src/main.rs`. That example shows
+the cpu-readback case (which exercises the bridge path); the GPU
+adapters use the same hook but skip the `set_*_bridge` step.
+
+The hook is the canonical opt-in registration point. Future adapters
+that need pre-start GpuContext access should use it; adapters that
+need per-acquire host work should also expose a `set_*_bridge` setter
+on `GpuContext` mirroring `set_cpu_readback_bridge`. Application
+authors call `install_setup_hook` exactly once per adapter they want
+to expose to subprocesses — explicit, greppable, no ambient
+"Cargo-feature-pulls-everything-in" surprises.
+
 ## Implementation issues
 
 The subprocess runtimes for the three already-shipped adapters

--- a/examples/polyglot-cpu-readback-blur/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-cpu-readback-blur-scenario"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback" }
+serde_json = "1.0"
+png = "0.17"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+vulkanalia = { workspace = true }

--- a/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
+++ b/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot cpu-readback blur processor — Deno twin of
+ * `python/cpu_readback_blur.py` (#529).
+ *
+ * Receives a trigger Videoframe, opens the host-pre-allocated
+ * cpu-readback surface through `CpuReadbackContext.acquireWrite`,
+ * applies a hand-rolled separable Gaussian blur to the BGRA bytes,
+ * and releases — the host adapter flushes CPU→GPU. After the runtime
+ * stops, the host reads the surface back and writes a PNG that
+ * should visually show the blurred input.
+ *
+ * Deno has no numpy / cv2 binding ecosystem; the Gaussian is
+ * separable so a pure-TS implementation runs in O(N·k) per axis pass
+ * (vs. O(N·k²) for a naive 2D convolution) without external deps.
+ *
+ * Config keys:
+ *     cpu_readback_surface_id (number, required)
+ *         Host-assigned u64 surface id the host pre-registered with
+ *         the cpu-readback adapter.
+ *     kernel_size (number, default 11)
+ *         Gaussian kernel side length (odd integer).
+ *     sigma (number, default 4.0)
+ *         Gaussian sigma.
+ */
+
+import type {
+  ReactiveProcessor,
+  RuntimeContextFullAccess,
+  RuntimeContextLimitedAccess,
+} from "../../../libs/streamlib-deno/mod.ts";
+import { CpuReadbackContext } from "../../../libs/streamlib-deno/adapters/cpu_readback.ts";
+
+export default class CpuReadbackBlurProcessor implements ReactiveProcessor {
+  private surfaceId: bigint = 0n;
+  private kernelSize = 11;
+  private sigma = 4.0;
+  private cpuReadback: CpuReadbackContext | null = null;
+  private blurCount = 0;
+  private errorCount = 0;
+  private lastError: string | null = null;
+
+  setup(ctx: RuntimeContextFullAccess): void {
+    const cfg = ctx.config;
+    const sidRaw = cfg["cpu_readback_surface_id"];
+    if (typeof sidRaw !== "number" && typeof sidRaw !== "bigint") {
+      throw new Error(
+        `[CpuReadbackBlur/deno] cpu_readback_surface_id must be a number, got ${typeof sidRaw}`,
+      );
+    }
+    this.surfaceId = typeof sidRaw === "bigint" ? sidRaw : BigInt(sidRaw);
+    const ksRaw = cfg["kernel_size"];
+    // Force odd
+    this.kernelSize = Math.max(
+      3,
+      ((typeof ksRaw === "number" ? Math.floor(ksRaw) : 11) | 1),
+    );
+    const sigmaRaw = cfg["sigma"];
+    this.sigma = typeof sigmaRaw === "number" ? sigmaRaw : 4.0;
+    this.cpuReadback = CpuReadbackContext.fromRuntime(ctx);
+    console.error(
+      `[CpuReadbackBlur/deno] setup surface_id=${this.surfaceId} ` +
+        `kernel=${this.kernelSize} sigma=${this.sigma}`,
+    );
+  }
+
+  async process(ctx: RuntimeContextLimitedAccess): Promise<void> {
+    // Drain the trigger frame so the upstream port doesn't backpressure.
+    const _frame = ctx.inputs.read("video_in");
+    if (!_frame) return;
+
+    if (this.blurCount > 0) return;
+    if (!this.cpuReadback) {
+      throw new Error(
+        "[CpuReadbackBlur/deno] cpu-readback context not initialized",
+      );
+    }
+
+    try {
+      await this.applyBlurOnce();
+      this.blurCount += 1;
+      console.error(
+        `[CpuReadbackBlur/deno] blur applied (kernel=${this.kernelSize}, ` +
+          `sigma=${this.sigma})`,
+      );
+    } catch (e) {
+      this.errorCount += 1;
+      this.lastError = String(e);
+      console.error(
+        `[CpuReadbackBlur/deno] blur failed (count=${this.errorCount}): ${e}`,
+      );
+    }
+  }
+
+  private async applyBlurOnce(): Promise<void> {
+    await using guard = await this.cpuReadback!.acquireWrite(this.surfaceId);
+    const plane = guard.view.plane(0);
+    const w = plane.width;
+    const h = plane.height;
+    const bpp = plane.bytesPerPixel; // 4 for BGRA8
+    const kernel = buildGaussianKernel(this.kernelSize, this.sigma);
+
+    // Horizontal pass: bytes → tmp. Vertical pass: tmp → bytes.
+    // BGRA: blur B, G, R; leave A alone so the PNG alpha doesn't
+    // softed at the borders.
+    const tmp = new Uint8ClampedArray(plane.bytes.length);
+    separablePassHorizontal(
+      plane.bytes,
+      tmp,
+      w,
+      h,
+      bpp,
+      kernel,
+    );
+    separablePassVertical(
+      tmp,
+      plane.bytes,
+      w,
+      h,
+      bpp,
+      kernel,
+    );
+  }
+
+  teardown(_ctx: RuntimeContextFullAccess): void {
+    console.error(
+      `[CpuReadbackBlur/deno] teardown blurs=${this.blurCount} ` +
+        `errors=${this.errorCount} last_error=${this.lastError}`,
+    );
+  }
+}
+
+/** 1D Gaussian kernel — normalized to sum to 1.0. */
+function buildGaussianKernel(ks: number, sigma: number): Float32Array {
+  const k = new Float32Array(ks);
+  const center = (ks - 1) / 2;
+  let sum = 0;
+  for (let i = 0; i < ks; i += 1) {
+    const x = i - center;
+    const v = Math.exp(-(x * x) / (2 * sigma * sigma));
+    k[i] = v;
+    sum += v;
+  }
+  for (let i = 0; i < ks; i += 1) k[i] /= sum;
+  return k;
+}
+
+/** Apply the kernel along the horizontal axis. Edge pixels replicate.
+ * BGRA: blur channels 0/1/2 (B/G/R), pass channel 3 (A) through. */
+function separablePassHorizontal(
+  src: Uint8Array,
+  dst: Uint8ClampedArray,
+  w: number,
+  h: number,
+  bpp: number,
+  kernel: Float32Array,
+): void {
+  const ks = kernel.length;
+  const half = (ks - 1) >> 1;
+  const stride = w * bpp;
+  for (let y = 0; y < h; y += 1) {
+    const row = y * stride;
+    for (let x = 0; x < w; x += 1) {
+      let sumB = 0, sumG = 0, sumR = 0;
+      for (let i = 0; i < ks; i += 1) {
+        let xi = x + i - half;
+        if (xi < 0) xi = 0;
+        else if (xi >= w) xi = w - 1;
+        const off = row + xi * bpp;
+        const wgt = kernel[i];
+        sumB += src[off] * wgt;
+        sumG += src[off + 1] * wgt;
+        sumR += src[off + 2] * wgt;
+      }
+      const dstOff = row + x * bpp;
+      dst[dstOff] = sumB;
+      dst[dstOff + 1] = sumG;
+      dst[dstOff + 2] = sumR;
+      dst[dstOff + 3] = src[row + x * bpp + 3]; // A passthrough
+    }
+  }
+}
+
+/** Apply the kernel along the vertical axis. Edge pixels replicate. */
+function separablePassVertical(
+  src: Uint8ClampedArray,
+  dst: Uint8Array,
+  w: number,
+  h: number,
+  bpp: number,
+  kernel: Float32Array,
+): void {
+  const ks = kernel.length;
+  const half = (ks - 1) >> 1;
+  const stride = w * bpp;
+  for (let y = 0; y < h; y += 1) {
+    for (let x = 0; x < w; x += 1) {
+      let sumB = 0, sumG = 0, sumR = 0;
+      for (let i = 0; i < ks; i += 1) {
+        let yi = y + i - half;
+        if (yi < 0) yi = 0;
+        else if (yi >= h) yi = h - 1;
+        const off = yi * stride + x * bpp;
+        const wgt = kernel[i];
+        sumB += src[off] * wgt;
+        sumG += src[off + 1] * wgt;
+        sumR += src[off + 2] * wgt;
+      }
+      const dstOff = y * stride + x * bpp;
+      dst[dstOff] = Math.round(sumB);
+      dst[dstOff + 1] = Math.round(sumG);
+      dst[dstOff + 2] = Math.round(sumR);
+      dst[dstOff + 3] = src[y * stride + x * bpp + 3];
+    }
+  }
+}

--- a/examples/polyglot-cpu-readback-blur/deno/deno.json
+++ b/examples/polyglot-cpu-readback-blur/deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+  }
+}

--- a/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-cpu-readback-blur-deno
+  version: "0.1.0"
+  description: "Polyglot cpu-readback adapter blur (#529) — Deno twin with hand-rolled separable Gaussian"
+
+processors:
+  - name: com.tatolab.cpu_readback_blur_deno
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered cpu-readback surface, applies a separable Gaussian blur, releases"
+    runtime: deno
+    execution: reactive
+    entrypoint: "cpu_readback_blur.ts:default"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-cpu-readback-blur/python/cpu_readback_blur.py
+++ b/examples/polyglot-cpu-readback-blur/python/cpu_readback_blur.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot cpu-readback blur processor — Python.
+
+End-to-end gate for the cpu-readback subprocess runtime (#529). The
+host pre-allocates a cpu-readback surface, registers it with the
+adapter, and uploads a vertical-color-band input pattern. This
+processor receives a trigger Videoframe, opens the host surface
+through ``CpuReadbackContext.acquire_write``, applies a Gaussian blur
+to the BGRA bytes, and releases — the host adapter flushes the
+modified bytes back into the surface's `VkImage`. After the runtime
+stops, the host reads the surface back and writes a PNG that should
+visually show the blurred input.
+
+The Gaussian uses ``cv2.GaussianBlur`` if OpenCV is available; falls
+back to a numpy separable kernel if it isn't (so the example still
+runs on hosts without ``opencv-python``). Either path keeps the
+identity-of-bytes invariant: the modified ndarray aliases the host
+staging buffer, so writes happen in place.
+
+Config keys:
+    cpu_readback_surface_id (int, required)
+        Host-assigned u64 surface id the host pre-registered with the
+        cpu-readback adapter. The processor calls
+        ``acquire_write(int(surface_id))`` on that id.
+    kernel_size (int, default 11)
+        Gaussian kernel side length (odd integer). Bigger = more
+        blur. Visual gate works at any size ≥ 5.
+    sigma (float, default 4.0)
+        Gaussian sigma. Bigger = more blur.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+from streamlib.adapters.cpu_readback import CpuReadbackContext
+
+
+class CpuReadbackBlurProcessor:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        cfg = ctx.config
+        self._surface_id = int(cfg["cpu_readback_surface_id"])
+        # Force kernel size to be odd so cv2.GaussianBlur accepts it.
+        self._kernel_size = max(3, int(cfg.get("kernel_size", 11)) | 1)
+        self._sigma = float(cfg.get("sigma", 4.0))
+        self._cpu_readback = CpuReadbackContext.from_runtime(ctx)
+        self._blur_count = 0
+        self._error_count = 0
+        self._last_error: Optional[str] = None
+        print(
+            f"[CpuReadbackBlur/py] setup surface_id={self._surface_id} "
+            f"kernel={self._kernel_size} sigma={self._sigma}",
+            flush=True,
+        )
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        # We don't care about frame contents — frame is the trigger.
+        # Drain it so the upstream port doesn't backpressure.
+        _frame = ctx.inputs.read("video_in")
+        if _frame is None:
+            return
+
+        # Apply blur ONCE — repeat invocations would re-blur an already-
+        # blurred image, which would still validate the wire path but
+        # would obscure the visual gate.
+        if self._blur_count > 0:
+            return
+
+        try:
+            self._apply_blur_once()
+            self._blur_count += 1
+            print(
+                f"[CpuReadbackBlur/py] blur applied (kernel={self._kernel_size}, "
+                f"sigma={self._sigma})",
+                flush=True,
+            )
+        except Exception as e:  # surface, don't crash — host gates on PNG output
+            self._error_count += 1
+            self._last_error = str(e)
+            print(
+                f"[CpuReadbackBlur/py] blur failed (count={self._error_count}): {e}",
+                flush=True,
+            )
+
+    def _apply_blur_once(self) -> None:
+        with self._cpu_readback.acquire_write(self._surface_id) as view:
+            plane = view.plane(0)
+            arr = plane.numpy  # (H, W, 4) BGRA, dtype uint8 — aliases staging
+            blurred = self._gaussian_blur(arr)
+            # In-place copy so the staging buffer ALIAS sees the result.
+            # (Reassigning `arr = blurred` would not write back.)
+            arr[...] = blurred
+
+    def _gaussian_blur(self, arr: Any) -> Any:
+        """Gaussian blur via cv2 if available, numpy fallback otherwise."""
+        try:
+            import cv2  # type: ignore
+            return cv2.GaussianBlur(
+                arr, (self._kernel_size, self._kernel_size), self._sigma
+            )
+        except ImportError:
+            return self._numpy_gaussian_blur(arr)
+
+    def _numpy_gaussian_blur(self, arr: Any) -> Any:
+        """Pure-numpy separable Gaussian blur fallback. Slower than cv2
+        but produces a visually-identical result for our purposes."""
+        import numpy as np
+
+        k = self._build_kernel()
+        # Separable 1D kernel applied along axis 1 (horizontal) then
+        # axis 0 (vertical). Pad with edge replication to avoid dark
+        # borders.
+        pad = self._kernel_size // 2
+        # Don't blur the alpha channel — keep it opaque so the PNG
+        # alpha doesn't go translucent at the borders.
+        rgb = arr[..., :3].astype(np.float32)
+        # Horizontal
+        rgb_h = np.zeros_like(rgb)
+        padded = np.pad(rgb, ((0, 0), (pad, pad), (0, 0)), mode="edge")
+        for i in range(self._kernel_size):
+            rgb_h += k[i] * padded[:, i : i + arr.shape[1], :]
+        # Vertical
+        rgb_v = np.zeros_like(rgb_h)
+        padded = np.pad(rgb_h, ((pad, pad), (0, 0), (0, 0)), mode="edge")
+        for i in range(self._kernel_size):
+            rgb_v += k[i] * padded[i : i + arr.shape[0], :, :]
+        out = np.empty_like(arr)
+        out[..., :3] = np.clip(rgb_v, 0, 255).astype(np.uint8)
+        out[..., 3] = arr[..., 3]
+        return out
+
+    def _build_kernel(self):
+        import math
+
+        import numpy as np
+
+        ks = self._kernel_size
+        sigma = self._sigma
+        center = ks // 2
+        x = np.arange(ks, dtype=np.float64) - center
+        k = np.exp(-(x * x) / (2.0 * sigma * sigma))
+        k /= k.sum()
+        return k.astype(np.float32)
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        print(
+            f"[CpuReadbackBlur/py] teardown blurs={self._blur_count} "
+            f"errors={self._error_count} last_error={self._last_error}",
+            flush=True,
+        )

--- a/examples/polyglot-cpu-readback-blur/python/pyproject.toml
+++ b/examples/polyglot-cpu-readback-blur/python/pyproject.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[project]
+name = "polyglot-cpu-readback-blur"
+version = "0.1.0"
+description = "Polyglot cpu-readback Gaussian blur — Python processor"
+requires-python = ">=3.10"
+dependencies = [
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+    "numpy>=1.24.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-cpu-readback-blur
+  version: "0.1.0"
+  description: "Polyglot cpu-readback adapter blur (#529) — Python cv2.GaussianBlur with numpy fallback"
+
+processors:
+  - name: com.tatolab.cpu_readback_blur
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered cpu-readback surface, applies a Gaussian blur, releases"
+    runtime: python
+    execution: reactive
+    entrypoint: "cpu_readback_blur:CpuReadbackBlurProcessor"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -1,0 +1,384 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Polyglot cpu-readback adapter scenario (#529).
+//!
+//! End-to-end gate for the cpu-readback subprocess runtime: the host
+//! pre-registers ONE cpu-readback surface and uploads a known input
+//! pattern; a Python or Deno polyglot processor opens the surface
+//! through `CpuReadbackContext.acquire_write`, applies a Gaussian blur
+//! (cv2 in Python, hand-rolled separable kernel in Deno), and on
+//! release the host-side adapter flushes CPU→GPU. After the runtime
+//! stops, this binary reads the surface back through the adapter and
+//! writes the result to a PNG. Reading that PNG with the Read tool is
+//! the visual gate — the output must show the blurred input pattern.
+//!
+//! Pipeline shape:
+//!
+//!   ┌──────────────────┐   trigger frame   ┌────────────────────────┐
+//!   │ BgraFileSource   │ ────────────────► │ Polyglot Blur Processor│
+//!   │ (reads tiny      │                   │  (Python / Deno)       │
+//!   │  BGRA fixture)   │                   │  acquires surface_id=1 │
+//!   └──────────────────┘                   │  applies Gaussian blur │
+//!                                          └────────────────────────┘
+//!
+//! BgraFileSource's emitted `Videoframe` is just the trigger that
+//! drives the polyglot processor's `process()` call — the polyglot
+//! processor ignores `frame.surface_id` and works on the
+//! cpu-readback host surface (id `1`) the host pre-registered.
+//!
+//! Build the Python `.slpkg` first:
+//!   cargo run -p streamlib-cli -- pack examples/polyglot-cpu-readback-blur/python
+//!
+//! Run:
+//!   cargo run -p polyglot-cpu-readback-blur-scenario -- \
+//!       --runtime=python --output=/tmp/cpu-readback-blur.png
+//!   cargo run -p polyglot-cpu-readback-blur-scenario -- \
+//!       --runtime=deno   --output=/tmp/cpu-readback-blur.png
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
+use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
+use streamlib_adapter_abi::{SurfaceFormat, SurfaceId};
+use streamlib_adapter_cpu_readback::{
+    CpuReadbackBridgeImpl, CpuReadbackSurfaceAdapter, HostSurfaceRegistration,
+};
+
+/// Single host surface id used throughout this scenario. The polyglot
+/// processor receives this id via its config.
+const SCENARIO_SURFACE_ID: SurfaceId = 1;
+
+/// Square dimensions for the cpu-readback surface. Small enough to
+/// keep the run fast; large enough that a Gaussian blur is visually
+/// obvious in the output PNG.
+const SURFACE_SIZE: u32 = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeKind {
+    Python,
+    Deno,
+}
+
+impl RuntimeKind {
+    fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "python" => Ok(Self::Python),
+            "deno" => Ok(Self::Deno),
+            other => Err(format!(
+                "unknown --runtime value '{other}' (expected 'python' or 'deno')"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Deno => "deno",
+        }
+    }
+
+    fn processor_name(self) -> &'static str {
+        match self {
+            Self::Python => "com.tatolab.cpu_readback_blur",
+            Self::Deno => "com.tatolab.cpu_readback_blur_deno",
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1);
+
+    let mut runtime_kind = RuntimeKind::Python;
+    let mut output_png = PathBuf::from("/tmp/cpu-readback-blur.png");
+    let mut kernel_size: u32 = 11;
+    let mut sigma: f32 = 4.0;
+
+    for a in args {
+        if let Some(value) = a.strip_prefix("--runtime=") {
+            runtime_kind =
+                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+        } else if let Some(value) = a.strip_prefix("--output=") {
+            output_png = PathBuf::from(value);
+        } else if let Some(value) = a.strip_prefix("--kernel-size=") {
+            kernel_size = value.parse().map_err(|e| {
+                StreamError::Configuration(format!("invalid --kernel-size: {e}"))
+            })?;
+        } else if let Some(value) = a.strip_prefix("--sigma=") {
+            sigma = value.parse().map_err(|e| {
+                StreamError::Configuration(format!("invalid --sigma: {e}"))
+            })?;
+        }
+    }
+
+    println!("=== Polyglot cpu-readback adapter scenario (#529) ===");
+    println!("Runtime:     {}", runtime_kind.as_str());
+    println!(
+        "Surface:     {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (id {SCENARIO_SURFACE_ID})"
+    );
+    println!("Blur:        kernel={kernel_size} sigma={sigma}");
+    println!("Output PNG:  {}", output_png.display());
+    println!();
+
+    let runtime = StreamRuntime::new()?;
+
+    // Slot the setup hook will populate with the cpu-readback adapter
+    // it constructs — main.rs reuses this Arc post-stop to read the
+    // surface back for the output PNG.
+    let adapter_slot: Arc<Mutex<Option<Arc<CpuReadbackSurfaceAdapter>>>> =
+        Arc::new(Mutex::new(None));
+
+    {
+        let adapter_slot = Arc::clone(&adapter_slot);
+        runtime.install_setup_hook(move |gpu| {
+            let adapter = Arc::new(CpuReadbackSurfaceAdapter::new(Arc::clone(
+                gpu.device().vulkan_device(),
+            )));
+            register_host_surface(&adapter, gpu)?;
+            upload_input_pattern(&adapter)?;
+            gpu.set_cpu_readback_bridge(Arc::new(CpuReadbackBridgeImpl::new(
+                Arc::clone(&adapter),
+            )));
+            *adapter_slot.lock().unwrap() = Some(adapter);
+            println!("✓ cpu-readback adapter registered, surface uploaded, bridge installed");
+            Ok(())
+        });
+    }
+
+    // Load the polyglot package.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match runtime_kind {
+        RuntimeKind::Python => {
+            let slpkg_path =
+                manifest_dir.join("python/polyglot-cpu-readback-blur-0.1.0.slpkg");
+            if !slpkg_path.exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-cpu-readback-blur/python",
+                    slpkg_path.display()
+                )));
+            }
+            runtime.load_package(&slpkg_path)?;
+        }
+        RuntimeKind::Deno => {
+            let project_path = manifest_dir.join("deno");
+            if !project_path.join("streamlib.yaml").exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Deno project not found: {}",
+                    project_path.display()
+                )));
+            }
+            runtime.load_project(&project_path)?;
+        }
+    }
+
+    // Trigger source: a tiny BGRA fixture that drives Videoframes
+    // through the pipeline so the polyglot processor's `process()` is
+    // invoked. Frame contents are unused (the polyglot processor works
+    // on the pre-registered cpu-readback surface, not the trigger
+    // frame's pixel buffer).
+    let fixture_path = write_trigger_fixture()
+        .map_err(StreamError::Configuration)?;
+
+    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
+        BgraFileSourceProcessor::Config {
+            file_path: fixture_path
+                .to_str()
+                .ok_or_else(|| {
+                    StreamError::Configuration(
+                        "fixture path has non-utf8 component".into(),
+                    )
+                })?
+                .to_string(),
+            width: 4,
+            height: 4,
+            fps: 5,
+            frame_count: 3,
+        },
+    ))?;
+    println!("+ BgraFileSource: {source}");
+
+    let blur_config = serde_json::json!({
+        "cpu_readback_surface_id": SCENARIO_SURFACE_ID,
+        "kernel_size": kernel_size,
+        "sigma": sigma,
+    });
+    let blur = runtime.add_processor(ProcessorSpec::new(
+        runtime_kind.processor_name(),
+        blur_config,
+    ))?;
+    println!("+ Blur:           {blur}");
+
+    runtime.connect(
+        OutputLinkPortRef::new(&source, "video"),
+        InputLinkPortRef::new(&blur, "video_in"),
+    )?;
+    println!("\nPipeline: BgraFileSource → {} blur\n", runtime_kind.as_str());
+
+    println!("Starting pipeline...");
+    runtime.start()?;
+
+    // Give the polyglot processor time to receive at least one trigger
+    // frame and complete the cpu-readback acquire/blur/release cycle.
+    std::thread::sleep(Duration::from_secs(3));
+
+    println!("Stopping pipeline...");
+    runtime.stop()?;
+
+    // Read the surface back through the adapter and write the output
+    // PNG. Reading this PNG with the Read tool is the visual gate.
+    println!("\nReading cpu-readback surface back through the adapter...");
+    let adapter = adapter_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| {
+            StreamError::Runtime(
+                "cpu-readback adapter slot is empty — setup hook never ran"
+                    .into(),
+            )
+        })?;
+    write_output_png(&adapter, &output_png)?;
+    println!("✓ Output PNG written: {}", output_png.display());
+
+    Ok(())
+}
+
+/// Allocate a render-target-capable DMA-BUF VkImage and an exportable
+/// timeline semaphore, then register the pair with the cpu-readback
+/// adapter under [`SCENARIO_SURFACE_ID`].
+fn register_host_surface(
+    adapter: &Arc<CpuReadbackSurfaceAdapter>,
+    gpu: &GpuContext,
+) -> Result<()> {
+    let texture = gpu.acquire_render_target_dma_buf_image(
+        SURFACE_SIZE,
+        SURFACE_SIZE,
+        TextureFormat::Bgra8Unorm,
+    )?;
+    let timeline = Arc::new(
+        VulkanTimelineSemaphore::new(adapter.device().device(), 0).map_err(|e| {
+            StreamError::Configuration(format!("create timeline semaphore: {e}"))
+        })?,
+    );
+    adapter
+        .register_host_surface(
+            SCENARIO_SURFACE_ID,
+            HostSurfaceRegistration {
+                texture,
+                timeline,
+                initial_image_layout: vulkanalia::vk::ImageLayout::UNDEFINED.as_raw(),
+                format: SurfaceFormat::Bgra8,
+            },
+        )
+        .map_err(|e| {
+            StreamError::Configuration(format!("register_host_surface: {e}"))
+        })?;
+    Ok(())
+}
+
+/// Pre-populate the cpu-readback surface with a known input pattern —
+/// vertical color bands so the Gaussian blur's smoothing is obvious in
+/// the output PNG. Uses the adapter's `acquire_write_by_id` API; the
+/// guard's Drop runs the CPU→GPU sync.
+fn upload_input_pattern(adapter: &Arc<CpuReadbackSurfaceAdapter>) -> Result<()> {
+    let mut guard = adapter.acquire_write_by_id(SCENARIO_SURFACE_ID).map_err(|e| {
+        StreamError::Configuration(format!("upload_input_pattern acquire: {e}"))
+    })?;
+
+    {
+        let view = guard.view_mut();
+        let plane = view.plane_mut(0);
+        let bytes = plane.bytes_mut();
+        let stride = (SURFACE_SIZE * 4) as usize;
+        let band_w = (SURFACE_SIZE / 4) as usize;
+
+        // BGRA bands: blue, green, red, white (in BGRA byte order).
+        let bands: [[u8; 4]; 4] = [
+            [255, 0, 0, 255],     // Blue
+            [0, 255, 0, 255],     // Green
+            [0, 0, 255, 255],     // Red
+            [255, 255, 255, 255], // White
+        ];
+
+        for y in 0..SURFACE_SIZE as usize {
+            for x in 0..SURFACE_SIZE as usize {
+                let band = (x / band_w).min(3);
+                let pixel_off = y * stride + x * 4;
+                bytes[pixel_off..pixel_off + 4].copy_from_slice(&bands[band]);
+            }
+        }
+    }
+    drop(guard);
+    Ok(())
+}
+
+/// Write a minimal BGRA fixture file. BgraFileSource reads it
+/// frame-by-frame; the resulting Videoframes are the trigger that
+/// drives the polyglot processor's `process()` call. Frame contents
+/// are unused — the polyglot processor works on the pre-registered
+/// cpu-readback surface, not the trigger frame's pixel buffer.
+fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let path = std::env::temp_dir().join("cpu-readback-blur-trigger.bgra");
+    // 4x4 BGRA × 3 frames = 192 bytes of zeros. Just enough bytes for
+    // BgraFileSource to consume `frame_count=3` × `width*height*4`.
+    let mut f = File::create(&path).map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(&[0u8; 4 * 4 * 4 * 3])
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// Acquire the cpu-readback surface for read, dump the BGRA bytes into
+/// a PNG (BGRA→RGBA channel swap to match PNG color order), write to
+/// `output`. The reader of this PNG is the visual gate that decides
+/// whether the polyglot subprocess actually applied the blur.
+fn write_output_png(
+    adapter: &Arc<CpuReadbackSurfaceAdapter>,
+    output: &std::path::Path,
+) -> Result<()> {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let guard = adapter.acquire_read_by_id(SCENARIO_SURFACE_ID).map_err(|e| {
+        StreamError::Configuration(format!(
+            "acquire_read_by_id for output PNG: {e}"
+        ))
+    })?;
+
+    let view = guard.view();
+    let plane = view.plane(0);
+    let bgra = plane.bytes();
+    let mut rgba = vec![0u8; bgra.len()];
+    for (src, dst) in bgra.chunks_exact(4).zip(rgba.chunks_exact_mut(4)) {
+        dst[0] = src[2]; // R ← B
+        dst[1] = src[1]; // G ← G
+        dst[2] = src[0]; // B ← R
+        dst[3] = src[3]; // A
+    }
+
+    let file = File::create(output).map_err(|e| {
+        StreamError::Configuration(format!(
+            "create output PNG {}: {e}",
+            output.display()
+        ))
+    })?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), SURFACE_SIZE, SURFACE_SIZE);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+    writer
+        .write_image_data(&rgba)
+        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+    Ok(())
+}

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -51,6 +51,29 @@ use crate::view::{
 /// observe the image↔buffer copies.
 const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Per-plane staging-buffer view returned by
+/// [`CpuReadbackSurfaceAdapter::snapshot_plane_geometry`]. The `staging`
+/// `Arc` is cloned from the adapter's owned slot — keeping the buffer
+/// alive while a host bridge surface-share-checks-it-in does NOT extend
+/// its lifetime past surface unregister, but it does prevent the
+/// adapter's slot from being torn down underneath an in-flight bridge
+/// call.
+pub struct CpuReadbackStagingPlane {
+    pub staging: Arc<VulkanPixelBuffer>,
+    pub width: u32,
+    pub height: u32,
+    pub bytes_per_pixel: u32,
+}
+
+/// Snapshot of a registered surface's plane geometry. Used by the
+/// host-side bridge that wraps this adapter for the escalate-IPC seam.
+pub struct CpuReadbackSurfaceSnapshot {
+    pub width: u32,
+    pub height: u32,
+    pub format: SurfaceFormat,
+    pub planes: Vec<CpuReadbackStagingPlane>,
+}
+
 /// Explicit GPU→CPU [`SurfaceAdapter`] implementation.
 ///
 /// Construct with [`Self::new`] passing the host's [`VulkanDevice`].
@@ -189,19 +212,130 @@ impl CpuReadbackSurfaceAdapter {
         self.surfaces.lock().len()
     }
 
+    /// Blocking read acquire keyed by `SurfaceId` instead of a full
+    /// [`StreamlibSurface`] descriptor. The escalate-IPC dispatch path
+    /// uses this — the wire format only carries the id, and the
+    /// adapter's internal per-surface state already holds everything
+    /// the descriptor would supply (transport handles, sync state,
+    /// dimensions, format).
+    pub fn acquire_read_by_id<'g>(
+        &'g self,
+        surface_id: SurfaceId,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let snap = match self.try_begin(surface_id, false)? {
+            Some(s) => s,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id,
+                    holder: "writer".to_string(),
+                });
+            }
+        };
+        self.finalize_acquire(surface_id, false, &snap)?;
+        Ok(ReadGuard::new(self, surface_id, build_read_view(&snap)))
+    }
+
+    /// Blocking write acquire keyed by `SurfaceId`.
+    pub fn acquire_write_by_id<'g>(
+        &'g self,
+        surface_id: SurfaceId,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let snap = match self.try_begin(surface_id, true)? {
+            Some(s) => s,
+            None => {
+                let map = self.surfaces.lock();
+                let holder = match map.get(&surface_id) {
+                    Some(s) if s.write_held => "writer".to_string(),
+                    Some(s) => format!("{} reader(s)", s.read_holders),
+                    None => "unknown".to_string(),
+                };
+                drop(map);
+                return Err(AdapterError::WriteContended {
+                    surface_id,
+                    holder,
+                });
+            }
+        };
+        self.finalize_acquire(surface_id, true, &snap)?;
+        Ok(WriteGuard::new(self, surface_id, build_write_view(&snap)))
+    }
+
+    /// Non-blocking read acquire keyed by `SurfaceId`.
+    pub fn try_acquire_read_by_id<'g>(
+        &'g self,
+        surface_id: SurfaceId,
+    ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
+        let snap = match self.try_begin(surface_id, false)? {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        self.finalize_acquire(surface_id, false, &snap)?;
+        Ok(Some(ReadGuard::new(
+            self,
+            surface_id,
+            build_read_view(&snap),
+        )))
+    }
+
+    /// Non-blocking write acquire keyed by `SurfaceId`.
+    pub fn try_acquire_write_by_id<'g>(
+        &'g self,
+        surface_id: SurfaceId,
+    ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
+        let snap = match self.try_begin(surface_id, true)? {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        self.finalize_acquire(surface_id, true, &snap)?;
+        Ok(Some(WriteGuard::new(
+            self,
+            surface_id,
+            build_write_view(&snap),
+        )))
+    }
+
+    /// Snapshot the per-plane staging buffers for `surface_id` plus
+    /// surface dimensions and format. Returns `None` if the surface is
+    /// not registered. Used by the [`CpuReadbackBridge`] impl in
+    /// subprocess-runtime glue to surface staging buffers via
+    /// surface-share without re-deriving plane geometry.
+    pub fn snapshot_plane_geometry(
+        &self,
+        surface_id: SurfaceId,
+    ) -> Option<CpuReadbackSurfaceSnapshot> {
+        let map = self.surfaces.lock();
+        let state = map.get(&surface_id)?;
+        let planes = state
+            .planes
+            .iter()
+            .map(|p| CpuReadbackStagingPlane {
+                staging: Arc::clone(&p.staging),
+                width: p.width,
+                height: p.height,
+                bytes_per_pixel: p.bytes_per_pixel,
+            })
+            .collect();
+        Some(CpuReadbackSurfaceSnapshot {
+            width: state.width,
+            height: state.height,
+            format: state.format,
+            planes,
+        })
+    }
+
     /// Common acquire path: wait timeline, then issue
     /// `vkCmdCopyImageToBuffer` into the per-plane staging buffers.
     /// Returns the snapshot needed to build a view, with state's
     /// `read_holders` / `write_held` already incremented.
     fn try_begin(
         &self,
-        surface: &StreamlibSurface,
+        surface_id: SurfaceId,
         write: bool,
     ) -> Result<Option<AcquireSnapshot>, AdapterError> {
         let mut map = self.surfaces.lock();
         let state = map
-            .get_mut(&surface.id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+            .get_mut(&surface_id)
+            .ok_or(AdapterError::SurfaceNotFound { surface_id })?;
 
         if state.write_held {
             return Ok(None);
@@ -216,7 +350,7 @@ impl CpuReadbackSurfaceAdapter {
             .texture
             .vulkan_inner()
             .image()
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
+            .ok_or(AdapterError::SurfaceNotFound { surface_id })?;
         let from = state.current_layout;
         let format = state.format;
         let width = state.width;
@@ -714,69 +848,28 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
         &'g self,
         surface: &StreamlibSurface,
     ) -> Result<ReadGuard<'g, Self>, AdapterError> {
-        let snap = match self.try_begin(surface, false)? {
-            Some(s) => s,
-            None => {
-                return Err(AdapterError::WriteContended {
-                    surface_id: surface.id,
-                    holder: "writer".to_string(),
-                });
-            }
-        };
-        self.finalize_acquire(surface.id, false, &snap)?;
-        Ok(ReadGuard::new(self, surface.id, build_read_view(&snap)))
+        self.acquire_read_by_id(surface.id)
     }
 
     fn acquire_write<'g>(
         &'g self,
         surface: &StreamlibSurface,
     ) -> Result<WriteGuard<'g, Self>, AdapterError> {
-        let snap = match self.try_begin(surface, true)? {
-            Some(s) => s,
-            None => {
-                let map = self.surfaces.lock();
-                let holder = match map.get(&surface.id) {
-                    Some(s) if s.write_held => "writer".to_string(),
-                    Some(s) => format!("{} reader(s)", s.read_holders),
-                    None => "unknown".to_string(),
-                };
-                drop(map);
-                return Err(AdapterError::WriteContended {
-                    surface_id: surface.id,
-                    holder,
-                });
-            }
-        };
-        self.finalize_acquire(surface.id, true, &snap)?;
-        Ok(WriteGuard::new(self, surface.id, build_write_view(&snap)))
+        self.acquire_write_by_id(surface.id)
     }
 
     fn try_acquire_read<'g>(
         &'g self,
         surface: &StreamlibSurface,
     ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
-        let snap = match self.try_begin(surface, false)? {
-            Some(s) => s,
-            None => return Ok(None),
-        };
-        self.finalize_acquire(surface.id, false, &snap)?;
-        Ok(Some(ReadGuard::new(self, surface.id, build_read_view(&snap))))
+        self.try_acquire_read_by_id(surface.id)
     }
 
     fn try_acquire_write<'g>(
         &'g self,
         surface: &StreamlibSurface,
     ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
-        let snap = match self.try_begin(surface, true)? {
-            Some(s) => s,
-            None => return Ok(None),
-        };
-        self.finalize_acquire(surface.id, true, &snap)?;
-        Ok(Some(WriteGuard::new(
-            self,
-            surface.id,
-            build_write_view(&snap),
-        )))
+        self.try_acquire_write_by_id(surface.id)
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {

--- a/libs/streamlib-adapter-cpu-readback/src/bridge.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/bridge.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`streamlib::core::context::CpuReadbackBridge`] implementation
+//! that drives this crate's [`CpuReadbackSurfaceAdapter`].
+//!
+//! Application code constructs one `CpuReadbackBridgeImpl` per
+//! `Arc<CpuReadbackSurfaceAdapter>` and registers it on the runtime's
+//! `GpuContext` via
+//! [`streamlib::core::context::GpuContext::set_cpu_readback_bridge`].
+//! After that, any subprocess customer that issues an
+//! `acquire_cpu_readback` escalate request reaches this bridge, which
+//! performs the host-side acquire and hands back per-plane staging
+//! buffers for the escalate handler to publish via surface-share.
+
+use std::sync::Arc;
+
+use streamlib::core::context::{
+    CpuReadbackAccessMode, CpuReadbackAcquired, CpuReadbackBridge, CpuReadbackPlane,
+};
+use streamlib_adapter_abi::{ReadGuard, SurfaceId, WriteGuard};
+
+use crate::adapter::CpuReadbackSurfaceAdapter;
+
+/// Either an active read or write guard from the cpu-readback adapter,
+/// type-erased into the engine-side [`CpuReadbackBridge`] contract.
+/// The variant fields are read by the guards' `Drop` impls only — the
+/// adapter's release-side work (CPU→GPU flush on write + timeline
+/// signal) runs there.
+#[allow(dead_code)]
+enum BridgeGuard {
+    Read(ReadGuard<'static, CpuReadbackSurfaceAdapter>),
+    Write(WriteGuard<'static, CpuReadbackSurfaceAdapter>),
+}
+
+// SAFETY: The guards' lifetime parameter is `'static` only because we
+// extend the borrow via the `Arc<CpuReadbackSurfaceAdapter>` field
+// `_adapter_keepalive` on the bridge — the adapter outlives every
+// guard the bridge produces because guards are always dropped before
+// the bridge itself, and the bridge holds the only reference path that
+// could otherwise drop the adapter.
+unsafe impl Send for BridgeGuard {}
+unsafe impl Sync for BridgeGuard {}
+
+/// `CpuReadbackBridge` impl backed by an in-process
+/// [`CpuReadbackSurfaceAdapter`].
+pub struct CpuReadbackBridgeImpl {
+    adapter: Arc<CpuReadbackSurfaceAdapter>,
+}
+
+impl CpuReadbackBridgeImpl {
+    pub fn new(adapter: Arc<CpuReadbackSurfaceAdapter>) -> Self {
+        Self { adapter }
+    }
+}
+
+impl CpuReadbackBridge for CpuReadbackBridgeImpl {
+    fn acquire(
+        &self,
+        surface_id: SurfaceId,
+        mode: CpuReadbackAccessMode,
+    ) -> Result<CpuReadbackAcquired, String> {
+        // Snapshot plane geometry up-front so the response can describe
+        // the staging buffers without re-locking the adapter after the
+        // acquire (which would otherwise have to expose more internals).
+        let snapshot = self
+            .adapter
+            .snapshot_plane_geometry(surface_id)
+            .ok_or_else(|| {
+                format!(
+                    "cpu-readback bridge: surface_id {surface_id} not registered with adapter"
+                )
+            })?;
+
+        // SAFETY: Extending the guard's lifetime to `'static`. The
+        // guard is owned by `BridgeGuard` boxed below, which itself is
+        // owned by the escalate handler's
+        // `EscalateHandleRegistry::CpuReadback` slot for the duration
+        // of the matching `release_handle`. The adapter is held by
+        // `self.adapter: Arc<CpuReadbackSurfaceAdapter>`; the guards
+        // contain a back-reference to the adapter via
+        // `ReadGuard` / `WriteGuard`, but those references are valid
+        // as long as the bridge (and thus the Arc) lives. The host
+        // runtime drops the registry before dropping the bridge, so
+        // the ordering invariant holds.
+        let adapter_static: &'static CpuReadbackSurfaceAdapter =
+            unsafe { std::mem::transmute(self.adapter.as_ref()) };
+
+        let guard = match mode {
+            CpuReadbackAccessMode::Read => {
+                let g = adapter_static
+                    .acquire_read_by_id(surface_id)
+                    .map_err(|e| format!("cpu-readback adapter.acquire_read failed: {e}"))?;
+                BridgeGuard::Read(g)
+            }
+            CpuReadbackAccessMode::Write => {
+                let g = adapter_static
+                    .acquire_write_by_id(surface_id)
+                    .map_err(|e| format!("cpu-readback adapter.acquire_write failed: {e}"))?;
+                BridgeGuard::Write(g)
+            }
+        };
+
+        let planes = snapshot
+            .planes
+            .into_iter()
+            .map(|p| CpuReadbackPlane {
+                staging: p.staging,
+                width: p.width,
+                height: p.height,
+                bytes_per_pixel: p.bytes_per_pixel,
+            })
+            .collect();
+
+        Ok(CpuReadbackAcquired {
+            width: snapshot.width,
+            height: snapshot.height,
+            format: snapshot.format,
+            planes,
+            guard: Box::new(BridgeGuardKeepalive {
+                _guard: guard,
+                _adapter_keepalive: Arc::clone(&self.adapter),
+            }),
+        })
+    }
+}
+
+/// Keepalive bundle stored as the type-erased guard on
+/// [`CpuReadbackAcquired::guard`]. Drop order matters: the inner
+/// `BridgeGuard` (which holds a reference to the adapter) must drop
+/// before the `Arc<CpuReadbackSurfaceAdapter>`. Rust's struct drop
+/// order is field-declaration order, so `_guard` is dropped first,
+/// then `_adapter_keepalive`.
+struct BridgeGuardKeepalive {
+    _guard: BridgeGuard,
+    _adapter_keepalive: Arc<CpuReadbackSurfaceAdapter>,
+}

--- a/libs/streamlib-adapter-cpu-readback/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/lib.rs
@@ -29,11 +29,15 @@
 #![cfg(target_os = "linux")]
 
 mod adapter;
+mod bridge;
 mod context;
 mod state;
 mod view;
 
-pub use adapter::CpuReadbackSurfaceAdapter;
+pub use adapter::{
+    CpuReadbackStagingPlane, CpuReadbackSurfaceAdapter, CpuReadbackSurfaceSnapshot,
+};
+pub use bridge::CpuReadbackBridgeImpl;
 pub use context::CpuReadbackContext;
 pub use state::HostSurfaceRegistration;
 pub use view::{

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -8,7 +8,46 @@
 /**
  * Polyglot subprocess escalate-on-behalf request (subprocess → host)
  */
-export type EscalateRequest = EscalateRequestAcquireImage | EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestReleaseHandle;
+export type EscalateRequest = EscalateRequestAcquireCpuReadback | EscalateRequestAcquireImage | EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestReleaseHandle;
+
+/**
+ * Access mode for the acquire. `read` triggers a host-side
+ * `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-buffer
+ * FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush back when
+ * the subprocess later calls `release_handle`. Maps onto the cpu-readback
+ * adapter's `acquire_read` / `acquire_write` entrypoints.
+ */
+export enum EscalateRequestAcquireCpuReadbackMode {
+  Read = "read",
+  Write = "write",
+}
+
+export interface EscalateRequestAcquireCpuReadback {
+  op: "acquire_cpu_readback";
+
+  /**
+   * Access mode for the acquire. `read` triggers a host-side
+   * `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-buffer
+   * FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush back when
+   * the subprocess later calls `release_handle`. Maps onto the cpu-readback
+   * adapter's `acquire_read` / `acquire_write` entrypoints.
+   */
+  mode: EscalateRequestAcquireCpuReadbackMode;
+
+  /**
+   * Correlates request with response. UUID string.
+   */
+  request_id: string;
+
+  /**
+   * Host-assigned surface id (the u64 carried by `StreamlibSurface::id`) of
+   * a surface previously registered with the host's cpu-readback adapter via
+   * `register_host_surface`. JTD has no native u64 — the wire form is the
+   * decimal string representation, parsed back into u64 by the host before
+   * dispatch.
+   */
+  surface_id: string;
+}
 
 export interface EscalateRequestAcquireImage {
   op: "acquire_image";

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_response.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_response.ts
@@ -24,12 +24,35 @@ export interface EscalateResponseErr {
   request_id: string;
 }
 
+export interface EscalateResponseOkCpuReadbackPlane {
+  /**
+   * Plane bytes-per-pixel. BGRA/RGBA: 4. NV12 plane 0 (Y): 1. NV12 plane 1 (UV
+   * interleaved): 2.
+   */
+  bytes_per_pixel: number;
+
+  /**
+   * Plane height in texels.
+   */
+  height: number;
+
+  /**
+   * Surface-share UUID for this plane's staging buffer.
+   */
+  staging_surface_id: string;
+
+  /**
+   * Plane width in texels.
+   */
+  width: number;
+}
+
 export interface EscalateResponseOk {
   result: "ok";
 
   /**
-   * Opaque handle returned by the host. For acquire_pixel_buffer this is the
-   * PixelBufferPoolId the host registered with its pixel-buffer pool and
+   * Opaque handle returned by the host. For acquire_pixel_buffer this is
+   * the PixelBufferPoolId the host registered with its pixel-buffer pool and
    * SurfaceStore. For acquire_texture this is a host-side UUID keying the
    * EscalateHandleRegistry's texture slot. For release_handle this echoes the
    * released id.
@@ -40,6 +63,17 @@ export interface EscalateResponseOk {
    * Correlates response with request. Matches request_id in EscalateRequest.
    */
   request_id: string;
+
+  /**
+   * Per-plane staging-buffer descriptors set on `acquire_cpu_readback`
+   * responses. Length equals `SurfaceFormat::plane_count` for the target
+   * surface (1 for BGRA8/RGBA8, 2 for NV12). Each entry's `staging_surface_id`
+   * can be `check_out`ed from the surface-share service to obtain a DMA-BUF FD
+   * over the host-allocated staging `VulkanPixelBuffer` for that plane; mmap
+   * that FD to read or write the plane's tightly-packed bytes (`width * height
+   * * bytes_per_pixel` per plane).
+   */
+  cpu_readback_planes?: EscalateResponseOkCpuReadbackPlane[];
 
   /**
    * Resolved pixel or texture format identifier.
@@ -53,7 +87,8 @@ export interface EscalateResponseOk {
   height?: number;
 
   /**
-   * Resolved usage tokens (set on acquire_texture responses).
+   * Resolved usage tokens (set on acquire_texture responses). Array reflects
+   * the exact flags the host honored.
    */
   usage?: string[];
 

--- a/libs/streamlib-deno/adapters/cpu_readback.ts
+++ b/libs/streamlib-deno/adapters/cpu_readback.ts
@@ -4,11 +4,11 @@
 /**
  * Explicit GPU→CPU surface adapter — Deno customer-facing API.
  *
- * Mirrors the Rust crate `streamlib-adapter-cpu-readback` (#514, #533).
- * The subprocess's actual GPU→CPU copy is performed by the host
- * adapter via per-plane `vkCmdCopyImageToBuffer` against per-plane
- * HOST_VISIBLE staging buffers; this module declares the type shapes
- * a Deno customer programs against.
+ * Mirrors the Rust crate `streamlib-adapter-cpu-readback` (#514, #529,
+ * #533). The subprocess's actual GPU→CPU copy is performed by the
+ * host (the adapter runs in-process on the host and issues
+ * `vkCmdCopyImageToBuffer` against per-plane HOST_VISIBLE staging
+ * buffers).
  *
  *  - `CpuReadbackPlaneView` / `CpuReadbackPlaneViewMut` — per-plane
  *    byte slices (`Uint8Array`) and dimensions in plane texels. NV12
@@ -17,26 +17,52 @@
  *    metadata plus the array of plane views inside `acquireRead` /
  *    `acquireWrite` scopes. `planeCount` reflects the surface's
  *    `SurfaceFormat`: 1 for BGRA8/RGBA8, 2 for NV12.
- *  - `CpuReadbackContext` interface — runtime hands one out;
- *    customers use TC39 `using` blocks for scoped acquire/release.
+ *  - `CpuReadbackContext` — concrete subprocess runtime. Wires the
+ *    SDK's escalate channel (host-side `acquire` / release op) to
+ *    the surface-share `resolveSurface` path (per-plane staging
+ *    buffer mmap). Customers use TC39 `await using` for scoped
+ *    acquire/release.
  *
  * This is the **single sanctioned CPU exit** in the surface-adapter
  * architecture. GPU adapters (`vulkan`, `opengl`, `skia`)
  * deliberately do not expose CPU bytes — switching to this adapter
  * is the contractual signal that you've opted in to a host-side
  * GPU→CPU roundtrip. Do not use this in performance-critical
- * pipelines; the copy is per-acquire and blocks on
- * `vkQueueWaitIdle`.
+ * pipelines; the copy is per-acquire and the host blocks on a
+ * per-submit fence.
+ *
+ * Note: the API here is `async` (Promises + `await using`), unlike
+ * the synchronous Python equivalent. Deno's stdio + the escalate
+ * channel are Promise-based; the language idiom for scoped async
+ * release is `await using`. Customers `await` the acquire, then
+ * leave scope normally — the guard's `[Symbol.asyncDispose]` runs
+ * the release.
  */
 
 import {
   STREAMLIB_ADAPTER_ABI_VERSION,
   type StreamlibSurface,
-  type SurfaceAccessGuard,
   type SurfaceFormat,
 } from "../surface_adapter.ts";
+import type { EscalateChannel, EscalateResponseOk } from "../escalate.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };
+
+/** Minimal subset of `GpuContextLimitedAccess` the cpu-readback runtime
+ * needs: per-plane staging-surface lookup. The full shape lives in
+ * `context.ts`; we type against a structural subset here so tests can
+ * stub it without dragging the FFI in. */
+export interface CpuReadbackGpuLimitedAccess {
+  resolveSurface(stagingSurfaceId: string): {
+    readonly width: number;
+    readonly height: number;
+    readonly bytesPerRow: number;
+    lock(readOnly: boolean): void;
+    unlock(readOnly: boolean): void;
+    asBuffer(): ArrayBuffer;
+    release(): void;
+  };
+}
 
 /** Read-only view of a single plane of an acquired surface. */
 export interface CpuReadbackPlaneView {
@@ -87,23 +113,210 @@ export interface CpuReadbackWriteView {
   plane(index: number): CpuReadbackPlaneViewMut;
 }
 
-/** Public cpu-readback adapter contract. */
-export interface CpuReadbackSurfaceAdapter {
-  acquireRead(
-    surface: StreamlibSurface,
-  ): SurfaceAccessGuard<CpuReadbackReadView>;
-  acquireWrite(
-    surface: StreamlibSurface,
-  ): SurfaceAccessGuard<CpuReadbackWriteView>;
-  tryAcquireRead(
-    surface: StreamlibSurface,
-  ): SurfaceAccessGuard<CpuReadbackReadView> | null;
-  tryAcquireWrite(
-    surface: StreamlibSurface,
-  ): SurfaceAccessGuard<CpuReadbackWriteView> | null;
+/** Async-disposable guard returned by `acquireRead` / `acquireWrite`.
+ * `await using` runs `[Symbol.asyncDispose]` at scope exit, which
+ * unlocks every plane's staging buffer and tells the host to release
+ * the adapter guard (CPU→GPU flush on write + timeline signal). */
+export interface CpuReadbackAccessGuard<V> extends AsyncDisposable {
+  readonly view: V;
+  readonly handleId: string;
 }
 
-/** Customer-facing context. Same shape as the adapter — the runtime
- * wraps the adapter and hands the context out. Mirrors the Rust
- * `CpuReadbackContext`. */
-export type CpuReadbackContext = CpuReadbackSurfaceAdapter;
+const _FORMAT_FROM_WIRE: Record<string, SurfaceFormat> = {
+  bgra8: 0 as SurfaceFormat, // SurfaceFormat.BGRA8
+  rgba8: 1 as SurfaceFormat, // SurfaceFormat.RGBA8
+  nv12: 2 as SurfaceFormat, // SurfaceFormat.NV12
+};
+
+function _formatFromWire(wire: string | undefined): SurfaceFormat {
+  if (!wire) return 0 as SurfaceFormat; // BGRA8 default
+  const fmt = _FORMAT_FROM_WIRE[wire.toLowerCase()];
+  if (fmt === undefined) {
+    throw new Error(
+      `unknown cpu-readback surface format on the wire: ${JSON.stringify(wire)}`,
+    );
+  }
+  return fmt;
+}
+
+function _surfaceIdFrom(surface: StreamlibSurface | bigint | number): bigint {
+  if (typeof surface === "bigint") return surface;
+  if (typeof surface === "number") return BigInt(Math.trunc(surface));
+  // StreamlibSurface descriptor
+  const id = (surface as { id?: bigint | number }).id;
+  if (id === undefined) {
+    throw new TypeError(
+      `CpuReadbackContext: expected StreamlibSurface, bigint, or number — got ${
+        typeof surface
+      }`,
+    );
+  }
+  return typeof id === "bigint" ? id : BigInt(Math.trunc(id));
+}
+
+/** Customer-facing context for the Deno subprocess SDK.
+ *
+ * Customers obtain one via the SDK's `adapters` factory; tests
+ * construct one directly with `new CpuReadbackContext(gpu, escalate)`.
+ *
+ *     await using guard = await ctx.acquireWrite(surface);
+ *     guard.view.plane(0).bytes.set(myImage);
+ *     // [Symbol.asyncDispose] runs at scope exit:
+ *     //   unlock + release every plane staging buffer, then
+ *     //   send release_handle so the host flushes CPU→GPU.
+ */
+export class CpuReadbackContext {
+  private readonly gpu: CpuReadbackGpuLimitedAccess;
+  private readonly escalate: EscalateChannel;
+
+  constructor(gpu: CpuReadbackGpuLimitedAccess, escalate: EscalateChannel) {
+    this.gpu = gpu;
+    this.escalate = escalate;
+  }
+
+  async acquireRead(
+    surface: StreamlibSurface | bigint | number,
+  ): Promise<CpuReadbackAccessGuard<CpuReadbackReadView>> {
+    return await this._acquire(surface, "read", false);
+  }
+
+  async acquireWrite(
+    surface: StreamlibSurface | bigint | number,
+  ): Promise<CpuReadbackAccessGuard<CpuReadbackWriteView>> {
+    return (await this._acquire(
+      surface,
+      "write",
+      true,
+    )) as CpuReadbackAccessGuard<CpuReadbackWriteView>;
+  }
+
+  /** Non-blocking variant. Today the wire format is request/response,
+   * so the host blocks on the bridge call; callers fall back to
+   * `acquireRead` here. A future change can add a dedicated
+   * try-acquire escalate op. */
+  async tryAcquireRead(
+    surface: StreamlibSurface | bigint | number,
+  ): Promise<CpuReadbackAccessGuard<CpuReadbackReadView>> {
+    return await this.acquireRead(surface);
+  }
+
+  async tryAcquireWrite(
+    surface: StreamlibSurface | bigint | number,
+  ): Promise<CpuReadbackAccessGuard<CpuReadbackWriteView>> {
+    return await this.acquireWrite(surface);
+  }
+
+  private async _acquire(
+    surface: StreamlibSurface | bigint | number,
+    mode: "read" | "write",
+    writable: boolean,
+  ): Promise<CpuReadbackAccessGuard<CpuReadbackReadView | CpuReadbackWriteView>> {
+    const surfaceId = _surfaceIdFrom(surface);
+    const response = await this.escalate.acquireCpuReadback(surfaceId, mode);
+    const handleId = response.handle_id;
+
+    let view: CpuReadbackReadView | CpuReadbackWriteView;
+    const lockedHandles: ReturnType<
+      CpuReadbackGpuLimitedAccess["resolveSurface"]
+    >[] = [];
+    try {
+      view = this._buildView(response, writable, lockedHandles);
+    } catch (e) {
+      // Unwind any plane handles already locked, then drop the host's
+      // adapter guard so it doesn't leak.
+      this._releaseLocked(lockedHandles, writable);
+      try {
+        await this.escalate.releaseHandle(handleId);
+      } catch (_releaseErr) {
+        // Surface the original failure — release errors during a
+        // failure unwind are diagnostic-only.
+      }
+      throw e;
+    }
+
+    const release = async () => {
+      this._releaseLocked(lockedHandles, writable);
+      await this.escalate.releaseHandle(handleId);
+    };
+
+    return {
+      view,
+      handleId,
+      [Symbol.asyncDispose]: release,
+    };
+  }
+
+  private _releaseLocked(
+    handles: ReturnType<CpuReadbackGpuLimitedAccess["resolveSurface"]>[],
+    writable: boolean,
+  ): void {
+    // Release in reverse acquire order. Best-effort: a single bad
+    // handle must not block the rest of the cleanup.
+    for (let i = handles.length - 1; i >= 0; i -= 1) {
+      const handle = handles[i];
+      try {
+        handle.unlock(!writable);
+      } catch (_e) { /* swallow */ }
+      try {
+        handle.release();
+      } catch (_e) { /* swallow */ }
+    }
+    handles.length = 0;
+  }
+
+  private _buildView(
+    response: EscalateResponseOk,
+    writable: boolean,
+    lockedHandles: ReturnType<
+      CpuReadbackGpuLimitedAccess["resolveSurface"]
+    >[],
+  ): CpuReadbackReadView | CpuReadbackWriteView {
+    const format = _formatFromWire(response.format);
+    const width = response.width ?? 0;
+    const height = response.height ?? 0;
+    const planeDescriptors = response.cpu_readback_planes ?? [];
+    if (planeDescriptors.length === 0) {
+      throw new Error(
+        "cpu-readback acquire response missing cpu_readback_planes",
+      );
+    }
+
+    const planeViews: (CpuReadbackPlaneView | CpuReadbackPlaneViewMut)[] = [];
+    for (const descriptor of planeDescriptors) {
+      const handle = this.gpu.resolveSurface(descriptor.staging_surface_id);
+      handle.lock(!writable);
+      lockedHandles.push(handle);
+
+      const buf = handle.asBuffer();
+      const expected = handle.bytesPerRow * descriptor.height;
+      // The mmap may be larger than the tightly-packed plane (e.g. the
+      // staging buffer was sized to bytesPerRow*height but the response
+      // describes plane geometry). Slice to the descriptor extent so
+      // customer-visible bytes match the documented shape.
+      const bytes = new Uint8Array(buf, 0, expected);
+      planeViews.push({
+        width: descriptor.width,
+        height: descriptor.height,
+        bytesPerPixel: descriptor.bytes_per_pixel,
+        rowStride: descriptor.width * descriptor.bytes_per_pixel,
+        bytes,
+      });
+    }
+
+    return {
+      width,
+      height,
+      format,
+      planeCount: planeViews.length,
+      planes: planeViews,
+      plane(index: number) {
+        if (index < 0 || index >= planeViews.length) {
+          throw new RangeError(
+            `cpu-readback plane index ${index} out of range (0..${planeViews.length})`,
+          );
+        }
+        return planeViews[index];
+      },
+    } as CpuReadbackReadView | CpuReadbackWriteView;
+  }
+}

--- a/libs/streamlib-deno/adapters/cpu_readback.ts
+++ b/libs/streamlib-deno/adapters/cpu_readback.ts
@@ -44,6 +44,7 @@ import {
   type StreamlibSurface,
   type SurfaceFormat,
 } from "../surface_adapter.ts";
+import { getChannel } from "../escalate.ts";
 import type { EscalateChannel, EscalateResponseOk } from "../escalate.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };
@@ -172,6 +173,18 @@ export class CpuReadbackContext {
   constructor(gpu: CpuReadbackGpuLimitedAccess, escalate: EscalateChannel) {
     this.gpu = gpu;
     this.escalate = escalate;
+  }
+
+  /**
+   * Build from a typed runtime context. Mirrors Python's
+   * `CpuReadbackContext.from_runtime`. Pulls the process-wide escalate
+   * channel singleton (installed by the subprocess runner) and pairs
+   * it with the runtime context's `gpuLimitedAccess`.
+   */
+  static fromRuntime(
+    ctx: { readonly gpuLimitedAccess: CpuReadbackGpuLimitedAccess },
+  ): CpuReadbackContext {
+    return new CpuReadbackContext(ctx.gpuLimitedAccess, getChannel());
   }
 
   async acquireRead(

--- a/libs/streamlib-deno/adapters/cpu_readback_test.ts
+++ b/libs/streamlib-deno/adapters/cpu_readback_test.ts
@@ -1,0 +1,366 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the Deno cpu-readback subprocess runtime (#529).
+ *
+ * The escalate channel and `gpuLimitedAccess` are stubbed so these
+ * tests assert the wire-protocol glue and view assembly without
+ * spawning a real subprocess or touching a GPU.
+ *
+ * Real subprocess+GPU end-to-end testing ships with the polyglot
+ * E2E harness in `examples/deno-cpu-readback-numpy-blur/`.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  CpuReadbackContext,
+  type CpuReadbackGpuLimitedAccess,
+} from "./cpu_readback.ts";
+import {
+  EscalateChannel,
+  EscalateError,
+  type EscalateOkResponse,
+} from "../escalate.ts";
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/** Stub `GpuSurface` exposing the subset `CpuReadbackGpuLimitedAccess`
+ * needs. Tracks lock/unlock/release calls for assertion. */
+class _FakeStagingHandle {
+  width: number;
+  height: number;
+  bytesPerPixel: number;
+  bytesPerRow: number;
+  buffer: Uint8Array;
+  locks: boolean[] = [];
+  unlocks: boolean[] = [];
+  released = false;
+
+  constructor(width: number, height: number, bytesPerPixel: number) {
+    this.width = width;
+    this.height = height;
+    this.bytesPerPixel = bytesPerPixel;
+    this.bytesPerRow = width * bytesPerPixel;
+    this.buffer = new Uint8Array(this.bytesPerRow * height);
+  }
+
+  lock(readOnly: boolean): void {
+    this.locks.push(readOnly);
+  }
+
+  unlock(readOnly: boolean): void {
+    this.unlocks.push(readOnly);
+  }
+
+  asBuffer(): ArrayBuffer {
+    // Hand out the underlying buffer so the view can mutate it. Deno
+    // typing requires we narrow ArrayBufferLike → ArrayBuffer; this
+    // is safe because Uint8Array always allocates over an ArrayBuffer
+    // unless explicitly given a SharedArrayBuffer (we don't).
+    return this.buffer.buffer as ArrayBuffer;
+  }
+
+  release(): void {
+    this.released = true;
+  }
+}
+
+class _FakeGpu implements CpuReadbackGpuLimitedAccess {
+  resolved: string[] = [];
+  constructor(private readonly handles: Record<string, _FakeStagingHandle>) {}
+
+  resolveSurface(stagingId: string) {
+    this.resolved.push(stagingId);
+    const h = this.handles[stagingId];
+    if (!h) {
+      throw new Error(`fake host: unknown staging surface ${stagingId}`);
+    }
+    return h;
+  }
+}
+
+interface _RecordedRequest {
+  op: string;
+  surfaceId?: string;
+  mode?: string;
+  handleId?: string;
+}
+
+class _FakeEscalate {
+  readonly requests: _RecordedRequest[] = [];
+
+  constructor(
+    private readonly acquireResponse: EscalateOkResponse,
+    private readonly acquireError?: Error,
+  ) {}
+
+  async acquireCpuReadback(
+    surfaceId: bigint,
+    mode: "read" | "write",
+  ): Promise<EscalateOkResponse> {
+    this.requests.push({
+      op: "acquire_cpu_readback",
+      surfaceId: surfaceId.toString(),
+      mode,
+    });
+    if (this.acquireError) throw this.acquireError;
+    return await Promise.resolve(this.acquireResponse);
+  }
+
+  async releaseHandle(handleId: string): Promise<EscalateOkResponse> {
+    this.requests.push({ op: "release_handle", handleId });
+    return await Promise.resolve({
+      result: "ok" as const,
+      request_id: "release",
+      handle_id: handleId,
+    });
+  }
+
+  // Methods we don't exercise but the EscalateChannel type expects.
+  acquirePixelBuffer = unused;
+  acquireTexture = unused;
+  logFireAndForget = unused;
+  request = unused;
+  handleIncoming = unused;
+  cancelAll = unused;
+}
+
+// deno-lint-ignore no-explicit-any
+const unused: any = () => {
+  throw new Error("not implemented in test stub");
+};
+
+// ---------------------------------------------------------------------------
+// Response builders
+// ---------------------------------------------------------------------------
+
+function bgraAcquireResponse(
+  handleId = "host-handle-bgra",
+): EscalateOkResponse {
+  return {
+    result: "ok" as const,
+    request_id: "req-1",
+    handle_id: handleId,
+    width: 4,
+    height: 2,
+    format: "bgra8",
+    cpu_readback_planes: [
+      {
+        staging_surface_id: "stg-bgra-0",
+        width: 4,
+        height: 2,
+        bytes_per_pixel: 4,
+      },
+    ],
+  };
+}
+
+function nv12AcquireResponse(
+  handleId = "host-handle-nv12",
+): EscalateOkResponse {
+  return {
+    result: "ok" as const,
+    request_id: "req-nv12",
+    handle_id: handleId,
+    width: 8,
+    height: 4,
+    format: "nv12",
+    cpu_readback_planes: [
+      {
+        staging_surface_id: "stg-nv12-y",
+        width: 8,
+        height: 4,
+        bytes_per_pixel: 1,
+      },
+      {
+        staging_surface_id: "stg-nv12-uv",
+        width: 4,
+        height: 2,
+        bytes_per_pixel: 2,
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test("acquireWrite BGRA — view aliases staging buffer; release fires on dispose", async () => {
+  const handle = new _FakeStagingHandle(4, 2, 4);
+  const gpu = new _FakeGpu({ "stg-bgra-0": handle });
+  const escalate = new _FakeEscalate(bgraAcquireResponse());
+  const ctx = new CpuReadbackContext(
+    gpu,
+    escalate as unknown as EscalateChannel,
+  );
+
+  {
+    await using guard = await ctx.acquireWrite(42n);
+    assertEquals(guard.handleId, "host-handle-bgra");
+    assertEquals(guard.view.planeCount, 1);
+    const plane = guard.view.plane(0);
+    assertEquals(plane.width, 4);
+    assertEquals(plane.height, 2);
+    assertEquals(plane.bytesPerPixel, 4);
+    assertEquals(plane.rowStride, 16);
+    assertEquals(plane.bytes.byteLength, 32); // 4 cols × 2 rows × 4 bytes
+    // Mutate via the alias; the staging buffer sees the write.
+    plane.bytes.fill(0xff);
+    assertEquals(handle.buffer[0], 0xff);
+    assertEquals(handle.buffer[31], 0xff);
+  }
+
+  // Order: acquire → release. surface_id marshalled as decimal string.
+  assertEquals(escalate.requests.length, 2);
+  assertEquals(escalate.requests[0].op, "acquire_cpu_readback");
+  assertEquals(escalate.requests[0].surfaceId, "42");
+  assertEquals(escalate.requests[0].mode, "write");
+  assertEquals(escalate.requests[1].op, "release_handle");
+  assertEquals(escalate.requests[1].handleId, "host-handle-bgra");
+  // Lifecycle: locked-for-write, unlocked-for-write, released.
+  assertEquals(handle.locks, [false]);
+  assertEquals(handle.unlocks, [false]);
+  assertEquals(handle.released, true);
+});
+
+Deno.test("acquireRead uses read-only lock", async () => {
+  const handle = new _FakeStagingHandle(4, 2, 4);
+  const gpu = new _FakeGpu({ "stg-bgra-0": handle });
+  const escalate = new _FakeEscalate(bgraAcquireResponse("read-h"));
+  const ctx = new CpuReadbackContext(
+    gpu,
+    escalate as unknown as EscalateChannel,
+  );
+
+  {
+    await using _guard = await ctx.acquireRead(7);
+    // body deliberately empty — assertion is on the lifecycle below.
+  }
+
+  assertEquals(escalate.requests[0].mode, "read");
+  assertEquals(handle.locks, [true]);
+  assertEquals(handle.unlocks, [true]);
+  assertEquals(handle.released, true);
+});
+
+Deno.test("acquireWrite NV12 exposes Y + UV planes with correct geometry", async () => {
+  const y = new _FakeStagingHandle(8, 4, 1);
+  const uv = new _FakeStagingHandle(4, 2, 2);
+  const gpu = new _FakeGpu({ "stg-nv12-y": y, "stg-nv12-uv": uv });
+  const escalate = new _FakeEscalate(nv12AcquireResponse());
+  const ctx = new CpuReadbackContext(
+    gpu,
+    escalate as unknown as EscalateChannel,
+  );
+
+  {
+    await using guard = await ctx.acquireWrite(99n);
+    assertEquals(guard.view.planeCount, 2);
+    const yp = guard.view.plane(0);
+    const uvp = guard.view.plane(1);
+    assertEquals([yp.width, yp.height, yp.bytesPerPixel], [8, 4, 1]);
+    assertEquals(yp.bytes.byteLength, 32);
+    assertEquals([uvp.width, uvp.height, uvp.bytesPerPixel], [4, 2, 2]);
+    assertEquals(uvp.bytes.byteLength, 16);
+    // Independent backing — write to Y must not touch UV.
+    yp.bytes.fill(200);
+    let sum = 0;
+    for (let i = 0; i < uv.buffer.length; i += 1) sum += uv.buffer[i];
+    assertEquals(sum, 0);
+  }
+
+  assertEquals(gpu.resolved, ["stg-nv12-y", "stg-nv12-uv"]);
+  assertEquals(y.released, true);
+  assertEquals(uv.released, true);
+});
+
+Deno.test("release_handle still fires when view assembly fails mid-acquire", async () => {
+  const y = new _FakeStagingHandle(8, 4, 1);
+  // Deliberately omit stg-nv12-uv to force resolveSurface to throw.
+  const gpu = new _FakeGpu({ "stg-nv12-y": y });
+  const escalate = new _FakeEscalate(nv12AcquireResponse("nv12-h"));
+  const ctx = new CpuReadbackContext(
+    gpu,
+    escalate as unknown as EscalateChannel,
+  );
+
+  await assertRejects(
+    () => ctx.acquireWrite(99n),
+    Error,
+    "unknown staging surface",
+  );
+
+  // Y plane was locked then unlocked + released on the unwind path.
+  assertEquals(y.locks, [false]);
+  assertEquals(y.unlocks, [false]);
+  assertEquals(y.released, true);
+  // release_handle still fired even though acquire raised.
+  const releaseCalls = escalate.requests.filter((r) =>
+    r.op === "release_handle"
+  );
+  assertEquals(releaseCalls.length, 1);
+  assertEquals(releaseCalls[0].handleId, "nv12-h");
+});
+
+Deno.test("acquireWrite propagates EscalateError from the host", async () => {
+  const escalate = new _FakeEscalate(
+    bgraAcquireResponse(),
+    new EscalateError("host returned err: surface 42 not registered"),
+  );
+  const ctx = new CpuReadbackContext(
+    new _FakeGpu({}),
+    escalate as unknown as EscalateChannel,
+  );
+
+  await assertRejects(
+    () => ctx.acquireWrite(42n),
+    EscalateError,
+    "not registered",
+  );
+  // No release_handle should fire when the acquire never succeeded.
+  assertEquals(
+    escalate.requests.filter((r) => r.op === "release_handle").length,
+    0,
+  );
+});
+
+Deno.test("acquireCpuReadback wire format encodes surface_id as decimal string", async () => {
+  // EscalateChannel.acquireCpuReadback marshals bigint to a decimal
+  // string per the JTD wire format. Capture the writer payload and
+  // feed back a synthetic ok response so the promise resolves cleanly.
+  let captured: Record<string, unknown> | null = null;
+  let channel: EscalateChannel | null = null;
+  const writer = (msg: Record<string, unknown>) => {
+    captured = msg;
+    // Schedule the synthetic response on the next microtask so the
+    // pending map has the entry by the time we deliver it.
+    queueMicrotask(() => {
+      channel!.handleIncoming({
+        rpc: "escalate_response",
+        result: "ok",
+        request_id: msg.request_id,
+        handle_id: "captured",
+      });
+    });
+    return Promise.resolve();
+  };
+  channel = new EscalateChannel(writer);
+  await channel.acquireCpuReadback(0xdeadbeefn, "write");
+  assertEquals(captured!.op, "acquire_cpu_readback");
+  assertEquals(captured!.surface_id, "3735928559");
+  assertEquals(captured!.mode, "write");
+});
+
+Deno.test("acquireCpuReadback rejects invalid mode locally", async () => {
+  const channel = new EscalateChannel(() => Promise.resolve());
+  await assertRejects(
+    // deno-lint-ignore no-explicit-any
+    () => channel.acquireCpuReadback(1n, "read-only" as any),
+    EscalateError,
+    "must be 'read' or 'write'",
+  );
+});

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -229,3 +229,28 @@ export class EscalateChannel {
     return `dn-${Date.now().toString(36)}-${this.counter}`;
   }
 }
+
+/**
+ * Process-wide escalate channel singleton — mirror of Python's
+ * `streamlib.escalate.channel()`. Subprocess runner installs it after
+ * wiring the bridge stdio pipes; processor code (and SDK helpers like
+ * `CpuReadbackContext.fromRuntime`) reach for it via `getChannel()`.
+ *
+ * Throws if the channel hasn't been installed — that only happens when
+ * processor code runs outside the normal subprocess_runner lifecycle
+ * (e.g. bare unit tests without a host).
+ */
+let _channelSingleton: EscalateChannel | null = null;
+
+export function installChannel(channel: EscalateChannel): void {
+  _channelSingleton = channel;
+}
+
+export function getChannel(): EscalateChannel {
+  if (_channelSingleton === null) {
+    throw new EscalateError(
+      "escalate channel not installed — getChannel() is only available inside the subprocess lifecycle",
+    );
+  }
+  return _channelSingleton;
+}

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -19,11 +19,13 @@
 
 import type {
   EscalateRequest,
+  EscalateRequestAcquireCpuReadback,
   EscalateRequestAcquirePixelBuffer,
   EscalateRequestAcquireTexture,
   EscalateRequestLog,
   EscalateRequestReleaseHandle,
 } from "./_generated_/com_streamlib_escalate_request.ts";
+import { EscalateRequestAcquireCpuReadbackMode } from "./_generated_/com_streamlib_escalate_request.ts";
 import type {
   EscalateResponse,
   EscalateResponseErr,
@@ -32,6 +34,7 @@ import type {
 
 export type {
   EscalateRequest,
+  EscalateRequestAcquireCpuReadback,
   EscalateRequestAcquirePixelBuffer,
   EscalateRequestAcquireTexture,
   EscalateRequestLog,
@@ -40,6 +43,7 @@ export type {
   EscalateResponseErr,
   EscalateResponseOk,
 };
+export { EscalateRequestAcquireCpuReadbackMode };
 
 /** Backwards-compat alias for the `ok` variant of [`EscalateResponse`]. */
 export type EscalateOkResponse = EscalateResponseOk;
@@ -55,6 +59,7 @@ export const ESCALATE_RESPONSE_RPC = "escalate_response";
  * `request_id` when serializing onto the wire.
  */
 export type EscalateOpPayload =
+  | Omit<EscalateRequestAcquireCpuReadback, "request_id">
   | Omit<EscalateRequestAcquirePixelBuffer, "request_id">
   | Omit<EscalateRequestAcquireTexture, "request_id">
   | Omit<EscalateRequestReleaseHandle, "request_id">;
@@ -108,6 +113,40 @@ export class EscalateChannel {
       height,
       format,
       usage: [...usage],
+    });
+  }
+
+  /**
+   * Request a host-side cpu-readback acquire of an already-registered
+   * surface. `surfaceId` is the host-assigned `u64`; we marshal it as
+   * a decimal string per the JTD wire format. `mode` is `"read"` or
+   * `"write"`.
+   *
+   * Returns the `ok`-payload, which includes `cpu_readback_planes` —
+   * a list of per-plane descriptors `{staging_surface_id, width,
+   * height, bytes_per_pixel}` the subprocess uses to `check_out` each
+   * plane's staging buffer from the surface-share service.
+   */
+  async acquireCpuReadback(
+    surfaceId: bigint | number,
+    mode: "read" | "write",
+  ): Promise<EscalateOkResponse> {
+    if (mode !== "read" && mode !== "write") {
+      throw new EscalateError(
+        `acquireCpuReadback: mode must be 'read' or 'write', got ${
+          JSON.stringify(mode)
+        }`,
+      );
+    }
+    const wireMode = mode === "read"
+      ? EscalateRequestAcquireCpuReadbackMode.Read
+      : EscalateRequestAcquireCpuReadbackMode.Write;
+    return this.request({
+      op: "acquire_cpu_readback",
+      surface_id: typeof surfaceId === "bigint"
+        ? surfaceId.toString()
+        : Math.trunc(surfaceId).toString(),
+      mode: wireMode,
     });
   }
 

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -23,7 +23,7 @@ import {
   NativeRuntimeContextFullAccess,
   NativeRuntimeContextLimitedAccess,
 } from "./context.ts";
-import { EscalateChannel } from "./escalate.ts";
+import { EscalateChannel, installChannel } from "./escalate.ts";
 import {
   closeLibcHandle,
   readFrame as readEscalateFrame,
@@ -130,6 +130,10 @@ async function main(): Promise<void> {
   // read site (outer loop + run-phase concurrent reader). Constructed
   // BEFORE installing logging so `log.install` has a channel to drain to.
   const escalateChannel = new EscalateChannel(bridgeSendJson);
+  // Process-wide singleton so SDK helpers (e.g. `CpuReadbackContext`)
+  // can reach the channel without it being threaded through every
+  // call site. Mirrors the Python SDK's `install_channel`.
+  installChannel(escalateChannel);
 
   // Install unified logging: writer task + console / Deno.stdout/stderr
   // interceptors. After this point, `console.*` and `Deno.stdout.write`

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -23,6 +23,7 @@ class EscalateRequest:
     @classmethod
     def from_json_data(cls, data: Any) -> 'EscalateRequest':
         variants: Dict[str, Type[EscalateRequest]] = {
+            "acquire_cpu_readback": EscalateRequestAcquireCPUReadback,
             "acquire_image": EscalateRequestAcquireImage,
             "acquire_pixel_buffer": EscalateRequestAcquirePixelBuffer,
             "acquire_texture": EscalateRequestAcquireTexture,
@@ -34,6 +35,66 @@ class EscalateRequest:
 
     def to_json_data(self) -> Any:
         pass
+
+class EscalateRequestAcquireCPUReadbackMode(Enum):
+    """
+    Access mode for the acquire. `read` triggers a host-side
+    `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-buffer
+    FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush back when
+    the subprocess later calls `release_handle`. Maps onto the cpu-readback
+    adapter's `acquire_read` / `acquire_write` entrypoints.
+    """
+
+    READ = "read"
+    WRITE = "write"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestAcquireCPUReadbackMode':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestAcquireCPUReadback(EscalateRequest):
+    mode: 'EscalateRequestAcquireCPUReadbackMode'
+    """
+    Access mode for the acquire. `read` triggers a host-side
+    `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-buffer
+    FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush back when
+    the subprocess later calls `release_handle`. Maps onto the cpu-readback
+    adapter's `acquire_read` / `acquire_write` entrypoints.
+    """
+
+    request_id: 'str'
+    """
+    Correlates request with response. UUID string.
+    """
+
+    surface_id: 'str'
+    """
+    Host-assigned surface id (the u64 carried by `StreamlibSurface::id`) of
+    a surface previously registered with the host's cpu-readback adapter via
+    `register_host_surface`. JTD has no native u64 — the wire form is the
+    decimal string representation, parsed back into u64 by the host before
+    dispatch.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestAcquireCPUReadback':
+        return cls(
+            "acquire_cpu_readback",
+            _from_json_data(EscalateRequestAcquireCPUReadbackMode, data.get("mode")),
+            _from_json_data(str, data.get("request_id")),
+            _from_json_data(str, data.get("surface_id")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "acquire_cpu_readback" }
+        data["mode"] = _to_json_data(self.mode)
+        data["request_id"] = _to_json_data(self.request_id)
+        data["surface_id"] = _to_json_data(self.surface_id)
+        return data
 
 @dataclass
 class EscalateRequestAcquireImage(EscalateRequest):

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_response.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_response.py
@@ -59,11 +59,52 @@ class EscalateResponseErr(EscalateResponse):
         return data
 
 @dataclass
+class EscalateResponseOkCPUReadbackPlane:
+    bytes_per_pixel: 'int'
+    """
+    Plane bytes-per-pixel. BGRA/RGBA: 4. NV12 plane 0 (Y): 1. NV12 plane 1 (UV
+    interleaved): 2.
+    """
+
+    height: 'int'
+    """
+    Plane height in texels.
+    """
+
+    staging_surface_id: 'str'
+    """
+    Surface-share UUID for this plane's staging buffer.
+    """
+
+    width: 'int'
+    """
+    Plane width in texels.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateResponseOkCPUReadbackPlane':
+        return cls(
+            _from_json_data(int, data.get("bytes_per_pixel")),
+            _from_json_data(int, data.get("height")),
+            _from_json_data(str, data.get("staging_surface_id")),
+            _from_json_data(int, data.get("width")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["bytes_per_pixel"] = _to_json_data(self.bytes_per_pixel)
+        data["height"] = _to_json_data(self.height)
+        data["staging_surface_id"] = _to_json_data(self.staging_surface_id)
+        data["width"] = _to_json_data(self.width)
+        return data
+
+@dataclass
 class EscalateResponseOk(EscalateResponse):
     handle_id: 'str'
     """
-    Opaque handle returned by the host. For acquire_pixel_buffer this is the
-    PixelBufferPoolId the host registered with its pixel-buffer pool and
+    Opaque handle returned by the host. For acquire_pixel_buffer this is
+    the PixelBufferPoolId the host registered with its pixel-buffer pool and
     SurfaceStore. For acquire_texture this is a host-side UUID keying the
     EscalateHandleRegistry's texture slot. For release_handle this echoes the
     released id.
@@ -72,6 +113,17 @@ class EscalateResponseOk(EscalateResponse):
     request_id: 'str'
     """
     Correlates response with request. Matches request_id in EscalateRequest.
+    """
+
+    cpu_readback_planes: 'Optional[List[EscalateResponseOkCPUReadbackPlane]]'
+    """
+    Per-plane staging-buffer descriptors set on `acquire_cpu_readback`
+    responses. Length equals `SurfaceFormat::plane_count` for the target surface
+    (1 for BGRA8/RGBA8, 2 for NV12). Each entry's `staging_surface_id` can be
+    `check_out`ed from the surface-share service to obtain a DMA-BUF FD over
+    the host-allocated staging `VulkanPixelBuffer` for that plane; mmap that
+    FD to read or write the plane's tightly-packed bytes (`width * height *
+    bytes_per_pixel` per plane).
     """
 
     format: 'Optional[str]'
@@ -87,13 +139,13 @@ class EscalateResponseOk(EscalateResponse):
 
     usage: 'Optional[List[str]]'
     """
-    Resolved usage tokens (set on acquire_texture responses).
+    Resolved usage tokens (set on acquire_texture responses). Array reflects the
+    exact flags the host honored.
     """
 
     width: 'Optional[int]'
     """
-    Width in pixels (set on acquire_pixel_buffer and acquire_texture
-    responses).
+    Width in pixels (set on acquire_pixel_buffer and acquire_texture responses).
     """
 
 
@@ -103,6 +155,7 @@ class EscalateResponseOk(EscalateResponse):
             "ok",
             _from_json_data(str, data.get("handle_id")),
             _from_json_data(str, data.get("request_id")),
+            _from_json_data(Optional[List[EscalateResponseOkCPUReadbackPlane]], data.get("cpu_readback_planes")),
             _from_json_data(Optional[str], data.get("format")),
             _from_json_data(Optional[int], data.get("height")),
             _from_json_data(Optional[List[str]], data.get("usage")),
@@ -113,6 +166,8 @@ class EscalateResponseOk(EscalateResponse):
         data = { "result": "ok" }
         data["handle_id"] = _to_json_data(self.handle_id)
         data["request_id"] = _to_json_data(self.request_id)
+        if self.cpu_readback_planes is not None:
+             data["cpu_readback_planes"] = _to_json_data(self.cpu_readback_planes)
         if self.format is not None:
              data["format"] = _to_json_data(self.format)
         if self.height is not None:

--- a/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
@@ -3,12 +3,11 @@
 
 """Explicit GPU→CPU surface adapter — Python customer-facing API.
 
-Mirrors the Rust crate ``streamlib-adapter-cpu-readback`` (#514, #533).
-The subprocess's actual GPU→CPU copy is performed by the host (the
-adapter runs in-process on the host and issues
+Mirrors the Rust crate ``streamlib-adapter-cpu-readback`` (#514, #529,
+#533). The subprocess's actual GPU→CPU copy is performed by the host
+(the adapter runs in-process on the host and issues
 ``vkCmdCopyImageToBuffer`` against per-plane HOST_VISIBLE staging
-buffers). This module provides the type shapes a Python customer
-programs against:
+buffers). This module provides the customer-facing shapes:
 
   * ``CpuReadbackPlaneView`` / ``CpuReadbackPlaneViewMut`` — per-plane
     byte slices and dimensions. For BGRA/RGBA there's exactly one
@@ -16,10 +15,13 @@ programs against:
   * ``CpuReadbackReadView`` / ``CpuReadbackWriteView`` — surface-level
     metadata plus the tuple of plane views the customer sees inside
     ``acquire_read`` / ``acquire_write`` scopes. Each plane view
-    exposes ``bytes`` (a ``bytes`` slice or ``memoryview``) and
-    ``numpy`` (a ``numpy.ndarray`` aliasing the same memory).
-  * ``CpuReadbackContext`` Protocol — the subprocess runtime
-    implements this and hands a customer-facing context out.
+    exposes ``bytes`` (a ``memoryview``) and ``numpy`` (a
+    ``numpy.ndarray`` aliasing the same memory).
+  * ``CpuReadbackContext`` — concrete subprocess runtime. Wraps an
+    escalate channel (for the host-side ``acquire`` / release op)
+    and a ``gpu_limited_access`` (for ``check_out`` of each plane's
+    staging buffer FD). Customers obtain one via the SDK; tests
+    construct one directly with ``CpuReadbackContext.from_runtime``.
   * Acquire-time logging line ``cpu-readback: GPU→CPU copy of NxN
     {format} surface, M bytes total (P planes)`` — emitted by the host
     adapter so customers see they paid for the copy.
@@ -29,15 +31,16 @@ architecture. GPU adapters (``streamlib.adapters.vulkan`` /
 ``opengl`` / ``skia``) deliberately do not expose CPU bytes —
 switching to this adapter is the contractual signal that you've
 opted in to a host-side GPU→CPU roundtrip. Do not use this in
-performance-critical pipelines; the copy is per-acquire and blocks
-on ``vkQueueWaitIdle``.
+performance-critical pipelines; the copy is per-acquire and the
+host blocks on a per-submit fence.
 """
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
+import ctypes
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol, Tuple, runtime_checkable
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple
 
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
@@ -54,7 +57,6 @@ __all__ = [
     "CpuReadbackPlaneViewMut",
     "CpuReadbackReadView",
     "CpuReadbackWriteView",
-    "CpuReadbackSurfaceAdapter",
     "CpuReadbackContext",
 ]
 
@@ -151,33 +153,81 @@ class CpuReadbackWriteView:
         return self.planes[index]
 
 
-@runtime_checkable
-class CpuReadbackSurfaceAdapter(Protocol):
-    """Protocol an in-process Python cpu-readback adapter implements."""
-
-    def acquire_read(
-        self, surface: StreamlibSurface
-    ) -> AbstractContextManager[CpuReadbackReadView]: ...
-
-    def acquire_write(
-        self, surface: StreamlibSurface
-    ) -> AbstractContextManager[CpuReadbackWriteView]: ...
-
-    def try_acquire_read(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[CpuReadbackReadView]]: ...
-
-    def try_acquire_write(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[CpuReadbackWriteView]]: ...
+_FORMAT_FROM_WIRE = {
+    "bgra8": SurfaceFormat.BGRA8,
+    "rgba8": SurfaceFormat.RGBA8,
+    "nv12": SurfaceFormat.NV12,
+}
 
 
-@runtime_checkable
-class CpuReadbackContext(Protocol):
-    """Customer-facing handle the subprocess runtime hands out.
+def _surface_id_from(surface) -> int:
+    """Extract the host-assigned surface_id from a StreamlibSurface
+    Protocol object or an int."""
+    if isinstance(surface, int):
+        return surface
+    sid = getattr(surface, "id", None)
+    if sid is None:
+        raise TypeError(
+            f"CpuReadbackContext: expected StreamlibSurface or int, got {surface!r}"
+        )
+    return int(sid)
 
-    Equivalent shape to the Rust ``CpuReadbackContext`` — thin wrapper
-    over a ``CpuReadbackSurfaceAdapter`` so customer code can write::
+
+def _format_from_wire(wire: Optional[str]) -> SurfaceFormat:
+    if wire is None:
+        # Defensive: the host always sets `format` on
+        # acquire_cpu_readback responses, but if a buggy host omits it
+        # we fall back to BGRA8 — the most common single-plane shape.
+        return SurfaceFormat.BGRA8
+    fmt = _FORMAT_FROM_WIRE.get(wire.lower())
+    if fmt is None:
+        raise ValueError(f"unknown cpu-readback surface format on the wire: {wire!r}")
+    return fmt
+
+
+def _build_plane_view_pair(
+    handle, width: int, height: int, bytes_per_pixel: int
+) -> Tuple["memoryview", "np.ndarray"]:
+    """Construct a `(memoryview, ndarray)` aliasing the locked staging
+    buffer's bytes. Both views share the same backing kernel mmap.
+
+    `handle` is a `NativeGpuSurfaceHandle` already locked for the
+    requested mode. Caller is responsible for ``unlock()`` after the
+    context exits.
+    """
+    import numpy as np
+
+    base = handle.base_address
+    if not base:
+        raise RuntimeError(
+            "cpu-readback: staging surface base address is null after lock — "
+            "the host's surface-share registration may be stale"
+        )
+    byte_size = handle.bytes_per_row * height
+    raw = (ctypes.c_uint8 * byte_size).from_address(base)
+    mv = memoryview(raw).cast("B")
+    # Plane shape: (height, width, bytes_per_pixel). For NV12 UV the
+    # caller sees (H/2, W/2, 2) — half-width × half-height ×
+    # 2 bpp interleaved. Strides match the staging buffer's
+    # tightly-packed row pitch (= width * bpp = bytes_per_row).
+    arr = np.ndarray(
+        shape=(height, width, bytes_per_pixel),
+        dtype=np.uint8,
+        buffer=raw,
+        strides=(handle.bytes_per_row, bytes_per_pixel, 1),
+    )
+    return mv, arr
+
+
+class CpuReadbackContext:
+    """Customer-facing handle bound to the subprocess's escalate channel
+    and surface-share client.
+
+    Customers obtain one via the SDK's ``adapters`` factory; tests build
+    one directly from a ``gpu_limited_access`` and an ``EscalateChannel``
+    via :meth:`from_runtime`.
+
+    Use as a context manager::
 
         with ctx.acquire_write(surface) as view:
             # Single-plane (BGRA): one entry in view.planes.
@@ -192,18 +242,150 @@ class CpuReadbackContext(Protocol):
             uv[...] = chroma_uv
     """
 
+    def __init__(self, gpu_limited_access, escalate_channel) -> None:
+        self._gpu = gpu_limited_access
+        self._escalate = escalate_channel
+
+    @classmethod
+    def from_runtime(cls, runtime_context) -> "CpuReadbackContext":
+        """Build from a typed runtime context (limited or full access).
+
+        The runtime exposes ``gpu_limited_access`` for surface-share
+        lookups; the escalate channel is the process-wide singleton
+        installed by the subprocess runner.
+        """
+        from streamlib.escalate import channel as _escalate_channel
+
+        return cls(runtime_context.gpu_limited_access, _escalate_channel())
+
+    @contextmanager
     def acquire_read(
-        self, surface: StreamlibSurface
-    ) -> AbstractContextManager[CpuReadbackReadView]: ...
+        self, surface
+    ) -> "Iterator[CpuReadbackReadView]":
+        """Block until the host has copied the surface into staging
+        buffers, hand back a read view, and on exit release the host's
+        adapter guard so the timeline can advance."""
+        with self._acquire(surface, mode="read", writable=False) as view:
+            yield view  # type: ignore[misc]
 
+    @contextmanager
     def acquire_write(
-        self, surface: StreamlibSurface
-    ) -> AbstractContextManager[CpuReadbackWriteView]: ...
+        self, surface
+    ) -> "Iterator[CpuReadbackWriteView]":
+        """Block until the host has copied the surface into staging
+        buffers, hand back a write view, and on exit (a) flush mutated
+        bytes back into the host's `VkImage` via
+        `vkCmdCopyBufferToImage`, then (b) release the adapter guard
+        so the timeline release-value signals."""
+        with self._acquire(surface, mode="write", writable=True) as view:
+            yield view  # type: ignore[misc]
 
-    def try_acquire_read(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[CpuReadbackReadView]]: ...
+    def try_acquire_read(self, surface):
+        """Non-blocking read acquire is not yet wired through escalate
+        IPC. Falls back to blocking ``acquire_read`` for now; a future
+        change can add a dedicated escalate op (today the wire format
+        is request/response and the host blocks on the bridge call)."""
+        return self.acquire_read(surface)
 
-    def try_acquire_write(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[CpuReadbackWriteView]]: ...
+    def try_acquire_write(self, surface):
+        """See :meth:`try_acquire_read`."""
+        return self.acquire_write(surface)
+
+    @contextmanager
+    def _acquire(
+        self, surface, mode: str, writable: bool
+    ) -> "Iterator[object]":
+        surface_id = _surface_id_from(surface)
+        response = self._escalate.acquire_cpu_readback(surface_id, mode)
+        handle_id = response["handle_id"]
+
+        try:
+            yield from self._build_view(response, writable)
+        finally:
+            # Always release the host-side adapter guard. Releases happen
+            # in reverse order of acquire — surface-share unmap+release
+            # for each plane (handled by the per-handle release in the
+            # try block above; if we got here without yielding, the
+            # plane handles weren't constructed yet) plus the final
+            # adapter-guard release via release_handle.
+            self._escalate.release_handle(handle_id)
+
+    def _build_view(self, response, writable: bool):
+        """Resolve each plane's staging buffer, lock it, build a view,
+        and yield the assembled read/write view to the caller. Surface
+        unmaps and unlocks happen in reverse order in the finally
+        block."""
+        format_ = _format_from_wire(response.get("format"))
+        width = int(response.get("width", 0))
+        height = int(response.get("height", 0))
+        plane_descriptors = response.get("cpu_readback_planes") or []
+        if not plane_descriptors:
+            raise RuntimeError(
+                "cpu-readback acquire response missing cpu_readback_planes"
+            )
+
+        locked_handles = []
+        plane_views = []
+        try:
+            for descriptor in plane_descriptors:
+                staging_id = descriptor["staging_surface_id"]
+                pwidth = int(descriptor["width"])
+                pheight = int(descriptor["height"])
+                pbpp = int(descriptor["bytes_per_pixel"])
+                handle = self._gpu.resolve_surface(staging_id)
+                handle.lock(read_only=not writable)
+                locked_handles.append(handle)
+                mv, arr = _build_plane_view_pair(
+                    handle, pwidth, pheight, pbpp
+                )
+                if writable:
+                    plane_views.append(
+                        CpuReadbackPlaneViewMut(
+                            width=pwidth,
+                            height=pheight,
+                            bytes_per_pixel=pbpp,
+                            bytes=mv,
+                            numpy=arr,
+                        )
+                    )
+                else:
+                    plane_views.append(
+                        CpuReadbackPlaneView(
+                            width=pwidth,
+                            height=pheight,
+                            bytes_per_pixel=pbpp,
+                            bytes=mv,
+                            numpy=arr,
+                        )
+                    )
+
+            if writable:
+                view = CpuReadbackWriteView(
+                    width=width,
+                    height=height,
+                    format=format_,
+                    planes=tuple(plane_views),
+                )
+            else:
+                view = CpuReadbackReadView(
+                    width=width,
+                    height=height,
+                    format=format_,
+                    planes=tuple(plane_views),
+                )
+            yield view
+        finally:
+            # Release every plane handle we managed to lock — even on
+            # partial failure. Reverse order matches acquire order.
+            for handle in reversed(locked_handles):
+                try:
+                    handle.unlock(read_only=not writable)
+                except Exception:
+                    # Best-effort: the host's release_handle in the
+                    # outer finally still runs and clears the underlying
+                    # surface-share entries.
+                    pass
+                try:
+                    handle.release()
+                except Exception:
+                    pass

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -105,6 +105,34 @@ class EscalateChannel:
             }
         )
 
+    def acquire_cpu_readback(
+        self, surface_id: int, mode: str
+    ) -> Dict[str, Any]:
+        """Request a host-side cpu-readback acquire of an already-registered
+        surface. ``surface_id`` is the host-assigned ``u64`` (we marshal it
+        as decimal string per the JTD wire format). ``mode`` is ``"read"``
+        or ``"write"``.
+
+        Returns the ``ok``-payload dict, which includes
+        ``cpu_readback_planes`` — a list of per-plane descriptors
+        ``{staging_surface_id, width, height, bytes_per_pixel}`` the
+        subprocess uses to ``check_out`` each plane's staging buffer
+        from the surface-share service.
+
+        On failure raises :class:`EscalateError`.
+        """
+        if mode not in ("read", "write"):
+            raise ValueError(
+                f"acquire_cpu_readback: mode must be 'read' or 'write', got {mode!r}"
+            )
+        return self.request(
+            {
+                "op": "acquire_cpu_readback",
+                "surface_id": str(int(surface_id)),
+                "mode": mode,
+            }
+        )
+
     def release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Tell the host to drop its strong reference to ``handle_id``."""
         return self.request(

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cpu_readback.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cpu_readback.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Unit tests for the Python cpu-readback subprocess runtime (#529).
+
+These tests exercise the wire-protocol glue and view assembly without
+spinning up a real subprocess or GPU. The escalate channel and
+``gpu_limited_access`` are stubbed so the test asserts:
+
+* the request shape matches the JTD schema (op / surface_id / mode);
+* per-plane staging surfaces are resolved + locked + unlocked +
+  released in the right order;
+* views expose ``memoryview`` and numpy-array aliases over the same
+  staging memory;
+* failures during plane resolve unwind cleanly (no leaked locks);
+* ``release_handle`` always fires on context exit.
+
+A real subprocess+GPU end-to-end test ships with the polyglot E2E
+harness in ``examples/python-cpu-readback-cv2-blur/``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pytest
+
+from streamlib.adapters.cpu_readback import (
+    CpuReadbackContext,
+    CpuReadbackPlaneView,
+    CpuReadbackPlaneViewMut,
+    CpuReadbackReadView,
+    CpuReadbackWriteView,
+)
+from streamlib.surface_adapter import SurfaceFormat
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeStagingHandle:
+    """Stand-in for ``NativeGpuSurfaceHandle`` backed by a Python bytearray.
+
+    Tracks lock/unlock/release calls so tests can assert the correct
+    teardown order.
+    """
+
+    def __init__(self, width: int, height: int, bytes_per_pixel: int):
+        self.width = width
+        self.height = height
+        self.bytes_per_pixel = bytes_per_pixel
+        self.bytes_per_row = width * bytes_per_pixel
+        self._buffer = (
+            ctypes.c_uint8 * (self.bytes_per_row * height)
+        )()
+        self.locks: List[bool] = []
+        self.unlocks: List[bool] = []
+        self.released = False
+
+    @property
+    def base_address(self) -> int:
+        return ctypes.addressof(self._buffer)
+
+    def lock(self, read_only: bool = True) -> None:
+        self.locks.append(read_only)
+
+    def unlock(self, read_only: bool = True) -> None:
+        self.unlocks.append(read_only)
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeGpuLimitedAccess:
+    """Stand-in for ``NativeGpuContextLimitedAccess.resolve_surface``."""
+
+    def __init__(self, plane_handles: Dict[str, _FakeStagingHandle]):
+        self._handles = plane_handles
+        self.resolved: List[str] = []
+
+    def resolve_surface(self, staging_id: str) -> _FakeStagingHandle:
+        self.resolved.append(staging_id)
+        if staging_id not in self._handles:
+            raise RuntimeError(f"fake host: unknown staging surface {staging_id!r}")
+        return self._handles[staging_id]
+
+
+@dataclass
+class _RecordedRequest:
+    op: str
+    surface_id: Optional[str]
+    mode: Optional[str]
+    handle_id: Optional[str]
+
+
+class _FakeEscalateChannel:
+    """Stand-in for ``EscalateChannel``. Records every request and
+    returns whichever responses the test queued for ``acquire_cpu_readback``
+    and ``release_handle`` ops."""
+
+    def __init__(
+        self,
+        acquire_response: Dict[str, Any],
+        release_response: Optional[Dict[str, Any]] = None,
+    ):
+        self._acquire_response = acquire_response
+        self._release_response = release_response or {
+            "result": "ok",
+            "request_id": "release",
+            "handle_id": "fake-handle",
+        }
+        self.requests: List[_RecordedRequest] = []
+
+    def acquire_cpu_readback(
+        self, surface_id: int, mode: str
+    ) -> Dict[str, Any]:
+        self.requests.append(
+            _RecordedRequest(
+                op="acquire_cpu_readback",
+                surface_id=str(int(surface_id)),
+                mode=mode,
+                handle_id=None,
+            )
+        )
+        return self._acquire_response
+
+    def release_handle(self, handle_id: str) -> Dict[str, Any]:
+        self.requests.append(
+            _RecordedRequest(
+                op="release_handle",
+                surface_id=None,
+                mode=None,
+                handle_id=handle_id,
+            )
+        )
+        return self._release_response
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _bgra_acquire_response(handle_id: str = "host-handle-1") -> Dict[str, Any]:
+    return {
+        "result": "ok",
+        "request_id": "req-1",
+        "handle_id": handle_id,
+        "width": 4,
+        "height": 2,
+        "format": "bgra8",
+        "cpu_readback_planes": [
+            {
+                "staging_surface_id": "stg-bgra-0",
+                "width": 4,
+                "height": 2,
+                "bytes_per_pixel": 4,
+            }
+        ],
+    }
+
+
+def _nv12_acquire_response(handle_id: str = "host-handle-nv12") -> Dict[str, Any]:
+    # NV12 8x4: Y plane 8x4 (1bpp), UV plane 4x2 (2bpp).
+    return {
+        "result": "ok",
+        "request_id": "req-nv12",
+        "handle_id": handle_id,
+        "width": 8,
+        "height": 4,
+        "format": "nv12",
+        "cpu_readback_planes": [
+            {
+                "staging_surface_id": "stg-nv12-y",
+                "width": 8,
+                "height": 4,
+                "bytes_per_pixel": 1,
+            },
+            {
+                "staging_surface_id": "stg-nv12-uv",
+                "width": 4,
+                "height": 2,
+                "bytes_per_pixel": 2,
+            },
+        ],
+    }
+
+
+def test_acquire_write_round_trip_bgra_aliases_staging_buffer():
+    """Customer can mutate the numpy array; the bytes/memoryview view
+    sees the same memory; release_handle fires on exit."""
+    handle = _FakeStagingHandle(width=4, height=2, bytes_per_pixel=4)
+    gpu = _FakeGpuLimitedAccess({"stg-bgra-0": handle})
+    escalate = _FakeEscalateChannel(_bgra_acquire_response())
+    ctx = CpuReadbackContext(gpu, escalate)
+
+    surface_id = 42
+    with ctx.acquire_write(surface_id) as view:
+        assert isinstance(view, CpuReadbackWriteView)
+        assert view.format == SurfaceFormat.BGRA8
+        assert view.width == 4 and view.height == 2
+        assert view.plane_count == 1
+        plane = view.plane(0)
+        assert isinstance(plane, CpuReadbackPlaneViewMut)
+        # Mutate via numpy: paint the entire plane red (BGRA = 00 00 FF FF).
+        plane.numpy[..., :] = (0, 0, 255, 255)
+        # The bytes view sees the same memory (alias, not a copy).
+        assert bytes(plane.bytes[:4]) == b"\x00\x00\xff\xff"
+
+    # Order of requests: acquire then release.
+    assert [r.op for r in escalate.requests] == [
+        "acquire_cpu_readback",
+        "release_handle",
+    ]
+    # Wire format: surface_id is decimal string (JTD has no native u64).
+    acquire = escalate.requests[0]
+    assert acquire.surface_id == str(surface_id)
+    assert acquire.mode == "write"
+    # release_handle echoes the host's handle_id.
+    assert escalate.requests[1].handle_id == "host-handle-1"
+    # Lifecycle: locked-for-write, unlocked-for-write, released.
+    assert handle.locks == [False]
+    assert handle.unlocks == [False]
+    assert handle.released is True
+
+
+def test_acquire_read_uses_read_only_lock_and_returns_immutable_view():
+    handle = _FakeStagingHandle(width=4, height=2, bytes_per_pixel=4)
+    gpu = _FakeGpuLimitedAccess({"stg-bgra-0": handle})
+    escalate = _FakeEscalateChannel(_bgra_acquire_response("read-handle"))
+    ctx = CpuReadbackContext(gpu, escalate)
+
+    with ctx.acquire_read(surface=7) as view:
+        assert isinstance(view, CpuReadbackReadView)
+        assert view.plane_count == 1
+        assert isinstance(view.plane(0), CpuReadbackPlaneView)
+        # The read view's numpy still aliases — we just rely on the
+        # type system + customer convention to not write through it.
+        assert view.plane(0).numpy.shape == (2, 4, 4)
+
+    assert escalate.requests[0].mode == "read"
+    # Read locks the staging surface read-only.
+    assert handle.locks == [True]
+    assert handle.unlocks == [True]
+    assert handle.released is True
+
+
+def test_acquire_write_nv12_exposes_two_planes_with_correct_geometry():
+    y_handle = _FakeStagingHandle(width=8, height=4, bytes_per_pixel=1)
+    uv_handle = _FakeStagingHandle(width=4, height=2, bytes_per_pixel=2)
+    gpu = _FakeGpuLimitedAccess(
+        {"stg-nv12-y": y_handle, "stg-nv12-uv": uv_handle}
+    )
+    escalate = _FakeEscalateChannel(_nv12_acquire_response())
+    ctx = CpuReadbackContext(gpu, escalate)
+
+    with ctx.acquire_write(surface=99) as view:
+        assert view.format == SurfaceFormat.NV12
+        assert view.plane_count == 2
+        y, uv = view.plane(0), view.plane(1)
+        # NV12 plane 0: full-resolution Y, 1 bpp.
+        assert (y.width, y.height, y.bytes_per_pixel) == (8, 4, 1)
+        assert y.numpy.shape == (4, 8, 1)
+        # NV12 plane 1: half-resolution interleaved UV, 2 bpp.
+        assert (uv.width, uv.height, uv.bytes_per_pixel) == (4, 2, 2)
+        assert uv.numpy.shape == (2, 4, 2)
+        # Independent backing — writing to Y must not touch UV.
+        y.numpy[...] = 200
+        assert int(np.asarray(uv.numpy).sum()) == 0
+
+    assert gpu.resolved == ["stg-nv12-y", "stg-nv12-uv"]
+    assert y_handle.released and uv_handle.released
+
+
+def test_release_handle_fires_even_when_view_assembly_fails():
+    """If a plane fails to resolve mid-assembly, the prior planes get
+    unlocked + released and the host-side handle still gets dropped."""
+    y_handle = _FakeStagingHandle(width=8, height=4, bytes_per_pixel=1)
+    # Deliberately omit the UV plane so resolve_surface raises.
+    gpu = _FakeGpuLimitedAccess({"stg-nv12-y": y_handle})
+    escalate = _FakeEscalateChannel(_nv12_acquire_response("nv12-h"))
+    ctx = CpuReadbackContext(gpu, escalate)
+
+    with pytest.raises(RuntimeError, match="unknown staging surface"):
+        with ctx.acquire_write(surface=99) as _view:
+            pytest.fail("should not reach the body — UV resolve failed")
+
+    # Y plane was locked then unlocked + released on the unwind path.
+    assert y_handle.locks == [False]
+    assert y_handle.unlocks == [False]
+    assert y_handle.released is True
+    # release_handle still fired even though acquire raised — the host
+    # would otherwise leak the adapter guard.
+    release_calls = [r for r in escalate.requests if r.op == "release_handle"]
+    assert len(release_calls) == 1
+    assert release_calls[0].handle_id == "nv12-h"
+
+
+def test_acquire_write_propagates_escalate_error():
+    """When the host returns Err, the context manager surfaces it as
+    EscalateError and never enters the body."""
+    from streamlib.escalate import EscalateError
+
+    class _ErrChannel:
+        def acquire_cpu_readback(self, surface_id, mode):
+            raise EscalateError(
+                "host returned err: surface 42 not registered with adapter"
+            )
+
+        def release_handle(self, handle_id):
+            pytest.fail("release_handle must not fire when acquire raised")
+
+    ctx = CpuReadbackContext(
+        _FakeGpuLimitedAccess({}),
+        _ErrChannel(),
+    )
+    with pytest.raises(EscalateError, match="not registered"):
+        with ctx.acquire_write(surface=42) as _:
+            pytest.fail("body must not run")
+
+
+def test_acquire_write_accepts_streamlib_surface_protocol_object():
+    """`CpuReadbackContext` accepts either a bare int or any object
+    with an `id` attribute matching the StreamlibSurface Protocol."""
+
+    @dataclass
+    class _SurfaceLike:
+        id: int
+
+    handle = _FakeStagingHandle(width=4, height=2, bytes_per_pixel=4)
+    gpu = _FakeGpuLimitedAccess({"stg-bgra-0": handle})
+    escalate = _FakeEscalateChannel(_bgra_acquire_response())
+    ctx = CpuReadbackContext(gpu, escalate)
+
+    with ctx.acquire_write(_SurfaceLike(id=12345)) as _:
+        pass
+
+    assert escalate.requests[0].surface_id == "12345"
+
+
+def test_acquire_cpu_readback_rejects_invalid_mode_on_channel():
+    """`EscalateChannel.acquire_cpu_readback` rejects bad modes locally
+    so a typo doesn't end up on the wire."""
+    from streamlib.escalate import EscalateChannel
+
+    # The channel doesn't actually need real pipes for this validation.
+    channel = EscalateChannel.__new__(EscalateChannel)  # bypass __init__
+    with pytest.raises(ValueError, match="must be 'read' or 'write'"):
+        channel.acquire_cpu_readback(42, "read-only")

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -148,6 +148,9 @@ winit = "0.30"  # Window creation and event loop for display processor
 raw-window-handle = "0.6"  # Raw window handle types for Vulkan surface creation
 # Wire-format helpers for the per-runtime surface-sharing socket
 streamlib-surface-client = { path = "../streamlib-surface-client" }
+# Surface adapter ABI types referenced by the host-side CpuReadbackBridge
+# trait (linux-only; the cpu-readback adapter is linux-only).
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
@@ -161,8 +164,6 @@ serial_test = "3.2"  # Run tests sequentially to avoid global PUBSUB interferenc
 tempfile = "3.14"  # Temporary directories for config tests
 criterion = { version = "0.5", features = ["html_reports"] }  # Benches for logging hot path (#447)
 png = "0.17"  # PNG decoding for shader-output fixture comparisons
-# SubprocessCrashHarness for the EPOLLHUP watchdog integration test (#520)
-streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
 
 [[bench]]
 name = "logging"

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -99,6 +99,33 @@ mapping:
             customers' behalf; customers never invoke acquire_image
             directly.
         type: string
+  acquire_cpu_readback:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      surface_id:
+        metadata:
+          description: >
+            Host-assigned surface id (the u64 carried by `StreamlibSurface::id`)
+            of a surface previously registered with the host's cpu-readback
+            adapter via `register_host_surface`. JTD has no native u64 — the
+            wire form is the decimal string representation, parsed back into
+            u64 by the host before dispatch.
+        type: string
+      mode:
+        metadata:
+          description: >
+            Access mode for the acquire. `read` triggers a host-side
+            `vkCmdCopyImageToBuffer` and hands the subprocess read-only
+            staging-buffer FDs; `write` does the same plus a
+            `vkCmdCopyBufferToImage` flush back when the subprocess later
+            calls `release_handle`. Maps onto the cpu-readback adapter's
+            `acquire_read` / `acquire_write` entrypoints.
+        enum:
+          - read
+          - write
   release_handle:
     properties:
       request_id:

--- a/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_response@1.0.0.yaml
@@ -53,6 +53,37 @@ mapping:
             reflects the exact flags the host honored.
         elements:
           type: string
+      cpu_readback_planes:
+        metadata:
+          description: >
+            Per-plane staging-buffer descriptors set on `acquire_cpu_readback`
+            responses. Length equals `SurfaceFormat::plane_count` for the
+            target surface (1 for BGRA8/RGBA8, 2 for NV12). Each entry's
+            `staging_surface_id` can be `check_out`ed from the surface-share
+            service to obtain a DMA-BUF FD over the host-allocated staging
+            `VulkanPixelBuffer` for that plane; mmap that FD to read or
+            write the plane's tightly-packed bytes (`width * height *
+            bytes_per_pixel` per plane).
+        elements:
+          properties:
+            staging_surface_id:
+              metadata:
+                description: "Surface-share UUID for this plane's staging buffer."
+              type: string
+            width:
+              metadata:
+                description: "Plane width in texels."
+              type: uint32
+            height:
+              metadata:
+                description: "Plane height in texels."
+              type: uint32
+            bytes_per_pixel:
+              metadata:
+                description: >
+                  Plane bytes-per-pixel. BGRA/RGBA: 4. NV12 plane 0 (Y): 1.
+                  NV12 plane 1 (UV interleaved): 2.
+              type: uint32
   err:
     properties:
       request_id:

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op")]
 pub enum EscalateRequest {
+    #[serde(rename = "acquire_cpu_readback")]
+    AcquireCpuReadback(EscalateRequestAcquireCpuReadback),
+
     #[serde(rename = "acquire_image")]
     AcquireImage(EscalateRequestAcquireImage),
 
@@ -26,6 +29,45 @@ pub enum EscalateRequest {
 
     #[serde(rename = "release_handle")]
     ReleaseHandle(EscalateRequestReleaseHandle),
+}
+
+/// Access mode for the acquire. `read` triggers a host-side
+/// `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-buffer
+/// FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush back when
+/// the subprocess later calls `release_handle`. Maps onto the cpu-readback
+/// adapter's `acquire_read` / `acquire_write` entrypoints.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestAcquireCpuReadbackMode {
+    #[serde(rename = "read")]
+    #[default]
+    Read,
+
+    #[serde(rename = "write")]
+    Write,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestAcquireCpuReadback {
+    /// Access mode for the acquire. `read` triggers a host-side
+    /// `vkCmdCopyImageToBuffer` and hands the subprocess read-only staging-
+    /// buffer FDs; `write` does the same plus a `vkCmdCopyBufferToImage` flush
+    /// back when the subprocess later calls `release_handle`. Maps onto the
+    /// cpu-readback adapter's `acquire_read` / `acquire_write` entrypoints.
+    #[serde(rename = "mode")]
+    pub mode: EscalateRequestAcquireCpuReadbackMode,
+
+    /// Correlates request with response. UUID string.
+    #[serde(rename = "request_id")]
+    pub request_id: String,
+
+    /// Host-assigned surface id (the u64 carried by `StreamlibSurface::id`) of
+    /// a surface previously registered with the host's cpu-readback adapter via
+    /// `register_host_surface`. JTD has no native u64 — the wire form is the
+    /// decimal string representation, parsed back into u64 by the host before
+    /// dispatch.
+    #[serde(rename = "surface_id")]
+    pub surface_id: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
@@ -31,12 +31,33 @@ pub struct EscalateResponseErr {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct EscalateResponseOkCpuReadbackPlane {
+    /// Plane bytes-per-pixel. BGRA/RGBA: 4. NV12 plane 0 (Y): 1. NV12 plane 1
+    /// (UV interleaved): 2.
+    #[serde(rename = "bytes_per_pixel")]
+    pub bytes_per_pixel: u32,
+
+    /// Plane height in texels.
+    #[serde(rename = "height")]
+    pub height: u32,
+
+    /// Surface-share UUID for this plane's staging buffer.
+    #[serde(rename = "staging_surface_id")]
+    pub staging_surface_id: String,
+
+    /// Plane width in texels.
+    #[serde(rename = "width")]
+    pub width: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EscalateResponseOk {
     /// Opaque handle returned by the host. For acquire_pixel_buffer this is
-    /// the PixelBufferPoolId the host registered with its pixel-buffer pool
-    /// and SurfaceStore. For acquire_texture this is a host-side UUID keying
-    /// the EscalateHandleRegistry's texture slot. For release_handle this
-    /// echoes the released id.
+    /// the PixelBufferPoolId the host registered with its pixel-buffer pool and
+    /// SurfaceStore. For acquire_texture this is a host-side UUID keying the
+    /// EscalateHandleRegistry's texture slot. For release_handle this echoes
+    /// the released id.
     #[serde(rename = "handle_id")]
     pub handle_id: String,
 
@@ -44,22 +65,37 @@ pub struct EscalateResponseOk {
     #[serde(rename = "request_id")]
     pub request_id: String,
 
+    /// Per-plane staging-buffer descriptors set on `acquire_cpu_readback`
+    /// responses. Length equals `SurfaceFormat::plane_count` for the
+    /// target surface (1 for BGRA8/RGBA8, 2 for NV12). Each entry's
+    /// `staging_surface_id` can be `check_out`ed from the surface-share
+    /// service to obtain a DMA-BUF FD over the host-allocated staging
+    /// `VulkanPixelBuffer` for that plane; mmap that FD to read or write the
+    /// plane's tightly-packed bytes (`width * height * bytes_per_pixel` per
+    /// plane).
+    #[serde(rename = "cpu_readback_planes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_readback_planes: Option<Vec<EscalateResponseOkCpuReadbackPlane>>,
+
     /// Resolved pixel or texture format identifier.
     #[serde(rename = "format")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
 
-    /// Height in pixels (set on acquire_pixel_buffer and acquire_texture responses).
+    /// Height in pixels (set on acquire_pixel_buffer and acquire_texture
+    /// responses).
     #[serde(rename = "height")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
 
-    /// Resolved usage tokens (set on acquire_texture responses).
+    /// Resolved usage tokens (set on acquire_texture responses). Array reflects
+    /// the exact flags the host honored.
     #[serde(rename = "usage")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Vec<String>>,
 
-    /// Width in pixels (set on acquire_pixel_buffer and acquire_texture responses).
+    /// Width in pixels (set on acquire_pixel_buffer and acquire_texture
+    /// responses).
     #[serde(rename = "width")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -21,16 +21,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::_generated_::com_streamlib_escalate_request::{
+    EscalateRequestAcquireCpuReadback, EscalateRequestAcquireCpuReadbackMode,
     EscalateRequestAcquireImage, EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
     EscalateRequestLog, EscalateRequestLogLevel, EscalateRequestLogSource,
     EscalateRequestReleaseHandle,
 };
 use crate::_generated_::com_streamlib_escalate_response::{
-    EscalateResponseErr, EscalateResponseOk,
+    EscalateResponseErr, EscalateResponseOk, EscalateResponseOkCpuReadbackPlane,
 };
 use crate::_generated_::{EscalateRequest, EscalateResponse};
 use crate::core::context::{PooledTextureHandle, TexturePoolDescriptor};
 use crate::core::context::GpuContextLimitedAccess;
+#[cfg(target_os = "linux")]
+use crate::core::context::{CpuReadbackAccessMode, CpuReadbackAcquired, CpuReadbackBridge};
 use crate::core::logging::{push_polyglot_record, LogLevel, LogRecord, Source};
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
 
@@ -52,6 +55,7 @@ fn request_id(op: &EscalateRequest) -> Option<&str> {
         EscalateRequest::AcquirePixelBuffer(p) => Some(&p.request_id),
         EscalateRequest::AcquireTexture(p) => Some(&p.request_id),
         EscalateRequest::AcquireImage(p) => Some(&p.request_id),
+        EscalateRequest::AcquireCpuReadback(p) => Some(&p.request_id),
         EscalateRequest::ReleaseHandle(p) => Some(&p.request_id),
         EscalateRequest::Log(_) => None,
     }
@@ -67,6 +71,47 @@ pub(crate) enum RegisteredHandle {
     PixelBuffer(RhiPixelBuffer),
     #[allow(dead_code)]
     Texture(PooledTextureHandle),
+    /// cpu-readback acquire: holds the adapter guard plus the per-plane
+    /// surface-share registrations the escalate handler created. Both
+    /// are torn down together — see [`CpuReadbackHandle::drop`].
+    #[cfg(target_os = "linux")]
+    #[allow(dead_code)]
+    CpuReadback(CpuReadbackHandle),
+}
+
+/// Lifetime bundle for a single cpu-readback acquire. Drop runs the
+/// adapter's release-side work first (CPU→GPU flush on write + timeline
+/// signal), then releases the per-plane surface-share entries so the
+/// subprocess can no longer `check_out` stale staging buffers.
+#[cfg(target_os = "linux")]
+pub(crate) struct CpuReadbackHandle {
+    /// Type-erased `ReadGuard` / `WriteGuard` from the cpu-readback
+    /// adapter. `Option` so Drop can take it before the surface-share
+    /// release loop, keeping ordering explicit.
+    guard: Option<Box<dyn Send + Sync>>,
+    /// Per-plane surface-share IDs registered for this acquire.
+    staging_surface_ids: Vec<String>,
+    /// Surface-share service handle, cloned at insert time so Drop
+    /// doesn't need a sandbox reference.
+    surface_store: crate::core::context::SurfaceStore,
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for CpuReadbackHandle {
+    fn drop(&mut self) {
+        // Drop the adapter guard first so the CPU→GPU flush + timeline
+        // signal complete before the staging buffers are unregistered.
+        self.guard.take();
+        for id in self.staging_surface_ids.drain(..) {
+            if let Err(e) = self.surface_store.release(&id) {
+                tracing::debug!(
+                    "[escalate] cpu-readback staging release for '{}' returned error: {}",
+                    id,
+                    e
+                );
+            }
+        }
+    }
 }
 
 /// Tracks resources acquired on behalf of a subprocess so `release_handle` —
@@ -95,9 +140,39 @@ impl EscalateHandleRegistry {
         map.insert(handle_id, RegisteredHandle::Texture(texture));
     }
 
+    /// Register a cpu-readback acquire so the host keeps the adapter
+    /// guard + per-plane surface-share entries alive until the
+    /// subprocess sends `release_handle`. Linux-only: the cpu-readback
+    /// adapter is Linux-only.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn insert_cpu_readback(&self, handle_id: String, handle: CpuReadbackHandle) {
+        let mut map = self.handles.lock().expect("poisoned");
+        map.insert(handle_id, RegisteredHandle::CpuReadback(handle));
+    }
+
+    /// Remove a handle by id without distinguishing variant. Visible
+    /// for tests; the production `release_handle` path uses
+    /// [`Self::remove_handle_typed`] so it can branch on whether the
+    /// removed entry was a cpu-readback acquire.
+    #[cfg(test)]
     pub(crate) fn remove_handle(&self, handle_id: &str) -> bool {
         let mut map = self.handles.lock().expect("poisoned");
         map.remove(handle_id).is_some()
+    }
+
+    /// Like [`Self::remove_handle`] but reports whether the removed
+    /// entry was a cpu-readback handle. Used by the escalate
+    /// `release_handle` path to skip the generic surface-share release
+    /// (cpu-readback handles clean up their own surface-share entries
+    /// in `Drop`).
+    pub(crate) fn remove_handle_typed(&self, handle_id: &str) -> RemovedHandle {
+        let mut map = self.handles.lock().expect("poisoned");
+        match map.remove(handle_id) {
+            None => RemovedHandle::NotFound,
+            #[cfg(target_os = "linux")]
+            Some(RegisteredHandle::CpuReadback(_)) => RemovedHandle::CpuReadback,
+            Some(_) => RemovedHandle::Generic,
+        }
     }
 
     pub(crate) fn clear(&self) {
@@ -110,6 +185,14 @@ impl EscalateHandleRegistry {
     pub(crate) fn handle_count(&self) -> usize {
         self.handles.lock().expect("poisoned").len()
     }
+}
+
+/// Discriminator returned by [`EscalateHandleRegistry::remove_handle_typed`].
+pub(crate) enum RemovedHandle {
+    NotFound,
+    Generic,
+    #[cfg(target_os = "linux")]
+    CpuReadback,
 }
 
 /// Dispatch an [`EscalateRequest`] against `sandbox`. Returns
@@ -154,6 +237,7 @@ pub(crate) fn handle_escalate_op(
                             height: Some(height),
                             format: Some(pixel_format_to_wire(parsed).to_string()),
                             usage: None,
+                            cpu_readback_planes: None,
                         })
                     }
                     Err(e) => EscalateResponse::Err(EscalateResponseErr {
@@ -209,6 +293,7 @@ pub(crate) fn handle_escalate_op(
                         height: Some(height),
                         format: Some(texture_format_to_wire(parsed_format).to_string()),
                         usage: Some(texture_usages_to_wire(parsed_usage)),
+                        cpu_readback_planes: None,
                     })
                 }
                 Err(e) => EscalateResponse::Err(EscalateResponseErr {
@@ -260,6 +345,7 @@ pub(crate) fn handle_escalate_op(
                             "texture_binding".to_string(),
                             "copy_src".to_string(),
                         ]),
+                        cpu_readback_planes: None,
                     }),
                     Err(e) => EscalateResponse::Err(EscalateResponseErr {
                         request_id: rid,
@@ -276,26 +362,65 @@ pub(crate) fn handle_escalate_op(
                 }))
             }
         }
+        EscalateRequest::AcquireCpuReadback(EscalateRequestAcquireCpuReadback {
+            request_id: _,
+            surface_id,
+            mode,
+        }) => {
+            #[cfg(target_os = "linux")]
+            {
+                Some(handle_acquire_cpu_readback(sandbox, registry, rid, &surface_id, mode))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = (surface_id, mode);
+                Some(EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: "acquire_cpu_readback is only available on Linux".to_string(),
+                }))
+            }
+        }
         EscalateRequest::ReleaseHandle(EscalateRequestReleaseHandle {
             request_id: _,
             handle_id,
         }) => {
-            let removed = registry.remove_handle(&handle_id);
-            Some(if removed {
-                release_surface_share_surface(sandbox, &handle_id);
-                EscalateResponse::Ok(EscalateResponseOk {
-                    request_id: rid,
-                    handle_id,
-                    width: None,
-                    height: None,
-                    format: None,
-                    usage: None,
-                })
-            } else {
-                EscalateResponse::Err(EscalateResponseErr {
+            let removed = registry.remove_handle_typed(&handle_id);
+            Some(match removed {
+                RemovedHandle::NotFound => EscalateResponse::Err(EscalateResponseErr {
                     request_id: rid,
                     message: format!("handle_id '{handle_id}' not found in registry"),
-                })
+                }),
+                RemovedHandle::Generic => {
+                    // Pixel-buffer / texture / image acquires were
+                    // checked into the surface-share service under the
+                    // returned handle_id; pair the registry eviction
+                    // with the matching service release.
+                    release_surface_share_surface(sandbox, &handle_id);
+                    EscalateResponse::Ok(EscalateResponseOk {
+                        request_id: rid,
+                        handle_id,
+                        width: None,
+                        height: None,
+                        format: None,
+                        usage: None,
+                        cpu_readback_planes: None,
+                    })
+                }
+                #[cfg(target_os = "linux")]
+                RemovedHandle::CpuReadback => {
+                    // `CpuReadbackHandle::drop` already released the
+                    // per-plane surface-share registrations and ran the
+                    // adapter's release-side work. Nothing else to do.
+                    EscalateResponse::Ok(EscalateResponseOk {
+                        request_id: rid,
+                        handle_id,
+                        width: None,
+                        height: None,
+                        format: None,
+                        usage: None,
+                        cpu_readback_planes: None,
+                    })
+                }
             })
         }
         EscalateRequest::Log(log_op) => {
@@ -416,6 +541,168 @@ fn assign_image_handle_id(
         store.register_texture(&handle_id, texture)?;
     }
     Ok(handle_id)
+}
+
+/// Map a wire-format `acquire_cpu_readback` request through the
+/// registered [`CpuReadbackBridge`] and surface the per-plane staging
+/// buffers via the host's surface-share service.
+///
+/// Failure modes (each surfaced as an [`EscalateResponse::Err`] keyed
+/// by the original request_id):
+///
+/// 1. `surface_id` doesn't parse as a `u64` — wire format is decimal.
+/// 2. No bridge is registered — the host runtime didn't wire a
+///    cpu-readback adapter into [`crate::core::context::GpuContext::set_cpu_readback_bridge`].
+/// 3. Bridge `acquire` returned an error — typically "surface not
+///    registered" or a Vulkan submit failure inside the adapter.
+/// 4. Surface-share service is not initialized on the host.
+/// 5. `check_in` for any plane staging buffer failed — fully unwinds
+///    any prior plane registrations and drops the adapter guard before
+///    returning so the host doesn't leak DMA-BUF FDs.
+#[cfg(target_os = "linux")]
+fn handle_acquire_cpu_readback(
+    sandbox: &GpuContextLimitedAccess,
+    registry: &EscalateHandleRegistry,
+    rid: String,
+    surface_id_str: &str,
+    mode: EscalateRequestAcquireCpuReadbackMode,
+) -> EscalateResponse {
+    use std::sync::Arc;
+
+    use crate::core::rhi::{RhiPixelBuffer, RhiPixelBufferRef};
+
+    let surface_id: streamlib_adapter_abi::SurfaceId = match surface_id_str.parse() {
+        Ok(v) => v,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!(
+                    "acquire_cpu_readback: surface_id '{surface_id_str}' is not a u64 decimal: {e}"
+                ),
+            });
+        }
+    };
+
+    let bridge_mode = match mode {
+        EscalateRequestAcquireCpuReadbackMode::Read => CpuReadbackAccessMode::Read,
+        EscalateRequestAcquireCpuReadbackMode::Write => CpuReadbackAccessMode::Write,
+    };
+
+    let bridge: Arc<dyn CpuReadbackBridge> = match sandbox.escalate(|full| {
+        full.cpu_readback_bridge().ok_or_else(|| {
+            crate::core::error::StreamError::Configuration(
+                "acquire_cpu_readback: no CpuReadbackBridge registered on GpuContext".into(),
+            )
+        })
+    }) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: e.to_string(),
+            });
+        }
+    };
+
+    let acquired = match bridge.acquire(surface_id, bridge_mode) {
+        Ok(a) => a,
+        Err(msg) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!("acquire_cpu_readback bridge.acquire failed: {msg}"),
+            });
+        }
+    };
+
+    let surface_store = match sandbox.surface_store() {
+        Some(s) => s,
+        None => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: "acquire_cpu_readback: surface-share service not initialized on host"
+                    .into(),
+            });
+        }
+    };
+
+    let mut planes_wire =
+        Vec::<EscalateResponseOkCpuReadbackPlane>::with_capacity(acquired.planes.len());
+    let mut registered_ids: Vec<String> = Vec::with_capacity(acquired.planes.len());
+
+    for plane in &acquired.planes {
+        // Wrap the staging VulkanPixelBuffer in an RhiPixelBuffer so
+        // surface-share's check_in (which exports per-plane DMA-BUF FDs)
+        // can register it. The Arc keeps the staging buffer alive for
+        // the lifetime of the surface-share entry.
+        let pixel_buffer = RhiPixelBuffer::new(RhiPixelBufferRef {
+            inner: Arc::clone(&plane.staging),
+        });
+        match surface_store.check_in(&pixel_buffer) {
+            Ok(plane_surface_id) => {
+                planes_wire.push(EscalateResponseOkCpuReadbackPlane {
+                    staging_surface_id: plane_surface_id.clone(),
+                    width: plane.width,
+                    height: plane.height,
+                    bytes_per_pixel: plane.bytes_per_pixel,
+                });
+                registered_ids.push(plane_surface_id);
+            }
+            Err(e) => {
+                // Unwind: release any prior plane registrations and
+                // drop the adapter guard before returning so the host
+                // doesn't end up holding the surface against the next
+                // acquire from the same subprocess.
+                for id in &registered_ids {
+                    let _ = surface_store.release(id);
+                }
+                drop(acquired);
+                return EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: format!(
+                        "acquire_cpu_readback: surface-share check_in failed for plane: {e}"
+                    ),
+                });
+            }
+        }
+    }
+
+    let handle_id = uuid::Uuid::new_v4().to_string();
+    let CpuReadbackAcquired {
+        width,
+        height,
+        format,
+        planes: _,
+        guard,
+    } = acquired;
+    registry.insert_cpu_readback(
+        handle_id.clone(),
+        CpuReadbackHandle {
+            guard: Some(guard),
+            staging_surface_ids: registered_ids,
+            surface_store,
+        },
+    );
+
+    EscalateResponse::Ok(EscalateResponseOk {
+        request_id: rid,
+        handle_id,
+        width: Some(width),
+        height: Some(height),
+        format: Some(surface_format_to_wire(format).to_string()),
+        usage: None,
+        cpu_readback_planes: Some(planes_wire),
+    })
+}
+
+/// Wire-format name for a [`SurfaceFormat`], matching the lowercase
+/// snake-case convention used by the rest of the escalate schema.
+#[cfg(target_os = "linux")]
+fn surface_format_to_wire(fmt: streamlib_adapter_abi::SurfaceFormat) -> &'static str {
+    match fmt {
+        streamlib_adapter_abi::SurfaceFormat::Bgra8 => "bgra8",
+        streamlib_adapter_abi::SurfaceFormat::Rgba8 => "rgba8",
+        streamlib_adapter_abi::SurfaceFormat::Nv12 => "nv12",
+    }
 }
 
 /// Best-effort surface-share service release paired with registry eviction on Linux.
@@ -771,6 +1058,7 @@ mod tests {
             height: Some(16),
             format: Some("bgra32".into()),
             usage: None,
+            cpu_readback_planes: None,
         });
         let env = envelope_response(resp);
         assert_eq!(
@@ -840,6 +1128,105 @@ mod tests {
                 "storage_binding".to_string()
             ]
         );
+    }
+
+    /// Wire-format names for `SurfaceFormat`. Locks the contract the
+    /// Python and Deno cpu-readback runtimes parse against.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn surface_format_to_wire_uses_lowercase_snake_case() {
+        use streamlib_adapter_abi::SurfaceFormat;
+        assert_eq!(super::surface_format_to_wire(SurfaceFormat::Bgra8), "bgra8");
+        assert_eq!(super::surface_format_to_wire(SurfaceFormat::Rgba8), "rgba8");
+        assert_eq!(super::surface_format_to_wire(SurfaceFormat::Nv12), "nv12");
+    }
+
+    /// `AcquireCpuReadback` with no bridge registered must surface a
+    /// clean error response (not a panic) so the subprocess can
+    /// translate it into a Python/Deno exception. Gated on the GPU-
+    /// init path because constructing a `GpuContextLimitedAccess`
+    /// without a real device is not supported on this platform.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn acquire_cpu_readback_without_bridge_returns_err() {
+        use crate::core::context::{GpuContext, GpuContextLimitedAccess};
+
+        let gpu = match GpuContext::init_for_platform_sync() {
+            Ok(g) => g,
+            Err(_) => {
+                println!(
+                    "acquire_cpu_readback_without_bridge_returns_err: no GPU device — skipping"
+                );
+                return;
+            }
+        };
+        let sandbox = GpuContextLimitedAccess::new(gpu);
+        let registry = EscalateHandleRegistry::new();
+
+        let req = EscalateRequest::AcquireCpuReadback(EscalateRequestAcquireCpuReadback {
+            request_id: "req-cpu-1".to_string(),
+            surface_id: "42".to_string(),
+            mode: EscalateRequestAcquireCpuReadbackMode::Read,
+        });
+        let response = handle_escalate_op(&sandbox, &registry, req)
+            .expect("acquire_cpu_readback always produces a response");
+        match response {
+            EscalateResponse::Err(err) => {
+                assert_eq!(err.request_id, "req-cpu-1");
+                assert!(
+                    err.message.contains("CpuReadbackBridge"),
+                    "expected error to mention bridge, got: {}",
+                    err.message
+                );
+            }
+            EscalateResponse::Ok(_) => {
+                panic!("acquire_cpu_readback must fail when no bridge is registered")
+            }
+        }
+        assert_eq!(
+            registry.handle_count(),
+            0,
+            "no handle should be registered on the failure path"
+        );
+    }
+
+    /// `AcquireCpuReadback` with malformed `surface_id` must report a
+    /// parse error keyed by the original request_id.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn acquire_cpu_readback_malformed_surface_id_returns_err() {
+        use crate::core::context::{GpuContext, GpuContextLimitedAccess};
+
+        let gpu = match GpuContext::init_for_platform_sync() {
+            Ok(g) => g,
+            Err(_) => {
+                println!(
+                    "acquire_cpu_readback_malformed_surface_id_returns_err: no GPU — skipping"
+                );
+                return;
+            }
+        };
+        let sandbox = GpuContextLimitedAccess::new(gpu);
+        let registry = EscalateHandleRegistry::new();
+
+        let req = EscalateRequest::AcquireCpuReadback(EscalateRequestAcquireCpuReadback {
+            request_id: "req-cpu-bad".to_string(),
+            surface_id: "not-a-u64".to_string(),
+            mode: EscalateRequestAcquireCpuReadbackMode::Write,
+        });
+        let response = handle_escalate_op(&sandbox, &registry, req)
+            .expect("acquire_cpu_readback must produce a response");
+        match response {
+            EscalateResponse::Err(err) => {
+                assert_eq!(err.request_id, "req-cpu-bad");
+                assert!(
+                    err.message.contains("not a u64") || err.message.contains("invalid"),
+                    "expected parse-error message, got: {}",
+                    err.message
+                );
+            }
+            EscalateResponse::Ok(_) => panic!("malformed surface_id must not succeed"),
+        }
     }
 
     #[test]

--- a/libs/streamlib/src/core/context/cpu_readback_bridge.rs
+++ b/libs/streamlib/src/core/context/cpu_readback_bridge.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side dispatch trait the escalate handler uses to drive
+//! cpu-readback acquires on behalf of subprocess customers.
+//!
+//! The trait lives here (in `streamlib`) because the escalate IPC
+//! handler is here. Implementations live in adapter crates (or
+//! application code that wraps an adapter) — those can depend on
+//! `streamlib`, the reverse cannot. Register an implementation via
+//! [`crate::core::context::GpuContext::set_cpu_readback_bridge`] before
+//! spawning subprocesses that issue `acquire_cpu_readback`.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{SurfaceFormat, SurfaceId};
+
+use crate::adapter_support::VulkanPixelBuffer;
+
+/// Wire-format access mode mirrored from the escalate schema.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum CpuReadbackAccessMode {
+    Read,
+    Write,
+}
+
+/// Per-plane staging buffer the bridge hands back on a successful
+/// acquire. The escalate handler check-ins each `staging` buffer with
+/// the surface-share service and surfaces the registered surface IDs to
+/// the subprocess.
+pub struct CpuReadbackPlane {
+    pub staging: Arc<VulkanPixelBuffer>,
+    pub width: u32,
+    pub height: u32,
+    pub bytes_per_pixel: u32,
+}
+
+/// Result of [`CpuReadbackBridge::acquire`]. Owns the underlying adapter
+/// guard (so its `Drop` runs the CPU→GPU flush on write release + signals
+/// the timeline) and exposes the per-plane staging buffers the escalate
+/// handler will publish via surface-share.
+pub struct CpuReadbackAcquired {
+    pub width: u32,
+    pub height: u32,
+    pub format: SurfaceFormat,
+    pub planes: Vec<CpuReadbackPlane>,
+    /// Type-erased guard kept alive until the bridge is asked to release
+    /// the matching `bridge_handle`. Dropping it triggers the adapter's
+    /// release-side work.
+    pub guard: Box<dyn Send + Sync>,
+}
+
+/// Dispatch trait the host runtime uses to talk to a cpu-readback
+/// adapter without taking a build-time dependency on it.
+///
+/// Implementations are registered on [`crate::core::context::GpuContext`]
+/// via [`crate::core::context::GpuContext::set_cpu_readback_bridge`]; the
+/// escalate handler reaches them from inside `escalate(|full| ...)` so
+/// the bridge call always runs with `FullAccess` capability.
+pub trait CpuReadbackBridge: Send + Sync {
+    /// Acquire scoped read or write access to a host-registered surface.
+    /// The returned [`CpuReadbackAcquired::guard`] keeps the underlying
+    /// adapter guard alive until the bridge sees a matching `release`.
+    fn acquire(
+        &self,
+        surface_id: SurfaceId,
+        mode: CpuReadbackAccessMode,
+    ) -> Result<CpuReadbackAcquired, String>;
+}

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -48,6 +48,8 @@ impl RhiBlitter for NoOpBlitter {
     fn clear_cache(&self) {}
 }
 
+#[cfg(target_os = "linux")]
+use super::cpu_readback_bridge::CpuReadbackBridge;
 use super::surface_store::SurfaceStore;
 use super::texture_pool::{
     PooledTextureHandle, TexturePool, TexturePoolConfig, TexturePoolDescriptor,
@@ -390,6 +392,12 @@ pub struct GpuContext {
     /// device. The compiler acquires this during Phase 4 of spawn_processor
     /// and releases it after waiting for the device to go idle.
     processor_setup_lock: Arc<Mutex<()>>,
+    /// Host-side bridge for the cpu-readback escalate op. Set by application
+    /// code that wires a `CpuReadbackSurfaceAdapter` into the runtime; left
+    /// unset on hosts that don't expose cpu-readback to subprocess customers
+    /// (the escalate handler responds with an `Err` in that case).
+    #[cfg(target_os = "linux")]
+    cpu_readback_bridge: Arc<Mutex<Option<Arc<dyn CpuReadbackBridge>>>>,
 }
 
 impl GpuContext {
@@ -408,6 +416,8 @@ impl GpuContext {
             buffer_texture_cache: Arc::new(Mutex::new(HashMap::new())),
             camera_timeline_semaphore_handle: Arc::new(AtomicU64::new(0)),
             processor_setup_lock: Arc::new(Mutex::new(())),
+            #[cfg(target_os = "linux")]
+            cpu_readback_bridge: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -426,6 +436,8 @@ impl GpuContext {
             buffer_texture_cache: Arc::new(Mutex::new(HashMap::new())),
             camera_timeline_semaphore_handle: Arc::new(AtomicU64::new(0)),
             processor_setup_lock: Arc::new(Mutex::new(())),
+            #[cfg(target_os = "linux")]
+            cpu_readback_bridge: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1040,6 +1052,25 @@ impl GpuContext {
         self.surface_store.lock().unwrap().clone()
     }
 
+    // =========================================================================
+    // CpuReadbackBridge — host-side dispatch for the cpu-readback escalate op
+    // =========================================================================
+
+    /// Register a [`CpuReadbackBridge`] implementation. The escalate handler
+    /// dispatches `acquire_cpu_readback` requests through this bridge; until
+    /// it is set, those requests fail with an "unsupported" error response.
+    /// Linux-only: the cpu-readback adapter is Linux-only.
+    #[cfg(target_os = "linux")]
+    pub fn set_cpu_readback_bridge(&self, bridge: Arc<dyn CpuReadbackBridge>) {
+        *self.cpu_readback_bridge.lock().unwrap() = Some(bridge);
+    }
+
+    /// Get the registered [`CpuReadbackBridge`], if any.
+    #[cfg(target_os = "linux")]
+    pub fn cpu_readback_bridge(&self) -> Option<Arc<dyn CpuReadbackBridge>> {
+        self.cpu_readback_bridge.lock().unwrap().clone()
+    }
+
     /// Check in a pixel buffer to the surface-share service, returning a surface ID.
     ///
     /// The surface ID can be shared with other processes (e.g., Python subprocesses)
@@ -1593,6 +1624,13 @@ impl GpuContextFullAccess {
     /// Check out a surface by ID.
     pub fn check_out_surface(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
         self.inner.check_out_surface(surface_id)
+    }
+
+    /// Get the registered cpu-readback bridge, if any. Reachable only inside
+    /// `escalate(|full| ...)` since it requires `FullAccess`.
+    #[cfg(target_os = "linux")]
+    pub fn cpu_readback_bridge(&self) -> Option<Arc<dyn CpuReadbackBridge>> {
+        self.inner.cpu_readback_bridge()
     }
 }
 

--- a/libs/streamlib/src/core/context/mod.rs
+++ b/libs/streamlib/src/core/context/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 mod audio_clock;
+#[cfg(target_os = "linux")]
+mod cpu_readback_bridge;
 mod gpu_context;
 mod runtime_context;
 mod surface_store;
@@ -11,6 +13,10 @@ mod time_context;
 pub use audio_clock::{
     AudioClock, AudioClockConfig, AudioTickCallback, AudioTickContext, SharedAudioClock,
     SoftwareAudioClock,
+};
+#[cfg(target_os = "linux")]
+pub use cpu_readback_bridge::{
+    CpuReadbackAccessMode, CpuReadbackAcquired, CpuReadbackBridge, CpuReadbackPlane,
 };
 pub use gpu_context::{GpuContext, GpuContextFullAccess, GpuContextLimitedAccess};
 pub use runtime_context::{

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -123,6 +123,13 @@ pub struct StreamRuntime {
     /// `fdatasync`s the log file.
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
     _logging_guard: crate::core::logging::StreamlibLoggingGuard,
+    /// Engine-extension hooks invoked exactly once during [`Self::start`],
+    /// after the [`GpuContext`] is initialized and before any
+    /// processor's `setup()` runs. Used to register host-side bridges
+    /// (e.g. [`crate::core::context::CpuReadbackBridge`]) whose
+    /// construction needs the live GpuContext but whose registration
+    /// must precede the first `process()` call. Drained on each `start()`.
+    setup_hooks: Arc<Mutex<Vec<Box<dyn FnOnce(&GpuContext) -> Result<()> + Send>>>>,
 }
 
 impl StreamRuntime {
@@ -224,7 +231,25 @@ impl StreamRuntime {
             surface_socket_path,
             #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
             _logging_guard,
+            setup_hooks: Arc::new(Mutex::new(Vec::new())),
         }))
+    }
+
+    /// Register a one-shot hook to run during [`Self::start`], after the
+    /// [`GpuContext`] is initialized and before any processor's
+    /// `setup()` runs. The hook receives the live `Arc<GpuContext>`,
+    /// giving caller code a window to register engine extensions —
+    /// today the canonical use is wiring a
+    /// [`crate::core::context::CpuReadbackBridge`] via
+    /// [`crate::core::context::GpuContext::set_cpu_readback_bridge`]
+    /// before subprocess processors fire their first
+    /// `acquire_cpu_readback`. Hooks fire FIFO; a hook returning `Err`
+    /// aborts `start()` with the same error.
+    pub fn install_setup_hook<F>(&self, hook: F)
+    where
+        F: FnOnce(&GpuContext) -> Result<()> + Send + 'static,
+    {
+        self.setup_hooks.lock().push(Box::new(hook));
     }
 
     /// Path of the per-runtime surface-sharing Unix socket.
@@ -621,6 +646,21 @@ impl StreamRuntime {
         tracing::info!("[start] Initializing GPU context...");
         let gpu = GpuContext::init_for_platform_sync()?;
         tracing::info!("[start] GPU context initialized");
+
+        // Drain pre-start hooks now — after the GpuContext is live but
+        // before any processor setup runs. Adapter bridges register
+        // themselves here so processors that issue escalate ops in
+        // their first `process()` find the bridge already in place.
+        let hooks: Vec<Box<dyn FnOnce(&GpuContext) -> Result<()> + Send>> = {
+            let mut guard = self.setup_hooks.lock();
+            std::mem::take(&mut *guard)
+        };
+        if !hooks.is_empty() {
+            tracing::info!("[start] Running {} setup hook(s)", hooks.len());
+            for hook in hooks {
+                hook(&gpu)?;
+            }
+        }
 
         // Initialize SurfaceStore for cross-process GPU surface sharing (macOS only)
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Wires the cpu-readback adapter's escalate-IPC seam end-to-end. Adds the host-side `CpuReadbackBridge` trait (engine extension point in `streamlib::core::context`), dispatch in `subprocess_escalate.rs`, additive `acquire_*_by_id` accessors on the adapter, and a `CpuReadbackBridgeImpl` in the adapter crate.
- Ships concrete subprocess runtimes for both polyglot SDKs: Python `CpuReadbackContext` (cv2 with numpy fallback) and Deno `CpuReadbackContext` (TC39 `await using`). Python and Deno escalate channels both gain `acquire_cpu_readback`.
- Polyglot E2E in `examples/polyglot-cpu-readback-blur/` runs through `StreamRuntime`: a real Python or Deno subprocess opens a host-pre-allocated cpu-readback surface, applies a Gaussian blur, releases. Host reads back through the adapter and writes a PNG visually proving the round-trip.

## Closes
Closes #529

## Test plan

- [x] `cargo test -p streamlib --lib subprocess_escalate` — 31 passed (3 new: `surface_format_to_wire_uses_lowercase_snake_case`, `acquire_cpu_readback_without_bridge_returns_err`, `acquire_cpu_readback_malformed_surface_id_returns_err`)
- [x] `cargo test -p streamlib-adapter-cpu-readback --tests` — 2 passed (existing conformance, unaffected by additive `acquire_*_by_id` refactor)
- [x] Python tests: `pytest libs/streamlib-python/python/streamlib/tests/` — 66 passed (7 new in `test_adapters_cpu_readback.py`: BGRA write round-trip, read-only lock, NV12 plane geometry, unwind-on-failure, EscalateError propagation, StreamlibSurface Protocol input, mode validation)
- [x] Deno tests: `deno test libs/streamlib-deno/` — 61 passed (7 new in `cpu_readback_test.ts`: parallel coverage of the Python suite)
- [x] **E2E Python** (`cargo run -p polyglot-cpu-readback-blur-scenario -- --runtime=python --output=/tmp/cpu-readback-blur-python.png`) — runtime ran cleanly, polyglot processor logged `[CpuReadbackBlur/py] blur applied (kernel=11, sigma=4.0)`, host adapter logged GPU↔CPU copies for both write (subprocess acquire) and read (post-stop readback), output PNG written and visually inspected — see image below.
- [x] **E2E Deno** — same flow with `--runtime=deno`, polyglot processor logged `[CpuReadbackBlur/deno] blur applied`, output PNG visually inspected.

## Architectural seams proved by the E2E PNG

If any of these were broken, the PNG would show the unblurred input or noise instead of the smooth blur:

1. `acquire_cpu_readback` escalate dispatch (subprocess → host bridge)
2. Host `vkCmdCopyImageToBuffer` of registered VkImage → staging VkBuffer
3. Surface-share registration of the staging FD under a fresh UUID
4. SCM_RIGHTS FD passing to the subprocess
5. Subprocess `mmap` + Python/Deno transform in its own address space
6. `release_handle` triggers host `vkCmdCopyBufferToImage` (CPU→GPU sync)
7. Post-stop readback through `acquire_read_by_id` sees the subprocess's writes

## Engine extension point added

`StreamRuntime::install_setup_hook(F)` — small new API. Hooks fire after `GpuContext::init_for_platform_sync` but before any processor's `setup()` runs. Used by the example to register the `CpuReadbackBridge` before the polyglot processor's first `process()` call. Generic enough that future adapter bridges (OpenGL, Vulkan, Skia for #530, #531, #513) can use the same hook.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno (host bridge + dispatch in Rust; runtimes in Python and Deno; polyglot E2E exercises both)
- **Schema regenerated**: yes — `escalate_request@1.0.0.yaml` adds `acquire_cpu_readback` variant; `escalate_response@1.0.0.yaml` adds optional `cpu_readback_planes` field. Regenerated for Rust + Python + Deno via `cargo xtask generate-schemas`.
- **Python and Deno both covered?** yes — parallel `CpuReadbackContext` implementations, parallel test suites (7 each), and both runtimes exercised by the polyglot E2E example.
- **E2E tests run**:
  - [x] Host-Rust: `acquire_cpu_readback_without_bridge_returns_err`, `acquire_cpu_readback_malformed_surface_id_returns_err`
  - [x] Python subprocess: real subprocess via `polyglot-cpu-readback-blur` scenario, output PNG visually verified
  - [x] Deno subprocess: same path with `--runtime=deno`, output PNG visually verified
- **FD-passing path**: DMA-BUF FD via the existing surface-share registry — staging `VulkanPixelBuffer` exports DMA-BUF FDs, host check-ins them per plane, subprocess SCM_RIGHTS check-outs.

## Stale-criterion update

The original issue body had an exit criterion to replace `vkQueueWaitIdle` with per-submit fence wait. That work landed earlier as #539 (commit `6786eb6`); the criterion was struck through with reasoning preserved in the issue body when this work picked up.

## Follow-ups

- #541 — `fix(xtask): generate-schemas non-idempotent for empty-struct configs`. Surfaced when this PR ran the regen pipeline; reverted unrelated regenerated files and only kept the escalate-schema diffs.
- #542 — `feat(polyglot): manual + continuous execution mode examples + tests + docs`. Surfaced during the post-Stage-4 architecture discussion. The `manual` and `continuous` execution modes are wired through both Python and Deno subprocess runners but unexercised; the issue tracks shipping reference examples, replacing wall-clock pacing with a monotonic-clock-driven dispatch (per project policy on time-keeping), and closing the docs gap.

## E2E output PNGs

![cpu-readback E2E output — Python (cv2.GaussianBlur, kernel=11, sigma=4.0)](https://gh-artifact.tatolab.com/pr-543/cpu-readback-blur-python.jpg)

*Python (`cv2.GaussianBlur`, kernel=11, sigma=4.0). 4 vertical color bands (blue / green / red / white) with the Gaussian-blur transitions clearly visible at band edges — the visual gate that proves the host→subprocess→host round-trip applied the transform on real GPU memory.*

![cpu-readback E2E output — Deno (hand-rolled separable Gaussian, kernel=11, sigma=4.0)](https://gh-artifact.tatolab.com/pr-543/cpu-readback-blur-deno.jpg)

*Deno (hand-rolled separable Gaussian, kernel=11, sigma=4.0). Same scenario, separate subprocess, independent transform implementation — same visual gate.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

