### PR TITLE
refactor(adapter-abi): split SurfaceAlreadyRegistered from SurfaceNotFound (#558)

### DIFF
--- a/docs/architecture/subprocess-rhi-parity.md
+++ b/docs/architecture/subprocess-rhi-parity.md
@@ -108,9 +108,14 @@ three flow through the same `consumer-rhi` types.
 > Updated 2026-04-28 — #562 cpu-readback rewire (Path E) landed.
 > The cdylib swap to `ConsumerVulkanDevice` and the
 > `streamlib-consumer-rhi` crate extraction now hold for **all three
-> active adapters** (Vulkan, OpenGL, cpu-readback); Skia (#513) is
-> frozen until its host crate ships and will land directly on the
-> single-pattern shape from day one.
+> active adapters** (Vulkan, OpenGL, cpu-readback).
+>
+> ~~Skia (#513) is frozen until its host crate ships and will land
+> directly on the single-pattern shape from day one.~~ — Superseded
+> 2026-04-29: all five P0s (#550, #551, #552, #553, #555) closed, so
+> #513 and #515 unfrozen the same day. Skia and the processor-port
+> refactor are now eligible to start; both must still land on the
+> single-pattern shape.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -131,7 +136,7 @@ three flow through the same `consumer-rhi` types.
 │  │ TextureFormat / TextureUsages / PixelFormat                   │   │
 │  │ ✓ Capability boundary TYPE-SYSTEM enforced                    │   │
 │  └───────────────────────────────────────────────────────────────┘   │
-│       ▲      ▲      ▲       (skia frozen, #513)                      │
+│       ▲      ▲      ▲       (skia in flight, #513 — unfrozen 04-29)  │
 │  ┌────┴──┬───┴──┬───┴────────┐                                       │
 │  │ vk-   │ gl-  │cpu-rb-     │  All three adapters ride consumer-rhi.│
 │  │ adptr │adptr │adptr       │  Each is generic over                 │
@@ -169,29 +174,31 @@ three flow through the same `consumer-rhi` types.
 
 ## Open follow-ups (after #562 lands)
 
-The remaining P0s in milestone #16 close out the residual technical
-debt the consumer-rhi extraction made visible:
+> Updated 2026-04-29 — every P0 below closed. Section preserved with
+> strike-throughs so future readers can see the original gating chain.
 
-- **#550** [P0] — escalate-IPC `RegisterComputeKernel` +
+- ~~**#550** [P0] — escalate-IPC `RegisterComputeKernel` +
   `RunComputeKernel`; retire the `vulkan_compute_dispatch` raw-vulkan
-  helper inside each cdylib (≈200 LOC × 2 still in tree).
-- **#553** [P0] — retire `surface_share_vulkan_linux` (≈280 LOC × 2)
+  helper inside each cdylib (≈200 LOC × 2 still in tree).~~ Closed
+  2026-04-29 (#571).
+- ~~**#553** [P0] — retire `surface_share_vulkan_linux` (≈280 LOC × 2)
   from the cdylibs once #550 covers compute and #551 covers
-  registration.
-- **#551** [P0] — pull the registration `Registry<T: SurfaceRegistration>`
+  registration.~~ Closed 2026-04-29 (#573).
+- ~~**#551** [P0] — pull the registration `Registry<T: SurfaceRegistration>`
   into `streamlib-adapter-abi` so adapter crates stop redoing the same
-  per-surface book-keeping.
-- **#555** [P0] — CI boundary-grep as defense in depth around the
+  per-surface book-keeping.~~ Closed 2026-04-28.
+- ~~**#555** [P0] — CI boundary-grep as defense in depth around the
   type-system boundary. Must include "no cdylib transitively pulls
   the full `streamlib` crate" plus "no adapter crate's runtime
   `[dependencies]` lists `streamlib`" — covers cpu-readback once it
-  lands the rewire.
+  lands the rewire.~~ Closed 2026-04-29 (#570 + tightening in #574).
 - **#556** [P1] — adapter-authoring blueprint, codifies the
   single-pattern shape so future adapters land on the right shape
   by default.
 - **#513** (skia adapter), **#515** (processor-port refactor) —
-  `frozen` until the P0s above land. Skia must follow the
-  single-pattern shape from day one.
+  ~~`frozen` until the P0s above land.~~ Unfrozen 2026-04-29 once
+  the P0 chain closed. Skia must follow the single-pattern shape
+  from day one.
 
 ## Trip-wires
 
@@ -207,13 +214,15 @@ Revisit when:
 
 Milestone *Surface Adapter Architecture* (#16):
 
-- **#550** [P0] — escalate-IPC `RegisterComputeKernel` + `RunComputeKernel`; on-disk pipeline cache; retire `vulkan_compute_dispatch`.
-- **#551** [P0] — extract `Registry<T: SurfaceRegistration>` into `streamlib-adapter-abi`.
-- **#552** [P0] — promote `streamlib::adapter_support` → `streamlib-consumer-rhi` crate.
-- **#553** [P0] — retire `surface_share_vulkan_linux` from natives.
-- **#555** [P0] — boundary-grep CI check.
+- ~~**#550** [P0] — escalate-IPC `RegisterComputeKernel` + `RunComputeKernel`; on-disk pipeline cache; retire `vulkan_compute_dispatch`.~~ Closed 2026-04-29 (#571).
+- ~~**#551** [P0] — extract `Registry<T: SurfaceRegistration>` into `streamlib-adapter-abi`.~~ Closed 2026-04-28.
+- ~~**#552** [P0] — promote `streamlib::adapter_support` → `streamlib-consumer-rhi` crate.~~ Closed 2026-04-28.
+- ~~**#553** [P0] — retire `surface_share_vulkan_linux` from natives.~~ Closed 2026-04-29 (#573).
+- ~~**#555** [P0] — boundary-grep CI check.~~ Closed 2026-04-29 (#570 + #574).
 - **#556** [P1] — adapter authoring blueprint.
-- **#513** (skia adapter), **#515** (processor-port refactor) — `frozen` until P0s land.
+- **#558** — dedicated `AdapterError::SurfaceAlreadyRegistered` variant.
+- **#565** — CUDA surface adapter.
+- **#513** (skia adapter), **#515** (processor-port refactor) — ~~`frozen` until P0s land.~~ Unfrozen 2026-04-29 — eligible to start.
 
 ## Related
 

--- a/libs/streamlib-adapter-abi/src/error.rs
+++ b/libs/streamlib-adapter-abi/src/error.rs
@@ -29,6 +29,12 @@ pub enum AdapterError {
     #[error("surface {surface_id} not found")]
     SurfaceNotFound { surface_id: SurfaceId },
 
+    /// `register_host_surface` was called with an id already present in
+    /// the adapter's surface registry. Distinct from [`Self::SurfaceNotFound`]
+    /// — the surface *is* registered; that's the conflict.
+    #[error("surface {surface_id} is already registered")]
+    SurfaceAlreadyRegistered { surface_id: SurfaceId },
+
     /// The host-side IPC channel went away before/during the operation.
     #[error("IPC disconnected: {reason}")]
     IpcDisconnected { reason: String },

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -254,7 +254,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackSurfaceAdapter<D> {
             height,
         };
         if !self.surfaces.register(id, state) {
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+            return Err(AdapterError::SurfaceAlreadyRegistered { surface_id: id });
         }
         Ok(())
     }

--- a/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
@@ -17,8 +17,15 @@
 #[path = "common.rs"]
 mod common;
 
+use std::sync::Arc;
+
+use streamlib::host_rhi::{HostMarker, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore};
+use streamlib::core::rhi::{PixelFormat, TextureFormat};
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
-use streamlib_adapter_abi::{AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceId};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId,
+};
+use streamlib_adapter_cpu_readback::{HostSurfaceRegistration, VulkanLayout};
 
 use common::HostFixture;
 
@@ -55,5 +62,55 @@ fn cpu_readback_adapter_passes_run_conformance() {
             assert_eq!(surface_id, 0xdead_beef);
         }
         other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_registration_returns_surface_already_registered() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "cpu-readback duplicate-registration: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+    let id: SurfaceId = 0xfeed_face;
+    let _first = fixture.register_surface(id, 64, 64);
+
+    // Build a fresh registration for the same id and assert the
+    // adapter rejects it as `SurfaceAlreadyRegistered` rather than
+    // the overloaded `SurfaceNotFound`.
+    let stream_texture = fixture
+        .gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture_arc = Arc::clone(stream_texture.vulkan_inner());
+    let staging = Arc::new(
+        HostVulkanPixelBuffer::new(fixture.adapter.device(), 64, 64, 4, PixelFormat::Bgra32)
+            .expect("staging plane"),
+    );
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(fixture.adapter.device().device(), 0)
+            .expect("timeline"),
+    );
+    let result = fixture.adapter.register_host_surface(
+        id,
+        HostSurfaceRegistration::<HostMarker> {
+            texture: Some(texture_arc),
+            staging_planes: vec![staging],
+            timeline,
+            initial_image_layout: VulkanLayout::UNDEFINED,
+            format: SurfaceFormat::Bgra8,
+            width: 64,
+            height: 64,
+        },
+    );
+    match result {
+        Err(AdapterError::SurfaceAlreadyRegistered { surface_id }) => {
+            assert_eq!(surface_id, id);
+        }
+        other => panic!("expected SurfaceAlreadyRegistered, got {other:?}"),
     }
 }

--- a/libs/streamlib-adapter-opengl/src/adapter.rs
+++ b/libs/streamlib-adapter-opengl/src/adapter.rs
@@ -68,8 +68,8 @@ impl OpenGlSurfaceAdapter {
     /// long-lived FBOs / VAOs / shader bindings across acquires.
     ///
     /// `id` MUST be unique across the adapter's lifetime; double-
-    /// registration returns an error and leaves the existing entry
-    /// untouched.
+    /// registration returns [`AdapterError::SurfaceAlreadyRegistered`]
+    /// and leaves the existing entry untouched.
     #[instrument(level = "debug", skip(self, registration), fields(surface_id = id))]
     pub fn register_host_surface(
         &self,
@@ -160,7 +160,7 @@ impl OpenGlSurfaceAdapter {
                 gl::DeleteTextures(1, &texture);
                 self.runtime.destroy_image(image);
             }
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+            return Err(AdapterError::SurfaceAlreadyRegistered { surface_id: id });
         }
         Ok(())
     }

--- a/libs/streamlib-adapter-opengl/tests/conformance.rs
+++ b/libs/streamlib-adapter-opengl/tests/conformance.rs
@@ -75,9 +75,10 @@ fn duplicate_registration_returns_surface_already_registered() {
     let _first = fixture.register_surface(id, 64, 64);
 
     // Build a second registration against a fresh DMA-BUF for the
-    // same id. The adapter must reject the duplicate AND tear down
-    // the EGLImage / GL texture it just constructed for this attempt
-    // (verified by build green — leaks would surface on Drop).
+    // same id. The adapter must reject it as
+    // `SurfaceAlreadyRegistered`. The duplicate-rejection path also
+    // tears down the just-built EGLImage / GL texture; that cleanup
+    // is exercised here but isn't independently asserted.
     let texture = fixture
         .gpu
         .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)

--- a/libs/streamlib-adapter-opengl/tests/conformance.rs
+++ b/libs/streamlib-adapter-opengl/tests/conformance.rs
@@ -19,8 +19,10 @@
 #[path = "common.rs"]
 mod common;
 
+use streamlib::core::rhi::TextureFormat;
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
 use streamlib_adapter_abi::{AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceId};
+use streamlib_adapter_opengl::{HostSurfaceRegistration, DRM_FORMAT_ARGB8888};
 
 use common::HostFixture;
 
@@ -59,3 +61,50 @@ fn opengl_adapter_passes_run_conformance() {
         other => panic!("expected SurfaceNotFound for unknown id, got {other:?}"),
     }
 }
+
+#[test]
+fn duplicate_registration_returns_surface_already_registered() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!("opengl-adapter duplicate-registration: skipping — no Vulkan or no EGL");
+            return;
+        }
+    };
+    let id: SurfaceId = 0xfeed_face;
+    let _first = fixture.register_surface(id, 64, 64);
+
+    // Build a second registration against a fresh DMA-BUF for the
+    // same id. The adapter must reject the duplicate AND tear down
+    // the EGLImage / GL texture it just constructed for this attempt
+    // (verified by build green — leaks would surface on Drop).
+    let texture = fixture
+        .gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane_layout = texture
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = texture.vulkan_inner().chosen_drm_format_modifier();
+    let registration = HostSurfaceRegistration {
+        dma_buf_fd,
+        width: 64,
+        height: 64,
+        drm_fourcc: DRM_FORMAT_ARGB8888,
+        drm_format_modifier: modifier,
+        plane_offset: plane_layout[0].0,
+        plane_stride: plane_layout[0].1,
+    };
+    match fixture.adapter.register_host_surface(id, registration) {
+        Err(AdapterError::SurfaceAlreadyRegistered { surface_id }) => {
+            assert_eq!(surface_id, id);
+        }
+        other => panic!("expected SurfaceAlreadyRegistered, got {other:?}"),
+    }
+}
+

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -84,7 +84,8 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
     ///
     /// `id` is assigned by the host (typically from the surface-share
     /// service); it MUST be unique across the adapter's lifetime.
-    /// Returns an error if `id` is already registered.
+    /// Returns [`AdapterError::SurfaceAlreadyRegistered`] if `id` is
+    /// already registered.
     pub fn register_host_surface(
         &self,
         id: SurfaceId,
@@ -104,7 +105,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             },
         );
         if !inserted {
-            return Err(AdapterError::SurfaceNotFound { surface_id: id });
+            return Err(AdapterError::SurfaceAlreadyRegistered { surface_id: id });
         }
         Ok(())
     }

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -105,3 +105,39 @@ fn vulkan_adapter_passes_run_conformance() {
         other => panic!("expected SurfaceNotFound, got {other:?}"),
     }
 }
