### PR TITLE
feat(adapter-skia): Skia surface adapter — host crate + polyglot Python wrapper (#513)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "libs/streamlib-adapter-opengl", # OpenGL/EGL surface adapter — canonical implementor of GlWritable; DMA-BUF + DRM modifier import (Linux)
     "libs/streamlib-adapter-cpu-readback", # Explicit GPU→CPU surface adapter — sole implementor of CpuReadable / CpuWritable (Linux)
     "libs/streamlib-adapter-cpu-readback-helpers", # Test-helper binaries for streamlib-adapter-cpu-readback — held in a dedicated crate so streamlib doesn't leak into adapter-cpu-readback's runtime dep graph (Linux)
+    "libs/streamlib-adapter-skia", # Skia surface adapter — composes on streamlib-adapter-vulkan; customer sees skia::Surface directly, never GrVkImageInfo / VkImageLayout (Linux)
     "libs/streamlib-deno-native", # FFI cdylib for Deno subprocess iceoryx2 access
     "libs/streamlib-python-native", # FFI cdylib for Python subprocess iceoryx2 access
     "libs/streamlib-ipc-types",  # Shared iceoryx2 payload types for cross-process IPC
@@ -41,6 +42,7 @@ members = [
     "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
     "examples/polyglot-opengl-fragment-shader", # Example: Polyglot OpenGL adapter — Python Mandelbrot / Deno plasma fragment shader rendered into a host DMA-BUF (#530)
     "examples/polyglot-vulkan-compute",   # Example: Polyglot Vulkan adapter — Python/Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage (#531)
+    "examples/polyglot-skia-canvas",      # Example: Polyglot Skia adapter — Python skia-python draws into a host DMA-BUF VkImage via composing on the Vulkan adapter (#513)
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)
@@ -111,6 +113,24 @@ vulkanalia-vma = { git = "https://github.com/tatolab/vulkanalia.git", rev = "982
 
 # SPIR-V reflection for descriptor-set-layout validation in the compute-kernel RHI.
 rspirv-reflect = "0.9.0"
+
+# Skia bindings for the streamlib-adapter-skia crate.
+#
+# - `vulkan`: GrDirectContext + GrVkImageInfo + GrBackendRenderTarget
+#   machinery needed to wrap a host-allocated VkImage as a SkSurface.
+# - `binary-cache` (default): pull pre-built Skia binaries from the
+#   rust-skia release tarballs instead of compiling Skia C++ from
+#   source. Without this the build needs `git-sync-deps`, GN, ninja,
+#   and 15+ minutes — way out of scope for this repo's CI.
+#
+# We deliberately do NOT enable `textlayout` / `embed-icudtl` / `pdf`
+# (the rust-skia defaults) — those drag fontconfig + freetype + harfbuzz
+# + ICU / harfbuzz-icu link deps that aren't available in dev-package
+# form on a baseline Linux install. The text-rendering Python smoke
+# test from the v1 issue body moves to the polyglot Skia follow-up
+# along with the rest of the wrapper layer; the Rust adapter doesn't
+# render text.
+skia-safe = { version = "0.86", features = ["vulkan"] }
 
 # Shader compilation
 # TODO: Add when implementing HLSL shader compilation:

--- a/examples/polyglot-skia-canvas/Cargo.toml
+++ b/examples/polyglot-skia-canvas/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-skia-canvas-scenario"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+serde_json = "1.0"
+png = "0.17"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
+vulkanalia = { workspace = true }

--- a/examples/polyglot-skia-canvas/python/pyproject.toml
+++ b/examples/polyglot-skia-canvas/python/pyproject.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[project]
+name = "polyglot-skia-canvas"
+version = "0.1.0"
+description = "Polyglot Skia adapter scenario — Python skia.Surface drawn into a host DMA-BUF VkImage"
+requires-python = ">=3.10"
+dependencies = [
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+    "skia-python>=120",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot Skia canvas processor — Python.
+
+End-to-end gate for the subprocess :class:`SkiaContext` runtime
+(#513). The host pre-allocates a render-target-capable DMA-BUF
+surface AND an exportable timeline semaphore, registers both with
+surface-share, and installs no bridge (Skia composes on the Vulkan
+adapter, which doesn't need one). This processor receives a trigger
+``Videoframe``, opens the host surface through
+``SkiaContext.acquire_write`` (which under the hood opens
+``VulkanContext.acquire_write``, builds a Skia ``GrBackendRenderTarget``,
+and yields a ``skia.Surface``), draws a known shape (red disc on
+blue background), and releases — Skia's flush+submit drains the GPU
+and the inner Vulkan adapter signals the timeline so the host's
+pre-stop readback sees the drawing.
+
+Config keys:
+    skia_surface_uuid (str, required)
+        Surface-share UUID the host registered the render-target image
+        + timeline semaphore under.
+    width / height (int, required)
+        Surface dimensions.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+from streamlib.adapters.skia import SkiaContext
+from streamlib.surface_adapter import (
+    StreamlibSurface,
+    SurfaceFormat,
+    SurfaceUsage,
+)
+
+
+class SkiaCanvasProcessor:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        cfg = ctx.config
+        self._uuid = str(cfg["skia_surface_uuid"])
+        self._width = int(cfg["width"])
+        self._height = int(cfg["height"])
+        self._skia_ctx = SkiaContext.from_runtime(ctx)
+        self._drawn = False
+        self._error: Optional[str] = None
+        # The Skia adapter wraps the inner Vulkan adapter, which
+        # registers surfaces lazily on first acquire. Build a minimal
+        # `StreamlibSurface` descriptor here that carries the UUID +
+        # dims; surface-share fills in the rest under the hood.
+        self._surface = StreamlibSurface(
+            id=self._uuid,
+            width=self._width,
+            height=self._height,
+            format=SurfaceFormat.Bgra8,
+            usage=SurfaceUsage.RENDER_TARGET | SurfaceUsage.SAMPLED,
+        )
+        print(
+            f"[SkiaCanvas/py] setup uuid={self._uuid} "
+            f"size={self._width}x{self._height}",
+            flush=True,
+        )
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("video_in")
+        if frame is None:
+            return
+        if self._drawn:
+            return
+        try:
+            self._draw_once()
+            self._drawn = True
+            print(
+                f"[SkiaCanvas/py] Skia canvas drawn into surface '{self._uuid}'",
+                flush=True,
+            )
+        except Exception as e:
+            self._error = str(e)
+            print(
+                f"[SkiaCanvas/py] draw failed: {e}", flush=True,
+            )
+
+    def _draw_once(self) -> None:
+        import skia
+
+        with self._skia_ctx.acquire_write(self._surface) as guard:
+            sk_surface = guard.surface
+            canvas = sk_surface.getCanvas()
+            # Background — solid blue.
+            canvas.clear(skia.ColorBLUE)
+            # Foreground — bright red disc, antialiased, centered.
+            paint = skia.Paint()
+            paint.setColor(skia.ColorRED)
+            paint.setAntiAlias(True)
+            cx = self._width / 2.0
+            cy = self._height / 2.0
+            radius = min(self._width, self._height) * 0.35
+            canvas.drawCircle(cx, cy, radius, paint)
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        print(
+            f"[SkiaCanvas/py] teardown drawn={self._drawn} error={self._error}",
+            flush=True,
+        )

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-skia-canvas
+  version: "0.1.0"
+  description: "Polyglot Skia adapter scenario (#513) — Python Skia processor draws a canvas into a host DMA-BUF VkImage via streamlib.adapters.skia.SkiaContext"
+
+processors:
+  - name: com.tatolab.skia_canvas
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a skia.Surface, draws a known shape, releases"
+    runtime: python
+    execution: reactive
+    entrypoint: "skia_canvas:SkiaCanvasProcessor"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -1,0 +1,409 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Polyglot Skia adapter scenario (#513).
+//!
+//! End-to-end gate for the subprocess `SkiaContext` runtime: the host
+//! pre-allocates ONE render-target-capable DMA-BUF surface AND an
+//! exportable `HostVulkanTimelineSemaphore`, registers both with
+//! surface-share under a known UUID. A Python polyglot processor opens
+//! the surface through `SkiaContext.acquire_write` (which under the
+//! hood opens `VulkanContext.acquire_write` to get the imported
+//! VkImage, builds a `skia.GrBackendRenderTarget`, and yields a
+//! `skia.Surface`), draws a known shape (red disc on blue background),
+//! and releases — Skia's flush-and-submit drains the GPU and the inner
+//! Vulkan adapter signals the timeline so the host's pre-stop readback
+//! sees the drawing. This binary then reads the surface back via
+//! Vulkan and writes a PNG; reading the PNG with the Read tool is the
+//! visual gate.
+//!
+//! Skia is composed on Vulkan in the subprocess (no `slpn_skia_*` FFI;
+//! `streamlib.adapters.skia.SkiaContext` uses the existing
+//! `slpn_vulkan_*` symbols + skia-python). Deno is intentionally
+//! deferred: there is no Deno Skia binding ecosystem (#513 AI Agent
+//! Notes — same construction-language argument as the abandoned #481
+//! polyglot deferral).
+//!
+//! Build the Python `.slpkg` first:
+//!   cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python
+//!
+//! Run:
+//!   cargo run -p polyglot-skia-canvas-scenario -- \
+//!       --output=/tmp/skia-canvas-py.png
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use streamlib::core::rhi::TextureFormat;
+use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
+
+const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-000000005c1a";
+const SURFACE_SIZE: u32 = 256;
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1);
+    let mut output_png = PathBuf::from("/tmp/skia-canvas-py.png");
+    for a in args {
+        if let Some(value) = a.strip_prefix("--output=") {
+            output_png = PathBuf::from(value);
+        }
+    }
+
+    println!("=== Polyglot Skia adapter canvas scenario (#513) ===");
+    println!(
+        "Surface:    {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (uuid {SCENARIO_SURFACE_UUID})"
+    );
+    println!("Output PNG: {}", output_png.display());
+    println!();
+
+    let runtime = StreamRuntime::new()?;
+
+    let texture_slot: Arc<
+        Mutex<Option<streamlib::core::rhi::StreamTexture>>,
+    > = Arc::new(Mutex::new(None));
+    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
+        Arc::new(Mutex::new(None));
+    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+
+    {
+        let texture_slot = Arc::clone(&texture_slot);
+        let device_slot = Arc::clone(&device_slot);
+        let timeline_slot = Arc::clone(&timeline_slot);
+        runtime.install_setup_hook(move |gpu| {
+            // BGRA8 because skia-python's default ColorType for
+            // wrap_backend_render_target on Skia-Vulkan is BGRA on
+            // little-endian hosts; this keeps the Python side from
+            // having to translate.
+            let texture = gpu.acquire_render_target_dma_buf_image(
+                SURFACE_SIZE,
+                SURFACE_SIZE,
+                TextureFormat::Bgra8Unorm,
+            )?;
+            let host_device = Arc::clone(gpu.device().vulkan_device());
+            let timeline = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        StreamError::Configuration(format!(
+                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                        ))
+                    })?,
+            );
+            let store = gpu.surface_store().ok_or_else(|| {
+                StreamError::Configuration(
+                    "surface_store unavailable — host runtime built without \
+                     a surface-share service (Linux subprocess flow requires it)"
+                        .into(),
+                )
+            })?;
+            store
+                .register_texture(
+                    SCENARIO_SURFACE_UUID,
+                    &texture,
+                    Some(timeline.as_ref()),
+                )
+                .map_err(|e| {
+                    StreamError::Configuration(format!("register_texture: {e}"))
+                })?;
+            // No bridge wiring: Skia composes on the Vulkan adapter,
+            // which has no per-acquire host work — every line of GPU
+            // dispatch happens inside the subprocess process via
+            // skia-python.
+            *texture_slot.lock().unwrap() = Some(texture);
+            *device_slot.lock().unwrap() = Some(host_device);
+            *timeline_slot.lock().unwrap() = Some(timeline);
+            println!(
+                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                SCENARIO_SURFACE_UUID
+            );
+            Ok(())
+        });
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let slpkg_path =
+        manifest_dir.join("python/polyglot-skia-canvas-0.1.0.slpkg");
+    if !slpkg_path.exists() {
+        return Err(StreamError::Configuration(format!(
+            "Package not found: {}\n\
+             Run: cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python",
+            slpkg_path.display()
+        )));
+    }
+    runtime.load_package(&slpkg_path)?;
+
+    let fixture_path =
+        write_trigger_fixture().map_err(StreamError::Configuration)?;
+    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
+        BgraFileSourceProcessor::Config {
+            file_path: fixture_path
+                .to_str()
+                .ok_or_else(|| {
+                    StreamError::Configuration(
+                        "fixture path has non-utf8 component".into(),
+                    )
+                })?
+                .to_string(),
+            width: 4,
+            height: 4,
+            fps: 5,
+            frame_count: 3,
+        },
+    ))?;
+    println!("+ BgraFileSource: {source}");
+
+    let canvas_config = serde_json::json!({
+        "skia_surface_uuid": SCENARIO_SURFACE_UUID,
+        "width": SURFACE_SIZE,
+        "height": SURFACE_SIZE,
+    });
+    let canvas = runtime.add_processor(ProcessorSpec::new(
+        "com.tatolab.skia_canvas",
+        canvas_config,
+    ))?;
+    println!("+ Skia canvas processor: {canvas}");
+
+    runtime.connect(
+        OutputLinkPortRef::new(&source, "video"),
+        InputLinkPortRef::new(&canvas, "video_in"),
+    )?;
+    println!("\nPipeline: BgraFileSource → python skia-canvas\n");
+
+    println!("Starting pipeline...");
+    runtime.start()?;
+    std::thread::sleep(Duration::from_secs(4));
+    println!("Stopping pipeline...");
+    runtime.stop()?;
+
+    println!("\nReading host surface back via Vulkan...");
+    let texture = texture_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| {
+            StreamError::Runtime(
+                "host texture slot is empty — setup hook never ran".into(),
+            )
+        })?;
+    let device = device_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| StreamError::Runtime("device slot is empty".into()))?;
+    let bgra = vulkan_readback(&device, &texture);
+    write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
+    println!("✓ Output PNG written: {}", output_png.display());
+    Ok(())
+}
+
+fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let path = std::env::temp_dir().join("skia-canvas-trigger.bgra");
+    let mut f = File::create(&path)
+        .map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(&[0u8; 4 * 4 * 4 * 3])
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// Read pixels from the host `StreamTexture` back into a CPU buffer.
+/// Mirrors the helper in `examples/polyglot-vulkan-compute` —
+/// transient HOST_VISIBLE staging buffer + `vkCmdCopyImageToBuffer`
+/// + `queue_wait_idle`.
+fn vulkan_readback(
+    device: &Arc<HostVulkanDevice>,
+    texture: &streamlib::core::rhi::StreamTexture,
+) -> Vec<u8> {
+    use vulkanalia::prelude::v1_4::*;
+    use vulkanalia::vk;
+
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+    let image = texture
+        .vulkan_inner()
+        .image()
+        .expect("StreamTexture must have a Vulkan image handle on Linux");
+    let width = texture.width();
+    let height = texture.height();
+    let bytes = (width as u64) * (height as u64) * 4;
+
+    let buf = unsafe {
+        dev.create_buffer(
+            &vk::BufferCreateInfo::builder()
+                .size(bytes)
+                .usage(vk::BufferUsageFlags::TRANSFER_DST)
+                .sharing_mode(vk::SharingMode::EXCLUSIVE)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_buffer");
+    let mem_req = unsafe { dev.get_buffer_memory_requirements(buf) };
+    let inst = device.instance();
+    let phys = device.physical_device();
+    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
+    let needed =
+        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+    let mem_idx = (0..mem_props.memory_type_count)
+        .find(|i| {
+            let bit = 1u32 << i;
+            (mem_req.memory_type_bits & bit) != 0
+                && mem_props.memory_types[*i as usize]
+                    .property_flags
+                    .contains(needed)
+        })
+        .expect("host-visible memory type");
+    let mem = unsafe {
+        dev.allocate_memory(
+            &vk::MemoryAllocateInfo::builder()
+                .allocation_size(mem_req.size)
+                .memory_type_index(mem_idx)
+                .build(),
+            None,
+        )
+    }
+    .expect("allocate_memory");
+    unsafe { dev.bind_buffer_memory(buf, mem, 0) }.expect("bind_buffer_memory");
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmd = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers")[0];
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    // Skia leaves the image in whatever layout it transitioned to
+    // during `MakeFromBackendRenderTarget`-driven rendering; the
+    // inner Vulkan adapter's release-time `current_layout` isn't
+    // updated by Skia. We use a generic `GENERAL` → `TRANSFER_SRC_OPTIMAL`
+    // barrier here that's tolerant of either GENERAL or
+    // COLOR_ATTACHMENT_OPTIMAL on the way in.
+    let to_src = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let bs = [to_src];
+    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let copy = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [copy];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            buf,
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
+    let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
+    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }
+        .expect("submit");
+    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
+
+    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
+        .expect("map_memory");
+    let slice =
+        unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
+    let out = slice.to_vec();
+    unsafe { dev.unmap_memory(mem) };
+    unsafe { dev.destroy_command_pool(pool, None) };
+    unsafe { dev.destroy_buffer(buf, None) };
+    unsafe { dev.free_memory(mem, None) };
+    out
+}
+
+fn write_png(
+    bgra: &[u8],
+    width: u32,
+    height: u32,
+    output: &std::path::Path,
+) -> Result<()> {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    // Surface is allocated as `Bgra8Unorm`; PNG wants RGBA byte order.
+    // Swap the per-pixel B↔R channels.
+    let mut rgba = bgra.to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+
+    let file = File::create(output).map_err(|e| {
+        StreamError::Configuration(format!(
+            "create output PNG {}: {e}",
+            output.display()
+        ))
+    })?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+    writer
+        .write_image_data(&rgba)
+        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+    Ok(())
+}

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-skia"
+description = "Skia surface adapter (Linux). Customer sees skia::Surface directly — never GrVkImageInfo, GrBackendTexture, or VkImageLayout. Composes on streamlib-adapter-vulkan via the VulkanWritable / VulkanImageInfoExt capability traits from streamlib-adapter-abi."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_skia"
+path = "src/lib.rs"
+
+[dependencies]
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+thiserror.workspace = true
+tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+vulkanalia.workspace = true
+skia-safe = { workspace = true }
+# vkGetInstanceProcAddr lives on vulkanalia's private StaticCommands;
+# we dlopen libvulkan ourselves to grab the PFN once at construction
+# time (Skia copies it internally during make_vulkan, so the Library
+# handle can be dropped right after).
+libloading = "0.8"
+
+# `streamlib` is a *test*-only dep: the round-trip / conformance
+# tests bring up a `HostVulkanDevice`. The runtime crate (above)
+# does NOT pull `streamlib`, so subprocess cdylibs depending on
+# `streamlib-adapter-skia` get the consumer-rhi carve-out only, with
+# `streamlib` absent from their dep graph (enforced by `cargo xtask
+# check-boundaries`).
+#
+# A subprocess test-helper binary (analogous to
+# `streamlib-adapter-vulkan-helpers`) is intentionally NOT shipped
+# in v1: the Skia adapter composes on `streamlib-adapter-vulkan` and
+# does not allocate per-acquire GPU resources of its own, so
+# subprocess-crash cleanup is already covered by the inner Vulkan
+# adapter's tests. A Skia-specific helper will land alongside the
+# polyglot Skia wrapper follow-up issue.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+streamlib = { path = "../streamlib" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+tracing-subscriber.workspace = true
+
+[[test]]
+name = "conformance"
+path = "tests/conformance.rs"
+
+[[test]]
+name = "round_trip_skia_canvas"
+path = "tests/round_trip_skia_canvas.rs"
+
+[[test]]
+name = "concurrent_skia_and_vulkan_read"
+path = "tests/concurrent_skia_and_vulkan_read.rs"
+
+[[test]]
+name = "layout_never_leaks"
+path = "tests/layout_never_leaks.rs"
+
+[[test]]
+name = "subprocess_crash_mid_write"
+path = "tests/subprocess_crash_mid_write.rs"
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -49,6 +49,10 @@ streamlib = { path = "../streamlib" }
 streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
 streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
 tracing-subscriber.workspace = true
+# Used by the visual-evidence dump in `round_trip_skia_canvas` and the
+# new `skia_visual_evidence` test — write the host-readback BGRA bytes
+# back out as a PNG when `STREAMLIB_SKIA_E2E_PNG_DIR` is set.
+png = "0.17"
 
 [[test]]
 name = "conformance"
@@ -69,6 +73,10 @@ path = "tests/layout_never_leaks.rs"
 [[test]]
 name = "subprocess_crash_mid_write"
 path = "tests/subprocess_crash_mid_write.rs"
+
+[[test]]
+name = "skia_visual_evidence"
+path = "tests/skia_visual_evidence.rs"
 
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -78,5 +78,9 @@ path = "tests/subprocess_crash_mid_write.rs"
 name = "skia_visual_evidence"
 path = "tests/skia_visual_evidence.rs"
 
+[[test]]
+name = "skia_animated_stress"
+path = "tests/skia_animated_stress.rs"
+
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-skia/src/adapter.rs
+++ b/libs/streamlib-adapter-skia/src/adapter.rs
@@ -1,0 +1,465 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `SkiaSurfaceAdapter<D>` — Skia-typed `SurfaceAdapter`.
+//!
+//! Composes on `streamlib-adapter-vulkan`'s `VulkanSurfaceAdapter<D>`
+//! (held as `Arc<VulkanSurfaceAdapter<D>>`). The inner adapter does
+//! the timeline-semaphore wait and `VkImageLayout` transition; this
+//! adapter wraps the resulting `VkImage` as a Skia `Surface`
+//! (write) or `Image` (read) using the create-time metadata exposed
+//! by `VulkanImageInfoExt`.
+//!
+//! Generic over the device flavor `D: VulkanRhiDevice` for the same
+//! reason `VulkanSurfaceAdapter<D>` is — works against either
+//! `HostVulkanDevice` (in-tree host) or `ConsumerVulkanDevice`
+//! (subprocess cdylib). The single-pattern shape from
+//! `docs/architecture/subprocess-rhi-parity.md` carries through.
+
+use std::ffi::c_void;
+use std::sync::{Arc, Mutex};
+
+use libloading::Library;
+use skia_safe::gpu::vk::{
+    Alloc, AllocFlag, BackendContext, GetProcOf, ImageInfo as SkiaVkImageInfo,
+};
+use skia_safe::gpu::{
+    backend_render_targets, backend_textures, direct_contexts, images as skia_images, surfaces,
+    BackendTexture, DirectContext, Protected, SurfaceOrigin,
+};
+use skia_safe::{AlphaType, ColorSpace, ColorType};
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceId, VulkanImageInfoExt,
+    WriteGuard,
+};
+use streamlib_adapter_vulkan::VulkanSurfaceAdapter;
+use streamlib_consumer_rhi::VulkanRhiDevice;
+use vulkanalia::loader::LIBRARY;
+use vulkanalia::vk::{self, Handle as _, DeviceV1_0, InstanceV1_0};
+
+use crate::error::SkiaAdapterError;
+use crate::view::{SkiaReadView, SkiaWriteView};
+
+/// Skia-typed surface adapter. Composes on
+/// [`VulkanSurfaceAdapter<D>`]; customers see only `skia::Surface` /
+/// `skia::Image` through the [`SurfaceAdapter`] trait.
+///
+/// Skia's `GrDirectContext` is single-thread-affine and `!Send`; we
+/// hold it inside a [`SyncDirectContext`] newtype with explicit
+/// `unsafe impl Send + Sync` so the [`SurfaceAdapter`] trait's
+/// `Send + Sync` bound is satisfiable. The adapter serializes every
+/// operation through `Mutex<SyncDirectContext>`, so the upgrade is
+/// sound. This is the standard pattern in graphics frameworks
+/// (gst-plugin-skia, the rust-skia examples).
+pub struct SkiaSurfaceAdapter<D: VulkanRhiDevice + 'static> {
+    inner: Arc<VulkanSurfaceAdapter<D>>,
+    direct_context: Arc<Mutex<SyncDirectContext>>,
+}
+
+/// Newtype wrapping Skia's `DirectContext` to manually claim
+/// `Send + Sync`. Skia treats `GrDirectContext` as single-thread-
+/// affine; the surrounding `Mutex` provides that invariant.
+pub(crate) struct SyncDirectContext(pub(crate) DirectContext);
+
+unsafe impl Send for SyncDirectContext {}
+unsafe impl Sync for SyncDirectContext {}
+
+impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
+    /// Build a Skia adapter on top of an existing Vulkan adapter.
+    ///
+    /// Constructs Skia's `BackendContext` from the underlying device's
+    /// vulkanalia handles (instance, physical device, device, queue,
+    /// queue family) and a `GetProc` shim that resolves Vulkan
+    /// function pointers via the same `vkGetInstance/DeviceProcAddr`
+    /// chain vulkanalia is already using. Returns
+    /// [`SkiaAdapterError::DirectContextBuildFailed`] when Skia
+    /// rejects the backend context (rare — typically caused by a
+    /// missing extension).
+    pub fn new(
+        inner: Arc<VulkanSurfaceAdapter<D>>,
+    ) -> Result<Self, SkiaAdapterError> {
+        let direct_context = build_direct_context(inner.device())?;
+        Ok(Self {
+            inner,
+            direct_context: Arc::new(Mutex::new(SyncDirectContext(direct_context))),
+        })
+    }
+
+    /// Returns the inner Vulkan adapter — power-user accessor for
+    /// callers that need to also touch the surface as raw Vulkan
+    /// (debug tooling, custom RHIs). Customers should prefer the
+    /// scoped `acquire_*` API.
+    pub fn inner(&self) -> &Arc<VulkanSurfaceAdapter<D>> {
+        &self.inner
+    }
+}
+
+/// Build a Skia `DirectContext` from a `VulkanRhiDevice`.
+///
+/// `vkGetInstanceProcAddr` is the bottom of the Vulkan loader chain;
+/// vulkanalia keeps it on a private `StaticCommands` field, so we
+/// load it directly from `libvulkan.so` via `libloading`. Skia copies
+/// every resolved proc into its own command tables when
+/// `direct_contexts::make_vulkan` constructs the DirectContext, so
+/// the captured fn pointer only needs to live across this function;
+/// dropping the `Library` after `make_vulkan` is safe — `libvulkan`
+/// stays loaded for the process lifetime via vulkanalia's own loader.
+fn build_direct_context<D: VulkanRhiDevice>(
+    device: &Arc<D>,
+) -> Result<DirectContext, SkiaAdapterError> {
+    let instance = device.instance();
+    let physical_device = device.physical_device();
+    let logical_device = device.device();
+    let queue = device.queue();
+    let queue_family_index = device.queue_family_index() as usize;
+
+    let library = unsafe { Library::new(LIBRARY) }.map_err(|e| {
+        SkiaAdapterError::DirectContextBuildFailed {
+            reason: format!("dlopen {LIBRARY}: {e}"),
+        }
+    })?;
+    let get_instance_proc_addr_sym: libloading::Symbol<vk::PFN_vkGetInstanceProcAddr> =
+        unsafe { library.get(b"vkGetInstanceProcAddr\0") }.map_err(|e| {
+            SkiaAdapterError::DirectContextBuildFailed {
+                reason: format!("dlsym vkGetInstanceProcAddr: {e}"),
+            }
+        })?;
+    let entry_get_instance_proc_addr: vk::PFN_vkGetInstanceProcAddr =
+        *get_instance_proc_addr_sym;
+    let device_get_device_proc_addr = instance.commands().get_device_proc_addr;
+    let instance_handle = instance.handle();
+    let device_handle = logical_device.handle();
+
+    // Skia hands us its own typed handles inside GetProcOf — we use
+    // those directly rather than caching ours, because Skia is allowed
+    // to invoke `get_proc` with `VkInstance::null()` during the bootstrap
+    // phase (`vkGetInstanceProcAddr(NULL, "vkCreateInstance")` etc.)
+    // and the spec requires that to work. The underlying handles are
+    // the same VkInstance/VkDevice we passed; their raw bits round-trip
+    // through skia's pointer-shaped typedefs and back to vulkanalia's
+    // Handle::from_raw.
+    //
+    // Suppress the unused warning on the cached handles — they'd be
+    // load-bearing if Skia stopped passing the instance/device through
+    // GetProcOf, so keeping them around as a fall-back-source-of-truth
+    // is documented insurance.
+    let _instance_handle_kept = instance_handle;
+    let _device_handle_kept = device_handle;
+    let get_proc = move |of: GetProcOf| -> *const c_void {
+        match of {
+            GetProcOf::Instance(skia_instance, name) => unsafe {
+                let raw: Option<unsafe extern "system" fn()> =
+                    entry_get_instance_proc_addr(
+                        vk::Instance::from_raw(skia_instance as usize),
+                        name,
+                    );
+                match raw {
+                    Some(f) => f as *const c_void,
+                    None => std::ptr::null(),
+                }
+            },
+            GetProcOf::Device(skia_device, name) => unsafe {
+                let raw: Option<unsafe extern "system" fn()> =
+                    device_get_device_proc_addr(
+                        vk::Device::from_raw(skia_device as usize),
+                        name,
+                    );
+                match raw {
+                    Some(f) => f as *const c_void,
+                    None => std::ptr::null(),
+                }
+            },
+        }
+    };
+
+    let backend_context = unsafe {
+        BackendContext::new(
+            instance_handle.as_raw() as _,
+            physical_device.as_raw() as _,
+            device_handle.as_raw() as _,
+            (queue.as_raw() as _, queue_family_index),
+            &get_proc,
+        )
+    };
+
+    direct_contexts::make_vulkan(&backend_context, None).ok_or_else(|| {
+        SkiaAdapterError::DirectContextBuildFailed {
+            reason: "skia_safe::gpu::direct_contexts::make_vulkan returned None"
+                .into(),
+        }
+    })
+}
+
+/// Map a Vulkan `vk::Format` to a Skia `ColorType`.
+fn vk_format_to_skia_color_type(format: vk::Format) -> Option<ColorType> {
+    match format {
+        vk::Format::B8G8R8A8_UNORM | vk::Format::B8G8R8A8_SRGB => {
+            Some(ColorType::BGRA8888)
+        }
+        vk::Format::R8G8B8A8_UNORM | vk::Format::R8G8B8A8_SRGB => {
+            Some(ColorType::RGBA8888)
+        }
+        vk::Format::R16G16B16A16_SFLOAT => Some(ColorType::RGBAF16),
+        vk::Format::R32G32B32A32_SFLOAT => Some(ColorType::RGBAF32),
+        _ => None,
+    }
+}
+
+/// Build a Skia `gpu::vk::ImageInfo` from the inner Vulkan view's
+/// metadata. Skia's `ImageInfo::new` doesn't take `image_usage_flags`
+/// or `sample_count` — those are public fields on the resulting
+/// struct, set after construction.
+///
+/// Type-cast strategy: skia-safe re-exports its `vk::*` types as
+/// bindgen-generated typed integers (e.g. `pub use sb::VkFormat as
+/// Format` where `VkFormat` is a typed integer). Vulkanalia hides
+/// these behind newtypes. Both representations are the same width on
+/// 64-bit platforms (Vulkan handles are u64-sized non-dispatchable;
+/// enums are i32; bitmasks are u32) — `as _` lets the compiler
+/// resolve the inferred coercion target.
+fn build_skia_image_info<V: VulkanImageInfoExt>(
+    view: &V,
+) -> Result<SkiaVkImageInfo, SkiaAdapterError> {
+    let info = view.vk_image_info();
+    let vk_format = vk::Format::from_raw(info.format);
+    if vk_format == vk::Format::UNDEFINED {
+        return Err(SkiaAdapterError::UndefinedFormat);
+    }
+
+    // SAFETY: caller (the adapter) ensures the underlying VkImage and
+    // VkDeviceMemory outlive the SkiaWriteView that wraps this info,
+    // which in turn outlives any GrBackendRenderTarget built from it.
+    // The inner WriteGuard pinned inside SkiaWriteView keeps the
+    // streamlib-side Arc<P::Texture> alive for the same scope.
+    let alloc = unsafe {
+        Alloc::from_device_memory(
+            info.memory_handle as _,
+            info.memory_offset,
+            info.memory_size,
+            AllocFlag::empty(),
+        )
+    };
+
+    // Skia's render-target paths reject `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`
+    // — `wrap_backend_render_target` returns `None` on that combo even
+    // though the underlying image is render-target-capable per the EGL
+    // probe. We tell Skia the image is OPTIMAL: tiled DMA-BUF images
+    // with a non-LINEAR DRM modifier behave equivalently to OPTIMAL
+    // for Skia's purposes (the actual layout is opaque to the driver-
+    // visible Vulkan commands Skia issues), so this cast doesn't
+    // change runtime behavior — it just gets past Skia's validation.
+    // LINEAR-tiled DMA-BUF imports are correctly reported as LINEAR.
+    let normalized_tiling = if info.tiling == vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT.as_raw() {
+        vk::ImageTiling::OPTIMAL.as_raw()
+    } else {
+        info.tiling
+    };
+
+    tracing::debug!(
+        target: "streamlib_adapter_skia::adapter",
+        vk_image = format!("0x{:x}", view.vk_image().0),
+        vk_image_layout = view.vk_image_layout().0,
+        memory_handle = format!("0x{:x}", info.memory_handle),
+        memory_offset = info.memory_offset,
+        memory_size = info.memory_size,
+        memory_property_flags = format!("0x{:x}", info.memory_property_flags),
+        format = info.format,
+        tiling = normalized_tiling,
+        usage_flags = format!("0x{:x}", info.usage_flags),
+        sample_count = info.sample_count,
+        level_count = info.level_count,
+        queue_family = info.queue_family,
+        protected = info.protected,
+        "build_skia_image_info"
+    );
+
+    let mut skia_info = unsafe {
+        SkiaVkImageInfo::new(
+            view.vk_image().0 as _,
+            alloc,
+            std::mem::transmute::<i32, skia_safe::gpu::vk::ImageTiling>(normalized_tiling),
+            std::mem::transmute::<i32, skia_safe::gpu::vk::ImageLayout>(
+                view.vk_image_layout().0,
+            ),
+            std::mem::transmute::<i32, skia_safe::gpu::vk::Format>(info.format),
+            info.level_count,
+            Some(info.queue_family),
+            None, // ycbcr_conversion_info
+            Some(if info.protected != 0 {
+                Protected::Yes
+            } else {
+                Protected::No
+            }),
+            None, // sharing_mode defaults to EXCLUSIVE
+        )
+    };
+
+    skia_info.image_usage_flags = info.usage_flags;
+    skia_info.sample_count = info.sample_count;
+
+    Ok(skia_info)
+}
+
+impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
+    fn wrap_write<'g>(
+        &'g self,
+        inner_guard: WriteGuard<'g, VulkanSurfaceAdapter<D>>,
+        width: i32,
+        height: i32,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let surface_id = inner_guard.surface_id();
+        let view = inner_guard.view();
+        let info = view.vk_image_info();
+
+        let skia_info = build_skia_image_info(view).map_err(skia_to_adapter_error)?;
+        let color_type = vk_format_to_skia_color_type(vk::Format::from_raw(info.format))
+            .ok_or_else(|| AdapterError::IpcDisconnected {
+                reason: format!(
+                    "unsupported vk::Format {} for Skia BGRA/RGBA mapping",
+                    info.format
+                ),
+            })?;
+
+        let backend_render_target = backend_render_targets::make_vk((width, height), &skia_info);
+
+        let mut ctx_guard = self
+            .direct_context
+            .lock()
+            .map_err(|_| AdapterError::IpcDisconnected {
+                reason: "Skia DirectContext mutex poisoned".into(),
+            })?;
+        let surface = surfaces::wrap_backend_render_target(
+            &mut ctx_guard.0,
+            &backend_render_target,
+            SurfaceOrigin::TopLeft,
+            color_type,
+            None::<ColorSpace>,
+            None,
+        )
+        .ok_or_else(|| AdapterError::IpcDisconnected {
+            reason: "skia_safe::gpu::surfaces::wrap_backend_render_target returned None"
+                .into(),
+        })?;
+        drop(ctx_guard);
+
+        let view = SkiaWriteView::new(
+            surface,
+            backend_render_target,
+            inner_guard,
+            Arc::clone(&self.direct_context),
+        );
+
+        Ok(WriteGuard::new(self, surface_id, view))
+    }
+
+    fn wrap_read<'g>(
+        &'g self,
+        inner_guard: ReadGuard<'g, VulkanSurfaceAdapter<D>>,
+        width: i32,
+        height: i32,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let surface_id = inner_guard.surface_id();
+        let view = inner_guard.view();
+        let info = view.vk_image_info();
+
+        let skia_info = build_skia_image_info(view).map_err(skia_to_adapter_error)?;
+        let color_type = vk_format_to_skia_color_type(vk::Format::from_raw(info.format))
+            .ok_or_else(|| AdapterError::IpcDisconnected {
+                reason: format!(
+                    "unsupported vk::Format {} for Skia BGRA/RGBA mapping",
+                    info.format
+                ),
+            })?;
+
+        let backend_texture: BackendTexture = unsafe {
+            backend_textures::make_vk((width, height), &skia_info, "streamlib-skia-read")
+        };
+
+        let mut ctx_guard = self
+            .direct_context
+            .lock()
+            .map_err(|_| AdapterError::IpcDisconnected {
+                reason: "Skia DirectContext mutex poisoned".into(),
+            })?;
+        let image = skia_images::borrow_texture_from(
+            &mut ctx_guard.0,
+            &backend_texture,
+            SurfaceOrigin::TopLeft,
+            color_type,
+            AlphaType::Opaque,
+            None::<ColorSpace>,
+        )
+        .ok_or_else(|| AdapterError::IpcDisconnected {
+            reason: "skia_safe::gpu::images::borrow_texture_from returned None".into(),
+        })?;
+        drop(ctx_guard);
+
+        let view = SkiaReadView::new(image, inner_guard, Arc::clone(&self.direct_context));
+        Ok(ReadGuard::new(self, surface_id, view))
+    }
+}
+
+fn skia_to_adapter_error(e: SkiaAdapterError) -> AdapterError {
+    AdapterError::IpcDisconnected {
+        reason: format!("skia adapter: {e}"),
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for SkiaSurfaceAdapter<D> {
+    type ReadView<'g> = SkiaReadView<'g, D>;
+    type WriteView<'g> = SkiaWriteView<'g, D>;
+
+    fn acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let inner_guard = self.inner.acquire_read(surface)?;
+        self.wrap_read(inner_guard, surface.width as i32, surface.height as i32)
+    }
+
+    fn acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let inner_guard = self.inner.acquire_write(surface)?;
+        self.wrap_write(inner_guard, surface.width as i32, surface.height as i32)
+    }
+
+    fn try_acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
+        match self.inner.try_acquire_read(surface)? {
+            Some(g) => self
+                .wrap_read(g, surface.width as i32, surface.height as i32)
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn try_acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
+        match self.inner.try_acquire_write(surface)? {
+            Some(g) => self
+                .wrap_write(g, surface.width as i32, surface.height as i32)
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn end_read_access(&self, _surface_id: SurfaceId) {
+        // No-op. SkiaReadView::drop runs after the ReadGuard's Drop
+        // hook fires this method (Rust drops fields *after* the
+        // explicit Drop impl), and SkiaReadView::drop is what actually
+        // releases the inner ReadGuard — which signals the timeline.
+        // Doing anything here would be a use-after-release.
+    }
+
+    fn end_write_access(&self, _surface_id: SurfaceId) {
+        // No-op — same reason as end_read_access. SkiaWriteView::drop
+        // is the one place we flush Skia + signal the timeline.
+    }
+}
+

--- a/libs/streamlib-adapter-skia/src/adapter.rs
+++ b/libs/streamlib-adapter-skia/src/adapter.rs
@@ -35,7 +35,7 @@ use streamlib_adapter_abi::{
 use streamlib_adapter_vulkan::VulkanSurfaceAdapter;
 use streamlib_consumer_rhi::VulkanRhiDevice;
 use vulkanalia::loader::LIBRARY;
-use vulkanalia::vk::{self, Handle as _, DeviceV1_0, InstanceV1_0};
+use vulkanalia::vk::{self, DeviceV1_0, Handle as _, InstanceV1_0};
 
 use crate::error::SkiaAdapterError;
 use crate::view::{SkiaReadView, SkiaWriteView};
@@ -127,24 +127,14 @@ fn build_direct_context<D: VulkanRhiDevice>(
     let entry_get_instance_proc_addr: vk::PFN_vkGetInstanceProcAddr =
         *get_instance_proc_addr_sym;
     let device_get_device_proc_addr = instance.commands().get_device_proc_addr;
-    let instance_handle = instance.handle();
-    let device_handle = logical_device.handle();
 
-    // Skia hands us its own typed handles inside GetProcOf — we use
-    // those directly rather than caching ours, because Skia is allowed
-    // to invoke `get_proc` with `VkInstance::null()` during the bootstrap
-    // phase (`vkGetInstanceProcAddr(NULL, "vkCreateInstance")` etc.)
-    // and the spec requires that to work. The underlying handles are
-    // the same VkInstance/VkDevice we passed; their raw bits round-trip
-    // through skia's pointer-shaped typedefs and back to vulkanalia's
-    // Handle::from_raw.
-    //
-    // Suppress the unused warning on the cached handles — they'd be
-    // load-bearing if Skia stopped passing the instance/device through
-    // GetProcOf, so keeping them around as a fall-back-source-of-truth
-    // is documented insurance.
-    let _instance_handle_kept = instance_handle;
-    let _device_handle_kept = device_handle;
+    // Skia hands us its own typed handles inside GetProcOf and we use
+    // those directly. The Vulkan spec requires
+    // `vkGetInstanceProcAddr(NULL, "vkCreateInstance")` to work, so
+    // accepting the skia-provided pointer (which may be `null` during
+    // bootstrap) is the correct shape. The handles' raw bits round-trip
+    // through skia's pointer-shaped typedefs back to vulkanalia's
+    // `Handle::from_raw` cleanly on every Linux target.
     let get_proc = move |of: GetProcOf| -> *const c_void {
         match of {
             GetProcOf::Instance(skia_instance, name) => unsafe {
@@ -174,9 +164,9 @@ fn build_direct_context<D: VulkanRhiDevice>(
 
     let backend_context = unsafe {
         BackendContext::new(
-            instance_handle.as_raw() as _,
+            instance.handle().as_raw() as _,
             physical_device.as_raw() as _,
-            device_handle.as_raw() as _,
+            logical_device.handle().as_raw() as _,
             (queue.as_raw() as _, queue_family_index),
             &get_proc,
         )

--- a/libs/streamlib-adapter-skia/src/context.rs
+++ b/libs/streamlib-adapter-skia/src/context.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `SkiaContext<D>` — customer-facing one-stop API.
+//!
+//! ```ignore
+//! let vk_ctx = streamlib_adapter_vulkan::VulkanContext::new(adapter);
+//! let skia_ctx = streamlib_adapter_skia::SkiaContext::new(&vk_ctx)?;
+//! {
+//!     let mut guard = skia_ctx.acquire_write(&surface)?;
+//!     let canvas = guard.view_mut().surface_mut().canvas();
+//!     canvas.clear(skia_safe::Color::BLUE);
+//! } // guard drops — Skia flush + timeline signal happen here
+//! ```
+//!
+//! The context is a thin convenience over [`crate::SkiaSurfaceAdapter`];
+//! every operation maps to a [`streamlib_adapter_abi::SurfaceAdapter`]
+//! method on the inner adapter. Generic over the device flavor `D:
+//! VulkanRhiDevice` so it works against either `HostVulkanDevice` (host
+//! side) or `ConsumerVulkanDevice` (cdylib).
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, WriteGuard,
+};
+use streamlib_adapter_vulkan::VulkanContext;
+use streamlib_consumer_rhi::VulkanRhiDevice;
+
+use crate::adapter::SkiaSurfaceAdapter;
+use crate::error::SkiaAdapterError;
+
+/// Customer-facing handle bound to a single runtime, generic over the
+/// device flavor.
+///
+/// Holds a shared reference to a [`SkiaSurfaceAdapter`] (typically
+/// stored on the runtime itself); cheap to clone. Customers obtain
+/// one via the runtime's setup hook; tests construct one directly.
+pub struct SkiaContext<D: VulkanRhiDevice + 'static> {
+    adapter: Arc<SkiaSurfaceAdapter<D>>,
+}
+
+impl<D: VulkanRhiDevice + 'static> Clone for SkiaContext<D> {
+    fn clone(&self) -> Self {
+        Self {
+            adapter: Arc::clone(&self.adapter),
+        }
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> SkiaContext<D> {
+    /// Build a Skia context on top of the given Vulkan context.
+    ///
+    /// Constructs a single Skia `DirectContext` shared by all
+    /// `acquire_*` calls. The customer never sees `GrVkBackendContext` —
+    /// it's owned internally by the adapter.
+    pub fn new(
+        vulkan_ctx: &VulkanContext<D>,
+    ) -> Result<Self, SkiaAdapterError> {
+        let adapter = SkiaSurfaceAdapter::new(Arc::clone(vulkan_ctx.adapter()))?;
+        Ok(Self {
+            adapter: Arc::new(adapter),
+        })
+    }
+
+    /// Construct a [`SkiaContext`] directly from a pre-built adapter.
+    /// Most callers want [`Self::new`]; this exists for tests that
+    /// share an adapter `Arc` across multiple context handles.
+    pub fn from_adapter(adapter: Arc<SkiaSurfaceAdapter<D>>) -> Self {
+        Self { adapter }
+    }
+
+    pub fn adapter(&self) -> &Arc<SkiaSurfaceAdapter<D>> {
+        &self.adapter
+    }
+
+    /// Blocking read acquire. Guard's view returns a
+    /// [`crate::SkiaReadView`] exposing the `skia::Image`.
+    pub fn acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'a, SkiaSurfaceAdapter<D>>, AdapterError> {
+        self.adapter.acquire_read(surface)
+    }
+
+    /// Blocking write acquire. Guard's view returns a
+    /// [`crate::SkiaWriteView`] exposing the `skia::Surface`.
+    pub fn acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'a, SkiaSurfaceAdapter<D>>, AdapterError> {
+        self.adapter.acquire_write(surface)
+    }
+
+    /// Non-blocking read acquire — `Ok(None)` on contention.
+    pub fn try_acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'a, SkiaSurfaceAdapter<D>>>, AdapterError> {
+        self.adapter.try_acquire_read(surface)
+    }
+
+    /// Non-blocking write acquire — `Ok(None)` on contention.
+    pub fn try_acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'a, SkiaSurfaceAdapter<D>>>, AdapterError> {
+        self.adapter.try_acquire_write(surface)
+    }
+}

--- a/libs/streamlib-adapter-skia/src/error.rs
+++ b/libs/streamlib-adapter-skia/src/error.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Skia adapter error taxonomy.
+
+use thiserror::Error;
+
+/// Errors specific to constructing or operating the Skia surface
+/// adapter.
+///
+/// Per-acquire failures travel through the standard
+/// [`streamlib_adapter_abi::AdapterError`]; this enum covers the
+/// adapter's setup-time and Skia-binding failure modes.
+#[derive(Debug, Error)]
+pub enum SkiaAdapterError {
+    /// Skia's `gpu::DirectContext` could not be created from the
+    /// underlying Vulkan handles. Carries Skia's reason.
+    #[error("skia DirectContext build failed: {reason}")]
+    DirectContextBuildFailed { reason: String },
+
+    /// Wrapping a host-allocated `VkImage` as a Skia
+    /// `GrBackendRenderTarget` returned `None`. Most common cause is
+    /// `VK_FORMAT_UNDEFINED` reaching Skia (means the underlying
+    /// `VulkanImageInfoExt::vk_image_info()` is incomplete) or a
+    /// usage flag set Skia rejects.
+    #[error("skia BackendRenderTarget wrap failed: {reason}")]
+    BackendRenderTargetWrapFailed { reason: String },
+
+    /// Wrapping the host's `VkImage` as a Skia `Image` (read path)
+    /// returned `None`. Same root causes as
+    /// [`Self::BackendRenderTargetWrapFailed`].
+    #[error("skia Image wrap failed: {reason}")]
+    ImageWrapFailed { reason: String },
+
+    /// `VulkanImageInfoExt::vk_image_info()` reported
+    /// `VK_FORMAT_UNDEFINED`. Skia rejects this — the upstream
+    /// `VulkanTextureLike` impl is missing format metadata.
+    #[error("vk_image_info reported VK_FORMAT_UNDEFINED — upstream VulkanTextureLike impl is missing format metadata")]
+    UndefinedFormat,
+}

--- a/libs/streamlib-adapter-skia/src/lib.rs
+++ b/libs/streamlib-adapter-skia/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Skia surface adapter — composes on `streamlib-adapter-vulkan` so
+//! customers get a `skia::Surface` (write) or `skia::Image` (read)
+//! straight from a `StreamlibSurface`. The adapter does the
+//! `VkImageLayout` transitions, builds the `GrVkBackendContext` once
+//! per context, and bridges Skia's `GrFlushInfo` semaphore in/out to
+//! the inner adapter's timeline-semaphore signal/wait — none of which
+//! the customer ever sees.
+//!
+//! Trait-composition shape:
+//!
+//! ```ignore
+//! impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for SkiaSurfaceAdapter<D> {
+//!     type WriteView<'g> = SkiaWriteView<'g, D>;
+//!     type ReadView<'g>  = SkiaReadView<'g, D>;
+//! }
+//! ```
+//!
+//! The inner `VulkanWriteView<'g>` is held *inside* `SkiaWriteView`
+//! and never reaches the customer; the deliberate
+//! `VulkanWritable::vk_image_layout()` escape hatch from
+//! `streamlib-adapter-abi` lives on a capability trait that public
+//! consumers of `SurfaceAdapter` cannot reach. See
+//! `docs/architecture/surface-adapter.md` for the full architecture
+//! brief.
+
+#![cfg(target_os = "linux")]
+
+mod adapter;
+mod context;
+mod error;
+mod view;
+
+pub use adapter::SkiaSurfaceAdapter;
+pub use context::SkiaContext;
+pub use error::SkiaAdapterError;
+pub use view::{SkiaReadView, SkiaWriteView};

--- a/libs/streamlib-adapter-skia/src/view.rs
+++ b/libs/streamlib-adapter-skia/src/view.rs
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Read and write views handed to consumers inside an acquire scope.
+//!
+//! The view owns the Skia `Surface` / `Image` and the inner
+//! `VulkanSurfaceAdapter` guard. On drop the view (a) flushes any
+//! pending Skia work via `Surface::flush_and_submit` against a
+//! `MutexGuard<DirectContext>` taken for the duration of the flush,
+//! then (b) releases the inner Vulkan guard, which signals the next
+//! timeline value via `inner.end_write_access` / `end_read_access`.
+//!
+//! This is why [`crate::SkiaSurfaceAdapter::end_write_access`] /
+//! [`crate::SkiaSurfaceAdapter::end_read_access`] are no-ops: the
+//! field-drop order in `streamlib_adapter_abi::WriteGuard` runs the
+//! adapter's `end_*_access` *before* dropping the view, but our work
+//! has to happen in the opposite order — flush THEN signal — so the
+//! drop logic lives on the view itself.
+
+use std::mem::ManuallyDrop;
+use std::sync::{Arc, Mutex};
+
+use skia_safe::gpu::SyncCpu;
+use streamlib_adapter_abi::{ReadGuard, WriteGuard};
+use streamlib_adapter_vulkan::VulkanSurfaceAdapter;
+use streamlib_consumer_rhi::VulkanRhiDevice;
+use vulkanalia::vk;
+
+use crate::adapter::SyncDirectContext;
+
+/// Write view of an acquired Skia surface — exposes the
+/// `skia_safe::Surface` the customer draws into. The customer never
+/// sees `GrVkImageInfo`, `VkImageLayout`, or the underlying Vulkan
+/// handles; those are managed internally by the adapter.
+pub struct SkiaWriteView<'g, D: VulkanRhiDevice + 'static> {
+    /// `Some` while the view is live; `None` after the drop hook
+    /// has consumed it for flush + release.
+    skia_surface: Option<skia_safe::Surface>,
+    /// Inner Vulkan write guard. Held in `ManuallyDrop` so the
+    /// view's drop hook can flush Skia before the inner guard's
+    /// drop signals the timeline. See module docs.
+    inner_guard: ManuallyDrop<WriteGuard<'g, VulkanSurfaceAdapter<D>>>,
+    /// Skia's `DirectContext` (wrapped to claim `Send + Sync` —
+    /// adapter-side mutex serializes access). The `Mutex` makes the
+    /// adapter `Sync` (the conformance suite's parallel-readers
+    /// thread test demands this); customers should still serialize
+    /// Skia work per processor in practice.
+    direct_context: Arc<Mutex<SyncDirectContext>>,
+    /// Held alongside the `Surface` so any post-flush layout
+    /// inspection (`get_vk_image_info` / `set_vk_image_layout`) has
+    /// the original handle to query. The `Surface` owns its own
+    /// refcount on the underlying `GrBackendRenderTarget`, so this
+    /// is currently unused at drop — kept for future expansion
+    /// (passing the post-flush layout back into the inner adapter
+    /// instead of relying on the static `GENERAL` transition the
+    /// inner adapter sets).
+    #[allow(dead_code)]
+    pub(crate) backend_render_target: skia_safe::gpu::BackendRenderTarget,
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> SkiaWriteView<'g, D> {
+    /// Construct a Skia write view. Called from
+    /// [`crate::SkiaSurfaceAdapter::acquire_write`].
+    pub(crate) fn new(
+        skia_surface: skia_safe::Surface,
+        backend_render_target: skia_safe::gpu::BackendRenderTarget,
+        inner_guard: WriteGuard<'g, VulkanSurfaceAdapter<D>>,
+        direct_context: Arc<Mutex<SyncDirectContext>>,
+    ) -> Self {
+        Self {
+            skia_surface: Some(skia_surface),
+            inner_guard: ManuallyDrop::new(inner_guard),
+            direct_context,
+            backend_render_target,
+        }
+    }
+
+    /// Borrow the Skia surface for drawing.
+    pub fn surface(&self) -> &skia_safe::Surface {
+        self.skia_surface
+            .as_ref()
+            .expect("SkiaWriteView::surface called after drop")
+    }
+
+    /// Mutably borrow the Skia surface for drawing.
+    pub fn surface_mut(&mut self) -> &mut skia_safe::Surface {
+        self.skia_surface
+            .as_mut()
+            .expect("SkiaWriteView::surface_mut called after drop")
+    }
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaWriteView<'g, D> {
+    fn drop(&mut self) {
+        // Order matters:
+        //  1. Flush + submit Skia surface, sync_cpu = true → wait
+        //     for GPU work to drain so the host can host-signal the
+        //     timeline below.
+        //  2. Drop the Skia surface (releases its DirectContext refs).
+        //  3. Drop the inner WriteGuard → triggers
+        //     inner.end_write_access → host-signals the next timeline
+        //     value, unblocking the next acquire.
+        if let Some(mut surface) = self.skia_surface.take() {
+            match self.direct_context.lock() {
+                Ok(mut ctx_guard) => {
+                    // flush_and_submit_surface flushes Skia's pending
+                    // commands for `surface` and submits them to the
+                    // GPU; SyncCpu::Yes blocks until the GPU is done.
+                    ctx_guard
+                        .0
+                        .flush_and_submit_surface(&mut surface, Some(SyncCpu::Yes));
+                }
+                Err(_) => {
+                    tracing::error!(
+                        "SkiaWriteView::drop: direct_context mutex poisoned — \
+                         skipping flush, GPU work may not be drained before timeline signal"
+                    );
+                }
+            }
+            // Surface is now dropped — releases its DirectContext refcount.
+            drop(surface);
+        }
+
+        // SAFETY: inner_guard is in ManuallyDrop so this is the one
+        // and only place we drop it. Drop fires `inner.end_write_access`
+        // which signals the timeline.
+        unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
+    }
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> std::fmt::Debug for SkiaWriteView<'g, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SkiaWriteView")
+            .field("active", &self.skia_surface.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+// SkiaWriteView is Send + Sync: skia_safe::Surface is Send (rust-skia
+// marks RCHandle<SkSurface> Send + !Sync); the Mutex<DirectContext>
+// covers Sync semantics. Customers are still expected to drive Skia
+// from one thread per context; the trait-level Send + Sync is for the
+// adapter shape, not for genuinely parallel Skia drawing.
+unsafe impl<'g, D: VulkanRhiDevice + 'static> Send for SkiaWriteView<'g, D> {}
+unsafe impl<'g, D: VulkanRhiDevice + 'static> Sync for SkiaWriteView<'g, D> {}
+
+/// Read view of an acquired Skia surface — exposes a `skia::Image`
+/// that wraps the host's `VkImage` for sampling. Skia treats the
+/// image as immutable; drop releases the inner read guard.
+pub struct SkiaReadView<'g, D: VulkanRhiDevice + 'static> {
+    skia_image: Option<skia_safe::Image>,
+    inner_guard: ManuallyDrop<ReadGuard<'g, VulkanSurfaceAdapter<D>>>,
+    /// Held so reads don't tear-down the DirectContext while a Skia
+    /// `Image` is still pinning a refcount.
+    _direct_context: Arc<Mutex<SyncDirectContext>>,
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> SkiaReadView<'g, D> {
+    pub(crate) fn new(
+        skia_image: skia_safe::Image,
+        inner_guard: ReadGuard<'g, VulkanSurfaceAdapter<D>>,
+        direct_context: Arc<Mutex<SyncDirectContext>>,
+    ) -> Self {
+        Self {
+            skia_image: Some(skia_image),
+            inner_guard: ManuallyDrop::new(inner_guard),
+            _direct_context: direct_context,
+        }
+    }
+
+    /// Borrow the Skia image (read-only sampling source).
+    pub fn image(&self) -> &skia_safe::Image {
+        self.skia_image
+            .as_ref()
+            .expect("SkiaReadView::image called after drop")
+    }
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaReadView<'g, D> {
+    fn drop(&mut self) {
+        // No flush needed for read — Skia hasn't issued GPU work
+        // against this image. Drop the image (releases DirectContext
+        // refcount), then drop the inner guard (signals timeline).
+        if let Some(image) = self.skia_image.take() {
+            drop(image);
+        }
+        // SAFETY: same as SkiaWriteView::drop.
+        unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
+    }
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> std::fmt::Debug for SkiaReadView<'g, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SkiaReadView")
+            .field("active", &self.skia_image.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+unsafe impl<'g, D: VulkanRhiDevice + 'static> Send for SkiaReadView<'g, D> {}
+unsafe impl<'g, D: VulkanRhiDevice + 'static> Sync for SkiaReadView<'g, D> {}
+
+// Compile-time assertion: Skia views must NOT impl `CpuReadable` /
+// `CpuWritable`. Switching to `streamlib-adapter-cpu-readback` is the
+// contractual signal for "I want CPU bytes" — see #514. Same trick the
+// vulkan and opengl adapters use.
+mod _assert_skia_views_not_cpu_readable {
+    use super::{SkiaReadView, SkiaWriteView};
+    use streamlib_adapter_abi::CpuReadable;
+    use streamlib_consumer_rhi::ConsumerVulkanDevice;
+
+    trait AmbiguousIfImpl<A> {
+        fn some_item() {}
+    }
+    impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+    #[allow(dead_code)]
+    struct Invalid;
+    impl<T: ?Sized + CpuReadable> AmbiguousIfImpl<Invalid> for T {}
+
+    const _: fn() = || {
+        let _ = <SkiaReadView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
+        let _ = <SkiaWriteView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
+    };
+}
+
+/// Helper used by the adapter when we need a `vk::Format` and other
+/// raw vulkanalia values without depending on the trait machinery.
+#[allow(dead_code)]
+pub(crate) const fn vk_format_undefined() -> vk::Format {
+    vk::Format::UNDEFINED
+}

--- a/libs/streamlib-adapter-skia/src/view.rs
+++ b/libs/streamlib-adapter-skia/src/view.rs
@@ -96,10 +96,14 @@ impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaWriteView<'g, D> {
         //  1. Flush + submit Skia surface, sync_cpu = true → wait
         //     for GPU work to drain so the host can host-signal the
         //     timeline below.
-        //  2. Drop the Skia surface (releases its DirectContext refs).
-        //  3. Drop the inner WriteGuard → triggers
-        //     inner.end_write_access → host-signals the next timeline
-        //     value, unblocking the next acquire.
+        //  2. Drop the Skia surface inside the same mutex scope —
+        //     RCHandle drop decrements the surface's refcount on the
+        //     DirectContext, which can issue cleanup commands. Skia
+        //     treats DirectContext as single-thread-affine, so the
+        //     cleanup must run while we still hold the mutex.
+        //  3. Release the mutex, then drop the inner WriteGuard →
+        //     triggers inner.end_write_access → host-signals the next
+        //     timeline value, unblocking the next acquire.
         if let Some(mut surface) = self.skia_surface.take() {
             match self.direct_context.lock() {
                 Ok(mut ctx_guard) => {
@@ -109,16 +113,22 @@ impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaWriteView<'g, D> {
                     ctx_guard
                         .0
                         .flush_and_submit_surface(&mut surface, Some(SyncCpu::Yes));
+                    // Drop the Skia surface BEFORE the ctx_guard goes
+                    // out of scope. The ctx_guard's drop releases the
+                    // mutex; doing the surface drop after that would
+                    // run RCHandle cleanup unprotected.
+                    drop(surface);
                 }
                 Err(_) => {
                     tracing::error!(
                         "SkiaWriteView::drop: direct_context mutex poisoned — \
                          skipping flush, GPU work may not be drained before timeline signal"
                     );
+                    // Mutex poisoned means we're already in a degraded
+                    // state — drop the surface anyway so we don't leak.
+                    drop(surface);
                 }
             }
-            // Surface is now dropped — releases its DirectContext refcount.
-            drop(surface);
         }
 
         // SAFETY: inner_guard is in ManuallyDrop so this is the one
@@ -136,13 +146,15 @@ impl<'g, D: VulkanRhiDevice + 'static> std::fmt::Debug for SkiaWriteView<'g, D> 
     }
 }
 
-// SkiaWriteView is Send + Sync: skia_safe::Surface is Send (rust-skia
-// marks RCHandle<SkSurface> Send + !Sync); the Mutex<DirectContext>
-// covers Sync semantics. Customers are still expected to drive Skia
-// from one thread per context; the trait-level Send + Sync is for the
-// adapter shape, not for genuinely parallel Skia drawing.
-unsafe impl<'g, D: VulkanRhiDevice + 'static> Send for SkiaWriteView<'g, D> {}
-unsafe impl<'g, D: VulkanRhiDevice + 'static> Sync for SkiaWriteView<'g, D> {}
+// SkiaWriteView is auto-derived `!Send + !Sync` because
+// `skia_safe::Surface` is `RCHandle<SkSurface>` (a raw pointer wrapper)
+// and rust-skia marks it accordingly. We deliberately do NOT add an
+// `unsafe impl Send + Sync` — the SurfaceAdapter trait only requires
+// the *adapter* to be `Send + Sync`, not the views. Forcing the views
+// to Send would let customers move a Skia Surface across threads,
+// breaking Skia's single-thread-affinity contract on `GrDirectContext`.
+// Each thread that needs Skia work calls `acquire_write` on its own
+// thread, gets its own non-Send guard, and drops it on the same thread.
 
 /// Read view of an acquired Skia surface — exposes a `skia::Image`
 /// that wraps the host's `VkImage` for sampling. Skia treats the
@@ -150,9 +162,11 @@ unsafe impl<'g, D: VulkanRhiDevice + 'static> Sync for SkiaWriteView<'g, D> {}
 pub struct SkiaReadView<'g, D: VulkanRhiDevice + 'static> {
     skia_image: Option<skia_safe::Image>,
     inner_guard: ManuallyDrop<ReadGuard<'g, VulkanSurfaceAdapter<D>>>,
-    /// Held so reads don't tear-down the DirectContext while a Skia
-    /// `Image` is still pinning a refcount.
-    _direct_context: Arc<Mutex<SyncDirectContext>>,
+    /// Held so the `Image`'s `RCHandle` cleanup path (refcount-decrement
+    /// → potential GPU command emission) runs under the same mutex
+    /// `SkiaWriteView::drop` uses. Skia's `GrDirectContext` is single-
+    /// thread-affine; both read and write drops must lock.
+    direct_context: Arc<Mutex<SyncDirectContext>>,
 }
 
 impl<'g, D: VulkanRhiDevice + 'static> SkiaReadView<'g, D> {
@@ -164,7 +178,7 @@ impl<'g, D: VulkanRhiDevice + 'static> SkiaReadView<'g, D> {
         Self {
             skia_image: Some(skia_image),
             inner_guard: ManuallyDrop::new(inner_guard),
-            _direct_context: direct_context,
+            direct_context,
         }
     }
 
@@ -179,10 +193,20 @@ impl<'g, D: VulkanRhiDevice + 'static> SkiaReadView<'g, D> {
 impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaReadView<'g, D> {
     fn drop(&mut self) {
         // No flush needed for read — Skia hasn't issued GPU work
-        // against this image. Drop the image (releases DirectContext
-        // refcount), then drop the inner guard (signals timeline).
+        // against this image. But the `Image`'s `RCHandle` drop
+        // decrements its refcount on the DirectContext, which can
+        // emit GPU cleanup commands; Skia's DirectContext is single-
+        // thread-affine, so the drop must happen under the mutex.
         if let Some(image) = self.skia_image.take() {
-            drop(image);
+            match self.direct_context.lock() {
+                Ok(_ctx_guard) => drop(image),
+                Err(_) => {
+                    tracing::error!(
+                        "SkiaReadView::drop: direct_context mutex poisoned"
+                    );
+                    drop(image);
+                }
+            }
         }
         // SAFETY: same as SkiaWriteView::drop.
         unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
@@ -197,8 +221,10 @@ impl<'g, D: VulkanRhiDevice + 'static> std::fmt::Debug for SkiaReadView<'g, D> {
     }
 }
 
-unsafe impl<'g, D: VulkanRhiDevice + 'static> Send for SkiaReadView<'g, D> {}
-unsafe impl<'g, D: VulkanRhiDevice + 'static> Sync for SkiaReadView<'g, D> {}
+// SkiaReadView is auto-derived `!Send + !Sync` for the same reason as
+// SkiaWriteView — Skia's `Image` is `RCHandle<SkImage>`, and forcing
+// the view across threads would break Skia's single-thread contract.
+// See SkiaWriteView's note above.
 
 // Compile-time assertion: Skia views must NOT impl `CpuReadable` /
 // `CpuWritable`. Switching to `streamlib-adapter-cpu-readback` is the

--- a/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
+++ b/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `concurrent_skia_and_vulkan_read` — Skia READ + raw-Vulkan READ on
+//! the same surface in flight at once both succeed; pixel content
+//! unchanged after both guards drop.
+//!
+//! Validates the [`SurfaceAdapter`] contract that two readers can
+//! hold the same surface concurrently. Skia composes on the same
+//! `VulkanSurfaceAdapter`; both adapters are pointed at the same
+//! `Arc<VulkanSurfaceAdapter>`, then we acquire reads through both
+//! customer-facing types and confirm neither errors and neither
+//! upgrades to a writer.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState, SurfaceTransportHandle,
+    SurfaceUsage,
+};
+use streamlib_adapter_skia::SkiaSurfaceAdapter;
+use streamlib_adapter_vulkan::{
+    HostSurfaceRegistration, VulkanLayout, VulkanReadView, VulkanSurfaceAdapter,
+};
+
+const W: u32 = 64;
+const H: u32 = 64;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_skia=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+fn skia_read_and_vulkan_read_share_surface() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("concurrent_skia_and_vulkan_read: skipping — no Vulkan device");
+            return;
+        }
+    };
+    let host_device: Arc<HostVulkanDevice> = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&host_device)));
+    let skia_adapter = match SkiaSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("concurrent_skia_and_vulkan_read: skipping — Skia setup failed: {e}");
+            return;
+        }
+    };
+
+    // Register a single surface against the inner adapter; both the
+    // raw Vulkan adapter and the Skia adapter (which composes on it)
+    // see it.
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    );
+    let surface_id = 0xdada_dada;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture: texture.clone(),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // Acquire two concurrent readers via different adapter façades.
+    let skia_guard = skia_adapter
+        .acquire_read(&surface_desc)
+        .expect("skia acquire_read");
+    let vk_guard = inner
+        .acquire_read(&surface_desc)
+        .expect("vulkan acquire_read");
+
+    // Both guards live; access them to keep the Drop pending.
+    let _ = skia_guard.view().image();
+    let vk_view: &VulkanReadView<'_> = vk_guard.view();
+    // The raw-Vulkan view exposes the VkImage handle; we just confirm
+    // it's reachable while the Skia guard is also alive.
+    let _ = streamlib_adapter_abi::VulkanWritable::vk_image(vk_view);
+
+    drop(skia_guard);
+    drop(vk_guard);
+
+    // After both readers release, a fresh acquire_read still succeeds —
+    // i.e. the registry's read_holders counter returned to 0 cleanly.
+    let again = skia_adapter
+        .acquire_read(&surface_desc)
+        .expect("skia re-acquire_read after dual release");
+    drop(again);
+}

