### PR TITLE
feat(rhi): host-side TextureReadback API + migrate polyglot examples (#583)

### DIFF
--- a/docs/architecture/texture-readback.md
+++ b/docs/architecture/texture-readback.md
@@ -1,0 +1,164 @@
+# Host-side texture readback in the RHI
+
+streamlib's RHI exposes one canonical primitive for reading a host
+`StreamTexture` back into CPU memory: `VulkanTextureReadback` (Linux)
+plus the public binding-shape types in `core::rhi`
+(`TextureReadbackDescriptor`, `TextureSourceLayout`, `ReadbackTicket`,
+`TextureReadbackError`). **Every callsite that needs to copy GPU pixels
+back to the host uses this abstraction — do not hand-roll a staging
+buffer, command pool, command buffer, fence, or queue submit for an
+image-to-buffer copy.**
+
+This is engine-model territory: the RHI is the single gateway to the
+GPU, and the readback handle is the single gateway for image →
+HOST_VISIBLE buffer transfer. Adding a third shape every time a new
+binary needs to grab pixels is the failure mode this doc exists to
+prevent.
+
+## What the abstraction does for you
+
+Given a fixed format/extent declared at construction, the handle:
+
+1. **Allocates the staging buffer once** through VMA's default
+   allocator (HOST_VISIBLE | HOST_COHERENT, persistent-mapped). No
+   per-submit allocation. Sized to `width * height * bpp`.
+2. **Owns its command pool, command buffer, and timeline semaphore.**
+   None of this is your code anymore.
+3. **Records `vkCmdCopyImageToBuffer` with full barrier semantics**
+   per submit — pre-barrier `source_layout → TRANSFER_SRC_OPTIMAL`,
+   the copy, post-barrier `TRANSFER_SRC_OPTIMAL → source_layout`
+   (so the texture is restored to its prior layout) and a buffer
+   barrier `TRANSFER_WRITE → HOST_READ` so the host map sees
+   coherent bytes.
+4. **Submits through `HostVulkanDevice::submit_to_queue`** — same
+   per-queue mutex everything else in the engine uses.
+5. **Signals a timeline semaphore at a monotonic counter value.**
+   The returned `ReadbackTicket` wraps that counter; callers wait
+   on the timeline via `try_read` / `wait_and_read`.
+
+## Adding a new readback callsite — the recipe
+
+1. **Construct a handle once at setup time** for each
+   `(format, extent)` you need to read back:
+
+   ```rust
+   let readback = gpu.create_texture_readback(&TextureReadbackDescriptor {
+       label: "my-binary/readback",
+       format: TextureFormat::Bgra8Unorm,
+       width: 512,
+       height: 512,
+   })?;
+   ```
+
+   Store the `Arc<VulkanTextureReadback>` somewhere it outlives the
+   read loop (a slot owned by `main`, a struct field on a processor,
+   etc.).
+
+2. **Submit + wait per frame:**
+
+   ```rust
+   let ticket = readback.submit(&texture, TextureSourceLayout::General)?;
+   let bytes = readback.wait_and_read(ticket, u64::MAX)?;  // &[u8]
+   // ... consume `bytes` ...
+   ```
+
+   `bytes` borrows the handle's mapped staging buffer; the next
+   `submit` is a compile-time conflict with that borrow, which is
+   exactly the safety invariant we want (the next GPU copy would
+   overwrite the bytes you're holding).
+
+3. **Zero-copy variant** for streaming bytes into a sink (ffmpeg
+   stdin, PNG encoder, etc.):
+
+   ```rust
+   readback.wait_and_read_with(ticket, u64::MAX, |bgra| {
+       ffmpeg_stdin.write_all(bgra)
+   })??;
+   ```
+
+   The closure runs after the wait completes; the handle resets to
+   idle when it returns.
+
+## Single-in-flight per handle
+
+Each handle has one staging buffer + one command buffer + one
+timeline semaphore. A second `submit()` before the prior ticket is
+waited returns `TextureReadbackError::InFlight`. For genuine parallel
+readbacks, **hold N handles** — one per in-flight slot. Mirrors
+`VulkanComputeKernel`'s shape exactly.
+
+The trade-off is intentional: the alternative (ringed staging buffers
+inside one handle) doubles the memory cost per handle and complicates
+the borrow story for the returned `&[u8]`. Real callers either need
+sequential reads (every frame, drained before the next) or a small
+fixed parallelism (N ≤ frames-in-flight) — both are clean as N
+handles.
+
+## What's deliberately not covered
+
+- **Multi-plane formats** (NV12 etc.). Single-plane only today —
+  every shipped polyglot example reads a packed BGRA / RGBA surface.
+  Extend the abstraction with a `plane_count` knob when the first
+  multi-plane host-side readback callsite arrives.
+- **Caller-supplied staging buffers.** The handle owns its staging
+  buffer. If a future caller has reason to read into someone else's
+  buffer (e.g. into a pre-mapped `RhiPixelBuffer`), extend the
+  abstraction with an `into_buffer` variant.
+- **Asynchronous-with-callback API** (`submit(then: impl FnOnce)`).
+  The current `try_read` / `wait_and_read` shape is sufficient for
+  every shipped callsite. Add a callback variant if a future caller
+  needs it.
+- **Cross-queue readback** (transfer queue instead of graphics).
+  `submit_to_queue` automatically picks the right per-queue mutex
+  based on the queue handle, but the readback today always uses the
+  device's primary graphics queue. A `with_queue` knob is the right
+  extension point if a future caller wants the dedicated transfer
+  queue for compute-graphics overlap.
+- **Allocation-failure simulation** in unit tests. VMA out-of-budget
+  is reachable in adversarial tests; we don't have a reliable
+  in-process knob to trigger it deterministically. The error
+  taxonomy still names `StagingBufferAlloc`; coverage is via real
+  allocation pressure in E2E.
+
+## Why this shape
+
+Production realtime engines (Unreal `FRHIGPUTextureReadback`, bgfx
+`bgfx::readTexture`, WebGPU `copyTextureToBuffer + mapAsync`,
+Granite's timeline-semaphore-backed copy) all converge on the same
+answer: a pre-allocated staging buffer + fenced or timeline-wait
+ticket. We picked the timeline-semaphore variant because:
+
+- Timeline semaphores are already the codebase's preferred sync
+  primitive (see `vulkan_command_buffer.rs`,
+  `streamlib-adapter-cpu-readback`'s submit path,
+  `consumer_vulkan_sync.rs`).
+- Vulkan 1.2 core, supported on every driver streamlib targets.
+- Monotonic counter values are a natural fit for ticketing —
+  `try_read` is `vkGetSemaphoreCounterValue >= ticket.counter`,
+  no separate fence-pool bookkeeping needed.
+- Multiple in-flight reads (when the caller holds N handles) fall
+  out for free — each handle's timeline is independent.
+
+A binary fence per handle would also have worked. Timeline matches
+codebase precedent and Granite's reference shape, so that's the call.
+
+## Boundary check
+
+Polyglot example/scenario binaries no longer carry an allowlist
+entry for raw `vulkanalia` — every host-side per-frame readback
+rides this primitive. If a future example needs a different shape of
+readback (multi-plane, async-with-callback, etc.), extend
+`VulkanTextureReadback` instead of reaching for raw vulkanalia. The
+boundary check (`cargo xtask check-boundaries`) will fail any PR
+that reintroduces raw vulkanalia in `examples/polyglot-*` — the
+violation message points back here.
+
+## Reference
+
+- Implementation: `libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs`
+- Public types: `libs/streamlib/src/core/rhi/texture_readback.rs`
+- GpuContext factory: `GpuContext::create_texture_readback`
+  (`libs/streamlib/src/core/context/gpu_context.rs`)
+- Engine precedent: `compute-kernel.md` and
+  `libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs`
+- Trade-off discussion: issue #583

--- a/examples/polyglot-cpu-readback-blur/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/Cargo.toml
@@ -14,5 +14,3 @@ streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-read
 serde_json = "1.0"
 png = "0.17"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-vulkanalia = { workspace = true }

--- a/examples/polyglot-opengl-fragment-shader/Cargo.toml
+++ b/examples/polyglot-opengl-fragment-shader/Cargo.toml
@@ -15,4 +15,3 @@ png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-adapter-opengl = { path = "../../libs/streamlib-adapter-opengl" }
-vulkanalia = { workspace = true }

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -30,9 +30,11 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use streamlib::host_rhi::HostVulkanDevice;
-use streamlib::core::rhi::TextureFormat;
+use streamlib::core::rhi::{
+    TextureFormat, TextureReadbackDescriptor, TextureSourceLayout,
+};
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
+use streamlib::host_rhi::VulkanTextureReadback;
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
 /// UUID the host registers the render-target surface under. The
@@ -102,20 +104,19 @@ fn main() -> Result<()> {
 
     let runtime = StreamRuntime::new()?;
 
-    // Slots the setup hook populates with the host StreamTexture and
-    // the underlying HostVulkanDevice so main.rs can read the surface back
-    // post-stop and write the output PNG. We can't keep the
+    // Slots the setup hook populates so main.rs can read the surface
+    // back post-stop and write the output PNG. We can't keep the
     // `&GpuContext` borrow past the hook, so we Arc-clone the bits we
     // need.
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
-    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
+    let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let device_slot = Arc::clone(&device_slot);
+        let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
                 SURFACE_SIZE,
@@ -143,9 +144,19 @@ fn main() -> Result<()> {
                         "register_texture: {e}"
                     ))
                 })?;
+
+            // RHI-owned readback handle for the post-stop pixel
+            // capture — staging buffer + command resources + timeline
+            // semaphore allocate once at construction.
+            let readback = gpu.create_texture_readback(&TextureReadbackDescriptor {
+                label: "polyglot-opengl-fragment-shader/readback",
+                format: TextureFormat::Bgra8Unorm,
+                width: SURFACE_SIZE,
+                height: SURFACE_SIZE,
+            })?;
+
             *texture_slot.lock().unwrap() = Some(texture);
-            *device_slot.lock().unwrap() =
-                Some(Arc::clone(gpu.device().vulkan_device()));
+            *readback_slot.lock().unwrap() = Some(readback);
             println!(
                 "✓ render-target DMA-BUF surface registered as '{}'",
                 SCENARIO_SURFACE_UUID
@@ -248,14 +259,19 @@ fn main() -> Result<()> {
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
-    let device = device_slot
+    let readback = readback_slot
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| {
-            StreamError::Runtime("device slot is empty".into())
-        })?;
-    let bgra = vulkan_readback(&device, &texture);
+        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+    // OpenGL adapter leaves the image in GENERAL.
+    let ticket = readback
+        .submit(&texture, TextureSourceLayout::General)
+        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+    let bgra = readback
+        .wait_and_read(ticket, u64::MAX)
+        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .to_vec();
     write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
 
@@ -275,188 +291,6 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     f.write_all(&[0u8; 4 * 4 * 4 * 3])
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(path)
-}
-
-/// Read pixels from the host `StreamTexture` back into a CPU buffer
-/// for verification. Returns BGRA8 bytes, `width*height*4` size.
-///
-/// Uses a transient HOST_VISIBLE staging buffer + `vkCmdCopyImageToBuffer`
-/// + queue wait — the canonical Vulkan readback shape, parallel to the
-/// `host_readback` helper in `streamlib-adapter-opengl/tests/common.rs`.
-fn vulkan_readback(
-    device: &Arc<HostVulkanDevice>,
-    texture: &streamlib::core::rhi::StreamTexture,
-) -> Vec<u8> {
-    use vulkanalia::prelude::v1_4::*;
-    use vulkanalia::vk;
-
-    let dev = device.device();
-    let queue = device.queue();
-    let qf = device.queue_family_index();
-    let image = texture
-        .vulkan_inner()
-        .image()
-        .expect("StreamTexture must have a Vulkan image handle on Linux");
-    let width = texture.width();
-    let height = texture.height();
-    let bytes = (width as u64) * (height as u64) * 4;
-
-    let buf = unsafe {
-        dev.create_buffer(
-            &vk::BufferCreateInfo::builder()
-                .size(bytes)
-                .usage(vk::BufferUsageFlags::TRANSFER_DST)
-                .sharing_mode(vk::SharingMode::EXCLUSIVE)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_buffer");
-    let mem_req = unsafe { dev.get_buffer_memory_requirements(buf) };
-    let inst = device.instance();
-    let phys = device.physical_device();
-    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
-    let needed =
-        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
-    let mem_idx = (0..mem_props.memory_type_count)
-        .find(|i| {
-            let bit = 1u32 << i;
-            (mem_req.memory_type_bits & bit) != 0
-                && mem_props.memory_types[*i as usize]
-                    .property_flags
-                    .contains(needed)
-        })
-        .expect("host-visible memory type");
-    let mem = unsafe {
-        dev.allocate_memory(
-            &vk::MemoryAllocateInfo::builder()
-                .allocation_size(mem_req.size)
-                .memory_type_index(mem_idx)
-                .build(),
-            None,
-        )
-    }
-    .expect("allocate_memory");
-    unsafe { dev.bind_buffer_memory(buf, mem, 0) }.expect("bind_buffer_memory");
-
-    let pool = unsafe {
-        dev.create_command_pool(
-            &vk::CommandPoolCreateInfo::builder()
-                .queue_family_index(qf)
-                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_command_pool");
-    let cmd = unsafe {
-        dev.allocate_command_buffers(
-            &vk::CommandBufferAllocateInfo::builder()
-                .command_pool(pool)
-                .level(vk::CommandBufferLevel::PRIMARY)
-                .command_buffer_count(1)
-                .build(),
-        )
-    }
-    .expect("allocate_command_buffers")[0];
-    unsafe {
-        dev.begin_command_buffer(
-            cmd,
-            &vk::CommandBufferBeginInfo::builder()
-                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
-                .build(),
-        )
-    }
-    .expect("begin_command_buffer");
-
-    // The OpenGL adapter leaves the image in GENERAL layout (it never
-    // transitions out). Move to TRANSFER_SRC_OPTIMAL for the copy, then
-    // back to GENERAL.
-    let to_src = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
-        .dst_stage_mask(vk::PipelineStageFlags2::COPY)
-        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
-        .old_layout(vk::ImageLayout::GENERAL)
-        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-        .src_queue_family_index(qf)
-        .dst_queue_family_index(qf)
-        .image(image)
-        .subresource_range(
-            vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .level_count(1)
-                .layer_count(1)
-                .build(),
-        )
-        .build();
-    let bs = [to_src];
-    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
-    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
-
-    let copy = vk::BufferImageCopy::builder()
-        .buffer_offset(0)
-        .buffer_row_length(0)
-        .buffer_image_height(0)
-        .image_subresource(
-            vk::ImageSubresourceLayers::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .layer_count(1)
-                .build(),
-        )
-        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-        .image_extent(vk::Extent3D { width, height, depth: 1 })
-        .build();
-    let regions = [copy];
-    unsafe {
-        dev.cmd_copy_image_to_buffer(
-            cmd,
-            image,
-            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-            buf,
-            &regions,
-        )
-    };
-
-    let to_general = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(vk::PipelineStageFlags2::COPY)
-        .src_access_mask(vk::AccessFlags2::TRANSFER_READ)
-        .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
-        .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-        .new_layout(vk::ImageLayout::GENERAL)
-        .src_queue_family_index(qf)
-        .dst_queue_family_index(qf)
-        .image(image)
-        .subresource_range(
-            vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .level_count(1)
-                .layer_count(1)
-                .build(),
-        )
-        .build();
-    let bs2 = [to_general];
-    let dep2 = vk::DependencyInfo::builder().image_memory_barriers(&bs2).build();
-    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep2) };
-
-    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
-    let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
-    let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
-    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }
-        .expect("submit");
-    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
-
-    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
-        .expect("map_memory");
-    let slice =
-        unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
-    let out = slice.to_vec();
-    unsafe { dev.unmap_memory(mem) };
-    unsafe { dev.destroy_command_pool(pool, None) };
-    unsafe { dev.destroy_buffer(buf, None) };
-    unsafe { dev.free_memory(mem, None) };
-    out
 }
 
 /// Encode BGRA bytes as RGBA PNG (channel-swap on the fly).

--- a/examples/polyglot-skia-canvas/Cargo.toml
+++ b/examples/polyglot-skia-canvas/Cargo.toml
@@ -15,4 +15,3 @@ png = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
-vulkanalia = { workspace = true }

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -47,9 +47,11 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use streamlib::core::rhi::TextureFormat;
+use streamlib::core::rhi::{
+    TextureFormat, TextureReadbackDescriptor, TextureSourceLayout,
+};
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
-use streamlib::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
+use streamlib::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
 const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-000000005c1a";
@@ -90,15 +92,15 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
-    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
-        Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let device_slot = Arc::clone(&device_slot);
         let timeline_slot = Arc::clone(&timeline_slot);
+        let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             // BGRA8: the EGL DMA-BUF importer hands the subprocess a
             // `GL_RGBA8`-typed `GL_TEXTURE_2D` regardless of host
@@ -111,14 +113,16 @@ fn main() -> Result<()> {
                 SURFACE_SIZE,
                 TextureFormat::Bgra8Unorm,
             )?;
-            let host_device = Arc::clone(gpu.device().vulkan_device());
             let timeline = Arc::new(
-                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
-                    .map_err(|e| {
-                        StreamError::Configuration(format!(
-                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
-                        ))
-                    })?,
+                HostVulkanTimelineSemaphore::new_exportable(
+                    gpu.device().vulkan_device().device(),
+                    0,
+                )
+                .map_err(|e| {
+                    StreamError::Configuration(format!(
+                        "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                    ))
+                })?,
             );
             let store = gpu.surface_store().ok_or_else(|| {
                 StreamError::Configuration(
@@ -140,9 +144,20 @@ fn main() -> Result<()> {
             // which has no per-acquire host work — every line of GPU
             // dispatch happens inside the subprocess process via
             // skia-python's GL backend (`MakeGL(MakeEGL())`).
+
+            // RHI-owned readback handle, reused for every frame —
+            // staging buffer + command pool/buffer + timeline semaphore
+            // allocated once at construction.
+            let readback = gpu.create_texture_readback(&TextureReadbackDescriptor {
+                label: "polyglot-skia-canvas/readback",
+                format: TextureFormat::Bgra8Unorm,
+                width: SURFACE_SIZE,
+                height: SURFACE_SIZE,
+            })?;
+
             *texture_slot.lock().unwrap() = Some(texture);
-            *device_slot.lock().unwrap() = Some(host_device);
             *timeline_slot.lock().unwrap() = Some(timeline);
+            *readback_slot.lock().unwrap() = Some(readback);
             println!(
                 "✓ render-target DMA-BUF + timeline registered as '{}'",
                 SCENARIO_SURFACE_UUID
@@ -258,11 +273,11 @@ fn main() -> Result<()> {
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
-    let device = device_slot
+    let readback = readback_slot
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("device slot is empty".into()))?;
+        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
 
     // 60Hz readback loop. The Python subprocess draws as fast as it
     // gets trigger frames from BgraFileSource (also 60fps); host
@@ -270,6 +285,12 @@ fn main() -> Result<()> {
     // sees a fresh draw. Drift between the two clocks is bounded by
     // `glFinish` on Skia release — torn frames are bounded by Skia's
     // single-step write atomicity, not by inter-process timing.
+    //
+    // Skia leaves the image in whatever layout it transitioned to
+    // during `MakeFromBackendRenderTarget`-driven rendering; passing
+    // `TextureSourceLayout::General` is the tolerant choice that
+    // matches what the inner Vulkan adapter's release-time setup
+    // expects on the next acquire.
     let run_start = Instant::now();
     let mut hero_pixels: Option<Vec<u8>> = None;
     let mut readback_times: Vec<Duration> = Vec::with_capacity(FRAME_COUNT as usize);
@@ -281,14 +302,26 @@ fn main() -> Result<()> {
             std::thread::sleep(sleep);
         }
         let rb_start = Instant::now();
-        let bgra = vulkan_readback(&device, &texture);
+        let ticket = readback
+            .submit(&texture, TextureSourceLayout::General)
+            .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+        let capture_hero = f == HERO_FRAME_INDEX;
+        let mut hero_capture: Option<Vec<u8>> = None;
+        readback
+            .wait_and_read_with(ticket, u64::MAX, |bgra| -> std::io::Result<()> {
+                if capture_hero {
+                    hero_capture = Some(bgra.to_vec());
+                }
+                ffmpeg_stdin.write_all(bgra)
+            })
+            .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+            .map_err(|e| {
+                StreamError::Runtime(format!("ffmpeg stdin write: {e}"))
+            })?;
         readback_times.push(rb_start.elapsed());
-        if f == HERO_FRAME_INDEX {
-            hero_pixels = Some(bgra.clone());
+        if let Some(pixels) = hero_capture {
+            hero_pixels = Some(pixels);
         }
-        ffmpeg_stdin.write_all(&bgra).map_err(|e| {
-            StreamError::Runtime(format!("ffmpeg stdin write: {e}"))
-        })?;
         if (f + 1) % 120 == 0 {
             let wall = run_start.elapsed().as_secs_f32();
             let avg_rb_ms = readback_times.iter().sum::<Duration>().as_secs_f32()
@@ -347,167 +380,6 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     f.write_all(&vec![0u8; total])
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(path)
-}
-
-/// Read pixels from the host `StreamTexture` back into a CPU buffer.
-/// Mirrors the helper in `examples/polyglot-vulkan-compute` —
-/// transient HOST_VISIBLE staging buffer + `vkCmdCopyImageToBuffer`
-/// + `queue_wait_idle`.
-fn vulkan_readback(
-    device: &Arc<HostVulkanDevice>,
-    texture: &streamlib::core::rhi::StreamTexture,
-) -> Vec<u8> {
-    use vulkanalia::prelude::v1_4::*;
-    use vulkanalia::vk;
-
-    let dev = device.device();
-    let queue = device.queue();
-    let qf = device.queue_family_index();
-    let image = texture
-        .vulkan_inner()
-        .image()
-        .expect("StreamTexture must have a Vulkan image handle on Linux");
-    let width = texture.width();
-    let height = texture.height();
-    let bytes = (width as u64) * (height as u64) * 4;
-
-    let buf = unsafe {
-        dev.create_buffer(
-            &vk::BufferCreateInfo::builder()
-                .size(bytes)
-                .usage(vk::BufferUsageFlags::TRANSFER_DST)
-                .sharing_mode(vk::SharingMode::EXCLUSIVE)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_buffer");
-    let mem_req = unsafe { dev.get_buffer_memory_requirements(buf) };
-    let inst = device.instance();
-    let phys = device.physical_device();
-    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
-    let needed =
-        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
-    let mem_idx = (0..mem_props.memory_type_count)
-        .find(|i| {
-            let bit = 1u32 << i;
-            (mem_req.memory_type_bits & bit) != 0
-                && mem_props.memory_types[*i as usize]
-                    .property_flags
-                    .contains(needed)
-        })
-        .expect("host-visible memory type");
-    let mem = unsafe {
-        dev.allocate_memory(
-            &vk::MemoryAllocateInfo::builder()
-                .allocation_size(mem_req.size)
-                .memory_type_index(mem_idx)
-                .build(),
-            None,
-        )
-    }
-    .expect("allocate_memory");
-    unsafe { dev.bind_buffer_memory(buf, mem, 0) }.expect("bind_buffer_memory");
-
-    let pool = unsafe {
-        dev.create_command_pool(
-            &vk::CommandPoolCreateInfo::builder()
-                .queue_family_index(qf)
-                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_command_pool");
-    let cmd = unsafe {
-        dev.allocate_command_buffers(
-            &vk::CommandBufferAllocateInfo::builder()
-                .command_pool(pool)
-                .level(vk::CommandBufferLevel::PRIMARY)
-                .command_buffer_count(1)
-                .build(),
-        )
-    }
-    .expect("allocate_command_buffers")[0];
-    unsafe {
-        dev.begin_command_buffer(
-            cmd,
-            &vk::CommandBufferBeginInfo::builder()
-                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
-                .build(),
-        )
-    }
-    .expect("begin_command_buffer");
-
-    // Skia leaves the image in whatever layout it transitioned to
-    // during `MakeFromBackendRenderTarget`-driven rendering; the
-    // inner Vulkan adapter's release-time `current_layout` isn't
-    // updated by Skia. We use a generic `GENERAL` → `TRANSFER_SRC_OPTIMAL`
-    // barrier here that's tolerant of either GENERAL or
-    // COLOR_ATTACHMENT_OPTIMAL on the way in.
-    let to_src = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
-        .dst_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
-        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
-        .old_layout(vk::ImageLayout::GENERAL)
-        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-        .src_queue_family_index(qf)
-        .dst_queue_family_index(qf)
-        .image(image)
-        .subresource_range(
-            vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .level_count(1)
-                .layer_count(1)
-                .build(),
-        )
-        .build();
-    let bs = [to_src];
-    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
-    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
-
-    let copy = vk::BufferImageCopy::builder()
-        .buffer_offset(0)
-        .buffer_row_length(0)
-        .buffer_image_height(0)
-        .image_subresource(
-            vk::ImageSubresourceLayers::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .layer_count(1)
-                .build(),
-        )
-        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-        .image_extent(vk::Extent3D { width, height, depth: 1 })
-        .build();
-    let regions = [copy];
-    unsafe {
-        dev.cmd_copy_image_to_buffer(
-            cmd,
-            image,
-            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-            buf,
-            &regions,
-        )
-    };
-
-    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
-    let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
-    let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
-    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }
-        .expect("submit");
-    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
-
-    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
-        .expect("map_memory");
-    let slice =
-        unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
-    let out = slice.to_vec();
-    unsafe { dev.unmap_memory(mem) };
-    unsafe { dev.destroy_command_pool(pool, None) };
-    unsafe { dev.destroy_buffer(buf, None) };
-    unsafe { dev.free_memory(mem, None) };
-    out
 }
 
 fn write_png(

--- a/examples/polyglot-vulkan-compute/Cargo.toml
+++ b/examples/polyglot-vulkan-compute/Cargo.toml
@@ -18,4 +18,3 @@ sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }
-vulkanalia = { workspace = true }

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -38,10 +38,11 @@ use std::time::Duration;
 use streamlib::core::context::ComputeKernelBridge;
 use streamlib::core::rhi::{
     derive_bindings_from_spirv, ComputeKernelDescriptor, StreamTexture, TextureFormat,
+    TextureReadbackDescriptor, TextureSourceLayout,
 };
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
 use streamlib::host_rhi::{
-    HostVulkanDevice, HostVulkanTimelineSemaphore, VulkanComputeKernel,
+    HostVulkanDevice, HostVulkanTimelineSemaphore, VulkanComputeKernel, VulkanTextureReadback,
 };
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
@@ -226,15 +227,15 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
-    let device_slot: Arc<Mutex<Option<Arc<HostVulkanDevice>>>> =
-        Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
-        let device_slot = Arc::clone(&device_slot);
         let timeline_slot = Arc::clone(&timeline_slot);
+        let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
                 SURFACE_SIZE,
@@ -287,9 +288,19 @@ fn main() -> Result<()> {
             ));
             gpu.set_compute_kernel_bridge(bridge);
 
+            // RHI-owned readback handle for the post-stop pixel
+            // capture — the staging buffer + command resources +
+            // timeline semaphore allocate once at construction.
+            let readback = gpu.create_texture_readback(&TextureReadbackDescriptor {
+                label: "polyglot-vulkan-compute/readback",
+                format: TextureFormat::Rgba8Unorm,
+                width: SURFACE_SIZE,
+                height: SURFACE_SIZE,
+            })?;
+
             *texture_slot.lock().unwrap() = Some(texture);
-            *device_slot.lock().unwrap() = Some(host_device);
             *timeline_slot.lock().unwrap() = Some(timeline);
+            *readback_slot.lock().unwrap() = Some(readback);
             println!(
                 "✓ render-target DMA-BUF + timeline registered as '{}'",
                 SCENARIO_SURFACE_UUID
@@ -392,12 +403,18 @@ fn main() -> Result<()> {
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
-    let device = device_slot
+    let readback = readback_slot
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("device slot is empty".into()))?;
-    let bgra = vulkan_readback(&device, &texture);
+        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+    let ticket = readback
+        .submit(&texture, TextureSourceLayout::General)
+        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+    let bgra = readback
+        .wait_and_read(ticket, u64::MAX)
+        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .to_vec();
     write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
 
@@ -422,185 +439,6 @@ fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
     f.write_all(&[0u8; 4 * 4 * 4 * 3])
         .map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(path)
-}
-
-/// Read pixels from the host `StreamTexture` back into a CPU buffer for
-/// PNG verification. Mirrors the helper in
-/// `examples/polyglot-opengl-fragment-shader` — transient HOST_VISIBLE
-/// staging buffer + `vkCmdCopyImageToBuffer` + `queue_wait_idle`.
-fn vulkan_readback(
-    device: &Arc<HostVulkanDevice>,
-    texture: &streamlib::core::rhi::StreamTexture,
-) -> Vec<u8> {
-    use vulkanalia::prelude::v1_4::*;
-    use vulkanalia::vk;
-
-    let dev = device.device();
-    let queue = device.queue();
-    let qf = device.queue_family_index();
-    let image = texture
-        .vulkan_inner()
-        .image()
-        .expect("StreamTexture must have a Vulkan image handle on Linux");
-    let width = texture.width();
-    let height = texture.height();
-    let bytes = (width as u64) * (height as u64) * 4;
-
-    let buf = unsafe {
-        dev.create_buffer(
-            &vk::BufferCreateInfo::builder()
-                .size(bytes)
-                .usage(vk::BufferUsageFlags::TRANSFER_DST)
-                .sharing_mode(vk::SharingMode::EXCLUSIVE)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_buffer");
-    let mem_req = unsafe { dev.get_buffer_memory_requirements(buf) };
-    let inst = device.instance();
-    let phys = device.physical_device();
-    let mem_props = unsafe { inst.get_physical_device_memory_properties(phys) };
-    let needed =
-        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
-    let mem_idx = (0..mem_props.memory_type_count)
-        .find(|i| {
-            let bit = 1u32 << i;
-            (mem_req.memory_type_bits & bit) != 0
-                && mem_props.memory_types[*i as usize]
-                    .property_flags
-                    .contains(needed)
-        })
-        .expect("host-visible memory type");
-    let mem = unsafe {
-        dev.allocate_memory(
-            &vk::MemoryAllocateInfo::builder()
-                .allocation_size(mem_req.size)
-                .memory_type_index(mem_idx)
-                .build(),
-            None,
-        )
-    }
-    .expect("allocate_memory");
-    unsafe { dev.bind_buffer_memory(buf, mem, 0) }.expect("bind_buffer_memory");
-
-    let pool = unsafe {
-        dev.create_command_pool(
-            &vk::CommandPoolCreateInfo::builder()
-                .queue_family_index(qf)
-                .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-                .build(),
-            None,
-        )
-    }
-    .expect("create_command_pool");
-    let cmd = unsafe {
-        dev.allocate_command_buffers(
-            &vk::CommandBufferAllocateInfo::builder()
-                .command_pool(pool)
-                .level(vk::CommandBufferLevel::PRIMARY)
-                .command_buffer_count(1)
-                .build(),
-        )
-    }
-    .expect("allocate_command_buffers")[0];
-    unsafe {
-        dev.begin_command_buffer(
-            cmd,
-            &vk::CommandBufferBeginInfo::builder()
-                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
-                .build(),
-        )
-    }
-    .expect("begin_command_buffer");
-
-    // The compute dispatch left the image in GENERAL — transition to
-    // TRANSFER_SRC_OPTIMAL for the copy, then back to GENERAL.
-    let to_src = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
-        .dst_stage_mask(vk::PipelineStageFlags2::COPY)
-        .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
-        .old_layout(vk::ImageLayout::GENERAL)
-        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-        .src_queue_family_index(qf)
-        .dst_queue_family_index(qf)
-        .image(image)
-        .subresource_range(
-            vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .level_count(1)
-                .layer_count(1)
-                .build(),
-        )
-        .build();
-    let bs = [to_src];
-    let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
-    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep) };
-
-    let copy = vk::BufferImageCopy::builder()
-        .buffer_offset(0)
-        .buffer_row_length(0)
-        .buffer_image_height(0)
-        .image_subresource(
-            vk::ImageSubresourceLayers::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .layer_count(1)
-                .build(),
-        )
-        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-        .image_extent(vk::Extent3D { width, height, depth: 1 })
-        .build();
-    let regions = [copy];
-    unsafe {
-        dev.cmd_copy_image_to_buffer(
-            cmd,
-            image,
-            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-            buf,
-            &regions,
-        )
-    };
-
-    let to_general = vk::ImageMemoryBarrier2::builder()
-        .src_stage_mask(vk::PipelineStageFlags2::COPY)
-        .src_access_mask(vk::AccessFlags2::TRANSFER_READ)
-        .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
-        .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
-        .new_layout(vk::ImageLayout::GENERAL)
-        .src_queue_family_index(qf)
-        .dst_queue_family_index(qf)
-        .image(image)
-        .subresource_range(
-            vk::ImageSubresourceRange::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .level_count(1)
-                .layer_count(1)
-                .build(),
-        )
-        .build();
-    let bs2 = [to_general];
-    let dep2 = vk::DependencyInfo::builder().image_memory_barriers(&bs2).build();
-    unsafe { dev.cmd_pipeline_barrier2(cmd, &dep2) };
-
-    unsafe { dev.end_command_buffer(cmd) }.expect("end_command_buffer");
-    let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
-    let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
-    unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }
-        .expect("submit");
-    unsafe { dev.queue_wait_idle(queue) }.expect("queue_wait_idle");
-
-    let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
-        .expect("map_memory");
-    let slice =
-        unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
-    let out = slice.to_vec();
-    unsafe { dev.unmap_memory(mem) };
-    unsafe { dev.destroy_command_pool(pool, None) };
-    unsafe { dev.destroy_buffer(buf, None) };
-    unsafe { dev.free_memory(mem, None) };
-    out
 }
 
 fn write_png(

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -979,6 +979,34 @@ impl GpuContext {
         Ok(Arc::new(kernel))
     }
 
+    /// Create a host-side texture-readback handle bound to a fixed
+    /// format/extent. The staging buffer + command resources + timeline
+    /// semaphore are allocated once at construction and reused across
+    /// every submit. Single-in-flight per handle (mirroring
+    /// [`crate::vulkan::rhi::VulkanComputeKernel`]); for parallel
+    /// readbacks, hold N handles.
+    #[cfg(target_os = "linux")]
+    pub fn create_texture_readback(
+        &self,
+        descriptor: &crate::core::rhi::TextureReadbackDescriptor<'_>,
+    ) -> Result<Arc<crate::vulkan::rhi::VulkanTextureReadback>> {
+        tracing::debug!(
+            rhi_op = "create_texture_readback",
+            label = descriptor.label,
+            format = ?descriptor.format,
+            width = descriptor.width,
+            height = descriptor.height,
+            bytes = descriptor.staging_size(),
+            "GpuContext::create_texture_readback"
+        );
+        let vulkan_device = &self.device.inner;
+        let handle = crate::vulkan::rhi::VulkanTextureReadback::new_into_stream_error(
+            vulkan_device,
+            descriptor,
+        )?;
+        Ok(Arc::new(handle))
+    }
+
     /// Initialize GPU context for the current platform.
     pub fn init_for_platform() -> Result<Self> {
         #[cfg(target_os = "macos")]

--- a/libs/streamlib/src/core/rhi/mod.rs
+++ b/libs/streamlib/src/core/rhi/mod.rs
@@ -18,6 +18,7 @@ mod pixel_buffer_pool;
 mod pixel_buffer_ref;
 mod texture;
 mod texture_cache;
+mod texture_readback;
 
 pub use backend::RhiBackend;
 pub use blitter::RhiBlitter;
@@ -44,3 +45,6 @@ pub use pixel_buffer_ref::RhiPixelBufferRef;
 pub use streamlib_consumer_rhi::{PixelFormat, TextureFormat, TextureUsages};
 pub use texture::{NativeTextureHandle, StreamTexture, TextureDescriptor};
 pub use texture_cache::{RhiTextureCache, RhiTextureView};
+pub use texture_readback::{
+    ReadbackTicket, TextureReadbackDescriptor, TextureReadbackError, TextureSourceLayout,
+};

--- a/libs/streamlib/src/core/rhi/texture_readback.rs
+++ b/libs/streamlib/src/core/rhi/texture_readback.rs
@@ -30,8 +30,8 @@ pub struct TextureReadbackDescriptor<'a> {
     pub height: u32,
 }
 
-/// Last-known image layout the texture is in when handed to
-/// [`submit`](super::super::vulkan::rhi::VulkanTextureReadback::submit).
+/// Last-known image layout the texture is in when handed to the
+/// readback handle's `submit`.
 ///
 /// The readback transitions `source_layout → TRANSFER_SRC_OPTIMAL` for
 /// the copy and back to `source_layout` afterward, so the texture is in

--- a/libs/streamlib/src/core/rhi/texture_readback.rs
+++ b/libs/streamlib/src/core/rhi/texture_readback.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Public descriptor + error types for the host-side texture-readback RHI primitive.
+//!
+//! Pattern follows production engines (Unreal `FRHIGPUTextureReadback`, bgfx
+//! `bgfx::readTexture`, WebGPU `copyTextureToBuffer + mapAsync`, Granite
+//! `copy_image_to_buffer + vkSemaphoreWaitKHR`): caller creates a readback
+//! handle bound to a fixed format/extent, then submits copies that return a
+//! ticket; the staging buffer + command resources + timeline semaphore are
+//! allocated once at construction and reused across submits.
+
+use crate::core::rhi::TextureFormat;
+
+/// Texture-readback descriptor: pin format + extent at construction.
+///
+/// The handle's staging buffer is sized to `width * height *
+/// format.bytes_per_pixel()` and reused across every submit. Submits
+/// against a texture whose format/extent disagree with the descriptor
+/// return [`TextureReadbackError::DescriptorMismatch`].
+#[derive(Debug, Clone)]
+pub struct TextureReadbackDescriptor<'a> {
+    /// Human-readable label used in error messages and tracing.
+    pub label: &'a str,
+    /// Pixel format of the texture(s) this readback will copy from.
+    pub format: TextureFormat,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
+/// Last-known image layout the texture is in when handed to
+/// [`submit`](super::super::vulkan::rhi::VulkanTextureReadback::submit).
+///
+/// The readback transitions `source_layout → TRANSFER_SRC_OPTIMAL` for
+/// the copy and back to `source_layout` afterward, so the texture is in
+/// the same layout before and after.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextureSourceLayout {
+    /// Image was last used in compute / general read-write
+    /// (`VK_IMAGE_LAYOUT_GENERAL`). The default for textures produced by
+    /// compute kernels and for images coming back from graphics-API
+    /// composers (Skia, OpenGL) that don't expose an explicit layout.
+    General,
+    /// Image was last used as a color attachment in a render pass
+    /// (`VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL`).
+    ColorAttachment,
+    /// Image was last used as a shader-read-only sampled texture
+    /// (`VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`).
+    ShaderReadOnly,
+}
+
+/// Opaque ticket returned by submit; pass to `try_read` / `wait_and_read`
+/// to retrieve the staging buffer's contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadbackTicket {
+    /// Identity of the readback handle that issued the ticket. Tickets
+    /// from one handle are not valid against another.
+    pub(crate) handle_id: u64,
+    /// Timeline counter value the handle's signal semaphore reaches when
+    /// the GPU copy is complete.
+    pub(crate) counter: u64,
+}
+
+/// Error taxonomy for the texture-readback RHI primitive.
+///
+/// Named variants — each carries enough context to diagnose without
+/// re-running. `From<TextureReadbackError> for StreamError` (in the
+/// host-side impl module) keeps callers in the existing `Result<T>`
+/// channel.
+#[derive(Debug, thiserror::Error)]
+pub enum TextureReadbackError {
+    /// Failed to create the staging buffer or its memory.
+    #[error("texture readback '{label}': failed to create staging buffer ({size} bytes): {cause}")]
+    StagingBufferAlloc {
+        label: String,
+        size: u64,
+        cause: String,
+    },
+    /// Failed to create the command pool, command buffer, or fence/semaphore.
+    #[error("texture readback '{label}': failed to create command resource ({what}): {cause}")]
+    CommandResources {
+        label: String,
+        what: &'static str,
+        cause: String,
+    },
+    /// Texture handed to submit() doesn't match the descriptor's
+    /// format/extent.
+    #[error(
+        "texture readback '{label}': texture (format={actual_format:?}, {actual_width}x{actual_height}) \
+         does not match descriptor (format={expected_format:?}, {expected_width}x{expected_height})"
+    )]
+    DescriptorMismatch {
+        label: String,
+        expected_format: TextureFormat,
+        expected_width: u32,
+        expected_height: u32,
+        actual_format: TextureFormat,
+        actual_width: u32,
+        actual_height: u32,
+    },
+    /// Texture handed to submit() has no Vulkan image handle (e.g. the
+    /// texture was constructed for a non-Vulkan backend).
+    #[error("texture readback '{label}': texture has no Vulkan image handle")]
+    TextureMissingVulkanImage { label: String },
+    /// submit() called while a prior submit's ticket hasn't been waited.
+    /// The handle is single-in-flight: hold N handles for N parallel
+    /// readbacks, mirroring `VulkanComputeKernel`.
+    #[error(
+        "texture readback '{label}': submit() called with prior ticket (counter={pending}) still in flight"
+    )]
+    InFlight { label: String, pending: u64 },
+    /// try_read / wait_and_read called with no in-flight submission.
+    #[error("texture readback '{label}': no in-flight submission to read from")]
+    NoSubmission { label: String },
+    /// Ticket from a different readback handle was passed.
+    #[error(
+        "texture readback '{label}': ticket from foreign handle (id {ticket_handle_id}, this handle id {handle_id})"
+    )]
+    ForeignTicket {
+        label: String,
+        handle_id: u64,
+        ticket_handle_id: u64,
+    },
+    /// Ticket counter doesn't match the in-flight submission (caller
+    /// passed a ticket from a different submit on the same handle —
+    /// since the handle is single-in-flight this means a ticket was
+    /// reused across submits).
+    #[error(
+        "texture readback '{label}': ticket counter {ticket} does not match in-flight counter {pending}"
+    )]
+    StaleTicket {
+        label: String,
+        ticket: u64,
+        pending: u64,
+    },
+    /// Command recording or queue submission failed.
+    #[error("texture readback '{label}': {what} failed: {cause}")]
+    Submit {
+        label: String,
+        what: &'static str,
+        cause: String,
+    },
+    /// Wait timed out (`wait_and_read` with explicit timeout).
+    #[error("texture readback '{label}': wait timed out after {timeout_ns}ns")]
+    WaitTimeout { label: String, timeout_ns: u64 },
+}
+
+impl TextureReadbackDescriptor<'_> {
+    /// Total staging-buffer size in bytes for this descriptor.
+    pub fn staging_size(&self) -> u64 {
+        (self.width as u64) * (self.height as u64) * (self.format.bytes_per_pixel() as u64)
+    }
+}

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -192,7 +192,7 @@ pub mod linux_surface_share {
 pub mod host_rhi {
     pub use crate::vulkan::rhi::{
         HostMarker, HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTexture,
-        HostVulkanTimelineSemaphore, VulkanComputeKernel,
+        HostVulkanTimelineSemaphore, VulkanComputeKernel, VulkanTextureReadback,
     };
 }
 

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -60,6 +60,9 @@ pub use vulkan_pixel_buffer_pool::VulkanPixelBufferPool;
 mod vulkan_compute_kernel;
 pub use vulkan_compute_kernel::VulkanComputeKernel;
 
+mod vulkan_texture_readback;
+pub use vulkan_texture_readback::VulkanTextureReadback;
+
 mod vulkan_format_converter;
 pub use vulkan_format_converter::VulkanFormatConverter;
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -1,0 +1,1169 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side texture readback: GPU image → HOST_VISIBLE staging buffer.
+//!
+//! Engine precedent: Unreal `FRHIGPUTextureReadback`, bgfx
+//! `bgfx::readTexture`, WebGPU `copyTextureToBuffer + mapAsync`,
+//! Granite `copy_image_to_buffer + vkSemaphoreWaitKHR`. Caller creates
+//! a handle bound to a fixed format/extent; per submit, the handle
+//! transitions the image into `TRANSFER_SRC_OPTIMAL`, copies into a
+//! reusable persistent-mapped staging buffer, transitions back, and
+//! signals a timeline semaphore. Tickets are timeline counter values.
+//!
+//! Single-in-flight per handle (the staging buffer + command buffer are
+//! one-each, mirroring [`super::VulkanComputeKernel`]). For parallel
+//! readbacks, hold N handles.
+//!
+//! All submits ride [`super::HostVulkanDevice::submit_to_queue`] — same
+//! per-queue mutex everything else uses.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+use vulkanalia_vma as vma;
+use vma::Alloc as _;
+
+use crate::core::rhi::{
+    ReadbackTicket, StreamTexture, TextureFormat, TextureReadbackDescriptor, TextureReadbackError,
+    TextureSourceLayout,
+};
+use crate::core::{Result, StreamError};
+
+use super::HostVulkanDevice;
+
+/// Process-wide handle-id counter. Used to tag every readback handle so
+/// foreign tickets are caught at try_read / wait_and_read.
+static HANDLE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Host-side texture readback primitive. Bound to a fixed format/extent
+/// at construction; the staging buffer + command resources + timeline
+/// semaphore are allocated once and reused across every submit.
+pub struct VulkanTextureReadback {
+    label: String,
+    handle_id: u64,
+    vulkan_device: Arc<HostVulkanDevice>,
+    device: vulkanalia::Device,
+    queue: vk::Queue,
+    queue_family_index: u32,
+    format: TextureFormat,
+    width: u32,
+    height: u32,
+    /// Total staging-buffer size in bytes (`width * height * bpp`).
+    bytes: u64,
+    /// VMA staging buffer (HOST_VISIBLE | HOST_COHERENT, persistent-mapped).
+    staging_buffer: vk::Buffer,
+    staging_allocation: vma::Allocation,
+    mapped_ptr: *mut u8,
+    /// Owned command pool + command buffer. Reset per submit.
+    command_pool: vk::CommandPool,
+    command_buffer: vk::CommandBuffer,
+    /// Owned timeline semaphore. Each submit signals at a higher counter
+    /// value; tickets are those counter values. `next_counter` is the
+    /// value the next submit will signal at.
+    timeline: vk::Semaphore,
+    state: Mutex<State>,
+}
+
+#[derive(Debug)]
+struct State {
+    /// Counter value the next submit will signal at. Monotonic, never
+    /// decreases.
+    next_counter: u64,
+    /// `Some(counter)` if a submit is in flight at that counter; `None`
+    /// when idle.
+    pending: Option<u64>,
+}
+
+impl VulkanTextureReadback {
+    /// Create a new readback handle bound to a fixed format/extent.
+    ///
+    /// Allocates the staging buffer, command pool/buffer, and timeline
+    /// semaphore up-front. On any error every previously-allocated
+    /// resource is torn down before returning so the construction path
+    /// never leaks.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            rhi_op = "create_texture_readback",
+            label = descriptor.label,
+            format = ?descriptor.format,
+            width = descriptor.width,
+            height = descriptor.height,
+            bytes = descriptor.staging_size(),
+        )
+    )]
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &TextureReadbackDescriptor<'_>,
+    ) -> std::result::Result<Self, TextureReadbackError> {
+        let label = descriptor.label.to_string();
+        let bytes = descriptor.staging_size();
+        let queue = vulkan_device.queue();
+        let queue_family_index = vulkan_device.queue_family_index();
+        let device = vulkan_device.device().clone();
+
+        // ---- Staging buffer (VMA default allocator, HOST_VISIBLE | HOST_COHERENT, persistent-mapped) ----
+        // Non-export readback — no DMA-BUF, no custom pool. The VMA
+        // default allocator is the right fit; the export pool isolation
+        // pattern in `vma-export-pools.md` is for exportable
+        // allocations only.
+        let buffer_info = vk::BufferCreateInfo::builder()
+            .size(bytes)
+            .usage(vk::BufferUsageFlags::TRANSFER_DST)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+        let alloc_opts = vma::AllocationOptions {
+            // HOST_ACCESS_RANDOM: reading. MAPPED: persistent map.
+            flags: vma::AllocationCreateFlags::HOST_ACCESS_RANDOM
+                | vma::AllocationCreateFlags::MAPPED,
+            required_flags: vk::MemoryPropertyFlags::HOST_VISIBLE
+                | vk::MemoryPropertyFlags::HOST_COHERENT,
+            ..Default::default()
+        };
+
+        let allocator = vulkan_device.allocator();
+        let (staging_buffer, staging_allocation) =
+            unsafe { allocator.create_buffer(buffer_info, &alloc_opts) }.map_err(|e| {
+                TextureReadbackError::StagingBufferAlloc {
+                    label: label.clone(),
+                    size: bytes,
+                    cause: e.to_string(),
+                }
+            })?;
+
+        let alloc_info = allocator.get_allocation_info(staging_allocation);
+        let mapped_ptr = alloc_info.pMappedData.cast::<u8>();
+        if mapped_ptr.is_null() {
+            unsafe { allocator.destroy_buffer(staging_buffer, staging_allocation) };
+            return Err(TextureReadbackError::StagingBufferAlloc {
+                label,
+                size: bytes,
+                cause: "VMA returned null mapped pointer despite MAPPED flag".into(),
+            });
+        }
+
+        // ---- Command pool + buffer (RESET_COMMAND_BUFFER so we can re-record per submit) ----
+        let command_pool = match unsafe {
+            device.create_command_pool(
+                &vk::CommandPoolCreateInfo::builder()
+                    .queue_family_index(queue_family_index)
+                    .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
+                    .build(),
+                None,
+            )
+        } {
+            Ok(p) => p,
+            Err(e) => {
+                unsafe { allocator.destroy_buffer(staging_buffer, staging_allocation) };
+                return Err(TextureReadbackError::CommandResources {
+                    label,
+                    what: "command pool",
+                    cause: e.to_string(),
+                });
+            }
+        };
+
+        let command_buffer = match unsafe {
+            device.allocate_command_buffers(
+                &vk::CommandBufferAllocateInfo::builder()
+                    .command_pool(command_pool)
+                    .level(vk::CommandBufferLevel::PRIMARY)
+                    .command_buffer_count(1)
+                    .build(),
+            )
+        } {
+            Ok(bufs) => bufs[0],
+            Err(e) => {
+                unsafe {
+                    device.destroy_command_pool(command_pool, None);
+                    allocator.destroy_buffer(staging_buffer, staging_allocation);
+                }
+                return Err(TextureReadbackError::CommandResources {
+                    label,
+                    what: "command buffer",
+                    cause: e.to_string(),
+                });
+            }
+        };
+
+        // ---- Timeline semaphore (counter starts at 0; first submit signals at 1) ----
+        let mut type_info = vk::SemaphoreTypeCreateInfo::builder()
+            .semaphore_type(vk::SemaphoreType::TIMELINE)
+            .initial_value(0)
+            .build();
+        let sem_info = vk::SemaphoreCreateInfo::builder()
+            .push_next(&mut type_info)
+            .build();
+        let timeline = match unsafe { device.create_semaphore(&sem_info, None) } {
+            Ok(s) => s,
+            Err(e) => {
+                unsafe {
+                    device.destroy_command_pool(command_pool, None);
+                    allocator.destroy_buffer(staging_buffer, staging_allocation);
+                }
+                return Err(TextureReadbackError::CommandResources {
+                    label,
+                    what: "timeline semaphore",
+                    cause: e.to_string(),
+                });
+            }
+        };
+
+        let handle_id = HANDLE_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+        Ok(Self {
+            label,
+            handle_id,
+            vulkan_device: Arc::clone(vulkan_device),
+            device,
+            queue,
+            queue_family_index,
+            format: descriptor.format,
+            width: descriptor.width,
+            height: descriptor.height,
+            bytes,
+            staging_buffer,
+            staging_allocation,
+            mapped_ptr,
+            command_pool,
+            command_buffer,
+            timeline,
+            state: Mutex::new(State {
+                next_counter: 0,
+                pending: None,
+            }),
+        })
+    }
+
+    /// Submit a copy of `texture` into the handle's staging buffer.
+    ///
+    /// `source_layout` is the layout the texture is currently in; the
+    /// readback transitions it to `TRANSFER_SRC_OPTIMAL` for the copy
+    /// and back to `source_layout` afterward. Single-in-flight: a second
+    /// submit before the prior ticket is waited returns
+    /// [`TextureReadbackError::InFlight`].
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            rhi_op = "texture_readback_submit",
+            label = self.label.as_str(),
+            handle_id = self.handle_id,
+            source_layout = ?source_layout,
+        )
+    )]
+    pub fn submit(
+        &self,
+        texture: &StreamTexture,
+        source_layout: TextureSourceLayout,
+    ) -> std::result::Result<ReadbackTicket, TextureReadbackError> {
+        // ---- Validate descriptor match ----
+        if texture.format() != self.format
+            || texture.width() != self.width
+            || texture.height() != self.height
+        {
+            return Err(TextureReadbackError::DescriptorMismatch {
+                label: self.label.clone(),
+                expected_format: self.format,
+                expected_width: self.width,
+                expected_height: self.height,
+                actual_format: texture.format(),
+                actual_width: texture.width(),
+                actual_height: texture.height(),
+            });
+        }
+
+        let image = texture.vulkan_inner().image().ok_or_else(|| {
+            TextureReadbackError::TextureMissingVulkanImage {
+                label: self.label.clone(),
+            }
+        })?;
+
+        // ---- Single-in-flight check + counter allocation ----
+        let counter = {
+            let mut state = self.state.lock();
+            if let Some(pending) = state.pending {
+                return Err(TextureReadbackError::InFlight {
+                    label: self.label.clone(),
+                    pending,
+                });
+            }
+            state.next_counter += 1;
+            let c = state.next_counter;
+            state.pending = Some(c);
+            c
+        };
+
+        // From this point on, any failure must clear `pending` so the
+        // handle is recoverable.
+        let result = self.record_and_submit(image, source_layout, counter);
+        if result.is_err() {
+            self.state.lock().pending = None;
+        }
+        result.map(|_| ReadbackTicket {
+            handle_id: self.handle_id,
+            counter,
+        })
+    }
+
+    /// Non-blocking check + read. Returns `Ok(Some(bytes))` if the GPU
+    /// copy has completed, `Ok(None)` if still in flight, or `Err` for
+    /// foreign / stale tickets and driver errors.
+    ///
+    /// On `Some`, the handle is reset to idle — the next `submit()` may
+    /// overwrite the staging buffer. The returned slice borrows the
+    /// handle's mapped memory; the borrow's lifetime ties to `&self`.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            rhi_op = "texture_readback_try_read",
+            label = self.label.as_str(),
+            handle_id = self.handle_id,
+            ticket = ticket.counter,
+        )
+    )]
+    pub fn try_read(
+        &self,
+        ticket: ReadbackTicket,
+    ) -> std::result::Result<Option<&[u8]>, TextureReadbackError> {
+        self.validate_ticket(ticket)?;
+        let current = unsafe { self.device.get_semaphore_counter_value(self.timeline) }
+            .map_err(|e| TextureReadbackError::Submit {
+                label: self.label.clone(),
+                what: "vkGetSemaphoreCounterValue",
+                cause: e.to_string(),
+            })?;
+        if current < ticket.counter {
+            return Ok(None);
+        }
+        self.state.lock().pending = None;
+        Ok(Some(self.mapped_slice()))
+    }
+
+    /// Block until the GPU copy completes, then return the staging
+    /// buffer contents. Pass `u64::MAX` as `timeout_ns` for "no timeout".
+    ///
+    /// On success the handle is reset to idle. The returned slice
+    /// borrows the handle's mapped memory; the borrow's lifetime ties
+    /// to `&self`.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            rhi_op = "texture_readback_wait_and_read",
+            label = self.label.as_str(),
+            handle_id = self.handle_id,
+            ticket = ticket.counter,
+            timeout_ns,
+        )
+    )]
+    pub fn wait_and_read(
+        &self,
+        ticket: ReadbackTicket,
+        timeout_ns: u64,
+    ) -> std::result::Result<&[u8], TextureReadbackError> {
+        self.validate_ticket(ticket)?;
+        let semaphores = [self.timeline];
+        let values = [ticket.counter];
+        let info = vk::SemaphoreWaitInfo::builder()
+            .flags(vk::SemaphoreWaitFlags::empty())
+            .semaphores(&semaphores)
+            .values(&values)
+            .build();
+        let outcome = unsafe { self.device.wait_semaphores(&info, timeout_ns) }.map_err(|e| {
+            TextureReadbackError::Submit {
+                label: self.label.clone(),
+                what: "vkWaitSemaphores",
+                cause: e.to_string(),
+            }
+        })?;
+        // Vulkan reports timeout as `VK_TIMEOUT` (a positive success
+        // code), not as an error. vulkanalia returns it via Ok().
+        if outcome == vk::SuccessCode::TIMEOUT {
+            return Err(TextureReadbackError::WaitTimeout {
+                label: self.label.clone(),
+                timeout_ns,
+            });
+        }
+        self.state.lock().pending = None;
+        Ok(self.mapped_slice())
+    }
+
+    /// Borrow the staging buffer through a closure — the closure runs
+    /// after `wait_semaphores` returns, then the handle resets to idle.
+    /// Useful when the bytes are streamed directly into ffmpeg / a PNG
+    /// encoder / etc. without an intermediate `Vec<u8>`.
+    pub fn wait_and_read_with<R>(
+        &self,
+        ticket: ReadbackTicket,
+        timeout_ns: u64,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> std::result::Result<R, TextureReadbackError> {
+        let bytes = self.wait_and_read(ticket, timeout_ns)?;
+        Ok(f(bytes))
+    }
+
+    /// Format the handle was constructed with.
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+
+    /// Width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Total staging-buffer size in bytes (`width * height * bpp`).
+    pub fn staging_size(&self) -> u64 {
+        self.bytes
+    }
+
+    /// Process-unique handle id.
+    pub fn handle_id(&self) -> u64 {
+        self.handle_id
+    }
+
+    // ---- internals ----------------------------------------------------------
+
+    fn validate_ticket(
+        &self,
+        ticket: ReadbackTicket,
+    ) -> std::result::Result<(), TextureReadbackError> {
+        if ticket.handle_id != self.handle_id {
+            return Err(TextureReadbackError::ForeignTicket {
+                label: self.label.clone(),
+                handle_id: self.handle_id,
+                ticket_handle_id: ticket.handle_id,
+            });
+        }
+        let state = self.state.lock();
+        match state.pending {
+            None => Err(TextureReadbackError::NoSubmission {
+                label: self.label.clone(),
+            }),
+            Some(pending) if pending != ticket.counter => Err(TextureReadbackError::StaleTicket {
+                label: self.label.clone(),
+                ticket: ticket.counter,
+                pending,
+            }),
+            Some(_) => Ok(()),
+        }
+    }
+
+    fn mapped_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.mapped_ptr, self.bytes as usize) }
+    }
+
+    fn record_and_submit(
+        &self,
+        image: vk::Image,
+        source_layout: TextureSourceLayout,
+        counter: u64,
+    ) -> std::result::Result<(), TextureReadbackError> {
+        let qf = self.queue_family_index;
+        let vk_layout = vk_layout_for(source_layout);
+
+        unsafe {
+            self.device
+                .reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
+                .map_err(|e| TextureReadbackError::Submit {
+                    label: self.label.clone(),
+                    what: "vkResetCommandBuffer",
+                    cause: e.to_string(),
+                })?;
+
+            let begin_info = vk::CommandBufferBeginInfo::builder()
+                .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                .build();
+            self.device
+                .begin_command_buffer(self.command_buffer, &begin_info)
+                .map_err(|e| TextureReadbackError::Submit {
+                    label: self.label.clone(),
+                    what: "vkBeginCommandBuffer",
+                    cause: e.to_string(),
+                })?;
+
+            // Pre-barrier: source_layout → TRANSFER_SRC_OPTIMAL.
+            // ALL_COMMANDS / MEMORY_WRITE in the src masks is the
+            // tolerant pattern matching the polyglot examples — covers
+            // any stage that may have last written the image.
+            let to_src = vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+                .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+                .dst_access_mask(vk::AccessFlags2::TRANSFER_READ)
+                .old_layout(vk_layout)
+                .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .image(image)
+                .subresource_range(
+                    vk::ImageSubresourceRange::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .level_count(1)
+                        .layer_count(1)
+                        .build(),
+                )
+                .build();
+            let pre_barriers = [to_src];
+            let pre_dep = vk::DependencyInfo::builder()
+                .image_memory_barriers(&pre_barriers)
+                .build();
+            self.device.cmd_pipeline_barrier2(self.command_buffer, &pre_dep);
+
+            // Copy.
+            let copy = vk::BufferImageCopy::builder()
+                .buffer_offset(0)
+                .buffer_row_length(0)
+                .buffer_image_height(0)
+                .image_subresource(
+                    vk::ImageSubresourceLayers::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .layer_count(1)
+                        .build(),
+                )
+                .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+                .image_extent(vk::Extent3D {
+                    width: self.width,
+                    height: self.height,
+                    depth: 1,
+                })
+                .build();
+            let regions = [copy];
+            self.device.cmd_copy_image_to_buffer(
+                self.command_buffer,
+                image,
+                vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+                self.staging_buffer,
+                &regions,
+            );
+
+            // Post-barrier: TRANSFER_SRC_OPTIMAL → source_layout
+            // (restore), plus a buffer barrier so the host reading the
+            // staging buffer after wait sees the writes.
+            let to_orig = vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::COPY)
+                .src_access_mask(vk::AccessFlags2::TRANSFER_READ)
+                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+                .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+                .new_layout(vk_layout)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .image(image)
+                .subresource_range(
+                    vk::ImageSubresourceRange::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .level_count(1)
+                        .layer_count(1)
+                        .build(),
+                )
+                .build();
+            let buffer_to_host = vk::BufferMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::COPY)
+                .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                .dst_stage_mask(vk::PipelineStageFlags2::HOST)
+                .dst_access_mask(vk::AccessFlags2::HOST_READ)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .buffer(self.staging_buffer)
+                .offset(0)
+                .size(self.bytes)
+                .build();
+            let post_image = [to_orig];
+            let post_buffer = [buffer_to_host];
+            let post_dep = vk::DependencyInfo::builder()
+                .image_memory_barriers(&post_image)
+                .buffer_memory_barriers(&post_buffer)
+                .build();
+            self.device.cmd_pipeline_barrier2(self.command_buffer, &post_dep);
+
+            self.device
+                .end_command_buffer(self.command_buffer)
+                .map_err(|e| TextureReadbackError::Submit {
+                    label: self.label.clone(),
+                    what: "vkEndCommandBuffer",
+                    cause: e.to_string(),
+                })?;
+
+            // Signal the timeline at `counter`.
+            let cmd_info = vk::CommandBufferSubmitInfo::builder()
+                .command_buffer(self.command_buffer)
+                .build();
+            let sig_info = vk::SemaphoreSubmitInfo::builder()
+                .semaphore(self.timeline)
+                .value(counter)
+                .stage_mask(vk::PipelineStageFlags2::COPY)
+                .build();
+            let cmd_infos = [cmd_info];
+            let sig_infos = [sig_info];
+            let submit = vk::SubmitInfo2::builder()
+                .command_buffer_infos(&cmd_infos)
+                .signal_semaphore_infos(&sig_infos)
+                .build();
+
+            self.vulkan_device
+                .submit_to_queue(self.queue, &[submit], vk::Fence::null())
+                .map_err(|e| TextureReadbackError::Submit {
+                    label: self.label.clone(),
+                    what: "queue submit",
+                    cause: e.to_string(),
+                })?;
+        }
+
+        Ok(())
+    }
+}
+
+fn vk_layout_for(layout: TextureSourceLayout) -> vk::ImageLayout {
+    match layout {
+        TextureSourceLayout::General => vk::ImageLayout::GENERAL,
+        TextureSourceLayout::ColorAttachment => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        TextureSourceLayout::ShaderReadOnly => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+    }
+}
+
+impl Drop for VulkanTextureReadback {
+    fn drop(&mut self) {
+        unsafe {
+            // Wait for any in-flight submission so we don't tear down
+            // resources the GPU still holds.
+            let _ = self.device.device_wait_idle();
+            self.device.destroy_semaphore(self.timeline, None);
+            self.device.destroy_command_pool(self.command_pool, None);
+            self.vulkan_device
+                .allocator()
+                .destroy_buffer(self.staging_buffer, self.staging_allocation);
+        }
+    }
+}
+
+// Vulkan handles in this struct are protected by the handle's owned
+// timeline semaphore: only one submit is in-flight at a time, and the
+// state mutex serializes counter allocation across threads.
+unsafe impl Send for VulkanTextureReadback {}
+unsafe impl Sync for VulkanTextureReadback {}
+
+impl std::fmt::Debug for VulkanTextureReadback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanTextureReadback")
+            .field("label", &self.label)
+            .field("handle_id", &self.handle_id)
+            .field("format", &self.format)
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("bytes", &self.bytes)
+            .finish()
+    }
+}
+
+impl From<TextureReadbackError> for StreamError {
+    fn from(e: TextureReadbackError) -> Self {
+        StreamError::GpuError(e.to_string())
+    }
+}
+
+/// Convenience for callers that already work in `Result<T, StreamError>`.
+impl VulkanTextureReadback {
+    pub fn new_into_stream_error(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &TextureReadbackDescriptor<'_>,
+    ) -> Result<Self> {
+        Self::new(vulkan_device, descriptor).map_err(StreamError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::rhi::TextureDescriptor;
+
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
+            Ok(d) => Some(Arc::new(d)),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                None
+            }
+        }
+    }
+
+    /// Allocate a host-side BGRA8 texture with TRANSFER_SRC + STORAGE
+    /// usage and fill plane 0 with a deterministic pattern via a
+    /// pre-recorded copy from a HOST_VISIBLE staging buffer.
+    fn make_filled_texture(
+        device: &Arc<HostVulkanDevice>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        pattern: impl Fn(u32, u32) -> [u8; 4],
+    ) -> StreamTexture {
+        use crate::core::rhi::PixelFormat;
+        use crate::vulkan::rhi::HostVulkanPixelBuffer;
+
+        let bpp = format.bytes_per_pixel();
+        // Allocate staging via the export-capable pool — fine for fill:
+        // we only need HOST_VISIBLE + TRANSFER_SRC.
+        let pix_format = match format {
+            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => PixelFormat::Bgra32,
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => PixelFormat::Bgra32,
+            other => panic!("test fixture only supports 8-bit RGBA/BGRA, got {other:?}"),
+        };
+        let staging =
+            HostVulkanPixelBuffer::new(device, width, height, bpp, pix_format).expect("staging");
+        unsafe {
+            let mut p = staging.mapped_ptr();
+            for y in 0..height {
+                for x in 0..width {
+                    let px = pattern(x, y);
+                    std::ptr::copy_nonoverlapping(px.as_ptr(), p, 4);
+                    p = p.add(4);
+                }
+            }
+        }
+
+        // Allocate the destination texture via the device's RHI helper —
+        // a `STORAGE_BINDING | COPY_SRC | COPY_DST` 2D image. We can't
+        // use `acquire_render_target_dma_buf_image` here because tests
+        // don't have a `GpuContext`; we go straight to `HostVulkanTexture`.
+        let desc = TextureDescriptor {
+            width,
+            height,
+            format,
+            usage: crate::core::rhi::TextureUsages::COPY_SRC
+                | crate::core::rhi::TextureUsages::COPY_DST
+                | crate::core::rhi::TextureUsages::STORAGE_BINDING,
+            label: Some("readback-test-texture"),
+        };
+        let host_tex = crate::vulkan::rhi::HostVulkanTexture::new(device, &desc).expect("texture");
+        let texture = StreamTexture {
+            inner: Arc::new(host_tex),
+        };
+
+        // Record + submit a one-shot copy from staging → texture.
+        let dev = device.device();
+        let queue = device.queue();
+        let qf = device.queue_family_index();
+        let pool = unsafe {
+            dev.create_command_pool(
+                &vk::CommandPoolCreateInfo::builder()
+                    .queue_family_index(qf)
+                    .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                    .build(),
+                None,
+            )
+        }
+        .expect("pool");
+        let cmd = unsafe {
+            dev.allocate_command_buffers(
+                &vk::CommandBufferAllocateInfo::builder()
+                    .command_pool(pool)
+                    .level(vk::CommandBufferLevel::PRIMARY)
+                    .command_buffer_count(1)
+                    .build(),
+            )
+        }
+        .expect("cmd")[0];
+        unsafe {
+            dev.begin_command_buffer(
+                cmd,
+                &vk::CommandBufferBeginInfo::builder()
+                    .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                    .build(),
+            )
+            .expect("begin");
+
+            // UNDEFINED → TRANSFER_DST_OPTIMAL.
+            let to_dst = vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .src_access_mask(vk::AccessFlags2::empty())
+                .dst_stage_mask(vk::PipelineStageFlags2::COPY)
+                .dst_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .image(texture.vulkan_inner().image().expect("vk image"))
+                .subresource_range(
+                    vk::ImageSubresourceRange::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .level_count(1)
+                        .layer_count(1)
+                        .build(),
+                )
+                .build();
+            let bs = [to_dst];
+            let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+            dev.cmd_pipeline_barrier2(cmd, &dep);
+
+            let copy = vk::BufferImageCopy::builder()
+                .buffer_offset(0)
+                .buffer_row_length(0)
+                .buffer_image_height(0)
+                .image_subresource(
+                    vk::ImageSubresourceLayers::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .layer_count(1)
+                        .build(),
+                )
+                .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+                .image_extent(vk::Extent3D { width, height, depth: 1 })
+                .build();
+            let regions = [copy];
+            dev.cmd_copy_buffer_to_image(
+                cmd,
+                staging.buffer(),
+                texture.vulkan_inner().image().expect("vk image"),
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                &regions,
+            );
+
+            // TRANSFER_DST_OPTIMAL → GENERAL.
+            let to_general = vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::COPY)
+                .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .dst_access_mask(vk::AccessFlags2::MEMORY_READ)
+                .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                .new_layout(vk::ImageLayout::GENERAL)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .image(texture.vulkan_inner().image().expect("vk image"))
+                .subresource_range(
+                    vk::ImageSubresourceRange::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .level_count(1)
+                        .layer_count(1)
+                        .build(),
+                )
+                .build();
+            let bs2 = [to_general];
+            let dep2 = vk::DependencyInfo::builder().image_memory_barriers(&bs2).build();
+            dev.cmd_pipeline_barrier2(cmd, &dep2);
+
+            dev.end_command_buffer(cmd).expect("end");
+            let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
+            let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
+            device
+                .submit_to_queue(queue, &submits, vk::Fence::null())
+                .expect("submit fill");
+            dev.queue_wait_idle(queue).expect("wait idle");
+            dev.destroy_command_pool(pool, None);
+        }
+
+        texture
+    }
+
+    /// Positive: round-trip a known pattern through the readback
+    /// primitive on a 32x32 texture.
+    #[test]
+    fn submit_then_wait_returns_expected_bytes() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let width = 32u32;
+        let height = 32u32;
+        let pattern = |x: u32, y: u32| {
+            [
+                ((x.wrapping_mul(7)) & 0xFF) as u8,
+                ((y.wrapping_mul(11)) & 0xFF) as u8,
+                (((x ^ y).wrapping_mul(13)) & 0xFF) as u8,
+                0xFF,
+            ]
+        };
+        let texture =
+            make_filled_texture(&device, width, height, TextureFormat::Bgra8Unorm, pattern);
+
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-positive",
+                format: TextureFormat::Bgra8Unorm,
+                width,
+                height,
+            },
+        )
+        .expect("readback");
+
+        let ticket = readback
+            .submit(&texture, TextureSourceLayout::General)
+            .expect("submit");
+        let bytes = readback.wait_and_read(ticket, u64::MAX).expect("wait");
+        for y in 0..height {
+            for x in 0..width {
+                let off = ((y * width + x) * 4) as usize;
+                assert_eq!(
+                    &bytes[off..off + 4],
+                    &pattern(x, y),
+                    "mismatch at ({x},{y})"
+                );
+            }
+        }
+    }
+
+    /// Positive: multiple submits sequentially on a single handle. After
+    /// each wait, the next submit must succeed and the bytes reflect
+    /// the (re-filled) texture.
+    #[test]
+    fn multiple_sequential_submits_work() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let width = 16u32;
+        let height = 16u32;
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-sequential",
+                format: TextureFormat::Bgra8Unorm,
+                width,
+                height,
+            },
+        )
+        .expect("readback");
+
+        for run in 0..3u32 {
+            let pattern = move |x: u32, y: u32| {
+                [
+                    ((x + run * 5) & 0xFF) as u8,
+                    ((y + run * 7) & 0xFF) as u8,
+                    ((run * 11) & 0xFF) as u8,
+                    0xFF,
+                ]
+            };
+            let texture =
+                make_filled_texture(&device, width, height, TextureFormat::Bgra8Unorm, pattern);
+            let ticket = readback.submit(&texture, TextureSourceLayout::General).expect("submit");
+            let bytes = readback.wait_and_read(ticket, u64::MAX).expect("wait");
+            for y in 0..height {
+                for x in 0..width {
+                    let off = ((y * width + x) * 4) as usize;
+                    assert_eq!(
+                        &bytes[off..off + 4],
+                        &pattern(x, y),
+                        "run {run}: mismatch at ({x},{y})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Negative: descriptor / texture mismatch must error at submit time.
+    #[test]
+    fn rejects_descriptor_mismatch() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let texture = make_filled_texture(
+            &device,
+            32,
+            32,
+            TextureFormat::Bgra8Unorm,
+            |_, _| [0, 0, 0, 0xFF],
+        );
+
+        // Wrong width.
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-wrong-width",
+                format: TextureFormat::Bgra8Unorm,
+                width: 64,
+                height: 32,
+            },
+        )
+        .expect("readback");
+        let err = readback
+            .submit(&texture, TextureSourceLayout::General)
+            .err()
+            .expect("expected mismatch");
+        assert!(matches!(err, TextureReadbackError::DescriptorMismatch { .. }));
+
+        // Wrong format.
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-wrong-format",
+                format: TextureFormat::Rgba16Float,
+                width: 32,
+                height: 32,
+            },
+        )
+        .expect("readback");
+        let err = readback
+            .submit(&texture, TextureSourceLayout::General)
+            .err()
+            .expect("expected mismatch");
+        assert!(matches!(err, TextureReadbackError::DescriptorMismatch { .. }));
+    }
+
+    /// Negative: a second submit before the first ticket is waited
+    /// returns InFlight.
+    #[test]
+    fn second_submit_before_wait_errors_in_flight() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let texture = make_filled_texture(
+            &device,
+            32,
+            32,
+            TextureFormat::Bgra8Unorm,
+            |_, _| [1, 2, 3, 4],
+        );
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-in-flight",
+                format: TextureFormat::Bgra8Unorm,
+                width: 32,
+                height: 32,
+            },
+        )
+        .expect("readback");
+        let ticket = readback.submit(&texture, TextureSourceLayout::General).expect("first");
+        let err = readback
+            .submit(&texture, TextureSourceLayout::General)
+            .err()
+            .expect("expected in-flight");
+        assert!(matches!(err, TextureReadbackError::InFlight { .. }));
+        // Drain so Drop doesn't have to wait on a half-recorded submit.
+        let _ = readback.wait_and_read(ticket, u64::MAX).expect("drain");
+    }
+
+    /// Negative: a ticket from one handle is rejected by another.
+    #[test]
+    fn foreign_ticket_rejected() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let texture = make_filled_texture(
+            &device,
+            16,
+            16,
+            TextureFormat::Bgra8Unorm,
+            |_, _| [0, 0, 0, 0xFF],
+        );
+        let rb1 = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-foreign-1",
+                format: TextureFormat::Bgra8Unorm,
+                width: 16,
+                height: 16,
+            },
+        )
+        .expect("rb1");
+        let rb2 = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-foreign-2",
+                format: TextureFormat::Bgra8Unorm,
+                width: 16,
+                height: 16,
+            },
+        )
+        .expect("rb2");
+        let ticket = rb1.submit(&texture, TextureSourceLayout::General).expect("submit");
+        // rb2 doesn't own this ticket — should reject.
+        let err = rb2.try_read(ticket).err().expect("expected foreign");
+        assert!(matches!(err, TextureReadbackError::ForeignTicket { .. }));
+        let _ = rb1.wait_and_read(ticket, u64::MAX).expect("drain");
+    }
+
+    /// Negative: try_read with no in-flight submission errors NoSubmission.
+    #[test]
+    fn try_read_with_no_submission_errors_no_submission() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-no-sub",
+                format: TextureFormat::Bgra8Unorm,
+                width: 8,
+                height: 8,
+            },
+        )
+        .expect("readback");
+        let ticket = ReadbackTicket {
+            handle_id: readback.handle_id,
+            counter: 1,
+        };
+        let err = readback.try_read(ticket).err().expect("expected no submission");
+        assert!(matches!(err, TextureReadbackError::NoSubmission { .. }));
+    }
+
+    /// Multiple readback handles can be in flight concurrently.
+    /// Validates the design assertion that parallel readbacks are
+    /// achieved by holding N handles, not by parallelism on one.
+    #[test]
+    fn multiple_handles_can_be_in_flight_concurrently() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let texture = make_filled_texture(
+            &device,
+            16,
+            16,
+            TextureFormat::Bgra8Unorm,
+            |x, y| [(x as u8), (y as u8), (x as u8) ^ (y as u8), 0xFF],
+        );
+        let rb1 = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-parallel-1",
+                format: TextureFormat::Bgra8Unorm,
+                width: 16,
+                height: 16,
+            },
+        )
+        .expect("rb1");
+        let rb2 = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-parallel-2",
+                format: TextureFormat::Bgra8Unorm,
+                width: 16,
+                height: 16,
+            },
+        )
+        .expect("rb2");
+        let t1 = rb1.submit(&texture, TextureSourceLayout::General).expect("submit 1");
+        let t2 = rb2.submit(&texture, TextureSourceLayout::General).expect("submit 2");
+        // Both tickets must wait + read independently.
+        let _ = rb1.wait_and_read(t1, u64::MAX).expect("read 1");
+        let _ = rb2.wait_and_read(t2, u64::MAX).expect("read 2");
+    }
+
+    /// Drop on an idle handle must not panic.
+    #[test]
+    fn drop_on_idle_handle_no_panic() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let readback = VulkanTextureReadback::new(
+            &device,
+            &TextureReadbackDescriptor {
+                label: "rt-drop-idle",
+                format: TextureFormat::Bgra8Unorm,
+                width: 8,
+                height: 8,
+            },
+        )
+        .expect("readback");
+        drop(readback);
+    }
+
+    /// Bytes-per-pixel for Bgra8Unorm and Rgba8Unorm: descriptor sizes
+    /// match the staging buffer and constructed handles report the
+    /// expected dimensions.
+    #[test]
+    fn descriptor_sizes_and_metadata_round_trip() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let descriptor = TextureReadbackDescriptor {
+            label: "rt-meta",
+            format: TextureFormat::Bgra8Unorm,
+            width: 100,
+            height: 50,
+        };
+        assert_eq!(descriptor.staging_size(), 100 * 50 * 4);
+        let readback = VulkanTextureReadback::new(&device, &descriptor).expect("readback");
+        assert_eq!(readback.format(), TextureFormat::Bgra8Unorm);
+        assert_eq!(readback.width(), 100);
+        assert_eq!(readback.height(), 50);
+        assert_eq!(readback.staging_size(), 100 * 50 * 4);
+        assert!(readback.handle_id() > 0);
+    }
+}

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -632,9 +632,25 @@ fn vk_layout_for(layout: TextureSourceLayout) -> vk::ImageLayout {
 impl Drop for VulkanTextureReadback {
     fn drop(&mut self) {
         unsafe {
-            // Wait for any in-flight submission so we don't tear down
-            // resources the GPU still holds.
-            let _ = self.device.device_wait_idle();
+            // Wait only for THIS handle's pending submission rather
+            // than calling `device_wait_idle()` — the doc explicitly
+            // recommends holding N handles for parallel readback, so a
+            // device-wide stall on every handle drop would serialize
+            // unrelated work. Timeline starts at 0; if `next_counter`
+            // is still 0, no submit has ever happened and the wait
+            // returns immediately. If a submit is in flight, waiting
+            // on the value that submit signals at is sufficient.
+            let target = self.state.lock().next_counter;
+            if target > 0 {
+                let semaphores = [self.timeline];
+                let values = [target];
+                let info = vk::SemaphoreWaitInfo::builder()
+                    .flags(vk::SemaphoreWaitFlags::empty())
+                    .semaphores(&semaphores)
+                    .values(&values)
+                    .build();
+                let _ = self.device.wait_semaphores(&info, u64::MAX);
+            }
             self.device.destroy_semaphore(self.timeline, None);
             self.device.destroy_command_pool(self.command_pool, None);
             self.vulkan_device

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -308,13 +308,11 @@ const VULKANALIA_ALLOWLIST: &[AllowEntry] = &[
     // of `use vulkanalia` or a `vulkanalia` Cargo dep in the cdylibs
     // is a regression of the FullAccess capability boundary.
     //
-    // Polyglot example/scenario binaries that exercise the consumer
-    // path end-to-end.
-    AllowEntry {
-        path: "examples/polyglot-",
-        kind: AllowKind::PathPrefix,
-        rationale: "polyglot scenario binaries demonstrate the consumer path end-to-end",
-    },
+    // Polyglot example/scenario binaries are NOT allowlisted post-#583
+    // — every host-side per-frame readback rides the host RHI's
+    // `VulkanTextureReadback` primitive; any reintroduction of raw
+    // `vulkanalia` in those crates means an example bypassed the RHI.
+    //
     // Test code in any crate is allowed to use vulkanalia directly to
     // bring up real devices for end-to-end validation.
     AllowEntry {
@@ -421,11 +419,10 @@ const VULKANALIA_CARGO_DEP_ALLOWLIST: &[AllowEntry] = &[
     // Subprocess cdylibs are intentionally NOT allowlisted post-#572 —
     // their `Cargo.toml`s no longer declare `vulkanalia`, and any
     // reintroduction is a capability-boundary regression.
-    AllowEntry {
-        path: "examples/polyglot-",
-        kind: AllowKind::PathPrefix,
-        rationale: "polyglot scenario binaries exercise the consumer path end-to-end",
-    },
+    //
+    // Polyglot example/scenario binaries are intentionally NOT
+    // allowlisted post-#583 — host-side readback rides
+    // `VulkanTextureReadback` via the streamlib host RHI.
 ];
 
 // ---------------------------------------------------------------------------
@@ -539,12 +536,12 @@ const PRIVILEGED_VK_ALLOWLIST: &[AllowEntry] = &[
     // call appearing inside a cdylib means a regression of the
     // FullAccess capability boundary.
     //
-    // Examples and tests bring up real devices for end-to-end validation.
-    AllowEntry {
-        path: "examples/polyglot-",
-        kind: AllowKind::PathPrefix,
-        rationale: "polyglot scenario binaries exercise privileged paths end-to-end",
-    },
+    // Polyglot example/scenario binaries are NOT allowlisted post-#583
+    // — host-side readback rides `VulkanTextureReadback` via the
+    // streamlib host RHI; raw privileged-vk inside them indicates the
+    // example bypassed the RHI.
+    //
+    // Tests bring up real devices for end-to-end validation.
     AllowEntry {
         path: "tests",
         kind: AllowKind::PathSegment,


### PR DESCRIPTION
## Summary

- Add `VulkanTextureReadback` host-side RHI primitive: pre-allocated staging buffer + reusable command resources + timeline-semaphore ticketing. Format/extent pinned at construction; single-in-flight per handle (mirrors `VulkanComputeKernel`); for parallel readback, hold N handles. Submits ride `HostVulkanDevice::submit_to_queue` — same per-queue mutex everything else uses.
- Public binding-shape types in `core::rhi::texture_readback`: `TextureReadbackDescriptor`, `TextureSourceLayout`, `ReadbackTicket`, named-variant `TextureReadbackError`. Factory exposed via `GpuContext::create_texture_readback`.
- Migrate `polyglot-skia-canvas` (per-frame hot path), `polyglot-vulkan-compute`, `polyglot-opengl-fragment-shader` off their hand-rolled per-frame raw-vulkanalia readback loops; delete ~480 lines of duplication. Drop unused `vulkanalia` dep from `polyglot-cpu-readback-blur`.
- Remove blanket `examples/polyglot-` allowlist entries from `cargo xtask check-boundaries` — host-side readback now rides the RHI exclusively; any future example reaching for raw vulkanalia is a CI failure.
- New `docs/architecture/texture-readback.md` codifying the engine-model recipe (mirrors `compute-kernel.md`).

## Closes

Closes #583

## Exit criteria (from #583)

- [x] Host-side `TextureReadback` exists with named-variant error taxonomy + `tracing::instrument` on every public method at trait birth.
- [x] All three polyglot examples migrated; each example's `vulkan_readback` fn deleted; readback handle pre-allocated once before main loop.
- [x] Boundary-check allowlist entries for `examples/polyglot-` raw-vulkanalia readback removed; `cargo xtask check-boundaries` passes (`1881 file(s) scanned, no violations`).
- [x] E2E green on all three examples (skia-canvas full 30s × 60fps + Mandelbrot py/deno + plasma waves py/deno; zero `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed` / panics across every run).

## Test plan

### Unit tests (`vulkan::rhi::vulkan_texture_readback::tests`)

9 tests, all passing on this workstation:

```
test descriptor_sizes_and_metadata_round_trip ... ok
test rejects_descriptor_mismatch ... ok
test submit_then_wait_returns_expected_bytes ... ok
test try_read_with_no_submission_errors_no_submission ... ok
test multiple_handles_can_be_in_flight_concurrently ... ok
test drop_on_idle_handle_no_panic ... ok
test foreign_ticket_rejected ... ok
test second_submit_before_wait_errors_in_flight ... ok
test multiple_sequential_submits_work ... ok
```

Coverage: positive (round-trip a known pattern; sequential submits return correct bytes for each frame), negative (descriptor/format/extent mismatch; in-flight rejection; foreign-ticket rejection; no-submission), edge (drop on idle, metadata round-trip).

### Boundary check

```
$ cargo run -p xtask --bin xtask -- check-boundaries
check-boundaries: 1881 file(s) scanned, no violations
$ cargo test -p xtask check_boundaries
test result: ok. 30 passed; 0 failed
```

### E2E (per docs/testing.md)

#### polyglot-skia-canvas (60fps × 30s = 1800 readbacks/run)

```
- Scenario:        per-frame readback, hot path
- Build profile:   debug
- Frame count:     1800/1800 (full run, no early exit)
- Wall time:       30.0s
- Avg readback:    1.55 ms
- OUT_OF_DEVICE_MEMORY:  0
- DEVICE_LOST:           0
- process() failed:      0
- panicked:              0
- Hero PNG (frame 900, t=15.00s): read with the Read tool;
  matches the expected animated Skia canvas — green orbital
  ring, colored dots, sine wave at bottom, color swatch row,
  gradient background.
```

#### polyglot-vulkan-compute (one-shot, post-stop)

```
- Python: ✓ Mandelbrot rendered (purple/pink), 0 errors
- Deno:   ✓ Mandelbrot rendered (green/red),    0 errors
```

#### polyglot-opengl-fragment-shader (one-shot, post-stop)

```
- Python: ✓ Mandelbrot rendered (purple/pink), 0 errors
- Deno:   ✓ plasma waves rendered (yellow/green/pink), 0 errors
```

## Polyglot coverage

- **Runtimes affected**: rust (host-side RHI + 3 example binaries; no cdylib touch — `streamlib::host_rhi` is host-only by construction)
- **Schema regenerated**: n/a (no IPC change)
- **Python and Deno both covered?** yes — every migrated example was E2E-validated against both the Python and Deno subprocess runtimes
- **FD-passing path**: n/a (in-process readback)

## Pre-PR review gate

`pr-review-gate` returned DISCUSS with four items. Verified each independently:

1. **Cross-platform doc link** to a Linux-only path → fixed (replaced intra-doc link with prose).
2. **VMA pool-backed deviation** → user explicitly approved the default-allocator choice during plan announcement (`vma-export-pools.md` is about isolating *exportable* allocations; non-export readback uses the default allocator).
3. **`device_wait_idle` in Drop** → fixed (Drop now waits only on this handle's own timeline counter, since the doc explicitly recommends N-handle parallelism and a device-wide stall on each Drop would serialize unrelated GPU work).
4. **GPU-skipped tests silently report ok** → matches the existing `VulkanComputeKernel` convention; out of scope for this PR. CI runs on a GPU host.

## Follow-ups

- #584 (filed) — RHI: shared `FencePool`/`TimelinePool` primitive on `HostVulkanDevice` so single-in-flight handle types stop owning their completion-signal object for the lifetime of the handle. Engine-precedent ask; defer until the per-handle cost is observable in profiles. Filed under RHI Pipeline Abstraction Buildout milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)