### PR TITLE
feat(adapter-cuda): host-flavor crate scaffold + carve-out test (#587)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
     "libs/streamlib-adapter-opengl", # OpenGL/EGL surface adapter — canonical implementor of GlWritable; DMA-BUF + DRM modifier import (Linux)
     "libs/streamlib-adapter-cpu-readback", # Explicit GPU→CPU surface adapter — sole implementor of CpuReadable / CpuWritable (Linux)
     "libs/streamlib-adapter-cpu-readback-helpers", # Test-helper binaries for streamlib-adapter-cpu-readback — held in a dedicated crate so streamlib doesn't leak into adapter-cpu-readback's runtime dep graph (Linux)
+    "libs/streamlib-adapter-cuda", # CUDA surface adapter — Vulkan↔CUDA OPAQUE_FD interop foundation for GPU-resident AI inference (Linux, #587)
+    "libs/streamlib-adapter-cuda-helpers", # Test-helper crate for streamlib-adapter-cuda — held in a dedicated crate so streamlib (and the optional CUDA SDK) don't leak into adapter-cuda's runtime dep graph (Linux)
     "libs/streamlib-adapter-skia", # Skia surface adapter — composes on streamlib-adapter-vulkan; customer sees skia::Surface directly, never GrVkImageInfo / VkImageLayout (Linux)
     "libs/streamlib-deno-native", # FFI cdylib for Deno subprocess iceoryx2 access
     "libs/streamlib-python-native", # FFI cdylib for Python subprocess iceoryx2 access

--- a/libs/streamlib-adapter-cuda-helpers/Cargo.toml
+++ b/libs/streamlib-adapter-cuda-helpers/Cargo.toml
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test-helper crate for `streamlib-adapter-cuda`. Held in a dedicated
+# crate so the `streamlib` runtime dep these tests need does NOT
+# propagate into the adapter's runtime dep graph (and from there into
+# future `streamlib-python-native` / `-deno-native` CUDA wiring,
+# which must stay `streamlib`-free per #560 / #562 / the `cuda` cdylib
+# work in #589/#590).
+#
+# The carve-out test (`tests/cuda_carve_out.rs`) lives here and is
+# gated behind the `cuda` Cargo feature, which pulls `cudarc` in
+# optionally; building the workspace without `--features cuda` skips
+# the test entirely so contributors without a CUDA toolkit can still
+# run `cargo test`.
+
+[package]
+name = "streamlib-adapter-cuda-helpers"
+description = "Test-helper crate for streamlib-adapter-cuda. Internal — not published; the helpers exist solely so adapter-cuda tests and the CUDA carve-out semantic test can bring up a real HostVulkanDevice + cudarc CUDA context without forcing streamlib (or the CUDA SDK) onto adapter-cuda's runtime dep graph."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+# Empty lib to satisfy Cargo's "either lib or another target" rule.
+# Future #589/#590 work will likely add a `[[bin]]` subprocess helper
+# here once the cdylib + DLPack story lands; the empty lib stub stays.
+path = "src/lib.rs"
+
+[features]
+# Enable to compile the CUDA carve-out test. Off by default so
+# contributors without `libcuda.so` can still run the workspace test
+# suite. cudarc itself is configured with `fallback-dynamic-loading`
+# so build-time CUDA toolkit presence is NOT required even when this
+# feature is on; runtime absence is detected via cudarc's `Lib`
+# accessor and the test skips with rc 77 (CARGO_TEST_SKIP) instead of
+# failing.
+default = []
+cuda = ["dep:cudarc"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib = { path = "../streamlib" }
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+vulkanalia.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+libc.workspace = true
+# Optional CUDA bindings — `fallback-dynamic-loading` loads libcuda.so
+# lazily via dlopen on first call (toolkit absence at build time is
+# fine; runtime absence skips the test rather than failing). Drop the
+# default features so we don't drag cuBLAS / cuRAND / NVRTC into the
+# build for #587's needs.
+# Pin to a specific CUDA toolkit version (`cuda-12090`) so the build
+# does NOT require `nvcc` to be installed (`cuda-version-from-build-system`
+# is the alternative but errors when nvcc is absent). `cuda-12090`
+# bindings call the older `_v2`-suffixed external-resource symbols
+# which remain ABI-stable through cuda 13.x — runtime libcudart
+# continues to export them, so the dlopen path works regardless of
+# which toolkit version is installed on the test machine.
+cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver", "runtime", "fallback-dynamic-loading", "cuda-12090"] }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+# Serialize Vulkan-device-touching tests; concurrent `VkDevice` /
+# `VkInstance` creation on NVIDIA Linux trips the dual-device crash
+# documented in `docs/learnings/nvidia-dual-vulkan-device-crash.md`.
+serial_test = "3.2"
+
+[[test]]
+name = "cuda_carve_out"
+path = "tests/cuda_carve_out.rs"
+required-features = ["cuda"]
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-cuda-helpers/src/lib.rs
+++ b/libs/streamlib-adapter-cuda-helpers/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Test-helper crate for `streamlib-adapter-cuda`. Currently empty —
+//! the carve-out test in `tests/cuda_carve_out.rs` carries all the
+//! interesting code. See `Cargo.toml` for the rationale on why this
+//! split exists (preserve the cdylib boundary for future #589/#590
+//! work).

--- a/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
+++ b/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
@@ -197,10 +197,30 @@ fn host_buffer_to_cuda_byte_equal_round_trip() {
     // CUDA waits on value 1 below, which is unconditionally past.
 
     // ── Phase 3: export OPAQUE_FDs from the registered surface ─────
-    let memory_fd = pixel_buffer
+    // Round-trip through the adapter's registry accessors (rather than
+    // the local Arcs) so this also exercises `surface_pixel_buffer` /
+    // `surface_timeline` — the production cdylib path will read FDs
+    // out of the registered surface, not from a local handle. Returning
+    // `None` here means the registry forgot the surface, which would be
+    // a regression in `register_host_surface`.
+    let registered_pixel_buffer = adapter
+        .surface_pixel_buffer(SURFACE_ID)
+        .expect("CudaSurfaceAdapter::surface_pixel_buffer must return registered buffer");
+    let registered_timeline = adapter
+        .surface_timeline(SURFACE_ID)
+        .expect("CudaSurfaceAdapter::surface_timeline must return registered timeline");
+    assert!(
+        Arc::ptr_eq(&registered_pixel_buffer, &pixel_buffer),
+        "registry-returned pixel_buffer Arc must point at the originally-registered buffer"
+    );
+    assert!(
+        Arc::ptr_eq(&registered_timeline, &timeline),
+        "registry-returned timeline Arc must point at the originally-registered timeline"
+    );
+    let memory_fd = registered_pixel_buffer
         .export_opaque_fd_memory()
         .expect("HostVulkanPixelBuffer::export_opaque_fd_memory");
-    let timeline_fd = timeline
+    let timeline_fd = registered_timeline
         .export_opaque_fd()
         .expect("HostVulkanTimelineSemaphore::export_opaque_fd");
 

--- a/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
+++ b/libs/streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs
@@ -1,0 +1,327 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CUDA carve-out semantic test for `streamlib-adapter-cuda` (#587).
+//!
+//! Validates the foundation primitive every dependent piece of CUDA
+//! interop work rides on:
+//!
+//! 1. The host allocates an OPAQUE_FD-exportable HOST_VISIBLE
+//!    `VkBuffer` via `HostVulkanPixelBuffer::new_opaque_fd_export`
+//!    (new in #587) and a Vulkan timeline semaphore via
+//!    `HostVulkanTimelineSemaphore::new_exportable`.
+//! 2. The host registers the surface with `CudaSurfaceAdapter`, writes
+//!    a known BGRA pattern through the mapped pointer, and signals the
+//!    timeline on guard drop (timeline value 1).
+//! 3. The host exports an OPAQUE_FD for the buffer's
+//!    `VkDeviceMemory` and an OPAQUE_FD for the timeline.
+//! 4. CUDA imports both via `cudaImportExternalMemory` /
+//!    `cudaImportExternalSemaphore`, waits on the timeline at
+//!    value 1, runs a `cudaMemcpyAsync` device→host into a CPU
+//!    buffer, and asserts byte-equal against the source pattern.
+//!
+//! This is the simplest test that proves the OPAQUE_FD primitive
+//! works end-to-end. VkImage interop (with `cudaExternalMemoryGetMappedMipmappedArray`)
+//! is deferred to #588 — it requires the wire-format extension to
+//! carry full `VkImageCreateInfo` round-trip and a CUDA texture
+//! object to handle tile-aware reads. The buffer-flavored primitive
+//! tested here is sufficient for the scaffold.
+//!
+//! Test gating:
+//! - `#[cfg(feature = "cuda")]` — the test is only compiled when the
+//!   `cuda` feature on `streamlib-adapter-cuda-helpers` is enabled.
+//!   Default-OFF keeps `cargo test` working for contributors without
+//!   `libcuda.so`.
+//! - `cudarc::runtime::sys::is_culib_present()` — runtime probe for
+//!   the CUDA driver. The test prints a skip message and returns
+//!   when libcudart can't be dlopen'd. Combined with the build-time
+//!   feature gate, this lets the test compile on a CUDA-less builder
+//!   and skip cleanly on a CUDA-less runner.
+//! - `#[serial]` — same `VkInstance` / `VkDevice` discipline as
+//!   the cpu-readback helper's carve-out (NVIDIA dual-device crash).
+
+#![cfg(all(target_os = "linux", feature = "cuda"))]
+
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+use serial_test::serial;
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::PixelFormat;
+use streamlib::host_rhi::{
+    HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore,
+};
+use streamlib_adapter_abi::{
+    StreamlibSurface, SurfaceFormat, SurfaceSyncState, SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+
+const W: u32 = 32;
+const H: u32 = 32;
+const BPP: u32 = 4;
+const SURFACE_ID: u64 = 0xCDA0_0001;
+
+fn try_init_gpu() -> Option<Arc<GpuContext>> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_cuda=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok().map(Arc::new)
+}
+
+#[test]
+#[serial]
+fn host_buffer_to_cuda_byte_equal_round_trip() {
+    use cudarc::runtime::result::external_memory;
+    use cudarc::runtime::sys;
+
+    // ── Phase 0: skip if Vulkan or CUDA not available ──────────────
+    let Some(gpu) = try_init_gpu() else {
+        println!("cuda carve-out: no Vulkan device — skipping");
+        return;
+    };
+    let host_device: Arc<HostVulkanDevice> = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_buffer_pool().is_none() {
+        println!(
+            "cuda carve-out: OPAQUE_FD buffer pool unavailable — driver doesn't support \
+             external memory; skipping"
+        );
+        return;
+    }
+    if !unsafe { sys::is_culib_present() } {
+        println!("cuda carve-out: libcudart not present — skipping (CUDA toolkit absent)");
+        return;
+    }
+
+    // Pick GPU 0 — the test rig assumption (UUID matching across
+    // multi-GPU rigs is #588's concern).
+    let device_set = unsafe { sys::cudaSetDevice(0) }.result();
+    if let Err(e) = device_set {
+        println!("cuda carve-out: cudaSetDevice(0) failed: {e:?} — skipping");
+        return;
+    }
+
+    // ── Phase 1: host allocates OPAQUE_FD-exportable pixel buffer ──
+    let pixel_buffer = match HostVulkanPixelBuffer::new_opaque_fd_export(
+        &host_device,
+        W,
+        H,
+        BPP,
+        PixelFormat::Bgra32,
+    ) {
+        Ok(b) => Arc::new(b),
+        Err(e) => {
+            println!("cuda carve-out: new_opaque_fd_export failed: {e} — skipping");
+            return;
+        }
+    };
+    let timeline = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0) {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            println!("cuda carve-out: timeline new_exportable failed: {e} — skipping");
+            return;
+        }
+    };
+    let buffer_size = pixel_buffer.size() as usize;
+    assert_eq!(
+        buffer_size,
+        (W * H * BPP) as usize,
+        "buffer size matches W*H*BPP"
+    );
+
+    // ── Phase 2: register with the adapter, write a pattern through
+    //    the host adapter's acquire_write, signal timeline (= 1) on
+    //    guard drop ─────────────────────────────────────────────────
+    let adapter = Arc::new(CudaSurfaceAdapter::new(Arc::clone(&host_device)));
+    adapter
+        .register_host_surface(
+            SURFACE_ID,
+            HostSurfaceRegistration {
+                pixel_buffer: Arc::clone(&pixel_buffer),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+    let surface = StreamlibSurface::new(
+        SURFACE_ID,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    );
+
+    let pattern: Vec<u8> = (0..buffer_size)
+        .map(|i| ((i * 31) & 0xFF) as u8)
+        .collect();
+
+    // Take the write acquire to exercise the trait, then write through
+    // the underlying mapped pointer (the view doesn't expose mapped
+    // bytes yet — that's the cuda-typed view work in #589/#590).
+    {
+        use streamlib_adapter_abi::SurfaceAdapter as _;
+        let _wguard = adapter
+            .acquire_write(&surface)
+            .expect("host acquire_write");
+        // SAFETY: `pixel_buffer` is HOST_VISIBLE | HOST_COHERENT and the
+        // mapped pointer stays valid for the buffer's lifetime; we hold
+        // an Arc through the entire test. Single-writer discipline is
+        // enforced by the SurfaceAdapter trait — we hold the write
+        // guard for the duration of this block.
+        unsafe {
+            let dst = pixel_buffer.mapped_ptr();
+            std::ptr::copy_nonoverlapping(pattern.as_ptr(), dst, buffer_size);
+        }
+        // Drop on scope exit advances the timeline to 1 via signal_host.
+    }
+
+    // Sanity: re-acquire read to confirm the host adapter sees the
+    // pattern. The acquire waits on timeline=1 (already signaled)
+    // and returns immediately.
+    {
+        use streamlib_adapter_abi::SurfaceAdapter as _;
+        let _rguard = adapter
+            .acquire_read(&surface)
+            .expect("host acquire_read sanity");
+        let host_view = unsafe {
+            std::slice::from_raw_parts(pixel_buffer.mapped_ptr(), buffer_size)
+        };
+        assert_eq!(
+            host_view, pattern,
+            "host adapter's mapped pointer must observe the pattern post-acquire-write"
+        );
+    }
+    // After the read acquire+release the timeline has advanced to 2.
+    // CUDA waits on value 1 below, which is unconditionally past.
+
+    // ── Phase 3: export OPAQUE_FDs from the registered surface ─────
+    let memory_fd = pixel_buffer
+        .export_opaque_fd_memory()
+        .expect("HostVulkanPixelBuffer::export_opaque_fd_memory");
+    let timeline_fd = timeline
+        .export_opaque_fd()
+        .expect("HostVulkanTimelineSemaphore::export_opaque_fd");
+
+    // ── Phase 4: import into CUDA, wait on timeline, memcpy d→h ────
+    // SAFETY: CUDA Driver API contract per
+    // `cudarc::runtime::result::external_memory::import_external_memory_opaque_fd`
+    // and the cudaImportExternalMemory docs:
+    //   - On UNIX, ownership of `memory_fd` transfers to the CUDA
+    //     driver on successful import. We MUST NOT close the fd
+    //     ourselves after this point (and the `pixel_buffer`'s
+    //     in-process VkDeviceMemory remains owned by Vulkan; the FD
+    //     is a separate kernel reference).
+    //   - Same applies to `timeline_fd` after cudaImportExternalSemaphore.
+    let ext_mem = unsafe {
+        match external_memory::import_external_memory_opaque_fd(memory_fd, buffer_size as u64) {
+            Ok(m) => m,
+            Err(e) => {
+                // FD ownership did NOT transfer on error — close it
+                // to avoid leaking. Same for the timeline fd we
+                // haven't tried to import yet.
+                libc::close(memory_fd);
+                libc::close(timeline_fd);
+                panic!("cudaImportExternalMemory failed: {e:?}");
+            }
+        }
+    };
+
+    let dev_ptr = unsafe {
+        match external_memory::get_mapped_buffer(ext_mem, 0, buffer_size as u64) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = external_memory::destroy_external_memory(ext_mem);
+                libc::close(timeline_fd);
+                panic!("cudaExternalMemoryGetMappedBuffer failed: {e:?}");
+            }
+        }
+    };
+
+    // Build the descriptor via `zeroed()` + assignment so the body is
+    // robust across `cuda-11040..=12090` (no `reserved` field) and
+    // `cuda-13000..` (with `reserved: [u32; 16]`). The crate is
+    // currently pinned to `cuda-12090`; either way `mem::zeroed()`
+    // produces a valid descriptor — unused union arms stay zero, the
+    // optional `reserved` (when present) is zero per spec.
+    let mut sem_desc: sys::cudaExternalSemaphoreHandleDesc = unsafe { std::mem::zeroed() };
+    sem_desc.type_ =
+        sys::cudaExternalSemaphoreHandleType::cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd;
+    sem_desc.handle = sys::cudaExternalSemaphoreHandleDesc__bindgen_ty_1 { fd: timeline_fd };
+    sem_desc.flags = 0;
+    let mut ext_sem = MaybeUninit::<sys::cudaExternalSemaphore_t>::uninit();
+    let import_sem_result = unsafe {
+        sys::cudaImportExternalSemaphore(ext_sem.as_mut_ptr(), &sem_desc).result()
+    };
+    if let Err(e) = import_sem_result {
+        let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+        unsafe { libc::close(timeline_fd) };
+        panic!("cudaImportExternalSemaphore failed: {e:?}");
+    }
+    let ext_sem = unsafe { ext_sem.assume_init() };
+
+    let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+    unsafe { sys::cudaStreamCreate(stream.as_mut_ptr()) }
+        .result()
+        .expect("cudaStreamCreate");
+    let stream = unsafe { stream.assume_init() };
+
+    // Wait params for a TIMELINE semaphore: only `params.fence.value` is
+    // meaningful; the nested struct/union types are awkward to spell out
+    // by hand, so zeroed() + assignment is the cleanest path. CUDA spec
+    // permits this — the unused union arms (nvSciSync, keyedMutex) are
+    // only consulted when `type_` indicates that flavor.
+    let mut wait_params: sys::cudaExternalSemaphoreWaitParams =
+        unsafe { std::mem::zeroed() };
+    wait_params.params.fence.value = 1;
+    wait_params.flags = 0;
+
+    // The `_v2` suffixed name is the canonical extern in cuda
+    // 11.4..12.9 bindings; the unsuffixed `cudaWaitExternalSemaphoresAsync`
+    // is gated on cuda-13xxx. We pin to `cuda-12090` (see helpers
+    // Cargo.toml) so the `_v2` symbol is the right one. The runtime
+    // libcudart on cuda 13.x continues to export `_v2` for ABI
+    // stability, so the dlopen path resolves.
+    let wait_result = unsafe {
+        sys::cudaWaitExternalSemaphoresAsync_v2(&ext_sem, &wait_params, 1, stream).result()
+    };
+    if let Err(e) = wait_result {
+        let _ = unsafe { sys::cudaStreamDestroy(stream).result() };
+        let _ = unsafe { sys::cudaDestroyExternalSemaphore(ext_sem).result() };
+        let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+        panic!("cudaWaitExternalSemaphoresAsync failed: {e:?}");
+    }
+
+    let mut host_buf = vec![0u8; buffer_size];
+    unsafe {
+        sys::cudaMemcpyAsync(
+            host_buf.as_mut_ptr() as *mut std::ffi::c_void,
+            dev_ptr,
+            buffer_size,
+            sys::cudaMemcpyKind::cudaMemcpyDeviceToHost,
+            stream,
+        )
+        .result()
+        .expect("cudaMemcpyAsync DeviceToHost");
+        sys::cudaStreamSynchronize(stream)
+            .result()
+            .expect("cudaStreamSynchronize");
+    }
+
+    // ── Phase 5: byte-equal assertion ──────────────────────────────
+    assert_eq!(
+        host_buf, pattern,
+        "CUDA's view of the OPAQUE_FD-imported buffer must observe \
+         the same bytes the host wrote through Vulkan's mapped pointer"
+    );
+
+    // ── Phase 6: cleanup ───────────────────────────────────────────
+    unsafe {
+        let _ = sys::cudaStreamDestroy(stream).result();
+        let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+        let _ = external_memory::destroy_external_memory(ext_mem);
+    }
+    // memory_fd and timeline_fd ownership transferred to CUDA on
+    // successful import — do NOT close.
+}

--- a/libs/streamlib-adapter-cuda/Cargo.toml
+++ b/libs/streamlib-adapter-cuda/Cargo.toml
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-cuda"
+description = "CUDA surface adapter (Linux). Imports a host-allocated Vulkan resource into a CUDA context via VK_KHR_external_memory_fd ↔ cudaImportExternalMemory + VK_KHR_external_semaphore_fd ↔ cudaImportExternalSemaphore. Foundation for GPU-resident AI inference (PyTorch / TensorRT / ONNX-Runtime CUDA backend) on subprocess customers without the CPU readback round-trip."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_cuda"
+path = "src/lib.rs"
+
+[features]
+# Default OFF — enabling pulls the CUDA SDK into this crate's transitive
+# build surface. cudarc itself loads `libcuda.so` lazily via dlopen
+# (`fallback-dynamic-loading`), so toolkit absence at runtime is a
+# graceful skip rather than a build error; the feature flag still
+# gates the *type surface* (CUDA-typed views, FFI hooks) so non-CUDA
+# customers don't pay for unused API.
+#
+# #587 introduces the feature scaffold so customers know how to opt in;
+# the dependent CUDA cdylib + DLPack work (#589/#590) wires its
+# functionality into the public surface.
+default = []
+cuda = []
+
+[dependencies]
+streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+thiserror.workspace = true
+tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
+streamlib-surface-client = { path = "../streamlib-surface-client" }
+vulkanalia.workspace = true
+libc.workspace = true
+
+# `streamlib` and the helper-binary crate are *test*-only deps: the
+# carve-out test brings up a `HostVulkanDevice`, allocates an
+# OPAQUE_FD-exportable buffer + timeline, and (when the `cuda`
+# feature on the helpers crate is enabled) imports both into CUDA
+# via cudarc to assert byte-equal. The runtime crate (above) does
+# NOT pull `streamlib`, so future subprocess cdylibs depending on
+# `streamlib-adapter-cuda` get the consumer-rhi carve-out only,
+# with `streamlib` absent from their dep graph. The helper bin
+# lives in `streamlib-adapter-cuda-helpers` for the same reason —
+# see that crate's Cargo.toml for the full rationale.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+streamlib = { path = "../streamlib" }
+streamlib-adapter-cuda-helpers = { path = "../streamlib-adapter-cuda-helpers" }
+tracing-subscriber.workspace = true
+
+[[test]]
+name = "conformance"
+path = "tests/conformance.rs"
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-cuda/src/adapter.rs
+++ b/libs/streamlib-adapter-cuda/src/adapter.rs
@@ -1,0 +1,392 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `CudaSurfaceAdapter<D>` — CUDA-typed `SurfaceAdapter`.
+//!
+//! Generic over the device flavor: `D = HostVulkanDevice` for host-side
+//! adapter use today (allocate OPAQUE_FD-exportable resources, register,
+//! hand fds to CUDA). The four trait methods on `VulkanRhiDevice`
+//! (`device()`, `queue()`, `queue_family_index()`, `submit_to_queue()`)
+//! are everything the adapter needs from the device; the timeline-
+//! semaphore type is picked up via `D::Privilege::TimelineSemaphore`
+//! and abstracted behind `VulkanTimelineSemaphoreLike` so wait + signal
+//! works against either flavor.
+//!
+//! The adapter:
+//! - Owns a registry of registered surfaces keyed by [`SurfaceId`].
+//! - Waits on the timeline semaphore at the start of every acquire so
+//!   prior CUDA / GPU work has drained before the host touches the
+//!   buffer.
+//! - Signals the next timeline value on guard drop so the next acquire
+//!   wakes up.
+//!
+//! Per-acquire host *work* (e.g. `vkCmdCopyImageToBuffer`) is **not
+//! present** here, on purpose: CUDA imports the OPAQUE_FD memory once at
+//! registration time and dispatches kernels in its own context. The
+//! timeline semaphore is the only sync surface that has to cross the
+//! Vulkan↔CUDA boundary per acquire.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, Registry, StreamlibSurface, SurfaceAdapter, SurfaceId,
+    SurfaceRegistration, WriteGuard,
+};
+use streamlib_consumer_rhi::{
+    DevicePrivilege, VulkanPixelBufferLike, VulkanRhiDevice, VulkanTimelineSemaphoreLike,
+};
+use vulkanalia::vk;
+
+use crate::state::{HostSurfaceRegistration, SurfaceState};
+use crate::view::{CudaReadView, CudaWriteView};
+
+/// Default per-acquire timeline-wait timeout. Long enough to cover any
+/// realistic GPU queue depth; short enough that a deadlock turns into
+/// an `AdapterError::SyncTimeout` rather than wedging the consumer.
+const DEFAULT_TIMELINE_WAIT: Duration = Duration::from_secs(5);
+
+/// CUDA-targeted [`SurfaceAdapter`] implementation. Generic over the
+/// device flavor — instantiate as
+/// `CudaSurfaceAdapter<HostVulkanDevice>` host-side; future cdylib work
+/// (#589/#590) will add a consumer-flavor instantiation.
+pub struct CudaSurfaceAdapter<D: VulkanRhiDevice> {
+    device: Arc<D>,
+    surfaces: Registry<SurfaceState<D::Privilege>>,
+    /// Per-acquire timeline-wait timeout. Adjustable via
+    /// [`Self::with_acquire_timeout`].
+    acquire_timeout: Duration,
+}
+
+impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
+    /// Construct an empty adapter bound to `device`.
+    pub fn new(device: Arc<D>) -> Self {
+        Self {
+            device,
+            surfaces: Registry::new(),
+            acquire_timeout: DEFAULT_TIMELINE_WAIT,
+        }
+    }
+
+    /// Override the per-acquire timeline-wait timeout. Default 5 s.
+    pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
+        self
+    }
+
+    /// Returns the underlying device for callers (test harnesses, the
+    /// `CudaContext`, raw-handle escape hatches) that need it.
+    pub fn device(&self) -> &Arc<D> {
+        &self.device
+    }
+
+    /// Register an allocated (or imported) surface with this adapter.
+    ///
+    /// `id` is assigned by the caller (typically from the surface-share
+    /// service); it MUST be unique across the adapter's lifetime.
+    /// Returns [`AdapterError::SurfaceAlreadyRegistered`] if `id` is
+    /// already registered.
+    pub fn register_host_surface(
+        &self,
+        id: SurfaceId,
+        registration: HostSurfaceRegistration<D::Privilege>,
+    ) -> Result<(), AdapterError> {
+        let inserted = self.surfaces.register(
+            id,
+            SurfaceState {
+                surface_id: id,
+                pixel_buffer: registration.pixel_buffer,
+                timeline: registration.timeline,
+                current_layout: registration.initial_layout,
+                read_holders: 0,
+                write_held: false,
+                current_release_value: 0,
+            },
+        );
+        if !inserted {
+            return Err(AdapterError::SurfaceAlreadyRegistered { surface_id: id });
+        }
+        Ok(())
+    }
+
+    /// Drop a registered surface. Pending guards keep the underlying
+    /// `Arc<TimelineSemaphore>` and `Arc<PixelBuffer>` alive; the next
+    /// acquire returns [`AdapterError::SurfaceNotFound`].
+    pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
+        self.surfaces.unregister(id).is_some()
+    }
+
+    /// Snapshot the registry size — primarily for tests and
+    /// observability.
+    pub fn registered_count(&self) -> usize {
+        self.surfaces.len()
+    }
+
+    /// Power-user accessor: the registered pixel-buffer Arc for a
+    /// surface, if registered. Used by the carve-out test in
+    /// `streamlib-adapter-cuda-helpers` to call
+    /// `export_opaque_fd_memory()` on the underlying buffer; future
+    /// cdylib work will route this through the surface-share service
+    /// instead. Returns `None` when the surface isn't registered.
+    pub fn surface_pixel_buffer(
+        &self,
+        id: SurfaceId,
+    ) -> Option<Arc<<D::Privilege as DevicePrivilege>::PixelBuffer>> {
+        self.surfaces
+            .with(id, |state| Arc::clone(&state.pixel_buffer))
+    }
+
+    /// Power-user accessor: the registered timeline-semaphore Arc for
+    /// a surface. Used by the carve-out test to call
+    /// `export_opaque_fd()` on the underlying timeline; cdylib work
+    /// will route this through the surface-share service.
+    pub fn surface_timeline(
+        &self,
+        id: SurfaceId,
+    ) -> Option<Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>> {
+        self.surfaces
+            .with(id, |state| Arc::clone(&state.timeline))
+    }
+
+    fn try_begin_read(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadAcquired<D::Privilege>>, AdapterError> {
+        let id = surface.id;
+        self.surfaces.try_begin_read(id, |state| {
+            let timeline = Arc::clone(&state.timeline);
+            let wait_value = state.current_release_value;
+            let buffer = state.pixel_buffer.buffer();
+            let size = state.pixel_buffer.size();
+            Ok(ReadAcquired {
+                timeline,
+                wait_value,
+                buffer,
+                size,
+            })
+        })
+    }
+
+    fn try_begin_write(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteAcquired<D::Privilege>>, AdapterError> {
+        let id = surface.id;
+        self.surfaces.try_begin_write(id, |state| {
+            let timeline = Arc::clone(&state.timeline);
+            let wait_value = state.current_release_value;
+            let buffer = state.pixel_buffer.buffer();
+            let size = state.pixel_buffer.size();
+            Ok(WriteAcquired {
+                timeline,
+                wait_value,
+                buffer,
+                size,
+            })
+        })
+    }
+
+    fn finalize_read(
+        &self,
+        surface_id: SurfaceId,
+        acquired: ReadAcquired<D::Privilege>,
+    ) -> Result<(vk::Buffer, vk::DeviceSize), AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            self.surfaces.rollback_read(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+        Ok((acquired.buffer, acquired.size))
+    }
+
+    fn finalize_write(
+        &self,
+        surface_id: SurfaceId,
+        acquired: WriteAcquired<D::Privilege>,
+    ) -> Result<(vk::Buffer, vk::DeviceSize), AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            self.surfaces.rollback_write(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+        Ok((acquired.buffer, acquired.size))
+    }
+}
+
+/// Snapshot taken under the registry lock so the timeline wait can run
+/// unlocked. `read_holders` / `write_held` are already incremented;
+/// rollback paths decrement them on failure.
+struct ReadAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
+    wait_value: u64,
+    buffer: vk::Buffer,
+    size: vk::DeviceSize,
+}
+
+struct WriteAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
+    wait_value: u64,
+    buffer: vk::Buffer,
+    size: vk::DeviceSize,
+}
+
+impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
+    type ReadView<'g> = CudaReadView<'g>;
+    type WriteView<'g> = CudaWriteView<'g>;
+
+    fn acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'g, Self>, AdapterError> {
+        let acquired = match self.try_begin_read(surface)? {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder: "writer".to_string(),
+                });
+            }
+        };
+        let (buffer, size) = self.finalize_read(surface.id, acquired)?;
+        Ok(ReadGuard::new(
+            self,
+            surface.id,
+            CudaReadView {
+                buffer,
+                size,
+                _marker: PhantomData,
+            },
+        ))
+    }
+
+    fn acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'g, Self>, AdapterError> {
+        let acquired = match self.try_begin_write(surface)? {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder: self.surfaces.describe_contention(surface.id),
+                });
+            }
+        };
+        let (buffer, size) = self.finalize_write(surface.id, acquired)?;
+        Ok(WriteGuard::new(
+            self,
+            surface.id,
+            CudaWriteView {
+                buffer,
+                size,
+                _marker: PhantomData,
+            },
+        ))
+    }
+
+    fn try_acquire_read<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'g, Self>>, AdapterError> {
+        let acquired = match self.try_begin_read(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let (buffer, size) = self.finalize_read(surface.id, acquired)?;
+        Ok(Some(ReadGuard::new(
+            self,
+            surface.id,
+            CudaReadView {
+                buffer,
+                size,
+                _marker: PhantomData,
+            },
+        )))
+    }
+
+    fn try_acquire_write<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'g, Self>>, AdapterError> {
+        let acquired = match self.try_begin_write(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let (buffer, size) = self.finalize_write(surface.id, acquired)?;
+        Ok(Some(WriteGuard::new(
+            self,
+            surface.id,
+            CudaWriteView {
+                buffer,
+                size,
+                _marker: PhantomData,
+            },
+        )))
+    }
+
+    fn end_read_access(&self, surface_id: SurfaceId) {
+        // Inner Option: `None` means "not the last reader, skip signal".
+        // Outer Option: `None` means "surface raced an unregister".
+        let signal: Option<Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)>> =
+            self.surfaces.with_mut(surface_id, |state| {
+                debug_assert!(state.read_holders > 0, "read release without acquire");
+                state.dec_read_holders();
+                if state.read_holders > 0 {
+                    return None;
+                }
+                let next = state.next_release_value();
+                state.current_release_value = next;
+                Some((Arc::clone(&state.timeline), next))
+            });
+        let signal = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_read_access on unknown surface — racing unregister"
+                );
+                return;
+            }
+        };
+        if let Some((timeline, value)) = signal {
+            if let Err(e) = timeline.signal_host(value) {
+                tracing::error!(?surface_id, %value, %e, "timeline signal failed on read release");
+            }
+        }
+    }
+
+    fn end_write_access(&self, surface_id: SurfaceId) {
+        let signal: Option<(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>, u64)> =
+            self.surfaces.with_mut(surface_id, |state| {
+                debug_assert!(state.write_held, "write release without acquire");
+                state.set_write_held(false);
+                let next = state.next_release_value();
+                state.current_release_value = next;
+                (Arc::clone(&state.timeline), next)
+            });
+        let (timeline, value) = match signal {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    ?surface_id,
+                    "end_write_access on unknown surface — racing unregister"
+                );
+                return;
+            }
+        };
+        if let Err(e) = timeline.signal_host(value) {
+            tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");
+        }
+    }
+}