--- a/libs/streamlib-adapter-skia/tests/conformance.rs
+++ b/libs/streamlib-adapter-skia/tests/conformance.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_skia::tests::conformance` — runs the public
+//! `run_conformance` suite from `streamlib-adapter-abi` against a real
+//! Skia adapter wired to a host-allocated DMA-BUF render-target image
+//! and an exportable timeline semaphore.
+//!
+//! The Skia adapter composes on `streamlib-adapter-vulkan`, so a green
+//! run confirms the trait composition shape from #509 / #511 holds —
+//! `for<'g> Inner::WriteView<'g>: VulkanWritable + VulkanImageInfoExt`
+//! is satisfied by the inner Vulkan adapter's views, and Skia's
+//! `Surface` / `Image` propagate the `Send + Sync` invariant the
+//! conformance suite's parallel-readers test demands.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
+use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_skia::SkiaSurfaceAdapter;
+use streamlib_adapter_vulkan::{HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter};
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=debug,streamlib_adapter_vulkan=warn,streamlib=warn",
+        )
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+fn register_one(
+    inner: &VulkanSurfaceAdapter<HostVulkanDevice>,
+    _gpu: &GpuContext,
+    id: SurfaceId,
+) -> StreamlibSurface {
+    // Skia's `check_image_info` (`GrVkGpu.cpp:1298-1302`) requires
+    // both TRANSFER_SRC and TRANSFER_DST on every wrapped image, in
+    // addition to whatever role-specific usage the image is used
+    // for. The conformance fixture deliberately allocates a plain
+    // device-local OPTIMAL VkImage (no DMA-BUF, no DRM modifier
+    // tiling) via `HostVulkanTexture::new_device_local` so the
+    // surface-share registry's queue-family-foreign import doesn't
+    // factor into Skia's wrap-time validation; production Skia work
+    // (polyglot wrapper follow-up) goes through
+    // `acquire_render_target_dma_buf_image`, which already includes
+    // COPY_DST in its usage set.
+    let desc = TextureDescriptor::new(64, 64, TextureFormat::Bgra8Unorm).with_usage(
+        TextureUsages::RENDER_ATTACHMENT
+            | TextureUsages::TEXTURE_BINDING
+            | TextureUsages::COPY_SRC
+            | TextureUsages::COPY_DST,
+    );
+    let raw_tex = HostVulkanTexture::new_device_local(inner.device(), &desc)
+        .expect("HostVulkanTexture::new_device_local");
+    let texture = Arc::new(raw_tex);
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(inner.device().device(), 0).expect("timeline"),
+    );
+    inner
+        .register_host_surface(
+            id,
+            HostSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    StreamlibSurface::new(
+        id,
+        64,
+        64,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    )
+}
+
+struct ConformanceFactory<'a> {
+    inner: &'a VulkanSurfaceAdapter<HostVulkanDevice>,
+    gpu: &'a GpuContext,
+}
+
+impl<'a> streamlib_adapter_abi::testing::ConformanceSurfaceFactory for ConformanceFactory<'a> {
+    fn make(&self, id: SurfaceId) -> StreamlibSurface {
+        register_one(self.inner, self.gpu, id)
+    }
+}
+
+#[test]
+fn skia_adapter_passes_run_conformance() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("skia-adapter conformance: skipping — no Vulkan device available");
+            return;
+        }
+    };
+    let inner = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(
+        gpu.device().vulkan_device(),
+    )));
+    let skia_adapter = match SkiaSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia-adapter conformance: skipping — Skia DirectContext build failed: {e}");
+            return;
+        }
+    };
+
+    let factory = ConformanceFactory {
+        inner: inner.as_ref(),
+        gpu: &gpu,
+    };
+    run_conformance(&skia_adapter, factory);
+
+    // Unknown surface id must propagate as SurfaceNotFound through
+    // the composed adapter. The Skia adapter delegates registration
+    // to the inner Vulkan adapter, so the inner adapter is the source
+    // of the error — we just verify it travels back unchanged.
+    let bogus = empty_surface(0xdead_beef);
+    match skia_adapter.acquire_read(&bogus) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_beef);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}

--- a/libs/streamlib-adapter-skia/tests/layout_never_leaks.rs
+++ b/libs/streamlib-adapter-skia/tests/layout_never_leaks.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `layout_never_leaks` — internal-only assertion that the Skia
+//! adapter's public API surface never returns a `GrVkImageInfo` (or
+//! any Vulkan handle / layout) to customers. Only `skia::Surface`
+//! (write) and `skia::Image` (read) are reachable through the
+//! `SurfaceAdapter` trait.
+//!
+//! The Vulkan layout escape hatch from `streamlib-adapter-abi`
+//! (`VulkanWritable::vk_image_layout()`, `VulkanImageInfoExt::vk_image_info()`)
+//! is what `SkiaSurfaceAdapter` uses internally to construct
+//! Skia's `GrVkImageInfo`. Customers of `SurfaceAdapter` must NOT be
+//! able to reach those — Skia's history of `GrVkImageInfo.fImageLayout`
+//! leaking is exactly the failure mode we're avoiding here.
+//!
+//! Implementation: this is a compile-time check via the
+//! `assert_not_impl_all!`-style ambiguous-impl trick — same pattern
+//! the Vulkan adapter uses to assert its views don't impl
+//! `CpuReadable`. If `SkiaWriteView` ever starts impl'ing
+//! `VulkanWritable` or `VulkanImageInfoExt`, this test stops
+//! compiling.
+
+#![cfg(target_os = "linux")]
+
+use streamlib_adapter_abi::{VulkanImageInfoExt, VulkanWritable};
+use streamlib_adapter_skia::{SkiaReadView, SkiaWriteView};
+use streamlib_consumer_rhi::ConsumerVulkanDevice;
+
+trait AmbiguousIfImpl<A> {
+    #[allow(dead_code)]
+    fn some_item() {}
+}
+impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+
+#[allow(dead_code)]
+struct ImplsVulkanWritable;
+impl<T: ?Sized + VulkanWritable> AmbiguousIfImpl<ImplsVulkanWritable> for T {}
+
+#[allow(dead_code)]
+struct ImplsVulkanImageInfoExt;
+impl<T: ?Sized + VulkanImageInfoExt> AmbiguousIfImpl<ImplsVulkanImageInfoExt> for T {}
+
+const _: fn() = || {
+    // If SkiaWriteView<'static, ConsumerVulkanDevice> impls
+    // VulkanWritable, the call below is ambiguous and the const-fn
+    // body fails to compile. Same for SkiaReadView. The negative
+    // assertion holds today: both views expose only Skia handles.
+    let _ = <SkiaWriteView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
+    let _ = <SkiaReadView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
+};
+
+#[test]
+fn skia_views_do_not_expose_vulkan_image_info() {
+    // The compile-time assertion above is the actual gate; this
+    // function exists so `cargo test -p streamlib-adapter-skia
+    // --test layout_never_leaks` reports a green status when the
+    // crate compiles.
+    println!(
+        "SkiaWriteView and SkiaReadView do not implement VulkanWritable / VulkanImageInfoExt — \
+         layout state stays inside the adapter."
+    );
+}

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
@@ -1,0 +1,281 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `round_trip_skia_canvas` — Skia draws a known shape into a
+//! WRITE-acquired surface, then the host reads back the rendered
+//! pixels via a HOST_VISIBLE staging buffer + transfer queue copy
+//! and asserts the pixel content matches Skia's expected
+//! rasterization (with antialiasing tolerance).
+//!
+//! This is the canonical end-to-end test for the Skia adapter: it
+//! exercises every layer — `acquire_write` → wrap as Skia surface →
+//! draw via `Canvas` → flush_and_submit → release → host readback.
+//! The pixel comparison validates the entire pipeline, including
+//! VkImageLayout transitions and timeline-semaphore sync.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use skia_safe::{Color, Color4f, Paint, Point};
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState, SurfaceTransportHandle,
+    SurfaceUsage,
+};
+use streamlib_adapter_skia::SkiaSurfaceAdapter;
+use streamlib_adapter_vulkan::{HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter};
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 256;
+const H: u32 = 256;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_skia=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+fn round_trip_skia_canvas() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("round_trip_skia_canvas: skipping — no Vulkan device");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&host_device)));
+    let skia_adapter = match SkiaSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("round_trip_skia_canvas: skipping — Skia setup failed: {e}");
+            return;
+        }
+    };
+
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    );
+    let surface_id = 0x5e1a_5e1a;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture: texture.clone(),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // === Skia draw scope ============================================
+    {
+        let mut guard = skia_adapter
+            .acquire_write(&surface_desc)
+            .expect("skia acquire_write");
+        let view = guard.view_mut();
+        let canvas = view.surface_mut().canvas();
+        // Background — solid blue (BGRA8 with R=0, G=0, B=255, A=255).
+        canvas.clear(Color::BLUE);
+        // Foreground — bright red disc at the center.
+        let mut paint = Paint::new(Color4f::new(1.0, 0.0, 0.0, 1.0), None);
+        paint.set_anti_alias(true);
+        canvas.draw_circle(Point::new(W as f32 * 0.5, H as f32 * 0.5), 64.0, &paint);
+    } // guard drops → flush_and_submit + timeline signal happens here.
+    assert!(
+        timeline.current_value().expect("timeline value") >= 1,
+        "timeline must advance after Skia write",
+    );
+
+    // === Host readback ==============================================
+    let pixels = host_readback_bgra(&host_device, &texture, W, H);
+
+    // === Pixel-content assertions ===================================
+    // Center pixel — inside the red disc — should be roughly pure red.
+    let center = sample(&pixels, W as i32 / 2, H as i32 / 2, W);
+    assert_pixel_close(
+        "center (red disc)",
+        center,
+        [0, 0, 255, 255], // BGRA8: B=0, G=0, R=255, A=255
+        12,
+    );
+    // Corner pixel — outside the disc — should be roughly pure blue.
+    let corner = sample(&pixels, 4, 4, W);
+    assert_pixel_close(
+        "corner (blue background)",
+        corner,
+        [255, 0, 0, 255], // BGRA8: B=255, G=0, R=0, A=255
+        4,
+    );
+}
+
+fn sample(pixels: &[u8], x: i32, y: i32, width: u32) -> [u8; 4] {
+    let stride = width as usize * 4;
+    let off = y as usize * stride + x as usize * 4;
+    [
+        pixels[off],
+        pixels[off + 1],
+        pixels[off + 2],
+        pixels[off + 3],
+    ]
+}
+
+fn assert_pixel_close(label: &str, actual: [u8; 4], expected: [u8; 4], tolerance: u8) {
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (*a as i32 - *e as i32).unsigned_abs();
+        assert!(
+            diff <= tolerance as u32,
+            "{label}: channel {i} expected ~{e} got {a} (diff {diff}, tolerance {tolerance}), full pixel actual={actual:?} expected={expected:?}"
+        );
+    }
+}
+
+/// Read back BGRA8 pixels from a host-allocated `VkImage` via a
+/// HOST_VISIBLE staging buffer + transfer queue copy. The Vulkan
+/// adapter's `acquire_write` left the image in `GENERAL` layout; we
+/// transition to `TRANSFER_SRC_OPTIMAL` for the copy and back.
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    texture: &Arc<streamlib::host_rhi::HostVulkanTexture>,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let image = texture.image().expect("texture image");
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .base_mip_level(0)
+                .level_count(1)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .mip_level(0)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}

