### PR TITLE
feat(adapter-skia): GL backend (Skia-on-OpenGL composition) (#576)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ rspirv-reflect = "0.9.0"
 # test from the v1 issue body moves to the polyglot Skia follow-up
 # along with the rest of the wrapper layer; the Rust adapter doesn't
 # render text.
-skia-safe = { version = "0.86", features = ["vulkan"] }
+skia-safe = { version = "0.86", features = ["vulkan", "gl"] }
 
 # Shader compilation
 # TODO: Add when implementing HLSL shader compilation:

--- a/libs/streamlib-adapter-abi/src/error.rs
+++ b/libs/streamlib-adapter-abi/src/error.rs
@@ -39,6 +39,20 @@ pub enum AdapterError {
     #[error("IPC disconnected: {reason}")]
     IpcDisconnected { reason: String },
 
+    /// The underlying backend GPU/framework API rejected an operation
+    /// that should structurally have succeeded — e.g. Skia's
+    /// `wrap_backend_render_target` returning `None`, EGL `make_current`
+    /// failing on a known-good context, a Vulkan submit returning a
+    /// driver-side error during a layout transition. The backend's
+    /// failure carries no actionable inner cause; `reason` is a
+    /// human-readable description.
+    ///
+    /// Distinct from [`Self::IpcDisconnected`] (the wire is alive — the
+    /// backend itself said no) and [`Self::UnsupportedFormat`] (the
+    /// rejection is *not* about pixel format / layout).
+    #[error("backend rejected operation: {reason}")]
+    BackendRejected { reason: String },
+
     /// A wait on the timeline semaphore exceeded the configured timeout.
     #[error("sync timeout after {duration:?}")]
     SyncTimeout { duration: Duration },

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -716,7 +716,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackCopyTrigger<D::Privilege>
         &self,
         ctx: &CpuReadbackTriggerContext<'_, D::Privilege>,
     ) -> Result<u64, AdapterError> {
-        let image = ctx.image.ok_or(AdapterError::IpcDisconnected {
+        let image = ctx.image.ok_or(AdapterError::BackendRejected {
             reason:
                 "InProcessCpuReadbackCopyTrigger requires a source VkImage; consumer-flavor surfaces have none"
                     .into(),
@@ -735,7 +735,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackCopyTrigger<D::Privilege>
         &self,
         ctx: &CpuReadbackTriggerContext<'_, D::Privilege>,
     ) -> Result<u64, AdapterError> {
-        let image = ctx.image.ok_or(AdapterError::IpcDisconnected {
+        let image = ctx.image.ok_or(AdapterError::BackendRejected {
             reason: "InProcessCpuReadbackCopyTrigger requires a source VkImage on flush".into(),
         })?;
         submit_image_buffer_copy(
@@ -786,7 +786,7 @@ fn submit_image_buffer_copy<D: VulkanRhiDevice, P: DevicePrivilege>(
         .build();
     if let Err(e) = unsafe { vk_device.begin_command_buffer(cmd, &begin_info) } {
         unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::IpcDisconnected {
+        return Err(AdapterError::BackendRejected {
             reason: format!("begin_command_buffer: {e}"),
         });
     }
@@ -858,7 +858,7 @@ fn submit_image_buffer_copy<D: VulkanRhiDevice, P: DevicePrivilege>(
 
     if let Err(e) = unsafe { vk_device.end_command_buffer(cmd) } {
         unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::IpcDisconnected {
+        return Err(AdapterError::BackendRejected {
             reason: format!("end_command_buffer: {e}"),
         });
     }
@@ -878,7 +878,7 @@ fn submit_image_buffer_copy<D: VulkanRhiDevice, P: DevicePrivilege>(
 
     let submit_result = unsafe { device.submit_to_queue(queue, &[submit], vk::Fence::null()) };
     unsafe { vk_device.destroy_command_pool(pool, None) };
-    submit_result.map_err(|e| AdapterError::IpcDisconnected {
+    submit_result.map_err(|e| AdapterError::BackendRejected {
         reason: format!("submit_to_queue: {e}"),
     })?;
 
@@ -929,7 +929,7 @@ fn create_one_shot_command_buffer(
         .build();
     let pool =
         unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
-            AdapterError::IpcDisconnected {
+            AdapterError::BackendRejected {
                 reason: format!("create_command_pool: {e}"),
             }
         })?;
@@ -943,7 +943,7 @@ fn create_one_shot_command_buffer(
         Ok(v) => v,
         Err(e) => {
             unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
+            return Err(AdapterError::BackendRejected {
                 reason: format!("allocate_command_buffers: {e}"),
             });
         }

--- a/libs/streamlib-adapter-opengl/src/adapter.rs
+++ b/libs/streamlib-adapter-opengl/src/adapter.rs
@@ -132,7 +132,7 @@ impl OpenGlSurfaceAdapter {
             if err != gl::NO_ERROR {
                 gl::DeleteTextures(1, &texture);
                 self.runtime.destroy_image(image);
-                return Err(AdapterError::IpcDisconnected {
+                return Err(AdapterError::BackendRejected {
                     reason: format!(
                         "glEGLImageTargetTexture2DOES failed: GL error 0x{:x}; \
                          likely external_only modifier (host should pick a \
@@ -356,7 +356,7 @@ impl SurfaceAdapter for OpenGlSurfaceAdapter {
 }
 
 fn egl_to_adapter(err: EglRuntimeError) -> AdapterError {
-    AdapterError::IpcDisconnected {
+    AdapterError::BackendRejected {
         reason: format!("egl runtime: {err}"),
     }
 }

--- a/libs/streamlib-adapter-opengl/src/egl.rs
+++ b/libs/streamlib-adapter-opengl/src/egl.rs
@@ -296,6 +296,26 @@ impl EglRuntime {
     pub unsafe fn image_target_texture_2d(&self, image: egl::Image) {
         unsafe { (self.image_target_texture_2d_oes)(gl::TEXTURE_2D, image.as_ptr()) };
     }
+
+    /// Resolve a GL/EGL function pointer by name via
+    /// `eglGetProcAddress`.
+    ///
+    /// Returned for adapters that compose on this runtime and need to
+    /// build their own GL function tables — Skia's `gl::Interface`,
+    /// for example, holds its own private proc table separate from
+    /// the global `gl` crate's table. Caller passes `name` without a
+    /// trailing NUL; non-extension core entrypoints resolve regardless
+    /// of make-current state, but extension entrypoints (everything
+    /// suffixed `*OES`, `*KHR`, `*EXT`) require the EGL context to be
+    /// current on the calling thread per the EGL spec.
+    ///
+    /// Returns `null` when `name` is not exported.
+    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
+        match self.egl.get_proc_address(name) {
+            Some(f) => f as *const std::ffi::c_void,
+            None => std::ptr::null(),
+        }
+    }
 }
 
 impl Drop for EglRuntime {

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -30,14 +30,6 @@ skia-safe = { workspace = true }
 # time (Skia copies it internally during make_vulkan, so the Library
 # handle can be dropped right after).
 libloading = "0.8"
-# GL backend deps. The GL composition borrows the OpenGl adapter's
-# EGL runtime (`lock_make_current`) and binds `gl_texture_id`-typed
-# views as Skia `BackendTexture`s. `khronos-egl` is unused at runtime
-# here but is the source of the EGL types `streamlib-adapter-opengl`
-# returns; `gl` is needed if a future test wants to drive raw GL
-# alongside Skia.
-khronos-egl = { version = "6.0", features = ["dynamic"] }
-gl = "0.14"
 
 # `streamlib` is a *test*-only dep: the round-trip / conformance
 # tests bring up a `HostVulkanDevice`. The runtime crate (above)

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -91,5 +91,13 @@ path = "tests/round_trip_skia_canvas_gl.rs"
 name = "conformance_gl"
 path = "tests/conformance_gl.rs"
 
+[[test]]
+name = "skia_visual_evidence_gl"
+path = "tests/skia_visual_evidence_gl.rs"
+
+[[test]]
+name = "skia_animated_stress_gl"
+path = "tests/skia_animated_stress_gl.rs"
+
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl" }
 streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
 vulkanalia.workspace = true
 skia-safe = { workspace = true }
@@ -29,6 +30,14 @@ skia-safe = { workspace = true }
 # time (Skia copies it internally during make_vulkan, so the Library
 # handle can be dropped right after).
 libloading = "0.8"
+# GL backend deps. The GL composition borrows the OpenGl adapter's
+# EGL runtime (`lock_make_current`) and binds `gl_texture_id`-typed
+# views as Skia `BackendTexture`s. `khronos-egl` is unused at runtime
+# here but is the source of the EGL types `streamlib-adapter-opengl`
+# returns; `gl` is needed if a future test wants to drive raw GL
+# alongside Skia.
+khronos-egl = { version = "6.0", features = ["dynamic"] }
+gl = "0.14"
 
 # `streamlib` is a *test*-only dep: the round-trip / conformance
 # tests bring up a `HostVulkanDevice`. The runtime crate (above)
@@ -81,6 +90,14 @@ path = "tests/skia_visual_evidence.rs"
 [[test]]
 name = "skia_animated_stress"
 path = "tests/skia_animated_stress.rs"
+
+[[test]]
+name = "round_trip_skia_canvas_gl"
+path = "tests/round_trip_skia_canvas_gl.rs"
+
+[[test]]
+name = "conformance_gl"
+path = "tests/conformance_gl.rs"
 
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-skia/src/adapter.rs
+++ b/libs/streamlib-adapter-skia/src/adapter.rs
@@ -38,6 +38,7 @@ use vulkanalia::loader::LIBRARY;
 use vulkanalia::vk::{self, DeviceV1_0, Handle as _, InstanceV1_0};
 
 use crate::error::SkiaAdapterError;
+use crate::skia_internal::SyncDirectContext;
 use crate::view::{SkiaReadView, SkiaWriteView};
 
 /// Skia-typed surface adapter. Composes on
@@ -55,14 +56,6 @@ pub struct SkiaSurfaceAdapter<D: VulkanRhiDevice + 'static> {
     inner: Arc<VulkanSurfaceAdapter<D>>,
     direct_context: Arc<Mutex<SyncDirectContext>>,
 }
-
-/// Newtype wrapping Skia's `DirectContext` to manually claim
-/// `Send + Sync`. Skia treats `GrDirectContext` as single-thread-
-/// affine; the surrounding `Mutex` provides that invariant.
-pub(crate) struct SyncDirectContext(pub(crate) DirectContext);
-
-unsafe impl Send for SyncDirectContext {}
-unsafe impl Sync for SyncDirectContext {}
 
 impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
     /// Build a Skia adapter on top of an existing Vulkan adapter.
@@ -303,9 +296,10 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
 
         let skia_info = build_skia_image_info(view).map_err(skia_to_adapter_error)?;
         let color_type = vk_format_to_skia_color_type(vk::Format::from_raw(info.format))
-            .ok_or_else(|| AdapterError::IpcDisconnected {
+            .ok_or_else(|| AdapterError::UnsupportedFormat {
+                surface_id,
                 reason: format!(
-                    "unsupported vk::Format {} for Skia BGRA/RGBA mapping",
+                    "vk::Format {} not in Skia BGRA/RGBA mapping",
                     info.format
                 ),
             })?;
@@ -315,7 +309,7 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
         let mut ctx_guard = self
             .direct_context
             .lock()
-            .map_err(|_| AdapterError::IpcDisconnected {
+            .map_err(|_| AdapterError::BackendRejected {
                 reason: "Skia DirectContext mutex poisoned".into(),
             })?;
         let surface = surfaces::wrap_backend_render_target(
@@ -326,7 +320,7 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
             None::<ColorSpace>,
             None,
         )
-        .ok_or_else(|| AdapterError::IpcDisconnected {
+        .ok_or_else(|| AdapterError::BackendRejected {
             reason: "skia_safe::gpu::surfaces::wrap_backend_render_target returned None"
                 .into(),
         })?;
@@ -354,9 +348,10 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
 
         let skia_info = build_skia_image_info(view).map_err(skia_to_adapter_error)?;
         let color_type = vk_format_to_skia_color_type(vk::Format::from_raw(info.format))
-            .ok_or_else(|| AdapterError::IpcDisconnected {
+            .ok_or_else(|| AdapterError::UnsupportedFormat {
+                surface_id,
                 reason: format!(
-                    "unsupported vk::Format {} for Skia BGRA/RGBA mapping",
+                    "vk::Format {} not in Skia BGRA/RGBA mapping",
                     info.format
                 ),
             })?;
@@ -368,7 +363,7 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
         let mut ctx_guard = self
             .direct_context
             .lock()
-            .map_err(|_| AdapterError::IpcDisconnected {
+            .map_err(|_| AdapterError::BackendRejected {
                 reason: "Skia DirectContext mutex poisoned".into(),
             })?;
         let image = skia_images::borrow_texture_from(
@@ -379,7 +374,7 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
             AlphaType::Opaque,
             None::<ColorSpace>,
         )
-        .ok_or_else(|| AdapterError::IpcDisconnected {
+        .ok_or_else(|| AdapterError::BackendRejected {
             reason: "skia_safe::gpu::images::borrow_texture_from returned None".into(),
         })?;
         drop(ctx_guard);
@@ -390,7 +385,7 @@ impl<D: VulkanRhiDevice + 'static> SkiaSurfaceAdapter<D> {
 }
 
 fn skia_to_adapter_error(e: SkiaAdapterError) -> AdapterError {
-    AdapterError::IpcDisconnected {
+    AdapterError::BackendRejected {
         reason: format!("skia adapter: {e}"),
     }
 }

--- a/libs/streamlib-adapter-skia/src/gl_adapter.rs
+++ b/libs/streamlib-adapter-skia/src/gl_adapter.rs
@@ -24,8 +24,8 @@ use skia_safe::gpu::{
 };
 use skia_safe::{AlphaType, ColorSpace, ColorType};
 use streamlib_adapter_abi::{
-    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId,
-    WriteGuard,
+    AdapterError, GlWritable, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat,
+    SurfaceId, WriteGuard,
 };
 use streamlib_adapter_opengl::{EglRuntime, OpenGlSurfaceAdapter, GL_TEXTURE_2D};
 
@@ -100,7 +100,11 @@ impl SkiaGlSurfaceAdapter {
         surface: &StreamlibSurface,
     ) -> Result<WriteGuard<'g, Self>, AdapterError> {
         let surface_id = inner_guard.surface_id();
-        let texture_id = inner_guard.view().gl_texture_id();
+        // Route through `GlWritable` rather than the view's inherent
+        // `gl_texture_id` method so the capability-trait composition
+        // is explicit at the call site — matches the issue's
+        // "composition via the GlWritable marker" framing.
+        let texture_id = GlWritable::gl_texture_id(inner_guard.view());
         let color_type = surface_format_to_color_type(surface.format).ok_or_else(|| {
             AdapterError::UnsupportedFormat {
                 surface_id,
@@ -160,7 +164,7 @@ impl SkiaGlSurfaceAdapter {
         surface: &StreamlibSurface,
     ) -> Result<ReadGuard<'g, Self>, AdapterError> {
         let surface_id = inner_guard.surface_id();
-        let texture_id = inner_guard.view().gl_texture_id();
+        let texture_id = GlWritable::gl_texture_id(inner_guard.view());
         let color_type = surface_format_to_color_type(surface.format).ok_or_else(|| {
             AdapterError::UnsupportedFormat {
                 surface_id,

--- a/libs/streamlib-adapter-skia/src/gl_adapter.rs
+++ b/libs/streamlib-adapter-skia/src/gl_adapter.rs
@@ -1,0 +1,306 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `SkiaGlSurfaceAdapter` — Skia-typed `SurfaceAdapter` composing on
+//! [`OpenGlSurfaceAdapter`].
+//!
+//! Customers writing Skia code on top of an existing GL stack
+//! (skia-python, gst-plugin-skia, custom GL applications) acquire
+//! through this adapter and get a `skia_safe::Surface` (write) or
+//! `skia_safe::Image` (read) directly. The `gl_texture_id`,
+//! EGLImage, and DMA-BUF FD never reach them.
+//!
+//! Mirror-shape of [`crate::SkiaSurfaceAdapter`] but composed on
+//! [`OpenGlSurfaceAdapter`] via the `GlWritable` capability marker
+//! from `streamlib-adapter-abi`. Both backends share the same
+//! [`crate::skia_internal::SyncDirectContext`] mutex pattern and
+//! drop-order template — see `skia_internal.rs`.
+
+use std::sync::{Arc, Mutex};
+
+use skia_safe::gpu::{
+    self, backend_textures, direct_contexts, gl as gpu_gl, surfaces, Mipmapped, Protected,
+    SurfaceOrigin,
+};
+use skia_safe::{AlphaType, ColorSpace, ColorType};
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId,
+    WriteGuard,
+};
+use streamlib_adapter_opengl::{EglRuntime, OpenGlSurfaceAdapter, GL_TEXTURE_2D};
+
+use crate::error::SkiaAdapterError;
+use crate::gl_view::{SkiaGlReadView, SkiaGlWriteView};
+use crate::skia_internal::SyncDirectContext;
+
+/// Skia surface adapter composed on the OpenGL/EGL adapter.
+///
+/// Constructs a single Skia GL `DirectContext` shared by all
+/// `acquire_*` calls; the EGL context must be current at construction
+/// time (handled internally) and at every Skia operation (handled by
+/// the views' drop hooks via [`EglRuntime::lock_make_current`]).
+pub struct SkiaGlSurfaceAdapter {
+    inner: Arc<OpenGlSurfaceAdapter>,
+    egl: Arc<EglRuntime>,
+    direct_context: Arc<Mutex<SyncDirectContext>>,
+}
+
+impl SkiaGlSurfaceAdapter {
+    /// Build a Skia GL adapter on top of an existing OpenGL adapter.
+    ///
+    /// Acquires `lock_make_current`, builds a Skia GL interface via
+    /// `interfaces::make_egl()` (which resolves GL function pointers
+    /// via `eglGetProcAddress`), constructs the `GrDirectContext`,
+    /// then releases the EGL lock. Returns
+    /// [`SkiaAdapterError::DirectContextBuildFailed`] when either the
+    /// interface or the DirectContext can't be created.
+    pub fn new(inner: Arc<OpenGlSurfaceAdapter>) -> Result<Self, SkiaAdapterError> {
+        let egl = Arc::clone(inner.runtime());
+        let _current = egl.lock_make_current().map_err(|e| {
+            SkiaAdapterError::DirectContextBuildFailed {
+                reason: format!("lock_make_current: {e}"),
+            }
+        })?;
+        // Build a Skia GL `Interface` with proc resolution routed
+        // through `EglRuntime::get_proc_address` (i.e.
+        // `eglGetProcAddress` under the hood). The closure is borrowed
+        // for the duration of `new_load_with`; Skia copies any
+        // resolved fn pointers into its own internal proc table during
+        // interface construction, so the closure (and its captured
+        // `&EglRuntime`) does not need to outlive this call.
+        let interface = skia_safe::gpu::gl::Interface::new_load_with(|sym| {
+            egl.get_proc_address(sym)
+        })
+        .ok_or_else(|| SkiaAdapterError::DirectContextBuildFailed {
+            reason: "skia_safe::gpu::gl::Interface::new_load_with returned None".into(),
+        })?;
+        let direct_context = direct_contexts::make_gl(interface, None).ok_or_else(|| {
+            SkiaAdapterError::DirectContextBuildFailed {
+                reason: "skia_safe::gpu::direct_contexts::make_gl returned None".into(),
+            }
+        })?;
+        drop(_current);
+        Ok(Self {
+            inner,
+            egl,
+            direct_context: Arc::new(Mutex::new(SyncDirectContext(direct_context))),
+        })
+    }
+
+    /// Inner OpenGL adapter — power-user accessor for callers that
+    /// need to issue raw GL alongside Skia (debug tooling, custom
+    /// rendering passes).
+    pub fn inner(&self) -> &Arc<OpenGlSurfaceAdapter> {
+        &self.inner
+    }
+
+    fn wrap_write<'g>(
+        &'g self,
+        inner_guard: WriteGuard<'g, OpenGlSurfaceAdapter>,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let surface_id = inner_guard.surface_id();
+        let texture_id = inner_guard.view().gl_texture_id();
+        let color_type = surface_format_to_color_type(surface.format).ok_or_else(|| {
+            AdapterError::UnsupportedFormat {
+                surface_id,
+                reason: format!(
+                    "SurfaceFormat {:?} not supported by Skia GL backend",
+                    surface.format
+                ),
+            }
+        })?;
+
+        let _current = self.egl.lock_make_current().map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("lock_make_current (acquire_write): {e}"),
+            }
+        })?;
+
+        let backend_texture = build_backend_texture(
+            texture_id,
+            surface.width as i32,
+            surface.height as i32,
+            surface.format,
+        );
+
+        let mut ctx_guard = self.direct_context.lock().map_err(|_| {
+            AdapterError::BackendRejected {
+                reason: "Skia DirectContext mutex poisoned".into(),
+            }
+        })?;
+        let skia_surface = surfaces::wrap_backend_texture(
+            &mut ctx_guard.0,
+            &backend_texture,
+            SurfaceOrigin::TopLeft,
+            None,
+            color_type,
+            None::<ColorSpace>,
+            None,
+        )
+        .ok_or_else(|| AdapterError::BackendRejected {
+            reason: "skia_safe::gpu::surfaces::wrap_backend_texture returned None".into(),
+        })?;
+        drop(ctx_guard);
+        drop(_current);
+
+        let view = SkiaGlWriteView::new(
+            skia_surface,
+            backend_texture,
+            inner_guard,
+            Arc::clone(&self.direct_context),
+            Arc::clone(&self.egl),
+        );
+        Ok(WriteGuard::new(self, surface_id, view))
+    }
+
+    fn wrap_read<'g>(
+        &'g self,
+        inner_guard: ReadGuard<'g, OpenGlSurfaceAdapter>,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let surface_id = inner_guard.surface_id();
+        let texture_id = inner_guard.view().gl_texture_id();
+        let color_type = surface_format_to_color_type(surface.format).ok_or_else(|| {
+            AdapterError::UnsupportedFormat {
+                surface_id,
+                reason: format!(
+                    "SurfaceFormat {:?} not supported by Skia GL backend",
+                    surface.format
+                ),
+            }
+        })?;
+
+        let _current = self.egl.lock_make_current().map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("lock_make_current (acquire_read): {e}"),
+            }
+        })?;
+
+        let backend_texture = build_backend_texture(
+            texture_id,
+            surface.width as i32,
+            surface.height as i32,
+            surface.format,
+        );
+
+        let mut ctx_guard = self.direct_context.lock().map_err(|_| {
+            AdapterError::BackendRejected {
+                reason: "Skia DirectContext mutex poisoned".into(),
+            }
+        })?;
+        let image = skia_safe::gpu::images::borrow_texture_from(
+            &mut ctx_guard.0,
+            &backend_texture,
+            SurfaceOrigin::TopLeft,
+            color_type,
+            AlphaType::Opaque,
+            None::<ColorSpace>,
+        )
+        .ok_or_else(|| AdapterError::BackendRejected {
+            reason: "skia_safe::gpu::images::borrow_texture_from returned None".into(),
+        })?;
+        drop(ctx_guard);
+        drop(_current);
+
+        let view = SkiaGlReadView::new(
+            image,
+            inner_guard,
+            Arc::clone(&self.direct_context),
+            Arc::clone(&self.egl),
+        );
+        Ok(ReadGuard::new(self, surface_id, view))
+    }
+}
+
+/// Build a Skia [`gpu::BackendTexture`] from the GL texture id imported
+/// by [`OpenGlSurfaceAdapter`].
+///
+/// `format` (the Skia GL `Format` enum) is the GL *internal* format —
+/// what the driver thinks the texture's storage looks like. The
+/// EGLImage import binds the underlying DMA-BUF as `GL_RGBA8` for both
+/// `Bgra8` and `Rgba8` `SurfaceFormat`s; we tell Skia `RGBA8` and let
+/// the [`ColorType`] (chosen by [`surface_format_to_color_type`])
+/// disambiguate the in-memory channel order.
+fn build_backend_texture(
+    texture_id: u32,
+    width: i32,
+    height: i32,
+    _format: SurfaceFormat,
+) -> gpu::BackendTexture {
+    let info = gpu_gl::TextureInfo {
+        target: GL_TEXTURE_2D,
+        id: texture_id,
+        format: gpu_gl::Format::RGBA8.into(),
+        protected: Protected::No,
+    };
+    // SAFETY: `make_gl` is `unsafe` because Skia trusts the caller's
+    // claim that the GL texture id is live and bound to a real
+    // `GL_TEXTURE_2D`. The `OpenGlSurfaceAdapter` registry maintains
+    // that invariant for the lifetime of the inner `WriteGuard` /
+    // `ReadGuard` we hold downstream.
+    unsafe { backend_textures::make_gl((width, height), Mipmapped::No, info, "streamlib-skia-gl") }
+}
+
+/// Map [`SurfaceFormat`] → Skia [`ColorType`]. Both BGRA8 and RGBA8
+/// surfaces ride a `GL_RGBA8` storage format internally; the
+/// [`ColorType`] is what tells Skia how to interpret the bytes.
+fn surface_format_to_color_type(format: SurfaceFormat) -> Option<ColorType> {
+    match format {
+        SurfaceFormat::Bgra8 => Some(ColorType::BGRA8888),
+        SurfaceFormat::Rgba8 => Some(ColorType::RGBA8888),
+        SurfaceFormat::Nv12 => None,
+    }
+}
+
+impl SurfaceAdapter for SkiaGlSurfaceAdapter {
+    type ReadView<'g> = SkiaGlReadView<'g>;
+    type WriteView<'g> = SkiaGlWriteView<'g>;
+
+    fn acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let inner_guard = self.inner.acquire_read(surface)?;
+        self.wrap_read(inner_guard, surface)
+    }
+
+    fn acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let inner_guard = self.inner.acquire_write(surface)?;
+        self.wrap_write(inner_guard, surface)
+    }
+
+    fn try_acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
+        match self.inner.try_acquire_read(surface)? {
+            Some(g) => self.wrap_read(g, surface).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn try_acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
+        match self.inner.try_acquire_write(surface)? {
+            Some(g) => self.wrap_write(g, surface).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn end_read_access(&self, _surface_id: SurfaceId) {
+        // No-op — see end_write_access.
+    }
+
+    fn end_write_access(&self, _surface_id: SurfaceId) {
+        // No-op. The view's drop hook is the one place that flushes
+        // Skia + releases the EGL lock + drops the inner guard
+        // (which fires inner.end_write_access → glFinish). Doing
+        // anything here would be a use-after-release.
+    }
+}

--- a/libs/streamlib-adapter-skia/src/gl_context.rs
+++ b/libs/streamlib-adapter-skia/src/gl_context.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `SkiaGlContext` — customer-facing one-stop API for the GL-backed
+//! Skia adapter.
+//!
+//! ```ignore
+//! let gl_ctx = streamlib_adapter_opengl::OpenGlContext::new(adapter);
+//! let skia_gl_ctx = streamlib_adapter_skia::SkiaGlContext::new(&gl_ctx)?;
+//! {
+//!     let mut guard = skia_gl_ctx.acquire_write(&surface)?;
+//!     let canvas = guard.view_mut().surface_mut().canvas();
+//!     canvas.clear(skia_safe::Color::BLUE);
+//! } // guard drops — Skia flush + glFinish via the inner OpenGl
+//!   // adapter's release path.
+//! ```
+//!
+//! Mirror-shape of [`crate::SkiaContext`]. Customers obtain one via
+//! the runtime's setup hook; tests construct one directly.
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, WriteGuard,
+};
+use streamlib_adapter_opengl::OpenGlContext;
+
+use crate::error::SkiaAdapterError;
+use crate::gl_adapter::SkiaGlSurfaceAdapter;
+
+/// Customer-facing handle for the GL-backed Skia adapter.
+#[derive(Clone)]
+pub struct SkiaGlContext {
+    adapter: Arc<SkiaGlSurfaceAdapter>,
+}
+
+impl SkiaGlContext {
+    /// Build a Skia GL context on top of the given OpenGL context.
+    pub fn new(opengl_ctx: &OpenGlContext) -> Result<Self, SkiaAdapterError> {
+        let adapter = SkiaGlSurfaceAdapter::new(Arc::clone(opengl_ctx.adapter()))?;
+        Ok(Self {
+            adapter: Arc::new(adapter),
+        })
+    }
+
+    /// Construct a [`SkiaGlContext`] directly from a pre-built adapter.
+    /// Most callers want [`Self::new`]; this exists for tests that
+    /// share an adapter `Arc` across multiple context handles.
+    pub fn from_adapter(adapter: Arc<SkiaGlSurfaceAdapter>) -> Self {
+        Self { adapter }
+    }
+
+    pub fn adapter(&self) -> &Arc<SkiaGlSurfaceAdapter> {
+        &self.adapter
+    }
+
+    pub fn acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'a, SkiaGlSurfaceAdapter>, AdapterError> {
+        self.adapter.acquire_read(surface)
+    }
+
+    pub fn acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'a, SkiaGlSurfaceAdapter>, AdapterError> {
+        self.adapter.acquire_write(surface)
+    }
+
+    pub fn try_acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'a, SkiaGlSurfaceAdapter>>, AdapterError> {
+        self.adapter.try_acquire_read(surface)
+    }
+
+    pub fn try_acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'a, SkiaGlSurfaceAdapter>>, AdapterError> {
+        self.adapter.try_acquire_write(surface)
+    }
+}

--- a/libs/streamlib-adapter-skia/src/gl_view.rs
+++ b/libs/streamlib-adapter-skia/src/gl_view.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Read and write views for the GL-backed Skia adapter.
+//!
+//! Symmetric with the Vulkan-backed `SkiaWriteView` / `SkiaReadView`:
+//! the customer sees only `skia_safe::Surface` (write) or
+//! `skia_safe::Image` (read); the GL `texture id` and the underlying
+//! DMA-BUF FD never reach them.
+//!
+//! The drop ordering is the GL flavor of the same recipe used by the
+//! Vulkan side. Skia work must run on a thread with the EGL context
+//! current, so the view's drop hook locks the
+//! [`EglRuntime::lock_make_current`][lmc] guard *before* it locks
+//! `direct_context`. After Skia's flush, the EGL lock is released
+//! before the inner [`OpenGlSurfaceAdapter`]'s release path runs —
+//! the inner adapter's `end_*_access` re-acquires `lock_make_current`
+//! to issue `glFinish`, and holding both at once would deadlock.
+//!
+//! [lmc]: streamlib_adapter_opengl::EglRuntime::lock_make_current
+
+use std::mem::ManuallyDrop;
+use std::sync::{Arc, Mutex};
+
+use streamlib_adapter_abi::{ReadGuard, WriteGuard};
+use streamlib_adapter_opengl::{EglRuntime, OpenGlSurfaceAdapter};
+
+use crate::skia_internal::{
+    assert_skia_views_not_cpu_readable, drop_skia_image_under_lock,
+    flush_and_drop_skia_surface, SyncDirectContext,
+};
+
+/// Write view for the GL-backed Skia adapter.
+pub struct SkiaGlWriteView<'g> {
+    /// `Some` while the view is live; `None` after the drop hook has
+    /// consumed it for flush + release.
+    skia_surface: Option<skia_safe::Surface>,
+    /// Inner GL write guard. Wrapped in `ManuallyDrop` so the view's
+    /// drop hook can flush Skia + release the EGL lock before the
+    /// inner adapter's `end_write_access` runs.
+    inner_guard: ManuallyDrop<WriteGuard<'g, OpenGlSurfaceAdapter>>,
+    direct_context: Arc<Mutex<SyncDirectContext>>,
+    egl: Arc<EglRuntime>,
+    /// Held alongside the `Surface` to keep the imported `BackendTexture`
+    /// alive across the surface's lifetime. Skia's `Surface` does not
+    /// own its backing texture by refcount on the GL side — the
+    /// `BackendTexture` value owns the wrap-state, and dropping it
+    /// before the surface is invalid.
+    #[allow(dead_code)]
+    pub(crate) backend_texture: skia_safe::gpu::BackendTexture,
+}
+
+impl<'g> SkiaGlWriteView<'g> {
+    pub(crate) fn new(
+        skia_surface: skia_safe::Surface,
+        backend_texture: skia_safe::gpu::BackendTexture,
+        inner_guard: WriteGuard<'g, OpenGlSurfaceAdapter>,
+        direct_context: Arc<Mutex<SyncDirectContext>>,
+        egl: Arc<EglRuntime>,
+    ) -> Self {
+        Self {
+            skia_surface: Some(skia_surface),
+            inner_guard: ManuallyDrop::new(inner_guard),
+            direct_context,
+            egl,
+            backend_texture,
+        }
+    }
+
+    /// Borrow the Skia surface for drawing.
+    pub fn surface(&self) -> &skia_safe::Surface {
+        self.skia_surface
+            .as_ref()
+            .expect("SkiaGlWriteView::surface called after drop")
+    }
+
+    /// Mutably borrow the Skia surface for drawing.
+    pub fn surface_mut(&mut self) -> &mut skia_safe::Surface {
+        self.skia_surface
+            .as_mut()
+            .expect("SkiaGlWriteView::surface_mut called after drop")
+    }
+}
+
+impl<'g> Drop for SkiaGlWriteView<'g> {
+    fn drop(&mut self) {
+        // Order matters:
+        //  1. lock_make_current — Skia's flush_and_submit_surface
+        //     issues GL commands; the EGL context must be current on
+        //     this thread.
+        //  2. flush_and_drop_skia_surface — locks `direct_context`,
+        //     drains the GPU via SyncCpu::Yes, drops the surface
+        //     under the lock.
+        //  3. Drop the EGL guard. The inner OpenGl adapter's
+        //     `end_write_access` re-acquires `lock_make_current` to
+        //     issue `glFinish` — holding the EGL lock while dropping
+        //     the inner guard would deadlock (parking_lot's
+        //     `make_current_lock` is not reentrant).
+        //  4. Drop the inner guard. Triggers
+        //     `OpenGlSurfaceAdapter::end_write_access` → glFinish,
+        //     which is what the next consumer waits on for handoff.
+        if let Some(surface) = self.skia_surface.take() {
+            match self.egl.lock_make_current() {
+                Ok(_current) => {
+                    flush_and_drop_skia_surface(&self.direct_context, surface);
+                    // _current drops here, releasing the EGL mutex
+                    // before the inner guard's drop runs.
+                }
+                Err(e) => {
+                    tracing::error!(
+                        ?e,
+                        "SkiaGlWriteView::drop: lock_make_current failed — \
+                         skipping flush, GPU work may not be drained before \
+                         glFinish"
+                    );
+                    // Drop the surface anyway so we don't leak. Skia's
+                    // internal cleanup may emit GL commands without a
+                    // current context; this is a degraded path.
+                    drop(surface);
+                }
+            }
+        }
+
+        // SAFETY: `inner_guard` is in `ManuallyDrop` so this is the
+        // one and only place we drop it.
+        unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
+    }
+}
+
+impl<'g> std::fmt::Debug for SkiaGlWriteView<'g> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SkiaGlWriteView")
+            .field("active", &self.skia_surface.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+// SkiaGlWriteView is auto-derived `!Send + !Sync` for the same reason
+// as SkiaWriteView: `skia_safe::Surface` is `RCHandle<SkSurface>`, and
+// forcing the view across threads breaks Skia's single-thread
+// affinity contract on `GrDirectContext`. See `view.rs`'s note.
+
+/// Read view for the GL-backed Skia adapter.
+pub struct SkiaGlReadView<'g> {
+    skia_image: Option<skia_safe::Image>,
+    inner_guard: ManuallyDrop<ReadGuard<'g, OpenGlSurfaceAdapter>>,
+    direct_context: Arc<Mutex<SyncDirectContext>>,
+    egl: Arc<EglRuntime>,
+}
+
+impl<'g> SkiaGlReadView<'g> {
+    pub(crate) fn new(
+        skia_image: skia_safe::Image,
+        inner_guard: ReadGuard<'g, OpenGlSurfaceAdapter>,
+        direct_context: Arc<Mutex<SyncDirectContext>>,
+        egl: Arc<EglRuntime>,
+    ) -> Self {
+        Self {
+            skia_image: Some(skia_image),
+            inner_guard: ManuallyDrop::new(inner_guard),
+            direct_context,
+            egl,
+        }
+    }
+
+    /// Borrow the Skia image (read-only sampling source).
+    pub fn image(&self) -> &skia_safe::Image {
+        self.skia_image
+            .as_ref()
+            .expect("SkiaGlReadView::image called after drop")
+    }
+}
+
+impl<'g> Drop for SkiaGlReadView<'g> {
+    fn drop(&mut self) {
+        // Reads emit no GPU work, but Skia's `Image::drop` decrements
+        // a refcount on `DirectContext` and may issue cleanup commands
+        // — same EGL-current invariant as writes.
+        if let Some(image) = self.skia_image.take() {
+            match self.egl.lock_make_current() {
+                Ok(_current) => {
+                    drop_skia_image_under_lock(&self.direct_context, image);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        ?e,
+                        "SkiaGlReadView::drop: lock_make_current failed — \
+                         dropping image without an EGL-current context"
+                    );
+                    drop(image);
+                }
+            }
+        }
+        // SAFETY: `inner_guard` is in `ManuallyDrop` so this is the
+        // one and only place we drop it.
+        unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
+    }
+}
+
+impl<'g> std::fmt::Debug for SkiaGlReadView<'g> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SkiaGlReadView")
+            .field("active", &self.skia_image.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+assert_skia_views_not_cpu_readable!(
+    _assert_skia_gl_views_not_cpu_readable,
+    SkiaGlReadView<'static>,
+    SkiaGlWriteView<'static>,
+);

--- a/libs/streamlib-adapter-skia/src/lib.rs
+++ b/libs/streamlib-adapter-skia/src/lib.rs
@@ -31,9 +31,16 @@
 mod adapter;
 mod context;
 mod error;
+mod gl_adapter;
+mod gl_context;
+mod gl_view;
+mod skia_internal;
 mod view;
 
 pub use adapter::SkiaSurfaceAdapter;
 pub use context::SkiaContext;
 pub use error::SkiaAdapterError;
+pub use gl_adapter::SkiaGlSurfaceAdapter;
+pub use gl_context::SkiaGlContext;
+pub use gl_view::{SkiaGlReadView, SkiaGlWriteView};
 pub use view::{SkiaReadView, SkiaWriteView};

--- a/libs/streamlib-adapter-skia/src/skia_internal.rs
+++ b/libs/streamlib-adapter-skia/src/skia_internal.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared scaffolding used by every Skia backend (Vulkan, GL, …).
+//!
+//! Skia's `GrDirectContext` is single-thread-affine and `!Send` regardless
+//! of which graphics backend it sits on top of, and the adapter trait
+//! requires `Send + Sync` on the adapter type. The fix is the same on
+//! every backend: wrap the `DirectContext` in a newtype that manually
+//! claims `Send + Sync`, then serialize every operation through a
+//! surrounding `Mutex`. The mutex is what *actually* upholds the
+//! single-thread-affinity invariant — the `unsafe impl` is sound iff
+//! the mutex is always held during Skia work.
+//!
+//! The same applies to the surface flush / drop hazard: every backend's
+//! `WriteView::drop` must (1) flush + submit the Skia surface (2) drop
+//! the Skia surface inside the mutex scope (RCHandle drop emits cleanup
+//! commands that must stay on the same thread) (3) release the mutex
+//! before triggering the inner adapter's release path. This module
+//! exposes a helper that bottles that recipe so each backend's view
+//! drop only has to call one function instead of recreating the
+//! ordering by hand.
+
+use std::sync::Mutex;
+
+use skia_safe::gpu::{DirectContext, SyncCpu};
+
+/// Newtype wrapping Skia's `DirectContext` to manually claim
+/// `Send + Sync`.
+///
+/// Skia treats `GrDirectContext` as single-thread-affine; the surrounding
+/// [`Mutex`] in every backend adapter is what actually upholds that
+/// invariant. The `unsafe impl Send + Sync` here is sound *only* when
+/// the holder serializes every dereference through that mutex — which
+/// every Skia adapter in this crate does.
+pub(crate) struct SyncDirectContext(pub(crate) DirectContext);
+
+// SAFETY: Skia's `GrDirectContext` is `!Send + !Sync` because it's
+// single-thread-affine. Adapters wrap this newtype in `Mutex<…>` and
+// only ever touch the inner `DirectContext` while holding the mutex,
+// so the upgrade to `Send + Sync` is sound.
+unsafe impl Send for SyncDirectContext {}
+unsafe impl Sync for SyncDirectContext {}
+
+/// Flush + drop a Skia surface under the adapter's `DirectContext`
+/// mutex.
+///
+/// Order:
+///   1. Acquire the mutex.
+///   2. `flush_and_submit_surface(SyncCpu::Yes)` so the GPU drains
+///      before the inner adapter's release-side timeline signal /
+///      `glFinish` fires.
+///   3. Drop the surface *inside* the mutex scope — `RCHandle::drop`
+///      decrements the surface's refcount on the `DirectContext` and
+///      can issue cleanup commands. Skia's `DirectContext` is
+///      single-thread-affine; doing the drop after the mutex is
+///      released runs RCHandle cleanup unprotected.
+///
+/// On poisoned-mutex the surface is dropped without a flush — degraded
+/// path, no panic. Logged at error level so a downstream watchdog can
+/// flag the loss of the GPU drain.
+pub(crate) fn flush_and_drop_skia_surface(
+    direct_context: &Mutex<SyncDirectContext>,
+    mut surface: skia_safe::Surface,
+) {
+    match direct_context.lock() {
+        Ok(mut ctx_guard) => {
+            ctx_guard
+                .0
+                .flush_and_submit_surface(&mut surface, Some(SyncCpu::Yes));
+            drop(surface);
+        }
+        Err(_) => {
+            tracing::error!(
+                "skia_internal::flush_and_drop_skia_surface: direct_context mutex \
+                 poisoned — skipping flush, GPU work may not be drained before \
+                 the inner adapter's release signal"
+            );
+            drop(surface);
+        }
+    }
+}
+
+/// Drop a Skia image under the adapter's `DirectContext` mutex.
+///
+/// Read views don't need a flush (Skia hasn't issued GPU work against
+/// the image — `borrow_texture_from` just wraps a sampler-source
+/// view), but the `Image`'s `RCHandle::drop` still emits cleanup on
+/// the `DirectContext` and must run while the mutex is held.
+pub(crate) fn drop_skia_image_under_lock(
+    direct_context: &Mutex<SyncDirectContext>,
+    image: skia_safe::Image,
+) {
+    match direct_context.lock() {
+        Ok(_ctx_guard) => drop(image),
+        Err(_) => {
+            tracing::error!(
+                "skia_internal::drop_skia_image_under_lock: direct_context mutex \
+                 poisoned"
+            );
+            drop(image);
+        }
+    }
+}
+
+/// Compile-time invariant: Skia views must NOT impl
+/// [`streamlib_adapter_abi::CpuReadable`] or
+/// [`streamlib_adapter_abi::CpuWritable`].
+///
+/// Switching to `streamlib-adapter-cpu-readback` is the contractual
+/// signal for "I want CPU bytes" — see #514. This macro stamps out
+/// the type-level "ambiguous-impl" trick that turns an accidental
+/// `impl CpuReadable for ...` into a compile error.
+///
+/// Pass the view types as a comma-separated list; the macro generates
+/// a private `mod _assert_*` for each one. Trailing comma is fine.
+macro_rules! assert_skia_views_not_cpu_readable {
+    ($module:ident, $($ty:ty),+ $(,)?) => {
+        mod $module {
+            #[allow(unused_imports)]
+            use super::*;
+            use streamlib_adapter_abi::CpuReadable;
+
+            trait AmbiguousIfImpl<A> {
+                fn some_item() {}
+            }
+            impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+            #[allow(dead_code)]
+            struct Invalid;
+            impl<T: ?Sized + CpuReadable> AmbiguousIfImpl<Invalid> for T {}
+
+            const _: fn() = || {
+                $(
+                    let _ = <$ty as AmbiguousIfImpl<_>>::some_item;
+                )+
+            };
+        }
+    };
+}
+
+pub(crate) use assert_skia_views_not_cpu_readable;

--- a/libs/streamlib-adapter-skia/src/view.rs
+++ b/libs/streamlib-adapter-skia/src/view.rs
@@ -20,13 +20,15 @@
 use std::mem::ManuallyDrop;
 use std::sync::{Arc, Mutex};
 
-use skia_safe::gpu::SyncCpu;
 use streamlib_adapter_abi::{ReadGuard, WriteGuard};
 use streamlib_adapter_vulkan::VulkanSurfaceAdapter;
 use streamlib_consumer_rhi::VulkanRhiDevice;
 use vulkanalia::vk;
 
-use crate::adapter::SyncDirectContext;
+use crate::skia_internal::{
+    assert_skia_views_not_cpu_readable, drop_skia_image_under_lock,
+    flush_and_drop_skia_surface, SyncDirectContext,
+};
 
 /// Write view of an acquired Skia surface — exposes the
 /// `skia_safe::Surface` the customer draws into. The customer never
@@ -92,45 +94,9 @@ impl<'g, D: VulkanRhiDevice + 'static> SkiaWriteView<'g, D> {
 
 impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaWriteView<'g, D> {
     fn drop(&mut self) {
-        // Order matters:
-        //  1. Flush + submit Skia surface, sync_cpu = true → wait
-        //     for GPU work to drain so the host can host-signal the
-        //     timeline below.
-        //  2. Drop the Skia surface inside the same mutex scope —
-        //     RCHandle drop decrements the surface's refcount on the
-        //     DirectContext, which can issue cleanup commands. Skia
-        //     treats DirectContext as single-thread-affine, so the
-        //     cleanup must run while we still hold the mutex.
-        //  3. Release the mutex, then drop the inner WriteGuard →
-        //     triggers inner.end_write_access → host-signals the next
-        //     timeline value, unblocking the next acquire.
-        if let Some(mut surface) = self.skia_surface.take() {
-            match self.direct_context.lock() {
-                Ok(mut ctx_guard) => {
-                    // flush_and_submit_surface flushes Skia's pending
-                    // commands for `surface` and submits them to the
-                    // GPU; SyncCpu::Yes blocks until the GPU is done.
-                    ctx_guard
-                        .0
-                        .flush_and_submit_surface(&mut surface, Some(SyncCpu::Yes));
-                    // Drop the Skia surface BEFORE the ctx_guard goes
-                    // out of scope. The ctx_guard's drop releases the
-                    // mutex; doing the surface drop after that would
-                    // run RCHandle cleanup unprotected.
-                    drop(surface);
-                }
-                Err(_) => {
-                    tracing::error!(
-                        "SkiaWriteView::drop: direct_context mutex poisoned — \
-                         skipping flush, GPU work may not be drained before timeline signal"
-                    );
-                    // Mutex poisoned means we're already in a degraded
-                    // state — drop the surface anyway so we don't leak.
-                    drop(surface);
-                }
-            }
+        if let Some(surface) = self.skia_surface.take() {
+            flush_and_drop_skia_surface(&self.direct_context, surface);
         }
-
         // SAFETY: inner_guard is in ManuallyDrop so this is the one
         // and only place we drop it. Drop fires `inner.end_write_access`
         // which signals the timeline.
@@ -192,21 +158,8 @@ impl<'g, D: VulkanRhiDevice + 'static> SkiaReadView<'g, D> {
 
 impl<'g, D: VulkanRhiDevice + 'static> Drop for SkiaReadView<'g, D> {
     fn drop(&mut self) {
-        // No flush needed for read — Skia hasn't issued GPU work
-        // against this image. But the `Image`'s `RCHandle` drop
-        // decrements its refcount on the DirectContext, which can
-        // emit GPU cleanup commands; Skia's DirectContext is single-
-        // thread-affine, so the drop must happen under the mutex.
         if let Some(image) = self.skia_image.take() {
-            match self.direct_context.lock() {
-                Ok(_ctx_guard) => drop(image),
-                Err(_) => {
-                    tracing::error!(
-                        "SkiaReadView::drop: direct_context mutex poisoned"
-                    );
-                    drop(image);
-                }
-            }
+            drop_skia_image_under_lock(&self.direct_context, image);
         }
         // SAFETY: same as SkiaWriteView::drop.
         unsafe { ManuallyDrop::drop(&mut self.inner_guard) };
@@ -226,28 +179,15 @@ impl<'g, D: VulkanRhiDevice + 'static> std::fmt::Debug for SkiaReadView<'g, D> {
 // the view across threads would break Skia's single-thread contract.
 // See SkiaWriteView's note above.
 
-// Compile-time assertion: Skia views must NOT impl `CpuReadable` /
-// `CpuWritable`. Switching to `streamlib-adapter-cpu-readback` is the
-// contractual signal for "I want CPU bytes" — see #514. Same trick the
-// vulkan and opengl adapters use.
-mod _assert_skia_views_not_cpu_readable {
-    use super::{SkiaReadView, SkiaWriteView};
-    use streamlib_adapter_abi::CpuReadable;
-    use streamlib_consumer_rhi::ConsumerVulkanDevice;
-
-    trait AmbiguousIfImpl<A> {
-        fn some_item() {}
-    }
-    impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
-    #[allow(dead_code)]
-    struct Invalid;
-    impl<T: ?Sized + CpuReadable> AmbiguousIfImpl<Invalid> for T {}
-
-    const _: fn() = || {
-        let _ = <SkiaReadView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
-        let _ = <SkiaWriteView<'static, ConsumerVulkanDevice> as AmbiguousIfImpl<_>>::some_item;
-    };
-}
+// Compile-time invariant: Skia views must NOT impl `CpuReadable` /
+// `CpuWritable`. The macro from `skia_internal` stamps out the
+// type-level "ambiguous-impl" trick so the GL backend's views and
+// any future Skia backend pick up the same invariant for free.
+assert_skia_views_not_cpu_readable!(
+    _assert_skia_vk_views_not_cpu_readable,
+    SkiaReadView<'static, streamlib_consumer_rhi::ConsumerVulkanDevice>,
+    SkiaWriteView<'static, streamlib_consumer_rhi::ConsumerVulkanDevice>,
+);
 
 /// Helper used by the adapter when we need a `vk::Format` and other
 /// raw vulkanalia values without depending on the trait machinery.

--- a/libs/streamlib-adapter-skia/tests/conformance_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/conformance_gl.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_skia::tests::conformance_gl` — runs the public
+//! `run_conformance` suite from `streamlib-adapter-abi` against the
+//! GL-backed Skia adapter wired to a host-allocated DMA-BUF render-
+//! target image and a real surfaceless EGL+GL context.
+//!
+//! Mirror of `conformance.rs` (Vulkan-backed) but composed on
+//! `OpenGlSurfaceAdapter`. A green run confirms the trait-composition
+//! shape from #509 / #511 holds for GL too — `for<'g>
+//! Inner::WriteView<'g>: GlWritable` is satisfied by the inner
+//! OpenGl adapter's views, and Skia's `Surface` / `Image` propagate
+//! the `Send + Sync` invariant the conformance suite's parallel-
+//! readers test demands.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_opengl::{
+    EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter, DRM_FORMAT_ARGB8888,
+};
+use streamlib_adapter_skia::SkiaGlSurfaceAdapter;
+
+fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=debug,streamlib_adapter_opengl=warn,streamlib=warn",
+        )
+        .try_init();
+    let gpu = GpuContext::init_for_platform_sync().ok()?;
+    let egl = match EglRuntime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            println!("conformance_gl: skipping — EGL unavailable: {e}");
+            return None;
+        }
+    };
+    Some((gpu, egl))
+}
+
+fn register_one(
+    inner: &OpenGlSurfaceAdapter,
+    gpu: &GpuContext,
+    id: SurfaceId,
+) -> StreamlibSurface {
+    let texture = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane_layout = texture
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = texture.vulkan_inner().chosen_drm_format_modifier();
+
+    let registration = HostSurfaceRegistration {
+        dma_buf_fd,
+        width: 64,
+        height: 64,
+        drm_fourcc: DRM_FORMAT_ARGB8888,
+        drm_format_modifier: modifier,
+        plane_offset: plane_layout[0].0,
+        plane_stride: plane_layout[0].1,
+    };
+    inner
+        .register_host_surface(id, registration)
+        .expect("register_host_surface");
+    // We deliberately leak the `StreamTexture` here for the lifetime
+    // of the test — the GL adapter holds the DMA-BUF FD imported via
+    // EGL, and the host VkImage backing must outlive every guard the
+    // conformance suite acquires.
+    std::mem::forget(texture);
+    StreamlibSurface::new(
+        id,
+        64,
+        64,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    )
+}
+
+struct ConformanceFactory<'a> {
+    inner: &'a OpenGlSurfaceAdapter,
+    gpu: &'a GpuContext,
+}
+
+impl streamlib_adapter_abi::testing::ConformanceSurfaceFactory for ConformanceFactory<'_> {
+    fn make(&self, id: SurfaceId) -> StreamlibSurface {
+        register_one(self.inner, self.gpu, id)
+    }
+}
+
+#[test]
+fn skia_gl_adapter_passes_run_conformance() {
+    let (gpu, egl) = match try_init() {
+        Some(t) => t,
+        None => {
+            println!("skia-gl-adapter conformance: skipping — no Vulkan or no EGL");
+            return;
+        }
+    };
+    let inner = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+    let skia_gl_adapter = match SkiaGlSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia-gl-adapter conformance: skipping — Skia DirectContext build failed: {e}");
+            return;
+        }
+    };
+
+    let factory = ConformanceFactory {
+        inner: inner.as_ref(),
+        gpu: &gpu,
+    };
+    run_conformance(&skia_gl_adapter, factory);
+
+    // Unknown surface id must propagate as SurfaceNotFound through
+    // the composed adapter. The Skia GL adapter delegates registration
+    // to the inner OpenGl adapter, so the inner adapter is the source
+    // of the error — we just verify it travels back unchanged.
+    let bogus = empty_surface(0xdead_beef);
+    match skia_gl_adapter.acquire_read(&bogus) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_beef);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}

--- a/libs/streamlib-adapter-skia/tests/conformance_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/conformance_gl.rs
@@ -16,10 +16,10 @@
 
 #![cfg(target_os = "linux")]
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use streamlib::core::context::GpuContext;
-use streamlib::core::rhi::TextureFormat;
+use streamlib::core::rhi::{StreamTexture, TextureFormat};
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
 use streamlib_adapter_abi::{
     AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
@@ -48,60 +48,69 @@ fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
     Some((gpu, egl))
 }
 
-fn register_one(
-    inner: &OpenGlSurfaceAdapter,
-    gpu: &GpuContext,
-    id: SurfaceId,
-) -> StreamlibSurface {
-    let texture = gpu
-        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
-        .expect("acquire_render_target_dma_buf_image");
-    let dma_buf_fd = texture
-        .vulkan_inner()
-        .export_dma_buf_fd()
-        .expect("export DMA-BUF");
-    let plane_layout = texture
-        .vulkan_inner()
-        .dma_buf_plane_layout()
-        .expect("dma_buf_plane_layout");
-    let modifier = texture.vulkan_inner().chosen_drm_format_modifier();
-
-    let registration = HostSurfaceRegistration {
-        dma_buf_fd,
-        width: 64,
-        height: 64,
-        drm_fourcc: DRM_FORMAT_ARGB8888,
-        drm_format_modifier: modifier,
-        plane_offset: plane_layout[0].0,
-        plane_stride: plane_layout[0].1,
-    };
-    inner
-        .register_host_surface(id, registration)
-        .expect("register_host_surface");
-    // We deliberately leak the `StreamTexture` here for the lifetime
-    // of the test — the GL adapter holds the DMA-BUF FD imported via
-    // EGL, and the host VkImage backing must outlive every guard the
-    // conformance suite acquires.
-    std::mem::forget(texture);
-    StreamlibSurface::new(
-        id,
-        64,
-        64,
-        SurfaceFormat::Bgra8,
-        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
-        SurfaceTransportHandle::empty(),
-        SurfaceSyncState::default(),
-    )
-}
-
+/// Factory that owns the per-surface `StreamTexture`s for the
+/// duration of the conformance run. The GL adapter imports each
+/// texture's DMA-BUF FD into an EGLImage at registration time; the
+/// host-side `VkImage` backing must outlive every guard the
+/// conformance suite acquires, so we hold the textures here rather
+/// than leaking via `std::mem::forget`.
 struct ConformanceFactory<'a> {
     inner: &'a OpenGlSurfaceAdapter,
     gpu: &'a GpuContext,
+    textures: Mutex<Vec<StreamTexture>>,
+}
+
+impl<'a> ConformanceFactory<'a> {
+    fn new(inner: &'a OpenGlSurfaceAdapter, gpu: &'a GpuContext) -> Self {
+        Self {
+            inner,
+            gpu,
+            textures: Mutex::new(Vec::new()),
+        }
+    }
 }
 
 impl streamlib_adapter_abi::testing::ConformanceSurfaceFactory for ConformanceFactory<'_> {
     fn make(&self, id: SurfaceId) -> StreamlibSurface {
-        register_one(self.inner, self.gpu, id)
+        let texture = self
+            .gpu
+            .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+            .expect("acquire_render_target_dma_buf_image");
+        let dma_buf_fd = texture
+            .vulkan_inner()
+            .export_dma_buf_fd()
+            .expect("export DMA-BUF");
+        let plane_layout = texture
+            .vulkan_inner()
+            .dma_buf_plane_layout()
+            .expect("dma_buf_plane_layout");
+        let modifier = texture.vulkan_inner().chosen_drm_format_modifier();
+
+        let registration = HostSurfaceRegistration {
+            dma_buf_fd,
+            width: 64,
+            height: 64,
+            drm_fourcc: DRM_FORMAT_ARGB8888,
+            drm_format_modifier: modifier,
+            plane_offset: plane_layout[0].0,
+            plane_stride: plane_layout[0].1,
+        };
+        self.inner
+            .register_host_surface(id, registration)
+            .expect("register_host_surface");
+        self.textures
+            .lock()
+            .expect("textures mutex poisoned")
+            .push(texture);
+        StreamlibSurface::new(
+            id,
+            64,
+            64,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        )
     }
 }
 
@@ -123,10 +132,7 @@ fn skia_gl_adapter_passes_run_conformance() {
         }
     };
 
-    let factory = ConformanceFactory {
-        inner: inner.as_ref(),
-        gpu: &gpu,
-    };
+    let factory = ConformanceFactory::new(inner.as_ref(), &gpu);
     run_conformance(&skia_gl_adapter, factory);
 
     // Unknown surface id must propagate as SurfaceNotFound through

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
@@ -1,0 +1,296 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `round_trip_skia_canvas_gl` — Skia (GL backend) draws a known shape
+//! into a WRITE-acquired surface, then the host reads back the
+//! rendered pixels via Vulkan and asserts the pixel content matches
+//! Skia's expected rasterization (with antialiasing tolerance).
+//!
+//! Mirror of `round_trip_skia_canvas` (Vulkan backend), but composed
+//! on `OpenGlSurfaceAdapter`. Validates the full Skia-on-GL path:
+//! `acquire_write` → wrap as Skia surface → draw via `Canvas` →
+//! `flush_and_submit_surface(SyncCpu::Yes)` → `glFinish` → host Vulkan
+//! readback through the same DMA-BUF.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use skia_safe::{Color, Color4f, Paint, Point};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib::host_rhi::HostVulkanDevice;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState, SurfaceTransportHandle,
+    SurfaceUsage,
+};
+use streamlib_adapter_opengl::{
+    EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter, DRM_FORMAT_ARGB8888,
+};
+use streamlib_adapter_skia::SkiaGlSurfaceAdapter;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 256;
+const H: u32 = 256;
+
+fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=debug,streamlib_adapter_opengl=warn,streamlib=warn",
+        )
+        .try_init();
+    let gpu = GpuContext::init_for_platform_sync().ok()?;
+    let egl = match EglRuntime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            println!("round_trip_skia_canvas_gl: skipping — EGL unavailable: {e}");
+            return None;
+        }
+    };
+    Some((gpu, egl))
+}
+
+#[test]
+fn round_trip_skia_canvas_gl() {
+    let (gpu, egl) = match try_init() {
+        Some(t) => t,
+        None => {
+            println!("round_trip_skia_canvas_gl: skipping — no Vulkan or no EGL");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+    let skia_adapter = match SkiaGlSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("round_trip_skia_canvas_gl: skipping — Skia GL setup failed: {e}");
+            return;
+        }
+    };
+
+    // === Allocate host DMA-BUF surface, register with the GL adapter ====
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = stream_tex
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane_layout = stream_tex
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = stream_tex.vulkan_inner().chosen_drm_format_modifier();
+
+    let surface_id = 0xc1ea_5e1au64;
+    let registration = HostSurfaceRegistration {
+        dma_buf_fd,
+        width: W,
+        height: H,
+        // Vulkan `Bgra8Unorm` is "memory: B,G,R,A". DRM_FORMAT_ARGB8888
+        // is the matching fourcc — see `tests/common.rs` of the
+        // OpenGL adapter for the full reasoning.
+        drm_fourcc: DRM_FORMAT_ARGB8888,
+        drm_format_modifier: modifier,
+        plane_offset: plane_layout[0].0,
+        plane_stride: plane_layout[0].1,
+    };
+    inner
+        .register_host_surface(surface_id, registration)
+        .expect("register_host_surface");
+
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // === Skia draw scope (GL backend) ===================================
+    {
+        let mut guard = skia_adapter
+            .acquire_write(&surface_desc)
+            .expect("skia_gl acquire_write");
+        let view = guard.view_mut();
+        let canvas = view.surface_mut().canvas();
+        // Background — solid blue (BGRA8 with R=0, G=0, B=255, A=255).
+        canvas.clear(Color::BLUE);
+        // Foreground — bright red disc at the center.
+        let mut paint = Paint::new(Color4f::new(1.0, 0.0, 0.0, 1.0), None);
+        paint.set_anti_alias(true);
+        canvas.draw_circle(Point::new(W as f32 * 0.5, H as f32 * 0.5), 64.0, &paint);
+    } // guard drops → flush_and_submit_surface → glFinish.
+
+    // === Host readback ==================================================
+    let pixels = host_readback_bgra(&host_device, stream_tex.vulkan_inner().image().expect("image"), W, H);
+
+    // === Pixel-content assertions =======================================
+    let center = sample(&pixels, W as i32 / 2, H as i32 / 2, W);
+    assert_pixel_close(
+        "center (red disc)",
+        center,
+        [0, 0, 255, 255], // BGRA8: B=0, G=0, R=255, A=255
+        12,
+    );
+    let corner = sample(&pixels, 4, 4, W);
+    assert_pixel_close(
+        "corner (blue background)",
+        corner,
+        [255, 0, 0, 255], // BGRA8: B=255, G=0, R=0, A=255
+        4,
+    );
+}
+
+fn sample(pixels: &[u8], x: i32, y: i32, width: u32) -> [u8; 4] {
+    let stride = width as usize * 4;
+    let off = y as usize * stride + x as usize * 4;
+    [
+        pixels[off],
+        pixels[off + 1],
+        pixels[off + 2],
+        pixels[off + 3],
+    ]
+}
+
+fn assert_pixel_close(label: &str, actual: [u8; 4], expected: [u8; 4], tolerance: u8) {
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (*a as i32 - *e as i32).unsigned_abs();
+        assert!(
+            diff <= tolerance as u32,
+            "{label}: channel {i} expected ~{e} got {a} (diff {diff}, tolerance {tolerance}), full pixel actual={actual:?} expected={expected:?}"
+        );
+    }
+}
+
+/// Read back BGRA8 pixels from a host-allocated `VkImage` via a
+/// HOST_VISIBLE staging buffer + transfer queue copy. The OpenGl
+/// adapter's `acquire_write` left the image at GENERAL layout (the
+/// host-side Vulkan view; GL doesn't change Vulkan's recorded layout
+/// across the DMA-BUF handoff). We transition to TRANSFER_SRC_OPTIMAL
+/// for the copy and back.
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
@@ -131,6 +131,14 @@ fn round_trip_skia_canvas_gl() {
     let pixels = host_readback_bgra(&host_device, stream_tex.vulkan_inner().image().expect("image"), W, H);
 
     // === Pixel-content assertions =======================================
+    // Asymmetric tolerances: the corner is far from any geometry and
+    // sits inside the flat blue clear, so it must be (255,0,0,255)
+    // within driver rounding (tolerance 4). The geometric center sits
+    // inside the red disc but near the AA-blended edge transitions of
+    // any rasterizer's circle; tolerance 12 accommodates that bleed
+    // without weakening the channel-order check (a swap would shift
+    // 255 to a different channel and blow either tolerance). Mirrors
+    // the Vulkan-backend round-trip test's tolerances.
     let center = sample(&pixels, W as i32 / 2, H as i32 / 2, W);
     assert_pixel_close(
         "center (red disc)",

--- a/libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs
@@ -1,0 +1,525 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `skia_animated_stress_gl` — GL-backed companion of
+//! `skia_animated_stress`. Drives `SkiaGlSurfaceAdapter` through 1800
+//! acquire/draw/flush/release iterations (60 fps × 30 s) with the same
+//! animated scene, pipes host-readback frames to ffmpeg as `bgra` raw
+//! video, and produces an MP4 + hero PNG.
+//!
+//! Why this exists: the Vulkan-backend already has this stress run for
+//! a confidence baseline; the GL backend should pass the same gate
+//! (no per-frame leaks in the EGL make-current path, no descriptor /
+//! fence growth via Skia's GL backend, no glFinish-driven stalls
+//! beyond budget) before customers point an existing Skia-on-GL stack
+//! at it.
+//!
+//! Run with:
+//!
+//! ```bash
+//! STREAMLIB_SKIA_E2E_VIDEO_DIR=/tmp/skia-stress-gl \
+//!     cargo test -p streamlib-adapter-skia \
+//!         --test skia_animated_stress_gl \
+//!         -- --ignored --nocapture
+//! ```
+
+#![cfg(target_os = "linux")]
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use skia_safe::{
+    gradient_shader, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,
+};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib::host_rhi::HostVulkanDevice;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_opengl::{
+    EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter, DRM_FORMAT_ARGB8888,
+};
+use streamlib_adapter_skia::SkiaGlSurfaceAdapter;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 512;
+const H: u32 = 512;
+const FPS: u32 = 60;
+const DURATION_SECS: u32 = 30;
+const FRAME_COUNT: u32 = FPS * DURATION_SECS;
+
+fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=warn,streamlib_adapter_opengl=warn,streamlib=warn",
+        )
+        .try_init();
+    let gpu = GpuContext::init_for_platform_sync().ok()?;
+    let egl = match EglRuntime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            println!("skia_animated_stress_gl: skipping — EGL unavailable: {e}");
+            return None;
+        }
+    };
+    Some((gpu, egl))
+}
+
+#[test]
+#[ignore = "30 s × 60 fps stress run + ffmpeg encode; explicit-only"]
+fn skia_animated_stress_gl() {
+    let video_dir = match std::env::var("STREAMLIB_SKIA_E2E_VIDEO_DIR") {
+        Ok(d) if !d.is_empty() => PathBuf::from(d),
+        _ => panic!(
+            "STREAMLIB_SKIA_E2E_VIDEO_DIR must be set to a directory \
+             where the MP4 + hero PNG should land"
+        ),
+    };
+    std::fs::create_dir_all(&video_dir).expect("create_dir_all");
+    let mp4_path = video_dir.join("skia_animated_stress_gl.mp4");
+    let hero_path = video_dir.join("skia_animated_stress_gl_hero.png");
+
+    let (gpu, egl) = match try_init() {
+        Some(t) => t,
+        None => {
+            println!("skia_animated_stress_gl: skipping — no Vulkan or no EGL");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+    let skia_gl_adapter = match SkiaGlSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia_animated_stress_gl: skipping — Skia GL setup failed: {e}");
+            return;
+        }
+    };
+
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = stream_tex
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane_layout = stream_tex
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = stream_tex.vulkan_inner().chosen_drm_format_modifier();
+    let surface_id = 0xa11_a11bu64;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                dma_buf_fd,
+                width: W,
+                height: H,
+                drm_fourcc: DRM_FORMAT_ARGB8888,
+                drm_format_modifier: modifier,
+                plane_offset: plane_layout[0].0,
+                plane_stride: plane_layout[0].1,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // Pin to /usr/bin/ffmpeg if present (apt's ffmpeg has libx264);
+    // /usr/local/bin's Vulkan-focused build sometimes lacks it.
+    let ffmpeg_bin = if std::path::Path::new("/usr/bin/ffmpeg").exists() {
+        "/usr/bin/ffmpeg"
+    } else {
+        "ffmpeg"
+    };
+    println!(
+        "[skia_animated_stress_gl] spawning {ffmpeg_bin} → {}",
+        mp4_path.display()
+    );
+    let mut ffmpeg = Command::new(ffmpeg_bin)
+        .args([
+            "-y",
+            "-loglevel", "error",
+            "-f", "rawvideo",
+            "-pix_fmt", "bgra",
+            "-s", &format!("{}x{}", W, H),
+            "-r", &FPS.to_string(),
+            "-i", "-",
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            "-preset", "veryfast",
+            "-crf", "20",
+            "-movflags", "+faststart",
+            mp4_path.to_str().expect("mp4 path utf-8"),
+        ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("ffmpeg spawn (install ffmpeg if missing)");
+    let mut ffmpeg_stdin = ffmpeg.stdin.take().expect("ffmpeg stdin");
+
+    let run_start = Instant::now();
+    let mut adapter_times: Vec<Duration> = Vec::with_capacity(FRAME_COUNT as usize);
+    let hero_frame_index = (FPS * (DURATION_SECS / 2)) as usize;
+    let mut hero_pixels: Option<Vec<u8>> = None;
+
+    for f in 0..FRAME_COUNT {
+        let t = f as f32 / FPS as f32;
+
+        let adapter_start = Instant::now();
+        {
+            let mut guard = skia_gl_adapter
+                .acquire_write(&surface_desc)
+                .expect("skia_gl acquire_write");
+            let view = guard.view_mut();
+            let canvas = view.surface_mut().canvas();
+            draw_animated_frame(canvas, t);
+        } // guard drops → flush_and_submit_surface(SyncCpu::Yes) → glFinish.
+        let adapter_elapsed = adapter_start.elapsed();
+        adapter_times.push(adapter_elapsed);
+
+        let pixels = host_readback_bgra(
+            &host_device,
+            stream_tex.vulkan_inner().image().expect("image handle"),
+            W,
+            H,
+        );
+        if (f as usize) == hero_frame_index {
+            hero_pixels = Some(pixels.clone());
+        }
+        ffmpeg_stdin.write_all(&pixels).expect("ffmpeg stdin write");
+
+        if (f + 1) % 120 == 0 {
+            let wall = run_start.elapsed().as_secs_f32();
+            let adapter_avg_ms =
+                adapter_times.iter().sum::<Duration>().as_secs_f32() * 1000.0
+                    / (f as f32 + 1.0);
+            println!(
+                "[skia_animated_stress_gl] frame {:>4}/{} wall={:>5.1}s adapter_avg={:>5.2}ms",
+                f + 1,
+                FRAME_COUNT,
+                wall,
+                adapter_avg_ms,
+            );
+        }
+    }
+
+    drop(ffmpeg_stdin);
+    let ffmpeg_status = ffmpeg.wait().expect("ffmpeg wait");
+    assert!(
+        ffmpeg_status.success(),
+        "ffmpeg encode failed: {ffmpeg_status:?}"
+    );
+
+    let total = run_start.elapsed();
+    let total_s = total.as_secs_f32();
+    let adapter_total: Duration = adapter_times.iter().sum();
+    let adapter_avg_ms = adapter_total.as_secs_f32() * 1000.0 / FRAME_COUNT as f32;
+    let adapter_min_ms = adapter_times.iter().min().unwrap().as_secs_f32() * 1000.0;
+    let adapter_max_ms = adapter_times.iter().max().unwrap().as_secs_f32() * 1000.0;
+    let mut sorted = adapter_times.clone();
+    sorted.sort_unstable();
+    let p50_ms = sorted[FRAME_COUNT as usize / 2].as_secs_f32() * 1000.0;
+    let p95_ms = sorted[(FRAME_COUNT as usize * 95) / 100].as_secs_f32() * 1000.0;
+    let p99_ms = sorted[(FRAME_COUNT as usize * 99) / 100].as_secs_f32() * 1000.0;
+
+    println!(
+        "[skia_animated_stress_gl] DONE — {} frames in {:.2}s wall (incl. readback + ffmpeg I/O)",
+        FRAME_COUNT, total_s
+    );
+    println!(
+        "[skia_animated_stress_gl] adapter throughput: {:.1} fps headroom",
+        FRAME_COUNT as f32 / adapter_total.as_secs_f32()
+    );
+    println!(
+        "[skia_animated_stress_gl] adapter frame time: avg={:.2}ms min={:.2}ms p50={:.2}ms p95={:.2}ms p99={:.2}ms max={:.2}ms",
+        adapter_avg_ms, adapter_min_ms, p50_ms, p95_ms, p99_ms, adapter_max_ms
+    );
+
+    // 4× the 60 fps budget — sized for hardware/driver headroom, not a
+    // tight perf gate. A leak would push avg above this long before
+    // 1800 frames complete.
+    let target_avg_ms = 1000.0 / FPS as f32 * 4.0;
+    assert!(
+        adapter_avg_ms < target_avg_ms,
+        "adapter average frame time {:.2}ms exceeds 4× the 60 fps budget ({:.2}ms) — \
+         likely a leak (descriptor pools / make-current overhead / GPU memory growing per frame)",
+        adapter_avg_ms,
+        target_avg_ms,
+    );
+
+    if let Some(pixels) = hero_pixels {
+        write_bgra_as_png(&pixels, W, H, &hero_path);
+        println!(
+            "[skia_animated_stress_gl] hero PNG (frame {}, t={:.2}s): {}",
+            hero_frame_index,
+            hero_frame_index as f32 / FPS as f32,
+            hero_path.display()
+        );
+    }
+    println!("[skia_animated_stress_gl] MP4: {}", mp4_path.display());
+}
+
+fn draw_animated_frame(canvas: &skia_safe::Canvas, t: f32) {
+    use std::f32::consts::TAU;
+
+    let top = hsl(t * 40.0, 0.80, 0.20);
+    let bottom = hsl(t * 40.0 + 120.0, 0.80, 0.55);
+    let bg_grad = gradient_shader::linear(
+        (Point::new(0.0, 0.0), Point::new(0.0, H as f32)),
+        &[top, bottom][..],
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    )
+    .expect("background gradient");
+    let mut bg = Paint::default();
+    bg.set_shader(bg_grad);
+    canvas.draw_rect(Rect::new(0.0, 0.0, W as f32, H as f32), &bg);
+
+    let ring_radius = 180.0 + (t * TAU * 0.5).sin() * 18.0;
+    let mut ring = Paint::new(hsl(t * 60.0, 0.95, 0.55), None);
+    ring.set_style(PaintStyle::Stroke);
+    ring.set_stroke_width(6.0 + (t * TAU * 0.3).sin().abs() * 4.0);
+    ring.set_anti_alias(true);
+    canvas.draw_circle(
+        Point::new(W as f32 * 0.5, H as f32 * 0.5),
+        ring_radius,
+        &ring,
+    );
+
+    for i in 0..5 {
+        let phase = i as f32 * 0.4;
+        let fx = 0.5 + 0.6 * (i as f32 * 0.3);
+        let fy = 0.7 + 0.5 * (i as f32 * 0.2);
+        let x = W as f32 * 0.5 + (t * fx + phase).sin() * (190.0 - i as f32 * 12.0);
+        let y = H as f32 * 0.5 + (t * fy + phase).cos() * (180.0 - i as f32 * 14.0);
+        let radius = 26.0 + (t * 1.6 + phase).sin() * 10.0;
+        let mut color = hsl(t * 70.0 + i as f32 * 72.0, 0.92, 0.58);
+        color.a = 0.78;
+        let mut paint = Paint::new(color, None);
+        paint.set_anti_alias(true);
+        canvas.draw_circle(Point::new(x, y), radius, &paint);
+    }
+
+    let spokes = 16;
+    let cx = W as f32 * 0.5;
+    let cy = H as f32 * 0.5;
+    let inner_r = 36.0;
+    let outer_r = 70.0 + (t * TAU * 0.4).sin() * 18.0;
+    let mut spoke = Paint::new(hsl(t * 90.0 + 200.0, 0.6, 0.85), None);
+    spoke.set_style(PaintStyle::Stroke);
+    spoke.set_stroke_width(2.0);
+    spoke.set_anti_alias(true);
+    let mut path = Path::new();
+    for s in 0..spokes {
+        let a = s as f32 / spokes as f32 * TAU + t * 1.2;
+        path.move_to(Point::new(cx + a.cos() * inner_r, cy + a.sin() * inner_r));
+        path.line_to(Point::new(cx + a.cos() * outer_r, cy + a.sin() * outer_r));
+    }
+    canvas.draw_path(&path, &spoke);
+
+    let mut curve = Path::new();
+    let segments = 96;
+    let amp = 30.0 + (t * 0.7).sin() * 12.0;
+    let baseline = H as f32 - 56.0;
+    let phase = t * 3.0;
+    curve.move_to(Point::new(0.0, baseline));
+    for i in 1..=segments {
+        let u = i as f32 / segments as f32;
+        let x = u * W as f32;
+        let y = baseline - (u * TAU * 3.0 + phase).sin() * amp;
+        curve.line_to(Point::new(x, y));
+    }
+    let mut curve_paint = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.92), None);
+    curve_paint.set_style(PaintStyle::Stroke);
+    curve_paint.set_stroke_width(3.5);
+    curve_paint.set_anti_alias(true);
+    canvas.draw_path(&curve, &curve_paint);
+
+    let strip_y = H as f32 - 22.0;
+    let strip_h = 14.0;
+    for i in 0..7 {
+        let mut tile = Paint::default();
+        tile.set_color4f(hsl(t * 120.0 + i as f32 * 51.0, 0.95, 0.55), None);
+        let x0 = 16.0 + i as f32 * 22.0;
+        canvas.draw_rect(
+            Rect::new(x0, strip_y, x0 + 18.0, strip_y + strip_h),
+            &tile,
+        );
+    }
+}
+
+fn hsl(h: f32, s: f32, l: f32) -> Color4f {
+    let h = h.rem_euclid(360.0);
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+    let (r, g, b) = match (h / 60.0) as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    Color4f::new(r + m, g + m, b + m, 1.0)
+}
+
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}
+
+fn write_bgra_as_png(bgra: &[u8], width: u32, height: u32, path: &std::path::Path) {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let mut rgba = bgra.to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+    let file = File::create(path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .unwrap_or_else(|e| panic!("PNG header: {e}"));
+    writer
+        .write_image_data(&rgba)
+        .unwrap_or_else(|e| panic!("PNG body: {e}"));
+}

--- a/libs/streamlib-adapter-skia/tests/skia_visual_evidence_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_visual_evidence_gl.rs
@@ -1,0 +1,382 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `skia_visual_evidence_gl` — GL-backed companion of
+//! `skia_visual_evidence`. Draws the same showcase scene through
+//! `SkiaGlSurfaceAdapter` and writes a PNG of the Vulkan-readback so a
+//! human can confirm the GL backend is rendering correctly into the
+//! shared DMA-BUF.
+//!
+//! Run with:
+//!
+//! ```bash
+//! STREAMLIB_SKIA_E2E_PNG_DIR=/tmp/skia-evidence-gl \
+//!     cargo test -p streamlib-adapter-skia \
+//!         --test skia_visual_evidence_gl \
+//!         -- --ignored --nocapture
+//! ```
+//!
+//! Same `#[ignore]`-by-default rationale as the Vulkan-backend version.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use skia_safe::{
+    gradient_shader, Color, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,
+};
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib::host_rhi::HostVulkanDevice;
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_opengl::{
+    EglRuntime, HostSurfaceRegistration, OpenGlSurfaceAdapter, DRM_FORMAT_ARGB8888,
+};
+use streamlib_adapter_skia::SkiaGlSurfaceAdapter;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+const W: u32 = 512;
+const H: u32 = 512;
+
+fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=debug,streamlib_adapter_opengl=warn,streamlib=warn",
+        )
+        .try_init();
+    let gpu = GpuContext::init_for_platform_sync().ok()?;
+    let egl = match EglRuntime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            println!("skia_visual_evidence_gl: skipping — EGL unavailable: {e}");
+            return None;
+        }
+    };
+    Some((gpu, egl))
+}
+
+#[test]
+#[ignore = "produces an on-disk PNG artifact; run explicitly with --ignored when generating PR evidence"]
+fn skia_visual_evidence_gl() {
+    let png_dir = match std::env::var("STREAMLIB_SKIA_E2E_PNG_DIR") {
+        Ok(d) if !d.is_empty() => PathBuf::from(d),
+        _ => panic!(
+            "STREAMLIB_SKIA_E2E_PNG_DIR must be set to a directory where the \
+             evidence PNG should be written"
+        ),
+    };
+    std::fs::create_dir_all(&png_dir).expect("create_dir_all");
+    let png_path = png_dir.join("skia_visual_evidence_gl.png");
+
+    let (gpu, egl) = match try_init() {
+        Some(t) => t,
+        None => {
+            println!("skia_visual_evidence_gl: skipping — no Vulkan or no EGL");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    let inner = Arc::new(OpenGlSurfaceAdapter::new(Arc::clone(&egl)));
+    let skia_gl_adapter = match SkiaGlSurfaceAdapter::new(Arc::clone(&inner)) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("skia_visual_evidence_gl: skipping — Skia GL setup failed: {e}");
+            return;
+        }
+    };
+
+    // === Allocate host DMA-BUF surface, register with the GL adapter ====
+    let stream_tex = gpu
+        .acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = stream_tex
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane_layout = stream_tex
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = stream_tex.vulkan_inner().chosen_drm_format_modifier();
+    let surface_id = 0xe0e1_e0e2u64;
+    inner
+        .register_host_surface(
+            surface_id,
+            HostSurfaceRegistration {
+                dma_buf_fd,
+                width: W,
+                height: H,
+                drm_fourcc: DRM_FORMAT_ARGB8888,
+                drm_format_modifier: modifier,
+                plane_offset: plane_layout[0].0,
+                plane_stride: plane_layout[0].1,
+            },
+        )
+        .expect("register_host_surface");
+    let surface_desc = StreamlibSurface::new(
+        surface_id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED | SurfaceUsage::CPU_READBACK,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    // === Skia draw: showcase scene (mirrors the Vulkan-backend test) ====
+    {
+        let mut guard = skia_gl_adapter
+            .acquire_write(&surface_desc)
+            .expect("skia_gl acquire_write");
+        let view = guard.view_mut();
+        let canvas = view.surface_mut().canvas();
+
+        // Background: vertical gradient (deep navy → bright cyan)
+        let grad = gradient_shader::linear(
+            (Point::new(0.0, 0.0), Point::new(0.0, H as f32)),
+            &[
+                Color4f::new(0.05, 0.10, 0.30, 1.0),
+                Color4f::new(0.20, 0.85, 1.00, 1.0),
+            ][..],
+            None,
+            TileMode::Clamp,
+            None,
+            None,
+        )
+        .expect("background gradient");
+        let mut bg_paint = Paint::default();
+        bg_paint.set_shader(grad);
+        canvas.draw_rect(Rect::new(0.0, 0.0, W as f32, H as f32), &bg_paint);
+
+        let mut ring = Paint::new(Color4f::new(1.0, 0.85, 0.10, 1.0), None);
+        ring.set_style(PaintStyle::Stroke);
+        ring.set_stroke_width(8.0);
+        ring.set_anti_alias(true);
+        canvas.draw_circle(Point::new(W as f32 * 0.5, H as f32 * 0.5), 180.0, &ring);
+
+        let mut disc = Paint::new(Color4f::new(0.95, 0.15, 0.20, 1.0), None);
+        disc.set_anti_alias(true);
+        canvas.draw_circle(Point::new(W as f32 * 0.5, H as f32 * 0.5), 120.0, &disc);
+
+        let mut lens = Paint::new(Color4f::new(0.85, 0.20, 0.85, 0.55), None);
+        lens.set_anti_alias(true);
+        canvas.draw_circle(
+            Point::new(W as f32 * 0.5 + 60.0, H as f32 * 0.5 - 30.0),
+            70.0,
+            &lens,
+        );
+
+        let mut curve = Path::new();
+        let segments = 96;
+        let amp: f32 = 38.0;
+        let baseline: f32 = H as f32 - 64.0;
+        curve.move_to(Point::new(0.0, baseline));
+        for i in 1..=segments {
+            let t = i as f32 / segments as f32;
+            let x = t * W as f32;
+            let phase = t * std::f32::consts::PI * 4.0;
+            let y = baseline - phase.sin() * amp;
+            curve.line_to(Point::new(x, y));
+        }
+        let mut curve_paint = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.92), None);
+        curve_paint.set_style(PaintStyle::Stroke);
+        curve_paint.set_stroke_width(4.0);
+        curve_paint.set_anti_alias(true);
+        canvas.draw_path(&curve, &curve_paint);
+
+        let strip_y = H as f32 - 30.0;
+        let strip_h = 18.0;
+        for (i, color) in [
+            Color::RED,
+            Color::from_argb(255, 255, 165, 0),
+            Color::YELLOW,
+            Color::GREEN,
+            Color::CYAN,
+            Color::BLUE,
+            Color::from_argb(255, 138, 43, 226),
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut tile = Paint::default();
+            tile.set_color(*color);
+            let x0 = 16.0 + i as f32 * 22.0;
+            canvas.draw_rect(
+                Rect::new(x0, strip_y, x0 + 18.0, strip_y + strip_h),
+                &tile,
+            );
+        }
+
+        for &(cx, cy) in &[
+            (16.0, 16.0),
+            (W as f32 - 16.0, 16.0),
+            (16.0, H as f32 - 16.0),
+            (W as f32 - 16.0, H as f32 - 16.0),
+        ] {
+            let mut corner = Paint::new(Color4f::new(1.0, 1.0, 1.0, 0.9), None);
+            corner.set_anti_alias(true);
+            canvas.draw_circle(Point::new(cx, cy), 6.0, &corner);
+        }
+    } // guard drops → flush_and_submit_surface → glFinish via inner adapter.
+
+    // === Host readback ==============================================
+    let pixels = host_readback_bgra(
+        &host_device,
+        stream_tex.vulkan_inner().image().expect("image handle"),
+        W,
+        H,
+    );
+    write_bgra_as_png(&pixels, W, H, &png_path);
+    println!(
+        "[skia_visual_evidence_gl] wrote {}",
+        png_path.display()
+    );
+}
+
+fn host_readback_bgra(
+    device: &Arc<HostVulkanDevice>,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    use streamlib::core::rhi::PixelFormat;
+    use streamlib::host_rhi::HostVulkanPixelBuffer;
+
+    let staging = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
+        .expect("staging pixel buffer");
+    let dev = device.device();
+    let queue = device.queue();
+    let qf = device.queue_family_index();
+
+    let pool = unsafe {
+        dev.create_command_pool(
+            &vk::CommandPoolCreateInfo::builder()
+                .queue_family_index(qf)
+                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                .build(),
+            None,
+        )
+    }
+    .expect("create_command_pool");
+    let cmds = unsafe {
+        dev.allocate_command_buffers(
+            &vk::CommandBufferAllocateInfo::builder()
+                .command_pool(pool)
+                .level(vk::CommandBufferLevel::PRIMARY)
+                .command_buffer_count(1)
+                .build(),
+        )
+    }
+    .expect("allocate_command_buffers");
+    let cmd = cmds[0];
+
+    unsafe {
+        dev.begin_command_buffer(
+            cmd,
+            &vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build(),
+        )
+    }
+    .expect("begin_command_buffer");
+
+    let to_transfer = vk::ImageMemoryBarrier2::builder()
+        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::GENERAL)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(qf)
+        .dst_queue_family_index(qf)
+        .image(image)
+        .subresource_range(
+            vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build(),
+        )
+        .build();
+    let barriers = [to_transfer];
+    let dep = vk::DependencyInfo::builder()
+        .image_memory_barriers(&barriers)
+        .build();
+    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
+
+    let region = vk::BufferImageCopy::builder()
+        .buffer_offset(0)
+        .buffer_row_length(0)
+        .buffer_image_height(0)
+        .image_subresource(
+            vk::ImageSubresourceLayers::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .layer_count(1)
+                .build(),
+        )
+        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+        .image_extent(vk::Extent3D { width, height, depth: 1 })
+        .build();
+    let regions = [region];
+    unsafe {
+        dev.cmd_copy_image_to_buffer(
+            cmd,
+            image,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            staging.buffer(),
+            &regions,
+        )
+    };
+
+    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
+
+    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+        .command_buffer(cmd)
+        .build()];
+    let submit = vk::SubmitInfo2::builder()
+        .command_buffer_infos(&cmd_infos)
+        .build();
+    unsafe {
+        device
+            .submit_to_queue(queue, &[submit], vk::Fence::null())
+            .expect("submit");
+        dev.queue_wait_idle(queue).expect("queue_wait_idle");
+        dev.destroy_command_pool(pool, None);
+    }
+
+    let size = (width as usize) * (height as usize) * 4;
+    let mapped = staging.mapped_ptr();
+    assert!(!mapped.is_null());
+    let mut out = vec![0u8; size];
+    unsafe {
+        std::ptr::copy_nonoverlapping(mapped, out.as_mut_ptr(), size);
+    }
+    out
+}
+
+fn write_bgra_as_png(bgra: &[u8], width: u32, height: u32, path: &std::path::Path) {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let mut rgba = bgra.to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        px.swap(0, 2);
+    }
+    let file = File::create(path)
+        .unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .unwrap_or_else(|e| panic!("PNG header: {e}"));
+    writer
+        .write_image_data(&rgba)
+        .unwrap_or_else(|e| panic!("PNG body: {e}"));
+}

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -191,7 +191,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             .flags(vk::CommandPoolCreateFlags::TRANSIENT)
             .build();
         let pool = unsafe { device.create_command_pool(&pool_info, None) }
