### PR TITLE
feat(polyglot): uniform monotonic_now_ns() API across Python + Deno SDKs

### DIFF
--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -16,13 +16,13 @@ crate-type = ["cdylib"]
 [dependencies]
 streamlib-ipc-types = { path = "../streamlib-ipc-types" }
 iceoryx2 = "0.8.1"
+libc.workspace = true
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc.workspace = true
 streamlib-surface-client = { path = "../streamlib-surface-client" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -104,13 +104,25 @@ pub unsafe extern "C" fn sldn_context_destroy(ctx: *mut DenoNativeContext) {
     }
 }
 
-/// Get current monotonic time in nanoseconds.
+/// Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+///
+/// Values are comparable across processes on the same kernel — to host
+/// `Instant` reads and to the Python cdylib's [`slpn_monotonic_now_ns`].
+/// The canonical timestamp source for ALL polyglot work; do not use
+/// wall-clock APIs (`Date.now`, `performance.now`) for cross-process timing.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sldn_context_time_ns(_ctx: *const DenoNativeContext) -> i64 {
-    let duration = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    duration.as_nanos() as i64
+pub unsafe extern "C" fn sldn_monotonic_now_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts is a valid stack slot. CLOCK_MONOTONIC is supported on
+    // every platform this cdylib targets (Linux, macOS); the only failure
+    // mode is EFAULT/EINVAL, which our arguments make unreachable.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    (ts.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(ts.tv_nsec as u64)
 }
 
 // ============================================================================

--- a/libs/streamlib-deno/clock.ts
+++ b/libs/streamlib-deno/clock.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Canonical monotonic-clock timestamp source for the Deno SDK.
+ *
+ * Use `monotonicNowNs()` for any timestamp that needs to be compared
+ * across processes — frame stamps, escalate request IDs, log
+ * correlation tokens, anything that crosses the host/subprocess boundary.
+ *
+ * Wraps the cdylib's `sldn_monotonic_now_ns()` which calls
+ * `clock_gettime(CLOCK_MONOTONIC)` — identical to the syscall Rust's
+ * `std::time::Instant::now()` makes on Linux and to what
+ * `streamlib-python-native`'s `slpn_monotonic_now_ns()` does. Values
+ * from all three sources share the same kernel epoch and are directly
+ * comparable.
+ *
+ * Wall-clock APIs (`Date.now`, `performance.now`) are NOT comparable
+ * across processes — `Date.now` drifts under NTP, `performance.now` is
+ * relative to each process's `performance.timeOrigin`. Use them only
+ * when human-readable wall-clock time is genuinely required (e.g.
+ * ISO8601 log formatting).
+ */
+
+import type { NativeLib } from "./native.ts";
+
+let _lib: NativeLib | null = null;
+
+/**
+ * Wire the native FFI lib for `monotonicNowNs()`. Called by
+ * `subprocess_runner` after `loadNativeLib()`. Idempotent.
+ */
+export function install(lib: NativeLib): void {
+  _lib = lib;
+}
+
+/** Drop the cached lib reference. Test-only. */
+export function _resetForTests(): void {
+  _lib = null;
+}
+
+/**
+ * Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+ *
+ * Comparable across processes on the same kernel — to host Rust
+ * `Instant` reads and to the Python SDK's `streamlib.monotonic_now_ns()`.
+ *
+ * Throws if called before `install()` has wired the native lib —
+ * subprocess_runner installs it during startup so processor code can
+ * call this freely.
+ */
+export function monotonicNowNs(): bigint {
+  if (!_lib) {
+    throw new Error(
+      "streamlib clock not installed — call clock.install(lib) before " +
+        "monotonicNowNs() (subprocess_runner does this automatically)",
+    );
+  }
+  return _lib.symbols.sldn_monotonic_now_ns() as bigint;
+}

