### PR TITLE
feat(adapter-opengl): subprocess OpenGlContext runtime + polyglot scenario

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "examples/camera-deno-subprocess",   # Example: Camera → Deno subprocess → Display pipeline
     "examples/polyglot-dma-buf-consumer", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
     "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
+    "examples/polyglot-opengl-fragment-shader", # Example: Polyglot OpenGL adapter — Python Mandelbrot / Deno plasma fragment shader rendered into a host DMA-BUF (#530)
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)

--- a/examples/polyglot-opengl-fragment-shader/Cargo.toml
+++ b/examples/polyglot-opengl-fragment-shader/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-opengl-fragment-shader-scenario"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+serde_json = "1.0"
+png = "0.17"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl" }
+vulkanalia = { workspace = true }

--- a/examples/polyglot-opengl-fragment-shader/deno/deno.json
+++ b/examples/polyglot-opengl-fragment-shader/deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+  }
+}

--- a/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
+++ b/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
@@ -1,0 +1,399 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot OpenGL fragment-shader processor — Deno twin of
+ * `examples/polyglot-opengl-fragment-shader/python/opengl_fragment_shader.py`.
+ *
+ * End-to-end gate for the subprocess `OpenGLContext` runtime (#530).
+ * The host pre-allocates a render-target-capable DMA-BUF surface and
+ * registers it with surface-share. This processor receives a trigger
+ * Videoframe, opens the host surface through `OpenGLContext.acquireWrite`
+ * (which imports the DMA-BUF as an `EGLImage` + `GL_TEXTURE_2D` and
+ * makes the adapter's EGL context current on the calling thread), uses
+ * `Deno.dlopen` against `libGL.so.1` to compile a plasma-effect
+ * fragment shader, attaches an FBO to the imported texture, draws a
+ * fullscreen quad, and releases — the adapter's `glFinish` on release
+ * ensures the host's DMA-BUF readback sees the writes.
+ *
+ * Different effect from the Python twin so the two output PNGs are
+ * visually distinct: Python renders a Mandelbrot zoom; Deno renders
+ * sine-interference plasma waves.
+ *
+ * Real Deno customers can use any GL library (a community FFI binding,
+ * a game-engine wrapper, etc.) — the SDK is library-agnostic and just
+ * makes the EGL context current. This processor uses raw `Deno.dlopen`
+ * to keep the dep surface minimal and parallel to the Python twin.
+ *
+ * Config keys:
+ *   opengl_surface_uuid (string, required)
+ *     Surface-share UUID the host registered the render-target image
+ *     under. Passed to `OpenGLContext.acquireWrite`.
+ *   width (number, required)
+ *     Surface width in pixels — the FBO viewport is set to this.
+ *   height (number, required)
+ *     Surface height in pixels.
+ */
+
+import type {
+  ReactiveProcessor,
+  RuntimeContextFullAccess,
+  RuntimeContextLimitedAccess,
+} from "../../../libs/streamlib-deno/mod.ts";
+import { OpenGLContext } from "../../../libs/streamlib-deno/adapters/opengl.ts";
+
+// =============================================================================
+// Minimal libGL.so.1 binding via Deno.dlopen
+// =============================================================================
+
+const GL_FRAGMENT_SHADER = 0x8B30;
+const GL_VERTEX_SHADER = 0x8B31;
+const GL_COMPILE_STATUS = 0x8B81;
+const GL_LINK_STATUS = 0x8B82;
+const GL_INFO_LOG_LENGTH = 0x8B84;
+const GL_FRAMEBUFFER = 0x8D40;
+const GL_COLOR_ATTACHMENT0 = 0x8CE0;
+const GL_FRAMEBUFFER_COMPLETE = 0x8CD5;
+const GL_TEXTURE_2D = 0x0DE1;
+const GL_TRIANGLE_STRIP = 0x0005;
+const GL_NO_ERROR = 0;
+
+const glSymbols = {
+  glCreateShader: { parameters: ["u32"], result: "u32" },
+  glShaderSource: {
+    parameters: ["u32", "i32", "buffer", "buffer"],
+    result: "void",
+  },
+  glCompileShader: { parameters: ["u32"], result: "void" },
+  glGetShaderiv: {
+    parameters: ["u32", "u32", "buffer"],
+    result: "void",
+  },
+  glGetShaderInfoLog: {
+    parameters: ["u32", "i32", "buffer", "buffer"],
+    result: "void",
+  },
+  glDeleteShader: { parameters: ["u32"], result: "void" },
+  glCreateProgram: { parameters: [], result: "u32" },
+  glAttachShader: { parameters: ["u32", "u32"], result: "void" },
+  glLinkProgram: { parameters: ["u32"], result: "void" },
+  glGetProgramiv: {
+    parameters: ["u32", "u32", "buffer"],
+    result: "void",
+  },
+  glGetProgramInfoLog: {
+    parameters: ["u32", "i32", "buffer", "buffer"],
+    result: "void",
+  },
+  glDeleteProgram: { parameters: ["u32"], result: "void" },
+  glUseProgram: { parameters: ["u32"], result: "void" },
+  glGetUniformLocation: {
+    parameters: ["u32", "buffer"],
+    result: "i32",
+  },
+  glUniform2f: {
+    parameters: ["i32", "f32", "f32"],
+    result: "void",
+  },
+  glGenFramebuffers: {
+    parameters: ["i32", "buffer"],
+    result: "void",
+  },
+  glDeleteFramebuffers: {
+    parameters: ["i32", "buffer"],
+    result: "void",
+  },
+  glBindFramebuffer: {
+    parameters: ["u32", "u32"],
+    result: "void",
+  },
+  glFramebufferTexture2D: {
+    parameters: ["u32", "u32", "u32", "u32", "i32"],
+    result: "void",
+  },
+  glCheckFramebufferStatus: {
+    parameters: ["u32"],
+    result: "u32",
+  },
+  glGenVertexArrays: {
+    parameters: ["i32", "buffer"],
+    result: "void",
+  },
+  glDeleteVertexArrays: {
+    parameters: ["i32", "buffer"],
+    result: "void",
+  },
+  glBindVertexArray: { parameters: ["u32"], result: "void" },
+  glViewport: {
+    parameters: ["i32", "i32", "i32", "i32"],
+    result: "void",
+  },
+  glDrawArrays: {
+    parameters: ["u32", "i32", "i32"],
+    result: "void",
+  },
+  glFinish: { parameters: [], result: "void" },
+  glGetError: { parameters: [], result: "u32" },
+} as const;
+
+// deno-lint-ignore no-explicit-any
+let glLib: { symbols: any } | null = null;
+
+function loadLibGL(): { symbols: typeof glSymbols extends infer _ ? any : never } {
+  if (glLib === null) {
+    glLib = Deno.dlopen("libGL.so.1", glSymbols);
+  }
+  // deno-lint-ignore no-explicit-any
+  return glLib as any;
+}
+
+// =============================================================================
+// Shaders — sine-interference plasma waves
+// =============================================================================
+
+/**
+ * Encode a string into a `Uint8Array<ArrayBuffer>` (not
+ * `Uint8Array<ArrayBufferLike>` which `TextEncoder` returns) — Deno FFI
+ * APIs require the concrete `ArrayBuffer` parameterization.
+ */
+function encodeUtf8(s: string): Uint8Array<ArrayBuffer> {
+  const tmp = new TextEncoder().encode(s);
+  const out = new Uint8Array(new ArrayBuffer(tmp.byteLength));
+  out.set(tmp);
+  return out;
+}
+
+const VERTEX_SHADER = encodeUtf8(`#version 330 core
+const vec2 positions[4] = vec2[4](
+    vec2(-1.0, -1.0), vec2( 1.0, -1.0),
+    vec2(-1.0,  1.0), vec2( 1.0,  1.0)
+);
+void main() {
+    gl_Position = vec4(positions[gl_VertexID], 0.0, 1.0);
+}
+\0`);
+
+// Classic demoscene plasma — superimposed sines hashed through a cosine
+// palette. Different visual fingerprint from the Python Mandelbrot.
+const FRAGMENT_SHADER = encodeUtf8(`#version 330 core
+out vec4 fragColor;
+uniform vec2 resolution;
+void main() {
+    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 p = uv * 6.0 - 3.0;
+    float v = 0.0;
+    v += sin(p.x * 1.7);
+    v += sin(p.y * 2.3 + 1.1);
+    v += sin((p.x + p.y) * 1.3 + 2.7);
+    v += sin(length(p) * 3.7);
+    v *= 0.25;
+    // Cosine palette in HSV-ish space (Inigo Quilez style).
+    vec3 a = vec3(0.5, 0.5, 0.5);
+    vec3 b = vec3(0.5, 0.5, 0.5);
+    vec3 c = vec3(2.0, 1.0, 0.0);
+    vec3 d = vec3(0.5, 0.20, 0.25);
+    vec3 col = a + b * cos(6.28318 * (c * v + d));
+    fragColor = vec4(col, 1.0);
+}
+\0`);
+
+// =============================================================================
+// GL helpers
+// =============================================================================
+
+// deno-lint-ignore no-explicit-any
+function compileShader(gl: any, source: Uint8Array<ArrayBuffer>, kind: number, name: string): number {
+  const sh = gl.symbols.glCreateShader(kind);
+  if (sh === 0) throw new Error(`glCreateShader(${name}) returned 0`);
+  // glShaderSource takes (count, **strings, *lengths). We pack a single
+  // pointer-to-pointer via a u64-aligned buffer.
+  const srcPtr = Deno.UnsafePointer.of(source);
+  if (srcPtr === null) throw new Error("null shader source pointer");
+  const ptrBuf = new BigUint64Array(1);
+  ptrBuf[0] = BigInt(Deno.UnsafePointer.value(srcPtr));
+  gl.symbols.glShaderSource(sh, 1, new Uint8Array(ptrBuf.buffer), null);
+  gl.symbols.glCompileShader(sh);
+  const status = new Int32Array(1);
+  gl.symbols.glGetShaderiv(sh, GL_COMPILE_STATUS, new Uint8Array(status.buffer));
+  if (status[0] === 0) {
+    const logLen = new Int32Array(1);
+    gl.symbols.glGetShaderiv(
+      sh,
+      GL_INFO_LOG_LENGTH,
+      new Uint8Array(logLen.buffer),
+    );
+    const len = Math.max(logLen[0], 1024);
+    const log = new Uint8Array(len);
+    const actual = new Int32Array(1);
+    gl.symbols.glGetShaderInfoLog(sh, len, new Uint8Array(actual.buffer), log);
+    gl.symbols.glDeleteShader(sh);
+    const msg = new TextDecoder().decode(log.subarray(0, actual[0]));
+    throw new Error(`${name} shader compile failed: ${msg}`);
+  }
+  return sh;
+}
+
+// deno-lint-ignore no-explicit-any
+function linkProgram(gl: any, vs: number, fs: number): number {
+  const prog = gl.symbols.glCreateProgram();
+  if (prog === 0) throw new Error("glCreateProgram returned 0");
+  gl.symbols.glAttachShader(prog, vs);
+  gl.symbols.glAttachShader(prog, fs);
+  gl.symbols.glLinkProgram(prog);
+  const status = new Int32Array(1);
+  gl.symbols.glGetProgramiv(prog, GL_LINK_STATUS, new Uint8Array(status.buffer));
+  if (status[0] === 0) {
+    const logLen = new Int32Array(1);
+    gl.symbols.glGetProgramiv(
+      prog,
+      GL_INFO_LOG_LENGTH,
+      new Uint8Array(logLen.buffer),
+    );
+    const len = Math.max(logLen[0], 1024);
+    const log = new Uint8Array(len);
+    const actual = new Int32Array(1);
+    gl.symbols.glGetProgramInfoLog(prog, len, new Uint8Array(actual.buffer), log);
+    gl.symbols.glDeleteProgram(prog);
+    const msg = new TextDecoder().decode(log.subarray(0, actual[0]));
+    throw new Error(`program link failed: ${msg}`);
+  }
+  return prog;
+}
+
+// =============================================================================
+// Processor
+// =============================================================================
+
+export default class OpenGlFragmentShaderProcessor implements ReactiveProcessor {
+  private uuid = "";
+  private width = 0;
+  private height = 0;
+  private opengl: OpenGLContext | null = null;
+  private rendered = false;
+  private errorMessage: string | null = null;
+
+  setup(ctx: RuntimeContextFullAccess): void {
+    const cfg = ctx.config;
+    this.uuid = String(cfg["opengl_surface_uuid"]);
+    this.width = Number(cfg["width"] ?? 0);
+    this.height = Number(cfg["height"] ?? 0);
+    this.opengl = OpenGLContext.fromRuntime(ctx);
+    console.error(
+      `[OpenGlFragmentShader/deno] setup uuid=${this.uuid} ` +
+        `size=${this.width}x${this.height}`,
+    );
+  }
+
+  process(ctx: RuntimeContextLimitedAccess): void {
+    const result = ctx.inputs.read("video_in");
+    if (!result) return;
+    if (this.rendered) return;
+    try {
+      this.renderOnce();
+      this.rendered = true;
+      console.error(
+        `[OpenGlFragmentShader/deno] plasma rendered into surface '${this.uuid}'`,
+      );
+    } catch (e) {
+      this.errorMessage = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[OpenGlFragmentShader/deno] render failed: ${this.errorMessage}`,
+      );
+    }
+  }
+
+  private renderOnce(): void {
+    if (this.opengl === null) {
+      throw new Error("OpenGLContext was not initialized in setup");
+    }
+    using guard = this.opengl.acquireWrite(this.uuid);
+    const textureId = guard.view.glTextureId;
+    const gl = loadLibGL();
+
+    // Empty VAO — desktop core requires one bound; geometry comes from
+    // gl_VertexID in the vertex shader.
+    const vao = new Uint32Array(1);
+    gl.symbols.glGenVertexArrays(1, new Uint8Array(vao.buffer));
+    gl.symbols.glBindVertexArray(vao[0]);
+    try {
+      const vs = compileShader(gl, VERTEX_SHADER, GL_VERTEX_SHADER, "vertex");
+      let program: number;
+      try {
+        const fs = compileShader(
+          gl,
+          FRAGMENT_SHADER,
+          GL_FRAGMENT_SHADER,
+          "fragment",
+        );
+        try {
+          program = linkProgram(gl, vs, fs);
+        } finally {
+          gl.symbols.glDeleteShader(fs);
+        }
+      } finally {
+        gl.symbols.glDeleteShader(vs);
+      }
+
+      try {
+        // FBO with the imported texture as color attachment.
+        const fbo = new Uint32Array(1);
+        gl.symbols.glGenFramebuffers(1, new Uint8Array(fbo.buffer));
+        gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, fbo[0]);
+        gl.symbols.glFramebufferTexture2D(
+          GL_FRAMEBUFFER,
+          GL_COLOR_ATTACHMENT0,
+          GL_TEXTURE_2D,
+          textureId,
+          0,
+        );
+        const status = gl.symbols.glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        if (status !== GL_FRAMEBUFFER_COMPLETE) {
+          throw new Error(
+            `FBO incomplete (status=0x${status.toString(16)}) — the imported ` +
+              `texture may have been bound with an external_only modifier; ` +
+              `the host allocator should pick a tiled, render-target-capable ` +
+              `DRM modifier`,
+          );
+        }
+
+        gl.symbols.glViewport(0, 0, this.width, this.height);
+        gl.symbols.glUseProgram(program);
+
+        const resolutionName = new TextEncoder().encode("resolution\0");
+        const loc = gl.symbols.glGetUniformLocation(program, resolutionName);
+        if (loc >= 0) {
+          gl.symbols.glUniform2f(loc, this.width, this.height);
+        }
+
+        gl.symbols.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        gl.symbols.glFinish();
+
+        const glErr = gl.symbols.glGetError();
+        if (glErr !== GL_NO_ERROR) {
+          throw new Error(
+            `GL error 0x${glErr.toString(16)} after draw — see ` +
+              `docs/learnings/nvidia-egl-dmabuf-render-target.md`,
+          );
+        }
+
+        gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        gl.symbols.glDeleteFramebuffers(1, new Uint8Array(fbo.buffer));
+      } finally {
+        gl.symbols.glDeleteProgram(program);
+      }
+    } finally {
+      gl.symbols.glBindVertexArray(0);
+      gl.symbols.glDeleteVertexArrays(1, new Uint8Array(vao.buffer));
+    }
+    // `using guard` runs adapter `end_write_access` at scope exit which
+    // drains GL via glFinish so the host's DMA-BUF readback sees a
+    // fully-flushed image.
+  }
+
+  teardown(_ctx: RuntimeContextFullAccess): void {
+    console.error(
+      `[OpenGlFragmentShader/deno] teardown rendered=${this.rendered} ` +
+        `error=${this.errorMessage}`,
+    );
+  }
+}

--- a/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-opengl-fragment-shader-deno
+  version: "0.1.0"
+  description: "Polyglot OpenGL adapter scenario (#530) — Deno plasma fragment shader rendered into a host DMA-BUF surface"
+
+processors:
+  - name: com.tatolab.opengl_fragment_shader_deno
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a plasma-effect fragment shader, releases"
+    runtime: deno
+    execution: reactive
+    entrypoint: "opengl_fragment_shader.ts:default"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-opengl-fragment-shader/python/opengl_fragment_shader.py
+++ b/examples/polyglot-opengl-fragment-shader/python/opengl_fragment_shader.py
@@ -1,0 +1,394 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot OpenGL fragment-shader processor — Python.
+
+End-to-end gate for the subprocess `OpenGLContext` runtime (#530). The
+host pre-allocates a render-target-capable DMA-BUF surface and registers
+it with surface-share. This processor receives a trigger Videoframe,
+opens the host surface through ``OpenGLContext.acquire_write`` (which
+imports the DMA-BUF as an `EGLImage` + `GL_TEXTURE_2D` and makes the
+adapter's EGL context current on the calling thread), uses raw ctypes
+against ``libGL.so.1`` to compile a Mandelbrot fragment shader, attaches
+an FBO to the imported texture, draws a fullscreen quad, and releases —
+the adapter's `glFinish` on release ensures the host's DMA-BUF readback
+sees the writes.
+
+No PyOpenGL / ModernGL dependency: ``ctypes`` is sufficient for the
+~12 GL functions this needs, parallel to what the Deno twin does via
+``Deno.dlopen``. Real customers can use whatever GL library they prefer
+— the SDK is library-agnostic; it just makes the EGL context current
+and hands back a `GL_TEXTURE_2D` id.
+
+Config keys:
+    opengl_surface_uuid (str, required)
+        Surface-share UUID the host registered the render-target image
+        under. Passed to ``OpenGLContext.acquire_write``.
+    width (int, required)
+        Surface width in pixels — the FBO viewport is set to this.
+    height (int, required)
+        Surface height in pixels.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+from typing import Optional
+
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+from streamlib.adapters.opengl import OpenGLContext
+
+
+# =============================================================================
+# Minimal libGL.so.1 binding via ctypes
+# =============================================================================
+#
+# Only the ~12 functions this scenario needs. Real customers using a
+# library like PyOpenGL get a full surface for free.
+#
+# We resolve via libGL.so.1 directly — the function pointers are valid
+# in whatever EGL context is current on the calling thread, which is the
+# adapter's context for the lifetime of an `acquire_write` scope.
+
+GL_FRAGMENT_SHADER = 0x8B30
+GL_VERTEX_SHADER = 0x8B31
+GL_COMPILE_STATUS = 0x8B81
+GL_LINK_STATUS = 0x8B82
+GL_INFO_LOG_LENGTH = 0x8B84
+GL_FRAMEBUFFER = 0x8D40
+GL_COLOR_ATTACHMENT0 = 0x8CE0
+GL_FRAMEBUFFER_COMPLETE = 0x8CD5
+GL_TEXTURE_2D = 0x0DE1
+GL_TRIANGLE_STRIP = 0x0005
+GL_FLOAT = 0x1406
+GL_NO_ERROR = 0
+
+
+def _load_libgl():
+    """dlopen libGL.so.1 with all the symbol signatures this processor needs."""
+    name = ctypes.util.find_library("GL") or "libGL.so.1"
+    lib = ctypes.cdll.LoadLibrary(name)
+
+    def sig(fn_name, restype, *argtypes):
+        fn = getattr(lib, fn_name)
+        fn.restype = restype
+        fn.argtypes = list(argtypes)
+        return fn
+
+    return {
+        "CreateShader": sig("glCreateShader", ctypes.c_uint32, ctypes.c_uint32),
+        "ShaderSource": sig(
+            "glShaderSource",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_int32,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.POINTER(ctypes.c_int32),
+        ),
+        "CompileShader": sig("glCompileShader", None, ctypes.c_uint32),
+        "GetShaderiv": sig(
+            "glGetShaderiv",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_int32),
+        ),
+        "GetShaderInfoLog": sig(
+            "glGetShaderInfoLog",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_int32,
+            ctypes.POINTER(ctypes.c_int32),
+            ctypes.c_char_p,
+        ),
+        "DeleteShader": sig("glDeleteShader", None, ctypes.c_uint32),
+        "CreateProgram": sig("glCreateProgram", ctypes.c_uint32),
+        "AttachShader": sig("glAttachShader", None, ctypes.c_uint32, ctypes.c_uint32),
+        "LinkProgram": sig("glLinkProgram", None, ctypes.c_uint32),
+        "GetProgramiv": sig(
+            "glGetProgramiv",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_int32),
+        ),
+        "GetProgramInfoLog": sig(
+            "glGetProgramInfoLog",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_int32,
+            ctypes.POINTER(ctypes.c_int32),
+            ctypes.c_char_p,
+        ),
+        "DeleteProgram": sig("glDeleteProgram", None, ctypes.c_uint32),
+        "UseProgram": sig("glUseProgram", None, ctypes.c_uint32),
+        "GetUniformLocation": sig(
+            "glGetUniformLocation", ctypes.c_int32, ctypes.c_uint32, ctypes.c_char_p
+        ),
+        "Uniform2f": sig(
+            "glUniform2f", None, ctypes.c_int32, ctypes.c_float, ctypes.c_float
+        ),
+        "GenFramebuffers": sig(
+            "glGenFramebuffers", None, ctypes.c_int32, ctypes.POINTER(ctypes.c_uint32)
+        ),
+        "DeleteFramebuffers": sig(
+            "glDeleteFramebuffers",
+            None,
+            ctypes.c_int32,
+            ctypes.POINTER(ctypes.c_uint32),
+        ),
+        "BindFramebuffer": sig(
+            "glBindFramebuffer", None, ctypes.c_uint32, ctypes.c_uint32
+        ),
+        "FramebufferTexture2D": sig(
+            "glFramebufferTexture2D",
+            None,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.c_int32,
+        ),
+        "CheckFramebufferStatus": sig(
+            "glCheckFramebufferStatus", ctypes.c_uint32, ctypes.c_uint32
+        ),
+        "GenVertexArrays": sig(
+            "glGenVertexArrays", None, ctypes.c_int32, ctypes.POINTER(ctypes.c_uint32)
+        ),
+        "DeleteVertexArrays": sig(
+            "glDeleteVertexArrays",
+            None,
+            ctypes.c_int32,
+            ctypes.POINTER(ctypes.c_uint32),
+        ),
+        "BindVertexArray": sig("glBindVertexArray", None, ctypes.c_uint32),
+        "Viewport": sig(
+            "glViewport",
+            None,
+            ctypes.c_int32,
+            ctypes.c_int32,
+            ctypes.c_int32,
+            ctypes.c_int32,
+        ),
+        "DrawArrays": sig(
+            "glDrawArrays", None, ctypes.c_uint32, ctypes.c_int32, ctypes.c_int32
+        ),
+        "Finish": sig("glFinish", None),
+        "GetError": sig("glGetError", ctypes.c_uint32),
+    }
+
+
+# =============================================================================
+# Shaders — Mandelbrot zoom into Seahorse Valley
+# =============================================================================
+
+_VERTEX_SHADER = b"""\
+#version 330 core
+const vec2 positions[4] = vec2[4](
+    vec2(-1.0, -1.0), vec2( 1.0, -1.0),
+    vec2(-1.0,  1.0), vec2( 1.0,  1.0)
+);
+void main() {
+    gl_Position = vec4(positions[gl_VertexID], 0.0, 1.0);
+}
+"""
+
+_FRAGMENT_SHADER = b"""\
+#version 330 core
+out vec4 fragColor;
+uniform vec2 resolution;
+void main() {
+    vec2 uv = gl_FragCoord.xy / resolution;
+    // Seahorse Valley region - narrow zoom shows the recursive structure.
+    vec2 c = vec2(-0.7453, 0.1127) + (uv - 0.5) * 0.018;
+    vec2 z = vec2(0.0);
+    int last_iter = 0;
+    const int max_iter = 256;
+    bool escaped = false;
+    for (int i = 0; i < max_iter; i++) {
+        if (dot(z, z) > 4.0) {
+            last_iter = i;
+            escaped = true;
+            break;
+        }
+        z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
+    }
+    if (!escaped) {
+        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        // Smooth coloring + cosine palette (Inigo Quilez style).
+        float smoothed = float(last_iter) - log2(log2(dot(z, z))) + 4.0;
+        float t = smoothed / float(max_iter);
+        vec3 a = vec3(0.5);
+        vec3 b = vec3(0.5);
+        vec3 c2 = vec3(1.0);
+        vec3 d = vec3(0.0, 0.33, 0.67);
+        vec3 col = a + b * cos(6.28318 * (c2 * t + d));
+        fragColor = vec4(col, 1.0);
+    }
+}
+"""
+
+
+def _compile_shader(gl, source: bytes, kind: int, kind_name: str) -> int:
+    """Compile a shader and raise with the GL info log if it fails."""
+    sh = gl["CreateShader"](kind)
+    if sh == 0:
+        raise RuntimeError(f"glCreateShader({kind_name}) returned 0")
+    src_buf = ctypes.c_char_p(source)
+    arr = (ctypes.c_char_p * 1)(src_buf)
+    gl["ShaderSource"](sh, 1, arr, None)
+    gl["CompileShader"](sh)
+    status = ctypes.c_int32(0)
+    gl["GetShaderiv"](sh, GL_COMPILE_STATUS, ctypes.byref(status))
+    if status.value == 0:
+        log_len = ctypes.c_int32(0)
+        gl["GetShaderiv"](sh, GL_INFO_LOG_LENGTH, ctypes.byref(log_len))
+        log_buf = ctypes.create_string_buffer(log_len.value or 1024)
+        actual = ctypes.c_int32(0)
+        gl["GetShaderInfoLog"](sh, log_len.value or 1024, ctypes.byref(actual), log_buf)
+        gl["DeleteShader"](sh)
+        raise RuntimeError(
+            f"{kind_name} shader compile failed: {log_buf.value.decode(errors='replace')}"
+        )
+    return sh
+
+
+def _link_program(gl, vs: int, fs: int) -> int:
+    prog = gl["CreateProgram"]()
+    if prog == 0:
+        raise RuntimeError("glCreateProgram returned 0")
+    gl["AttachShader"](prog, vs)
+    gl["AttachShader"](prog, fs)
+    gl["LinkProgram"](prog)
+    status = ctypes.c_int32(0)
+    gl["GetProgramiv"](prog, GL_LINK_STATUS, ctypes.byref(status))
+    if status.value == 0:
+        log_len = ctypes.c_int32(0)
+        gl["GetProgramiv"](prog, GL_INFO_LOG_LENGTH, ctypes.byref(log_len))
+        log_buf = ctypes.create_string_buffer(log_len.value or 1024)
+        actual = ctypes.c_int32(0)
+        gl["GetProgramInfoLog"](prog, log_len.value or 1024, ctypes.byref(actual), log_buf)
+        gl["DeleteProgram"](prog)
+        raise RuntimeError(
+            f"program link failed: {log_buf.value.decode(errors='replace')}"
+        )
+    return prog
+
+
+class OpenGlFragmentShaderProcessor:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        cfg = ctx.config
+        self._uuid = str(cfg["opengl_surface_uuid"])
+        self._width = int(cfg["width"])
+        self._height = int(cfg["height"])
+        self._opengl = OpenGLContext.from_runtime(ctx)
+        self._gl: Optional[dict] = None
+        self._rendered = False
+        self._error: Optional[str] = None
+        print(
+            f"[OpenGlFragmentShader/py] setup uuid={self._uuid} "
+            f"size={self._width}x{self._height}",
+            flush=True,
+        )
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("video_in")
+        if frame is None:
+            return
+        if self._rendered:
+            return  # Render once; subsequent frames are no-ops.
+        try:
+            self._render_once()
+            self._rendered = True
+            print(
+                f"[OpenGlFragmentShader/py] Mandelbrot rendered into surface '{self._uuid}'",
+                flush=True,
+            )
+        except Exception as e:
+            self._error = str(e)
+            print(
+                f"[OpenGlFragmentShader/py] render failed: {e}", flush=True,
+            )
+
+    def _render_once(self) -> None:
+        # Acquire the surface — adapter makes the EGL context current on
+        # this thread for the lifetime of the with-block.
+        with self._opengl.acquire_write(self._uuid) as view:
+            texture_id = view.gl_texture_id
+            # Lazy-load libGL — defer until the EGL context is current
+            # so symbol resolution sees a real GL state machine.
+            if self._gl is None:
+                self._gl = _load_libgl()
+            gl = self._gl
+
+            # Empty VAO — desktop core requires one bound; we generate
+            # geometry from gl_VertexID in the vertex shader.
+            vao = ctypes.c_uint32(0)
+            gl["GenVertexArrays"](1, ctypes.byref(vao))
+            gl["BindVertexArray"](vao.value)
+
+            vs = _compile_shader(gl, _VERTEX_SHADER, GL_VERTEX_SHADER, "vertex")
+            fs = _compile_shader(
+                gl, _FRAGMENT_SHADER, GL_FRAGMENT_SHADER, "fragment"
+            )
+            try:
+                program = _link_program(gl, vs, fs)
+            finally:
+                gl["DeleteShader"](vs)
+                gl["DeleteShader"](fs)
+
+            try:
+                # FBO with the imported texture as color attachment.
+                fbo = ctypes.c_uint32(0)
+                gl["GenFramebuffers"](1, ctypes.byref(fbo))
+                gl["BindFramebuffer"](GL_FRAMEBUFFER, fbo.value)
+                gl["FramebufferTexture2D"](
+                    GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                    texture_id, 0,
+                )
+                status = gl["CheckFramebufferStatus"](GL_FRAMEBUFFER)
+                if status != GL_FRAMEBUFFER_COMPLETE:
+                    raise RuntimeError(
+                        f"FBO incomplete (status=0x{status:x}) — the imported "
+                        "texture may have been bound with an external_only "
+                        "modifier; the host allocator should pick a tiled, "
+                        "render-target-capable DRM modifier"
+                    )
+
+                gl["Viewport"](0, 0, self._width, self._height)
+                gl["UseProgram"](program)
+
+                resolution_loc = gl["GetUniformLocation"](program, b"resolution")
+                if resolution_loc >= 0:
+                    gl["Uniform2f"](
+                        resolution_loc, float(self._width), float(self._height)
+                    )
+
+                gl["DrawArrays"](GL_TRIANGLE_STRIP, 0, 4)
+                gl["Finish"]()
+
+                gl_err = gl["GetError"]()
+                if gl_err != GL_NO_ERROR:
+                    raise RuntimeError(
+                        f"GL error 0x{gl_err:x} after draw — see "
+                        "docs/learnings/nvidia-egl-dmabuf-render-target.md"
+                    )
+
+                gl["BindFramebuffer"](GL_FRAMEBUFFER, 0)
+                gl["DeleteFramebuffers"](1, ctypes.byref(fbo))
+            finally:
+                gl["DeleteProgram"](program)
+                gl["BindVertexArray"](0)
+                gl["DeleteVertexArrays"](1, ctypes.byref(vao))
+        # acquire_write's __exit__ runs adapter `end_write_access`
+        # which does a final glFinish so the host's DMA-BUF readback
+        # sees a fully-flushed image.
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        print(
+            f"[OpenGlFragmentShader/py] teardown rendered={self._rendered} "
+            f"error={self._error}",
+            flush=True,
+        )

--- a/examples/polyglot-opengl-fragment-shader/python/pyproject.toml
+++ b/examples/polyglot-opengl-fragment-shader/python/pyproject.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[project]
+name = "polyglot-opengl-fragment-shader"
+version = "0.1.0"
+description = "Polyglot OpenGL adapter scenario — Python Mandelbrot fragment shader"
+requires-python = ">=3.10"
+dependencies = [
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-opengl-fragment-shader
+  version: "0.1.0"
+  description: "Polyglot OpenGL adapter scenario (#530) — Python Mandelbrot fragment shader rendered into a host DMA-BUF surface"
+
+processors:
+  - name: com.tatolab.opengl_fragment_shader
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a Mandelbrot fragment shader, releases"
+    runtime: python
+    execution: reactive
+    entrypoint: "opengl_fragment_shader:OpenGlFragmentShaderProcessor"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -1,0 +1,493 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Polyglot OpenGL adapter scenario (#530).
+//!
+//! End-to-end gate for the subprocess `OpenGLContext` runtime: the host
+//! pre-allocates ONE render-target-capable DMA-BUF surface and registers
+//! it with surface-share under a known UUID. A Python or Deno polyglot
+//! processor opens the surface through `OpenGLContext.acquire_write`,
+//! compiles a fragment shader (Mandelbrot in Python, plasma waves in
+//! Deno), binds an FBO to the imported `GL_TEXTURE_2D`, draws a
+//! fullscreen quad, releases — the adapter's `glFinish` on release
+//! ensures cross-API consumers see the writes through the underlying
+//! DMA-BUF. After the runtime stops, this binary reads the surface
+//! back via Vulkan and writes a PNG; reading that PNG with the Read
+//! tool is the visual gate.
+//!
+//! Build the Python `.slpkg` first:
+//!   cargo run -p streamlib-cli -- pack examples/polyglot-opengl-fragment-shader/python
+//!
+//! Run:
+//!   cargo run -p polyglot-opengl-fragment-shader-scenario -- \
+//!       --runtime=python --output=/tmp/opengl-mandelbrot.png
+//!   cargo run -p polyglot-opengl-fragment-shader-scenario -- \
+//!       --runtime=deno   --output=/tmp/opengl-plasma.png
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use streamlib::adapter_support::VulkanDevice;
+use streamlib::core::rhi::TextureFormat;
+use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
+use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
+
+/// UUID the host registers the render-target surface under. The
+/// polyglot processor reads it from its config and passes it to
+/// `OpenGLContext.acquire_write`.
+const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-0000000005c0";
+
+/// Side length of the surface. Square keeps Mandelbrot/plasma math
+/// straightforward; 512 is large enough to be visually obvious and
+/// small enough that the scenario runs in a couple seconds.
+const SURFACE_SIZE: u32 = 512;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeKind {
+    Python,
+    Deno,
+}
+
+impl RuntimeKind {
+    fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "python" => Ok(Self::Python),
+            "deno" => Ok(Self::Deno),
+            other => Err(format!(
+                "unknown --runtime value '{other}' (expected 'python' or 'deno')"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Deno => "deno",
+        }
+    }
+
+    fn processor_name(self) -> &'static str {
+        match self {
+            Self::Python => "com.tatolab.opengl_fragment_shader",
+            Self::Deno => "com.tatolab.opengl_fragment_shader_deno",
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1);
+
+    let mut runtime_kind = RuntimeKind::Python;
+    let mut output_png = PathBuf::from("/tmp/opengl-fragment-shader.png");
+
+    for a in args {
+        if let Some(value) = a.strip_prefix("--runtime=") {
+            runtime_kind =
+                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+        } else if let Some(value) = a.strip_prefix("--output=") {
+            output_png = PathBuf::from(value);
+        }
+    }
+
+    println!("=== Polyglot OpenGL adapter fragment-shader scenario (#530) ===");
+    println!("Runtime:     {}", runtime_kind.as_str());
+    println!(
+        "Surface:     {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (uuid {SCENARIO_SURFACE_UUID})"
+    );
+    println!("Output PNG:  {}", output_png.display());
+    println!();
+
+    let runtime = StreamRuntime::new()?;
+
+    // Slots the setup hook populates with the host StreamTexture and
+    // the underlying VulkanDevice so main.rs can read the surface back
+    // post-stop and write the output PNG. We can't keep the
+    // `&GpuContext` borrow past the hook, so we Arc-clone the bits we
+    // need.
+    let texture_slot: Arc<
+        Mutex<Option<streamlib::core::rhi::StreamTexture>>,
+    > = Arc::new(Mutex::new(None));
+    let device_slot: Arc<Mutex<Option<Arc<VulkanDevice>>>> =
+        Arc::new(Mutex::new(None));
+
+    {
+        let texture_slot = Arc::clone(&texture_slot);
+        let device_slot = Arc::clone(&device_slot);
+        runtime.install_setup_hook(move |gpu| {
+            let texture = gpu.acquire_render_target_dma_buf_image(
+                SURFACE_SIZE,
+                SURFACE_SIZE,
+                TextureFormat::Bgra8Unorm,
+            )?;
+            // Register with surface-share so the subprocess can look
+            // it up via `gpu_limited_access.resolve_surface`. The
+            // adapter's `OpenGlSurfaceAdapter` then imports the
+            // resulting DMA-BUF FD as an EGLImage + GL_TEXTURE_2D.
+            let store = gpu.surface_store().ok_or_else(|| {
+                StreamError::Configuration(
+                    "surface_store unavailable — host runtime built without \
+                     a surface-share service (Linux subprocess flow requires it)"
+                        .into(),
+                )
+            })?;
+            store
+                .register_texture(SCENARIO_SURFACE_UUID, &texture)
+                .map_err(|e| {
+                    StreamError::Configuration(format!(
+                        "register_texture: {e}"
+                    ))
+                })?;
+            *texture_slot.lock().unwrap() = Some(texture);
+            *device_slot.lock().unwrap() =
+                Some(Arc::clone(gpu.device().vulkan_device()));
+            println!(
+                "✓ render-target DMA-BUF surface registered as '{}'",
+                SCENARIO_SURFACE_UUID
+            );
+            Ok(())
+        });
+    }
+
+    // Load the polyglot package.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match runtime_kind {
+        RuntimeKind::Python => {
+            let slpkg_path = manifest_dir
+                .join("python/polyglot-opengl-fragment-shader-0.1.0.slpkg");
+            if !slpkg_path.exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-opengl-fragment-shader/python",
+                    slpkg_path.display()
+                )));
+            }
+            runtime.load_package(&slpkg_path)?;
+        }
+        RuntimeKind::Deno => {
+            let project_path = manifest_dir.join("deno");
+            if !project_path.join("streamlib.yaml").exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Deno project not found: {}",
+                    project_path.display()
+                )));
+            }
+            runtime.load_project(&project_path)?;
+        }
+    }
+
+    // Trigger source: BgraFileSource emits a few `Videoframe`s so the
+    // polyglot processor's `process()` is invoked. The processor
+    // ignores frame contents — it works on the pre-registered host
+    // surface, not the trigger frame's pixel buffer.
+    let fixture_path = write_trigger_fixture()
+        .map_err(StreamError::Configuration)?;
+
+    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
+        BgraFileSourceProcessor::Config {
+            file_path: fixture_path
+                .to_str()
+                .ok_or_else(|| {
+                    StreamError::Configuration(
+                        "fixture path has non-utf8 component".into(),
+                    )
+                })?
+                .to_string(),
+            width: 4,
+            height: 4,
+            fps: 5,
+            frame_count: 3,
+        },
+    ))?;
+    println!("+ BgraFileSource: {source}");
+
+    let shader_config = serde_json::json!({
+        "opengl_surface_uuid": SCENARIO_SURFACE_UUID,
+        "width": SURFACE_SIZE,
+        "height": SURFACE_SIZE,
+    });
+    let shader = runtime.add_processor(ProcessorSpec::new(
+        runtime_kind.processor_name(),
+        shader_config,
+    ))?;
+    println!("+ Fragment shader: {shader}");
+
+    runtime.connect(
+        OutputLinkPortRef::new(&source, "video"),
+        InputLinkPortRef::new(&shader, "video_in"),
+    )?;
+    println!(
+        "\nPipeline: BgraFileSource → {} fragment-shader\n",
+        runtime_kind.as_str()
+    );
+
+    println!("Starting pipeline...");
+    runtime.start()?;
+
+    // Give the polyglot processor time to receive a trigger frame and
+    // complete the GL acquire/draw/release cycle. The Python/Deno
+    // processors guard against re-rendering on subsequent frames so the
+    // PNG stays clean.
+    std::thread::sleep(Duration::from_secs(4));
+
+    println!("Stopping pipeline...");
+    runtime.stop()?;
+
+    // Read the surface back via Vulkan and write the output PNG.
+    println!("\nReading host surface back via Vulkan...");
+    let texture = texture_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| {
+            StreamError::Runtime(
+                "host texture slot is empty — setup hook never ran".into(),
+            )
+        })?;
+    let device = device_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| {
+            StreamError::Runtime("device slot is empty".into())
+        })?;
+    let bgra = vulkan_readback(&device, &texture);
+    write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
+    println!("✓ Output PNG written: {}", output_png.display());
+
+    Ok(())
+}
+
+/// Write a tiny BGRA fixture file. BgraFileSource reads it
+/// frame-by-frame; the resulting `Videoframe`s are the trigger that
+/// drives the polyglot processor's `process()` call.
+fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let path = std::env::temp_dir().join("opengl-fragment-shader-trigger.bgra");
+    let mut f = File::create(&path)
+        .map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(&[0u8; 4 * 4 * 4 * 3])
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// Read pixels from the host `StreamTexture` back into a CPU buffer
+/// for verification. Returns BGRA8 bytes, `width*height*4` size.
+///
+/// Uses a transient HOST_VISIBLE staging buffer + `vkCmdCopyImageToBuffer`
+/// + queue wait — the canonical Vulkan readback shape, parallel to the
+/// `host_readback` helper in `streamlib-adapter-opengl/tests/common.rs`.
+fn vulkan_readback(
+    device: &Arc<VulkanDevice>,
+    texture: &streamlib::core::rhi::StreamTexture,
+) -> Vec<u8> {
+    use vulkanalia::prelude::v1_4::*;
+    use vulkanalia::vk;
+
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+    let image = texture
+        .vulkan_inner()
+        .image()
+        .expect("StreamTexture must have a Vulkan image handle on Linux");
+    let width = texture.width();
+    let height = texture.height();
+    let bytes = (width as u64) * (height as u64) * 4;
+
+    let buf = unsafe {
+        dev.create_buffer(
+            &vk::BufferCreateInfo::builder()
+                .size(bytes)
+                .usage(vk::BufferUsageFlags::TRANSFER_DST)
+                .sharing_mode(vk::SharingMode::EXCLUSIVE)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_buffer");
+    let mem_req = unsafe { dev.get_buffer_memory_requirements(buf) };
+    let inst = device.instance();
+    let phys = device.physical_device();
+    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
+    let needed =
+        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+    let mem_idx = (0..mem_props.memory_type_count)
+        .find(|i| {
+            let bit = 1u32 << i;
+            (mem_req.memory_type_bits & bit) != 0
+                && mem_props.memory_types[*i as usize]
+                    .property_flags
+                    .contains(needed)
+        })
+        .expect("host-visible memory type");
+    let mem = unsafe {
+        dev.allocate_memory(
+            &vk::MemoryAllocateInfo::builder()
+                .allocation_size(mem_req.size)
+                .memory_type_index(mem_idx)
+                .build(),
+            None,
+        )
+    }
+    .expect("allocate_memory");
+    unsafe { dev.bind_buffer_memory(buf, mem, 0) }.expect("bind_buffer_memory");
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers")[0];
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    // The OpenGL adapter leaves the image in GENERAL layout (it never
+    // transitions out). Move to TRANSFER_SRC_OPTIMAL for the copy, then
+    // back to GENERAL.
+    let to_src = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs = [to_src];
+    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let copy = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [copy];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            buf,
+            &regions,
+        )
+    };
+
+    let to_general = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::COPY)
+        .src_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+        .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .new_layout(vk::ImageLayout::GENERAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs2 = [to_general];
+    let dep2 = vk::DependencyInfo::builder().image_memory_barriers(&bs2).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep2) };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
+    let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }
+        .expect("submit");
+    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
+
+    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
+        .expect("map_memory");
+    let slice =
+        unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
+    let out = slice.to_vec();
+    unsafe { dev.unmap_memory(mem) };
+    unsafe { dev.destroy_command_pool(pool, None) };
+    unsafe { dev.destroy_buffer(buf, None) };
+    unsafe { dev.free_memory(mem, None) };
+    out
+}
+
+/// Encode BGRA bytes as RGBA PNG (channel-swap on the fly).
+fn write_png(
+    bgra: &[u8],
+    width: u32,
+    height: u32,
+    output: &std::path::Path,
+) -> Result<()> {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let mut rgba = vec![0u8; bgra.len()];
+    for (src, dst) in bgra.chunks_exact(4).zip(rgba.chunks_exact_mut(4)) {
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+        dst[3] = src[3];
+    }
+
+    let file = File::create(output).map_err(|e| {
+        StreamError::Configuration(format!(
+            "create output PNG {}: {e}",
+            output.display()
+        ))
+    })?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+    writer
+        .write_image_data(&rgba)
+        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+    Ok(())
+}

--- a/libs/streamlib-adapter-opengl/src/egl.rs
+++ b/libs/streamlib-adapter-opengl/src/egl.rs
@@ -13,11 +13,12 @@
 //! way out so a different thread can take over on the next call.
 
 use std::ffi::{c_void, CStr, CString};
+use std::mem::ManuallyDrop;
 use std::os::raw::c_char;
 use std::sync::Arc;
 
 use khronos_egl as egl;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 use thiserror::Error;
 use tracing::{debug, instrument};
 
@@ -234,6 +235,20 @@ impl EglRuntime {
         })
     }
 
+    /// Owned-Arc variant of [`Self::lock_make_current`] returning a
+    /// `'static`, [`Send`] guard that anchors its own `Arc<EglRuntime>`.
+    ///
+    /// Required by the polyglot FFI bindings, where acquire and release
+    /// happen across separate FFI calls and the borrow-style guard's
+    /// lifetime can't span them. In-process Rust callers should prefer
+    /// [`Self::lock_make_current`] — its borrow-checked guard catches
+    /// scope mistakes at compile time.
+    pub fn arc_lock_make_current(
+        self: &Arc<Self>,
+    ) -> Result<OwnedMakeCurrentGuard, EglRuntimeError> {
+        OwnedMakeCurrentGuard::new(Arc::clone(self))
+    }
+
     /// Wrap `eglCreateImage(EGL_LINUX_DMA_BUF_EXT, …)` for the
     /// caller. Returns the imported [`khronos_egl::Image`]; destroy
     /// via [`Self::destroy_image`].
@@ -304,6 +319,65 @@ impl Drop for MakeCurrentGuard<'_> {
         let _ = self.runtime.egl.make_current(self.runtime.display, None, None, None);
     }
 }
+
+/// Owned-Arc make-current guard. `'static` and [`Send`]; anchors its
+/// own `Arc<EglRuntime>` so the guard can outlive any borrow of the
+/// runtime — required by the polyglot FFI bindings, where acquire and
+/// release happen across separate FFI calls.
+pub struct OwnedMakeCurrentGuard {
+    runtime: Arc<EglRuntime>,
+    lock: ManuallyDrop<MutexGuard<'static, ()>>,
+}
+
+impl OwnedMakeCurrentGuard {
+    fn new(runtime: Arc<EglRuntime>) -> Result<Self, EglRuntimeError> {
+        let lock_borrowed = runtime.make_current_lock.lock();
+        runtime
+            .egl
+            .make_current(
+                runtime.display,
+                None,
+                None,
+                Some(runtime.context),
+            )
+            .map_err(|e| EglRuntimeError::MakeCurrent(format!("acquire: {e}")))?;
+        // SAFETY: `lock_borrowed` borrows `runtime.make_current_lock`. We
+        // anchor an `Arc<EglRuntime>` inside the same struct, so the
+        // referent outlives the (lifetime-extended) guard. The guard is
+        // dropped before the Arc in our manual `Drop` impl, restoring
+        // the borrow ordering.
+        let lock = unsafe {
+            std::mem::transmute::<MutexGuard<'_, ()>, MutexGuard<'static, ()>>(lock_borrowed)
+        };
+        Ok(Self {
+            runtime,
+            lock: ManuallyDrop::new(lock),
+        })
+    }
+}
+
+impl Drop for OwnedMakeCurrentGuard {
+    fn drop(&mut self) {
+        let _ = self
+            .runtime
+            .egl
+            .make_current(self.runtime.display, None, None, None);
+        // SAFETY: the lock has not yet been dropped (we never call
+        // `ManuallyDrop::drop` outside this Drop impl). Drop it here to
+        // release the mutex before our Arc reference goes away.
+        unsafe { ManuallyDrop::drop(&mut self.lock) };
+    }
+}
+
+// SAFETY: `MutexGuard<'_, ()>` is `Send` only when the underlying
+// `Mutex<()>` is `Send + Sync` (parking_lot's mutex is). The
+// `Arc<EglRuntime>` is `Send` (we declared `EglRuntime: Send + Sync`
+// at the top of this module). EGL's `make_current` is per-thread —
+// the guard's invariant ("EGL context is current on the holder's
+// thread") ports across thread moves only if the holder
+// re-makes-current after move; in practice the FFI binds the guard to
+// the calling thread's life-cycle and never moves it.
+unsafe impl Send for OwnedMakeCurrentGuard {}
 
 /// Pick an EGL config that's renderable as OpenGL and supports
 /// pbuffer surfaces. We don't actually create a pbuffer (surfaceless
@@ -398,5 +472,32 @@ mod tests {
         assert_eq!(DRM_FORMAT_ABGR8888, 0x34_32_42_41);
         // "AR24" → [0x41, 0x52, 0x32, 0x34] → 0x34_32_52_41.
         assert_eq!(DRM_FORMAT_ARGB8888, 0x34_32_52_41);
+    }
+
+    /// `arc_lock_make_current` returns a `'static`-lifetime guard that
+    /// outlives any borrow of the [`EglRuntime`]. The polyglot FFI uses
+    /// this so `acquire_*` / `release_*` can hold the EGL mutex across
+    /// separate FFI calls. Drop releases the mutex (verified by
+    /// re-acquiring on the same thread).
+    #[test]
+    fn arc_lock_make_current_is_static_and_releases_on_drop() {
+        let runtime = match EglRuntime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                println!("arc_lock_make_current: skipping — no EGL on this host: {e}");
+                return;
+            }
+        };
+        let guard1 = runtime.arc_lock_make_current().expect("first acquire");
+        // Concrete check on the lifetime: the guard must satisfy
+        // `'static + Send` so the FFI can stash it in a HashMap entry.
+        fn assert_static_send<T: Send + 'static>(_: &T) {}
+        assert_static_send(&guard1);
+        drop(guard1);
+        // After release the mutex is free — re-acquiring on the same
+        // thread must succeed without deadlocking.
+        let _guard2 = runtime
+            .arc_lock_make_current()
+            .expect("re-acquire after drop");
     }
 }

