### PR TITLE
feat(python): concrete StreamlibSurface dataclass (#581)

### DIFF
--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -111,8 +111,6 @@ def _hsl_to_color4f(h: float, s: float, l: float):
     import skia
 
     h = h % 360.0
-    if h < 0.0:
-        h += 360.0
     c = (1.0 - abs(2.0 * l - 1.0)) * s
     x = c * (1.0 - abs((h / 60.0) % 2.0 - 1.0))
     m = l - c / 2.0

--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -4,18 +4,25 @@
 """Polyglot Skia canvas processor — Python.
 
 End-to-end gate for the subprocess :class:`SkiaContext` runtime
-(#577). The host pre-allocates a render-target-capable DMA-BUF
-surface AND an exportable timeline semaphore, registers both with
-surface-share, and installs no bridge (Skia composes on the OpenGL
-adapter, which doesn't need one). This processor receives a trigger
-``Videoframe``, opens the host surface through
-``SkiaContext.acquire_write`` (which under the hood opens
-``OpenGLContext.acquire_write``, imports the DMA-BUF as a
-``GL_TEXTURE_2D`` via EGL, builds a Skia ``GrBackendTexture``, and
-yields a ``skia.Surface``), draws a known shape (red disc on blue
-background), and releases — Skia's flush+submit drains the GPU and
-the inner OpenGL adapter runs ``glFinish`` so the host's pre-stop
-readback sees the drawing.
+(#577 / #581). Mirrors the in-process Rust stress test
+``libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs``: the
+host pre-allocates a render-target-capable DMA-BUF surface AND an
+exportable timeline semaphore, registers both with surface-share, and
+spawns this Python processor. On every trigger frame the processor
+opens the host surface through ``SkiaContext.acquire_write`` (which
+under the hood opens ``OpenGLContext.acquire_write``, imports the
+DMA-BUF as a ``GL_TEXTURE_2D`` via EGL, builds a Skia
+``GrBackendTexture``, and yields a ``skia.Surface``), draws the
+animated scene at frame index ``frame_count``, and releases — Skia's
+flush+submit drains the GPU and the inner OpenGL adapter runs
+``glFinish`` so the host's per-frame readback sees the drawing.
+
+The animated scene matches the Rust stress test field-for-field
+(HSL-modulated linear gradient background + animated stroked ring +
+five orbiting discs + spinning spoke wheel + sine curve at the
+baseline + color strip), so the produced MP4 + hero PNG should be
+visually indistinguishable from the in-process Rust stress run on the
+same surface size.
 
 Config keys:
     skia_surface_uuid (str, required)
@@ -23,10 +30,14 @@ Config keys:
         + timeline semaphore under.
     width / height (int, required)
         Surface dimensions.
+    fps (int, optional, default 60)
+        Frame rate. ``t = frame_count / fps`` is the animation clock
+        passed into the draw routine.
 """
 
 from __future__ import annotations
 
+import math
 from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
@@ -40,8 +51,9 @@ class SkiaCanvasProcessor:
         self._uuid = str(cfg["skia_surface_uuid"])
         self._width = int(cfg["width"])
         self._height = int(cfg["height"])
+        self._fps = int(cfg.get("fps", 60))
         self._skia_ctx = SkiaContext.from_runtime(ctx)
-        self._drawn = False
+        self._frame_count = 0
         self._error: Optional[str] = None
         self._surface = StreamlibSurface(
             id=self._uuid,
@@ -52,7 +64,7 @@ class SkiaCanvasProcessor:
         )
         print(
             f"[SkiaCanvas/py] setup uuid={self._uuid} "
-            f"size={self._width}x{self._height}",
+            f"size={self._width}x{self._height}@{self._fps}fps",
             flush=True,
         )
 
@@ -60,40 +72,167 @@ class SkiaCanvasProcessor:
         frame = ctx.inputs.read("video_in")
         if frame is None:
             return
-        if self._drawn:
-            return
         try:
-            self._draw_once()
-            self._drawn = True
-            print(
-                f"[SkiaCanvas/py] Skia canvas drawn into surface '{self._uuid}'",
-                flush=True,
-            )
+            t = self._frame_count / float(self._fps)
+            self._draw(t)
+            self._frame_count += 1
+            if self._frame_count % 120 == 0:
+                print(
+                    f"[SkiaCanvas/py] drew frame {self._frame_count} (t={t:.2f}s)",
+                    flush=True,
+                )
         except Exception as e:
             self._error = str(e)
-            print(
-                f"[SkiaCanvas/py] draw failed: {e}", flush=True,
-            )
+            print(f"[SkiaCanvas/py] draw failed at frame {self._frame_count}: {e}",
+                  flush=True)
 
-    def _draw_once(self) -> None:
-        import skia
-
+    def _draw(self, t: float) -> None:
         with self._skia_ctx.acquire_write(self._surface) as guard:
             sk_surface = guard.surface
             canvas = sk_surface.getCanvas()
-            # Background — solid blue.
-            canvas.clear(skia.ColorBLUE)
-            # Foreground — bright red disc, antialiased, centered.
-            paint = skia.Paint()
-            paint.setColor(skia.ColorRED)
-            paint.setAntiAlias(True)
-            cx = self._width / 2.0
-            cy = self._height / 2.0
-            radius = min(self._width, self._height) * 0.35
-            canvas.drawCircle(cx, cy, radius, paint)
+            _draw_animated_frame(canvas, t, self._width, self._height)
 
     def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print(
-            f"[SkiaCanvas/py] teardown drawn={self._drawn} error={self._error}",
+            f"[SkiaCanvas/py] teardown drew={self._frame_count} error={self._error}",
             flush=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Animated draw — port of `draw_animated_frame` in
+# `libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs`.
+# Field-for-field; tweaks only where skia-python's API requires it.
+# ---------------------------------------------------------------------------
+
+
+def _hsl_to_color4f(h: float, s: float, l: float):
+    """Mirror of the Rust `hsl` helper. Returns a `skia.Color4f`."""
+    import skia
+
+    h = h % 360.0
+    if h < 0.0:
+        h += 360.0
+    c = (1.0 - abs(2.0 * l - 1.0)) * s
+    x = c * (1.0 - abs((h / 60.0) % 2.0 - 1.0))
+    m = l - c / 2.0
+    sextant = int(h / 60.0)
+    if sextant == 0:
+        r, g, b = c, x, 0.0
+    elif sextant == 1:
+        r, g, b = x, c, 0.0
+    elif sextant == 2:
+        r, g, b = 0.0, c, x
+    elif sextant == 3:
+        r, g, b = 0.0, x, c
+    elif sextant == 4:
+        r, g, b = x, 0.0, c
+    else:
+        r, g, b = c, 0.0, x
+    return skia.Color4f(r + m, g + m, b + m, 1.0)
+
+
+def _color4f_to_int(color4f) -> int:
+    """skia-python's gradient APIs want ARGB ints; convert from Color4f."""
+    import skia
+
+    a = max(0.0, min(1.0, color4f.fA))
+    r = max(0.0, min(1.0, color4f.fR))
+    g = max(0.0, min(1.0, color4f.fG))
+    b = max(0.0, min(1.0, color4f.fB))
+    return skia.ColorSetARGB(int(a * 255), int(r * 255), int(g * 255), int(b * 255))
+
+
+def _draw_animated_frame(canvas, t: float, width: int, height: int) -> None:
+    import skia
+
+    tau = 2.0 * math.pi
+    w = float(width)
+    h = float(height)
+
+    # Background — vertical linear gradient between two HSL-modulated colors.
+    top = _color4f_to_int(_hsl_to_color4f(t * 40.0, 0.80, 0.20))
+    bottom = _color4f_to_int(_hsl_to_color4f(t * 40.0 + 120.0, 0.80, 0.55))
+    bg_shader = skia.GradientShader.MakeLinear(
+        [skia.Point(0.0, 0.0), skia.Point(0.0, h)],
+        [top, bottom],
+    )
+    bg_paint = skia.Paint()
+    bg_paint.setShader(bg_shader)
+    canvas.drawRect(skia.Rect.MakeLTRB(0.0, 0.0, w, h), bg_paint)
+
+    # Animated stroked ring.
+    ring_radius = 180.0 + math.sin(t * tau * 0.5) * 18.0
+    ring_color = _hsl_to_color4f(t * 60.0, 0.95, 0.55)
+    ring = skia.Paint()
+    ring.setColor4f(ring_color, None)
+    ring.setStyle(skia.Paint.Style.kStroke_Style)
+    ring.setStrokeWidth(6.0 + abs(math.sin(t * tau * 0.3)) * 4.0)
+    ring.setAntiAlias(True)
+    canvas.drawCircle(w * 0.5, h * 0.5, ring_radius, ring)
+
+    # Five orbiting discs at slightly translucent fill.
+    for i in range(5):
+        phase = i * 0.4
+        fx = 0.5 + 0.6 * (i * 0.3)
+        fy = 0.7 + 0.5 * (i * 0.2)
+        x = w * 0.5 + math.sin(t * fx + phase) * (190.0 - i * 12.0)
+        y = h * 0.5 + math.cos(t * fy + phase) * (180.0 - i * 14.0)
+        radius = 26.0 + math.sin(t * 1.6 + phase) * 10.0
+        color = _hsl_to_color4f(t * 70.0 + i * 72.0, 0.92, 0.58)
+        color = skia.Color4f(color.fR, color.fG, color.fB, 0.78)
+        paint = skia.Paint()
+        paint.setColor4f(color, None)
+        paint.setAntiAlias(True)
+        canvas.drawCircle(x, y, radius, paint)
+
+    # Spoke wheel, 16 spokes rotating around the center.
+    spokes = 16
+    cx = w * 0.5
+    cy = h * 0.5
+    inner_r = 36.0
+    outer_r = 70.0 + math.sin(t * tau * 0.4) * 18.0
+    spoke_color = _hsl_to_color4f(t * 90.0 + 200.0, 0.6, 0.85)
+    spoke = skia.Paint()
+    spoke.setColor4f(spoke_color, None)
+    spoke.setStyle(skia.Paint.Style.kStroke_Style)
+    spoke.setStrokeWidth(2.0)
+    spoke.setAntiAlias(True)
+    spoke_path = skia.Path()
+    for s in range(spokes):
+        a = (s / spokes) * tau + t * 1.2
+        spoke_path.moveTo(cx + math.cos(a) * inner_r, cy + math.sin(a) * inner_r)
+        spoke_path.lineTo(cx + math.cos(a) * outer_r, cy + math.sin(a) * outer_r)
+    canvas.drawPath(spoke_path, spoke)
+
+    # Sine curve along the lower edge — 96 segments, slowly drifting
+    # amplitude + phase.
+    curve = skia.Path()
+    segments = 96
+    amp = 30.0 + math.sin(t * 0.7) * 12.0
+    baseline = h - 56.0
+    phase = t * 3.0
+    curve.moveTo(0.0, baseline)
+    for i in range(1, segments + 1):
+        u = i / segments
+        x = u * w
+        y = baseline - math.sin(u * tau * 3.0 + phase) * amp
+        curve.lineTo(x, y)
+    curve_paint = skia.Paint()
+    curve_paint.setColor4f(skia.Color4f(1.0, 1.0, 1.0, 0.92), None)
+    curve_paint.setStyle(skia.Paint.Style.kStroke_Style)
+    curve_paint.setStrokeWidth(3.5)
+    curve_paint.setAntiAlias(True)
+    canvas.drawPath(curve, curve_paint)
+
+    # Color strip — 7 small rects rotating through HSL.
+    strip_y = h - 22.0
+    strip_h = 14.0
+    for i in range(7):
+        tile = skia.Paint()
+        tile.setColor4f(_hsl_to_color4f(t * 120.0 + i * 51.0, 0.95, 0.55), None)
+        x0 = 16.0 + i * 22.0
+        canvas.drawRect(
+            skia.Rect.MakeLTRB(x0, strip_y, x0 + 18.0, strip_y + strip_h),
+            tile,
         )

--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -27,30 +27,11 @@ Config keys:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
 from streamlib.adapters.skia import SkiaContext
-from streamlib.surface_adapter import SurfaceFormat, SurfaceUsage
-
-
-@dataclass(frozen=True)
-class _SurfaceDescriptor:
-    """Minimal duck-typed descriptor for `SkiaContext.acquire_*`.
-
-    The Skia wrapper needs `id` (surface-share UUID), `width`, `height`,
-    `format` to build a `GrBackendTexture`. `streamlib.surface_adapter`
-    exports `StreamlibSurface` only as a `typing.Protocol` (not a
-    concrete class), so processors construct their own descriptor; any
-    object with these attributes is accepted.
-    """
-
-    id: str
-    width: int
-    height: int
-    format: int
-    usage: int
+from streamlib.surface_adapter import StreamlibSurface, SurfaceFormat, SurfaceUsage
 
 
 class SkiaCanvasProcessor:
@@ -62,7 +43,7 @@ class SkiaCanvasProcessor:
         self._skia_ctx = SkiaContext.from_runtime(ctx)
         self._drawn = False
         self._error: Optional[str] = None
-        self._surface = _SurfaceDescriptor(
+        self._surface = StreamlibSurface(
             id=self._uuid,
             width=self._width,
             height=self._height,

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -1,44 +1,51 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Polyglot Skia adapter scenario (#577).
+//! Polyglot Skia adapter scenario (#577 / #581).
 //!
-//! End-to-end gate for the subprocess `SkiaContext` runtime: the host
-//! pre-allocates ONE render-target-capable DMA-BUF surface AND an
-//! exportable `HostVulkanTimelineSemaphore`, registers both with
-//! surface-share under a known UUID. A Python polyglot processor opens
-//! the surface through `SkiaContext.acquire_write` (which under the
-//! hood opens `OpenGLContext.acquire_write` to import the DMA-BUF as a
+//! End-to-end gate for the subprocess `SkiaContext` runtime, mirroring
+//! the in-process Rust stress test
+//! `libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs`
+//! across the polyglot boundary: the host pre-allocates ONE
+//! render-target-capable DMA-BUF surface AND an exportable
+//! `HostVulkanTimelineSemaphore`, registers both with surface-share
+//! under a known UUID. A Python polyglot processor opens the surface
+//! through `SkiaContext.acquire_write` (which under the hood opens
+//! `OpenGLContext.acquire_write` to import the DMA-BUF as a
 //! `GL_TEXTURE_2D` via EGL, builds a `skia.GrBackendTexture`, and
-//! yields a `skia.Surface`), draws a known shape (red disc on blue
-//! background), and releases — Skia's flush-and-submit drains the GPU
-//! and the inner OpenGL adapter runs `glFinish` so the host's pre-stop
-//! readback sees the drawing. This binary then reads the surface back
-//! via Vulkan and writes a PNG; reading the PNG with the Read tool is
-//! the visual gate.
+//! yields a `skia.Surface`), draws the animated 60fps × 30s scene,
+//! and releases — Skia's flush+submit drains GPU and the inner OpenGL
+//! adapter runs `glFinish` so the host's per-frame Vulkan readback
+//! sees coherent BGRA bytes.
+//!
+//! While the pipeline is live the main thread runs a 60Hz readback
+//! loop that pipes each frame's BGRA into ffmpeg → an MP4. A hero PNG
+//! is captured at frame 900 (15s in). Reading the hero PNG with the
+//! Read tool is the visual gate; the MP4 is the long-form evidence.
 //!
 //! Skia is composed on OpenGL in the subprocess (no `slpn_skia_*`
 //! FFI; `streamlib.adapters.skia.SkiaContext` uses the existing
 //! `slpn_opengl_*` symbols + skia-python's `GrDirectContext.MakeGL`).
-//! The pivot from Vulkan to GL inside Python is forced by skia-python's
-//! pybind11 Vulkan binding being unimplemented — see #577 / the
-//! adapter's `skia.py` module docstring. The Rust adapter's Vulkan
-//! backend is unchanged. Deno is intentionally deferred: there is no
-//! maintained Deno Skia binding (same construction-language argument
-//! as the abandoned #481 polyglot deferral).
+//! See `libs/streamlib-python/python/streamlib/adapters/skia.py` for
+//! why GL, not Vulkan, in Python.
 //!
 //! Build the Python `.slpkg` first:
 //!   cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python
 //!
 //! Run:
 //!   cargo run -p polyglot-skia-canvas-scenario -- \
-//!       --output=/tmp/skia-canvas-py.png
+//!       --output-dir=/tmp/skia-canvas-py
+//!   # produces:
+//!   #   /tmp/skia-canvas-py/skia_canvas.mp4
+//!   #   /tmp/skia-canvas-py/skia_canvas_hero.png
 
 #![cfg(target_os = "linux")]
 
+use std::io::Write as _;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use streamlib::core::rhi::TextureFormat;
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
@@ -46,22 +53,36 @@ use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
 const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-000000005c1a";
-const SURFACE_SIZE: u32 = 256;
+const SURFACE_SIZE: u32 = 512;
+const FPS: u32 = 60;
+const DURATION_SECS: u32 = 30;
+const FRAME_COUNT: u32 = FPS * DURATION_SECS;
+const HERO_FRAME_INDEX: u32 = FPS * (DURATION_SECS / 2);
 
 fn main() -> Result<()> {
     let args = std::env::args().skip(1);
-    let mut output_png = PathBuf::from("/tmp/skia-canvas-py.png");
+    let mut output_dir = PathBuf::from("/tmp/skia-canvas-py");
     for a in args {
-        if let Some(value) = a.strip_prefix("--output=") {
-            output_png = PathBuf::from(value);
+        if let Some(value) = a.strip_prefix("--output-dir=") {
+            output_dir = PathBuf::from(value);
         }
     }
+    std::fs::create_dir_all(&output_dir).map_err(|e| {
+        StreamError::Configuration(format!(
+            "create output dir {}: {e}",
+            output_dir.display()
+        ))
+    })?;
+    let mp4_path = output_dir.join("skia_canvas.mp4");
+    let hero_path = output_dir.join("skia_canvas_hero.png");
 
-    println!("=== Polyglot Skia adapter canvas scenario (#577) ===");
+    println!("=== Polyglot Skia adapter canvas scenario (#577 / #581) ===");
     println!(
         "Surface:    {SURFACE_SIZE}x{SURFACE_SIZE} BGRA8 (uuid {SCENARIO_SURFACE_UUID})"
     );
-    println!("Output PNG: {}", output_png.display());
+    println!("Animation:  {FPS} fps × {DURATION_SECS}s = {FRAME_COUNT} frames");
+    println!("MP4:        {}", mp4_path.display());
+    println!("Hero PNG:   {} (frame {HERO_FRAME_INDEX})", hero_path.display());
     println!();
 
     let runtime = StreamRuntime::new()?;
@@ -156,8 +177,8 @@ fn main() -> Result<()> {
                 .to_string(),
             width: 4,
             height: 4,
-            fps: 5,
-            frame_count: 3,
+            fps: FPS,
+            frame_count: FRAME_COUNT,
         },
     ))?;
     println!("+ BgraFileSource: {source}");
@@ -166,6 +187,7 @@ fn main() -> Result<()> {
         "skia_surface_uuid": SCENARIO_SURFACE_UUID,
         "width": SURFACE_SIZE,
         "height": SURFACE_SIZE,
+        "fps": FPS,
     });
     let canvas = runtime.add_processor(ProcessorSpec::new(
         "com.tatolab.skia_canvas",
@@ -179,13 +201,54 @@ fn main() -> Result<()> {
     )?;
     println!("\nPipeline: BgraFileSource → python skia-canvas\n");
 
+    // Spawn ffmpeg before starting the runtime so the first readback
+    // has somewhere to land.
+    let ffmpeg_bin = if std::path::Path::new("/usr/bin/ffmpeg").exists() {
+        "/usr/bin/ffmpeg"
+    } else {
+        "ffmpeg"
+    };
+    println!("Spawning {ffmpeg_bin} → {}", mp4_path.display());
+    let mut ffmpeg = Command::new(ffmpeg_bin)
+        .args([
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "bgra",
+            "-s",
+            &format!("{}x{}", SURFACE_SIZE, SURFACE_SIZE),
+            "-r",
+            &FPS.to_string(),
+            "-i",
+            "-",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "20",
+            "-movflags",
+            "+faststart",
+            mp4_path.to_str().expect("mp4 path utf-8"),
+        ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            StreamError::Configuration(format!(
+                "ffmpeg spawn (install ffmpeg if missing): {e}"
+            ))
+        })?;
+    let mut ffmpeg_stdin = ffmpeg.stdin.take().expect("ffmpeg stdin");
+
     println!("Starting pipeline...");
     runtime.start()?;
-    std::thread::sleep(Duration::from_secs(4));
-    println!("Stopping pipeline...");
-    runtime.stop()?;
 
-    println!("\nReading host surface back via Vulkan...");
     let texture = texture_slot
         .lock()
         .unwrap()
@@ -200,9 +263,72 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| StreamError::Runtime("device slot is empty".into()))?;
-    let bgra = vulkan_readback(&device, &texture);
-    write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
-    println!("✓ Output PNG written: {}", output_png.display());
+
+    // 60Hz readback loop. The Python subprocess draws as fast as it
+    // gets trigger frames from BgraFileSource (also 60fps); host
+    // readback runs at the same cadence so each captured BGRA buffer
+    // sees a fresh draw. Drift between the two clocks is bounded by
+    // `glFinish` on Skia release — torn frames are bounded by Skia's
+    // single-step write atomicity, not by inter-process timing.
+    let run_start = Instant::now();
+    let mut hero_pixels: Option<Vec<u8>> = None;
+    let mut readback_times: Vec<Duration> = Vec::with_capacity(FRAME_COUNT as usize);
+    for f in 0..FRAME_COUNT {
+        let target =
+            run_start + Duration::from_secs_f64((f as f64) / (FPS as f64));
+        let now = Instant::now();
+        if let Some(sleep) = target.checked_duration_since(now) {
+            std::thread::sleep(sleep);
+        }
+        let rb_start = Instant::now();
+        let bgra = vulkan_readback(&device, &texture);
+        readback_times.push(rb_start.elapsed());
+        if f == HERO_FRAME_INDEX {
+            hero_pixels = Some(bgra.clone());
+        }
+        ffmpeg_stdin.write_all(&bgra).map_err(|e| {
+            StreamError::Runtime(format!("ffmpeg stdin write: {e}"))
+        })?;
+        if (f + 1) % 120 == 0 {
+            let wall = run_start.elapsed().as_secs_f32();
+            let avg_rb_ms = readback_times.iter().sum::<Duration>().as_secs_f32()
+                * 1000.0
+                / (f as f32 + 1.0);
+            println!(
+                "  frame {:>4}/{FRAME_COUNT} wall={:>5.1}s readback_avg={:>5.2}ms",
+                f + 1,
+                wall,
+                avg_rb_ms
+            );
+        }
+    }
+
+    println!("Stopping pipeline...");
+    runtime.stop()?;
+
+    drop(ffmpeg_stdin);
+    let ffmpeg_status = ffmpeg.wait().map_err(|e| {
+        StreamError::Runtime(format!("ffmpeg wait: {e}"))
+    })?;
+    if !ffmpeg_status.success() {
+        return Err(StreamError::Runtime(format!(
+            "ffmpeg encode failed: {ffmpeg_status:?}"
+        )));
+    }
+
+    if let Some(pixels) = hero_pixels {
+        write_png(&pixels, SURFACE_SIZE, SURFACE_SIZE, &hero_path)?;
+        println!(
+            "✓ hero PNG (frame {HERO_FRAME_INDEX}, t={:.2}s): {}",
+            HERO_FRAME_INDEX as f32 / FPS as f32,
+            hero_path.display()
+        );
+    } else {
+        return Err(StreamError::Runtime(
+            "hero frame was never captured — readback loop exited early".into(),
+        ));
+    }
+    println!("✓ MP4: {}", mp4_path.display());
     Ok(())
 }
 
@@ -210,10 +336,15 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     use std::fs::File;
     use std::io::Write;
 
+    // 4×4 BGRA trigger frames — content doesn't matter; the subprocess
+    // ignores the buffer and uses each frame as a per-tick wakeup so
+    // it can run a Skia draw against the host's render-target surface.
     let path = std::env::temp_dir().join("skia-canvas-trigger.bgra");
     let mut f = File::create(&path)
         .map_err(|e| format!("create {}: {e}", path.display()))?;
-    f.write_all(&[0u8; 4 * 4 * 4 * 3])
+    let bytes_per_frame: usize = 4 * 4 * 4;
+    let total = bytes_per_frame * (FRAME_COUNT as usize);
+    f.write_all(&vec![0u8; total])
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(path)
 }

--- a/libs/streamlib-python/python/streamlib/surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/surface_adapter.py
@@ -4,8 +4,11 @@
 """Python mirror of streamlib_adapter_abi.
 
 Provides:
-  - StreamlibSurface, SurfaceFormat, SurfaceUsage, AccessMode (Protocols
-    and IntFlag/IntEnum types matching the Rust shape).
+  - StreamlibSurface — concrete frozen dataclass carrying the
+    customer-visible fields (id / width / height / format / usage).
+    Adapters' `acquire_*` accept these directly.
+  - SurfaceFormat, SurfaceUsage, AccessMode — IntFlag/IntEnum types
+    matching the Rust shape.
   - _SurfaceTransportHandleC, _SurfaceSyncStateC, _StreamlibSurfaceC
     ctypes mirrors locked to the Rust #[repr(C)] layout. Twin tests in
     libs/streamlib-adapter-abi/src/surface.rs (Rust) and
@@ -23,6 +26,7 @@ from __future__ import annotations
 
 import ctypes
 import enum
+from dataclasses import dataclass
 from typing import Iterator, Protocol, runtime_checkable
 
 # ABI version major. Subprocess SDK refuses adapters with a different
@@ -156,20 +160,25 @@ class _StreamlibSurfaceC(ctypes.Structure):
 
 
 # ---------------------------------------------------------------------------
-# Adapter trait shape (Protocols)
+# Customer-visible surface descriptor
 # ---------------------------------------------------------------------------
 
 
-@runtime_checkable
-class StreamlibSurface(Protocol):
-    """Customer-visible view of a `StreamlibSurface` descriptor.
+@dataclass(frozen=True)
+class StreamlibSurface:
+    """Customer-visible descriptor for a host-allocated GPU surface.
 
-    Adapter implementations may also expose the underlying ctypes
-    struct (`_StreamlibSurfaceC`) for FFI calls — keep that path
-    private to the adapter, customers never see it.
+    Constructed by polyglot processors at `setup` time from the
+    surface-share registry key the host published the surface under,
+    then passed to adapter `acquire_*` to open the host's backing.
+
+    `id` is the surface-share registry key (a UUID string for the
+    GPU adapters; stringified u64 for cpu-readback). The numeric
+    `SurfaceId` carried inside the FFI struct (`_StreamlibSurfaceC`)
+    is adapter-internal — customers never see it.
     """
 
-    id: int
+    id: str
     width: int
     height: int
     format: int

--- a/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py
@@ -18,6 +18,7 @@ from streamlib.surface_adapter import (
     AccessMode,
     MAX_DMA_BUF_PLANES,
     STREAMLIB_ADAPTER_ABI_VERSION,
+    StreamlibSurface,
     SurfaceFormat,
     SurfaceUsage,
     _StreamlibSurfaceC,
@@ -160,3 +161,35 @@ def test_surface_format_round_trip():
     assert SurfaceUsage.SAMPLED in flags
     assert SurfaceUsage.RENDER_TARGET in flags
     assert SurfaceUsage.CPU_READBACK not in flags
+
+
+def test_streamlib_surface_constructible_with_uuid_id():
+    """Concrete `StreamlibSurface` is the public, customer-visible type
+    polyglot processors construct at `setup` and pass to adapter
+    `acquire_*`."""
+    uuid = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    s = StreamlibSurface(
+        id=uuid,
+        width=1920,
+        height=1080,
+        format=int(SurfaceFormat.BGRA8),
+        usage=int(SurfaceUsage.RENDER_TARGET | SurfaceUsage.SAMPLED),
+    )
+    assert s.id == uuid
+    assert s.width == 1920
+    assert s.height == 1080
+    assert SurfaceFormat(s.format) is SurfaceFormat.BGRA8
+    flags = SurfaceUsage(s.usage)
+    assert SurfaceUsage.RENDER_TARGET in flags
+    assert SurfaceUsage.SAMPLED in flags
+
+
+def test_streamlib_surface_is_frozen():
+    """The dataclass is frozen so adapters can cache the descriptor
+    without worrying about callers mutating it after they pass it in."""
+    import dataclasses
+    import pytest
+
+    s = StreamlibSurface(id="abc", width=64, height=64, format=0, usage=1)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.width = 128  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Two related changes to ship a properly-validated polyglot Skia adapter:

1. **Concrete `StreamlibSurface` dataclass.** `streamlib.surface_adapter.StreamlibSurface` was a `typing.Protocol` (not constructible), forcing the polyglot Skia canvas processor to declare an inline `_SurfaceDescriptor` workaround. Replace with a `@dataclass(frozen=True)` so polyglot processors construct surface descriptors directly. `id` is typed `str` to match the surface-share registry-key shape customers actually pass (UUIDs for vulkan/opengl/skia, stringified u64 for cpu-readback).
2. **Polyglot Skia E2E uplift to 60fps × 30s animated stress run.** The previous `polyglot-skia-canvas` example drew a single static red disc on blue and called it done — not an actual proof of the dataclass change under load. Port the animated scene from `libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs` field-for-field to the Python side: HSL-modulated linear gradient background, animated stroked ring, five orbiting discs, spinning spoke wheel, baseline sine curve, color strip. Drive 1800 frames at 60fps over 30 wall-clock seconds, run a 60Hz host-side Vulkan readback loop while the pipeline is live, pipe each frame's BGRA into ffmpeg → MP4 (libx264 yuv420p), capture a hero PNG at frame 900 (15s in).

## Closes

Closes #581

## E2E evidence

Run command:

```bash
cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python
cargo run -p polyglot-skia-canvas-scenario -- --output-dir=/tmp/skia-canvas-e2e
```

Produces `/tmp/skia-canvas-e2e/skia_canvas.mp4` (4.4 MB libx264) +
`/tmp/skia-canvas-e2e/skia_canvas_hero.png` (42 KB).

**Hero PNG — frame 900 (t=15.00s):**

![Skia animated stress hero frame](https://gh-artifact.tatolab.com/pr-582/skia_canvas_hero.jpg)

**Full 30s run (MP4):** https://gh-artifact.tatolab.com/pr-582/skia_canvas.mp4

The full animated scene from the Rust stress reference: gradient background, bright green stroked ring, five orbiting discs (teal / magenta / blue / green / orange), 16-spoke wheel in the center, white sine curve along the baseline, color strip at the bottom. Produced via Python subprocess driving Skia via `SkiaContext.acquire_write` → `OpenGLContext.acquire_write` → EGL DMA-BUF import → Skia `GrBackendTexture` → 60Hz Vulkan readback on the host.

### Run signals

| signal | value |
|---|---|
| `OUT_OF_DEVICE_MEMORY` | 0 |
| `DEVICE_LOST` | 0 |
| `process() failed` | 0 |
| BgraFileSource frames published | 1796 / 1800 |
| Python `[SkiaCanvas/py] drew frame` high-water | 1740 |
| Host readback loop completed | 1800 / 1800 |
| Readback avg (post-warm-up) | ~10.28 ms — well within the 16.67 ms 60fps budget |
| Wall clock | 30.0 s |
| MP4 written | yes (libx264 yuv420p, faststart) |
| Hero PNG written | yes (frame 900) |
| Pipeline stop | clean (Python subprocess exit 0) |

## Exit criteria

- [x] `streamlib.surface_adapter` exposes a public, constructible surface-descriptor type processors can pass directly to `acquire_*`.
- [x] `examples/polyglot-skia-canvas/python/skia_canvas.py` drops its inline `_SurfaceDescriptor` and uses the public type.
- [~] **Deviation, agreed in chat:** the issue's third exit criterion was "the existing Protocol-shaped `StreamlibSurface` contract remains usable for `isinstance` / static checks." Pre-1.0, no real consumer calls `isinstance(x, StreamlibSurface)` and no static type checker runs on the polyglot examples — so the simpler shape (drop the Protocol entirely, ship one concrete `StreamlibSurface`) was chosen. If a real consumer ever needs structural typing for a custom surface-like class, `StreamlibSurfaceProtocol` can be added then.

## Polyglot coverage

- **Runtimes affected**: python only.
- **Schema regenerated**: n/a (no escalate IPC change).
- **Python and Deno both covered?** Schema-only / language-specific by construction — Deno's `StreamlibSurface` is a TypeScript `interface` (already structurally constructible by object literal), so the Protocol-vs-concrete asymmetry is purely Python-side per the legitimate split in `.claude/workflows/polyglot.md`.
- **E2E tests run**:
  - [x] Python subprocess (skia canvas, animated 60fps × 30s): hero PNG above.
  - [N/A] Host-Rust: no Rust adapter changes (only the example's `main.rs`).
  - [N/A] Deno subprocess: not affected.
- **FD-passing path**: pre-existing surface-share check_in (DMA-BUF + sync FD), unchanged.

## Test plan

- [x] `pytest libs/streamlib-python/python/streamlib/tests/test_surface_adapter.py` — 14 passed (12 existing + 2 new). New tests:
  - `test_streamlib_surface_constructible_with_uuid_id` — constructs `StreamlibSurface(id="<uuid>", ...)` and asserts fields preserved.
  - `test_streamlib_surface_is_frozen` — asserts `dataclasses.FrozenInstanceError` on mutation.
- [x] `pytest libs/streamlib-python/python/` — 61 passed (full Python suite).
- [x] `cargo check -p polyglot-skia-canvas-scenario` — clean.
- [x] **E2E**: `cargo run -p polyglot-skia-canvas-scenario -- --output-dir=…` — see evidence section above.

## Pre-PR review gate

PASS verdict from `pr-review-gate` (Opus). Items raised + verified:

| # | item | resolution |
|---|---|---|
| 1 | `_StreamlibSurfaceC.id: c_uint64` vs `StreamlibSurface.id: str` asymmetry | Intentional. Customer-facing `id` is a surface-share registry key; the FFI struct's `id` is a separate adapter-internal local u64 generated by `next(_SURFACE_ID_COUNTER)` inside each `_resolve_and_register`. They live at different layers. |
| 2 | Dropped exit criterion 3 (Protocol satisfaction) | Explicit deviation, see Exit criteria § above. |
| 3 | `vulkan_readback` raw vulkanalia outside the RHI, called 1800x | Pre-existing helper from #580; allowlisted by `cargo xtask check-boundaries` for `examples/polyglot-` paths (verified in `xtask/src/check_boundaries.rs:314 / 425 / 544`). Per-call cleanup is correct; no leak across 1800 invocations. |
| 4 | Host readback loop unsynchronized with the registered timeline semaphore | Acknowledged in code comment. Cross-API memory ordering is covered by Skia release's `glFinish` + the readback's `ALL_COMMANDS → ALL_TRANSFER` Vulkan barrier. Latency drift possible (host may read frame N-1 instead of N), tearing is not. Empirically validated by the 1800-frame run. |
| 5 | Dead branch in `_hsl_to_color4f` (`if h < 0.0: h += 360.0`) | Fixed in commit c8f97e8. |

## Follow-ups

- `polyglot-opengl-fragment-shader` and `polyglot-vulkan-compute` examples are next for the same animated-stress + MP4 + hero-PNG uplift. Filing as a separate ticket — out of scope for #581 but tracked. (Will surface a follow-up issue link here once filed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

