### PR TITLE
refactor(adapter-abi): extract Registry<T: SurfaceRegistration> scaffolding

### DIFF
--- a/libs/streamlib-adapter-abi/Cargo.toml
+++ b/libs/streamlib-adapter-abi/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags.workspace = true
+parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-abi/src/lib.rs
+++ b/libs/streamlib-adapter-abi/src/lib.rs
@@ -12,6 +12,7 @@ mod conformance;
 mod error;
 mod guard;
 mod mock;
+mod registry;
 mod surface;
 
 #[cfg(target_os = "linux")]
@@ -25,6 +26,7 @@ pub use adapter::{
 };
 pub use error::AdapterError;
 pub use guard::{ReadGuard, WriteGuard};
+pub use registry::{Registry, SurfaceRegistration};
 pub use surface::{
     AccessMode, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
     SurfaceUsage, StreamlibSurface,

--- a/libs/streamlib-adapter-abi/src/registry.rs
+++ b/libs/streamlib-adapter-abi/src/registry.rs
@@ -1,0 +1,411 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared registry-lock + contention-counter scaffolding for surface
+//! adapters. The per-framework `SurfaceState` (timeline + texture +
+//! layout + plane geometry) stays in each adapter crate; what's
+//! centralized here is the read/write contention state machine and
+//! the `Mutex<HashMap<SurfaceId, T>>` ownership pattern that every
+//! adapter shares.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+
+use crate::error::AdapterError;
+use crate::surface::SurfaceId;
+
+/// Per-surface state contract every adapter's `SurfaceState` impls so
+/// [`Registry`] can run the contention check without knowing the
+/// framework-specific fields.
+///
+/// Implementors store `read_holders: u64` + `write_held: bool` (the
+/// existing convention). Reading + mutating these is the entire
+/// contract — finalization (timeline wait, layout transition, copy)
+/// stays per-adapter.
+pub trait SurfaceRegistration {
+    fn write_held(&self) -> bool;
+    fn read_holders(&self) -> u64;
+    fn set_write_held(&mut self, held: bool);
+    fn inc_read_holders(&mut self);
+    fn dec_read_holders(&mut self);
+}
+
+/// `Mutex<HashMap<SurfaceId, T>>` wrapper that all in-tree adapters
+/// (and 3rd-party adapters that adopt the trait) share.
+///
+/// The [`try_begin_read`](Self::try_begin_read) /
+/// [`try_begin_write`](Self::try_begin_write) helpers run a per-adapter
+/// snapshot closure under the same lock that performs the contention
+/// check, so the adapter's framework-specific state extraction is
+/// atomic with the counter mutation. [`rollback_read`](Self::rollback_read)
+/// / [`rollback_write`](Self::rollback_write) are the symmetric paths
+/// used on guard-drop or post-acquire timeout.
+///
+/// The lock is coarse — one `Mutex` covers every registered surface —
+/// but it matches the pre-extraction shape and keeps the contention
+/// check trivial. Refining lock granularity can come later if a real
+/// scenario surfaces it.
+pub struct Registry<T: SurfaceRegistration> {
+    inner: Mutex<HashMap<SurfaceId, T>>,
+}
+
+impl<T: SurfaceRegistration> Default for Registry<T> {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<T: SurfaceRegistration> Registry<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a new surface entry. Returns `false` if `id` was already
+    /// registered (the existing entry is left untouched).
+    pub fn register(&self, id: SurfaceId, state: T) -> bool {
+        let mut map = self.inner.lock();
+        if map.contains_key(&id) {
+            return false;
+        }
+        map.insert(id, state);
+        true
+    }
+
+    /// Drop a registered surface. Returns the removed state if any so
+    /// the adapter can run its destructor logic outside the lock
+    /// (e.g. EGLImage destruction on the EGL make-current thread).
+    pub fn unregister(&self, id: SurfaceId) -> Option<T> {
+        self.inner.lock().remove(&id)
+    }
+
+    /// Run a closure with shared access to the surface state, if it's
+    /// still registered. Returns `None` for unknown ids.
+    pub fn with<R, F: FnOnce(&T) -> R>(&self, id: SurfaceId, f: F) -> Option<R> {
+        self.inner.lock().get(&id).map(f)
+    }
+
+    /// Run a closure with mutable access to the surface state. Used by
+    /// finalize-side commits (e.g. layout-transition writes) and other
+    /// per-adapter state edits that aren't covered by the
+    /// `try_begin_*` / `rollback_*` helpers.
+    pub fn with_mut<R, F: FnOnce(&mut T) -> R>(&self, id: SurfaceId, f: F) -> Option<R> {
+        self.inner.lock().get_mut(&id).map(f)
+    }
+
+    /// Drain the entire registry under the lock and run `f` for each
+    /// `(id, state)`. Used by `Drop` impls that need to clean up GL /
+    /// Vulkan resources owned by every entry without leaving the lock
+    /// held while doing so. The map is empty after `drain`.
+    pub fn drain<F: FnMut(SurfaceId, T)>(&self, mut f: F) {
+        let drained: Vec<(SurfaceId, T)> = self.inner.lock().drain().collect();
+        for (id, state) in drained {
+            f(id, state);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+
+    /// Try to begin a read. Returns:
+    /// - `Err(SurfaceNotFound)` if `id` isn't registered;
+    /// - `Ok(None)` if a writer holds the surface (contention — caller
+    ///   decides whether to escalate to [`AdapterError::WriteContended`]
+    ///   or report try-acquire failure);
+    /// - `Ok(Some(snapshot_value))` if the read is granted, with
+    ///   `read_holders` already incremented under the lock.
+    ///
+    /// `snapshot` extracts whatever per-acquire data the adapter needs
+    /// (timeline value, image handle, plane buffers, etc.) while the
+    /// lock is held. If `snapshot` errors the counter is NOT
+    /// incremented — atomic with the contention check.
+    pub fn try_begin_read<R, F>(
+        &self,
+        id: SurfaceId,
+        snapshot: F,
+    ) -> Result<Option<R>, AdapterError>
+    where
+        F: FnOnce(&mut T) -> Result<R, AdapterError>,
+    {
+        let mut map = self.inner.lock();
+        let state = map
+            .get_mut(&id)
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
+        if state.write_held() {
+            return Ok(None);
+        }
+        let r = snapshot(state)?;
+        state.inc_read_holders();
+        Ok(Some(r))
+    }
+
+    /// Try to begin a write. Same shape as
+    /// [`try_begin_read`](Self::try_begin_read), but contention also
+    /// triggers when any reader holds the surface. On success
+    /// `write_held` is already set under the lock.
+    pub fn try_begin_write<R, F>(
+        &self,
+        id: SurfaceId,
+        snapshot: F,
+    ) -> Result<Option<R>, AdapterError>
+    where
+        F: FnOnce(&mut T) -> Result<R, AdapterError>,
+    {
+        let mut map = self.inner.lock();
+        let state = map
+            .get_mut(&id)
+            .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
+        if state.write_held() || state.read_holders() > 0 {
+            return Ok(None);
+        }
+        let r = snapshot(state)?;
+        state.set_write_held(true);
+        Ok(Some(r))
+    }
+
+    /// Decrement `read_holders` (saturating). Used on guard-drop and
+    /// post-acquire-timeout / post-finalize-error paths. Silently
+    /// no-ops if `id` raced an unregister.
+    pub fn rollback_read(&self, id: SurfaceId) {
+        if let Some(state) = self.inner.lock().get_mut(&id) {
+            state.dec_read_holders();
+        }
+    }
+
+    /// Clear `write_held`. Symmetric with
+    /// [`rollback_read`](Self::rollback_read).
+    pub fn rollback_write(&self, id: SurfaceId) {
+        if let Some(state) = self.inner.lock().get_mut(&id) {
+            state.set_write_held(false);
+        }
+    }
+
+    /// Build a one-line description of who's currently holding the
+    /// surface, for [`AdapterError::WriteContended`] error bodies.
+    /// Returns `"unknown"` if the id isn't registered.
+    pub fn describe_contention(&self, id: SurfaceId) -> String {
+        match self.inner.lock().get(&id) {
+            Some(s) if s.write_held() => "writer".to_string(),
+            Some(s) => format!("{} reader(s)", s.read_holders()),
+            None => "unknown".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `SurfaceRegistration` impl for behavioral tests.
+    #[derive(Default)]
+    struct TestState {
+        write_held: bool,
+        read_holders: u64,
+    }
+
+    impl SurfaceRegistration for TestState {
+        fn write_held(&self) -> bool {
+            self.write_held
+        }
+        fn read_holders(&self) -> u64 {
+            self.read_holders
+        }
+        fn set_write_held(&mut self, held: bool) {
+            self.write_held = held;
+        }
+        fn inc_read_holders(&mut self) {
+            self.read_holders += 1;
+        }
+        fn dec_read_holders(&mut self) {
+            self.read_holders = self.read_holders.saturating_sub(1);
+        }
+    }
+
+    fn registry_with(id: SurfaceId) -> Registry<TestState> {
+        let r = Registry::<TestState>::new();
+        assert!(r.register(id, TestState::default()));
+        r
+    }
+
+    #[test]
+    fn unknown_surface_returns_not_found() {
+        let r = Registry::<TestState>::new();
+        let res = r.try_begin_read(42, |_| Ok(()));
+        assert!(matches!(
+            res,
+            Err(AdapterError::SurfaceNotFound { surface_id: 42 })
+        ));
+    }
+
+    #[test]
+    fn read_plus_read_concurrent_allowed() {
+        let r = registry_with(1);
+        // First read.
+        let snap1 = r.try_begin_read(1, |_| Ok(())).unwrap();
+        assert!(snap1.is_some());
+        // Second concurrent read — also granted.
+        let snap2 = r.try_begin_read(1, |_| Ok(())).unwrap();
+        assert!(snap2.is_some());
+        r.with(1, |s| {
+            assert_eq!(s.read_holders, 2);
+            assert!(!s.write_held);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn read_blocks_write() {
+        let r = registry_with(1);
+        let _read = r.try_begin_read(1, |_| Ok(())).unwrap().unwrap();
+        let write = r.try_begin_write(1, |_| Ok(())).unwrap();
+        assert!(write.is_none(), "write must be contended by reader");
+        // State was not mutated.
+        r.with(1, |s| {
+            assert_eq!(s.read_holders, 1);
+            assert!(!s.write_held);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn write_blocks_read() {
+        let r = registry_with(1);
+        let _write = r.try_begin_write(1, |_| Ok(())).unwrap().unwrap();
+        let read = r.try_begin_read(1, |_| Ok(())).unwrap();
+        assert!(read.is_none(), "read must be contended by writer");
+        r.with(1, |s| {
+            assert_eq!(s.read_holders, 0);
+            assert!(s.write_held);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn write_blocks_write() {
+        let r = registry_with(1);
+        let _w1 = r.try_begin_write(1, |_| Ok(())).unwrap().unwrap();
+        let w2 = r.try_begin_write(1, |_| Ok(())).unwrap();
+        assert!(w2.is_none(), "second writer must be contended");
+    }
+
+    #[test]
+    fn rollback_decrements_counters() {
+        let r = registry_with(1);
+        r.try_begin_read(1, |_| Ok(())).unwrap().unwrap();
+        r.try_begin_read(1, |_| Ok(())).unwrap().unwrap();
+        r.with(1, |s| assert_eq!(s.read_holders, 2)).unwrap();
+        r.rollback_read(1);
+        r.with(1, |s| assert_eq!(s.read_holders, 1)).unwrap();
+        r.rollback_read(1);
+        r.with(1, |s| assert_eq!(s.read_holders, 0)).unwrap();
+    }
+
+    #[test]
+    fn rollback_read_is_saturating() {
+        let r = registry_with(1);
+        // No reader; rollback must not underflow.
+        r.rollback_read(1);
+        r.with(1, |s| assert_eq!(s.read_holders, 0)).unwrap();
+    }
+
+    #[test]
+    fn rollback_write_clears_flag() {
+        let r = registry_with(1);
+        r.try_begin_write(1, |_| Ok(())).unwrap().unwrap();
+        r.with(1, |s| assert!(s.write_held)).unwrap();
+        r.rollback_write(1);
+        r.with(1, |s| assert!(!s.write_held)).unwrap();
+    }
+
+    #[test]
+    fn rollback_unknown_surface_no_ops() {
+        let r = Registry::<TestState>::new();
+        // Must not panic on unknown id.
+        r.rollback_read(99);
+        r.rollback_write(99);
+    }
+
+    #[test]
+    fn snapshot_error_does_not_mutate_counters() {
+        let r = registry_with(1);
+        let res = r.try_begin_read::<(), _>(1, |_| {
+            Err(AdapterError::SurfaceNotFound { surface_id: 1 })
+        });
+        assert!(matches!(
+            res,
+            Err(AdapterError::SurfaceNotFound { surface_id: 1 })
+        ));
+        r.with(1, |s| {
+            assert_eq!(s.read_holders, 0);
+            assert!(!s.write_held);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn snapshot_runs_under_lock_with_mut_state() {
+        // The closure receives `&mut T`, so adapters can do per-acquire
+        // state edits (e.g. record last_acquire_value) atomic with the
+        // contention check. Use a side-channel — bumping write_held in
+        // a read closure would be wrong; this test just confirms the
+        // snapshot return value is plumbed through.
+        let r = registry_with(1);
+        let token = r
+            .try_begin_read(1, |_state| Ok(42_u64))
+            .unwrap()
+            .unwrap();
+        assert_eq!(token, 42);
+        r.with(1, |s| assert_eq!(s.read_holders, 1)).unwrap();
+    }
+
+    #[test]
+    fn describe_contention_reports_holders() {
+        let r = registry_with(1);
+        assert_eq!(r.describe_contention(1), "0 reader(s)");
+        r.try_begin_read(1, |_| Ok(())).unwrap().unwrap();
+        r.try_begin_read(1, |_| Ok(())).unwrap().unwrap();
+        assert_eq!(r.describe_contention(1), "2 reader(s)");
+        r.rollback_read(1);
+        r.rollback_read(1);
+        r.try_begin_write(1, |_| Ok(())).unwrap().unwrap();
+        assert_eq!(r.describe_contention(1), "writer");
+        assert_eq!(r.describe_contention(99), "unknown");
+    }
+
+    #[test]
+    fn unregister_returns_state_and_removes() {
+        let r = registry_with(1);
+        assert_eq!(r.len(), 1);
+        let taken = r.unregister(1);
+        assert!(taken.is_some());
+        assert_eq!(r.len(), 0);
+        assert!(r.unregister(1).is_none());
+    }
+
+    #[test]
+    fn duplicate_register_rejected() {
+        let r = Registry::<TestState>::new();
+        assert!(r.register(7, TestState::default()));
+        assert!(!r.register(7, TestState::default()));
+    }
+
+    #[test]
+    fn drain_visits_every_entry_and_empties() {
+        let r = Registry::<TestState>::new();
+        r.register(1, TestState::default());
+        r.register(2, TestState::default());
+        r.register(3, TestState::default());
+        let mut seen = Vec::new();
+        r.drain(|id, _| seen.push(id));
+        seen.sort_unstable();
+        assert_eq!(seen, vec![1, 2, 3]);
+        assert!(r.is_empty());
+    }
+}

--- a/libs/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -26,16 +26,15 @@
 //! READ guard `Drop` simply signals the timeline; nothing is flushed
 //! back since the customer can't have mutated the read view.
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use parking_lot::Mutex;
 use streamlib::adapter_support::{VulkanDevice, VulkanPixelBuffer, VulkanTimelineSemaphore};
 use streamlib::core::rhi::PixelFormat;
 use streamlib_adapter_abi::{
-    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, WriteGuard,
+    AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId,
+    SurfaceRegistration, WriteGuard,
 };
 use tracing::instrument;
 use vulkanalia::prelude::v1_4::*;
@@ -86,7 +85,7 @@ pub struct CpuReadbackSurfaceSnapshot {
 /// API or via the [`crate::CpuReadbackContext`] convenience.
 pub struct CpuReadbackSurfaceAdapter {
     device: Arc<VulkanDevice>,
-    surfaces: Mutex<HashMap<SurfaceId, SurfaceState>>,
+    surfaces: Registry<SurfaceState>,
     acquire_timeout: Duration,
 }
 
@@ -95,7 +94,7 @@ impl CpuReadbackSurfaceAdapter {
     pub fn new(device: Arc<VulkanDevice>) -> Self {
         Self {
             device,
-            surfaces: Mutex::new(HashMap::new()),
+            surfaces: Registry::new(),
             acquire_timeout: DEFAULT_ACQUIRE_TIMEOUT,
         }
     }
@@ -126,11 +125,6 @@ impl CpuReadbackSurfaceAdapter {
         id: SurfaceId,
         registration: HostSurfaceRegistration,
     ) -> Result<(), AdapterError> {
-        let mut map = self.surfaces.lock();
-        if map.contains_key(&id) {
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
-        }
-
         let width = registration.texture.width();
         let height = registration.texture.height();
         let format = registration.format;
@@ -183,33 +177,37 @@ impl CpuReadbackSurfaceAdapter {
             });
         }
 
-        map.insert(
-            id,
-            SurfaceState {
-                surface_id: id,
-                texture: registration.texture,
-                planes,
-                timeline: registration.timeline,
-                current_layout: VulkanLayout(registration.initial_image_layout),
-                read_holders: 0,
-                write_held: false,
-                current_release_value: 0,
-                format,
-                width,
-                height,
-            },
-        );
+        let state = SurfaceState {
+            surface_id: id,
+            texture: registration.texture,
+            planes,
+            timeline: registration.timeline,
+            current_layout: VulkanLayout(registration.initial_image_layout),
+            read_holders: 0,
+            write_held: false,
+            current_release_value: 0,
+            format,
+            width,
+            height,
+        };
+        if !self.surfaces.register(id, state) {
+            // Local `state` (and its `planes` Vec) drops here, releasing
+            // the staging `VulkanPixelBuffer`s we just allocated. Return
+            // SurfaceNotFound to match the pre-Registry semantics —
+            // callers reading that error treat it as "id collision".
+            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+        }
         Ok(())
     }
 
     /// Drop a registered surface.
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
-        self.surfaces.lock().remove(&id).is_some()
+        self.surfaces.unregister(id).is_some()
     }
 
     /// Snapshot the registry size — primarily for tests / observability.
     pub fn registered_count(&self) -> usize {
-        self.surfaces.lock().len()
+        self.surfaces.len()
     }
 
     /// Blocking read acquire keyed by `SurfaceId` instead of a full
@@ -222,7 +220,7 @@ impl CpuReadbackSurfaceAdapter {
         &'g self,
         surface_id: SurfaceId,
     ) -> Result<ReadGuard<'g, Self>, AdapterError> {
-        let snap = match self.try_begin(surface_id, false)? {
+        let snap = match self.try_begin_read_inner(surface_id)? {
             Some(s) => s,
             None => {
                 return Err(AdapterError::WriteContended {
@@ -240,19 +238,12 @@ impl CpuReadbackSurfaceAdapter {
         &'g self,
         surface_id: SurfaceId,
     ) -> Result<WriteGuard<'g, Self>, AdapterError> {
-        let snap = match self.try_begin(surface_id, true)? {
+        let snap = match self.try_begin_write_inner(surface_id)? {
             Some(s) => s,
             None => {
-                let map = self.surfaces.lock();
-                let holder = match map.get(&surface_id) {
-                    Some(s) if s.write_held => "writer".to_string(),
-                    Some(s) => format!("{} reader(s)", s.read_holders),
-                    None => "unknown".to_string(),
-                };
-                drop(map);
                 return Err(AdapterError::WriteContended {
                     surface_id,
-                    holder,
+                    holder: self.surfaces.describe_contention(surface_id),
                 });
             }
         };
@@ -265,7 +256,7 @@ impl CpuReadbackSurfaceAdapter {
         &'g self,
         surface_id: SurfaceId,
     ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
-        let snap = match self.try_begin(surface_id, false)? {
+        let snap = match self.try_begin_read_inner(surface_id)? {
             Some(s) => s,
             None => return Ok(None),
         };
@@ -282,7 +273,7 @@ impl CpuReadbackSurfaceAdapter {
         &'g self,
         surface_id: SurfaceId,
     ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
-        let snap = match self.try_begin(surface_id, true)? {
+        let snap = match self.try_begin_write_inner(surface_id)? {
             Some(s) => s,
             None => return Ok(None),
         };
@@ -303,47 +294,34 @@ impl CpuReadbackSurfaceAdapter {
         &self,
         surface_id: SurfaceId,
     ) -> Option<CpuReadbackSurfaceSnapshot> {
-        let map = self.surfaces.lock();
-        let state = map.get(&surface_id)?;
-        let planes = state
-            .planes
-            .iter()
-            .map(|p| CpuReadbackStagingPlane {
-                staging: Arc::clone(&p.staging),
-                width: p.width,
-                height: p.height,
-                bytes_per_pixel: p.bytes_per_pixel,
-            })
-            .collect();
-        Some(CpuReadbackSurfaceSnapshot {
-            width: state.width,
-            height: state.height,
-            format: state.format,
-            planes,
+        self.surfaces.with(surface_id, |state| {
+            let planes = state
+                .planes
+                .iter()
+                .map(|p| CpuReadbackStagingPlane {
+                    staging: Arc::clone(&p.staging),
+                    width: p.width,
+                    height: p.height,
+                    bytes_per_pixel: p.bytes_per_pixel,
+                })
+                .collect();
+            CpuReadbackSurfaceSnapshot {
+                width: state.width,
+                height: state.height,
+                format: state.format,
+                planes,
+            }
         })
     }
 
-    /// Common acquire path: wait timeline, then issue
-    /// `vkCmdCopyImageToBuffer` into the per-plane staging buffers.
-    /// Returns the snapshot needed to build a view, with state's
-    /// `read_holders` / `write_held` already incremented.
-    fn try_begin(
-        &self,
+    /// Snapshot the per-acquire state needed to drive
+    /// `vkCmdCopyImageToBuffer`. Adapter-internal helper invoked under
+    /// the registry lock; commits `read_holders++` /
+    /// `write_held = true` atomically with the snapshot.
+    fn snapshot_for_acquire(
+        state: &mut SurfaceState,
         surface_id: SurfaceId,
-        write: bool,
-    ) -> Result<Option<AcquireSnapshot>, AdapterError> {
-        let mut map = self.surfaces.lock();
-        let state = map
-            .get_mut(&surface_id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id })?;
-
-        if state.write_held {
-            return Ok(None);
-        }
-        if write && state.read_holders > 0 {
-            return Ok(None);
-        }
-
+    ) -> Result<AcquireSnapshot, AdapterError> {
         let timeline = Arc::clone(&state.timeline);
         let wait_value = state.current_release_value;
         let image = state
@@ -367,14 +345,7 @@ impl CpuReadbackSurfaceAdapter {
                 byte_size: p.byte_size(),
             })
             .collect();
-
-        if write {
-            state.write_held = true;
-        } else {
-            state.read_holders += 1;
-        }
-
-        Ok(Some(AcquireSnapshot {
+        Ok(AcquireSnapshot {
             timeline,
             wait_value,
             image,
@@ -383,7 +354,23 @@ impl CpuReadbackSurfaceAdapter {
             width,
             height,
             planes: plane_snaps,
-        }))
+        })
+    }
+
+    fn try_begin_read_inner(
+        &self,
+        surface_id: SurfaceId,
+    ) -> Result<Option<AcquireSnapshot>, AdapterError> {
+        self.surfaces
+            .try_begin_read(surface_id, |state| Self::snapshot_for_acquire(state, surface_id))
+    }
+
+    fn try_begin_write_inner(
+        &self,
+        surface_id: SurfaceId,
+    ) -> Result<Option<AcquireSnapshot>, AdapterError> {
+        self.surfaces
+            .try_begin_write(surface_id, |state| Self::snapshot_for_acquire(state, surface_id))
     }
 
     fn finalize_acquire(
@@ -398,7 +385,7 @@ impl CpuReadbackSurfaceAdapter {
             .wait(snap.wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
-            self.rollback(surface_id, write);
+            self.rollback_acquire(surface_id, write);
             return Err(AdapterError::SyncTimeout {
                 duration: self.acquire_timeout,
             });
@@ -425,26 +412,24 @@ impl CpuReadbackSurfaceAdapter {
         // Issue: image (current layout) → TRANSFER_SRC_OPTIMAL → copy
         //        → image (TRANSFER_SRC_OPTIMAL → GENERAL).
         if let Err(err) = self.copy_image_to_buffer(snap) {
-            self.rollback(surface_id, write);
+            self.rollback_acquire(surface_id, write);
             return Err(err);
         }
 
         // Image is in GENERAL after the copy path.
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
+        self.surfaces.with_mut(surface_id, |state| {
             state.current_layout = VulkanLayout::GENERAL;
-        }
+        });
         Ok(())
     }
 
-    fn rollback(&self, surface_id: SurfaceId, write: bool) {
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
-            if write {
-                state.write_held = false;
-            } else {
-                state.read_holders = state.read_holders.saturating_sub(1);
-            }
+    /// Symmetric counter rollback for the acquire path. Forwards to
+    /// the Registry's read/write rollback helpers based on `write`.
+    fn rollback_acquire(&self, surface_id: SurfaceId, write: bool) {
+        if write {
+            self.surfaces.rollback_write(surface_id);
+        } else {
+            self.surfaces.rollback_read(surface_id);
         }
     }
 
@@ -873,54 +858,47 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        let (timeline, value) = {
-            let mut map = self.surfaces.lock();
-            let state = match map.get_mut(&surface_id) {
-                Some(s) => s,
-                None => {
-                    tracing::warn!(
-                        ?surface_id,
-                        "end_read_access on unknown surface — racing unregister"
-                    );
-                    return;
-                }
-            };
+        // Inner Option: `None` means "not the last reader, skip signal".
+        // Outer Option: `None` means the surface raced an unregister.
+        let signal = self.surfaces.with_mut(surface_id, |state| {
             debug_assert!(state.read_holders > 0, "read release without acquire");
-            state.read_holders = state.read_holders.saturating_sub(1);
+            state.dec_read_holders();
             if state.read_holders > 0 {
-                return;
+                return None;
             }
             let next = state.next_release_value();
             state.current_release_value = next;
-            (Arc::clone(&state.timeline), next)
+            Some((Arc::clone(&state.timeline), next))
+        });
+        let signal = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_read_access on unknown surface — racing unregister"
+                );
+                return;
+            }
         };
-        if let Err(e) = timeline.signal_host(value) {
-            tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+        if let Some((timeline, value)) = signal {
+            if let Err(e) = timeline.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+            }
         }
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
         // Snapshot the work we need to do under the lock, then run the
-        // GPU copy unlocked.
-        let snap = {
-            let mut map = self.surfaces.lock();
-            let state = match map.get_mut(&surface_id) {
-                Some(s) => s,
-                None => {
-                    tracing::warn!(
-                        ?surface_id,
-                        "end_write_access on unknown surface — racing unregister"
-                    );
-                    return;
-                }
-            };
+        // GPU copy unlocked. Outer Option: surface raced an unregister.
+        // Inner Option: surface exists but its vulkan image is gone —
+        // we still clear write_held and bail.
+        let snap = self.surfaces.with_mut(surface_id, |state| {
             debug_assert!(state.write_held, "write release without acquire");
             let image = match state.texture.vulkan_inner().image() {
                 Some(i) => i,
                 None => {
-                    state.write_held = false;
-                    tracing::warn!(?surface_id, "end_write_access: vulkan image unavailable");
-                    return;
+                    state.set_write_held(false);
+                    return None;
                 }
             };
             let planes: Vec<PlaneAcquireSlot> = state
@@ -935,11 +913,25 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
                     byte_size: p.byte_size(),
                 })
                 .collect();
-            FlushSnapshot {
+            Some(FlushSnapshot {
                 image,
                 from: state.current_layout,
                 format: state.format,
                 planes,
+            })
+        });
+        let snap = match snap {
+            Some(Some(s)) => s,
+            Some(None) => {
+                tracing::warn!(?surface_id, "end_write_access: vulkan image unavailable");
+                return;
+            }
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_write_access on unknown surface — racing unregister"
+                );
+                return;
             }
         };
 
@@ -951,24 +943,20 @@ impl SurfaceAdapter for CpuReadbackSurfaceAdapter {
             );
             // Even on copy failure, release the lock so the caller can
             // retry — leaving `write_held=true` would deadlock the surface.
-            let mut map = self.surfaces.lock();
-            if let Some(state) = map.get_mut(&surface_id) {
-                state.write_held = false;
-            }
+            self.surfaces.rollback_write(surface_id);
             return;
         }
 
-        let (timeline, value) = {
-            let mut map = self.surfaces.lock();
-            let state = match map.get_mut(&surface_id) {
-                Some(s) => s,
-                None => return,
-            };
-            state.write_held = false;
+        let signal = self.surfaces.with_mut(surface_id, |state| {
+            state.set_write_held(false);
             state.current_layout = VulkanLayout::GENERAL;
             let next = state.next_release_value();
             state.current_release_value = next;
             (Arc::clone(&state.timeline), next)
+        });
+        let (timeline, value) = match signal {
+            Some(s) => s,
+            None => return,
         };
         if let Err(e) = timeline.signal_host(value) {
             tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");

--- a/libs/streamlib-adapter-cpu-readback/src/state.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/state.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use streamlib::adapter_support::{VulkanPixelBuffer, VulkanTimelineSemaphore};
 use streamlib::core::rhi::StreamTexture;
-use streamlib_adapter_abi::{SurfaceFormat, SurfaceId};
+use streamlib_adapter_abi::{SurfaceFormat, SurfaceId, SurfaceRegistration};
 use vulkanalia::vk;
 
 /// `VkImageLayout` enumerant. Stored as `i32` per the Vulkan spec.
@@ -90,5 +90,23 @@ pub(crate) struct SurfaceState {
 impl SurfaceState {
     pub(crate) fn next_release_value(&self) -> u64 {
         self.current_release_value + 1
+    }
+}
+
+impl SurfaceRegistration for SurfaceState {
+    fn write_held(&self) -> bool {
+        self.write_held
+    }
+    fn read_holders(&self) -> u64 {
+        self.read_holders
+    }
+    fn set_write_held(&mut self, held: bool) {
+        self.write_held = held;
+    }
+    fn inc_read_holders(&mut self) {
+        self.read_holders += 1;
+    }
+    fn dec_read_holders(&mut self) {
+        self.read_holders = self.read_holders.saturating_sub(1);
     }
 }

--- a/libs/streamlib-adapter-opengl/src/adapter.rs
+++ b/libs/streamlib-adapter-opengl/src/adapter.rs
@@ -15,14 +15,12 @@
 //!   the registry-mutex level; concurrent GL access through the same
 //!   context is serialized by [`EglRuntime::lock_make_current`].
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use khronos_egl as egl;
-use parking_lot::Mutex;
 use streamlib_adapter_abi::{
-    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceId, WriteGuard,
+    AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceId, WriteGuard,
 };
 use tracing::{instrument, warn};
 
@@ -43,7 +41,7 @@ use crate::view::{OpenGlReadView, OpenGlWriteView};
 /// API or via the [`crate::OpenGlContext`] convenience.
 pub struct OpenGlSurfaceAdapter {
     runtime: Arc<EglRuntime>,
-    surfaces: Mutex<HashMap<SurfaceId, SurfaceState>>,
+    surfaces: Registry<SurfaceState>,
 }
 
 impl OpenGlSurfaceAdapter {
@@ -51,7 +49,7 @@ impl OpenGlSurfaceAdapter {
     pub fn new(runtime: Arc<EglRuntime>) -> Self {
         Self {
             runtime,
-            surfaces: Mutex::new(HashMap::new()),
+            surfaces: Registry::new(),
         }
     }
 
@@ -78,11 +76,10 @@ impl OpenGlSurfaceAdapter {
         id: SurfaceId,
         registration: HostSurfaceRegistration,
     ) -> Result<(), AdapterError> {
-        let mut map = self.surfaces.lock();
-        if map.contains_key(&id) {
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
-        }
-
+        // Reject duplicates up-front via the Registry's atomic insert
+        // below; build the EGLImage + GL texture without holding the
+        // registry lock so make-current and registry locks don't
+        // shoulder each other across user code.
         let _current = self.runtime.lock_make_current().map_err(egl_to_adapter)?;
 
         // Build the DMA-BUF import attribute list. Modifier is split
@@ -148,16 +145,23 @@ impl OpenGlSurfaceAdapter {
             gl::BindTexture(gl::TEXTURE_2D, 0);
         }
 
-        map.insert(
-            id,
-            SurfaceState {
-                surface_id: id,
-                image,
-                texture,
-                read_holders: 0,
-                write_held: false,
-            },
-        );
+        let state = SurfaceState {
+            surface_id: id,
+            image,
+            texture,
+            read_holders: 0,
+            write_held: false,
+        };
+        if !self.surfaces.register(id, state) {
+            // Lost a race to a concurrent registration with the same
+            // id (or caller passed a duplicate). Tear down what we
+            // just built so we don't leak the EGLImage / GL texture.
+            unsafe {
+                gl::DeleteTextures(1, &texture);
+                self.runtime.destroy_image(image);
+            }
+            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+        }
         Ok(())
     }
 
@@ -168,11 +172,7 @@ impl OpenGlSurfaceAdapter {
     /// Returns `true` if a surface was removed.
     #[instrument(level = "debug", skip(self), fields(surface_id = id))]
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
-        let removed = {
-            let mut map = self.surfaces.lock();
-            map.remove(&id)
-        };
-        let Some(state) = removed else {
+        let Some(state) = self.surfaces.unregister(id) else {
             return false;
         };
 
@@ -194,58 +194,45 @@ impl OpenGlSurfaceAdapter {
     /// Snapshot the registry size — primarily for tests and
     /// observability.
     pub fn registered_count(&self) -> usize {
-        self.surfaces.lock().len()
+        self.surfaces.len()
     }
 
     fn try_begin_read(
         &self,
         surface: &StreamlibSurface,
     ) -> Result<Option<u32>, AdapterError> {
-        let mut map = self.surfaces.lock();
-        let state = map
-            .get_mut(&surface.id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        if state.write_held {
-            return Ok(None);
-        }
-        state.read_holders += 1;
-        Ok(Some(state.texture))
+        self.surfaces
+            .try_begin_read(surface.id, |state| Ok(state.texture))
     }
 
     fn try_begin_write(
         &self,
         surface: &StreamlibSurface,
     ) -> Result<Option<u32>, AdapterError> {
-        let mut map = self.surfaces.lock();
-        let state = map
-            .get_mut(&surface.id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        if state.write_held || state.read_holders > 0 {
-            return Ok(None);
-        }
-        state.write_held = true;
-        Ok(Some(state.texture))
+        self.surfaces
+            .try_begin_write(surface.id, |state| Ok(state.texture))
     }
 }
 
 impl Drop for OpenGlSurfaceAdapter {
     fn drop(&mut self) {
-        let mut map = self.surfaces.lock();
-        if map.is_empty() {
+        if self.surfaces.is_empty() {
             return;
         }
         match self.runtime.lock_make_current() {
             Ok(_current) => {
-                for (_, state) in map.drain() {
-                    unsafe {
-                        gl::DeleteTextures(1, &state.texture);
-                        self.runtime.destroy_image(state.image);
-                    }
-                }
+                self.surfaces.drain(|_id, state| unsafe {
+                    gl::DeleteTextures(1, &state.texture);
+                    self.runtime.destroy_image(state.image);
+                });
             }
             Err(e) => {
                 warn!(?e, "could not make-current during adapter drop — leaking GL textures");
-                map.clear();
+                // Without a current context we can't safely delete the
+                // GL textures or EGLImages. Drop the entries anyway so
+                // we don't keep them alive past the adapter; the GL
+                // resources leak for the lifetime of the runtime.
+                self.surfaces.drain(|_id, _state| {});
             }
         }
     }
@@ -288,19 +275,10 @@ impl SurfaceAdapter for OpenGlSurfaceAdapter {
                     _marker: PhantomData,
                 },
             )),
-            None => {
-                let map = self.surfaces.lock();
-                let holder = match map.get(&surface.id) {
-                    Some(s) if s.write_held => "writer".to_string(),
-                    Some(s) => format!("{} reader(s)", s.read_holders),
-                    None => "unknown".to_string(),
-                };
-                drop(map);
-                Err(AdapterError::WriteContended {
-                    surface_id: surface.id,
-                    holder,
-                })
-            }
+            None => Err(AdapterError::WriteContended {
+                surface_id: surface.id,
+                holder: self.surfaces.describe_contention(surface.id),
+            }),
         }
     }
 
@@ -339,13 +317,13 @@ impl SurfaceAdapter for OpenGlSurfaceAdapter {
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        let mut map = self.surfaces.lock();
-        let Some(state) = map.get_mut(&surface_id) else {
+        let updated = self.surfaces.with_mut(surface_id, |state| {
+            debug_assert!(state.read_holders > 0, "read release without acquire");
+            state.read_holders = state.read_holders.saturating_sub(1);
+        });
+        if updated.is_none() {
             warn!(?surface_id, "end_read_access on unknown surface — racing unregister");
-            return;
-        };
-        debug_assert!(state.read_holders > 0, "read release without acquire");
-        state.read_holders = state.read_holders.saturating_sub(1);
+        }
         // Reads that just sample don't need a flush; if the caller
         // wrote uniforms or did indirect work they're responsible for
         // their own ordering. The adapter does NOT issue glFinish on
@@ -353,14 +331,14 @@ impl SurfaceAdapter for OpenGlSurfaceAdapter {
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
-        let mut map = self.surfaces.lock();
-        let Some(state) = map.get_mut(&surface_id) else {
+        let updated = self.surfaces.with_mut(surface_id, |state| {
+            debug_assert!(state.write_held, "write release without acquire");
+            state.write_held = false;
+        });
+        if updated.is_none() {
             warn!(?surface_id, "end_write_access on unknown surface — racing unregister");
             return;
-        };
-        debug_assert!(state.write_held, "write release without acquire");
-        state.write_held = false;
-        drop(map);
+        }
 
         // Drain the GL command stream so subsequent host Vulkan work
         // (or another adapter) sees the writes through the DMA-BUF.

--- a/libs/streamlib-adapter-opengl/src/state.rs
+++ b/libs/streamlib-adapter-opengl/src/state.rs
@@ -6,7 +6,7 @@
 //! enforces at the API level.
 
 use khronos_egl as egl;
-use streamlib_adapter_abi::SurfaceId;
+use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 
 #[allow(dead_code)] // referenced via SurfaceState; kept private to the adapter
 type EglImage = egl::Image;
@@ -56,3 +56,21 @@ pub(crate) struct SurfaceState {
 // both locks.
 unsafe impl Send for SurfaceState {}
 unsafe impl Sync for SurfaceState {}
+
+impl SurfaceRegistration for SurfaceState {
+    fn write_held(&self) -> bool {
+        self.write_held
+    }
+    fn read_holders(&self) -> u64 {
+        self.read_holders
+    }
+    fn set_write_held(&mut self, held: bool) {
+        self.write_held = held;
+    }
+    fn inc_read_holders(&mut self) {
+        self.read_holders += 1;
+    }
+    fn dec_read_holders(&mut self) {
+        self.read_holders = self.read_holders.saturating_sub(1);
+    }
+}

--- a/libs/streamlib-adapter-vulkan/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
-parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -15,17 +15,15 @@
 //! - Signals the next timeline value on guard drop so the next acquire
 //!   wakes up.
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use parking_lot::Mutex;
 use streamlib::adapter_support::{VulkanDevice, VulkanTimelineSemaphore};
 use streamlib::core::rhi::StreamTexture;
 use streamlib_adapter_abi::{
-    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceId, VkImageInfo,
-    WriteGuard,
+    AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceId,
+    SurfaceRegistration, VkImageInfo, WriteGuard,
 };
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
@@ -47,7 +45,7 @@ const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
 /// API or via the [`crate::VulkanContext`] convenience.
 pub struct VulkanSurfaceAdapter {
     device: Arc<VulkanDevice>,
-    surfaces: Mutex<HashMap<SurfaceId, SurfaceState>>,
+    surfaces: Registry<SurfaceState>,
     /// Per-acquire timeline wait timeout. Adjustable via
     /// [`Self::with_acquire_timeout`].
     acquire_timeout: Duration,
@@ -58,7 +56,7 @@ impl VulkanSurfaceAdapter {
     pub fn new(device: Arc<VulkanDevice>) -> Self {
         Self {
             device,
-            surfaces: Mutex::new(HashMap::new()),
+            surfaces: Registry::new(),
             acquire_timeout: DEFAULT_TIMELINE_WAIT,
         }
     }
@@ -85,11 +83,7 @@ impl VulkanSurfaceAdapter {
         id: SurfaceId,
         registration: HostSurfaceRegistration,
     ) -> Result<(), AdapterError> {
-        let mut map = self.surfaces.lock();
-        if map.contains_key(&id) {
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
-        }
-        map.insert(
+        let inserted = self.surfaces.register(
             id,
             SurfaceState {
                 surface_id: id,
@@ -102,6 +96,9 @@ impl VulkanSurfaceAdapter {
                 current_release_value: 0,
             },
         );
+        if !inserted {
+            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+        }
         Ok(())
     }
 
@@ -109,13 +106,13 @@ impl VulkanSurfaceAdapter {
     /// `Arc<VulkanTimelineSemaphore>` alive; the next acquire returns
     /// [`AdapterError::SurfaceNotFound`].
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
-        self.surfaces.lock().remove(&id).is_some()
+        self.surfaces.unregister(id).is_some()
     }
 
     /// Snapshot the registry size — primarily for tests and
     /// observability.
     pub fn registered_count(&self) -> usize {
-        self.surfaces.lock().len()
+        self.surfaces.len()
     }
 
     fn make_image_info(&self, texture: &StreamTexture) -> VkImageInfo {
@@ -265,62 +262,50 @@ impl VulkanSurfaceAdapter {
         &self,
         surface: &StreamlibSurface,
     ) -> Result<Option<ReadAcquired>, AdapterError> {
-        let mut map = self.surfaces.lock();
-        let state = map
-            .get_mut(&surface.id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        if state.write_held {
-            return Ok(None);
-        }
-        // Snapshot what we need before we drop the lock so the wait /
-        // layout transition runs unlocked. Counters are committed below.
-        let timeline = Arc::clone(&state.timeline);
-        let wait_value = state.current_release_value;
-        let image = state
-            .texture
-            .vulkan_inner()
-            .image()
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        let from = state.current_layout;
-        state.read_holders += 1;
-        state.last_acquire_value = wait_value;
-        Ok(Some(ReadAcquired {
-            timeline,
-            wait_value,
-            image,
-            from,
-            info: self.make_image_info(&state.texture),
-        }))
+        let id = surface.id;
+        self.surfaces.try_begin_read(id, |state| {
+            let timeline = Arc::clone(&state.timeline);
+            let wait_value = state.current_release_value;
+            let image = state
+                .texture
+                .vulkan_inner()
+                .image()
+                .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
+            let from = state.current_layout;
+            state.last_acquire_value = wait_value;
+            Ok(ReadAcquired {
+                timeline,
+                wait_value,
+                image,
+                from,
+                info: self.make_image_info(&state.texture),
+            })
+        })
     }
 
     fn try_begin_write(
         &self,
         surface: &StreamlibSurface,
     ) -> Result<Option<WriteAcquired>, AdapterError> {
-        let mut map = self.surfaces.lock();
-        let state = map
-            .get_mut(&surface.id)
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        if state.write_held || state.read_holders > 0 {
-            return Ok(None);
-        }
-        let timeline = Arc::clone(&state.timeline);
-        let wait_value = state.current_release_value;
-        let image = state
-            .texture
-            .vulkan_inner()
-            .image()
-            .ok_or(AdapterError::SurfaceNotFound { surface_id: surface.id })?;
-        let from = state.current_layout;
-        state.write_held = true;
-        state.last_acquire_value = wait_value;
-        Ok(Some(WriteAcquired {
-            timeline,
-            wait_value,
-            image,
-            from,
-            info: self.make_image_info(&state.texture),
-        }))
+        let id = surface.id;
+        self.surfaces.try_begin_write(id, |state| {
+            let timeline = Arc::clone(&state.timeline);
+            let wait_value = state.current_release_value;
+            let image = state
+                .texture
+                .vulkan_inner()
+                .image()
+                .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
+            let from = state.current_layout;
+            state.last_acquire_value = wait_value;
+            Ok(WriteAcquired {
+                timeline,
+                wait_value,
+                image,
+                from,
+                info: self.make_image_info(&state.texture),
+            })
+        })
     }
 
     /// Wait + transition + commit-layout for a successful read acquire.
@@ -335,7 +320,7 @@ impl VulkanSurfaceAdapter {
             .is_err()
         {
             // Roll back: the acquire had bumped read_holders; undo it.
-            self.rollback_read(surface_id);
+            self.surfaces.rollback_read(surface_id);
             return Err(AdapterError::SyncTimeout {
                 duration: self.acquire_timeout,
             });
@@ -343,13 +328,12 @@ impl VulkanSurfaceAdapter {
 
         let to = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
         if let Err(err) = self.transition_layout_sync(acquired.image, acquired.from.vk(), to) {
-            self.rollback_read(surface_id);
+            self.surfaces.rollback_read(surface_id);
             return Err(err);
         }
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
+        self.surfaces.with_mut(surface_id, |state| {
             state.current_layout = VulkanLayout(to.as_raw());
-        }
+        });
         Ok(to)
     }
 
@@ -363,7 +347,7 @@ impl VulkanSurfaceAdapter {
             .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
             .is_err()
         {
-            self.rollback_write(surface_id);
+            self.surfaces.rollback_write(surface_id);
             return Err(AdapterError::SyncTimeout {
                 duration: self.acquire_timeout,
             });
@@ -375,28 +359,13 @@ impl VulkanSurfaceAdapter {
         // destination; GENERAL is the right shape for the v1 adapter.
         let to = vk::ImageLayout::GENERAL;
         if let Err(err) = self.transition_layout_sync(acquired.image, acquired.from.vk(), to) {
-            self.rollback_write(surface_id);
+            self.surfaces.rollback_write(surface_id);
             return Err(err);
         }
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
+        self.surfaces.with_mut(surface_id, |state| {
             state.current_layout = VulkanLayout(to.as_raw());
-        }
+        });
         Ok(to)
-    }
-
-    fn rollback_read(&self, surface_id: SurfaceId) {
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
-            state.read_holders = state.read_holders.saturating_sub(1);
-        }
-    }
-
-    fn rollback_write(&self, surface_id: SurfaceId) {
-        let mut map = self.surfaces.lock();
-        if let Some(state) = map.get_mut(&surface_id) {
-            state.write_held = false;
-        }
     }
 }
 
@@ -458,16 +427,9 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
         let acquired = match self.try_begin_write(surface)? {
             Some(a) => a,
             None => {
-                let map = self.surfaces.lock();
-                let holder = match map.get(&surface.id) {
-                    Some(s) if s.write_held => "writer".to_string(),
-                    Some(s) => format!("{} reader(s)", s.read_holders),
-                    None => "unknown".to_string(),
-                };
-                drop(map);
                 return Err(AdapterError::WriteContended {
                     surface_id: surface.id,
-                    holder,
+                    holder: self.surfaces.describe_contention(surface.id),
                 });
             }
         };
@@ -533,52 +495,52 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
     }
 
     fn end_read_access(&self, surface_id: SurfaceId) {
-        let (timeline, value) = {
-            let mut map = self.surfaces.lock();
-            let state = match map.get_mut(&surface_id) {
-                Some(s) => s,
-                None => {
-                    tracing::warn!(
-                        ?surface_id,
-                        "end_read_access on unknown surface — racing unregister"
-                    );
-                    return;
-                }
-            };
+        // Inner Option: `None` means "not the last reader, skip signal".
+        // Outer Option: `None` means "surface raced an unregister".
+        let signal = self.surfaces.with_mut(surface_id, |state| {
             debug_assert!(state.read_holders > 0, "read release without acquire");
-            state.read_holders = state.read_holders.saturating_sub(1);
-            // Only the last reader advances the timeline — concurrent
-            // reads share a single release boundary.
+            state.dec_read_holders();
             if state.read_holders > 0 {
-                return;
+                return None;
             }
             let next = state.next_release_value();
             state.current_release_value = next;
-            (Arc::clone(&state.timeline), next)
+            Some((Arc::clone(&state.timeline), next))
+        });
+        let signal = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_read_access on unknown surface — racing unregister"
+                );
+                return;
+            }
         };
-        if let Err(e) = timeline.signal_host(value) {
-            tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+        if let Some((timeline, value)) = signal {
+            if let Err(e) = timeline.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+            }
         }
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
-        let (timeline, value) = {
-            let mut map = self.surfaces.lock();
-            let state = match map.get_mut(&surface_id) {
-                Some(s) => s,
-                None => {
-                    tracing::warn!(
-                        ?surface_id,
-                        "end_write_access on unknown surface — racing unregister"
-                    );
-                    return;
-                }
-            };
+        let signal = self.surfaces.with_mut(surface_id, |state| {
             debug_assert!(state.write_held, "write release without acquire");
-            state.write_held = false;
+            state.set_write_held(false);
             let next = state.next_release_value();
             state.current_release_value = next;
             (Arc::clone(&state.timeline), next)
+        });
+        let (timeline, value) = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_write_access on unknown surface — racing unregister"
+                );
+                return;
+            }
         };
         if let Err(e) = timeline.signal_host(value) {
             tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");

--- a/libs/streamlib-adapter-vulkan/src/state.rs
+++ b/libs/streamlib-adapter-vulkan/src/state.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use streamlib::adapter_support::VulkanTimelineSemaphore;
 use streamlib::core::rhi::StreamTexture;
-use streamlib_adapter_abi::SurfaceId;
+use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 use vulkanalia::vk;
 
 /// `VkImageLayout` enumerant. Stored as `i32` per the Vulkan spec.
@@ -82,5 +82,23 @@ pub(crate) struct SurfaceState {
 impl SurfaceState {
     pub(crate) fn next_release_value(&self) -> u64 {
         self.current_release_value + 1
+    }
+}
+
+impl SurfaceRegistration for SurfaceState {
+    fn write_held(&self) -> bool {
+        self.write_held
+    }
+    fn read_holders(&self) -> u64 {
+        self.read_holders
+    }
+    fn set_write_held(&mut self, held: bool) {
+        self.write_held = held;
+    }
+    fn inc_read_holders(&mut self) {
+        self.read_holders += 1;
+    }
+    fn dec_read_holders(&mut self) {
+        self.read_holders = self.read_holders.saturating_sub(1);
     }
 }


### PR DESCRIPTION
## Summary

- New `SurfaceRegistration` trait + `Registry<T>` struct in `streamlib-adapter-abi` centralize the read/write contention-counter + `Mutex<HashMap<SurfaceId, T>>` ownership pattern that was duplicated across `streamlib-adapter-{vulkan,opengl,cpu-readback}`.
- All three host adapter crates migrate to `Registry<SurfaceState>`; per-adapter `state.rs` types impl `SurfaceRegistration`. Every `surfaces.lock()` call site moves into Registry helpers (`register` / `unregister` / `with` / `with_mut` / `drain` / `try_begin_*` / `rollback_*` / `describe_contention` / `len` / `is_empty`).
- Pure refactor — no behavior change at any adapter call site.

## Closes

Closes #551

## Exit criteria

- [x] New trait `SurfaceRegistration` and struct `Registry<T: SurfaceRegistration>` in `streamlib-adapter-abi` with `try_begin_read` / `try_begin_write` helpers and decrement helpers (`rollback_read` / `rollback_write`) for guard-drop paths.
- [x] Vulkan, OpenGL, and CPU-readback adapter crates migrated to consume `Registry<T>` — their per-framework `SurfaceState` types impl `SurfaceRegistration`.
- [x] Lines of duplicated registry-lock code drop to zero in the per-adapter crates. cpu-readback's `try_begin(write: bool)` is split into `try_begin_read_inner` / `try_begin_write_inner` callers of the trait helpers via a shared `snapshot_for_acquire` builder.

## Design notes

- `Registry::try_begin_*` runs a per-adapter snapshot closure (`&mut T`) under the same lock as the contention check, so framework-specific state extraction is atomic with the counter mutation. `Ok(None)` means contended; `Err` from the closure does NOT increment counters.
- Single coarse `Mutex` covering all surfaces — matches the pre-extraction shape; refining lock granularity stays a future option if real contention surfaces.
- OpenGL `register_host_surface` builds the EGLImage + GL texture without holding the registry lock (previously held both EGL and registry locks together); the duplicate-id race is handled by tearing down the just-built EGLImage / texture before returning the error.
- cpu-readback `register_host_surface` builds the per-plane staging `VulkanPixelBuffer`s before `Registry::register` — a duplicate-id race wastes one allocation cycle, but duplicate-id is a programming error, not a hot path.

## Test plan

### Adapter test suites — all green

`cargo test -p streamlib-adapter-abi -p streamlib-adapter-vulkan -p streamlib-adapter-opengl -p streamlib-adapter-cpu-readback`

- `streamlib-adapter-abi` registry unit tests: 15 / 15 passed (read+read concurrent, read↔write blocking, write+write blocking, rollback decrement + saturation, snapshot-error rollback, contention description, register-rejects-duplicate, drain-empties).
- `streamlib-adapter-vulkan` conformance + sync correctness + write-excludes-read suites: all green.
- `streamlib-adapter-opengl` conformance + FBO completeness + round-trip + sample-from-surface suites: all green.
- `streamlib-adapter-cpu-readback` conformance + round-trip-read + round-trip-write + stride-offset-handling + multi-plane-round-trip + try-acquire-contention + cpu-readable-plane-aware + queue-isolation suites: all green.

### Workspace test baseline

`cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream --no-fail-fast`

- **passed=1077 failed=1 ignored=26**
- The single failure is `linux::surface_share::unix_socket_service::tests::oversize_fd_vec_rejected` — **pre-existing on `main`**, verified by stashing this PR's changes and re-running. Unrelated to adapter-abi or the host adapter crates touched here. Not addressing in this PR; should be a separate ticket.

### Pre-PR review

`pr-review-gate` returned **PASS** with non-blocking DISCUSS notes. Addressed in a follow-up commit on this branch: dead `parking_lot = "0.12"` deps in vulkan + cpu-readback adapter Cargo.tomls (the only Mutex now lives behind Registry; OpenGL keeps the dep for `EglRuntime`).

## Follow-ups

- The `AdapterError::SurfaceNotFound` variant is currently overloaded to also signal "id already registered" (preserved verbatim from pre-refactor behavior). A dedicated `AdapterError::SurfaceAlreadyRegistered` variant would read better — out of scope here, file when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)