--- a/libs/streamlib-adapter-cuda/src/context.rs
+++ b/libs/streamlib-adapter-cuda/src/context.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `CudaContext<D>` — the customer-facing one-stop API.
+//!
+//! Customers call:
+//!
+//! ```ignore
+//! let ctx = streamlib_adapter_cuda::CudaContext::new(adapter);
+//! {
+//!     let mut guard = ctx.acquire_write(&surface)?;
+//!     // guard.view_mut() is a CudaWriteView with a vk::Buffer handle.
+//! }
+//! ```
+//!
+//! The context is a thin convenience over
+//! [`crate::CudaSurfaceAdapter`]; every operation maps to a
+//! [`streamlib_adapter_abi::SurfaceAdapter`] method. Generic over the
+//! device flavor `D: VulkanRhiDevice` so it works against either
+//! `HostVulkanDevice` (host-side, today) or `ConsumerVulkanDevice`
+//! (cdylib, once #589/#590 wire it up).
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    AdapterError, ReadGuard, StreamlibSurface, SurfaceAdapter, WriteGuard,
+};
+use streamlib_consumer_rhi::VulkanRhiDevice;
+
+use crate::adapter::CudaSurfaceAdapter;
+
+/// Customer-facing handle bound to a single runtime, generic over the
+/// device flavor. Holds a shared reference to a [`CudaSurfaceAdapter`]
+/// (typically stored on the runtime itself); cheap to clone.
+pub struct CudaContext<D: VulkanRhiDevice + 'static> {
+    adapter: Arc<CudaSurfaceAdapter<D>>,
+}
+
+impl<D: VulkanRhiDevice + 'static> Clone for CudaContext<D> {
+    fn clone(&self) -> Self {
+        Self {
+            adapter: Arc::clone(&self.adapter),
+        }
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> CudaContext<D> {
+    pub fn new(adapter: Arc<CudaSurfaceAdapter<D>>) -> Self {
+        Self { adapter }
+    }
+
+    pub fn adapter(&self) -> &Arc<CudaSurfaceAdapter<D>> {
+        &self.adapter
+    }
+
+    /// Blocking read acquire.
+    pub fn acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<ReadGuard<'a, CudaSurfaceAdapter<D>>, AdapterError> {
+        self.adapter.acquire_read(surface)
+    }
+
+    /// Blocking write acquire.
+    pub fn acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<WriteGuard<'a, CudaSurfaceAdapter<D>>, AdapterError> {
+        self.adapter.acquire_write(surface)
+    }
+
+    /// Non-blocking read acquire — `Ok(None)` on contention.
+    pub fn try_acquire_read<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ReadGuard<'a, CudaSurfaceAdapter<D>>>, AdapterError> {
+        self.adapter.try_acquire_read(surface)
+    }
+
+    /// Non-blocking write acquire.
+    pub fn try_acquire_write<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<WriteGuard<'a, CudaSurfaceAdapter<D>>>, AdapterError> {
+        self.adapter.try_acquire_write(surface)
+    }
+}

