### PR TITLE
feat(adapter-vulkan): subprocess VulkanContext runtime + polyglot scenario

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "examples/polyglot-dma-buf-consumer", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
     "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
     "examples/polyglot-opengl-fragment-shader", # Example: Polyglot OpenGL adapter — Python Mandelbrot / Deno plasma fragment shader rendered into a host DMA-BUF (#530)
+    "examples/polyglot-vulkan-compute",   # Example: Polyglot Vulkan adapter — Python/Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage (#531)
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)

--- a/examples/polyglot-vulkan-compute/Cargo.toml
+++ b/examples/polyglot-vulkan-compute/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-vulkan-compute-scenario"
+version = "0.1.0"
+edition = "2024"
+publish = false
+build = "build.rs"
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+serde_json = "1.0"
+png = "0.17"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+vulkanalia = { workspace = true }

--- a/examples/polyglot-vulkan-compute/build.rs
+++ b/examples/polyglot-vulkan-compute/build.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![allow(clippy::disallowed_macros)] // build.rs uses println!/eprintln! for `cargo:` directives
+
+//! Compile `shaders/mandelbrot.comp` to SPIR-V via `glslc`. The example's
+//! `main.rs` embeds the resulting `.spv` via `include_bytes!` and ships
+//! it to the polyglot processor as a hex string in the processor config.
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    compile_compute_shaders();
+}
+
+#[cfg(target_os = "linux")]
+fn compile_compute_shaders() {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    let shaders: &[(&str, &str)] = &[
+        ("shaders/mandelbrot.comp", "mandelbrot.spv"),
+    ];
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    for (src, dst) in shaders {
+        let src_path = Path::new(src);
+        let dst_path: PathBuf = Path::new(&out_dir).join(dst);
+
+        println!("cargo:rerun-if-changed={}", src);
+
+        let glslc = std::env::var("GLSLC").unwrap_or_else(|_| "glslc".to_string());
+        let status = Command::new(&glslc)
+            .arg("-O")
+            .arg("--target-env=vulkan1.2")
+            .arg("-o")
+            .arg(&dst_path)
+            .arg(src_path)
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to invoke `{}` to compile {}: {}. Install shaderc-tools / vulkan-tools.",
+                    glslc,
+                    src,
+                    e
+                );
+            });
+        assert!(
+            status.success(),
+            "{} compilation failed (exit: {:?})",
+            src,
+            status.code()
+        );
+    }
+}

--- a/examples/polyglot-vulkan-compute/deno/deno.json
+++ b/examples/polyglot-vulkan-compute/deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+  }
+}

--- a/examples/polyglot-vulkan-compute/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/deno/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-vulkan-compute-deno
+  version: "0.1.0"
+  description: "Polyglot Vulkan adapter scenario (#531) — Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage"
+
+processors:
+  - name: com.tatolab.vulkan_compute_deno
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
+    runtime: deno
+    execution: reactive
+    entrypoint: "vulkan_compute.ts:default"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
+++ b/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot Vulkan compute processor — Deno twin of
+ * `examples/polyglot-vulkan-compute/python/vulkan_compute.py`.
+ *
+ * End-to-end gate for the subprocess `VulkanContext` runtime (#531).
+ * The host pre-allocates a render-target-capable DMA-BUF surface AND
+ * an exportable `VulkanTimelineSemaphore`, registers both with
+ * surface-share. This processor receives a trigger Videoframe, opens
+ * the host surface through `VulkanContext.acquireWrite` (which imports
+ * the DMA-BUF as a `VkImage` in the subprocess and imports the
+ * timeline via `from_imported_opaque_fd`), dispatches the Mandelbrot
+ * compute kernel via the cdylib's quarantined
+ * `sldn_vulkan_dispatch_compute` helper, and releases — the host
+ * adapter advances the timeline so the host's pre-stop readback sees
+ * the writes.
+ *
+ * Same compute shader as the Python twin, with `variant=1` so the
+ * cosine palette differs slightly — visually distinct PNGs make
+ * reviewer comparisons easy.
+ *
+ * Config keys: vulkan_surface_uuid, width, height, max_iter, variant,
+ * shader_spv_hex (hex-encoded SPIR-V from
+ * `examples/polyglot-vulkan-compute/shaders/mandelbrot.comp`).
+ */
+
+import type {
+  ReactiveProcessor,
+  RuntimeContextFullAccess,
+  RuntimeContextLimitedAccess,
+} from "../../../libs/streamlib-deno/mod.ts";
+import { VulkanContext } from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+export default class VulkanComputeProcessor implements ReactiveProcessor {
+  private uuid = "";
+  private width = 0;
+  private height = 0;
+  private maxIter = 0;
+  private variant = 1; // Default to Deno palette (#531).
+  private spv: Uint8Array | null = null;
+  private vk: VulkanContext | null = null;
+  private dispatched = false;
+  private errorMessage: string | null = null;
+
+  setup(ctx: RuntimeContextFullAccess): void {
+    const cfg = ctx.config;
+    this.uuid = String(cfg["vulkan_surface_uuid"]);
+    this.width = Number(cfg["width"] ?? 0);
+    this.height = Number(cfg["height"] ?? 0);
+    this.maxIter = Number(cfg["max_iter"] ?? 256);
+    this.variant = Number(cfg["variant"] ?? 1);
+    this.spv = hexToBytes(String(cfg["shader_spv_hex"] ?? ""));
+    this.vk = VulkanContext.fromRuntime(ctx);
+    console.error(
+      `[VulkanCompute/deno] setup uuid=${this.uuid} ` +
+        `size=${this.width}x${this.height} ` +
+        `spv_bytes=${this.spv.byteLength} variant=${this.variant}`,
+    );
+  }
+
+  process(ctx: RuntimeContextLimitedAccess): void {
+    const result = ctx.inputs.read("video_in");
+    if (!result) return;
+    if (this.dispatched) return;
+    try {
+      this.dispatchOnce();
+      this.dispatched = true;
+      console.error(
+        `[VulkanCompute/deno] Mandelbrot dispatched into surface '${this.uuid}'`,
+      );
+    } catch (e) {
+      this.errorMessage = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[VulkanCompute/deno] dispatch failed: ${this.errorMessage}`,
+      );
+    }
+  }
+
+  private dispatchOnce(): void {
+    if (this.vk === null || this.spv === null) {
+      throw new Error("VulkanContext / SPIR-V not initialized in setup");
+    }
+    // Push-constant layout matches the shader: `{u32 width, u32 height, u32 max_iter, u32 variant}`.
+    const pc = new Uint8Array(16);
+    const pcView = new DataView(pc.buffer);
+    pcView.setUint32(0, this.width, true);
+    pcView.setUint32(4, this.height, true);
+    pcView.setUint32(8, this.maxIter, true);
+    pcView.setUint32(12, this.variant, true);
+
+    // Shader's `local_size_x = local_size_y = 16`.
+    const local = 16;
+    const groupX = Math.ceil(this.width / local);
+    const groupY = Math.ceil(this.height / local);
+
+    using guard = this.vk.acquireWrite(this.uuid);
+    console.error(
+      `[VulkanCompute/deno] acquired vk_image=0x${guard.view.vkImage.toString(16)} ` +
+        `layout=${guard.view.vkImageLayout}`,
+    );
+    this.vk.dispatchCompute(
+      this.uuid,
+      this.spv,
+      pc,
+      groupX,
+      groupY,
+      1,
+    );
+  }
+
+  teardown(_ctx: RuntimeContextFullAccess): void {
+    console.error(
+      `[VulkanCompute/deno] teardown dispatched=${this.dispatched} ` +
+        `error=${this.errorMessage}`,
+    );
+  }
+}

--- a/examples/polyglot-vulkan-compute/python/pyproject.toml
+++ b/examples/polyglot-vulkan-compute/python/pyproject.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[project]
+name = "polyglot-vulkan-compute"
+version = "0.1.0"
+description = "Polyglot Vulkan adapter scenario — Python Mandelbrot compute kernel"
+requires-python = ">=3.10"
+dependencies = [
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/examples/polyglot-vulkan-compute/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/python/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-vulkan-compute
+  version: "0.1.0"
+  description: "Polyglot Vulkan adapter scenario (#531) — Python Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage"
+
+processors:
+  - name: com.tatolab.vulkan_compute
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
+    runtime: python
+    execution: reactive
+    entrypoint: "vulkan_compute:VulkanComputeProcessor"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-vulkan-compute/python/vulkan_compute.py
+++ b/examples/polyglot-vulkan-compute/python/vulkan_compute.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot Vulkan compute processor — Python.
+
+End-to-end gate for the subprocess `VulkanContext` runtime (#531). The
+host pre-allocates a render-target-capable DMA-BUF surface AND an
+exportable `VulkanTimelineSemaphore`, registers both with surface-share.
+This processor receives a trigger Videoframe, opens the host surface
+through ``VulkanContext.acquire_write`` (which imports the DMA-BUF as a
+``VkImage`` in the subprocess and imports the timeline via
+``from_imported_opaque_fd``), dispatches the Mandelbrot compute kernel
+via the cdylib's quarantined ``slpn_vulkan_dispatch_compute`` helper,
+and releases — the host adapter advances the timeline so the host's
+pre-stop readback sees the writes.
+
+No `pyvulkan` / `vulkan` Python binding required: the cdylib's
+`dispatch_compute` accepts SPIR-V bytes + push-constant bytes + group
+counts and runs the dispatch on the same `VkDevice` the adapter
+manages. Real customers can use whatever Vulkan binding they prefer
+through the ``raw_handles()`` escape hatch — the cdylib's runtime
+exposes its raw `VkInstance` / `VkDevice` / `VkQueue` for that.
+
+Config keys:
+    vulkan_surface_uuid (str, required)
+        Surface-share UUID the host registered the render-target image
+        + timeline semaphore under.
+    width (int, required)
+        Surface width in pixels.
+    height (int, required)
+        Surface height in pixels.
+    max_iter (int, required)
+        Mandelbrot iteration count (matches the shader's
+        ``pc.max_iter`` push-constant slot).
+    variant (int, required)
+        0 → Python palette (blue→green→red), 1 → Deno palette.
+    shader_spv_hex (str, required)
+        Hex-encoded SPIR-V bytecode for the Mandelbrot compute shader,
+        compiled at example-build-time from
+        ``examples/polyglot-vulkan-compute/shaders/mandelbrot.comp``.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+from streamlib.adapters.vulkan import VulkanContext
+
+
+class VulkanComputeProcessor:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        cfg = ctx.config
+        self._uuid = str(cfg["vulkan_surface_uuid"])
+        self._width = int(cfg["width"])
+        self._height = int(cfg["height"])
+        self._max_iter = int(cfg["max_iter"])
+        self._variant = int(cfg["variant"])
+        self._spv: bytes = bytes.fromhex(str(cfg["shader_spv_hex"]))
+        self._vk = VulkanContext.from_runtime(ctx)
+        self._dispatched = False
+        self._error: Optional[str] = None
+        print(
+            f"[VulkanCompute/py] setup uuid={self._uuid} "
+            f"size={self._width}x{self._height} "
+            f"spv_bytes={len(self._spv)} variant={self._variant}",
+            flush=True,
+        )
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("video_in")
+        if frame is None:
+            return
+        if self._dispatched:
+            return
+        try:
+            self._dispatch_once()
+            self._dispatched = True
+            print(
+                f"[VulkanCompute/py] Mandelbrot dispatched into surface '{self._uuid}'",
+                flush=True,
+            )
+        except Exception as e:
+            self._error = str(e)
+            print(
+                f"[VulkanCompute/py] dispatch failed: {e}", flush=True,
+            )
+
+    def _dispatch_once(self) -> None:
+        # Push constants: layout is `{u32 width, u32 height, u32 max_iter, u32 variant}`.
+        push_consts = struct.pack(
+            "<IIII",
+            self._width,
+            self._height,
+            self._max_iter,
+            self._variant,
+        )
+        # Group size matches the shader's `local_size_x = local_size_y = 16`.
+        local = 16
+        group_x = (self._width + local - 1) // local
+        group_y = (self._height + local - 1) // local
+
+        with self._vk.acquire_write(self._uuid) as view:
+            print(
+                f"[VulkanCompute/py] acquired vk_image=0x{view.vk_image:x} "
+                f"layout={view.vk_image_layout}",
+                flush=True,
+            )
+            self._vk.dispatch_compute(
+                self._uuid,
+                self._spv,
+                push_consts,
+                group_x,
+                group_y,
+                1,
+            )
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        print(
+            f"[VulkanCompute/py] teardown dispatched={self._dispatched} "
+            f"error={self._error}",
+            flush=True,
+        )

--- a/examples/polyglot-vulkan-compute/shaders/mandelbrot.comp
+++ b/examples/polyglot-vulkan-compute/shaders/mandelbrot.comp
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Mandelbrot fractal renderer — single-binding compute kernel exercised by
+// the polyglot Vulkan adapter scenario (#531). Customers (Python and Deno
+// polyglot processors) supply the SPIR-V to `dispatch_compute` along with
+// push-constant uniforms + dispatch group counts; the cdylib's quarantined
+// raw-vulkanalia compute helper writes pixels straight into the imported
+// host VkImage at GENERAL layout.
+//
+// Picks Seahorse Valley as the zoom target so the visual evidence is
+// recognizable in a PNG (a misordered channel or wrong stride is obviously
+// wrong against the expected smooth-coloring palette).
+
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+// `binding = 0` storage image — bound by the cdylib helper as the
+// imported VkImage at layout(rgba8) with `VK_FORMAT_B8G8R8A8_UNORM`.
+// Vulkan's storage-image format reinterprets the texel bytes as the
+// declared format, so we write `vec4(R, G, B, A)` and the host's
+// readback gets BGRA bytes that match the source pattern.
+layout(set = 0, binding = 0, rgba8) uniform image2D outputImage;
+
+// Push constants the customer fills in. The variant byte lets the Python
+// vs Deno scenario sit on slightly different palettes / zoom centres so a
+// reviewer can tell at a glance which subprocess wrote the image.
+layout(push_constant) uniform PushConstants {
+    uint width;
+    uint height;
+    uint max_iter;
+    uint variant;
+} pc;
+
+vec3 palette(float t) {
+    // Inigo Quilez cosine palette — recognizable smooth gradient.
+    vec3 a = vec3(0.5);
+    vec3 b = vec3(0.5);
+    vec3 c = vec3(1.0);
+    vec3 d = (pc.variant == 0u)
+        ? vec3(0.00, 0.33, 0.67)   // Python: blue → green → red
+        : vec3(0.50, 0.20, 0.25);  // Deno:   teal → orange → magenta
+    return a + b * cos(6.28318 * (c * t + d));
+}
+
+void main() {
+    uvec2 pix = gl_GlobalInvocationID.xy;
+    if (pix.x >= pc.width || pix.y >= pc.height) {
+        return;
+    }
+
+    vec2 uv = vec2(pix) / vec2(pc.width, pc.height);
+    // Seahorse Valley centre with a tight zoom so the recursive structure
+    // is obvious in a 512x512 frame.
+    vec2 c = vec2(-0.7453, 0.1127) + (uv - 0.5) * 0.018;
+    vec2 z = vec2(0.0);
+    int last_iter = 0;
+    bool escaped = false;
+    for (int i = 0; i < int(pc.max_iter); i++) {
+        if (dot(z, z) > 4.0) {
+            last_iter = i;
+            escaped = true;
+            break;
+        }
+        z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
+    }
+
+    vec3 col;
+    if (!escaped) {
+        col = vec3(0.0);
+    } else {
+        // Smooth coloring (continuous escape time).
+        float smoothed = float(last_iter) - log2(log2(dot(z, z))) + 4.0;
+        float t = smoothed / float(pc.max_iter);
+        col = palette(t);
+    }
+
+    imageStore(outputImage, ivec2(pix), vec4(col, 1.0));
+}

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -1,28 +1,32 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Polyglot OpenGL adapter scenario (#530).
+//! Polyglot Vulkan adapter scenario (#531).
 //!
-//! End-to-end gate for the subprocess `OpenGLContext` runtime: the host
-//! pre-allocates ONE render-target-capable DMA-BUF surface and registers
-//! it with surface-share under a known UUID. A Python or Deno polyglot
-//! processor opens the surface through `OpenGLContext.acquire_write`,
-//! compiles a fragment shader (Mandelbrot in Python, plasma waves in
-//! Deno), binds an FBO to the imported `GL_TEXTURE_2D`, draws a
-//! fullscreen quad, releases — the adapter's `glFinish` on release
-//! ensures cross-API consumers see the writes through the underlying
-//! DMA-BUF. After the runtime stops, this binary reads the surface
-//! back via Vulkan and writes a PNG; reading that PNG with the Read
-//! tool is the visual gate.
+//! End-to-end gate for the subprocess `VulkanContext` runtime: the host
+//! pre-allocates ONE render-target-capable DMA-BUF surface AND an
+//! exportable `VulkanTimelineSemaphore`, registers both with surface-share
+//! under a known UUID. A Python or Deno polyglot processor opens the
+//! surface through `VulkanContext.acquire_write` (which imports the
+//! DMA-BUF as a `VkImage` in the subprocess and imports the timeline via
+//! `from_imported_opaque_fd`), dispatches the Mandelbrot compute shader,
+//! and releases — the host adapter advances the timeline so the host's
+//! pre-stop readback sees the writes. This binary then reads the surface
+//! back via Vulkan and writes a PNG; reading the PNG with the Read tool
+//! is the visual gate.
+//!
+//! The compute shader (`shaders/mandelbrot.comp`) is compiled to SPIR-V
+//! at build time via `build.rs`, embedded as bytes here, and shipped to
+//! the polyglot processor via the processor config as a hex string.
 //!
 //! Build the Python `.slpkg` first:
-//!   cargo run -p streamlib-cli -- pack examples/polyglot-opengl-fragment-shader/python
+//!   cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-compute/python
 //!
 //! Run:
-//!   cargo run -p polyglot-opengl-fragment-shader-scenario -- \
-//!       --runtime=python --output=/tmp/opengl-mandelbrot.png
-//!   cargo run -p polyglot-opengl-fragment-shader-scenario -- \
-//!       --runtime=deno   --output=/tmp/opengl-plasma.png
+//!   cargo run -p polyglot-vulkan-compute-scenario -- \
+//!       --runtime=python --output=/tmp/vulkan-mandelbrot-py.png
+//!   cargo run -p polyglot-vulkan-compute-scenario -- \
+//!       --runtime=deno   --output=/tmp/vulkan-mandelbrot-deno.png
 
 #![cfg(target_os = "linux")]
 
@@ -30,19 +34,25 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use streamlib::adapter_support::VulkanDevice;
+use streamlib::adapter_support::{VulkanDevice, VulkanTimelineSemaphore};
 use streamlib::core::rhi::TextureFormat;
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
+/// Compiled SPIR-V for the Mandelbrot compute shader. Built by
+/// `build.rs` from `shaders/mandelbrot.comp`. Shipped to the polyglot
+/// processor as a hex-encoded string in the processor config.
+const MANDELBROT_SPV: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/mandelbrot.spv"));
+
 /// UUID the host registers the render-target surface under. The
 /// polyglot processor reads it from its config and passes it to
-/// `OpenGLContext.acquire_write`.
-const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-0000000005c0";
+/// `VulkanContext.acquire_write`.
+const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-0000000005c1";
 
-/// Side length of the surface. Square keeps Mandelbrot/plasma math
-/// straightforward; 512 is large enough to be visually obvious and
-/// small enough that the scenario runs in a couple seconds.
+/// Side length of the surface. Square keeps the kernel's group-count
+/// math straightforward; 512 is large enough to be visually obvious
+/// and small enough that the scenario runs in a couple seconds.
 const SURFACE_SIZE: u32 = 512;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -71,8 +81,8 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.opengl_fragment_shader",
-            Self::Deno => "com.tatolab.opengl_fragment_shader_deno",
+            Self::Python => "com.tatolab.vulkan_compute",
+            Self::Deno => "com.tatolab.vulkan_compute_deno",
         }
     }
 }
@@ -81,7 +91,7 @@ fn main() -> Result<()> {
     let args = std::env::args().skip(1);
 
     let mut runtime_kind = RuntimeKind::Python;
-    let mut output_png = PathBuf::from("/tmp/opengl-fragment-shader.png");
+    let mut output_png = PathBuf::from("/tmp/vulkan-mandelbrot.png");
 
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
@@ -92,40 +102,51 @@ fn main() -> Result<()> {
         }
     }
 
-    println!("=== Polyglot OpenGL adapter fragment-shader scenario (#530) ===");
+    println!("=== Polyglot Vulkan adapter compute scenario (#531) ===");
     println!("Runtime:     {}", runtime_kind.as_str());
     println!(
         "Surface:     {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (uuid {SCENARIO_SURFACE_UUID})"
     );
+    println!("SPIR-V:      {} bytes", MANDELBROT_SPV.len());
     println!("Output PNG:  {}", output_png.display());
     println!();
 
     let runtime = StreamRuntime::new()?;
 
-    // Slots the setup hook populates with the host StreamTexture and
-    // the underlying VulkanDevice so main.rs can read the surface back
-    // post-stop and write the output PNG. We can't keep the
-    // `&GpuContext` borrow past the hook, so we Arc-clone the bits we
-    // need.
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
     let device_slot: Arc<Mutex<Option<Arc<VulkanDevice>>>> =
         Arc::new(Mutex::new(None));
+    let timeline_slot: Arc<Mutex<Option<Arc<VulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
         let device_slot = Arc::clone(&device_slot);
+        let timeline_slot = Arc::clone(&timeline_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
                 SURFACE_SIZE,
                 SURFACE_SIZE,
-                TextureFormat::Bgra8Unorm,
+                TextureFormat::Rgba8Unorm,
             )?;
-            // Register with surface-share so the subprocess can look
-            // it up via `gpu_limited_access.resolve_surface`. The
-            // adapter's `OpenGlSurfaceAdapter` then imports the
-            // resulting DMA-BUF FD as an EGLImage + GL_TEXTURE_2D.
+            let host_device = Arc::clone(gpu.device().vulkan_device());
+            // The Vulkan adapter on the host needs a per-surface
+            // exportable timeline. The host signals it after the
+            // subprocess release; the subprocess waits on it before
+            // every acquire.
+            let timeline = Arc::new(
+                VulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        StreamError::Configuration(format!(
+                            "VulkanTimelineSemaphore::new_exportable: {e}"
+                        ))
+                    })?,
+            );
+            // Surface-share registration carries BOTH the DMA-BUF FD
+            // and the timeline OPAQUE_FD so the subprocess can wire up
+            // the host adapter's `register_host_surface` directly.
             let store = gpu.surface_store().ok_or_else(|| {
                 StreamError::Configuration(
                     "surface_store unavailable — host runtime built without \
@@ -133,36 +154,36 @@ fn main() -> Result<()> {
                         .into(),
                 )
             })?;
-            // OpenGL adapter doesn't need an explicit Vulkan timeline:
-            // `glFinish` on release plus DMA-BUF kernel-fence semantics
-            // carry visibility for the host's pre-stop readback.
             store
-                .register_texture(SCENARIO_SURFACE_UUID, &texture, None)
+                .register_texture(
+                    SCENARIO_SURFACE_UUID,
+                    &texture,
+                    Some(timeline.as_ref()),
+                )
                 .map_err(|e| {
                     StreamError::Configuration(format!(
                         "register_texture: {e}"
                     ))
                 })?;
             *texture_slot.lock().unwrap() = Some(texture);
-            *device_slot.lock().unwrap() =
-                Some(Arc::clone(gpu.device().vulkan_device()));
+            *device_slot.lock().unwrap() = Some(host_device);
+            *timeline_slot.lock().unwrap() = Some(timeline);
             println!(
-                "✓ render-target DMA-BUF surface registered as '{}'",
+                "✓ render-target DMA-BUF + timeline registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())
         });
     }
 
-    // Load the polyglot package.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
             let slpkg_path = manifest_dir
-                .join("python/polyglot-opengl-fragment-shader-0.1.0.slpkg");
+                .join("python/polyglot-vulkan-compute-0.1.0.slpkg");
             if !slpkg_path.exists() {
                 return Err(StreamError::Configuration(format!(
-                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-opengl-fragment-shader/python",
+                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-compute/python",
                     slpkg_path.display()
                 )));
             }
@@ -180,10 +201,10 @@ fn main() -> Result<()> {
         }
     }
 
-    // Trigger source: BgraFileSource emits a few `Videoframe`s so the
-    // polyglot processor's `process()` is invoked. The processor
-    // ignores frame contents — it works on the pre-registered host
-    // surface, not the trigger frame's pixel buffer.
+    // Trigger source: a few BGRA frames so the polyglot processor's
+    // `process()` is invoked. Frame contents are ignored — the processor
+    // works on the pre-registered host surface, not the trigger frame's
+    // pixel buffer.
     let fixture_path = write_trigger_fixture()
         .map_err(StreamError::Configuration)?;
 
@@ -205,39 +226,40 @@ fn main() -> Result<()> {
     ))?;
     println!("+ BgraFileSource: {source}");
 
-    let shader_config = serde_json::json!({
-        "opengl_surface_uuid": SCENARIO_SURFACE_UUID,
+    let spv_hex = bytes_to_hex(MANDELBROT_SPV);
+    let variant: u32 = match runtime_kind {
+        RuntimeKind::Python => 0,
+        RuntimeKind::Deno => 1,
+    };
+    let compute_config = serde_json::json!({
+        "vulkan_surface_uuid": SCENARIO_SURFACE_UUID,
         "width": SURFACE_SIZE,
         "height": SURFACE_SIZE,
+        "max_iter": 256,
+        "variant": variant,
+        "shader_spv_hex": spv_hex,
     });
-    let shader = runtime.add_processor(ProcessorSpec::new(
+    let compute = runtime.add_processor(ProcessorSpec::new(
         runtime_kind.processor_name(),
-        shader_config,
+        compute_config,
     ))?;
-    println!("+ Fragment shader: {shader}");
+    println!("+ Vulkan compute processor: {compute}");
 
     runtime.connect(
         OutputLinkPortRef::new(&source, "video"),
-        InputLinkPortRef::new(&shader, "video_in"),
+        InputLinkPortRef::new(&compute, "video_in"),
     )?;
     println!(
-        "\nPipeline: BgraFileSource → {} fragment-shader\n",
+        "\nPipeline: BgraFileSource → {} vulkan-compute\n",
         runtime_kind.as_str()
     );
 
     println!("Starting pipeline...");
     runtime.start()?;
-
-    // Give the polyglot processor time to receive a trigger frame and
-    // complete the GL acquire/draw/release cycle. The Python/Deno
-    // processors guard against re-rendering on subsequent frames so the
-    // PNG stays clean.
     std::thread::sleep(Duration::from_secs(4));
-
     println!("Stopping pipeline...");
     runtime.stop()?;
 
-    // Read the surface back via Vulkan and write the output PNG.
     println!("\nReading host surface back via Vulkan...");
     let texture = texture_slot
         .lock()
@@ -252,9 +274,7 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| {
-            StreamError::Runtime("device slot is empty".into())
-        })?;
+        .ok_or_else(|| StreamError::Runtime("device slot is empty".into()))?;
     let bgra = vulkan_readback(&device, &texture);
     write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
@@ -262,14 +282,19 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Write a tiny BGRA fixture file. BgraFileSource reads it
-/// frame-by-frame; the resulting `Videoframe`s are the trigger that
-/// drives the polyglot processor's `process()` call.
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
 fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     use std::fs::File;
     use std::io::Write;
 
-    let path = std::env::temp_dir().join("opengl-fragment-shader-trigger.bgra");
+    let path = std::env::temp_dir().join("vulkan-compute-trigger.bgra");
     let mut f = File::create(&path)
         .map_err(|e| format!("create {}: {e}", path.display()))?;
     f.write_all(&[0u8; 4 * 4 * 4 * 3])
@@ -277,12 +302,10 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     Ok(path)
 }
 
-/// Read pixels from the host `StreamTexture` back into a CPU buffer
-/// for verification. Returns BGRA8 bytes, `width*height*4` size.
-///
-/// Uses a transient HOST_VISIBLE staging buffer + `vkCmdCopyImageToBuffer`
-/// + queue wait — the canonical Vulkan readback shape, parallel to the
-/// `host_readback` helper in `streamlib-adapter-opengl/tests/common.rs`.
+/// Read pixels from the host `StreamTexture` back into a CPU buffer for
+/// PNG verification. Mirrors the helper in
+/// `examples/polyglot-opengl-fragment-shader` — transient HOST_VISIBLE
+/// staging buffer + `vkCmdCopyImageToBuffer` + `queue_wait_idle`.
 fn vulkan_readback(
     device: &Arc<VulkanDevice>,
     texture: &streamlib::core::rhi::StreamTexture,
@@ -369,9 +392,8 @@ fn vulkan_readback(
     }
     .expect("begin_command_buffer");
 
-    // The OpenGL adapter leaves the image in GENERAL layout (it never
-    // transitions out). Move to TRANSFER_SRC_OPTIMAL for the copy, then
-    // back to GENERAL.
+    // The compute dispatch left the image in GENERAL — transition to
+    // TRANSFER_SRC_OPTIMAL for the copy, then back to GENERAL.
     let to_src = vk::ImageMemoryBarrier2::builder()
         .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
         .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
@@ -459,7 +481,6 @@ fn vulkan_readback(
     out
 }
 
-/// Encode BGRA bytes as RGBA PNG (channel-swap on the fly).
 fn write_png(
     bgra: &[u8],
     width: u32,
@@ -469,13 +490,11 @@ fn write_png(
     use std::fs::File;
     use std::io::BufWriter;
 
-    let mut rgba = vec![0u8; bgra.len()];
-    for (src, dst) in bgra.chunks_exact(4).zip(rgba.chunks_exact_mut(4)) {
-        dst[0] = src[2];
-        dst[1] = src[1];
-        dst[2] = src[0];
-        dst[3] = src[3];
-    }
+    // Surface is allocated as `Rgba8Unorm` end-to-end (host allocator,
+    // subprocess storage-image view, shader's `rgba8` qualifier all
+    // match), so the readback bytes are already RGBA — no channel
+    // swap needed for PNG encoding.
+    let rgba = bgra.to_vec();
 
     let file = File::create(output).map_err(|e| {
         StreamError::Configuration(format!(

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -35,6 +35,11 @@ vulkanalia = { workspace = true }
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
 streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
+# Subprocess-side Vulkan runtime (#531). Same shape as streamlib-python-native
+# — wraps the host `VulkanSurfaceAdapter` so subprocess code never
+# re-implements layout-transition / timeline-wait / queue-mutex semantics.
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib = { path = "../streamlib" }
 
 
 [lints]

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -954,6 +954,15 @@ mod gpu_surface {
         /// per plane, keyed by plane index; single-plane surfaces carry a
         /// one-element vec. Mirrors the Python-native twin.
         pub fds: Vec<RawFd>,
+        /// Optional OPAQUE_FD timeline-semaphore handle the host attached
+        /// when registering the surface (#531). Routed into the Vulkan
+        /// adapter's `VulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// the subprocess reuses the host adapter's timeline-wait + signal
+        /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
+        /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
+        /// closed when the handle is dropped, unless the import has taken
+        /// ownership.
+        pub sync_fd: Option<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
         /// Per-plane row pitch in bytes (source-of-truth from the host's
@@ -1020,6 +1029,15 @@ mod gpu_surface {
             for fd in &self.fds {
                 if *fd >= 0 {
                     unsafe { libc::close(*fd) };
+                }
+            }
+            // Close the sync FD if the Vulkan adapter import didn't take
+            // ownership. The adapter's `register_surface` takes the fd by
+            // value via `take_sync_fd` so a successful import zeros out
+            // this slot before drop runs.
+            if let Some(fd) = self.sync_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
                 }
             }
         }
@@ -2134,6 +2152,10 @@ mod surface_client {
         size: u64,
         drm_format_modifier: u64,
         format: String,
+        /// Optional OPAQUE_FD timeline-semaphore handle the host attached at
+        /// register time. Stored so cache hits can hand a fresh dup to each
+        /// new `SurfaceHandle`; closed with the cache entry.
+        sync_fd: Option<RawFd>,
     }
 
     impl Drop for CachedSurface {
@@ -2141,6 +2163,11 @@ mod surface_client {
             for fd in &self.fds {
                 if *fd >= 0 {
                     unsafe { libc::close(*fd) };
+                }
+            }
+            if let Some(fd) = self.sync_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
                 }
             }
         }
@@ -2313,9 +2340,28 @@ mod surface_client {
                     }
                     return std::ptr::null_mut();
                 }