-            .map_err(|e| AdapterError::IpcDisconnected {
+            .map_err(|e| AdapterError::BackendRejected {
                 reason: format!("create_command_pool: {e}"),
             })?;
 
@@ -203,7 +203,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         let cmd_buffers = unsafe { device.allocate_command_buffers(&alloc_info) }
             .map_err(|e| {
                 unsafe { device.destroy_command_pool(pool, None) };
-                AdapterError::IpcDisconnected {
+                AdapterError::BackendRejected {
                     reason: format!("allocate_command_buffers: {e}"),
                 }
             })?;
@@ -214,7 +214,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             .build();
         if let Err(e) = unsafe { device.begin_command_buffer(cmd, &begin_info) } {
             unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
+            return Err(AdapterError::BackendRejected {
                 reason: format!("begin_command_buffer: {e}"),
             });
         }
@@ -250,7 +250,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
 
         if let Err(e) = unsafe { device.end_command_buffer(cmd) } {
             unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
+            return Err(AdapterError::BackendRejected {
                 reason: format!("end_command_buffer: {e}"),
             });
         }
@@ -266,7 +266,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             self.device.submit_to_queue(queue, &[submit], vk::Fence::null())
         } {
             unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
+            return Err(AdapterError::BackendRejected {
                 reason: format!("submit_to_queue: {e}"),
             });
         }
@@ -275,7 +275,7 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         // consumer's view assumes the new layout is visible.
         if let Err(e) = unsafe { device.queue_wait_idle(queue) } {
             unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::IpcDisconnected {
+            return Err(AdapterError::BackendRejected {
                 reason: format!("queue_wait_idle: {e}"),
             });
         }


### PR DESCRIPTION
## Visual evidence

### Static frame (single-shot GL adapter sanity)

![Skia GL backend visual evidence — gradient background, antialiased filled and stroked circles, alpha-blended lens, 96-segment sine path, 7-color tile strip, corner AA dots — same scene as the Vulkan-backend skia_visual_evidence](https://gh-artifact.tatolab.com/pr-579/skia_visual_evidence_gl.png)

*512×512 PNG produced by `cargo test -p streamlib-adapter-skia --test skia_visual_evidence_gl -- --ignored --nocapture`. Full path: Skia GL draw → `Surface::flush_and_submit_surface(SyncCpu::Yes)` → host `vkCmdCopyImageToBuffer` from the same DMA-BUF Skia rendered into. Demonstrates linear gradient shader, antialiased fills, alpha blending (magenta lens overlapping red disc), antialiased path strokes, color reproduction across the BGRA8 pipeline. Same showcase scene as the Vulkan-backend `skia_visual_evidence` test — side-by-side demonstrates the GL backend renders pixel-equivalent output.*

### Animated stress (1800 frames @ 60 fps × 30 s)

[**▶ skia_animated_stress_gl.mp4**](https://gh-artifact.tatolab.com/pr-579/skia_animated_stress_gl.mp4) — 4.5 MB H.264 / 30 s / 60 fps / 512×512 (commit `7e566ed`). Hero frame at t=15 s:

![Skia GL animated stress hero frame at t=15s — pulsing cyan stroked ring, 16-spoke starburst at center, 5 hue-cycling alpha-blended Lissajous balls scattered across, traveling sine wave at the bottom, hue-cycled rainbow tile strip](https://gh-artifact.tatolab.com/pr-579/skia_animated_stress_gl_hero.png)

*Stress run via `cargo test -p streamlib-adapter-skia --test skia_animated_stress_gl -- --ignored --nocapture`. 1800 acquire/draw/flush/release iterations against the same DMA-BUF with an animated scene (gradient + 5 Lissajous balls + rotating spokes + traveling sine + hue-cycling tiles, ~25 draw calls/frame). Asserts adapter avg frame time stays under 4× the 60 fps budget. **Result on this branch (NVIDIA RTX 3090, driver 570.x)**:*

| Metric | Value |
|---|---|
| Frames | **1800 / 1800** complete |
| Wall-clock duration | 17.4 s (incl. host readback + ffmpeg I/O) |
| **Adapter throughput headroom** | **615 fps** (avg 1.62 ms / acquire+draw+flush+release) |
| Frame-time percentiles | p50 1.47 ms / p95 2.28 ms / p99 3.49 ms / max 101.41 ms (single warmup outlier) |
| Output | 4.5 MB MP4 + 45 KB hero PNG |

*Adapter avg crept from 1.30 ms → 1.62 ms over the run and stayed bounded. Gates against descriptor-pool / make-current / GPU-memory leaks that would have surfaced as the avg blowing past the 4× budget long before 1800 iterations.*

## Summary

- **GL backend for `streamlib-adapter-skia`**: new sibling type `SkiaGlSurfaceAdapter` composing on `streamlib-adapter-opengl::OpenGlSurfaceAdapter` via the `GlWritable` capability marker. Customers with an existing Skia-on-GL stack (skia-python, gst-plugin-skia, custom GL apps) acquire through this adapter and get a `skia_safe::Surface` (write) / `skia_safe::Image` (read) directly — DMA-BUF FDs, EGLImages, and `gl_texture_id`s never reach them.
- **Vulkan-backend untouched**: existing `SkiaSurfaceAdapter<D>` and its 5 tests stay green (per exit criterion 3 of #576).
- **Shared `skia_internal` module**: extracts `SyncDirectContext` (manual `Send + Sync` newtype around Skia's `!Send` `GrDirectContext`), `flush_and_drop_skia_surface` (load-bearing drop-order recipe), `drop_skia_image_under_lock`, and `assert_skia_views_not_cpu_readable!` (compile-time invariant macro). Both backends compose on these — no duplication of the unsafe `Send` claim or the drop-ordering hazard. Mirrors how Skia itself ships sibling Vulkan/GL/Metal/D3D backends under a shared `GrDirectContext` layer (Ganesh's `src/gpu/ganesh/{vk,gl,mtl,d3d}` layout).
- **Production-grade error taxonomy cleanup**: new `AdapterError::BackendRejected { reason }` variant added to `streamlib-adapter-abi`. 22 `IpcDisconnected` misuses (where the wire was alive but the *backend GPU API* said no — Skia `wrap_*` returning None, EGL `make_current` failing on a known-good context, Vulkan submits returning driver-side errors during layout transitions) migrated across `streamlib-adapter-{vulkan,opengl,cpu-readback,skia}`. Format-mismatch cases get `UnsupportedFormat`. Shape matches Dawn's `WGPUErrorType` convention (opaque + reason string, no backend tag, no nested cause). Decision rationale: research subagent's verdict (Opus, max effort) — Dawn's `Internal` bucket and Skia's own backend-folder split are the closest precedents.
- **`EglRuntime::get_proc_address`**: minimal public accessor on `streamlib-adapter-opengl` so Skia's `gl::Interface` can build its private proc table via `eglGetProcAddress` without enabling skia-safe's `egl` feature (which was functionally equivalent but would have required a clang-driven from-source rebuild of skia-bindings on every clean checkout).

## Closes

Closes #576

## Exit criteria (from issue body, all met)

- [x] **`SkiaSurfaceAdapter` (or a sibling type) gains a GL composition path**: sibling type `SkiaGlSurfaceAdapter` composing on `OpenGlSurfaceAdapter`. The `GlWritable` capability marker is wired explicitly: `gl_adapter.rs` reads the inner view's texture id via `GlWritable::gl_texture_id(...)` rather than the inherent method, so the trait composition is grep-able at the call site.
- [x] **Conformance suite from #509 passes against the GL backend**: `tests/conformance_gl.rs::skia_gl_adapter_passes_run_conformance` runs the standard 8-contract suite + the SurfaceNotFound bonus test. Green.
- [x] **Existing Vulkan-backend tests stay green (no regression to v1)**: all 5 sibling tests pass (`conformance`, `round_trip_skia_canvas`, `concurrent_skia_and_vulkan_read`, `layout_never_leaks`, `subprocess_crash_mid_write`).

## Test plan

### GL adapter tests (new, all green)
- [x] `cargo test -p streamlib-adapter-skia --test conformance_gl` — `run_conformance` 8-contract suite green; `SurfaceNotFound` propagates through the composed adapter.
- [x] `cargo test -p streamlib-adapter-skia --test round_trip_skia_canvas_gl` — Skia GL draws red disc on blue, host reads back via Vulkan; pixel-content asserts pass within antialiasing tolerance.
- [x] **Visual evidence**: `cargo test -p streamlib-adapter-skia --test skia_visual_evidence_gl -- --ignored --nocapture` — see top of PR body.
- [x] **Animated stress**: `cargo test -p streamlib-adapter-skia --test skia_animated_stress_gl -- --ignored --nocapture` — 1800 frames, 615 fps adapter headroom — see top of PR body.

### Workspace test gate (sibling adapter crates after `IpcDisconnected → BackendRejected` migration, all green)
- [x] `cargo test -p streamlib-adapter-abi -p streamlib-adapter-vulkan -p streamlib-adapter-opengl -p streamlib-adapter-cpu-readback -p streamlib-adapter-skia -- --test-threads=1` — every test green. Note: parallel-mode runs occasionally trip on shared GPU state across crates (pre-existing flake unrelated to this PR); serial mode is the canonical signal.

### Boundary CI (cdylib capability boundary preserved)
- [x] `cargo xtask check-boundaries` — 1866 files scanned, 0 violations.
- [x] `cargo tree -p streamlib-python-native | grep -c "^streamlib v"` → 0
- [x] `cargo tree -p streamlib-deno-native | grep -c "^streamlib v"` → 0

## Pre-PR review iteration

Single `pr-review-gate` iteration (Opus, max effort). Verdict: DISCUSS. Session agent independently verified each flagged item against the actual code; addressed in fixup commit `7986f31`:
- Routed `gl_adapter`'s texture-id read through `GlWritable::gl_texture_id` explicitly so the capability-trait composition matches what the doc-comments and issue body both promise (was hitting `OpenGlWriteView`'s inherent method previously).
- Dropped unused `khronos-egl` + `gl` Cargo deps (speculative additions; per CLAUDE.md "don't design for hypothetical futures").
- Replaced `std::mem::forget(texture)` in `conformance_gl.rs` with a factory-owned `Vec<StreamTexture>` — leaks aren't the right shape here.
- Added a comment explaining the asymmetric pixel tolerances in `round_trip_skia_canvas_gl` (12 center for AA edge bleed, 4 corner for flat clear color).

Independent spot-checks beyond the reviewer's flags:
- Drop ordering in `SkiaGlWriteView::drop` verified — EGL lock acquired → flush → EGL lock released → inner guard drop (which re-acquires EGL for `glFinish`). No reentrant deadlock; matches parking_lot's non-reentrant invariant.
- `IpcDisconnected → BackendRejected` migration mechanical, no semantics change; all 22 sites verified to use the right successor variant (format-mismatch → `UnsupportedFormat`, backend-API rejection → `BackendRejected`).

## Polyglot coverage

- **Runtimes affected**: rust (only)
- **Schema regenerated**: n/a — no escalate-IPC schema changes
- **Python and Deno both covered?** Rust-only by construction. The Python wrapper rewrite (composing on `streamlib.adapters.opengl` instead of `vulkan` per skia-python's `VulkanBackendContext` stub — see #576's AI Agent Notes) is the load-bearing reason this issue exists, but the Python wiring lands in **#577** (which blocks on this PR). Deno does not have a Skia binding ecosystem — same construction-language argument as #578's polyglot coverage line.
- **E2E tests run**:
  - [x] Host-Rust: `round_trip_skia_canvas_gl` + `conformance_gl` (passes)
  - Python subprocess: tracked in #577 against this PR's GL backend.
  - Deno: deferred — no Skia binding.
- **FD-passing path**: DMA-BUF FD (host-allocated render-target VkImage shared cross-process via surface-share, imported into the subprocess as a `GL_TEXTURE_2D` via EGL DMA-BUF import).

## Follow-ups

- **#577** — feat(adapter-skia): polyglot Skia E2E + SubprocessCrashHarness coverage. Unblocks once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