--- a/libs/streamlib-adapter-cuda/src/lib.rs
+++ b/libs/streamlib-adapter-cuda/src/lib.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CUDA surface adapter — imports a host-allocated, OPAQUE_FD-exportable
+//! Vulkan resource into a CUDA context via `VK_KHR_external_memory_fd` ↔
+//! `cudaImportExternalMemory`, and a Vulkan timeline semaphore via
+//! `VK_KHR_external_semaphore_fd` ↔ `cudaImportExternalSemaphore`.
+//!
+//! Lets subprocess customers (Python / Deno) run GPU-resident AI
+//! inference (PyTorch / TensorRT / ONNX-Runtime CUDA backend) on captured
+//! frames without the CPU readback round-trip the
+//! `streamlib-adapter-cpu-readback` adapter incurs. On-path consumer is
+//! the Anduril AI Grand Prix drone-racing pipeline (NVIDIA Jetson Orin /
+//! x86 + dGPU).
+//!
+//! This crate (#587) ships the *host-flavor scaffold* — the
+//! `SurfaceAdapter` shape, the registry-of-state machinery, and the
+//! host-side OPAQUE_FD export entry points the carve-out test in
+//! `streamlib-adapter-cuda-helpers` exercises. Subprocess FFI, DLPack
+//! capsule construction, and polyglot E2E ship in dependent issues
+//! (#589 Python, #590 Deno).
+
+#![cfg(target_os = "linux")]
+
+mod adapter;
+mod context;
+mod state;
+mod view;
+
+pub use adapter::CudaSurfaceAdapter;
+pub use context::CudaContext;
+pub use state::HostSurfaceRegistration;
+pub use streamlib_consumer_rhi::VulkanLayout;
+pub use view::{CudaReadView, CudaWriteView};