--- a/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
@@ -1,0 +1,583 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `skia_animated_stress` — `#[ignore]`-by-default stress test that
+//! drives the Skia adapter through 1800 acquire/draw/flush/release
+//! iterations (60 fps × 30 s) with a real animated scene and pipes
+//! the host-readback frames into ffmpeg as `bgra` raw video to produce
+//! an MP4 plus a hero PNG snapshot.
+//!
+//! Why this exists:
+//!
+//! 1. Real-world Skia is animated graphics. The static
+//!    `round_trip_skia_canvas` proves a single frame works; this
+//!    proves the adapter survives long-running animation without
+//!    leaking GPU memory, exhausting descriptor pools, wrapping
+//!    timeline counters, or otherwise blowing up.
+//! 2. Asserts the timeline counter advances exactly once per frame
+//!    (1800 frames → final value 1800). Any per-iteration fence-
+//!    pool / submission leak shows up as a counter mismatch or a
+//!    timeline wait timeout long before 1800 iterations.
+//! 3. Produces a video artifact reviewers can scrub to confirm the
+//!    output is visually coherent — color reproduction, AA, alpha
+//!    blending, and gradient shaders all stay correct under motion.
+//!
+//! Run with:
+//!
+//! ```bash
+//! STREAMLIB_SKIA_E2E_VIDEO_DIR=/tmp/skia-stress \
+//!     cargo test -p streamlib-adapter-skia \
+//!         --test skia_animated_stress \
+//!         -- --ignored --nocapture
+//! ```
+//!
+//! Outputs in `$STREAMLIB_SKIA_E2E_VIDEO_DIR`:
+//!   - `skia_animated_stress.mp4` — full 30 s × 60 fps H.264 encode.
+//!   - `skia_animated_stress_hero.png` — frame at t=15 s.
+
+#![cfg(target_os = "linux")]
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use skia_safe::{
+    gradient_shader, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,
+};
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_skia::SkiaSurfaceAdapter;
+use streamlib_adapter_vulkan::{HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter};
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 512;
+const H: u32 = 512;
+const FPS: u32 = 60;
+const DURATION_SECS: u32 = 30;
+const FRAME_COUNT: u32 = FPS * DURATION_SECS;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_skia=warn,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+#[ignore = "30 s × 60 fps stress run + ffmpeg encode; explicit-only"]
+fn skia_animated_stress() {
+    let video_dir = match std::env::var("STREAMLIB_SKIA_E2E_VIDEO_DIR") {
+        Ok(d) if !d.is_empty() => PathBuf::from(d),
+        _ => panic!(
+            "STREAMLIB_SKIA_E2E_VIDEO_DIR must be set to a directory \
+             where the MP4 + hero PNG should land"
+        ),
+    };
+    std::fs::create_dir_all(&video_dir).expect("create_dir_all");
+    let mp4_path = video_dir.join("skia_animated_stress.mp4");
+    let hero_path = video_dir.join("skia_animated_stress_hero.png");
+
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("skia_animated_stress: skipping — no Vulkan device");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&host_device)));
+    let skia_adapter = match SkiaSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia_animated_stress: skipping — Skia setup failed: {e}");
+            return;
+        }
+    };
+
+    // Production allocation path (what the polyglot wrapper will hit).
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    );
+    let surface_id = 0xa11_a11a;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture: texture.clone(),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // Spawn ffmpeg as a child, raw BGRA over stdin → libx264 over MP4
+    // out. `-r 60` tags every input frame as a 60 fps frame regardless
+    // of the wall-clock generation rate; the file plays back as
+    // 30 seconds of 60 fps Skia output.
+    // Pin to /usr/bin/ffmpeg explicitly: this machine has a Vulkan-
+    // focused ffmpeg 8.0 in /usr/local/bin that lacks libx264.
+    // /usr/bin/ffmpeg (apt's 6.x) carries libx264.
+    let ffmpeg_bin = if std::path::Path::new("/usr/bin/ffmpeg").exists() {
+        "/usr/bin/ffmpeg"
+    } else {
+        "ffmpeg"
+    };
+    println!(
+        "[skia_animated_stress] spawning {ffmpeg_bin} → {}",
+        mp4_path.display()
+    );
+    let mut ffmpeg = Command::new(ffmpeg_bin)
+        .args([
+            "-y",
+            "-loglevel", "error",
+            "-f", "rawvideo",
+            "-pix_fmt", "bgra",
+            "-s", &format!("{}x{}", W, H),
+            "-r", &FPS.to_string(),
+            "-i", "-",
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            "-preset", "veryfast",
+            "-crf", "20",
+            "-movflags", "+faststart",
+            mp4_path.to_str().expect("mp4 path utf-8"),
+        ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ffmpeg spawn (install ffmpeg if missing)");
+    let mut ffmpeg_stdin = ffmpeg.stdin.take().expect("ffmpeg stdin");
+
+    // === Main loop =================================================
+    let run_start = Instant::now();
+    let mut adapter_times: Vec<Duration> = Vec::with_capacity(FRAME_COUNT as usize);
+    let hero_frame_index = (FPS * (DURATION_SECS / 2)) as usize; // ~t=15s
+    let mut hero_pixels: Option<Vec<u8>> = None;
+
+    for f in 0..FRAME_COUNT {
+        let t = f as f32 / FPS as f32;
+
+        // Adapter scope: acquire → Skia draw → flush + signal on guard
+        // drop. Time the whole acquire/draw/flush/release path — that's
+        // the canonical "is the adapter capable of 60 fps" metric.
+        let adapter_start = Instant::now();
+        {
+            let mut guard = skia_adapter
+                .acquire_write(&surface_desc)
+                .expect("skia acquire_write");
+            let view = guard.view_mut();
+            let canvas = view.surface_mut().canvas();
+            draw_animated_frame(canvas, t);
+        } // guard drops → flush_and_submit_surface(SyncCpu::Yes) → inner
+          // adapter end_write_access → host-signal timeline value f+1.
+        let adapter_elapsed = adapter_start.elapsed();
+        adapter_times.push(adapter_elapsed);
+
+        // Host readback into a CPU buffer; pipe into ffmpeg.
+        // (For real swapchain present this would be a vkQueuePresentKHR
+        // instead — readback is the test-rig substitute.)
+        let pixels = host_readback_bgra(&host_device, &texture, W, H);
+        if (f as usize) == hero_frame_index {
+            hero_pixels = Some(pixels.clone());
+        }
+        ffmpeg_stdin
+            .write_all(&pixels)
+            .expect("ffmpeg stdin write");
+
+        if (f + 1) % 120 == 0 {
+            let wall = run_start.elapsed().as_secs_f32();
+            let adapter_avg_ms =
+                adapter_times.iter().sum::<Duration>().as_secs_f32() * 1000.0
+                    / (f as f32 + 1.0);
+            println!(
+                "[skia_animated_stress] frame {:>4}/{} wall={:>5.1}s adapter_avg={:>5.2}ms timeline={}",
+                f + 1,
+                FRAME_COUNT,
+                wall,
+                adapter_avg_ms,
+                timeline.current_value().expect("timeline value"),
+            );
+        }
+    }
+
+    // Close stdin → ffmpeg finalizes the MP4.
+    drop(ffmpeg_stdin);
+    let ffmpeg_status = ffmpeg.wait().expect("ffmpeg wait");
+    assert!(ffmpeg_status.success(), "ffmpeg encode failed: {ffmpeg_status:?}");
+
+    // === Stats ======================================================
+    let total = run_start.elapsed();
+    let total_s = total.as_secs_f32();
+    let adapter_total: Duration = adapter_times.iter().sum();
+    let adapter_avg_ms =
+        adapter_total.as_secs_f32() * 1000.0 / FRAME_COUNT as f32;
+    let adapter_min_ms = adapter_times
+        .iter()
+        .min()
+        .unwrap()
+        .as_secs_f32()
+        * 1000.0;
+    let adapter_max_ms = adapter_times
+        .iter()
+        .max()
+        .unwrap()
+        .as_secs_f32()
+        * 1000.0;
+    let mut sorted = adapter_times.clone();
+    sorted.sort_unstable();
+    let p50_ms = sorted[FRAME_COUNT as usize / 2].as_secs_f32() * 1000.0;
+    let p95_ms = sorted[(FRAME_COUNT as usize * 95) / 100].as_secs_f32() * 1000.0;
+    let p99_ms = sorted[(FRAME_COUNT as usize * 99) / 100].as_secs_f32() * 1000.0;
+
+    println!(
+        "[skia_animated_stress] DONE — {} frames in {:.2}s wall (incl. readback + ffmpeg I/O)",
+        FRAME_COUNT, total_s
+    );
+    println!(
+        "[skia_animated_stress] adapter throughput (acquire/draw/flush/release only): \
+         {:.1} fps headroom",
+        FRAME_COUNT as f32 / adapter_total.as_secs_f32()
+    );
+    println!(
+        "[skia_animated_stress] adapter frame time: avg={:.2}ms min={:.2}ms p50={:.2}ms p95={:.2}ms p99={:.2}ms max={:.2}ms",
+        adapter_avg_ms, adapter_min_ms, p50_ms, p95_ms, p99_ms, adapter_max_ms
+    );
+    println!(
+        "[skia_animated_stress] timeline final value = {} (expected {})",
+        timeline.current_value().expect("timeline value"),
+        FRAME_COUNT
+    );
+
+    // === Invariants =================================================
+    // The timeline counter must advance exactly once per acquire_write
+    // release. Anything else means we lost a signal somewhere.
+    assert_eq!(
+        timeline.current_value().expect("timeline value"),
+        FRAME_COUNT as u64,
+        "timeline counter should equal frame count after the run",
+    );
+
+    // Adapter must keep up with 60 fps. We give it 4× headroom (16.6ms
+    // per frame target → 66ms allowance) so this isn't hardware-flaky.
+    let target_avg_ms = 1000.0 / FPS as f32 * 4.0; // 66.6 ms
+    assert!(
+        adapter_avg_ms < target_avg_ms,
+        "adapter average frame time {:.2}ms exceeds 4× the 60 fps budget ({:.2}ms) — \
+         likely a leak (descriptor pools / fence pool / GPU memory growing per frame)",
+        adapter_avg_ms,
+        target_avg_ms,
+    );
+
+    // === Hero PNG ===================================================
+    if let Some(pixels) = hero_pixels {
+        write_bgra_as_png(&pixels, W, H, &hero_path);
+        println!(
+            "[skia_animated_stress] hero PNG (frame {}, t={:.2}s): {}",
+            hero_frame_index,
+            hero_frame_index as f32 / FPS as f32,
+            hero_path.display()
+        );
+    }
+    println!("[skia_animated_stress] MP4: {}", mp4_path.display());
+}
+
+// =============================================================================
+// Animated scene — exercises gradients, AA fills, AA strokes, paths,
+// alpha blending, and color-cycling under motion.
+// =============================================================================
+
+fn draw_animated_frame(canvas: &skia_safe::Canvas, t: f32) {
+    use std::f32::consts::TAU;
+
+    // Background — animated linear gradient. Top hue cycles every 9 s,
+    // bottom hue offsets by 120°. Tests gradient_shader::linear stability.
+    let top = hsl(t * 40.0, 0.80, 0.20);
+    let bottom = hsl(t * 40.0 + 120.0, 0.80, 0.55);
+    let bg_grad = gradient_shader::linear(
+        (Point::new(0.0, 0.0), Point::new(0.0, H as f32)),
+        &[top, bottom][..],
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    )
+    .expect("background gradient");
+    let mut bg = Paint::default();
+    bg.set_shader(bg_grad);
+    canvas.draw_rect(Rect::new(0.0, 0.0, W as f32, H as f32), &bg);
+
+    // Pulsing rotating ring — exercises stroked path AA + animated transform.
+    let ring_radius = 180.0 + (t * TAU * 0.5).sin() * 18.0;
+    let mut ring = Paint::new(hsl(t * 60.0, 0.95, 0.55), None);
+    ring.set_style(PaintStyle::Stroke);
+    ring.set_stroke_width(6.0 + (t * TAU * 0.3).sin().abs() * 4.0);
+    ring.set_anti_alias(true);
+    canvas.draw_circle(
+        Point::new(W as f32 * 0.5, H as f32 * 0.5),
+        ring_radius,
+        &ring,
+    );
+
+    // Five Lissajous-trajectory bouncing balls. Hue-cycling fills,
+    // alpha-blending overlap.
+    for i in 0..5 {
+        let phase = i as f32 * 0.4;
+        let fx = 0.5 + 0.6 * (i as f32 * 0.3);
+        let fy = 0.7 + 0.5 * (i as f32 * 0.2);
+        let x = W as f32 * 0.5 + (t * fx + phase).sin() * (190.0 - i as f32 * 12.0);
+        let y = H as f32 * 0.5 + (t * fy + phase).cos() * (180.0 - i as f32 * 14.0);
+        let radius = 26.0 + (t * 1.6 + phase).sin() * 10.0;
+        let mut color = hsl(t * 70.0 + i as f32 * 72.0, 0.92, 0.58);
+        color.a = 0.78; // alpha-blending exercise
+        let mut paint = Paint::new(color, None);
+        paint.set_anti_alias(true);
+        canvas.draw_circle(Point::new(x, y), radius, &paint);
+    }
+
+    // 16-spoke starburst — stroked lines, exercises path drawing under
+    // rotation. Length pulses with a different period than the ring.
+    let spokes = 16;
+    let cx = W as f32 * 0.5;
+    let cy = H as f32 * 0.5;
+    let inner_r = 36.0;
+    let outer_r = 70.0 + (t * TAU * 0.4).sin() * 18.0;
+    let mut spoke = Paint::new(hsl(t * 90.0 + 200.0, 0.6, 0.85), None);
+    spoke.set_style(PaintStyle::Stroke);
+    spoke.set_stroke_width(2.0);
+    spoke.set_anti_alias(true);
+    let mut path = Path::new();
+    for s in 0..spokes {
+        let a = s as f32 / spokes as f32 * TAU + t * 1.2;
+        path.move_to(Point::new(cx + a.cos() * inner_r, cy + a.sin() * inner_r));
+        path.line_to(Point::new(cx + a.cos() * outer_r, cy + a.sin() * outer_r));
+    }
+    canvas.draw_path(&path, &spoke);
+
+    // Traveling sine wave at the bottom — exercises long stroked path
+    // with phase animation.
+    let mut curve = Path::new();
+    let segments = 96;
+    let amp = 30.0 + (t * 0.7).sin() * 12.0;
+    let baseline = H as f32 - 56.0;
+    let phase = t * 3.0;
+    curve.move_to(Point::new(0.0, baseline));
+    for i in 1..=segments {
+        let u = i as f32 / segments as f32;
+        let x = u * W as f32;
+        let y = baseline - (u * TAU * 3.0 + phase).sin() * amp;
+        curve.line_to(Point::new(x, y));
+    }
+    let mut curve_paint = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.92), None);
+    curve_paint.set_style(PaintStyle::Stroke);
+    curve_paint.set_stroke_width(3.5);
+    curve_paint.set_anti_alias(true);
+    canvas.draw_path(&curve, &curve_paint);
+
+    // Hue-cycling color tile strip — confirms color reproduction holds
+    // through every frame.
+    let strip_y = H as f32 - 22.0;
+    let strip_h = 14.0;
+    for i in 0..7 {
+        let mut tile = Paint::default();
+        tile.set_color4f(
+            hsl(t * 120.0 + i as f32 * 51.0, 0.95, 0.55),
+            None,
+        );
+        let x0 = 16.0 + i as f32 * 22.0;
+        canvas.draw_rect(
+            Rect::new(x0, strip_y, x0 + 18.0, strip_y + strip_h),
+            &tile,
+        );
+    }
+}
+
+/// Convert HSL to a `Color4f`. h in degrees (any range), s/l in 0..1.
+fn hsl(h: f32, s: f32, l: f32) -> Color4f {
+    let h = h.rem_euclid(360.0);
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+    let (r, g, b) = match (h / 60.0) as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    Color4f::new(r + m, g + m, b + m, 1.0)
+}
+
+// =============================================================================
+// Vulkan readback + PNG writer (lifted from `skia_visual_evidence.rs` —
+// kept locally so the test file is self-contained).
+// =============================================================================
+
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    texture: &Arc<streamlib::host_rhi::HostVulkanTexture>,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let image = texture.image().expect("texture image");
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .base_mip_level(0)
+                .level_count(1)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .mip_level(0)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}
+
+fn write_bgra_as_png(bgra: &[u8], width: u32, height: u32, path: &std::path::Path) {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let mut rgba = bgra.to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+    let file = File::create(path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .unwrap_or_else(|e| panic!("PNG header: {e}"));
+    writer
+        .write_image_data(&rgba)
+        .unwrap_or_else(|e| panic!("PNG body: {e}"));
+}

--- a/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
@@ -1,0 +1,390 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `skia_visual_evidence` — `#[ignore]`-by-default test that draws a
+//! richer Skia scene through the adapter (multiple antialiased shapes,
+//! gradients, paths, alpha blending) and writes a PNG of the
+//! Vulkan-readback so a human can confirm Skia is actually rendering
+//! into the host's `VkImage` end-to-end.
+//!
+//! Run with:
+//!
+//! ```bash
+//! STREAMLIB_SKIA_E2E_PNG_DIR=/tmp/skia-evidence \
+//!     cargo test -p streamlib-adapter-skia \
+//!         --test skia_visual_evidence \
+//!         -- --ignored --nocapture
+//! ```
+//!
+//! The test is `#[ignore]` because (a) it produces an artifact file
+//! that's only useful when explicitly requested, and (b) the
+//! `round_trip_skia_canvas` integration test already gates the
+//! correctness invariants (red disc center pixel, blue corner pixel)
+//! on every CI run. This test exists purely to produce
+//! reviewer-readable PNG evidence for PRs.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use skia_safe::{
+    gradient_shader, Color, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,
+};
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_skia::SkiaSurfaceAdapter;
+use streamlib_adapter_vulkan::{HostSurfaceRegistration, VulkanLayout, VulkanSurfaceAdapter};
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 512;
+const H: u32 = 512;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_skia=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+#[test]
+#[ignore = "produces an on-disk PNG artifact; run explicitly with --ignored when generating PR evidence"]
+fn skia_visual_evidence() {
+    let png_dir = match std::env::var("STREAMLIB_SKIA_E2E_PNG_DIR") {
+        Ok(d) if !d.is_empty() => PathBuf::from(d),
+        _ => panic!(
+            "STREAMLIB_SKIA_E2E_PNG_DIR must be set to a directory where the \
+             evidence PNG should be written"
+        ),
+    };
+    std::fs::create_dir_all(&png_dir).expect("create_dir_all");
+    let png_path = png_dir.join("skia_visual_evidence.png");
+
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("skia_visual_evidence: skipping — no Vulkan device");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(VulkanSurfaceAdapter::new(Arc::clone(&host_device)));
+    let skia_adapter = match SkiaSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia_visual_evidence: skipping — Skia setup failed: {e}");
+            return;
+        }
+    };
+
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let texture = stream_tex.vulkan_inner().clone();
+    let timeline = Arc::new(
+        HostVulkanTimelineSemaphore::new(host_device.device(), 0).expect("timeline"),
+    );
+    let surface_id = 0xe0e1_e0e1;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                texture: texture.clone(),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // === Skia draw: showcase scene ==================================
+    {
+        let mut guard = skia_adapter
+            .acquire_write(&surface_desc)
+            .expect("skia acquire_write");
+        let view = guard.view_mut();
+        let canvas = view.surface_mut().canvas();
+
+        // Background: vertical gradient (deep navy → bright cyan)
+        let grad = gradient_shader::linear(
+            (Point::new(0.0, 0.0), Point::new(0.0, H as f32)),
+            &[
+                Color4f::new(0.05, 0.10, 0.30, 1.0),
+                Color4f::new(0.20, 0.85, 1.00, 1.0),
+            ][..],
+            None,
+            TileMode::Clamp,
+            None,
+            None,
+        )
+        .expect("background gradient");
+        let mut bg_paint = Paint::default();
+        bg_paint.set_shader(grad);
+        canvas.draw_rect(Rect::new(0.0, 0.0, W as f32, H as f32), &bg_paint);
+
+        // Concentric ring (stroked, antialiased)
+        let mut ring = Paint::new(Color4f::new(1.0, 0.85, 0.10, 1.0), None);
+        ring.set_style(PaintStyle::Stroke);
+        ring.set_stroke_width(8.0);
+        ring.set_anti_alias(true);
+        canvas.draw_circle(
+            Point::new(W as f32 * 0.5, H as f32 * 0.5),
+            180.0,
+            &ring,
+        );
+
+        // Filled red disc (center, large) — same shape as the
+        // round-trip test's pixel assertion uses
+        let mut disc = Paint::new(Color4f::new(0.95, 0.15, 0.20, 1.0), None);
+        disc.set_anti_alias(true);
+        canvas.draw_circle(
+            Point::new(W as f32 * 0.5, H as f32 * 0.5),
+            120.0,
+            &disc,
+        );
+
+        // Semi-transparent magenta lens (alpha blending)
+        let mut lens = Paint::new(Color4f::new(0.85, 0.20, 0.85, 0.55), None);
+        lens.set_anti_alias(true);
+        canvas.draw_circle(
+            Point::new(W as f32 * 0.5 + 60.0, H as f32 * 0.5 - 30.0),
+            70.0,
+            &lens,
+        );
+
+        // Sine-curve path (stroked)
+        let mut curve = Path::new();
+        let segments = 96;
+        let amp: f32 = 38.0;
+        let baseline: f32 = H as f32 - 64.0;
+        curve.move_to(Point::new(0.0, baseline));
+        for i in 1..=segments {
+            let t = i as f32 / segments as f32;
+            let x = t * W as f32;
+            let phase = t * std::f32::consts::PI * 4.0;
+            let y = baseline - phase.sin() * amp;
+            curve.line_to(Point::new(x, y));
+        }
+        let mut curve_paint = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.92), None);
+        curve_paint.set_style(PaintStyle::Stroke);
+        curve_paint.set_stroke_width(4.0);
+        curve_paint.set_anti_alias(true);
+        canvas.draw_path(&curve, &curve_paint);
+
+        // Color tile strip (bottom-left) — shows color reproduction
+        // across the rendering pipeline.
+        let strip_y = H as f32 - 30.0;
+        let strip_h = 18.0;
+        for (i, color) in [
+            Color::RED,
+            Color::from_argb(255, 255, 165, 0), // orange
+            Color::YELLOW,
+            Color::GREEN,
+            Color::CYAN,
+            Color::BLUE,
+            Color::from_argb(255, 138, 43, 226), // violet
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut tile = Paint::default();
+            tile.set_color(*color);
+            let x0 = 16.0 + i as f32 * 22.0;
+            canvas.draw_rect(
+                Rect::new(x0, strip_y, x0 + 18.0, strip_y + strip_h),
+                &tile,
+            );
+        }
+
+        // Small reference glyphs in the corners — proves edges are
+        // rendered crisply (not just the center disc).
+        for &(cx, cy) in &[
+            (16.0, 16.0),
+            (W as f32 - 16.0, 16.0),
+            (16.0, H as f32 - 16.0),
+            (W as f32 - 16.0, H as f32 - 16.0),
+        ] {
+            let mut corner = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.9), None);
+            corner.set_anti_alias(true);
+            canvas.draw_circle(Point::new(cx, cy), 6.0, &corner);
+        }
+    } // guard drops → flush_and_submit + timeline signal happens here
+
+    assert!(
+        timeline.current_value().expect("timeline value") >= 1,
+        "timeline must advance after Skia write"
+    );
+
+    // === Host readback ==============================================
+    let pixels = host_readback_bgra(&host_device, &texture, W, H);
+
+    // === Save PNG ===================================================
+    write_bgra_as_png(&pixels, W, H, &png_path);
+    println!(
+        "[skia_visual_evidence] wrote {}",
+        png_path.display()
+    );
+}
+
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    texture: &Arc<streamlib::host_rhi::HostVulkanTexture>,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let image = texture.image().expect("texture image");
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .base_mip_level(0)
+                .level_count(1)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .mip_level(0)
+                .base_array_layer(0)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}
+
+fn write_bgra_as_png(bgra: &[u8], width: u32, height: u32, path: &std::path::Path) {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    // Convert BGRA → RGBA per-pixel for PNG byte order.
+    let mut rgba = bgra.to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+    let file = File::create(path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .unwrap_or_else(|e| panic!("PNG header: {e}"));
+    writer
+        .write_image_data(&rgba)
+        .unwrap_or_else(|e| panic!("PNG body: {e}"));
+}

--- a/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `subprocess_crash_mid_write` — placeholder for a Skia-specific
+//! crash test.
+//!
+//! `streamlib_adapter_abi::testing::SubprocessCrashHarness` covers
+//! host-side cleanup when a polyglot subprocess holds a surface
+//! guard and is `SIGKILL`ed mid-acquire. The Skia adapter composes on
+//! `streamlib-adapter-vulkan` and does not allocate any per-acquire
+//! GPU resources of its own — the wrapped `skia::Surface` /
+//! `skia::Image` only borrow the inner Vulkan adapter's
+//! resources. `streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs`
+//! already exercises the cleanup path for that inner adapter, and a
+//! Skia subprocess crash exercises the same path.
+//!
+//! When the polyglot Skia wrapper lands (filed as a follow-up issue
+//! against this milestone), this test should grow real Skia-side
+//! coverage: a Python subprocess that opens a `skia.Surface`, draws,
+//! and crashes mid-flush. For now, this file is a documented skip.
+
+#![cfg(target_os = "linux")]
+
+#[test]
+fn subprocess_crash_test_deferred_to_polyglot_followup() {
+    println!(
+        "subprocess_crash_mid_write: deferred — Skia adapter does not allocate \
+         per-acquire GPU resources beyond what the inner Vulkan adapter holds. \
+         streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs covers the \
+         cleanup path Skia depends on; a Skia-specific subprocess test will land \
+         alongside the polyglot Skia wrapper follow-up."
+    );
+}

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -123,32 +123,44 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         self.surfaces.len()
     }
 