--- a/libs/streamlib-deno/clock_test.ts
+++ b/libs/streamlib-deno/clock_test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the canonical monotonic-clock timestamp source.
+ *
+ * Loads the actual streamlib-deno-native cdylib so the test exercises
+ * the real `clock_gettime(CLOCK_MONOTONIC)` syscall path, not a mock.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertThrows,
+} from "@std/assert";
+
+import * as clock from "./clock.ts";
+import { loadNativeLib, type NativeLib } from "./native.ts";
+
+function resolveNativeLibPath(): string {
+  const fromEnv = Deno.env.get("STREAMLIB_NATIVE_LIB_PATH");
+  if (fromEnv) return fromEnv;
+  // Fallback to the standard cargo target dir at workspace root. The
+  // tests assume the cdylib has been built (cargo build -p
+  // streamlib-deno-native).
+  const cwd = Deno.cwd();
+  // streamlib-deno tests run with cwd at libs/streamlib-deno; walk up.
+  return `${cwd}/../../target/debug/libstreamlib_deno_native.so`;
+}
+
+function withInstalledLib(): NativeLib {
+  const lib = loadNativeLib(resolveNativeLibPath());
+  clock.install(lib);
+  return lib;
+}
+
+Deno.test("monotonicNowNs returns a positive bigint", () => {
+  const lib = withInstalledLib();
+  try {
+    const value = clock.monotonicNowNs();
+    assertEquals(typeof value, "bigint");
+    assertGreater(value, 0n);
+  } finally {
+    clock._resetForTests();
+    lib.close();
+  }
+});
+
+Deno.test("monotonicNowNs is non-decreasing across N consecutive calls", () => {
+  const lib = withInstalledLib();
+  try {
+    const samples: bigint[] = [];
+    for (let i = 0; i < 1000; i++) samples.push(clock.monotonicNowNs());
+    for (let i = 1; i < samples.length; i++) {
+      assertGreaterOrEqual(
+        samples[i],
+        samples[i - 1],
+        `clock went backwards at i=${i}: ${samples[i]} < ${samples[i - 1]}`,
+      );
+    }
+  } finally {
+    clock._resetForTests();
+    lib.close();
+  }
+});
+
+Deno.test("monotonicNowNs advances under CPU load", () => {
+  const lib = withInstalledLib();
+  try {
+    const start = clock.monotonicNowNs();
+    let acc = 0;
+    for (let i = 0; i < 100_000; i++) acc += i;
+    const end = clock.monotonicNowNs();
+    assertGreater(
+      end - start,
+      1_000n,
+      `clock barely moved: ${end - start} ns`,
+    );
+    assert(acc > 0); // keep the optimizer honest
+  } finally {
+    clock._resetForTests();
+    lib.close();
+  }
+});
+
+Deno.test("monotonicNowNs has sub-microsecond resolution", () => {
+  const lib = withInstalledLib();
+  try {
+    let foundSubUs = false;
+    for (let i = 0; i < 1000; i++) {
+      const a = clock.monotonicNowNs();
+      const b = clock.monotonicNowNs();
+      const delta = b - a;
+      if (delta > 0n && delta < 1_000n) {
+        foundSubUs = true;
+        break;
+      }
+    }
+    assert(foundSubUs, "expected at least one sub-microsecond delta");
+  } finally {
+    clock._resetForTests();
+    lib.close();
+  }
+});
+
+Deno.test("monotonicNowNs throws before install()", () => {
+  // Defensive — _resetForTests should have left the module uninstalled.
+  clock._resetForTests();
+  assertThrows(
+    () => clock.monotonicNowNs(),
+    Error,
+    "streamlib clock not installed",
+  );
+});

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -163,8 +163,15 @@ export class NativeProcessorState {
     return this.escalate.releaseHandle(handleId);
   }
 
+  /**
+   * Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+   *
+   * Comparable across processes — to host Rust `Instant` reads and to
+   * the Python SDK's `streamlib.monotonic_now_ns()`. Equivalent to the
+   * module-level `monotonicNowNs(lib)`.
+   */
   get timeNs(): bigint {
-    return this.lib.symbols.sldn_context_time_ns(this.ctxPtr) as bigint;
+    return this.lib.symbols.sldn_monotonic_now_ns() as bigint;
   }
 
   /** Construct a full-access GPU view (allocations + resolution). */

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -38,6 +38,7 @@ import type {
   EscalateResponseErr,
   EscalateResponseOk,
 } from "./_generated_/com_streamlib_escalate_response.ts";