--- a/libs/streamlib-adapter-cuda/src/state.rs
+++ b/libs/streamlib-adapter-cuda/src/state.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Per-surface adapter state.
+//!
+//! `CudaSurfaceAdapter<D>` is generic over the device flavor (`HostMarker`
+//! today; future cdylib work will add a consumer flavor). The structs in
+//! this module carry the privilege parameter through so the pixel-buffer
+//! and timeline-semaphore types resolve to the matching flavor (`Host*`
+//! or, eventually, `Consumer*`) at instantiation.
+//!
+//! The CUDA adapter mirrors the *crate split* of
+//! `streamlib-adapter-cpu-readback` (adapter crate + helpers crate) and
+//! the *struct shape* of `streamlib-adapter-vulkan` (no per-acquire
+//! trigger or bridge — the host registers the OPAQUE_FD-exportable
+//! resource and the carve-out test imports it into CUDA directly,
+//! because GPU-resident inference dispatches inside the CUDA context
+//! without needing per-acquire host work).
+
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
+use streamlib_consumer_rhi::{DevicePrivilege, VulkanLayout};
+
+/// Inputs handed to [`crate::CudaSurfaceAdapter::register_host_surface`].
+///
+/// On the host side `pixel_buffer` is a fresh
+/// `Arc<HostVulkanPixelBuffer>` from `HostVulkanPixelBuffer::new_opaque_fd_export`
+/// (the OPAQUE_FD-exportable HOST_VISIBLE staging buffer the CUDA carve-out
+/// test imports via `cudaImportExternalMemory`). The adapter holds the
+/// `Arc` for the surface's lifetime so the underlying GPU memory stays
+/// alive while CUDA references the imported handle.
+pub struct HostSurfaceRegistration<P: DevicePrivilege> {
+    /// OPAQUE_FD-exportable HOST_VISIBLE staging buffer — the resource
+    /// CUDA imports via `cudaImportExternalMemory`. Host- or consumer-
+    /// flavored per `P`.
+    pub pixel_buffer: Arc<P::PixelBuffer>,
+    /// Timeline semaphore — host- or consumer-flavored per `P`. Both
+    /// flavors implement
+    /// [`streamlib_consumer_rhi::VulkanTimelineSemaphoreLike`] so the
+    /// adapter's wait + signal calls work uniformly.
+    pub timeline: Arc<P::TimelineSemaphore>,
+    /// Initial layout the resource is in at registration time. For
+    /// pixel buffers this is unused (buffers don't have layouts), but
+    /// the field is kept for shape parity with `streamlib-adapter-vulkan`
+    /// so the future #589/#590 work can add VkImage support without
+    /// breaking the registration shape. Pass [`VulkanLayout::UNDEFINED`].
+    pub initial_layout: VulkanLayout,
+}
+
+/// Per-surface state held inside the adapter's `Registry<...>`.
+///
+/// All mutation goes through the registry's locking so `acquire_*` /
+/// `end_*_access` stay sequenced — the trait's `&self` shape is
+/// satisfied by interior mutability.
+pub(crate) struct SurfaceState<P: DevicePrivilege> {
+    #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
+    pub(crate) surface_id: SurfaceId,
+    pub(crate) pixel_buffer: Arc<P::PixelBuffer>,
+    pub(crate) timeline: Arc<P::TimelineSemaphore>,
+    #[allow(dead_code)] // shape-parity with the Vulkan adapter; read by future image support
+    pub(crate) current_layout: VulkanLayout,
+    pub(crate) read_holders: u64,
+    pub(crate) write_held: bool,
+    /// The value `signal_host` was last advanced to. The next acquire
+    /// waits on this value (so any prior writer's GPU work has drained)
+    /// and the next release advances it by one.
+    pub(crate) current_release_value: u64,
+}
+
+impl<P: DevicePrivilege> SurfaceState<P> {
+    pub(crate) fn next_release_value(&self) -> u64 {
+        self.current_release_value + 1
+    }
+}
+
+impl<P: DevicePrivilege> SurfaceRegistration for SurfaceState<P> {
+    fn write_held(&self) -> bool {
+        self.write_held
+    }
+    fn read_holders(&self) -> u64 {
+        self.read_holders
+    }
+    fn set_write_held(&mut self, held: bool) {
+        self.write_held = held;
+    }
+    fn inc_read_holders(&mut self) {
+        self.read_holders += 1;
+    }
+    fn dec_read_holders(&mut self) {
+        self.read_holders = self.read_holders.saturating_sub(1);
+    }
+}