+    /// Resolve the full [`VkImageInfo`] descriptor for a registered
+    /// surface. Returns `None` if the surface isn't registered.
+    ///
+    /// The descriptor is per-image (fixed at registration time) — it
+    /// does NOT change across acquires. Polyglot Skia wrappers (and
+    /// any other adapter that needs to wrap the underlying `VkImage`
+    /// as a framework-native render target) call this once on
+    /// registration to build their backend-context state, then read
+    /// only the per-acquire `vk_image_layout` from the live view.
+    pub fn surface_image_info(
+        &self,
+        id: SurfaceId,
+    ) -> Option<VkImageInfo> {
+        self.surfaces
+            .with(id, |state| self.make_image_info(&state.texture))
+    }
+
     fn make_image_info(
         &self,
         texture: &<D::Privilege as DevicePrivilege>::Texture,
     ) -> VkImageInfo {
-        // Best-effort image info — fields the adapter doesn't track
-        // (memory binding, ycbcr conversion) stay zeroed. Skia and other
-        // VkImageInfoExt consumers can extend this once the adapter
-        // tracks more per-surface state. `memory_size` is a tight-pixel
-        // estimate (no tile padding), matching the pre-genericization
-        // behavior so debug snapshots / sizing heuristics stay stable.
-        let bytes_per_pixel = texture.format().bytes_per_pixel() as u64;
+        // Populated from VulkanTextureLike's create-time metadata.
+        // `memory_handle` is opaque (raw VkDeviceMemory bits) for
+        // frameworks like Skia that need to wrap the image as a
+        // GrBackendRenderTarget.
         VkImageInfo {
-            format: 0,
-            tiling: vk::ImageTiling::OPTIMAL.as_raw(),
-            usage_flags: 0,
-            sample_count: vk::SampleCountFlags::_1.bits(),
-            level_count: 1,
+            format: texture.vk_format().as_raw(),
+            tiling: texture.vk_image_tiling().as_raw(),
+            usage_flags: texture.vk_image_usage_flags().bits(),
+            sample_count: texture.vk_sample_count().bits(),
+            level_count: texture.vk_level_count(),
             queue_family: self.device.queue_family_index(),
-            memory_handle: 0,
-            memory_offset: 0,
-            memory_size: (texture.width() as u64)
-                * (texture.height() as u64)
-                * bytes_per_pixel,
-            memory_property_flags: 0,
-            protected: 0,
-            ycbcr_conversion: 0,
+            memory_handle: texture.vk_memory().as_raw(),
+            memory_offset: texture.vk_memory_offset(),
+            memory_size: texture.vk_memory_size(),
+            memory_property_flags: texture.vk_memory_property_flags().bits(),
+            protected: u32::from(texture.vk_protected()),
+            ycbcr_conversion: texture.vk_ycbcr_conversion_handle(),
             _reserved: [0; 16],
         }
     }

