### PR TITLE
feat(adapter-cuda): subprocess CUDA runtimes for Python + Deno cdylibs (#589 + #590)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,27 @@ rspirv-reflect = "0.9.0"
 # so the cdylib boundary doesn't pick up Python or ML transitive deps.
 dlpark = { version = "=0.6.0", default-features = false }
 
+# CUDA bindings — used by `streamlib-adapter-cuda-helpers` (test-only,
+# behind a `cuda` Cargo feature) and by the polyglot cdylib runtimes
+# (`streamlib-python-native`, `streamlib-deno-native`) to import OPAQUE_FD
+# Vulkan memory + timeline semaphores into CUDA via
+# `cudaImportExternalMemory` / `cudaImportExternalSemaphore`. The cdylibs
+# depend on cudarc unconditionally (Linux-only) but `fallback-dynamic-loading`
+# means libcuda.so is only required at runtime — build hosts without a
+# CUDA toolkit still compile the cdylib, and runtime detection via
+# `cudarc::runtime::sys::is_culib_present()` lets the adapter fail
+# gracefully on CUDA-less machines.
+#
+# Pin to `cuda-12090` so the build does NOT require `nvcc` (the
+# `cuda-version-from-build-system` alternative errors when nvcc is
+# absent). The `_v2`-suffixed external-resource symbols this binding
+# exposes remain ABI-stable through CUDA 13.x — runtime libcudart
+# continues to export them, so the dlopen path resolves regardless of
+# which CUDA version is installed on the runner. `default-features =
+# false` skips cuBLAS / cuRAND / NVRTC; we only need `runtime` (for
+# external-memory + external-semaphore APIs).
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "fallback-dynamic-loading", "cuda-12090"] }
+
 # Skia bindings for the streamlib-adapter-skia crate.
 #
 # - `vulkan`: GrDirectContext + GrVkImageInfo + GrBackendRenderTarget

--- a/libs/streamlib-adapter-cuda-helpers/Cargo.toml
+++ b/libs/streamlib-adapter-cuda-helpers/Cargo.toml
@@ -50,19 +50,11 @@ vulkanalia.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 libc.workspace = true
-# Optional CUDA bindings — `fallback-dynamic-loading` loads libcuda.so
-# lazily via dlopen on first call (toolkit absence at build time is
-# fine; runtime absence skips the test rather than failing). Drop the
-# default features so we don't drag cuBLAS / cuRAND / NVRTC into the
-# build for #587's needs.
-# Pin to a specific CUDA toolkit version (`cuda-12090`) so the build
-# does NOT require `nvcc` to be installed (`cuda-version-from-build-system`
-# is the alternative but errors when nvcc is absent). `cuda-12090`
-# bindings call the older `_v2`-suffixed external-resource symbols
-# which remain ABI-stable through cuda 13.x — runtime libcudart
-# continues to export them, so the dlopen path works regardless of
-# which toolkit version is installed on the test machine.
-cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver", "runtime", "fallback-dynamic-loading", "cuda-12090"] }
+# Optional CUDA bindings — see workspace `Cargo.toml` for the
+# `fallback-dynamic-loading` + `cuda-12090` rationale. `optional = true`
+# is the only knob this crate adds on top of the workspace dep, so the
+# `cuda` Cargo feature still gates whether the binding is compiled in.
+cudarc = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 # Serialize Vulkan-device-touching tests; concurrent `VkDevice` /

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -43,6 +43,16 @@ streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
 # runs host-side, triggered via the `run_cpu_readback_copy` escalate
 # IPC; the consumer waits on the imported timeline through the carve-out.
 streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
+# Subprocess-side CUDA runtime (#590). Mirrors the Python sibling
+# (#589) — generic-over-device adapter, instantiated here against
+# `ConsumerVulkanDevice`, OPAQUE_FD VkBuffer + timeline imported into
+# CUDA via `cudaImportExternalMemory` / `cudaImportExternalSemaphore`,
+# DLPack capsule emitted across the FFI boundary.
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
+# CUDA bindings — see streamlib-python-native/Cargo.toml for the
+# `fallback-dynamic-loading` rationale. Same workspace pin so the two
+# cdylibs stay lockstep on CUDA ABI.
+cudarc.workspace = true
 
 
 [lints]

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -3937,6 +3937,1056 @@ mod cpu_readback {
     }
 }
 