+import { monotonicNowNs } from "./clock.ts";
 
 export type {
   EscalateRequest,
@@ -358,8 +359,18 @@ export class EscalateChannel {
   private nextRequestId(): string {
     this.counter += 1;
     // Short correlation id is enough — request_id only has to be unique
-    // within this subprocess's escalate channel.
-    return `dn-${Date.now().toString(36)}-${this.counter}`;
+    // within this subprocess's escalate channel. Stamps with the
+    // canonical monotonic clock for cross-process consistency; falls
+    // back to `Date.now()` only if the clock isn't installed yet (which
+    // can happen during early bridge handshakes before subprocess_runner
+    // wires the FFI lib).
+    let stamp: number;
+    try {
+      stamp = Number(monotonicNowNs() & 0xffffffffn);
+    } catch {
+      stamp = Date.now();
+    }
+    return `dn-${stamp.toString(36)}-${this.counter}`;
   }
 }
 

--- a/libs/streamlib-deno/mod.ts
+++ b/libs/streamlib-deno/mod.ts
@@ -33,3 +33,9 @@ export type { NativeLib } from "./native.ts";
 
 // Unified polyglot logging — see issue #444 / parent #430.
 export * as log from "./log.ts";
+
+// Canonical monotonic timestamp source — `clock_gettime(CLOCK_MONOTONIC)`.
+// Use for any timestamp that crosses the host/subprocess boundary or is
+// compared against another runtime's stamps.
+export { monotonicNowNs } from "./clock.ts";
+export * as clock from "./clock.ts";

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -18,9 +18,9 @@ const symbols = {
     parameters: ["pointer"] as const,
     result: "void" as const,
   },
-  sldn_context_time_ns: {
-    parameters: ["pointer"] as const,
-    result: "i64" as const,
+  sldn_monotonic_now_ns: {
+    parameters: [] as const,
+    result: "u64" as const,
   },
 
   // Input

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -30,6 +30,7 @@ import {
   resolveEscalateFd,
   writeFrame as writeEscalateFrame,
 } from "./escalate_fd.ts";
+import * as clock from "./clock.ts";
 import * as log from "./log.ts";
 import type {
   ContinuousProcessor,
@@ -165,6 +166,10 @@ async function main(): Promise<void> {
     await log.shutdown();
     Deno.exit(1);
   }
+
+  // Wire the canonical monotonic clock to the FFI before any code that
+  // might call `monotonicNowNs()` runs.
+  clock.install(lib);
 
   // Create native context
   const processorIdBuf = cString(processorId);

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -128,13 +128,31 @@ async function main(): Promise<void> {
 
   // Escalate channel — requests from the TS processor go out on stdout,
   // host responses arrive on stdin and are routed here from every stdin
-  // read site (outer loop + run-phase concurrent reader). Constructed
-  // BEFORE installing logging so `log.install` has a channel to drain to.
+  // read site (outer loop + run-phase concurrent reader).
   const escalateChannel = new EscalateChannel(bridgeSendJson);
   // Process-wide singleton so SDK helpers (e.g. `CpuReadbackContext`)
   // can reach the channel without it being threaded through every
   // call site. Mirrors the Python SDK's `install_channel`.
   installChannel(escalateChannel);
+
+  // Load the native library and wire the canonical monotonic clock
+  // BEFORE installing logging, so the very first log record's escalate
+  // request_id stamps with `monotonicNowNs()` and not the documented
+  // `Date.now()` fallback.
+  let lib: NativeLib;
+  try {
+    lib = loadNativeLib(nativeLibPath);
+  } catch (e) {
+    // Log channel isn't installed yet, so the failure can't go through
+    // `log.error`; surface to host via the bridge + raw stderr instead.
+    await bridgeSendJson({
+      rpc: "error",
+      error: `Failed to load native lib: ${e}`,
+    });
+    closeLibcHandle();
+    fatalPreInstall(`Failed to load native lib: ${e}`);
+  }
+  clock.install(lib);
 
   // Install unified logging: writer task + console / Deno.stdout/stderr
   // interceptors. After this point, `console.*` and `Deno.stdout.write`
@@ -151,25 +169,6 @@ async function main(): Promise<void> {
     native_lib: nativeLibPath,
     execution_mode: executionMode,
   });
-
-  // Load native library
-  let lib: NativeLib;
-  try {
-    lib = loadNativeLib(nativeLibPath);
-  } catch (e) {
-    log.error("Failed to load native lib", {
-      processor_id: processorId,
-      error: String(e),
-    });
-    await bridgeSendJson({ rpc: "error", error: `Failed to load native lib: ${e}` });
-    closeLibcHandle();
-    await log.shutdown();
-    Deno.exit(1);
-  }
-
-  // Wire the canonical monotonic clock to the FFI before any code that
-  // might call `monotonicNowNs()` runs.
-  clock.install(lib);
 
   // Create native context
   const processorIdBuf = cString(processorId);

--- a/libs/streamlib-deno/types.ts
+++ b/libs/streamlib-deno/types.ts
@@ -1,6 +1,27 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+/**
+ * # Timestamps
+ *
+ * For any timestamp that crosses the host/subprocess boundary or is
+ * compared against another runtime's stamps — frame stamps (the
+ * `timestampNs` parameter on `OutputPorts.write` is the canonical case),
+ * log correlation, escalate request IDs, anything similar — use
+ * `monotonicNowNs()` from `mod.ts`. It calls
+ * `clock_gettime(CLOCK_MONOTONIC)`, the same kernel syscall the host
+ * Rust runtime and the Python SDK make, so values share a system-wide
+ * epoch and are directly comparable.
+ *
+ * Do NOT use `Date.now()` or `performance.now()` for cross-process
+ * timestamps. `Date.now()` is wall-clock and drifts under NTP;
+ * `performance.now()` is relative to the Deno process's
+ * `performance.timeOrigin` (process start), so two Deno subprocesses
+ * spawned at different instants get different "0" points. Wall-clock
+ * APIs remain appropriate for ISO8601 formatting and other genuinely
+ * human-facing display.
+ */
+
 import type { EscalateOkResponse } from "./escalate.ts";
 
 /**

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib"]
 [dependencies]
 streamlib-ipc-types = { path = "../streamlib-ipc-types" }
 iceoryx2 = "0.8.1"
+libc.workspace = true
 rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc.workspace = true
 streamlib-surface-client = { path = "../streamlib-surface-client" }
 # Subprocess-side OpenGl runtime (#530). Reuses the host adapter crate's
 # EglRuntime + OpenGlSurfaceAdapter so subprocess code never re-derives EGL

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -105,13 +105,25 @@ pub unsafe extern "C" fn slpn_context_destroy(ctx: *mut PythonNativeContext) {
     }
 }
 
-/// Get current monotonic time in nanoseconds.
+/// Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+///
+/// Values are comparable across processes on the same kernel — to host
+/// `Instant` reads and to the Deno cdylib's [`sldn_monotonic_now_ns`].
+/// The canonical timestamp source for ALL polyglot work; do not use
+/// wall-clock APIs (`time.time`, `Date.now`) for cross-process timing.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slpn_context_time_ns(_ctx: *const PythonNativeContext) -> i64 {
-    let duration = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    duration.as_nanos() as i64
+pub unsafe extern "C" fn slpn_monotonic_now_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts is a valid stack slot. CLOCK_MONOTONIC is supported on
+    // every platform this cdylib targets (Linux, macOS); the only failure
+    // mode is EFAULT/EINVAL, which our arguments make unreachable.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    (ts.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(ts.tv_nsec as u64)
 }
 
 // ============================================================================

--- a/libs/streamlib-python/python/streamlib/__init__.py
+++ b/libs/streamlib-python/python/streamlib/__init__.py
@@ -32,6 +32,11 @@ class PixelFormat:
 # Routes through the escalate-IPC `{op:"log"}` path to the host JSONL.
 from . import log
 
+# Canonical monotonic timestamp source — `clock_gettime(CLOCK_MONOTONIC)`.
+# Use for any timestamp that crosses the host/subprocess boundary or is
+# compared against another runtime's stamps.
+from .clock import monotonic_now_ns
+
 # Re-export decorators and schema API
 from .decorators import (
     # Processor decorators
@@ -71,6 +76,8 @@ GpuContextLimitedAccess = NativeGpuContextLimitedAccess
 __all__ = [
     # Unified logging
     "log",
+    # Canonical timestamp source
+    "monotonic_now_ns",
     # Processor decorators
     "processor",
     "input",

--- a/libs/streamlib-python/python/streamlib/clock.py
+++ b/libs/streamlib-python/python/streamlib/clock.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Canonical monotonic-clock timestamp source for the Python SDK.
+
+Use `streamlib.monotonic_now_ns()` for any timestamp that needs to be
+compared across processes — frame stamps, escalate request IDs, log
+correlation tokens, anything that crosses the host/subprocess boundary.
+
+The function calls `clock_gettime(CLOCK_MONOTONIC)` via Python's `time`
+module — identical to the syscall `streamlib-python-native`'s
+`slpn_monotonic_now_ns()` makes, and to the syscall Rust's
+`std::time::Instant::now()` makes on Linux. Values from all three
+sources share the same kernel epoch and are directly comparable.
+
+Wall-clock APIs (`time.time`, `datetime.now`, `time.time_ns`) are NOT
+comparable across processes — they drift under NTP and reflect
+different epochs. Use them only when human-readable wall-clock time
+is genuinely required (e.g. ISO8601 log formatting).
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def monotonic_now_ns() -> int:
+    """Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+
+    Comparable across processes on the same kernel — to host Rust
+    `Instant` reads and to the Deno SDK's `monotonicNowNs()`.
+    """
+    return time.clock_gettime_ns(time.CLOCK_MONOTONIC)

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -10,6 +10,23 @@ to integrate with the Rust runtime.
 Schema decorators allow defining custom data schemas that are backed by
 Rust's DynamicDataFrameSchema, enabling seamless data flow between Python
 and Rust processors.
+
+Timestamps
+----------
+
+For any timestamp that crosses the host/subprocess boundary or is
+compared against another runtime's stamps — frame stamps, log
+correlation, escalate request IDs, anything similar — use
+``streamlib.monotonic_now_ns()``. It calls
+``clock_gettime(CLOCK_MONOTONIC)``, the same kernel syscall the host
+Rust runtime and the Deno SDK make, so values share a system-wide
+epoch and are directly comparable.
+
+Do NOT use ``time.time()``, ``datetime.now()``, or ``time.time_ns()``
+for cross-process timestamps — wall-clock APIs drift under NTP and
+reflect different epochs from one process to the next. Wall-clock
+APIs are still appropriate for ISO8601 formatting and other genuinely
+human-facing display.
 """
 
 from typing import Optional, Union, List, Type

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -126,8 +126,8 @@ def load_native_lib(lib_path):
     lib.slpn_context_create.restype = ctypes.c_void_p
     lib.slpn_context_destroy.argtypes = [ctypes.c_void_p]
     lib.slpn_context_destroy.restype = None
-    lib.slpn_context_time_ns.argtypes = [ctypes.c_void_p]
-    lib.slpn_context_time_ns.restype = ctypes.c_int64
+    lib.slpn_monotonic_now_ns.argtypes = []
+    lib.slpn_monotonic_now_ns.restype = ctypes.c_uint64
 
     # Input
     lib.slpn_input_subscribe.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
@@ -310,7 +310,7 @@ class NativeOutputs:
         import ctypes
 
         if timestamp_ns is None:
-            timestamp_ns = self._lib.slpn_context_time_ns(self._ctx_ptr)
+            timestamp_ns = self._lib.slpn_monotonic_now_ns()
 
         packed = msgpack.packb(data, use_bin_type=True)
         data_buf = (ctypes.c_uint8 * len(packed))(*packed)
@@ -600,8 +600,13 @@ class NativeProcessorState:
 
     @property
     def time(self) -> int:
-        """Current monotonic time in nanoseconds."""
-        return self._lib.slpn_context_time_ns(self._ctx_ptr)
+        """Current monotonic time in nanoseconds via `clock_gettime(CLOCK_MONOTONIC)`.
+
+        Comparable across processes — to host Rust `Instant` reads and to
+        the Deno SDK's `monotonicNowNs()`. Equivalent to the module-level
+        `streamlib.monotonic_now_ns()`.
+        """
+        return self._lib.slpn_monotonic_now_ns()
 
     def gpu_limited_access(self) -> NativeGpuContextLimitedAccess:
         """Return the limited-access GPU view (resolution only)."""

--- a/libs/streamlib-python/python/streamlib/tests/test_clock.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_clock.py
@@ -3,9 +3,33 @@
 
 """Tests for the canonical monotonic-clock timestamp source."""
 
+import ctypes
+import os
 import time
+from pathlib import Path
+
+import pytest
 
 import streamlib
+
+
+def _locate_python_native_lib():
+    """Find `libstreamlib_python_native.so` for direct ctypes loading.
+
+    Mirrors the resolution other polyglot tests use (env var override,
+    else workspace `target/{debug,release}` walk).
+    """
+    env = os.environ.get("STREAMLIB_PYTHON_NATIVE_LIB")
+    if env and Path(env).exists():
+        return Path(env)
+    here = Path(__file__).resolve()
+    # tests/test_clock.py → streamlib/ → python/ → streamlib-python/ → libs/ → workspace.
+    workspace = here.parents[5]
+    for profile in ("debug", "release"):
+        candidate = workspace / "target" / profile / "libstreamlib_python_native.so"
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def test_monotonic_now_ns_returns_int():
@@ -47,6 +71,50 @@ def test_monotonic_matches_clock_gettime_within_jitter():
     # The two streamlib reads bracket the time-module read; the
     # time-module read must fall within them (modulo monotonicity).
     assert a <= b <= c, f"out of order: a={a}, b={b}, c={c}"
+
+
+@pytest.fixture(scope="module")
+def cdylib():
+    """Lazily load `libstreamlib_python_native.so` for direct FFI tests.
+
+    Skips the test cleanly when the cdylib hasn't been built (CI runs
+    that build only the Python wheel, not the workspace).
+    """
+    path = _locate_python_native_lib()
+    if path is None:
+        pytest.skip(
+            "libstreamlib_python_native.so not built — "
+            "run `cargo build -p streamlib-python-native` first",
+        )
+    lib = ctypes.CDLL(str(path))
+    lib.slpn_monotonic_now_ns.argtypes = []
+    lib.slpn_monotonic_now_ns.restype = ctypes.c_uint64
+    return lib
+
+
+def test_cdylib_slpn_monotonic_now_ns_matches_clock_gettime(cdylib):
+    """The cdylib export must read CLOCK_MONOTONIC, not wall-clock.
+
+    Pins the Rust body so a regression to `SystemTime::now()` (the
+    pre-#545 behavior) breaks this test. Brackets a `clock_gettime`
+    read with two cdylib reads — the cdylib values must surround
+    the direct syscall value, which can only happen if the cdylib
+    is reading the same kernel CLOCK_MONOTONIC source.
+    """
+    a = cdylib.slpn_monotonic_now_ns()
+    b = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+    c = cdylib.slpn_monotonic_now_ns()
+    assert a <= b <= c, (
+        f"cdylib reads outside CLOCK_MONOTONIC: a={a}, gettime={b}, c={c}. "
+        "If a > b > c by years, the cdylib likely reverted to wall-clock."
+    )
+
+
+def test_cdylib_slpn_monotonic_now_ns_is_non_decreasing(cdylib):
+    """N consecutive cdylib calls produce a non-decreasing sequence."""
+    samples = [cdylib.slpn_monotonic_now_ns() for _ in range(1000)]
+    for prev, curr in zip(samples, samples[1:]):
+        assert curr >= prev, f"cdylib clock went backwards: {curr} < {prev}"
 
 
 def test_sub_microsecond_resolution():

--- a/libs/streamlib-python/python/streamlib/tests/test_clock.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_clock.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for the canonical monotonic-clock timestamp source."""
+
+import time
+
+import streamlib
+
+
+def test_monotonic_now_ns_returns_int():
+    """Public API returns a Python int (not float, not bytes)."""
+    value = streamlib.monotonic_now_ns()
+    assert isinstance(value, int)
+    assert value > 0
+
+
+def test_monotonic_non_decreasing_across_calls():
+    """N consecutive calls produce a non-decreasing sequence."""
+    samples = [streamlib.monotonic_now_ns() for _ in range(1000)]
+    for prev, curr in zip(samples, samples[1:]):
+        assert curr >= prev, f"clock went backwards: {curr} < {prev}"
+
+
+def test_monotonic_advances_under_load():
+    """Clock advances by at least a few microseconds across a busy loop."""
+    start = streamlib.monotonic_now_ns()
+    # Burn a small amount of CPU; deliberately not time.sleep to avoid
+    # hiding a stuck clock behind a sleeping kernel.
+    accumulator = 0
+    for i in range(100_000):
+        accumulator += i
+    end = streamlib.monotonic_now_ns()
+    assert end - start > 1_000, f"clock barely moved: {end - start} ns"
+
+
+def test_monotonic_matches_clock_gettime_within_jitter():
+    """Public API agrees with `clock_gettime(CLOCK_MONOTONIC)` modulo wake-up jitter.
+
+    Pins the canonical-source contract: `streamlib.monotonic_now_ns()`
+    is identical to the syscall both the cdylib and Rust's `Instant::now()`
+    make.
+    """
+    a = streamlib.monotonic_now_ns()
+    b = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
+    c = streamlib.monotonic_now_ns()
+    # The two streamlib reads bracket the time-module read; the
+    # time-module read must fall within them (modulo monotonicity).
+    assert a <= b <= c, f"out of order: a={a}, b={b}, c={c}"
+
+
+def test_sub_microsecond_resolution():
+    """Two consecutive reads can differ by less than 1µs (sub-µs resolution)."""
+    # Take many pairs and check at least one pair has sub-µs delta. On
+    # modern Linux clock_gettime resolves to ~10-100ns so this should
+    # happen within a handful of iterations; we sample widely to make
+    # the test robust against scheduling jitter.
+    found_sub_us = False
+    for _ in range(1000):
+        a = streamlib.monotonic_now_ns()
+        b = streamlib.monotonic_now_ns()
+        if 0 < (b - a) < 1_000:
+            found_sub_us = True
+            break
+    assert found_sub_us, "expected at least one sub-microsecond delta"

--- a/libs/streamlib/tests/polyglot_linux_monotonic_clock_parity.rs
+++ b/libs/streamlib/tests/polyglot_linux_monotonic_clock_parity.rs
@@ -1,0 +1,294 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-runtime monotonic-clock parity test (#545).
+//!
+//! Validates that `streamlib.monotonic_now_ns()` (Python),
+//! `monotonicNowNs()` (Deno), and `clock_gettime(CLOCK_MONOTONIC)` (host
+//! Rust) all read from the same kernel-wide clock — i.e. their values
+//! fall within a tight wall-time window when captured in lock-step.
+//!
+//! Pattern: each subprocess starts up, blocks on stdin, and on a single
+//! signal byte captures its monotonic value and writes it to stdout. The
+//! host samples its own value immediately before and after the signal.
+//! All three values must fall within a bounded delta — the bound is
+//! orchestration jitter (signal RTT through stdin/stdout), not the
+//! clock itself.
+//!
+//! Skips cleanly when prerequisites are missing (no python3, no deno, no
+//! cdylib built).
+//!
+//! Closes #545.
+
+#![cfg(target_os = "linux")]
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Locate `libstreamlib_python_native.so` under the workspace target dir.
+fn locate_python_native_lib() -> Option<PathBuf> {
+    locate_native_lib("libstreamlib_python_native.so")
+}
+
+/// Locate `libstreamlib_deno_native.so` under the workspace target dir.
+fn locate_deno_native_lib() -> Option<PathBuf> {
+    locate_native_lib("libstreamlib_deno_native.so")
+}
+
+fn locate_native_lib(file_name: &str) -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    for profile in &["debug", "release"] {
+        let candidate = workspace.join("target").join(profile).join(file_name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn binary_available(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn host_monotonic_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: ts is a valid stack slot; CLOCK_MONOTONIC is supported on Linux.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    (ts.tv_sec as u64) * 1_000_000_000 + ts.tv_nsec as u64
+}
+
+fn python_driver_source() -> &'static str {
+    // Reads one byte from stdin (the signal); captures monotonic;
+    // writes "<value>\n" to stdout; exits.
+    r#"
+import sys
+
+# Add the SDK package path before import so we don't need it pip-installed.
+sys.path.insert(0, sys.argv[1])
+
+import streamlib
+
+sys.stdin.buffer.read(1)
+ns = streamlib.monotonic_now_ns()
+sys.stdout.write(str(ns) + "\n")
+sys.stdout.flush()
+"#
+}
+
+fn deno_driver_source(deno_pkg_dir: &str, native_lib: &str) -> String {
+    // Equivalent driver for Deno. Loads the cdylib and the SDK directly
+    // from the workspace path; no jsr install required.
+    format!(
+        r#"
+import {{ loadNativeLib }} from "{deno_pkg_dir}/native.ts";
+import * as clock from "{deno_pkg_dir}/clock.ts";
+
+const lib = loadNativeLib("{native_lib}");
+clock.install(lib);
+
+// Read one byte from stdin as the start signal.
+const buf = new Uint8Array(1);
+await Deno.stdin.read(buf);
+
+const ns = clock.monotonicNowNs();
+const text = new TextEncoder().encode(ns.toString() + "\n");
+await Deno.stdout.write(text);
+"#
+    )
+}
+
+#[test]
+fn python_and_deno_monotonic_clocks_share_epoch_with_host() {
+    let py_native_lib = match locate_python_native_lib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "polyglot_linux_monotonic_clock_parity: libstreamlib_python_native.so not \
+                 built; run `cargo build -p streamlib-python-native` first — skipping"
+            );
+            return;
+        }
+    };
+    let deno_native_lib = match locate_deno_native_lib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "polyglot_linux_monotonic_clock_parity: libstreamlib_deno_native.so not \
+                 built; run `cargo build -p streamlib-deno-native` first — skipping"
+            );
+            return;
+        }
+    };
+    if !binary_available("python3") {
+        eprintln!("polyglot_linux_monotonic_clock_parity: python3 not on PATH — skipping");
+        return;
+    }
+    if !binary_available("deno") {
+        eprintln!("polyglot_linux_monotonic_clock_parity: deno not on PATH — skipping");
+        return;
+    }
+
+    // Resolve SDK source paths at the workspace.
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let workspace = PathBuf::from(&manifest_dir).join("..").join("..");
+    let python_pkg = workspace
+        .join("libs/streamlib-python/python")
+        .canonicalize()
+        .expect("python pkg path");
+    let deno_pkg = workspace
+        .join("libs/streamlib-deno")
+        .canonicalize()
+        .expect("deno pkg path");
+
+    // Write the deno driver to a temp file (Deno doesn't accept inline
+    // module sources via -e + bare import specifiers).
+    let deno_driver = deno_driver_source(
+        deno_pkg.to_str().unwrap(),
+        deno_native_lib.to_str().unwrap(),
+    );
+    let tmp_dir = std::env::temp_dir().join("streamlib-clock-parity");
+    std::fs::create_dir_all(&tmp_dir).expect("create tmp dir");
+    let deno_driver_path = tmp_dir.join("clock_parity.ts");
+    std::fs::write(&deno_driver_path, &deno_driver).expect("write deno driver");
+
+    // Spawn python.
+    let mut python = Command::new("python3")
+        .arg("-c")
+        .arg(python_driver_source())
+        .arg(python_pkg.to_str().unwrap())
+        .env("STREAMLIB_PYTHON_NATIVE", py_native_lib.to_str().unwrap())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3");
+
+    // Spawn deno. Permit-flags scoped to what the driver actually uses.
+    let mut deno = Command::new("deno")
+        .arg("run")
+        .arg("--quiet")
+        .arg("--allow-ffi")
+        .arg("--allow-read")
+        .arg(deno_driver_path.to_str().unwrap())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn deno");
+
+    // Both subprocesses block on stdin. Send the signal as close together
+    // in wall-time as possible, bracketing with host monotonic samples.
+    let host_before = host_monotonic_ns();
+    python
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"\x01")
+        .expect("signal python");
+    deno.stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"\x01")
+        .expect("signal deno");
+    // Drop stdins to flush + close so the child reads return immediately.
+    drop(python.stdin.take());
+    drop(deno.stdin.take());
+
+    // Drain outputs. Each writes a single decimal nanosecond value + newline.
+    let mut py_out = String::new();
+    python
+        .stdout
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut py_out)
+        .expect("read python stdout");
+    let mut deno_out = String::new();
+    deno.stdout
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut deno_out)
+        .expect("read deno stdout");
+    let host_after = host_monotonic_ns();
+
+    let py_status = python.wait().expect("python wait");
+    let deno_status = deno.wait().expect("deno wait");
+
+    if !py_status.success() {
+        let mut stderr = String::new();
+        python
+            .stderr
+            .as_mut()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .ok();
+        panic!("python driver failed: status={py_status:?} stderr={stderr}");
+    }
+    if !deno_status.success() {
+        let mut stderr = String::new();
+        deno.stderr
+            .as_mut()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .ok();
+        panic!("deno driver failed: status={deno_status:?} stderr={stderr}");
+    }
+
+    let py_ns: u64 = py_out
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("python value not a u64 (got {py_out:?}): {e}"));
+    let deno_ns: u64 = deno_out
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("deno value not a u64 (got {deno_out:?}): {e}"));
+
+    // Pin the same-clock-domain invariant. Each subprocess captured its
+    // value strictly between `host_before` and `host_after`, modulo
+    // signal RTT and stdin-buffering jitter. Because the host samples
+    // and the subprocess samples both call `clock_gettime(CLOCK_MONOTONIC)`,
+    // values are directly comparable and cannot disagree by more than
+    // the orchestration window.
+    //
+    // Window bound: 50 ms. Generous enough to absorb stdin-buffering /
+    // process scheduling on a CI host, tight enough that a wrong-clock
+    // bug (e.g. CLOCK_REALTIME drifting NTP-corrected, or a per-process
+    // origin-relative timestamp) would blow it out by orders of magnitude.
+    const WINDOW_NS: u64 = 50_000_000;
+
+    let window = host_after.saturating_sub(host_before);
+    assert!(
+        py_ns >= host_before.saturating_sub(WINDOW_NS)
+            && py_ns <= host_after.saturating_add(WINDOW_NS),
+        "python clock outside host window: host_before={host_before} host_after={host_after} \
+         py={py_ns} window={window}",
+    );
+    assert!(
+        deno_ns >= host_before.saturating_sub(WINDOW_NS)
+            && deno_ns <= host_after.saturating_add(WINDOW_NS),
+        "deno clock outside host window: host_before={host_before} host_after={host_after} \
+         deno={deno_ns} window={window}",
+    );
+
+    let py_to_deno_delta = py_ns.abs_diff(deno_ns);
+    assert!(
+        py_to_deno_delta <= WINDOW_NS,
+        "python and deno clocks disagree beyond orchestration window: \
+         py={py_ns} deno={deno_ns} delta={py_to_deno_delta}",
+    );
+
+    eprintln!(
+        "polyglot_linux_monotonic_clock_parity: pass — host[{host_before}..{host_after}] \
+         py={py_ns} deno={deno_ns} (delta_py_deno={py_to_deno_delta} ns)"
+    );
+}


### PR DESCRIPTION
## Summary

- **Rename + fix in place** of the cdylib's misnamed `*_context_time_ns` exports (which took an unused `_ctx` arg and called `SystemTime::now()` despite claiming monotonic) → `*_monotonic_now_ns()` calling `clock_gettime(CLOCK_MONOTONIC)` and returning `u64`. Pre-1.0 → no deprecated alias.
- **Public API**: `streamlib.monotonic_now_ns()` (Python) and `monotonicNowNs()` (Deno), wired through subprocess_runner. Three runtimes (host Rust, Python, Deno) now read the same kernel-wide clock; subprocess timestamps are directly comparable to host stamps.
- **Cross-runtime parity test** (`polyglot_linux_monotonic_clock_parity.rs`): spawns Python and Deno subprocesses, signals each through stdin in lock-step, asserts all three monotonic reads fall within a 50 ms host orchestration window.

## Closes

Closes #545

## Scope correction (vs. issue body's audit)

The issue's "audit and replace every wall-clock timestamp" framing surfaced a tension on closer inspection: log records' `source_ts` field (in `log.py` and `log.ts`) is **legitimately wall-clock** because it feeds ISO8601 formatting via `_format_source_ts` / `formatSourceTs`. The host attaches its own `host_ts` as the cross-process correlation primitive (see comment in `log.ts:234`), so the migration intentionally **does not** touch those 5 sites in each runtime. The frame-default-stamp path (`processor_context.write` / `context.ts`'s `timeNs` getter) and the escalate request-ID correlation suffix (`escalate.ts:362`) — the actual cross-process-comparison call sites — **are** migrated.

A separate follow-up could add a `source_monotonic_ns` field alongside `source_ts` in the polyglot log schema if cross-process log ordering becomes load-bearing; out of scope here as it requires schema regen across all three runtimes.

The Apple `iosurface` pool-UUID stamps in both natives use a wall-clock stamp as a uniqueness suffix on a UUID, not a clock-domain primitive. Left as-is; uniqueness is preserved either way.

The "lint to flag non-canonical clocks in customer code" exit criterion was marked stretch in the issue body; deferred as a separate hardening issue if substantial.

## Pre-PR review gate

`pr-review-gate` ran with verdict `DISCUSS` and flagged 2 items — both verified as real and addressed in the second commit:

1. **cdylib body not pinned by a direct test** — `streamlib.monotonic_now_ns()` calls `time.clock_gettime_ns` directly (not the cdylib), so the original Python tests wouldn't have caught a regression of `slpn_monotonic_now_ns` back to `SystemTime::now()`. Added two cdylib-direct ctypes tests in `test_clock.py` that load the `.so` and call the export — `test_cdylib_slpn_monotonic_now_ns_matches_clock_gettime` brackets a `clock_gettime` read with two cdylib reads, so a wall-clock revert (which would yield ~1.7e18 vs ~6.6e14) fails the assertion.
2. **`subprocess_runner.ts` install ordering** — `clock.install` ran AFTER `log.install`, so `log.info("Subprocess runner starting", …)` and any pre-lib-load log records had their escalate request-ids stamped via the documented `Date.now()` fallback. Reordered: load lib + install clock BEFORE `log.install`, so the very first record carries a monotonic stamp. Lib-load failures now route through the bridge + raw stderr (no log channel yet).

## Test plan

- [x] **Python unit tests** (`test_clock.py`): `pytest python/streamlib/tests/test_clock.py -v` → 7 passed (5 public-API tests + 2 new cdylib-direct tests).
- [x] **Python full suite**: `pytest python/streamlib/tests/` → 75 passed.
- [x] **Deno unit tests** (`clock_test.ts`): `deno test --allow-ffi --allow-env --allow-read --no-check clock_test.ts` → 5 passed.
- [x] **Deno full suite**: `deno test --no-check` → 63 passed (`--no-check` skips pre-existing type errors in `adapters/vulkan.ts` that exist on `main`).
- [x] **Cross-runtime parity**: `cargo test -p streamlib --test polyglot_linux_monotonic_clock_parity` → 1 passed. Sample run: host=[660627744462053..660627787179760] py=660627770283702 deno=660627778382833 (delta_py_deno=8.1ms, both within 50ms host window).
- [x] **Workspace `cargo check --workspace --tests`**: clean.
- [x] **Boundary check**: `cargo xtask check-boundaries` — `1927 file(s) scanned, no violations`.

## Polyglot coverage

- **Runtimes affected**: rust (parity test) | python | deno
- **Schema regenerated**: n/a (no JTD schema changes)
- **Python and Deno both covered?** yes — symmetric public API, symmetric cdylib export, symmetric internal-caller migration.
- **E2E tests run**:
  - [x] Host-Rust: `polyglot_linux_monotonic_clock_parity` — pass
  - [x] Python subprocess: driven via parity test — pass
  - [x] Deno subprocess: driven via parity test — pass
- **FD-passing path**: n/a (clock op is in-process, no FD passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)