--- a/libs/streamlib-adapter-opengl/src/lib.rs
+++ b/libs/streamlib-adapter-opengl/src/lib.rs
@@ -26,6 +26,9 @@ mod view;
 
 pub use adapter::OpenGlSurfaceAdapter;
 pub use context::OpenGlContext;
-pub use egl::{EglRuntime, EglRuntimeError, DRM_FORMAT_ABGR8888, DRM_FORMAT_ARGB8888};
+pub use egl::{
+    EglRuntime, EglRuntimeError, OwnedMakeCurrentGuard, DRM_FORMAT_ABGR8888,
+    DRM_FORMAT_ARGB8888,
+};
 pub use state::HostSurfaceRegistration;
 pub use view::{OpenGlReadView, OpenGlWriteView, GL_TEXTURE_2D};

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -30,6 +30,11 @@ streamlib-surface-client = { path = "../streamlib-surface-client" }
 # hard link to libvulkan.so so the cdylib loads on systems without a Vulkan
 # driver.
 vulkanalia = { workspace = true }
+# Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
+# EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
+# bring-up or DMA-BUF → GL_TEXTURE_2D import.
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
 
 
 [lints]

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -956,11 +956,23 @@ mod gpu_surface {
         pub fds: Vec<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
+        /// Per-plane row pitch in bytes (source-of-truth from the host's
+        /// DRM-modifier-aware allocator). Required by EGL DMA-BUF import
+        /// (`EGL_DMA_BUF_PLANE{N}_PITCH_EXT`).
+        pub plane_strides: Vec<u64>,
         pub width: u32,
         pub height: u32,
         pub bytes_per_row: u32,
         /// Total byte size across all planes — the sum of `plane_sizes`.
         pub size: u64,
+        /// DRM format modifier of the underlying host `VkImage`. Required
+        /// by EGL DMA-BUF import; zero means LINEAR / not applicable.
+        /// Render-target consumers MUST refuse LINEAR on NVIDIA — see
+        /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
+        pub drm_format_modifier: u64,
+        /// Format string from the wire response (e.g. `"Bgra8Unorm"`).
+        /// Used to derive a DRM_FORMAT_* fourcc for EGL import.
+        pub format: String,
         /// Host-mapped base address of plane 0, populated by `lock` (Vulkan
         /// path) or `plane_mmap` (CPU path). Multi-plane accessor reads
         /// from [`Self::plane_mapped_ptrs`].
@@ -1207,6 +1219,56 @@ mod gpu_surface {
     ) -> u64 {
         unsafe { handle.as_ref() }
             .and_then(|h| h.plane_sizes.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane row pitch in bytes. Required by EGL DMA-BUF import
+    /// (`EGL_DMA_BUF_PLANE{N}_PITCH_EXT`); the Vulkan import path reads
+    /// from `bytes_per_row` instead. Returns `0` on null handle / out
+    /// of range plane index.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_stride(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_strides.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane offset into its DMA-BUF fd. Returns `0` on null handle
+    /// / out of range plane index.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_offset(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_offsets.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane DMA-BUF file descriptor, or `-1` on null handle / out of
+    /// range plane index. The fd is owned by the [`SurfaceHandle`]; the
+    /// caller MUST `dup()` if they need an independent copy.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_plane_fd(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> i32 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.fds.get(plane_index as usize).copied())
+            .unwrap_or(-1)
+    }
+
+    /// DRM format modifier of the underlying host `VkImage`. Required by
+    /// EGL DMA-BUF import; zero means LINEAR / not applicable.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_gpu_surface_drm_format_modifier(
+        handle: *const SurfaceHandle,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .map(|h| h.drm_format_modifier)
             .unwrap_or(0)
     }
 
@@ -2065,10 +2127,13 @@ mod surface_client {
         fds: Vec<RawFd>,
         plane_sizes: Vec<u64>,
         plane_offsets: Vec<u64>,
+        plane_strides: Vec<u64>,
         width: u32,
         height: u32,
         bytes_per_row: u32,
         size: u64,
+        drm_format_modifier: u64,
+        format: String,
     }
 
     impl Drop for CachedSurface {
@@ -2253,10 +2318,13 @@ mod surface_client {
                     fds: dup_fds,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
+                    plane_strides: cached.plane_strides.clone(),
                     width: cached.width,
                     height: cached.height,
                     bytes_per_row: cached.bytes_per_row,
                     size: cached.size,
+                    drm_format_modifier: cached.drm_format_modifier,
+                    format: cached.format.clone(),
                     mapped_ptr: std::ptr::null_mut(),
                     plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
                     is_locked: false,
@@ -2351,6 +2419,19 @@ mod surface_client {
             .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
             .filter(|v: &Vec<u64>| v.len() == received_fds.len())
             .unwrap_or_else(|| vec![0u64; received_fds.len()]);
+        // `plane_strides` and `drm_format_modifier` are required by EGL
+        // DMA-BUF import (#530); the Vulkan import path ignores them and
+        // reads `bytes_per_row` instead.
+        let plane_strides: Vec<u64> = response
+            .get("plane_strides")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![bytes_per_row as u64; received_fds.len()]);
+        let drm_format_modifier = response
+            .get("drm_format_modifier")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         let size: u64 = plane_sizes.iter().copied().sum();
 
         let mut cache_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
@@ -2378,10 +2459,13 @@ mod surface_client {
                     fds: cache_fds,
                     plane_sizes: plane_sizes.clone(),
                     plane_offsets: plane_offsets.clone(),
+                    plane_strides: plane_strides.clone(),
                     width,
                     height,
                     bytes_per_row,
                     size,
+                    drm_format_modifier,
+                    format: format_str.to_string(),
                 },
             );
         } else {
@@ -2395,10 +2479,13 @@ mod surface_client {
             fds: received_fds,
             plane_sizes,
             plane_offsets,
+            plane_strides,
             width,
             height,
             bytes_per_row,
             size,
+            drm_format_modifier,
+            format: format_str.to_string(),
             mapped_ptr: std::ptr::null_mut(),
             plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
             is_locked: false,
@@ -2503,6 +2590,375 @@ mod surface_client {
         std::ptr::null_mut()
     }
 
+}
+
+// ============================================================================
+// C ABI — OpenGL/EGL adapter runtime (#530, Linux)
+//
+// Deno twin of `streamlib-python-native::opengl`. Same shape, `sldn_`
+// prefix. See the Python-side module for documentation on the wire format,
+// thread-safety, and ordering invariants.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod opengl {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_opengl::{
+        EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter,
+        OwnedMakeCurrentGuard, DRM_FORMAT_ABGR8888, DRM_FORMAT_ARGB8888,
+    };
+
+    use super::gpu_surface::SurfaceHandle;
+
+    pub struct OpenGlRuntimeHandle {
+        egl: Arc<EglRuntime>,
+        adapter: Arc<OpenGlSurfaceAdapter>,
+        held: Mutex<HashMap<u64, HeldAcquire>>,
+    }
+
+    enum HeldKind {
+        Read,
+        Write,
+    }
+
+    struct HeldAcquire {
+        kind: HeldKind,
+        texture_id: u32,
+        make_current: OwnedMakeCurrentGuard,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_runtime_new() -> *mut OpenGlRuntimeHandle {
+        let egl = match EglRuntime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_opengl_runtime_new: EglRuntime::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let adapter = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+        Box::into_raw(Box::new(OpenGlRuntimeHandle {
+            egl,
+            adapter,
+            held: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_runtime_free(rt: *mut OpenGlRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_register_surface(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *const SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_opengl_register_surface: null runtime");
+                return -1;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_ref() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("sldn_opengl_register_surface: null gpu_handle");
+                return -1;
+            }
+        };
+        let fd = match gpu.fds.first().copied() {
+            Some(f) if f >= 0 => f,
+            _ => {
+                tracing::error!(
+                    "sldn_opengl_register_surface: surface has no DMA-BUF fd"
+                );
+                return -1;
+            }
+        };
+        let drm_fourcc = match drm_fourcc_for_format(&gpu.format) {
+            Some(c) => c,
+            None => {
+                tracing::error!(
+                    "sldn_opengl_register_surface: unsupported format '{}'",
+                    gpu.format
+                );
+                return -1;
+            }
+        };
+        let stride = gpu
+            .plane_strides
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.bytes_per_row as u64);
+        let offset = gpu.plane_offsets.first().copied().unwrap_or(0);
+        let registration = HostSurfaceRegistration {
+            dma_buf_fd: fd,
+            width: gpu.width,
+            height: gpu.height,
+            drm_fourcc,
+            drm_format_modifier: gpu.drm_format_modifier,
+            plane_offset: offset,
+            plane_stride: stride,
+        };
+        match rt.adapter.register_host_surface(surface_id, registration) {
+            Ok(()) => 0,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_opengl_register_surface: register_host_surface failed: {:?}",
+                    e
+                );
+                -1
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_unregister_surface(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        if rt.adapter.unregister_host_surface(surface_id) {
+            0
+        } else {
+            -1
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_acquire_write(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> u32 {
+        acquire_inner(rt, surface_id, HeldKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_release_write(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, HeldKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_acquire_read(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> u32 {
+        acquire_inner(rt, surface_id, HeldKind::Read)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_release_read(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, HeldKind::Read)
+    }
+
+    fn acquire_inner(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        kind: HeldKind,
+    ) -> u32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_opengl_acquire_*: null runtime");
+                return 0;
+            }
+        };
+        let make_current = match rt.egl.arc_lock_make_current() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_opengl_acquire_*: arc_lock_make_current: {}",
+                    e
+                );
+                return 0;
+            }
+        };
+        let surface = StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        let texture_id = match kind {
+            HeldKind::Write => match rt.adapter.acquire_write(&surface) {
+                Ok(g) => {
+                    let t = g.view().gl_texture_id();
+                    std::mem::forget(g);
+                    t
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_opengl_acquire_write: adapter.acquire_write: {:?}",
+                        e
+                    );
+                    return 0;
+                }
+            },
+            HeldKind::Read => match rt.adapter.acquire_read(&surface) {
+                Ok(g) => {
+                    let t = g.view().gl_texture_id();
+                    std::mem::forget(g);
+                    t
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_opengl_acquire_read: adapter.acquire_read: {:?}",
+                        e
+                    );
+                    return 0;
+                }
+            },
+        };
+        let mut held = rt.held.lock().expect("opengl held: poisoned");
+        held.insert(
+            surface_id,
+            HeldAcquire {
+                kind,
+                texture_id,
+                make_current,
+            },
+        );
+        texture_id
+    }
+
+    fn release_inner(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        expected: HeldKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let removed = {
+            let mut held = rt.held.lock().expect("opengl held: poisoned");
+            held.remove(&surface_id)
+        };
+        let held = match removed {
+            Some(h) => h,
+            None => {
+                tracing::error!(
+                    "sldn_opengl_release_*: no acquire held for surface_id {}",
+                    surface_id
+                );
+                return -1;
+            }
+        };
+        if !matches!((&held.kind, &expected), (HeldKind::Read, HeldKind::Read) | (HeldKind::Write, HeldKind::Write)) {
+            tracing::error!(
+                "sldn_opengl_release_*: surface_id {} held in different mode than \
+                 release call expected — releasing it anyway",
+                surface_id
+            );
+        }
+        // CRITICAL: drop the make-current guard before calling
+        // `end_*_access` (the adapter's mutex is not reentrant).
+        drop(held.make_current);
+        match held.kind {
+            HeldKind::Read => rt.adapter.end_read_access(surface_id),
+            HeldKind::Write => rt.adapter.end_write_access(surface_id),
+        }
+        let _ = held.texture_id;
+        0
+    }
+
+    fn drm_fourcc_for_format(format: &str) -> Option<u32> {
+        match format {
+            "Bgra8Unorm" | "Bgra8UnormSrgb" => Some(DRM_FORMAT_ARGB8888),
+            "Rgba8Unorm" | "Rgba8UnormSrgb" => Some(DRM_FORMAT_ABGR8888),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod opengl {
+    use std::ffi::c_void;
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_runtime_new() -> *mut c_void {
+        tracing::error!("sldn_opengl_*: OpenGL adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *const c_void,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> u32 {
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> u32 {
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_opengl_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
 }
 
 // ============================================================================

--- a/libs/streamlib-deno/adapters/opengl.ts
+++ b/libs/streamlib-deno/adapters/opengl.ts
@@ -63,7 +63,184 @@ export interface OpenGLSurfaceAdapter {
   ): SurfaceAccessGuard<OpenGLWriteView> | null;
 }
 
-/** Customer-facing context. Same shape as the adapter — the runtime
- * wraps the adapter and hands the context out. Mirrors the Rust
- * `OpenGlContext`. */
-export type OpenGLContext = OpenGLSurfaceAdapter;
+/** Async-disposable guard returned by acquire ops. `using` (synchronous
+ * disposable) suffices because the OpenGL adapter's per-acquire path is
+ * fully synchronous — no IPC roundtrip on the hot path. */
+export interface OpenGLAccessGuard<V> extends Disposable {
+  readonly view: V;
+}
+
+/** Minimal subset of `GpuContextLimitedAccess` the OpenGL adapter
+ * runtime needs. The full shape lives in `context.ts`; we type against
+ * a structural subset here so tests can stub it without dragging the
+ * whole FFI surface. */
+export interface OpenGLGpuLimitedAccess {
+  resolveSurface(poolId: string): {
+    readonly nativeHandlePtr: Deno.PointerObject | null;
+    release(): void;
+  };
+  // deno-lint-ignore no-explicit-any
+  readonly nativeLib: { readonly symbols: any };
+}
+
+let _SURFACE_ID_COUNTER = 0n;
+function nextSurfaceId(): bigint {
+  _SURFACE_ID_COUNTER += 1n;
+  return _SURFACE_ID_COUNTER;
+}
+
+let _SHARED_INSTANCE: OpenGLContext | null = null;
+
+/** Subprocess-side OpenGL adapter runtime (#530, Linux).
+ *
+ * Brings up `streamlib-adapter-opengl::EglRuntime` +
+ * `OpenGlSurfaceAdapter` inside this subprocess and exposes scoped
+ * acquire/release that hands the customer a real `GL_TEXTURE_2D` id.
+ * The adapter's EGL context is current on the calling thread for the
+ * lifetime of an `acquire*` scope — any GL library that latches onto
+ * the current EGL context (raw `Deno.dlopen` against `libGLESv2.so`,
+ * a Deno-FFI game-engine binding, etc.) sees the texture id as live.
+ *
+ * Construct via `OpenGLContext.fromRuntime(ctx)` — single instance per
+ * subprocess. Repeat calls return the cached instance.
+ *
+ * Acquire / release MUST happen on the same thread. Deno's default is
+ * a single-threaded async event loop, so this is the natural shape.
+ */
+export class OpenGLContext {
+  private readonly gpu: OpenGLGpuLimitedAccess;
+  // deno-lint-ignore no-explicit-any
+  private readonly symbols: any;
+  private readonly rt: Deno.PointerObject;
+  private readonly surfaceIds = new Map<string, bigint>();
+  private readonly resolvedHandles = new Map<
+    string,
+    ReturnType<OpenGLGpuLimitedAccess["resolveSurface"]>
+  >();
+
+  constructor(gpu: OpenGLGpuLimitedAccess) {
+    this.gpu = gpu;
+    this.symbols = gpu.nativeLib.symbols;
+    const rtPtr = this.symbols.sldn_opengl_runtime_new();
+    if (rtPtr === null) {
+      throw new Error(
+        "OpenGLContext: sldn_opengl_runtime_new returned NULL — the " +
+          "subprocess could not bring up an EGL display + GL context. " +
+          "Check that libEGL.so.1 is installed and the driver supports " +
+          "EGL_EXT_image_dma_buf_import_modifiers.",
+      );
+    }
+    this.rt = rtPtr;
+  }
+
+  /** Build (or fetch the cached) `OpenGLContext` for this subprocess.
+   * The subprocess hosts at most one EGL display + GL context — calling
+   * this twice returns the same instance. */
+  static fromRuntime(
+    ctx: { readonly gpuLimitedAccess: OpenGLGpuLimitedAccess },
+  ): OpenGLContext {
+    if (_SHARED_INSTANCE === null) {
+      _SHARED_INSTANCE = new OpenGLContext(ctx.gpuLimitedAccess);
+    }
+    return _SHARED_INSTANCE;
+  }
+
+  private resolveAndRegister(poolId: string): bigint {
+    const cached = this.surfaceIds.get(poolId);
+    if (cached !== undefined) return cached;
+    const handle = this.gpu.resolveSurface(poolId);
+    const handlePtr = handle.nativeHandlePtr;
+    if (handlePtr === null) {
+      throw new Error(
+        `OpenGLContext: resolveSurface('${poolId}') returned a handle with a null native pointer`,
+      );
+    }
+    const surfaceId = nextSurfaceId();
+    const rc: number = this.symbols.sldn_opengl_register_surface(
+      this.rt,
+      surfaceId,
+      handlePtr,
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `OpenGLContext: register_surface failed for pool_id ` +
+          `'${poolId}' (rc=${rc}). Check the subprocess log for ` +
+          `EGL/DMA-BUF import errors — typically a wrong DRM modifier ` +
+          `or an unsupported pixel format.`,
+      );
+    }
+    this.surfaceIds.set(poolId, surfaceId);
+    // Hold the SDK handle so its FDs stay alive for the runtime's life.
+    this.resolvedHandles.set(poolId, handle);
+    return surfaceId;
+  }
+
+  private static surfacePoolId(
+    surface: StreamlibSurface | string | bigint,
+  ): string {
+    if (typeof surface === "string") return surface;
+    if (typeof surface === "bigint") return surface.toString();
+    const id = (surface as { id?: bigint | string | number }).id;
+    if (id === undefined) {
+      throw new TypeError(
+        `OpenGLContext: expected StreamlibSurface, string pool_id, or bigint — got ${
+          typeof surface
+        }`,
+      );
+    }
+    return String(id);
+  }
+
+  /** Acquire write access. Returns a `using`-disposable guard whose
+   * `view.glTextureId` is a `GL_TEXTURE_2D` valid in the adapter's EGL
+   * context, which is current on the calling thread for the guard's
+   * scope. On dispose the adapter drains GL (`glFinish`). */
+  acquireWrite(
+    surface: StreamlibSurface | string | bigint,
+  ): OpenGLAccessGuard<OpenGLWriteView> {
+    const poolId = OpenGLContext.surfacePoolId(surface);
+    const surfaceId = this.resolveAndRegister(poolId);
+    const textureId = Number(
+      this.symbols.sldn_opengl_acquire_write(this.rt, surfaceId),
+    );
+    if (textureId === 0) {
+      throw new Error(
+        `OpenGLContext.acquireWrite: sldn_opengl_acquire_write returned 0 for surface '${poolId}'`,
+      );
+    }
+    const symbols = this.symbols;
+    const rt = this.rt;
+    return {
+      view: { glTextureId: textureId, target: GL_TEXTURE_2D },
+      [Symbol.dispose]() {
+        symbols.sldn_opengl_release_write(rt, surfaceId);
+      },
+    };
+  }
+
+  /** Acquire read access. Same shape as `acquireWrite`, but the
+   * resulting texture is sample-only (multiple readers may coexist; no
+   * writer can be active). */
+  acquireRead(
+    surface: StreamlibSurface | string | bigint,
+  ): OpenGLAccessGuard<OpenGLReadView> {
+    const poolId = OpenGLContext.surfacePoolId(surface);
+    const surfaceId = this.resolveAndRegister(poolId);
+    const textureId = Number(
+      this.symbols.sldn_opengl_acquire_read(this.rt, surfaceId),
+    );
+    if (textureId === 0) {
+      throw new Error(
+        `OpenGLContext.acquireRead: sldn_opengl_acquire_read returned 0 for surface '${poolId}'`,
+      );
+    }
+    const symbols = this.symbols;
+    const rt = this.rt;
+    return {
+      view: { glTextureId: textureId, target: GL_TEXTURE_2D },
+      [Symbol.dispose]() {
+        symbols.sldn_opengl_release_read(rt, surfaceId);
+      },
+    };
+  }
+}

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -386,6 +386,12 @@ class NativeGpuContextLimitedAccess implements GpuContextLimitedAccess {
     this.surfaceHandlePtr = surfaceHandlePtr;
   }
 
+  /** Underlying cdylib FFI handle. Returned for in-tree adapter SDKs that
+   * need to call additional `sldn_*` ops without re-loading. */
+  get nativeLib(): NativeLib {
+    return this.lib;
+  }
+
   resolveSurface(poolId: string): GpuSurface {
     if (this.surfaceHandlePtr) {
       // Surface-share-backed resolution: pool_id → XPC lookup → IOSurface
@@ -472,13 +478,19 @@ class NativeGpuContextFullAccess extends NativeGpuContextLimitedAccess
  */
 class NativeGpuSurface implements GpuSurface {
   private lib: NativeLib;
-  private handlePtr: Deno.PointerObject;
+  private handlePtr: Deno.PointerObject | null;
   readonly surfaceId: number;
 
   constructor(lib: NativeLib, handlePtr: Deno.PointerObject, surfaceId: number) {
     this.lib = lib;
     this.handlePtr = handlePtr;
     this.surfaceId = surfaceId;
+  }
+
+  /** Adapter-internal: raw FFI handle pointer for in-tree adapter SDKs.
+   * Customer processors use `lock` / `asBuffer` instead. */
+  get nativeHandlePtr(): Deno.PointerObject | null {
+    return this.handlePtr;
   }
 
   get width(): number {
@@ -520,6 +532,9 @@ class NativeGpuSurface implements GpuSurface {
   }
 
   release(): void {
-    this.lib.symbols.sldn_gpu_surface_release(this.handlePtr);
+    if (this.handlePtr !== null) {
+      this.lib.symbols.sldn_gpu_surface_release(this.handlePtr);
+      this.handlePtr = null;
+    }
   }
 }

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -126,6 +126,66 @@ const symbols = {
     parameters: ["pointer", "buffer"] as const,
     result: "void" as const,
   },
+
+  // Per-plane surface-share accessors (#530). The OpenGL adapter needs
+  // `plane_stride` (EGL_DMA_BUF_PLANE{N}_PITCH_EXT) and
+  // `drm_format_modifier` (EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT) for
+  // EGL DMA-BUF import. The base accessors above (`width`, `height`,
+  // `bytes_per_row`) are tightly-packed-CPU-mmap-shaped and don't carry
+  // the modifier-aware row pitch the host allocator chose.
+  sldn_gpu_surface_plane_stride: {
+    parameters: ["pointer", "u32"] as const,
+    result: "u64" as const,
+  },
+  sldn_gpu_surface_plane_offset: {
+    parameters: ["pointer", "u32"] as const,
+    result: "u64" as const,
+  },
+  sldn_gpu_surface_plane_fd: {
+    parameters: ["pointer", "u32"] as const,
+    result: "i32" as const,
+  },
+  sldn_gpu_surface_drm_format_modifier: {
+    parameters: ["pointer"] as const,
+    result: "u64" as const,
+  },
+
+  // OpenGL adapter runtime (#530, Linux). Brings up
+  // `streamlib-adapter-opengl::EglRuntime` + `OpenGlSurfaceAdapter`
+  // inside the subprocess; exposes scoped acquire/release returning a
+  // `GL_TEXTURE_2D` id the customer's GL stack renders into.
+  sldn_opengl_runtime_new: {
+    parameters: [] as const,
+    result: "pointer" as const,
+  },
+  sldn_opengl_runtime_free: {
+    parameters: ["pointer"] as const,
+    result: "void" as const,
+  },
+  sldn_opengl_register_surface: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_opengl_unregister_surface: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_opengl_acquire_write: {
+    parameters: ["pointer", "u64"] as const,
+    result: "u32" as const,
+  },
+  sldn_opengl_release_write: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_opengl_acquire_read: {
+    parameters: ["pointer", "u64"] as const,
+    result: "u32" as const,
+  },
+  sldn_opengl_release_read: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
 } as const;
 
 export type NativeLib = Deno.DynamicLibrary<typeof symbols>;

--- a/libs/streamlib-deno/types.ts
+++ b/libs/streamlib-deno/types.ts
@@ -51,6 +51,15 @@ export interface GpuSurface {
 
   /** Release the surface handle. */
   release(): void;
+
+  /**
+   * Raw `*mut SurfaceHandle` pointer (untyped) for in-tree adapter SDKs
+   * that integrate with `streamlib-deno-native` via additional `sldn_*`
+   * FFI ops (e.g. `sldn_opengl_register_surface`). Customer processors
+   * should use `lock` / `asBuffer` above instead. Returns `null` when
+   * the surface has been released.
+   */
+  readonly nativeHandlePtr: Deno.PointerObject | null;
 }
 
 /**
@@ -60,7 +69,23 @@ export interface GpuSurface {
 export interface GpuContextLimitedAccess {
   /** Resolve a surface-share pool_id to a GPU surface handle. */
   resolveSurface(poolId: string): GpuSurface;
+
+  /**
+   * The cdylib handle this view's surfaces resolve against. Used by
+   * in-tree adapter SDKs to call additional `sldn_*` FFI ops without
+   * re-loading the cdylib.
+   */
+  readonly nativeLib: NativeLibSymbols;
 }
+
+/**
+ * Structural type for the FFI symbols `streamlib-deno-native` exposes.
+ * Adapter SDKs can call `nativeLib.sldn_opengl_*` once `nativeLib` is in
+ * hand. The full type lives in `native.ts`; this lightweight subset
+ * keeps `types.ts` from importing the FFI surface directly.
+ */
+// deno-lint-ignore no-explicit-any
+export type NativeLibSymbols = { readonly symbols: any };
 
 /**
  * Privileged GPU capability — includes limited-access ops plus allocations.

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -31,6 +31,11 @@ streamlib-surface-client = { path = "../streamlib-surface-client" }
 # hard link to libvulkan.so so the cdylib loads on systems without a Vulkan
 # driver.
 vulkanalia = { workspace = true }
+# Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
+# EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL
+# bring-up or DMA-BUF → GL_TEXTURE_2D import.
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
 
 
 [lints]

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -978,6 +978,11 @@ mod gpu_surface {
         pub fds: Vec<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
+        /// Per-plane row pitch in bytes, copied from the surface-share
+        /// lookup response. Required by EGL DMA-BUF import
+        /// (`EGL_DMA_BUF_PLANE{N}_PITCH_EXT`); the Vulkan import path
+        /// reads from `bytes_per_row` instead.
+        pub plane_strides: Vec<u64>,
         pub width: u32,
         pub height: u32,
         pub bytes_per_row: u32,
@@ -985,6 +990,16 @@ mod gpu_surface {
         /// kept cached so the Vulkan single-plane import path (`lock`) can
         /// continue to pass it without recomputing.
         pub size: u64,
+        /// DRM format modifier of the underlying host `VkImage`. Required
+        /// by EGL DMA-BUF import
+        /// (`EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT`); zero means
+        /// LINEAR / not applicable. Render-target consumers MUST refuse
+        /// LINEAR on NVIDIA — see
+        /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
+        pub drm_format_modifier: u64,
+        /// Format string from the wire response (e.g. `"Bgra8Unorm"`).
+        /// Used to derive a DRM_FORMAT_* fourcc for EGL import.
+        pub format: String,
         /// Host-mapped base address of plane 0, populated by `lock`. The
         /// multi-plane accessor reads from [`Self::plane_mapped_ptrs`].
         pub mapped_ptr: *mut u8,
@@ -1259,6 +1274,56 @@ mod gpu_surface {
     ) -> u64 {
         unsafe { handle.as_ref() }
             .and_then(|h| h.plane_sizes.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane row pitch in bytes. Required by EGL DMA-BUF import
+    /// (`EGL_DMA_BUF_PLANE{N}_PITCH_EXT`); the Vulkan import path reads
+    /// from `bytes_per_row` instead. Returns `0` on null handle / out
+    /// of range plane index.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_stride(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_strides.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane offset into its DMA-BUF fd. Returns `0` on null handle
+    /// / out of range plane index.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_offset(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.plane_offsets.get(plane_index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    /// Per-plane DMA-BUF file descriptor, or `-1` on null handle / out of
+    /// range plane index. The fd is owned by the [`SurfaceHandle`]; the
+    /// caller MUST `dup()` if they need an independent copy.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_plane_fd(
+        handle: *const SurfaceHandle,
+        plane_index: u32,
+    ) -> i32 {
+        unsafe { handle.as_ref() }
+            .and_then(|h| h.fds.get(plane_index as usize).copied())
+            .unwrap_or(-1)
+    }
+
+    /// DRM format modifier of the underlying host `VkImage`. Required by
+    /// EGL DMA-BUF import; zero means LINEAR / not applicable.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_gpu_surface_drm_format_modifier(
+        handle: *const SurfaceHandle,
+    ) -> u64 {
+        unsafe { handle.as_ref() }
+            .map(|h| h.drm_format_modifier)
             .unwrap_or(0)
     }
 
@@ -2213,10 +2278,13 @@ mod surface_client {
         fds: Vec<RawFd>,
         plane_sizes: Vec<u64>,
         plane_offsets: Vec<u64>,
+        plane_strides: Vec<u64>,
         width: u32,
         height: u32,
         bytes_per_row: u32,
         size: u64,
+        drm_format_modifier: u64,
+        format: String,
     }
 
     impl Drop for CachedSurface {
@@ -2418,10 +2486,13 @@ mod surface_client {
                     fds: dup_fds,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
+                    plane_strides: cached.plane_strides.clone(),
                     width: cached.width,
                     height: cached.height,
                     bytes_per_row: cached.bytes_per_row,
                     size: cached.size,
+                    drm_format_modifier: cached.drm_format_modifier,
+                    format: cached.format.clone(),
                     mapped_ptr: std::ptr::null_mut(),
                     plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
                     is_locked: false,
@@ -2521,6 +2592,20 @@ mod surface_client {
             .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
             .filter(|v: &Vec<u64>| v.len() == received_fds.len())
             .unwrap_or_else(|| vec![0u64; received_fds.len()]);
+        // `plane_strides` is the source-of-truth row pitch from the host's
+        // DRM-modifier-aware allocator. Falls back to width*bpp when the
+        // host omits it (legacy producers); EGL DMA-BUF import requires the
+        // real stride or the resulting GL_TEXTURE_2D will sample wrong.
+        let plane_strides: Vec<u64> = response
+            .get("plane_strides")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_u64()).collect())
+            .filter(|v: &Vec<u64>| v.len() == received_fds.len())
+            .unwrap_or_else(|| vec![bytes_per_row as u64; received_fds.len()]);
+        let drm_format_modifier = response
+            .get("drm_format_modifier")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         let size: u64 = plane_sizes.iter().copied().sum();
 
         // Cache: dup every plane for the cache's own copy so the returned
@@ -2550,10 +2635,13 @@ mod surface_client {
                     fds: cache_fds,
                     plane_sizes: plane_sizes.clone(),
                     plane_offsets: plane_offsets.clone(),
+                    plane_strides: plane_strides.clone(),
                     width,
                     height,
                     bytes_per_row,
                     size,
+                    drm_format_modifier,
+                    format: format_str.to_string(),
                 },
             );
         } else {
@@ -2567,10 +2655,13 @@ mod surface_client {
             fds: received_fds,
             plane_sizes,
             plane_offsets,
+            plane_strides,
             width,
             height,
             bytes_per_row,
             size,
+            drm_format_modifier,
+            format: format_str.to_string(),
             mapped_ptr: std::ptr::null_mut(),
             plane_mapped_ptrs: vec![std::ptr::null_mut(); n_planes],
             is_locked: false,
@@ -2685,6 +2776,426 @@ mod surface_client {
     ) {
     }
 
+}
+
+// ============================================================================
+// C ABI — OpenGL/EGL adapter runtime (#530, Linux)
+//
+// Brings up `streamlib-adapter-opengl::EglRuntime` + `OpenGlSurfaceAdapter`
+// inside the subprocess and exposes scoped acquire/release that returns the
+// imported `GL_TEXTURE_2D` id. Any GL library (PyOpenGL, ctypes against
+// `libGLESv2.so`, a game-engine binding, …) can use the texture as long as
+// it operates on whatever EGL context is current on the calling thread —
+// `slpn_opengl_acquire_*` makes the adapter's context current and
+// `slpn_opengl_release_*` releases it.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod opengl {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_opengl::{
+        EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter,
+        OwnedMakeCurrentGuard, DRM_FORMAT_ABGR8888, DRM_FORMAT_ARGB8888,
+    };
+
+    use super::gpu_surface::SurfaceHandle;
+
+    /// Process-scoped OpenGL runtime: one EGL display + GL context + adapter
+    /// per subprocess. Created on first FFI call; held until the cdylib is
+    /// torn down. Multiple per-surface acquires can be in flight serially —
+    /// the adapter's make-current mutex serializes EGL/GL access.
+    pub struct OpenGlRuntimeHandle {
+        egl: Arc<EglRuntime>,
+        adapter: Arc<OpenGlSurfaceAdapter>,
+        held: Mutex<HashMap<u64, HeldAcquire>>,
+    }
+
+    enum HeldKind {
+        Read,
+        Write,
+    }
+
+    struct HeldAcquire {
+        kind: HeldKind,
+        texture_id: u32,
+        // SAFETY-relevant: drop this BEFORE calling `end_*_access` on the
+        // adapter — `end_*_access` re-locks the make-current mutex
+        // internally for `glFinish`, and the adapter's mutex is not
+        // reentrant. The release FFI op handles the ordering.
+        make_current: OwnedMakeCurrentGuard,
+    }
+
+    /// Initialize an `EglRuntime` + `OpenGlSurfaceAdapter`. Returns NULL
+    /// on failure (typically because `libEGL.so.1` is not installed or the
+    /// driver doesn't support `EGL_EXT_image_dma_buf_import_modifiers`).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_runtime_new() -> *mut OpenGlRuntimeHandle {
+        let egl = match EglRuntime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_opengl_runtime_new: EglRuntime::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let adapter = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+        Box::into_raw(Box::new(OpenGlRuntimeHandle {
+            egl,
+            adapter,
+            held: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    /// Release the runtime's adapter, EGL context, and any pending acquire
+    /// guards (best-effort — pending acquires are released via the adapter's
+    /// `Drop`). Idempotent; null is a no-op.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_runtime_free(rt: *mut OpenGlRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    /// Register a host surface with the OpenGL adapter, importing its
+    /// DMA-BUF FD as an `EGLImage` and binding to a fresh `GL_TEXTURE_2D`.
+    ///
+    /// `surface_id` must be unique across the runtime's lifetime —
+    /// duplicates return -1. The caller (Python wrapper) owns the
+    /// `surface_id` namespace.
+    ///
+    /// Reads DMA-BUF FD + plane metadata + DRM modifier from `gpu_handle`
+    /// (produced by `slpn_surface_resolve_surface`); the FD is dup'd
+    /// internally by EGL.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_register_surface(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *const SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_opengl_register_surface: null runtime");
+                return -1;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_ref() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("slpn_opengl_register_surface: null gpu_handle");
+                return -1;
+            }
+        };
+        let fd = match gpu.fds.first().copied() {
+            Some(f) if f >= 0 => f,
+            _ => {
+                tracing::error!(
+                    "slpn_opengl_register_surface: surface has no DMA-BUF fd"
+                );
+                return -1;
+            }
+        };
+        let drm_fourcc = match drm_fourcc_for_format(&gpu.format) {
+            Some(c) => c,
+            None => {
+                tracing::error!(
+                    "slpn_opengl_register_surface: unsupported format '{}'",
+                    gpu.format
+                );
+                return -1;
+            }
+        };
+        let stride = gpu
+            .plane_strides
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.bytes_per_row as u64);
+        let offset = gpu.plane_offsets.first().copied().unwrap_or(0);
+        let registration = HostSurfaceRegistration {
+            dma_buf_fd: fd,
+            width: gpu.width,
+            height: gpu.height,
+            drm_fourcc,
+            drm_format_modifier: gpu.drm_format_modifier,
+            plane_offset: offset,
+            plane_stride: stride,
+        };
+        match rt.adapter.register_host_surface(surface_id, registration) {
+            Ok(()) => 0,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_opengl_register_surface: register_host_surface failed: {:?}",
+                    e
+                );
+                -1
+            }
+        }
+    }
+
+    /// Drop a registered surface from the adapter (releases its EGLImage +
+    /// GL_TEXTURE_2D). Returns 0 on success, -1 if not registered.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_unregister_surface(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        if rt.adapter.unregister_host_surface(surface_id) {
+            0
+        } else {
+            -1
+        }
+    }
+
+    /// Acquire write access. Returns the imported `GL_TEXTURE_2D` id, or 0
+    /// on contention / failure (a 0 GL texture id is reserved by GL itself,
+    /// so it's a safe sentinel). Makes the adapter's EGL context current
+    /// on the calling thread for the lifetime of the acquire. Pair every
+    /// successful return with `slpn_opengl_release_write` from the SAME
+    /// thread.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_acquire_write(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> u32 {
+        acquire_inner(rt, surface_id, HeldKind::Write)
+    }
+
+    /// Release write access acquired via [`slpn_opengl_acquire_write`].
+    /// Drains the GL command stream (`glFinish`) so cross-API consumers
+    /// see the writes. Returns 0 on success, -1 if no write was held.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_release_write(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, HeldKind::Write)
+    }
+
+    /// Acquire read access. Returns the imported `GL_TEXTURE_2D` id, or 0
+    /// on contention / failure.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_acquire_read(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> u32 {
+        acquire_inner(rt, surface_id, HeldKind::Read)
+    }
+
+    /// Release read access acquired via [`slpn_opengl_acquire_read`].
+    /// Returns 0 on success, -1 if no read was held.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_release_read(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, HeldKind::Read)
+    }
+
+    fn acquire_inner(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        kind: HeldKind,
+    ) -> u32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_opengl_acquire_*: null runtime");
+                return 0;
+            }
+        };
+        let make_current = match rt.egl.arc_lock_make_current() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_opengl_acquire_*: arc_lock_make_current: {}",
+                    e
+                );
+                return 0;
+            }
+        };
+        // The adapter only reads `surface.id` from its acquire path —
+        // transport/sync fields are unused for already-registered surfaces.
+        let surface = StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        let texture_id = match kind {
+            HeldKind::Write => match rt.adapter.acquire_write(&surface) {
+                Ok(g) => {
+                    let t = g.view().gl_texture_id();
+                    // Forget the WriteGuard so its Drop doesn't fire — we
+                    // call `end_write_access` manually on release.
+                    std::mem::forget(g);
+                    t
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_opengl_acquire_write: adapter.acquire_write: {:?}",
+                        e
+                    );
+                    return 0;
+                }
+            },
+            HeldKind::Read => match rt.adapter.acquire_read(&surface) {
+                Ok(g) => {
+                    let t = g.view().gl_texture_id();
+                    std::mem::forget(g);
+                    t
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_opengl_acquire_read: adapter.acquire_read: {:?}",
+                        e
+                    );
+                    return 0;
+                }
+            },
+        };
+        let mut held = rt.held.lock().expect("opengl held: poisoned");
+        held.insert(
+            surface_id,
+            HeldAcquire {
+                kind,
+                texture_id,
+                make_current,
+            },
+        );
+        texture_id
+    }
+
+    fn release_inner(
+        rt: *mut OpenGlRuntimeHandle,
+        surface_id: u64,
+        expected: HeldKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let removed = {
+            let mut held = rt.held.lock().expect("opengl held: poisoned");
+            held.remove(&surface_id)
+        };
+        let held = match removed {
+            Some(h) => h,
+            None => {
+                tracing::error!(
+                    "slpn_opengl_release_*: no acquire held for surface_id {}",
+                    surface_id
+                );
+                return -1;
+            }
+        };
+        if !matches!((&held.kind, &expected), (HeldKind::Read, HeldKind::Read) | (HeldKind::Write, HeldKind::Write)) {
+            tracing::error!(
+                "slpn_opengl_release_*: surface_id {} held in different mode than \
+                 release call expected — releasing it anyway",
+                surface_id
+            );
+        }
+        // CRITICAL ordering: drop the make-current guard FIRST so the
+        // adapter's `end_*_access` can re-lock the EGL mutex internally.
+        // `parking_lot::Mutex` is not reentrant.
+        drop(held.make_current);
+        match held.kind {
+            HeldKind::Read => rt.adapter.end_read_access(surface_id),
+            HeldKind::Write => rt.adapter.end_write_access(surface_id),
+        }
+        let _ = held.texture_id; // capture so the field isn't read-warned
+        0
+    }
+
+    /// Map a host-side `TextureFormat` debug string to the matching DRM
+    /// fourcc. Mirrors the Vulkan→DRM byte-order convention: `Bgra8Unorm`
+    /// is bytes `[B, G, R, A]` in memory, which is `DRM_FORMAT_ARGB8888`.
+    fn drm_fourcc_for_format(format: &str) -> Option<u32> {
+        match format {
+            "Bgra8Unorm" | "Bgra8UnormSrgb" => Some(DRM_FORMAT_ARGB8888),
+            "Rgba8Unorm" | "Rgba8UnormSrgb" => Some(DRM_FORMAT_ABGR8888),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod opengl {
+    use std::ffi::c_void;
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_runtime_new() -> *mut c_void {
+        tracing::error!("slpn_opengl_*: OpenGL adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *const c_void,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> u32 {
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> u32 {
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_opengl_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
 }
 
 // ============================================================================

--- a/libs/streamlib-python/python/streamlib/adapters/opengl.py
+++ b/libs/streamlib-python/python/streamlib/adapters/opengl.py
@@ -3,17 +3,23 @@
 
 """OpenGL/EGL surface adapter — Python customer-facing API.
 
-Mirrors the Rust crate ``streamlib-adapter-opengl`` (#512). The
-subprocess's actual EGL+GL handling lives in the runtime's native
-binding; this module provides:
+Mirrors the Rust crate ``streamlib-adapter-opengl`` (#512, #530). The
+subprocess's actual EGL+GL handling lives in `streamlib-python-native`
+(via the `slpn_opengl_*` FFI symbols, which delegate to the host
+adapter crate's `EglRuntime` and `OpenGlSurfaceAdapter`). This module
+provides:
 
   * Typed views the subprocess sees inside ``acquire_*`` scopes —
     ``OpenGLReadView`` / ``OpenGLWriteView`` exposing a single
     integer ``gl_texture_id`` and the constant ``target =
     GL_TEXTURE_2D``.
-  * An ``OpenGLContext`` Protocol the subprocess runtime implements —
-    customers call ``with ctx.acquire_write(surface) as view:`` and
-    bind ``view.gl_texture_id`` to their PyOpenGL / ModernGL stack.
+  * ``OpenGLContext`` — the concrete subprocess runtime. Customers
+    call ``with ctx.acquire_write(surface) as view:`` and bind
+    ``view.gl_texture_id`` to their PyOpenGL / ModernGL / raw
+    ctypes-against-libGLESv2 stack. The adapter's EGL context is
+    current on the calling thread for the lifetime of the acquire,
+    so any GL library that latches onto the current context "just
+    works."
 
 Customers never see DMA-BUF FDs, fourcc codes, plane offsets,
 strides, or DRM modifiers. Per the NVIDIA EGL DMA-BUF render-target
@@ -42,10 +48,12 @@ typical place is the subprocess processor's ``setup`` hook.
 
 from __future__ import annotations
 
+import ctypes
+import itertools
 import os
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
-from typing import Optional, Protocol, runtime_checkable
+from typing import Iterator, Optional, Protocol, runtime_checkable
 
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
@@ -58,6 +66,7 @@ __all__ = [
     "OpenGLReadView",
     "OpenGLWriteView",
     "OpenGLSurfaceAdapter",
+    "OpenGLContextProtocol",
     "OpenGLContext",
     "configure_pyopengl_for_streamlib_subprocess",
 ]
@@ -123,16 +132,10 @@ class OpenGLSurfaceAdapter(Protocol):
 
 
 @runtime_checkable
-class OpenGLContext(Protocol):
-    """Customer-facing handle the subprocess runtime hands out.
-
-    Equivalent shape to the Rust ``OpenGlContext`` — thin wrapper
-    over an ``OpenGLSurfaceAdapter`` so customer code can write::
-
-        with ctx.acquire_write(surface) as view:
-            do_gl_work(view.gl_texture_id)
-
-    The customer never types the words "DMA-BUF" or "modifier."
+class OpenGLContextProtocol(Protocol):
+    """Customer-facing handle the subprocess runtime hands out
+    (Protocol shape — :class:`OpenGLContext` below is the concrete
+    implementation).
     """
 
     def acquire_read(
@@ -164,5 +167,178 @@ def configure_pyopengl_for_streamlib_subprocess() -> None:
     os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
     os.environ.setdefault("PYOPENGL_CONTEXT_CHECKING", "False")
     os.environ.setdefault("PYOPENGL_ERROR_CHECKING", "False")
+
+
+# =============================================================================
+# Concrete OpenGLContext implementation (#530)
+# =============================================================================
+
+# Surface-id namespace inside this subprocess. Counted up by `from_runtime` —
+# the host's pool_id (string UUID) is mapped to a u64 the adapter uses
+# internally; customers never see the u64.
+_SURFACE_ID_COUNTER = itertools.count(start=1)
+
+
+class OpenGLContext:
+    """Subprocess-side OpenGL adapter runtime (#530).
+
+    Bring up the adapter's EGL display + GL context inside this
+    subprocess and expose scoped acquire/release that hands customers
+    a real ``GL_TEXTURE_2D`` id. The adapter's EGL context is current
+    on the calling thread for the lifetime of an ``acquire_*`` scope —
+    any GL library that latches onto the current EGL context (PyOpenGL
+    with ``PYOPENGL_PLATFORM=egl``, ModernGL, raw ctypes against
+    ``libGLESv2.so``, a Deno-FFI game-engine binding, etc.) will see
+    the texture id as live.
+
+    Construct via :meth:`from_runtime` — pass the typed runtime context
+    you receive in ``setup``/``process``. Single :class:`OpenGLContext`
+    per subprocess; :meth:`from_runtime` returns the cached instance on
+    repeat calls.
+
+    Acquire/release MUST happen on the same thread. The EGL spec
+    pins a context's "current" state to a thread; releasing on a
+    different thread leaks the context binding. Python processors
+    typically run on a single thread, so this is the natural shape.
+    """
+
+    _shared_instance: Optional["OpenGLContext"] = None
+
+    def __init__(self, gpu_limited_access) -> None:
+        # Reuse the cdylib the limited-access view has already loaded —
+        # `slpn_opengl_*` symbols are wired up alongside `slpn_surface_*`
+        # in `processor_context.load_native_lib`.
+        self._lib = gpu_limited_access.native_lib
+        self._gpu = gpu_limited_access
+        rt = self._lib.slpn_opengl_runtime_new()
+        if not rt:
+            raise RuntimeError(
+                "OpenGLContext: slpn_opengl_runtime_new returned NULL — the "
+                "subprocess could not bring up an EGL display + GL context. "
+                "Check that libEGL.so.1 is installed and the driver supports "
+                "EGL_EXT_image_dma_buf_import_modifiers."
+            )
+        self._rt = ctypes.c_void_p(rt)
+        # Map host pool_id (UUID) → local u64 surface_id.
+        self._surface_ids: dict[str, int] = {}
+        # Pin the resolved gpu surface handles for the runtime's lifetime so
+        # the underlying DMA-BUF FDs stay alive — the Rust adapter dups them
+        # via EGL on register, but holding the handle Python-side keeps the
+        # unlock/release contract consistent.
+        self._resolved_handles: dict[str, object] = {}
+
+    @classmethod
+    def from_runtime(cls, runtime_context) -> "OpenGLContext":
+        """Build (or fetch the cached) :class:`OpenGLContext` for this
+        subprocess.
+
+        The subprocess hosts at most one EGL display + GL context — calling
+        this twice with the same runtime returns the same instance.
+        """
+        if cls._shared_instance is None:
+            cls._shared_instance = cls(runtime_context.gpu_limited_access)
+        return cls._shared_instance
+
+    def _resolve_and_register(self, pool_id: str) -> int:
+        """Resolve `pool_id` via surface-share, register with the OpenGL
+        adapter, and return the local u64 surface_id. Idempotent — repeat
+        calls return the cached id."""
+        cached = self._surface_ids.get(pool_id)
+        if cached is not None:
+            return cached
+        handle = self._gpu.resolve_surface(pool_id)
+        # Adapter pulls the underlying *mut SurfaceHandle pointer out of the
+        # SDK's NativeGpuSurfaceHandle — see streamlib.gpu_surface for the
+        # shape. Public accessor on the SDK handle exposes the raw FFI
+        # pointer for adapter integration.
+        handle_ptr = handle.native_handle_ptr
+        if not handle_ptr:
+            raise RuntimeError(
+                f"OpenGLContext: resolve_surface('{pool_id}') returned a handle "
+                "with a null native pointer"
+            )
+        surface_id = next(_SURFACE_ID_COUNTER)
+        rc = self._lib.slpn_opengl_register_surface(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.c_void_p(handle_ptr),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"OpenGLContext: register_surface failed for pool_id "
+                f"'{pool_id}' (rc={rc}). Check the subprocess log for "
+                "EGL/DMA-BUF import errors — typically a wrong DRM modifier "
+                "or an unsupported pixel format."
+            )
+        self._surface_ids[pool_id] = surface_id
+        # Hold the SDK handle so its FDs stay alive for the runtime's life.
+        self._resolved_handles[pool_id] = handle
+        return surface_id
+
+    @staticmethod
+    def _surface_pool_id(surface) -> str:
+        """Extract the surface-share pool id (string UUID) from either a
+        `StreamlibSurface`-shaped object or a bare string."""
+        if isinstance(surface, str):
+            return surface
+        sid = getattr(surface, "id", None)
+        if sid is None:
+            raise TypeError(
+                f"OpenGLContext: expected StreamlibSurface or str pool_id, got {surface!r}"
+            )
+        return str(sid)
+
+    @contextmanager
+    def acquire_write(
+        self, surface
+    ) -> "Iterator[OpenGLWriteView]":
+        """Acquire write access. The adapter's EGL context is current on
+        the calling thread for the scope; ``view.gl_texture_id`` is a
+        ``GL_TEXTURE_2D`` valid in that context.
+
+        On scope exit the adapter drains GL (`glFinish`) so cross-API
+        consumers see the writes through the underlying DMA-BUF.
+        """
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._resolve_and_register(pool_id)
+        texture_id = int(
+            self._lib.slpn_opengl_acquire_write(self._rt, ctypes.c_uint64(surface_id))
+        )
+        if texture_id == 0:
+            raise RuntimeError(
+                f"OpenGLContext.acquire_write: slpn_opengl_acquire_write "
+                f"returned 0 for surface '{pool_id}' (contention or "
+                "EGL/GL failure — check the subprocess log)"
+            )
+        try:
+            yield OpenGLWriteView(gl_texture_id=texture_id)
+        finally:
+            self._lib.slpn_opengl_release_write(
+                self._rt, ctypes.c_uint64(surface_id)
+            )
+
+    @contextmanager
+    def acquire_read(
+        self, surface
+    ) -> "Iterator[OpenGLReadView]":
+        """Acquire read access — same shape as :meth:`acquire_write`,
+        but the resulting texture is sample-only (multiple readers may
+        coexist; no writer can be active)."""
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._resolve_and_register(pool_id)
+        texture_id = int(
+            self._lib.slpn_opengl_acquire_read(self._rt, ctypes.c_uint64(surface_id))
+        )
+        if texture_id == 0:
+            raise RuntimeError(
+                f"OpenGLContext.acquire_read: slpn_opengl_acquire_read "
+                f"returned 0 for surface '{pool_id}'"
+            )
+        try:
+            yield OpenGLReadView(gl_texture_id=texture_id)
+        finally:
+            self._lib.slpn_opengl_release_read(
+                self._rt, ctypes.c_uint64(surface_id)
+            )
 
 

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -203,6 +203,42 @@ def load_native_lib(lib_path):
     lib.slpn_surface_unregister_surface.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     lib.slpn_surface_unregister_surface.restype = None
 
+    # OpenGL adapter runtime (#530, Linux). Uses the host adapter crate's
+    # EglRuntime + OpenGlSurfaceAdapter for EGL bring-up + DMA-BUF→GL
+    # import; this binding only exposes scoped acquire/release returning
+    # a `GL_TEXTURE_2D` id the customer's GL library renders into.
+    lib.slpn_opengl_runtime_new.argtypes = []
+    lib.slpn_opengl_runtime_new.restype = ctypes.c_void_p
+    lib.slpn_opengl_runtime_free.argtypes = [ctypes.c_void_p]
+    lib.slpn_opengl_runtime_free.restype = None
+    lib.slpn_opengl_register_surface.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p,
+    ]
+    lib.slpn_opengl_register_surface.restype = ctypes.c_int32
+    lib.slpn_opengl_unregister_surface.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint64,
+    ]
+    lib.slpn_opengl_unregister_surface.restype = ctypes.c_int32
+    for _op in ("acquire_write", "acquire_read"):
+        _fn = getattr(lib, f"slpn_opengl_{_op}")
+        _fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        _fn.restype = ctypes.c_uint32
+    for _op in ("release_write", "release_read"):
+        _fn = getattr(lib, f"slpn_opengl_{_op}")
+        _fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        _fn.restype = ctypes.c_int32
+
+    # Per-plane surface-share accessors (#530). Required by the OpenGL
+    # adapter for `EGL_DMA_BUF_PLANE{N}_PITCH_EXT` import.
+    lib.slpn_gpu_surface_plane_stride.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    lib.slpn_gpu_surface_plane_stride.restype = ctypes.c_uint64
+    lib.slpn_gpu_surface_plane_offset.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    lib.slpn_gpu_surface_plane_offset.restype = ctypes.c_uint64
+    lib.slpn_gpu_surface_plane_fd.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    lib.slpn_gpu_surface_plane_fd.restype = ctypes.c_int32
+    lib.slpn_gpu_surface_drm_format_modifier.argtypes = [ctypes.c_void_p]
+    lib.slpn_gpu_surface_drm_format_modifier.restype = ctypes.c_uint64
+
     return lib
 
 
@@ -358,6 +394,26 @@ class NativeGpuSurfaceHandle:
         ref = self._lib.slpn_gpu_surface_iosurface_ref(self._handle_ptr)
         return ctypes.c_void_p(ref)
 
+    @property
+    def native_handle_ptr(self) -> int:
+        """Raw `*mut SurfaceHandle` pointer (untyped int) for adapter
+        crates that integrate with `streamlib-python-native`.
+
+        Reserved for in-tree adapter SDKs (e.g. `streamlib.adapters.opengl`)
+        that need to hand the underlying surface-share handle to a
+        cross-language adapter FFI op (e.g. `slpn_opengl_register_surface`).
+        Customer processors should use `lock` / `base_address` / numpy
+        accessors above instead.
+        """
+        return int(self._handle_ptr or 0)
+
+    @property
+    def native_lib(self):
+        """The cdylib handle this surface was resolved against. Used by
+        in-tree adapter SDKs to call additional `slpn_*` FFI ops without
+        re-loading the cdylib."""
+        return self._lib
+
     def release(self):
         """Release the C-side surface handle."""
         if self._pooled:
@@ -386,6 +442,17 @@ class NativeGpuContextLimitedAccess:
     def __init__(self, lib, handle_ptr):
         self._lib = lib
         self._handle_ptr = handle_ptr
+
+    @property
+    def native_lib(self):
+        """The cdylib handle this view's surfaces resolve against. Used
+        by in-tree adapter SDKs (e.g. ``streamlib.adapters.opengl``) to
+        call additional ``slpn_*`` FFI ops without re-loading the cdylib.
+
+        Customer processors should not need this — the view's
+        :meth:`resolve_surface` covers the common case.
+        """
+        return self._lib
 
     def resolve_surface(self, surface_id):
         """Resolve a surface-share pool UUID to a GPU surface handle."""

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -647,21 +647,6 @@ impl StreamRuntime {
         let gpu = GpuContext::init_for_platform_sync()?;
         tracing::info!("[start] GPU context initialized");
 
-        // Drain pre-start hooks now — after the GpuContext is live but
-        // before any processor setup runs. Adapter bridges register
-        // themselves here so processors that issue escalate ops in
-        // their first `process()` find the bridge already in place.
-        let hooks: Vec<Box<dyn FnOnce(&GpuContext) -> Result<()> + Send>> = {
-            let mut guard = self.setup_hooks.lock();
-            std::mem::take(&mut *guard)
-        };
-        if !hooks.is_empty() {
-            tracing::info!("[start] Running {} setup hook(s)", hooks.len());
-            for hook in hooks {
-                hook(&gpu)?;
-            }
-        }
-
         // Initialize SurfaceStore for cross-process GPU surface sharing (macOS only)
         #[cfg(target_os = "macos")]
         {
@@ -713,6 +698,22 @@ impl StreamRuntime {
             })?;
             gpu.set_surface_store(surface_store);
             tracing::info!("[start] SurfaceStore initialized against runtime-internal broker");
+        }
+
+        // Drain pre-start hooks now — after the GpuContext is FULLY live
+        // (device + SurfaceStore) but before any processor setup runs.
+        // Adapter bridges and surface registrations happen here so
+        // processors that issue escalate ops or `resolve_surface` lookups
+        // in their first `process()` find everything already in place.
+        let hooks: Vec<Box<dyn FnOnce(&GpuContext) -> Result<()> + Send>> = {
+            let mut guard = self.setup_hooks.lock();
+            std::mem::take(&mut *guard)
+        };
+        if !hooks.is_empty() {
+            tracing::info!("[start] Running {} setup hook(s)", hooks.len());
+            for hook in hooks {
+                hook(&gpu)?;
+            }
         }
 
         // Create shared timing context - clock starts now


### PR DESCRIPTION
## Summary

- Ships the subprocess-side `OpenGLContext` runtime for both Python and Deno against the host adapter from #512. Customers call `OpenGLContext.acquire_write(surface)` and get a real `GL_TEXTURE_2D` id; the adapter's EGL context is current on the calling thread for the acquire scope, so any GL library that latches onto the current context (PyOpenGL, ModernGL, raw `ctypes` against `libGLESv2.so`, a Deno-FFI game-engine binding, …) just works.
- Reuses `streamlib-adapter-opengl` directly — both native cdylibs depend on it and let the existing `EglRuntime` + `OpenGlSurfaceAdapter` do the EGL bring-up + DMA-BUF→`GL_TEXTURE_2D` import. No second EGL stack in subprocess code; the "extend, don't parallel-build" rule honored.
- New scenario `examples/polyglot-opengl-fragment-shader/` — host pre-allocates a render-target DMA-BUF surface, registers it in surface-share, then post-stop reads it back via Vulkan and writes a PNG. Python renders a Mandelbrot zoom (Seahorse Valley); Deno renders a sine-interference plasma. Distinct visual fingerprints per runtime.

## Closes
Closes #530

## Exit criteria

- [x] `streamlib-python-native`: subprocess-constructible `OpenGLContext` per #528's shape.
- [x] `streamlib-deno-native`: subprocess-constructible `OpenGLContext` per #528's shape.
- [x] Scenario binary `examples/polyglot-opengl-fragment-shader/` (Python + Deno) — subprocess imports a host DMA-BUF surface as a `GL_TEXTURE_2D`, renders a fragment-shader effect, releases.
- [x] Polyglot E2E with PNG visual evidence (embedded below).

## Test plan

- [x] `cargo test --workspace` (with `docs/testing-baseline.md` exclusion list) — zero failures.
- [x] `cargo test -p streamlib-adapter-opengl --lib` — 3 passed (new `arc_lock_make_current_is_static_and_releases_on_drop` pins the `'static + Send` lifetime invariant on `OwnedMakeCurrentGuard` and verifies drop releases the EGL mutex).
- [x] `cargo test -p streamlib-adapter-opengl --tests` — 4 integration tests (`conformance`, `fbo_completeness`, `sample_from_surface`, `round_trip_render_to_surface`) all pass — `arc_lock_make_current` doesn't regress the existing borrow-style `lock_make_current` path.
- [x] **E2E Python**: `cargo run -p polyglot-opengl-fragment-shader-scenario -- --runtime=python --output=/tmp/opengl-mandelbrot-py.png` — Python processor logs `Mandelbrot rendered into surface '...'`, host reads back via Vulkan, PNG visually inspected with the Read tool — see image below.
- [x] **E2E Deno**: same flow with `--runtime=deno --output=/tmp/opengl-plasma-deno.png` — Deno processor logs `plasma rendered into surface '...'`, PNG visually inspected.
- [x] **E2E regression** (cpu-readback): re-ran `polyglot-cpu-readback-blur-scenario` after the `install_setup_hook` ordering change — vertical-color-band-blur PNG matches the reference.

## Architectural seams proved by the E2E PNGs

If any of these were broken, the PNGs would show garbage / zeros / a different effect:

1. Surface-share `register_texture` on the host (DMA-BUF FD + DRM modifier + per-plane stride passed over Unix socket).
2. Subprocess `resolve_surface` lookup via SCM_RIGHTS.
3. EGL DMA-BUF import with the host-chosen tiled DRM modifier — render-target-capable on NVIDIA per `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
4. Adapter's EGL make-current discipline holding across the FFI-call boundary (the new `OwnedMakeCurrentGuard`).
5. Customer GL stack (raw `ctypes` in Python, `Deno.dlopen` in Deno) latching onto the adapter's EGL context via "whatever's current on this thread."
6. Adapter's `glFinish` on release ensuring cross-API visibility through the DMA-BUF.
7. Host Vulkan readback via `vkCmdCopyImageToBuffer` after the subprocess's writes.

## Engine extension surfaced

`StreamRuntime::install_setup_hook` drain moved to AFTER `SurfaceStore` init so hooks see a fully-live `GpuContext` (the doc contract says "after `GpuContext` is fully live, before processor `setup()` runs"; previously `surface_store()` was `None` inside hooks). Backwards-compatible — only existing hook user is the cpu-readback example, which doesn't read `surface_store` from its hook; its E2E was re-verified post-change.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno (host adapter dep added to both native libs; runtimes in Python and Deno; polyglot E2E exercises both)
- **Schema regenerated**: n/a — OpenGL rides the surface-share registry seam (per `docs/architecture/adapter-runtime-integration.md`). No new escalate ops.
- **Python and Deno both covered?** yes — parallel `OpenGLContext` implementations + parallel scenario processors, distinct fragment-shader effects per runtime to make the polyglot coverage visually obvious.
- **E2E tests run**:
  - [x] Host-Rust: `arc_lock_make_current_is_static_and_releases_on_drop` (lifetime invariant) + the four existing host-adapter integration tests
  - [x] Python subprocess: real subprocess via `polyglot-opengl-fragment-shader` scenario, Mandelbrot PNG visually verified
  - [x] Deno subprocess: same path with `--runtime=deno`, plasma PNG visually verified
- **FD-passing path**: DMA-BUF FD via the existing surface-share registry — host's `StreamTexture` is registered with its DRM modifier + plane strides, subprocess SCM_RIGHTS check-outs the FD, EGL DMA-BUF import sees the modifier and binds it as a render-target-capable `GL_TEXTURE_2D`.

## Stale-criterion update

Issue #530's AI Agent Notes claimed the subprocess SDKs already had an EGL display ("there's already exactly one"). That was stale — greps for `EGL` / `eglDisplay` in `streamlib-{python,deno}-native` came back empty. The notes were updated in place (struck through with reasoning preserved) before this work started.

## Pre-open review notes

`pr-review-gate` returned **PASS** with three DISCUSS-flagged items as informational follow-ups (none of them blocking, all defended in the reviewer's PASS rationale):

- The scenario binary's `vulkan_readback` helper calls vulkanalia directly to do a transient `vkCmdCopyImageToBuffer`. This is the second copy of the same shape (the first lives in `streamlib-adapter-opengl/tests/common.rs::host_readback`) — fine for a test/scenario-local carve-out, but if a third consumer arrives an RHI-level readback helper would be the right home. **Tracked**: file a follow-up if/when a third consumer needs this.
- The `install_setup_hook` reordering is a load-bearing engine-core change folded into a polyglot-runtime PR. The new ordering matches the doc's stated contract; the existing cpu-readback hook stays compatible. **Action taken**: change is justified by the same root cause as this PR (the OpenGL hook needs `surface_store` to register the host texture). The architecture doc at `docs/architecture/adapter-runtime-integration.md` already says hooks fire "after `GpuContext::init_for_platform_sync` has created the live `GpuContext`" — the prior code was the aspirational mismatch, now corrected.
- `OpenGLContext` is a per-subprocess singleton with no teardown path (`slpn_opengl_runtime_free` is never called from the SDK). EGL+GL state lives until subprocess exit. **Resolved (not tracked)**: this is correct as-is per the load-bearing one-subprocess-per-processor invariant. Each polyglot processor gets its own OS subprocess (intentional dependency-isolation boundary that lets the community chain processors with different numpy / PyTorch / etc. versions in the same graph). The singleton is therefore effectively per-processor, EGL display is process-scoped anyway, and Linux frees all process state at subprocess exit — there's no "across runs" leak because there's no "across runs" (a new processor instance means a new subprocess). The hypothetical scenarios that would make a teardown path matter (subprocess hot-reload, one subprocess hosting multiple `StreamRuntime`s) are explicitly not on the roadmap.

## Follow-ups

None blocking.

## E2E output PNGs

![polyglot OpenGL E2E output — Python Mandelbrot fragment shader rendered into the host DMA-BUF](https://gh-artifact.tatolab.com/pr-548/opengl-mandelbrot-py.jpg)

*Python (`ctypes` against `libGL.so.1`, Mandelbrot zoom into Seahorse Valley with smooth-iteration coloring + Inigo-Quilez cosine palette). The recursive structure is sharp — the GL fragment shader compiled in the subprocess and rendered into the host DMA-BUF, host Vulkan readback saw the writes after `glFinish` on release.*

![polyglot OpenGL E2E output — Deno plasma fragment shader rendered into the host DMA-BUF](https://gh-artifact.tatolab.com/pr-548/opengl-plasma-deno.jpg)

*Deno (`Deno.dlopen` against `libGL.so.1`, sine-interference plasma with cosine palette). Same scenario, separate subprocess, independent GL-binding implementation, different visual fingerprint — the polyglot coverage is visually unmistakable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

