### PR TITLE
refactor(consumer-rhi): Phase 1 — foundation for streamlib-consumer-rhi capability boundary

### DIFF
--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -42,7 +42,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
@@ -263,7 +263,7 @@ fn register_host_surface(
         TextureFormat::Bgra8Unorm,
     )?;
     let timeline = Arc::new(
-        VulkanTimelineSemaphore::new(adapter.device().device(), 0).map_err(|e| {
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).map_err(|e| {
             StreamError::Configuration(format!("create timeline semaphore: {e}"))
         })?,
     );

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use streamlib::adapter_support::VulkanDevice;
+use streamlib::adapter_support::HostVulkanDevice;
 use streamlib::core::rhi::TextureFormat;
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
@@ -103,14 +103,14 @@ fn main() -> Result<()> {
     let runtime = StreamRuntime::new()?;
 
     // Slots the setup hook populates with the host StreamTexture and
-    // the underlying VulkanDevice so main.rs can read the surface back
+    // the underlying HostVulkanDevice so main.rs can read the surface back
     // post-stop and write the output PNG. We can't keep the
     // `&GpuContext` borrow past the hook, so we Arc-clone the bits we
     // need.
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
-    let device_slot: Arc<Mutex<Option<Arc<VulkanDevice>>>> =
+    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
         Arc::new(Mutex::new(None));
 
     {
@@ -284,7 +284,7 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
 /// + queue wait — the canonical Vulkan readback shape, parallel to the
 /// `host_readback` helper in `streamlib-adapter-opengl/tests/common.rs`.
 fn vulkan_readback(
-    device: &Arc<VulkanDevice>,
+    device: &Arc<HostVulkanDevice>,
     texture: &streamlib::core::rhi::StreamTexture,
 ) -> Vec<u8> {
     use vulkanalia::prelude::v1_4::*;

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -5,7 +5,7 @@
 //!
 //! End-to-end gate for the subprocess `VulkanContext` runtime: the host
 //! pre-allocates ONE render-target-capable DMA-BUF surface AND an
-//! exportable `VulkanTimelineSemaphore`, registers both with surface-share
+//! exportable `HostVulkanTimelineSemaphore`, registers both with surface-share
 //! under a known UUID. A Python or Deno polyglot processor opens the
 //! surface through `VulkanContext.acquire_write` (which imports the
 //! DMA-BUF as a `VkImage` in the subprocess and imports the timeline via
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use streamlib::adapter_support::{VulkanDevice, VulkanTimelineSemaphore};
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::core::rhi::TextureFormat;
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
@@ -116,9 +116,9 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
-    let device_slot: Arc<Mutex<Option<Arc<VulkanDevice>>>> =
+    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
         Arc::new(Mutex::new(None));
-    let timeline_slot: Arc<Mutex<Option<Arc<VulkanTimelineSemaphore>>>> =
+    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
 
     {
@@ -137,10 +137,10 @@ fn main() -> Result<()> {
             // subprocess release; the subprocess waits on it before
             // every acquire.
             let timeline = Arc::new(
-                VulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                     .map_err(|e| {
                         StreamError::Configuration(format!(
-                            "VulkanTimelineSemaphore::new_exportable: {e}"
+                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
                         ))
                     })?,
             );
@@ -307,7 +307,7 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
 /// `examples/polyglot-opengl-fragment-shader` — transient HOST_VISIBLE
 /// staging buffer + `vkCmdCopyImageToBuffer` + `queue_wait_idle`.
 fn vulkan_readback(
-    device: &Arc<VulkanDevice>,
+    device: &Arc<HostVulkanDevice>,
     texture: &streamlib::core::rhi::StreamTexture,
 ) -> Vec<u8> {
     use vulkanalia::prelude::v1_4::*;

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -30,7 +30,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use streamlib::adapter_support::{VulkanDevice, VulkanPixelBuffer, VulkanTimelineSemaphore};
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore};
 use streamlib::core::rhi::PixelFormat;
 use streamlib_adapter_abi::{
     AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId,
@@ -58,7 +58,7 @@ const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
 /// adapter's slot from being torn down underneath an in-flight bridge
 /// call.
 pub struct CpuReadbackStagingPlane {
-    pub staging: Arc<VulkanPixelBuffer>,
+    pub staging: Arc<HostVulkanPixelBuffer>,
     pub width: u32,
     pub height: u32,
     pub bytes_per_pixel: u32,
@@ -75,23 +75,23 @@ pub struct CpuReadbackSurfaceSnapshot {
 
 /// Explicit GPU→CPU [`SurfaceAdapter`] implementation.
 ///
-/// Construct with [`Self::new`] passing the host's [`VulkanDevice`].
+/// Construct with [`Self::new`] passing the host's [`HostVulkanDevice`].
 /// Register host-allocated surfaces with [`Self::register_host_surface`];
-/// each registration allocates one dedicated [`VulkanPixelBuffer`] per
+/// each registration allocates one dedicated [`HostVulkanPixelBuffer`] per
 /// plane (HOST_VISIBLE/HOST_COHERENT linear buffer, sized exactly to the
 /// plane's pixel footprint) used as the staging area for image↔buffer
 /// copies. Consumers acquire scoped access through the standard
 /// [`SurfaceAdapter::acquire_read`] / [`SurfaceAdapter::acquire_write`]
 /// API or via the [`crate::CpuReadbackContext`] convenience.
 pub struct CpuReadbackSurfaceAdapter {
-    device: Arc<VulkanDevice>,
+    device: Arc<HostVulkanDevice>,
     surfaces: Registry<SurfaceState>,
     acquire_timeout: Duration,
 }
 
 impl CpuReadbackSurfaceAdapter {
     /// Construct an empty adapter bound to `device`.
-    pub fn new(device: Arc<VulkanDevice>) -> Self {
+    pub fn new(device: Arc<HostVulkanDevice>) -> Self {
         Self {
             device,
             surfaces: Registry::new(),
@@ -109,13 +109,13 @@ impl CpuReadbackSurfaceAdapter {
     }
 
     /// Returns the underlying device.
-    pub fn device(&self) -> &Arc<VulkanDevice> {
+    pub fn device(&self) -> &Arc<HostVulkanDevice> {
         &self.device
     }
 
     /// Register a host-allocated surface with this adapter.
     ///
-    /// Allocates one dedicated `VulkanPixelBuffer` per plane (HOST_VISIBLE,
+    /// Allocates one dedicated `HostVulkanPixelBuffer` per plane (HOST_VISIBLE,
     /// HOST_COHERENT, linear). Plane geometry is derived from
     /// [`HostSurfaceRegistration::format`] via [`SurfaceFormat::plane_count`]
     /// and [`SurfaceFormat::plane_byte_size`].
@@ -155,16 +155,16 @@ impl CpuReadbackSurfaceAdapter {
             // of identical dimensions — wrong shape for an adapter that
             // needs one buffer per registered surface plane.
             //
-            // The `PixelFormat` argument to `VulkanPixelBuffer::new` is
+            // The `PixelFormat` argument to `HostVulkanPixelBuffer::new` is
             // opaque metadata only — `bytes_per_pixel` drives the
             // allocation size. We pass `Bgra32` uniformly so the
             // staging buffer's recorded format isn't claiming a specific
             // pixel layout (Y/UV/RGB) the adapter never interprets.
             let staging = Arc::new(
-                VulkanPixelBuffer::new(&self.device, pw, ph, pbpp, PixelFormat::Bgra32).map_err(
+                HostVulkanPixelBuffer::new(&self.device, pw, ph, pbpp, PixelFormat::Bgra32).map_err(
                     |e| AdapterError::IpcDisconnected {
                         reason: format!(
-                            "VulkanPixelBuffer::new for cpu-readback staging plane {plane_idx}: {e}"
+                            "HostVulkanPixelBuffer::new for cpu-readback staging plane {plane_idx}: {e}"
                         ),
                     },
                 )?,
@@ -192,7 +192,7 @@ impl CpuReadbackSurfaceAdapter {
         };
         if !self.surfaces.register(id, state) {
             // Local `state` (and its `planes` Vec) drops here, releasing
-            // the staging `VulkanPixelBuffer`s we just allocated. Return
+            // the staging `HostVulkanPixelBuffer`s we just allocated. Return
             // SurfaceNotFound to match the pre-Registry semantics —
             // callers reading that error treat it as "id collision".
             return Err(AdapterError::SurfaceNotFound { surface_id: id });
@@ -716,7 +716,7 @@ struct PlaneAcquireSlot {
 /// copy can run unlocked. `read_holders` / `write_held` are already
 /// incremented; rollback paths decrement them on failure.
 struct AcquireSnapshot {
-    timeline: Arc<VulkanTimelineSemaphore>,
+    timeline: Arc<HostVulkanTimelineSemaphore>,
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,

--- a/libs/streamlib-adapter-cpu-readback/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/lib.rs
@@ -11,7 +11,7 @@
 //! deliberately do not implement these — that asymmetry is the
 //! architectural enforcement of "switch adapter to opt into CPU".
 //!
-//! Implementation rides on one [`streamlib::adapter_support::VulkanPixelBuffer`]
+//! Implementation rides on one [`streamlib::adapter_support::HostVulkanPixelBuffer`]
 //! (a HOST_VISIBLE, HOST_COHERENT linear `VkBuffer`) **per plane**.
 //! Single-plane formats (BGRA8/RGBA8) allocate one staging buffer;
 //! multi-plane formats (NV12) allocate one per logical plane (Y + UV).

--- a/libs/streamlib-adapter-cpu-readback/src/state.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/state.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::{VulkanPixelBuffer, VulkanTimelineSemaphore};
+use streamlib::adapter_support::{HostVulkanPixelBuffer, HostVulkanTimelineSemaphore};
 use streamlib::core::rhi::StreamTexture;
 use streamlib_adapter_abi::{SurfaceFormat, SurfaceId, SurfaceRegistration};
 use vulkanalia::vk;
@@ -31,13 +31,13 @@ impl VulkanLayout {
 ///
 /// The host allocates the texture (typically via
 /// `GpuContext::acquire_render_target_dma_buf_image`) and an exportable
-/// timeline semaphore (via `VulkanTimelineSemaphore::new_exportable`),
+/// timeline semaphore (via `HostVulkanTimelineSemaphore::new_exportable`),
 /// then registers them here. The adapter takes joint ownership and
 /// allocates one dedicated linear staging buffer per plane sized to the
 /// plane's pixel footprint.
 pub struct HostSurfaceRegistration {
     pub texture: StreamTexture,
-    pub timeline: Arc<VulkanTimelineSemaphore>,
+    pub timeline: Arc<HostVulkanTimelineSemaphore>,
     /// Initial layout the host left the image in after allocation.
     /// For freshly-allocated images this is typically
     /// `vk::ImageLayout::UNDEFINED` (raw value 0).
@@ -47,12 +47,12 @@ pub struct HostSurfaceRegistration {
     pub format: SurfaceFormat,
 }
 
-/// Per-plane staging slot. One [`VulkanPixelBuffer`] per plane, with the
+/// Per-plane staging slot. One [`HostVulkanPixelBuffer`] per plane, with the
 /// plane's tightly-packed `(width, height, bytes_per_pixel)` geometry
 /// recorded so the copy paths and the customer-facing view can compute
 /// strides without re-deriving from `format` on every access.
 pub(crate) struct PlaneSlot {
-    pub(crate) staging: Arc<VulkanPixelBuffer>,
+    pub(crate) staging: Arc<HostVulkanPixelBuffer>,
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) bytes_per_pixel: u32,
@@ -67,7 +67,7 @@ impl PlaneSlot {
 /// Per-surface state held inside the adapter's
 /// `Mutex<HashMap<SurfaceId, _>>`.
 ///
-/// Each entry owns one dedicated `VulkanPixelBuffer` per plane (a
+/// Each entry owns one dedicated `HostVulkanPixelBuffer` per plane (a
 /// HOST_VISIBLE/HOST_COHERENT linear `VkBuffer`) sized once at
 /// registration. The staging buffers are reused on every acquire — per-
 /// acquire allocation would be far too expensive on the hot path, and
@@ -77,7 +77,7 @@ pub(crate) struct SurfaceState {
     pub(crate) surface_id: SurfaceId,
     pub(crate) texture: StreamTexture,
     pub(crate) planes: Vec<PlaneSlot>,
-    pub(crate) timeline: Arc<VulkanTimelineSemaphore>,
+    pub(crate) timeline: Arc<HostVulkanTimelineSemaphore>,
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -10,7 +10,7 @@
 
 use std::sync::{Arc, OnceLock};
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::error::StreamError;
 use streamlib::core::rhi::TextureFormat;
@@ -116,7 +116,7 @@ impl HostFixture {
             .gpu
             .acquire_render_target_dma_buf_image(width, height, texture_format)?;
         let timeline = Arc::new(
-            VulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
+            HostVulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
                 .map_err(|e| StreamError::GpuError(format!("create timeline: {e}")))?,
         );
         self.adapter

--- a/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
@@ -45,7 +45,7 @@ fn register_one(
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let timeline = Arc::new(
-        VulkanTimelineSemaphore::new(adapter.device().device(), 0)
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
             .expect("create timeline"),
     );
     adapter

--- a/libs/streamlib-adapter-cpu-readback/tests/multi_plane_round_trip.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/multi_plane_round_trip.rs
@@ -8,7 +8,7 @@
 //! pattern in the same plane. Validates:
 //!
 //!  - Per-plane staging allocation (Y plane and UV plane each get their
-//!    own `VulkanPixelBuffer`).
+//!    own `HostVulkanPixelBuffer`).
 //!  - Per-plane `vkCmdCopyImageToBuffer` regions with the right
 //!    `VK_IMAGE_ASPECT_PLANE_{0,1}_BIT` aspect — wrong aspect or wrong
 //!    extent would scramble the read-back.

--- a/libs/streamlib-adapter-cpu-readback/tests/queue_isolation.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/queue_isolation.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use streamlib::adapter_support::VulkanDevice;
+use streamlib::adapter_support::HostVulkanDevice;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
@@ -47,7 +47,7 @@ use crate::common::HostFixture;
 /// with a per-call fence and wait for it. Used by the worker thread to
 /// keep the queue busy with unrelated submits while the main thread is
 /// running cpu-readback acquires.
-fn submit_noop_and_wait(device: &VulkanDevice) -> Result<(), String> {
+fn submit_noop_and_wait(device: &HostVulkanDevice) -> Result<(), String> {
     let raw = device.device();
     let queue = device.queue();
     let qf = device.queue_family_index();
@@ -120,7 +120,7 @@ fn acquire_release_cycles_robust_under_concurrent_queue_submits() {
 
     // Worker thread: keep the queue busy with unrelated noop submits
     // until the main thread tells it to stop. Each iteration goes
-    // through `VulkanDevice::submit_to_queue`, the same per-queue-
+    // through `HostVulkanDevice::submit_to_queue`, the same per-queue-
     // mutex-protected entrypoint the cpu-readback adapter uses, so we
     // exercise the same submission path under contention.
     let stop = Arc::new(AtomicBool::new(false));

--- a/libs/streamlib-adapter-opengl/src/state.rs
+++ b/libs/streamlib-adapter-opengl/src/state.rs
@@ -15,7 +15,7 @@ type EglImage = egl::Image;
 /// [`crate::OpenGlSurfaceAdapter::register_host_surface`].
 ///
 /// `dma_buf_fd` is the FD exported from a host-allocated `VkImage`
-/// (via `streamlib`'s `VulkanTexture::export_dma_buf_fd`). The adapter
+/// (via `streamlib`'s `HostVulkanTexture::export_dma_buf_fd`). The adapter
 /// dups it during EGL import; the caller may close their copy after
 /// `register_host_surface` returns.
 ///

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -120,12 +120,17 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         self.surfaces.len()
     }
 
-    fn make_image_info(&self, image: vk::Image) -> VkImageInfo {
+    fn make_image_info(
+        &self,
+        texture: &<D::Privilege as DevicePrivilege>::Texture,
+    ) -> VkImageInfo {
         // Best-effort image info — fields the adapter doesn't track
         // (memory binding, ycbcr conversion) stay zeroed. Skia and other
         // VkImageInfoExt consumers can extend this once the adapter
-        // tracks more per-surface state.
-        let _ = image; // future-proof: consumers will read this once filled
+        // tracks more per-surface state. `memory_size` is a tight-pixel
+        // estimate (no tile padding), matching the pre-genericization
+        // behavior so debug snapshots / sizing heuristics stay stable.
+        let bytes_per_pixel = texture.format().bytes_per_pixel() as u64;
         VkImageInfo {
             format: 0,
             tiling: vk::ImageTiling::OPTIMAL.as_raw(),
@@ -135,7 +140,9 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             queue_family: self.device.queue_family_index(),
             memory_handle: 0,
             memory_offset: 0,
-            memory_size: 0,
+            memory_size: (texture.width() as u64)
+                * (texture.height() as u64)
+                * bytes_per_pixel,
             memory_property_flags: 0,
             protected: 0,
             ycbcr_conversion: 0,
@@ -276,12 +283,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
             state.last_acquire_value = wait_value;
+            let info = self.make_image_info(&state.texture);
             Ok(ReadAcquired {
                 timeline,
                 wait_value,
                 image,
                 from,
-                info: self.make_image_info(image),
+                info,
             })
         })
     }
@@ -300,12 +308,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
             state.last_acquire_value = wait_value;
+            let info = self.make_image_info(&state.texture);
             Ok(WriteAcquired {
                 timeline,
                 wait_value,
                 image,
                 from,
-                info: self.make_image_info(image),
+                info,
             })
         })
     }

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -1,12 +1,20 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `VulkanSurfaceAdapter` — host-side `SurfaceAdapter` implementation
-//! that hands a host-allocated `VkImage` to consumers as a Vulkan-typed
-//! [`crate::VulkanReadView`] / [`crate::VulkanWriteView`].
+//! `VulkanSurfaceAdapter<D>` — Vulkan-typed `SurfaceAdapter`.
+//!
+//! Generic over the device flavor: `D = HostVulkanDevice` for host-side
+//! adapter use (allocate + register), `D = ConsumerVulkanDevice` for
+//! cdylib subprocess use (import + register). The four trait methods on
+//! `VulkanRhiDevice` (`device()`, `queue()`, `queue_family_index()`,
+//! `submit_to_queue()`) are everything the adapter needs from the
+//! device; the timeline semaphore type is picked up via
+//! `D::Privilege::TimelineSemaphore` and abstracted behind
+//! `VulkanTimelineSemaphoreLike` so the same wait + signal calls work
+//! against either flavor.
 //!
 //! The adapter:
-//! - Owns a registry of host-registered surfaces keyed by [`SurfaceId`].
+//! - Owns a registry of registered surfaces keyed by [`SurfaceId`].
 //! - Waits on the timeline semaphore at the start of every acquire so
 //!   prior GPU work has drained.
 //! - Issues a layout transition into the consumer's expected layout
@@ -19,8 +27,9 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTimelineSemaphore};
-use streamlib::core::rhi::StreamTexture;
+use streamlib::adapter_support::{
+    DevicePrivilege, VulkanRhiDevice, VulkanTextureLike, VulkanTimelineSemaphoreLike,
+};
 use streamlib_adapter_abi::{
     AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceId,
     SurfaceRegistration, VkImageInfo, WriteGuard,
@@ -36,24 +45,20 @@ use crate::view::{VulkanReadView, VulkanWriteView};
 /// an `AdapterError::SyncTimeout` rather than wedging the consumer.
 const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
 
-/// Vulkan-native [`SurfaceAdapter`] implementation.
-///
-/// Construct with [`Self::new`] passing the host's [`HostVulkanDevice`].
-/// Register host-allocated surfaces with [`Self::register_host_surface`];
-/// consumers acquire scoped access through the standard
-/// [`SurfaceAdapter::acquire_read`] / [`SurfaceAdapter::acquire_write`]
-/// API or via the [`crate::VulkanContext`] convenience.
-pub struct VulkanSurfaceAdapter {
-    device: Arc<HostVulkanDevice>,
-    surfaces: Registry<SurfaceState>,
+/// Vulkan-native [`SurfaceAdapter`] implementation. Generic over the
+/// device flavor — instantiate as `VulkanSurfaceAdapter<HostVulkanDevice>`
+/// host-side or `VulkanSurfaceAdapter<ConsumerVulkanDevice>` cdylib-side.
+pub struct VulkanSurfaceAdapter<D: VulkanRhiDevice> {
+    device: Arc<D>,
+    surfaces: Registry<SurfaceState<D::Privilege>>,
     /// Per-acquire timeline wait timeout. Adjustable via
     /// [`Self::with_acquire_timeout`].
     acquire_timeout: Duration,
 }
 
-impl VulkanSurfaceAdapter {
+impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
     /// Construct an empty adapter bound to `device`.
-    pub fn new(device: Arc<HostVulkanDevice>) -> Self {
+    pub fn new(device: Arc<D>) -> Self {
         Self {
             device,
             surfaces: Registry::new(),
@@ -69,11 +74,11 @@ impl VulkanSurfaceAdapter {
 
     /// Returns the underlying device for callers (test harnesses, the
     /// `VulkanContext`, raw-handle escape hatches) that need it.
-    pub fn device(&self) -> &Arc<HostVulkanDevice> {
+    pub fn device(&self) -> &Arc<D> {
         &self.device
     }
 
-    /// Register a host-allocated surface with this adapter.
+    /// Register an allocated (or imported) surface with this adapter.
     ///
     /// `id` is assigned by the host (typically from the surface-share
     /// service); it MUST be unique across the adapter's lifetime.
@@ -81,7 +86,7 @@ impl VulkanSurfaceAdapter {
     pub fn register_host_surface(
         &self,
         id: SurfaceId,
-        registration: HostSurfaceRegistration,
+        registration: HostSurfaceRegistration<D::Privilege>,
     ) -> Result<(), AdapterError> {
         let inserted = self.surfaces.register(
             id,
@@ -103,7 +108,7 @@ impl VulkanSurfaceAdapter {
     }
 
     /// Drop a registered surface. Pending guards keep the underlying
-    /// `Arc<HostVulkanTimelineSemaphore>` alive; the next acquire returns
+    /// `Arc<TimelineSemaphore>` alive; the next acquire returns
     /// [`AdapterError::SurfaceNotFound`].
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
         self.surfaces.unregister(id).is_some()
@@ -115,11 +120,12 @@ impl VulkanSurfaceAdapter {
         self.surfaces.len()
     }
 
-    fn make_image_info(&self, texture: &StreamTexture) -> VkImageInfo {
+    fn make_image_info(&self, image: vk::Image) -> VkImageInfo {
         // Best-effort image info — fields the adapter doesn't track
         // (memory binding, ycbcr conversion) stay zeroed. Skia and other
-        // VkImageInfoExt consumers can extend this once
-        // HostVulkanTexture exposes more accessors.
+        // VkImageInfoExt consumers can extend this once the adapter
+        // tracks more per-surface state.
+        let _ = image; // future-proof: consumers will read this once filled
         VkImageInfo {
             format: 0,
             tiling: vk::ImageTiling::OPTIMAL.as_raw(),
@@ -129,9 +135,7 @@ impl VulkanSurfaceAdapter {
             queue_family: self.device.queue_family_index(),
             memory_handle: 0,
             memory_offset: 0,
-            memory_size: ((texture.width() as u64)
-                * (texture.height() as u64)
-                * (texture.format().bytes_per_pixel() as u64)),
+            memory_size: 0,
             memory_property_flags: 0,
             protected: 0,
             ycbcr_conversion: 0,
@@ -261,14 +265,13 @@ impl VulkanSurfaceAdapter {
     fn try_begin_read(
         &self,
         surface: &StreamlibSurface,
-    ) -> Result<Option<ReadAcquired>, AdapterError> {
+    ) -> Result<Option<ReadAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_read(id, |state| {
             let timeline = Arc::clone(&state.timeline);
             let wait_value = state.current_release_value;
             let image = state
                 .texture
-                .vulkan_inner()
                 .image()
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
@@ -278,7 +281,7 @@ impl VulkanSurfaceAdapter {
                 wait_value,
                 image,
                 from,
-                info: self.make_image_info(&state.texture),
+                info: self.make_image_info(image),
             })
         })
     }
@@ -286,14 +289,13 @@ impl VulkanSurfaceAdapter {
     fn try_begin_write(
         &self,
         surface: &StreamlibSurface,
-    ) -> Result<Option<WriteAcquired>, AdapterError> {
+    ) -> Result<Option<WriteAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
         self.surfaces.try_begin_write(id, |state| {
             let timeline = Arc::clone(&state.timeline);
             let wait_value = state.current_release_value;
             let image = state
                 .texture
-                .vulkan_inner()
                 .image()
                 .ok_or(AdapterError::SurfaceNotFound { surface_id: id })?;
             let from = state.current_layout;
@@ -303,7 +305,7 @@ impl VulkanSurfaceAdapter {
                 wait_value,
                 image,
                 from,
-                info: self.make_image_info(&state.texture),
+                info: self.make_image_info(image),
             })
         })
     }
@@ -312,7 +314,7 @@ impl VulkanSurfaceAdapter {
     fn finalize_read(
         &self,
         surface_id: SurfaceId,
-        acquired: ReadAcquired,
+        acquired: ReadAcquired<D::Privilege>,
     ) -> Result<vk::ImageLayout, AdapterError> {
         if acquired
             .timeline
@@ -340,7 +342,7 @@ impl VulkanSurfaceAdapter {
     fn finalize_write(
         &self,
         surface_id: SurfaceId,
-        acquired: WriteAcquired,
+        acquired: WriteAcquired<D::Privilege>,
     ) -> Result<vk::ImageLayout, AdapterError> {
         if acquired
             .timeline
@@ -372,23 +374,23 @@ impl VulkanSurfaceAdapter {
 /// Snapshot taken under the registry lock so the timeline wait + layout
 /// transition can run unlocked. `read_holders` / `write_held` are
 /// already incremented; rollback paths decrement them on failure.
-struct ReadAcquired {
-    timeline: Arc<HostVulkanTimelineSemaphore>,
+struct ReadAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,
     info: VkImageInfo,
 }
 
-struct WriteAcquired {
-    timeline: Arc<HostVulkanTimelineSemaphore>,
+struct WriteAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,
     info: VkImageInfo,
 }
 
-impl SurfaceAdapter for VulkanSurfaceAdapter {
+impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
     type ReadView<'g> = VulkanReadView<'g>;
     type WriteView<'g> = VulkanWriteView<'g>;
 
@@ -497,16 +499,17 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
     fn end_read_access(&self, surface_id: SurfaceId) {
         // Inner Option: `None` means "not the last reader, skip signal".
         // Outer Option: `None` means "surface raced an unregister".
-        let signal = self.surfaces.with_mut(surface_id, |state| {
-            debug_assert!(state.read_holders > 0, "read release without acquire");
-            state.dec_read_holders();
-            if state.read_holders > 0 {
-                return None;
-            }
-            let next = state.next_release_value();
-            state.current_release_value = next;
-            Some((Arc::clone(&state.timeline), next))
-        });
+        let signal: Option<Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)>> =
+            self.surfaces.with_mut(surface_id, |state| {
+                debug_assert!(state.read_holders > 0, "read release without acquire");
+                state.dec_read_holders();
+                if state.read_holders > 0 {
+                    return None;
+                }
+                let next = state.next_release_value();
+                state.current_release_value = next;
+                Some((Arc::clone(&state.timeline), next))
+            });
         let signal = match signal {
             Some(s) => s,
             None => {
@@ -525,13 +528,14 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
     }
 
     fn end_write_access(&self, surface_id: SurfaceId) {
-        let signal = self.surfaces.with_mut(surface_id, |state| {
-            debug_assert!(state.write_held, "write release without acquire");
-            state.set_write_held(false);
-            let next = state.next_release_value();
-            state.current_release_value = next;
-            (Arc::clone(&state.timeline), next)
-        });
+        let signal: Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)> =
+            self.surfaces.with_mut(surface_id, |state| {
+                debug_assert!(state.write_held, "write release without acquire");
+                state.set_write_held(false);
+                let next = state.next_release_value();
+                state.current_release_value = next;
+                (Arc::clone(&state.timeline), next)
+            });
         let (timeline, value) = match signal {
             Some(s) => s,
             None => {
@@ -547,3 +551,4 @@ impl SurfaceAdapter for VulkanSurfaceAdapter {
         }
     }
 }
+

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use streamlib::adapter_support::{VulkanDevice, VulkanTimelineSemaphore};
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::core::rhi::StreamTexture;
 use streamlib_adapter_abi::{
     AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceId,
@@ -38,13 +38,13 @@ const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
 
 /// Vulkan-native [`SurfaceAdapter`] implementation.
 ///
-/// Construct with [`Self::new`] passing the host's [`VulkanDevice`].
+/// Construct with [`Self::new`] passing the host's [`HostVulkanDevice`].
 /// Register host-allocated surfaces with [`Self::register_host_surface`];
 /// consumers acquire scoped access through the standard
 /// [`SurfaceAdapter::acquire_read`] / [`SurfaceAdapter::acquire_write`]
 /// API or via the [`crate::VulkanContext`] convenience.
 pub struct VulkanSurfaceAdapter {
-    device: Arc<VulkanDevice>,
+    device: Arc<HostVulkanDevice>,
     surfaces: Registry<SurfaceState>,
     /// Per-acquire timeline wait timeout. Adjustable via
     /// [`Self::with_acquire_timeout`].
@@ -53,7 +53,7 @@ pub struct VulkanSurfaceAdapter {
 
 impl VulkanSurfaceAdapter {
     /// Construct an empty adapter bound to `device`.
-    pub fn new(device: Arc<VulkanDevice>) -> Self {
+    pub fn new(device: Arc<HostVulkanDevice>) -> Self {
         Self {
             device,
             surfaces: Registry::new(),
@@ -69,7 +69,7 @@ impl VulkanSurfaceAdapter {
 
     /// Returns the underlying device for callers (test harnesses, the
     /// `VulkanContext`, raw-handle escape hatches) that need it.
-    pub fn device(&self) -> &Arc<VulkanDevice> {
+    pub fn device(&self) -> &Arc<HostVulkanDevice> {
         &self.device
     }
 
@@ -103,7 +103,7 @@ impl VulkanSurfaceAdapter {
     }
 
     /// Drop a registered surface. Pending guards keep the underlying
-    /// `Arc<VulkanTimelineSemaphore>` alive; the next acquire returns
+    /// `Arc<HostVulkanTimelineSemaphore>` alive; the next acquire returns
     /// [`AdapterError::SurfaceNotFound`].
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
         self.surfaces.unregister(id).is_some()
@@ -119,7 +119,7 @@ impl VulkanSurfaceAdapter {
         // Best-effort image info — fields the adapter doesn't track
         // (memory binding, ycbcr conversion) stay zeroed. Skia and other
         // VkImageInfoExt consumers can extend this once
-        // VulkanTexture exposes more accessors.
+        // HostVulkanTexture exposes more accessors.
         VkImageInfo {
             format: 0,
             tiling: vk::ImageTiling::OPTIMAL.as_raw(),
@@ -373,7 +373,7 @@ impl VulkanSurfaceAdapter {
 /// transition can run unlocked. `read_holders` / `write_held` are
 /// already incremented; rollback paths decrement them on failure.
 struct ReadAcquired {
-    timeline: Arc<VulkanTimelineSemaphore>,
+    timeline: Arc<HostVulkanTimelineSemaphore>,
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,
@@ -381,7 +381,7 @@ struct ReadAcquired {
 }
 
 struct WriteAcquired {
-    timeline: Arc<VulkanTimelineSemaphore>,
+    timeline: Arc<HostVulkanTimelineSemaphore>,
     wait_value: u64,
     image: vk::Image,
     from: VulkanLayout,

--- a/libs/streamlib-adapter-vulkan/src/context.rs
+++ b/libs/streamlib-adapter-vulkan/src/context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `VulkanContext` — the customer-facing one-stop API.
+//! `VulkanContext<D>` — the customer-facing one-stop API.
 //!
 //! Customers call:
 //!
@@ -13,16 +13,15 @@
 //! }
 //! ```
 //!
-//! The context is a thin convenience over [`crate::VulkanSurfaceAdapter`];
-//! every operation maps to a [`streamlib_adapter_abi::SurfaceAdapter`]
-//! method. Provided here so the customer-facing API matches the
-//! parallel polyglot wrappers (`streamlib.vulkan.context()` in Python,
-//! `streamlib.vulkan.context()` in Deno) and so adapter authors have a
-//! single import path: `streamlib_adapter_vulkan::{VulkanContext,
-//! raw_handles}`.
+//! The context is a thin convenience over
+//! [`crate::VulkanSurfaceAdapter`]; every operation maps to a
+//! [`streamlib_adapter_abi::SurfaceAdapter`] method. Generic over the
+//! device flavor `D: VulkanRhiDevice` so it works against either
+//! `HostVulkanDevice` (host-side) or `ConsumerVulkanDevice` (cdylib).
 
 use std::sync::Arc;
 
+use streamlib::adapter_support::VulkanRhiDevice;
 use streamlib_adapter_abi::{
     AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, WriteGuard,
 };
@@ -30,33 +29,40 @@ use streamlib_adapter_abi::{
 use crate::adapter::VulkanSurfaceAdapter;
 use crate::raw_handles::{raw_handles, RawVulkanHandles};
 
-/// Customer-facing handle bound to a single host runtime.
+/// Customer-facing handle bound to a single runtime, generic over the
+/// device flavor.
 ///
 /// Holds a shared reference to a [`VulkanSurfaceAdapter`] (typically
 /// stored on the runtime itself); cheap to clone. Customers obtain one
 /// via the runtime; tests construct one directly.
-#[derive(Clone)]
-pub struct VulkanContext {
-    adapter: Arc<VulkanSurfaceAdapter>,
+pub struct VulkanContext<D: VulkanRhiDevice + 'static> {
+    adapter: Arc<VulkanSurfaceAdapter<D>>,
 }
 
-impl VulkanContext {
-    pub fn new(adapter: Arc<VulkanSurfaceAdapter>) -> Self {
+impl<D: VulkanRhiDevice + 'static> Clone for VulkanContext<D> {
+    fn clone(&self) -> Self {
+        Self {
+            adapter: Arc::clone(&self.adapter),
+        }
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> VulkanContext<D> {
+    pub fn new(adapter: Arc<VulkanSurfaceAdapter<D>>) -> Self {
         Self { adapter }
     }
 
-    pub fn adapter(&self) -> &Arc<VulkanSurfaceAdapter> {
+    pub fn adapter(&self) -> &Arc<VulkanSurfaceAdapter<D>> {
         &self.adapter
     }
 
-    /// Blocking read acquire. The guard's
-    /// [`streamlib_adapter_abi::WriteGuard::view`] / `view_mut` returns a
-    /// [`crate::VulkanReadView`] exposing the host's `VkImage` and the
-    /// layout the adapter transitioned it to.
+    /// Blocking read acquire. The guard's view returns a
+    /// [`crate::VulkanReadView`] exposing the `VkImage` and the layout
+    /// the adapter transitioned it to.
     pub fn acquire_read<'a>(
         &'a self,
         surface: &StreamlibSurface,
-    ) -> Result<ReadGuard<'a, VulkanSurfaceAdapter>, AdapterError> {
+    ) -> Result<ReadGuard<'a, VulkanSurfaceAdapter<D>>, AdapterError> {
         self.adapter.acquire_read(surface)
     }
 
@@ -64,7 +70,7 @@ impl VulkanContext {
     pub fn acquire_write<'a>(
         &'a self,
         surface: &StreamlibSurface,
-    ) -> Result<WriteGuard<'a, VulkanSurfaceAdapter>, AdapterError> {
+    ) -> Result<WriteGuard<'a, VulkanSurfaceAdapter<D>>, AdapterError> {
         self.adapter.acquire_write(surface)
     }
 
@@ -72,7 +78,7 @@ impl VulkanContext {
     pub fn try_acquire_read<'a>(
         &'a self,
         surface: &StreamlibSurface,
-    ) -> Result<Option<ReadGuard<'a, VulkanSurfaceAdapter>>, AdapterError> {
+    ) -> Result<Option<ReadGuard<'a, VulkanSurfaceAdapter<D>>>, AdapterError> {
         self.adapter.try_acquire_read(surface)
     }
 
@@ -80,12 +86,20 @@ impl VulkanContext {
     pub fn try_acquire_write<'a>(
         &'a self,
         surface: &StreamlibSurface,
-    ) -> Result<Option<WriteGuard<'a, VulkanSurfaceAdapter>>, AdapterError> {
+    ) -> Result<Option<WriteGuard<'a, VulkanSurfaceAdapter<D>>>, AdapterError> {
         self.adapter.try_acquire_write(surface)
     }
+}
 
-    /// Power-user surface — raw Vulkan handles (`VkInstance`, `VkDevice`,
-    /// `VkQueue`, …). The customer assumes responsibility for queue
+/// Host-only convenience: raw Vulkan handles
+/// (`VkInstance`, `VkDevice`, `VkQueue`, …) for power-user code that
+/// needs to drive the GPU directly. Available only on the host
+/// (`D = HostVulkanDevice`) since `RawVulkanHandles` is a host-shaped
+/// concept (full RHI surface). Consumer-side callers go through the
+/// adapter API.
+#[cfg(target_os = "linux")]
+impl VulkanContext<streamlib::adapter_support::HostVulkanDevice> {
+    /// Power-user surface — raw Vulkan handles. Caller assumes queue
     /// mutex discipline and lifetime; the adapter does not track work
     /// they submit through this path.
     pub fn raw_handles(&self) -> RawVulkanHandles {

--- a/libs/streamlib-adapter-vulkan/src/raw_handles.rs
+++ b/libs/streamlib-adapter-vulkan/src/raw_handles.rs
@@ -9,7 +9,7 @@
 //! resistance and handles sync + layout transitions; this is the "you
 //! own the footguns from here" surface.
 
-use streamlib::adapter_support::VulkanDevice;
+use streamlib::adapter_support::HostVulkanDevice;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
@@ -41,13 +41,13 @@ pub struct RawVulkanHandles {
     pub api_version: u32,
 }
 
-/// Snapshot the underlying `VulkanDevice`'s raw handles.
+/// Snapshot the underlying `HostVulkanDevice`'s raw handles.
 ///
 /// The handles are valid for the lifetime of the device; the customer
 /// MUST NOT outlive the runtime that owns it. There is intentionally
 /// no destructor or refcount handed back — this is the documented
 /// power-user surface that says *"you own the consequences"*.
-pub fn raw_handles(device: &VulkanDevice) -> RawVulkanHandles {
+pub fn raw_handles(device: &HostVulkanDevice) -> RawVulkanHandles {
     RawVulkanHandles {
         vk_instance: device.instance().handle().as_raw() as u64,
         vk_physical_device: device.physical_device().as_raw() as u64,

--- a/libs/streamlib-adapter-vulkan/src/state.rs
+++ b/libs/streamlib-adapter-vulkan/src/state.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::rhi::StreamTexture;
 use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 use vulkanalia::vk;
@@ -43,11 +43,11 @@ impl VulkanLayout {
 /// The host is responsible for allocating the texture (via
 /// `GpuContext::acquire_render_target_dma_buf_image` or equivalent) and
 /// creating an exportable timeline semaphore (via
-/// [`VulkanTimelineSemaphore::new_exportable`]). The adapter then takes
+/// [`HostVulkanTimelineSemaphore::new_exportable`]). The adapter then takes
 /// joint ownership and exposes scoped acquire/release for consumers.
 pub struct HostSurfaceRegistration {
     pub texture: StreamTexture,
-    pub timeline: Arc<VulkanTimelineSemaphore>,
+    pub timeline: Arc<HostVulkanTimelineSemaphore>,
     /// Initial layout the host left the image in after allocation. The
     /// first `acquire_*` will transition from here. For freshly-allocated
     /// images this is typically [`VulkanLayout::UNDEFINED`].
@@ -65,7 +65,7 @@ pub(crate) struct SurfaceState {
     #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
     pub(crate) surface_id: SurfaceId,
     pub(crate) texture: StreamTexture,
-    pub(crate) timeline: Arc<VulkanTimelineSemaphore>,
+    pub(crate) timeline: Arc<HostVulkanTimelineSemaphore>,
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,

--- a/libs/streamlib-adapter-vulkan/src/state.rs
+++ b/libs/streamlib-adapter-vulkan/src/state.rs
@@ -1,15 +1,18 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Per-surface adapter state. The adapter holds a registry of these
-//! keyed by [`streamlib_adapter_abi::SurfaceId`]; each entry tracks the
-//! host-allocated texture, the timeline semaphore the host advances on
-//! release, and the layout the next acquire transitions through.
+//! Per-surface adapter state.
+//!
+//! `VulkanSurfaceAdapter<D>` is generic over the device flavor — it
+//! works against either `HostVulkanDevice` (host-side allocate +
+//! register) or `ConsumerVulkanDevice` (consumer-side import +
+//! register). The structs in this module carry the privilege parameter
+//! through so the texture and timeline-semaphore types resolve to the
+//! matching flavor (`Host*` or `Consumer*`) at instantiation.
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::HostVulkanTimelineSemaphore;
-use streamlib::core::rhi::StreamTexture;
+use streamlib::adapter_support::DevicePrivilege;
 use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 use vulkanalia::vk;
 
@@ -38,34 +41,41 @@ impl VulkanLayout {
     }
 }
 
-/// Inputs the host hands to [`crate::VulkanSurfaceAdapter::register_host_surface`].
+/// Inputs handed to [`crate::VulkanSurfaceAdapter::register_host_surface`].
 ///
-/// The host is responsible for allocating the texture (via
-/// `GpuContext::acquire_render_target_dma_buf_image` or equivalent) and
-/// creating an exportable timeline semaphore (via
-/// [`HostVulkanTimelineSemaphore::new_exportable`]). The adapter then takes
-/// joint ownership and exposes scoped acquire/release for consumers.
-pub struct HostSurfaceRegistration {
-    pub texture: StreamTexture,
-    pub timeline: Arc<HostVulkanTimelineSemaphore>,
-    /// Initial layout the host left the image in after allocation. The
-    /// first `acquire_*` will transition from here. For freshly-allocated
+/// On the host side `texture` is a fresh
+/// `Arc<HostVulkanTexture>` from `HostVulkanTexture::new_render_target_dma_buf`.
+/// On the consumer side it's an `Arc<ConsumerVulkanTexture>` from
+/// `ConsumerVulkanTexture::import_render_target_dma_buf`. The adapter
+/// reads the `vk::Image` via the `VulkanTextureLike` trait — both
+/// flavors implement it — and holds the Arc as long as the surface is
+/// registered, so the underlying GPU memory stays alive.
+pub struct HostSurfaceRegistration<P: DevicePrivilege> {
+    /// Texture wrapper — host- or consumer-flavored per `P`.
+    pub texture: Arc<P::Texture>,
+    /// Timeline semaphore — host- or consumer-flavored per `P`. Both
+    /// flavors implement
+    /// [`streamlib::adapter_support::VulkanTimelineSemaphoreLike`] so
+    /// the adapter's wait + signal calls work uniformly.
+    pub timeline: Arc<P::TimelineSemaphore>,
+    /// Initial layout the texture is in at registration time. The first
+    /// `acquire_*` will transition from here. For freshly-allocated
     /// images this is typically [`VulkanLayout::UNDEFINED`].
     pub initial_layout: VulkanLayout,
 }
 
-/// Per-surface state held inside the adapter's `Mutex<HashMap<SurfaceId, _>>`.
+/// Per-surface state held inside the adapter's `Registry<...>`.
 ///
-/// All mutation goes through the adapter's lock so `acquire_*` /
-/// `end_*_access` stay sequenced — the trait's `&self` shape is satisfied
-/// by interior mutability. Counters are sized to whatever the underlying
-/// Vulkan timeline semaphore supports (u64); WriteContended is a fast
-/// pre-check before the timeline wait.
-pub(crate) struct SurfaceState {
+/// All mutation goes through the registry's locking so `acquire_*` /
+/// `end_*_access` stay sequenced — the trait's `&self` shape is
+/// satisfied by interior mutability. Counters are sized to whatever
+/// the underlying Vulkan timeline semaphore supports (u64);
+/// `WriteContended` is a fast pre-check before the timeline wait.
+pub(crate) struct SurfaceState<P: DevicePrivilege> {
     #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
     pub(crate) surface_id: SurfaceId,
-    pub(crate) texture: StreamTexture,
-    pub(crate) timeline: Arc<HostVulkanTimelineSemaphore>,
+    pub(crate) texture: Arc<P::Texture>,
+    pub(crate) timeline: Arc<P::TimelineSemaphore>,
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,
@@ -79,13 +89,13 @@ pub(crate) struct SurfaceState {
     pub(crate) current_release_value: u64,
 }
 
-impl SurfaceState {
+impl<P: DevicePrivilege> SurfaceState<P> {
     pub(crate) fn next_release_value(&self) -> u64 {
         self.current_release_value + 1
     }
 }
 
-impl SurfaceRegistration for SurfaceState {
+impl<P: DevicePrivilege> SurfaceRegistration for SurfaceState<P> {
     fn write_held(&self) -> bool {
         self.write_held
     }

--- a/libs/streamlib-adapter-vulkan/tests/bin/vulkan_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-vulkan/tests/bin/vulkan_adapter_subprocess_helper.rs
@@ -29,7 +29,7 @@ use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 use std::sync::Arc;
 
-use streamlib::adapter_support::{VulkanDevice, VulkanTexture, VulkanTimelineSemaphore};
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore};
 use streamlib::core::rhi::TextureFormat;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
@@ -126,13 +126,13 @@ fn run() -> ExitCode {
 
     // Build our own VkDevice. The parent has no GPU work in flight when
     // it spawns us, so the dual-VkDevice crash on NVIDIA does not apply.
-    let device = match VulkanDevice::new() {
+    let device = match HostVulkanDevice::new() {
         Ok(d) => Arc::new(d),
-        Err(e) => return die(Some(&socket), format!("VulkanDevice::new: {e}")),
+        Err(e) => return die(Some(&socket), format!("HostVulkanDevice::new: {e}")),
     };
 
     // Import VkImage with the host-chosen DRM modifier.
-    let texture = match VulkanTexture::import_render_target_dma_buf(
+    let texture = match HostVulkanTexture::import_render_target_dma_buf(
         &device,
         &dma_buf_fds,
         &req.plane_offsets,
@@ -149,7 +149,7 @@ fn run() -> ExitCode {
 
     // Import the timeline semaphore. Vulkan takes ownership of `sync_fd`
     // on success; we close every other fd.
-    let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+    let timeline = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
         device.device(),
         sync_fd,
     ) {
@@ -164,7 +164,7 @@ fn run() -> ExitCode {
 
     // dma_buf_fds were dup'd by the kernel during SCM_RIGHTS; the
     // VkImage import does NOT take ownership in our import path (the
-    // memory_fd helper inside VulkanDevice dups internally). Close our
+    // memory_fd helper inside HostVulkanDevice dups internally). Close our
     // copies — without this they leak across the helper's lifetime.
     for f in &dma_buf_fds {
         unsafe { libc::close(*f) };
@@ -246,7 +246,7 @@ fn run() -> ExitCode {
 
 /// Subprocess `vkCmdClearColorImage` — equivalent to a plain GPU write.
 fn subprocess_clear_image(
-    device: &Arc<VulkanDevice>,
+    device: &Arc<HostVulkanDevice>,
     image: vk::Image,
     color: [f32; 4],
 ) -> streamlib::core::Result<()> {
@@ -351,7 +351,7 @@ fn subprocess_clear_image(
 /// Subprocess readback — `vkCmdCopyImageToBuffer` into a staging buffer,
 /// then map and read.
 fn subprocess_readback_image(
-    device: &Arc<VulkanDevice>,
+    device: &Arc<HostVulkanDevice>,
     image: vk::Image,
     width: u32,
     height: u32,

--- a/libs/streamlib-adapter-vulkan/tests/common.rs
+++ b/libs/streamlib-adapter-vulkan/tests/common.rs
@@ -12,7 +12,7 @@ use std::os::unix::net::UnixStream;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::{StreamTexture, TextureFormat};
 use streamlib_adapter_abi::{
@@ -58,7 +58,7 @@ impl HostFixture {
             .acquire_render_target_dma_buf_image(width, height, TextureFormat::Bgra8Unorm)
             .expect("acquire_render_target_dma_buf_image");
         let timeline = Arc::new(
-            VulkanTimelineSemaphore::new_exportable(self.adapter.device().device(), 0)
+            HostVulkanTimelineSemaphore::new_exportable(self.adapter.device().device(), 0)
                 .expect("exportable timeline"),
         );
         self.adapter
@@ -93,7 +93,7 @@ impl HostFixture {
 pub struct RegisteredSurface {
     pub descriptor: StreamlibSurface,
     pub texture: StreamTexture,
-    pub timeline: Arc<VulkanTimelineSemaphore>,
+    pub timeline: Arc<HostVulkanTimelineSemaphore>,
     pub width: u32,
     pub height: u32,
 }

--- a/libs/streamlib-adapter-vulkan/tests/common.rs
+++ b/libs/streamlib-adapter-vulkan/tests/common.rs
@@ -12,7 +12,7 @@ use std::os::unix::net::UnixStream;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 
-use streamlib::adapter_support::HostVulkanTimelineSemaphore;
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::{StreamTexture, TextureFormat};
 use streamlib_adapter_abi::{
@@ -33,8 +33,8 @@ pub fn try_init_gpu() -> Option<GpuContext> {
 
 pub struct HostFixture {
     pub gpu: GpuContext,
-    pub adapter: Arc<VulkanSurfaceAdapter>,
-    pub ctx: VulkanContext,
+    pub adapter: Arc<VulkanSurfaceAdapter<HostVulkanDevice>>,
+    pub ctx: VulkanContext<HostVulkanDevice>,
 }
 
 impl HostFixture {
@@ -65,7 +65,7 @@ impl HostFixture {
             .register_host_surface(
                 surface_id,
                 HostSurfaceRegistration {
-                    texture: texture.clone(),
+                    texture: texture.vulkan_inner().clone(),
                     timeline: Arc::clone(&timeline),
                     initial_layout: VulkanLayout::UNDEFINED,
                 },

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::HostVulkanTimelineSemaphore;
+use streamlib::adapter_support::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
@@ -35,13 +35,14 @@ fn try_init_gpu() -> Option<GpuContext> {
 }
 
 fn register_one(
-    adapter: &VulkanSurfaceAdapter,
+    adapter: &VulkanSurfaceAdapter<HostVulkanDevice>,
     gpu: &GpuContext,
     id: SurfaceId,
 ) -> StreamlibSurface {
-    let texture = gpu
+    let stream_tex = gpu
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
     let timeline = Arc::new(
         HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
     );
@@ -67,7 +68,7 @@ fn register_one(
 }
 
 struct ConformanceFactory<'a> {
-    adapter: &'a VulkanSurfaceAdapter,
+    adapter: &'a VulkanSurfaceAdapter<HostVulkanDevice>,
     gpu: &'a GpuContext,
 }
 

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
@@ -43,7 +43,7 @@ fn register_one(
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let timeline = Arc::new(
-        VulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
     );
     adapter
         .register_host_surface(

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
@@ -99,7 +99,7 @@ fn host_writes_subprocess_reads_round_trip() {
 }
 
 fn host_clear_image(
-    device: &Arc<streamlib::adapter_support::VulkanDevice>,
+    device: &Arc<streamlib::adapter_support::HostVulkanDevice>,
     image: vk::Image,
     color: [f32; 4],
 ) {

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
@@ -83,7 +83,7 @@ fn subprocess_writes_host_reads_round_trip() {
 }
 
 fn host_readback(
-    device: &Arc<streamlib::adapter_support::VulkanDevice>,
+    device: &Arc<streamlib::adapter_support::HostVulkanDevice>,
     image: vk::Image,
     width: u32,
     height: u32,

--- a/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
+++ b/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
@@ -45,9 +45,10 @@ fn timeline_counter_advances_on_release_and_is_observable_by_next_acquire() {
     let ctx = VulkanContext::new(Arc::clone(&adapter));
 
     let surface_id: SurfaceId = 1;
-    let texture = gpu
+    let stream_tex = gpu
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
     let timeline = Arc::new(
         HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
             .expect("create timeline"),

--- a/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
+++ b/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::{
@@ -49,7 +49,7 @@ fn timeline_counter_advances_on_release_and_is_observable_by_next_acquire() {
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let timeline = Arc::new(
-        VulkanTimelineSemaphore::new(adapter.device().device(), 0)
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0)
             .expect("create timeline"),
     );
     adapter

--- a/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
+++ b/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
@@ -49,9 +49,10 @@ fn live_write_guard_blocks_acquire_read_until_dropped() {
     let ctx = VulkanContext::new(Arc::clone(&adapter));
 
     let surface_id: SurfaceId = 7;
-    let texture = gpu
+    let stream_tex = gpu
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
     let timeline = Arc::new(
         HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
     );

--- a/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
+++ b/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use streamlib::adapter_support::VulkanTimelineSemaphore;
+use streamlib::adapter_support::HostVulkanTimelineSemaphore;
 use streamlib::core::context::GpuContext;
 use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::{
@@ -53,7 +53,7 @@ fn live_write_guard_blocks_acquire_read_until_dropped() {
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
         .expect("acquire_render_target_dma_buf_image");
     let timeline = Arc::new(
-        VulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
     );
     adapter
         .register_host_surface(

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -932,7 +932,7 @@ mod gpu_surface {
     //!
     //! CPU access on lock goes through a Vulkan DMA-BUF import
     //! (`VkImportMemoryFdInfoKHR` + `vkBindBufferMemory` + `vkMapMemory`) —
-    //! same shape as the host's `VulkanPixelBuffer::from_dma_buf_fd` so both
+    //! same shape as the host's `HostVulkanPixelBuffer::from_dma_buf_fd` so both
     //! ends speak the canonical driver-supported path. The import-side only —
     //! allocation always escalates to the host per the research doc.
     use std::os::unix::io::RawFd;
@@ -956,7 +956,7 @@ mod gpu_surface {
         pub fds: Vec<RawFd>,
         /// Optional OPAQUE_FD timeline-semaphore handle the host attached
         /// when registering the surface (#531). Routed into the Vulkan
-        /// adapter's `VulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// adapter's `HostVulkanTimelineSemaphore::from_imported_opaque_fd` so
         /// the subprocess reuses the host adapter's timeline-wait + signal
         /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
         /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
@@ -3056,7 +3056,7 @@ mod opengl {
 //
 // Subprocess-side runtime mirroring the Python-native twin's `slpn_vulkan_*`
 // surface. Reuses `streamlib_adapter_vulkan::VulkanSurfaceAdapter` against a
-// subprocess-local `VulkanDevice` from the RHI: same timeline-wait, same
+// subprocess-local `HostVulkanDevice` from the RHI: same timeline-wait, same
 // layout-transition, same per-surface state machine. The cdylib never
 // re-implements layout transitions, command-pool lifetimes, fence handling,
 // or queue-mutex coordination — every line of that lives in
@@ -3070,7 +3070,7 @@ mod vulkan {
     use std::sync::{Arc, Mutex};
 
     use streamlib::adapter_support::{
-        VulkanDevice, VulkanTexture, VulkanTimelineSemaphore,
+        HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
     };
     use streamlib::core::rhi::TextureFormat;
     use streamlib_adapter_abi::{
@@ -3085,13 +3085,13 @@ mod vulkan {
     use super::gpu_surface::SurfaceHandle;
 
     pub struct VulkanRuntimeHandle {
-        device: Arc<VulkanDevice>,
+        device: Arc<HostVulkanDevice>,
         adapter: Arc<VulkanSurfaceAdapter>,
         registered: Mutex<HashMap<u64, RegisteredSurface>>,
     }
 
     /// See the Python-native twin for the rationale: only `vk::Image` is
-    /// cached because `VulkanTexture::clone` is a hollow no-image stub —
+    /// cached because `HostVulkanTexture::clone` is a hollow no-image stub —
     /// the texture itself is moved into `HostSurfaceRegistration` and
     /// the adapter owns its lifetime.
     struct RegisteredSurface {
@@ -3116,11 +3116,11 @@ mod vulkan {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
                 tracing::error!(
-                    "sldn_vulkan_runtime_new: VulkanDevice::new failed: {}",
+                    "sldn_vulkan_runtime_new: HostVulkanDevice::new failed: {}",
                     e
                 );
                 return std::ptr::null_mut();
@@ -3198,7 +3198,7 @@ mod vulkan {
         };
         let allocation_size = gpu.size;
 
-        let texture = match VulkanTexture::import_render_target_dma_buf(
+        let texture = match HostVulkanTexture::import_render_target_dma_buf(
             &rt.device,
             &gpu.fds,
             &gpu.plane_offsets,
@@ -3219,7 +3219,7 @@ mod vulkan {
             }
         };
         // Snapshot the VkImage handle BEFORE moving texture. See the
-        // Python-native twin for the `VulkanTexture::clone`-is-hollow
+        // Python-native twin for the `HostVulkanTexture::clone`-is-hollow
         // rationale.
         let vk_image = match texture.image() {
             Some(img) => img,
@@ -3237,13 +3237,13 @@ mod vulkan {
                 tracing::error!(
                     "sldn_vulkan_register_surface: surface '{}' has no sync_fd — \
                      the host must register the texture with an exportable \
-                     `VulkanTimelineSemaphore`.",
+                     `HostVulkanTimelineSemaphore`.",
                     surface_id
                 );
                 return -1;
             }
         };
-        let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+        let timeline = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
             rt.device.device(),
             raw_sync_fd,
         ) {
@@ -3535,12 +3535,12 @@ mod vulkan_compute_dispatch {
 
     use std::sync::Arc;
 
-    use streamlib::adapter_support::VulkanDevice;
+    use streamlib::adapter_support::HostVulkanDevice;
     use vulkanalia::prelude::v1_4::*;
     use vulkanalia::vk;
 
     pub fn dispatch_storage_image_compute(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         image: vk::Image,
         spv: &[u8],
         push_constants: &[u8],

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -3070,7 +3070,7 @@ mod vulkan {
     use std::sync::{Arc, Mutex};
 
     use streamlib::adapter_support::{
-        HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
+        HostMarker, HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
     };
     use streamlib::core::rhi::TextureFormat;
     use streamlib_adapter_abi::{
@@ -3086,7 +3086,7 @@ mod vulkan {
 
     pub struct VulkanRuntimeHandle {
         device: Arc<HostVulkanDevice>,
-        adapter: Arc<VulkanSurfaceAdapter>,
+        adapter: Arc<VulkanSurfaceAdapter<HostVulkanDevice>>,
         registered: Mutex<HashMap<u64, RegisteredSurface>>,
     }
 
@@ -3258,8 +3258,8 @@ mod vulkan {
             }
         };
 
-        let registration = HostSurfaceRegistration {
-            texture: streamlib::core::rhi::StreamTexture::from_vulkan(texture),
+        let registration = HostSurfaceRegistration::<HostMarker> {
+            texture: Arc::new(texture),
             timeline,
             initial_layout: VulkanLayout::UNDEFINED,
         };

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -953,7 +953,7 @@ mod gpu_surface {
     //!
     //! CPU access on lock goes through a Vulkan DMA-BUF import
     //! (`VkImportMemoryFdInfoKHR` + `vkBindBufferMemory` + `vkMapMemory`) —
-    //! same shape as the host's `VulkanPixelBuffer::from_dma_buf_fd` so both
+    //! same shape as the host's `HostVulkanPixelBuffer::from_dma_buf_fd` so both
     //! ends speak the canonical driver-supported path. The import-side only —
     //! allocation always escalates to the host per the research doc.
     use std::ffi::c_void;
@@ -978,7 +978,7 @@ mod gpu_surface {
         pub fds: Vec<RawFd>,
         /// Optional OPAQUE_FD timeline-semaphore handle the host attached
         /// when registering the surface (#531). Routed into the Vulkan
-        /// adapter's `VulkanTimelineSemaphore::from_imported_opaque_fd` so
+        /// adapter's `HostVulkanTimelineSemaphore::from_imported_opaque_fd` so
         /// the subprocess reuses the host adapter's timeline-wait + signal
         /// path. `None` for surfaces without explicit Vulkan sync (OpenGL
         /// adapter, CPU-readback, legacy DMA-BUF consumer flows). The fd is
@@ -2140,7 +2140,7 @@ mod surface_share_vulkan_linux {
 
         /// Import a DMA-BUF fd as a `HOST_VISIBLE | HOST_COHERENT` buffer,
         /// persistently mapped. Mirrors the host's
-        /// `VulkanPixelBuffer::from_dma_buf_fd` shape.
+        /// `HostVulkanPixelBuffer::from_dma_buf_fd` shape.
         ///
         /// On success, Vulkan takes ownership of `fd` — the caller must
         /// **not** `close(fd)`. On error, the caller retains ownership.
@@ -3298,7 +3298,7 @@ mod opengl {
 //
 // Subprocess-side runtime for the Vulkan-native surface adapter. Reuses the
 // host adapter crate's `VulkanSurfaceAdapter` against a subprocess-local
-// `VulkanDevice` from the RHI: same timeline-wait, same layout-transition,
+// `HostVulkanDevice` from the RHI: same timeline-wait, same layout-transition,
 // same per-surface state machine. The cdylib never re-implements layout
 // transitions, command-pool lifetimes, fence handling, or queue-mutex
 // coordination — every line of that lives in `streamlib-adapter-vulkan`.
@@ -3317,7 +3317,7 @@ mod vulkan {
     use std::sync::{Arc, Mutex};
 
     use streamlib::adapter_support::{
-        VulkanDevice, VulkanTexture, VulkanTimelineSemaphore,
+        HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
     };
     use streamlib::core::rhi::TextureFormat;
     use streamlib_adapter_abi::{
@@ -3334,7 +3334,7 @@ mod vulkan {
     /// Process-scoped Vulkan adapter runtime. One `VkDevice` + one
     /// `VulkanSurfaceAdapter` per subprocess; held for the cdylib's life.
     pub struct VulkanRuntimeHandle {
-        device: Arc<VulkanDevice>,
+        device: Arc<HostVulkanDevice>,
         adapter: Arc<VulkanSurfaceAdapter>,
         /// Per-surface book-keeping. The actual texture + timeline are
         /// owned by the adapter (transferred into `HostSurfaceRegistration`);
@@ -3346,7 +3346,7 @@ mod vulkan {
 
     struct RegisteredSurface {
         /// Cached `vk::Image` handle. The adapter owns the underlying
-        /// `VulkanTexture` (and therefore the `VkImage` lifetime); we
+        /// `HostVulkanTexture` (and therefore the `VkImage` lifetime); we
         /// just snapshot the handle for fast lookup. Valid until
         /// `unregister_host_surface` drops the adapter's record.
         vk_image: vk::Image,
@@ -3375,16 +3375,16 @@ mod vulkan {
         pub api_version: u32,
     }
 
-    /// Bring up `VulkanDevice` + `VulkanSurfaceAdapter`. Returns NULL on
+    /// Bring up `HostVulkanDevice` + `VulkanSurfaceAdapter`. Returns NULL on
     /// failure (typically because the driver doesn't support the required
     /// DMA-BUF / external-semaphore extensions).
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
                 tracing::error!(
-                    "slpn_vulkan_runtime_new: VulkanDevice::new failed: {}",
+                    "slpn_vulkan_runtime_new: HostVulkanDevice::new failed: {}",
                     e
                 );
                 return std::ptr::null_mut();
@@ -3480,7 +3480,7 @@ mod vulkan {
         // `import_render_target_dma_buf` `dup`s every FD internally — the
         // SurfaceHandle keeps its originals so callers can re-import for
         // a second adapter (e.g. CPU-readback alongside Vulkan).
-        let texture = match VulkanTexture::import_render_target_dma_buf(
+        let texture = match HostVulkanTexture::import_render_target_dma_buf(
             &rt.device,
             &gpu.fds,
             &gpu.plane_offsets,
@@ -3501,7 +3501,7 @@ mod vulkan {
             }
         };
         // Snapshot the `vk::Image` handle BEFORE transferring `texture`
-        // into the registration. `VulkanTexture::clone` is a hollow
+        // into the registration. `HostVulkanTexture::clone` is a hollow
         // metadata-only clone (`image: None`) by design, so we cannot
         // duplicate the texture itself; only the underlying VkImage
         // handle survives across the move.
@@ -3523,14 +3523,14 @@ mod vulkan {
                 tracing::error!(
                     "slpn_vulkan_register_surface: surface '{}' has no sync_fd — \
                      the host must register the texture with an exportable \
-                     `VulkanTimelineSemaphore` (see SurfaceStore::register_texture's \
+                     `HostVulkanTimelineSemaphore` (see SurfaceStore::register_texture's \
                      `timeline` argument).",
                     surface_id
                 );
                 return -1;
             }
         };
-        let timeline = match VulkanTimelineSemaphore::from_imported_opaque_fd(
+        let timeline = match HostVulkanTimelineSemaphore::from_imported_opaque_fd(
             rt.device.device(),
             raw_sync_fd,
         ) {
@@ -3887,12 +3887,12 @@ mod vulkan_compute_dispatch {
 
     use std::sync::Arc;
 
-    use streamlib::adapter_support::VulkanDevice;
+    use streamlib::adapter_support::HostVulkanDevice;
     use vulkanalia::prelude::v1_4::*;
     use vulkanalia::vk;
 
     pub fn dispatch_storage_image_compute(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         image: vk::Image,
         spv: &[u8],
         push_constants: &[u8],

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -3317,7 +3317,7 @@ mod vulkan {
     use std::sync::{Arc, Mutex};
 
     use streamlib::adapter_support::{
-        HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
+        HostMarker, HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
     };
     use streamlib::core::rhi::TextureFormat;
     use streamlib_adapter_abi::{
@@ -3335,7 +3335,7 @@ mod vulkan {
     /// `VulkanSurfaceAdapter` per subprocess; held for the cdylib's life.
     pub struct VulkanRuntimeHandle {
         device: Arc<HostVulkanDevice>,
-        adapter: Arc<VulkanSurfaceAdapter>,
+        adapter: Arc<VulkanSurfaceAdapter<HostVulkanDevice>>,
         /// Per-surface book-keeping. The actual texture + timeline are
         /// owned by the adapter (transferred into `HostSurfaceRegistration`);
         /// we keep only the raw `vk::Image` handle so
@@ -3553,8 +3553,8 @@ mod vulkan {
         // (not `texture.clone()` — Clone is a hollow no-image stub) into
         // the registration so the adapter owns the imported VkImage's
         // lifetime end-to-end.
-        let registration = HostSurfaceRegistration {
-            texture: streamlib::core::rhi::StreamTexture::from_vulkan(texture),
+        let registration = HostSurfaceRegistration::<HostMarker> {
+            texture: Arc::new(texture),
             timeline,
             initial_layout: VulkanLayout::UNDEFINED,
         };

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_response.rs
@@ -86,7 +86,7 @@ pub struct EscalateResponseOk {
     /// target surface (1 for BGRA8/RGBA8, 2 for NV12). Each entry's
     /// `staging_surface_id` can be `check_out`ed from the surface-share
     /// service to obtain a DMA-BUF FD over the host-allocated staging
-    /// `VulkanPixelBuffer` for that plane; mmap that FD to read or write the
+    /// `HostVulkanPixelBuffer` for that plane; mmap that FD to read or write the
     /// plane's tightly-packed bytes (`width * height * bytes_per_pixel` per
     /// plane).
     #[serde(rename = "cpu_readback_planes")]

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -731,7 +731,7 @@ where
     let mut registered_ids: Vec<String> = Vec::with_capacity(acquired.planes.len());
 
     for plane in &acquired.planes {
-        // Wrap the staging VulkanPixelBuffer in an RhiPixelBuffer so
+        // Wrap the staging HostVulkanPixelBuffer in an RhiPixelBuffer so
         // surface-share's check_in (which exports per-plane DMA-BUF FDs)
         // can register it. The Arc keeps the staging buffer alive for
         // the lifetime of the surface-share entry.

--- a/libs/streamlib/src/core/context/cpu_readback_bridge.rs
+++ b/libs/streamlib/src/core/context/cpu_readback_bridge.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use streamlib_adapter_abi::{SurfaceFormat, SurfaceId};
 
-use crate::adapter_support::VulkanPixelBuffer;
+use crate::adapter_support::HostVulkanPixelBuffer;
 
 /// Wire-format access mode mirrored from the escalate schema.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -31,7 +31,7 @@ pub enum CpuReadbackAccessMode {
 /// the surface-share service and surfaces the registered surface IDs to
 /// the subprocess.
 pub struct CpuReadbackPlane {
-    pub staging: Arc<VulkanPixelBuffer>,
+    pub staging: Arc<HostVulkanPixelBuffer>,
     pub width: u32,
     pub height: u32,
     pub bytes_per_pixel: u32,

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -801,9 +801,9 @@ impl GpuContext {
     /// tiled-modifier VMA pool.
     ///
     /// The driver picks one of the EGL-advertised render-target modifiers
-    /// from [`VulkanDevice::drm_modifier_table`]. The resulting
+    /// from [`HostVulkanDevice::drm_modifier_table`]. The resulting
     /// `StreamTexture` carries the chosen modifier on its inner
-    /// [`VulkanTexture`] (see [`VulkanTexture::chosen_drm_format_modifier`]),
+    /// [`HostVulkanTexture`] (see [`HostVulkanTexture::chosen_drm_format_modifier`]),
     /// ready to be carried in a `SurfaceTransportHandle` when the host
     /// surface-share service registers the surface.
     ///
@@ -877,7 +877,7 @@ impl GpuContext {
                 // streamlib runs on.
                 | TextureUsages::STORAGE_BINDING,
         );
-        let texture = crate::vulkan::rhi::VulkanTexture::new_render_target_dma_buf(
+        let texture = crate::vulkan::rhi::HostVulkanTexture::new_render_target_dma_buf(
             vulkan_device,
             &desc,
             &modifiers,

--- a/libs/streamlib/src/core/context/surface_store.rs
+++ b/libs/streamlib/src/core/context/surface_store.rs
@@ -1065,7 +1065,7 @@ impl SurfaceStore {
     /// exported as an OPAQUE_FD and shipped alongside the DMA-BUF FD. The
     /// surface-share service stores the FD; subprocess Vulkan adapters
     /// `check_out` it via [`streamlib_adapter_vulkan::VulkanSurfaceAdapter`]
-    /// and import it through `VulkanTimelineSemaphore::from_imported_opaque_fd`,
+    /// and import it through `HostVulkanTimelineSemaphore::from_imported_opaque_fd`,
     /// reusing the host adapter's timeline-wait + signal path (#531). `None`
     /// for adapters that don't need explicit Vulkan sync (OpenGL — its
     /// `glFinish` + DMA-BUF kernel-fence semantics carry visibility).
@@ -1074,7 +1074,7 @@ impl SurfaceStore {
         &self,
         surface_id: &str,
         texture: &crate::core::rhi::StreamTexture,
-        timeline: Option<&crate::vulkan::rhi::VulkanTimelineSemaphore>,
+        timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) -> Result<()> {
         // Export the DMA-BUF fd from the texture
         let fd = texture.inner.export_dma_buf_fd()?;
@@ -1321,11 +1321,11 @@ impl SurfaceStore {
                 .get()
                 .ok_or_else(|| {
                     StreamError::NotSupported(
-                        "lookup_texture: VulkanDevice not initialized for import".into(),
+                        "lookup_texture: HostVulkanDevice not initialized for import".into(),
                     )
                 })?;
 
-        let vulkan_texture = crate::vulkan::rhi::VulkanTexture::from_dma_buf_fd(
+        let vulkan_texture = crate::vulkan::rhi::HostVulkanTexture::from_dma_buf_fd(
             vulkan_device,
             dma_buf_fd,
             width,

--- a/libs/streamlib/src/core/rhi/device.rs
+++ b/libs/streamlib/src/core/rhi/device.rs
@@ -34,7 +34,7 @@ pub struct GpuDevice {
         feature = "backend-vulkan",
         all(target_os = "linux", not(feature = "backend-metal"))
     ))]
-    pub(crate) inner: std::sync::Arc<crate::vulkan::rhi::VulkanDevice>,
+    pub(crate) inner: std::sync::Arc<crate::vulkan::rhi::HostVulkanDevice>,
 
     #[cfg(target_os = "windows")]
     pub(crate) inner: std::sync::Arc<crate::windows::rhi::DX12Device>,
@@ -50,7 +50,7 @@ pub struct GpuDevice {
 }
 
 impl GpuDevice {
-    /// Adapter-facing: the underlying [`crate::vulkan::rhi::VulkanDevice`].
+    /// Adapter-facing: the underlying [`crate::vulkan::rhi::HostVulkanDevice`].
     ///
     /// Available only on Linux / when the Vulkan backend is selected.
     /// In-tree surface adapters reach for this when they need raw
@@ -61,7 +61,7 @@ impl GpuDevice {
         feature = "backend-vulkan",
         all(target_os = "linux", not(feature = "backend-metal"))
     ))]
-    pub fn vulkan_device(&self) -> &std::sync::Arc<crate::vulkan::rhi::VulkanDevice> {
+    pub fn vulkan_device(&self) -> &std::sync::Arc<crate::vulkan::rhi::HostVulkanDevice> {
         &self.inner
     }
 
@@ -94,7 +94,7 @@ impl GpuDevice {
             all(target_os = "linux", not(feature = "backend-metal"))
         ))]
         {
-            let device_arc = std::sync::Arc::new(crate::vulkan::rhi::VulkanDevice::new()?);
+            let device_arc = std::sync::Arc::new(crate::vulkan::rhi::HostVulkanDevice::new()?);
             let vulkan_queue = device_arc.create_command_queue_wrapper();
 
             // On macOS/iOS with Vulkan backend, also create Metal device/queue for Apple services

--- a/libs/streamlib/src/core/rhi/external_handle.rs
+++ b/libs/streamlib/src/core/rhi/external_handle.rs
@@ -145,7 +145,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
                 .get()
                 .ok_or_else(|| {
                     crate::core::StreamError::NotSupported(
-                        "DMA-BUF import: VulkanDevice not initialized (GpuDevice::new() not called)"
+                        "DMA-BUF import: HostVulkanDevice not initialized (GpuDevice::new() not called)"
                             .into(),
                     )
                 })?;
@@ -181,7 +181,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
         }
 
         let vulkan_pixel_buffer =
-            crate::vulkan::rhi::VulkanPixelBuffer::from_dma_buf_fds(
+            crate::vulkan::rhi::HostVulkanPixelBuffer::from_dma_buf_fds(
                 vulkan_device,
                 &fds,
                 &plane_sizes,

--- a/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib/src/core/rhi/pixel_buffer_ref.rs
@@ -9,7 +9,7 @@ use super::PixelFormat;
 ///
 /// Wraps the platform's native pixel buffer type:
 /// - macOS/iOS: CVPixelBufferRef (raw pointer, platform manages lifecycle)
-/// - Linux: Arc\<VulkanPixelBuffer\> (shared GPU staging buffer, Rust manages lifecycle)
+/// - Linux: Arc\<HostVulkanPixelBuffer\> (shared GPU staging buffer, Rust manages lifecycle)
 /// - Windows: ID3D11Texture2D* (future)
 ///
 /// Clone increments the appropriate refcount, Drop decrements it.
@@ -19,7 +19,7 @@ pub struct RhiPixelBufferRef {
     pub(crate) inner: std::ptr::NonNull<std::ffi::c_void>,
 
     #[cfg(target_os = "linux")]
-    pub(crate) inner: std::sync::Arc<crate::vulkan::rhi::VulkanPixelBuffer>,
+    pub(crate) inner: std::sync::Arc<crate::vulkan::rhi::HostVulkanPixelBuffer>,
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub(crate) _marker: std::marker::PhantomData<()>,
@@ -126,7 +126,7 @@ impl RhiPixelBufferRef {
         self.inner.as_ptr()
     }
 
-    /// Adapter-facing: the underlying [`crate::vulkan::rhi::VulkanPixelBuffer`].
+    /// Adapter-facing: the underlying [`crate::vulkan::rhi::HostVulkanPixelBuffer`].
     ///
     /// In-tree surface adapters (`streamlib-adapter-cpu-readback`, others
     /// that need to issue `vkCmdCopyImageToBuffer` /
@@ -137,7 +137,7 @@ impl RhiPixelBufferRef {
     /// to touch raw Vulkan types are the RHI itself and the in-tree
     /// adapters. Mirror of [`crate::core::rhi::StreamTexture::vulkan_inner`].
     #[cfg(target_os = "linux")]
-    pub fn vulkan_inner(&self) -> &std::sync::Arc<crate::vulkan::rhi::VulkanPixelBuffer> {
+    pub fn vulkan_inner(&self) -> &std::sync::Arc<crate::vulkan::rhi::HostVulkanPixelBuffer> {
         &self.inner
     }
 
@@ -183,7 +183,7 @@ impl Drop for RhiPixelBufferRef {
         {
             crate::metal::rhi::pixel_buffer_ref::drop_impl(self);
         }
-        // On Linux, VulkanPixelBuffer handles its own cleanup via its Drop impl.
+        // On Linux, HostVulkanPixelBuffer handles its own cleanup via its Drop impl.
         // No additional action needed here.
     }
 }

--- a/libs/streamlib/src/core/rhi/texture.rs
+++ b/libs/streamlib/src/core/rhi/texture.rs
@@ -155,7 +155,7 @@ pub struct StreamTexture {
         feature = "backend-vulkan",
         all(target_os = "linux", not(feature = "backend-metal"))
     ))]
-    pub(crate) inner: Arc<crate::vulkan::rhi::VulkanTexture>,
+    pub(crate) inner: Arc<crate::vulkan::rhi::HostVulkanTexture>,
 
     #[cfg(target_os = "windows")]
     pub(crate) inner: Arc<crate::windows::rhi::DX12Texture>,
@@ -284,9 +284,9 @@ impl StreamTexture {
             // When Metal is backend, inner is the MetalTexture
             #[cfg(not(feature = "backend-vulkan"))]
             inner: arc_texture.clone(),
-            // When Vulkan is backend on macOS, inner would be VulkanTexture (not set here)
+            // When Vulkan is backend on macOS, inner would be HostVulkanTexture (not set here)
             #[cfg(feature = "backend-vulkan")]
-            inner: Arc::new(crate::vulkan::rhi::VulkanTexture::placeholder()),
+            inner: Arc::new(crate::vulkan::rhi::HostVulkanTexture::placeholder()),
             metal_texture: Some(arc_texture),
         }
     }
@@ -296,7 +296,7 @@ impl StreamTexture {
         feature = "backend-vulkan",
         all(target_os = "linux", not(feature = "backend-metal"))
     ))]
-    pub fn from_vulkan(texture: crate::vulkan::rhi::VulkanTexture) -> Self {
+    pub fn from_vulkan(texture: crate::vulkan::rhi::HostVulkanTexture) -> Self {
         Self {
             inner: Arc::new(texture),
             #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -304,7 +304,7 @@ impl StreamTexture {
         }
     }
 
-    /// Adapter-facing: the underlying [`crate::vulkan::rhi::VulkanTexture`].
+    /// Adapter-facing: the underlying [`crate::vulkan::rhi::HostVulkanTexture`].
     ///
     /// In-tree surface adapters (`streamlib-adapter-vulkan`,
     /// `-skia`, `-opengl`, `-cpu-readback`) need direct access to the
@@ -316,7 +316,7 @@ impl StreamTexture {
         feature = "backend-vulkan",
         all(target_os = "linux", not(feature = "backend-metal"))
     ))]
-    pub fn vulkan_inner(&self) -> &Arc<crate::vulkan::rhi::VulkanTexture> {
+    pub fn vulkan_inner(&self) -> &Arc<crate::vulkan::rhi::HostVulkanTexture> {
         &self.inner
     }
 }

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -190,7 +190,8 @@ pub mod adapter_support {
         ConsumerMarker, ConsumerVulkanDevice, ConsumerVulkanPixelBuffer,
         ConsumerVulkanTexture, ConsumerVulkanTimelineSemaphore, DevicePrivilege, HostMarker,
         HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTexture,
-        HostVulkanTimelineSemaphore, VulkanRhiDevice,
+        HostVulkanTimelineSemaphore, VulkanRhiDevice, VulkanTextureLike,
+        VulkanTimelineSemaphoreLike,
     };
 }
 

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -171,15 +171,26 @@ pub mod linux_surface_share {
 }
 
 /// RHI types that in-tree surface adapters (`streamlib-adapter-vulkan`,
-/// `-opengl`, `-skia`, `-cpu-readback`) need to reach. NOT a general
-/// public surface — every entry here is load-bearing for the adapter
-/// architecture. The Vulkan boundary rule from `CLAUDE.md` still holds:
-/// nothing outside an adapter or `vulkan/rhi/` may import from this
-/// module.
+/// `-opengl`, `-skia`, `-cpu-readback`) and the polyglot cdylibs need
+/// to reach. NOT a general public surface — every entry here is
+/// load-bearing for the adapter architecture. The Vulkan boundary rule
+/// from `CLAUDE.md` still holds: nothing outside an adapter or
+/// `vulkan/rhi/` may import from this module.
+///
+/// Both the `Host*` and `Consumer*` flavors are surfaced here so
+/// adapter crates can be generic over `D: VulkanRhiDevice`. The
+/// follow-up `streamlib-consumer-rhi` crate will pull the `Consumer*`
+/// half into a dep that cdylibs can take *without* the rest of
+/// `streamlib`, type-system-enforcing the FullAccess capability
+/// boundary; until then this transitional re-export keeps the
+/// workspace compiling.
 #[cfg(target_os = "linux")]
 pub mod adapter_support {
     pub use crate::vulkan::rhi::{
-        VulkanDevice, VulkanPixelBuffer, VulkanTexture, VulkanTimelineSemaphore,
+        ConsumerMarker, ConsumerVulkanDevice, ConsumerVulkanPixelBuffer,
+        ConsumerVulkanTexture, ConsumerVulkanTimelineSemaphore, DevicePrivilege, HostMarker,
+        HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTexture,
+        HostVulkanTimelineSemaphore, VulkanRhiDevice,
     };
 }
 

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -9,7 +9,7 @@ use vma::Alloc as _;
 use crate::core::rhi::{PixelFormat, StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
 use crate::iceoryx2::OutputWriter;
-use crate::vulkan::rhi::VulkanTexture;
+use crate::vulkan::rhi::HostVulkanTexture;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use v4l::buffer::Type;
@@ -780,7 +780,7 @@ fn capture_thread_loop(
     let mut ring_texture_ids: Vec<String> = Vec::with_capacity(RING_TEXTURE_COUNT);
 
     for i in 0..RING_TEXTURE_COUNT {
-        let vk_texture = match VulkanTexture::new(vulkan_device, &ring_texture_desc) {
+        let vk_texture = match HostVulkanTexture::new(vulkan_device, &ring_texture_desc) {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!(
@@ -1719,7 +1719,7 @@ fn capture_thread_loop(
             }
         }
 
-        // Ring textures are owned by StreamTexture (Arc<VulkanTexture>) — they
+        // Ring textures are owned by StreamTexture (Arc<HostVulkanTexture>) — they
         // clean up via Drop when ring_textures goes out of scope. Clear the
         // texture cache references so display doesn't try to use stale textures.
         gpu_context.set_camera_timeline_semaphore(0);

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -243,7 +243,7 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
                     PUBSUB.publish(&shutdown_event.topic(), &shutdown_event);
                 }
 
-                // Camera textures are owned by the texture_cache / VulkanTexture Drop.
+                // Camera textures are owned by the texture_cache / HostVulkanTexture Drop.
 
                 // Clean up swapchain resources before exiting
                 if let Some(state) = app.swapchain_state.take() {
@@ -366,7 +366,7 @@ struct PersistentPipelineState {
 #[allow(dead_code)]
 struct DisplayEventLoopHandler {
     window: Option<Window>,
-    vulkan_device: Arc<crate::vulkan::rhi::VulkanDevice>,
+    vulkan_device: Arc<crate::vulkan::rhi::HostVulkanDevice>,
     gpu_context: GpuContextLimitedAccess,
     inputs: crate::iceoryx2::InputMailboxes,
     running: Arc<AtomicBool>,
@@ -1104,7 +1104,7 @@ fn crc32(kind: &[u8; 4], data: &[u8]) -> u32 {
 // ---------------------------------------------------------------------------
 
 fn create_swapchain_state(
-    vulkan_device: &crate::vulkan::rhi::VulkanDevice,
+    vulkan_device: &crate::vulkan::rhi::HostVulkanDevice,
     window: &Window,
     width: u32,
     height: u32,
@@ -1549,7 +1549,7 @@ fn create_swapchain_state(
 }
 
 fn recreate_swapchain(
-    vulkan_device: &crate::vulkan::rhi::VulkanDevice,
+    vulkan_device: &crate::vulkan::rhi::HostVulkanDevice,
     _window: &Window,
     old_state: &SwapchainState,
     width: u32,
@@ -1732,7 +1732,7 @@ fn recreate_swapchain(
 
 /// Destroy swapchain-related resources only (not the surface or persistent pipeline objects).
 fn destroy_swapchain_resources_only(
-    vulkan_device: &crate::vulkan::rhi::VulkanDevice,
+    vulkan_device: &crate::vulkan::rhi::HostVulkanDevice,
     state: &SwapchainState,
 ) {
     let device = vulkan_device.device();
@@ -1755,7 +1755,7 @@ fn destroy_swapchain_resources_only(
 
 /// Destroy all swapchain state including the surface (but not persistent pipeline objects).
 fn destroy_swapchain_state(
-    vulkan_device: &crate::vulkan::rhi::VulkanDevice,
+    vulkan_device: &crate::vulkan::rhi::HostVulkanDevice,
     state: &SwapchainState,
 ) {
     let instance = vulkan_device.instance();

--- a/libs/streamlib/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_decoder.rs
@@ -4,7 +4,7 @@
 // H.264 Decoder Processor
 //
 // Thin wrapper around vulkan_video::SimpleDecoder using the shared RHI
-// VulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
+// HostVulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
 
 use crate::_generated_::{Encodedvideoframe, Videoframe};
 use crate::core::context::GpuContextLimitedAccess;

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -4,7 +4,7 @@
 // H.264 Encoder Processor
 //
 // Thin wrapper around vulkan_video::SimpleEncoder using the shared RHI
-// VulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
+// HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
 // and queues — no separate device creation, no NVIDIA dual-device crash.
 //
 // The camera's GPU-resident textures are on the same device, so encode_image()

--- a/libs/streamlib/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_decoder.rs
@@ -4,7 +4,7 @@
 // H.265 Decoder Processor
 //
 // Thin wrapper around vulkan_video::SimpleDecoder using the shared RHI
-// VulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
+// HostVulkanDevice. Decoded NV12 frames are written to pixel buffers for output.
 
 use crate::_generated_::{Encodedvideoframe, Videoframe};
 use crate::core::context::GpuContextLimitedAccess;

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -4,7 +4,7 @@
 // H.265 Encoder Processor
 //
 // Thin wrapper around vulkan_video::SimpleEncoder using the shared RHI
-// VulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
+// HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
 // and queues — no separate device creation, no NVIDIA dual-device crash.
 //
 // The camera's GPU-resident textures are on the same device, so encode_image()

--- a/libs/streamlib/src/linux/surface_share/state.rs
+++ b/libs/streamlib/src/linux/surface_share/state.rs
@@ -43,9 +43,9 @@ pub struct SurfaceMetadata {
     pub drm_format_modifier: u64,
     /// Optional OPAQUE_FD timeline-semaphore handle owned by the table.
     /// Set when the host registers the surface with an exportable
-    /// `VulkanTimelineSemaphore` (#531). `check_out` / `lookup` `dup`s it
+    /// `HostVulkanTimelineSemaphore` (#531). `check_out` / `lookup` `dup`s it
     /// alongside the DMA-BUF plane fds so the subprocess Vulkan adapter
-    /// can call `VulkanTimelineSemaphore::from_imported_opaque_fd` and
+    /// can call `HostVulkanTimelineSemaphore::from_imported_opaque_fd` and
     /// reuse the host adapter's timeline-wait + signal path. `None` for
     /// surfaces that don't need explicit Vulkan sync (the OpenGL adapter
     /// path, CPU-readback, legacy `VkBuffer` pixel buffers).
@@ -99,7 +99,7 @@ pub struct SurfaceRegistration<'a> {
     /// [`SurfaceMetadata::drm_format_modifier`].
     pub drm_format_modifier: u64,
     /// Optional OPAQUE_FD timeline-semaphore handle exported by the host
-    /// (`VulkanTimelineSemaphore::export_opaque_fd`). The table takes
+    /// (`HostVulkanTimelineSemaphore::export_opaque_fd`). The table takes
     /// ownership on success and closes it on `release_surface`. `None`
     /// for adapters that don't need explicit Vulkan sync.
     pub sync_fd: Option<RawFd>,

--- a/libs/streamlib/src/vulkan/mod.rs
+++ b/libs/streamlib/src/vulkan/mod.rs
@@ -8,5 +8,5 @@ pub mod rhi;
 // Re-exports for public API (intentionally exposed for external use)
 #[allow(unused_imports)]
 pub use rhi::{
-    VulkanBlitter, VulkanCommandBuffer, VulkanCommandQueue, VulkanDevice, VulkanTexture,
+    VulkanBlitter, VulkanCommandBuffer, VulkanCommandQueue, HostVulkanDevice, HostVulkanTexture,
 };

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_device.rs
@@ -5,7 +5,7 @@
 //! subprocess (cdylib) use.
 //!
 //! The consumer-side device deliberately *does not* duplicate
-//! [`crate::vulkan::rhi::VulkanDevice`]. Where the host device owns
+//! [`crate::vulkan::rhi::HostVulkanDevice`]. Where the host device owns
 //! the privileged state — VMA allocator + DMA-BUF export pools, DRM
 //! modifier probe, transfer / encode / decode / compute queues, the
 //! per-queue submit-mutex matrix, swapchain extensions — the consumer

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_device.rs
@@ -1,0 +1,498 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Consumer-side Vulkan device — sandboxed subset of the RHI for
+//! subprocess (cdylib) use.
+//!
+//! The consumer-side device deliberately *does not* duplicate
+//! [`crate::vulkan::rhi::VulkanDevice`]. Where the host device owns
+//! the privileged state — VMA allocator + DMA-BUF export pools, DRM
+//! modifier probe, transfer / encode / decode / compute queues, the
+//! per-queue submit-mutex matrix, swapchain extensions — the consumer
+//! device holds only what the carve-out in
+//! `docs/architecture/subprocess-rhi-parity.md` permits:
+//!
+//! - DMA-BUF FD import (`vkAllocateMemory` with `VkImportMemoryFdInfoKHR`).
+//! - Tiled-image import via `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`
+//!   (the modifier comes pre-chosen from the host's descriptor).
+//! - Layout transitions on imported handles, single-shot at the
+//!   acquire/release boundary — submitted via the device's one queue.
+//! - `vkMapMemory` / `vkUnmapMemory` on imported memory.
+//! - `vkWaitSemaphores` / `vkSignalSemaphore` on imported timeline
+//!   semaphores (lives on
+//!   [`crate::vulkan::rhi::ConsumerVulkanTimelineSemaphore`]).
+//!
+//! Crucially, this struct is constructed via [`Self::new`], which spins
+//! up its *own* `VkInstance` + `VkDevice`. It does **not** share the
+//! host's logical device — that's load-bearing for the
+//! capability-boundary story (the cdylib never holds a reference to
+//! the host's `vulkanalia::Device`). The two devices target the same
+//! physical GPU but operate on disjoint Vulkan state objects, which
+//! also sidesteps the dual-`VkDevice` crash on NVIDIA Linux as long as
+//! their queue submissions don't overlap (the carve-out guarantees the
+//! consumer only submits at acquire/release boundaries while the host
+//! is paused).
+
+use std::ffi::{c_char, CStr};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vulkanalia::loader::{LibloadingLoader, LIBRARY};
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::core::{Result, StreamError};
+
+use super::{ConsumerMarker, VulkanRhiDevice};
+
+/// Consumer-only Vulkan device — see module docs.
+pub struct ConsumerVulkanDevice {
+    entry: vulkanalia::Entry,
+    instance: vulkanalia::Instance,
+    physical_device: vk::PhysicalDevice,
+    memory_properties: vk::PhysicalDeviceMemoryProperties,
+    device: vulkanalia::Device,
+    queue: vk::Queue,
+    queue_family_index: u32,
+    #[allow(dead_code)]
+    device_name: String,
+    /// Live count of memory allocations made via [`Self::import_dma_buf_memory`]
+    /// (raw `vkAllocateMemory`). Mirrors the host counterpart; surfaces leaks
+    /// on drop via the warning emitted in [`Drop`].
+    live_allocation_count: AtomicUsize,
+    /// Per-queue mutex serializing `vkQueueSubmit2` calls — Vulkan requires
+    /// external synchronization on the same `VkQueue` from multiple threads.
+    /// Single mutex is enough since the consumer device holds only one
+    /// queue.
+    queue_mutex: Mutex<()>,
+}
+
+impl ConsumerVulkanDevice {
+    /// Construct a fresh consumer-only Vulkan device targeting the
+    /// system's preferred discrete GPU.
+    ///
+    /// Enables only the extensions / features the carve-out needs:
+    /// `VK_KHR_external_memory{,_fd}`, `VK_EXT_external_memory_dma_buf`,
+    /// `VK_EXT_image_drm_format_modifier`,
+    /// `VK_KHR_external_semaphore_fd`, plus the Vulkan 1.3 sync-2 and
+    /// timeline-semaphore features. Every requested device extension
+    /// is *required* — failure surfaces as
+    /// [`StreamError::GpuError`] rather than a silent capability
+    /// downgrade, so cdylib code never tries to import a render-target
+    /// modifier on a driver that doesn't expose the extension.
+    pub fn new() -> Result<Self> {
+        let loader = unsafe { LibloadingLoader::new(LIBRARY) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to load Vulkan library: {e}")))?;
+        let entry = unsafe { vulkanalia::Entry::new(loader) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to load Vulkan entry: {e}")))?;
+
+        // Instance — minimal: just enough to enumerate physical devices.
+        // No surface extensions; the consumer doesn't render to a window.
+        let app_info = vk::ApplicationInfo::builder()
+            .application_name(b"StreamLibConsumer\0")
+            .application_version(vk::make_version(0, 1, 0))
+            .engine_name(b"StreamLib\0")
+            .engine_version(vk::make_version(0, 1, 0))
+            .api_version(vk::make_version(1, 4, 0))
+            .build();
+
+        let instance_info = vk::InstanceCreateInfo::builder()
+            .application_info(&app_info)
+            .build();
+
+        let instance = unsafe { entry.create_instance(&instance_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to create Vulkan instance: {e}")))?;
+
+        // Physical device — prefer DISCRETE_GPU, fall back to first available.
+        let physical_devices = unsafe { instance.enumerate_physical_devices() }
+            .map_err(|e| StreamError::GpuError(format!("Failed to enumerate physical devices: {e}")))?;
+        if physical_devices.is_empty() {
+            return Err(StreamError::GpuError("No Vulkan physical devices found".into()));
+        }
+        let physical_device = physical_devices
+            .iter()
+            .find(|&&pd| {
+                let props = unsafe { instance.get_physical_device_properties(pd) };
+                props.device_type == vk::PhysicalDeviceType::DISCRETE_GPU
+            })
+            .copied()
+            .unwrap_or(physical_devices[0]);
+
+        let device_props = unsafe { instance.get_physical_device_properties(physical_device) };
+        let device_name =
+            unsafe { CStr::from_ptr(device_props.device_name.as_ptr()) }.to_string_lossy().into_owned();
+
+        // Pick any GRAPHICS-capable queue family (graphics implies transfer +
+        // compute on every conformant Vulkan implementation, which covers
+        // every layout transition + sync the carve-out needs).
+        let queue_families =
+            unsafe { instance.get_physical_device_queue_family_properties(physical_device) };
+        let queue_family_index = queue_families
+            .iter()
+            .enumerate()
+            .find(|(_, props)| props.queue_flags.contains(vk::QueueFlags::GRAPHICS))
+            .map(|(idx, _)| idx as u32)
+            .ok_or_else(|| StreamError::GpuError("No graphics queue family on consumer device".into()))?;
+
+        // Required device extensions. All four are mandatory on the
+        // carve-out path — refusing to construct the device on a driver
+        // that doesn't expose them is the right shape (see module docs).
+        let available_device_ext_names: Vec<&CStr> = unsafe {
+            instance
+                .enumerate_device_extension_properties(physical_device, None)
+                .map_err(|e| StreamError::GpuError(format!("enumerate_device_extension_properties: {e}")))?
+        }
+        .iter()
+        .map(|ext| unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) })
+        .collect();
+
+        const REQUIRED: &[&CStr] = &[
+            c"VK_KHR_external_memory",
+            c"VK_KHR_external_memory_fd",
+            c"VK_EXT_external_memory_dma_buf",
+            c"VK_EXT_image_drm_format_modifier",
+            c"VK_KHR_external_semaphore_fd",
+        ];
+        let mut device_extensions: Vec<*const c_char> = Vec::with_capacity(REQUIRED.len());
+        for ext in REQUIRED {
+            if !available_device_ext_names.contains(ext) {
+                return Err(StreamError::GpuError(format!(
+                    "ConsumerVulkanDevice: required extension {} not available on this driver",
+                    ext.to_string_lossy()
+                )));
+            }
+            device_extensions.push(ext.as_ptr());
+        }
+
+        // Logical device. Sync2 + timeline semaphore are core in 1.3 but
+        // still need their feature flags enabled.
+        let queue_priorities = [1.0f32];
+        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+            .queue_family_index(queue_family_index)
+            .queue_priorities(&queue_priorities)
+            .build();
+        let queue_create_infos = [queue_create_info];
+
+        let mut sync2_features = vk::PhysicalDeviceSynchronization2Features::builder()
+            .synchronization2(true)
+            .build();
+        let mut timeline_features = vk::PhysicalDeviceTimelineSemaphoreFeatures::builder()
+            .timeline_semaphore(true)
+            .build();
+        let mut dynamic_rendering_features =
+            vk::PhysicalDeviceDynamicRenderingFeatures::builder()
+                .dynamic_rendering(true)
+                .build();
+        // samplerYcbcrConversion: required to import NV12 textures on the
+        // consumer side (multi-plane sampler-ycbcr support is core 1.1
+        // but gated by the feature flag).
+        let mut vulkan_1_1_features = vk::PhysicalDeviceVulkan11Features::builder()
+            .sampler_ycbcr_conversion(true)
+            .build();
+
+        let device_create_info = vk::DeviceCreateInfo::builder()
+            .queue_create_infos(&queue_create_infos)
+            .enabled_extension_names(&device_extensions)
+            .push_next(&mut sync2_features)
+            .push_next(&mut timeline_features)
+            .push_next(&mut dynamic_rendering_features)
+            .push_next(&mut vulkan_1_1_features)
+            .build();
+
+        let device = unsafe { instance.create_device(physical_device, &device_create_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("Failed to create consumer logical device: {e}")))?;
+
+        let queue = unsafe { device.get_device_queue(queue_family_index, 0) };
+        let memory_properties =
+            unsafe { instance.get_physical_device_memory_properties(physical_device) };
+
+        tracing::info!(
+            "ConsumerVulkanDevice initialized: {} (queue family {}, {} memory types)",
+            device_name,
+            queue_family_index,
+            memory_properties.memory_type_count
+        );
+
+        Ok(Self {
+            entry,
+            instance,
+            physical_device,
+            memory_properties,
+            device,
+            queue,
+            queue_family_index,
+            device_name,
+            live_allocation_count: AtomicUsize::new(0),
+            queue_mutex: Mutex::new(()),
+        })
+    }
+
+    /// Device label from `VkPhysicalDeviceProperties::deviceName`.
+    #[allow(dead_code)]
+    pub fn name(&self) -> &str {
+        &self.device_name
+    }
+
+    /// Loaded Vulkan entry points.
+    #[allow(dead_code)]
+    pub fn entry(&self) -> &vulkanalia::Entry {
+        &self.entry
+    }
+
+    /// Vulkan instance owned by this consumer device.
+    #[allow(dead_code)]
+    pub fn instance(&self) -> &vulkanalia::Instance {
+        &self.instance
+    }
+
+    /// Selected physical device.
+    pub fn physical_device(&self) -> vk::PhysicalDevice {
+        self.physical_device
+    }
+
+    /// Logical Vulkan device — exposed for the carve-out's import +
+    /// bind paths (creating an image / buffer, querying memory
+    /// requirements, building command buffers for layout transitions).
+    pub fn device(&self) -> &vulkanalia::Device {
+        &self.device
+    }
+
+    /// Default submit queue for layout transitions + sync work.
+    pub fn queue(&self) -> vk::Queue {
+        self.queue
+    }
+
+    /// Queue family that owns [`Self::queue`].
+    pub fn queue_family_index(&self) -> u32 {
+        self.queue_family_index
+    }
+
+    /// Find the first memory type whose bit is set in `type_filter` and
+    /// satisfies `required_properties`.
+    fn find_memory_type(
+        &self,
+        type_filter: u32,
+        required_properties: vk::MemoryPropertyFlags,
+    ) -> Result<u32> {
+        if required_properties.contains(vk::MemoryPropertyFlags::DEVICE_LOCAL) {
+            // Prefer pure DEVICE_LOCAL (main VRAM heap) over BAR aperture
+            // when DEVICE_LOCAL is requested.
+            for i in 0..self.memory_properties.memory_type_count {
+                let flags = self.memory_properties.memory_types[i as usize].property_flags;
+                if (type_filter & (1 << i)) != 0
+                    && flags.contains(vk::MemoryPropertyFlags::DEVICE_LOCAL)
+                    && !flags.contains(vk::MemoryPropertyFlags::HOST_VISIBLE)
+                {
+                    return Ok(i);
+                }
+            }
+            for i in 0..self.memory_properties.memory_type_count {
+                let flags = self.memory_properties.memory_types[i as usize].property_flags;
+                if (type_filter & (1 << i)) != 0
+                    && flags.contains(vk::MemoryPropertyFlags::DEVICE_LOCAL)
+                {
+                    return Ok(i);
+                }
+            }
+        }
+        for i in 0..self.memory_properties.memory_type_count {
+            let flags = self.memory_properties.memory_types[i as usize].property_flags;
+            if (type_filter & (1 << i)) != 0 && flags.contains(required_properties) {
+                return Ok(i);
+            }
+        }
+        Err(StreamError::GpuError(format!(
+            "ConsumerVulkanDevice: no suitable memory type (filter=0x{:x}, required={:?})",
+            type_filter, required_properties
+        )))
+    }
+
+    /// Import a DMA-BUF file descriptor as `VkDeviceMemory`. Pairs with
+    /// the host's `export_dma_buf_fd`: the host allocates, exports,
+    /// and registers in surface-share; the consumer looks up, imports,
+    /// and binds.
+    ///
+    /// fd ownership transfers to the Vulkan driver on success — caller
+    /// must NOT close `fd` afterwards. On error the caller still owns
+    /// `fd`.
+    pub fn import_dma_buf_memory(
+        &self,
+        fd: i32,
+        allocation_size: vk::DeviceSize,
+        memory_type_bits: u32,
+        preferred_flags: vk::MemoryPropertyFlags,
+    ) -> Result<vk::DeviceMemory> {
+        let memory_type_index = self.find_memory_type(memory_type_bits, preferred_flags)?;
+
+        let mut import_info = vk::ImportMemoryFdInfoKHR::builder()
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+            .fd(fd)
+            .build();
+
+        let alloc_info = vk::MemoryAllocateInfo::builder()
+            .allocation_size(allocation_size)
+            .memory_type_index(memory_type_index)
+            .push_next(&mut import_info)
+            .build();
+
+        let memory = unsafe { self.device.allocate_memory(&alloc_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "ConsumerVulkanDevice: import_dma_buf_memory failed: {e}"
+            ))
+        })?;
+
+        let count = self.live_allocation_count.fetch_add(1, Ordering::Relaxed) + 1;
+        tracing::debug!(
+            "ConsumerVulkanDevice: imported DMA-BUF ({} bytes, type={}, live={})",
+            allocation_size, memory_type_index, count
+        );
+
+        Ok(memory)
+    }
+
+    /// Free imported memory. Pair with [`Self::import_dma_buf_memory`].
+    /// Calling on memory not allocated through this method is undefined
+    /// behavior at the Vulkan level.
+    pub fn free_imported_memory(&self, memory: vk::DeviceMemory) {
+        unsafe { self.device.free_memory(memory, None) };
+        self.live_allocation_count.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Map imported device memory for CPU access. The returned pointer
+    /// is valid until [`Self::unmap_imported_memory`] is called.
+    pub fn map_imported_memory(
+        &self,
+        memory: vk::DeviceMemory,
+        size: vk::DeviceSize,
+    ) -> Result<*mut u8> {
+        let ptr = unsafe {
+            self.device
+                .map_memory(memory, 0, size, vk::MemoryMapFlags::empty())
+        }
+        .map_err(|e| {
+            StreamError::GpuError(format!(
+                "ConsumerVulkanDevice: map_imported_memory failed: {e}"
+            ))
+        })?;
+        Ok(ptr as *mut u8)
+    }
+
+    /// Unmap a previously-mapped imported memory region.
+    pub fn unmap_imported_memory(&self, memory: vk::DeviceMemory) {
+        unsafe { self.device.unmap_memory(memory) };
+    }
+
+    /// Submit command buffers under the per-queue mutex.
+    ///
+    /// # Safety
+    /// Standard `vkQueueSubmit2` preconditions apply (valid `submits`,
+    /// valid optional `fence`, no concurrent native submits to `queue`
+    /// outside this method).
+    pub unsafe fn submit_to_queue(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo2],
+        fence: vk::Fence,
+    ) -> Result<()> {
+        let _lock = self.queue_mutex.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { self.device.queue_submit2(queue, submits, fence) }
+            .map(|_| ())
+            .map_err(|e| StreamError::GpuError(format!("queue_submit2 failed: {e}")))
+    }
+
+    /// Current number of live DMA-BUF imports through this device.
+    /// Surfaced for tracing + leak detection on Drop.
+    #[allow(dead_code)]
+    pub fn live_import_allocation_count(&self) -> usize {
+        self.live_allocation_count.load(Ordering::Relaxed)
+    }
+}
+
+impl VulkanRhiDevice for ConsumerVulkanDevice {
+    type Privilege = ConsumerMarker;
+
+    fn device(&self) -> &vulkanalia::Device {
+        &self.device
+    }
+
+    fn queue(&self) -> vk::Queue {
+        self.queue
+    }
+
+    fn queue_family_index(&self) -> u32 {
+        self.queue_family_index
+    }
+
+    unsafe fn submit_to_queue(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo2],
+        fence: vk::Fence,
+    ) -> Result<()> {
+        unsafe { ConsumerVulkanDevice::submit_to_queue(self, queue, submits, fence) }
+    }
+}
+
+impl Drop for ConsumerVulkanDevice {
+    fn drop(&mut self) {
+        let live = self.live_allocation_count.load(Ordering::Relaxed);
+        if live > 0 {
+            tracing::warn!(
+                "ConsumerVulkanDevice dropping with {} live DMA-BUF imports (leak)",
+                live
+            );
+        }
+        unsafe {
+            let _ = self.device.device_wait_idle();
+            self.device.destroy_device(None);
+            self.instance.destroy_instance(None);
+        }
+    }
+}
+
+// Vulkan handles are thread-safe behind external synchronization which
+// the per-queue mutex provides for submits.
+unsafe impl Send for ConsumerVulkanDevice {}
+unsafe impl Sync for ConsumerVulkanDevice {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Try to construct a ConsumerVulkanDevice; return None if Vulkan
+    /// is unavailable in this environment (CI sandboxes, no GPU).
+    fn try_create() -> Option<Arc<ConsumerVulkanDevice>> {
+        match ConsumerVulkanDevice::new() {
+            Ok(d) => Some(Arc::new(d)),
+            Err(e) => {
+                println!("Skipping test — ConsumerVulkanDevice unavailable: {e}");
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn consumer_device_constructs() {
+        let device = match try_create() {
+            Some(d) => d,
+            None => return,
+        };
+        assert!(!device.name().is_empty());
+        // Sanity: the trait bound is wired to ConsumerMarker, not Host.
+        fn assert_consumer<D: VulkanRhiDevice<Privilege = ConsumerMarker>>(_: &D) {}
+        assert_consumer(&*device);
+    }
+
+    #[test]
+    fn consumer_device_exposes_queue() {
+        let device = match try_create() {
+            Some(d) => d,
+            None => return,
+        };
+        let _q = device.queue();
+        let _qfi = device.queue_family_index();
+        // Trait method also returns the same queue.
+        let _q_via_trait = <ConsumerVulkanDevice as VulkanRhiDevice>::queue(&device);
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_pixel_buffer.rs
@@ -1,0 +1,304 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Consumer-side Vulkan pixel buffer — imports a host-allocated
+//! HOST_VISIBLE DMA-BUF as a `VkBuffer` and exposes a CPU-mapped
+//! pointer for staging upload / readback.
+//!
+//! Mirrors [`crate::vulkan::rhi::ConsumerVulkanTexture`] for buffer
+//! handles. Single-plane and multi-plane import constructors only —
+//! no allocation, no DMA-BUF export.
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::core::rhi::PixelFormat;
+use crate::core::{Result, StreamError};
+
+use super::ConsumerVulkanDevice;
+
+/// One imported plane: buffer + memory + mapped pointer + size.
+struct ConsumerImportedPlane {
+    buffer: vk::Buffer,
+    memory: vk::DeviceMemory,
+    mapped_ptr: *mut u8,
+    size: vk::DeviceSize,
+}
+
+/// Consumer-side CPU-visible imported staging buffer. See module docs.
+pub struct ConsumerVulkanPixelBuffer {
+    vulkan_device: Arc<ConsumerVulkanDevice>,
+    /// Plane 0's `VkBuffer`. Single-plane imports use only this; multi-
+    /// plane imports keep planes 1..N in [`Self::extra_imported_planes`].
+    buffer: vk::Buffer,
+    imported_memory: vk::DeviceMemory,
+    /// Persistently mapped CPU pointer for plane 0.
+    mapped_ptr: *mut u8,
+    extra_imported_planes: Vec<ConsumerImportedPlane>,
+    width: u32,
+    height: u32,
+    bytes_per_pixel: u32,
+    format: PixelFormat,
+    /// Size of plane 0 in bytes.
+    size: vk::DeviceSize,
+}
+
+impl ConsumerVulkanPixelBuffer {
+    /// Import a single-plane DMA-BUF as a HOST_VISIBLE staging buffer.
+    pub fn from_dma_buf_fd(
+        vulkan_device: &Arc<ConsumerVulkanDevice>,
+        fd: std::os::unix::io::RawFd,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: PixelFormat,
+        allocation_size: vk::DeviceSize,
+    ) -> Result<Self> {
+        Self::from_dma_buf_fds(
+            vulkan_device,
+            &[fd],
+            &[allocation_size],
+            width,
+            height,
+            bytes_per_pixel,
+            format,
+        )
+    }
+
+    /// Import N planes from N DMA-BUF FDs — each gets its own
+    /// `VkBuffer` + imported `VkDeviceMemory` + mapping.
+    ///
+    /// Partial-failure semantics: every plane that succeeded is torn
+    /// down before the error is returned. fd ownership transfers to
+    /// the Vulkan driver on success per plane.
+    pub fn from_dma_buf_fds(
+        vulkan_device: &Arc<ConsumerVulkanDevice>,
+        fds: &[std::os::unix::io::RawFd],
+        plane_sizes: &[vk::DeviceSize],
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: PixelFormat,
+    ) -> Result<Self> {
+        if fds.is_empty() {
+            return Err(StreamError::Configuration(
+                "ConsumerVulkanPixelBuffer: fd vec must be non-empty".into(),
+            ));
+        }
+        if fds.len() != plane_sizes.len() {
+            return Err(StreamError::Configuration(format!(
+                "ConsumerVulkanPixelBuffer: plane_sizes length ({}) must match fds length ({})",
+                plane_sizes.len(),
+                fds.len()
+            )));
+        }
+        if fds.len() > streamlib_surface_client::MAX_DMA_BUF_PLANES {
+            return Err(StreamError::Configuration(format!(
+                "ConsumerVulkanPixelBuffer: plane count {} exceeds MAX_DMA_BUF_PLANES ({})",
+                fds.len(),
+                streamlib_surface_client::MAX_DMA_BUF_PLANES
+            )));
+        }
+
+        let derived_size = (width as vk::DeviceSize)
+            * (height as vk::DeviceSize)
+            * (bytes_per_pixel as vk::DeviceSize);
+
+        let mut imported: Vec<ConsumerImportedPlane> = Vec::with_capacity(fds.len());
+        for (idx, (&fd, &plane_size)) in fds.iter().zip(plane_sizes.iter()).enumerate() {
+            let effective_size = if plane_size > 0 {
+                plane_size
+            } else if idx == 0 {
+                derived_size
+            } else {
+                for plane in imported.into_iter() {
+                    teardown_plane(vulkan_device, plane);
+                }
+                return Err(StreamError::Configuration(format!(
+                    "ConsumerVulkanPixelBuffer: plane {} size=0 cannot be derived from width*height",
+                    idx
+                )));
+            };
+
+            match import_single_plane(vulkan_device, fd, effective_size) {
+                Ok(plane) => imported.push(plane),
+                Err(e) => {
+                    for plane in imported.into_iter() {
+                        teardown_plane(vulkan_device, plane);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        let plane0 = imported.remove(0);
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            buffer: plane0.buffer,
+            imported_memory: plane0.memory,
+            mapped_ptr: plane0.mapped_ptr,
+            extra_imported_planes: imported,
+            width,
+            height,
+            bytes_per_pixel,
+            format,
+            size: plane0.size,
+        })
+    }
+
+    /// Persistently mapped CPU pointer for plane 0. Use
+    /// [`Self::plane_mapped_ptr`] for any plane.
+    pub fn mapped_ptr(&self) -> *mut u8 {
+        self.mapped_ptr
+    }
+
+    /// Number of planes — `1` for single-plane imports, `N` for multi-
+    /// plane.
+    pub fn plane_count(&self) -> u32 {
+        1 + self.extra_imported_planes.len() as u32
+    }
+
+    /// Mapped CPU pointer for plane `plane_index`, or null if out of
+    /// range.
+    pub fn plane_mapped_ptr(&self, plane_index: u32) -> *mut u8 {
+        if plane_index == 0 {
+            return self.mapped_ptr;
+        }
+        self.extra_imported_planes
+            .get(plane_index as usize - 1)
+            .map(|p| p.mapped_ptr)
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    /// Byte size of plane `plane_index`, or `0` if out of range.
+    pub fn plane_size(&self, plane_index: u32) -> vk::DeviceSize {
+        if plane_index == 0 {
+            return self.size;
+        }
+        self.extra_imported_planes
+            .get(plane_index as usize - 1)
+            .map(|p| p.size)
+            .unwrap_or(0)
+    }
+
+    /// Buffer width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Buffer height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Bytes per pixel.
+    pub fn bytes_per_pixel(&self) -> u32 {
+        self.bytes_per_pixel
+    }
+
+    /// Pixel format.
+    pub fn format(&self) -> PixelFormat {
+        self.format
+    }
+
+    /// Plane 0 size in bytes.
+    pub fn size(&self) -> vk::DeviceSize {
+        self.size
+    }
+
+    /// Underlying `VkBuffer` for plane 0.
+    pub fn buffer(&self) -> vk::Buffer {
+        self.buffer
+    }
+}
+
+fn import_single_plane(
+    vulkan_device: &Arc<ConsumerVulkanDevice>,
+    fd: std::os::unix::io::RawFd,
+    effective_size: vk::DeviceSize,
+) -> Result<ConsumerImportedPlane> {
+    let device = vulkan_device.device();
+
+    let mut external_buffer_info = vk::ExternalMemoryBufferCreateInfo::builder()
+        .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT)
+        .build();
+
+    let buffer_info = vk::BufferCreateInfo::builder()
+        .size(effective_size)
+        .usage(
+            vk::BufferUsageFlags::TRANSFER_SRC
+                | vk::BufferUsageFlags::TRANSFER_DST
+                | vk::BufferUsageFlags::STORAGE_BUFFER,
+        )
+        .sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .push_next(&mut external_buffer_info)
+        .build();
+
+    let buffer = unsafe { device.create_buffer(&buffer_info, None) }.map_err(|e| {
+        StreamError::GpuError(format!(
+            "ConsumerVulkanPixelBuffer: create_buffer failed: {e}"
+        ))
+    })?;
+
+    let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
+    let alloc_size = effective_size.max(mem_requirements.size);
+
+    let memory = vulkan_device
+        .import_dma_buf_memory(
+            fd,
+            alloc_size,
+            mem_requirements.memory_type_bits,
+            vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+        )
+        .map_err(|e| {
+            unsafe { device.destroy_buffer(buffer, None) };
+            e
+        })?;
+
+    unsafe { device.bind_buffer_memory(buffer, memory, 0) }.map_err(|e| {
+        vulkan_device.free_imported_memory(memory);
+        unsafe { device.destroy_buffer(buffer, None) };
+        StreamError::GpuError(format!(
+            "ConsumerVulkanPixelBuffer: bind_buffer_memory failed: {e}"
+        ))
+    })?;
+
+    let mapped_ptr = vulkan_device
+        .map_imported_memory(memory, effective_size)
+        .map_err(|e| {
+            vulkan_device.free_imported_memory(memory);
+            unsafe { device.destroy_buffer(buffer, None) };
+            e
+        })?;
+
+    Ok(ConsumerImportedPlane {
+        buffer,
+        memory,
+        mapped_ptr,
+        size: effective_size,
+    })
+}
+
+fn teardown_plane(vulkan_device: &Arc<ConsumerVulkanDevice>, plane: ConsumerImportedPlane) {
+    unsafe { vulkan_device.device().destroy_buffer(plane.buffer, None) };
+    vulkan_device.unmap_imported_memory(plane.memory);
+    vulkan_device.free_imported_memory(plane.memory);
+}
+
+impl Drop for ConsumerVulkanPixelBuffer {
+    fn drop(&mut self) {
+        unsafe {
+            self.vulkan_device.device().destroy_buffer(self.buffer, None);
+        }
+        self.vulkan_device.unmap_imported_memory(self.imported_memory);
+        self.vulkan_device.free_imported_memory(self.imported_memory);
+        for plane in self.extra_imported_planes.drain(..) {
+            teardown_plane(&self.vulkan_device, plane);
+        }
+    }
+}
+
+unsafe impl Send for ConsumerVulkanPixelBuffer {}
+unsafe impl Sync for ConsumerVulkanPixelBuffer {}

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_sync.rs
@@ -132,3 +132,12 @@ impl Drop for ConsumerVulkanTimelineSemaphore {
 
 unsafe impl Send for ConsumerVulkanTimelineSemaphore {}
 unsafe impl Sync for ConsumerVulkanTimelineSemaphore {}
+
+impl super::VulkanTimelineSemaphoreLike for ConsumerVulkanTimelineSemaphore {
+    fn wait(&self, value: u64, timeout_ns: u64) -> Result<()> {
+        ConsumerVulkanTimelineSemaphore::wait(self, value, timeout_ns)
+    }
+    fn signal_host(&self, value: u64) -> Result<()> {
+        ConsumerVulkanTimelineSemaphore::signal_host(self, value)
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_sync.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Consumer-side timeline semaphore — imports a host-allocated
+//! exportable timeline semaphore via OPAQUE_FD and exposes the wait /
+//! signal-from-host / counter-read operations.
+//!
+//! Mirrors [`crate::vulkan::rhi::ConsumerVulkanTexture`] for sync
+//! primitives. There is no `new` / `new_exportable` constructor: the
+//! consumer never originates a timeline semaphore — it only imports
+//! one the host already created.
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+use vulkanalia::vk::KhrExternalSemaphoreFdExtensionDeviceCommands;
+
+use crate::core::{Result, StreamError};
+
+use super::ConsumerVulkanDevice;
+
+/// Consumer-side timeline semaphore. See module docs.
+pub struct ConsumerVulkanTimelineSemaphore {
+    vulkan_device: Arc<ConsumerVulkanDevice>,
+    semaphore: vk::Semaphore,
+}
+
+impl ConsumerVulkanTimelineSemaphore {
+    /// Import a host-side exportable timeline semaphore via OPAQUE_FD.
+    ///
+    /// The consumer creates a fresh `VkSemaphore` against its own
+    /// device, then `vkImportSemaphoreFdKHR` replaces the payload with
+    /// the host's timeline state. After import, `wait` /
+    /// `signal_host` / `current_value` operate against the same
+    /// timeline as the host.
+    ///
+    /// fd ownership transfers to the Vulkan driver on success — caller
+    /// must NOT close `fd` afterwards. On error the caller still owns
+    /// it.
+    pub fn from_imported_opaque_fd(
+        vulkan_device: &Arc<ConsumerVulkanDevice>,
+        fd: std::os::unix::io::RawFd,
+    ) -> Result<Self> {
+        let device = vulkan_device.device();
+        let mut type_info = vk::SemaphoreTypeCreateInfo::builder()
+            .semaphore_type(vk::SemaphoreType::TIMELINE)
+            .initial_value(0)
+            .build();
+        let info = vk::SemaphoreCreateInfo::builder()
+            .push_next(&mut type_info)
+            .build();
+        let semaphore = unsafe { device.create_semaphore(&info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "ConsumerVulkanTimelineSemaphore: create_semaphore failed: {e}"
+            ))
+        })?;
+
+        let import_info = vk::ImportSemaphoreFdInfoKHR::builder()
+            .semaphore(semaphore)
+            .flags(vk::SemaphoreImportFlags::empty())
+            .handle_type(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
+            .fd(fd)
+            .build();
+
+        if let Err(e) = unsafe { device.import_semaphore_fd_khr(&import_info) } {
+            unsafe { device.destroy_semaphore(semaphore, None) };
+            return Err(StreamError::GpuError(format!(
+                "ConsumerVulkanTimelineSemaphore: import_semaphore_fd_khr failed: {e}"
+            )));
+        }
+
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            semaphore,
+        })
+    }
+
+    /// Block until the timeline counter has reached or surpassed
+    /// `value`. `timeout_ns` of `u64::MAX` means "no timeout".
+    pub fn wait(&self, value: u64, timeout_ns: u64) -> Result<()> {
+        let semaphores = [self.semaphore];
+        let values = [value];
+        let info = vk::SemaphoreWaitInfo::builder()
+            .flags(vk::SemaphoreWaitFlags::empty())
+            .semaphores(&semaphores)
+            .values(&values)
+            .build();
+        unsafe { self.vulkan_device.device().wait_semaphores(&info, timeout_ns) }
+            .map(|_| ())
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "wait_semaphores(value={value}, timeout_ns={timeout_ns}): {e}"
+                ))
+            })
+    }
+
+    /// Host-side signal: advance the counter to `value` directly from
+    /// the CPU. `value` MUST be greater than the current counter.
+    pub fn signal_host(&self, value: u64) -> Result<()> {
+        let info = vk::SemaphoreSignalInfo::builder()
+            .semaphore(self.semaphore)
+            .value(value)
+            .build();
+        unsafe { self.vulkan_device.device().signal_semaphore(&info) }.map_err(|e| {
+            StreamError::GpuError(format!("signal_semaphore(value={value}): {e}"))
+        })
+    }
+
+    /// Read the timeline counter via `vkGetSemaphoreCounterValue`.
+    pub fn current_value(&self) -> Result<u64> {
+        unsafe { self.vulkan_device.device().get_semaphore_counter_value(self.semaphore) }.map_err(
+            |e| StreamError::GpuError(format!("get_semaphore_counter_value: {e}")),
+        )
+    }
+
+    /// Raw `vk::Semaphore` handle for inclusion in queue submit infos.
+    pub fn semaphore(&self) -> vk::Semaphore {
+        self.semaphore
+    }
+}
+
+impl Drop for ConsumerVulkanTimelineSemaphore {
+    fn drop(&mut self) {
+        unsafe {
+            self.vulkan_device
+                .device()
+                .destroy_semaphore(self.semaphore, None)
+        };
+    }
+}
+
+unsafe impl Send for ConsumerVulkanTimelineSemaphore {}
+unsafe impl Sync for ConsumerVulkanTimelineSemaphore {}

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
@@ -353,4 +353,13 @@ impl super::VulkanTextureLike for ConsumerVulkanTexture {
     fn chosen_drm_format_modifier(&self) -> u64 {
         ConsumerVulkanTexture::chosen_drm_format_modifier(self)
     }
+    fn width(&self) -> u32 {
+        ConsumerVulkanTexture::width(self)
+    }
+    fn height(&self) -> u32 {
+        ConsumerVulkanTexture::height(self)
+    }
+    fn format(&self) -> crate::core::rhi::TextureFormat {
+        ConsumerVulkanTexture::format(self)
+    }
 }

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
@@ -1,0 +1,347 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Consumer-side Vulkan texture — imports a host-allocated DMA-BUF
+//! into the consumer's `VkDevice` and exposes the resulting `VkImage`.
+//!
+//! Surface adapters running inside a cdylib hand subprocess customers
+//! a [`crate::core::rhi::StreamTexture`] backed by one of these. The
+//! type carries only the carve-out methods: import constructors, raw
+//! accessors, lazy image-view creation. There is no allocation path
+//! and no DMA-BUF export — the host owns those.
+
+use std::sync::{Arc, OnceLock};
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::core::rhi::{TextureFormat, TextureUsages};
+use crate::core::{Result, StreamError};
+
+use super::ConsumerVulkanDevice;
+
+/// Convert RHI [`TextureFormat`] to the matching `vk::Format`.
+fn texture_format_to_vk(format: TextureFormat) -> vk::Format {
+    match format {
+        TextureFormat::Rgba8Unorm => vk::Format::R8G8B8A8_UNORM,
+        TextureFormat::Rgba8UnormSrgb => vk::Format::R8G8B8A8_SRGB,
+        TextureFormat::Bgra8Unorm => vk::Format::B8G8R8A8_UNORM,
+        TextureFormat::Bgra8UnormSrgb => vk::Format::B8G8R8A8_SRGB,
+        TextureFormat::Rgba16Float => vk::Format::R16G16B16A16_SFLOAT,
+        TextureFormat::Rgba32Float => vk::Format::R32G32B32A32_SFLOAT,
+        TextureFormat::Nv12 => vk::Format::G8_B8R8_2PLANE_420_UNORM,
+    }
+}
+
+/// Convert RHI [`TextureUsages`] to Vulkan usage flags.
+fn texture_usages_to_vk(usage: TextureUsages) -> vk::ImageUsageFlags {
+    let mut flags = vk::ImageUsageFlags::empty();
+    if usage.contains(TextureUsages::COPY_SRC) {
+        flags |= vk::ImageUsageFlags::TRANSFER_SRC;
+    }
+    if usage.contains(TextureUsages::COPY_DST) {
+        flags |= vk::ImageUsageFlags::TRANSFER_DST;
+    }
+    if usage.contains(TextureUsages::TEXTURE_BINDING) {
+        flags |= vk::ImageUsageFlags::SAMPLED;
+    }
+    if usage.contains(TextureUsages::STORAGE_BINDING) {
+        flags |= vk::ImageUsageFlags::STORAGE;
+    }
+    if usage.contains(TextureUsages::RENDER_ATTACHMENT) {
+        flags |= vk::ImageUsageFlags::COLOR_ATTACHMENT;
+    }
+    if flags.is_empty() {
+        flags = vk::ImageUsageFlags::SAMPLED | vk::ImageUsageFlags::TRANSFER_SRC;
+    }
+    flags
+}
+
+/// Consumer-side Vulkan texture. See module docs.
+pub struct ConsumerVulkanTexture {
+    /// Owning consumer device, kept for `Drop` and lazy-view creation.
+    vulkan_device: Arc<ConsumerVulkanDevice>,
+    image: vk::Image,
+    /// Imported `VkDeviceMemory` from the host's DMA-BUF FD.
+    imported_memory: vk::DeviceMemory,
+    cached_image_view: OnceLock<vk::ImageView>,
+    /// DRM format modifier the host's driver chose at allocation time.
+    /// Zero is reserved for `DRM_FORMAT_MOD_LINEAR` — sampler-only on
+    /// NVIDIA, refused at the render-target import path.
+    drm_format_modifier: u64,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+}
+
+impl ConsumerVulkanTexture {
+    /// Import a host-allocated render-target DMA-BUF as a tiled image
+    /// on the consumer device.
+    ///
+    /// The host pre-chose a non-LINEAR DRM modifier
+    /// (`new_render_target_dma_buf` on the host side); the consumer
+    /// reproduces the exact image-create state via
+    /// `VkImageDrmFormatModifierExplicitCreateInfoEXT` so the GPU
+    /// memory layout is consistent across the IPC boundary.
+    ///
+    /// fd ownership: the consumer transfers ownership to Vulkan on
+    /// success (the driver dups internally and releases on
+    /// `vkFreeMemory`). On error the caller still owns `fds[0]`.
+    pub fn import_render_target_dma_buf(
+        vulkan_device: &Arc<ConsumerVulkanDevice>,
+        fds: &[std::os::unix::io::RawFd],
+        plane_offsets: &[u64],
+        plane_strides: &[u64],
+        drm_format_modifier: u64,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        allocation_size: vk::DeviceSize,
+    ) -> Result<Self> {
+        if fds.is_empty() {
+            return Err(StreamError::GpuError(
+                "ConsumerVulkanTexture::import_render_target_dma_buf: empty fd vec".into(),
+            ));
+        }
+        if plane_offsets.len() != fds.len() || plane_strides.len() != fds.len() {
+            return Err(StreamError::GpuError(format!(
+                "import_render_target_dma_buf: plane arrays length mismatch — fds={} offsets={} strides={}",
+                fds.len(),
+                plane_offsets.len(),
+                plane_strides.len()
+            )));
+        }
+        if drm_format_modifier == 0 {
+            return Err(StreamError::GpuError(
+                "import_render_target_dma_buf: zero (LINEAR) modifier — host should have allocated a tiled modifier; LINEAR DMA-BUFs are sampler-only on NVIDIA".into(),
+            ));
+        }
+
+        let device = vulkan_device.device();
+        let vk_format = texture_format_to_vk(format);
+
+        let plane_layouts: Vec<vk::SubresourceLayout> = plane_offsets
+            .iter()
+            .zip(plane_strides.iter())
+            .map(|(off, stride)| vk::SubresourceLayout {
+                offset: *off,
+                size: 0,
+                row_pitch: *stride,
+                array_pitch: 0,
+                depth_pitch: 0,
+            })
+            .collect();
+
+        let mut explicit_modifier_info = vk::ImageDrmFormatModifierExplicitCreateInfoEXT::builder()
+            .drm_format_modifier(drm_format_modifier)
+            .plane_layouts(&plane_layouts);
+        let mut external_image_info = vk::ExternalMemoryImageCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::DMA_BUF_EXT);
+
+        let image_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D { width, height, depth: 1 })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::_1)
+            .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
+            .usage(
+                vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::TRANSFER_DST
+                    | vk::ImageUsageFlags::SAMPLED
+                    | vk::ImageUsageFlags::COLOR_ATTACHMENT
+                    | vk::ImageUsageFlags::STORAGE,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push_next(&mut explicit_modifier_info)
+            .push_next(&mut external_image_info);
+
+        let image = unsafe { device.create_image(&image_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "import_render_target_dma_buf: create_image failed (modifier=0x{:016x}): {e}",
+                drm_format_modifier
+            ))
+        })?;
+
+        let mem_requirements = unsafe { device.get_image_memory_requirements(image) };
+        let alloc_size = allocation_size.max(mem_requirements.size);
+
+        // Single-plane import covers BGRA / RGBA — the formats #510
+        // currently publishes RT modifiers for. Multi-plane import via
+        // VkBindImagePlaneMemoryInfo is added when a multi-plane
+        // consumer surfaces.
+        let memory = vulkan_device
+            .import_dma_buf_memory(
+                fds[0],
+                alloc_size,
+                mem_requirements.memory_type_bits,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            )
+            .map_err(|e| {
+                unsafe { device.destroy_image(image, None) };
+                e
+            })?;
+
+        unsafe { device.bind_image_memory(image, memory, 0) }.map_err(|e| {
+            vulkan_device.free_imported_memory(memory);
+            unsafe { device.destroy_image(image, None) };
+            StreamError::GpuError(format!(
+                "import_render_target_dma_buf: bind_image_memory failed: {e}"
+            ))
+        })?;
+
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            image,
+            imported_memory: memory,
+            cached_image_view: OnceLock::new(),
+            drm_format_modifier,
+            width,
+            height,
+            format,
+        })
+    }
+
+    /// Import a single-plane LINEAR DMA-BUF as a sampler-only image.
+    ///
+    /// Use [`Self::import_render_target_dma_buf`] when the consumer
+    /// will render INTO the imported image — LINEAR is sampler-only on
+    /// NVIDIA.
+    pub fn from_dma_buf_fd(
+        vulkan_device: &Arc<ConsumerVulkanDevice>,
+        fd: std::os::unix::io::RawFd,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        allocation_size: vk::DeviceSize,
+    ) -> Result<Self> {
+        let device = vulkan_device.device();
+        let vk_format = texture_format_to_vk(format);
+
+        let image_info = vk::ImageCreateInfo::builder()
+            .image_type(vk::ImageType::_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D { width, height, depth: 1 })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::_1)
+            .tiling(vk::ImageTiling::LINEAR)
+            .usage(
+                vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::TRANSFER_DST
+                    | vk::ImageUsageFlags::SAMPLED,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .build();
+
+        let image = unsafe { device.create_image(&image_info, None) }.map_err(|e| {
+            StreamError::GpuError(format!(
+                "ConsumerVulkanTexture::from_dma_buf_fd: create_image failed: {e}"
+            ))
+        })?;
+
+        let mem_requirements = unsafe { device.get_image_memory_requirements(image) };
+        let alloc_size = allocation_size.max(mem_requirements.size);
+
+        let memory = vulkan_device
+            .import_dma_buf_memory(
+                fd,
+                alloc_size,
+                mem_requirements.memory_type_bits,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            )
+            .map_err(|e| {
+                unsafe { device.destroy_image(image, None) };
+                e
+            })?;
+
+        unsafe { device.bind_image_memory(image, memory, 0) }.map_err(|e| {
+            vulkan_device.free_imported_memory(memory);
+            unsafe { device.destroy_image(image, None) };
+            StreamError::GpuError(format!(
+                "ConsumerVulkanTexture::from_dma_buf_fd: bind_image_memory failed: {e}"
+            ))
+        })?;
+
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            image,
+            imported_memory: memory,
+            cached_image_view: OnceLock::new(),
+            drm_format_modifier: 0,
+            width,
+            height,
+            format,
+        })
+    }
+
+    /// Underlying `VkImage` handle.
+    pub fn image(&self) -> vk::Image {
+        self.image
+    }
+
+    /// Texture width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Texture height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Texture format.
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+
+    /// DRM format modifier propagated from the host's allocation. Zero
+    /// for textures imported via [`Self::from_dma_buf_fd`] (LINEAR).
+    pub fn chosen_drm_format_modifier(&self) -> u64 {
+        self.drm_format_modifier
+    }
+
+    /// Lazy-cached `VkImageView` covering the texture's full subresource
+    /// range. Created on first call; subsequent calls return the cached
+    /// handle.
+    pub fn image_view(&self) -> Result<vk::ImageView> {
+        if let Some(&view) = self.cached_image_view.get() {
+            return Ok(view);
+        }
+        let vk_format = texture_format_to_vk(self.format);
+        let view_info = vk::ImageViewCreateInfo::builder()
+            .image(self.image)
+            .view_type(vk::ImageViewType::_2D)
+            .format(vk_format)
+            .subresource_range(
+                vk::ImageSubresourceRange::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .base_mip_level(0)
+                    .level_count(1)
+                    .base_array_layer(0)
+                    .layer_count(1)
+                    .build(),
+            )
+            .build();
+        let view = unsafe { self.vulkan_device.device().create_image_view(&view_info, None) }
+            .map_err(|e| StreamError::GpuError(format!("create_image_view failed: {e}")))?;
+        let _ = self.cached_image_view.set(view);
+        Ok(*self.cached_image_view.get().unwrap())
+    }
+}
+
+impl Drop for ConsumerVulkanTexture {
+    fn drop(&mut self) {
+        if let Some(&view) = self.cached_image_view.get() {
+            unsafe { self.vulkan_device.device().destroy_image_view(view, None) };
+        }
+        unsafe { self.vulkan_device.device().destroy_image(self.image, None) };
+        self.vulkan_device.free_imported_memory(self.imported_memory);
+    }
+}
+
+unsafe impl Send for ConsumerVulkanTexture {}
+unsafe impl Sync for ConsumerVulkanTexture {}

--- a/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/consumer_vulkan_texture.rs
@@ -345,3 +345,12 @@ impl Drop for ConsumerVulkanTexture {
 
 unsafe impl Send for ConsumerVulkanTexture {}
 unsafe impl Sync for ConsumerVulkanTexture {}
+
+impl super::VulkanTextureLike for ConsumerVulkanTexture {
+    fn image(&self) -> Option<vk::Image> {
+        Some(ConsumerVulkanTexture::image(self))
+    }
+    fn chosen_drm_format_modifier(&self) -> u64 {
+        ConsumerVulkanTexture::chosen_drm_format_modifier(self)
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/device_capability.rs
+++ b/libs/streamlib/src/vulkan/rhi/device_capability.rs
@@ -41,9 +41,92 @@ impl sealed::Sealed for ConsumerMarker {}
 
 /// Sealed trait restricting privilege markers to [`HostMarker`] and
 /// [`ConsumerMarker`].
-pub trait DevicePrivilege: sealed::Sealed + 'static + Send + Sync {}
-impl DevicePrivilege for HostMarker {}
-impl DevicePrivilege for ConsumerMarker {}
+///
+/// Carries the timeline-semaphore + texture associated types so adapter
+/// code that holds `Arc<P::TimelineSemaphore>` / `Arc<P::Texture>`
+/// resolves to the right concrete types at instantiation. Both flavors
+/// implement the corresponding `*Like` trait so the adapter can call
+/// `wait` / `signal_host` / `image` without knowing which side it's on.
+pub trait DevicePrivilege: sealed::Sealed + 'static + Send + Sync {
+    /// Concrete timeline-semaphore type for this privilege flavor.
+    type TimelineSemaphore: VulkanTimelineSemaphoreLike + Send + Sync + 'static;
+    /// Concrete texture type for this privilege flavor.
+    type Texture: VulkanTextureLike + Send + Sync + 'static;
+}
+
+#[cfg(target_os = "linux")]
+impl DevicePrivilege for HostMarker {
+    type TimelineSemaphore = super::HostVulkanTimelineSemaphore;
+    type Texture = super::HostVulkanTexture;
+}
+
+#[cfg(target_os = "linux")]
+impl DevicePrivilege for ConsumerMarker {
+    type TimelineSemaphore = super::ConsumerVulkanTimelineSemaphore;
+    type Texture = super::ConsumerVulkanTexture;
+}
+
+// Non-Linux: HostMarker still resolves but to phantom unit types for
+// platforms where the DMA-BUF / OPAQUE_FD machinery isn't built.
+// ConsumerMarker only exists on Linux today.
+#[cfg(not(target_os = "linux"))]
+impl DevicePrivilege for HostMarker {
+    type TimelineSemaphore = NotAvailableOnThisPlatform;
+    type Texture = NotAvailableOnThisPlatform;
+}
+
+/// Phantom type for platforms where DMA-BUF / OPAQUE_FD primitives
+/// aren't built. Stays uninstantiable so trait bounds resolve at
+/// type-check time but no caller can construct one.
+#[cfg(not(target_os = "linux"))]
+pub enum NotAvailableOnThisPlatform {}
+
+#[cfg(not(target_os = "linux"))]
+impl VulkanTimelineSemaphoreLike for NotAvailableOnThisPlatform {
+    fn wait(&self, _value: u64, _timeout_ns: u64) -> crate::core::Result<()> {
+        match *self {}
+    }
+    fn signal_host(&self, _value: u64) -> crate::core::Result<()> {
+        match *self {}
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl VulkanTextureLike for NotAvailableOnThisPlatform {
+    fn image(&self) -> Option<vk::Image> {
+        match *self {}
+    }
+    fn chosen_drm_format_modifier(&self) -> u64 {
+        match *self {}
+    }
+}
+
+/// Operations the surface adapter needs from a timeline semaphore. Both
+/// [`crate::vulkan::rhi::HostVulkanTimelineSemaphore`] and
+/// [`crate::vulkan::rhi::ConsumerVulkanTimelineSemaphore`] implement
+/// this with delegating bodies — the trait exists so `VulkanSurfaceAdapter`
+/// can be generic over the device flavor without dynamic dispatch.
+pub trait VulkanTimelineSemaphoreLike {
+    /// Block until the timeline counter reaches or exceeds `value`.
+    fn wait(&self, value: u64, timeout_ns: u64) -> crate::core::Result<()>;
+    /// Host-side signal: advance the counter to `value`.
+    fn signal_host(&self, value: u64) -> crate::core::Result<()>;
+}
+
+/// Operations the surface adapter needs from a Vulkan-flavored texture.
+/// Both [`crate::vulkan::rhi::HostVulkanTexture`] and
+/// [`crate::vulkan::rhi::ConsumerVulkanTexture`] implement this; the
+/// adapter holds `Arc<P::Texture>` and reads the `vk::Image` + DRM
+/// modifier through this trait without caring whether it's host or
+/// consumer.
+pub trait VulkanTextureLike {
+    /// `vk::Image` handle, or `None` for placeholder textures.
+    fn image(&self) -> Option<vk::Image>;
+    /// DRM format modifier the host's driver chose at allocation time
+    /// (consumer side: propagated from the host descriptor). Zero means
+    /// `DRM_FORMAT_MOD_LINEAR` or "not applicable".
+    fn chosen_drm_format_modifier(&self) -> u64;
+}
 
 /// Minimal device shape every surface adapter needs at the layout-
 /// transition + submit seam.

--- a/libs/streamlib/src/vulkan/rhi/device_capability.rs
+++ b/libs/streamlib/src/vulkan/rhi/device_capability.rs
@@ -99,6 +99,15 @@ impl VulkanTextureLike for NotAvailableOnThisPlatform {
     fn chosen_drm_format_modifier(&self) -> u64 {
         match *self {}
     }
+    fn width(&self) -> u32 {
+        match *self {}
+    }
+    fn height(&self) -> u32 {
+        match *self {}
+    }
+    fn format(&self) -> crate::core::rhi::TextureFormat {
+        match *self {}
+    }
 }
 
 /// Operations the surface adapter needs from a timeline semaphore. Both
@@ -116,9 +125,8 @@ pub trait VulkanTimelineSemaphoreLike {
 /// Operations the surface adapter needs from a Vulkan-flavored texture.
 /// Both [`crate::vulkan::rhi::HostVulkanTexture`] and
 /// [`crate::vulkan::rhi::ConsumerVulkanTexture`] implement this; the
-/// adapter holds `Arc<P::Texture>` and reads the `vk::Image` + DRM
-/// modifier through this trait without caring whether it's host or
-/// consumer.
+/// adapter holds `Arc<P::Texture>` and reads the `vk::Image` + metadata
+/// through this trait without caring whether it's host or consumer.
 pub trait VulkanTextureLike {
     /// `vk::Image` handle, or `None` for placeholder textures.
     fn image(&self) -> Option<vk::Image>;
@@ -126,6 +134,12 @@ pub trait VulkanTextureLike {
     /// (consumer side: propagated from the host descriptor). Zero means
     /// `DRM_FORMAT_MOD_LINEAR` or "not applicable".
     fn chosen_drm_format_modifier(&self) -> u64;
+    /// Texture width in pixels.
+    fn width(&self) -> u32;
+    /// Texture height in pixels.
+    fn height(&self) -> u32;
+    /// Texture format.
+    fn format(&self) -> crate::core::rhi::TextureFormat;
 }
 
 /// Minimal device shape every surface adapter needs at the layout-

--- a/libs/streamlib/src/vulkan/rhi/device_capability.rs
+++ b/libs/streamlib/src/vulkan/rhi/device_capability.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Capability markers and the small device-shape trait surface adapters
+//! abstract over.
+//!
+//! [`HostMarker`] and [`ConsumerMarker`] are the privilege flavors a
+//! Vulkan-typed RHI resource can be parameterized on. They feed into the
+//! source-level split (`HostVulkanDevice` / `ConsumerVulkanDevice` and
+//! the parametric texture / pixel-buffer / timeline-semaphore types) so
+//! the FullAccess capability boundary is enforced by the type system,
+//! not by convention.
+//!
+//! [`VulkanRhiDevice`] is the minimal set of methods every surface
+//! adapter needs at its layout-transition seam: a logical device, the
+//! queue it submits to, that queue's family index, and a mutex-protected
+//! submit. Both flavors implement it; adapter code is generic over
+//! `D: VulkanRhiDevice<Privilege = …>` and works against either.
+
+use vulkanalia::vk;
+
+use crate::core::Result;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Privilege marker for host-side Vulkan resources — full RHI access
+/// (allocation, queue submit, modifier choice, kernel construction,
+/// swapchain).
+pub struct HostMarker;
+impl sealed::Sealed for HostMarker {}
+
+/// Privilege marker for consumer-side Vulkan resources — carve-out
+/// only. See `docs/architecture/subprocess-rhi-parity.md`: DMA-BUF FD
+/// import + bind + map, tiled-image import via
+/// `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`, layout transitions on
+/// imported handles, sync wait/signal on imported timeline semaphores.
+pub struct ConsumerMarker;
+impl sealed::Sealed for ConsumerMarker {}
+
+/// Sealed trait restricting privilege markers to [`HostMarker`] and
+/// [`ConsumerMarker`].
+pub trait DevicePrivilege: sealed::Sealed + 'static + Send + Sync {}
+impl DevicePrivilege for HostMarker {}
+impl DevicePrivilege for ConsumerMarker {}
+
+/// Minimal device shape every surface adapter needs at the layout-
+/// transition + submit seam.
+///
+/// Implementations expose their raw `vulkanalia::Device` so adapters
+/// can record command buffers, but capability enforcement happens at
+/// the **crate boundary**: `streamlib-consumer-rhi` only re-exports
+/// the consumer-flavored device, so a cdylib depending on it cannot
+/// reach the host's `VkDevice` (the one tied to swapchains, host VMA
+/// pools, encoder/decoder queues, and modifier-probing state).
+pub trait VulkanRhiDevice: Send + Sync {
+    /// Privilege marker — `HostMarker` or `ConsumerMarker`.
+    type Privilege: DevicePrivilege;
+
+    /// Logical Vulkan device.
+    fn device(&self) -> &vulkanalia::Device;
+
+    /// Default submit queue.
+    fn queue(&self) -> vk::Queue;
+
+    /// Queue family that owns [`Self::queue`].
+    fn queue_family_index(&self) -> u32;
+
+    /// Submit command buffers under the device's per-queue mutex.
+    /// Vulkan requires external synchronization for `vkQueueSubmit2`
+    /// against the same `VkQueue` from multiple threads; the host's
+    /// per-queue mutex is the canonical way streamlib serializes that.
+    /// Consumer-side devices can use a single mutex since they only
+    /// hold one queue.
+    ///
+    /// # Safety
+    /// Caller must satisfy the standard `vkQueueSubmit2` preconditions
+    /// (valid `submits`, valid optional `fence`, no concurrent native
+    /// submits to `queue` outside this trait).
+    unsafe fn submit_to_queue(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo2],
+        fence: vk::Fence,
+    ) -> Result<()>;
+}

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -13,6 +13,15 @@ mod vulkan_device;
 mod vulkan_sync;
 mod vulkan_texture;
 
+#[cfg(target_os = "linux")]
+mod consumer_vulkan_device;
+#[cfg(target_os = "linux")]
+mod consumer_vulkan_pixel_buffer;
+#[cfg(target_os = "linux")]
+mod consumer_vulkan_sync;
+#[cfg(target_os = "linux")]
+mod consumer_vulkan_texture;
+
 pub use device_capability::{ConsumerMarker, DevicePrivilege, HostMarker, VulkanRhiDevice};
 pub use vulkan_command_buffer::VulkanCommandBuffer;
 pub use vulkan_command_queue::VulkanCommandQueue;
@@ -23,6 +32,15 @@ pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 #[allow(unused_imports)]
 pub use vulkan_sync::VulkanTimelineSemaphore;
 pub use vulkan_texture::VulkanTexture;
+
+#[cfg(target_os = "linux")]
+pub use consumer_vulkan_device::ConsumerVulkanDevice;
+#[cfg(target_os = "linux")]
+pub use consumer_vulkan_pixel_buffer::ConsumerVulkanPixelBuffer;
+#[cfg(target_os = "linux")]
+pub use consumer_vulkan_sync::ConsumerVulkanTimelineSemaphore;
+#[cfg(target_os = "linux")]
+pub use consumer_vulkan_texture::ConsumerVulkanTexture;
 
 mod vulkan_blitter;
 pub use vulkan_blitter::VulkanBlitter;

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -6,12 +6,14 @@
 //! Device, texture, command buffer/queue, sync, pixel buffer, and texture cache
 //! are fully implemented via ash. Blitter and format converter are partial.
 
+mod device_capability;
 mod vulkan_command_buffer;
 mod vulkan_command_queue;
 mod vulkan_device;
 mod vulkan_sync;
 mod vulkan_texture;
 
+pub use device_capability::{ConsumerMarker, DevicePrivilege, HostMarker, VulkanRhiDevice};
 pub use vulkan_command_buffer::VulkanCommandBuffer;
 pub use vulkan_command_queue::VulkanCommandQueue;
 pub use vulkan_device::VulkanDevice;

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -22,7 +22,10 @@ mod consumer_vulkan_sync;
 #[cfg(target_os = "linux")]
 mod consumer_vulkan_texture;
 
-pub use device_capability::{ConsumerMarker, DevicePrivilege, HostMarker, VulkanRhiDevice};
+pub use device_capability::{
+    ConsumerMarker, DevicePrivilege, HostMarker, VulkanRhiDevice, VulkanTextureLike,
+    VulkanTimelineSemaphoreLike,
+};
 pub use vulkan_command_buffer::VulkanCommandBuffer;
 pub use vulkan_command_queue::VulkanCommandQueue;
 pub use vulkan_device::HostVulkanDevice;

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -25,13 +25,13 @@ mod consumer_vulkan_texture;
 pub use device_capability::{ConsumerMarker, DevicePrivilege, HostMarker, VulkanRhiDevice};
 pub use vulkan_command_buffer::VulkanCommandBuffer;
 pub use vulkan_command_queue::VulkanCommandQueue;
-pub use vulkan_device::VulkanDevice;
+pub use vulkan_device::HostVulkanDevice;
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 #[cfg(target_os = "linux")]
 #[allow(unused_imports)]
-pub use vulkan_sync::VulkanTimelineSemaphore;
-pub use vulkan_texture::VulkanTexture;
+pub use vulkan_sync::HostVulkanTimelineSemaphore;
+pub use vulkan_texture::HostVulkanTexture;
 
 #[cfg(target_os = "linux")]
 pub use consumer_vulkan_device::ConsumerVulkanDevice;
@@ -46,7 +46,7 @@ mod vulkan_blitter;
 pub use vulkan_blitter::VulkanBlitter;
 
 pub(crate) mod vulkan_pixel_buffer;
-pub use vulkan_pixel_buffer::VulkanPixelBuffer;
+pub use vulkan_pixel_buffer::HostVulkanPixelBuffer;
 
 mod vulkan_texture_cache;
 pub use vulkan_texture_cache::VulkanTextureCache;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -10,11 +10,11 @@ use crate::core::rhi::blitter::RhiBlitter;
 use crate::core::rhi::RhiPixelBuffer;
 use crate::core::{Result, StreamError};
 
-use super::VulkanDevice;
+use super::HostVulkanDevice;
 
 /// Vulkan implementation of [`RhiBlitter`] for GPU copy operations on Linux.
 pub struct VulkanBlitter {
-    vulkan_device: Arc<VulkanDevice>,
+    vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     #[allow(dead_code)]
@@ -24,7 +24,7 @@ pub struct VulkanBlitter {
 
 impl VulkanBlitter {
     /// Create a new Vulkan blitter with a dedicated command pool.
-    pub fn new(vulkan_device: &Arc<VulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Result<Self> {
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Result<Self> {
         let device = vulkan_device.device();
         let pool_info = vk::CommandPoolCreateInfo::builder()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
@@ -187,15 +187,15 @@ unsafe impl Sync for VulkanBlitter {}
 mod tests {
     use super::*;
     use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
-    use crate::vulkan::rhi::{VulkanDevice, VulkanPixelBuffer};
+    use crate::vulkan::rhi::{HostVulkanDevice, HostVulkanPixelBuffer};
     use std::sync::Arc;
 
     fn make_rhi_buffer(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
     ) -> RhiPixelBuffer {
-        let buf = VulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        let buf = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
             .expect("pixel buffer allocation failed");
         RhiPixelBuffer::new(RhiPixelBufferRef {
             inner: Arc::new(buf),
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_blit_copy_between_equal_size_buffers() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_blit_copy_rejects_mismatched_buffer_sizes() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_buffer.rs
@@ -8,14 +8,14 @@ use std::sync::Arc;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use super::{VulkanDevice, VulkanTexture};
+use super::{HostVulkanDevice, HostVulkanTexture};
 
 /// Vulkan command buffer wrapper.
 ///
 /// Command buffers are single-use: create, record, commit.
 /// The buffer is automatically begun when created.
 pub struct VulkanCommandBuffer {
-    vulkan_device: Arc<VulkanDevice>,
+    vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -25,7 +25,7 @@ pub struct VulkanCommandBuffer {
 impl VulkanCommandBuffer {
     /// Create a new command buffer wrapper.
     pub fn new(
-        vulkan_device: Arc<VulkanDevice>,
+        vulkan_device: Arc<HostVulkanDevice>,
         queue: vk::Queue,
         command_pool: vk::CommandPool,
         command_buffer: vk::CommandBuffer,
@@ -41,7 +41,7 @@ impl VulkanCommandBuffer {
     }
 
     /// Copy one texture to another.
-    pub fn copy_texture(&mut self, src: &VulkanTexture, dst: &VulkanTexture) {
+    pub fn copy_texture(&mut self, src: &HostVulkanTexture, dst: &HostVulkanTexture) {
         // Skip if either texture doesn't have a valid image
         let (Some(src_image), Some(dst_image)) = (src.image(), dst.image()) else {
             return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
@@ -10,13 +10,13 @@ use vulkanalia::vk;
 
 use crate::core::{Result, StreamError};
 
-use super::{VulkanCommandBuffer, VulkanDevice};
+use super::{VulkanCommandBuffer, HostVulkanDevice};
 
 /// Vulkan command queue wrapper.
 ///
 /// Manages the Vulkan queue and command pool for allocating command buffers.
 pub struct VulkanCommandQueue {
-    vulkan_device: Arc<VulkanDevice>,
+    vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -24,7 +24,7 @@ pub struct VulkanCommandQueue {
 
 impl VulkanCommandQueue {
     /// Create a new command queue wrapper.
-    pub fn new(vulkan_device: Arc<VulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Self {
+    pub fn new(vulkan_device: Arc<HostVulkanDevice>, queue: vk::Queue, queue_family_index: u32) -> Self {
         let device = vulkan_device.device().clone();
 
         // Create command pool for this queue family
@@ -100,11 +100,11 @@ unsafe impl Sync for VulkanCommandQueue {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vulkan::rhi::VulkanDevice;
+    use crate::vulkan::rhi::HostVulkanDevice;
 
     #[test]
     fn test_creates_command_buffer() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_empty_command_buffer_commit_and_wait_completes() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -27,7 +27,7 @@ use crate::core::rhi::{
 };
 use crate::core::{Result, StreamError};
 
-use super::VulkanDevice;
+use super::HostVulkanDevice;
 
 /// One compute kernel: shader pipeline + descriptor set + per-dispatch primitives.
 ///
@@ -38,7 +38,7 @@ use super::VulkanDevice;
 /// this abstraction targets.
 pub struct VulkanComputeKernel {
     label: String,
-    vulkan_device: Arc<VulkanDevice>,
+    vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
     queue: vk::Queue,
     bindings: Vec<ComputeBindingSpec>,
@@ -85,7 +85,7 @@ impl VulkanComputeKernel {
     /// `bindings` match the shader's descriptor types, and rejects any mismatch
     /// before allocating Vulkan objects.
     pub fn new(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         descriptor: &ComputeKernelDescriptor<'_>,
     ) -> Result<Self> {
         let queue = vulkan_device.queue();
@@ -920,10 +920,10 @@ fn vk_image_view_for(texture: &StreamTexture) -> Result<vk::ImageView> {
 mod tests {
     use super::*;
     use crate::core::rhi::PixelFormat;
-    use crate::vulkan::rhi::VulkanPixelBuffer;
+    use crate::vulkan::rhi::HostVulkanPixelBuffer;
 
-    fn try_vulkan_device() -> Option<Arc<VulkanDevice>> {
-        match VulkanDevice::new() {
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
             Ok(d) => Some(Arc::new(d)),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -935,10 +935,10 @@ mod tests {
     /// Allocate a HOST_VISIBLE storage buffer of `element_count * 4` bytes
     /// usable as both an input and output of the test_blend kernel.
     fn make_storage_buffer(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         element_count: u32,
     ) -> RhiPixelBuffer {
-        let vk_buf = VulkanPixelBuffer::new(device, element_count, 1, 4, PixelFormat::Bgra32)
+        let vk_buf = HostVulkanPixelBuffer::new(device, element_count, 1, 4, PixelFormat::Bgra32)
             .expect("Failed to create storage buffer");
         let ref_ = crate::core::rhi::RhiPixelBufferRef {
             inner: Arc::new(vk_buf),
@@ -982,7 +982,7 @@ mod tests {
     }
 
     fn run_blend_kernel_for(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         input_count: u32,
         element_count: u32,
     ) -> (Vec<RhiPixelBuffer>, RhiPixelBuffer) {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -18,7 +18,7 @@ use crate::core::{Result, StreamError};
 
 #[cfg(target_os = "linux")]
 use super::drm_modifier_probe::{self, DrmModifierTable};
-use super::{VulkanCommandQueue, VulkanTexture};
+use super::{HostMarker, VulkanCommandQueue, VulkanRhiDevice, VulkanTexture};
 
 /// Vulkan GPU device.
 ///
@@ -1315,6 +1315,31 @@ impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
     fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
         let _guard = self.lock_device();
         f();
+    }
+}
+
+impl VulkanRhiDevice for VulkanDevice {
+    type Privilege = HostMarker;
+
+    fn device(&self) -> &vulkanalia::Device {
+        &self.device
+    }
+
+    fn queue(&self) -> vk::Queue {
+        self.queue
+    }
+
+    fn queue_family_index(&self) -> u32 {
+        self.queue_family_index
+    }
+
+    unsafe fn submit_to_queue(
+        &self,
+        queue: vk::Queue,
+        submits: &[vk::SubmitInfo2],
+        fence: vk::Fence,
+    ) -> Result<()> {
+        unsafe { VulkanDevice::submit_to_queue(self, queue, submits, fence) }
     }
 }
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -18,13 +18,13 @@ use crate::core::{Result, StreamError};
 
 #[cfg(target_os = "linux")]
 use super::drm_modifier_probe::{self, DrmModifierTable};
-use super::{HostMarker, VulkanCommandQueue, VulkanRhiDevice, VulkanTexture};
+use super::{HostMarker, VulkanCommandQueue, VulkanRhiDevice, HostVulkanTexture};
 
 /// Vulkan GPU device.
 ///
 /// Wraps the Vulkan instance, physical device, and logical device.
 /// On macOS/iOS, uses MoltenVK to provide Vulkan API on top of Metal.
-pub struct VulkanDevice {
+pub struct HostVulkanDevice {
     entry: vulkanalia::Entry,
     instance: vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
@@ -81,7 +81,7 @@ pub struct VulkanDevice {
     /// Render-target-capable DRM modifiers per format from the EGL probe at
     /// device init. Empty when libEGL is unavailable or the probe failed.
     /// Callers consult this before requesting
-    /// [`VulkanTexture::new_render_target_dma_buf`].
+    /// [`HostVulkanTexture::new_render_target_dma_buf`].
     #[cfg(target_os = "linux")]
     drm_modifier_table: Arc<DrmModifierTable>,
     /// Tracks DMA-BUF import-path allocations (raw vkAllocateMemory for import only).
@@ -100,7 +100,7 @@ pub struct VulkanDevice {
     device_mutex: Mutex<()>,
 }
 
-impl VulkanDevice {
+impl HostVulkanDevice {
     /// Create a new Vulkan device.
     ///
     /// On macOS/iOS, this loads MoltenVK and enables VK_EXT_metal_objects
@@ -864,7 +864,7 @@ fn probe_tiled_dma_buf_memory_type(
     )))
 }
 
-impl VulkanDevice {
+impl HostVulkanDevice {
     /// Build VMA pools dedicated to DMA-BUF exportable allocations.
     ///
     /// Each pool is pinned to a memory type that supports the relevant property
@@ -895,7 +895,7 @@ impl VulkanDevice {
     )> {
         // ── Find memory type for HOST_VISIBLE DMA-BUF exportable buffers ──
         // The probe must mirror the real buffer create info used by
-        // `VulkanPixelBuffer::new`, including the `ExternalMemoryBufferCreateInfo`
+        // `HostVulkanPixelBuffer::new`, including the `ExternalMemoryBufferCreateInfo`
         // pNext chain — DMA-BUF external buffers have a narrower
         // `memoryTypeBits` than plain buffers, and omitting the chain lets VMA
         // pick a memory type the real buffer won't accept at bind time
@@ -932,7 +932,7 @@ impl VulkanDevice {
         })?;
 
         // ── Find memory type for DEVICE_LOCAL DMA-BUF exportable images ──
-        // Same rationale: the real image (`VulkanTexture::new`) carries
+        // Same rationale: the real image (`HostVulkanTexture::new`) carries
         // `ExternalMemoryImageCreateInfo::DMA_BUF_EXT` which can narrow
         // `memoryTypeBits`.
         let mut probe_image_external_info = vk::ExternalMemoryImageCreateInfo::builder()
@@ -985,7 +985,7 @@ impl VulkanDevice {
         // ── Create the pools ──────────────────────────────────────────────────
         // VMA's pMemoryAllocateNext stores a raw pointer to the export info.
         // Box gives a stable heap address — we keep the Boxes alive by returning
-        // them alongside the pools. Drop order (handled by VulkanDevice::drop):
+        // them alongside the pools. Drop order (handled by HostVulkanDevice::drop):
         // pool → Box, so the pointer is valid for the pool's entire lifetime.
         let mut buffer_pool_options = vma::PoolOptions::default();
         buffer_pool_options = buffer_pool_options.push_next(buffer_export_info.as_mut());
@@ -1117,8 +1117,8 @@ impl VulkanDevice {
     }
 
     /// Create a texture on this device.
-    pub fn create_texture(self: &Arc<Self>, desc: &TextureDescriptor) -> Result<VulkanTexture> {
-        VulkanTexture::new(self, desc)
+    pub fn create_texture(self: &Arc<Self>, desc: &TextureDescriptor) -> Result<HostVulkanTexture> {
+        HostVulkanTexture::new(self, desc)
     }
 
     /// Create a non-exportable device-local texture for same-process consumers.
@@ -1131,8 +1131,8 @@ impl VulkanDevice {
     pub fn create_texture_local(
         self: &Arc<Self>,
         desc: &TextureDescriptor,
-    ) -> Result<VulkanTexture> {
-        VulkanTexture::new_device_local(self, desc)
+    ) -> Result<HostVulkanTexture> {
+        HostVulkanTexture::new_device_local(self, desc)
     }
 
     /// Create a VulkanCommandQueue wrapper for the shared command queue.
@@ -1300,7 +1300,7 @@ impl VulkanDevice {
     }
 }
 
-impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
+impl vulkan_video::RhiQueueSubmitter for HostVulkanDevice {
     unsafe fn submit_to_queue(
         &self,
         queue: vk::Queue,
@@ -1318,7 +1318,7 @@ impl vulkan_video::RhiQueueSubmitter for VulkanDevice {
     }
 }
 
-impl VulkanRhiDevice for VulkanDevice {
+impl VulkanRhiDevice for HostVulkanDevice {
     type Privilege = HostMarker;
 
     fn device(&self) -> &vulkanalia::Device {
@@ -1339,11 +1339,11 @@ impl VulkanRhiDevice for VulkanDevice {
         submits: &[vk::SubmitInfo2],
         fence: vk::Fence,
     ) -> Result<()> {
-        unsafe { VulkanDevice::submit_to_queue(self, queue, submits, fence) }
+        unsafe { HostVulkanDevice::submit_to_queue(self, queue, submits, fence) }
     }
 }
 
-impl VulkanDevice {
+impl HostVulkanDevice {
     /// Copy a host-visible VkBuffer to a device-local VkImage (RGBA upload).
     ///
     /// Transitions the image UNDEFINED → TRANSFER_DST → SHADER_READ_ONLY.
@@ -1511,7 +1511,7 @@ impl VulkanDevice {
 
         let count = self.live_allocation_count.fetch_add(1, Ordering::Relaxed) + 1;
         tracing::debug!(
-            "VulkanDevice: DMA-BUF memory imported ({} bytes, type={}, live={})",
+            "HostVulkanDevice: DMA-BUF memory imported ({} bytes, type={}, live={})",
             allocation_size, memory_type_index, count
         );
 
@@ -1548,7 +1548,7 @@ impl VulkanDevice {
     /// Render-target-capable DRM format modifiers, by DRM FOURCC, from the
     /// EGL probe at device init. Empty when the probe failed. Callers
     /// pass [`DrmModifierTable::rt_modifiers`] into
-    /// [`VulkanTexture::new_render_target_dma_buf`].
+    /// [`HostVulkanTexture::new_render_target_dma_buf`].
     #[cfg(target_os = "linux")]
     pub fn drm_modifier_table(&self) -> &Arc<DrmModifierTable> {
         &self.drm_modifier_table
@@ -1587,12 +1587,12 @@ impl VulkanDevice {
     }
 }
 
-impl Drop for VulkanDevice {
+impl Drop for HostVulkanDevice {
     fn drop(&mut self) {
         let live = self.live_allocation_count.load(Ordering::Relaxed);
         if live > 0 {
             tracing::warn!(
-                "VulkanDevice dropping with {} live import allocations (leak)",
+                "HostVulkanDevice dropping with {} live import allocations (leak)",
                 live
             );
         }
@@ -1629,17 +1629,17 @@ impl Drop for VulkanDevice {
     }
 }
 
-// VulkanDevice is Send + Sync because Vulkan handles are thread-safe
-unsafe impl Send for VulkanDevice {}
-unsafe impl Sync for VulkanDevice {}
+// HostVulkanDevice is Send + Sync because Vulkan handles are thread-safe
+unsafe impl Send for HostVulkanDevice {}
+unsafe impl Sync for HostVulkanDevice {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Try to create a VulkanDevice; return None if GPU/Vulkan is unavailable (CI).
-    fn try_create_device() -> Option<Arc<VulkanDevice>> {
-        match VulkanDevice::new() {
+    /// Try to create a HostVulkanDevice; return None if GPU/Vulkan is unavailable (CI).
+    fn try_create_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
             Ok(d) => Some(Arc::new(d)),
             Err(e) => {
                 println!("Skipping test — Vulkan not available: {e}");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
@@ -13,7 +13,7 @@ use crate::core::rhi::{
 };
 use crate::core::{Result, StreamError};
 
-use super::{VulkanComputeKernel, VulkanDevice};
+use super::{VulkanComputeKernel, HostVulkanDevice};
 
 /// Push-constants struct matching the `nv12_to_bgra` compute shader's
 /// `layout(push_constant)` block (width, height, flags). Flags encode:
@@ -38,7 +38,7 @@ pub struct VulkanFormatConverter {
 
 impl VulkanFormatConverter {
     pub fn new(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         source_bytes_per_pixel: u32,
         dest_bytes_per_pixel: u32,
     ) -> Result<Self> {
@@ -113,10 +113,10 @@ mod tests {
     use super::*;
     use crate::core::rhi::RhiPixelBufferRef;
     use crate::core::StreamError;
-    use crate::vulkan::rhi::VulkanPixelBuffer;
+    use crate::vulkan::rhi::HostVulkanPixelBuffer;
 
-    fn try_vulkan_device() -> Option<Arc<VulkanDevice>> {
-        match VulkanDevice::new() {
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
             Ok(d) => Some(Arc::new(d)),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -126,13 +126,13 @@ mod tests {
     }
 
     fn make_pixel_buffer(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
         bytes_per_pixel: u32,
         format: PixelFormat,
     ) -> RhiPixelBuffer {
-        let vk_buf = VulkanPixelBuffer::new(device, width, height, bytes_per_pixel, format)
+        let vk_buf = HostVulkanPixelBuffer::new(device, width, height, bytes_per_pixel, format)
             .expect("Failed to create pixel buffer");
         let ref_ = RhiPixelBufferRef {
             inner: Arc::new(vk_buf),
@@ -313,7 +313,7 @@ mod tests {
     }
 
     fn run_shader_against_fixture_input(
-        device: &Arc<VulkanDevice>,
+        device: &Arc<HostVulkanDevice>,
         nv12_bytes: &[u8],
     ) -> Vec<u8> {
         let nv12_buf = make_pixel_buffer(

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -11,19 +11,19 @@ use vma::Alloc as _;
 use crate::core::rhi::PixelFormat;
 use crate::core::{Result, StreamError};
 
-use super::VulkanDevice;
+use super::HostVulkanDevice;
 
-/// Process-global VulkanDevice reference for DMA-BUF import.
+/// Process-global HostVulkanDevice reference for DMA-BUF import.
 ///
 /// Set once during [`GpuDevice::new()`] on Linux. The import trait
 /// (`RhiPixelBufferImport::from_external_handle`) is a static method with no
 /// device parameter, so this global bridges that gap.
 #[cfg(target_os = "linux")]
-pub(crate) static VULKAN_DEVICE_FOR_IMPORT: std::sync::OnceLock<Arc<VulkanDevice>> =
+pub(crate) static VULKAN_DEVICE_FOR_IMPORT: std::sync::OnceLock<Arc<HostVulkanDevice>> =
     std::sync::OnceLock::new();
 
 /// One extra plane of a multi-plane DMA-BUF import (planes 1..N on the
-/// Linux side). Plane 0 lives in [`VulkanPixelBuffer::buffer`] /
+/// Linux side). Plane 0 lives in [`HostVulkanPixelBuffer::buffer`] /
 /// `imported_memory` / `mapped_ptr` for back-compat with the
 /// single-plane accessors; additional planes are stored here so an
 /// exported multi-plane format (e.g. NV12 with disjoint Y and UV
@@ -37,9 +37,9 @@ struct VulkanImportedPlane {
 }
 
 /// CPU-visible staging buffer for pixel data upload/readback.
-pub struct VulkanPixelBuffer {
-    /// VulkanDevice reference for tracked allocation/free through the RHI.
-    vulkan_device: Arc<VulkanDevice>,
+pub struct HostVulkanPixelBuffer {
+    /// HostVulkanDevice reference for tracked allocation/free through the RHI.
+    vulkan_device: Arc<HostVulkanDevice>,
     buffer: vk::Buffer,
     /// VMA allocation (HOST_VISIBLE | DEDICATED_MEMORY for DMA-BUF export).
     allocation: Option<vma::Allocation>,
@@ -62,7 +62,7 @@ pub struct VulkanPixelBuffer {
     size: vk::DeviceSize,
 }
 
-impl VulkanPixelBuffer {
+impl HostVulkanPixelBuffer {
     /// Create a new DMA-BUF exportable CPU-visible staging buffer via the
     /// device's dedicated VMA export pool.
     ///
@@ -70,7 +70,7 @@ impl VulkanPixelBuffer {
     /// avoiding NVIDIA driver failures where global export configuration causes
     /// OOM after swapchain creation.
     pub fn new(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
         bytes_per_pixel: u32,
@@ -247,7 +247,7 @@ impl VulkanPixelBuffer {
 }
 
 #[cfg(target_os = "linux")]
-impl VulkanPixelBuffer {
+impl HostVulkanPixelBuffer {
     /// Export the buffer's memory as a DMA-BUF file descriptor.
     pub fn export_dma_buf_fd(&self) -> Result<std::os::unix::io::RawFd> {
         // Determine which DeviceMemory to export from
@@ -281,7 +281,7 @@ impl VulkanPixelBuffer {
     /// existing single-plane callers — new code should prefer the
     /// multi-plane signature even when there is only one plane.
     pub fn from_dma_buf_fd(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         fd: std::os::unix::io::RawFd,
         width: u32,
         height: u32,
@@ -311,7 +311,7 @@ impl VulkanPixelBuffer {
     /// caller retains ownership of the fds — each fd is consumed by
     /// `vkAllocateMemory` only on success.
     pub fn from_dma_buf_fds(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         fds: &[std::os::unix::io::RawFd],
         plane_sizes: &[vk::DeviceSize],
         width: u32,
@@ -396,10 +396,10 @@ impl VulkanPixelBuffer {
 }
 
 /// Create one `VkBuffer` + bind one imported `VkDeviceMemory` + map it.
-/// Used by [`VulkanPixelBuffer::from_dma_buf_fds`] once per plane.
+/// Used by [`HostVulkanPixelBuffer::from_dma_buf_fds`] once per plane.
 #[cfg(target_os = "linux")]
 fn import_single_plane(
-    vulkan_device: &Arc<VulkanDevice>,
+    vulkan_device: &Arc<HostVulkanDevice>,
     fd: std::os::unix::io::RawFd,
     effective_size: vk::DeviceSize,
 ) -> Result<VulkanImportedPlane> {
@@ -461,10 +461,10 @@ fn import_single_plane(
     })
 }
 
-/// Partial-unwind helper for [`VulkanPixelBuffer::from_dma_buf_fds`] —
+/// Partial-unwind helper for [`HostVulkanPixelBuffer::from_dma_buf_fds`] —
 /// tears down one already-imported plane when a later plane fails.
 #[cfg(target_os = "linux")]
-fn teardown_imported_plane(vulkan_device: &Arc<VulkanDevice>, plane: VulkanImportedPlane) {
+fn teardown_imported_plane(vulkan_device: &Arc<HostVulkanDevice>, plane: VulkanImportedPlane) {
     unsafe {
         vulkan_device.device().destroy_buffer(plane.buffer, None);
     }
@@ -472,7 +472,7 @@ fn teardown_imported_plane(vulkan_device: &Arc<VulkanDevice>, plane: VulkanImpor
     vulkan_device.free_imported_memory(plane.memory);
 }
 
-impl Drop for VulkanPixelBuffer {
+impl Drop for HostVulkanPixelBuffer {
     fn drop(&mut self) {
         #[cfg(target_os = "linux")]
         if self.imported_from_dma_buf {
@@ -498,8 +498,8 @@ impl Drop for VulkanPixelBuffer {
 }
 
 // Safety: Vulkan handles are thread-safe
-unsafe impl Send for VulkanPixelBuffer {}
-unsafe impl Sync for VulkanPixelBuffer {}
+unsafe impl Send for HostVulkanPixelBuffer {}
+unsafe impl Sync for HostVulkanPixelBuffer {}
 
 #[cfg(test)]
 mod tests {
@@ -507,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_pool_buffer_creation_1920x1080_bgra32() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -515,7 +515,7 @@ mod tests {
             }
         };
 
-        let buf = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let buf = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer creation failed");
 
         assert_eq!(buf.width(), 1920);
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_buffer_write_and_readback() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -544,7 +544,7 @@ mod tests {
             }
         };
 
-        let buf = VulkanPixelBuffer::new(&device, 64, 64, 4, PixelFormat::Bgra32)
+        let buf = HostVulkanPixelBuffer::new(&device, 64, 64, 4, PixelFormat::Bgra32)
             .expect("buffer creation failed");
 
         let size = buf.size() as usize;
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_dma_buf_export() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -582,7 +582,7 @@ mod tests {
             }
         };
 
-        let buf = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let buf = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer creation failed");
 
         let fd = buf.export_dma_buf_fd().expect("DMA-BUF export failed");
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_multiple_buffers_coexist() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -603,13 +603,13 @@ mod tests {
             }
         };
 
-        let b0 = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let b0 = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer 0 failed");
-        let b1 = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let b1 = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer 1 failed");
-        let b2 = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let b2 = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer 2 failed");
-        let b3 = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let b3 = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer 3 failed");
 
         assert_ne!(b0.buffer(), vk::Buffer::null());
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_drop_frees_without_panic() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -637,7 +637,7 @@ mod tests {
             }
         };
 
-        let buf = VulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
+        let buf = HostVulkanPixelBuffer::new(&device, 1920, 1080, 4, PixelFormat::Bgra32)
             .expect("buffer creation failed");
         drop(buf);
 
@@ -646,7 +646,7 @@ mod tests {
 
     #[test]
     fn test_dma_buf_import_round_trip() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -658,7 +658,7 @@ mod tests {
         let width = 64u32;
         let height = 64u32;
         let bpp = 4u32;
-        let src = VulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
+        let src = HostVulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
             .expect("source buffer creation failed");
 
         let size = src.size() as usize;
@@ -674,7 +674,7 @@ mod tests {
         assert!(fd >= 0);
 
         // Import into a new buffer from the DMA-BUF fd
-        let imported = VulkanPixelBuffer::from_dma_buf_fd(
+        let imported = HostVulkanPixelBuffer::from_dma_buf_fd(
             &device,
             fd,
             width,
@@ -705,12 +705,12 @@ mod tests {
 
     /// Multi-plane `from_dma_buf_fds` round-trip: import two independently
     /// allocated + pattern-written DMA-BUFs as the two planes of a single
-    /// `VulkanPixelBuffer`, confirm `plane_count()` reports 2, and each
+    /// `HostVulkanPixelBuffer`, confirm `plane_count()` reports 2, and each
     /// plane's bytes survive intact. Mirrors the symmetry the polyglot
     /// Python and Deno shims provide via `*_gpu_surface_plane_{count,size,mmap,base_address}`.
     #[test]
     fn test_dma_buf_import_multi_plane_round_trip() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -726,9 +726,9 @@ mod tests {
         // Two independent source buffers, each seeded with a distinct
         // byte pattern so a cross-plane swap would be visible in the
         // readback.
-        let src0 = VulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
+        let src0 = HostVulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
             .expect("source plane 0 creation failed");
-        let src1 = VulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
+        let src1 = HostVulkanPixelBuffer::new(&device, width, height, bpp, PixelFormat::Bgra32)
             .expect("source plane 1 creation failed");
         let pattern0: [u8; 4] = [0xA0, 0xA1, 0xA2, 0xA3];
         let pattern1: [u8; 4] = [0xB0, 0xB1, 0xB2, 0xB3];
@@ -743,7 +743,7 @@ mod tests {
         let fd1 = src1.export_dma_buf_fd().expect("plane 1 export failed");
 
         // Import both as planes of a single pixel buffer.
-        let imported = VulkanPixelBuffer::from_dma_buf_fds(
+        let imported = HostVulkanPixelBuffer::from_dma_buf_fds(
             &device,
             &[fd0, fd1],
             &[plane_size, plane_size],
@@ -801,7 +801,7 @@ mod tests {
     /// enforce on sends/receives.
     #[test]
     fn test_dma_buf_import_rejects_oversize_plane_vec() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -818,7 +818,7 @@ mod tests {
                 .collect();
         let sizes: Vec<vk::DeviceSize> = vec![1024; fds.len()];
 
-        let result = VulkanPixelBuffer::from_dma_buf_fds(
+        let result = HostVulkanPixelBuffer::from_dma_buf_fds(
             &device,
             &fds,
             &sizes,

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
@@ -8,16 +8,16 @@ use std::sync::{Arc, Mutex};
 use crate::core::rhi::{PixelBufferPoolId, PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
 use crate::core::{Result, StreamError};
 
-use super::{VulkanDevice, VulkanPixelBuffer};
+use super::{HostVulkanDevice, HostVulkanPixelBuffer};
 
-/// Reusable pool of [`VulkanPixelBuffer`]s for efficient buffer recycling.
+/// Reusable pool of [`HostVulkanPixelBuffer`]s for efficient buffer recycling.
 pub struct VulkanPixelBufferPool {
-    device: Arc<VulkanDevice>,
+    device: Arc<HostVulkanDevice>,
     width: u32,
     height: u32,
     bytes_per_pixel: u32,
     format: PixelFormat,
-    buffers: Vec<Arc<VulkanPixelBuffer>>,
+    buffers: Vec<Arc<HostVulkanPixelBuffer>>,
     next_index: AtomicUsize,
     buffer_to_pool_id: Mutex<HashMap<usize, PixelBufferPoolId>>,
 }
@@ -30,7 +30,7 @@ impl VulkanPixelBufferPool {
     /// pre-allocation is acceptable — the pool degrades gracefully under
     /// memory pressure rather than failing the entire pipeline.
     pub fn new(
-        device: Arc<VulkanDevice>,
+        device: Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
         bytes_per_pixel: u32,
@@ -42,7 +42,7 @@ impl VulkanPixelBufferPool {
         let mut last_err: Option<StreamError> = None;
 
         for i in 0..pre_allocate {
-            match VulkanPixelBuffer::new(&device, width, height, bytes_per_pixel, format) {
+            match HostVulkanPixelBuffer::new(&device, width, height, bytes_per_pixel, format) {
                 Ok(buffer) => {
                     buffers.push(Arc::new(buffer));
                     buffer_to_pool_id.insert(i, PixelBufferPoolId::new());
@@ -146,11 +146,11 @@ unsafe impl Sync for VulkanPixelBufferPool {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vulkan::rhi::VulkanDevice;
+    use crate::vulkan::rhi::HostVulkanDevice;
 
     #[test]
     fn test_pool_acquire_returns_buffer() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_pool_exhaustion_returns_error() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_pool_reuses_buffer_after_release() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
@@ -26,7 +26,7 @@ use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::window::{Window, WindowAttributes, WindowId};
 
-use super::VulkanDevice;
+use super::HostVulkanDevice;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Custom VMA allocator builders for testing different configurations
@@ -34,7 +34,7 @@ use super::VulkanDevice;
 
 /// Build a VMA allocator with the BROKEN config — pTypeExternalMemoryHandleTypes
 /// set globally for all memory types.
-fn build_vma_with_global_export(device: &VulkanDevice) -> vma::Allocator {
+fn build_vma_with_global_export(device: &HostVulkanDevice) -> vma::Allocator {
     let instance = device.instance();
     let vk_device = device.device();
     let physical_device = device.physical_device();
@@ -53,7 +53,7 @@ fn build_vma_with_global_export(device: &VulkanDevice) -> vma::Allocator {
 }
 
 /// Build a VMA allocator with NO global export config. Pools handle export.
-fn build_vma_without_global_export(device: &VulkanDevice) -> vma::Allocator {
+fn build_vma_without_global_export(device: &HostVulkanDevice) -> vma::Allocator {
     let instance = device.instance();
     let vk_device = device.device();
     let physical_device = device.physical_device();
@@ -196,7 +196,7 @@ enum TestScenario {
 /// This is critical because the bug only triggers AFTER the compositor has had
 /// a chance to import the swapchain images as DMA-BUFs.
 struct SwapchainTestApp {
-    device: Arc<VulkanDevice>,
+    device: Arc<HostVulkanDevice>,
     scenario: TestScenario,
     width: u32,
     height: u32,
@@ -662,7 +662,7 @@ struct SwapchainResources {
 }
 
 fn create_swapchain(
-    device: &VulkanDevice,
+    device: &HostVulkanDevice,
     surface: vk::SurfaceKHR,
     width: u32,
     height: u32,
@@ -746,8 +746,8 @@ fn create_swapchain(
 // Test harness — runs a scenario inside winit's event loop
 // ─────────────────────────────────────────────────────────────────────────────
 
-fn try_create_device() -> Option<Arc<VulkanDevice>> {
-    match VulkanDevice::new() {
+fn try_create_device() -> Option<Arc<HostVulkanDevice>> {
+    match HostVulkanDevice::new() {
         Ok(d) => Some(Arc::new(d)),
         Err(e) => {
             println!("Skipping — Vulkan device unavailable: {e}");
@@ -935,7 +935,7 @@ fn test_swapchain_allocation_scenarios() {
 /// Helper that runs a scenario via the shared event loop.
 fn run_scenario_via_event_loop(
     event_loop: &mut EventLoop<()>,
-    device: Arc<VulkanDevice>,
+    device: Arc<HostVulkanDevice>,
     scenario: TestScenario,
 ) -> AllocationOutcome {
     use winit::platform::run_on_demand::EventLoopExtRunOnDemand;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
@@ -186,7 +186,7 @@ unsafe impl Sync for VulkanFence {}
 /// file descriptor to a subprocess, which imports it via
 /// [`Self::from_imported_opaque_fd`] into its own `VkDevice`. The two
 /// processes then signal/wait the same timeline.
-pub struct VulkanTimelineSemaphore {
+pub struct HostVulkanTimelineSemaphore {
     device: vulkanalia::Device,
     semaphore: vk::Semaphore,
     /// Whether the semaphore was created with VK_KHR_external_semaphore_fd
@@ -195,7 +195,7 @@ pub struct VulkanTimelineSemaphore {
 }
 
 #[cfg(target_os = "linux")]
-impl VulkanTimelineSemaphore {
+impl HostVulkanTimelineSemaphore {
     /// Create an in-process timeline semaphore (no export).
     ///
     /// Pair with [`Self::wait`] / [`Self::signal_host`] / [`Self::signal_on_queue`]
@@ -315,7 +315,7 @@ impl VulkanTimelineSemaphore {
     pub fn export_opaque_fd(&self) -> Result<std::os::unix::io::RawFd> {
         if !self.exportable {
             return Err(StreamError::GpuError(
-                "VulkanTimelineSemaphore::export_opaque_fd: semaphore was not created with `new_exportable`".into(),
+                "HostVulkanTimelineSemaphore::export_opaque_fd: semaphore was not created with `new_exportable`".into(),
             ));
         }
         let info = vk::SemaphoreGetFdInfoKHR::builder()
@@ -387,25 +387,25 @@ impl VulkanTimelineSemaphore {
 }
 
 #[cfg(target_os = "linux")]
-impl Drop for VulkanTimelineSemaphore {
+impl Drop for HostVulkanTimelineSemaphore {
     fn drop(&mut self) {
         unsafe { self.device.destroy_semaphore(self.semaphore, None) };
     }
 }
 
 #[cfg(target_os = "linux")]
-unsafe impl Send for VulkanTimelineSemaphore {}
+unsafe impl Send for HostVulkanTimelineSemaphore {}
 #[cfg(target_os = "linux")]
-unsafe impl Sync for VulkanTimelineSemaphore {}
+unsafe impl Sync for HostVulkanTimelineSemaphore {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vulkan::rhi::VulkanDevice;
+    use crate::vulkan::rhi::HostVulkanDevice;
 
     #[test]
     fn test_semaphore_creation() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => d,
             Err(_) => {
                 println!("Skipping test - Vulkan not available");
@@ -421,14 +421,14 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn timeline_semaphore_host_signal_advances_counter() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => d,
             Err(_) => {
                 println!("Skipping test - Vulkan not available");
                 return;
             }
         };
-        let sem = VulkanTimelineSemaphore::new(device.device(), 0)
+        let sem = HostVulkanTimelineSemaphore::new(device.device(), 0)
             .expect("create timeline semaphore");
         assert_eq!(sem.current_value().unwrap(), 0);
         sem.signal_host(7).expect("host signal");
@@ -444,14 +444,14 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn timeline_semaphore_exports_valid_opaque_fd() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => d,
             Err(_) => {
                 println!("Skipping test - Vulkan not available");
                 return;
             }
         };
-        let sem = match VulkanTimelineSemaphore::new_exportable(device.device(), 0) {
+        let sem = match HostVulkanTimelineSemaphore::new_exportable(device.device(), 0) {
             Ok(s) => s,
             Err(_) => {
                 println!("Skipping — VK_KHR_external_semaphore_fd unavailable on this driver");
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_fence_creation() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => d,
             Err(_) => {
                 println!("Skipping test - Vulkan not available");

--- a/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
@@ -398,6 +398,16 @@ unsafe impl Send for HostVulkanTimelineSemaphore {}
 #[cfg(target_os = "linux")]
 unsafe impl Sync for HostVulkanTimelineSemaphore {}
 
+#[cfg(target_os = "linux")]
+impl super::VulkanTimelineSemaphoreLike for HostVulkanTimelineSemaphore {
+    fn wait(&self, value: u64, timeout_ns: u64) -> crate::core::Result<()> {
+        HostVulkanTimelineSemaphore::wait(self, value, timeout_ns)
+    }
+    fn signal_host(&self, value: u64) -> crate::core::Result<()> {
+        HostVulkanTimelineSemaphore::signal_host(self, value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -974,6 +974,22 @@ impl Drop for HostVulkanTexture {
 unsafe impl Send for HostVulkanTexture {}
 unsafe impl Sync for HostVulkanTexture {}
 
+impl super::VulkanTextureLike for HostVulkanTexture {
+    fn image(&self) -> Option<vk::Image> {
+        HostVulkanTexture::image(self)
+    }
+    fn chosen_drm_format_modifier(&self) -> u64 {
+        #[cfg(target_os = "linux")]
+        {
+            HostVulkanTexture::chosen_drm_format_modifier(self)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            0
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -988,6 +988,15 @@ impl super::VulkanTextureLike for HostVulkanTexture {
             0
         }
     }
+    fn width(&self) -> u32 {
+        HostVulkanTexture::width(self)
+    }
+    fn height(&self) -> u32 {
+        HostVulkanTexture::height(self)
+    }
+    fn format(&self) -> crate::core::rhi::TextureFormat {
+        HostVulkanTexture::format(self)
+    }
 }
 
 #[cfg(test)]

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -13,7 +13,7 @@ use vma::Alloc as _;
 use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
 use crate::core::{Result, StreamError};
 
-use super::VulkanDevice;
+use super::HostVulkanDevice;
 
 #[cfg(target_os = "linux")]
 use super::drm_modifier_probe::fourcc;
@@ -84,11 +84,11 @@ fn texture_usages_to_vk(usage: TextureUsages) -> vk::ImageUsageFlags {
 ///
 /// Wraps a VkImage with associated memory and metadata.
 /// Can be created from scratch or imported from an IOSurface via VK_EXT_metal_objects.
-pub struct VulkanTexture {
-    /// VulkanDevice reference for tracked allocation/free through the RHI.
-    vulkan_device: Option<Arc<VulkanDevice>>,
+pub struct HostVulkanTexture {
+    /// HostVulkanDevice reference for tracked allocation/free through the RHI.
+    vulkan_device: Option<Arc<HostVulkanDevice>>,
     image: Option<vk::Image>,
-    /// VMA allocation (always allocated with DMA-BUF export flags via VulkanDevice).
+    /// VMA allocation (always allocated with DMA-BUF export flags via HostVulkanDevice).
     allocation: Option<vma::Allocation>,
     /// Imported device memory for DMA-BUF import path (VMA cannot import external memory).
     #[cfg(target_os = "linux")]
@@ -116,7 +116,7 @@ pub struct VulkanTexture {
     format: TextureFormat,
 }
 
-impl VulkanTexture {
+impl HostVulkanTexture {
     /// Create a new DMA-BUF exportable Vulkan texture via the device's
     /// dedicated VMA export pool.
     ///
@@ -125,7 +125,7 @@ impl VulkanTexture {
     /// allocations from the default VMA pool. This avoids NVIDIA driver
     /// failures where global export configuration causes OOM after swapchain
     /// creation.
-    pub fn new(vulkan_device: &Arc<VulkanDevice>, desc: &TextureDescriptor) -> Result<Self> {
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>, desc: &TextureDescriptor) -> Result<Self> {
         let vk_format = texture_format_to_vk(desc.format);
         let usage_flags = texture_usages_to_vk(desc.usage);
 
@@ -205,7 +205,7 @@ impl VulkanTexture {
     /// VMA allocator with no external memory info. For same-process textures that
     /// don't need cross-process sharing.
     pub fn new_device_local(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         desc: &TextureDescriptor,
     ) -> Result<Self> {
         let vk_format = texture_format_to_vk(desc.format);
@@ -277,7 +277,7 @@ impl VulkanTexture {
     /// want a linear allocation should use [`Self::new`].
     #[cfg(target_os = "linux")]
     pub fn new_render_target_dma_buf(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         desc: &TextureDescriptor,
         modifier_candidates: &[u64],
     ) -> Result<Self> {
@@ -370,7 +370,7 @@ impl VulkanTexture {
         }
 
         tracing::info!(
-            "VulkanTexture render-target DMA-BUF: {}x{} {:?} → modifier 0x{:016x}",
+            "HostVulkanTexture render-target DMA-BUF: {}x{} {:?} → modifier 0x{:016x}",
             desc.width,
             desc.height,
             desc.format,
@@ -472,7 +472,7 @@ impl VulkanTexture {
         })
     }
 
-    /// Create a placeholder texture for cases where a VulkanTexture is needed
+    /// Create a placeholder texture for cases where a HostVulkanTexture is needed
     /// but the actual texture is stored elsewhere (e.g., Metal texture on macOS).
     pub fn placeholder() -> Self {
         Self {
@@ -526,7 +526,7 @@ impl VulkanTexture {
         }
 
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("Cannot create image view: no VulkanDevice stored".into())
+            StreamError::GpuError("Cannot create image view: no HostVulkanDevice stored".into())
         })?;
         let image = self.image.ok_or_else(|| {
             StreamError::GpuError("Cannot create image view: no image".into())
@@ -557,7 +557,7 @@ impl VulkanTexture {
 }
 
 #[cfg(target_os = "linux")]
-impl VulkanTexture {
+impl HostVulkanTexture {
     /// DRM format modifier the driver picked at allocation time.
     ///
     /// Zero for textures created via [`Self::new`] / [`Self::new_device_local`]
@@ -582,7 +582,7 @@ impl VulkanTexture {
     /// build.
     pub fn dma_buf_plane_layout(&self) -> Result<Vec<(u64, u64)>> {
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("dma_buf_plane_layout: no VulkanDevice".into())
+            StreamError::GpuError("dma_buf_plane_layout: no HostVulkanDevice".into())
         })?;
         let image = self.image.ok_or_else(|| {
             StreamError::GpuError("dma_buf_plane_layout: no image".into())
@@ -642,7 +642,7 @@ impl VulkanTexture {
         }
 
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("Cannot export DMA-BUF: no VulkanDevice stored".into())
+            StreamError::GpuError("Cannot export DMA-BUF: no HostVulkanDevice stored".into())
         })?;
 
         // Get DeviceMemory from raw allocation (export/import path) or VMA allocation
@@ -693,7 +693,7 @@ impl VulkanTexture {
     /// success (the driver `dup`s internally and releases on
     /// `vkFreeMemory`). On error the caller still owns `fds[0]`.
     pub fn import_render_target_dma_buf(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         fds: &[std::os::unix::io::RawFd],
         plane_offsets: &[u64],
         plane_strides: &[u64],
@@ -824,7 +824,7 @@ impl VulkanTexture {
 
     /// Import a texture from a DMA-BUF file descriptor.
     pub fn from_dma_buf_fd(
-        vulkan_device: &Arc<VulkanDevice>,
+        vulkan_device: &Arc<HostVulkanDevice>,
         fd: std::os::unix::io::RawFd,
         width: u32,
         height: u32,
@@ -902,7 +902,7 @@ impl VulkanTexture {
     }
 }
 
-impl Clone for VulkanTexture {
+impl Clone for HostVulkanTexture {
     fn clone(&self) -> Self {
         Self {
             vulkan_device: None,
@@ -925,7 +925,7 @@ impl Clone for VulkanTexture {
     }
 }
 
-impl Drop for VulkanTexture {
+impl Drop for HostVulkanTexture {
     fn drop(&mut self) {
         // Destroy cached image view before the image it references
         if let Some(&view) = self.cached_image_view.get() {
@@ -970,18 +970,18 @@ impl Drop for VulkanTexture {
     }
 }
 
-// VulkanTexture is Send + Sync because Vulkan handles are thread-safe
-unsafe impl Send for VulkanTexture {}
-unsafe impl Sync for VulkanTexture {}
+// HostVulkanTexture is Send + Sync because Vulkan handles are thread-safe
+unsafe impl Send for HostVulkanTexture {}
+unsafe impl Sync for HostVulkanTexture {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vulkan::rhi::VulkanDevice;
+    use crate::vulkan::rhi::HostVulkanDevice;
 
     #[test]
     fn test_pool_texture_creation_1920x1080_bgra8() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -990,7 +990,7 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Bgra8Unorm);
-        let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+        let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
 
         assert!(texture.image().is_some());
         assert_eq!(texture.width(), 1920);
@@ -1007,7 +1007,7 @@ mod tests {
 
     #[test]
     fn test_texture_drop_frees_memory() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1016,7 +1016,7 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Bgra8Unorm);
-        let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+        let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
         drop(texture);
 
         println!("Texture drop completed without panic");
@@ -1024,7 +1024,7 @@ mod tests {
 
     #[test]
     fn test_multiple_textures_coexist() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1034,10 +1034,10 @@ mod tests {
 
         let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Bgra8Unorm);
 
-        let t0 = VulkanTexture::new(&device, &desc).expect("texture 0 failed");
-        let t1 = VulkanTexture::new(&device, &desc).expect("texture 1 failed");
-        let t2 = VulkanTexture::new(&device, &desc).expect("texture 2 failed");
-        let t3 = VulkanTexture::new(&device, &desc).expect("texture 3 failed");
+        let t0 = HostVulkanTexture::new(&device, &desc).expect("texture 0 failed");
+        let t1 = HostVulkanTexture::new(&device, &desc).expect("texture 1 failed");
+        let t2 = HostVulkanTexture::new(&device, &desc).expect("texture 2 failed");
+        let t3 = HostVulkanTexture::new(&device, &desc).expect("texture 3 failed");
 
         assert!(t0.image().is_some());
         assert!(t1.image().is_some());
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_dma_buf_export() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1065,18 +1065,18 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Bgra8Unorm);
-        let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+        let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
 
         let fd = texture.export_dma_buf_fd().expect("DMA-BUF export failed");
         assert!(fd >= 0, "DMA-BUF fd must be non-negative, got {fd}");
 
         println!("DMA-BUF exported: fd={fd}");
-        // fd is closed by VulkanTexture::drop via cached_dma_buf_fd
+        // fd is closed by HostVulkanTexture::drop via cached_dma_buf_fd
     }
 
     #[test]
     fn test_placeholder_has_no_resources() {
-        let tex = VulkanTexture::placeholder();
+        let tex = HostVulkanTexture::placeholder();
         assert!(tex.image().is_none());
         assert_eq!(tex.width(), 0);
         assert_eq!(tex.height(), 0);
@@ -1101,7 +1101,7 @@ mod tests {
     /// dedicated allocation + multi-type fallback (no export flags).
     #[test]
     fn test_camera_display_allocation_pattern() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1114,12 +1114,12 @@ mod tests {
         let width = 1920u32;
         let height = 1080u32;
 
-        // Step 1: Camera pixel buffers via VulkanPixelBuffer (raw exportable allocation)
-        use crate::vulkan::rhi::VulkanPixelBuffer;
+        // Step 1: Camera pixel buffers via HostVulkanPixelBuffer (raw exportable allocation)
+        use crate::vulkan::rhi::HostVulkanPixelBuffer;
         use crate::core::rhi::PixelFormat;
         let mut pixel_buffers = Vec::new();
         for i in 0..4 {
-            let buf = VulkanPixelBuffer::new(&device, width, height, 4, PixelFormat::Bgra32)
+            let buf = HostVulkanPixelBuffer::new(&device, width, height, 4, PixelFormat::Bgra32)
                 .unwrap_or_else(|e| panic!("pixel buffer [{i}] creation failed: {e}"));
             assert!(!buf.mapped_ptr().is_null());
             pixel_buffers.push(buf);
@@ -1237,7 +1237,7 @@ mod tests {
 
     #[test]
     fn test_various_formats() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1249,7 +1249,7 @@ mod tests {
 
         for format in formats {
             let desc = TextureDescriptor::new(1920, 1080, format);
-            let texture = VulkanTexture::new(&device, &desc)
+            let texture = HostVulkanTexture::new(&device, &desc)
                 .unwrap_or_else(|e| panic!("Failed to create texture with {format:?}: {e}"));
 
             assert!(texture.image().is_some());
@@ -1260,7 +1260,7 @@ mod tests {
 
     #[test]
     fn test_device_local_texture_creation() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1270,7 +1270,7 @@ mod tests {
 
         let desc = TextureDescriptor::new(1920, 1080, TextureFormat::Rgba8Unorm)
             .with_usage(TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING);
-        let texture = VulkanTexture::new_device_local(&device, &desc)
+        let texture = HostVulkanTexture::new_device_local(&device, &desc)
             .expect("device-local texture creation failed");
 
         assert!(texture.image().is_some());
@@ -1283,7 +1283,7 @@ mod tests {
 
     #[test]
     fn test_lazy_image_view() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1292,7 +1292,7 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(640, 480, TextureFormat::Rgba8Unorm);
-        let texture = VulkanTexture::new(&device, &desc)
+        let texture = HostVulkanTexture::new(&device, &desc)
             .expect("texture creation failed");
 
         // First call creates the image view
@@ -1317,7 +1317,7 @@ mod tests {
     fn test_render_target_dma_buf_round_trip() {
         use crate::vulkan::rhi::drm_modifier_probe::fourcc;
 
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
                 println!("Skipping — no Vulkan device: {e}");
@@ -1340,7 +1340,7 @@ mod tests {
                 | TextureUsages::TEXTURE_BINDING
                 | TextureUsages::COPY_SRC,
         );
-        let texture = VulkanTexture::new_render_target_dma_buf(&device, &desc, modifiers)
+        let texture = HostVulkanTexture::new_render_target_dma_buf(&device, &desc, modifiers)
             .expect("RT DMA-BUF allocation must succeed when modifiers exist");
 
         assert!(texture.image().is_some());
@@ -1384,7 +1384,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_render_target_dma_buf_empty_modifiers_rejected() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
                 println!("Skipping — no Vulkan device: {e}");
@@ -1393,7 +1393,7 @@ mod tests {
         };
         let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm)
             .with_usage(TextureUsages::RENDER_ATTACHMENT);
-        let result = VulkanTexture::new_render_target_dma_buf(&device, &desc, &[]);
+        let result = HostVulkanTexture::new_render_target_dma_buf(&device, &desc, &[]);
         let err = match result {
             Ok(_) => panic!("empty modifier list must reject, but allocation succeeded"),
             Err(e) => e,
@@ -1407,7 +1407,7 @@ mod tests {
 
     #[test]
     fn test_ring_texture_lifecycle() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -1419,8 +1419,8 @@ mod tests {
             .with_usage(TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING);
 
         // Create 2 ring textures (matches RING_TEXTURE_COUNT)
-        let t0 = VulkanTexture::new(&device, &desc).expect("ring texture 0 failed");
-        let t1 = VulkanTexture::new(&device, &desc).expect("ring texture 1 failed");
+        let t0 = HostVulkanTexture::new(&device, &desc).expect("ring texture 0 failed");
+        let t1 = HostVulkanTexture::new(&device, &desc).expect("ring texture 1 failed");
 
         // Both should have valid images and image views
         assert!(t0.image().is_some());

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
@@ -100,12 +100,12 @@ unsafe impl Sync for VulkanTextureCache {}
 mod tests {
     use super::*;
     use crate::core::rhi::{TextureDescriptor, TextureFormat};
-    use crate::vulkan::rhi::{VulkanDevice, VulkanTexture};
+    use crate::vulkan::rhi::{HostVulkanDevice, HostVulkanTexture};
     use std::sync::Arc;
 
     #[test]
     fn test_creates_image_view_for_valid_image() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -114,7 +114,7 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm);
-        let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+        let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
         let image = match texture.image() {
             Some(i) => i,
             None => {
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_returns_cached_view_for_same_image() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -142,7 +142,7 @@ mod tests {
         };
 
         let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm);
-        let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+        let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
         let image = match texture.image() {
             Some(i) => i,
             None => {
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_flush_destroys_all_cached_views() {
-        let device = match VulkanDevice::new() {
+        let device = match HostVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
@@ -178,7 +178,7 @@ mod tests {
         // Create views for two textures so the cache is non-empty
         for _ in 0..2 {
             let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm);
-            let texture = VulkanTexture::new(&device, &desc).expect("texture creation failed");
+            let texture = HostVulkanTexture::new(&device, &desc).expect("texture creation failed");
             if let Some(image) = texture.image() {
                 cache
                     .create_view_from_image(image, vk::Format::B8G8R8A8_UNORM, 64, 64)

--- a/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
+++ b/libs/streamlib/tests/polyglot_linux_resolve_surface_multi_plane.rs
@@ -14,7 +14,7 @@
 //! DMA-BUFs — the shim only `mmap`s them, never Vulkan-imports, so
 //! SCM_RIGHTS + `mmap(MAP_SHARED)` is enough.
 //!
-//! The Rust-side test goes through `VulkanPixelBuffer::from_dma_buf_fds`
+//! The Rust-side test goes through `HostVulkanPixelBuffer::from_dma_buf_fds`
 //! via `SurfaceStore::check_out`, which *does* Vulkan-import each plane.
 //! NVIDIA's driver rejects memfds as DMA_BUF_EXT handles, so the Rust
 //! case uses `TestDmaBufProducer` to mint two real Vulkan-exported
@@ -296,7 +296,7 @@ fn rust_surface_store_resolve_surface_multi_plane() {
     use streamlib::core::context::GpuContext;
     use streamlib::core::context::SurfaceStore;
 
-    // Initialize the process-global `VulkanDevice` — `SurfaceStore::check_out`
+    // Initialize the process-global `HostVulkanDevice` — `SurfaceStore::check_out`
     // needs it for DMA-BUF import. `GpuContext::init_for_platform` wires up
     // the global; duplicate calls across tests are accepted via
     // `OnceLock::get_or_init`.

--- a/libs/vulkan-video/tests/shared_device_test.rs
+++ b/libs/vulkan-video/tests/shared_device_test.rs
@@ -5,7 +5,7 @@
 //! using the `from_device()` constructors with a shared Vulkan device.
 //!
 //! This test creates its own Vulkan instance, device, and VMA allocator
-//! (mirroring what streamlib's VulkanDevice would provide), then exercises
+//! (mirroring what streamlib's HostVulkanDevice would provide), then exercises
 //! the `SimpleEncoder::from_device()` and `SimpleDecoder::from_device()`
 //! paths to confirm the shared-device integration works end-to-end.
 //!


### PR DESCRIPTION
## Summary

Phase 1 of #552 — foundation for the `streamlib-consumer-rhi` capability-boundary refactor. **Does not yet enforce the boundary at the crate level** (cdylibs still link the full `streamlib` crate); Phase 2 (#560) extracts the consumer-rhi crate and swaps the cdylibs, which is what physically delivers the type-system enforcement.

What this PR ships:

- `VulkanRhiDevice` trait + `HostMarker` / `ConsumerMarker` privilege markers gated by a sealed `DevicePrivilege` trait.
- `VulkanTextureLike` / `VulkanTimelineSemaphoreLike` operation traits — minimal surface for the adapter to call uniformly across host vs consumer flavors.
- `ConsumerVulkanDevice` / `ConsumerVulkanTexture` / `ConsumerVulkanPixelBuffer` / `ConsumerVulkanTimelineSemaphore` types, fully implemented, sitting alongside the existing `Host*` types in `libs/streamlib/src/vulkan/rhi/`. Each holds only the carve-out surface (DMA-BUF FD import + bind + map, tiled-image import via `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`, layout transitions on imported handles, sync wait/signal on imported timeline semaphores) — no allocation, no DMA-BUF export, no privileged primitives.
- Source-level rename `VulkanX` → `HostVulkanX` across the workspace (57 files).
- `VulkanSurfaceAdapter<D: VulkanRhiDevice>` and `VulkanContext<D>` parametric. Test helpers + cdylibs updated to specify `<HostVulkanDevice>` (the cdylibs continue using host types in this PR; Phase 2 swaps them to `Consumer*`).

## Closes (partial — Phase 1 of two)

This PR delivers part of #552. Filed Phase 2 as #560 (sub-issue of #552). #552 closes when both ship.

## Deferred to Phase 2 (#560), explicit rationale

| Issue body item | Phase 2 status |
| --- | --- |
| New crate `libs/streamlib-consumer-rhi/`, `Consumer*` types move there | Phase 2 |
| cdylibs drop `streamlib = { path = ... }` dep | Phase 2 |
| Compile-time negative test (compile_fail doctest) | Phase 2 |
| CLAUDE.md "Vulkan RHI Boundary" mentions `streamlib-consumer-rhi` | Phase 2 |
| Convert `StreamTexture::inner` to a `Host`/`Consumer` enum | **Sidestepped** — Phase 1's `Arc<P::Texture>`-parametric `HostSurfaceRegistration` removed the need for the cdylib to wrap textures in `StreamTexture`, so the enum-split's stated motivation is gone. Verify at Phase 2 pickup; #560 calls this out in its AI Agent Notes. |

## Notable design decisions

- `HostSurfaceRegistration<P: DevicePrivilege>` carries `texture: Arc<P::Texture>` and `timeline: Arc<P::TimelineSemaphore>` — both flavors implement the matching `*Like` trait, so the adapter does layout transitions + waits without dynamic dispatch. The previous shape took a `StreamTexture` and was parametric on nothing; the new shape lets the same adapter implementation work against either device flavor.
- `VulkanContext<D>::raw_handles()` is gated to `D = HostVulkanDevice` only — the raw-handle escape hatch is a host-shaped concept (full RHI surface). Consumer-side callers go through the adapter API.
- `streamlib-adapter-cpu-readback` and `streamlib-adapter-opengl` are NOT genericized — neither holds a Vulkan device for runtime use (cpu-readback escalates IPC to host, opengl uses an `EglRuntime`), so the device-flavor parameterization doesn't apply.
- `DevicePrivilege::TimelineSemaphore` and `::Texture` are associated types resolving to the matching concrete flavor. The non-Linux `NotAvailableOnThisPlatform` empty enum keeps the trait bound resolvable on macOS/Windows where DMA-BUF / OPAQUE_FD machinery isn't built.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo build --workspace --tests` passes (test binaries compile clean)
- [x] `cargo check --workspace --tests` passes (no errors; pre-existing dead-code warnings only)
- [ ] `cargo test --workspace` — unit + adapter conformance suites (existing tests cover the renamed surface; new `ConsumerVulkanDevice` tests are intentionally thin, since the type isn't on a production codepath in Phase 1 — Phase 2's #560 calls out semantic-test coverage as a Phase 2 exit criterion)
- [ ] E2E regression: `examples/polyglot-vulkan-compute/` continues to build (covered by `cargo build --workspace`); runtime exercise remains the same as before since cdylibs still use `Host*` types in this PR

## Polyglot coverage

- **Runtimes affected**: rust (rename ripple in `streamlib-python-native` + `streamlib-deno-native` cdylibs)
- **Schema regenerated**: n/a — no escalate IPC ops added
- **Python and Deno both covered?** yes — both cdylibs received the same rename + adapter genericization updates
- **E2E tests run**:
  - [x] Workspace + tests compile clean (cdylib build is the gate Phase 1 cares about; behavior is unchanged since both still use `HostVulkanDevice`)
- **FD-passing path**: n/a — Phase 1 doesn't change the wire format

## pr-review-gate

PASS with three DISCUSS items, all surfaced and addressed:

1. `make_image_info` had silently regressed `memory_size` to 0 — fixed in commit `1d582d8` by extending `VulkanTextureLike` with `width` / `height` / `format` and computing the estimate from those.
2. `StreamTexture::inner` enum split deferred — sidestepped by parametric design; called out in #560.
3. Consumer-device test coverage thin — called out in #560 as a Phase 2 exit criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
