### PR TITLE
feat(adapter-skia): rewire Python wrapper onto GL backend + polyglot E2E + crash test

### DIFF
--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -4,17 +4,18 @@
 """Polyglot Skia canvas processor — Python.
 
 End-to-end gate for the subprocess :class:`SkiaContext` runtime
-(#513). The host pre-allocates a render-target-capable DMA-BUF
+(#577). The host pre-allocates a render-target-capable DMA-BUF
 surface AND an exportable timeline semaphore, registers both with
-surface-share, and installs no bridge (Skia composes on the Vulkan
+surface-share, and installs no bridge (Skia composes on the OpenGL
 adapter, which doesn't need one). This processor receives a trigger
 ``Videoframe``, opens the host surface through
 ``SkiaContext.acquire_write`` (which under the hood opens
-``VulkanContext.acquire_write``, builds a Skia ``GrBackendRenderTarget``,
-and yields a ``skia.Surface``), draws a known shape (red disc on
-blue background), and releases — Skia's flush+submit drains the GPU
-and the inner Vulkan adapter signals the timeline so the host's
-pre-stop readback sees the drawing.
+``OpenGLContext.acquire_write``, imports the DMA-BUF as a
+``GL_TEXTURE_2D`` via EGL, builds a Skia ``GrBackendTexture``, and
+yields a ``skia.Surface``), draws a known shape (red disc on blue
+background), and releases — Skia's flush+submit drains the GPU and
+the inner OpenGL adapter runs ``glFinish`` so the host's pre-stop
+readback sees the drawing.
 
 Config keys:
     skia_surface_uuid (str, required)
@@ -26,15 +27,30 @@ Config keys:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
 from streamlib.adapters.skia import SkiaContext
-from streamlib.surface_adapter import (
-    StreamlibSurface,
-    SurfaceFormat,
-    SurfaceUsage,
-)
+from streamlib.surface_adapter import SurfaceFormat, SurfaceUsage
+
+
+@dataclass(frozen=True)
+class _SurfaceDescriptor:
+    """Minimal duck-typed descriptor for `SkiaContext.acquire_*`.
+
+    The Skia wrapper needs `id` (surface-share UUID), `width`, `height`,
+    `format` to build a `GrBackendTexture`. `streamlib.surface_adapter`
+    exports `StreamlibSurface` only as a `typing.Protocol` (not a
+    concrete class), so processors construct their own descriptor; any
+    object with these attributes is accepted.
+    """
+
+    id: str
+    width: int
+    height: int
+    format: int
+    usage: int
 
 
 class SkiaCanvasProcessor:
@@ -46,16 +62,12 @@ class SkiaCanvasProcessor:
         self._skia_ctx = SkiaContext.from_runtime(ctx)
         self._drawn = False
         self._error: Optional[str] = None
-        # The Skia adapter wraps the inner Vulkan adapter, which
-        # registers surfaces lazily on first acquire. Build a minimal
-        # `StreamlibSurface` descriptor here that carries the UUID +
-        # dims; surface-share fills in the rest under the hood.
-        self._surface = StreamlibSurface(
+        self._surface = _SurfaceDescriptor(
             id=self._uuid,
             width=self._width,
             height=self._height,
-            format=SurfaceFormat.Bgra8,
-            usage=SurfaceUsage.RENDER_TARGET | SurfaceUsage.SAMPLED,
+            format=int(SurfaceFormat.BGRA8),
+            usage=int(SurfaceUsage.RENDER_TARGET | SurfaceUsage.SAMPLED),
         )
         print(
             f"[SkiaCanvas/py] setup uuid={self._uuid} "

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: polyglot-skia-canvas
   version: "0.1.0"
-  description: "Polyglot Skia adapter scenario (#513) — Python Skia processor draws a canvas into a host DMA-BUF VkImage via streamlib.adapters.skia.SkiaContext"
+  description: "Polyglot Skia adapter scenario (#577) — Python Skia processor (composed on the OpenGL adapter via skia-python's GrDirectContext.MakeGL) draws a canvas into a host DMA-BUF VkImage via streamlib.adapters.skia.SkiaContext"
 
 processors:
   - name: com.tatolab.skia_canvas

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
         }
     }
 
-    println!("=== Polyglot Skia adapter canvas scenario (#513) ===");
+    println!("=== Polyglot Skia adapter canvas scenario (#577) ===");
     println!(
         "Surface:    {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (uuid {SCENARIO_SURFACE_UUID})"
     );
@@ -115,10 +115,10 @@ fn main() -> Result<()> {
                 .map_err(|e| {
                     StreamError::Configuration(format!("register_texture: {e}"))
                 })?;
-            // No bridge wiring: Skia composes on the Vulkan adapter,
+            // No bridge wiring: Skia composes on the OpenGL adapter,
             // which has no per-acquire host work — every line of GPU
             // dispatch happens inside the subprocess process via
-            // skia-python.
+            // skia-python's GL backend (`MakeGL(MakeEGL())`).
             *texture_slot.lock().unwrap() = Some(texture);
             *device_slot.lock().unwrap() = Some(host_device);
             *timeline_slot.lock().unwrap() = Some(timeline);

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -1,28 +1,31 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Polyglot Skia adapter scenario (#513).
+//! Polyglot Skia adapter scenario (#577).
 //!
 //! End-to-end gate for the subprocess `SkiaContext` runtime: the host
 //! pre-allocates ONE render-target-capable DMA-BUF surface AND an
 //! exportable `HostVulkanTimelineSemaphore`, registers both with
 //! surface-share under a known UUID. A Python polyglot processor opens
 //! the surface through `SkiaContext.acquire_write` (which under the
-//! hood opens `VulkanContext.acquire_write` to get the imported
-//! VkImage, builds a `skia.GrBackendRenderTarget`, and yields a
-//! `skia.Surface`), draws a known shape (red disc on blue background),
-//! and releases — Skia's flush-and-submit drains the GPU and the inner
-//! Vulkan adapter signals the timeline so the host's pre-stop readback
-//! sees the drawing. This binary then reads the surface back via
-//! Vulkan and writes a PNG; reading the PNG with the Read tool is the
-//! visual gate.
+//! hood opens `OpenGLContext.acquire_write` to import the DMA-BUF as a
+//! `GL_TEXTURE_2D` via EGL, builds a `skia.GrBackendTexture`, and
+//! yields a `skia.Surface`), draws a known shape (red disc on blue
+//! background), and releases — Skia's flush-and-submit drains the GPU
+//! and the inner OpenGL adapter runs `glFinish` so the host's pre-stop
+//! readback sees the drawing. This binary then reads the surface back
+//! via Vulkan and writes a PNG; reading the PNG with the Read tool is
+//! the visual gate.
 //!
-//! Skia is composed on Vulkan in the subprocess (no `slpn_skia_*` FFI;
-//! `streamlib.adapters.skia.SkiaContext` uses the existing
-//! `slpn_vulkan_*` symbols + skia-python). Deno is intentionally
-//! deferred: there is no Deno Skia binding ecosystem (#513 AI Agent
-//! Notes — same construction-language argument as the abandoned #481
-//! polyglot deferral).
+//! Skia is composed on OpenGL in the subprocess (no `slpn_skia_*`
+//! FFI; `streamlib.adapters.skia.SkiaContext` uses the existing
+//! `slpn_opengl_*` symbols + skia-python's `GrDirectContext.MakeGL`).
+//! The pivot from Vulkan to GL inside Python is forced by skia-python's
+//! pybind11 Vulkan binding being unimplemented — see #577 / the
+//! adapter's `skia.py` module docstring. The Rust adapter's Vulkan
+//! backend is unchanged. Deno is intentionally deferred: there is no
+//! maintained Deno Skia binding (same construction-language argument
+//! as the abandoned #481 polyglot deferral).
 //!
 //! Build the Python `.slpkg` first:
 //!   cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python
@@ -76,10 +79,12 @@ fn main() -> Result<()> {
         let device_slot = Arc::clone(&device_slot);
         let timeline_slot = Arc::clone(&timeline_slot);
         runtime.install_setup_hook(move |gpu| {
-            // BGRA8 because skia-python's default ColorType for
-            // wrap_backend_render_target on Skia-Vulkan is BGRA on
-            // little-endian hosts; this keeps the Python side from
-            // having to translate.
+            // BGRA8: the EGL DMA-BUF importer hands the subprocess a
+            // `GL_RGBA8`-typed `GL_TEXTURE_2D` regardless of host
+            // channel order; the Python wrapper passes
+            // `kBGRA_8888_ColorType` to Skia, which then interprets the
+            // bytes back-to-front so what gets drawn ends up in the
+            // host's BGRA memory in the right order.
             let texture = gpu.acquire_render_target_dma_buf_image(
                 SURFACE_SIZE,
                 SURFACE_SIZE,

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -30,6 +30,16 @@ skia-safe = { workspace = true }
 # time (Skia copies it internally during make_vulkan, so the Library
 # handle can be dropped right after).
 libloading = "0.8"
+# `streamlib-surface-client` / `serde` / `serde_json` / `libc` are
+# used by the in-crate `tests/bin/skia_adapter_subprocess_helper` test
+# binary (mirror of `streamlib-adapter-opengl`'s in-crate helper). They
+# live under regular `[dependencies]` rather than `[dev-dependencies]`
+# because Cargo's `[[bin]]` targets don't see dev-deps. Same shape as
+# `streamlib-adapter-opengl/Cargo.toml`.
+streamlib-surface-client = { path = "../streamlib-surface-client" }
+serde = { workspace = true }
+serde_json.workspace = true
+libc.workspace = true
 
 # `streamlib` is a *test*-only dep: the round-trip / conformance
 # tests bring up a `HostVulkanDevice`. The runtime crate (above)
@@ -37,14 +47,6 @@ libloading = "0.8"
 # `streamlib-adapter-skia` get the consumer-rhi carve-out only, with
 # `streamlib` absent from their dep graph (enforced by `cargo xtask
 # check-boundaries`).
-#
-# A subprocess test-helper binary (analogous to
-# `streamlib-adapter-vulkan-helpers`) is intentionally NOT shipped
-# in v1: the Skia adapter composes on `streamlib-adapter-vulkan` and
-# does not allocate per-acquire GPU resources of its own, so
-# subprocess-crash cleanup is already covered by the inner Vulkan
-# adapter's tests. A Skia-specific helper will land alongside the
-# polyglot Skia wrapper follow-up issue.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 streamlib = { path = "../streamlib" }
 streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
@@ -98,6 +100,15 @@ path = "tests/skia_visual_evidence_gl.rs"
 [[test]]
 name = "skia_animated_stress_gl"
 path = "tests/skia_animated_stress_gl.rs"
+
+# Subprocess test helper for `subprocess_crash_mid_write`. Built as a
+# normal binary by `cargo test` and discovered at runtime via
+# `env!("CARGO_BIN_EXE_…")`. Mirror of
+# `streamlib-adapter-opengl/tests/bin/opengl_adapter_subprocess_helper.rs`.
+[[bin]]
+name = "skia_adapter_subprocess_helper"
+path = "tests/bin/skia_adapter_subprocess_helper.rs"
+test = false
 
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-skia/tests/bin/skia_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-skia/tests/bin/skia_adapter_subprocess_helper.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Subprocess test helper for the Skia adapter's crash-mid-write test.
+//!
+//! Receives a DMA-BUF FD over `STREAMLIB_HELPER_SOCKET_FD`, imports it
+//! into the GL-backed Skia adapter (`SkiaGlContext` on top of
+//! `OpenGlSurfaceAdapter`), drives a Skia draw, then either signals
+//! success or `abort()`s mid-flight depending on argv[1].
+//!
+//! Roles:
+//! - `wait-only` — import + register + signal ready + park until
+//!   killed.
+//! - `crash-mid-write` — import + register + acquire a Skia write
+//!   guard + draw a known shape into the canvas + `abort()` BEFORE the
+//!   guard's drop hook can call `flush_and_submit_surface` and the
+//!   inner OpenGL release's `glFinish`. Validates that the host's
+//!   per-surface state survives a SIGKILL on a subprocess that holds
+//!   live Skia + EGL state.
+
+#![cfg(target_os = "linux")]
+
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceFormat, SurfaceSyncState, SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_opengl::{
+    EglRuntime, HostSurfaceRegistration, OpenGlContext, OpenGlSurfaceAdapter,
+};
+use streamlib_adapter_skia::SkiaGlContext;
+
+const HELPER_SURFACE_ID: u64 = 0xfeed_face;
+
+#[derive(Debug, serde::Deserialize)]
+struct HelperRequest {
+    width: u32,
+    height: u32,
+    drm_fourcc: u32,
+    drm_format_modifier: u64,
+    plane_offset: u64,
+    plane_stride: u64,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct HelperResponse {
+    ok: bool,
+    note: String,
+}
+
+fn die(socket: Option<&UnixStream>, msg: String) -> ExitCode {
+    eprintln!("[skia-helper] FATAL: {msg}");
+    if let Some(s) = socket {
+        let resp = HelperResponse {
+            ok: false,
+            note: msg,
+        };
+        let body = serde_json::to_vec(&resp).unwrap_or_default();
+        let _ = streamlib_surface_client::send_message_with_fds(s, &body, &[]);
+    }
+    ExitCode::from(1)
+}
+
+fn run() -> ExitCode {
+    let role = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "wait-only".to_string());
+    let sock_fd_str = match std::env::var("STREAMLIB_HELPER_SOCKET_FD") {
+        Ok(v) => v,
+        Err(_) => return die(None, "STREAMLIB_HELPER_SOCKET_FD unset".into()),
+    };
+    let sock_fd: RawFd = match sock_fd_str.parse() {
+        Ok(v) => v,
+        Err(_) => return die(None, "STREAMLIB_HELPER_SOCKET_FD not an integer".into()),
+    };
+    let socket = unsafe { UnixStream::from_raw_fd(sock_fd) };
+
+    // Read length-prefixed JSON + DMA-BUF fd via SCM_RIGHTS.
+    let mut len_buf = [0u8; 4];
+    let mut total = 0;
+    while total < 4 {
+        let n = unsafe {
+            libc::read(
+                socket.as_raw_fd(),
+                len_buf[total..].as_mut_ptr() as *mut libc::c_void,
+                4 - total,
+            )
+        };
+        if n <= 0 {
+            return die(Some(&socket), "read length prefix failed".into());
+        }
+        total += n as usize;
+    }
+    let msg_len = u32::from_be_bytes(len_buf) as usize;
+    let (payload, fds) = match streamlib_surface_client::recv_message_with_fds(
+        &socket, msg_len, 1,
+    ) {
+        Ok(p) => p,
+        Err(e) => return die(Some(&socket), format!("recv_message_with_fds: {e}")),
+    };
+    let req: HelperRequest = match serde_json::from_slice(&payload) {
+        Ok(r) => r,
+        Err(e) => return die(Some(&socket), format!("parse request: {e}")),
+    };
+    let dma_buf_fd = match fds.first() {
+        Some(&fd) => fd,
+        None => return die(Some(&socket), "no DMA-BUF fd received".into()),
+    };
+
+    // Bring up the OpenGL adapter (EGL display + GL context + the
+    // adapter's `OpenGlSurfaceAdapter`), import the host's DMA-BUF, and
+    // wrap with a `SkiaGlContext`. Mirrors the customer-side path the
+    // Python wrapper exercises, just in Rust.
+    let runtime = match EglRuntime::new() {
+        Ok(r) => r,
+        Err(e) => return die(Some(&socket), format!("EglRuntime::new: {e}")),
+    };
+    let adapter = Arc::new(OpenGlSurfaceAdapter::new(runtime));
+    let registration = HostSurfaceRegistration {
+        dma_buf_fd,
+        width: req.width,
+        height: req.height,
+        drm_fourcc: req.drm_fourcc,
+        drm_format_modifier: req.drm_format_modifier,
+        plane_offset: req.plane_offset,
+        plane_stride: req.plane_stride,
+    };
+    if let Err(e) = adapter.register_host_surface(HELPER_SURFACE_ID, registration) {
+        return die(Some(&socket), format!("register_host_surface: {e}"));
+    }
+    // EGL dups the FD on import; close our copy.
+    unsafe { libc::close(dma_buf_fd) };
+
+    let opengl_ctx = OpenGlContext::new(Arc::clone(&adapter));
+    let skia_ctx = match SkiaGlContext::new(&opengl_ctx) {
+        Ok(c) => c,
+        Err(e) => return die(Some(&socket), format!("SkiaGlContext::new: {e}")),
+    };
+
+    // Tell the parent we're up. The parent's harness only starts its
+    // SIGKILL countdown after it has confirmed the helper reached this
+    // point.
+    let resp = HelperResponse {
+        ok: true,
+        note: format!("registered + skia_gl_context built ({role})"),
+    };
+    let body = serde_json::to_vec(&resp).unwrap_or_default();
+    let _ = streamlib_surface_client::send_message_with_fds(&socket, &body, &[]);
+
+    match role.as_str() {
+        "wait-only" => {
+            // Park forever — the parent SIGKILLs us via the harness.
+            std::thread::park();
+            ExitCode::SUCCESS
+        }
+        "crash-mid-write" => crash_mid_skia_write(&skia_ctx, req.width, req.height),
+        other => die(Some(&socket), format!("unknown role {other}")),
+    }
+}
+
+/// Acquire a Skia write guard, issue a draw command stream, and
+/// `abort()` BEFORE the guard's drop hook fires. Drop is what would
+/// normally call `flush_and_submit_surface` (drain Skia's GPU work)
+/// and `glFinish` (drain GL via the OpenGL adapter's release). By
+/// `abort()`ing before drop, we're "mid-`flush_and_submit_surface`"
+/// in the relevant sense — the host has work in flight that the
+/// subprocess never got around to draining, and the host's per-surface
+/// state must still survive the SIGKILL that follows.
+fn crash_mid_skia_write(skia_ctx: &SkiaGlContext, width: u32, height: u32) -> ExitCode {
+    let surface_descriptor = StreamlibSurface::new(
+        HELPER_SURFACE_ID,
+        width,
+        height,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::RENDER_TARGET | SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    let mut guard = match skia_ctx.acquire_write(&surface_descriptor) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("[skia-helper] acquire_write: {e}");
+            std::process::abort();
+        }
+    };
+    {
+        let view = guard.view_mut();
+        let sk_surface = view.surface_mut();
+        let canvas = sk_surface.canvas();
+        canvas.clear(skia_safe::Color::BLUE);
+        let mut paint = skia_safe::Paint::default();
+        paint.set_color(skia_safe::Color::RED);
+        paint.set_anti_alias(true);
+        let cx = (width as f32) * 0.5;
+        let cy = (height as f32) * 0.5;
+        let radius = (width.min(height) as f32) * 0.35;
+        canvas.draw_circle((cx, cy), radius, &paint);
+    }
+    // Spec'd to crash with the guard still live — `abort()` skips
+    // `Drop`, so neither `flush_and_submit_surface` nor `glFinish`
+    // runs.
+    std::process::abort();
+}
+
+fn main() -> ExitCode {
+    run()
+}

--- a/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
@@ -1,33 +1,187 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `subprocess_crash_mid_write` — placeholder for a Skia-specific
-//! crash test.
+//! `streamlib_adapter_skia::tests::subprocess_crash_mid_write` —
+//! exercises the public `SubprocessCrashHarness` from
+//! `streamlib-adapter-abi::testing` against a subprocess that has
+//! built a full `SkiaGlContext` on top of the OpenGL adapter, drawn
+//! into a Skia canvas, and then `abort()`s before its drop hook can
+//! call `flush_and_submit_surface`.
 //!
-//! `streamlib_adapter_abi::testing::SubprocessCrashHarness` covers
-//! host-side cleanup when a polyglot subprocess holds a surface
-//! guard and is `SIGKILL`ed mid-acquire. The Skia adapter composes on
-//! `streamlib-adapter-vulkan` and does not allocate any per-acquire
-//! GPU resources of its own — the wrapped `skia::Surface` /
-//! `skia::Image` only borrow the inner Vulkan adapter's
-//! resources. `streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs`
-//! already exercises the cleanup path for that inner adapter, and a
-//! Skia subprocess crash exercises the same path.
+//! The harness spawns the helper subprocess
+//! (`skia_adapter_subprocess_helper`), the helper imports a DMA-BUF
+//! passed via SCM_RIGHTS into its own EGL+GL stack, brings up Skia,
+//! issues a draw on the canvas, then — per the `crash-mid-write`
+//! role — `abort()`s with the write guard still live. The host-side
+//! observation closure watches the inherited pipe FD and reports
+//! cleanup once the kernel reaps the subprocess.
 //!
-//! When the polyglot Skia wrapper lands (filed as a follow-up issue
-//! against this milestone), this test should grow real Skia-side
-//! coverage: a Python subprocess that opens a `skia.Surface`, draws,
-//! and crashes mid-flush. For now, this file is a documented skip.
+//! Independent of the Python bridge — exercises the Rust adapter
+//! directly against `HostVulkanDevice`. The Python wrapper rides the
+//! same code paths transitively (`streamlib.adapters.skia.SkiaContext`
+//! composes on `OpenGLContext`, just as `SkiaGlContext` does in Rust).
+//!
+//! Mirror of
+//! `streamlib-adapter-opengl/tests/subprocess_crash_mid_write.rs` —
+//! the wrappage difference is that the helper here also constructs a
+//! `SkiaGlContext` and acquires a Skia write guard before the abort,
+//! exercising the additional drop-order chain
+//! (`SkiaGlWriteView::drop` → `flush_and_submit_surface` →
+//! `lock_make_current` → `OpenGlSurfaceAdapter::end_write_access` →
+//! `glFinish`) that the OpenGL adapter test alone does not cover.
 
 #![cfg(target_os = "linux")]
 
+use std::os::fd::IntoRawFd;
+use std::os::unix::net::UnixStream;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::TextureFormat;
+use streamlib_adapter_abi::testing::{CrashTiming, SubprocessCrashHarness};
+use streamlib_adapter_opengl::DRM_FORMAT_ARGB8888;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(
+            "streamlib_adapter_skia=debug,\
+             streamlib_adapter_opengl=warn,\
+             streamlib=warn",
+        )
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
 #[test]
-fn subprocess_crash_test_deferred_to_polyglot_followup() {
-    println!(
-        "subprocess_crash_mid_write: deferred — Skia adapter does not allocate \
-         per-acquire GPU resources beyond what the inner Vulkan adapter holds. \
-         streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs covers the \
-         cleanup path Skia depends on; a Skia-specific subprocess test will land \
-         alongside the polyglot Skia wrapper follow-up."
+fn subprocess_crash_mid_skia_write_observed_by_harness() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!(
+                "subprocess_crash_mid_skia_write: skipping — no Vulkan / no GPU"
+            );
+            return;
+        }
+    };
+
+    // Allocate a host render-target DMA-BUF the subprocess will import
+    // through EGL + GL + Skia.
+    let texture = gpu
+        .acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        .expect("acquire_render_target_dma_buf_image");
+    let dma_buf_fd = texture
+        .vulkan_inner()
+        .export_dma_buf_fd()
+        .expect("export DMA-BUF");
+    let plane = texture
+        .vulkan_inner()
+        .dma_buf_plane_layout()
+        .expect("dma_buf_plane_layout");
+    let modifier = texture.vulkan_inner().chosen_drm_format_modifier();
+
+    // Pipe pair — the parent observes EOF on the read end once the
+    // subprocess is reaped (kernel closes the inherited write end on
+    // exit / SIGKILL). Standard "did cleanup fire?" observation
+    // primitive, mirror of the OpenGL adapter's crash test.
+    let mut pipe_fds = [-1i32; 2];
+    unsafe {
+        let r = libc::pipe(pipe_fds.as_mut_ptr());
+        assert_eq!(r, 0, "pipe() failed: {}", std::io::Error::last_os_error());
+        let flags = libc::fcntl(pipe_fds[0], libc::F_GETFL);
+        libc::fcntl(pipe_fds[0], libc::F_SETFL, flags | libc::O_NONBLOCK);
+        let wf = libc::fcntl(pipe_fds[1], libc::F_GETFD);
+        libc::fcntl(pipe_fds[1], libc::F_SETFD, wf & !libc::FD_CLOEXEC);
+    }
+    let read_fd = pipe_fds[0];
+    let write_fd = pipe_fds[1];
+
+    // The helper reads the surface descriptor + DMA-BUF fd over a
+    // socketpair (SCM_RIGHTS) — set that up here.
+    let (parent_sock, child_sock) = UnixStream::pair().expect("socketpair");
+    let child_fd = child_sock.into_raw_fd();
+    unsafe {
+        let f = libc::fcntl(child_fd, libc::F_GETFD);
+        libc::fcntl(child_fd, libc::F_SETFD, f & !libc::FD_CLOEXEC);
+    }
+
+    let bin_path = env!("CARGO_BIN_EXE_skia_adapter_subprocess_helper");
+    let mut cmd = Command::new(bin_path);
+    cmd.arg("crash-mid-write")
+        .env("STREAMLIB_HELPER_SOCKET_FD", child_fd.to_string())
+        .env("STREAMLIB_HELPER_OBSERVE_FD", write_fd.to_string())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let request = serde_json::json!({
+        "width": 64u32,
+        "height": 64u32,
+        // Vulkan `Bgra8Unorm` is "memory: B,G,R,A". DRM_FORMAT_ARGB8888
+        // is the matching fourcc on a little-endian host — see
+        // `streamlib-adapter-opengl/tests/common.rs` for the full
+        // reasoning. Using ABGR8888 here would silently swap R↔B on
+        // every GL-side write because the EGL importer trusts the
+        // declared fourcc.
+        "drm_fourcc": DRM_FORMAT_ARGB8888,
+        "drm_format_modifier": modifier,
+        "plane_offset": plane[0].0,
+        "plane_stride": plane[0].1,
+    });
+    let request_bytes = serde_json::to_vec(&request).expect("serialize");
+    let parent_sock_for_hook = parent_sock;
+
+    // Bump the cleanup timeout vs. the OpenGL adapter's 3s budget.
+    // The Skia helper does noticeably more work in `crash-mid-write`
+    // (constructs `SkiaGlContext` via `MakeGL`, acquires a write
+    // guard, issues a Skia draw) before reaching the `abort()`. On a
+    // cold cache that startup can run several hundred ms — give the
+    // harness room without regressing on signal.
+    let outcome = SubprocessCrashHarness::new(cmd)
+        .with_timing(CrashTiming::AfterDelay(Duration::from_millis(400)))
+        .with_cleanup_timeout(Duration::from_secs(8))
+        .with_post_spawn(move |_child| {
+            streamlib_surface_client::send_message_with_fds(
+                &parent_sock_for_hook,
+                &request_bytes,
+                &[dma_buf_fd],
+            )?;
+            unsafe {
+                libc::close(child_fd);
+                libc::close(write_fd);
+                libc::close(dma_buf_fd);
+            }
+            Ok(())
+        })
+        .run(|| {
+            let mut buf = [0u8; 1];
+            let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, 1) };
+            if n == 0 {
+                Ok(())
+            } else {
+                Err("subprocess still has open write end")
+            }
+        })
+        .expect("crash harness ran");
+
+    unsafe {
+        libc::close(read_fd);
+    }
+
+    assert!(
+        outcome.cleanup_latency < Duration::from_secs(8),
+        "cleanup_latency {:?} exceeded budget",
+        outcome.cleanup_latency
     );
+    let exit_status = outcome.exit_status.expect("child waited");
+    assert!(
+        !exit_status.success(),
+        "subprocess SIGKILL'd by harness must NOT report success: {exit_status:?}"
+    );
+
+    // Keep the host texture live until after the harness asserts the
+    // child exited — the registered DMA-BUF FD has to remain valid
+    // while the subprocess is importing it.
+    drop(texture);
+    drop(gpu);
 }

--- a/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
@@ -34,6 +34,7 @@
 
 use std::os::fd::IntoRawFd;
 use std::os::unix::net::UnixStream;
+use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -173,10 +174,20 @@ fn subprocess_crash_mid_skia_write_observed_by_harness() {
         "cleanup_latency {:?} exceeded budget",
         outcome.cleanup_latency
     );
+    // Discriminate "actually got into the crash path" from "died at
+    // setup": helper's own `abort()` raises SIGABRT, the harness's
+    // watchdog SIGKILLs if the helper out-runs the AfterDelay window.
+    // Either is a signal-terminated exit (no exit code). A `die()` /
+    // `ExitCode(1)` from a setup-time failure (e.g. `EglRuntime::new`,
+    // `SkiaGlContext::new`, `register_host_surface`) returns
+    // `signal() == None`, which we want to fail-loud rather than
+    // silently green via a mere `!success()` check.
     let exit_status = outcome.exit_status.expect("child waited");
     assert!(
-        !exit_status.success(),
-        "subprocess SIGKILL'd by harness must NOT report success: {exit_status:?}"
+        exit_status.signal().is_some(),
+        "expected signal-terminated subprocess (SIGABRT from helper's \
+         own abort() or SIGKILL from harness watchdog); got {exit_status:?} \
+         which means setup failed before the crash path was reached"
     );
 
     // Keep the host texture live until after the harness asserts the

--- a/libs/streamlib-python/python/streamlib/adapters/skia.py
+++ b/libs/streamlib-python/python/streamlib/adapters/skia.py
@@ -3,30 +3,42 @@
 
 """Skia surface adapter — Python customer-facing API.
 