--- a/libs/streamlib-consumer-rhi/src/consumer_vulkan_texture.rs
+++ b/libs/streamlib-consumer-rhi/src/consumer_vulkan_texture.rs
@@ -66,6 +66,16 @@ pub struct ConsumerVulkanTexture {
     image: vk::Image,
     /// Imported `VkDeviceMemory` from the host's DMA-BUF FD.
     imported_memory: vk::DeviceMemory,
+    /// Byte size of the imported memory allocation. Tracked because
+    /// `VulkanTextureLike::vk_memory_size` needs it for Skia's
+    /// `GrVkAlloc.fSize` and serializing debug snapshots.
+    imported_memory_size: vk::DeviceSize,
+    /// `VkImageTiling` used at create time — `DRM_FORMAT_MODIFIER_EXT`
+    /// for `import_render_target_dma_buf`, `LINEAR` for
+    /// `from_dma_buf_fd`.
+    vk_image_tiling: vk::ImageTiling,
+    /// `VkImageUsageFlags` the image was created with.
+    vk_image_usage_flags: vk::ImageUsageFlags,
     cached_image_view: OnceLock<vk::ImageView>,
     /// DRM format modifier the host's driver chose at allocation time.
     /// Zero is reserved for `DRM_FORMAT_MOD_LINEAR` — sampler-only on
@@ -121,6 +131,14 @@ impl ConsumerVulkanTexture {
 
         let device = vulkan_device.device();
         let vk_format = texture_format_to_vk(format);
+        // Same usage set as the raw create_info builder below — tracked
+        // separately so VulkanTextureLike::vk_image_usage_flags can
+        // report it without re-reading the image_create_info chain.
+        let usage_flags = vk::ImageUsageFlags::TRANSFER_SRC
+            | vk::ImageUsageFlags::TRANSFER_DST
+            | vk::ImageUsageFlags::SAMPLED
+            | vk::ImageUsageFlags::COLOR_ATTACHMENT
+            | vk::ImageUsageFlags::STORAGE;
 
         let plane_layouts: Vec<vk::SubresourceLayout> = plane_offsets
             .iter()
@@ -148,13 +166,7 @@ impl ConsumerVulkanTexture {
             .array_layers(1)
             .samples(vk::SampleCountFlags::_1)
             .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
-            .usage(
-                vk::ImageUsageFlags::TRANSFER_SRC
-                    | vk::ImageUsageFlags::TRANSFER_DST
-                    | vk::ImageUsageFlags::SAMPLED
-                    | vk::ImageUsageFlags::COLOR_ATTACHMENT
-                    | vk::ImageUsageFlags::STORAGE,
-            )
+            .usage(usage_flags)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED)
             .push_next(&mut explicit_modifier_info)
@@ -198,6 +210,9 @@ impl ConsumerVulkanTexture {
             vulkan_device: Arc::clone(vulkan_device),
             image,
             imported_memory: memory,
+            imported_memory_size: alloc_size,
+            vk_image_tiling: vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT,
+            vk_image_usage_flags: usage_flags,
             cached_image_view: OnceLock::new(),
             drm_format_modifier,
             width,
@@ -221,6 +236,9 @@ impl ConsumerVulkanTexture {
     ) -> Result<Self> {
         let device = vulkan_device.device();
         let vk_format = texture_format_to_vk(format);
+        let usage_flags = vk::ImageUsageFlags::TRANSFER_SRC
+            | vk::ImageUsageFlags::TRANSFER_DST
+            | vk::ImageUsageFlags::SAMPLED;
 
         let image_info = vk::ImageCreateInfo::builder()
             .image_type(vk::ImageType::_2D)
@@ -230,11 +248,7 @@ impl ConsumerVulkanTexture {
             .array_layers(1)
             .samples(vk::SampleCountFlags::_1)
             .tiling(vk::ImageTiling::LINEAR)
-            .usage(
-                vk::ImageUsageFlags::TRANSFER_SRC
-                    | vk::ImageUsageFlags::TRANSFER_DST
-                    | vk::ImageUsageFlags::SAMPLED,
-            )
+            .usage(usage_flags)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED)
             .build();
@@ -272,6 +286,9 @@ impl ConsumerVulkanTexture {
             vulkan_device: Arc::clone(vulkan_device),
             image,
             imported_memory: memory,
+            imported_memory_size: alloc_size,
+            vk_image_tiling: vk::ImageTiling::LINEAR,
+            vk_image_usage_flags: usage_flags,
             cached_image_view: OnceLock::new(),
             drm_format_modifier: 0,
             width,
@@ -364,4 +381,23 @@ impl VulkanTextureLike for ConsumerVulkanTexture {
     fn format(&self) -> TextureFormat {
         ConsumerVulkanTexture::format(self)
     }
+    fn vk_format(&self) -> vk::Format {
+        texture_format_to_vk(self.format)
+    }
+    fn vk_image_tiling(&self) -> vk::ImageTiling {
+        self.vk_image_tiling
+    }
+    fn vk_image_usage_flags(&self) -> vk::ImageUsageFlags {
+        self.vk_image_usage_flags
+    }
+    fn vk_memory(&self) -> vk::DeviceMemory {
+        self.imported_memory
+    }
+    fn vk_memory_size(&self) -> vk::DeviceSize {
+        self.imported_memory_size
+    }
+    // Defaults cover sample_count, level_count, memory_offset (0 because
+    // import binds at offset 0), memory_property_flags (DEVICE_LOCAL —
+    // both consumer-side import paths request DEVICE_LOCAL), protected,
+    // ycbcr_conversion_handle.
 }

--- a/libs/streamlib-consumer-rhi/src/device_capability.rs
+++ b/libs/streamlib-consumer-rhi/src/device_capability.rs
@@ -138,6 +138,22 @@ pub trait VulkanPixelBufferLike {
 /// adapter holds `Arc<P::Texture>` and reads the `vk::Image` +
 /// metadata through this trait without caring whether it's host or
 /// consumer.
+///
+/// The trait is split into two groups:
+///
+/// - **Identity / shape** ([`Self::image`], [`Self::format`],
+///   [`Self::width`], [`Self::height`], [`Self::chosen_drm_format_modifier`]):
+///   the original surface-adapter v1 surface — what an adapter needs
+///   to record a layout transition on the right `VkImage` of the right
+///   shape.
+/// - **Full image metadata** ([`Self::vk_format`] through
+///   [`Self::vk_ycbcr_conversion_handle`]): what frameworks like Skia
+///   need to wrap an externally-allocated `VkImage` as their native
+///   surface type (`GrVkBackendContext` → `GrBackendRenderTarget` →
+///   `SkSurface`). Defaults match the streamlib surface-adapter
+///   model: DEVICE_LOCAL, single-sample, single-mip, unprotected, no
+///   YCbCr conversion, bound at offset 0. Constructors that violate
+///   any default override the corresponding method.
 pub trait VulkanTextureLike {
     /// `vk::Image` handle, or `None` for placeholder textures.
     fn image(&self) -> Option<vk::Image>;
@@ -151,6 +167,73 @@ pub trait VulkanTextureLike {
     fn height(&self) -> u32;
     /// Texture format.
     fn format(&self) -> crate::TextureFormat;
+
+    /// Vulkan format the image was created with. Distinct from
+    /// [`Self::format`] (the RHI-level enum) — this is the raw
+    /// `vk::Format` the framework consumer sees. Required because
+    /// Skia rejects `VK_FORMAT_UNDEFINED`.
+    fn vk_format(&self) -> vk::Format;
+
+    /// `VkImageTiling` used at image creation. `OPTIMAL` for the
+    /// standard render-target path; `DRM_FORMAT_MODIFIER_EXT` for
+    /// tiled DMA-BUF render targets.
+    fn vk_image_tiling(&self) -> vk::ImageTiling;
+
+    /// `VkImageUsageFlags` the image was created with. Skia checks
+    /// these bits to decide which surface ops are valid (e.g.
+    /// `COLOR_ATTACHMENT` is required for `wrap_backend_render_target`).
+    fn vk_image_usage_flags(&self) -> vk::ImageUsageFlags;
+
+    /// `VkDeviceMemory` handle the image is bound to. Returns
+    /// `vk::DeviceMemory::null()` for placeholder textures.
+    fn vk_memory(&self) -> vk::DeviceMemory;
+
+    /// Byte size of the memory allocation backing the image.
+    fn vk_memory_size(&self) -> vk::DeviceSize;
+
+    /// `VkSampleCountFlagBits` the image was created with. Default
+    /// `_1` covers every surface-adapter-managed texture today;
+    /// multi-sample render targets aren't part of the surface-adapter
+    /// contract.
+    fn vk_sample_count(&self) -> vk::SampleCountFlags {
+        vk::SampleCountFlags::_1
+    }
+
+    /// Number of mip levels. Default `1` — surface-adapter textures
+    /// don't carry mipmaps.
+    fn vk_level_count(&self) -> u32 {
+        1
+    }
+
+    /// Byte offset of the image's storage within [`Self::vk_memory`].
+    /// Default `0` — surface-adapter textures bind at offset 0
+    /// (VMA dedicated allocations and DMA-BUF imports both).
+    fn vk_memory_offset(&self) -> vk::DeviceSize {
+        0
+    }
+
+    /// `VkMemoryPropertyFlags` of the backing allocation. Default
+    /// `DEVICE_LOCAL` matches the universal surface-adapter shape
+    /// (render targets are GPU-local; HOST_VISIBLE staging buffers
+    /// live on [`VulkanPixelBufferLike`], not here).
+    fn vk_memory_property_flags(&self) -> vk::MemoryPropertyFlags {
+        vk::MemoryPropertyFlags::DEVICE_LOCAL
+    }
+
+    /// `true` if the image was allocated with
+    /// `VK_IMAGE_CREATE_PROTECTED_BIT`. Default `false` — surface-
+    /// adapter textures aren't protected-content.
+    fn vk_protected(&self) -> bool {
+        false
+    }
+
+    /// `VkSamplerYcbcrConversion` handle as `u64`, or `0` if unused.
+    /// Default `0` — adapter-internal NV12 conversion is the
+    /// surface-adapter contract; YCbCr conversion handles aren't
+    /// exposed across the boundary.
+    fn vk_ycbcr_conversion_handle(&self) -> u64 {
+        0
+    }
 }
 
 /// Minimal device shape every surface adapter needs at the layout-

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -3107,6 +3107,35 @@ mod vulkan {
         pub api_version: u32,
     }
 
+    /// Per-image VkImageInfo descriptor for a registered surface.
+    /// Mirrors `streamlib_adapter_abi::VkImageInfo` field-for-field —
+    /// kept as a separate `#[repr(C)]` here so the cdylib's ABI
+    /// surface stays self-contained (the SDK doesn't need to mirror
+    /// `streamlib-adapter-abi` to read this).
+    ///
+    /// Per-image (fixed at registration), NOT per-acquire. Polyglot
+    /// Skia wrappers call `slpn_vulkan_get_image_info` once per
+    /// registered surface to populate their backend-context state;
+    /// per-acquire `vk_image_layout` still flows through
+    /// [`SlpnVulkanView`].
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct SlpnVulkanImageInfo {
+        pub format: i32,
+        pub tiling: i32,
+        pub usage_flags: u32,
+        pub sample_count: u32,
+        pub level_count: u32,
+        pub queue_family: u32,
+        pub memory_handle: u64,
+        pub memory_offset: u64,
+        pub memory_size: u64,
+        pub memory_property_flags: u32,
+        pub protected: u32,
+        pub ycbcr_conversion: u64,
+        pub _reserved: [u8; 16],
+    }
+
     /// Bring up `ConsumerVulkanDevice` + `VulkanSurfaceAdapter`. Returns NULL on
     /// failure (typically because the driver doesn't support the required
     /// DMA-BUF / external-semaphore extensions).
@@ -3384,6 +3413,56 @@ mod vulkan {
         out.vk_queue = handles.vk_queue;
         out.vk_queue_family_index = handles.vk_queue_family_index;
         out.api_version = handles.api_version;
+        0
+    }
+
+    /// Fetch the per-image VkImageInfo descriptor for a registered
+    /// surface. Returns 0 on success, -1 on null pointer or
+    /// unregistered surface.
+    ///
+    /// Per-image (fixed at registration time). Polyglot wrappers that
+    /// build a framework-native handle from the underlying VkImage
+    /// (Skia's `GrBackendRenderTarget`, vulkano's `Image`, etc.)
+    /// call this once per registration to populate their backend
+    /// state; the per-acquire `vk_image_layout` still flows through
+    /// [`SlpnVulkanView`] on every acquire.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_get_image_info(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        out: *mut SlpnVulkanImageInfo,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return -1,
+        };
+        let out = match unsafe { out.as_mut() } {
+            Some(o) => o,
+            None => return -1,
+        };
+        let info = match rt.adapter.surface_image_info(surface_id) {
+            Some(i) => i,
+            None => {
+                tracing::error!(
+                    "slpn_vulkan_get_image_info: surface_id {} not registered",
+                    surface_id
+                );
+                return -1;
+            }
+        };
+        out.format = info.format;
+        out.tiling = info.tiling;
+        out.usage_flags = info.usage_flags;
+        out.sample_count = info.sample_count;
+        out.level_count = info.level_count;
+        out.queue_family = info.queue_family;
+        out.memory_handle = info.memory_handle;
+        out.memory_offset = info.memory_offset;
+        out.memory_size = info.memory_size;
+        out.memory_property_flags = info.memory_property_flags;
+        out.protected = info.protected;
+        out.ycbcr_conversion = info.ycbcr_conversion;
+        out._reserved = [0; 16];
         0
     }
 
@@ -4315,6 +4394,23 @@ mod vulkan {
         pub api_version: u32,
     }
 
+    #[repr(C)]
+    pub struct SlpnVulkanImageInfo {
+        pub format: i32,
+        pub tiling: i32,
+        pub usage_flags: u32,
+        pub sample_count: u32,
+        pub level_count: u32,
+        pub queue_family: u32,
+        pub memory_handle: u64,
+        pub memory_offset: u64,
+        pub memory_size: u64,
+        pub memory_property_flags: u32,
+        pub protected: u32,
+        pub ycbcr_conversion: u64,
+        pub _reserved: [u8; 16],
+    }
+
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_vulkan_runtime_new() -> *mut c_void {
         tracing::error!("slpn_vulkan_*: Vulkan adapter runtime is Linux-only");
@@ -4379,6 +4475,15 @@ mod vulkan {
     pub unsafe extern "C" fn slpn_vulkan_raw_handles(
         _rt: *mut c_void,
         _out: *mut SlpnVulkanRawHandles,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_get_image_info(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out: *mut SlpnVulkanImageInfo,
     ) -> i32 {
         -1
     }

--- a/libs/streamlib-python/python/streamlib/adapters/__init__.py
+++ b/libs/streamlib-python/python/streamlib/adapters/__init__.py
@@ -10,6 +10,6 @@ shapes and convenience wrappers customer code uses against the
 subprocess-side native binding (``streamlib-python-native``).
 """
 
-from streamlib.adapters import cpu_readback, opengl, vulkan
+from streamlib.adapters import cpu_readback, opengl, skia, vulkan
 
-__all__ = ["cpu_readback", "opengl", "vulkan"]
+__all__ = ["cpu_readback", "opengl", "skia", "vulkan"]

--- a/libs/streamlib-python/python/streamlib/adapters/skia.py
+++ b/libs/streamlib-python/python/streamlib/adapters/skia.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Skia surface adapter — Python customer-facing API.
+
+Mirrors the Rust crate ``streamlib-adapter-skia`` (#513) by
+**composing on the Python ``vulkan`` adapter** (``streamlib.adapters.vulkan``)
+plus ``skia-python`` to wrap the underlying ``VkImage`` as a
+``skia.Surface`` (write) or ``skia.Image`` (read). The cdylib stays
+small — there is no ``slpn_skia_*`` FFI surface; every line of
+Vulkan handling routes through the existing ``slpn_vulkan_*`` symbols
+the ``vulkan`` adapter wires up.
+
+This is the canonical adapter-on-adapter composition shape, mirrored
+in Python: ``SkiaContext`` constrains its inner type to
+:class:`streamlib.adapters.vulkan.VulkanContext` (the public
+customer-facing handle, NOT the FFI runtime), so the Skia wrapper
+inherits every line of layout-transition + timeline-wait the host
+adapter does. The customer never sees ``GrVkImageInfo``,
+``VkImageLayout``, or any Vulkan handle — only ``skia.Surface``
+(write) and ``skia.Image`` (read) come out of the public API.
+
+Polyglot coverage: Python only. ``skia-python`` is the only
+maintained cross-language Skia binding for the runtimes streamlib
+supports — there is no Deno equivalent. The Deno wrapper for this
+adapter is deliberately deferred (same construction-language
+argument as the abandoned ``#481`` polyglot deferral); a Deno
+customer that needs Skia today should drive Skia themselves against
+:meth:`VulkanContext.raw_handles` until a Deno Skia binding emerges.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+from streamlib.adapters.vulkan import (
+    VulkanContext,
+    VulkanImageInfo,
+    VulkanReadView,
+    VulkanWriteView,
+)
+from streamlib.surface_adapter import (
+    STREAMLIB_ADAPTER_ABI_VERSION,
+    StreamlibSurface,
+)
+
+__all__ = [
+    "STREAMLIB_ADAPTER_ABI_VERSION",
+    "SkiaReadView",
+    "SkiaWriteView",
+    "SkiaContextProtocol",
+    "SkiaContext",
+]
+
+
+# Vulkan format / image-tiling integer constants. Matches Vulkan spec
+# values; bindgen-generated `skia.VkFormat` / `skia.VkImageLayout`
+# enums use the same values, so callers can transmute via int.
+class _VkFormat:
+    UNDEFINED = 0
+    R8G8B8A8_UNORM = 37
+    R8G8B8A8_SRGB = 43
+    B8G8R8A8_UNORM = 44
+    B8G8R8A8_SRGB = 50
+    R16G16B16A16_SFLOAT = 97
+    R32G32B32A32_SFLOAT = 109
+
+
+class _VkImageTiling:
+    OPTIMAL = 0
+    LINEAR = 1
+    DRM_FORMAT_MODIFIER_EXT = 1000158000
+
+
+@dataclass(frozen=True)
+class SkiaWriteView:
+    """View handed back inside an ``acquire_write`` scope.
+
+    ``surface`` is a live ``skia.Surface`` wrapping the host's
+    ``VkImage``. The customer draws into ``surface.canvas()``;
+    on scope exit the wrapper flushes Skia's command stream and
+    releases the underlying Vulkan acquire (which signals the host's
+    timeline so the next consumer wakes up).
+    """
+
+    surface: object  # skia.Surface — typed `object` so this module imports cleanly without skia-python
+
+
+@dataclass(frozen=True)
+class SkiaReadView:
+    """View handed back inside an ``acquire_read`` scope.
+
+    ``image`` is a live ``skia.Image`` referencing the host's
+    ``VkImage``. The customer samples it; on scope exit the wrapper
+    drops the image and releases the underlying Vulkan acquire.
+    """
+
+    image: object  # skia.Image
+
+
+@runtime_checkable
+class SkiaContextProtocol(Protocol):
+    """Customer-facing handle the subprocess runtime hands out.
+
+    Same shape as the Rust ``streamlib_adapter_skia::SkiaContext``:
+    scoped acquire/release returning a typed view. The trait
+    composition pitch from #509 / #511 — Skia composes on Vulkan via
+    the capability marker traits — translates to "uses
+    :class:`VulkanContext` internally" in Python, since runtime
+    checkability replaces the trait-bound machinery.
+    """
+
+    def acquire_read(self, surface): ...
+
+    def acquire_write(self, surface): ...
+
+
+class SkiaContext:
+    """Subprocess-side Skia adapter runtime (#513).
+
+    Composes on :class:`streamlib.adapters.vulkan.VulkanContext` —
+    every Vulkan operation (host surface registration, timeline-wait,
+    layout transitions) routes through the inner Vulkan adapter, and
+    Skia is the framework that wraps the resulting ``VkImage``.
+
+    Construct via :meth:`from_runtime`. Single :class:`SkiaContext`
+    per subprocess; :meth:`from_runtime` returns the cached instance
+    on repeat calls. The wrapper builds its ``GrDirectContext`` once
+    against the inner Vulkan device's raw handles; per-acquire
+    construction wraps the live ``VkImage`` as a Skia
+    ``BackendRenderTarget`` and flushes on scope exit.
+
+    Importing this module requires ``skia-python``. The import is
+    deferred to first construction so that loading
+    ``streamlib.adapters`` doesn't pay the ``skia-python`` import
+    cost for customers that don't use Skia.
+    """
+
+    _shared_instance: Optional["SkiaContext"] = None
+
+    def __init__(self, vulkan_ctx: VulkanContext) -> None:
+        # Defer the skia-python import to construction so loading the
+        # `streamlib.adapters` package doesn't drag skia-python in for
+        # customers that don't use Skia. Failures (skia-python not
+        # installed) surface here with a clear message instead of at
+        # import time.
+        try:
+            import skia  # noqa: F401  (used in helper methods below)
+        except ImportError as e:
+            raise RuntimeError(
+                "SkiaContext requires `skia-python` (>= m120 for Vulkan "
+                "backend support). Install via `pip install skia-python`."
+            ) from e
+        self._skia = skia  # cache the module
+        self._vulkan = vulkan_ctx
+        self._direct_context = self._build_direct_context(vulkan_ctx)
+        # Cache `VulkanImageInfo` per surface — fixed per registration,
+        # avoid re-fetching on every acquire.
+        self._image_info_cache: dict[str, VulkanImageInfo] = {}
+
+    @classmethod
+    def from_runtime(cls, runtime_context) -> "SkiaContext":
+        """Build (or fetch the cached) :class:`SkiaContext` for this
+        subprocess. The inner :class:`VulkanContext` is fetched via
+        its own :meth:`VulkanContext.from_runtime` — a single
+        ``VulkanContext`` is shared between this Skia adapter and any
+        other Vulkan-using adapter the same subprocess hosts.
+        """
+        if cls._shared_instance is None:
+            vulkan_ctx = VulkanContext.from_runtime(runtime_context)
+            cls._shared_instance = cls(vulkan_ctx)
+        return cls._shared_instance
+
+    def _build_direct_context(self, vulkan_ctx: VulkanContext):
+        """Build a ``skia.GrDirectContext`` from the inner Vulkan
+        device's raw handles. Invoked once at construction; the
+        resulting context is shared across every acquire.
+
+        Skia's Vulkan backend needs a ``GetProc`` callback to resolve
+        Vulkan function pointers; we reuse the streamlib-loaded
+        ``libvulkan.so.1`` via ``ctypes`` and forward calls into
+        ``vkGetInstanceProcAddr`` / ``vkGetDeviceProcAddr``.
+        """
+        skia = self._skia
+        handles = vulkan_ctx.raw_handles()
+
+        # Build GrVkBackendContext — populate fields directly since
+        # skia-python's `GrVkBackendContext()` ctor takes no args.
+        backend_ctx = skia.GrVkBackendContext()
+        backend_ctx.fInstance = handles.vk_instance
+        backend_ctx.fPhysicalDevice = handles.vk_physical_device
+        backend_ctx.fDevice = handles.vk_device
+        backend_ctx.fQueue = handles.vk_queue
+        backend_ctx.fGraphicsQueueIndex = handles.vk_queue_family_index
+        # Skia accepts `fMaxAPIVersion = 0` as "use whatever the
+        # device supports"; setting it explicitly to the device's
+        # version avoids subtle init-time fallbacks.
+        backend_ctx.fMaxAPIVersion = handles.api_version
+        backend_ctx.fGetProc = self._make_skia_get_proc()
+
+        ctx = skia.GrDirectContext.MakeVulkan(backend_ctx)
+        if ctx is None:
+            raise RuntimeError(
+                "SkiaContext: skia.GrDirectContext.MakeVulkan returned None — "
+                "Skia could not bring up a Vulkan backend against the "
+                "subprocess's VkDevice. Verify skia-python was built with "
+                "Vulkan support (m120+) and that the device exposes the "
+                "extensions Skia requires (sync2, dynamic-rendering, "
+                "sampler-ycbcr-conversion are enabled by streamlib's "
+                "ConsumerVulkanDevice)."
+            )
+        return ctx
+
+    def _make_skia_get_proc(self):
+        """Build the ``GetProc`` callback skia-python uses to resolve
+        Vulkan function pointers.
+
+        Loaded once per :class:`SkiaContext`. Skia copies the resolved
+        procs into its own command tables during ``MakeVulkan`` so the
+        callback only needs to be live across that single call.
+        """
+        import ctypes
+
+        # Open libvulkan and grab vkGetInstanceProcAddr.
+        libvulkan = ctypes.CDLL("libvulkan.so.1", mode=ctypes.RTLD_GLOBAL)
+        get_instance_proc_addr = libvulkan.vkGetInstanceProcAddr
+        get_instance_proc_addr.restype = ctypes.c_void_p
+        get_instance_proc_addr.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+        # vkGetDeviceProcAddr is itself fetched via vkGetInstanceProcAddr —
+        # we resolve once at setup so the per-call closure stays cheap.
+        vk_dev_proc_name = b"vkGetDeviceProcAddr"
+        # We need an instance to resolve get_device_proc_addr. Use the
+        # Vulkan adapter's instance.
+        handles = self._vulkan.raw_handles()
+        vk_instance = ctypes.c_void_p(handles.vk_instance)
+        get_device_proc_addr_addr = get_instance_proc_addr(
+            vk_instance, vk_dev_proc_name
+        )
+        if not get_device_proc_addr_addr:
+            raise RuntimeError(
+                "SkiaContext: vkGetInstanceProcAddr could not resolve "
+                "vkGetDeviceProcAddr on the active VkInstance"
+            )
+        # Cast the address to the right callable shape.
+        get_device_proc_addr = ctypes.CFUNCTYPE(
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p
+        )(get_device_proc_addr_addr)
+
+        def get_proc(name: str, instance, device) -> int:
+            """Resolve a Vulkan proc address.
+
+            skia-python invokes this with ``(name, instance, device)``
+            where exactly one of ``instance`` / ``device`` is non-zero.
+            Returns the function pointer as an integer (skia-python
+            treats it as ``intptr_t``).
+            """
+            name_bytes = name.encode("ascii") if isinstance(name, str) else name
+            if device:
+                addr = get_device_proc_addr(
+                    ctypes.c_void_p(int(device)), name_bytes
+                )
+            else:
+                addr = get_instance_proc_addr(
+                    ctypes.c_void_p(int(instance)) if instance else None,
+                    name_bytes,
+                )
+            return int(addr) if addr else 0
+
+        return get_proc
+
+    @staticmethod
+    def _surface_pool_id(surface) -> str:
+        if isinstance(surface, str):
+            return surface
+        sid = getattr(surface, "id", None)
+        if sid is None:
+            raise TypeError(
+                f"SkiaContext: expected StreamlibSurface or str pool_id, got {surface!r}"
+            )
+        return str(sid)
+
+    def _vk_image_info(self, surface) -> VulkanImageInfo:
+        pool_id = self._surface_pool_id(surface)
+        cached = self._image_info_cache.get(pool_id)
+        if cached is not None:
+            return cached
+        info = self._vulkan.image_info(surface)
+        self._image_info_cache[pool_id] = info
+        return info
+
+    def _build_skia_vk_image_info(
+        self, vk_image: int, vk_image_layout: int, info: VulkanImageInfo
+    ):
+        """Translate a per-acquire ``VulkanWriteView`` / ``VulkanReadView``
+        + the surface's static :class:`VulkanImageInfo` into a
+        ``skia.GrVkImageInfo`` populated for ``GrBackendRenderTarget``.
+        """
+        skia = self._skia
+
+        alloc = skia.GrVkAlloc()
+        alloc.fMemory = info.memory_handle
+        alloc.fOffset = info.memory_offset
+        alloc.fSize = info.memory_size
+        alloc.fFlags = 0  # NONE — Skia treats borrowed memory as opaque
+
+        vk_info = skia.GrVkImageInfo()
+        vk_info.fImage = vk_image
+        vk_info.fAlloc = alloc
+        # Skia's render-target paths reject `DRM_FORMAT_MODIFIER_EXT`;
+        # the host always allocates with OPTIMAL or
+        # `DRM_FORMAT_MODIFIER_EXT` (for cross-process tiled DMA-BUF).
+        # Tiled-modifier images behave like OPTIMAL for the GPU
+        # commands Skia issues, so we report OPTIMAL to keep Skia
+        # happy. Pure LINEAR (sampler-only on NVIDIA) is preserved.
+        if info.tiling == _VkImageTiling.DRM_FORMAT_MODIFIER_EXT:
+            vk_info.fImageTiling = _VkImageTiling.OPTIMAL
+        else:
+            vk_info.fImageTiling = info.tiling
+        vk_info.fImageLayout = vk_image_layout
+        vk_info.fFormat = info.format
+        vk_info.fImageUsageFlags = info.usage_flags
+        vk_info.fSampleCount = info.sample_count
+        vk_info.fLevelCount = info.level_count
+        vk_info.fCurrentQueueFamily = info.queue_family
+        vk_info.fProtected = bool(info.protected)
+        return vk_info
+
+    @staticmethod
+    def _color_type_for_vk_format(skia, vk_format: int):
+        if vk_format in (_VkFormat.B8G8R8A8_UNORM, _VkFormat.B8G8R8A8_SRGB):
+            return skia.kBGRA_8888_ColorType
+        if vk_format in (_VkFormat.R8G8B8A8_UNORM, _VkFormat.R8G8B8A8_SRGB):
+            return skia.kRGBA_8888_ColorType
+        if vk_format == _VkFormat.R16G16B16A16_SFLOAT:
+            return skia.kRGBA_F16_ColorType
+        if vk_format == _VkFormat.R32G32B32A32_SFLOAT:
+            return skia.kRGBA_F32_ColorType
+        raise RuntimeError(
+            f"SkiaContext: unsupported vk::Format {vk_format} — Skia adapter "
+            "currently maps BGRA8/RGBA8/RGBAF16/RGBAF32 only"
+        )
+
+    @staticmethod
+    def _surface_dims(surface) -> tuple[int, int]:
+        if isinstance(surface, StreamlibSurface):
+            return int(surface.width), int(surface.height)
+        # Fall back to attribute access for duck-typed surface descriptors.
+        w = getattr(surface, "width", None)
+        h = getattr(surface, "height", None)
+        if w is None or h is None:
+            raise TypeError(
+                "SkiaContext: surface must carry width/height (StreamlibSurface "
+                f"or compatible), got {surface!r}"
+            )
+        return int(w), int(h)
+
+    @contextmanager
+    def acquire_write(self, surface) -> Iterator[SkiaWriteView]:
+        """Acquire write access. Yields a :class:`SkiaWriteView` whose
+        ``surface`` is a live ``skia.Surface`` wrapping the host's
+        ``VkImage``. The customer draws into ``surface.canvas()``;
+        on scope exit the wrapper:
+
+        1. Calls ``surface.flushAndSubmit(syncCpu=True)`` to drain
+           Skia's GPU work.
+        2. Drops the Skia ``Surface`` so its DirectContext refcount
+           is released.
+        3. Exits the inner ``VulkanContext.acquire_write`` scope,
+           which signals the host's timeline so the next consumer
+           wakes up.
+        """
+        skia = self._skia
+        info = self._vk_image_info(surface)
+        width, height = self._surface_dims(surface)
+        color_type = self._color_type_for_vk_format(skia, info.format)
+        with self._vulkan.acquire_write(surface) as vk_view:
+            sk_surface = self._wrap_as_skia_surface(
+                vk_view, info, width, height, color_type
+            )
+            try:
+                yield SkiaWriteView(surface=sk_surface)
+            finally:
+                # SyncCpu::Yes — block until the GPU has executed all
+                # of Skia's command submissions. Without this, the
+                # vulkan release below host-signals the timeline
+                # before the GPU is done, racing the next consumer.
+                sk_surface.flushAndSubmit(syncCpu=True)
+                # Releasing the Surface refcount decrements the
+                # DirectContext's pinning. The vulkan release in the
+                # outer `with` then runs and signals the timeline.
+                del sk_surface
+
+    @contextmanager
+    def acquire_read(self, surface) -> Iterator[SkiaReadView]:
+        """Acquire read access. Yields a :class:`SkiaReadView` whose
+        ``image`` is a live ``skia.Image`` referencing the host's
+        ``VkImage``. Read-only — no flush needed on scope exit.
+        """
+        skia = self._skia
+        info = self._vk_image_info(surface)
+        width, height = self._surface_dims(surface)
+        color_type = self._color_type_for_vk_format(skia, info.format)
+        with self._vulkan.acquire_read(surface) as vk_view:
+            sk_image = self._wrap_as_skia_image(
+                vk_view, info, width, height, color_type
+            )
+            try:
+                yield SkiaReadView(image=sk_image)
+            finally:
+                del sk_image
+
+    def _wrap_as_skia_surface(
+        self,
+        vk_view: VulkanWriteView,
+        info: VulkanImageInfo,
+        width: int,
+        height: int,
+        color_type,
+    ):
+        """Build a ``skia.Surface`` from a write-acquired ``VkImage``."""
+        skia = self._skia
+        vk_info = self._build_skia_vk_image_info(
+            vk_view.vk_image, vk_view.vk_image_layout, info
+        )
+        backend_render_target = skia.GrBackendRenderTarget(
+            width, height, vk_info
+        )
+        sk_surface = skia.Surface.MakeFromBackendRenderTarget(
+            self._direct_context,
+            backend_render_target,
+            skia.kTopLeft_GrSurfaceOrigin,
+            color_type,
+            None,  # color_space
+            None,  # surface_props
+        )
+        if sk_surface is None:
+            raise RuntimeError(
+                f"SkiaContext.acquire_write: skia.Surface.MakeFromBackendRenderTarget "
+                f"returned None for surface (vk_image=0x{vk_view.vk_image:x}, "
+                f"format={info.format}, usage_flags=0x{info.usage_flags:x}). "
+                "Common causes: missing VK_IMAGE_USAGE_TRANSFER_DST_BIT on the "
+                "host VkImage allocation; format / color-type mismatch; or "
+                "Skia's GrVkCaps doesn't list the format as renderable."
+            )
+        return sk_surface
+
+    def _wrap_as_skia_image(
+        self,
+        vk_view: VulkanReadView,
+        info: VulkanImageInfo,
+        width: int,
+        height: int,
+        color_type,
+    ):
+        """Build a ``skia.Image`` from a read-acquired ``VkImage``."""
+        skia = self._skia
+        vk_info = self._build_skia_vk_image_info(
+            vk_view.vk_image, vk_view.vk_image_layout, info
+        )
+        backend_texture = skia.GrBackendTexture(width, height, vk_info)
+        sk_image = skia.Image.MakeFromTexture(
+            self._direct_context,
+            backend_texture,
+            skia.kTopLeft_GrSurfaceOrigin,
+            color_type,
+            skia.kPremul_AlphaType,
+            None,  # color_space
+        )
+        if sk_image is None:
+            raise RuntimeError(
+                f"SkiaContext.acquire_read: skia.Image.MakeFromTexture returned "
+                f"None for surface (vk_image=0x{vk_view.vk_image:x})"
+            )
+        return sk_image

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -46,6 +46,7 @@ from streamlib.surface_adapter import (
 __all__ = [
     "STREAMLIB_ADAPTER_ABI_VERSION",
     "RawVulkanHandles",
+    "VulkanImageInfo",
     "VulkanReadView",
     "VulkanWriteView",
     "VulkanSurfaceAdapter",
@@ -64,6 +65,36 @@ class VkImageLayout:
     SHADER_READ_ONLY_OPTIMAL = 5
     TRANSFER_SRC_OPTIMAL = 6
     TRANSFER_DST_OPTIMAL = 7
+
+
+@dataclass(frozen=True)
+class VulkanImageInfo:
+    """Per-image VkImageInfo descriptor for a registered surface.
+
+    Mirrors ``streamlib_adapter_abi::VkImageInfo`` field-for-field —
+    customers wrapping the underlying ``VkImage`` as a framework-native
+    handle (Skia's ``GrVkImageInfo``, vulkano's ``Image``, etc.) read
+    this once on registration to populate their backend-context state.
+    The per-acquire layout still flows through :class:`VulkanReadView`
+    / :class:`VulkanWriteView`'s ``vk_image_layout`` field.
+
+    All Vulkan enum / bitmask fields are kept as raw integers (the
+    underlying types are ``i32`` / ``u32`` / ``u64`` per the spec) so
+    this dataclass stays binding-agnostic.
+    """
+
+    format: int
+    tiling: int
+    usage_flags: int
+    sample_count: int
+    level_count: int
+    queue_family: int
+    memory_handle: int
+    memory_offset: int
+    memory_size: int
+    memory_property_flags: int
+    protected: int
+    ycbcr_conversion: int
 
 
 @dataclass(frozen=True)
@@ -200,6 +231,26 @@ class _SlpnVulkanRawHandles(ctypes.Structure):
     ]
 
 
+class _SlpnVulkanImageInfo(ctypes.Structure):
+    """C struct matching `streamlib_python_native::vulkan::SlpnVulkanImageInfo`."""
+
+    _fields_ = [
+        ("format", ctypes.c_int32),
+        ("tiling", ctypes.c_int32),
+        ("usage_flags", ctypes.c_uint32),
+        ("sample_count", ctypes.c_uint32),
+        ("level_count", ctypes.c_uint32),
+        ("queue_family", ctypes.c_uint32),
+        ("memory_handle", ctypes.c_uint64),
+        ("memory_offset", ctypes.c_uint64),
+        ("memory_size", ctypes.c_uint64),
+        ("memory_property_flags", ctypes.c_uint32),
+        ("protected", ctypes.c_uint32),
+        ("ycbcr_conversion", ctypes.c_uint64),
+        ("_reserved", ctypes.c_uint8 * 16),
+    ]
+
+
 class VulkanContext:
     """Subprocess-side Vulkan adapter runtime (#531).
 
@@ -314,6 +365,13 @@ class VulkanContext:
         lib.slpn_vulkan_raw_handles.argtypes = [
             ctypes.c_void_p,
             ctypes.POINTER(_SlpnVulkanRawHandles),
+        ]
+
+        lib.slpn_vulkan_get_image_info.restype = ctypes.c_int32
+        lib.slpn_vulkan_get_image_info.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.POINTER(_SlpnVulkanImageInfo),
         ]
 
         # Compute dispatch routes through escalate IPC (`register_compute_kernel`
@@ -523,4 +581,46 @@ class VulkanContext:
             vk_queue=int(h.vk_queue),
             vk_queue_family_index=int(h.vk_queue_family_index),
             api_version=int(h.api_version),
+        )
+
+    def image_info(self, surface) -> VulkanImageInfo:
+        """Return the per-image VkImageInfo descriptor for a registered
+        surface. Resolves and registers the surface lazily if it
+        hasn't been touched yet (same shape as
+        :meth:`acquire_write` / :meth:`acquire_read`).
+
+        Per-image: the descriptor is fixed at registration time and
+        does NOT change across acquires. Customers that wrap the
+        underlying ``VkImage`` as a framework-native handle (Skia's
+        ``GrVkImageInfo``, vulkano's ``Image``, etc.) call this once
+        per surface and cache the result; the per-acquire layout
+        flows through the ``vk_image_layout`` field on
+        :class:`VulkanReadView` / :class:`VulkanWriteView`.
+        """
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._resolve_and_register(pool_id)
+        info = _SlpnVulkanImageInfo()
+        rc = self._lib.slpn_vulkan_get_image_info(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.byref(info),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.image_info: slpn_vulkan_get_image_info "
+                f"returned {rc} for surface '{pool_id}'"
+            )
+        return VulkanImageInfo(
+            format=int(info.format),
+            tiling=int(info.tiling),
+            usage_flags=int(info.usage_flags),
+            sample_count=int(info.sample_count),
+            level_count=int(info.level_count),
+            queue_family=int(info.queue_family),
+            memory_handle=int(info.memory_handle),
+            memory_offset=int(info.memory_offset),
+            memory_size=int(info.memory_size),
+            memory_property_flags=int(info.memory_property_flags),
+            protected=int(info.protected),
+            ycbcr_conversion=int(info.ycbcr_conversion),
         )

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -882,6 +882,18 @@ impl GpuContext {
             TextureUsages::RENDER_ATTACHMENT
                 | TextureUsages::TEXTURE_BINDING
                 | TextureUsages::COPY_SRC
+                // COPY_DST is required by Skia's `check_image_info`
+                // gate (`GrVkGpu.cpp:1298-1302`): Skia mandates both
+                // `VK_IMAGE_USAGE_TRANSFER_SRC_BIT` and
+                // `VK_IMAGE_USAGE_TRANSFER_DST_BIT` on every
+                // externally-allocated image it wraps as a Surface or
+                // Image — without TRANSFER_DST, both
+                // `wrap_backend_render_target` and `borrow_texture_from`
+                // silently return `None`. The bit is also additive
+                // for OpenGL / Vulkan compute / cpu-readback adapters,
+                // so it lives at the canonical render-target
+                // allocation point rather than per-adapter.
+                | TextureUsages::COPY_DST
                 // STORAGE_BINDING is on by default so subprocess Vulkan
                 // adapters can bind the imported VkImage as a storage
                 // image for compute writes (#531). Render-target +

--- a/libs/streamlib/src/vulkan/rhi/host_marker.rs
+++ b/libs/streamlib/src/vulkan/rhi/host_marker.rs
@@ -87,6 +87,21 @@ mod placeholder {
         fn format(&self) -> TextureFormat {
             match *self {}
         }
+        fn vk_format(&self) -> vulkanalia::vk::Format {
+            match *self {}
+        }
+        fn vk_image_tiling(&self) -> vulkanalia::vk::ImageTiling {
+            match *self {}
+        }
+        fn vk_image_usage_flags(&self) -> vulkanalia::vk::ImageUsageFlags {
+            match *self {}
+        }
+        fn vk_memory(&self) -> vulkanalia::vk::DeviceMemory {
+            match *self {}
+        }
+        fn vk_memory_size(&self) -> vulkanalia::vk::DeviceSize {
+            match *self {}
+        }
     }
 
     impl VulkanPixelBufferLike for NotAvailableOnThisPlatform {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -80,6 +80,30 @@ fn texture_usages_to_vk(usage: TextureUsages) -> vk::ImageUsageFlags {
     flags
 }
 
+/// Per-construction Vulkan image metadata exposed through
+/// [`super::VulkanTextureLike`] to surface-adapter consumers (Skia in
+/// particular needs the full create-time descriptor to wrap the image
+/// as a `GrBackendRenderTarget`).
+///
+/// Memory binding (`vk_memory`, `vk_memory_offset`, `vk_memory_size`)
+/// is populated lazily from VMA's `get_allocation_info` for the VMA
+/// path or directly from the import call for the DMA-BUF / IOSurface
+/// path — see [`HostVulkanTexture::vk_memory_binding`].
+#[derive(Clone, Copy)]
+struct HostVkImageMeta {
+    vk_image_tiling: vk::ImageTiling,
+    vk_image_usage_flags: vk::ImageUsageFlags,
+}
+
+impl Default for HostVkImageMeta {
+    fn default() -> Self {
+        Self {
+            vk_image_tiling: vk::ImageTiling::OPTIMAL,
+            vk_image_usage_flags: vk::ImageUsageFlags::empty(),
+        }
+    }
+}
+
 /// Vulkan texture wrapper.
 ///
 /// Wraps a VkImage with associated memory and metadata.
@@ -93,6 +117,12 @@ pub struct HostVulkanTexture {
     /// Imported device memory for DMA-BUF import path (VMA cannot import external memory).
     #[cfg(target_os = "linux")]
     imported_memory: Option<vk::DeviceMemory>,
+    /// Allocation size for the imported_memory path (the size we passed
+    /// to `vkAllocateMemory` via `import_dma_buf_memory`). Tracked
+    /// because `VulkanTextureLike::vk_memory_size` needs it for Skia's
+    /// `GrVkAlloc.fSize`.
+    #[cfg(target_os = "linux")]
+    imported_memory_size: vk::DeviceSize,
     /// Cached DMA-BUF fd to avoid leaking a new fd on each export call.
     #[cfg(target_os = "linux")]
     cached_dma_buf_fd: OnceLock<std::os::unix::io::RawFd>,
@@ -114,6 +144,9 @@ pub struct HostVulkanTexture {
     width: u32,
     height: u32,
     format: TextureFormat,
+    /// Per-construction Vulkan image metadata for trait-level
+    /// inspection (Skia adapter, debug snapshots).
+    vk_image_meta: HostVkImageMeta,
 }
 
 impl HostVulkanTexture {
@@ -186,6 +219,8 @@ impl HostVulkanTexture {
             #[cfg(target_os = "linux")]
             imported_memory: None,
             #[cfg(target_os = "linux")]
+            imported_memory_size: 0,
+            #[cfg(target_os = "linux")]
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -196,6 +231,10 @@ impl HostVulkanTexture {
             width: desc.width,
             height: desc.height,
             format: desc.format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::OPTIMAL,
+                vk_image_usage_flags: usage_flags,
+            },
         })
     }
 
@@ -245,6 +284,8 @@ impl HostVulkanTexture {
             #[cfg(target_os = "linux")]
             imported_memory: None,
             #[cfg(target_os = "linux")]
+            imported_memory_size: 0,
+            #[cfg(target_os = "linux")]
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -255,6 +296,10 @@ impl HostVulkanTexture {
             width: desc.width,
             height: desc.height,
             format: desc.format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::OPTIMAL,
+                vk_image_usage_flags: usage_flags,
+            },
         })
     }
 
@@ -382,6 +427,7 @@ impl HostVulkanTexture {
             image: Some(image),
             allocation: Some(allocation),
             imported_memory: None,
+            imported_memory_size: 0,
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -390,6 +436,10 @@ impl HostVulkanTexture {
             width: desc.width,
             height: desc.height,
             format: desc.format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT,
+                vk_image_usage_flags: usage_flags,
+            },
         })
     }
 
@@ -469,6 +519,12 @@ impl HostVulkanTexture {
             width,
             height,
             format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::OPTIMAL,
+                vk_image_usage_flags: vk::ImageUsageFlags::SAMPLED
+                    | vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::TRANSFER_DST,
+            },
         })
     }
 
@@ -482,6 +538,8 @@ impl HostVulkanTexture {
             #[cfg(target_os = "linux")]
             imported_memory: None,
             #[cfg(target_os = "linux")]
+            imported_memory_size: 0,
+            #[cfg(target_os = "linux")]
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -492,6 +550,7 @@ impl HostVulkanTexture {
             width: 0,
             height: 0,
             format: TextureFormat::Rgba8Unorm,
+            vk_image_meta: HostVkImageMeta::default(),
         }
     }
 
@@ -725,6 +784,22 @@ impl HostVulkanTexture {
 
         let device = vulkan_device.device();
         let vk_format = texture_format_to_vk(format);
+        // Same usage set as the create_info builder below — tracked
+        // separately so VulkanTextureLike::vk_image_usage_flags can
+        // report it without re-reading the image_create_info chain.
+        // TRANSFER_DST is required by Skia's `check_image_info` gate
+        // (and by symmetric host↔consumer parity); see the matching
+        // comment in
+        // `streamlib::core::context::GpuContext::acquire_render_target_dma_buf_image`.
+        let usage_flags = vk::ImageUsageFlags::TRANSFER_SRC
+            | vk::ImageUsageFlags::TRANSFER_DST
+            | vk::ImageUsageFlags::SAMPLED
+            | vk::ImageUsageFlags::COLOR_ATTACHMENT
+            // STORAGE for subprocess compute shaders that bind the
+            // imported VkImage as a storage image (#531). Must match
+            // the host's `acquire_render_target_dma_buf_image` usage
+            // flags or the cross-process import fails.
+            | vk::ImageUsageFlags::STORAGE;
 
         let plane_layouts: Vec<vk::SubresourceLayout> = plane_offsets
             .iter()
@@ -754,17 +829,7 @@ impl HostVulkanTexture {
             .array_layers(1)
             .samples(vk::SampleCountFlags::_1)
             .tiling(vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT)
-            .usage(
-                vk::ImageUsageFlags::TRANSFER_SRC
-                    | vk::ImageUsageFlags::TRANSFER_DST
-                    | vk::ImageUsageFlags::SAMPLED
-                    | vk::ImageUsageFlags::COLOR_ATTACHMENT
-                    // STORAGE for subprocess compute shaders that bind
-                    // the imported VkImage as a storage image (#531).
-                    // Must match the host's `acquire_render_target_dma_buf_image`
-                    // usage flags or the cross-process import fails.
-                    | vk::ImageUsageFlags::STORAGE,
-            )
+            .usage(usage_flags)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED)
             .push_next(&mut explicit_modifier_info)
@@ -811,6 +876,7 @@ impl HostVulkanTexture {
             image: Some(image),
             allocation: None,
             imported_memory: Some(memory),
+            imported_memory_size: alloc_size,
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -819,6 +885,10 @@ impl HostVulkanTexture {
             width,
             height,
             format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT,
+                vk_image_usage_flags: usage_flags,
+            },
         })
     }
 
@@ -833,6 +903,9 @@ impl HostVulkanTexture {
     ) -> Result<Self> {
         let device = vulkan_device.device();
         let vk_format = texture_format_to_vk(format);
+        let usage_flags = vk::ImageUsageFlags::TRANSFER_SRC
+            | vk::ImageUsageFlags::TRANSFER_DST
+            | vk::ImageUsageFlags::SAMPLED;
 
         let image_info = vk::ImageCreateInfo::builder()
             .image_type(vk::ImageType::_2D)
@@ -846,11 +919,7 @@ impl HostVulkanTexture {
             .array_layers(1)
             .samples(vk::SampleCountFlags::_1)
             .tiling(vk::ImageTiling::LINEAR)
-            .usage(
-                vk::ImageUsageFlags::TRANSFER_SRC
-                    | vk::ImageUsageFlags::TRANSFER_DST
-                    | vk::ImageUsageFlags::SAMPLED,
-            )
+            .usage(usage_flags)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED)
             .build();
@@ -890,6 +959,7 @@ impl HostVulkanTexture {
             image: Some(image),
             allocation: None,
             imported_memory: Some(memory),
+            imported_memory_size: alloc_size,
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -898,6 +968,10 @@ impl HostVulkanTexture {
             width,
             height,
             format,
+            vk_image_meta: HostVkImageMeta {
+                vk_image_tiling: vk::ImageTiling::LINEAR,
+                vk_image_usage_flags: usage_flags,
+            },
         })
     }
 }
@@ -911,6 +985,8 @@ impl Clone for HostVulkanTexture {
             #[cfg(target_os = "linux")]
             imported_memory: None,
             #[cfg(target_os = "linux")]
+            imported_memory_size: 0,
+            #[cfg(target_os = "linux")]
             cached_dma_buf_fd: OnceLock::new(),
             cached_image_view: OnceLock::new(),
             imported_from_iosurface: false,
@@ -921,6 +997,7 @@ impl Clone for HostVulkanTexture {
             width: self.width,
             height: self.height,
             format: self.format,
+            vk_image_meta: HostVkImageMeta::default(),
         }
     }
 }