--- a/libs/streamlib-adapter-cuda/src/view.rs
+++ b/libs/streamlib-adapter-cuda/src/view.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Read and write views handed back to consumers inside an acquire
+//! scope.
+//!
+//! For #587's host-flavor scaffold, the views expose the underlying
+//! `vk::Buffer` handle and the buffer size — enough metadata for the
+//! carve-out test to validate that registration + acquire flow through
+//! the trait correctly. Public CUDA-typed accessors (raw `CUdeviceptr`,
+//! DLPack capsule construction) ship in #589/#590 once the cdylib +
+//! `cudarc` integration land. The view types themselves stay compatible
+//! across that change — only their inherent methods grow.
+
+use std::marker::PhantomData;
+
+use vulkanalia::vk;
+
+/// Read view of an acquired surface — exposes the host's `vk::Buffer`
+/// handle and the buffer's size in bytes. CUDA-typed accessors arrive
+/// in #589/#590.
+pub struct CudaReadView<'g> {
+    pub(crate) buffer: vk::Buffer,
+    pub(crate) size: vk::DeviceSize,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl<'g> CudaReadView<'g> {
+    /// Underlying Vulkan buffer handle.
+    pub fn vk_buffer(&self) -> vk::Buffer {
+        self.buffer
+    }
+    /// Buffer size in bytes.
+    pub fn size(&self) -> vk::DeviceSize {
+        self.size
+    }
+}
+
+/// Write view of an acquired surface — symmetric counterpart to
+/// [`CudaReadView`].
+pub struct CudaWriteView<'g> {
+    pub(crate) buffer: vk::Buffer,
+    pub(crate) size: vk::DeviceSize,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl<'g> CudaWriteView<'g> {
+    /// Underlying Vulkan buffer handle.
+    pub fn vk_buffer(&self) -> vk::Buffer {
+        self.buffer
+    }
+    /// Buffer size in bytes.
+    pub fn size(&self) -> vk::DeviceSize {
+        self.size
+    }
+}

