### PR TITLE
fix(adapter-cpu-readback): lazy numpy import on plane views

### DIFF
--- a/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cpu_readback.py
@@ -105,19 +105,29 @@ class CpuReadbackPlaneView:
     ``(height, width, bytes_per_pixel)``, dtype ``numpy.uint8``).
     Plane dimensions are in plane texels — for NV12's UV plane that
     means half the surface width × half the surface height.
+
+    ``.numpy`` lazy-imports ``numpy`` on access; consumers that only
+    touch ``.bytes`` (a ``memoryview``) don't need numpy installed.
+    Accessing ``.numpy`` without numpy on the path raises
+    ``ModuleNotFoundError``.
     """
 
     width: int
     height: int
     bytes_per_pixel: int
     bytes: memoryview
-    numpy: "np.ndarray"
 
     @property
     def row_stride(self) -> int:
         """Tightly-packed row stride in bytes
         (``width * bytes_per_pixel``)."""
         return self.width * self.bytes_per_pixel
+
+    @property
+    def numpy(self) -> "np.ndarray":
+        return _build_ndarray_view(
+            self.bytes, self.height, self.width, self.bytes_per_pixel
+        )
 
 
 @dataclass(frozen=True)
@@ -128,17 +138,36 @@ class CpuReadbackPlaneViewMut:
     ``numpy.ndarray`` aliasing the same memory. Edits to any plane are
     flushed back to the host ``VkImage`` via per-plane
     ``vkCmdCopyBufferToImage`` on guard drop.
+
+    ``.numpy`` lazy-imports ``numpy`` on access; consumers that only
+    touch ``.bytes`` (a writable ``memoryview``) don't need numpy
+    installed.
     """
 
     width: int
     height: int
     bytes_per_pixel: int
     bytes: memoryview
-    numpy: "np.ndarray"
 
     @property
     def row_stride(self) -> int:
         return self.width * self.bytes_per_pixel
+
+    @property
+    def numpy(self) -> "np.ndarray":
+        return _build_ndarray_view(
+            self.bytes, self.height, self.width, self.bytes_per_pixel
+        )
+
+
+def _build_ndarray_view(
+    buf: memoryview, height: int, width: int, bytes_per_pixel: int
+) -> "np.ndarray":
+    import numpy as np
+
+    return np.frombuffer(buf, dtype=np.uint8).reshape(
+        height, width, bytes_per_pixel
+    )
 
 
 @dataclass(frozen=True)
@@ -532,8 +561,6 @@ class CpuReadbackContext:
             release_fn(self._rt, ctypes.c_uint64(surface_id))
 
     def _build_view(self, view_struct: _SlpnCpuReadbackView, writable: bool):
-        import numpy as np
-
         plane_count = int(view_struct.plane_count)
         if plane_count == 0:
             raise RuntimeError("cpu-readback acquire returned zero planes")
@@ -552,16 +579,6 @@ class CpuReadbackContext:
             mv = memoryview(raw).cast("B")
             if not writable:
                 mv = mv.toreadonly()
-            arr = np.ndarray(
-                shape=(int(p.height), int(p.width), int(p.bytes_per_pixel)),
-                dtype=np.uint8,
-                buffer=raw,
-                strides=(
-                    int(p.width) * int(p.bytes_per_pixel),
-                    int(p.bytes_per_pixel),
-                    1,
-                ),
-            )
             if writable:
                 plane_views.append(
                     CpuReadbackPlaneViewMut(
@@ -569,7 +586,6 @@ class CpuReadbackContext:
                         height=int(p.height),
                         bytes_per_pixel=int(p.bytes_per_pixel),
                         bytes=mv,
-                        numpy=arr,
                     )
                 )
             else:
@@ -579,7 +595,6 @@ class CpuReadbackContext:
                         height=int(p.height),
                         bytes_per_pixel=int(p.bytes_per_pixel),
                         bytes=mv,
-                        numpy=arr,
                     )
                 )
         if writable:

--- a/libs/streamlib-python/python/streamlib/tests/test_cpu_readback_view.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_cpu_readback_view.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for the lazy-numpy contract on cpu-readback plane views.
+
+Pins issue #603: a polyglot Python consumer that only touches
+``plane.bytes`` (a memoryview) must be able to acquire / construct a
+view without numpy installed. ``plane.numpy`` is opt-in and only
+imports numpy on access.
+"""
+
+import ctypes
+import sys
+
+import pytest
+
+from streamlib.adapters.cpu_readback import (
+    CpuReadbackPlaneView,
+    CpuReadbackPlaneViewMut,
+)
+
+
+def _writable_memoryview(byte_size: int) -> tuple[memoryview, "ctypes.Array[ctypes.c_uint8]"]:
+    """Allocate a writable byte buffer + return (memoryview, raw)."""
+    raw = (ctypes.c_uint8 * byte_size)()
+    mv = memoryview(raw).cast("B")
+    return mv, raw
+
+
+def test_plane_view_constructs_without_numpy(monkeypatch):
+    """Constructing a plane view and reading .bytes must not import numpy."""
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+    mv, _raw = _writable_memoryview(2 * 2 * 4)
+    view = CpuReadbackPlaneView(
+        width=2, height=2, bytes_per_pixel=4, bytes=mv.toreadonly()
+    )
+
+    assert view.width == 2
+    assert view.height == 2
+    assert view.bytes_per_pixel == 4
+    assert view.row_stride == 8
+    assert view.bytes.readonly
+    assert view.bytes.nbytes == 16
+
+
+def test_plane_view_mut_constructs_without_numpy(monkeypatch):
+    """Mutable plane view: .bytes is writable, no numpy on the path."""
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+    mv, _raw = _writable_memoryview(2 * 2 * 4)
+    view = CpuReadbackPlaneViewMut(
+        width=2, height=2, bytes_per_pixel=4, bytes=mv
+    )
+
+    view.bytes[0] = 0xAB
+    assert view.bytes[0] == 0xAB
+    assert not view.bytes.readonly
+
+
+def test_plane_view_numpy_raises_when_numpy_missing(monkeypatch):
+    """Accessing .numpy without numpy installed surfaces ModuleNotFoundError."""
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+    mv, _raw = _writable_memoryview(4)
+    view = CpuReadbackPlaneView(
+        width=1, height=1, bytes_per_pixel=4, bytes=mv.toreadonly()
+    )
+
+    with pytest.raises(ModuleNotFoundError):
+        _ = view.numpy
+
+
+def test_plane_view_mut_numpy_raises_when_numpy_missing(monkeypatch):
+    """Same lazy contract on the mutable variant."""
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+    mv, _raw = _writable_memoryview(4)
+    view = CpuReadbackPlaneViewMut(
+        width=1, height=1, bytes_per_pixel=4, bytes=mv
+    )
+
+    with pytest.raises(ModuleNotFoundError):
+        _ = view.numpy
+
+
+def test_plane_view_numpy_aliases_bytes_when_numpy_installed():
+    """When numpy is available, .numpy returns a (H, W, BPP) uint8 ndarray
+    that aliases .bytes — write through one, see it on the other."""
+    np = pytest.importorskip("numpy")
+
+    mv, _raw = _writable_memoryview(2 * 3 * 4)
+    view = CpuReadbackPlaneViewMut(
+        width=3, height=2, bytes_per_pixel=4, bytes=mv
+    )
+
+    arr = view.numpy
+    assert arr.shape == (2, 3, 4)
+    assert arr.dtype == np.uint8
+
+    arr[1, 2, 3] = 0xCD
+    # Last byte of a 24-byte buffer reflects the write.
+    assert view.bytes[2 * 3 * 4 - 1] == 0xCD
+    # Bidirectional: write through .bytes, see it via the same ndarray.
+    view.bytes[0] = 0x42
+    assert arr[0, 0, 0] == 0x42
+
+
+def test_plane_view_numpy_inherits_readonly_from_bytes():
+    """Read-only plane view: numpy view is read-only too."""
+    np = pytest.importorskip("numpy")
+
+    mv, _raw = _writable_memoryview(4)
+    view = CpuReadbackPlaneView(
+        width=1, height=1, bytes_per_pixel=4, bytes=mv.toreadonly()
+    )
+
+    arr = view.numpy
+    assert arr.shape == (1, 1, 4)
+    assert not arr.flags.writeable
+    with pytest.raises(ValueError):
+        arr[0, 0, 0] = 1


### PR DESCRIPTION
## Summary

- `streamlib.adapters.cpu_readback._build_view` no longer imports numpy or constructs an `np.ndarray` per plane on every acquire.
- `CpuReadbackPlaneView` / `CpuReadbackPlaneViewMut` drop the `numpy: "np.ndarray"` field; `.numpy` is now a `@property` that lazy-imports numpy and returns `np.frombuffer(self.bytes).reshape(H, W, BPP)` — a view aliasing the same memory.
- Polyglot Python consumers that only touch `plane.bytes` (memoryview) no longer need numpy installed.

## Closes

Closes #603

## Exit criteria

- [x] Polyglot consumers that only access `plane.bytes` can acquire / write cpu-readback surfaces without numpy installed.
- [x] Consumers that access `plane.numpy` continue to work; the import happens lazily on first access and surfaces `ModuleNotFoundError` if numpy isn't installed.
- [x] Existing cpu-readback consumers (e.g. `polyglot-cpu-readback-blur`) keep working without changes — single call site `arr = plane.numpy; arr[...] = blurred` still writes through to staging.

## Test plan

- [x] `tests/test_cpu_readback_view.py` — 6 unit tests covering both no-numpy paths (`monkeypatch.setitem(sys.modules, "numpy", None)`) and the with-numpy paths (alias-bytes, shape/dtype, readonly inheritance). 6/6 passing.
- [x] Adjacent SDK suite — 74 passed (2 unrelated pre-existing failures in `test_subprocess_runner_cleanup.py`; same on `main` — `_MockNativeLib` missing the `slpn_timerfd_create` attribute introduced by the timerfd work in #542 / PR #602).
- ⏭ Polyglot E2E (`polyglot-cpu-readback-blur`) not re-run end-to-end — the example's only `plane.numpy` call site (`arr = plane.numpy; arr[...] = blurred`) was inspected and the new property semantics preserve the alias-memory contract it depends on.

## Polyglot coverage

- **Runtimes affected**: python
- **Schema regenerated**: n/a
- **Python and Deno both covered?** schema-only / language-specific by construction — numpy is a Python-only concept; the Deno `cpu_readback.ts` view does not have an analogous eager-import path.
- **E2E tests run**:
  - [x] Python unit: `test_cpu_readback_view.py` (6 tests, all passing)
  - [n/a] Deno: language-specific carve-out
- **FD-passing path**: n/a (no IPC change)

## Reviewer notes (non-blocking)

The pre-PR review surfaced two DISCUSS items that did not result in code changes:

1. The lazy `_build_ndarray_view` helper assumes `len(buf) == H*W*BPP`. Pre-existing assumption — the original code hard-coded `strides=(W*BPP, BPP, 1)` against the same invariant; the cpu-readback host adapter's staging buffers are tightly packed by contract. No defensive check added (CLAUDE.md "don't validate impossibilities").
2. `.numpy` returns a fresh ndarray view per access (old eager-field shape returned the same object identity each access; both still alias the same memory). The single existing consumer caches `arr = plane.numpy` once; identity stability was never a documented part of the contract.

## Follow-ups

- Pre-existing test failure in `test_subprocess_runner_cleanup.py::test_cleanup_called_once_on_setup_*` — `_MockNativeLib` missing `slpn_timerfd_create` after the timerfd work landed. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)