+                let cached_sync_dup: Option<RawFd> = match cached.sync_fd {
+                    Some(src) => {
+                        let dup = unsafe { libc::dup(src) };
+                        if dup < 0 {
+                            tracing::error!(
+                                "surface_resolve_surface: dup cached sync_fd failed for '{}': {}",
+                                pool_id_str,
+                                std::io::Error::last_os_error()
+                            );
+                            for fd in &dup_fds {
+                                unsafe { libc::close(*fd) };
+                            }
+                            return std::ptr::null_mut();
+                        }
+                        Some(dup)
+                    }
+                    None => None,
+                };
                 let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
                     fds: dup_fds,
+                    sync_fd: cached_sync_dup,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
                     plane_strides: cached.plane_strides.clone(),
@@ -2358,7 +2404,7 @@ mod surface_client {
             stream,
             &request,
             &[],
-            wire::MAX_DMA_BUF_PLANES,
+            wire::MAX_SCM_RIGHTS_FDS,
         ) {
             Ok(r) => r,
             Err(e) => {
@@ -2385,6 +2431,33 @@ mod surface_client {
                 "surface_resolve_surface: no DMA-BUF fd for '{}'",
                 pool_id_str
             );
+            return std::ptr::null_mut();
+        }
+
+        // Peel off the optional trailing sync-FD (#531) — same wire shape
+        // as the Python-native twin.
+        let has_sync_fd = response
+            .get("has_sync_fd")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if has_sync_fd
+            && !received_fds.is_empty()
+        {
+            let mut all = received_fds;
+            let sync = all.pop();
+            (all, sync)
+        } else {
+            (received_fds, None)
+        };
+
+        if received_fds.is_empty() {
+            tracing::error!(
+                "surface_resolve_surface: no plane fds for '{}' after peeling sync_fd",
+                pool_id_str
+            );
+            if let Some(s) = sync_fd {
+                unsafe { libc::close(s) };
+            }
             return std::ptr::null_mut();
         }
 
@@ -2444,6 +2517,18 @@ mod surface_client {
             }
             cache_fds.push(dup);
         }
+        let cache_sync_fd: Option<RawFd> = match sync_fd {
+            Some(src) if cache_dup_ok => {
+                let dup = unsafe { libc::dup(src) };
+                if dup < 0 {
+                    cache_dup_ok = false;
+                    None
+                } else {
+                    Some(dup)
+                }
+            }
+            _ => None,
+        };
         if cache_dup_ok {
             let mut cache = handle.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
@@ -2466,17 +2551,22 @@ mod surface_client {
                     size,
                     drm_format_modifier,
                     format: format_str.to_string(),
+                    sync_fd: cache_sync_fd,
                 },
             );
         } else {
             for fd in &cache_fds {
                 unsafe { libc::close(*fd) };
             }
+            if let Some(fd) = cache_sync_fd {
+                unsafe { libc::close(fd) };
+            }
         }
 
         let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
             fds: received_fds,
+            sync_fd,
             plane_sizes,
             plane_offsets,
             plane_strides,