--- a/libs/streamlib-adapter-cuda/tests/conformance.rs
+++ b/libs/streamlib-adapter-cuda/tests/conformance.rs
@@ -1,0 +1,199 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cuda::tests::conformance` — runs the public
+//! `run_conformance` suite from `streamlib-adapter-abi` against the
+//! CUDA adapter, plus a duplicate-registration negative case.
+//!
+//! Exercises the same eight contracts MockAdapter passes (acquire/drop
+//! pairs, parallel reads, `WriteContended` on contention, `try_acquire_*`
+//! returning `Ok(None)`, multi-thread Send+Sync). A green run confirms
+//! the trait shape is honored — it does NOT prove CUDA interop; that's
+//! the carve-out test in `streamlib-adapter-cuda-helpers`.
+//!
+//! The test allocates an OPAQUE_FD-exportable HOST_VISIBLE buffer
+//! (the resource shape CUDA imports). Even when CUDA isn't installed
+//! the conformance test runs, because the OPAQUE_FD pool is a pure
+//! Vulkan construct — no CUDA SDK touched.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::PixelFormat;
+use streamlib::host_rhi::{HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore};
+use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+
+const W: u32 = 32;
+const H: u32 = 32;
+
+fn try_init_gpu() -> Option<GpuContext> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_cuda=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok()
+}
+
+fn register_one(
+    adapter: &CudaSurfaceAdapter<HostVulkanDevice>,
+    id: SurfaceId,
+) -> Result<StreamlibSurface, String> {
+    let host_device = Arc::clone(adapter.device());
+    let pixel_buffer = HostVulkanPixelBuffer::new_opaque_fd_export(
+        &host_device,
+        W,
+        H,
+        4,
+        PixelFormat::Bgra32,
+    )
+    .map_err(|e| format!("HostVulkanPixelBuffer::new_opaque_fd_export: {e}"))?;
+    let timeline = HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+        .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))?;
+    adapter
+        .register_host_surface(
+            id,
+            HostSurfaceRegistration {
+                pixel_buffer: Arc::new(pixel_buffer),
+                timeline: Arc::new(timeline),
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .map_err(|e| format!("register_host_surface: {e}"))?;
+    Ok(StreamlibSurface::new(
+        id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    ))
+}
+
+struct ConformanceFactory<'a> {
+    adapter: &'a CudaSurfaceAdapter<HostVulkanDevice>,
+}
+
+impl<'a> streamlib_adapter_abi::testing::ConformanceSurfaceFactory for ConformanceFactory<'a> {
+    fn make(&self, id: SurfaceId) -> StreamlibSurface {
+        register_one(self.adapter, id).expect("register_one")
+    }
+}
+
+#[test]
+fn cuda_adapter_passes_run_conformance() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("cuda-adapter conformance: skipping — no Vulkan device available");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_buffer_pool().is_none() {
+        println!(
+            "cuda-adapter conformance: skipping — OPAQUE_FD buffer pool unavailable on this driver"
+        );
+        return;
+    }
+    let adapter = CudaSurfaceAdapter::new(host_device);
+
+    let factory = ConformanceFactory { adapter: &adapter };
+    run_conformance(&adapter, factory);
+
+    let bogus = empty_surface(0xdead_beef);
+    match adapter.acquire_read(&bogus) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_beef);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_registration_returns_surface_already_registered() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!(
+                "cuda-adapter duplicate-registration: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_buffer_pool().is_none() {
+        println!(
+            "cuda-adapter duplicate-registration: skipping — OPAQUE_FD pool unavailable"
+        );
+        return;
+    }
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0xfeed_face;
+    if register_one(&adapter, id).is_err() {
+        println!(
+            "cuda-adapter duplicate-registration: skipping — first registration failed"
+        );
+        return;
+    }
+    // Build a second registration's resources directly so the typed
+    // AdapterError variant survives back to this test (the local
+    // `register_one` helper wraps errors in `String` for ergonomics).
+    let pixel_buffer = HostVulkanPixelBuffer::new_opaque_fd_export(
+        &host_device,
+        W,
+        H,
+        4,
+        PixelFormat::Bgra32,
+    )
+    .expect("second pixel buffer");
+    let timeline =
+        HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+            .expect("second timeline");
+    let result = adapter.register_host_surface(
+        id,
+        streamlib_adapter_cuda::HostSurfaceRegistration {
+            pixel_buffer: Arc::new(pixel_buffer),
+            timeline: Arc::new(timeline),
+            initial_layout: VulkanLayout::UNDEFINED,
+        },
+    );
+    match result {
+        Err(AdapterError::SurfaceAlreadyRegistered { surface_id }) => {
+            assert_eq!(surface_id, id);
+        }
+        other => panic!("expected SurfaceAlreadyRegistered, got {other:?}"),
+    }
+}
+
+#[test]
+fn unregister_returns_true_on_first_call_false_on_second() {
+    let gpu = match try_init_gpu() {
+        Some(g) => g,
+        None => {
+            println!("cuda-adapter unregister: skipping — no Vulkan device available");
+            return;
+        }
+    };
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_buffer_pool().is_none() {
+        println!("cuda-adapter unregister: skipping — OPAQUE_FD pool unavailable");
+        return;
+    }
+    let adapter = CudaSurfaceAdapter::new(host_device);
+    let id: SurfaceId = 0xb16b_00b5;
+    if register_one(&adapter, id).is_err() {
+        println!("cuda-adapter unregister: skipping — registration failed");
+        return;
+    }
+    assert!(adapter.unregister_host_surface(id), "first unregister should succeed");
+    assert!(!adapter.unregister_host_surface(id), "second unregister should fail");
+    assert_eq!(adapter.registered_count(), 0);
+}

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -67,6 +67,13 @@ pub struct HostVulkanDevice {
     /// for an RT-capable one.
     #[cfg(target_os = "linux")]
     dma_buf_image_pool_tiled: Option<vma::Pool>,
+    /// VMA pool for OPAQUE_FD exportable HOST_VISIBLE buffers — the export
+    /// flavor CUDA / OpenCL interop expects. Separate from
+    /// [`Self::dma_buf_buffer_pool`] because `VkExportMemoryAllocateInfo`'s
+    /// `handleTypes` differ (OPAQUE_FD vs DMA_BUF_EXT) and a single VMA pool
+    /// can carry only one chained `pNext`.
+    #[cfg(target_os = "linux")]
+    opaque_fd_buffer_pool: Option<vma::Pool>,
     /// Backing storage for the buffer pool's VkExportMemoryAllocateInfo. VMA stores
     /// a raw pointer to this struct via pMemoryAllocateNext, so we must keep it
     /// alive for the pool's entire lifetime.
@@ -78,6 +85,14 @@ pub struct HostVulkanDevice {
     /// Backing storage for the tiled image pool's VkExportMemoryAllocateInfo.
     #[cfg(target_os = "linux")]
     _dma_buf_image_tiled_export_info: Option<Box<vk::ExportMemoryAllocateInfo>>,
+    /// Backing storage for the OPAQUE_FD buffer pool's VkExportMemoryAllocateInfo.
+    #[cfg(target_os = "linux")]
+    _opaque_fd_buffer_export_info: Option<Box<vk::ExportMemoryAllocateInfo>>,
+    /// `VkPhysicalDeviceIDProperties::deviceUUID` queried at construction.
+    /// Required by CUDA-Vulkan interop on multi-GPU rigs to match the
+    /// CUDA device whose `cudaDeviceProp::uuid` equals this value;
+    /// using a mismatched device silently fails on the import.
+    physical_device_uuid: [u8; 16],
     /// Render-target-capable DRM modifiers per format from the EGL probe at
     /// device init. Empty when libEGL is unavailable or the probe failed.
     /// Callers consult this before requesting
@@ -234,6 +249,22 @@ impl HostVulkanDevice {
         let device_props = unsafe { instance.get_physical_device_properties(physical_device) };
         let device_name =
             unsafe { CStr::from_ptr(device_props.device_name.as_ptr()) }.to_string_lossy();
+
+        // 5b. Query VkPhysicalDeviceIDProperties::deviceUUID via
+        //     vkGetPhysicalDeviceProperties2. CUDA-Vulkan interop matches
+        //     this against `cudaDeviceProp::uuid` (16 bytes) to pick the
+        //     right CUDA device; on multi-GPU rigs (Jetson + dGPU,
+        //     prosumer workstations) using a mismatched device fails
+        //     silently when CUDA imports the OPAQUE_FD memory.
+        let mut id_props = vk::PhysicalDeviceIDProperties::default();
+        let mut props2 = vk::PhysicalDeviceProperties2::builder()
+            .push_next(&mut id_props)
+            .build();
+        unsafe { instance.get_physical_device_properties2(physical_device, &mut props2) };
+        // `id_props.device_uuid` is `ByteArray<16>` (a transparent newtype
+        // around `[u8; 16]`); use the upstream `From<ByteArray<N>> for [u8; N]`
+        // impl to land in plain-array shape.
+        let physical_device_uuid: [u8; 16] = id_props.device_uuid.into();
 
         let device_type_str = match device_props.device_type {
             vk::PhysicalDeviceType::DISCRETE_GPU => "Discrete GPU",
@@ -697,6 +728,27 @@ impl HostVulkanDevice {
             }
         };
 
+        // Build the OPAQUE_FD buffer pool — used by CUDA / OpenCL interop
+        // (host allocates, exports OPAQUE_FD, CUDA `cudaImportExternalMemory`
+        // imports it). Independent of the DMA-BUF pools below; needs its
+        // own pool because VMA carries one chained `VkExportMemoryAllocateInfo`
+        // per pool. Probe failure is non-fatal — callers refuse the
+        // allocation if the pool isn't available.
+        #[cfg(target_os = "linux")]
+        let (opaque_fd_buffer_pool, opaque_fd_buffer_export_info) = if supports_external_memory {
+            match Self::create_opaque_fd_buffer_pool(&allocator) {
+                Ok((pool, export_info)) => (Some(pool), Some(export_info)),
+                Err(e) => {
+                    tracing::warn!(
+                        "OPAQUE_FD buffer pool creation failed — CUDA/OpenCL interop will be unavailable: {e}"
+                    );
+                    (None, None)
+                }
+            }
+        } else {
+            (None, None)
+        };
+
         // Build DMA-BUF export pools on Linux when external memory is supported.
         // The tiled pool is built only when the EGL probe found at least one
         // RT-capable modifier for BGRA — that's the probe shape.
@@ -781,6 +833,11 @@ impl HostVulkanDevice {
             _dma_buf_image_export_info: dma_buf_image_export_info,
             #[cfg(target_os = "linux")]
             _dma_buf_image_tiled_export_info: dma_buf_image_tiled_export_info,
+            #[cfg(target_os = "linux")]
+            opaque_fd_buffer_pool,
+            #[cfg(target_os = "linux")]
+            _opaque_fd_buffer_export_info: opaque_fd_buffer_export_info,
+            physical_device_uuid,
             #[cfg(target_os = "linux")]
             drm_modifier_table,
             live_allocation_count: AtomicUsize::new(0),
@@ -1065,6 +1122,78 @@ impl HostVulkanDevice {
             image_export_info,
             tiled_export_info,
         ))
+    }
+
+    /// Build a VMA pool dedicated to OPAQUE_FD-exportable HOST_VISIBLE buffers.
+    ///
+    /// Used by CUDA / OpenCL interop: the host allocates from this pool,
+    /// `vkGetMemoryFdKHR` with `OPAQUE_FD` produces a kernel fd, and the
+    /// remote API (`cudaImportExternalMemory` etc.) imports the same
+    /// underlying memory by fd. Sibling of [`Self::create_dma_buf_pools`];
+    /// kept separate because a VMA pool can chain only one
+    /// `VkExportMemoryAllocateInfo` per pool, and OPAQUE_FD vs DMA_BUF_EXT
+    /// are mutually-exclusive handle types.
+    ///
+    /// The export info `Box` is returned alongside the pool — callers
+    /// must keep it alive for the pool's entire lifetime (VMA stores
+    /// raw pointers via `pMemoryAllocateNext`).
+    #[cfg(target_os = "linux")]
+    fn create_opaque_fd_buffer_pool(
+        allocator: &Arc<vma::Allocator>,
+    ) -> Result<(vma::Pool, Box<vk::ExportMemoryAllocateInfo>)> {
+        // Probe with the same shape `HostVulkanPixelBuffer::new_opaque_fd_export`
+        // will use: HOST_VISIBLE | HOST_COHERENT, TRANSFER_SRC | TRANSFER_DST,
+        // chained `VkExternalMemoryBufferCreateInfo::OPAQUE_FD`. The probe's
+        // memoryTypeBits must match the real buffer's or the bind fails
+        // with VUID-vkBindBufferMemory-memory-01035.
+        let mut probe_external_info = vk::ExternalMemoryBufferCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD);
+        let probe_buffer_info = vk::BufferCreateInfo::builder()
+            .size(64 * 1024)
+            .usage(
+                vk::BufferUsageFlags::TRANSFER_SRC
+                    | vk::BufferUsageFlags::TRANSFER_DST
+                    | vk::BufferUsageFlags::STORAGE_BUFFER,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .push_next(&mut probe_external_info);
+        let probe_alloc_opts = vma::AllocationOptions {
+            flags: vma::AllocationCreateFlags::DEDICATED_MEMORY
+                | vma::AllocationCreateFlags::MAPPED
+                | vma::AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE,
+            required_flags: vk::MemoryPropertyFlags::HOST_VISIBLE
+                | vk::MemoryPropertyFlags::HOST_COHERENT,
+            ..Default::default()
+        };
+        let mem_type_idx = unsafe {
+            allocator.find_memory_type_index_for_buffer_info(
+                probe_buffer_info,
+                &probe_alloc_opts,
+            )
+        }
+        .map_err(|e| {
+            StreamError::GpuError(format!(
+                "find memory type for OPAQUE_FD buffer pool: {e}"
+            ))
+        })?;
+
+        let mut export_info = Box::new(
+            vk::ExportMemoryAllocateInfo::builder()
+                .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD)
+                .build(),
+        );
+        let mut pool_options = vma::PoolOptions::default();
+        pool_options = pool_options.push_next(export_info.as_mut());
+        pool_options.memory_type_index = mem_type_idx;
+        let pool = allocator
+            .create_pool(&pool_options)
+            .map_err(|e| StreamError::GpuError(format!("create OPAQUE_FD buffer pool: {e}")))?;
+
+        tracing::info!(
+            "OPAQUE_FD VMA buffer pool created — mem_type={}",
+            mem_type_idx
+        );
+        Ok((pool, export_info))
     }
 
     /// Find a memory type that satisfies both the type filter and required properties.
@@ -1554,6 +1683,28 @@ impl HostVulkanDevice {
         self.dma_buf_image_pool_tiled.as_ref()
     }
 
+    /// VMA pool dedicated to OPAQUE_FD-exportable HOST_VISIBLE buffers.
+    ///
+    /// Returns `None` when external memory isn't supported on this device,
+    /// or when the pool's memory-type probe failed at construction.
+    /// Used by CUDA / OpenCL interop — see
+    /// [`super::HostVulkanPixelBuffer::new_opaque_fd_export`].
+    #[cfg(target_os = "linux")]
+    pub fn opaque_fd_buffer_pool(&self) -> Option<&vma::Pool> {
+        self.opaque_fd_buffer_pool.as_ref()
+    }
+
+    /// `VkPhysicalDeviceIDProperties::deviceUUID` queried at construction.
+    ///
+    /// 16-byte big-endian UUID identifying this physical device.
+    /// CUDA-Vulkan interop matches this against `cudaDeviceProp::uuid`
+    /// to pick the correct CUDA device on multi-GPU rigs; using a
+    /// mismatched device fails silently when CUDA imports an
+    /// OPAQUE_FD memory or semaphore exported from this device.
+    pub fn physical_device_uuid(&self) -> [u8; 16] {
+        self.physical_device_uuid
+    }
+
     /// Render-target-capable DRM format modifiers, by DRM FOURCC, from the
     /// EGL probe at device init. Empty when the probe failed. Callers
     /// pass [`DrmModifierTable::rt_modifiers`] into
@@ -1611,7 +1762,7 @@ impl Drop for HostVulkanDevice {
         }
 
         // Critical drop order:
-        //  1. DMA-BUF pools — release Arc<Allocator> refs and call vmaDestroyPool
+        //  1. DMA-BUF + OPAQUE_FD pools — release Arc<Allocator> refs and call vmaDestroyPool
         //  2. Allocator — call vmaDestroyAllocator (only after all Arc refs gone)
         //  3. Export info Boxes — VMA no longer references them after pool destruction
         //  4. Device + instance — Vulkan handles
@@ -1620,6 +1771,7 @@ impl Drop for HostVulkanDevice {
             drop(self.dma_buf_buffer_pool.take());
             drop(self.dma_buf_image_pool.take());
             drop(self.dma_buf_image_pool_tiled.take());
+            drop(self.opaque_fd_buffer_pool.take());
         }
 
         drop(self.allocator.take());
@@ -1629,6 +1781,7 @@ impl Drop for HostVulkanDevice {
             drop(self._dma_buf_buffer_export_info.take());
             drop(self._dma_buf_image_export_info.take());
             drop(self._dma_buf_image_tiled_export_info.take());
+            drop(self._opaque_fd_buffer_export_info.take());
         }
 
         unsafe {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -806,9 +806,13 @@ mod tests {
         }
     }
 
-    /// `physical_device_uuid()` returns 16 bytes that are not all zero
-    /// (NVIDIA / AMD / Intel all populate the UUID; an all-zero result
-    /// signals the `vkGetPhysicalDeviceProperties2` query never ran).
+    /// `physical_device_uuid()` returns 16 bytes that look like a real
+    /// UUID — neither all-zero (would indicate `vkGetPhysicalDeviceProperties2`
+    /// never ran) nor all-the-same-byte (would catch a constant-write bug
+    /// like `[0u8; 16].fill(1)`). Real GPU UUIDs from NVIDIA / AMD / Intel
+    /// have many distinct byte values; a threshold of >= 4 distinct bytes
+    /// is comfortably below every observed real-device UUID and well
+    /// above any plausible constant-write bug.
     #[cfg(target_os = "linux")]
     #[test]
     fn physical_device_uuid_is_populated() {
@@ -824,6 +828,23 @@ mod tests {
             uuid.iter().any(|b| *b != 0),
             "physical_device_uuid should not be all-zero — got {uuid:?}"
         );
+        let distinct: std::collections::HashSet<u8> = uuid.iter().copied().collect();
+        assert!(
+            distinct.len() >= 4,
+            "physical_device_uuid should have >= 4 distinct byte values \
+             (real GPU UUIDs do; a constant-write bug wouldn't) — got {uuid:02x?} \
+             with {} distinct values",
+            distinct.len()
+        );
+
+        // Cheap idempotence check: the accessor is a copy of a stored
+        // array; calling it twice must yield identical bytes.
+        assert_eq!(
+            uuid,
+            device.physical_device_uuid(),
+            "physical_device_uuid must be stable across calls"
+        );
+
         println!("physical_device_uuid: {uuid:02x?}");
     }
 

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -49,6 +49,11 @@ pub struct HostVulkanPixelBuffer {
     /// Whether this buffer was imported from a DMA-BUF fd.
     #[cfg(target_os = "linux")]
     imported_from_dma_buf: bool,
+    /// Whether this buffer was allocated from the OPAQUE_FD export pool
+    /// (vs the DMA_BUF export pool). Determines which `handle_type` is
+    /// passed to `vkGetMemoryFdKHR` on export.
+    #[cfg(target_os = "linux")]
+    is_opaque_fd_export: bool,
     /// Persistently mapped CPU pointer — plane 0 for multi-plane imports.
     mapped_ptr: *mut u8,
     /// Planes 1..N for multi-plane DMA-BUF imports. Empty for single-plane
@@ -144,6 +149,8 @@ impl HostVulkanPixelBuffer {
             imported_memory: None,
             #[cfg(target_os = "linux")]
             imported_from_dma_buf: false,
+            #[cfg(target_os = "linux")]
+            is_opaque_fd_export: false,
             mapped_ptr,
             #[cfg(target_os = "linux")]
             extra_imported_planes: Vec::new(),
@@ -269,6 +276,137 @@ impl super::VulkanPixelBufferLike for HostVulkanPixelBuffer {
 
 #[cfg(target_os = "linux")]
 impl HostVulkanPixelBuffer {
+    /// Create a new OPAQUE_FD-exportable HOST_VISIBLE staging buffer via
+    /// the device's dedicated [`HostVulkanDevice::opaque_fd_buffer_pool`].
+    ///
+    /// Companion to [`Self::new`]: same memory shape (HOST_VISIBLE +
+    /// HOST_COHERENT, persistently mapped), but the export pool's
+    /// chained `VkExportMemoryAllocateInfo::handleTypes` carries
+    /// `OPAQUE_FD` instead of `DMA_BUF_EXT`. `OPAQUE_FD` is the handle
+    /// type CUDA / OpenCL interop expects for `cudaImportExternalMemory`
+    /// (and analogous OpenCL APIs).
+    ///
+    /// Returns `Err` when the device's OPAQUE_FD pool is unavailable
+    /// (external memory unsupported, or pool construction failed at
+    /// device init). Callers must NOT silently fall back to a
+    /// non-exportable allocation — the resulting buffer would be
+    /// unusable for CUDA / OpenCL interop and the failure would
+    /// surface only at `vkGetMemoryFdKHR` time.
+    pub fn new_opaque_fd_export(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        width: u32,
+        height: u32,
+        bytes_per_pixel: u32,
+        format: PixelFormat,
+    ) -> Result<Self> {
+        let size = (width as vk::DeviceSize)
+            * (height as vk::DeviceSize)
+            * (bytes_per_pixel as vk::DeviceSize);
+
+        let mut external_buffer_info = vk::ExternalMemoryBufferCreateInfo::builder()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD)
+            .build();
+
+        let buffer_info = vk::BufferCreateInfo::builder()
+            .size(size)
+            .usage(
+                vk::BufferUsageFlags::TRANSFER_SRC
+                    | vk::BufferUsageFlags::TRANSFER_DST
+                    | vk::BufferUsageFlags::STORAGE_BUFFER,
+            )
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .push_next(&mut external_buffer_info);
+
+        let alloc_opts = vma::AllocationOptions {
+            flags: vma::AllocationCreateFlags::DEDICATED_MEMORY
+                | vma::AllocationCreateFlags::MAPPED
+                | vma::AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE,
+            required_flags: vk::MemoryPropertyFlags::HOST_VISIBLE
+                | vk::MemoryPropertyFlags::HOST_COHERENT,
+            ..Default::default()
+        };
+
+        let pool = vulkan_device.opaque_fd_buffer_pool().ok_or_else(|| {
+            StreamError::GpuError(
+                "OPAQUE_FD buffer pool unavailable — external memory unsupported \
+                 or pool construction failed; CUDA / OpenCL interop requires this pool"
+                    .into(),
+            )
+        })?;
+        let (buffer, allocation) = unsafe { pool.create_buffer(buffer_info, &alloc_opts) }
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "Failed to create OPAQUE_FD exportable buffer: {e}"
+                ))
+            })?;
+
+        let allocator = vulkan_device.allocator();
+        let alloc_info = allocator.get_allocation_info(allocation);
+        let mapped_ptr = alloc_info.pMappedData.cast::<u8>();
+        if mapped_ptr.is_null() {
+            unsafe { allocator.destroy_buffer(buffer, allocation) };
+            return Err(StreamError::GpuError(
+                "VMA OPAQUE_FD staging buffer mapped pointer is null — expected persistent mapping".into(),
+            ));
+        }
+
+        Ok(Self {
+            vulkan_device: Arc::clone(vulkan_device),
+            buffer,
+            allocation: Some(allocation),
+            imported_memory: None,
+            imported_from_dma_buf: false,
+            is_opaque_fd_export: true,
+            mapped_ptr,
+            extra_imported_planes: Vec::new(),
+            width,
+            height,
+            bytes_per_pixel,
+            format,
+            size,
+        })
+    }
+
+    /// Export the buffer's memory as an OPAQUE_FD file descriptor.
+    ///
+    /// Only valid for buffers created via [`Self::new_opaque_fd_export`];
+    /// returns `Err` for DMA-BUF-flavored allocations (call
+    /// [`Self::export_dma_buf_fd`] instead). Each call returns a fresh
+    /// kernel fd (the driver dups internally) — the caller owns it and
+    /// is responsible for closing it (or for transferring ownership via
+    /// SCM_RIGHTS / `cudaImportExternalMemory` etc., both of which
+    /// `dup` again on receipt).
+    pub fn export_opaque_fd_memory(&self) -> Result<std::os::unix::io::RawFd> {
+        if !self.is_opaque_fd_export {
+            return Err(StreamError::GpuError(
+                "HostVulkanPixelBuffer::export_opaque_fd_memory: buffer was not created \
+                 with `new_opaque_fd_export`; the underlying memory carries DMA_BUF_EXT \
+                 (or no) export flags and OPAQUE_FD export will fail at the driver"
+                    .into(),
+            ));
+        }
+        let allocation = self.allocation.as_ref().ok_or_else(|| {
+            StreamError::GpuError(
+                "HostVulkanPixelBuffer::export_opaque_fd_memory: buffer has no VMA allocation"
+                    .into(),
+            )
+        })?;
+        let alloc_info = self.vulkan_device.allocator().get_allocation_info(*allocation);
+        let memory = alloc_info.deviceMemory;
+
+        let get_fd_info = vk::MemoryGetFdInfoKHR::builder()
+            .memory(memory)
+            .handle_type(vk::ExternalMemoryHandleTypeFlags::OPAQUE_FD)
+            .build();
+
+        use vulkanalia::vk::KhrExternalMemoryFdExtensionDeviceCommands;
+        let fd = unsafe { self.vulkan_device.device().get_memory_fd_khr(&get_fd_info) }
+            .map_err(|e| {
+                StreamError::GpuError(format!("Failed to export OPAQUE_FD memory fd: {e}"))
+            })?;
+        Ok(fd)
+    }
+
     /// Export the buffer's memory as a DMA-BUF file descriptor.
     pub fn export_dma_buf_fd(&self) -> Result<std::os::unix::io::RawFd> {
         // Determine which DeviceMemory to export from
@@ -405,6 +543,7 @@ impl HostVulkanPixelBuffer {
             allocation: None,
             imported_memory: Some(plane0.memory),
             imported_from_dma_buf: true,
+            is_opaque_fd_export: false,
             mapped_ptr: plane0.mapped_ptr,
             extra_imported_planes: imported,
             width,
@@ -414,6 +553,7 @@ impl HostVulkanPixelBuffer {
             size: plane0.size,
         })
     }
+
 }
 
 /// Create one `VkBuffer` + bind one imported `VkDeviceMemory` + map it.
@@ -612,6 +752,79 @@ mod tests {
         println!("DMA-BUF exported: fd={fd}");
         // fd ownership is caller's — close it
         unsafe { libc::close(fd) };
+    }
+
+    /// `new_opaque_fd_export` allocates from the OPAQUE_FD pool;
+    /// `export_opaque_fd_memory` returns a valid kernel fd; cross-flavor
+    /// export is rejected (calling `export_opaque_fd_memory` on a DMA-BUF
+    /// buffer produces an error).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn opaque_fd_export_round_trip_and_cross_flavor_rejection() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        if device.opaque_fd_buffer_pool().is_none() {
+            println!("Skipping - OPAQUE_FD buffer pool unavailable on this driver");
+            return;
+        }
+
+        // Positive: OPAQUE_FD-allocated buffer exports an OPAQUE_FD fd.
+        let buf = HostVulkanPixelBuffer::new_opaque_fd_export(
+            &device,
+            128,
+            128,
+            4,
+            PixelFormat::Bgra32,
+        )
+        .expect("new_opaque_fd_export failed");
+        assert!(!buf.mapped_ptr().is_null(), "mapped pointer should be non-null");
+        assert_eq!(buf.size(), (128 * 128 * 4) as vk::DeviceSize);
+        let fd = buf
+            .export_opaque_fd_memory()
+            .expect("export_opaque_fd_memory failed");
+        assert!(fd >= 0, "OPAQUE_FD fd must be non-negative");
+        unsafe { libc::close(fd) };
+
+        // Negative: DMA-BUF-allocated buffer rejects OPAQUE_FD export.
+        let dma_buf = HostVulkanPixelBuffer::new(&device, 64, 64, 4, PixelFormat::Bgra32)
+            .expect("dma-buf buffer failed");
+        match dma_buf.export_opaque_fd_memory() {
+            Err(crate::core::StreamError::GpuError(msg)) => {
+                assert!(
+                    msg.contains("not created with `new_opaque_fd_export`"),
+                    "error must call out the cross-flavor mismatch, got: {msg}"
+                );
+            }
+            other => panic!(
+                "expected cross-flavor rejection on DMA-BUF buffer, got {other:?}"
+            ),
+        }
+    }
+
+    /// `physical_device_uuid()` returns 16 bytes that are not all zero
+    /// (NVIDIA / AMD / Intel all populate the UUID; an all-zero result
+    /// signals the `vkGetPhysicalDeviceProperties2` query never ran).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn physical_device_uuid_is_populated() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        let uuid = device.physical_device_uuid();
+        assert!(
+            uuid.iter().any(|b| *b != 0),
+            "physical_device_uuid should not be all-zero — got {uuid:?}"
+        );
+        println!("physical_device_uuid: {uuid:02x?}");
     }
 
     #[test]

--- a/xtask/src/check_boundaries.rs
+++ b/xtask/src/check_boundaries.rs
@@ -442,6 +442,7 @@ const NO_STREAMLIB_RUNTIME_DEP: &[&str] = &[
     "libs/streamlib-adapter-opengl/Cargo.toml",
     "libs/streamlib-adapter-cpu-readback/Cargo.toml",
     "libs/streamlib-adapter-skia/Cargo.toml",
+    "libs/streamlib-adapter-cuda/Cargo.toml",
 ];
 
 fn check_cdylib_and_adapter_runtime_deps(


### PR DESCRIPTION
## Summary

- Stand up `streamlib-adapter-cuda` (+ `-helpers`) for Vulkan↔CUDA OPAQUE_FD interop — foundation for GPU-resident AI inference on subprocess customers via PyTorch / TensorRT / ONNX-Runtime CUDA backend (drone-racing on-path consumer per #565).
- Extend the host RHI with an OPAQUE_FD VMA buffer pool sibling to the DMA-BUF pools, `physical_device_uuid()` query, and `HostVulkanPixelBuffer::new_opaque_fd_export` + `export_opaque_fd_memory`.
- Carve-out integration test executes end-to-end on the dev machine: host writes a BGRA pattern, CUDA imports OPAQUE_FD memory + timeline, `cudaWaitExternalSemaphoresAsync_v2` + `cudaMemcpyAsync` device→host, byte-equal assertion passes.

## Closes

Closes #587

## Exit criteria

- [x] `libs/streamlib-adapter-cuda/` scaffolded with runtime deps `streamlib-adapter-abi` + `streamlib-consumer-rhi` (Linux target). CUDA SDK gated behind a Cargo feature on the helpers crate (the runtime crate exposes a `cuda` feature flag for forward-compat with #589/#590), default OFF.
- [x] Host-flavor `CudaSurfaceAdapter` instantiable against a `HostVulkanDevice` (`HostMarker` privilege); carve-out semantic test passes (host writes pattern → CUDA imports memory + timeline → CUDA reads → byte-equal assertion).
- [x] cdylib boundary preserved: `cargo tree -p streamlib-{python,deno}-native | grep -c "^streamlib v"` returns 0 (this PR does not wire the new crate into either cdylib).

## Architectural choices (issue body explicitly delegates these)

- **Crate split mirrors `streamlib-adapter-cpu-readback`** (adapter + helpers) so `streamlib` stays a dev-dep only and the cdylib boundary holds. Helpers crate hosts the CUDA-feature-gated carve-out test.
- **Adapter struct shape mirrors `streamlib-adapter-vulkan`** (no per-acquire trigger or bridge — CUDA imports OPAQUE_FD once and dispatches in its own context; only timeline sync crosses the Vulkan↔CUDA boundary per acquire).
- **Generic over `D: VulkanRhiDevice`** so the same crate slots into the future `ConsumerVulkanDevice` cdylib path in #589/#590 without surface change.
- **VkBuffer (not VkImage) for the carve-out** — byte-equal validation requires deterministic linear layout. VkImage import via `cudaExternalMemoryGetMappedMipmappedArray` lands when #588 extends the wire format with full `VkImageCreateInfo`.
- **`cudarc 0.19` pinned to `cuda-12090` bindings + `fallback-dynamic-loading`** — the `_v2`-suffixed external-resource symbols stay ABI-stable through cuda 13.x, and no `nvcc` is required at build time. Test skips with rc-style logging when `libcudart` isn't installed.

## Test plan

- [x] `cargo test -p streamlib --lib vulkan::rhi::vulkan_pixel_buffer::tests` — 10 passed (includes 2 new: OPAQUE_FD round-trip + cross-flavor rejection; UUID populated + idempotent + has ≥4 distinct bytes).
- [x] `cargo test -p streamlib-adapter-cuda` — 3 passed (run_conformance, duplicate registration, unregister).
- [x] `cargo test -p streamlib-adapter-cuda-helpers --features cuda` — carve-out byte-equal **passed** end-to-end with real CUDA on the dev machine.
- [x] `cargo test --workspace --no-fail-fast --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — 1162 passed / 1 failed (pre-existing flake `linux::surface_share::unix_socket_service::tests::oversize_fd_vec_rejected` — verified to fail on `main` too) / 34 ignored across 124 binaries.
- [x] `cargo xtask check-boundaries` — 1912 files scanned, no violations. The new adapter crate is in `NO_STREAMLIB_RUNTIME_DEP` so the cdylib boundary stays enforced.

## Pre-PR review

`pr-review-gate` returned **PASS** with 4 DISCUSS-grade items. Two were addressed in a follow-up commit:

- Carve-out test now exports FDs through the adapter's `surface_pixel_buffer` / `surface_timeline` accessors (with `Arc::ptr_eq` to confirm registry retention) instead of local `Arc`s. Removes the dead-on-arrival concern about the accessors and exercises the production cdylib lookup pattern.
- `physical_device_uuid_is_populated` strengthened to assert ≥4 distinct byte values + idempotence across calls. Catches constant-write bugs the original "any non-zero" assertion would have missed.

The other two flags (unconditional timeline wait, FD-cleanup error paths) verified correct as written — see commit message on `9ce4638` for the rationale.

## Follow-ups

- #588 extends the wire format with full `VkImageCreateInfo` round-trip + a CUDA bridge trait — unblocks VkImage import via `cudaExternalMemoryGetMappedMipmappedArray`.
- #589 / #590 wire the cdylib runtimes (Python + Deno DLPack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)