@@ -974,6 +1051,32 @@ impl Drop for HostVulkanTexture {
 unsafe impl Send for HostVulkanTexture {}
 unsafe impl Sync for HostVulkanTexture {}
 
+impl HostVulkanTexture {
+    /// Memory binding tuple `(memory, offset, size)` resolved against
+    /// whichever path created the image — VMA for the standard
+    /// allocators, the imported `VkDeviceMemory` for the DMA-BUF
+    /// import paths, or `(null, 0, 0)` for placeholder / IOSurface-
+    /// import textures (Skia consumers must check before relying on
+    /// `vk_memory()`).
+    fn vk_memory_binding(&self) -> (vk::DeviceMemory, vk::DeviceSize, vk::DeviceSize) {
+        // VMA path: query allocation_info on demand. The lookup is a
+        // simple struct read from VMA's internal allocation handle.
+        if let (Some(vk_dev), Some(allocation)) =
+            (&self.vulkan_device, self.allocation.as_ref())
+        {
+            let info = vk_dev.allocator().get_allocation_info(*allocation);
+            return (info.deviceMemory, info.offset, info.size);
+        }
+        // DMA-BUF import path (Linux only).
+        #[cfg(target_os = "linux")]
+        if let Some(memory) = self.imported_memory {
+            return (memory, 0, self.imported_memory_size);
+        }
+        // Placeholder / IOSurface — no Vulkan memory binding.
+        (vk::DeviceMemory::null(), 0, 0)
+    }
+}
+
 impl super::VulkanTextureLike for HostVulkanTexture {
     fn image(&self) -> Option<vk::Image> {
         HostVulkanTexture::image(self)
@@ -996,6 +1099,24 @@ impl super::VulkanTextureLike for HostVulkanTexture {
     }
     fn format(&self) -> crate::core::rhi::TextureFormat {
         HostVulkanTexture::format(self)
+    }
+    fn vk_format(&self) -> vk::Format {
+        texture_format_to_vk(self.format)
+    }
+    fn vk_image_tiling(&self) -> vk::ImageTiling {
+        self.vk_image_meta.vk_image_tiling
+    }
+    fn vk_image_usage_flags(&self) -> vk::ImageUsageFlags {
+        self.vk_image_meta.vk_image_usage_flags
+    }
+    fn vk_memory(&self) -> vk::DeviceMemory {
+        self.vk_memory_binding().0
+    }
+    fn vk_memory_offset(&self) -> vk::DeviceSize {
+        self.vk_memory_binding().1
+    }
+    fn vk_memory_size(&self) -> vk::DeviceSize {
+        self.vk_memory_binding().2
     }
 }
 

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -444,6 +444,7 @@ const NO_STREAMLIB_RUNTIME_DEP: &[&str] = &[
     "libs/streamlib-adapter-vulkan/Cargo.toml",
     "libs/streamlib-adapter-opengl/Cargo.toml",
     "libs/streamlib-adapter-cpu-readback/Cargo.toml",
+    "libs/streamlib-adapter-skia/Cargo.toml",
 ];
 
 fn check_cdylib_and_adapter_runtime_deps(


### PR DESCRIPTION
## Visual evidence

### Static frame (single-shot adapter sanity)

![Skia adapter visual evidence — gradient background, antialiased filled and stroked circles, alpha-blended lens, 96-segment sine path, 7-color tile strip, corner AA dots](https://gh-artifact.tatolab.com/pr-578/skia_visual_evidence.png)

*512×512 PNG produced by `cargo test -p streamlib-adapter-skia --test skia_visual_evidence -- --ignored --nocapture` (commit `61194ae`). Full path: Skia draw → `Surface::flush_and_submit_surface(SyncCpu::Yes)` → host `vkCmdCopyImageToBuffer` from the same VkImage Skia rendered into → BGRA→RGBA channel swap → `png` encode. Demonstrates linear gradient shader, antialiased fills, alpha blending (magenta lens overlapping the red disc), antialiased path strokes, color reproduction across the BGRA8 pipeline, and edge AA crispness.*

### Animated stress (1800 frames @ 60 fps × 30 s)

[**▶ skia_animated_stress.mp4**](https://gh-artifact.tatolab.com/pr-578/skia_animated_stress.mp4) — 4.5 MB H.264 / 30.000s / 60 fps / 512×512 (commit `e1e4988`). Hero frame at t=15s:

![Skia animated stress hero frame at t=15s — pulsing cyan stroked ring, rotating 16-spoke starburst at center, 5 hue-cycling alpha-blended Lissajous balls scattered across, traveling sine wave at the bottom, hue-cycled rainbow tile strip](https://gh-artifact.tatolab.com/pr-578/skia_animated_stress_hero.png)

*Stress run via `cargo test -p streamlib-adapter-skia --test skia_animated_stress -- --ignored --nocapture` — 1800 acquire_write/draw/flush/release iterations against the same VkImage with an animated scene (gradient + 5 Lissajous balls + rotating spokes + traveling sine + hue-cycling tiles, ~25 draw calls/frame). Asserts the timeline counter advances exactly once per frame (final value = 1800 — every signal accounted for, no missed ones), and that adapter avg frame time stays under 4× the 60 fps budget. **Result on this branch (NVIDIA RTX 3090, driver 570.x)**:*

| Metric | Value |
|---|---|
| Frames | **1800 / 1800** complete |
| Wall-clock duration | 19.4 s (incl. host readback + ffmpeg I/O) |
| **Adapter throughput headroom** | **1101 fps** (avg 0.91 ms / acquire+draw+flush+release) |
| Frame-time percentiles | p50 1.07 ms / p95 1.24 ms / p99 1.42 ms / max 17.53 ms (single warmup outlier) |
| Timeline final value | **1800** (= frame count, exact — no missed signals) |
| Output | 4.5 MB MP4 + 45 KB hero PNG |

*Adapter avg crept from 0.55 ms → 0.91 ms over the run and leveled off in the second half — bounded transient cache warmup, not unbounded growth. Gates against descriptor-pool / fence-pool / GPU-memory leaks that would have surfaced as a counter mismatch or a timeline-wait timeout long before 1800 iterations.*


## Summary

- New crate `streamlib-adapter-skia`: `SkiaSurfaceAdapter<D: VulkanRhiDevice>` composing on `streamlib-adapter-vulkan` via `VulkanWritable + VulkanImageInfoExt`. Customer sees `skia::Surface` (write) / `skia::Image` (read) directly; never `GrVkImageInfo`, `VkImageLayout`, or any Vulkan handle.
- Upstream: `VulkanTextureLike` extended with 8 accessors so `VulkanImageInfoExt::vk_image_info()` stops returning zeros (Skia rejects `VK_FORMAT_UNDEFINED`). `acquire_render_target_dma_buf_image` adds `COPY_DST` (Skia's `check_image_info` requires both `TRANSFER_SRC` and `TRANSFER_DST` — root cause identified by 5 parallel Opus research agents reading Skia C++ source).
- Polyglot Python: new `streamlib.adapters.skia.SkiaContext` composing on the existing Python `vulkan.py` adapter + `skia-python`. Cdylib stays small — no `slpn_skia_*` block; one additive `slpn_vulkan_get_image_info` FFI symbol exposes per-surface `VkImageInfo`.
- New scenario binary `examples/polyglot-skia-canvas/` (Rust host + Python skia processor) draws into a host DMA-BUF surface, host reads back via Vulkan, writes a PNG.

## Closes

Closes #513

## Exit criteria (from issue body, all met)

- [x] New crate `libs/streamlib-adapter-skia/` (Rust) + Python wrapper (`streamlib/adapters/skia.py`).
- [x] Implements `SurfaceAdapter` from #509 by composing `streamlib-adapter-vulkan` via `for<'g> Inner::WriteView<'g>: VulkanWritable + VulkanImageInfoExt`.
- [x] Customer-facing API: `streamlib.skia.context()` → `SkiaContext`; `with ctx.acquire_write(surface) as guard:` yields `guard.surface: skia.Surface`; `guard.image: skia.Image` for read mode.
- [x] `GrVkBackendContext` built once per context from the underlying adapter's handles.
- [x] Layout state never crosses the public adapter boundary — internal `VkImageLayout` transitions via the `VulkanWritable::vk_image_layout()` escape hatch from the inner view.
- [x] `GrFlushInfo` / `flush_and_submit_surface(SyncCpu::Yes)` bridged to the timeline-semaphore signal/wait.
- [x] `run_conformance` from `streamlib-adapter-abi` passes against the Vulkan backend.
- [ ] **Deferred to #576** (filed at PR-open, same milestone): GL backend (`SkiaSurfaceAdapter` composing on `streamlib-adapter-opengl` via `GlWritable`).

## Test plan

### Rust adapter tests (all green)
- [x] `cargo test -p streamlib-adapter-skia` — 5 tests pass:
  - `conformance::skia_adapter_passes_run_conformance` (8-contract suite from #509)
  - `round_trip_skia_canvas::round_trip_skia_canvas` — Skia draws a red disc on blue, host reads back via Vulkan, asserts pixel content within antialiasing tolerance
  - `concurrent_skia_and_vulkan_read::skia_read_and_vulkan_read_share_surface`
  - `layout_never_leaks::skia_views_do_not_expose_vulkan_image_info` — compile-time encapsulation invariant
  - `subprocess_crash_mid_write::subprocess_crash_test_deferred_to_polyglot_followup` — placeholder; real Skia-side crash test deferred to #577 (the inner Vulkan adapter's `subprocess_crash_mid_write` covers DMA-BUF cleanup; Skia composes on it and adds no per-acquire GPU state of its own)

### Workspace test gate
- [x] `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — green except the pre-existing `linux::surface_share::unix_socket_service::tests::oversize_fd_vec_rejected` failure (reproduced on `main` — unrelated to this PR).
- [x] Sibling adapter tests still green: `streamlib-adapter-vulkan` (conformance + duplicate-registration), `streamlib-adapter-opengl` (conformance + duplicate-registration), `streamlib-adapter-cpu-readback`. Confirms the upstream `acquire_render_target_dma_buf_image` `+COPY_DST` change is purely additive.

### Boundary CI (cdylib capability boundary preserved)
- [x] `cargo xtask check-boundaries`: 1842 files scanned, 0 violations. New `streamlib-adapter-skia/Cargo.toml` added to `NO_STREAMLIB_RUNTIME_DEP`.
- [x] `cargo tree -p streamlib-python-native | grep -c "^streamlib v"` → 0
- [x] `cargo tree -p streamlib-deno-native | grep -c "^streamlib v"` → 0
- [x] `cargo test -p xtask check_boundaries` — 30 fixture tests pass.

### E2E sweep (verifies no regression in `acquire_render_target_dma_buf_image`-affected paths)
- [x] Camera→Display via `e2e_camera_display.sh`: vivid green-bar pattern + telemetry overlay visible in PNG sample (read with the Read tool); 0 OOM, clean shutdown. Note: the fixture's pass/fail heuristic is broken on `main` too — actual functionality verified via PNG content inspection.
- [x] H264 encoder→decoder→display roundtrip via `vulkan-video-roundtrip h264 /dev/video0 12`: exit 0, 0 `OUT_OF_DEVICE_MEMORY`, 0 `DEVICE_LOST`, 0 `process() failed`, 2 progress markers, vivid pattern visible through encode/decode in PNG sample.
- [x] H265 same: exit 0, 0 errors, vivid pattern through HEVC.

## Pre-PR review iterations

Two pre-PR review iterations against this PR (`pr-review-gate` skill, Opus reviewer, max effort).

**Iteration 1: DISCUSS** — 8 items flagged. Session agent verified each:
- ✅ Acted: `SkiaWriteView` / `SkiaReadView` no longer claim `Send + Sync` (auto-derive `!Send + !Sync` correctly via `RCHandle` raw-pointer field) — customer code can't move a Skia surface across threads, breaking Skia's single-thread-affinity contract.
- ✅ Acted: Drop ordering tightened — `Surface` / `Image` drop happens INSIDE the `direct_context` mutex scope so RCHandle cleanup commands stay single-threaded.
- ✅ Acted: removed dead `_instance_handle_kept` / `_device_handle_kept` captures.
- ⏭ Documented deferral: `subprocess_crash_mid_write` test is a placeholder; real Skia-side crash test goes in **#577** (filed at PR-open).
- ⏭ Documented scope-cut: Python smoke draws a disc instead of text (issue body line 127 asked for text); text rendering would drag fontconfig/freetype/harfbuzz/ICU into the build; covered by **#577**.
- ✓ Dismissed (false positive): `transmute<i32, skia_safe::vk::*>` for tiling/layout/format is sound for valid Vulkan input — Skia's bindgen-generated enums have the spec discriminants.
- ✓ Dismissed (round-trip covers it): conformance fixture uses `new_device_local` while production uses DMA-BUF; the modifier-substitution path IS exercised by `round_trip_skia_canvas`.
- ✓ Dismissed (cross-adapter follow-up): `AdapterError::IpcDisconnected` is misleading for Skia wrap failures — same imprecision exists in inner Vulkan adapter; taxonomy refresh is out of scope.

**Iteration 2: PASS** — reviewer verified the three real fixes and confirmed no regressions from the polish commit. Iteration capped per skill protocol.

## Follow-ups filed

- **#576** — feat(adapter-skia): GL backend (Skia-on-OpenGL composition).
- **#577** — feat(adapter-skia): polyglot Skia E2E + SubprocessCrashHarness coverage.

Both in the **Surface Adapter Architecture** milestone per the user's "if it's adapter-related put it in this milestone" direction.

## Polyglot coverage

- **Runtimes affected**: rust + python
- **Schema regenerated**: n/a — no escalate-IPC schema changes
- **Python and Deno both covered?** Python yes; Deno deferred (no Deno Skia binding ecosystem — same construction-language argument as the abandoned #481 polyglot deferral). Deferral documented in the issue body's AI Agent Notes; not a quiet drift.
- **E2E tests run**:
  - [x] Host-Rust: `round_trip_skia_canvas` (passes)
  - [x] Python subprocess: structural — wrapper compiles, scenario binary compiles, empirical `dir()` check on `skia-python 144` confirmed `GrBackendRenderTarget(width, height, GrVkImageInfo)` + `Surface.MakeFromBackendRenderTarget` overloads exist. Real polyglot E2E tracked in #577.
- **FD-passing path**: DMA-BUF FD (host-allocated render-target VkImage shared cross-process via surface-share)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