@@ -2956,6 +3046,861 @@ mod opengl {
     pub unsafe extern "C" fn sldn_opengl_release_read(
         _rt: *mut c_void,
         _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+}
+
+// ============================================================================
+// C ABI — Vulkan adapter runtime (#531, Linux)
+//
+// Subprocess-side runtime mirroring the Python-native twin's `slpn_vulkan_*`
+// surface. Reuses `streamlib_adapter_vulkan::VulkanSurfaceAdapter` against a
+// subprocess-local `VulkanDevice` from the RHI: same timeline-wait, same
+// layout-transition, same per-surface state machine. The cdylib never
+// re-implements layout transitions, command-pool lifetimes, fence handling,
+// or queue-mutex coordination — every line of that lives in
+// `streamlib-adapter-vulkan`.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod vulkan {
+    use std::collections::HashMap;
+    use std::os::unix::io::RawFd;
+    use std::sync::{Arc, Mutex};
+
+    use streamlib::adapter_support::{
+        VulkanDevice, VulkanTexture, VulkanTimelineSemaphore,
+    };
+    use streamlib::core::rhi::TextureFormat;
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_vulkan::{
+        raw_handles, HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter,
+    };
+    use vulkanalia::vk;
+
+    use super::gpu_surface::SurfaceHandle;
+
+    pub struct VulkanRuntimeHandle {
+        device: Arc<VulkanDevice>,
+        adapter: Arc<VulkanSurfaceAdapter>,
+        registered: Mutex<HashMap<u64, RegisteredSurface>>,
+    }
+
+    /// See the Python-native twin for the rationale: only `vk::Image` is
+    /// cached because `VulkanTexture::clone` is a hollow no-image stub —
+    /// the texture itself is moved into `HostSurfaceRegistration` and
+    /// the adapter owns its lifetime.
+    struct RegisteredSurface {
+        vk_image: vk::Image,
+    }
+
+    #[repr(C)]
+    pub struct SldnVulkanView {
+        pub vk_image: u64,
+        pub vk_image_layout: i32,
+    }
+
+    #[repr(C)]
+    pub struct SldnVulkanRawHandles {
+        pub vk_instance: u64,
+        pub vk_physical_device: u64,
+        pub vk_device: u64,
+        pub vk_queue: u64,
+        pub vk_queue_family_index: u32,
+        pub api_version: u32,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_vulkan_runtime_new: VulkanDevice::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&device)));
+        Box::into_raw(Box::new(VulkanRuntimeHandle {
+            device,
+            adapter,
+            registered: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_runtime_free(rt: *mut VulkanRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    fn texture_format_from_str(format: &str) -> Option<TextureFormat> {
+        match format {
+            "Bgra8Unorm" => Some(TextureFormat::Bgra8Unorm),
+            "Bgra8UnormSrgb" => Some(TextureFormat::Bgra8UnormSrgb),
+            "Rgba8Unorm" => Some(TextureFormat::Rgba8Unorm),
+            "Rgba8UnormSrgb" => Some(TextureFormat::Rgba8UnormSrgb),
+            _ => None,
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_register_surface(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_vulkan_register_surface: null runtime");
+                return -1;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("sldn_vulkan_register_surface: null gpu_handle");
+                return -1;
+            }
+        };
+        if gpu.fds.is_empty() {
+            tracing::error!(
+                "sldn_vulkan_register_surface: surface has no DMA-BUF fds"
+            );
+            return -1;
+        }
+        if gpu.drm_format_modifier == 0 {
+            tracing::error!(
+                "sldn_vulkan_register_surface: surface has DRM_FORMAT_MOD_LINEAR \
+                 (zero modifier) — render-target Vulkan import requires a tiled \
+                 modifier; see docs/learnings/nvidia-egl-dmabuf-render-target.md"
+            );
+            return -1;
+        }
+        let texture_format = match texture_format_from_str(&gpu.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "sldn_vulkan_register_surface: unsupported format '{}' \
+                     (v1 supports Bgra8Unorm, Bgra8UnormSrgb, Rgba8Unorm, Rgba8UnormSrgb)",
+                    gpu.format
+                );
+                return -1;
+            }
+        };
+        let allocation_size = gpu.size;
+
+        let texture = match VulkanTexture::import_render_target_dma_buf(
+            &rt.device,
+            &gpu.fds,
+            &gpu.plane_offsets,
+            &gpu.plane_strides,
+            gpu.drm_format_modifier,
+            gpu.width,
+            gpu.height,
+            texture_format,
+            allocation_size,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_vulkan_register_surface: import_render_target_dma_buf: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+        // Snapshot the VkImage handle BEFORE moving texture. See the
+        // Python-native twin for the `VulkanTexture::clone`-is-hollow
+        // rationale.
+        let vk_image = match texture.image() {
+            Some(img) => img,
+            None => {
+                tracing::error!(
+                    "sldn_vulkan_register_surface: imported texture has no VkImage handle"
+                );
+                return -1;
+            }
+        };
+
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_vulkan_register_surface: surface '{}' has no sync_fd — \
+                     the host must register the texture with an exportable \
+                     `VulkanTimelineSemaphore`.",
+                    surface_id
+                );
+                return -1;
+            }
+        };
+        let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+            rt.device.device(),
+            raw_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                gpu.sync_fd = Some(raw_sync_fd);
+                tracing::error!(
+                    "sldn_vulkan_register_surface: from_imported_opaque_fd: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+
+        let registration = HostSurfaceRegistration {
+            texture: streamlib::core::rhi::StreamTexture::from_vulkan(texture),
+            timeline,
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+
+        if let Err(e) = rt
+            .adapter
+            .register_host_surface(surface_id, registration)
+        {
+            tracing::error!(
+                "sldn_vulkan_register_surface: register_host_surface failed: {:?}",
+                e
+            );
+            return -1;
+        }
+
+        rt.registered
+            .lock()
+            .expect("sldn_vulkan registered: poisoned")
+            .insert(surface_id, RegisteredSurface { vk_image });
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_unregister_surface(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let removed = rt
+            .registered
+            .lock()
+            .expect("sldn_vulkan registered: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return -1;
+        }
+        if rt.adapter.unregister_host_surface(surface_id) {
+            0
+        } else {
+            -1
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_acquire_write(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnVulkanView,
+    ) -> i32 {
+        acquire_inner(rt, surface_id, out_view, AcquireKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_write(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, AcquireKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_acquire_read(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnVulkanView,
+    ) -> i32 {
+        acquire_inner(rt, surface_id, out_view, AcquireKind::Read)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_read(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, AcquireKind::Read)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_raw_handles(
+        rt: *mut VulkanRuntimeHandle,
+        out: *mut SldnVulkanRawHandles,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let out = match unsafe { out.as_mut() } {
+            Some(o) => o,
+            None => return -1,
+        };
+        let handles = raw_handles(&rt.device);
+        out.vk_instance = handles.vk_instance;
+        out.vk_physical_device = handles.vk_physical_device;
+        out.vk_device = handles.vk_device;
+        out.vk_queue = handles.vk_queue;
+        out.vk_queue_family_index = handles.vk_queue_family_index;
+        out.api_version = handles.api_version;
+        0
+    }
+
+    #[derive(Clone, Copy)]
+    enum AcquireKind {
+        Read,
+        Write,
+    }
+
+    fn acquire_inner(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnVulkanView,
+        kind: AcquireKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_vulkan_acquire_*: null runtime");
+                return -1;
+            }
+        };
+        let out_view = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => {
+                tracing::error!("sldn_vulkan_acquire_*: null out_view");
+                return -1;
+            }
+        };
+        let surface = StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        match kind {
+            AcquireKind::Write => {
+                use streamlib_adapter_abi::VulkanWritable;
+                match rt.adapter.acquire_write(&surface) {
+                    Ok(g) => {
+                        out_view.vk_image = g.view().vk_image().0;
+                        out_view.vk_image_layout = g.view().vk_image_layout().0;
+                        std::mem::forget(g);
+                        0
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_vulkan_acquire_write: adapter.acquire_write: {:?}",
+                            e
+                        );
+                        -1
+                    }
+                }
+            }
+            AcquireKind::Read => {
+                use streamlib_adapter_abi::VulkanWritable;
+                match rt.adapter.acquire_read(&surface) {
+                    Ok(g) => {
+                        out_view.vk_image = g.view().vk_image().0;
+                        out_view.vk_image_layout = g.view().vk_image_layout().0;
+                        std::mem::forget(g);
+                        0
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_vulkan_acquire_read: adapter.acquire_read: {:?}",
+                            e
+                        );
+                        -1
+                    }
+                }
+            }
+        }
+    }
+
+    fn release_inner(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        kind: AcquireKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        match kind {
+            AcquireKind::Read => rt.adapter.end_read_access(surface_id),
+            AcquireKind::Write => rt.adapter.end_write_access(surface_id),
+        }
+        0
+    }
+
+    /// Twin of `slpn_vulkan_dispatch_compute` — same v1 limitation
+    /// (#525 follow-up). Quarantined raw-vulkanalia compute dispatch
+    /// against a single-binding storage image. Signature identical to
+    /// the Python-native variant.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_dispatch_compute(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        spv_ptr: *const u8,
+        spv_len: usize,
+        push_constants_ptr: *const u8,
+        push_constants_size: u32,
+        group_count_x: u32,
+        group_count_y: u32,
+        group_count_z: u32,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        if spv_ptr.is_null() || spv_len == 0 {
+            return -2;
+        }
+        if spv_len % 4 != 0 {
+            return -3;
+        }
+        let vk_image = {
+            let registered = rt
+                .registered
+                .lock()
+                .expect("sldn_vulkan registered: poisoned");
+            match registered.get(&surface_id) {
+                Some(e) => e.vk_image,
+                None => {
+                    tracing::error!(
+                        "sldn_vulkan_dispatch_compute: surface_id {} not registered",
+                        surface_id
+                    );
+                    return -4;
+                }
+            }
+        };
+
+        let spv: &[u8] = unsafe { std::slice::from_raw_parts(spv_ptr, spv_len) };
+        let push_constants: &[u8] = if push_constants_size == 0 {
+            &[]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(
+                    push_constants_ptr,
+                    push_constants_size as usize,
+                )
+            }
+        };
+
+        match super::vulkan_compute_dispatch::dispatch_storage_image_compute(
+            &rt.device,
+            vk_image,
+            spv,
+            push_constants,
+            group_count_x,
+            group_count_y,
+            group_count_z,
+        ) {
+            Ok(()) => 0,
+            Err(e) => {
+                tracing::error!("sldn_vulkan_dispatch_compute: {}", e);
+                -10
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod vulkan_compute_dispatch {
+    //! Mirror of streamlib-python-native's `vulkan_compute_dispatch`
+    //! module. v1 quarantined compute-dispatch helper; replace once
+    //! #525's escalate-IPC `RunComputeKernel` lands.
+
+    use std::sync::Arc;
+
+    use streamlib::adapter_support::VulkanDevice;
+    use vulkanalia::prelude::v1_4::*;
+    use vulkanalia::vk;
+
+    pub fn dispatch_storage_image_compute(
+        device: &Arc<VulkanDevice>,
+        image: vk::Image,
+        spv: &[u8],
+        push_constants: &[u8],
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<(), String> {
+        let dev = device.device();
+        let queue = device.queue();
+        let qf = device.queue_family_index();
+
+        let spv_words: &[u32] = unsafe {
+            std::slice::from_raw_parts(spv.as_ptr() as *const u32, spv.len() / 4)
+        };
+
+        let view_info = vk::ImageViewCreateInfo::builder()
+            .image(image)
+            .view_type(vk::ImageViewType::_2D)
+            .format(vk::Format::R8G8B8A8_UNORM)
+            .components(vk::ComponentMapping::default())
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let image_view = unsafe { dev.create_image_view(&view_info, None) }
+            .map_err(|e| format!("create_image_view: {e}"))?;
+        let cleanup_view = || unsafe { dev.destroy_image_view(image_view, None) };
+
+        let bindings = [vk::DescriptorSetLayoutBinding::builder()
+            .binding(0)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::COMPUTE)
+            .build()];
+        let dsl_info = vk::DescriptorSetLayoutCreateInfo::builder()
+            .bindings(&bindings)
+            .build();
+        let dsl = unsafe { dev.create_descriptor_set_layout(&dsl_info, None) }
+            .map_err(|e| {
+                cleanup_view();
+                format!("create_descriptor_set_layout: {e}")
+            })?;
+        let cleanup_dsl = || unsafe { dev.destroy_descriptor_set_layout(dsl, None) };
+
+        let pool_sizes = [vk::DescriptorPoolSize::builder()
+            .type_(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count(1)
+            .build()];
+        let pool_info = vk::DescriptorPoolCreateInfo::builder()
+            .pool_sizes(&pool_sizes)
+            .max_sets(1)
+            .build();
+        let dpool = unsafe { dev.create_descriptor_pool(&pool_info, None) }
+            .map_err(|e| {
+                cleanup_dsl();
+                cleanup_view();
+                format!("create_descriptor_pool: {e}")
+            })?;
+        let cleanup_dpool = || unsafe { dev.destroy_descriptor_pool(dpool, None) };
+
+        let layouts = [dsl];
+        let alloc_info = vk::DescriptorSetAllocateInfo::builder()
+            .descriptor_pool(dpool)
+            .set_layouts(&layouts)
+            .build();
+        let descriptor_set = unsafe { dev.allocate_descriptor_sets(&alloc_info) }
+            .map_err(|e| {
+                cleanup_dpool();
+                cleanup_dsl();
+                cleanup_view();
+                format!("allocate_descriptor_sets: {e}")
+            })?[0];
+
+        let image_info = [vk::DescriptorImageInfo::builder()
+            .image_view(image_view)
+            .image_layout(vk::ImageLayout::GENERAL)
+            .build()];
+        let writes = [vk::WriteDescriptorSet::builder()
+            .dst_set(descriptor_set)
+            .dst_binding(0)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .image_info(&image_info)
+            .build()];
+        unsafe {
+            dev.update_descriptor_sets(&writes, &[] as &[vk::CopyDescriptorSet])
+        };
+
+        let push_const_ranges: Vec<vk::PushConstantRange> = if push_constants.is_empty() {
+            Vec::new()
+        } else {
+            vec![vk::PushConstantRange::builder()
+                .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                .offset(0)
+                .size(push_constants.len() as u32)
+                .build()]
+        };
+        let mut pl_builder = vk::PipelineLayoutCreateInfo::builder().set_layouts(&layouts);
+        if !push_const_ranges.is_empty() {
+            pl_builder = pl_builder.push_constant_ranges(&push_const_ranges);
+        }
+        let pipeline_layout =
+            unsafe { dev.create_pipeline_layout(&pl_builder.build(), None) }.map_err(|e| {
+                cleanup_dpool();
+                cleanup_dsl();
+                cleanup_view();
+                format!("create_pipeline_layout: {e}")
+            })?;
+        let cleanup_pl = || unsafe { dev.destroy_pipeline_layout(pipeline_layout, None) };
+
+        let shader_info = vk::ShaderModuleCreateInfo::builder()
+            .code(spv_words)
+            .build();
+        let shader = unsafe { dev.create_shader_module(&shader_info, None) }.map_err(|e| {
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_shader_module: {e}")
+        })?;
+        let cleanup_shader = || unsafe { dev.destroy_shader_module(shader, None) };
+
+        let entry_name = b"main\0";
+        let stage = vk::PipelineShaderStageCreateInfo::builder()
+            .stage(vk::ShaderStageFlags::COMPUTE)
+            .module(shader)
+            .name(entry_name)
+            .build();
+        let pipeline_info = vk::ComputePipelineCreateInfo::builder()
+            .stage(stage)
+            .layout(pipeline_layout)
+            .build();
+        let (pipelines, _result_code) = unsafe {
+            dev.create_compute_pipelines(
+                vk::PipelineCache::null(),
+                &[pipeline_info],
+                None,
+            )
+        }
+        .map_err(|e| {
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_compute_pipelines: {:?}", e)
+        })?;
+        let pipeline = pipelines[0];
+        let cleanup_pipeline = || unsafe { dev.destroy_pipeline(pipeline, None) };
+
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let cmd_pool = unsafe { dev.create_command_pool(&pool_info, None) }.map_err(|e| {
+            cleanup_pipeline();
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_command_pool: {e}")
+        })?;
+        let cleanup_cmd_pool = || unsafe { dev.destroy_command_pool(cmd_pool, None) };
+
+        let cmd_alloc = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(cmd_pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd = unsafe { dev.allocate_command_buffers(&cmd_alloc) }.map_err(|e| {
+            cleanup_cmd_pool();
+            cleanup_pipeline();
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("allocate_command_buffers: {e}")
+        })?[0];
+
+        let begin = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        unsafe { dev.begin_command_buffer(cmd, &begin) }
+            .map_err(|e| format!("begin_command_buffer: {e}"))?;
+
+        unsafe {
+            dev.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::COMPUTE, pipeline);
+            dev.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                pipeline_layout,
+                0,
+                &[descriptor_set],
+                &[],
+            );
+            if !push_constants.is_empty() {
+                dev.cmd_push_constants(
+                    cmd,
+                    pipeline_layout,
+                    vk::ShaderStageFlags::COMPUTE,
+                    0,
+                    push_constants,
+                );
+            }
+            dev.cmd_dispatch(cmd, group_x, group_y, group_z);
+        }
+
+        let barrier = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .src_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+            .old_layout(vk::ImageLayout::GENERAL)
+            .new_layout(vk::ImageLayout::GENERAL)
+            .src_queue_family_index(qf)
+            .dst_queue_family_index(qf)
+            .image(image)
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let barriers = [barrier];
+        let dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&barriers)
+            .build();
+        unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+        unsafe { dev.end_command_buffer(cmd) }
+            .map_err(|e| format!("end_command_buffer: {e}"))?;
+
+        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cmd)
+            .build()];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cmd_infos)
+            .build();
+        unsafe { device.submit_to_queue(queue, &[submit], vk::Fence::null()) }
+            .map_err(|e| format!("submit_to_queue: {e}"))?;
+        unsafe { dev.queue_wait_idle(queue) }
+            .map_err(|e| format!("queue_wait_idle: {e}"))?;
+
+        cleanup_cmd_pool();
+        cleanup_pipeline();
+        cleanup_shader();
+        cleanup_pl();
+        cleanup_dpool();
+        cleanup_dsl();
+        cleanup_view();
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod vulkan {
+    use std::ffi::c_void;
+
+    #[repr(C)]
+    pub struct SldnVulkanView {
+        pub vk_image: u64,
+        pub vk_image_layout: i32,
+    }
+
+    #[repr(C)]
+    pub struct SldnVulkanRawHandles {
+        pub vk_instance: u64,
+        pub vk_physical_device: u64,
+        pub vk_device: u64,
+        pub vk_queue: u64,
+        pub vk_queue_family_index: u32,
+        pub api_version: u32,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_runtime_new() -> *mut c_void {
+        tracing::error!("sldn_vulkan_*: Vulkan adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnVulkanView,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnVulkanView,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_raw_handles(
+        _rt: *mut c_void,
+        _out: *mut SldnVulkanRawHandles,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_dispatch_compute(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _spv_ptr: *const u8,
+        _spv_len: usize,
+        _push_constants_ptr: *const u8,
+        _push_constants_size: u32,
+        _group_count_x: u32,
+        _group_count_y: u32,
+        _group_count_z: u32,
     ) -> i32 {
         -1
     }

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -4,32 +4,32 @@
 /**
  * Vulkan-native surface adapter — Deno customer-facing API.
  *
- * Mirrors the Rust crate `streamlib-adapter-vulkan` (#511). The
- * subprocess's actual Vulkan handling lives in
- * `streamlib-deno-native`'s `SurfaceShareVulkanDevice`; this module
- * provides:
+ * Mirrors the Rust crate `streamlib-adapter-vulkan` (#511, #531). The
+ * subprocess's actual Vulkan handling delegates to
+ * `streamlib-deno-native`'s `sldn_vulkan_*` FFI surface, which itself
+ * wraps the host adapter crate's `VulkanSurfaceAdapter` against a
+ * subprocess-local `VulkanDevice`. There is **no** parallel Vulkan
+ * implementation per language — every line of layout-transition,
+ * timeline-wait, and queue-mutex coordination lives in
+ * `streamlib-adapter-vulkan` and runs in the subprocess process.
+ *
+ * This module provides:
  *
  *  - `VulkanReadView` / `VulkanWriteView` — typed views the subprocess
  *    sees inside `acquireRead` / `acquireWrite` scopes; expose
  *    `vkImage` (a `bigint` Vulkan handle) plus the current
  *    `vkImageLayout`.
- *  - `VulkanContext` interface — the runtime hands one out, customers
- *    use TC39 `using` blocks for scoped acquire/release.
+ *  - The `VulkanContext` class — built via `VulkanContext.fromRuntime()`
+ *    inside a polyglot processor's `setup` hook. Customers acquire
+ *    scoped read/write access via TC39 `using` blocks and dispatch
+ *    their own raw vulkanalia / Deno-FFI work against `view.vkImage`.
  *  - `RawVulkanHandles` + `rawHandles()` shape — escape hatch for
  *    customers driving Vulkan directly.
- *
- * Note: the issue body specifies the path
- * `streamlib-deno/types/adapters/vulkan.ts`. The existing layout
- * keeps top-level modules (`surface_adapter.ts`, `escalate.ts`, etc.)
- * directly under `streamlib-deno/`, so we put the new module under
- * `streamlib-deno/adapters/vulkan.ts` to match. If a future
- * refactor introduces `types/`, this file moves with it.
  */
 
 import {
   STREAMLIB_ADAPTER_ABI_VERSION,
   type StreamlibSurface,
-  type SurfaceAccessGuard,
 } from "../surface_adapter.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };
@@ -87,7 +87,305 @@ export interface VulkanSurfaceAdapter {
   rawHandles(): RawVulkanHandles;
 }
 
-/** Customer-facing context. Same shape as the adapter — the runtime
- * wraps the adapter and hands the context out. Mirrors the Rust
- * `VulkanContext`. */
-export type VulkanContext = VulkanSurfaceAdapter;
+// =============================================================================
+// Concrete VulkanContext implementation (#531)
+// =============================================================================
+//
+// Mirrors `streamlib-deno/adapters/opengl.ts::OpenGLContext` exactly:
+// cached singleton per subprocess, surface-share `pool_id` → local
+// `surface_id` mapping, FFI calls into `sldn_vulkan_*` symbols loaded by
+// the runner.
+
+/** Async-disposable guard returned by acquire ops. `using` (synchronous
+ * disposable) suffices because the per-acquire path is fully synchronous
+ * — the host adapter blocks on the timeline wait before returning. */
+export interface VulkanAccessGuard<V> extends Disposable {
+  readonly view: V;
+}
+
+/** Minimal subset of `GpuContextLimitedAccess` the Vulkan adapter
+ * runtime needs. The full shape lives in `context.ts`; we type against
+ * a structural subset here so tests can stub it without dragging the
+ * whole FFI surface. */
+export interface VulkanGpuLimitedAccess {
+  resolveSurface(poolId: string): {
+    readonly nativeHandlePtr: Deno.PointerObject | null;
+    release(): void;
+  };
+  // deno-lint-ignore no-explicit-any
+  readonly nativeLib: { readonly symbols: any };
+}
+
+let _SURFACE_ID_COUNTER = 0n;
+function nextSurfaceId(): bigint {
+  _SURFACE_ID_COUNTER += 1n;
+  return _SURFACE_ID_COUNTER;
+}
+
+let _SHARED_INSTANCE: VulkanContext | null = null;
+
+/** Subprocess-side Vulkan adapter runtime (#531, Linux).
+ *
+ * Brings up `streamlib::adapter_support::VulkanDevice` +
+ * `streamlib_adapter_vulkan::VulkanSurfaceAdapter` inside this
+ * subprocess and exposes scoped acquire/release that hands customers a
+ * real `VkImage` handle plus the layout the adapter transitioned to.
+ * The acquire/release calls reuse every line of host-RHI logic
+ * (timeline wait, layout transition, queue-mutex coordination,
+ * contention checking) — the Deno side is a thin FFI shim.
+ *
+ * Construct via `VulkanContext.fromRuntime(ctx)` — single instance per
+ * subprocess. Repeat calls return the cached instance.
+ *
+ * Customers dispatch their own Vulkan work using their preferred Deno
+ * Vulkan binding (raw `Deno.dlopen` against `libvulkan.so.1`,
+ * `@webgpu/types`-flavored helpers, etc.). The cdylib's runtime exposes
+ * its raw handles through `rawHandles()` so the customer's submissions
+ * interleave correctly with the adapter's layout transitions on the
+ * same `VkQueue`.
+ */
+export class VulkanContext {
+  private readonly gpu: VulkanGpuLimitedAccess;
+  // deno-lint-ignore no-explicit-any
+  private readonly symbols: any;
+  private readonly rt: Deno.PointerObject;
+  private readonly surfaceIds = new Map<string, bigint>();
+  private readonly resolvedHandles = new Map<
+    string,
+    ReturnType<VulkanGpuLimitedAccess["resolveSurface"]>
+  >();
+
+  constructor(gpu: VulkanGpuLimitedAccess) {
+    this.gpu = gpu;
+    this.symbols = gpu.nativeLib.symbols;
+    const rtPtr = this.symbols.sldn_vulkan_runtime_new();
+    if (rtPtr === null) {
+      throw new Error(
+        "VulkanContext: sldn_vulkan_runtime_new returned NULL — the " +
+          "subprocess could not bring up a Vulkan device. Check that " +
+          "libvulkan.so.1 is installed and the driver supports " +
+          "VK_KHR_external_memory_fd, VK_EXT_external_memory_dma_buf, " +
+          "VK_EXT_image_drm_format_modifier, and " +
+          "VK_KHR_external_semaphore_fd.",
+      );
+    }
+    this.rt = rtPtr;
+  }
+
+  /** Build (or fetch the cached) `VulkanContext` for this subprocess. */
+  static fromRuntime(
+    ctx: { readonly gpuLimitedAccess: VulkanGpuLimitedAccess },
+  ): VulkanContext {
+    if (_SHARED_INSTANCE === null) {
+      _SHARED_INSTANCE = new VulkanContext(ctx.gpuLimitedAccess);
+    }
+    return _SHARED_INSTANCE;
+  }
+
+  private resolveAndRegister(poolId: string): bigint {
+    const cached = this.surfaceIds.get(poolId);
+    if (cached !== undefined) return cached;
+    const handle = this.gpu.resolveSurface(poolId);
+    const handlePtr = handle.nativeHandlePtr;
+    if (handlePtr === null) {
+      throw new Error(
+        `VulkanContext: resolveSurface('${poolId}') returned a handle with a null native pointer`,
+      );
+    }
+    const surfaceId = nextSurfaceId();
+    const rc: number = this.symbols.sldn_vulkan_register_surface(
+      this.rt,
+      surfaceId,
+      handlePtr,
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `VulkanContext: register_surface failed for pool_id ` +
+          `'${poolId}' (rc=${rc}). Check the subprocess log for ` +
+          `import errors — typically a missing sync_fd, an unsupported ` +
+          `DRM modifier, or an unsupported pixel format.`,
+      );
+    }
+    this.surfaceIds.set(poolId, surfaceId);
+    this.resolvedHandles.set(poolId, handle);
+    return surfaceId;
+  }
+
+  private static surfacePoolId(
+    surface: StreamlibSurface | string | bigint,
+  ): string {
+    if (typeof surface === "string") return surface;
+    if (typeof surface === "bigint") return surface.toString();
+    const id = (surface as { id?: bigint | string | number }).id;
+    if (id === undefined) {
+      throw new TypeError(
+        `VulkanContext: expected StreamlibSurface, string pool_id, or bigint — got ${
+          typeof surface
+        }`,
+      );
+    }
+    return String(id);
+  }
+
+  /** Read a `VulkanView`-shaped struct out of a Deno FFI buffer the
+   * cdylib populated. The struct layout is `{u64 vk_image, i32 vk_image_layout}`
+   * — 16 bytes total with 4-byte tail padding. */
+  private static readView(buf: Uint8Array): {
+    vkImage: bigint;
+    vkImageLayout: number;
+  } {
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    return {
+      vkImage: dv.getBigUint64(0, true),
+      vkImageLayout: dv.getInt32(8, true),
+    };
+  }
+
+  /** Acquire write access. Returns a `using`-disposable guard whose
+   * `view.vkImage` is a `VkImage` valid against the cdylib's
+   * `VkDevice`, transitioned to `GENERAL`. On dispose the adapter
+   * advances the host's timeline so the next consumer can wake up;
+   * the customer must `vkQueueWaitIdle` (or chain a binary semaphore
+   * on their submission) BEFORE leaving the scope so writes are
+   * visible. */
+  acquireWrite(
+    surface: StreamlibSurface | string | bigint,
+  ): VulkanAccessGuard<VulkanWriteView> {
+    const poolId = VulkanContext.surfacePoolId(surface);
+    const surfaceId = this.resolveAndRegister(poolId);
+    const buf = new Uint8Array(16);
+    const rc = this.symbols.sldn_vulkan_acquire_write(
+      this.rt,
+      surfaceId,
+      Deno.UnsafePointer.of(buf),
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `VulkanContext.acquireWrite: sldn_vulkan_acquire_write returned ${rc} for surface '${poolId}'`,
+      );
+    }
+    const v = VulkanContext.readView(buf);
+    const symbols = this.symbols;
+    const rt = this.rt;
+    return {
+      view: {
+        vkImage: v.vkImage,
+        vkImageLayout: v.vkImageLayout as VkImageLayout,
+      },
+      [Symbol.dispose]() {
+        symbols.sldn_vulkan_release_write(rt, surfaceId);
+      },
+    };
+  }
+
+  /** Acquire read access. Same shape as `acquireWrite`, but the image
+   * is in `SHADER_READ_ONLY_OPTIMAL` (multiple readers may coexist; no
+   * writer can be active). */
+  acquireRead(
+    surface: StreamlibSurface | string | bigint,
+  ): VulkanAccessGuard<VulkanReadView> {
+    const poolId = VulkanContext.surfacePoolId(surface);
+    const surfaceId = this.resolveAndRegister(poolId);
+    const buf = new Uint8Array(16);
+    const rc = this.symbols.sldn_vulkan_acquire_read(
+      this.rt,
+      surfaceId,
+      Deno.UnsafePointer.of(buf),
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `VulkanContext.acquireRead: sldn_vulkan_acquire_read returned ${rc} for surface '${poolId}'`,
+      );
+    }
+    const v = VulkanContext.readView(buf);
+    const symbols = this.symbols;
+    const rt = this.rt;
+    return {
+      view: {
+        vkImage: v.vkImage,
+        vkImageLayout: v.vkImageLayout as VkImageLayout,
+      },
+      [Symbol.dispose]() {
+        symbols.sldn_vulkan_release_read(rt, surfaceId);
+      },
+    };
+  }
+
+  /** Dispatch a single-binding compute shader against the surface's
+   * imported `VkImage`. The surface MUST currently be held in WRITE
+   * mode (call inside an `acquireWrite` `using` block).
+   *
+   * The shader's `binding=0` is bound as a storage image; up to
+   * `pushConstants.byteLength` bytes of push constants are written at
+   * offset 0.
+   *
+   * **v1 limitation (#525 follow-up):** the cdylib builds the compute
+   * pipeline + descriptor set + command buffer + fence inline using
+   * raw vulkanalia. Replace once the escalate-IPC `RunComputeKernel`
+   * op lands. */
+  dispatchCompute(
+    surface: StreamlibSurface | string | bigint,
+    spirv: Uint8Array,
+    pushConstants: Uint8Array,
+    groupCountX: number,
+    groupCountY: number,
+    groupCountZ: number,
+  ): void {
+    const poolId = VulkanContext.surfacePoolId(surface);
+    const cached = this.surfaceIds.get(poolId);
+    if (cached === undefined) {
+      throw new Error(
+        `VulkanContext.dispatchCompute: surface '${poolId}' is not registered ` +
+          "— call acquireWrite inside a `using` block first.",
+      );
+    }
+    const spvPtr = Deno.UnsafePointer.of(spirv);
+    const pcPtr = pushConstants.byteLength === 0
+      ? null
+      : Deno.UnsafePointer.of(pushConstants);
+    const rc: number = this.symbols.sldn_vulkan_dispatch_compute(
+      this.rt,
+      cached,
+      spvPtr,
+      BigInt(spirv.byteLength),
+      pcPtr,
+      pushConstants.byteLength,
+      groupCountX,
+      groupCountY,
+      groupCountZ,
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `VulkanContext.dispatchCompute: sldn_vulkan_dispatch_compute returned ${rc} for surface '${poolId}'`,
+      );
+    }
+  }
+
+  /** Return the cdylib runtime's raw Vulkan handles — same shape as
+   * `streamlib_adapter_vulkan::raw_handles()`. Use these to drive your
+   * preferred Vulkan binding against the SAME `VkDevice` the adapter
+   * manages.
+   *
+   * Struct layout: `{u64 vk_instance, u64 vk_physical_device, u64
+   * vk_device, u64 vk_queue, u32 vk_queue_family_index, u32
+   * api_version}` — 40 bytes total. */
+  rawHandles(): RawVulkanHandles {
+    const buf = new Uint8Array(40);
+    const rc = this.symbols.sldn_vulkan_raw_handles(
+      this.rt,
+      Deno.UnsafePointer.of(buf),
+    );
+    if (rc !== 0) {
+      throw new Error(`VulkanContext.rawHandles: sldn_vulkan_raw_handles returned ${rc}`);
+    }
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    return {
+      vkInstance: dv.getBigUint64(0, true),
+      vkPhysicalDevice: dv.getBigUint64(8, true),
+      vkDevice: dv.getBigUint64(16, true),
+      vkQueue: dv.getBigUint64(24, true),
+      vkQueueFamilyIndex: dv.getUint32(32, true),
+      apiVersion: dv.getUint32(36, true),
+    };
+  }
+}

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -186,6 +186,62 @@ const symbols = {
     parameters: ["pointer", "u64"] as const,
     result: "i32" as const,
   },
+
+  // Vulkan adapter runtime (#531, Linux). Same shape as `sldn_opengl_*`
+  // but wraps `streamlib_adapter_vulkan::VulkanSurfaceAdapter` against a
+  // subprocess-local `VulkanDevice` from the RHI.  Acquire returns the
+  // imported `VkImage` + layout via an out-pointer struct (the symbol
+  // matches `streamlib_deno_native::vulkan::SldnVulkanView`).
+  sldn_vulkan_runtime_new: {
+    parameters: [] as const,
+    result: "pointer" as const,
+  },
+  sldn_vulkan_runtime_free: {
+    parameters: ["pointer"] as const,
+    result: "void" as const,
+  },
+  sldn_vulkan_register_surface: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_unregister_surface: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_acquire_write: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_release_write: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_acquire_read: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_release_read: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_raw_handles: {
+    parameters: ["pointer", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_vulkan_dispatch_compute: {
+    parameters: [
+      "pointer",  // rt
+      "u64",      // surface_id
+      "pointer",  // spv_ptr
+      "usize",    // spv_len
+      "pointer",  // push_constants_ptr
+      "u32",      // push_constants_size
+      "u32",      // group_count_x
+      "u32",      // group_count_y
+      "u32",      // group_count_z
+    ] as const,
+    result: "i32" as const,
+  },
 } as const;
 
 export type NativeLib = Deno.DynamicLibrary<typeof symbols>;

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -36,6 +36,14 @@ vulkanalia = { workspace = true }
 # bring-up or DMA-BUF → GL_TEXTURE_2D import.
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
 streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
+# Subprocess-side Vulkan runtime (#531). Reuses the host adapter crate's
+# `VulkanSurfaceAdapter` against a subprocess-local `VulkanDevice` from the
+# RHI: same timeline-wait, same layout-transition, same acquire/release
+# state machine. The dual-VkDevice crash on NVIDIA does not apply because
+# this VkDevice is created before any other in-process Vulkan device has
+# active GPU work — see `docs/learnings/nvidia-dual-vulkan-device-crash.md`.
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib = { path = "../streamlib" }
 
 
 [lints]

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -976,6 +976,15 @@ mod gpu_surface {
         /// modifiers with disjoint Y/UV allocations) carry one per plane,
         /// keyed by plane index.
         pub fds: Vec<RawFd>,
+        /// Optional OPAQUE_FD timeline-semaphore handle the host attached
+        /// when registering the surface (#531). Routed into the Vulkan
+        /// adapter's `VulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// the subprocess reuses the host adapter's timeline-wait + signal
+        /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
+        /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
+        /// closed when the handle is dropped, unless the import has taken
+        /// ownership (Vulkan import takes ownership on success).
+        pub sync_fd: Option<RawFd>,
         pub plane_sizes: Vec<u64>,
         pub plane_offsets: Vec<u64>,
         /// Per-plane row pitch in bytes, copied from the surface-share
@@ -1062,6 +1071,15 @@ mod gpu_surface {
             for fd in &self.fds {
                 if *fd >= 0 {
                     unsafe { libc::close(*fd) };
+                }
+            }
+            // Close the sync FD if the Vulkan adapter import didn't take
+            // ownership. The adapter's `register_surface` takes the fd by
+            // value via `take_sync_fd` so a successful import zeros out
+            // this slot before drop runs.
+            if let Some(fd) = self.sync_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
                 }
             }
         }
@@ -2285,6 +2303,10 @@ mod surface_client {
         size: u64,
         drm_format_modifier: u64,
         format: String,
+        /// Optional OPAQUE_FD timeline-semaphore handle the host attached at
+        /// register time. Stored so cache hits can hand a fresh dup to each
+        /// new `SurfaceHandle`; closed with the cache entry.
+        sync_fd: Option<RawFd>,
     }
 
     impl Drop for CachedSurface {
@@ -2292,6 +2314,11 @@ mod surface_client {
             for fd in &self.fds {
                 if *fd >= 0 {
                     unsafe { libc::close(*fd) };
+                }
+            }
+            if let Some(fd) = self.sync_fd {
+                if fd >= 0 {
+                    unsafe { libc::close(fd) };
                 }
             }
         }
@@ -2481,9 +2508,28 @@ mod surface_client {
                     }
                     return std::ptr::null_mut();
                 }
+                let cached_sync_dup: Option<RawFd> = match cached.sync_fd {
+                    Some(src) => {
+                        let dup = unsafe { libc::dup(src) };
+                        if dup < 0 {
+                            tracing::error!(
+                                "surface_resolve_surface: dup cached sync_fd failed for '{}': {}",
+                                pool_id_str,
+                                std::io::Error::last_os_error()
+                            );
+                            for fd in &dup_fds {
+                                unsafe { libc::close(*fd) };
+                            }
+                            return std::ptr::null_mut();
+                        }
+                        Some(dup)
+                    }
+                    None => None,
+                };
                 let n_planes = dup_fds.len();
                 return Box::into_raw(Box::new(SurfaceHandle {
                     fds: dup_fds,
+                    sync_fd: cached_sync_dup,
                     plane_sizes: cached.plane_sizes.clone(),
                     plane_offsets: cached.plane_offsets.clone(),
                     plane_strides: cached.plane_strides.clone(),
@@ -2527,7 +2573,7 @@ mod surface_client {
             stream,
             &request,
             &[],
-            wire::MAX_DMA_BUF_PLANES,
+            wire::MAX_SCM_RIGHTS_FDS,
         ) {
             Ok(r) => r,
             Err(e) => {
@@ -2554,6 +2600,36 @@ mod surface_client {
                 "surface_resolve_surface: no DMA-BUF fd for '{}'",
                 pool_id_str
             );
+            return std::ptr::null_mut();
+        }
+
+        // Peel off the optional trailing sync-FD when the response carries
+        // one. The host's surface-share service appends it to SCM_RIGHTS
+        // after the DMA-BUF plane FDs and signals its presence with
+        // `has_sync_fd: true` so subprocess code can route it into the
+        // Vulkan adapter's timeline-semaphore import (#531).
+        let has_sync_fd = response
+            .get("has_sync_fd")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let (received_fds, sync_fd): (Vec<RawFd>, Option<RawFd>) = if has_sync_fd
+            && !received_fds.is_empty()
+        {
+            let mut all = received_fds;
+            let sync = all.pop();
+            (all, sync)
+        } else {
+            (received_fds, None)
+        };
+
+        if received_fds.is_empty() {
+            tracing::error!(
+                "surface_resolve_surface: no plane fds for '{}' after peeling sync_fd",
+                pool_id_str
+            );
+            if let Some(s) = sync_fd {
+                unsafe { libc::close(s) };
+            }
             return std::ptr::null_mut();
         }
 
@@ -2609,7 +2685,9 @@ mod surface_client {
         let size: u64 = plane_sizes.iter().copied().sum();
 
         // Cache: dup every plane for the cache's own copy so the returned
-        // handle owns its own fds independently.
+        // handle owns its own fds independently. Same for the optional
+        // sync_fd — the cache and the handed-out handle each get their
+        // own dup, so neither closes from underneath the other.
         let mut cache_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
         let mut cache_dup_ok = true;
         for fd in &received_fds {
@@ -2620,6 +2698,18 @@ mod surface_client {
             }
             cache_fds.push(dup);
         }
+        let cache_sync_fd: Option<RawFd> = match sync_fd {
+            Some(src) if cache_dup_ok => {
+                let dup = unsafe { libc::dup(src) };
+                if dup < 0 {
+                    cache_dup_ok = false;
+                    None
+                } else {
+                    Some(dup)
+                }
+            }
+            _ => None,
+        };
         if cache_dup_ok {
             let mut cache = handle.resolve_cache.lock().expect("poisoned");
             if cache.len() >= MAX_RESOLVE_CACHE {
@@ -2642,17 +2732,22 @@ mod surface_client {
                     size,
                     drm_format_modifier,
                     format: format_str.to_string(),
+                    sync_fd: cache_sync_fd,
                 },
             );
         } else {
             for fd in &cache_fds {
                 unsafe { libc::close(*fd) };
             }
+            if let Some(fd) = cache_sync_fd {
+                unsafe { libc::close(fd) };
+            }
         }
 
         let n_planes = received_fds.len();
         Box::into_raw(Box::new(SurfaceHandle {
             fds: received_fds,
+            sync_fd,
             plane_sizes,
             plane_offsets,
             plane_strides,
@@ -3193,6 +3288,988 @@ mod opengl {
     pub unsafe extern "C" fn slpn_opengl_release_read(
         _rt: *mut c_void,
         _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+}
+
+// ============================================================================
+// C ABI — Vulkan adapter runtime (#531, Linux)
+//
+// Subprocess-side runtime for the Vulkan-native surface adapter. Reuses the
+// host adapter crate's `VulkanSurfaceAdapter` against a subprocess-local
+// `VulkanDevice` from the RHI: same timeline-wait, same layout-transition,
+// same per-surface state machine. The cdylib never re-implements layout
+// transitions, command-pool lifetimes, fence handling, or queue-mutex
+// coordination — every line of that lives in `streamlib-adapter-vulkan`.
+//
+// Acquire returns a `SlpnVulkanView` (raw `VkImage` handle + layout) so the
+// Python / Deno SDK can dispatch its own raw vulkanalia / Deno-FFI work
+// against the imported image. Future tickets (subprocess `ComputeKernel`
+// parity, see #525) will close the remaining gap by escalating compute
+// dispatches to the host's `GpuContext::create_compute_kernel` path.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod vulkan {
+    use std::collections::HashMap;
+    use std::os::unix::io::RawFd;
+    use std::sync::{Arc, Mutex};
+
+    use streamlib::adapter_support::{
+        VulkanDevice, VulkanTexture, VulkanTimelineSemaphore,
+    };
+    use streamlib::core::rhi::TextureFormat;
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_vulkan::{
+        raw_handles, HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter,
+    };
+    use vulkanalia::vk;
+
+    use super::gpu_surface::SurfaceHandle;
+
+    /// Process-scoped Vulkan adapter runtime. One `VkDevice` + one
+    /// `VulkanSurfaceAdapter` per subprocess; held for the cdylib's life.
+    pub struct VulkanRuntimeHandle {
+        device: Arc<VulkanDevice>,
+        adapter: Arc<VulkanSurfaceAdapter>,
+        /// Per-surface book-keeping. The actual texture + timeline are
+        /// owned by the adapter (transferred into `HostSurfaceRegistration`);
+        /// we keep only the raw `vk::Image` handle so
+        /// `slpn_vulkan_dispatch_compute` can look it up without a
+        /// round-trip through the adapter's lock + `try_begin_write`.
+        registered: Mutex<HashMap<u64, RegisteredSurface>>,
+    }
+
+    struct RegisteredSurface {
+        /// Cached `vk::Image` handle. The adapter owns the underlying
+        /// `VulkanTexture` (and therefore the `VkImage` lifetime); we
+        /// just snapshot the handle for fast lookup. Valid until
+        /// `unregister_host_surface` drops the adapter's record.
+        vk_image: vk::Image,
+    }
+
+    /// Returned to Python / Deno via out-pointer on `slpn_vulkan_acquire_*`.
+    /// Mirrors `streamlib_adapter_vulkan::VulkanWriteView` but flattened
+    /// into a `#[repr(C)]` struct so customers can mmap it via ctypes /
+    /// Deno.UnsafePointer.
+    #[repr(C)]
+    pub struct SlpnVulkanView {
+        pub vk_image: u64,
+        pub vk_image_layout: i32,
+    }
+
+    /// Mirrors `streamlib_adapter_vulkan::RawVulkanHandles`. Returned by
+    /// `slpn_vulkan_raw_handles` so power-user callers can drive Vulkan
+    /// directly from the same `VkDevice` the adapter uses.
+    #[repr(C)]
+    pub struct SlpnVulkanRawHandles {
+        pub vk_instance: u64,
+        pub vk_physical_device: u64,
+        pub vk_device: u64,
+        pub vk_queue: u64,
+        pub vk_queue_family_index: u32,
+        pub api_version: u32,
+    }
+
+    /// Bring up `VulkanDevice` + `VulkanSurfaceAdapter`. Returns NULL on
+    /// failure (typically because the driver doesn't support the required
+    /// DMA-BUF / external-semaphore extensions).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
+        let device = match VulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_vulkan_runtime_new: VulkanDevice::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+        let adapter = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&device)));
+        Box::into_raw(Box::new(VulkanRuntimeHandle {
+            device,
+            adapter,
+            registered: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_runtime_free(rt: *mut VulkanRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    /// Map the surface-share format string onto the RHI [`TextureFormat`]
+    /// the host's allocator picked. `None` means an unsupported format —
+    /// the v1 Vulkan adapter only handles 8-bit-per-channel BGRA / RGBA
+    /// render targets (every other path currently goes through the
+    /// CPU-readback / OpenGL adapters).
+    fn texture_format_from_str(format: &str) -> Option<TextureFormat> {
+        match format {
+            "Bgra8Unorm" => Some(TextureFormat::Bgra8Unorm),
+            "Bgra8UnormSrgb" => Some(TextureFormat::Bgra8UnormSrgb),
+            "Rgba8Unorm" => Some(TextureFormat::Rgba8Unorm),
+            "Rgba8UnormSrgb" => Some(TextureFormat::Rgba8UnormSrgb),
+            _ => None,
+        }
+    }
+
+    /// Register a host surface with the Vulkan adapter — imports the
+    /// DMA-BUF FDs as a `VkImage` on the subprocess `VkDevice`, imports
+    /// the host's exportable timeline semaphore via OPAQUE_FD, and hands
+    /// the `HostSurfaceRegistration` to the adapter.
+    ///
+    /// On success, the FDs on `gpu_handle` are consumed: the adapter
+    /// owns the imported texture / semaphore for the surface's lifetime.
+    /// On failure the FDs remain owned by the SurfaceHandle (caller
+    /// continues to manage them through `slpn_gpu_surface_release`).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_register_surface(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_vulkan_register_surface: null runtime");
+                return -1;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("slpn_vulkan_register_surface: null gpu_handle");
+                return -1;
+            }
+        };
+        if gpu.fds.is_empty() {
+            tracing::error!(
+                "slpn_vulkan_register_surface: surface has no DMA-BUF fds"
+            );
+            return -1;
+        }
+        if gpu.drm_format_modifier == 0 {
+            tracing::error!(
+                "slpn_vulkan_register_surface: surface has DRM_FORMAT_MOD_LINEAR \
+                 (zero modifier) — render-target Vulkan import requires a tiled \
+                 modifier; see docs/learnings/nvidia-egl-dmabuf-render-target.md"
+            );
+            return -1;
+        }
+        let texture_format = match texture_format_from_str(&gpu.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "slpn_vulkan_register_surface: unsupported format '{}' \
+                     (v1 supports Bgra8Unorm, Bgra8UnormSrgb, Rgba8Unorm, Rgba8UnormSrgb)",
+                    gpu.format
+                );
+                return -1;
+            }
+        };
+        let allocation_size = gpu.size;
+
+        // Import each DMA-BUF FD into the cdylib's VkDevice as a VkImage.
+        // `import_render_target_dma_buf` `dup`s every FD internally — the
+        // SurfaceHandle keeps its originals so callers can re-import for
+        // a second adapter (e.g. CPU-readback alongside Vulkan).
+        let texture = match VulkanTexture::import_render_target_dma_buf(
+            &rt.device,
+            &gpu.fds,
+            &gpu.plane_offsets,
+            &gpu.plane_strides,
+            gpu.drm_format_modifier,
+            gpu.width,
+            gpu.height,
+            texture_format,
+            allocation_size,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_vulkan_register_surface: import_render_target_dma_buf: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+        // Snapshot the `vk::Image` handle BEFORE transferring `texture`
+        // into the registration. `VulkanTexture::clone` is a hollow
+        // metadata-only clone (`image: None`) by design, so we cannot
+        // duplicate the texture itself; only the underlying VkImage
+        // handle survives across the move.
+        let vk_image = match texture.image() {
+            Some(img) => img,
+            None => {
+                tracing::error!(
+                    "slpn_vulkan_register_surface: imported texture has no VkImage handle"
+                );
+                return -1;
+            }
+        };
+
+        // Import the host's timeline semaphore. The OPAQUE_FD on the
+        // SurfaceHandle is `take`n: Vulkan owns it on success.
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_vulkan_register_surface: surface '{}' has no sync_fd — \
+                     the host must register the texture with an exportable \
+                     `VulkanTimelineSemaphore` (see SurfaceStore::register_texture's \
+                     `timeline` argument).",
+                    surface_id
+                );
+                return -1;
+            }
+        };
+        let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+            rt.device.device(),
+            raw_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                // Vulkan retained ownership only on success; restore the
+                // SurfaceHandle's slot so the caller can still close it.
+                gpu.sync_fd = Some(raw_sync_fd);
+                tracing::error!(
+                    "slpn_vulkan_register_surface: from_imported_opaque_fd: {}",
+                    e
+                );
+                return -1;
+            }
+        };
+
+        // The host's `acquire_render_target_dma_buf_image` leaves the
+        // image in UNDEFINED initially; subsequent acquires transition
+        // through GENERAL / SHADER_READ_ONLY_OPTIMAL. Move `texture`
+        // (not `texture.clone()` — Clone is a hollow no-image stub) into
+        // the registration so the adapter owns the imported VkImage's
+        // lifetime end-to-end.
+        let registration = HostSurfaceRegistration {
+            texture: streamlib::core::rhi::StreamTexture::from_vulkan(texture),
+            timeline,
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+
+        if let Err(e) = rt
+            .adapter
+            .register_host_surface(surface_id, registration)
+        {
+            tracing::error!(
+                "slpn_vulkan_register_surface: register_host_surface({}): {:?}",
+                surface_id, e
+            );
+            return -1;
+        }
+
+        rt.registered
+            .lock()
+            .expect("slpn_vulkan registered: poisoned")
+            .insert(surface_id, RegisteredSurface { vk_image });
+        0
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_unregister_surface(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let removed = rt
+            .registered
+            .lock()
+            .expect("slpn_vulkan registered: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return -1;
+        }
+        if rt
+            .adapter
+            .unregister_host_surface(surface_id)
+        {
+            0
+        } else {
+            -1
+        }
+    }
+
+    /// Acquire write access. Populates `*out_view` with the imported
+    /// `VkImage` handle and the layout the adapter transitioned to
+    /// (`GENERAL`). Returns 0 on success, -1 on contention / failure.
+    /// The acquire is held inside the adapter; pair every successful
+    /// acquire with `slpn_vulkan_release_write` from the SAME thread.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_acquire_write(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnVulkanView,
+    ) -> i32 {
+        acquire_inner(rt, surface_id, out_view, AcquireKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_write(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, AcquireKind::Write)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_acquire_read(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnVulkanView,
+    ) -> i32 {
+        acquire_inner(rt, surface_id, out_view, AcquireKind::Read)
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_read(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        release_inner(rt, surface_id, AcquireKind::Read)
+    }
+
+    /// Power-user surface — the same handles `streamlib_adapter_vulkan::raw_handles`
+    /// returns to in-process Rust callers. Subprocess customers wrap them
+    /// with their own Vulkan binding for compute / blit work that the
+    /// adapter doesn't model. Returns 0 on success, -1 if `out` is null.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_raw_handles(
+        rt: *mut VulkanRuntimeHandle,
+        out: *mut SlpnVulkanRawHandles,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let out = match unsafe { out.as_mut() } {
+            Some(o) => o,
+            None => return -1,
+        };
+        let handles = raw_handles(&rt.device);
+        out.vk_instance = handles.vk_instance;
+        out.vk_physical_device = handles.vk_physical_device;
+        out.vk_device = handles.vk_device;
+        out.vk_queue = handles.vk_queue;
+        out.vk_queue_family_index = handles.vk_queue_family_index;
+        out.api_version = handles.api_version;
+        0
+    }
+
+    #[derive(Clone, Copy)]
+    enum AcquireKind {
+        Read,
+        Write,
+    }
+
+    fn acquire_inner(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnVulkanView,
+        kind: AcquireKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_vulkan_acquire_*: null runtime");
+                return -1;
+            }
+        };
+        let out_view = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => {
+                tracing::error!("slpn_vulkan_acquire_*: null out_view");
+                return -1;
+            }
+        };
+        // The adapter only reads `surface.id` from its acquire path —
+        // transport / sync / format fields are unused for already-
+        // registered surfaces, so we synthesize a minimal descriptor.
+        let surface = StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        match kind {
+            AcquireKind::Write => {
+                use streamlib_adapter_abi::VulkanWritable;
+                match rt.adapter.acquire_write(&surface) {
+                    Ok(g) => {
+                        out_view.vk_image = g.view().vk_image().0;
+                        out_view.vk_image_layout = g.view().vk_image_layout().0;
+                        // Forget the WriteGuard so its Drop doesn't fire — we
+                        // call `end_write_access` manually on release.
+                        std::mem::forget(g);
+                        0
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_vulkan_acquire_write({}): {:?}",
+                            surface_id, e
+                        );
+                        -1
+                    }
+                }
+            }
+            AcquireKind::Read => {
+                use streamlib_adapter_abi::VulkanWritable;
+                match rt.adapter.acquire_read(&surface) {
+                    Ok(g) => {
+                        out_view.vk_image = g.view().vk_image().0;
+                        out_view.vk_image_layout = g.view().vk_image_layout().0;
+                        std::mem::forget(g);
+                        0
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_vulkan_acquire_read({}): {:?}",
+                            surface_id, e
+                        );
+                        -1
+                    }
+                }
+            }
+        }
+    }
+
+    fn release_inner(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        kind: AcquireKind,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        match kind {
+            AcquireKind::Read => {
+                rt.adapter
+                    .end_read_access(surface_id)
+            }
+            AcquireKind::Write => {
+                rt.adapter
+                    .end_write_access(surface_id)
+            }
+        }
+        0
+    }
+
+    /// Dispatch a single-binding compute shader against the surface's
+    /// imported `VkImage`. The image must be currently held in WRITE
+    /// mode (use `slpn_vulkan_acquire_write` first). The shader binds
+    /// the image as a `binding=0` storage image and may use up to
+    /// `push_constants_size` bytes of push constants.
+    ///
+    /// **v1 limitation (#525 follow-up).** This function builds the
+    /// compute pipeline + descriptor set + command buffer + fence
+    /// inline using raw vulkanalia, instead of escalating to the host's
+    /// `GpuContext::create_compute_kernel` (which has SPIR-V reflection
+    /// + descriptor-set lifetime + pipeline cache). It's a quarantined
+    /// bypass — every line lives in this one function, and the
+    /// follow-up ticket replaces it with an escalate-IPC
+    /// `RunComputeKernel` op once #525's RHI-parity decision lands.
+    ///
+    /// Submits to the same `VkQueue` the adapter uses for layout
+    /// transitions, so this runs serially with adapter activity on
+    /// that queue. Blocks until the dispatch + a `vkCmdPipelineBarrier`
+    /// (storage-write → memory-read across all stages) have completed,
+    /// so the next host-side readback observes the writes.
+    ///
+    /// Returns 0 on success, negative error code on failure.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_dispatch_compute(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        spv_ptr: *const u8,
+        spv_len: usize,
+        push_constants_ptr: *const u8,
+        push_constants_size: u32,
+        group_count_x: u32,
+        group_count_y: u32,
+        group_count_z: u32,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        if spv_ptr.is_null() || spv_len == 0 {
+            tracing::error!("slpn_vulkan_dispatch_compute: null/empty spv");
+            return -2;
+        }
+        if spv_len % 4 != 0 {
+            tracing::error!(
+                "slpn_vulkan_dispatch_compute: spv_len {} not a multiple of 4",
+                spv_len
+            );
+            return -3;
+        }
+        // Look up the surface's cached VkImage handle. The adapter owns
+        // the underlying texture; we cached the handle at register time
+        // so dispatch is a single hash-lookup with no adapter-lock.
+        let vk_image = {
+            let registered = rt
+                .registered
+                .lock()
+                .expect("slpn_vulkan registered: poisoned");
+            match registered.get(&surface_id) {
+                Some(e) => e.vk_image,
+                None => {
+                    tracing::error!(
+                        "slpn_vulkan_dispatch_compute: surface_id {} not registered",
+                        surface_id
+                    );
+                    return -4;
+                }
+            }
+        };
+
+        let spv: &[u8] = unsafe { std::slice::from_raw_parts(spv_ptr, spv_len) };
+        let push_constants: &[u8] = if push_constants_size == 0 {
+            &[]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(
+                    push_constants_ptr,
+                    push_constants_size as usize,
+                )
+            }
+        };
+
+        match super::vulkan_compute_dispatch::dispatch_storage_image_compute(
+            &rt.device,
+            vk_image,
+            spv,
+            push_constants,
+            group_count_x,
+            group_count_y,
+            group_count_z,
+        ) {
+            Ok(()) => 0,
+            Err(e) => {
+                tracing::error!("slpn_vulkan_dispatch_compute: {}", e);
+                -10
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod vulkan_compute_dispatch {
+    //! Quarantined v1 compute-dispatch helper for `slpn_vulkan_dispatch_compute`
+    //! / `sldn_vulkan_dispatch_compute`. Builds a single-binding compute
+    //! pipeline + descriptor set + command buffer + fence inline using
+    //! raw vulkanalia. **Replace with escalate-IPC `RunComputeKernel`
+    //! once #525 lands** — the host's `GpuContext::create_compute_kernel`
+    //! is the canonical path and has SPIR-V reflection + descriptor-set
+    //! lifetime + pipeline cache the cdylib can't replicate.
+    //!
+    //! Layout assumed by the shader:
+    //!   layout(set = 0, binding = 0, rgba8) uniform image2D outputImage;
+    //!   layout(push_constant) uniform PushConstants { … } pc;
+
+    use std::sync::Arc;
+
+    use streamlib::adapter_support::VulkanDevice;
+    use vulkanalia::prelude::v1_4::*;
+    use vulkanalia::vk;
+
+    pub fn dispatch_storage_image_compute(
+        device: &Arc<VulkanDevice>,
+        image: vk::Image,
+        spv: &[u8],
+        push_constants: &[u8],
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<(), String> {
+        let dev = device.device();
+        let queue = device.queue();
+        let qf = device.queue_family_index();
+
+        // Re-cast the SPIR-V byte slice as `&[u32]`. vulkanalia's builder
+        // wants the u32 word view; `spv_len % 4 == 0` is enforced upstream.
+        let spv_words: &[u32] = unsafe {
+            std::slice::from_raw_parts(spv.as_ptr() as *const u32, spv.len() / 4)
+        };
+
+        // Image view over the imported VkImage so the descriptor binds
+        // a 2D storage image. Mirrors the host adapter's `make_image_info`
+        // — single mip, single layer, COLOR aspect.
+        let view_info = vk::ImageViewCreateInfo::builder()
+            .image(image)
+            .view_type(vk::ImageViewType::_2D)
+            .format(vk::Format::R8G8B8A8_UNORM)
+            .components(vk::ComponentMapping::default())
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let image_view = unsafe { dev.create_image_view(&view_info, None) }
+            .map_err(|e| format!("create_image_view: {e}"))?;
+
+        let cleanup_view = || unsafe { dev.destroy_image_view(image_view, None) };
+
+        // Descriptor set layout: 1 storage image at binding 0.
+        let bindings = [vk::DescriptorSetLayoutBinding::builder()
+            .binding(0)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::COMPUTE)
+            .build()];
+        let dsl_info = vk::DescriptorSetLayoutCreateInfo::builder()
+            .bindings(&bindings)
+            .build();
+        let dsl = unsafe { dev.create_descriptor_set_layout(&dsl_info, None) }
+            .map_err(|e| {
+                cleanup_view();
+                format!("create_descriptor_set_layout: {e}")
+            })?;
+        let cleanup_dsl = || unsafe { dev.destroy_descriptor_set_layout(dsl, None) };
+
+        // Descriptor pool — single set with one storage image.
+        let pool_sizes = [vk::DescriptorPoolSize::builder()
+            .type_(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count(1)
+            .build()];
+        let pool_info = vk::DescriptorPoolCreateInfo::builder()
+            .pool_sizes(&pool_sizes)
+            .max_sets(1)
+            .build();
+        let dpool = unsafe { dev.create_descriptor_pool(&pool_info, None) }
+            .map_err(|e| {
+                cleanup_dsl();
+                cleanup_view();
+                format!("create_descriptor_pool: {e}")
+            })?;
+        let cleanup_dpool = || unsafe { dev.destroy_descriptor_pool(dpool, None) };
+
+        let layouts = [dsl];
+        let alloc_info = vk::DescriptorSetAllocateInfo::builder()
+            .descriptor_pool(dpool)
+            .set_layouts(&layouts)
+            .build();
+        let descriptor_set = unsafe { dev.allocate_descriptor_sets(&alloc_info) }
+            .map_err(|e| {
+                cleanup_dpool();
+                cleanup_dsl();
+                cleanup_view();
+                format!("allocate_descriptor_sets: {e}")
+            })?[0];
+
+        let image_info = [vk::DescriptorImageInfo::builder()
+            .image_view(image_view)
+            .image_layout(vk::ImageLayout::GENERAL)
+            .build()];
+        let writes = [vk::WriteDescriptorSet::builder()
+            .dst_set(descriptor_set)
+            .dst_binding(0)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .image_info(&image_info)
+            .build()];
+        unsafe {
+            dev.update_descriptor_sets(
+                &writes,
+                &[] as &[vk::CopyDescriptorSet],
+            )
+        };
+
+        // Pipeline layout — descriptor set + optional push constants.
+        let push_const_ranges: Vec<vk::PushConstantRange> = if push_constants.is_empty() {
+            Vec::new()
+        } else {
+            vec![vk::PushConstantRange::builder()
+                .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                .offset(0)
+                .size(push_constants.len() as u32)
+                .build()]
+        };
+        let mut pl_builder = vk::PipelineLayoutCreateInfo::builder().set_layouts(&layouts);
+        if !push_const_ranges.is_empty() {
+            pl_builder = pl_builder.push_constant_ranges(&push_const_ranges);
+        }
+        let pipeline_layout =
+            unsafe { dev.create_pipeline_layout(&pl_builder.build(), None) }.map_err(|e| {
+                cleanup_dpool();
+                cleanup_dsl();
+                cleanup_view();
+                format!("create_pipeline_layout: {e}")
+            })?;
+        let cleanup_pl = || unsafe { dev.destroy_pipeline_layout(pipeline_layout, None) };
+
+        // Shader module from SPIR-V.
+        let shader_info = vk::ShaderModuleCreateInfo::builder()
+            .code(spv_words)
+            .build();
+        let shader = unsafe { dev.create_shader_module(&shader_info, None) }.map_err(|e| {
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_shader_module: {e}")
+        })?;
+        let cleanup_shader = || unsafe { dev.destroy_shader_module(shader, None) };
+
+        // Compute pipeline.
+        let entry_name = b"main\0";
+        let stage = vk::PipelineShaderStageCreateInfo::builder()
+            .stage(vk::ShaderStageFlags::COMPUTE)
+            .module(shader)
+            .name(entry_name)
+            .build();
+        let pipeline_info = vk::ComputePipelineCreateInfo::builder()
+            .stage(stage)
+            .layout(pipeline_layout)
+            .build();
+        let (pipelines, _result_code) = unsafe {
+            dev.create_compute_pipelines(
+                vk::PipelineCache::null(),
+                &[pipeline_info],
+                None,
+            )
+        }
+        .map_err(|e| {
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_compute_pipelines: {:?}", e)
+        })?;
+        let pipeline = pipelines[0];
+        let cleanup_pipeline = || unsafe { dev.destroy_pipeline(pipeline, None) };
+
+        // Command pool + buffer.
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let cmd_pool = unsafe { dev.create_command_pool(&pool_info, None) }.map_err(|e| {
+            cleanup_pipeline();
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("create_command_pool: {e}")
+        })?;
+        let cleanup_cmd_pool = || unsafe { dev.destroy_command_pool(cmd_pool, None) };
+
+        let cmd_alloc = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(cmd_pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd = unsafe { dev.allocate_command_buffers(&cmd_alloc) }.map_err(|e| {
+            cleanup_cmd_pool();
+            cleanup_pipeline();
+            cleanup_shader();
+            cleanup_pl();
+            cleanup_dpool();
+            cleanup_dsl();
+            cleanup_view();
+            format!("allocate_command_buffers: {e}")
+        })?[0];
+
+        let begin = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        unsafe { dev.begin_command_buffer(cmd, &begin) }
+            .map_err(|e| format!("begin_command_buffer: {e}"))?;
+
+        unsafe {
+            dev.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::COMPUTE, pipeline);
+            dev.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                pipeline_layout,
+                0,
+                &[descriptor_set],
+                &[],
+            );
+            if !push_constants.is_empty() {
+                dev.cmd_push_constants(
+                    cmd,
+                    pipeline_layout,
+                    vk::ShaderStageFlags::COMPUTE,
+                    0,
+                    push_constants,
+                );
+            }
+            dev.cmd_dispatch(cmd, group_x, group_y, group_z);
+        }
+
+        // Barrier so the host's subsequent transfer / readback sees the
+        // dispatched writes.
+        let barrier = vk::ImageMemoryBarrier2::builder()
+            .src_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+            .src_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
+            .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+            .old_layout(vk::ImageLayout::GENERAL)
+            .new_layout(vk::ImageLayout::GENERAL)
+            .src_queue_family_index(qf)
+            .dst_queue_family_index(qf)
+            .image(image)
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .level_count(1)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let barriers = [barrier];
+        let dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&barriers)
+            .build();
+        unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+        unsafe { dev.end_command_buffer(cmd) }
+            .map_err(|e| format!("end_command_buffer: {e}"))?;
+
+        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cmd)
+            .build()];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cmd_infos)
+            .build();
+        unsafe { device.submit_to_queue(queue, &[submit], vk::Fence::null()) }
+            .map_err(|e| format!("submit_to_queue: {e}"))?;
+        unsafe { dev.queue_wait_idle(queue) }
+            .map_err(|e| format!("queue_wait_idle: {e}"))?;
+
+        cleanup_cmd_pool();
+        cleanup_pipeline();
+        cleanup_shader();
+        cleanup_pl();
+        cleanup_dpool();
+        cleanup_dsl();
+        cleanup_view();
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod vulkan {
+    use std::ffi::c_void;
+
+    #[repr(C)]
+    pub struct SlpnVulkanView {
+        pub vk_image: u64,
+        pub vk_image_layout: i32,
+    }
+
+    #[repr(C)]
+    pub struct SlpnVulkanRawHandles {
+        pub vk_instance: u64,
+        pub vk_physical_device: u64,
+        pub vk_device: u64,
+        pub vk_queue: u64,
+        pub vk_queue_family_index: u32,
+        pub api_version: u32,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_runtime_new() -> *mut c_void {
+        tracing::error!("slpn_vulkan_*: Vulkan adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnVulkanView,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnVulkanView,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_raw_handles(
+        _rt: *mut c_void,
+        _out: *mut SlpnVulkanRawHandles,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_dispatch_compute(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _spv_ptr: *const u8,
+        _spv_len: usize,
+        _push_constants_ptr: *const u8,
+        _push_constants_size: u32,
+        _group_count_x: u32,
+        _group_count_y: u32,
+        _group_count_z: u32,
     ) -> i32 {
         -1
     }

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -3,42 +3,44 @@
 
 """Vulkan-native surface adapter — Python customer-facing API.
 
-Mirrors the Rust crate ``streamlib-adapter-vulkan`` (#511). The
-subprocess's actual Vulkan handling lives in
-``streamlib-python-native``'s ``SurfaceShareVulkanDevice``; this
-module provides:
+Mirrors the Rust crate ``streamlib-adapter-vulkan`` (#511, #531). The
+subprocess's actual Vulkan handling delegates to
+``streamlib-python-native``'s ``slpn_vulkan_*`` FFI surface, which
+itself wraps the host adapter crate's ``VulkanSurfaceAdapter`` against
+a subprocess-local ``VulkanDevice``. There is **no** parallel Vulkan
+implementation per language — every line of layout-transition,
+timeline-wait, and queue-mutex coordination lives in
+``streamlib-adapter-vulkan`` and runs in the subprocess process.
+
+This module provides:
 
   * Typed views the subprocess sees inside ``acquire_*`` scopes —
     ``VulkanReadView`` / ``VulkanWriteView`` exposing ``vk_image`` (an
     integer handle) plus the current ``vk_image_layout``.
-  * A ``VulkanContext`` Protocol the subprocess runtime implements —
-    customers don't construct one, they receive it via the runtime
-    and call ``acquire_write(surface)`` inside a ``with`` block.
-  * ``raw_handles()`` — escape hatch returning the underlying
-    ``vk_instance``, ``vk_device``, ``vk_queue``, etc. as integer
-    handles for power-user callers that want to drive Vulkan
-    directly.
-
-Subprocess Vulkan adapters MUST NOT call ``vkCreateDevice`` themselves;
-the binding's ``SurfaceShareVulkanDevice`` already creates one at
-init. Per ``docs/learnings/nvidia-dual-vulkan-device-crash.md``, a
-second ``VkDevice`` while the first has active GPU work crashes on
-NVIDIA — same-process safety; subprocesses are independent processes.
+  * The ``VulkanContext`` class — built via :meth:`VulkanContext.from_runtime`
+    inside a polyglot processor's ``setup`` hook. Customers acquire
+    scoped read / write access via ``with ctx.acquire_write(surface)
+    as view:`` and dispatch their own raw vulkanalia / Deno-FFI work
+    against ``view.vk_image``.
+  * ``raw_handles()`` — escape hatch returning the cdylib's runtime
+    handles (``vk_instance``, ``vk_device``, ``vk_queue``, etc.) as
+    integer handles for power-user callers that want to drive Vulkan
+    directly. The handles point at the SAME ``VkDevice`` the adapter
+    runs on, so customer-driven submissions and adapter-driven layout
+    transitions interleave correctly under the device's queue mutex.
 """
 
 from __future__ import annotations
 
 import ctypes
-from contextlib import AbstractContextManager
+import itertools
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from typing import Iterator, Optional, Protocol, runtime_checkable
 
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
     StreamlibSurface,
-    SurfaceAdapter,
-    SurfaceFormat,
-    SurfaceUsage,
 )
 
 __all__ = [
@@ -47,6 +49,7 @@ __all__ = [
     "VulkanReadView",
     "VulkanWriteView",
     "VulkanSurfaceAdapter",
+    "VulkanContextProtocol",
     "VulkanContext",
 ]
 
@@ -137,14 +140,10 @@ class VulkanSurfaceAdapter(Protocol):
 
 
 @runtime_checkable
-class VulkanContext(Protocol):
-    """Customer-facing handle the subprocess runtime hands out.
-
-    Equivalent shape to the Rust ``VulkanContext`` — thin wrapper over
-    a ``VulkanSurfaceAdapter`` so customer code can write::
-
-        with ctx.acquire_write(surface) as view:
-            do_vulkan_work(view.vk_image, view.vk_image_layout)
+class VulkanContextProtocol(Protocol):
+    """Customer-facing handle the subprocess runtime hands out
+    (Protocol shape — :class:`VulkanContext` below is the concrete
+    implementation).
     """
 
     def acquire_read(
@@ -155,12 +154,374 @@ class VulkanContext(Protocol):
         self, surface: StreamlibSurface
     ) -> AbstractContextManager[VulkanWriteView]: ...
 
-    def try_acquire_read(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[VulkanReadView]]: ...
-
-    def try_acquire_write(
-        self, surface: StreamlibSurface
-    ) -> Optional[AbstractContextManager[VulkanWriteView]]: ...
-
     def raw_handles(self) -> RawVulkanHandles: ...
+
+
+# =============================================================================
+# Concrete VulkanContext implementation (#531)
+# =============================================================================
+#
+# Mirrors `streamlib.adapters.opengl.OpenGLContext` exactly: cached
+# singleton per subprocess, surface-share `pool_id` → local `surface_id`
+# mapping, FFI calls into `slpn_vulkan_*` symbols loaded by the runner.
+
+# `slpn_vulkan_register_surface` owns the SurfaceHandle's sync_fd and
+# DMA-BUF fds on success — the cdylib's `VulkanSurfaceAdapter::register_host_surface`
+# transfers ownership into the subprocess `VkDevice`'s imported VkImage and
+# imported timeline-semaphore. A successful return therefore zeroes out
+# the SurfaceHandle's sync_fd slot and the SDK keeps a Python-side
+# reference to the resolved handle so its remaining DMA-BUF fds stay alive.
+
+# Surface-id namespace inside this subprocess. Counted up by
+# `_resolve_and_register` — the host's pool_id (string UUID) is mapped to
+# a u64 the adapter uses internally; customers never see the u64.
+_VULKAN_SURFACE_ID_COUNTER = itertools.count(start=1)
+
+
+class _SlpnVulkanView(ctypes.Structure):
+    """C struct matching `streamlib_python_native::vulkan::SlpnVulkanView`."""
+
+    _fields_ = [
+        ("vk_image", ctypes.c_uint64),
+        ("vk_image_layout", ctypes.c_int32),
+    ]
+
+
+class _SlpnVulkanRawHandles(ctypes.Structure):
+    """C struct matching `streamlib_python_native::vulkan::SlpnVulkanRawHandles`."""
+
+    _fields_ = [
+        ("vk_instance", ctypes.c_uint64),
+        ("vk_physical_device", ctypes.c_uint64),
+        ("vk_device", ctypes.c_uint64),
+        ("vk_queue", ctypes.c_uint64),
+        ("vk_queue_family_index", ctypes.c_uint32),
+        ("api_version", ctypes.c_uint32),
+    ]
+
+
+class VulkanContext:
+    """Subprocess-side Vulkan adapter runtime (#531).
+
+    Brings up `streamlib::adapter_support::VulkanDevice` +
+    ``streamlib_adapter_vulkan::VulkanSurfaceAdapter`` inside this
+    subprocess and exposes scoped acquire/release that hands customers
+    a real ``VkImage`` handle plus the layout the adapter transitioned
+    to. The acquire/release calls reuse every line of host-RHI logic
+    (timeline wait, layout transition, queue-mutex coordination,
+    contention checking) — the Python side is a thin FFI shim.
+
+    Construct via :meth:`from_runtime` — pass the typed runtime context
+    you receive in ``setup`` / ``process``. Single :class:`VulkanContext`
+    per subprocess; :meth:`from_runtime` returns the cached instance on
+    repeat calls.
+
+    Customers dispatch their own Vulkan work (compute, transfer, blit,
+    etc.) using their preferred Vulkan binding — pyvulkan, raw ctypes
+    against ``libvulkan.so.1``, etc. The cdylib's runtime exposes its
+    raw handles through :meth:`raw_handles` so the customer's
+    submissions interleave correctly with the adapter's layout
+    transitions on the same ``VkQueue``.
+    """
+
+    _shared_instance: Optional["VulkanContext"] = None
+
+    def __init__(self, gpu_limited_access) -> None:
+        # Reuse the cdylib the limited-access view has already loaded —
+        # `slpn_vulkan_*` symbols are wired up alongside `slpn_surface_*`
+        # in `processor_context.load_native_lib`.
+        self._lib = gpu_limited_access.native_lib
+        self._gpu = gpu_limited_access
+        self._wire_signatures()
+        rt = self._lib.slpn_vulkan_runtime_new()
+        if not rt:
+            raise RuntimeError(
+                "VulkanContext: slpn_vulkan_runtime_new returned NULL — the "
+                "subprocess could not bring up a Vulkan device. Check that "
+                "libvulkan.so.1 is installed and the driver supports "
+                "VK_KHR_external_memory_fd, VK_EXT_external_memory_dma_buf, "
+                "VK_EXT_image_drm_format_modifier, and "
+                "VK_KHR_external_semaphore_fd."
+            )
+        self._rt = ctypes.c_void_p(rt)
+        # Map host pool_id (UUID) → local u64 surface_id.
+        self._surface_ids: dict[str, int] = {}
+        # Pin the resolved SDK handles so the SurfaceShare-owned plane fds
+        # stay alive for the runtime's lifetime — `register_surface`
+        # transfers the sync_fd into the cdylib's adapter, but the plane
+        # fds remain the SurfaceHandle's responsibility.
+        self._resolved_handles: dict[str, object] = {}
+
+    def _wire_signatures(self) -> None:
+        """Set ctypes signatures on every `slpn_vulkan_*` entry point.
+
+        Doing this once at construction lets every call site stay terse
+        and gives ctypes the type info it needs to coerce Python
+        ``int`` / ``bytes`` arguments into the right C widths.
+        """
+        lib = self._lib
+
+        lib.slpn_vulkan_runtime_new.restype = ctypes.c_void_p
+        lib.slpn_vulkan_runtime_new.argtypes = []
+
+        lib.slpn_vulkan_runtime_free.restype = None
+        lib.slpn_vulkan_runtime_free.argtypes = [ctypes.c_void_p]
+
+        lib.slpn_vulkan_register_surface.restype = ctypes.c_int32
+        lib.slpn_vulkan_register_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+        ]
+
+        lib.slpn_vulkan_unregister_surface.restype = ctypes.c_int32
+        lib.slpn_vulkan_unregister_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+        ]
+
+        for name in (
+            "slpn_vulkan_acquire_write",
+            "slpn_vulkan_acquire_read",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint64,
+                ctypes.POINTER(_SlpnVulkanView),
+            ]
+
+        for name in (
+            "slpn_vulkan_release_write",
+            "slpn_vulkan_release_read",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+
+        lib.slpn_vulkan_raw_handles.restype = ctypes.c_int32
+        lib.slpn_vulkan_raw_handles.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(_SlpnVulkanRawHandles),
+        ]
+
+        lib.slpn_vulkan_dispatch_compute.restype = ctypes.c_int32
+        lib.slpn_vulkan_dispatch_compute.argtypes = [
+            ctypes.c_void_p,        # rt
+            ctypes.c_uint64,        # surface_id
+            ctypes.c_void_p,        # spv_ptr
+            ctypes.c_size_t,        # spv_len
+            ctypes.c_void_p,        # push_constants_ptr
+            ctypes.c_uint32,        # push_constants_size
+            ctypes.c_uint32,        # group_count_x
+            ctypes.c_uint32,        # group_count_y
+            ctypes.c_uint32,        # group_count_z
+        ]
+
+    @classmethod
+    def from_runtime(cls, runtime_context) -> "VulkanContext":
+        """Build (or fetch the cached) :class:`VulkanContext` for this
+        subprocess.
+
+        The subprocess hosts at most one Vulkan adapter runtime — calling
+        this twice with the same runtime returns the same instance.
+        """
+        if cls._shared_instance is None:
+            cls._shared_instance = cls(runtime_context.gpu_limited_access)
+        return cls._shared_instance
+
+    def _resolve_and_register(self, pool_id: str) -> int:
+        """Resolve `pool_id` via surface-share, register with the Vulkan
+        adapter, and return the local u64 surface_id. Idempotent — repeat
+        calls return the cached id."""
+        cached = self._surface_ids.get(pool_id)
+        if cached is not None:
+            return cached
+        handle = self._gpu.resolve_surface(pool_id)
+        handle_ptr = handle.native_handle_ptr
+        if not handle_ptr:
+            raise RuntimeError(
+                f"VulkanContext: resolve_surface('{pool_id}') returned a handle "
+                "with a null native pointer"
+            )
+        surface_id = next(_VULKAN_SURFACE_ID_COUNTER)
+        rc = self._lib.slpn_vulkan_register_surface(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.c_void_p(handle_ptr),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext: register_surface failed for pool_id "
+                f"'{pool_id}' (rc={rc}). Check the subprocess log for "
+                "import errors — typically a missing sync_fd (host did not "
+                "register the texture with an exportable timeline), an "
+                "unsupported DRM modifier, or an unsupported pixel format."
+            )
+        self._surface_ids[pool_id] = surface_id
+        # Hold the SDK handle so its DMA-BUF plane fds stay alive for the
+        # runtime's lifetime. The sync_fd was transferred into the cdylib
+        # by `register_surface` and is now owned by Vulkan.
+        self._resolved_handles[pool_id] = handle
+        return surface_id
+
+    @staticmethod
+    def _surface_pool_id(surface) -> str:
+        """Extract the surface-share pool id (string UUID) from either a
+        `StreamlibSurface`-shaped object or a bare string."""
+        if isinstance(surface, str):
+            return surface
+        sid = getattr(surface, "id", None)
+        if sid is None:
+            raise TypeError(
+                f"VulkanContext: expected StreamlibSurface or str pool_id, got {surface!r}"
+            )
+        return str(sid)
+
+    @contextmanager
+    def acquire_write(
+        self, surface
+    ) -> "Iterator[VulkanWriteView]":
+        """Acquire write access. Returns a view exposing the imported
+        ``VkImage`` handle and the layout the adapter transitioned to
+        (``GENERAL``). On scope exit the adapter signals the host's
+        timeline so the next consumer can wake up; the customer is
+        responsible for ``vkQueueWaitIdle``-ing or chaining a binary
+        semaphore on their own submission BEFORE leaving the scope so
+        their writes are visible.
+        """
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._resolve_and_register(pool_id)
+        view = _SlpnVulkanView()
+        rc = self._lib.slpn_vulkan_acquire_write(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.byref(view),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.acquire_write: slpn_vulkan_acquire_write "
+                f"returned {rc} for surface '{pool_id}' (contention or "
+                "adapter failure — check the subprocess log)"
+            )
+        try:
+            yield VulkanWriteView(
+                vk_image=int(view.vk_image),
+                vk_image_layout=int(view.vk_image_layout),
+            )
+        finally:
+            self._lib.slpn_vulkan_release_write(
+                self._rt, ctypes.c_uint64(surface_id)
+            )
+
+    @contextmanager
+    def acquire_read(
+        self, surface
+    ) -> "Iterator[VulkanReadView]":
+        """Acquire read access — same shape as :meth:`acquire_write`,
+        but the resulting image is in ``SHADER_READ_ONLY_OPTIMAL``
+        (multiple readers may coexist; no writer can be active)."""
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._resolve_and_register(pool_id)
+        view = _SlpnVulkanView()
+        rc = self._lib.slpn_vulkan_acquire_read(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.byref(view),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.acquire_read: slpn_vulkan_acquire_read "
+                f"returned {rc} for surface '{pool_id}'"
+            )
+        try:
+            yield VulkanReadView(
+                vk_image=int(view.vk_image),
+                vk_image_layout=int(view.vk_image_layout),
+            )
+        finally:
+            self._lib.slpn_vulkan_release_read(
+                self._rt, ctypes.c_uint64(surface_id)
+            )
+
+    def dispatch_compute(
+        self,
+        surface,
+        spirv: bytes,
+        push_constants: bytes,
+        group_count_x: int,
+        group_count_y: int,
+        group_count_z: int,
+    ) -> None:
+        """Dispatch a single-binding compute shader against the surface's
+        imported ``VkImage``. The surface MUST currently be held in WRITE
+        mode (call inside an ``acquire_write`` ``with`` block).
+
+        The shader's `binding=0` is bound to the surface's `VkImage` as a
+        storage image (layout: ``GENERAL``). Up to ``len(push_constants)``
+        bytes of push constants are written at offset 0.
+
+        **v1 limitation (#525 follow-up):** the cdylib builds the
+        compute pipeline + descriptor set + command buffer + fence
+        inline using raw vulkanalia. The follow-up replaces this with
+        an escalate-IPC ``RunComputeKernel`` op that uses the host
+        RHI's ``GpuContext::create_compute_kernel`` (SPIR-V reflection,
+        descriptor-set lifetime, pipeline cache).
+        """
+        pool_id = self._surface_pool_id(surface)
+        cached = self._surface_ids.get(pool_id)
+        if cached is None:
+            raise RuntimeError(
+                f"VulkanContext.dispatch_compute: surface '{pool_id}' is not "
+                "registered — call acquire_write inside a `with` block first."
+            )
+        spv_buf = (ctypes.c_uint8 * len(spirv)).from_buffer_copy(spirv)
+        if push_constants:
+            pc_buf = (ctypes.c_uint8 * len(push_constants)).from_buffer_copy(
+                push_constants
+            )
+            pc_ptr = ctypes.cast(pc_buf, ctypes.c_void_p)
+        else:
+            pc_buf = None
+            pc_ptr = ctypes.c_void_p(0)
+        rc = self._lib.slpn_vulkan_dispatch_compute(
+            self._rt,
+            ctypes.c_uint64(cached),
+            ctypes.cast(spv_buf, ctypes.c_void_p),
+            ctypes.c_size_t(len(spirv)),
+            pc_ptr,
+            ctypes.c_uint32(len(push_constants)),
+            ctypes.c_uint32(group_count_x),
+            ctypes.c_uint32(group_count_y),
+            ctypes.c_uint32(group_count_z),
+        )
+        # Keep buffers alive until after the FFI call returns; the cdylib
+        # waits for `vkQueueWaitIdle` before returning so this is safe.
+        del spv_buf
+        del pc_buf
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.dispatch_compute: slpn_vulkan_dispatch_compute "
+                f"returned {rc} for surface '{pool_id}'"
+            )
+
+    def raw_handles(self) -> RawVulkanHandles:
+        """Return the cdylib runtime's raw Vulkan handles — same shape
+        as the Rust ``streamlib_adapter_vulkan::raw_handles()``. Use
+        these to drive your preferred Vulkan binding against the SAME
+        ``VkDevice`` the adapter manages."""
+        h = _SlpnVulkanRawHandles()
+        rc = self._lib.slpn_vulkan_raw_handles(self._rt, ctypes.byref(h))
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.raw_handles: slpn_vulkan_raw_handles returned {rc}"
+            )
+        return RawVulkanHandles(
+            vk_instance=int(h.vk_instance),
+            vk_physical_device=int(h.vk_physical_device),
+            vk_device=int(h.vk_device),
+            vk_queue=int(h.vk_queue),
+            vk_queue_family_index=int(h.vk_queue_family_index),
+            api_version=int(h.api_version),
+        )

--- a/libs/streamlib-surface-client/src/lib.rs
+++ b/libs/streamlib-surface-client/src/lib.rs
@@ -27,5 +27,5 @@ mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::{
     connect_to_surface_share_socket, recv_message_with_fds, send_message_with_fds,
-    send_request_with_fds, MAX_DMA_BUF_PLANES,
+    send_request_with_fds, MAX_DMA_BUF_PLANES, MAX_SCM_RIGHTS_FDS,
 };

--- a/libs/streamlib-surface-client/src/linux.rs
+++ b/libs/streamlib-surface-client/src/linux.rs
@@ -15,6 +15,13 @@ use std::path::Path;
 /// they cost an fd table entry.
 pub const MAX_DMA_BUF_PLANES: usize = 4;
 
+/// Total SCM_RIGHTS fd budget for a single surface-share message:
+/// [`MAX_DMA_BUF_PLANES`] + 1 trailing slot for an optional timeline-semaphore
+/// OPAQUE_FD (host → subprocess Vulkan-adapter sync handoff, #531). Wire
+/// helpers validate against this ceiling; senders that aren't passing a sync
+/// FD simply leave the slot unused.
+pub const MAX_SCM_RIGHTS_FDS: usize = MAX_DMA_BUF_PLANES + 1;
+
 /// Connect to the per-runtime surface-share Unix socket.
 pub fn connect_to_surface_share_socket(socket_path: &Path) -> std::io::Result<UnixStream> {
     UnixStream::connect(socket_path)
@@ -39,13 +46,13 @@ pub fn send_message_with_fds(
     data: &[u8],
     fds: &[RawFd],
 ) -> std::io::Result<()> {
-    if fds.len() > MAX_DMA_BUF_PLANES {
+    if fds.len() > MAX_SCM_RIGHTS_FDS {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "SCM_RIGHTS fd count {} exceeds MAX_DMA_BUF_PLANES={}",
+                "SCM_RIGHTS fd count {} exceeds MAX_SCM_RIGHTS_FDS={}",
                 fds.len(),
-                MAX_DMA_BUF_PLANES
+                MAX_SCM_RIGHTS_FDS
             ),
         ));
     }
@@ -469,8 +476,9 @@ mod tests {
         let _ = std::fs::remove_file(&socket_path);
     }
 
-    /// Sending `MAX_DMA_BUF_PLANES + 1` fds returns an error and performs no
-    /// syscall — caller-owned fds are not closed under our feet.
+    /// Sending `MAX_SCM_RIGHTS_FDS + 1` fds returns an error and performs no
+    /// syscall — caller-owned fds are not closed under our feet. The wire
+    /// budget is `MAX_DMA_BUF_PLANES` plane fds + 1 optional sync-fd slot.
     #[test]
     fn send_rejects_oversize_fd_vec_without_closing_caller_fds() {
         let socket_path = tmp_socket_path("oversize");
@@ -478,7 +486,7 @@ mod tests {
         let client = UnixStream::connect(&socket_path).expect("connect");
         let _accepted = listener.accept().expect("accept");
 
-        let fds: Vec<RawFd> = (0..=MAX_DMA_BUF_PLANES)
+        let fds: Vec<RawFd> = (0..=MAX_SCM_RIGHTS_FDS)
             .map(|i| make_memfd_with(format!("plane-{}", i).as_bytes()))
             .collect();
         let err = send_message_with_fds(&client, b"payload", &fds).expect_err("must reject");

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -546,7 +546,10 @@ fn assign_texture_handle_id(
     #[cfg(target_os = "linux")]
     {
         if let Some(store) = full.surface_store() {
-            store.register_texture(&handle_id, texture.texture())?;
+            // No timeline semaphore — escalate-IPC consumers (CPU-readback
+            // bridge) handle sync via the per-acquire response, not via a
+            // shared host timeline.
+            store.register_texture(&handle_id, texture.texture(), None)?;
         }
     }
     Ok(handle_id)
@@ -565,7 +568,7 @@ fn assign_image_handle_id(
 ) -> crate::core::error::Result<String> {
     let handle_id = Uuid::new_v4().to_string();
     if let Some(store) = full.surface_store() {
-        store.register_texture(&handle_id, texture)?;
+        store.register_texture(&handle_id, texture, None)?;
     }
     Ok(handle_id)
 }

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -867,7 +867,15 @@ impl GpuContext {
         let desc = TextureDescriptor::new(width, height, format).with_usage(
             TextureUsages::RENDER_ATTACHMENT
                 | TextureUsages::TEXTURE_BINDING
-                | TextureUsages::COPY_SRC,
+                | TextureUsages::COPY_SRC
+                // STORAGE_BINDING is on by default so subprocess Vulkan
+                // adapters can bind the imported VkImage as a storage
+                // image for compute writes (#531). Render-target +
+                // sample-only adapters (OpenGL fragment shader, Skia)
+                // still work — STORAGE is additive and tiled modifiers
+                // for these formats reliably support it on every driver
+                // streamlib runs on.
+                | TextureUsages::STORAGE_BINDING,
         );
         let texture = crate::vulkan::rhi::VulkanTexture::new_render_target_dma_buf(
             vulkan_device,

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -1060,14 +1060,41 @@ impl SurfaceStore {
     }
 
     /// Register a texture with the surface-share service via Unix socket.
+    ///
+    /// `timeline` — when `Some`, the host's exportable timeline semaphore is
+    /// exported as an OPAQUE_FD and shipped alongside the DMA-BUF FD. The
+    /// surface-share service stores the FD; subprocess Vulkan adapters
+    /// `check_out` it via [`streamlib_adapter_vulkan::VulkanSurfaceAdapter`]
+    /// and import it through `VulkanTimelineSemaphore::from_imported_opaque_fd`,
+    /// reusing the host adapter's timeline-wait + signal path (#531). `None`
+    /// for adapters that don't need explicit Vulkan sync (OpenGL — its
+    /// `glFinish` + DMA-BUF kernel-fence semantics carry visibility).
     #[cfg(target_os = "linux")]
     pub fn register_texture(
         &self,
         surface_id: &str,
         texture: &crate::core::rhi::StreamTexture,
+        timeline: Option<&crate::vulkan::rhi::VulkanTimelineSemaphore>,
     ) -> Result<()> {
         // Export the DMA-BUF fd from the texture
         let fd = texture.inner.export_dma_buf_fd()?;
+
+        // Optionally export the timeline-semaphore as an OPAQUE_FD. The host
+        // retains ownership of the semaphore object; this fd is duplicated by
+        // the kernel during SCM_RIGHTS and we close our copy after send.
+        let sync_fd: Option<std::os::unix::io::RawFd> = match timeline {
+            Some(t) => match t.export_opaque_fd() {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    unsafe { libc::close(fd) };
+                    return Err(StreamError::Configuration(format!(
+                        "register_texture: failed to export timeline opaque fd: {}",
+                        e
+                    )));
+                }
+            },
+            None => None,
+        };
 
         // Carry the DRM format modifier and per-plane row pitch so the
         // consumer-side EGL or Vulkan import can pass them via
@@ -1095,6 +1122,7 @@ impl SurfaceStore {
             "plane_offsets": plane_offsets,
             "plane_strides": plane_strides,
             "drm_format_modifier": drm_format_modifier,
+            "has_sync_fd": sync_fd.is_some(),
         });
 
         let connection = self.inner.connection.lock();
@@ -1102,9 +1130,15 @@ impl SurfaceStore {
             StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
+        let mut fds: Vec<std::os::unix::io::RawFd> = vec![fd];
+        if let Some(s) = sync_fd {
+            fds.push(s);
+        }
         let send_result =
-            streamlib_surface_client::send_request_with_fds(stream, &request, &[fd], 0);
-        unsafe { libc::close(fd) };
+            streamlib_surface_client::send_request_with_fds(stream, &request, &fds, 0);
+        for f in &fds {
+            unsafe { libc::close(*f) };
+        }
         let (response, response_fds) = send_result.map_err(|e| {
             StreamError::Configuration(format!("Unix socket register_texture failed: {}", e))
         })?;
@@ -1119,7 +1153,11 @@ impl SurfaceStore {
             )));
         }
 
-        tracing::debug!("SurfaceStore: Registered texture '{}'", surface_id);
+        tracing::debug!(
+            "SurfaceStore: Registered texture '{}' (sync_fd={})",
+            surface_id,
+            timeline.is_some(),
+        );
         Ok(())
     }
 
@@ -1367,6 +1405,7 @@ impl SurfaceStore {
         &self,
         _surface_id: &str,
         _texture: &crate::core::rhi::StreamTexture,
+        _timeline: Option<&()>,
     ) -> Result<()> {
         Err(StreamError::NotSupported(
             "Texture registration not supported on this platform".into(),

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -839,7 +839,11 @@ fn capture_thread_loop(
         {
             let surface_store = gpu_context.surface_store();
             if let Some(store) = surface_store {
-                if let Err(e) = store.register_texture(&texture_id, &stream_texture) {
+                // Camera ring textures don't carry a host-exported timeline:
+                // legacy DMA-BUF consumers (`polyglot-dma-buf-consumer`) read
+                // pixels via CPU mapping, not Vulkan compute, so explicit
+                // cross-process timeline sync is unused.
+                if let Err(e) = store.register_texture(&texture_id, &stream_texture, None) {
                     tracing::warn!(
                         camera = camera_name,
                         ring_index = i,

--- a/libs/streamlib/src/linux/surface_share/state.rs
+++ b/libs/streamlib/src/linux/surface_share/state.rs
@@ -41,6 +41,15 @@ pub struct SurfaceMetadata {
     /// from the EGL `external_only=FALSE` set; otherwise consumer-side
     /// FBO completeness will fail on NVIDIA.
     pub drm_format_modifier: u64,
+    /// Optional OPAQUE_FD timeline-semaphore handle owned by the table.
+    /// Set when the host registers the surface with an exportable
+    /// `VulkanTimelineSemaphore` (#531). `check_out` / `lookup` `dup`s it
+    /// alongside the DMA-BUF plane fds so the subprocess Vulkan adapter
+    /// can call `VulkanTimelineSemaphore::from_imported_opaque_fd` and
+    /// reuse the host adapter's timeline-wait + signal path. `None` for
+    /// surfaces that don't need explicit Vulkan sync (the OpenGL adapter
+    /// path, CPU-readback, legacy `VkBuffer` pixel buffers).
+    pub sync_fd: Option<RawFd>,
     pub checkout_count: u64,
 }
 
@@ -65,6 +74,11 @@ pub struct SurfacePlaneCheckout {
     pub plane_offsets: Vec<u64>,
     pub plane_strides: Vec<u64>,
     pub drm_format_modifier: u64,
+    /// Optional OPAQUE_FD for the surface's exportable timeline semaphore.
+    /// `None` for surfaces registered without one. The table-owned fd is
+    /// returned as-is; callers that hand it out via SCM_RIGHTS must `dup`
+    /// it first, just like the DMA-BUF plane fds.
+    pub sync_fd: Option<RawFd>,
 }
 
 /// Arguments to [`SurfaceShareState::register_surface`]. Grouped so the
@@ -84,6 +98,11 @@ pub struct SurfaceRegistration<'a> {
     /// DRM format modifier of the underlying VkImage. See
     /// [`SurfaceMetadata::drm_format_modifier`].
     pub drm_format_modifier: u64,
+    /// Optional OPAQUE_FD timeline-semaphore handle exported by the host
+    /// (`VulkanTimelineSemaphore::export_opaque_fd`). The table takes
+    /// ownership on success and closes it on `release_surface`. `None`
+    /// for adapters that don't need explicit Vulkan sync.
+    pub sync_fd: Option<RawFd>,
 }
 
 impl SurfaceShareState {
@@ -93,18 +112,19 @@ impl SurfaceShareState {
 
     /// Insert a surface into the table.
     ///
-    /// On rejection (duplicate surface_id), ownership of `dma_buf_fds` is
-    /// returned to the caller so it can decide whether to close them or hand
-    /// them to the next attempt. On success, the table owns the fds and
-    /// closes each on [`Self::release_surface`].
+    /// On rejection (duplicate surface_id), ownership of `dma_buf_fds` AND
+    /// the optional `sync_fd` is returned to the caller (the latter as the
+    /// `Err` tuple's second slot) so it can decide whether to close them or
+    /// hand them to the next attempt. On success, the table owns every fd
+    /// passed in and closes them on [`Self::release_surface`].
     pub fn register_surface(
         &self,
         reg: SurfaceRegistration<'_>,
-    ) -> Result<(), Vec<RawFd>> {
+    ) -> Result<(), (Vec<RawFd>, Option<RawFd>)> {
         let mut surfaces = self.inner.surfaces.write();
 
         if surfaces.contains_key(reg.surface_id) {
-            return Err(reg.dma_buf_fds);
+            return Err((reg.dma_buf_fds, reg.sync_fd));
         }
 
         self.inner.surface_counter.fetch_add(1, Ordering::Relaxed);
@@ -123,6 +143,7 @@ impl SurfaceShareState {
                 format: reg.format.to_string(),
                 resource_type: reg.resource_type.to_string(),
                 drm_format_modifier: reg.drm_format_modifier,
+                sync_fd: reg.sync_fd,
                 checkout_count: 0,
             },
         );
@@ -130,9 +151,10 @@ impl SurfaceShareState {
     }
 
     /// Return a clone of the surface's plane fd vec plus its plane-layout
-    /// arrays and the underlying VkImage's DRM format modifier. The
-    /// returned fds are the table's own — callers that hand them out via
-    /// SCM_RIGHTS must `dup` each fd first.
+    /// arrays, the underlying VkImage's DRM format modifier, and (if
+    /// registered) the timeline-semaphore OPAQUE_FD. The returned fds are
+    /// the table's own — callers that hand them out via SCM_RIGHTS must
+    /// `dup` each fd first.
     pub fn get_surface_planes(
         &self,
         surface_id: &str,
@@ -146,6 +168,7 @@ impl SurfaceShareState {
                 plane_offsets: metadata.plane_offsets.clone(),
                 plane_strides: metadata.plane_strides.clone(),
                 drm_format_modifier: metadata.drm_format_modifier,
+                sync_fd: metadata.sync_fd,
             }
         })
     }
@@ -156,6 +179,9 @@ impl SurfaceShareState {
             if metadata.runtime_id == runtime_id {
                 for fd in &metadata.dma_buf_fds {
                     unsafe { libc::close(*fd) };
+                }
+                if let Some(sync_fd) = metadata.sync_fd {
+                    unsafe { libc::close(sync_fd) };
                 }
                 surfaces.remove(surface_id);
                 return true;
@@ -198,6 +224,7 @@ mod tests {
             format: "Rgba8Unorm",
             resource_type,
             drm_format_modifier: 0,
+            sync_fd: None,
         }
     }
 
@@ -223,10 +250,11 @@ mod tests {
     fn duplicate_surface_id_rejected() {
         let state = SurfaceShareState::new();
         assert!(state.register_surface(reg("dup", "rt", "texture")).is_ok());
-        let rejected = state
+        let (rejected_planes, rejected_sync) = state
             .register_surface(reg("dup", "rt", "texture"))
             .expect_err("duplicate must be rejected");
-        assert_eq!(rejected, vec![-1], "rejected fds returned to caller");
+        assert_eq!(rejected_planes, vec![-1], "rejected plane fds returned to caller");
+        assert_eq!(rejected_sync, None, "no sync fd was registered, none returned");
     }
 
     /// The watchdog uses `surface_ids_by_runtime` to discover what to
@@ -304,6 +332,7 @@ mod tests {
                 format: "Nv12VideoRange",
                 resource_type: "pixel_buffer",
                 drm_format_modifier: 0,
+                sync_fd: None,
             })
             .expect("register multi-plane");
 

--- a/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::thread;
 
 use streamlib_surface_client::{
-    recv_message_with_fds, send_message_with_fds, MAX_DMA_BUF_PLANES,
+    recv_message_with_fds, send_message_with_fds, MAX_DMA_BUF_PLANES, MAX_SCM_RIGHTS_FDS,
 };
 
 use super::state::{SurfaceShareState, SurfaceRegistration};
@@ -180,7 +180,7 @@ fn handle_client_connection(
         }
 
         let (json_bytes, received_fds) =
-            recv_message_with_fds(&stream, msg_len, MAX_DMA_BUF_PLANES)?;
+            recv_message_with_fds(&stream, msg_len, MAX_SCM_RIGHTS_FDS)?;
 
         let request: serde_json::Value = serde_json::from_slice(&json_bytes).map_err(|e| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Invalid JSON: {}", e))
@@ -303,26 +303,51 @@ fn handle_register(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    if received_fds.is_empty() {
+    // Peel off the optional trailing sync-FD (#531). The host signals its
+    // presence via the JSON `has_sync_fd: true` flag; the FD itself sits
+    // last in the SCM_RIGHTS list, after every DMA-BUF plane FD.
+    let has_sync_fd = request
+        .get("has_sync_fd")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let plane_count = if has_sync_fd {
+        received_fds.len().saturating_sub(1)
+    } else {
+        received_fds.len()
+    };
+    let plane_fds: &[RawFd] = &received_fds[..plane_count];
+    let sync_src_fd: Option<RawFd> = if has_sync_fd {
+        received_fds.get(plane_count).copied()
+    } else {
+        None
+    };
+
+    if plane_fds.is_empty() {
         return (
             serde_json::json!({"error": "missing DMA-BUF fd(s)"}),
             Vec::new(),
         );
     }
-    if received_fds.len() > MAX_DMA_BUF_PLANES {
+    if plane_fds.len() > MAX_DMA_BUF_PLANES {
         return (
             serde_json::json!({
                 "error": format!(
                     "too many plane fds: {} > MAX_DMA_BUF_PLANES ({})",
-                    received_fds.len(), MAX_DMA_BUF_PLANES
+                    plane_fds.len(), MAX_DMA_BUF_PLANES
                 )
             }),
             Vec::new(),
         );
     }
+    if has_sync_fd && sync_src_fd.is_none() {
+        return (
+            serde_json::json!({"error": "has_sync_fd=true but no trailing sync FD attached"}),
+            Vec::new(),
+        );
+    }
 
     let (plane_sizes, plane_offsets, plane_strides) =
-        match parse_plane_arrays(request, received_fds.len()) {
+        match parse_plane_arrays(request, plane_fds.len()) {
             Some(arrays) => arrays,
             None => {
                 return (
@@ -346,11 +371,11 @@ fn handle_register(
         .and_then(|v| v.as_str())
         .unwrap_or("pixel_buffer");
 
-    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(received_fds.len());
-    for fd in received_fds {
+    let mut dup_plane_fds: Vec<RawFd> = Vec::with_capacity(plane_fds.len());
+    for fd in plane_fds {
         let dup_fd = unsafe { libc::dup(*fd) };
         if dup_fd < 0 {
-            for d in &dup_fds {
+            for d in &dup_plane_fds {
                 unsafe { libc::close(*d) };
             }
             return (
@@ -358,13 +383,30 @@ fn handle_register(
                 Vec::new(),
             );
         }
-        dup_fds.push(dup_fd);
+        dup_plane_fds.push(dup_fd);
     }
+
+    let dup_sync_fd: Option<RawFd> = match sync_src_fd {
+        Some(src) => {
+            let dup = unsafe { libc::dup(src) };
+            if dup < 0 {
+                for d in &dup_plane_fds {
+                    unsafe { libc::close(*d) };
+                }
+                return (
+                    serde_json::json!({"error": "failed to dup sync FD"}),
+                    Vec::new(),
+                );
+            }
+            Some(dup)
+        }
+        None => None,
+    };
 
     match state.register_surface(SurfaceRegistration {
         surface_id,
         runtime_id,
-        dma_buf_fds: dup_fds,
+        dma_buf_fds: dup_plane_fds,
         plane_sizes,
         plane_offsets,
         plane_strides,
@@ -373,19 +415,24 @@ fn handle_register(
         format,
         resource_type,
         drm_format_modifier,
+        sync_fd: dup_sync_fd,
     }) {
         Ok(()) => {
             tracing::debug!(
-                "[Surface share] register: surface '{}' for runtime '{}' ({} plane(s))",
+                "[Surface share] register: surface '{}' for runtime '{}' ({} plane(s), sync_fd={})",
                 surface_id,
                 runtime_id,
-                received_fds.len(),
+                plane_fds.len(),
+                has_sync_fd,
             );
             (serde_json::json!({"success": true}), Vec::new())
         }
-        Err(leftover) => {
-            for fd in &leftover {
+        Err((leftover_planes, leftover_sync)) => {
+            for fd in &leftover_planes {
                 unsafe { libc::close(*fd) };
+            }
+            if let Some(fd) = leftover_sync {
+                unsafe { libc::close(fd) };
             }
             tracing::warn!(
                 "[Surface share] register: surface '{}' already exists",
@@ -413,7 +460,7 @@ fn handle_lookup(
     // Dup each stored fd so the kernel-delivered fds in the peer's table are
     // independent of the table's own copies. On partial failure, close every
     // dup we already took.
-    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(checkout.dma_buf_fds.len());
+    let mut dup_fds: Vec<RawFd> = Vec::with_capacity(checkout.dma_buf_fds.len() + 1);
     for fd in &checkout.dma_buf_fds {
         let dup = unsafe { libc::dup(*fd) };
         if dup < 0 {
@@ -422,6 +469,25 @@ fn handle_lookup(
             }
             return (
                 serde_json::json!({"error": "failed to dup DMA-BUF fd"}),
+                Vec::new(),
+            );
+        }
+        dup_fds.push(dup);
+    }
+
+    // Append a dup of the timeline-semaphore OPAQUE_FD when the surface
+    // was registered with one (#531). Subprocess clients detect its
+    // presence via `has_sync_fd` in the response JSON and peel the
+    // trailing FD off the SCM_RIGHTS list.
+    let has_sync_fd = checkout.sync_fd.is_some();
+    if let Some(src_sync) = checkout.sync_fd {
+        let dup = unsafe { libc::dup(src_sync) };
+        if dup < 0 {
+            for d in &dup_fds {
+                unsafe { libc::close(*d) };
+            }
+            return (
+                serde_json::json!({"error": "failed to dup sync FD"}),
                 Vec::new(),
             );
         }
@@ -445,6 +511,7 @@ fn handle_lookup(
             "plane_offsets": checkout.plane_offsets,
             "plane_strides": checkout.plane_strides,
             "drm_format_modifier": checkout.drm_format_modifier,
+            "has_sync_fd": has_sync_fd,
         }),
         dup_fds,
     )
@@ -538,7 +605,7 @@ fn handle_check_in(
         dup_fds.push(dup);
     }
 
-    if let Err(leftover) = state.register_surface(SurfaceRegistration {
+    if let Err((leftover_planes, leftover_sync)) = state.register_surface(SurfaceRegistration {
         surface_id: &surface_id,
         runtime_id,
         dma_buf_fds: dup_fds,
@@ -550,9 +617,17 @@ fn handle_check_in(
         format,
         resource_type,
         drm_format_modifier,
+        // check_in is the subprocess-registers-pixel-buffer path used by
+        // CPU-readback / legacy DMA-BUF consumers. None of those need
+        // explicit Vulkan timeline sync — the wire format reserves the
+        // option for the host-registers-render-target-texture path.
+        sync_fd: None,
     }) {
-        for fd in &leftover {
+        for fd in &leftover_planes {
             unsafe { libc::close(*fd) };
+        }
+        if let Some(fd) = leftover_sync {
+            unsafe { libc::close(fd) };
         }
     }
 
@@ -997,6 +1072,7 @@ mod tests {
                     format: "Bgra32",
                     resource_type: "pixel_buffer",
                     drm_format_modifier: 0,
+                    sync_fd: None,
                 })
                 .expect("register");
         }

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -758,7 +758,12 @@ impl VulkanTexture {
                 vk::ImageUsageFlags::TRANSFER_SRC
                     | vk::ImageUsageFlags::TRANSFER_DST
                     | vk::ImageUsageFlags::SAMPLED
-                    | vk::ImageUsageFlags::COLOR_ATTACHMENT,
+                    | vk::ImageUsageFlags::COLOR_ATTACHMENT
+                    // STORAGE for subprocess compute shaders that bind
+                    // the imported VkImage as a storage image (#531).
+                    // Must match the host's `acquire_render_target_dma_buf_image`
+                    // usage flags or the cross-process import fails.
+                    | vk::ImageUsageFlags::STORAGE,
             )
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED)


### PR DESCRIPTION
## Summary

Ships the third subprocess runtime in the surface-adapter trio (after cpu-readback #529 and opengl #530). Python and Deno polyglot processors can now construct a real `VulkanContext`, acquire WRITE on a host-allocated DMA-BUF, dispatch a compute kernel against the imported `VkImage`, and release — exercising the host `VulkanSurfaceAdapter`'s timeline-wait + layout-transition path end-to-end.

The cdylibs delegate every line of layout-transition / timeline-wait / queue-mutex coordination to the in-tree `streamlib-adapter-vulkan` crate running against a subprocess-local `VulkanDevice` — **no per-language reimplementation**. This is the engine-grade path: subprocess code drives the *same* host `VulkanSurfaceAdapter` struct used by in-process Rust callers.

## Closes

Closes #531

## Major changes

1. **Surface-share IPC extension (additive).** Wire format gained an optional timeline-semaphore OPAQUE_FD slot (`MAX_SCM_RIGHTS_FDS = 5`, `has_sync_fd` JSON flag). `SurfaceStore::register_texture` takes `Option<&VulkanTimelineSemaphore>`; existing OpenGL / cpu-readback / camera-ring callers pass `None`. Backwards-compatible — surfaces registered without a sync-FD continue to work for the OpenGL adapter (where `glFinish` + DMA-BUF kernel-fence semantics carry visibility).

2. **Subprocess Vulkan adapter via FFI.** `streamlib-python-native` and `streamlib-deno-native` now depend on `streamlib-adapter-vulkan`. New `slpn_vulkan_*` / `sldn_vulkan_*` symbols wrap `VulkanSurfaceAdapter::register_host_surface` / `acquire_write` / `acquire_read` / `end_*_access` against a subprocess-local `VulkanDevice`. The subprocess imports the DMA-BUF as a `VkImage` (`VulkanTexture::import_render_target_dma_buf`) and the timeline as `VulkanTimelineSemaphore::from_imported_opaque_fd`, hands both to `register_host_surface`, and lets the in-tree adapter logic do the rest.

3. **`STORAGE_BINDING` added to `acquire_render_target_dma_buf_image`.** Required so subprocess compute shaders can bind the imported VkImage as a storage image. Mirror change in `import_render_target_dma_buf` so the cross-process import shape matches.

4. **Concrete `VulkanContext` in `streamlib-python` and `streamlib-deno`.** Cached singleton per subprocess (mirrors `OpenGLContext` / `CpuReadbackContext` shape). `from_runtime(ctx)` / `acquire_write(uuid)` / `acquire_read(uuid)` / `dispatch_compute(...)` / `raw_handles()`.

5. **Polyglot example `examples/polyglot-vulkan-compute/`.** Host scenario + Python and Deno polyglot processors + Mandelbrot Seahorse Valley compute shader (compiled at build time via `glslc`, shipped as hex-encoded SPIR-V in the processor config).

## v1 scope-cut — `dispatch_compute` (#525 follow-up)

`{slpn,sldn}_vulkan_dispatch_compute` builds a single-binding compute pipeline + descriptor set + command buffer + fence inline using raw vulkanalia, instead of escalating through `GpuContext::create_compute_kernel` (which has SPIR-V reflection + descriptor-set lifetime + pipeline cache). It's a quarantined helper in a sibling `vulkan_compute_dispatch` module, clearly marked as v1.

@user has confirmed the `RHI parity` rewrite (#525) is running in parallel and will refactor this away after merge. Don't take this as a precedent for new RHI-shape work in the cdylibs.

## E2E Test Report

- **Scenario**: Vulkan adapter compute (#531)
- **Example**: `polyglot-vulkan-compute-scenario`
- **Codec**: n/a (compute kernel)
- **Camera device**: n/a (BgraFileSource trigger)
- **Resolution**: 512x512 Rgba8Unorm
- **Duration / frame limit**: 4s (3 trigger frames)
- **Build profile**: debug cdylib + release scenario binary
- **Command**:
    ```
    cargo build -p streamlib-python-native -p streamlib-deno-native
    cargo run -p streamlib-cli --release -- pack examples/polyglot-vulkan-compute/python
    cargo run -p polyglot-vulkan-compute-scenario --release -- --runtime=python --output=/tmp/vulkan-compute-e2e/python-mandelbrot.png
    cargo run -p polyglot-vulkan-compute-scenario --release -- --runtime=deno   --output=/tmp/vulkan-compute-e2e/deno-mandelbrot.png
    ```

### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `Mandelbrot dispatched into surface ...`: seen on both runtimes
- `Output PNG written`: both PNGs produced

### PNG samples

- Directory: `/tmp/vulkan-compute-e2e/`
- Sample count: 2 (one per runtime)
- PNGs read with Read tool: `python-mandelbrot.png`, `deno-mandelbrot.png`
- **What was in the image(s)**:
  - `python-mandelbrot.png` (variant=0): magenta-to-purple background on the left, Mandelbrot Seahorse Valley fractal on the right with green/cyan recursive seahorse spirals visible — matches the cosine palette `vec3(0.00, 0.33, 0.67)` from the shader. The shader's full smooth-coloring + cardioid-tail structure is visible at the expected zoom (`(uv-0.5)*0.018` around `(-0.7453, 0.1127)`).
  - `deno-mandelbrot.png` (variant=1): green-to-black background, the same Mandelbrot Seahorse Valley fractal with red/teal recursive spirals — matches the cosine palette `vec3(0.50, 0.20, 0.25)`. Same fractal, distinct palette confirms the variant pushconstant is being honored.
- Anomalies: none

### PSNR

- Reference frame: n/a — synthetic compute output, no ground-truth reference.
- Y / U / V PSNR: n/a
- Command used: n/a

### Outcome

- **Pass**
- Caveats / follow-ups filed: #525 (subprocess RHI parity — replace `dispatch_compute` raw-vulkanalia helper with escalate-IPC `RunComputeKernel` op)

## Polyglot coverage

- **Runtimes affected**: rust + python + deno
- **Schema regenerated**: n/a (no escalate-IPC schema changes)
- **Python and Deno both covered?** yes
- **E2E tests run**:
  - [x] Host-Rust: workspace `cargo build --all-targets` passes; example binary builds
  - [x] Python subprocess: `polyglot-vulkan-compute-scenario --runtime=python` produces the expected Seahorse Valley fractal
  - [x] Deno subprocess: `polyglot-vulkan-compute-scenario --runtime=deno` produces the expected Seahorse Valley fractal
- **FD-passing path**: DMA-BUF FD + timeline OPAQUE_FD via SCM_RIGHTS over the surface-share Unix socket

## E2E PNG evidence

![Python subprocess Vulkan compute — Mandelbrot Seahorse Valley, variant=0 magenta/purple palette](https://gh-artifact.tatolab.com/pr-549/python-mandelbrot.jpg)

*Python subprocess (`variant=0`): magenta-to-purple background, Mandelbrot Seahorse Valley with green/cyan recursive seahorse spirals — cosine palette `vec3(0.00, 0.33, 0.67)`.*

![Deno subprocess Vulkan compute — Mandelbrot Seahorse Valley, variant=1 red/teal palette](https://gh-artifact.tatolab.com/pr-549/deno-mandelbrot.jpg)

*Deno subprocess (`variant=1`): green-to-black background, same fractal with red/teal recursive spirals — cosine palette `vec3(0.50, 0.20, 0.25)`. Same shader, distinct palette confirms the variant push-constant is honored end-to-end.*
🤖 Generated with [Claude Code](https://claude.com/claude-code)