+// ============================================================================
+// C ABI — cuda adapter runtime (#590, Linux)
+//
+// Subprocess-side runtime for the cuda adapter. Same single-pattern shape
+// as cpu-readback / vulkan / opengl: the adapter is generic over device
+// flavor, this cdylib instantiates it against `ConsumerVulkanDevice`, and
+// the OPAQUE_FD `VkBuffer` + timeline semaphore that surface-share hands
+// over are imported into Vulkan via `streamlib-consumer-rhi` and into
+// CUDA via `cudaImportExternalMemory` + `cudaImportExternalSemaphore`.
+// Per-acquire flow has no IPC: the host pipeline writes into the
+// OPAQUE_FD buffer and signals the shared timeline ambiently; the
+// consumer's `acquire_read` Vulkan-waits via the adapter, then CUDA-waits
+// via `cudaWaitExternalSemaphoresAsync` so CUDA driver state is in sync,
+// then hands a DLPack capsule back to Deno.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod cuda {
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::mem::MaybeUninit;
+    use std::os::unix::io::RawFd;
+    use std::sync::{Arc, Mutex};
+
+    use cudarc::runtime::result::external_memory;
+    use cudarc::runtime::sys;
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_cuda::dlpack::{
+        self, CapsuleOwner, Device as DlpackDevice, DeviceType as DlpackDeviceType,
+        ManagedTensor as DlpackManagedTensor,
+    };
+    use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+    use streamlib_consumer_rhi::{
+        ConsumerVulkanDevice, ConsumerVulkanPixelBuffer, ConsumerVulkanTimelineSemaphore,
+        PixelFormat,
+    };
+
+    use super::gpu_surface::SurfaceHandle;
+
+    /// `acquire_*` return values — wire-stable across the cdylib boundary.
+    pub const SLDN_CUDA_OK: i32 = 0;
+    pub const SLDN_CUDA_ERR: i32 = -1;
+    pub const SLDN_CUDA_CONTENDED: i32 = 1;
+
+    /// DLPack `DLDeviceType` discriminants exposed at the FFI surface so
+    /// the Python wrapper can interpret [`SldnCudaView::device_type`]
+    /// without re-importing the dlpark spec.
+    pub const SLDN_CUDA_DEVICE_TYPE_CUDA: i32 = DlpackDeviceType::Cuda as i32;
+    pub const SLDN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = DlpackDeviceType::CudaHost as i32;
+
+    /// Per-acquire timeline-wait timeout (nanoseconds). Long enough to
+    /// cover any realistic GPU queue depth; short enough that a deadlock
+    /// surfaces as `SLDN_CUDA_ERR` rather than wedging the consumer.
+    /// Mirrors `streamlib_adapter_cuda::CudaSurfaceAdapter`'s default
+    /// (5 s).
+    const ACQUIRE_TIMEOUT_NS: u64 = 5_000_000_000;
+
+    /// View handed back on every successful acquire. Carries the cached
+    /// CUDA device pointer (resolved once per surface at register time)
+    /// plus a freshly heap-allocated DLPack `*mut DLManagedTensor` the
+    /// caller takes ownership of — Deno wraps it as a `Uint8Array`-with-deleter
+    /// (or hands the raw `*mut DLManagedTensor` to a third-party DLPack
+    /// consumer). The capsule deleter drops an
+    /// `Arc<RegisteredCudaSurface>` clone, so the imported memory stays
+    /// alive until the consumer releases the capsule even if the adapter
+    /// guard has been released first.
+    ///
+    /// Note: the underlying `vk::Buffer` handle is deliberately NOT
+    /// exposed on this view. Consumers that need raw Vulkan access go
+    /// through `streamlib-adapter-vulkan`'s `SlpnVulkanView` instead;
+    /// switching to this adapter is the contractual signal for "I want
+    /// a DLPack capsule."
+    #[repr(C)]
+    pub struct SldnCudaView {
+        /// Buffer size in bytes — same value as
+        /// [`Self::dlpack_managed_tensor`]'s 1-D `u8` shape.
+        pub size: u64,
+        /// CUDA device pointer (`CUdeviceptr` cast to `u64`) returned by
+        /// `cudaExternalMemoryGetMappedBuffer`. Stable for the surface's
+        /// lifetime; cached at register time, not re-resolved on every
+        /// acquire.
+        pub device_ptr: u64,
+        /// DLPack `DLDeviceType` discriminant. `2` (`kDLCUDA`) for true
+        /// device memory; `3` (`kDLCUDAHost`) if `cudaPointerGetAttributes`
+        /// classifies the imported pointer as pinned-host (a regression
+        /// flagged by the carve-out test, currently driver-impossible on
+        /// our test rig but checked anyway). Mirrors
+        /// [`SLDN_CUDA_DEVICE_TYPE_CUDA`] / `_CUDA_HOST`.
+        pub device_type: i32,
+        /// CUDA device ordinal. Single-GPU rigs always see `0`; multi-GPU
+        /// UUID matching is a follow-up.
+        pub device_id: i32,
+        /// `*mut DLManagedTensor` — heap-allocated, ownership transfers
+        /// to the caller. The caller MUST eventually call the capsule's
+        /// `deleter` (typically by either (a) calling the deleter directly through
+        /// the JS side once the consumer is done, or (b) handing the
+        /// pointer to a third-party DLPack consumer that takes
+        /// ownership of the deleter call).
+        pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    /// Subprocess CUDA runtime — single-process global per cdylib load.
+    pub struct CudaRuntimeHandle {
+        device: Arc<ConsumerVulkanDevice>,
+        adapter: Arc<CudaSurfaceAdapter<ConsumerVulkanDevice>>,
+        cuda_device_ordinal: i32,
+        registered: Mutex<HashMap<u64, Arc<RegisteredCudaSurface>>>,
+    }
+
+    /// Per-surface registered state. The adapter's registry holds
+    /// references to the same Vulkan-side `Arc`s; this struct adds the
+    /// CUDA-side handles + the per-surface stream the cdylib uses for
+    /// `cudaWaitExternalSemaphoresAsync`. Stored behind an `Arc` so a
+    /// DLPack capsule's `manager_ctx` can clone it cheaply and keep
+    /// every CUDA import alive until the consumer releases the capsule.
+    struct RegisteredCudaSurface {
+        // Vulkan-side handles — held for Drop ordering. The adapter's
+        // registry holds its own Arc clones; ours ensure the CUDA
+        // imports below are torn down BEFORE the underlying Vulkan
+        // memory goes away (Vulkan teardown closes the FDs CUDA still
+        // references). Drop order: this struct's fields drop in
+        // declaration order, so put CUDA imports first.
+        ext_mem: sys::cudaExternalMemory_t,
+        ext_sem: sys::cudaExternalSemaphore_t,
+        stream: sys::cudaStream_t,
+        device_ptr: u64,
+        size: u64,
+        device_type: i32,
+        cuda_device_ordinal: i32,
+        // Vulkan-side imports follow — they outlive `ext_mem` / `ext_sem`
+        // because Drop runs in declaration order, but logically the
+        // adapter's registry already owns them. Holding our own clones
+        // is belt-and-suspenders.
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        pixel_buffer: Arc<ConsumerVulkanPixelBuffer>,
+        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+    }
+
+    // SAFETY: `cudaExternalMemory_t`, `cudaExternalSemaphore_t`, and
+    // `cudaStream_t` are opaque pointer-shaped handles. The CUDA Runtime
+    // API's threading contract permits use of these handles from any
+    // thread once created; resource teardown (`cudaDestroyExternalMemory`,
+    // `cudaDestroyExternalSemaphore`, `cudaStreamDestroy`) is similarly
+    // thread-safe. Our `Mutex<HashMap>` serializes registration /
+    // unregistration; per-acquire wait + sync calls are reentrant.
+    unsafe impl Send for RegisteredCudaSurface {}
+    unsafe impl Sync for RegisteredCudaSurface {}
+
+    impl Drop for RegisteredCudaSurface {
+        fn drop(&mut self) {
+            // CUDA-side teardown FIRST so the imports release their
+            // hold on the OPAQUE_FD kernel objects before Vulkan-side
+            // Arcs drop and teardown the underlying VkDeviceMemory /
+            // VkSemaphore.
+            unsafe {
+                if !self.stream.is_null() {
+                    let _ = sys::cudaStreamDestroy(self.stream).result();
+                }
+                if !self.ext_sem.is_null() {
+                    let _ = sys::cudaDestroyExternalSemaphore(self.ext_sem).result();
+                }
+                if !self.ext_mem.is_null() {
+                    let _ = external_memory::destroy_external_memory(self.ext_mem);
+                }
+            }
+        }
+    }
+
+    /// Bring up `ConsumerVulkanDevice` + `CudaSurfaceAdapter` against
+    /// CUDA device 0. Returns NULL on Vulkan or CUDA bring-up failure;
+    /// see the subprocess log for the underlying cause. Idempotent
+    /// callers can rebuild after a failure once the cause is fixed.
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info")]
+    pub unsafe extern "C" fn sldn_cuda_runtime_new() -> *mut CudaRuntimeHandle {
+        let device = match ConsumerVulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_runtime_new: ConsumerVulkanDevice::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+
+        // CUDA runtime presence: dlopens libcudart + libcuda lazily on
+        // the first CUDA call. `is_culib_present()` probes without
+        // initializing — used here to surface the no-CUDA case as a
+        // clean NULL return rather than a panic on the first import.
+        if !unsafe { sys::is_culib_present() } {
+            tracing::error!(
+                "sldn_cuda_runtime_new: libcudart not present — CUDA toolkit \
+                 absent on this machine; cuda adapter is unavailable"
+            );
+            return std::ptr::null_mut();
+        }
+
+        let cuda_device_ordinal: i32 = 0;
+        if let Err(e) = unsafe { sys::cudaSetDevice(cuda_device_ordinal) }.result() {
+            tracing::error!(
+                "sldn_cuda_runtime_new: cudaSetDevice({}) failed: {:?}",
+                cuda_device_ordinal,
+                e
+            );
+            return std::ptr::null_mut();
+        }
+
+        let adapter = Arc::new(CudaSurfaceAdapter::new(Arc::clone(&device)));
+        Box::into_raw(Box::new(CudaRuntimeHandle {
+            device,
+            adapter,
+            cuda_device_ordinal,
+            registered: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_runtime_free(rt: *mut CudaRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    /// Register a host cuda surface — imports the OPAQUE_FD `VkBuffer`
+    /// and timeline semaphore via [`streamlib_consumer_rhi`], then
+    /// re-imports the same FDs into CUDA via
+    /// `cudaImportExternalMemory` + `cudaImportExternalSemaphore`.
+    ///
+    /// Caller (the SDK) supplies `surface_id` (subprocess-local u64;
+    /// caller picks the namespace) and `gpu_handle` (a `SurfaceHandle*`
+    /// returned by `slpn_surface_resolve_surface` after a `check_out` of
+    /// the host's pre-registered cuda surface).
+    ///
+    /// Single-FD only: the host registers cuda surfaces as a
+    /// flat OPAQUE_FD `VkBuffer` per `HostVulkanPixelBuffer::new_opaque_fd_export`;
+    /// CUDA's `cudaExternalMemoryGetMappedBuffer` requires a flat memory
+    /// region (multi-plane variants need
+    /// `cudaExternalMemoryGetMappedMipmappedArray`, which doesn't have a
+    /// DLPack flavor — see the issue body for the OPAQUE_FD vs DMA-BUF
+    /// rationale).
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info", skip(rt, gpu_handle))]
+    pub unsafe extern "C" fn sldn_cuda_register_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_cuda_register_surface: null runtime");
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("sldn_cuda_register_surface: null gpu_handle");
+                return SLDN_CUDA_ERR;
+            }
+        };
+        if gpu.fds.len() != 1 {
+            tracing::error!(
+                "sldn_cuda_register_surface: cuda requires exactly 1 OPAQUE_FD plane; \
+                 gpu_handle has {} fd(s)",
+                gpu.fds.len()
+            );
+            return SLDN_CUDA_ERR;
+        }
+
+        // ── Step 1: import the OPAQUE_FD `VkBuffer` into Vulkan ─────────
+        // The fd is duplicated before the Vulkan import takes ownership
+        // because we re-import the same fd into CUDA below. Vulkan and
+        // CUDA each get their own dup; both close their dups on
+        // teardown (Vulkan via `vkFreeMemory` → driver, CUDA via
+        // `cudaDestroyExternalMemory` → driver).
+        let vk_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if vk_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: dup vk_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            return SLDN_CUDA_ERR;
+        }
+        let buffer_size = gpu
+            .plane_sizes
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.size);
+        if buffer_size == 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: surface '{}' has zero size",
+                surface_id
+            );
+            unsafe { libc::close(vk_fd) };
+            return SLDN_CUDA_ERR;
+        }
+        let pixel_buffer = match ConsumerVulkanPixelBuffer::from_opaque_fd(
+            &rt.device,
+            vk_fd,
+            gpu.width,
+            gpu.height,
+            gpu.bytes_per_row.div_ceil(gpu.width.max(1)),
+            PixelFormat::Bgra32,
+            buffer_size,
+        ) {
+            Ok(b) => Arc::new(b),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: from_opaque_fd failed: {} — \
+                     verify the host registered this surface with handle_type=opaque_fd",
+                    e
+                );
+                // Vulkan import takes the fd ownership only on success;
+                // on error we still own the dup.
+                unsafe { libc::close(vk_fd) };
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: surface '{}' has no sync_fd — \
+                     the host must register it with an exportable timeline semaphore \
+                     so cross-API sync (Vulkan ↔ CUDA) is well-defined",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        // Same dup story: timeline imports both into Vulkan and into CUDA.
+        let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if vk_sync_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: dup sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            // Restore the original fd onto the handle so its Drop closes it.
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: timeline from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_sync_fd) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
+        // CUDA takes ownership of the cuda-side dup on successful import.
+        let cuda_mem_fd = unsafe { libc::dup(raw_sync_fd) }; // placeholder — dup the BUFFER fd
+        // The above is a typo guard — the cuda-side memory fd is the
+        // BUFFER fd, not the sync fd. Redo cleanly:
+        unsafe { libc::close(cuda_mem_fd) };
+        let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if cuda_mem_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: dup cuda_mem_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            // Vulkan-side imports drop here via Arc — they own their own
+            // dups already. Restore sync_fd onto the handle so its Drop
+            // closes it (Vulkan timeline import owns its dup independently).
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        // SAFETY: `cudaImportExternalMemory` per CUDA docs:
+        // - On UNIX, ownership of `cuda_mem_fd` transfers to the CUDA
+        //   driver on successful import. We MUST NOT close it after.
+        // - On error, ownership stays with us — close the fd here.
+        let ext_mem = unsafe {
+            match external_memory::import_external_memory_opaque_fd(cuda_mem_fd, buffer_size) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_surface: cudaImportExternalMemory failed: {:?}",
+                        e
+                    );
+                    libc::close(cuda_mem_fd);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // SAFETY: `cudaExternalMemoryGetMappedBuffer` is the flat-pointer
+        // mapping helper. The returned pointer aliases the same kernel
+        // memory the OPAQUE_FD VkBuffer was bound to. Lifetime: valid
+        // until `cudaDestroyExternalMemory` (handled by Drop).
+        let dev_ptr = unsafe {
+            match external_memory::get_mapped_buffer(ext_mem, 0, buffer_size) {
+                Ok(p) => p as u64,
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_surface: cudaExternalMemoryGetMappedBuffer: {:?}",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 4: classify the device pointer (kDLCUDA vs kDLCUDAHost) ─
+        // The carve-out test (#588 Stage 8) flagged this as a load-bearing
+        // probe — a future driver could downgrade the import to pinned-host
+        // memory; the DLPack capsule must advertise the right device type
+        // or `torch.from_dlpack` will copy unnecessarily (or refuse).
+        let mut ptr_attrs = MaybeUninit::<sys::cudaPointerAttributes>::uninit();
+        let ptr_attrs = unsafe {
+            match sys::cudaPointerGetAttributes(ptr_attrs.as_mut_ptr(), dev_ptr as *const c_void)
+                .result()
+            {
+                Ok(()) => ptr_attrs.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_surface: cudaPointerGetAttributes failed: {:?}",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+        let device_type = match ptr_attrs.type_ {
+            sys::cudaMemoryType::cudaMemoryTypeDevice => SLDN_CUDA_DEVICE_TYPE_CUDA,
+            sys::cudaMemoryType::cudaMemoryTypeHost => SLDN_CUDA_DEVICE_TYPE_CUDA_HOST,
+            other => {
+                tracing::error!(
+                    "sldn_cuda_register_surface: imported OPAQUE_FD device pointer is \
+                     {:?} — neither cudaMemoryTypeDevice nor cudaMemoryTypeHost. \
+                     DLPack consumers cannot accept this; investigate driver before proceeding",
+                    other
+                );
+                let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if cuda_sync_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_surface: dup cuda_sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        // Same descriptor-construction story as the carve-out test:
+        // `cudaExternalSemaphoreHandleType`'s zero discriminant is invalid
+        // under modern Rust validity rules, so use `MaybeUninit::zeroed()`
+        // and write fields through raw pointers before `assume_init()`.
+        // `reserved` (cuda-13xxx only) inherits the zero pre-fill, which
+        // matches the spec contract.
+        let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
+        let sem_desc = unsafe {
+            let p = sem_desc.as_mut_ptr();
+            (&raw mut (*p).type_).write(
+                sys::cudaExternalSemaphoreHandleType::cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd,
+            );
+            (&raw mut (*p).handle).write(
+                sys::cudaExternalSemaphoreHandleDesc__bindgen_ty_1 { fd: cuda_sync_fd },
+            );
+            (&raw mut (*p).flags).write(0);
+            sem_desc.assume_init()
+        };
+        let mut ext_sem = MaybeUninit::<sys::cudaExternalSemaphore_t>::uninit();
+        let ext_sem = unsafe {
+            match sys::cudaImportExternalSemaphore(ext_sem.as_mut_ptr(), &sem_desc).result() {
+                Ok(()) => ext_sem.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_surface: cudaImportExternalSemaphore: {:?}",
+                        e
+                    );
+                    libc::close(cuda_sync_fd);
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 6: per-surface CUDA stream for the per-acquire wait ────
+        let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+        let stream = unsafe {
+            match sys::cudaStreamCreate(stream.as_mut_ptr()).result() {
+                Ok(()) => stream.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_surface: cudaStreamCreate: {:?}",
+                        e
+                    );
+                    let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 7: hand the imports to the adapter's registry ──────────
+        let registration = HostSurfaceRegistration {
+            pixel_buffer: Arc::clone(&pixel_buffer),
+            timeline: Arc::clone(&timeline),
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+        if let Err(e) = rt.adapter.register_host_surface(surface_id, registration) {
+            tracing::error!(
+                "sldn_cuda_register_surface: adapter.register_host_surface({}): {:?}",
+                surface_id,
+                e
+            );
+            unsafe {
+                let _ = sys::cudaStreamDestroy(stream).result();
+                let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+
+        // The original `raw_sync_fd` is owned by the SurfaceHandle's drop
+        // path. We've already dup'd it twice (Vulkan + CUDA timeline), so
+        // returning it to the handle's `sync_fd` slot is the canonical
+        // ownership recovery — same pattern as cpu-readback's
+        // register_surface error paths.
+        gpu.sync_fd = Some(raw_sync_fd);
+
+        let entry = Arc::new(RegisteredCudaSurface {
+            ext_mem,
+            ext_sem,
+            stream,
+            device_ptr: dev_ptr,
+            size: buffer_size,
+            device_type,
+            cuda_device_ordinal: rt.cuda_device_ordinal,
+            pixel_buffer,
+            timeline,
+        });
+        rt.registered
+            .lock()
+            .expect("sldn_cuda registered: poisoned")
+            .insert(surface_id, entry);
+        SLDN_CUDA_OK
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_unregister_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let removed = rt
+            .registered
+            .lock()
+            .expect("sldn_cuda registered: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return SLDN_CUDA_ERR;
+        }
+        if rt.adapter.unregister_host_surface(surface_id) {
+            SLDN_CUDA_OK
+        } else {
+            SLDN_CUDA_ERR
+        }
+    }
+
+    fn make_descriptor(surface_id: u64) -> StreamlibSurface {
+        StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        )
+    }
+
+    /// Build a fresh DLPack `*mut DLManagedTensor` over the cached
+    /// device pointer; capsule owner is an `Arc<RegisteredCudaSurface>`
+    /// clone so the imported memory stays alive across the FFI handoff.
+    fn build_capsule(entry: &Arc<RegisteredCudaSurface>) -> *mut DlpackManagedTensor {
+        // dlpark's `Device::cuda(usize)` helper covers `kDLCUDA` only;
+        // construct manually so the `kDLCUDAHost` branch (regression
+        // path flagged by the carve-out test) can ride the same code.
+        let device = DlpackDevice {
+            device_type: if entry.device_type == SLDN_CUDA_DEVICE_TYPE_CUDA_HOST {
+                DlpackDeviceType::CudaHost
+            } else {
+                DlpackDeviceType::Cuda
+            },
+            device_id: entry.cuda_device_ordinal,
+        };
+        let owner: CapsuleOwner = Box::new(Arc::clone(entry));
+        dlpack::build_byte_buffer_managed_tensor(entry.device_ptr, entry.size, device, owner)
+    }
+
+    /// Cross-API sync: after the adapter's Vulkan-side wait succeeds,
+    /// CUDA's view of the same kernel timeline must also reach the
+    /// signaled value before consumer kernels read the buffer. Issues a
+    /// `cudaWaitExternalSemaphoresAsync` against the surface's stream at
+    /// the timeline's current Vulkan-observed value, then synchronizes.
+    /// Returns `Ok(())` on success.
+    fn cuda_sync_after_acquire(entry: &RegisteredCudaSurface) -> Result<(), String> {
+        let wait_value = entry
+            .timeline
+            .current_value()
+            .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
+
+        let mut wait_params = MaybeUninit::<sys::cudaExternalSemaphoreWaitParams>::zeroed();
+        let wait_params = unsafe {
+            let p = wait_params.as_mut_ptr();
+            (&raw mut (*p).params.fence.value).write(wait_value);
+            (&raw mut (*p).flags).write(0);
+            wait_params.assume_init()
+        };
+
+        let wait_result = unsafe {
+            sys::cudaWaitExternalSemaphoresAsync_v2(
+                &entry.ext_sem,
+                &wait_params,
+                1,
+                entry.stream,
+            )
+            .result()
+        };
+        if let Err(e) = wait_result {
+            return Err(format!("cudaWaitExternalSemaphoresAsync: {e:?}"));
+        }
+        if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
+            return Err(format!("cudaStreamSynchronize: {e:?}"));
+        }
+        // SAFETY guard: the timeline can advance further between
+        // `current_value()` and `cudaWaitExternalSemaphoresAsync_v2`. That's
+        // fine — CUDA's wait-at-or-above semantics mean a stale `wait_value`
+        // is still valid (we just wait less). Underflow isn't possible:
+        // `current_value()` returns the present counter, never zero on a
+        // post-acquire path because the host adapter only signals values
+        // >= 1 on every release.
+        let _ = wait_value;
+        Ok(())
+    }
+
+    fn populate_view(
+        entry: &Arc<RegisteredCudaSurface>,
+        out: &mut SldnCudaView,
+    ) -> i32 {
+        let capsule = build_capsule(entry);
+        if capsule.is_null() {
+            tracing::error!("sldn_cuda: build_capsule returned null");
+            return SLDN_CUDA_ERR;
+        }
+        out.size = entry.size;
+        out.device_ptr = entry.device_ptr;
+        out.device_type = entry.device_type;
+        out.device_id = entry.cuda_device_ordinal;
+        out.dlpack_managed_tensor = capsule as *mut c_void;
+        SLDN_CUDA_OK
+    }
+
+    fn lookup_entry(
+        rt: &CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> Option<Arc<RegisteredCudaSurface>> {
+        rt.registered
+            .lock()
+            .expect("sldn_cuda registered: poisoned")
+            .get(&surface_id)
+            .cloned()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_acquire_read: surface_id {} not registered",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let surface = make_descriptor(surface_id);
+        let _ = ACQUIRE_TIMEOUT_NS; // wired through the adapter's default — fixed for v1
+        match rt.adapter.acquire_read(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_acquire_read({}): cuda sync failed: {} — \
+                         releasing the adapter guard so the timeline can \
+                         advance",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Err(e) => {
+                tracing::error!("sldn_cuda_acquire_read({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_acquire_write: surface_id {} not registered",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.acquire_write(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_acquire_write({}): cuda sync failed: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Err(e) => {
+                tracing::error!("sldn_cuda_acquire_write({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLDN_CUDA_ERR,
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.try_acquire_read(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_try_acquire_read({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Ok(None) => SLDN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("sldn_cuda_try_acquire_read({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLDN_CUDA_ERR,
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.try_acquire_write(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_try_acquire_write({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Ok(None) => SLDN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("sldn_cuda_try_acquire_write({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        rt.adapter.end_read_access(surface_id);
+        SLDN_CUDA_OK
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        rt.adapter.end_write_access(surface_id);
+        SLDN_CUDA_OK
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::mem::{offset_of, size_of};
+
+        // Layout regression — pins the FFI struct shape across the
+        // cdylib boundary. Python's ctypes / Deno's DataView readers
+        // depend on these offsets matching exactly.
+        #[test]
+        fn sldn_cuda_view_layout_matches_spec_64bit() {
+            // SldnCudaView fields in declaration order:
+            //   size                 : u64    @ 0
+            //   device_ptr           : u64    @ 8
+            //   device_type          : i32    @ 16
+            //   device_id            : i32    @ 20
+            //   dlpack_managed_tensor: ptr    @ 24 (8 bytes on 64-bit)
+            assert_eq!(size_of::<SldnCudaView>(), 32);
+            assert_eq!(offset_of!(SldnCudaView, size), 0);
+            assert_eq!(offset_of!(SldnCudaView, device_ptr), 8);
+            assert_eq!(offset_of!(SldnCudaView, device_type), 16);
+            assert_eq!(offset_of!(SldnCudaView, device_id), 20);
+            assert_eq!(offset_of!(SldnCudaView, dlpack_managed_tensor), 24);
+        }
+
+        #[test]
+        fn sldn_cuda_constants_match_dlpack_spec() {
+            // DLPack v0.8 — these discriminants are wire ABI; a future
+            // dlpark renumbering would land here as a compile failure.
+            assert_eq!(SLDN_CUDA_DEVICE_TYPE_CUDA, 2);
+            assert_eq!(SLDN_CUDA_DEVICE_TYPE_CUDA_HOST, 3);
+            assert_eq!(SLDN_CUDA_OK, 0);
+            assert_eq!(SLDN_CUDA_ERR, -1);
+            assert_eq!(SLDN_CUDA_CONTENDED, 1);
+        }
+
+        // Same smoke test as the python-native sibling (#589): the
+        // runtime returns NULL on Vulkan/CUDA-less CI runners and
+        // succeeds + tears down cleanly on developer boxes; both
+        // outcomes must be panic-free.
+        #[test]
+        fn runtime_new_is_panic_safe_without_cuda() {
+            let rt = unsafe { sldn_cuda_runtime_new() };
+            if !rt.is_null() {
+                unsafe { sldn_cuda_runtime_free(rt) };
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod cuda {
+    use std::ffi::c_void;
+
+    pub const SLDN_CUDA_OK: i32 = 0;
+    pub const SLDN_CUDA_ERR: i32 = -1;
+    pub const SLDN_CUDA_CONTENDED: i32 = 1;
+    pub const SLDN_CUDA_DEVICE_TYPE_CUDA: i32 = 2;
+    pub const SLDN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = 3;
+
+    #[repr(C)]
+    pub struct SldnCudaView {
+        pub size: u64,
+        pub device_ptr: u64,
+        pub device_type: i32,
+        pub device_id: i32,
+        pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_runtime_new() -> *mut c_void {
+        tracing::error!("sldn_cuda_*: cuda adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+}
+
+
+
 #[cfg(not(target_os = "linux"))]
 mod vulkan {
     use std::ffi::c_void;

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4304,10 +4304,6 @@ mod cuda {
 
         // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
         // CUDA takes ownership of the cuda-side dup on successful import.
-        let cuda_mem_fd = unsafe { libc::dup(raw_sync_fd) }; // placeholder — dup the BUFFER fd
-        // The above is a typo guard — the cuda-side memory fd is the
-        // BUFFER fd, not the sync fd. Redo cleanly:
-        unsafe { libc::close(cuda_mem_fd) };
         let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
         if cuda_mem_fd < 0 {
             tracing::error!(
@@ -4596,14 +4592,13 @@ mod cuda {
         if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
             return Err(format!("cudaStreamSynchronize: {e:?}"));
         }
-        // SAFETY guard: the timeline can advance further between
-        // `current_value()` and `cudaWaitExternalSemaphoresAsync_v2`. That's
-        // fine — CUDA's wait-at-or-above semantics mean a stale `wait_value`
-        // is still valid (we just wait less). Underflow isn't possible:
-        // `current_value()` returns the present counter, never zero on a
-        // post-acquire path because the host adapter only signals values
-        // >= 1 on every release.
-        let _ = wait_value;
+        // Race note: the timeline can advance further between
+        // `current_value()` (above) and `cudaWaitExternalSemaphoresAsync_v2`
+        // returning. CUDA's wait-at-or-above semantics make a stale
+        // `wait_value` still valid (we just wait less). Underflow isn't
+        // possible: `current_value()` returns the present counter, never
+        // zero on a post-acquire path because the host adapter only
+        // signals values >= 1 on every release.
         Ok(())
     }
 

--- a/libs/streamlib-deno/adapters/cuda.ts
+++ b/libs/streamlib-deno/adapters/cuda.ts
@@ -1,0 +1,453 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CUDA surface adapter — Deno customer-facing API.
+ *
+ * Mirrors the Rust crate `streamlib-adapter-cuda` (#587 / #588). The
+ * Deno subprocess delegates to `streamlib-deno-native`'s `sldn_cuda_*`
+ * FFI surface, which wraps `CudaSurfaceAdapter<ConsumerVulkanDevice>`
+ * plus `cudaImportExternalMemory` / `cudaImportExternalSemaphore`
+ * against the host-allocated OPAQUE_FD `VkBuffer` + timeline semaphore.
+ * Per-acquire control flow:
+ *
+ * 1. The Deno SDK looks the host's pre-registered cuda surface up via
+ *    surface-share once (`sldn_cuda_register_surface`). The OPAQUE_FD
+ *    memory + timeline FDs enter the cdylib's address space, get
+ *    imported into Vulkan via `streamlib-consumer-rhi` AND re-imported
+ *    into CUDA via `cudaImportExternalMemory` /
+ *    `cudaImportExternalSemaphore`. The CUDA device pointer
+ *    (`cudaExternalMemoryGetMappedBuffer`) is cached for the surface's
+ *    lifetime.
+ * 2. Every `acquireRead` / `acquireWrite` waits on the imported timeline
+ *    (Vulkan-side via the adapter; CUDA-side via
+ *    `cudaWaitExternalSemaphoresAsync_v2` so CUDA driver state is in
+ *    sync with Vulkan's view of the kernel timeline) and hands back a
+ *    raw `*mut DLManagedTensor` pointer plus a `consume()` helper.
+ *
+ * **Deno's DLPack story is less mature than Python's.** PyTorch /
+ * NumPy / JAX expose `from_dlpack` consumers; Deno's ML ecosystem
+ * (TensorFlow.js, ONNX-Runtime-Web, third-party WebGPU bindings) does
+ * not yet have a native `from_dlpack` that takes a `DLManagedTensor*`
+ * shape. This wrapper still emits the spec-compliant capsule pointer
+ * so future consumers can plug in zero-copy; today the typical use is
+ * to hand the pointer to a custom native module (a separate Deno
+ * `dlopen`'d cdylib that knows how to consume DLPack) or to drive
+ * host-side validation.
+ *
+ * There is no per-acquire IPC — the host's pipeline is expected to
+ * write into the OPAQUE_FD buffer and signal the shared timeline
+ * ambiently. Customers who need an explicit host-side trigger should
+ * use `streamlib.adapters.cpu_readback` instead.
+ */
+
+import {
+  STREAMLIB_ADAPTER_ABI_VERSION,
+  type StreamlibSurface,
+  type SurfaceFormat,
+} from "../surface_adapter.ts";
+
+export { STREAMLIB_ADAPTER_ABI_VERSION };
+
+/** `sldn_cuda_*` return values — must match the cdylib's
+ * `SLDN_CUDA_OK` / `_ERR` / `_CONTENDED` constants. */
+const RC_OK = 0;
+const RC_CONTENDED = 1;
+
+/** DLPack `DLDeviceType` discriminants — kDLCUDA = 2, kDLCUDAHost = 3. */
+const DEVICE_TYPE_CUDA = 2;
+const DEVICE_TYPE_CUDA_HOST = 3;
+
+/** `SlpnCudaView` `#[repr(C)]` layout, pinned by the cdylib's
+ * `sldn_cuda_view_layout_matches_spec_64bit` test:
+ *   size                 : u64    @ 0   (8 bytes)
+ *   device_ptr           : u64    @ 8   (8)
+ *   device_type          : i32    @ 16  (4)
+ *   device_id            : i32    @ 20  (4)
+ *   dlpack_managed_tensor: ptr    @ 24  (8 bytes on 64-bit)
+ * Total = 32 bytes. */
+const VIEW_STRUCT_SIZE = 32;
+
+/** `DLManagedTensor` deleter offset — pinned by the layout regression
+ * test in `streamlib-adapter-cuda::dlpack`:
+ *   dl_tensor   : 48 bytes @ 0
+ *   manager_ctx : 8 bytes @ 48
+ *   deleter     : 8 bytes @ 56  ← function pointer void(*)(DLManagedTensor*)
+ */
+const DLPACK_DELETER_OFFSET = 56;
+
+/** Read-side view inside an `acquireRead` scope.
+ *
+ * `dlpackPtr` is a raw `*mut DLManagedTensor` — pass it to a native
+ * DLPack consumer for zero-copy access, or call `consume()` to mark
+ * that ownership has transferred (which prevents the dispose path
+ * from double-freeing). The capsule's underlying CUDA device memory
+ * lives until either (a) the consumer calls the deleter or (b) the
+ * dispose path calls it on consumer-less drops.
+ *
+ * The view is valid only inside the `await using` scope — after the
+ * scope exits, the adapter releases its guard and the host pipeline
+ * is free to overwrite the buffer. If you need to retain the tensor
+ * beyond the scope, hand the `dlpackPtr` to a consumer that copies
+ * the data out (or that itself outlives the scope and accepts
+ * ownership).
+ */
+export interface CudaReadView {
+  readonly format: SurfaceFormat;
+  /** Buffer size in bytes. */
+  readonly size: bigint;
+  /** CUDA device pointer (`CUdeviceptr` cast to `u64`). */
+  readonly devicePtr: bigint;
+  /** DLPack `DLDeviceType` discriminant (`kDLCUDA` = 2 or
+   * `kDLCUDAHost` = 3). */
+  readonly deviceType: number;
+  /** CUDA device ordinal. Single-GPU rigs always see `0`. */
+  readonly deviceId: number;
+  /** Raw `*mut DLManagedTensor`. Pass to a native DLPack consumer or
+   * call [`consume`] before scope exit. */
+  readonly dlpackPtr: Deno.PointerObject;
+  /** Mark that an external consumer has taken ownership of the DLPack
+   * capsule (and is responsible for calling the deleter). After
+   * `consume()`, the dispose path will NOT call the deleter — calling
+   * `consume()` on a capsule the consumer did NOT claim will leak the
+   * `DLManagedTensor` heap allocation. */
+  consume(): void;
+}
+
+/** Write-side view. Same shape as [`CudaReadView`]; CUDA writes land
+ * in the OPAQUE_FD buffer and become visible to the host pipeline
+ * after the adapter guard is released. */
+export interface CudaWriteView {
+  readonly format: SurfaceFormat;
+  readonly size: bigint;
+  readonly devicePtr: bigint;
+  readonly deviceType: number;
+  readonly deviceId: number;
+  readonly dlpackPtr: Deno.PointerObject;
+  consume(): void;
+}
+
+/** Async-disposable guard returned by `acquireRead` / `acquireWrite`.
+ * `await using` runs `[Symbol.asyncDispose]` at scope exit, which
+ * releases the adapter guard (so the timeline can advance) and
+ * conditionally calls the DLPack deleter (only if `consume()` was
+ * NOT invoked on the view). */
+export interface CudaAccessGuard<V> extends AsyncDisposable {
+  readonly view: V;
+}
+
+/** Minimal subset of `GpuContextLimitedAccess` the cuda runtime needs. */
+export interface CudaGpuLimitedAccess {
+  resolveSurface(poolId: string): {
+    readonly nativeHandlePtr: Deno.PointerObject | null;
+    release(): void;
+  };
+  // deno-lint-ignore no-explicit-any
+  readonly nativeLib: { readonly symbols: any };
+}
+
+let _SURFACE_ID_COUNTER = 0n;
+function nextSurfaceId(): bigint {
+  _SURFACE_ID_COUNTER += 1n;
+  return _SURFACE_ID_COUNTER;
+}
+
+let _SHARED_INSTANCE: CudaContext | null = null;
+
+function surfacePoolId(
+  surface: StreamlibSurface | string | bigint | number,
+): string {
+  if (typeof surface === "string") return surface;
+  if (typeof surface === "bigint") return surface.toString();
+  if (typeof surface === "number") return String(Math.trunc(surface));
+  const id = (surface as { id?: bigint | string | number }).id;
+  if (id === undefined) {
+    throw new TypeError(
+      `CudaContext: expected StreamlibSurface or pool_id, got ${typeof surface}`,
+    );
+  }
+  return String(id);
+}
+
+function surfaceFormatFrom(
+  surface: StreamlibSurface | string | bigint | number,
+): SurfaceFormat {
+  if (typeof surface === "object" && surface !== null) {
+    const fmt = (surface as { format?: number }).format;
+    if (fmt !== undefined) return fmt as SurfaceFormat;
+  }
+  return 0 as SurfaceFormat; // BGRA8 default
+}
+
+/** Function-pointer signature for DLPack deleters. */
+const DLPACK_DELETER_DEFINITION = {
+  parameters: ["pointer"] as const,
+  result: "void" as const,
+} as const;
+
+/** Read the function pointer at offset 56 inside a DLManagedTensor and
+ * call it. The deleter frees the producer-side state (shape, strides,
+ * manager_ctx, the ManagedTensor itself); after the call the pointer
+ * is invalidated. */
+function callDlpackDeleter(dlpackPtr: Deno.PointerObject): void {
+  const view = new Deno.UnsafePointerView(dlpackPtr);
+  const deleterAddr = view.getBigUint64(DLPACK_DELETER_OFFSET);
+  if (deleterAddr === 0n) return;
+  const deleterPtr = Deno.UnsafePointer.create(deleterAddr);
+  if (deleterPtr === null) return;
+  // `Deno.UnsafeFnPointer` infers its argument type from the pointer's
+  // type parameter; cast through `unknown` to satisfy the inferred
+  // generic since `Deno.PointerObject` defaults to `<unknown>`.
+  const deleterFn = new Deno.UnsafeFnPointer(
+    deleterPtr as Deno.PointerObject<typeof DLPACK_DELETER_DEFINITION>,
+    DLPACK_DELETER_DEFINITION,
+  );
+  // SAFETY: `dlpackPtr` is the same pointer the deleter expects. The
+  // deleter is `void(*)(DLManagedTensor*)` per DLPack spec.
+  deleterFn.call(dlpackPtr);
+}
+
+/** Customer-facing context for the Deno subprocess SDK.
+ *
+ *     await using guard = await ctx.acquireRead(surface);
+ *     // Hand guard.view.dlpackPtr to a native consumer if one exists.
+ *     // Otherwise leave it to the dispose path to clean up.
+ */
+export class CudaContext {
+  private readonly gpu: CudaGpuLimitedAccess;
+  // deno-lint-ignore no-explicit-any
+  private readonly symbols: any;
+  private readonly rt: Deno.PointerObject;
+  private readonly surfaceIds = new Map<string, bigint>();
+  private readonly resolvedHandles = new Map<
+    string,
+    ReturnType<CudaGpuLimitedAccess["resolveSurface"]>
+  >();
+
+  constructor(gpu: CudaGpuLimitedAccess) {
+    this.gpu = gpu;
+    this.symbols = gpu.nativeLib.symbols;
+    const rtPtr = this.symbols.sldn_cuda_runtime_new();
+    if (rtPtr === null) {
+      throw new Error(
+        "CudaContext: sldn_cuda_runtime_new returned NULL — the subprocess " +
+          "could not bring up a Vulkan device + CUDA context. Check that " +
+          "libvulkan.so.1, libcuda.so.1, and libcudart.so are installed and " +
+          "that the driver supports VK_KHR_external_memory_fd, " +
+          "VK_EXT_external_memory_dma_buf, and VK_KHR_external_semaphore_fd. " +
+          "See the subprocess log for the underlying error.",
+      );
+    }
+    this.rt = rtPtr;
+  }
+
+  static fromRuntime(
+    ctx: { readonly gpuLimitedAccess: CudaGpuLimitedAccess },
+  ): CudaContext {
+    if (_SHARED_INSTANCE === null) {
+      _SHARED_INSTANCE = new CudaContext(ctx.gpuLimitedAccess);
+    }
+    return _SHARED_INSTANCE;
+  }
+
+  /** Close the cdylib runtime. After `close()` the context is unusable;
+   * mostly for tests. */
+  close(): void {
+    this.symbols.sldn_cuda_runtime_free(this.rt);
+    _SHARED_INSTANCE = null;
+  }
+
+  private resolveAndRegister(poolId: string): bigint {
+    const cached = this.surfaceIds.get(poolId);
+    if (cached !== undefined) return cached;
+    const handle = this.gpu.resolveSurface(poolId);
+    const handlePtr = handle.nativeHandlePtr;
+    if (handlePtr === null) {
+      throw new Error(
+        `CudaContext: resolveSurface('${poolId}') returned a handle with a null native pointer`,
+      );
+    }
+    const surfaceId = nextSurfaceId();
+    const rc: number = this.symbols.sldn_cuda_register_surface(
+      this.rt,
+      surfaceId,
+      handlePtr,
+    );
+    if (rc !== RC_OK) {
+      throw new Error(
+        `CudaContext: register_surface failed for pool_id ` +
+          `'${poolId}' (rc=${rc}). Common causes: host registered the ` +
+          `surface as DMA-BUF rather than OPAQUE_FD (cuda requires ` +
+          `handle_type=opaque_fd); host did not attach an exportable ` +
+          `timeline semaphore (cuda requires sync_fd); or libcudart / ` +
+          `libcuda.so missing.`,
+      );
+    }
+    this.surfaceIds.set(poolId, surfaceId);
+    this.resolvedHandles.set(poolId, handle);
+    return surfaceId;
+  }
+
+  acquireRead(
+    surface: StreamlibSurface | string | bigint | number,
+  ): Promise<CudaAccessGuard<CudaReadView>> {
+    return this._acquire(surface, false, true) as Promise<
+      CudaAccessGuard<CudaReadView>
+    >;
+  }
+
+  acquireWrite(
+    surface: StreamlibSurface | string | bigint | number,
+  ): Promise<CudaAccessGuard<CudaWriteView>> {
+    return this._acquire(surface, true, true) as Promise<
+      CudaAccessGuard<CudaWriteView>
+    >;
+  }
+
+  tryAcquireRead(
+    surface: StreamlibSurface | string | bigint | number,
+  ): Promise<CudaAccessGuard<CudaReadView> | null> {
+    return this._acquire(surface, false, false) as Promise<
+      CudaAccessGuard<CudaReadView> | null
+    >;
+  }
+
+  tryAcquireWrite(
+    surface: StreamlibSurface | string | bigint | number,
+  ): Promise<CudaAccessGuard<CudaWriteView> | null> {
+    return this._acquire(surface, true, false) as Promise<
+      CudaAccessGuard<CudaWriteView> | null
+    >;
+  }
+
+  private _acquire(
+    surface: StreamlibSurface | string | bigint | number,
+    write: boolean,
+    blocking: boolean,
+  ): Promise<CudaAccessGuard<CudaReadView | CudaWriteView> | null> {
+    // The cdylib's acquire is synchronous (no per-acquire IPC) — wrap
+    // in a Promise so the API mirrors cpu_readback's `await using` shape.
+    return new Promise((resolve, reject) => {
+      try {
+        const poolId = surfacePoolId(surface);
+        const format = surfaceFormatFrom(surface);
+        const surfaceId = this.resolveAndRegister(poolId);
+        const buf = new Uint8Array(VIEW_STRUCT_SIZE);
+        const fn = blocking
+          ? (write
+            ? this.symbols.sldn_cuda_acquire_write
+            : this.symbols.sldn_cuda_acquire_read)
+          : (write
+            ? this.symbols.sldn_cuda_try_acquire_write
+            : this.symbols.sldn_cuda_try_acquire_read);
+        const rc: number = fn(this.rt, surfaceId, Deno.UnsafePointer.of(buf));
+        if (rc === RC_CONTENDED) {
+          resolve(null);
+          return;
+        }
+        if (rc !== RC_OK) {
+          reject(
+            new Error(
+              `CudaContext.${blocking ? "" : "try_"}acquire_${
+                write ? "write" : "read"
+              }: rc=${rc} for surface '${poolId}'`,
+            ),
+          );
+          return;
+        }
+
+        const view = this.parseView(buf, format, write);
+        const surfaceIdSnapshot = surfaceId;
+        const symbols = this.symbols;
+        const rt = this.rt;
+        const writeMode = write;
+        const dlpackPtr = view.dlpackPtr;
+        let consumed = false;
+        // The view's `consume()` flips the consumed flag — must be set
+        // BEFORE constructing the returned guard so JS code that does
+        // `view.consume()` inside the scope flows correctly through the
+        // dispose path.
+        (view as { consume: () => void }).consume = () => {
+          consumed = true;
+        };
+
+        resolve({
+          view,
+          [Symbol.asyncDispose]: () => {
+            // Free the DLManagedTensor heap allocation only if the
+            // consumer didn't claim it. After `consume()`, the consumer
+            // is responsible — calling the deleter here would
+            // double-free the producer-side state.
+            if (!consumed) {
+              try {
+                callDlpackDeleter(dlpackPtr);
+              } catch (_e) {
+                // Deleter failure is logged on the cdylib side; we
+                // can't propagate from a dispose path without breaking
+                // the scope contract.
+              }
+            }
+            if (writeMode) {
+              symbols.sldn_cuda_release_write(rt, surfaceIdSnapshot);
+            } else {
+              symbols.sldn_cuda_release_read(rt, surfaceIdSnapshot);
+            }
+            return Promise.resolve();
+          },
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  private parseView(
+    buf: Uint8Array,
+    format: SurfaceFormat,
+    writable: boolean,
+  ): CudaReadView | CudaWriteView {
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const size = dv.getBigUint64(0, true);
+    const devicePtr = dv.getBigUint64(8, true);
+    const deviceType = dv.getInt32(16, true);
+    const deviceId = dv.getInt32(20, true);
+    const dlpackAddrLow = dv.getUint32(24, true);
+    const dlpackAddrHigh = dv.getUint32(28, true);
+    const dlpackAddr = (BigInt(dlpackAddrHigh) << 32n) | BigInt(dlpackAddrLow);
+    if (dlpackAddr === 0n) {
+      throw new Error(
+        "CudaContext: cdylib returned null DLPack managed tensor pointer",
+      );
+    }
+    const dlpackPtr = Deno.UnsafePointer.create(dlpackAddr);
+    if (dlpackPtr === null) {
+      throw new Error(
+        "CudaContext: DLPack managed tensor pointer could not be wrapped",
+      );
+    }
+    if (deviceType !== DEVICE_TYPE_CUDA && deviceType !== DEVICE_TYPE_CUDA_HOST) {
+      throw new Error(
+        `CudaContext: cdylib returned unexpected deviceType=${deviceType} ` +
+          `(expected kDLCUDA=2 or kDLCUDAHost=3)`,
+      );
+    }
+    // `consume` is filled in by `_acquire` once the closure has scope
+    // over the `consumed` flag. Stub here keeps the type checker happy.
+    const view = {
+      format,
+      size,
+      devicePtr,
+      deviceType,
+      deviceId,
+      dlpackPtr,
+      consume: () => {
+        throw new Error(
+          "CudaContext: consume() must be called on the view returned by acquire, not the parsed bytes",
+        );
+      },
+    };
+    return writable
+      ? (view as unknown as CudaWriteView)
+      : (view as unknown as CudaReadView);
+  }
+}

--- a/libs/streamlib-deno/adapters/cuda.ts
+++ b/libs/streamlib-deno/adapters/cuda.ts
@@ -127,12 +127,17 @@ export interface CudaWriteView {
   consume(): void;
 }
 
-/** Async-disposable guard returned by `acquireRead` / `acquireWrite`.
- * `await using` runs `[Symbol.asyncDispose]` at scope exit, which
- * releases the adapter guard (so the timeline can advance) and
- * conditionally calls the DLPack deleter (only if `consume()` was
- * NOT invoked on the view). */
-export interface CudaAccessGuard<V> extends AsyncDisposable {
+/** Disposable guard returned by `acquireRead` / `acquireWrite`.
+ * `using` runs `[Symbol.dispose]` at scope exit, which releases the
+ * adapter guard (so the timeline can advance) and conditionally calls
+ * the DLPack deleter (only if `consume()` was NOT invoked on the view).
+ *
+ * Sync-disposable rather than async-disposable because the cuda
+ * adapter has no per-acquire IPC — the cdylib's `sldn_cuda_*` calls
+ * are synchronous all the way down. (Contrast with `cpu_readback`,
+ * which goes async because every acquire round-trips an escalate-IPC
+ * trigger.) */
+export interface CudaAccessGuard<V> extends Disposable {
   readonly view: V;
 }
 
@@ -209,7 +214,7 @@ function callDlpackDeleter(dlpackPtr: Deno.PointerObject): void {
 
 /** Customer-facing context for the Deno subprocess SDK.
  *
- *     await using guard = await ctx.acquireRead(surface);
+ *     using guard = ctx.acquireRead(surface);
  *     // Hand guard.view.dlpackPtr to a native consumer if one exists.
  *     // Otherwise leave it to the dispose path to clean up.
  */
@@ -290,115 +295,102 @@ export class CudaContext {
 
   acquireRead(
     surface: StreamlibSurface | string | bigint | number,
-  ): Promise<CudaAccessGuard<CudaReadView>> {
-    return this._acquire(surface, false, true) as Promise<
-      CudaAccessGuard<CudaReadView>
+  ): CudaAccessGuard<CudaReadView> {
+    return this._acquire(surface, false, true) as CudaAccessGuard<
+      CudaReadView
     >;
   }
 
   acquireWrite(
     surface: StreamlibSurface | string | bigint | number,
-  ): Promise<CudaAccessGuard<CudaWriteView>> {
-    return this._acquire(surface, true, true) as Promise<
-      CudaAccessGuard<CudaWriteView>
+  ): CudaAccessGuard<CudaWriteView> {
+    return this._acquire(surface, true, true) as CudaAccessGuard<
+      CudaWriteView
     >;
   }
 
   tryAcquireRead(
     surface: StreamlibSurface | string | bigint | number,
-  ): Promise<CudaAccessGuard<CudaReadView> | null> {
-    return this._acquire(surface, false, false) as Promise<
-      CudaAccessGuard<CudaReadView> | null
-    >;
+  ): CudaAccessGuard<CudaReadView> | null {
+    return this._acquire(surface, false, false) as
+      | CudaAccessGuard<CudaReadView>
+      | null;
   }
 
   tryAcquireWrite(
     surface: StreamlibSurface | string | bigint | number,
-  ): Promise<CudaAccessGuard<CudaWriteView> | null> {
-    return this._acquire(surface, true, false) as Promise<
-      CudaAccessGuard<CudaWriteView> | null
-    >;
+  ): CudaAccessGuard<CudaWriteView> | null {
+    return this._acquire(surface, true, false) as
+      | CudaAccessGuard<CudaWriteView>
+      | null;
   }
 
   private _acquire(
     surface: StreamlibSurface | string | bigint | number,
     write: boolean,
     blocking: boolean,
-  ): Promise<CudaAccessGuard<CudaReadView | CudaWriteView> | null> {
-    // The cdylib's acquire is synchronous (no per-acquire IPC) — wrap
-    // in a Promise so the API mirrors cpu_readback's `await using` shape.
-    return new Promise((resolve, reject) => {
-      try {
-        const poolId = surfacePoolId(surface);
-        const format = surfaceFormatFrom(surface);
-        const surfaceId = this.resolveAndRegister(poolId);
-        const buf = new Uint8Array(VIEW_STRUCT_SIZE);
-        const fn = blocking
-          ? (write
-            ? this.symbols.sldn_cuda_acquire_write
-            : this.symbols.sldn_cuda_acquire_read)
-          : (write
-            ? this.symbols.sldn_cuda_try_acquire_write
-            : this.symbols.sldn_cuda_try_acquire_read);
-        const rc: number = fn(this.rt, surfaceId, Deno.UnsafePointer.of(buf));
-        if (rc === RC_CONTENDED) {
-          resolve(null);
-          return;
-        }
-        if (rc !== RC_OK) {
-          reject(
-            new Error(
-              `CudaContext.${blocking ? "" : "try_"}acquire_${
-                write ? "write" : "read"
-              }: rc=${rc} for surface '${poolId}'`,
-            ),
-          );
-          return;
-        }
+  ): CudaAccessGuard<CudaReadView | CudaWriteView> | null {
+    const poolId = surfacePoolId(surface);
+    const format = surfaceFormatFrom(surface);
+    const surfaceId = this.resolveAndRegister(poolId);
+    const buf = new Uint8Array(VIEW_STRUCT_SIZE);
+    const fn = blocking
+      ? (write
+        ? this.symbols.sldn_cuda_acquire_write
+        : this.symbols.sldn_cuda_acquire_read)
+      : (write
+        ? this.symbols.sldn_cuda_try_acquire_write
+        : this.symbols.sldn_cuda_try_acquire_read);
+    const rc: number = fn(this.rt, surfaceId, Deno.UnsafePointer.of(buf));
+    if (rc === RC_CONTENDED) {
+      return null;
+    }
+    if (rc !== RC_OK) {
+      throw new Error(
+        `CudaContext.${blocking ? "" : "try_"}acquire_${
+          write ? "write" : "read"
+        }: rc=${rc} for surface '${poolId}'`,
+      );
+    }
 
-        const view = this.parseView(buf, format, write);
-        const surfaceIdSnapshot = surfaceId;
-        const symbols = this.symbols;
-        const rt = this.rt;
-        const writeMode = write;
-        const dlpackPtr = view.dlpackPtr;
-        let consumed = false;
-        // The view's `consume()` flips the consumed flag — must be set
-        // BEFORE constructing the returned guard so JS code that does
-        // `view.consume()` inside the scope flows correctly through the
-        // dispose path.
-        (view as { consume: () => void }).consume = () => {
-          consumed = true;
-        };
+    const view = this.parseView(buf, format, write);
+    const surfaceIdSnapshot = surfaceId;
+    const symbols = this.symbols;
+    const rt = this.rt;
+    const writeMode = write;
+    const dlpackPtr = view.dlpackPtr;
+    let consumed = false;
+    // The view's `consume()` flips the consumed flag — must be set
+    // BEFORE constructing the returned guard so JS code that does
+    // `view.consume()` inside the scope flows correctly through the
+    // dispose path.
+    (view as { consume: () => void }).consume = () => {
+      consumed = true;
+    };
 
-        resolve({
-          view,
-          [Symbol.asyncDispose]: () => {
-            // Free the DLManagedTensor heap allocation only if the
-            // consumer didn't claim it. After `consume()`, the consumer
-            // is responsible — calling the deleter here would
-            // double-free the producer-side state.
-            if (!consumed) {
-              try {
-                callDlpackDeleter(dlpackPtr);
-              } catch (_e) {
-                // Deleter failure is logged on the cdylib side; we
-                // can't propagate from a dispose path without breaking
-                // the scope contract.
-              }
-            }
-            if (writeMode) {
-              symbols.sldn_cuda_release_write(rt, surfaceIdSnapshot);
-            } else {
-              symbols.sldn_cuda_release_read(rt, surfaceIdSnapshot);
-            }
-            return Promise.resolve();
-          },
-        });
-      } catch (e) {
-        reject(e);
-      }
-    });
+    return {
+      view,
+      [Symbol.dispose]: () => {
+        // Free the DLManagedTensor heap allocation only if the
+        // consumer didn't claim it. After `consume()`, the consumer
+        // is responsible — calling the deleter here would double-free
+        // the producer-side state.
+        if (!consumed) {
+          try {
+            callDlpackDeleter(dlpackPtr);
+          } catch (_e) {
+            // Deleter failure is logged on the cdylib side; we can't
+            // propagate from a dispose path without breaking the
+            // scope contract.
+          }
+        }
+        if (writeMode) {
+          symbols.sldn_cuda_release_write(rt, surfaceIdSnapshot);
+        } else {
+          symbols.sldn_cuda_release_read(rt, surfaceIdSnapshot);
+        }
+      },
+    };
   }
 
   private parseView(

--- a/libs/streamlib-deno/adapters/cuda.ts
+++ b/libs/streamlib-deno/adapters/cuda.ts
@@ -85,9 +85,9 @@ const DLPACK_DELETER_OFFSET = 56;
  * lives until either (a) the consumer calls the deleter or (b) the
  * dispose path calls it on consumer-less drops.
  *
- * The view is valid only inside the `await using` scope — after the
- * scope exits, the adapter releases its guard and the host pipeline
- * is free to overwrite the buffer. If you need to retain the tensor
+ * The view is valid only inside the `using` scope — after the scope
+ * exits, the adapter releases its guard and the host pipeline is
+ * free to overwrite the buffer. If you need to retain the tensor
  * beyond the scope, hand the `dlpackPtr` to a consumer that copies
  * the data out (or that itself outlives the scope and accepts
  * ownership).

--- a/libs/streamlib-deno/adapters/cuda_test.ts
+++ b/libs/streamlib-deno/adapters/cuda_test.ts
@@ -72,7 +72,11 @@ Deno.test("CudaReadView / CudaWriteView shapes round-trip dataclass-style", () =
   assertEquals(wv.deviceId, 1);
 });
 
-Deno.test("CudaAccessGuard satisfies AsyncDisposable", () => {
+Deno.test("CudaAccessGuard satisfies sync Disposable", () => {
+  // Sync `using` semantics: the cuda adapter has no per-acquire IPC,
+  // so the cdylib FFI is blocking but synchronous all the way down.
+  // Tracking #590's exit criterion verbatim ("`using` (Symbol.dispose)
+  // support") rather than mirroring cpu_readback's `await using` shape.
   const fakeCapsule = { _stub: true } as unknown as Deno.PointerObject;
   const view: CudaReadView = {
     format: 0 as unknown as CudaReadView["format"],
@@ -85,8 +89,8 @@ Deno.test("CudaAccessGuard satisfies AsyncDisposable", () => {
   };
   const guard: CudaAccessGuard<CudaReadView> = {
     view,
-    [Symbol.asyncDispose]: () => Promise.resolve(),
+    [Symbol.dispose]: () => {},
   };
   assertExists(guard.view);
-  assertExists(guard[Symbol.asyncDispose]);
+  assertExists(guard[Symbol.dispose]);
 });

--- a/libs/streamlib-deno/adapters/cuda_test.ts
+++ b/libs/streamlib-deno/adapters/cuda_test.ts
@@ -9,9 +9,9 @@
  * a host-allocated OPAQUE_FD `VkBuffer`, Deno opens the cdylib,
  * `sldn_cuda_acquire_read` → `Deno.UnsafePointerView` over the DLPack
  * capsule → byte-equal assertion against the host pattern) requires a
- * polyglot test harness that doesn't yet exist in tree — filed as a
- * follow-up. This file exercises the Deno module's contract against
- * the cdylib's documented FFI ABI.
+ * polyglot test harness that doesn't yet exist in tree — filed as
+ * #596. This file exercises the Deno module's contract against the
+ * cdylib's documented FFI ABI.
  */
 
 import { assertEquals, assertExists } from "@std/assert";

--- a/libs/streamlib-deno/adapters/cuda_test.ts
+++ b/libs/streamlib-deno/adapters/cuda_test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Smoke test for the Deno CUDA adapter wrapper module (#590).
+ *
+ * Confirms the module loads, layout constants match the cdylib, and
+ * the type shapes are present. A real subprocess test (host registers
+ * a host-allocated OPAQUE_FD `VkBuffer`, Deno opens the cdylib,
+ * `sldn_cuda_acquire_read` → `Deno.UnsafePointerView` over the DLPack
+ * capsule → byte-equal assertion against the host pattern) requires a
+ * polyglot test harness that doesn't yet exist in tree — filed as a
+ * follow-up. This file exercises the Deno module's contract against
+ * the cdylib's documented FFI ABI.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  type CudaAccessGuard,
+  CudaContext,
+  type CudaReadView,
+  type CudaWriteView,
+  STREAMLIB_ADAPTER_ABI_VERSION,
+} from "./cuda.ts";
+
+Deno.test("ABI version re-exported from surface_adapter", () => {
+  assertEquals(STREAMLIB_ADAPTER_ABI_VERSION, 1);
+});
+
+Deno.test("CudaContext class exposes the surface-adapter method set", () => {
+  const ctx = CudaContext as unknown as Record<string, unknown>;
+  // Static factory.
+  assertExists(ctx.fromRuntime);
+  // Instance methods (verify via prototype).
+  const proto = (CudaContext as unknown as { prototype: Record<string, unknown> })
+    .prototype;
+  assertExists(proto.acquireRead);
+  assertExists(proto.acquireWrite);
+  assertExists(proto.tryAcquireRead);
+  assertExists(proto.tryAcquireWrite);
+  assertExists(proto.close);
+});
+
+Deno.test("CudaReadView / CudaWriteView shapes round-trip dataclass-style", () => {
+  // Build literal objects matching the interface — the type checker
+  // would catch shape drift at compile time, but assertions here are
+  // a runtime guard against accidental optional fields.
+  const fakeCapsule = { _stub: true } as unknown as Deno.PointerObject;
+  const rv: CudaReadView = {
+    format: 0 as unknown as CudaReadView["format"],
+    size: 1024n * 1024n,
+    devicePtr: 0xDEAD_BEEF_CAFE_0000n,
+    deviceType: 2, // kDLCUDA
+    deviceId: 0,
+    dlpackPtr: fakeCapsule,
+    consume: () => {},
+  };
+  const wv: CudaWriteView = {
+    format: 0 as unknown as CudaWriteView["format"],
+    size: 2048n,
+    devicePtr: 0xDEAD_BEEF_CAFE_1000n,
+    deviceType: 3, // kDLCUDAHost
+    deviceId: 1,
+    dlpackPtr: fakeCapsule,
+    consume: () => {},
+  };
+  assertEquals(rv.size, 1024n * 1024n);
+  assertEquals(rv.deviceType, 2);
+  assertEquals(rv.deviceId, 0);
+  assertEquals(wv.size, 2048n);
+  assertEquals(wv.deviceType, 3);
+  assertEquals(wv.deviceId, 1);
+});
+
+Deno.test("CudaAccessGuard satisfies AsyncDisposable", () => {
+  const fakeCapsule = { _stub: true } as unknown as Deno.PointerObject;
+  const view: CudaReadView = {
+    format: 0 as unknown as CudaReadView["format"],
+    size: 4n,
+    devicePtr: 0n,
+    deviceType: 2,
+    deviceId: 0,
+    dlpackPtr: fakeCapsule,
+    consume: () => {},
+  };
+  const guard: CudaAccessGuard<CudaReadView> = {
+    view,
+    [Symbol.asyncDispose]: () => Promise.resolve(),
+  };
+  assertExists(guard.view);
+  assertExists(guard[Symbol.asyncDispose]);
+});

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -52,6 +52,21 @@ streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi" }
 # via a thin `run_cpu_readback_copy` escalate IPC; the consumer waits
 # on the imported timeline through the carve-out.
 streamlib-adapter-cpu-readback = { path = "../streamlib-adapter-cpu-readback" }
+# Subprocess-side CUDA runtime (#589). Same single-pattern shape as the
+# other adapters: generic over `D: VulkanRhiDevice`, instantiated here
+# against `ConsumerVulkanDevice`. The cdylib re-imports the OPAQUE_FD
+# `VkBuffer` + timeline into CUDA via `cudaImportExternalMemory` +
+# `cudaImportExternalSemaphore` and hands DLPack capsules back to
+# Python. No per-acquire IPC; the host's pipeline writes into the
+# OPAQUE_FD `VkBuffer` and signals the shared timeline ambiently.
+streamlib-adapter-cuda = { path = "../streamlib-adapter-cuda" }
+# CUDA bindings. Linux-only (the cuda module is `#[cfg(target_os =
+# "linux")]`), `fallback-dynamic-loading` means libcuda.so is dlopen'd
+# at runtime so a build host without a CUDA toolkit can still link the
+# cdylib; runtime absence is detected via
+# `cudarc::runtime::sys::is_culib_present()` and surfaces as a clean
+# init failure rather than a panic.
+cudarc.workspace = true
 
 
 [lints]

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -4740,10 +4740,6 @@ mod cuda {
 
         // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
         // CUDA takes ownership of the cuda-side dup on successful import.
-        let cuda_mem_fd = unsafe { libc::dup(raw_sync_fd) }; // placeholder — dup the BUFFER fd
-        // The above is a typo guard — the cuda-side memory fd is the
-        // BUFFER fd, not the sync fd. Redo cleanly:
-        unsafe { libc::close(cuda_mem_fd) };
         let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
         if cuda_mem_fd < 0 {
             tracing::error!(
@@ -5032,14 +5028,13 @@ mod cuda {
         if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
             return Err(format!("cudaStreamSynchronize: {e:?}"));
         }
-        // SAFETY guard: the timeline can advance further between
-        // `current_value()` and `cudaWaitExternalSemaphoresAsync_v2`. That's
-        // fine — CUDA's wait-at-or-above semantics mean a stale `wait_value`
-        // is still valid (we just wait less). Underflow isn't possible:
-        // `current_value()` returns the present counter, never zero on a
-        // post-acquire path because the host adapter only signals values
-        // >= 1 on every release.
-        let _ = wait_value;
+        // Race note: the timeline can advance further between
+        // `current_value()` (above) and `cudaWaitExternalSemaphoresAsync_v2`
+        // returning. CUDA's wait-at-or-above semantics make a stale
+        // `wait_value` still valid (we just wait less). Underflow isn't
+        // possible: `current_value()` returns the present counter, never
+        // zero on a post-acquire path because the host adapter only
+        // signals values >= 1 on every release.
         Ok(())
     }
 

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -4374,6 +4374,1061 @@ mod cpu_readback {
     }
 }
 
+// ============================================================================
+// C ABI — cuda adapter runtime (#589, Linux)
+//
+// Subprocess-side runtime for the cuda adapter. Same single-pattern shape
+// as cpu-readback / vulkan / opengl: the adapter is generic over device
+// flavor, this cdylib instantiates it against `ConsumerVulkanDevice`, and
+// the OPAQUE_FD `VkBuffer` + timeline semaphore that surface-share hands
+// over are imported into Vulkan via `streamlib-consumer-rhi` and into
+// CUDA via `cudaImportExternalMemory` + `cudaImportExternalSemaphore`.
+// Per-acquire flow has no IPC: the host pipeline writes into the
+// OPAQUE_FD buffer and signals the shared timeline ambiently; the
+// consumer's `acquire_read` Vulkan-waits via the adapter, then CUDA-waits
+// via `cudaWaitExternalSemaphoresAsync` so CUDA driver state is in sync,
+// then hands a DLPack capsule back to Python.
+// ============================================================================
+
+#[cfg(target_os = "linux")]
+mod cuda {
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::mem::MaybeUninit;
+    use std::os::unix::io::RawFd;
+    use std::sync::{Arc, Mutex};
+
+    use cudarc::runtime::result::external_memory;
+    use cudarc::runtime::sys;
+    use streamlib_adapter_abi::{
+        StreamlibSurface, SurfaceAdapter as _, SurfaceFormat, SurfaceSyncState,
+        SurfaceTransportHandle, SurfaceUsage,
+    };
+    use streamlib_adapter_cuda::dlpack::{
+        self, CapsuleOwner, Device as DlpackDevice, DeviceType as DlpackDeviceType,
+        ManagedTensor as DlpackManagedTensor,
+    };
+    use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+    use streamlib_consumer_rhi::{
+        ConsumerVulkanDevice, ConsumerVulkanPixelBuffer, ConsumerVulkanTimelineSemaphore,
+        PixelFormat,
+    };
+
+    use super::gpu_surface::SurfaceHandle;
+
+    /// `acquire_*` return values — wire-stable across the cdylib boundary.
+    pub const SLPN_CUDA_OK: i32 = 0;
+    pub const SLPN_CUDA_ERR: i32 = -1;
+    pub const SLPN_CUDA_CONTENDED: i32 = 1;
+
+    /// DLPack `DLDeviceType` discriminants exposed at the FFI surface so
+    /// the Python wrapper can interpret [`SlpnCudaView::device_type`]
+    /// without re-importing the dlpark spec.
+    pub const SLPN_CUDA_DEVICE_TYPE_CUDA: i32 = DlpackDeviceType::Cuda as i32;
+    pub const SLPN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = DlpackDeviceType::CudaHost as i32;
+
+    /// Per-acquire timeline-wait timeout (nanoseconds). Long enough to
+    /// cover any realistic GPU queue depth; short enough that a deadlock
+    /// surfaces as `SLPN_CUDA_ERR` rather than wedging the consumer.
+    /// Mirrors `streamlib_adapter_cuda::CudaSurfaceAdapter`'s default
+    /// (5 s).
+    const ACQUIRE_TIMEOUT_NS: u64 = 5_000_000_000;
+
+    /// View handed back on every successful acquire. Carries the cached
+    /// CUDA device pointer (resolved once per surface at register time)
+    /// plus a freshly heap-allocated DLPack `*mut DLManagedTensor` the
+    /// caller takes ownership of — Python wraps it as a PyCapsule
+    /// consumable by `torch.from_dlpack`. The capsule deleter drops an
+    /// `Arc<RegisteredCudaSurface>` clone, so the imported memory stays
+    /// alive until the consumer releases the capsule even if the adapter
+    /// guard has been released first.
+    ///
+    /// Note: the underlying `vk::Buffer` handle is deliberately NOT
+    /// exposed on this view. Consumers that need raw Vulkan access go
+    /// through `streamlib-adapter-vulkan`'s `SlpnVulkanView` instead;
+    /// switching to this adapter is the contractual signal for "I want
+    /// a DLPack capsule."
+    #[repr(C)]
+    pub struct SlpnCudaView {
+        /// Buffer size in bytes — same value as
+        /// [`Self::dlpack_managed_tensor`]'s 1-D `u8` shape.
+        pub size: u64,
+        /// CUDA device pointer (`CUdeviceptr` cast to `u64`) returned by
+        /// `cudaExternalMemoryGetMappedBuffer`. Stable for the surface's
+        /// lifetime; cached at register time, not re-resolved on every
+        /// acquire.
+        pub device_ptr: u64,
+        /// DLPack `DLDeviceType` discriminant. `2` (`kDLCUDA`) for true
+        /// device memory; `3` (`kDLCUDAHost`) if `cudaPointerGetAttributes`
+        /// classifies the imported pointer as pinned-host (a regression
+        /// flagged by the carve-out test, currently driver-impossible on
+        /// our test rig but checked anyway). Mirrors
+        /// [`SLPN_CUDA_DEVICE_TYPE_CUDA`] / `_CUDA_HOST`.
+        pub device_type: i32,
+        /// CUDA device ordinal. Single-GPU rigs always see `0`; multi-GPU
+        /// UUID matching is a follow-up.
+        pub device_id: i32,
+        /// `*mut DLManagedTensor` — heap-allocated, ownership transfers
+        /// to the caller. The caller MUST eventually call the capsule's
+        /// `deleter` (typically by handing the pointer to Python's
+        /// `PyCapsule` constructor with a name `"dl_managed_tensor"` and
+        /// `deleter` set to the spec-mandated trampoline that calls
+        /// `(*mt).deleter(mt)`).
+        pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    /// Subprocess CUDA runtime — single-process global per cdylib load.
+    pub struct CudaRuntimeHandle {
+        device: Arc<ConsumerVulkanDevice>,
+        adapter: Arc<CudaSurfaceAdapter<ConsumerVulkanDevice>>,
+        cuda_device_ordinal: i32,
+        registered: Mutex<HashMap<u64, Arc<RegisteredCudaSurface>>>,
+    }
+
+    /// Per-surface registered state. The adapter's registry holds
+    /// references to the same Vulkan-side `Arc`s; this struct adds the
+    /// CUDA-side handles + the per-surface stream the cdylib uses for
+    /// `cudaWaitExternalSemaphoresAsync`. Stored behind an `Arc` so a
+    /// DLPack capsule's `manager_ctx` can clone it cheaply and keep
+    /// every CUDA import alive until the consumer releases the capsule.
+    struct RegisteredCudaSurface {
+        // Vulkan-side handles — held for Drop ordering. The adapter's
+        // registry holds its own Arc clones; ours ensure the CUDA
+        // imports below are torn down BEFORE the underlying Vulkan
+        // memory goes away (Vulkan teardown closes the FDs CUDA still
+        // references). Drop order: this struct's fields drop in
+        // declaration order, so put CUDA imports first.
+        ext_mem: sys::cudaExternalMemory_t,
+        ext_sem: sys::cudaExternalSemaphore_t,
+        stream: sys::cudaStream_t,
+        device_ptr: u64,
+        size: u64,
+        device_type: i32,
+        cuda_device_ordinal: i32,
+        // Vulkan-side imports follow — they outlive `ext_mem` / `ext_sem`
+        // because Drop runs in declaration order, but logically the
+        // adapter's registry already owns them. Holding our own clones
+        // is belt-and-suspenders.
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        pixel_buffer: Arc<ConsumerVulkanPixelBuffer>,
+        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+    }
+
+    // SAFETY: `cudaExternalMemory_t`, `cudaExternalSemaphore_t`, and
+    // `cudaStream_t` are opaque pointer-shaped handles. The CUDA Runtime
+    // API's threading contract permits use of these handles from any
+    // thread once created; resource teardown (`cudaDestroyExternalMemory`,
+    // `cudaDestroyExternalSemaphore`, `cudaStreamDestroy`) is similarly
+    // thread-safe. Our `Mutex<HashMap>` serializes registration /
+    // unregistration; per-acquire wait + sync calls are reentrant.
+    unsafe impl Send for RegisteredCudaSurface {}
+    unsafe impl Sync for RegisteredCudaSurface {}
+
+    impl Drop for RegisteredCudaSurface {
+        fn drop(&mut self) {
+            // CUDA-side teardown FIRST so the imports release their
+            // hold on the OPAQUE_FD kernel objects before Vulkan-side
+            // Arcs drop and teardown the underlying VkDeviceMemory /
+            // VkSemaphore.
+            unsafe {
+                if !self.stream.is_null() {
+                    let _ = sys::cudaStreamDestroy(self.stream).result();
+                }
+                if !self.ext_sem.is_null() {
+                    let _ = sys::cudaDestroyExternalSemaphore(self.ext_sem).result();
+                }
+                if !self.ext_mem.is_null() {
+                    let _ = external_memory::destroy_external_memory(self.ext_mem);
+                }
+            }
+        }
+    }
+
+    /// Bring up `ConsumerVulkanDevice` + `CudaSurfaceAdapter` against
+    /// CUDA device 0. Returns NULL on Vulkan or CUDA bring-up failure;
+    /// see the subprocess log for the underlying cause. Idempotent
+    /// callers can rebuild after a failure once the cause is fixed.
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info")]
+    pub unsafe extern "C" fn slpn_cuda_runtime_new() -> *mut CudaRuntimeHandle {
+        let device = match ConsumerVulkanDevice::new() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_runtime_new: ConsumerVulkanDevice::new failed: {}",
+                    e
+                );
+                return std::ptr::null_mut();
+            }
+        };
+
+        // CUDA runtime presence: dlopens libcudart + libcuda lazily on
+        // the first CUDA call. `is_culib_present()` probes without
+        // initializing — used here to surface the no-CUDA case as a
+        // clean NULL return rather than a panic on the first import.
+        if !unsafe { sys::is_culib_present() } {
+            tracing::error!(
+                "slpn_cuda_runtime_new: libcudart not present — CUDA toolkit \
+                 absent on this machine; cuda adapter is unavailable"
+            );
+            return std::ptr::null_mut();
+        }
+
+        let cuda_device_ordinal: i32 = 0;
+        if let Err(e) = unsafe { sys::cudaSetDevice(cuda_device_ordinal) }.result() {
+            tracing::error!(
+                "slpn_cuda_runtime_new: cudaSetDevice({}) failed: {:?}",
+                cuda_device_ordinal,
+                e
+            );
+            return std::ptr::null_mut();
+        }
+
+        let adapter = Arc::new(CudaSurfaceAdapter::new(Arc::clone(&device)));
+        Box::into_raw(Box::new(CudaRuntimeHandle {
+            device,
+            adapter,
+            cuda_device_ordinal,
+            registered: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_runtime_free(rt: *mut CudaRuntimeHandle) {
+        if !rt.is_null() {
+            let _ = unsafe { Box::from_raw(rt) };
+        }
+    }
+
+    /// Register a host cuda surface — imports the OPAQUE_FD `VkBuffer`
+    /// and timeline semaphore via [`streamlib_consumer_rhi`], then
+    /// re-imports the same FDs into CUDA via
+    /// `cudaImportExternalMemory` + `cudaImportExternalSemaphore`.
+    ///
+    /// Caller (the SDK) supplies `surface_id` (subprocess-local u64;
+    /// caller picks the namespace) and `gpu_handle` (a `SurfaceHandle*`
+    /// returned by `slpn_surface_resolve_surface` after a `check_out` of
+    /// the host's pre-registered cuda surface).
+    ///
+    /// Single-FD only: the host registers cuda surfaces as a
+    /// flat OPAQUE_FD `VkBuffer` per `HostVulkanPixelBuffer::new_opaque_fd_export`;
+    /// CUDA's `cudaExternalMemoryGetMappedBuffer` requires a flat memory
+    /// region (multi-plane variants need
+    /// `cudaExternalMemoryGetMappedMipmappedArray`, which doesn't have a
+    /// DLPack flavor — see the issue body for the OPAQUE_FD vs DMA-BUF
+    /// rationale).
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info", skip(rt, gpu_handle))]
+    pub unsafe extern "C" fn slpn_cuda_register_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_cuda_register_surface: null runtime");
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("slpn_cuda_register_surface: null gpu_handle");
+                return SLPN_CUDA_ERR;
+            }
+        };
+        if gpu.fds.len() != 1 {
+            tracing::error!(
+                "slpn_cuda_register_surface: cuda requires exactly 1 OPAQUE_FD plane; \
+                 gpu_handle has {} fd(s)",
+                gpu.fds.len()
+            );
+            return SLPN_CUDA_ERR;
+        }
+
+        // ── Step 1: import the OPAQUE_FD `VkBuffer` into Vulkan ─────────
+        // The fd is duplicated before the Vulkan import takes ownership
+        // because we re-import the same fd into CUDA below. Vulkan and
+        // CUDA each get their own dup; both close their dups on
+        // teardown (Vulkan via `vkFreeMemory` → driver, CUDA via
+        // `cudaDestroyExternalMemory` → driver).
+        let vk_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if vk_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: dup vk_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            return SLPN_CUDA_ERR;
+        }
+        let buffer_size = gpu
+            .plane_sizes
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.size);
+        if buffer_size == 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: surface '{}' has zero size",
+                surface_id
+            );
+            unsafe { libc::close(vk_fd) };
+            return SLPN_CUDA_ERR;
+        }
+        let pixel_buffer = match ConsumerVulkanPixelBuffer::from_opaque_fd(
+            &rt.device,
+            vk_fd,
+            gpu.width,
+            gpu.height,
+            gpu.bytes_per_row.div_ceil(gpu.width.max(1)),
+            PixelFormat::Bgra32,
+            buffer_size,
+        ) {
+            Ok(b) => Arc::new(b),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: from_opaque_fd failed: {} — \
+                     verify the host registered this surface with handle_type=opaque_fd",
+                    e
+                );
+                // Vulkan import takes the fd ownership only on success;
+                // on error we still own the dup.
+                unsafe { libc::close(vk_fd) };
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: surface '{}' has no sync_fd — \
+                     the host must register it with an exportable timeline semaphore \
+                     so cross-API sync (Vulkan ↔ CUDA) is well-defined",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        // Same dup story: timeline imports both into Vulkan and into CUDA.
+        let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if vk_sync_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: dup sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            // Restore the original fd onto the handle so its Drop closes it.
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: timeline from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_sync_fd) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
+        // CUDA takes ownership of the cuda-side dup on successful import.
+        let cuda_mem_fd = unsafe { libc::dup(raw_sync_fd) }; // placeholder — dup the BUFFER fd
+        // The above is a typo guard — the cuda-side memory fd is the
+        // BUFFER fd, not the sync fd. Redo cleanly:
+        unsafe { libc::close(cuda_mem_fd) };
+        let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if cuda_mem_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: dup cuda_mem_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            // Vulkan-side imports drop here via Arc — they own their own
+            // dups already. Restore sync_fd onto the handle so its Drop
+            // closes it (Vulkan timeline import owns its dup independently).
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        // SAFETY: `cudaImportExternalMemory` per CUDA docs:
+        // - On UNIX, ownership of `cuda_mem_fd` transfers to the CUDA
+        //   driver on successful import. We MUST NOT close it after.
+        // - On error, ownership stays with us — close the fd here.
+        let ext_mem = unsafe {
+            match external_memory::import_external_memory_opaque_fd(cuda_mem_fd, buffer_size) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_surface: cudaImportExternalMemory failed: {:?}",
+                        e
+                    );
+                    libc::close(cuda_mem_fd);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // SAFETY: `cudaExternalMemoryGetMappedBuffer` is the flat-pointer
+        // mapping helper. The returned pointer aliases the same kernel
+        // memory the OPAQUE_FD VkBuffer was bound to. Lifetime: valid
+        // until `cudaDestroyExternalMemory` (handled by Drop).
+        let dev_ptr = unsafe {
+            match external_memory::get_mapped_buffer(ext_mem, 0, buffer_size) {
+                Ok(p) => p as u64,
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_surface: cudaExternalMemoryGetMappedBuffer: {:?}",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 4: classify the device pointer (kDLCUDA vs kDLCUDAHost) ─
+        // The carve-out test (#588 Stage 8) flagged this as a load-bearing
+        // probe — a future driver could downgrade the import to pinned-host
+        // memory; the DLPack capsule must advertise the right device type
+        // or `torch.from_dlpack` will copy unnecessarily (or refuse).
+        let mut ptr_attrs = MaybeUninit::<sys::cudaPointerAttributes>::uninit();
+        let ptr_attrs = unsafe {
+            match sys::cudaPointerGetAttributes(ptr_attrs.as_mut_ptr(), dev_ptr as *const c_void)
+                .result()
+            {
+                Ok(()) => ptr_attrs.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_surface: cudaPointerGetAttributes failed: {:?}",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+        let device_type = match ptr_attrs.type_ {
+            sys::cudaMemoryType::cudaMemoryTypeDevice => SLPN_CUDA_DEVICE_TYPE_CUDA,
+            sys::cudaMemoryType::cudaMemoryTypeHost => SLPN_CUDA_DEVICE_TYPE_CUDA_HOST,
+            other => {
+                tracing::error!(
+                    "slpn_cuda_register_surface: imported OPAQUE_FD device pointer is \
+                     {:?} — neither cudaMemoryTypeDevice nor cudaMemoryTypeHost. \
+                     DLPack consumers cannot accept this; investigate driver before proceeding",
+                    other
+                );
+                let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if cuda_sync_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_surface: dup cuda_sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            let _ = unsafe { external_memory::destroy_external_memory(ext_mem) };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        // Same descriptor-construction story as the carve-out test:
+        // `cudaExternalSemaphoreHandleType`'s zero discriminant is invalid
+        // under modern Rust validity rules, so use `MaybeUninit::zeroed()`
+        // and write fields through raw pointers before `assume_init()`.
+        // `reserved` (cuda-13xxx only) inherits the zero pre-fill, which
+        // matches the spec contract.
+        let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
+        let sem_desc = unsafe {
+            let p = sem_desc.as_mut_ptr();
+            (&raw mut (*p).type_).write(
+                sys::cudaExternalSemaphoreHandleType::cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd,
+            );
+            (&raw mut (*p).handle).write(
+                sys::cudaExternalSemaphoreHandleDesc__bindgen_ty_1 { fd: cuda_sync_fd },
+            );
+            (&raw mut (*p).flags).write(0);
+            sem_desc.assume_init()
+        };
+        let mut ext_sem = MaybeUninit::<sys::cudaExternalSemaphore_t>::uninit();
+        let ext_sem = unsafe {
+            match sys::cudaImportExternalSemaphore(ext_sem.as_mut_ptr(), &sem_desc).result() {
+                Ok(()) => ext_sem.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_surface: cudaImportExternalSemaphore: {:?}",
+                        e
+                    );
+                    libc::close(cuda_sync_fd);
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 6: per-surface CUDA stream for the per-acquire wait ────
+        let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+        let stream = unsafe {
+            match sys::cudaStreamCreate(stream.as_mut_ptr()).result() {
+                Ok(()) => stream.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_surface: cudaStreamCreate: {:?}",
+                        e
+                    );
+                    let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 7: hand the imports to the adapter's registry ──────────
+        let registration = HostSurfaceRegistration {
+            pixel_buffer: Arc::clone(&pixel_buffer),
+            timeline: Arc::clone(&timeline),
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+        if let Err(e) = rt.adapter.register_host_surface(surface_id, registration) {
+            tracing::error!(
+                "slpn_cuda_register_surface: adapter.register_host_surface({}): {:?}",
+                surface_id,
+                e
+            );
+            unsafe {
+                let _ = sys::cudaStreamDestroy(stream).result();
+                let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+
+        // The original `raw_sync_fd` is owned by the SurfaceHandle's drop
+        // path. We've already dup'd it twice (Vulkan + CUDA timeline), so
+        // returning it to the handle's `sync_fd` slot is the canonical
+        // ownership recovery — same pattern as cpu-readback's
+        // register_surface error paths.
+        gpu.sync_fd = Some(raw_sync_fd);
+
+        let entry = Arc::new(RegisteredCudaSurface {
+            ext_mem,
+            ext_sem,
+            stream,
+            device_ptr: dev_ptr,
+            size: buffer_size,
+            device_type,
+            cuda_device_ordinal: rt.cuda_device_ordinal,
+            pixel_buffer,
+            timeline,
+        });
+        rt.registered
+            .lock()
+            .expect("slpn_cuda registered: poisoned")
+            .insert(surface_id, entry);
+        SLPN_CUDA_OK
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_unregister_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let removed = rt
+            .registered
+            .lock()
+            .expect("slpn_cuda registered: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return SLPN_CUDA_ERR;
+        }
+        if rt.adapter.unregister_host_surface(surface_id) {
+            SLPN_CUDA_OK
+        } else {
+            SLPN_CUDA_ERR
+        }
+    }
+
+    fn make_descriptor(surface_id: u64) -> StreamlibSurface {
+        StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        )
+    }
+
+    /// Build a fresh DLPack `*mut DLManagedTensor` over the cached
+    /// device pointer; capsule owner is an `Arc<RegisteredCudaSurface>`
+    /// clone so the imported memory stays alive across the FFI handoff.
+    fn build_capsule(entry: &Arc<RegisteredCudaSurface>) -> *mut DlpackManagedTensor {
+        // dlpark's `Device::cuda(usize)` helper covers `kDLCUDA` only;
+        // construct manually so the `kDLCUDAHost` branch (regression
+        // path flagged by the carve-out test) can ride the same code.
+        let device = DlpackDevice {
+            device_type: if entry.device_type == SLPN_CUDA_DEVICE_TYPE_CUDA_HOST {
+                DlpackDeviceType::CudaHost
+            } else {
+                DlpackDeviceType::Cuda
+            },
+            device_id: entry.cuda_device_ordinal,
+        };
+        let owner: CapsuleOwner = Box::new(Arc::clone(entry));
+        dlpack::build_byte_buffer_managed_tensor(entry.device_ptr, entry.size, device, owner)
+    }
+
+    /// Cross-API sync: after the adapter's Vulkan-side wait succeeds,
+    /// CUDA's view of the same kernel timeline must also reach the
+    /// signaled value before consumer kernels read the buffer. Issues a
+    /// `cudaWaitExternalSemaphoresAsync` against the surface's stream at
+    /// the timeline's current Vulkan-observed value, then synchronizes.
+    /// Returns `Ok(())` on success.
+    fn cuda_sync_after_acquire(entry: &RegisteredCudaSurface) -> Result<(), String> {
+        let wait_value = entry
+            .timeline
+            .current_value()
+            .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
+
+        let mut wait_params = MaybeUninit::<sys::cudaExternalSemaphoreWaitParams>::zeroed();
+        let wait_params = unsafe {
+            let p = wait_params.as_mut_ptr();
+            (&raw mut (*p).params.fence.value).write(wait_value);
+            (&raw mut (*p).flags).write(0);
+            wait_params.assume_init()
+        };
+
+        let wait_result = unsafe {
+            sys::cudaWaitExternalSemaphoresAsync_v2(
+                &entry.ext_sem,
+                &wait_params,
+                1,
+                entry.stream,
+            )
+            .result()
+        };
+        if let Err(e) = wait_result {
+            return Err(format!("cudaWaitExternalSemaphoresAsync: {e:?}"));
+        }
+        if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
+            return Err(format!("cudaStreamSynchronize: {e:?}"));
+        }
+        // SAFETY guard: the timeline can advance further between
+        // `current_value()` and `cudaWaitExternalSemaphoresAsync_v2`. That's
+        // fine — CUDA's wait-at-or-above semantics mean a stale `wait_value`
+        // is still valid (we just wait less). Underflow isn't possible:
+        // `current_value()` returns the present counter, never zero on a
+        // post-acquire path because the host adapter only signals values
+        // >= 1 on every release.
+        let _ = wait_value;
+        Ok(())
+    }
+
+    fn populate_view(
+        entry: &Arc<RegisteredCudaSurface>,
+        out: &mut SlpnCudaView,
+    ) -> i32 {
+        let capsule = build_capsule(entry);
+        if capsule.is_null() {
+            tracing::error!("slpn_cuda: build_capsule returned null");
+            return SLPN_CUDA_ERR;
+        }
+        out.size = entry.size;
+        out.device_ptr = entry.device_ptr;
+        out.device_type = entry.device_type;
+        out.device_id = entry.cuda_device_ordinal;
+        out.dlpack_managed_tensor = capsule as *mut c_void;
+        SLPN_CUDA_OK
+    }
+
+    fn lookup_entry(
+        rt: &CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> Option<Arc<RegisteredCudaSurface>> {
+        rt.registered
+            .lock()
+            .expect("slpn_cuda registered: poisoned")
+            .get(&surface_id)
+            .cloned()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_acquire_read: surface_id {} not registered",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let surface = make_descriptor(surface_id);
+        let _ = ACQUIRE_TIMEOUT_NS; // wired through the adapter's default — fixed for v1
+        match rt.adapter.acquire_read(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_acquire_read({}): cuda sync failed: {} — \
+                         releasing the adapter guard so the timeline can \
+                         advance",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Err(e) => {
+                tracing::error!("slpn_cuda_acquire_read({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_acquire_write: surface_id {} not registered",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.acquire_write(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_acquire_write({}): cuda sync failed: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Err(e) => {
+                tracing::error!("slpn_cuda_acquire_write({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLPN_CUDA_ERR,
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.try_acquire_read(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_try_acquire_read({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Ok(None) => SLPN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("slpn_cuda_try_acquire_read({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLPN_CUDA_ERR,
+        };
+        let surface = make_descriptor(surface_id);
+        match rt.adapter.try_acquire_write(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_try_acquire_write({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                populate_view(&entry, out)
+            }
+            Ok(None) => SLPN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("slpn_cuda_try_acquire_write({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_read(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        rt.adapter.end_read_access(surface_id);
+        SLPN_CUDA_OK
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_write(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        rt.adapter.end_write_access(surface_id);
+        SLPN_CUDA_OK
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::mem::{offset_of, size_of};
+
+        // Layout regression — pins the FFI struct shape across the
+        // cdylib boundary. Python's ctypes / Deno's DataView readers
+        // depend on these offsets matching exactly.
+        #[test]
+        fn slpn_cuda_view_layout_matches_spec_64bit() {
+            // SlpnCudaView fields in declaration order:
+            //   size                 : u64    @ 0
+            //   device_ptr           : u64    @ 8
+            //   device_type          : i32    @ 16
+            //   device_id            : i32    @ 20
+            //   dlpack_managed_tensor: ptr    @ 24 (8 bytes on 64-bit)
+            assert_eq!(size_of::<SlpnCudaView>(), 32);
+            assert_eq!(offset_of!(SlpnCudaView, size), 0);
+            assert_eq!(offset_of!(SlpnCudaView, device_ptr), 8);
+            assert_eq!(offset_of!(SlpnCudaView, device_type), 16);
+            assert_eq!(offset_of!(SlpnCudaView, device_id), 20);
+            assert_eq!(offset_of!(SlpnCudaView, dlpack_managed_tensor), 24);
+        }
+
+        #[test]
+        fn slpn_cuda_constants_match_dlpack_spec() {
+            // DLPack v0.8 — these discriminants are wire ABI; a future
+            // dlpark renumbering would land here as a compile failure.
+            assert_eq!(SLPN_CUDA_DEVICE_TYPE_CUDA, 2);
+            assert_eq!(SLPN_CUDA_DEVICE_TYPE_CUDA_HOST, 3);
+            assert_eq!(SLPN_CUDA_OK, 0);
+            assert_eq!(SLPN_CUDA_ERR, -1);
+            assert_eq!(SLPN_CUDA_CONTENDED, 1);
+        }
+
+        // Runtime-construction smoke test: bring up + tear down the
+        // cuda runtime without panicking. The runtime returns NULL
+        // when Vulkan or CUDA is absent (the typical CI env), and
+        // succeeds when both are present (a developer's box). Both
+        // outcomes must be panic-free; this asserts neither path
+        // unwinds across the FFI boundary.
+        //
+        // Not gated on CUDA presence — the no-CUDA branch is the
+        // important one to exercise everywhere because that's what
+        // most CI runners hit. On a CUDA-equipped runner the runtime
+        // is constructed and immediately freed; that exercises the
+        // happy path's allocation + cleanup symmetry.
+        #[test]
+        fn runtime_new_is_panic_safe_without_cuda() {
+            let rt = unsafe { slpn_cuda_runtime_new() };
+            if !rt.is_null() {
+                unsafe { slpn_cuda_runtime_free(rt) };
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod cuda {
+    use std::ffi::c_void;
+
+    pub const SLPN_CUDA_OK: i32 = 0;
+    pub const SLPN_CUDA_ERR: i32 = -1;
+    pub const SLPN_CUDA_CONTENDED: i32 = 1;
+    pub const SLPN_CUDA_DEVICE_TYPE_CUDA: i32 = 2;
+    pub const SLPN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = 3;
+
+    #[repr(C)]
+    pub struct SlpnCudaView {
+        pub size: u64,
+        pub device_ptr: u64,
+        pub device_type: i32,
+        pub device_id: i32,
+        pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_runtime_new() -> *mut c_void {
+        tracing::error!("slpn_cuda_*: cuda adapter runtime is Linux-only");
+        std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_runtime_free(_rt: *mut c_void) {}
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_register_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_unregister_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_read(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+}
+
 #[cfg(not(target_os = "linux"))]
 mod vulkan {
     use std::ffi::c_void;

--- a/libs/streamlib-python/python/streamlib/adapters/__init__.py
+++ b/libs/streamlib-python/python/streamlib/adapters/__init__.py
@@ -5,11 +5,12 @@
 
 Each module under this package mirrors a Rust crate of the form
 ``streamlib-adapter-<name>``: ``vulkan``, ``opengl`` (#512), ``skia``
-(#513), ``cpu_readback`` (#514). The Python module provides type
-shapes and convenience wrappers customer code uses against the
-subprocess-side native binding (``streamlib-python-native``).
+(#513), ``cpu_readback`` (#514), ``cuda`` (#587 / #589). The Python
+module provides type shapes and convenience wrappers customer code
+uses against the subprocess-side native binding
+(``streamlib-python-native``).
 """
 
-from streamlib.adapters import cpu_readback, opengl, skia, vulkan
+from streamlib.adapters import cpu_readback, cuda, opengl, skia, vulkan
 
-__all__ = ["cpu_readback", "opengl", "skia", "vulkan"]
+__all__ = ["cpu_readback", "cuda", "opengl", "skia", "vulkan"]

--- a/libs/streamlib-python/python/streamlib/adapters/cuda.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cuda.py
@@ -1,0 +1,567 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""CUDA surface adapter — Python customer-facing API.
+
+Mirrors the Rust crate ``streamlib-adapter-cuda`` (#587 / #588). The
+Python subprocess delegates to ``streamlib-python-native``'s
+``slpn_cuda_*`` FFI surface, which itself wraps
+``CudaSurfaceAdapter<ConsumerVulkanDevice>`` plus
+``cudaImportExternalMemory`` / ``cudaImportExternalSemaphore`` against
+the host-allocated OPAQUE_FD ``VkBuffer`` + timeline semaphore.
+Per-acquire control flow:
+
+1. The Python SDK looks the host's pre-registered cuda surface up via
+   surface-share once (``slpn_cuda_register_surface``). The OPAQUE_FD
+   memory + timeline FDs enter the cdylib's address space, get
+   imported via ``ConsumerVulkanPixelBuffer::from_opaque_fd`` /
+   ``ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd`` AND
+   re-imported into CUDA via ``cudaImportExternalMemory`` /
+   ``cudaImportExternalSemaphore``. The CUDA device pointer
+   (``cudaExternalMemoryGetMappedBuffer``) is cached for the surface's
+   lifetime.
+2. Every ``acquire_read`` / ``acquire_write`` waits on the imported
+   timeline (Vulkan-side via the adapter; CUDA-side via
+   ``cudaWaitExternalSemaphoresAsync_v2`` so CUDA driver state is in
+   sync with Vulkan's view of the kernel timeline) and hands back a
+   DLPack PyCapsule named ``"dl_managed_tensor"`` consumable by
+   ``torch.from_dlpack`` zero-copy.
+
+There is no per-acquire IPC — the host's pipeline is expected to write
+into the OPAQUE_FD buffer and signal the shared timeline ambiently.
+Customers who need an explicit host-side trigger (e.g. an explicit
+``vkCmdCopyImageToBuffer`` per acquire) should use
+``streamlib.adapters.cpu_readback`` instead.
+
+Customer-facing shapes:
+
+  * ``CudaReadView`` / ``CudaWriteView`` — surface-level metadata plus
+    a ``dlpack`` PyCapsule the customer hands to ``torch.from_dlpack``
+    (or any other ``__dlpack__``-protocol consumer).
+  * ``CudaContext`` — concrete subprocess runtime. One per subprocess;
+    obtain via :meth:`CudaContext.from_runtime`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import itertools
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from streamlib.surface_adapter import (
+    STREAMLIB_ADAPTER_ABI_VERSION,
+    SurfaceFormat,
+)
+
+__all__ = [
+    "STREAMLIB_ADAPTER_ABI_VERSION",
+    "CudaReadView",
+    "CudaWriteView",
+    "CudaContext",
+]
+
+
+# ``slpn_cuda_*`` return values — must match the cdylib's
+# ``SLPN_CUDA_OK`` / ``_ERR`` / ``_CONTENDED`` constants.
+_RC_OK = 0
+_RC_ERR = -1
+_RC_CONTENDED = 1
+
+# DLPack ``DLDeviceType`` discriminants the cdylib hands back via
+# ``SlpnCudaView.device_type``. Mirrors the spec (and the cdylib's
+# ``SLPN_CUDA_DEVICE_TYPE_*`` constants).
+_DEVICE_TYPE_CUDA = 2
+_DEVICE_TYPE_CUDA_HOST = 3
+
+# Surface-id namespace inside this subprocess. The host's pool_id (a
+# string) is mapped to a u64 the cdylib uses internally; customers
+# never see the u64.
+_CUDA_SURFACE_ID_COUNTER = itertools.count(start=1)
+
+
+class _SlpnCudaView(ctypes.Structure):
+    """C struct matching ``streamlib_python_native::cuda::SlpnCudaView``.
+
+    Layout pinned by ``slpn_cuda_view_layout_matches_spec_64bit`` in
+    the cdylib's tests — fields, offsets, and sizes are part of the
+    ABI between this wrapper and the native library.
+    """
+
+    _fields_ = [
+        ("size", ctypes.c_uint64),
+        ("device_ptr", ctypes.c_uint64),
+        ("device_type", ctypes.c_int32),
+        ("device_id", ctypes.c_int32),
+        ("dlpack_managed_tensor", ctypes.c_void_p),
+    ]
+
+
+# DLPack capsule machinery
+# ---------------------------------------------------------------------------
+#
+# The DLPack v0.8 spec defines a producer/consumer handoff via PyCapsule:
+#
+# 1. Producer creates a heap-allocated ``DLManagedTensor*``, wraps it in
+#    ``PyCapsule_New(mt, "dl_managed_tensor", destructor)``.
+# 2. Consumer (e.g. PyTorch) calls ``PyCapsule_GetPointer(capsule,
+#    "dl_managed_tensor")`` to take ownership, then renames the capsule
+#    to ``"used_dl_managed_tensor"``. The consumer is now responsible
+#    for eventually calling ``mt->deleter(mt)``.
+# 3. If the consumer never takes the capsule (e.g. an exception fires
+#    before ``torch.from_dlpack`` runs), the capsule's destructor must
+#    call ``mt->deleter(mt)`` to free the producer-side state.
+#
+# The destructor inspects the capsule name to decide whether it owns
+# the cleanup. ``ctypes.pythonapi`` exposes the relevant CPython API.
+
+# The PyCapsule destructor is a C-level callback — `void(*)(PyObject*)`.
+# Parameter type is ``c_void_p`` (raw pointer) rather than ``py_object``
+# because the destructor fires during the capsule's tp_dealloc — going
+# through ``py_object`` would trigger ctypes' refcount manipulation
+# against an object that is in the process of being freed, which
+# segfaults under CPython 3.12+. The PyCapsule_* helpers below accept
+# the raw pointer via the same ``c_void_p`` argtype, so the destructor
+# threads it back without ever materializing a Python reference.
+_PyCapsule_Destructor = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+
+# ``DLManagedTensor`` layout (matches ``streamlib-adapter-cuda::dlpack``
+# tests pinning the v0.8 ABI on 64-bit):
+#   dl_tensor: 48 bytes @ 0
+#   manager_ctx: 8 bytes @ 48
+#   deleter: 8 bytes @ 56  ← function pointer ``void(*)(DLManagedTensor*)``
+_DLPACK_DELETER_OFFSET = 56
+_DLPACK_DELETER_TYPE = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+
+# Capsule name shipped to consumers. Must be byte-string for the C API.
+_DLPACK_CAPSULE_NAME = b"dl_managed_tensor"
+_DLPACK_CAPSULE_NAME_USED = b"used_dl_managed_tensor"
+
+
+def _wire_pythonapi():
+    """Wire ``ctypes.pythonapi`` argtypes / restypes for the
+    PyCapsule_* helpers. Idempotent — re-wiring is a no-op.
+
+    The destructor path passes a raw ``c_void_p`` PyObject* pointer
+    (not a ``py_object``) to avoid ctypes refcount manipulation
+    during ``tp_dealloc``; the consumer-facing ``PyCapsule_New``
+    output is a real ``py_object`` because that's what consumers see.
+    """
+    api = ctypes.pythonapi
+
+    api.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    api.PyCapsule_New.restype = ctypes.py_object
+
+    # Destructor-path overloads — accept raw ``PyObject*`` as
+    # ``c_void_p``. Outside the destructor, callers route through
+    # explicit ``ctypes.cast(capsule, c_void_p)`` so the same wrappers
+    # work both pre- and post-tp_dealloc.
+    api.PyCapsule_GetPointer.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    api.PyCapsule_GetPointer.restype = ctypes.c_void_p
+
+    api.PyCapsule_GetName.argtypes = [ctypes.c_void_p]
+    api.PyCapsule_GetName.restype = ctypes.c_char_p
+
+
+_wire_pythonapi()
+
+
+def _make_dlpack_capsule(mt_ptr: int) -> object:
+    """Wrap a ``*mut DLManagedTensor`` (raw integer address, returned
+    by the cdylib's ``slpn_cuda_acquire_*``) as a PyCapsule consumable
+    by ``torch.from_dlpack``.
+
+    Capsule destructor: if the consumer didn't claim the capsule (name
+    still ``"dl_managed_tensor"``), reach into the ``DLManagedTensor``
+    layout and call the producer-supplied deleter so resources don't
+    leak. If the consumer claimed it (name ``"used_dl_managed_tensor"``),
+    the consumer is responsible — do nothing.
+    """
+    if not mt_ptr:
+        raise RuntimeError(
+            "CudaContext: cdylib returned null DLManagedTensor pointer — "
+            "the cuda runtime is in a bad state"
+        )
+
+    # The destructor must keep a reference to itself for as long as the
+    # capsule could call it. Holding it on the capsule via
+    # PyCapsule_SetContext is one option; simpler: capture in a closure
+    # and stash on the returned capsule's __dict__-equivalent
+    # (PyCapsule_SetContext) — but PyCapsules don't have __dict__, so
+    # we take the standard approach: keep a global registry keyed on
+    # the capsule id so the destructor reference lives long enough.
+    #
+    # Even simpler: ctypes-bound CFUNCTYPE objects can outlive their
+    # containing scope as long as something refers to them. We cast
+    # the destructor to a plain c_void_p for PyCapsule_New (which only
+    # stores the address), and pin the CFUNCTYPE wrapper to a module-
+    # level `_capsule_destructors` set so it isn't GC'd until we
+    # explicitly remove it.
+
+    destructor_key = next(_destructor_id_counter)
+
+    @_PyCapsule_Destructor
+    def destructor(capsule):
+        # Read the capsule name. If the consumer claimed it, the name
+        # was renamed; we don't own the cleanup.
+        name_ptr = ctypes.pythonapi.PyCapsule_GetName(capsule)
+        if name_ptr is None:
+            # The capsule was invalidated; nothing to do.
+            _capsule_destructors.pop(destructor_key, None)
+            return
+        if name_ptr == _DLPACK_CAPSULE_NAME_USED:
+            # Consumer (PyTorch / etc.) took the capsule and is
+            # responsible for calling the deleter.
+            _capsule_destructors.pop(destructor_key, None)
+            return
+        # Producer-owned cleanup path: call the DLManagedTensor's
+        # deleter to free shape / strides / manager_ctx / the
+        # ManagedTensor itself.
+        raw_ptr = ctypes.pythonapi.PyCapsule_GetPointer(
+            capsule, _DLPACK_CAPSULE_NAME
+        )
+        if not raw_ptr:
+            _capsule_destructors.pop(destructor_key, None)
+            return
+        # Read the deleter function pointer at offset 56 in
+        # DLManagedTensor.
+        deleter_addr = ctypes.cast(
+            raw_ptr + _DLPACK_DELETER_OFFSET,
+            ctypes.POINTER(ctypes.c_void_p),
+        )[0]
+        if deleter_addr:
+            deleter_fn = _DLPACK_DELETER_TYPE(deleter_addr)
+            try:
+                deleter_fn(ctypes.c_void_p(raw_ptr))
+            except Exception:  # pragma: no cover - logged on the cdylib
+                pass
+        _capsule_destructors.pop(destructor_key, None)
+
+    _capsule_destructors[destructor_key] = destructor
+
+    capsule = ctypes.pythonapi.PyCapsule_New(
+        ctypes.c_void_p(mt_ptr),
+        _DLPACK_CAPSULE_NAME,
+        ctypes.cast(destructor, ctypes.c_void_p),
+    )
+    return capsule
+
+
+# Pin ctypes destructor closures so they outlive the capsules that
+# reference them. ``CFUNCTYPE``-bound objects aren't hashable, so use
+# a counter-keyed dict instead of a set. The destructor itself pops
+# its entry on call (consumed or not).
+_destructor_id_counter = itertools.count(start=1)
+_capsule_destructors: "dict[int, object]" = {}
+
+
+@dataclass(frozen=True)
+class CudaReadView:
+    """View handed back inside an ``acquire_read`` scope.
+
+    ``dlpack`` is a PyCapsule named ``"dl_managed_tensor"`` consumable
+    by ``torch.from_dlpack`` zero-copy. The capsule references the
+    cdylib-imported CUDA memory; the underlying memory stays alive
+    until the consumer (or the capsule's destructor) invokes the
+    DLPack deleter.
+
+    The view is valid only inside the ``with`` block. After the block
+    exits, the adapter releases its read guard — the host pipeline is
+    free to overwrite the buffer. If you need to retain the tensor
+    beyond the block, call ``.clone()`` on the PyTorch tensor (or the
+    framework equivalent) inside the block.
+    """
+
+    width: int
+    height: int
+    format: SurfaceFormat
+    size: int
+    device_id: int
+    device_type: int
+    dlpack: object  # PyCapsule
+
+
+@dataclass(frozen=True)
+class CudaWriteView:
+    """View handed back inside an ``acquire_write`` scope.
+
+    Same shape as [`CudaReadView`]. The DLPack capsule's underlying
+    memory is writable from CUDA — kernels that produce new frames
+    (e.g. compositing inference outputs) can dispatch against
+    ``torch.from_dlpack(view.dlpack)`` and the writes land in the
+    host-shared OPAQUE_FD buffer.
+    """
+
+    width: int
+    height: int
+    format: SurfaceFormat
+    size: int
+    device_id: int
+    device_type: int
+    dlpack: object  # PyCapsule
+
+
+def _surface_pool_id(surface) -> str:
+    """Extract the surface-share pool id (string) from either a
+    ``StreamlibSurface``-shaped object or a bare string / int."""
+    if isinstance(surface, str):
+        return surface
+    if isinstance(surface, int):
+        return str(surface)
+    sid = getattr(surface, "id", None)
+    if sid is None:
+        raise TypeError(
+            f"CudaContext: expected StreamlibSurface or pool_id, got {surface!r}"
+        )
+    return str(sid)
+
+
+def _surface_format_from(surface) -> SurfaceFormat:
+    """Best-effort SurfaceFormat extraction; falls back to BGRA8."""
+    fmt = getattr(surface, "format", None)
+    if fmt is None:
+        return SurfaceFormat.BGRA8
+    if isinstance(fmt, SurfaceFormat):
+        return fmt
+    return SurfaceFormat(int(fmt))
+
+
+class CudaContext:
+    """Customer-facing handle bound to the subprocess's cuda cdylib
+    runtime.
+
+    Use as a context manager::
+
+        with ctx.acquire_read(surface) as view:
+            tensor = torch.from_dlpack(view.dlpack)
+            # tensor lives on CUDA device `view.device_id`, no copy.
+            outputs = model(tensor)
+            # If you need outputs beyond the block, .clone() them now.
+    """
+
+    _shared_instance: Optional["CudaContext"] = None
+
+    def __init__(self, gpu_limited_access) -> None:
+        self._gpu = gpu_limited_access
+        self._lib = gpu_limited_access.native_lib
+        self._wire_signatures()
+        rt = self._lib.slpn_cuda_runtime_new()
+        if not rt:
+            raise RuntimeError(
+                "CudaContext: slpn_cuda_runtime_new returned NULL — the "
+                "subprocess could not bring up a Vulkan device + CUDA "
+                "context. Check that libvulkan.so.1, libcuda.so.1, and "
+                "libcudart.so are installed and that the driver supports "
+                "VK_KHR_external_memory_fd, VK_EXT_external_memory_dma_buf, "
+                "and VK_KHR_external_semaphore_fd. See the subprocess log "
+                "for the underlying error."
+            )
+        self._rt = ctypes.c_void_p(rt)
+
+        # pool_id (host-side string) → local u64 surface_id.
+        self._surface_ids: dict[str, int] = {}
+        # Pin resolved SurfaceHandle objects so the OPAQUE_FD plane and
+        # sync FDs stay alive for the surface's lifetime. The cdylib
+        # already dups before each Vulkan / CUDA import, but the
+        # SurfaceHandle drop closes the originals — keeping it alive
+        # is defense in depth.
+        self._resolved_handles: dict[str, object] = {}
+
+    @classmethod
+    def from_runtime(cls, runtime_context) -> "CudaContext":
+        """Build (or fetch the cached) :class:`CudaContext` for this
+        subprocess. The subprocess hosts at most one cuda runtime —
+        calling this twice with the same runtime returns the same
+        instance.
+        """
+        if cls._shared_instance is None:
+            cls._shared_instance = cls(runtime_context.gpu_limited_access)
+        return cls._shared_instance
+
+    def _wire_signatures(self) -> None:
+        lib = self._lib
+
+        lib.slpn_cuda_runtime_new.restype = ctypes.c_void_p
+        lib.slpn_cuda_runtime_new.argtypes = []
+
+        lib.slpn_cuda_runtime_free.restype = None
+        lib.slpn_cuda_runtime_free.argtypes = [ctypes.c_void_p]
+
+        lib.slpn_cuda_register_surface.restype = ctypes.c_int32
+        lib.slpn_cuda_register_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+        ]
+
+        lib.slpn_cuda_unregister_surface.restype = ctypes.c_int32
+        lib.slpn_cuda_unregister_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+        ]
+
+        for name in (
+            "slpn_cuda_acquire_read",
+            "slpn_cuda_acquire_write",
+            "slpn_cuda_try_acquire_read",
+            "slpn_cuda_try_acquire_write",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint64,
+                ctypes.POINTER(_SlpnCudaView),
+            ]
+
+        for name in (
+            "slpn_cuda_release_read",
+            "slpn_cuda_release_write",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+
+    def _resolve_and_register(self, pool_id: str) -> int:
+        """Resolve `pool_id` via surface-share, register with the cuda
+        adapter, and return the local u64 surface_id. Idempotent —
+        repeat calls return the cached id."""
+        cached = self._surface_ids.get(pool_id)
+        if cached is not None:
+            return cached
+        handle = self._gpu.resolve_surface(pool_id)
+        handle_ptr = handle.native_handle_ptr
+        if not handle_ptr:
+            raise RuntimeError(
+                f"CudaContext: resolve_surface('{pool_id}') returned a "
+                "handle with a null native pointer"
+            )
+        surface_id = next(_CUDA_SURFACE_ID_COUNTER)
+        rc = self._lib.slpn_cuda_register_surface(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.c_void_p(handle_ptr),
+        )
+        if rc != _RC_OK:
+            raise RuntimeError(
+                f"CudaContext: register_surface failed for pool_id "
+                f"'{pool_id}' (rc={rc}). Common causes: host registered "
+                f"the surface as DMA-BUF rather than OPAQUE_FD (cuda "
+                "requires `handle_type=opaque_fd`); host did not attach "
+                "an exportable timeline semaphore (cuda requires sync_fd); "
+                "or libcudart / libcuda.so missing. See the subprocess "
+                "log for specifics."
+            )
+        self._surface_ids[pool_id] = surface_id
+        self._resolved_handles[pool_id] = handle
+        return surface_id
+
+    @contextmanager
+    def acquire_read(self, surface) -> "Iterator[CudaReadView]":
+        """Block until the host has signaled the timeline; hand back a
+        DLPack-bearing read view. On exit, release the adapter guard
+        so the timeline can advance."""
+        with self._acquire(surface, write=False, blocking=True) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def acquire_write(self, surface) -> "Iterator[CudaWriteView]":
+        """Block until the host has signaled the timeline; hand back a
+        DLPack-bearing write view. CUDA writes land in the OPAQUE_FD
+        buffer; on exit, release the adapter guard so the host can
+        observe the new contents."""
+        with self._acquire(surface, write=True, blocking=True) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def try_acquire_read(self, surface) -> "Iterator[Optional[CudaReadView]]":
+        """Non-blocking read acquire. Yields a [`CudaReadView`] on
+        success or ``None`` on contention."""
+        with self._acquire(surface, write=False, blocking=False) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def try_acquire_write(
+        self, surface
+    ) -> "Iterator[Optional[CudaWriteView]]":
+        """Non-blocking write acquire. Yields a [`CudaWriteView`] on
+        success or ``None`` on contention."""
+        with self._acquire(surface, write=True, blocking=False) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def _acquire(self, surface, write: bool, blocking: bool) -> "Iterator[object]":
+        pool_id = _surface_pool_id(surface)
+        format_ = _surface_format_from(surface)
+        # Surface format is informational at the cuda layer (the
+        # buffer is flat bytes from CUDA's perspective); the host
+        # adapter doesn't read it. Recorded on the view so customers
+        # can interpret the bytes correctly.
+        surface_id = self._resolve_and_register(pool_id)
+        view_struct = _SlpnCudaView()
+        if blocking:
+            fn = (
+                self._lib.slpn_cuda_acquire_write
+                if write
+                else self._lib.slpn_cuda_acquire_read
+            )
+        else:
+            fn = (
+                self._lib.slpn_cuda_try_acquire_write
+                if write
+                else self._lib.slpn_cuda_try_acquire_read
+            )
+        rc = fn(self._rt, ctypes.c_uint64(surface_id), ctypes.byref(view_struct))
+        if rc == _RC_CONTENDED:
+            yield None
+            return
+        if rc != _RC_OK:
+            raise RuntimeError(
+                f"CudaContext.{'try_' if not blocking else ''}"
+                f"acquire_{'write' if write else 'read'}: rc={rc} for "
+                f"surface '{pool_id}'"
+            )
+        try:
+            yield self._build_view(view_struct, format_, write)
+        finally:
+            release_fn = (
+                self._lib.slpn_cuda_release_write
+                if write
+                else self._lib.slpn_cuda_release_read
+            )
+            release_fn(self._rt, ctypes.c_uint64(surface_id))
+
+    def _build_view(
+        self,
+        view_struct: _SlpnCudaView,
+        format_: SurfaceFormat,
+        writable: bool,
+    ):
+        mt_ptr = view_struct.dlpack_managed_tensor
+        if not mt_ptr:
+            raise RuntimeError(
+                "CudaContext: cdylib returned null DLPack managed tensor "
+                "pointer — the cuda runtime is in a bad state"
+            )
+        capsule = _make_dlpack_capsule(mt_ptr)
+        # Width / height are recorded on the original host surface but
+        # not threaded through the cuda FFI today (the buffer is flat
+        # bytes from CUDA's perspective, and DLPack consumers reshape
+        # via tensor.view(...) anyway). Customers needing dimension
+        # info can read it from the StreamlibSurface descriptor they
+        # passed in.
+        klass = CudaWriteView if writable else CudaReadView
+        return klass(
+            width=0,
+            height=0,
+            format=format_,
+            size=int(view_struct.size),
+            device_id=int(view_struct.device_id),
+            device_type=int(view_struct.device_type),
+            dlpack=capsule,
+        )

--- a/libs/streamlib-python/python/streamlib/adapters/cuda.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cuda.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import ctypes
 import itertools
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Iterator, Optional
@@ -203,8 +204,6 @@ def _make_dlpack_capsule(mt_ptr: int) -> object:
     # level `_capsule_destructors` set so it isn't GC'd until we
     # explicitly remove it.
 
-    destructor_key = next(_destructor_id_counter)
-
     @_PyCapsule_Destructor
     def destructor(capsule):
         # Read the capsule name. If the consumer claimed it, the name
@@ -212,12 +211,12 @@ def _make_dlpack_capsule(mt_ptr: int) -> object:
         name_ptr = ctypes.pythonapi.PyCapsule_GetName(capsule)
         if name_ptr is None:
             # The capsule was invalidated; nothing to do.
-            _capsule_destructors.pop(destructor_key, None)
+            _release_destructor(destructor)
             return
         if name_ptr == _DLPACK_CAPSULE_NAME_USED:
             # Consumer (PyTorch / etc.) took the capsule and is
             # responsible for calling the deleter.
-            _capsule_destructors.pop(destructor_key, None)
+            _release_destructor(destructor)
             return
         # Producer-owned cleanup path: call the DLManagedTensor's
         # deleter to free shape / strides / manager_ctx / the
@@ -226,7 +225,7 @@ def _make_dlpack_capsule(mt_ptr: int) -> object:
             capsule, _DLPACK_CAPSULE_NAME
         )
         if not raw_ptr:
-            _capsule_destructors.pop(destructor_key, None)
+            _release_destructor(destructor)
             return
         # Read the deleter function pointer at offset 56 in
         # DLManagedTensor.
@@ -240,9 +239,9 @@ def _make_dlpack_capsule(mt_ptr: int) -> object:
                 deleter_fn(ctypes.c_void_p(raw_ptr))
             except Exception:  # pragma: no cover - logged on the cdylib
                 pass
-        _capsule_destructors.pop(destructor_key, None)
+        _release_destructor(destructor)
 
-    _capsule_destructors[destructor_key] = destructor
+    _retain_destructor(destructor)
 
     capsule = ctypes.pythonapi.PyCapsule_New(
         ctypes.c_void_p(mt_ptr),
@@ -253,11 +252,35 @@ def _make_dlpack_capsule(mt_ptr: int) -> object:
 
 
 # Pin ctypes destructor closures so they outlive the capsules that
-# reference them. ``CFUNCTYPE``-bound objects aren't hashable, so use
-# a counter-keyed dict instead of a set. The destructor itself pops
-# its entry on call (consumed or not).
-_destructor_id_counter = itertools.count(start=1)
+# reference them: when the C side calls back through the function
+# pointer, the trampoline (the ``CFUNCTYPE`` wrapper) must still be
+# alive or the call segfaults.
+#
+# Keyed on ``id(destructor)`` rather than a counter so each entry is
+# self-identifying and there's no monotonic-ish state to race against
+# under PEP 703 free-threaded Python (where ``itertools.count`` may
+# need additional locking). Wrapped in a ``threading.Lock`` so dict
+# mutations are atomic across producer threads (capsule creation) and
+# consumer threads (capsule destruction); this is defense-in-depth on
+# top of CPython's per-dict critical-section guarantees in 3.13+.
+_capsule_destructors_lock = threading.Lock()
 _capsule_destructors: "dict[int, object]" = {}
+
+
+def _retain_destructor(destructor: object) -> None:
+    """Pin ``destructor`` in the global registry so it outlives the
+    PyCapsule that points at its C function pointer."""
+    with _capsule_destructors_lock:
+        _capsule_destructors[id(destructor)] = destructor
+
+
+def _release_destructor(destructor: object) -> None:
+    """Drop the registry's reference so the ``CFUNCTYPE`` wrapper can
+    be garbage-collected. Called from inside the destructor after the
+    PyCapsule_* C calls have completed; safe under all consumed /
+    unconsumed paths."""
+    with _capsule_destructors_lock:
+        _capsule_destructors.pop(id(destructor), None)
 
 
 @dataclass(frozen=True)

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Smoke test for the Python CUDA adapter wrapper module (#589).
+
+Confirms the module imports, the view dataclasses round-trip
+construction, the FFI struct layout matches what the cdylib emits,
+and the DLPack PyCapsule machinery is wired to ``ctypes.pythonapi``.
+
+A real subprocess test (host registers a host-allocated OPAQUE_FD
+``VkBuffer``, Python opens the cdylib, ``slpn_cuda_acquire_read`` →
+``torch.from_dlpack`` → byte-equal assertion against the host pattern)
+requires a polyglot test harness that doesn't yet exist in tree —
+filed as a follow-up. This file exercises the Python module's
+contract against the cdylib's documented FFI ABI.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+from streamlib.adapters import cuda as c
+from streamlib.surface_adapter import STREAMLIB_ADAPTER_ABI_VERSION, SurfaceFormat
+
+
+def test_module_re_exports_abi_version_constant():
+    assert c.STREAMLIB_ADAPTER_ABI_VERSION == STREAMLIB_ADAPTER_ABI_VERSION
+
+
+def test_slpn_cuda_view_layout_matches_cdylib():
+    # Mirrors `slpn_cuda_view_layout_matches_spec_64bit` in the cdylib's
+    # tests — these offsets / sizes are part of the wire ABI between
+    # the cdylib's `SlpnCudaView` and Python's `_SlpnCudaView`.
+    assert ctypes.sizeof(c._SlpnCudaView) == 32
+    fields = {name: c._SlpnCudaView.__dict__[name].offset for name, _ in c._SlpnCudaView._fields_}
+    assert fields == {
+        "size": 0,
+        "device_ptr": 8,
+        "device_type": 16,
+        "device_id": 20,
+        "dlpack_managed_tensor": 24,
+    }
+
+
+def test_constants_match_dlpack_spec():
+    # DLPack v0.8 `DLDeviceType` discriminants — wire ABI.
+    assert c._DEVICE_TYPE_CUDA == 2
+    assert c._DEVICE_TYPE_CUDA_HOST == 3
+    # `slpn_cuda_*` return values — must match the cdylib's
+    # SLPN_CUDA_OK / _ERR / _CONTENDED constants.
+    assert c._RC_OK == 0
+    assert c._RC_ERR == -1
+    assert c._RC_CONTENDED == 1
+    # DLManagedTensor deleter offset — pinned by adapter-cuda's dlpack
+    # layout regression test. dl_tensor (48) + manager_ctx (8) = 56.
+    assert c._DLPACK_DELETER_OFFSET == 56
+
+
+def test_cuda_views_round_trip_dataclass_construction():
+    # Use a `c_uint8 * 0` as a stand-in PyCapsule; the dataclass just
+    # holds the reference — it doesn't dereference.
+    fake_capsule = object()
+    rv = c.CudaReadView(
+        width=0,
+        height=0,
+        format=SurfaceFormat.BGRA8,
+        size=1024 * 1024,
+        device_id=0,
+        device_type=c._DEVICE_TYPE_CUDA,
+        dlpack=fake_capsule,
+    )
+    wv = c.CudaWriteView(
+        width=0,
+        height=0,
+        format=SurfaceFormat.BGRA8,
+        size=2048,
+        device_id=1,
+        device_type=c._DEVICE_TYPE_CUDA_HOST,
+        dlpack=fake_capsule,
+    )
+    assert rv.size == 1024 * 1024
+    assert rv.device_type == 2
+    assert rv.device_id == 0
+    assert wv.size == 2048
+    assert wv.device_type == 3
+    assert wv.device_id == 1
+    # Both views must hold the capsule reference; the producer relies
+    # on this to keep the underlying CUDA memory alive across the
+    # acquire scope.
+    assert rv.dlpack is fake_capsule
+    assert wv.dlpack is fake_capsule
+
+
+def test_pythonapi_pycapsule_helpers_are_wired():
+    # `_wire_pythonapi` runs at module import time; this asserts the
+    # argtypes / restypes survived intact for the helpers the capsule
+    # destructor reaches into. Argtypes for `PyCapsule_GetName` /
+    # `PyCapsule_GetPointer` use `c_void_p` (raw `PyObject*`) rather
+    # than `py_object` so the destructor path doesn't trigger ctypes
+    # refcount manipulation against an object in `tp_dealloc`.
+    assert ctypes.pythonapi.PyCapsule_New.restype == ctypes.py_object
+    assert ctypes.pythonapi.PyCapsule_GetPointer.argtypes == [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+    assert ctypes.pythonapi.PyCapsule_GetPointer.restype == ctypes.c_void_p
+    assert ctypes.pythonapi.PyCapsule_GetName.argtypes == [ctypes.c_void_p]
+    assert ctypes.pythonapi.PyCapsule_GetName.restype == ctypes.c_char_p
+
+
+def test_capsule_lifecycle_releases_destructor_pin():
+    """Confirms the PyCapsule destructor wiring is in place: the
+    destructor closure is pinned in `_capsule_destructors` for the
+    capsule's lifetime, then popped when the capsule is dropped.
+
+    Uses a fake `DLManagedTensor` with a NULL deleter at offset 56 —
+    the destructor's null-check skips the deleter call, so this test
+    exercises wire-up + cleanup without crossing the Python-callable-
+    during-GC boundary (the real deleter is exercised end-to-end by
+    `cuda_carve_out.rs` once the cdylib is loaded against a real
+    consumer).
+    """
+    # Build a fake DLManagedTensor: 64 bytes total, deleter slot at
+    # offset 56 is implicitly zero (calloc-style ctypes zeroing). The
+    # destructor reads the deleter pointer there and skips the call
+    # because it's NULL — no cross-runtime callback risk.
+    fake_mt = (ctypes.c_uint8 * 64)()
+    initial_pin_count = len(c._capsule_destructors)
+
+    capsule = c._make_dlpack_capsule(ctypes.addressof(fake_mt))
+    assert capsule is not None
+
+    # Pinning happened: one new entry in the destructor table while
+    # the capsule is live. The wrapper holds the CFUNCTYPE alive so
+    # PyCapsule_New's stored pointer remains valid.
+    assert len(c._capsule_destructors) == initial_pin_count + 1, (
+        "PyCapsule destructor must be pinned in _capsule_destructors "
+        "for the capsule's lifetime"
+    )
+
+    # Drop the capsule — destructor fires; null deleter slot means
+    # the destructor's deleter-call branch is skipped, but the
+    # cleanup branch (popping its own entry from the dict) runs.
+    del capsule
+    # Force a GC cycle so the destructor definitely runs.
+    import gc
+
+    gc.collect()
+
+    assert len(c._capsule_destructors) == initial_pin_count, (
+        "PyCapsule destructor must pop its own entry from "
+        f"_capsule_destructors on drop; expected {initial_pin_count} "
+        f"entries, found {len(c._capsule_destructors)}"
+    )
+
+
+def test_cuda_context_class_exposes_expected_method_set():
+    # Surface-adapter Protocol shape — any future Protocol type-check
+    # against `CudaContext` should structurally match these.
+    assert hasattr(c.CudaContext, "acquire_read")
+    assert hasattr(c.CudaContext, "acquire_write")
+    assert hasattr(c.CudaContext, "try_acquire_read")
+    assert hasattr(c.CudaContext, "try_acquire_write")
+    assert hasattr(c.CudaContext, "from_runtime")

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
@@ -162,3 +162,59 @@ def test_cuda_context_class_exposes_expected_method_set():
     assert hasattr(c.CudaContext, "try_acquire_read")
     assert hasattr(c.CudaContext, "try_acquire_write")
     assert hasattr(c.CudaContext, "from_runtime")
+
+
+def test_capsule_destructor_registry_survives_concurrent_create_drop():
+    """Stress the lock-guarded registry across many threads creating
+    and dropping capsules concurrently.
+
+    Locks in the no-GIL-readiness property (review #5 from the
+    pr-review-gate): the registry must end up empty after every
+    capsule has been dropped + collected, regardless of interleaving.
+    Under PEP 703 free-threaded Python, dict mutations need explicit
+    locking — `threading.Lock` around `_retain_destructor` /
+    `_release_destructor` covers that.
+    """
+    import threading
+    import gc
+
+    initial_size = len(c._capsule_destructors)
+    n_threads = 8
+    n_capsules_per_thread = 16
+
+    barrier = threading.Barrier(n_threads)
+
+    def churn():
+        # Synchronize start so the threads fight for the lock.
+        barrier.wait(timeout=5.0)
+        # Each thread allocates its own fake DLManagedTensors and creates
+        # / drops capsules over them. The deleter slot is NULL, so the
+        # destructor's "consumed" path is never exercised — we're only
+        # gating registry pin/release atomicity.
+        capsules = []
+        backing = []
+        for _ in range(n_capsules_per_thread):
+            mt = (ctypes.c_uint8 * 64)()
+            backing.append(mt)
+            capsules.append(c._make_dlpack_capsule(ctypes.addressof(mt)))
+        # Drop refs in reverse so the destructor calls don't all race
+        # with the thread's local frame teardown.
+        capsules.clear()
+        backing.clear()
+
+    threads = [threading.Thread(target=churn) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+
+    # Pump GC so any straggling capsules are finalized.
+    for _ in range(3):
+        gc.collect()
+
+    assert len(c._capsule_destructors) == initial_size, (
+        f"Registry must drain back to {initial_size} entries after concurrent "
+        f"churn; found {len(c._capsule_destructors)}. Either the lock isn't "
+        f"actually serializing dict mutations or the destructor's release "
+        f"path raced against the create path."
+    )

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
@@ -11,8 +11,8 @@ A real subprocess test (host registers a host-allocated OPAQUE_FD
 ``VkBuffer``, Python opens the cdylib, ``slpn_cuda_acquire_read`` →
 ``torch.from_dlpack`` → byte-equal assertion against the host pattern)
 requires a polyglot test harness that doesn't yet exist in tree —
-filed as a follow-up. This file exercises the Python module's
-contract against the cdylib's documented FFI ABI.
+filed as #596. This file exercises the Python module's contract
+against the cdylib's documented FFI ABI.
 """
 
 from __future__ import annotations
@@ -168,12 +168,23 @@ def test_capsule_destructor_registry_survives_concurrent_create_drop():
     """Stress the lock-guarded registry across many threads creating
     and dropping capsules concurrently.
 
-    Locks in the no-GIL-readiness property (review #5 from the
-    pr-review-gate): the registry must end up empty after every
-    capsule has been dropped + collected, regardless of interleaving.
-    Under PEP 703 free-threaded Python, dict mutations need explicit
-    locking — `threading.Lock` around `_retain_destructor` /
-    `_release_destructor` covers that.
+    On standard (GIL-protected) CPython this test passes whether the
+    `threading.Lock` is present or not — the GIL serializes dict ops
+    at the bytecode level, so the test alone can't catch a
+    missing-lock regression on a typical CI runner.
+
+    Where the test earns its keep is **PEP 703 free-threaded Python
+    (3.13t+)**: there, `_retain_destructor` and `_release_destructor`
+    can interleave on the dict and the explicit lock is what keeps
+    the registry coherent. Treating this as a no-GIL-readiness gate
+    means free-threaded CI (when we add it) catches a regression that
+    standard CI can't see.
+
+    The test still has standalone value on GIL-CPython: it confirms
+    the registry drains end-to-end across a many-threads churn
+    pattern (no leaked entries from a thread that didn't get cleaned
+    up; no double-pop crashes from a destructor running while
+    another thread is creating a new capsule).
     """
     import threading
     import gc

--- a/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib/src/linux/surface_share/unix_socket_service.rs
@@ -1235,10 +1235,18 @@ mod tests {
         );
     }
 
-    /// The service must refuse a check_in whose fd count exceeds the plane
-    /// cap instead of truncating silently. The check runs in the wire helper
-    /// before the handler, so this exercises the shared back-pressure path
-    /// every caller relies on.
+    /// The service must refuse a check_in whose fd count exceeds the wire
+    /// helper's SCM_RIGHTS cap instead of truncating silently. The check
+    /// runs in the wire helper before the handler, so this exercises the
+    /// shared back-pressure path every caller relies on.
+    ///
+    /// Cap shape (#588 / #559):
+    /// - `MAX_DMA_BUF_PLANES = 4` — the data-plane cap that adapters
+    ///   enforce; "this many plane fds, no more."
+    /// - `MAX_SCM_RIGHTS_FDS = MAX_DMA_BUF_PLANES + 1 = 5` — the wire-level
+    ///   cap that leaves a slot for an optional timeline-semaphore fd
+    ///   alongside the plane fds.
+    /// Sentinel: `MAX_SCM_RIGHTS_FDS + 1 = 6` is "one over the cap."
     #[test]
     fn oversize_fd_vec_rejected() {
         let state = SurfaceShareState::new();
@@ -1249,8 +1257,8 @@ mod tests {
 
         let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
 
-        // MAX_DMA_BUF_PLANES + 1 fds — one over the cap.
-        let fds: Vec<RawFd> = (0..=MAX_DMA_BUF_PLANES)
+        // MAX_SCM_RIGHTS_FDS + 1 fds — one over the wire-level cap.
+        let fds: Vec<RawFd> = (0..=MAX_SCM_RIGHTS_FDS)
             .map(|i| make_memfd_with(format!("plane-{}", i).as_bytes()))
             .collect();
 
@@ -1271,6 +1279,74 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 
         // Every caller fd is still valid; no leaks, no double-closes.
+        for fd in &fds {
+            let rc = unsafe { libc::fcntl(*fd, libc::F_GETFD) };
+            assert!(rc >= 0, "caller fd {} must still be valid", fd);
+            unsafe { libc::close(*fd) };
+        }
+
+        drop(stream);
+        service.stop();
+    }
+
+    /// Positive-case sibling of [`oversize_fd_vec_rejected`] — the wire
+    /// helper MUST accept exactly [`MAX_SCM_RIGHTS_FDS`] fds. Locks in
+    /// the high edge of the cap so a future cap shift fails loudly on
+    /// whichever edge actually moved (without this, only the
+    /// over-the-cap edge is regression-tested and a cap *increase* could
+    /// silently widen the wire surface).
+    #[test]
+    fn at_cap_fd_vec_accepted_by_wire_helper() {
+        // The wire helper itself is what we're gating — no daemon is
+        // needed beyond a connected socket so the helper's syscall path
+        // can run. Spinning up a real service-and-handler combo would
+        // also work but introduces ordering noise; the unit-level helper
+        // gate is the narrowest test.
+        let state = SurfaceShareState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+
+        // Exactly MAX_SCM_RIGHTS_FDS fds — the upper edge of the cap.
+        // Send-only: we don't care whether the daemon parses the JSON
+        // payload (it won't — `Custom` is a sentinel format string), only
+        // that the wire helper itself doesn't reject for fd-count.
+        let fds: Vec<RawFd> = (0..MAX_SCM_RIGHTS_FDS)
+            .map(|i| make_memfd_with(format!("at-cap-{}", i).as_bytes()))
+            .collect();
+        assert_eq!(fds.len(), MAX_SCM_RIGHTS_FDS);
+
+        let req = serde_json::json!({
+            "op": "check_in",
+            "runtime_id": "test-runtime-at-cap",
+            "width": 640,
+            "height": 480,
+            "format": "Custom",
+            "plane_sizes": vec![0u64; fds.len()],
+            "plane_offsets": vec![0u64; fds.len()],
+        });
+
+        // The wire helper must NOT reject for fd-count. The daemon may
+        // still error on payload parsing — we don't gate on the response,
+        // only on the helper's own input-validation step. A successful
+        // send (regardless of subsequent response shape) proves the cap
+        // edge is accepted.
+        let send_result = send_message_with_fds(
+            &stream,
+            req.to_string().as_bytes(),
+            &fds,
+        );
+        assert!(
+            send_result.is_ok(),
+            "wire helper must accept exactly MAX_SCM_RIGHTS_FDS={} fds; got {:?}",
+            MAX_SCM_RIGHTS_FDS,
+            send_result
+        );
+
+        // Caller fds are independent of what the daemon does — close them.
         for fd in &fds {
             let rc = unsafe { libc::fcntl(*fd, libc::F_GETFD) };
             assert!(rc >= 0, "caller fd {} must still be valid", fd);


### PR DESCRIPTION
## Summary

Pairs **#589** (Python cuda subprocess runtime + DLPack) and **#590** (Deno cuda subprocess runtime + DLPack) per the polyglot workflow rule. Wires `streamlib-adapter-cuda` into both `streamlib-python-native` and `streamlib-deno-native` so a subprocess customer can `acquire_read` / `acquire_write` a host-allocated OPAQUE_FD `VkBuffer` and consume it as a CUDA tensor via DLPack — `torch.from_dlpack(view.dlpack)` returns a CUDA tensor pointing at the host's GPU memory with no copy.

Also rolls in **#559** (1-line test fix that was failing on `main` before this PR).

## Closes

Closes #589
Closes #590
Closes #559

## What's in the PR

**Cdylib runtimes** (`slpn_cuda_*` / `sldn_cuda_*` FFI in both `streamlib-python-native` and `streamlib-deno-native`):
- Same single-pattern shape as cpu_readback / vulkan / opengl: `CudaSurfaceAdapter` is generic over `D: VulkanRhiDevice`, instantiated against `ConsumerVulkanDevice`.
- OPAQUE_FD `VkBuffer` + timeline imported into Vulkan via `streamlib-consumer-rhi`, AND into CUDA via `cudaImportExternalMemory` / `cudaImportExternalSemaphore`. CUDA device pointer cached for the surface's lifetime.
- Per-acquire flow: Vulkan-wait via the adapter, CUDA-wait via `cudaWaitExternalSemaphoresAsync_v2`, emit a fresh `*mut DLManagedTensor` whose owner holds an `Arc` clone of the registered surface (so the imported memory stays alive across the FFI handoff regardless of capsule release timing).
- No per-acquire IPC — host pipeline writes into the buffer and signals the timeline ambiently.

**Python wrapper** (`libs/streamlib-python/python/streamlib/adapters/cuda.py`):
- DLPack PyCapsule machinery handling both consumed (`used_dl_managed_tensor`) and unconsumed paths per the v0.8 spec.
- Lock-guarded destructor registry (`threading.Lock` + `id()` keying) so the trampoline outlives capsules under PEP 703 free-threaded Python.
- `c_void_p` argtype on `PyCapsule_GetName` / `PyCapsule_GetPointer` to avoid ctypes refcount manipulation against an object inside `tp_dealloc` (segfaulted on CPython 3.12+ with `py_object`).
- `with ctx.acquire_read(surface) as view: torch.from_dlpack(view.dlpack)` ergonomics.

**Deno wrapper** (`libs/streamlib-deno/adapters/cuda.ts`):
- Sync `using` / `Symbol.dispose` (cdylib FFI is synchronous all the way down — no per-acquire IPC like cpu_readback's trigger callback).
- Exposes raw `*mut DLManagedTensor` for future native consumers, with a `consume()` helper for explicit ownership transfer.
- `using guard = ctx.acquireRead(surface);` ergonomics.

**#559 fold-in** (`libs/streamlib/src/linux/surface_share/unix_socket_service.rs`):
- `oversize_fd_vec_rejected` test sentinel updated from `MAX_DMA_BUF_PLANES + 1` to `MAX_SCM_RIGHTS_FDS + 1` (the cap shifted with #531's timeline-semaphore slot).
- Adds `at_cap_fd_vec_accepted_by_wire_helper` positive-case sibling so both edges of the cap are regression-tested.

## Test plan

- [x] **Cdylib unit tests**: 3 each in `streamlib-python-native::cuda::tests` and `streamlib-deno-native::cuda::tests` — layout regression for `Slpn/SldnCudaView`, DLPack constants regression, runtime-construction panic-safety smoke test. All pass.
- [x] **Adapter-cuda tests**: 10 tests in `streamlib-adapter-cuda` (DLPack layout regression + behavioral). All pass.
- [x] **Python wrapper tests**: 8 tests in `test_adapters_cuda.py` — module import, FFI struct layout, DLPack constants, view dataclass round-trip, `pythonapi` PyCapsule wiring, destructor pin/release lifecycle, surface adapter method set, **concurrent-churn registry stress** (8 threads × 16 capsules). All pass.
- [x] **Deno wrapper tests**: 4 tests in `cuda_test.ts` — ABI version re-export, `CudaContext` method set, view interface round-trip, `CudaAccessGuard` sync `Disposable` shape. `deno check` clean.
- [x] **`cargo run -q -p xtask -- check-boundaries`**: 1918 files scanned, no violations.
- [x] **Cdylib boundary**: `cargo tree -p streamlib-{python,deno}-native | grep -c "^streamlib v"` returns **0** for both — `FullAccess` capability boundary remains type-system enforced.
- [x] **Pr-review-gate**: PASS on second pass, after addressing the first pass's 5 DISCUSS items + 3 cosmetic second-pass DISCUSS items.

## What's NOT in this PR

- **Polyglot subprocess byte-equal harness** (host registers OPAQUE_FD surface with a known pattern, spawns Python/Deno, asserts byte-equal via `torch.from_dlpack`). Filed as **#596** — no precedent for spawning-subprocess-and-asserting-via-FFI tests exists for any cdylib in tree (cpu_readback, vulkan, opengl all ship without one). Building it for cuda also closes the same gap for those three adapters retroactively.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno
- **Schema regenerated**: n/a (no escalate-IPC ops added — the cuda adapter has no per-acquire host work, so no `RunCudaCopy` / etc. needed)
- **Python and Deno both covered?** yes, paired in the same PR per `.claude/workflows/polyglot.md`
- **E2E tests run**:
  - [x] Host-Rust: `streamlib-adapter-cuda-helpers/tests/cuda_carve_out.rs` — full host-CUDA flow with OPAQUE_FD memory + timeline import (#587 / #588)
  - [x] Host-Rust: `streamlib-adapter-cuda-helpers/tests/opaque_fd_consumer_rhi_round_trip.rs` — surface-share + ConsumerVulkanDevice import path (#588 Stage 6)
  - [ ] Python subprocess: deferred to **#596**
  - [ ] Deno subprocess: deferred to **#596**
- **FD-passing path**: OPAQUE_FD (buffer) + OPAQUE_FD (timeline) — required by DLPack's flat-`void*` `DLTensor.data` contract (per #588's reasoning: only `cudaExternalMemoryGetMappedBuffer` produces a flat pointer, and only OPAQUE_FD `VkBuffer` works for that)

## Pre-existing issues observed during workspace baseline (not introduced by this PR)

- `streamlib-adapter-cpu-readback::round_trip_write_partial_modification_leaves_rest_untouched` and `streamlib-adapter-skia::skia_adapter_passes_run_conformance` flake under high-concurrency `cargo test --workspace` runs (likely the documented NVIDIA dual-VkDevice timing — see `docs/learnings/nvidia-dual-vulkan-device-crash.md`). Both pass standalone on this branch and on `main`. Not regressions.
- `streamlib-python-native` / `streamlib-deno-native` clippy `collapsible_if` warnings on lines 1080 / 1097 / 2057 are pre-existing and surfaced from a recent clippy version update; not in the cuda module's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)