-Mirrors the Rust crate ``streamlib-adapter-skia`` (#513) by
-**composing on the Python ``vulkan`` adapter** (``streamlib.adapters.vulkan``)
-plus ``skia-python`` to wrap the underlying ``VkImage`` as a
-``skia.Surface`` (write) or ``skia.Image`` (read). The cdylib stays
-small — there is no ``slpn_skia_*`` FFI surface; every line of
-Vulkan handling routes through the existing ``slpn_vulkan_*`` symbols
-the ``vulkan`` adapter wires up.
+Mirrors the Rust crate ``streamlib_adapter_skia::SkiaGlContext`` (#576,
+#577) by composing on the Python ``opengl`` adapter
+(``streamlib.adapters.opengl``) plus ``skia-python`` to wrap the
+underlying ``GL_TEXTURE_2D`` as a ``skia.Surface`` (write) or
+``skia.Image`` (read).
 
-This is the canonical adapter-on-adapter composition shape, mirrored
-in Python: ``SkiaContext`` constrains its inner type to
-:class:`streamlib.adapters.vulkan.VulkanContext` (the public
-customer-facing handle, NOT the FFI runtime), so the Skia wrapper
-inherits every line of layout-transition + timeline-wait the host
-adapter does. The customer never sees ``GrVkImageInfo``,
-``VkImageLayout``, or any Vulkan handle — only ``skia.Surface``
-(write) and ``skia.Image`` (read) come out of the public API.
+The cdylib stays small — there is no ``slpn_skia_*`` FFI surface; every
+line of GPU work routes through the existing ``slpn_opengl_*`` symbols
+the ``opengl`` adapter wires up.
 
-Polyglot coverage: Python only. ``skia-python`` is the only
-maintained cross-language Skia binding for the runtimes streamlib
-supports — there is no Deno equivalent. The Deno wrapper for this
-adapter is deliberately deferred (same construction-language
-argument as the abandoned ``#481`` polyglot deferral); a Deno
-customer that needs Skia today should drive Skia themselves against
-:meth:`VulkanContext.raw_handles` until a Deno Skia binding emerges.
+Why GL, not Vulkan, in Python
+-----------------------------
+
+skia-python's pybind11 Vulkan binding is unimplemented: ``GrVkBackendContext``
+exposes only the no-arg constructor (no setters for ``fInstance`` /
+``fDevice`` / ``fQueue`` / ``fGetProc``), ``GrVkAlloc`` and
+``GrVkDrawableInfo`` are upstream stubs, and ``GrVkImageInfo``'s
+``fImage`` / ``fImageTiling`` / ``fImageLayout`` / ``fFormat`` are
+commented out. Verified against ``v144.0.post2`` and ``main`` on
+2026-04-29.
+
+The Rust binding (``skia-safe``) is fully functional on Vulkan, so the
+Rust adapter's ``MakeVulkan`` path is unaffected — this is purely a
+Python-side limitation. The host VkImage allocation, DRM modifier
+choice, DMA-BUF export, and host-side readback all stay Vulkan; the
+subprocess imports the DMA-BUF as a ``GL_TEXTURE_2D`` via EGL DMA-BUF
+import (already wired by ``streamlib-adapter-opengl``) and Skia is
+constructed via ``skia.GrDirectContext.MakeGL()`` on top of that GL
+context.
+
+Polyglot coverage: Python only. ``skia-python`` is the only maintained
+cross-language Skia binding for the runtimes streamlib supports —
+there is no Deno equivalent. A Deno customer that needs Skia today
+should drive Skia themselves against
+:meth:`streamlib.adapters.opengl.OpenGLContext.acquire_*` until a Deno
+Skia binding emerges.
 """
 
 from __future__ import annotations
@@ -35,15 +47,13 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Iterator, Optional, Protocol, runtime_checkable
 
-from streamlib.adapters.vulkan import (
-    VulkanContext,
-    VulkanImageInfo,
-    VulkanReadView,
-    VulkanWriteView,
+from streamlib.adapters.opengl import (
+    GL_TEXTURE_2D,
+    OpenGLContext,
 )
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
-    StreamlibSurface,
+    SurfaceFormat,
 )
 
 __all__ = [
@@ -55,23 +65,13 @@ __all__ = [
 ]
 
 
-# Vulkan format / image-tiling integer constants. Matches Vulkan spec
-# values; bindgen-generated `skia.VkFormat` / `skia.VkImageLayout`
-# enums use the same values, so callers can transmute via int.
-class _VkFormat:
-    UNDEFINED = 0
-    R8G8B8A8_UNORM = 37
-    R8G8B8A8_SRGB = 43
-    B8G8R8A8_UNORM = 44
-    B8G8R8A8_SRGB = 50
-    R16G16B16A16_SFLOAT = 97
-    R32G32B32A32_SFLOAT = 109
-
-
-class _VkImageTiling:
-    OPTIMAL = 0
-    LINEAR = 1
-    DRM_FORMAT_MODIFIER_EXT = 1000158000
+# OpenGL ``GL_RGBA8`` internal format. The OpenGL adapter imports
+# DMA-BUFs as ``GL_RGBA8``-typed ``GL_TEXTURE_2D``s regardless of
+# whether the host allocated BGRA8 or RGBA8; the byte order is then
+# disambiguated downstream by Skia's ``ColorType``. Mirrors the Rust GL
+# backend's ``gpu_gl::Format::RGBA8`` choice in
+# ``streamlib-adapter-skia/src/gl_adapter.rs``.
+_GL_RGBA8: int = 0x8058
 
 
 @dataclass(frozen=True)
@@ -79,13 +79,17 @@ class SkiaWriteView:
     """View handed back inside an ``acquire_write`` scope.
 
     ``surface`` is a live ``skia.Surface`` wrapping the host's
-    ``VkImage``. The customer draws into ``surface.canvas()``;
+    ``GL_TEXTURE_2D``. The customer draws into ``surface.getCanvas()``;
     on scope exit the wrapper flushes Skia's command stream and
-    releases the underlying Vulkan acquire (which signals the host's
-    timeline so the next consumer wakes up).
+    releases the underlying OpenGL acquire (which runs ``glFinish`` so
+    the next consumer sees the writes).
     """
 
-    surface: object  # skia.Surface — typed `object` so this module imports cleanly without skia-python
+    # ``object`` (rather than ``skia.Surface``) so this module imports
+    # cleanly even when ``skia-python`` is not installed — failures
+    # then surface at :class:`SkiaContext` construction time with a
+    # clear message.
+    surface: object
 
 
 @dataclass(frozen=True)
@@ -93,23 +97,19 @@ class SkiaReadView:
     """View handed back inside an ``acquire_read`` scope.
 
     ``image`` is a live ``skia.Image`` referencing the host's
-    ``VkImage``. The customer samples it; on scope exit the wrapper
-    drops the image and releases the underlying Vulkan acquire.
+    ``GL_TEXTURE_2D``. The customer samples it; on scope exit the
+    wrapper drops the image and releases the underlying OpenGL acquire.
     """
 
-    image: object  # skia.Image
+    image: object
 
 
 @runtime_checkable
 class SkiaContextProtocol(Protocol):
     """Customer-facing handle the subprocess runtime hands out.
 
-    Same shape as the Rust ``streamlib_adapter_skia::SkiaContext``:
-    scoped acquire/release returning a typed view. The trait
-    composition pitch from #509 / #511 — Skia composes on Vulkan via
-    the capability marker traits — translates to "uses
-    :class:`VulkanContext` internally" in Python, since runtime
-    checkability replaces the trait-bound machinery.
+    Same shape as the Rust ``streamlib_adapter_skia::SkiaGlContext``:
+    scoped acquire/release returning a typed view.
     """
 
     def acquire_read(self, surface): ...
@@ -118,360 +118,267 @@ class SkiaContextProtocol(Protocol):
 
 
 class SkiaContext:
-    """Subprocess-side Skia adapter runtime (#513).
+    """Subprocess-side Skia adapter runtime.
 
-    Composes on :class:`streamlib.adapters.vulkan.VulkanContext` —
-    every Vulkan operation (host surface registration, timeline-wait,
-    layout transitions) routes through the inner Vulkan adapter, and
-    Skia is the framework that wraps the resulting ``VkImage``.
+    Composes on :class:`streamlib.adapters.opengl.OpenGLContext` —
+    every GL operation (host surface registration, EGL/DMA-BUF import,
+    ``glFinish`` handoff) routes through the inner OpenGL adapter, and
+    Skia is the framework that wraps the resulting ``GL_TEXTURE_2D``.
 
-    Construct via :meth:`from_runtime`. Single :class:`SkiaContext`
-    per subprocess; :meth:`from_runtime` returns the cached instance
-    on repeat calls. The wrapper builds its ``GrDirectContext`` once
-    against the inner Vulkan device's raw handles; per-acquire
-    construction wraps the live ``VkImage`` as a Skia
-    ``BackendRenderTarget`` and flushes on scope exit.
+    Construct via :meth:`from_runtime`. Single :class:`SkiaContext` per
+    subprocess; :meth:`from_runtime` returns the cached instance on
+    repeat calls. The wrapper builds its ``GrDirectContext`` once
+    against the OpenGL adapter's EGL+GL stack via
+    ``skia.GrDirectContext.MakeGL()``; per-acquire construction wraps
+    the live ``GL_TEXTURE_2D`` as a Skia ``GrBackendTexture`` and
+    flushes on scope exit.
 
     Importing this module requires ``skia-python``. The import is
     deferred to first construction so that loading
-    ``streamlib.adapters`` doesn't pay the ``skia-python`` import
-    cost for customers that don't use Skia.
+    ``streamlib.adapters`` doesn't pay the ``skia-python`` import cost
+    for customers that don't use Skia.
     """
 
     _shared_instance: Optional["SkiaContext"] = None
 
-    def __init__(self, vulkan_ctx: VulkanContext) -> None:
+    def __init__(self, opengl_ctx: OpenGLContext) -> None:
         # Defer the skia-python import to construction so loading the
         # `streamlib.adapters` package doesn't drag skia-python in for
         # customers that don't use Skia. Failures (skia-python not
         # installed) surface here with a clear message instead of at
         # import time.
         try:
-            import skia  # noqa: F401  (used in helper methods below)
+            import skia  # noqa: F401
         except ImportError as e:
             raise RuntimeError(
-                "SkiaContext requires `skia-python` (>= m120 for Vulkan "
-                "backend support). Install via `pip install skia-python`."
+                "SkiaContext requires `skia-python` (>=120). "
+                "Install via `pip install skia-python`."
             ) from e
-        self._skia = skia  # cache the module
-        self._vulkan = vulkan_ctx
-        self._direct_context = self._build_direct_context(vulkan_ctx)
-        # Cache `VulkanImageInfo` per surface — fixed per registration,
-        # avoid re-fetching on every acquire.
-        self._image_info_cache: dict[str, VulkanImageInfo] = {}
+        self._skia = skia
+        self._opengl = opengl_ctx
+        # ``GrDirectContext`` build is deferred to first acquire — see
+        # :meth:`_ensure_direct_context`.
+        self._direct_context = None
 
     @classmethod
     def from_runtime(cls, runtime_context) -> "SkiaContext":
         """Build (or fetch the cached) :class:`SkiaContext` for this
-        subprocess. The inner :class:`VulkanContext` is fetched via
-        its own :meth:`VulkanContext.from_runtime` — a single
-        ``VulkanContext`` is shared between this Skia adapter and any
-        other Vulkan-using adapter the same subprocess hosts.
+        subprocess. The inner :class:`OpenGLContext` is fetched via its
+        own :meth:`OpenGLContext.from_runtime` — a single
+        ``OpenGLContext`` is shared between this Skia adapter and any
+        other GL-using adapter the same subprocess hosts.
         """
         if cls._shared_instance is None:
-            vulkan_ctx = VulkanContext.from_runtime(runtime_context)
-            cls._shared_instance = cls(vulkan_ctx)
+            opengl_ctx = OpenGLContext.from_runtime(runtime_context)
+            cls._shared_instance = cls(opengl_ctx)
         return cls._shared_instance
 
-    def _build_direct_context(self, vulkan_ctx: VulkanContext):
-        """Build a ``skia.GrDirectContext`` from the inner Vulkan
-        device's raw handles. Invoked once at construction; the
-        resulting context is shared across every acquire.
+    def _ensure_direct_context(self):
+        """Build (lazily, on first acquire) a ``skia.GrDirectContext``
+        via ``skia.GrDirectContext.MakeGL(GrGLInterface.MakeEGL())``.
 
-        Skia's Vulkan backend needs a ``GetProc`` callback to resolve
-        Vulkan function pointers; we reuse the streamlib-loaded
-        ``libvulkan.so.1`` via ``ctypes`` and forward calls into
-        ``vkGetInstanceProcAddr`` / ``vkGetDeviceProcAddr``.
+        Two pieces of indirection are load-bearing here:
+
+        1. **EGL-specific interface.** ``MakeGL()`` with no args calls
+           ``GrGLMakeNativeInterface()``, which on Linux falls through
+           to GLX, NOT EGL. Subprocess GL is brought up against EGL
+           (the OpenGL adapter uses ``EGL_EXT_image_dma_buf_import``),
+           so we must hand Skia an interface explicitly resolved from
+           ``eglGetProcAddress``. ``GrGLInterface.MakeEGL()`` does
+           that. Mirror of the Rust GL backend's
+           ``Interface::new_load_with(|sym| egl.get_proc_address(sym))``
+           in ``streamlib-adapter-skia/src/gl_adapter.rs``.
+        2. **Lazy build.** The cdylib's ``slpn_opengl_runtime_new``
+           brings the EGL context up but only makes it current on
+           the calling thread between ``slpn_opengl_acquire_*`` and
+           ``slpn_opengl_release_*``. ``MakeEGL`` works regardless of
+           current-state (it asks the EGL impl directly), but we still
+           defer the build to inside the first acquire to keep all
+           Skia work on a thread where the adapter's EGL context is
+           current — that's where every subsequent ``MakeFromBackend*``
+           and ``flushAndSubmit`` runs.
+
+        Once built, the DirectContext is cached for the lifetime of
+        the :class:`SkiaContext` (Skia copies the resolved proc table
+        into its own command buffer, so the context is reusable
+        across future acquires of the same subprocess EGL stack).
         """
+        if self._direct_context is not None:
+            return self._direct_context
         skia = self._skia
-        handles = vulkan_ctx.raw_handles()
-
-        # Build GrVkBackendContext — populate fields directly since
-        # skia-python's `GrVkBackendContext()` ctor takes no args.
-        backend_ctx = skia.GrVkBackendContext()
-        backend_ctx.fInstance = handles.vk_instance
-        backend_ctx.fPhysicalDevice = handles.vk_physical_device
-        backend_ctx.fDevice = handles.vk_device
-        backend_ctx.fQueue = handles.vk_queue
-        backend_ctx.fGraphicsQueueIndex = handles.vk_queue_family_index
-        # Skia accepts `fMaxAPIVersion = 0` as "use whatever the
-        # device supports"; setting it explicitly to the device's
-        # version avoids subtle init-time fallbacks.
-        backend_ctx.fMaxAPIVersion = handles.api_version
-        backend_ctx.fGetProc = self._make_skia_get_proc()
-
-        ctx = skia.GrDirectContext.MakeVulkan(backend_ctx)
+        interface = skia.GrGLInterface.MakeEGL()
+        if interface is None:
+            raise RuntimeError(
+                "SkiaContext: skia.GrGLInterface.MakeEGL() returned None — "
+                "Skia could not resolve GL function pointers via "
+                "eglGetProcAddress. Verify skia-python was built with "
+                "EGL support and that libEGL.so.1 is loadable."
+            )
+        ctx = skia.GrDirectContext.MakeGL(interface)
         if ctx is None:
             raise RuntimeError(
-                "SkiaContext: skia.GrDirectContext.MakeVulkan returned None — "
-                "Skia could not bring up a Vulkan backend against the "
-                "subprocess's VkDevice. Verify skia-python was built with "
-                "Vulkan support (m120+) and that the device exposes the "
-                "extensions Skia requires (sync2, dynamic-rendering, "
-                "sampler-ycbcr-conversion are enabled by streamlib's "
-                "ConsumerVulkanDevice)."
+                "SkiaContext: skia.GrDirectContext.MakeGL(MakeEGL()) returned "
+                "None — Skia could not bring up a GL backend against the "
+                "subprocess's EGL context. Verify the OpenGL adapter's EGL "
+                "context is current at this point (this method is called "
+                "inside an `OpenGLContext.acquire_*` scope, which is "
+                "supposed to make EGL current)."
             )
+        self._direct_context = ctx
         return ctx
 
-    def _make_skia_get_proc(self):
-        """Build the ``GetProc`` callback skia-python uses to resolve
-        Vulkan function pointers.
-
-        Loaded once per :class:`SkiaContext`. Skia copies the resolved
-        procs into its own command tables during ``MakeVulkan`` so the
-        callback only needs to be live across that single call.
-        """
-        import ctypes
-
-        # Open libvulkan and grab vkGetInstanceProcAddr.
-        libvulkan = ctypes.CDLL("libvulkan.so.1", mode=ctypes.RTLD_GLOBAL)
-        get_instance_proc_addr = libvulkan.vkGetInstanceProcAddr
-        get_instance_proc_addr.restype = ctypes.c_void_p
-        get_instance_proc_addr.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-
-        # vkGetDeviceProcAddr is itself fetched via vkGetInstanceProcAddr —
-        # we resolve once at setup so the per-call closure stays cheap.
-        vk_dev_proc_name = b"vkGetDeviceProcAddr"
-        # We need an instance to resolve get_device_proc_addr. Use the
-        # Vulkan adapter's instance.
-        handles = self._vulkan.raw_handles()
-        vk_instance = ctypes.c_void_p(handles.vk_instance)
-        get_device_proc_addr_addr = get_instance_proc_addr(
-            vk_instance, vk_dev_proc_name
-        )
-        if not get_device_proc_addr_addr:
-            raise RuntimeError(
-                "SkiaContext: vkGetInstanceProcAddr could not resolve "
-                "vkGetDeviceProcAddr on the active VkInstance"
-            )
-        # Cast the address to the right callable shape.
-        get_device_proc_addr = ctypes.CFUNCTYPE(
-            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p
-        )(get_device_proc_addr_addr)
-
-        def get_proc(name: str, instance, device) -> int:
-            """Resolve a Vulkan proc address.
-
-            skia-python invokes this with ``(name, instance, device)``
-            where exactly one of ``instance`` / ``device`` is non-zero.
-            Returns the function pointer as an integer (skia-python
-            treats it as ``intptr_t``).
-            """
-            name_bytes = name.encode("ascii") if isinstance(name, str) else name
-            if device:
-                addr = get_device_proc_addr(
-                    ctypes.c_void_p(int(device)), name_bytes
-                )
-            else:
-                addr = get_instance_proc_addr(
-                    ctypes.c_void_p(int(instance)) if instance else None,
-                    name_bytes,
-                )
-            return int(addr) if addr else 0
-
-        return get_proc
-
     @staticmethod
-    def _surface_pool_id(surface) -> str:
-        if isinstance(surface, str):
-            return surface
-        sid = getattr(surface, "id", None)
-        if sid is None:
-            raise TypeError(
-                f"SkiaContext: expected StreamlibSurface or str pool_id, got {surface!r}"
-            )
-        return str(sid)
+    def _color_type(skia, surface_format: int):
+        """Map a :class:`SurfaceFormat` to a Skia ``ColorType``.
 
-    def _vk_image_info(self, surface) -> VulkanImageInfo:
-        pool_id = self._surface_pool_id(surface)
-        cached = self._image_info_cache.get(pool_id)
-        if cached is not None:
-            return cached
-        info = self._vulkan.image_info(surface)
-        self._image_info_cache[pool_id] = info
-        return info
-
-    def _build_skia_vk_image_info(
-        self, vk_image: int, vk_image_layout: int, info: VulkanImageInfo
-    ):
-        """Translate a per-acquire ``VulkanWriteView`` / ``VulkanReadView``
-        + the surface's static :class:`VulkanImageInfo` into a
-        ``skia.GrVkImageInfo`` populated for ``GrBackendRenderTarget``.
+        Mirrors ``surface_format_to_color_type`` in the Rust GL backend
+        (``gl_adapter.rs``): both BGRA8 and RGBA8 surfaces ride a
+        ``GL_RGBA8`` storage format internally; the ``ColorType`` is
+        what tells Skia how to interpret the bytes.
         """
-        skia = self._skia
-
-        alloc = skia.GrVkAlloc()
-        alloc.fMemory = info.memory_handle
-        alloc.fOffset = info.memory_offset
-        alloc.fSize = info.memory_size
-        alloc.fFlags = 0  # NONE — Skia treats borrowed memory as opaque
-
-        vk_info = skia.GrVkImageInfo()
-        vk_info.fImage = vk_image
-        vk_info.fAlloc = alloc
-        # Skia's render-target paths reject `DRM_FORMAT_MODIFIER_EXT`;
-        # the host always allocates with OPTIMAL or
-        # `DRM_FORMAT_MODIFIER_EXT` (for cross-process tiled DMA-BUF).
-        # Tiled-modifier images behave like OPTIMAL for the GPU
-        # commands Skia issues, so we report OPTIMAL to keep Skia
-        # happy. Pure LINEAR (sampler-only on NVIDIA) is preserved.
-        if info.tiling == _VkImageTiling.DRM_FORMAT_MODIFIER_EXT:
-            vk_info.fImageTiling = _VkImageTiling.OPTIMAL
-        else:
-            vk_info.fImageTiling = info.tiling
-        vk_info.fImageLayout = vk_image_layout
-        vk_info.fFormat = info.format
-        vk_info.fImageUsageFlags = info.usage_flags
-        vk_info.fSampleCount = info.sample_count
-        vk_info.fLevelCount = info.level_count
-        vk_info.fCurrentQueueFamily = info.queue_family
-        vk_info.fProtected = bool(info.protected)
-        return vk_info
-
-    @staticmethod
-    def _color_type_for_vk_format(skia, vk_format: int):
-        if vk_format in (_VkFormat.B8G8R8A8_UNORM, _VkFormat.B8G8R8A8_SRGB):
-            return skia.kBGRA_8888_ColorType
-        if vk_format in (_VkFormat.R8G8B8A8_UNORM, _VkFormat.R8G8B8A8_SRGB):
-            return skia.kRGBA_8888_ColorType
-        if vk_format == _VkFormat.R16G16B16A16_SFLOAT:
-            return skia.kRGBA_F16_ColorType
-        if vk_format == _VkFormat.R32G32B32A32_SFLOAT:
-            return skia.kRGBA_F32_ColorType
+        if surface_format == SurfaceFormat.BGRA8:
+            return skia.ColorType.kBGRA_8888_ColorType
+        if surface_format == SurfaceFormat.RGBA8:
+            return skia.ColorType.kRGBA_8888_ColorType
         raise RuntimeError(
-            f"SkiaContext: unsupported vk::Format {vk_format} — Skia adapter "
-            "currently maps BGRA8/RGBA8/RGBAF16/RGBAF32 only"
+            f"SkiaContext: unsupported SurfaceFormat {surface_format} — "
+            "Skia GL backend supports BGRA8 / RGBA8 only"
         )
+
+    @staticmethod
+    def _surface_format(surface) -> int:
+        if isinstance(surface, str):
+            raise TypeError(
+                "SkiaContext: bare pool_id strings are not enough to "
+                "construct a Skia view; pass a StreamlibSurface "
+                "(carries format / width / height)."
+            )
+        fmt = getattr(surface, "format", None)
+        if fmt is None:
+            raise TypeError(
+                "SkiaContext: surface must carry a `format` field "
+                f"(StreamlibSurface or compatible), got {surface!r}"
+            )
+        return int(fmt)
 
     @staticmethod
     def _surface_dims(surface) -> tuple[int, int]:
-        if isinstance(surface, StreamlibSurface):
-            return int(surface.width), int(surface.height)
-        # Fall back to attribute access for duck-typed surface descriptors.
         w = getattr(surface, "width", None)
         h = getattr(surface, "height", None)
         if w is None or h is None:
             raise TypeError(
-                "SkiaContext: surface must carry width/height (StreamlibSurface "
-                f"or compatible), got {surface!r}"
+                "SkiaContext: surface must carry width/height "
+                f"(StreamlibSurface or compatible), got {surface!r}"
             )
         return int(w), int(h)
+
+    def _build_backend_texture(
+        self, gl_texture_id: int, width: int, height: int
+    ):
+        """Build a Skia ``GrBackendTexture`` wrapping the OpenGL
+        adapter's imported ``GL_TEXTURE_2D``.
+
+        Internal format is ``GL_RGBA8`` regardless of host BGRA8/RGBA8
+        (the EGL DMA-BUF importer treats the underlying memory as
+        ``GL_RGBA8``); channel order is disambiguated by ``ColorType``,
+        not the GL internal format. Matches the Rust GL backend's
+        ``build_backend_texture`` shape.
+        """
+        skia = self._skia
+        gl_info = skia.GrGLTextureInfo(GL_TEXTURE_2D, gl_texture_id, _GL_RGBA8)
+        return skia.GrBackendTexture(
+            width, height, skia.GrMipmapped.kNo, gl_info
+        )
 
     @contextmanager
     def acquire_write(self, surface) -> Iterator[SkiaWriteView]:
         """Acquire write access. Yields a :class:`SkiaWriteView` whose
         ``surface`` is a live ``skia.Surface`` wrapping the host's
-        ``VkImage``. The customer draws into ``surface.canvas()``;
-        on scope exit the wrapper:
+        ``GL_TEXTURE_2D``. The customer draws into
+        ``surface.getCanvas()``; on scope exit the wrapper:
 
-        1. Calls ``surface.flushAndSubmit(syncCpu=True)`` to drain
-           Skia's GPU work.
-        2. Drops the Skia ``Surface`` so its DirectContext refcount
+        1. Calls ``surface.flushAndSubmit()`` to drain Skia's command
+           stream into GL.
+        2. Drops the Skia ``Surface`` so its ``DirectContext`` refcount
            is released.
-        3. Exits the inner ``VulkanContext.acquire_write`` scope,
-           which signals the host's timeline so the next consumer
-           wakes up.
+        3. Exits the inner :meth:`OpenGLContext.acquire_write` scope,
+           which runs ``glFinish`` so the next consumer sees the
+           writes through the underlying DMA-BUF.
         """
         skia = self._skia
-        info = self._vk_image_info(surface)
+        fmt = self._surface_format(surface)
         width, height = self._surface_dims(surface)
-        color_type = self._color_type_for_vk_format(skia, info.format)
-        with self._vulkan.acquire_write(surface) as vk_view:
-            sk_surface = self._wrap_as_skia_surface(
-                vk_view, info, width, height, color_type
+        color_type = self._color_type(skia, fmt)
+        with self._opengl.acquire_write(surface) as gl_view:
+            direct_context = self._ensure_direct_context()
+            backend_texture = self._build_backend_texture(
+                gl_view.gl_texture_id, width, height
             )
+            sk_surface = skia.Surface.MakeFromBackendTexture(
+                direct_context,
+                backend_texture,
+                skia.GrSurfaceOrigin.kTopLeft_GrSurfaceOrigin,
+                0,  # sample_count
+                color_type,
+                None,  # color_space
+                None,  # surface_props
+            )
+            if sk_surface is None:
+                raise RuntimeError(
+                    "SkiaContext.acquire_write: "
+                    "skia.Surface.MakeFromBackendTexture returned None for "
+                    f"surface (gl_texture={gl_view.gl_texture_id}, "
+                    f"format={fmt}, size={width}x{height}). Common causes: "
+                    "missing render-target capability on the imported GL "
+                    "texture; format/color-type mismatch; or Skia's "
+                    "GrGLCaps doesn't list RGBA8 as renderable on this "
+                    "driver."
+                )
             try:
                 yield SkiaWriteView(surface=sk_surface)
             finally:
-                # SyncCpu::Yes — block until the GPU has executed all
-                # of Skia's command submissions. Without this, the
-                # vulkan release below host-signals the timeline
-                # before the GPU is done, racing the next consumer.
-                sk_surface.flushAndSubmit(syncCpu=True)
-                # Releasing the Surface refcount decrements the
-                # DirectContext's pinning. The vulkan release in the
-                # outer `with` then runs and signals the timeline.
+                # Drain Skia's command stream into GL before the inner
+                # OpenGL release runs `glFinish`. Without this, the
+                # OpenGL release might signal the timeline before
+                # Skia's commands have made it into the GL queue.
+                sk_surface.flushAndSubmit()
+                # Drop the Surface refcount so the DirectContext is
+                # not pinned across the inner release.
                 del sk_surface
 
     @contextmanager
     def acquire_read(self, surface) -> Iterator[SkiaReadView]:
         """Acquire read access. Yields a :class:`SkiaReadView` whose
         ``image`` is a live ``skia.Image`` referencing the host's
-        ``VkImage``. Read-only — no flush needed on scope exit.
+        ``GL_TEXTURE_2D``. Read-only — no flush needed on scope exit.
         """
         skia = self._skia
-        info = self._vk_image_info(surface)
+        fmt = self._surface_format(surface)
         width, height = self._surface_dims(surface)
-        color_type = self._color_type_for_vk_format(skia, info.format)
-        with self._vulkan.acquire_read(surface) as vk_view:
-            sk_image = self._wrap_as_skia_image(
-                vk_view, info, width, height, color_type
+        color_type = self._color_type(skia, fmt)
+        with self._opengl.acquire_read(surface) as gl_view:
+            direct_context = self._ensure_direct_context()
+            backend_texture = self._build_backend_texture(
+                gl_view.gl_texture_id, width, height
             )
+            sk_image = skia.Image.MakeFromTexture(
+                direct_context,
+                backend_texture,
+                skia.GrSurfaceOrigin.kTopLeft_GrSurfaceOrigin,
+                color_type,
+                # `kOpaque_AlphaType` mirrors the Rust GL backend's
+                # `AlphaType::Opaque` choice in `gl_adapter.rs`.
+                skia.AlphaType.kOpaque_AlphaType,
+                None,  # color_space
+            )
+            if sk_image is None:
+                raise RuntimeError(
+                    "SkiaContext.acquire_read: skia.Image.MakeFromTexture "
+                    f"returned None for surface "
+                    f"(gl_texture={gl_view.gl_texture_id}, format={fmt}, "
+                    f"size={width}x{height})"
+                )
             try:
                 yield SkiaReadView(image=sk_image)
             finally:
                 del sk_image
-
-    def _wrap_as_skia_surface(
-        self,
-        vk_view: VulkanWriteView,
-        info: VulkanImageInfo,
-        width: int,
-        height: int,
-        color_type,
-    ):
-        """Build a ``skia.Surface`` from a write-acquired ``VkImage``."""
-        skia = self._skia
-        vk_info = self._build_skia_vk_image_info(
-            vk_view.vk_image, vk_view.vk_image_layout, info
-        )
-        backend_render_target = skia.GrBackendRenderTarget(
-            width, height, vk_info
-        )
-        sk_surface = skia.Surface.MakeFromBackendRenderTarget(
-            self._direct_context,
-            backend_render_target,
-            skia.kTopLeft_GrSurfaceOrigin,
-            color_type,
-            None,  # color_space
-            None,  # surface_props
-        )
-        if sk_surface is None:
-            raise RuntimeError(
-                f"SkiaContext.acquire_write: skia.Surface.MakeFromBackendRenderTarget "
-                f"returned None for surface (vk_image=0x{vk_view.vk_image:x}, "
-                f"format={info.format}, usage_flags=0x{info.usage_flags:x}). "
-                "Common causes: missing VK_IMAGE_USAGE_TRANSFER_DST_BIT on the "
-                "host VkImage allocation; format / color-type mismatch; or "
-                "Skia's GrVkCaps doesn't list the format as renderable."
-            )
-        return sk_surface
-
-    def _wrap_as_skia_image(
-        self,
-        vk_view: VulkanReadView,
-        info: VulkanImageInfo,
-        width: int,
-        height: int,
-        color_type,
-    ):
-        """Build a ``skia.Image`` from a read-acquired ``VkImage``."""
-        skia = self._skia
-        vk_info = self._build_skia_vk_image_info(
-            vk_view.vk_image, vk_view.vk_image_layout, info
-        )
-        backend_texture = skia.GrBackendTexture(width, height, vk_info)
-        sk_image = skia.Image.MakeFromTexture(
-            self._direct_context,
-            backend_texture,
-            skia.kTopLeft_GrSurfaceOrigin,
-            color_type,
-            skia.kPremul_AlphaType,
-            None,  # color_space
-        )
-        if sk_image is None:
-            raise RuntimeError(
-                f"SkiaContext.acquire_read: skia.Image.MakeFromTexture returned "
-                f"None for surface (vk_image=0x{vk_view.vk_image:x})"
-            )
-        return sk_image


### PR DESCRIPTION
## Summary

- Rewires `libs/streamlib-python/python/streamlib/adapters/skia.py` from composing on the broken Vulkan-shape skia-python wrapper (#513 v1) onto the OpenGL adapter via `skia.GrDirectContext.MakeGL(skia.GrGLInterface.MakeEGL())`. Construction is deferred to first acquire so the inner OpenGL adapter has made EGL current on the calling thread.
- Lands the Skia-specific `subprocess_crash_mid_write` test (`SubprocessCrashHarness` against a new in-crate `tests/bin/skia_adapter_subprocess_helper.rs`, mirror of the OpenGL adapter's pattern). The helper drives a Skia GL draw, then `abort()`s with the write guard live; the host verifies cleanup latency and non-zero exit.
- Fixes the polyglot-skia-canvas example which was broken at processor `setup()` for two reasons: `StreamlibSurface(...)` is a `typing.Protocol` (not constructible), and `SurfaceFormat.Bgra8` is the wrong casing (the Python enum uses `BGRA8`). Replaced with an inline `_SurfaceDescriptor` dataclass.

## Closes

Closes #577

## Exit criteria (from issue body)

- [x] `skia.py` rewritten to compose on `streamlib.adapters.opengl` and bring up Skia via `GrDirectContext.MakeGL(...)`. Customer-facing API surface (`SkiaContext`, `acquire_read` / `acquire_write`, the `surface` / `image` view fields) stays unchanged.
- [x] `examples/polyglot-skia-canvas` runs end-to-end on the Linux runner: BgraFileSource → Python skia processor (skia-python installed, drawing into the host VkImage) → host PNG via Vulkan readback. PNG content matches the expected drawing within antialiasing tolerance.
- [x] `streamlib_adapter_skia::tests::subprocess_crash_mid_write` replaces the placeholder with a real `SubprocessCrashHarness` test that drives a Skia draw and crashes the subprocess with the write guard live. Independent of the Python bridge — exercises the Rust adapter against `HostVulkanDevice`.

## Why GL, not Vulkan, on the Python side

skia-python's pybind11 Vulkan binding is unimplemented (verified against `v144.0.post2` and `main` on 2026-04-29):
- `GrVkBackendContext` exposes only the no-arg constructor — no setters for `fInstance` / `fDevice` / `fQueue` / `fGetProc`.
- `GrVkAlloc`, `GrVkDrawableInfo` are upstream stubs.
- `GrVkImageInfo`'s `fImage` / `fImageTiling` / `fImageLayout` / `fFormat` are commented out.

The Rust binding (`skia-safe`) is fully functional on Vulkan, so `streamlib_adapter_skia::SkiaContext` (Vulkan-backed) is unaffected. This PR pivots only the Python wrapper, which now composes on `SkiaGlContext`'s subprocess equivalent.

## Visual evidence

### Static frame (single-shot canvas — exit-criterion gate)

![polyglot-skia-canvas single-shot output](https://gh-artifact.tatolab.com/pr-580/skia-canvas-577.png)

*256×256 PNG produced by `cargo run -p polyglot-skia-canvas-scenario -- --output=/tmp/skia-canvas-py.png`. Full path: BgraFileSource → Python skia processor (`skia.GrDirectContext.MakeGL(GrGLInterface.MakeEGL())` against the subprocess's EGL+GL stack) → host `vkCmdCopyImageToBuffer` from the same DMA-BUF the Python side rendered into → PNG. The committed scenario draws the canonical "red antialiased disc on solid blue" — exit-criterion #2 from the issue body.*

### Animated stress (1800 frames @ 60 fps × 30 s — Python-side port of `skia_animated_stress_gl`)

[**▶ skia-canvas-577.mp4**](https://gh-artifact.tatolab.com/pr-580/skia-canvas-577.mp4) — 4.5 MB H.264 / 29.6 s / 60 fps / 512×512. Hero frame at t=15 s:

![Skia animated stress hero frame at t=15s — pulsing cyan stroked ring, 16-spoke starburst at center, 5 hue-cycling alpha-blended Lissajous balls scattered across, traveling sine wave at the bottom, hue-cycled rainbow tile strip](https://gh-artifact.tatolab.com/pr-580/skia-canvas-577-hero.png)

*Stress run captured by porting `streamlib-adapter-skia/tests/skia_animated_stress_gl.rs::draw_animated_frame` into Python (skia-python, same scene: HSL gradient bg + pulsing cyan ring + 5 hue-cycling Lissajous balls + 16-spoke starburst + traveling sine wave + hue-cycling tile strip), running 1775 / 1800 frames through the polyglot pipeline with the wrapper this PR ships, snapshotting Skia's surface per frame via `makeRasterImage().encodeToData()`, and encoding via `/usr/bin/ffmpeg -c:v libx264 -crf 20 -preset veryfast`. Same scene as #579's Rust-side stress test; the video demonstrates the **Python wrapper** holds up under sustained 60 fps load (~25 draw calls/frame, 30 s) with no leaks, no make-current hangs, no degraded EGL/GL state across iterations. The temporary multi-frame harness is not committed — the PR's example stays single-shot per #577's exit criteria.*

## Test plan

- [x] `cargo check --workspace --all-targets` — clean (only pre-existing warnings).
- [x] `cargo xtask check-boundaries` — clean (1875 files scanned, no violations).
- [x] `cargo test -p streamlib-adapter-skia -p streamlib-adapter-opengl` — all green, including `subprocess_crash_mid_skia_write_observed_by_harness`.
- [x] `cargo run -p polyglot-skia-canvas-scenario -- --output=/tmp/skia-canvas-py-577.png` — successful end-to-end run; PNG read with the Read tool shows an antialiased red disc on a solid blue background, matching what `skia_canvas.py` draws via `canvas.drawCircle`.
- [x] Python SDK tests pass: `pytest streamlib/tests/test_surface_adapter.py streamlib/tests/test_adapters_opengl.py` (17/17).
- [x] `nm -D target/debug/libstreamlib_python_native.so | grep slpn_opengl_` confirms all `slpn_opengl_*` symbols are wired; `slpn_vulkan_get_image_info` preserved per the issue's AI Agent Notes; no `slpn_skia_*` symbols added.
- [x] Skia wrapper imports cleanly without `skia-python` installed (the import is deferred to `SkiaContext.__init__`).

## Polyglot coverage

- **Runtimes affected**: rust, python
- **Schema regenerated**: n/a (no escalate IPC change)
- **Python and Deno both covered?** Python only by construction. `skia-python` is the only maintained cross-language Skia binding for the runtimes streamlib supports — there is no Deno equivalent. Same construction-language argument as the abandoned #481 polyglot deferral. Documented in the wrapper module docstring.
- **E2E tests run**:
  - [x] Host-Rust: `subprocess_crash_mid_skia_write_observed_by_harness` (host fixture + helper subprocess + harness)
  - [x] Python subprocess: `polyglot-skia-canvas-scenario` (BgraFileSource → Python skia processor → Vulkan readback → PNG)
  - [ ] Deno subprocess: n/a — no Deno Skia binding exists
- **FD-passing path**: DMA-BUF FD (host pre-allocates render-target VkImage; subprocess imports as `GL_TEXTURE_2D` via EGL)

## Follow-ups

- #581 — promote the inline `_SurfaceDescriptor` dataclass in `examples/polyglot-skia-canvas/python/skia_canvas.py` to a public concrete `SurfaceDescriptor` in `streamlib.surface_adapter`. Filed in this milestone; blocks #515 (processor-port refactor will hit the same need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