+
+#[test]
+fn duplicate_registration_returns_surface_already_registered() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("vulkan-adapter duplicate-registration: skipping — no Vulkan device available");
+            return;
+        }
+    };
+    let adapter = VulkanSurfaceAdapter::new(Arc::clone(gpu.device().vulkan_device()));
+    let id: SurfaceId = 0xfeed_face;
+    let _first = register_one(&adapter, &gpu, id);
+
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(adapter.device().device(), 0).expect("timeline"),
+    );
+    let result = adapter.register_host_surface(
+        id,
+        HostSurfaceRegistration {
+            texture,
+            timeline,
+            initial_layout: VulkanLayout::UNDEFINED,
+        },
+    );
+    match result {
+        Err(AdapterError::SurfaceAlreadyRegistered { surface_id }) => {
+            assert_eq!(surface_id, id);
+        }
+        other => panic!("expected SurfaceAlreadyRegistered, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add a dedicated `AdapterError::SurfaceAlreadyRegistered { surface_id }` variant in `streamlib-adapter-abi` and update all three host adapters' (`vulkan`, `opengl`, `cpu-readback`) `register_host_surface` paths to return it on duplicate-id rejection. Replaces the misleadingly-named `SurfaceNotFound` overload.
- Add a duplicate-registration assertion to each adapter's `tests/conformance.rs` — first negative test for that path.
- Bundles a small docs unfreeze: `docs/architecture/subprocess-rhi-parity.md` updated to reflect that the P0 chain (#550, #551, #552, #553, #555) gating #513/#515 closed today; both are now eligible to start. The bundling is acknowledged — it's small and timely (the P0 chain literally closed today as I was writing this); split-PR was an option but the doc would otherwise stay stale through the next merge cycle.

## Closes
Closes #558

## Exit criteria
- [x] `AdapterError::SurfaceAlreadyRegistered { surface_id: SurfaceId }` in `libs/streamlib-adapter-abi/src/error.rs` with the actionable message `"surface {surface_id} is already registered"`.
- [x] All three host adapters' `register_host_surface` paths return the new variant on duplicate registration. OpenGL's pre-existing cleanup-on-failure path (EGLImage + GL texture teardown) preserved as-is.
- [x] No callers needed updates — staleness audit confirmed no in-tree code pattern-matched the old `SurfaceNotFound` from the duplicate-registration path (every `SurfaceNotFound` callsite targets the unknown-surface lookup-miss path, which is unchanged).

## Test plan
- [x] `cargo test -p streamlib-adapter-abi -p streamlib-adapter-vulkan -p streamlib-adapter-opengl -p streamlib-adapter-cpu-readback` — all green; new `duplicate_registration_returns_surface_already_registered` test passes in each of the three adapter crates.
- [x] `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` → **passed=1141 failed=1 ignored=26**. The single failure (`linux::surface_share::unix_socket_service::tests::oversize_fd_vec_rejected`) reproduces on clean `main` with this branch's changes stashed — pre-existing and unrelated to AdapterError. Tracked in #559 (duplicate #569 closed 2026-04-29).

## Follow-ups
- **Pre-existing test failure** `linux::surface_share::unix_socket_service::tests::oversize_fd_vec_rejected` returns `UnexpectedEof` instead of `InvalidInput` — already tracked in #559 (`MAX_SCM_RIGHTS_FDS` cap raise stranded the test's "one over the cap" sentinel exactly *at* the cap). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)