### PR TITLE
feat(polyglot): thread-safe escalate IPC + worker-thread iceoryx2 publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "examples/polyglot-dma-buf-consumer", # Example: Camera → Python DMA-BUF consumer → Display (Linux polyglot E2E)
     "examples/polyglot-cpu-readback-blur", # Example: Polyglot cpu-readback adapter — Python cv2 / Deno hand-rolled Gaussian blur (#529)
     "examples/polyglot-manual-source",       # Example: Polyglot manual source — Python/Deno worker thread paced by MonotonicTimer (#542)
+    "examples/polyglot-manual-source/plugin", # Counting-sink Rust dylib plugin for polyglot-manual-source (#604)
     "examples/polyglot-continuous-processor", # Example: Polyglot continuous processor — Python/Deno process() driven by monotonic-clock timerfd (#542)
     "examples/polyglot-opengl-fragment-shader", # Example: Polyglot OpenGL adapter — Python Mandelbrot / Deno plasma fragment shader rendered into a host DMA-BUF (#530)
     "examples/polyglot-vulkan-compute",   # Example: Polyglot Vulkan adapter — Python/Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage (#531)

--- a/examples/polyglot-manual-source/deno/manual_source.ts
+++ b/examples/polyglot-manual-source/deno/manual_source.ts
@@ -2,73 +2,81 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Polyglot manual source — Deno reference example for issue #542.
+ * Polyglot manual source — Deno reference example for issues #542 + #604.
  *
  * Demonstrates the canonical `execution: manual` worker-loop idiom in
  * Deno — symmetrical to `python/manual_source.py`:
  *
- * 1. `start()` spawns a worker via async IIFE and returns promptly.
+ * 1. `start()` spawns a worker via async IIFE and returns promptly so
+ *    lifecycle commands (`stop`/`teardown`) can land.
  * 2. The worker uses `MonotonicTimer` for drift-free pacing
  *    (NOT `setTimeout`).
- * 3. Each tick, the worker writes an incrementing frame counter
- *    into a host-visible output file (atomic: write tmp + rename).
- *    The host reads this file post-stop to verify frames flowed.
+ * 3. Each tick, the worker calls `ctx.outputs.write(...)` to publish a
+ *    `Videoframe` over iceoryx2. The Rust counting-sink plugin
+ *    subscribes to the same iceoryx2 service and counts frames; the
+ *    scenario binary reads the sink's stats file post-stop to verify
+ *    frames flowed.
  * 4. `stop()` flips a shutdown flag and awaits the worker.
  *
- * If `start()` instead held a synchronous CPU loop, the subprocess
- * runner's _stdinReader couldn't deliver lifecycle messages and
- * teardown would hang. That's the failure mode this example exists
- * to rule out.
+ * Pre-#604, the Deno cdylib's `sldn_output_write` aliased `&mut`
+ * against the context (mirror of the Python issue). #604 moves the
+ * iceoryx2 publisher map behind a `Mutex` so concurrent
+ * `sldn_output_write` calls serialize. Combined with the runner's
+ * always-on `_stdinReader` (now wired in manual mode too), worker
+ * tasks can publish without deadlocking against the FD demuxer.
  *
- * Why a file and not the iceoryx2 output port: a polyglot source
- * that publishes Videoframe payloads needs to allocate pixel buffers
- * via escalate IPC `acquire_pixel_buffer` and call `outputs.write`
- * from a thread the host reads — concurrent escalate IPC from a
- * worker is not safe under the current bridge protocol. A
- * host-visible file sidesteps that out-of-scope plumbing and keeps
- * the example focused on the worker idiom.
+ * If `start()` instead held a synchronous CPU loop, the subprocess
+ * runner's `_stdinReader` couldn't deliver lifecycle messages and
+ * teardown would hang. That's the failure mode this example exists to
+ * rule out.
  */
 
 import {
   type ManualProcessor,
+  monotonicNowNs,
   MonotonicTimer,
   log,
   type RuntimeContextFullAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
+import type { OutputPorts } from "../../../libs/streamlib-deno/types.ts";
 
 export default class PolyglotManualSource implements ManualProcessor {
-  private outputFile = "";
   private intervalNs = 33n * 1_000_000n;
+  private width = 32;
+  private height = 32;
+  private surfaceIdPrefix = "polyglot-manual-source-deno";
   private frameCount = 0;
   private stopFlag = false;
   private worker: Promise<void> | null = null;
+  // Captured in setup() so the worker task can publish without the
+  // lifecycle ctx. NativeOutputPorts is a thin FFI shim — capturing it
+  // is safe across tasks.
+  private outputs: OutputPorts | null = null;
 
   setup(ctx: RuntimeContextFullAccess): void {
     const cfg = ctx.config;
-    const outRaw = cfg["output_file"];
-    if (typeof outRaw !== "string") {
-      throw new Error(
-        `output_file must be a string, got ${typeof outRaw}`,
-      );
-    }
-    this.outputFile = outRaw;
     const intMsRaw = cfg["interval_ms"];
     const intervalMs = typeof intMsRaw === "number" ? intMsRaw : 33;
     this.intervalNs = BigInt(intervalMs) * 1_000_000n;
-    // Initialize the file so the host always finds something to read.
-    this.writeCountAtomic(0);
+    if (typeof cfg["width"] === "number") this.width = cfg["width"];
+    if (typeof cfg["height"] === "number") this.height = cfg["height"];
+    if (typeof cfg["surface_id_prefix"] === "string") {
+      this.surfaceIdPrefix = cfg["surface_id_prefix"];
+    }
+    this.outputs = ctx.outputs;
     log.info("PolyglotManualSource setup", {
-      output_file: this.outputFile,
       interval_ns: String(this.intervalNs),
+      width: this.width,
+      height: this.height,
     });
   }
 
   start(_ctx: RuntimeContextFullAccess): void {
     // SHARP EDGE: this method MUST return promptly. The subprocess
-    // runner's outer command loop only iterates after start() returns;
-    // a long-running synchronous start() means lifecycle messages
-    // queue up and shutdown never happens. Spawn an async worker,
-    // return immediately.
+    // runner awaits start() inline; a synchronous CPU loop here means
+    // the `_stdinReader` IIFE that demuxes lifecycle commands never
+    // sees them and shutdown hangs. Spawn an async worker, return
+    // immediately.
     this.stopFlag = false;
     this.worker = this.workerLoop();
     log.info("PolyglotManualSource start: worker spawned");
@@ -87,21 +95,31 @@ export default class PolyglotManualSource implements ManualProcessor {
       }
       if (expirations === 0n) continue;
       for (let i = 0n; i < expirations && !this.stopFlag; i++) {
-        this.frameCount += 1;
-        this.writeCountAtomic(this.frameCount);
+        this.publishFrame();
       }
     }
   }
 
-  private writeCountAtomic(count: number): void {
+  private publishFrame(): void {
+    /** Publish one Videoframe on the `frame_out` port from this worker
+     * task. Exercises the Deno cdylib's `Mutex` around the iceoryx2
+     * publisher map (#604). */
+    if (this.outputs === null) return;
+    this.frameCount += 1;
+    const tsNs = monotonicNowNs();
+    const frame = {
+      surface_id: `${this.surfaceIdPrefix}-${this.frameCount}`,
+      width: this.width,
+      height: this.height,
+      timestamp_ns: String(tsNs),
+      frame_index: String(this.frameCount),
+    };
     try {
-      const tmp = `${this.outputFile}.tmp`;
-      Deno.writeTextFileSync(tmp, String(count));
-      Deno.renameSync(tmp, this.outputFile);
+      this.outputs.write("frame_out", frame, tsNs);
     } catch (e) {
-      log.warn("PolyglotManualSource write failed", {
+      log.warn("PolyglotManualSource publish failed", {
         error: String(e),
-        count,
+        frame_count: this.frameCount,
       });
     }
   }
@@ -117,8 +135,6 @@ export default class PolyglotManualSource implements ManualProcessor {
         });
       }
     }
-    // Final write so the host always sees the last value.
-    this.writeCountAtomic(this.frameCount);
     log.info("PolyglotManualSource stop: worker joined", {
       frames_emitted: this.frameCount,
     });

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -1,12 +1,15 @@
 package:
   name: polyglot-manual-source-deno
   version: "0.1.0"
-  description: "Polyglot manual source (#542) — Deno worker Promise paced by MonotonicTimer, writes BGRA frames into a host cpu-readback surface"
+  description: "Polyglot manual source (#542 / #604) — Deno worker Promise paced by MonotonicTimer publishes Videoframes via iceoryx2"
 
 processors:
   - name: com.tatolab.polyglot_manual_source_deno
     version: "1.0.0"
-    description: "Manual source: spawns a worker Promise in start() that writes incrementing frame counters to a host-pre-registered cpu-readback surface at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract."
+    description: "Manual source: spawns a worker Promise in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-task iceoryx2 publish path."
     runtime: deno
     execution: manual
     entrypoint: "manual_source.ts:default"
+    outputs:
+      - name: frame_out
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-manual-source/plugin/Cargo.toml
+++ b/examples/polyglot-manual-source/plugin/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-manual-source-counting-sink-plugin"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+streamlib = { path = "../../../libs/streamlib" }
+streamlib-plugin-abi = { path = "../../../libs/streamlib-plugin-abi" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = "0.1"

--- a/examples/polyglot-manual-source/plugin/src/lib.rs
+++ b/examples/polyglot-manual-source/plugin/src/lib.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Counting sink for the polyglot-manual-source example (#604).
+//!
+//! Subscribes to a `Videoframe` input port via iceoryx2, counts every
+//! frame received in `process()`, and writes a JSON stats file on
+//! `teardown()`. The scenario binary reads the stats file post-stop to
+//! verify the polyglot manual source actually published frames over
+//! iceoryx2 — the goal #604 unlocks (replacing PR #602's file-based
+//! placeholder verification).
+//!
+//! The output stats path is taken from the
+//! `STREAMLIB_POLYGLOT_MANUAL_SOURCE_SINK_OUTPUT` env var (set by the
+//! scenario binary). Using an env var sidesteps the JTD schema codegen
+//! dance that an in-tree config field would need, while still letting
+//! the scenario binary route per-runtime test runs to distinct files.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use streamlib::_generated_::Videoframe;
+use streamlib::core::{
+    Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError,
+};
+use streamlib_plugin_abi::export_plugin;
+
+const OUTPUT_ENV_VAR: &str = "STREAMLIB_POLYGLOT_MANUAL_SOURCE_SINK_OUTPUT";
+
+#[streamlib::processor("com.tatolab.polyglot_manual_source_counting_sink")]
+pub struct PolyglotManualSourceCountingSink {
+    output_file: Option<PathBuf>,
+    frame_counter: u64,
+    first_ns: u64,
+    last_ns: u64,
+}
+
+impl streamlib::core::ReactiveProcessor for PolyglotManualSourceCountingSink::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        let output = std::env::var(OUTPUT_ENV_VAR)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from);
+        if output.is_none() {
+            tracing::warn!(
+                "[CountingSink] {OUTPUT_ENV_VAR} not set — teardown will skip writing stats"
+            );
+        }
+        self.output_file = output;
+        std::future::ready(Ok(()))
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if !self.inputs.has_data("video_in") {
+            return Ok(());
+        }
+        let frame: Videoframe = self.inputs.read("video_in")?;
+        let ts: u64 = frame.timestamp_ns.parse().unwrap_or(0);
+        if self.frame_counter == 0 {
+            self.first_ns = ts;
+        }
+        self.last_ns = ts;
+        self.frame_counter += 1;
+        if self.frame_counter <= 3 || self.frame_counter % 30 == 0 {
+            tracing::debug!(
+                "[CountingSink] received frame {} ts_ns={}",
+                self.frame_counter,
+                ts
+            );
+        }
+        Ok(())
+    }
+
+    fn teardown(
+        &mut self,
+        _ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        let result = match &self.output_file {
+            Some(path) => {
+                // JSON has no native u64 — emit timestamps as decimal
+                // strings so the scenario binary's `parse_u64_or_string`
+                // shape continues to work and Python/Deno-comparison
+                // parity stays clean.
+                let stats = serde_json::json!({
+                    "frames_received": self.frame_counter,
+                    "first_timestamp_ns": self.first_ns.to_string(),
+                    "last_timestamp_ns": self.last_ns.to_string(),
+                });
+                std::fs::write(path, stats.to_string()).map_err(|e| {
+                    StreamError::Runtime(format!(
+                        "[CountingSink] failed to write stats to {}: {}",
+                        path.display(),
+                        e
+                    ))
+                })
+            }
+            None => Ok(()),
+        };
+        tracing::info!(
+            "[CountingSink] teardown — frames_received={}",
+            self.frame_counter,
+        );
+        std::future::ready(result)
+    }
+}
+
+export_plugin!(PolyglotManualSourceCountingSink::Processor);

--- a/examples/polyglot-manual-source/plugin/streamlib.yaml
+++ b/examples/polyglot-manual-source/plugin/streamlib.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+package:
+  name: polyglot-manual-source-counting-sink
+  version: "0.1.0"
+  description: "Rust counting sink for the polyglot-manual-source example (#604) — counts Videoframes received over iceoryx2 and writes JSON stats on teardown"
+
+processors:
+  - name: com.tatolab.polyglot_manual_source_counting_sink
+    version: "1.0.0"
+    description: "Reactive sink that counts Videoframes and writes count + first/last timestamp to a stats file on teardown. Used to validate that polyglot manual sources can publish via iceoryx2 from a worker thread (#604)."
+    runtime: rust
+    execution: reactive
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-manual-source/python/manual_source.py
+++ b/examples/polyglot-manual-source/python/manual_source.py
@@ -1,41 +1,39 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""Polyglot manual source — Python reference example for issue #542.
+"""Polyglot manual source — Python reference example for issues #542 + #604.
 
 Demonstrates the canonical `execution: manual` worker-thread idiom:
 
-1. ``start()`` spawns a worker thread and returns promptly.
-2. The worker uses `streamlib.MonotonicTimer` for drift-free pacing
-   (NOT `time.sleep`).
-3. Each tick, the worker writes an incrementing frame counter into a
-   host-visible output file (atomic: write tmp + rename). The host
-   reads this file post-stop to verify frames flowed.
-4. ``stop()`` flips a shutdown flag, joins the worker thread, and
-   returns. The runtime exits cleanly without falling through to
-   the host's SIGKILL fallback.
+1. ``start()`` spawns a worker thread and returns promptly so lifecycle
+   commands (``stop``/``teardown``) can land.
+2. The worker uses :class:`streamlib.MonotonicTimer` for drift-free
+   pacing (NOT ``time.sleep``).
+3. Each tick, the worker calls ``ctx.outputs.write(...)`` to publish a
+   ``Videoframe`` over iceoryx2 to the destination input port. The
+   counting-sink Rust plugin (``examples/polyglot-manual-source/plugin``)
+   subscribes to that port and counts frames; the scenario binary reads
+   the sink's stats file post-stop to verify frames flowed.
+4. ``stop()`` flips a shutdown flag, joins the worker thread, returns.
+
+Pre-#604, worker threads couldn't safely call ``outputs.write`` because
+the Python cdylib's ``slpn_output_write`` aliased ``&mut`` against the
+context across threads — instant UB once Python's ctypes released the
+GIL on the FFI dispatch. #604 adds a [`Mutex`] inside
+``PythonNativeContext`` so concurrent ``slpn_output_write`` calls
+serialize on the publisher map. The worker idiom below is now safe by
+construction.
 
 If ``start()`` instead held a ``while True`` loop synchronously, the
 subprocess runner's command loop would never iterate — no
 ``stop`` / ``teardown`` lifecycle message would land, and the host
 falls through to a 5-second SIGKILL after timeout. That's the
 failure mode this example exists to rule out.
-
-Why a file and not the iceoryx2 output port: a polyglot source that
-publishes ``Videoframe`` payloads needs to allocate pixel buffers via
-escalate IPC ``acquire_pixel_buffer`` and call ``outputs.write`` from
-a thread the host reads — concurrent escalate IPC from a worker
-thread is not safe under the current bridge protocol (the runner's
-outer command loop and the worker would both read from stdin). A
-host-visible file sidesteps that out-of-scope plumbing and keeps the
-example focused on the worker-thread idiom.
 """
 
 from __future__ import annotations
 
-import os
 import threading
-from pathlib import Path
 from typing import Optional
 
 import streamlib
@@ -46,33 +44,44 @@ class PolyglotManualSource:
     """Manual-mode polyglot source.
 
     Config keys:
-        output_file (str, required): host-visible file path the
-            worker thread writes the latest frame count into.
         interval_ms (int, default 33): tick interval. 33ms ≈ 30fps.
+        width (int, default 32): width to claim on the published Videoframe.
+        height (int, default 32): height to claim on the published Videoframe.
+        surface_id_prefix (str, default "polyglot-manual-source"): prefix
+            for the synthetic surface_id field on each frame. Sinks that
+            simply count don't need a real GPU surface; using a synthetic
+            placeholder lets the example run without a host
+            ``GpuContextFullAccess`` allocation.
     """
 
     def setup(self, ctx: RuntimeContextFullAccess) -> None:
         cfg = ctx.config
-        self._output_file = Path(str(cfg["output_file"]))
         self._interval_ns = int(cfg.get("interval_ms", 33)) * 1_000_000
+        self._width = int(cfg.get("width", 32))
+        self._height = int(cfg.get("height", 32))
+        self._surface_id_prefix = str(
+            cfg.get("surface_id_prefix", "polyglot-manual-source")
+        )
         self._frame_count = 0
         self._stop_event = threading.Event()
         self._worker: Optional[threading.Thread] = None
-        # Initialize the file so the host always finds something to read.
-        self._write_count_atomic(0)
+        # Capture the outputs view so the worker thread can publish without
+        # re-entering the lifecycle context. ``NativeOutputs`` holds only
+        # the cdylib handle + ctx pointer, both stable across the
+        # processor's lifetime.
+        self._outputs = ctx.outputs
         streamlib.log.info(
             "PolyglotManualSource setup",
-            output_file=str(self._output_file),
             interval_ns=self._interval_ns,
+            width=self._width,
+            height=self._height,
         )
 
     def start(self, _ctx: RuntimeContextFullAccess) -> None:
         # SHARP EDGE: this method MUST return promptly. The subprocess
-        # runner calls start() inline on the command loop thread; if
-        # it blocks (e.g. a `while True:` loop here), no subsequent
-        # `stop` / `teardown` lifecycle message can be received and
-        # the host falls through to a 5-second SIGKILL after timeout.
-        # Spawn a worker, return immediately.
+        # runner calls start() inline on the command loop thread; if it
+        # blocks, no subsequent `stop` / `teardown` lifecycle message can
+        # be received. Spawn a worker, return immediately.
         self._stop_event.clear()
         self._worker = threading.Thread(
             target=self._worker_loop,
@@ -84,8 +93,8 @@ class PolyglotManualSource:
 
     def _worker_loop(self) -> None:
         # MonotonicTimer is the canonical drift-free pacing primitive.
-        # Replaces `time.sleep(interval_s)` which drifts and doesn't
-        # match streamlib's monotonic-clock pacing philosophy.
+        # Replaces `time.sleep(interval_s)` which drifts and doesn't match
+        # streamlib's monotonic-clock pacing philosophy.
         with streamlib.MonotonicTimer(self._interval_ns) as timer:
             while not self._stop_event.is_set():
                 expirations = timer.wait(100)  # 100ms timeout bounds shutdown latency
@@ -97,20 +106,32 @@ class PolyglotManualSource:
                 for _ in range(expirations):
                     if self._stop_event.is_set():
                         return
-                    self._frame_count += 1
-                    self._write_count_atomic(self._frame_count)
+                    self._publish_frame()
 
-    def _write_count_atomic(self, count: int) -> None:
-        """Write `count` to the output file atomically (write-tmp + rename)."""
+    def _publish_frame(self) -> None:
+        """Publish one Videoframe on the `frame_out` port from this worker
+        thread. Exercises the cdylib Mutex around the iceoryx2 publisher
+        map (#604) — pre-fix, this raced with any other ``slpn_*`` call
+        from the runner's main thread and was instant UB."""
+        self._frame_count += 1
+        ts_ns = streamlib.monotonic_now_ns()
+        # The Videoframe schema accepts a synthetic surface_id (it's a
+        # string used by the consumer to look up a GPU surface — a sink
+        # that just counts doesn't need a real one).
+        frame = {
+            "surface_id": f"{self._surface_id_prefix}-{self._frame_count}",
+            "width": self._width,
+            "height": self._height,
+            "timestamp_ns": str(ts_ns),
+            "frame_index": str(self._frame_count),
+        }
         try:
-            tmp = self._output_file.with_suffix(self._output_file.suffix + ".tmp")
-            tmp.write_text(str(count))
-            os.replace(tmp, self._output_file)
+            self._outputs.write("frame_out", frame, timestamp_ns=ts_ns)
         except Exception as e:
             streamlib.log.warn(
-                "PolyglotManualSource write failed",
+                "PolyglotManualSource publish failed",
                 error=str(e),
-                count=count,
+                frame_count=self._frame_count,
             )
 
     def stop(self, _ctx: RuntimeContextFullAccess) -> None:
@@ -120,8 +141,6 @@ class PolyglotManualSource:
             worker.join(timeout=2.0)
             if worker.is_alive():
                 streamlib.log.warn("PolyglotManualSource worker did not exit within 2s")
-        # Final write so the host always sees the last value.
-        self._write_count_atomic(self._frame_count)
         streamlib.log.info(
             "PolyglotManualSource stop: worker joined",
             frames_emitted=self._frame_count,

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -1,12 +1,15 @@
 package:
   name: polyglot-manual-source
   version: "0.1.0"
-  description: "Polyglot manual source (#542) — Python worker thread paced by MonotonicTimer, writes BGRA frames into a host cpu-readback surface"
+  description: "Polyglot manual source (#542 / #604) — Python worker thread paced by MonotonicTimer publishes Videoframes via iceoryx2"
 
 processors:
   - name: com.tatolab.polyglot_manual_source
     version: "1.0.0"
-    description: "Manual source: spawns a worker thread in start() that writes incrementing frame counters to a host-pre-registered cpu-readback surface at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract."
+    description: "Manual source: spawns a worker thread in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-thread iceoryx2 publish path."
     runtime: python
     execution: manual
     entrypoint: "manual_source:PolyglotManualSource"
+    outputs:
+      - name: frame_out
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -1,27 +1,34 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Polyglot manual source reference example (issue #542).
+//! Polyglot manual source reference example (#542 / #604).
 //!
 //! Exercises the `execution: manual` worker-thread / async-loop idiom
-//! in both the Python and Deno SDKs.
+//! in both the Python and Deno SDKs, AND the iceoryx2 publish path
+//! from the worker — the gap #604 closes against the original #542 /
+//! PR #602 framing, which used a host-visible file as a placeholder.
+//!
+//! Pipeline:
+//!
+//!   polyglot manual source → Rust counting sink (frame_out → video_in)
 //!
 //! The polyglot processor's `start()` spawns a worker (thread on
 //! Python, async IIFE on Deno), the worker uses `MonotonicTimer` to
-//! pace tick-rate frame emission against `clock_gettime(CLOCK_MONOTONIC)`,
-//! and each tick atomically writes an incrementing frame counter into
-//! a host-visible output file. After the runtime stops, this binary
-//! reads the file and asserts the counter is at least the expected
-//! minimum — proving (a) the worker ran, (b) `start()` returned
-//! promptly so lifecycle messages could land, (c) `MonotonicTimer`
-//! paced correctly.
-//!
-//! See the per-runtime processor module docs for why a file and not
-//! an iceoryx2 output port: concurrent escalate-IPC from worker
-//! threads is out of scope under the current bridge protocol.
+//! pace tick-rate frame emission, and each tick calls
+//! `ctx.outputs.write("frame_out", videoframe, ts)`. The Rust counting
+//! sink subscribes to that port and writes `{"frames_received": N, ...}`
+//! to a stats file on `teardown()`. After the runtime stops, this
+//! binary reads the stats file and asserts the count is at least the
+//! expected minimum — proving (a) the worker ran, (b) `start()`
+//! returned promptly, (c) `outputs.write` from a worker thread is
+//! thread-safe under the new cdylib Mutex (#604), (d) the iceoryx2
+//! frame actually reached a subscriber.
 //!
 //! Build the Python `.slpkg` first (Deno doesn't need a pack step):
 //!   cargo run -p streamlib-cli -- pack examples/polyglot-manual-source/python
+//!
+//! Build the counting-sink plugin:
+//!   cargo build -p polyglot-manual-source-counting-sink-plugin
 //!
 //! Run:
 //!   cargo run -p polyglot-manual-source-scenario -- --runtime=python
@@ -33,16 +40,23 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Duration;
 
-use streamlib::core::StreamError;
+use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
 use streamlib::{ProcessorSpec, Result, StreamRuntime};
 
 const RUN_DURATION: Duration = Duration::from_secs(2);
 const INTERVAL_MS: u32 = 33;
-/// Minimum tick count we expect within `RUN_DURATION` allowing for
-/// startup latency and scheduler noise. ~30Hz × 2s = 60 nominal;
-/// require at least a third to keep the gate robust against CI
-/// jitter.
-const MIN_FRAMES_EMITTED: u32 = 20;
+/// Minimum frame count the counting sink must report inside
+/// `RUN_DURATION` allowing for startup latency and scheduler noise.
+/// ~30 Hz × 2 s = 60 nominal; require at least a third to keep the
+/// gate robust against CI jitter.
+const MIN_FRAMES_RECEIVED: u32 = 20;
+
+const COUNTING_SINK_PROCESSOR: &str = "com.tatolab.polyglot_manual_source_counting_sink";
+const COUNTING_SINK_PLUGIN_DYLIB: &str = "libpolyglot_manual_source_counting_sink_plugin.so";
+/// Env var the counting sink reads to know where to write JSON stats.
+/// Set unconditionally before `runtime.start()` so the sink picks it up
+/// in `setup()` even if the host hasn't yet exec'd the test binary.
+const SINK_OUTPUT_ENV_VAR: &str = "STREAMLIB_POLYGLOT_MANUAL_SOURCE_SINK_OUTPUT";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RuntimeKind {
@@ -76,10 +90,18 @@ impl RuntimeKind {
     }
 }
 
+#[derive(Debug)]
+struct SinkReport {
+    frames_received: u32,
+}
+
 fn main() -> ExitCode {
     match run() {
-        Ok(frames) => {
-            println!("✓ frames emitted: {frames} (>= {MIN_FRAMES_EMITTED})");
+        Ok(report) => {
+            println!(
+                "✓ frames received by counting sink: {} (>= {MIN_FRAMES_RECEIVED})",
+                report.frames_received,
+            );
             ExitCode::SUCCESS
         }
         Err(e) => {
@@ -89,35 +111,60 @@ fn main() -> ExitCode {
     }
 }
 
-fn run() -> Result<u32> {
+fn run() -> Result<SinkReport> {
     let mut runtime_kind = RuntimeKind::Python;
-    let mut output_file: Option<PathBuf> = None;
+    let mut sink_stats_file: Option<PathBuf> = None;
     for a in std::env::args().skip(1) {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
                 RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
-        } else if let Some(value) = a.strip_prefix("--output-file=") {
-            output_file = Some(PathBuf::from(value));
+        } else if let Some(value) = a.strip_prefix("--sink-stats-file=") {
+            sink_stats_file = Some(PathBuf::from(value));
         }
     }
-    let output_file = output_file.unwrap_or_else(|| {
+    let sink_stats_file = sink_stats_file.unwrap_or_else(|| {
         std::env::temp_dir().join(format!(
-            "polyglot-manual-source-{}-frames.txt",
-            std::process::id()
+            "polyglot-manual-source-{}-{}-sink-stats.json",
+            runtime_kind.as_str(),
+            std::process::id(),
         ))
     });
     // Clear any stale data from a prior run so the read-back is
     // unambiguous.
-    let _ = std::fs::remove_file(&output_file);
+    let _ = std::fs::remove_file(&sink_stats_file);
 
-    println!("=== Polyglot manual source scenario (#542) ===");
-    println!("Runtime:      {}", runtime_kind.as_str());
-    println!("Output file:  {}", output_file.display());
-    println!("Tick rate:    {INTERVAL_MS}ms");
-    println!("Run length:   {:?}", RUN_DURATION);
+    // Tell the counting-sink processor where to write its stats. Sidesteps
+    // the JTD config-schema codegen path that an in-tree processor with a
+    // typed config would normally use; for a self-contained example
+    // sidecar plugin, an env var is plenty.
+    // SAFETY: `set_var` is single-threaded by construction here (we're
+    // pre-`runtime.start()`); it's only unsafe under POSIX rules when
+    // racing against `getenv` on another thread.
+    unsafe {
+        std::env::set_var(SINK_OUTPUT_ENV_VAR, &sink_stats_file);
+    }
+
+    println!("=== Polyglot manual source scenario (#604) ===");
+    println!("Runtime:           {}", runtime_kind.as_str());
+    println!("Sink stats file:   {}", sink_stats_file.display());
+    println!("Tick rate:         {INTERVAL_MS}ms");
+    println!("Run length:        {:?}", RUN_DURATION);
 
     let runtime = StreamRuntime::new()?;
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // 1. Stage the counting-sink plugin. The plugin sub-crate builds a
+    //    cdylib that `runtime.load_project(plugin/)` picks up by
+    //    iterating `plugin/lib/` for `*.so`. Mirrors the camera-rust-plugin
+    //    pattern: the example's `cargo build` produces the dylib in
+    //    `target/<profile>/`, and the scenario binary copies it into
+    //    `plugin/lib/` before loading.
+    let plugin_dir = manifest_dir.join("plugin");
+    stage_plugin_dylib(&plugin_dir)?;
+    runtime.load_project(&plugin_dir)?;
+
+    // 2. Load the polyglot project (Python .slpkg or Deno project).
     match runtime_kind {
         RuntimeKind::Python => {
             let slpkg_path =
@@ -134,36 +181,103 @@ fn run() -> Result<u32> {
         }
     }
 
+    // 3. Add processors.
     let manual = runtime.add_processor(ProcessorSpec::new(
         runtime_kind.processor_name(),
         serde_json::json!({
-            "output_file": output_file.to_string_lossy(),
             "interval_ms": INTERVAL_MS,
         }),
     ))?;
     println!("+ ManualSource: {manual}");
 
+    let sink = runtime.add_processor(ProcessorSpec::new(
+        COUNTING_SINK_PROCESSOR,
+        // Sink reads its output path from `SINK_OUTPUT_ENV_VAR` set above —
+        // pass an empty config so the macro-derived `EmptyConfig` (the
+        // default for processors without a YAML config schema) deserializes
+        // cleanly.
+        serde_json::Value::Null,
+    ))?;
+    println!("+ CountingSink: {sink}");
+
+    // 4. Wire source → sink.
+    runtime.connect(
+        OutputLinkPortRef::new(&manual, "frame_out"),
+        InputLinkPortRef::new(&sink, "video_in"),
+    )?;
+
+    // 5. Run.
     runtime.start()?;
     std::thread::sleep(RUN_DURATION);
     runtime.stop()?;
 
-    let frames = read_frame_count(&output_file)?;
-    if frames < MIN_FRAMES_EMITTED {
+    let report = read_sink_report(&sink_stats_file)?;
+    if report.frames_received < MIN_FRAMES_RECEIVED {
         return Err(StreamError::Runtime(format!(
-            "manual source emitted only {frames} frames; expected >= {MIN_FRAMES_EMITTED}",
+            "counting sink received only {} frames; expected >= {MIN_FRAMES_RECEIVED}",
+            report.frames_received,
         )));
     }
-    Ok(frames)
+    Ok(report)
 }
 
-fn read_frame_count(path: &std::path::Path) -> Result<u32> {
+/// Locate the built plugin cdylib in the workspace target dir and copy
+/// it under `plugin/lib/` so `load_project` finds it. Mirrors the
+/// `camera-rust-plugin` example.
+fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
+    let lib_dir = plugin_dir.join("lib");
+    std::fs::create_dir_all(&lib_dir).map_err(|e| {
+        StreamError::Configuration(format!(
+            "failed to create plugin lib dir {}: {e}",
+            lib_dir.display(),
+        ))
+    })?;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| StreamError::Configuration("workspace root not found".into()))?;
+
+    let target_dir = workspace_root.join("target");
+    let candidates = [
+        target_dir.join("debug").join(COUNTING_SINK_PLUGIN_DYLIB),
+        target_dir.join("release").join(COUNTING_SINK_PLUGIN_DYLIB),
+    ];
+    let source = candidates.iter().find(|p| p.exists()).ok_or_else(|| {
+        StreamError::Configuration(format!(
+            "counting-sink plugin dylib not found. Build it first:\n  \
+             cargo build -p polyglot-manual-source-counting-sink-plugin\n\
+             Looked in:\n  {}\n  {}",
+            candidates[0].display(),
+            candidates[1].display(),
+        ))
+    })?;
+    let dest = lib_dir.join(COUNTING_SINK_PLUGIN_DYLIB);
+    std::fs::copy(source, &dest).map_err(|e| {
+        StreamError::Configuration(format!(
+            "failed to copy {} → {}: {e}",
+            source.display(),
+            dest.display(),
+        ))
+    })?;
+    Ok(())
+}
+
+fn read_sink_report(path: &std::path::Path) -> Result<SinkReport> {
     let raw = std::fs::read_to_string(path).map_err(|e| {
         StreamError::Runtime(format!(
-            "polyglot manual source did not write {} — worker thread may not have run: {e}",
+            "counting sink did not write {} — sink processor may not have received any frames: {e}",
             path.display()
         ))
     })?;
-    raw.trim()
-        .parse::<u32>()
-        .map_err(|e| StreamError::Runtime(format!("output file did not contain a u32: {e}")))
+    let v: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        StreamError::Runtime(format!("sink stats file is not valid JSON: {e}"))
+    })?;
+    let frames_received = v
+        .get("frames_received")
+        .and_then(|x| x.as_u64())
+        .ok_or_else(|| StreamError::Runtime("missing frames_received".into()))?
+        as u32;
+    Ok(SinkReport { frames_received })
 }

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use iceoryx2::port::listener::Listener;
@@ -31,9 +32,24 @@ const READ_MODE_SKIP_TO_LATEST: i32 = 0;
 const READ_MODE_READ_NEXT_IN_ORDER: i32 = 1;
 
 /// Per-processor native context holding iceoryx2 node and port state.
+///
+/// Mutable interior state lives behind [`Self::inner`]'s [`Mutex`] so
+/// concurrent FFI calls from different Deno tasks (or any future Worker)
+/// cannot alias `&mut` against each other (#604). Mirrors the
+/// `streamlib-python-native` shape so a fix or invariant in one cdylib
+/// applies to the other.
+///
+/// `node` is immutable after construction (its `service_builder` only
+/// borrows `&self`) so it sits outside the lock to keep the locked region
+/// small.
 pub struct DenoNativeContext {
     processor_id: String,
     node: Node<ipc::Service>,
+    inner: Mutex<DenoNativeContextInner>,
+}
+
+/// Mutable iceoryx2 port state guarded by [`DenoNativeContext::inner`].
+struct DenoNativeContextInner {
     subscribers: HashMap<String, SubscriberState>,
     publishers: HashMap<String, PublisherState>,
     /// Per-port read mode (port_name → READ_MODE_*). Default is SkipToLatest.
@@ -62,10 +78,12 @@ impl DenoNativeContext {
         Ok(Self {
             processor_id: processor_id.to_string(),
             node,
-            subscribers: HashMap::new(),
-            publishers: HashMap::new(),
-            port_read_modes: HashMap::new(),
-            notify_listener: None,
+            inner: Mutex::new(DenoNativeContextInner {
+                subscribers: HashMap::new(),
+                publishers: HashMap::new(),
+                port_read_modes: HashMap::new(),
+                notify_listener: None,
+            }),
         })
     }
 }
@@ -297,7 +315,7 @@ pub unsafe extern "C" fn sldn_input_subscribe(
     ctx: *mut DenoNativeContext,
     service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -346,7 +364,11 @@ pub unsafe extern "C" fn sldn_input_subscribe(
         }
     };
 
-    ctx.subscribers.insert(
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.subscribers.insert(
         service_name.to_string(),
         SubscriberState {
             subscriber,
@@ -369,7 +391,7 @@ pub unsafe extern "C" fn sldn_input_set_read_mode(
     port_name: *const c_char,
     mode: i32,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -378,7 +400,11 @@ pub unsafe extern "C" fn sldn_input_set_read_mode(
         None => return -1,
     };
 
-    ctx.port_read_modes.insert(port_name.to_string(), mode);
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.port_read_modes.insert(port_name.to_string(), mode);
     0
 }
 
@@ -387,14 +413,19 @@ pub unsafe extern "C" fn sldn_input_set_read_mode(
 /// Returns 1 if any data was received, 0 if none, -1 on error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sldn_input_poll(ctx: *mut DenoNativeContext) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
 
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
     let mut has_data = false;
 
-    for (_service_name, state) in ctx.subscribers.iter_mut() {
+    for (_service_name, state) in inner.subscribers.iter_mut() {
         while let Ok(Some(sample)) = state.subscriber.receive() {
             let buf: &[u8] = sample.payload();
             if buf.len() < FRAME_HEADER_SIZE {
@@ -442,7 +473,7 @@ pub unsafe extern "C" fn sldn_input_read(
     out_len: *mut u32,
     out_ts: *mut i64,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -451,14 +482,19 @@ pub unsafe extern "C" fn sldn_input_read(
         None => return -1,
     };
 
-    let read_mode = ctx
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
+    let read_mode = inner
         .port_read_modes
         .get(port_name)
         .copied()
         .unwrap_or(READ_MODE_SKIP_TO_LATEST);
 
     // Search all subscribers for pending data on this port
-    for (_service_name, state) in ctx.subscribers.iter_mut() {
+    for (_service_name, state) in inner.subscribers.iter_mut() {
         if let Some(queue) = state.pending.get_mut(port_name) {
             if queue.is_empty() {
                 continue;
@@ -518,7 +554,7 @@ pub unsafe extern "C" fn sldn_output_publish(
     max_payload_bytes: usize,
     notify_service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -618,7 +654,11 @@ pub unsafe extern "C" fn sldn_output_publish(
         _ => None,
     };
 
-    ctx.publishers.insert(
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.publishers.insert(
         port_name.to_string(),
         PublisherState {
             publisher,
@@ -633,6 +673,12 @@ pub unsafe extern "C" fn sldn_output_publish(
 
 /// Write data to a specific output port.
 ///
+/// Safe to call from any Deno task, including concurrently with other
+/// `sldn_*` ops on the same context — the inner [`Mutex`] serializes
+/// access to the iceoryx2 publisher map (#604). The lock is held through
+/// `loan_slice_uninit` + `send` + `notify`; iceoryx2's publisher path is
+/// lock-free zero-copy so the held duration is short.
+///
 /// Returns 0 on success, -1 on failure.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sldn_output_write(
@@ -642,7 +688,7 @@ pub unsafe extern "C" fn sldn_output_write(
     data_len: u32,
     timestamp_ns: i64,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -651,7 +697,12 @@ pub unsafe extern "C" fn sldn_output_write(
         None => return -1,
     };
 
-    let state = match ctx.publishers.get(port_name) {
+    let inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
+    let state = match inner.publishers.get(port_name) {
         Some(s) => s,
         None => {
             tracing::error!(
@@ -717,12 +768,18 @@ pub unsafe extern "C" fn sldn_event_subscribe(
     ctx: *mut DenoNativeContext,
     notify_service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
-    if ctx.notify_listener.is_some() {
-        return 0;
+    {
+        let inner = match ctx.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if inner.notify_listener.is_some() {
+            return 0;
+        }
     }
     let name = match unsafe { c_str_to_str(notify_service_name) } {
         Some(s) if !s.is_empty() => s,
@@ -765,7 +822,14 @@ pub unsafe extern "C" fn sldn_event_subscribe(
             return -1;
         }
     };
-    ctx.notify_listener = Some(listener);
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    // Re-check under the lock — another thread may have raced ahead.
+    if inner.notify_listener.is_none() {
+        inner.notify_listener = Some(listener);
+    }
     0
 }
 
@@ -779,11 +843,15 @@ pub unsafe extern "C" fn sldn_event_wait(
     ctx: *mut DenoNativeContext,
     timeout_ms: u32,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
-    let Some(listener) = ctx.notify_listener.as_ref() else {
+    let inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let Some(listener) = inner.notify_listener.as_ref() else {
         return -1;
     };
     let mut woke = false;

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -69,6 +69,17 @@ export const ESCALATE_REQUEST_RPC = "escalate_request";
 export const ESCALATE_RESPONSE_RPC = "escalate_response";
 
 /**
+ * Default upper bound on how long [`EscalateChannel.request`] waits for
+ * a correlated response before rejecting. Generous enough for realistic
+ * escalate ops (compute pipeline-cache cold start, GPU readback under
+ * load) but tight enough that a stuck host or zombie reader surfaces
+ * as a clear `EscalateError("escalate timed out…")` instead of an
+ * unobservable hang. Callers can override per-request via the
+ * `timeoutMs` option.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
  * Caller-facing payload — the discriminator variants of
  * [`EscalateRequest`] with `request_id` stripped. The channel injects
  * `request_id` when serializing onto the wire.
@@ -289,9 +300,10 @@ export class EscalateChannel {
 
   async request(
     op: EscalateOpPayload,
-    options: { allowContended?: boolean } = {},
+    options: { allowContended?: boolean; timeoutMs?: number } = {},
   ): Promise<EscalateOkResponse | null> {
     const allowContended = options.allowContended === true;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     const requestId = this.nextRequestId();
     const msg = {
       rpc: ESCALATE_REQUEST_RPC,
@@ -303,16 +315,41 @@ export class EscalateChannel {
         this.pending.set(requestId, { resolve, reject, allowContended });
       },
     );
-    try {
-      await this.writer(msg);
-    } catch (e) {
+    // Schedule a timeout that races with the response. Like
+    // `handleIncoming` and `cancelAll`, the timeout pops the pending
+    // entry under the same map so a late delivery sees no slot and is
+    // dropped — no resolve/reject double-fire.
+    const timeoutHandle = setTimeout(() => {
       const p = this.pending.get(requestId);
       if (p) {
         this.pending.delete(requestId);
-        p.reject(e as Error);
+        p.reject(
+          new EscalateError(`escalate timed out after ${timeoutMs}ms`),
+        );
+      }
+    }, timeoutMs);
+    try {
+      await this.writer(msg);
+    } catch (e) {
+      // Wrap non-EscalateError exceptions (broken pipe from the
+      // bridge writer, etc.) so callers see one error type for every
+      // failure mode of the channel — same uniformity the Python SDK
+      // gives.
+      const p = this.pending.get(requestId);
+      if (p) {
+        this.pending.delete(requestId);
+        p.reject(
+          e instanceof EscalateError
+            ? e
+            : new EscalateError(`escalate channel send failed: ${e}`),
+        );
       }
     }
-    return promise;
+    try {
+      return await promise;
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
   }
 
   /**

--- a/libs/streamlib-deno/escalate_concurrency_test.ts
+++ b/libs/streamlib-deno/escalate_concurrency_test.ts
@@ -19,7 +19,7 @@
  * `tests/polyglot_linux_execution_modes.rs` against a real subprocess.
  */
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import {
   EscalateChannel,
   EscalateError,
@@ -197,6 +197,129 @@ Deno.test("EscalateChannel: contended response on non-allowContended request rej
     caught = e;
   }
   assert(caught instanceof EscalateError, "expected EscalateError on contended");
+});
+
+Deno.test("EscalateChannel: writer rejection surfaces as EscalateError", async () => {
+  // Wrapping non-EscalateError exceptions matches the Python SDK's
+  // contract: a single error type for every channel failure mode.
+  const channel = new EscalateChannel(() => {
+    return Promise.reject(new Error("simulated broken pipe"));
+  });
+
+  let caught: unknown = null;
+  try {
+    await channel.request(
+      { op: "noop" } as unknown as Parameters<EscalateChannel["request"]>[0],
+    );
+  } catch (e) {
+    caught = e;
+  }
+  assert(
+    caught instanceof EscalateError,
+    `expected EscalateError, got ${
+      caught instanceof Error ? caught.constructor.name : typeof caught
+    }: ${caught}`,
+  );
+  assertStringIncludes((caught as EscalateError).message, "send failed");
+});
+
+Deno.test("EscalateChannel: existing EscalateError from writer passes through unwrapped", async () => {
+  // If the writer already raises EscalateError (e.g. the underlying
+  // bridge layer has its own typed errors), preserve it — don't double-
+  // wrap. This keeps surface area uniform without burying the inner
+  // EscalateError's message under a generic "send failed: …" prefix.
+  const inner = new EscalateError("inner error");
+  const channel = new EscalateChannel(() => Promise.reject(inner));
+
+  let caught: unknown = null;
+  try {
+    await channel.request(
+      { op: "noop" } as unknown as Parameters<EscalateChannel["request"]>[0],
+    );
+  } catch (e) {
+    caught = e;
+  }
+  assertEquals(caught, inner);
+});
+
+Deno.test("EscalateChannel: request times out via timeoutMs", async () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  const start = performance.now();
+  let caught: unknown = null;
+  try {
+    await channel.request(
+      { op: "blocked" } as unknown as Parameters<EscalateChannel["request"]>[0],
+      { timeoutMs: 100 },
+    );
+  } catch (e) {
+    caught = e;
+  }
+  const elapsed = performance.now() - start;
+
+  assert(caught instanceof EscalateError, "expected EscalateError on timeout");
+  assertStringIncludes((caught as EscalateError).message, "timed out");
+  // Tolerance: timer scheduling jitter on a busy box can extend the
+  // wait, but we should never finish *before* the timeout. The upper
+  // bound (1000ms) guards against the timeout being silently broken
+  // (e.g. someone removing the setTimeout but tests still passing
+  // because the channel drops responses).
+  assert(
+    elapsed >= 100,
+    `request returned in ${elapsed}ms — timeout fired too early`,
+  );
+  assert(
+    elapsed < 1000,
+    `request waited ${elapsed}ms — timeout much longer than expected`,
+  );
+});
+
+Deno.test("EscalateChannel: late response after timeout is dropped, doesn't poison next request", async () => {
+  // Race-safety: if a response arrives after `setTimeout` fires (the
+  // pending entry was popped by the timeout handler), `handleIncoming`
+  // looks the entry up and finds nothing — returns true but takes no
+  // action. The next request must see only its own response.
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  // First request — times out.
+  let caught: unknown = null;
+  try {
+    await channel.request(
+      { op: "first" } as unknown as Parameters<EscalateChannel["request"]>[0],
+      { timeoutMs: 50 },
+    );
+  } catch (e) {
+    caught = e;
+  }
+  assert(caught instanceof EscalateError);
+
+  await bridge.waitForCount(1);
+  // Late "stale" response arrives after the timeout.
+  channel.handleIncoming({
+    rpc: "escalate_response",
+    request_id: bridge.captured[0].request_id,
+    result: "ok",
+    stale: true,
+  });
+
+  // Second request should resolve to its own (fresh) response.
+  const p = channel.request(
+    { op: "second" } as unknown as Parameters<EscalateChannel["request"]>[0],
+  );
+  await bridge.waitForCount(2);
+  channel.handleIncoming({
+    rpc: "escalate_response",
+    request_id: bridge.captured[1].request_id,
+    result: "ok",
+    fresh: true,
+  });
+  const r = await p;
+  assert(r !== null);
+  const rec = r as unknown as Record<string, unknown>;
+  assertEquals(rec.fresh, true);
+  assertEquals(rec.stale, undefined, "stale response leaked into second request");
 });
 
 Deno.test("EscalateChannel: contended response on allowContended request resolves to null", async () => {

--- a/libs/streamlib-deno/escalate_concurrency_test.ts
+++ b/libs/streamlib-deno/escalate_concurrency_test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Concurrency tests for [`EscalateChannel`] (#604).
+ *
+ * The Deno bug shape under the pre-#604 architecture was *deadlock*,
+ * not data corruption (single-threaded async event loop, no sibling
+ * reader to alias the demuxer). When a manual-mode worker awaited an
+ * escalate response, no task pumped the FD reader and the response
+ * sat in the socketpair buffer forever. The fix moves the
+ * `_stdinReader` IIFE to run unconditionally (manual mode included),
+ * but the channel itself needs to demux concurrent requests by
+ * `request_id` regardless — these tests pin that contract directly,
+ * with a fake writer driving synthetic responses through
+ * `handleIncoming`.
+ *
+ * The FD path itself is exercised end-to-end by
+ * `tests/polyglot_linux_execution_modes.rs` against a real subprocess.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  EscalateChannel,
+  EscalateError,
+  type EscalateOkResponse,
+} from "./escalate.ts";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface CapturedRequest {
+  request_id: string;
+  payload: Record<string, unknown>;
+}
+
+class FakeBridge {
+  readonly captured: CapturedRequest[] = [];
+  private resolveCount?: () => void;
+  private targetCount = 0;
+
+  async write(msg: Record<string, unknown>): Promise<void> {
+    this.captured.push({
+      request_id: msg.request_id as string,
+      payload: { ...msg },
+    });
+    if (
+      this.resolveCount !== undefined && this.captured.length >= this.targetCount
+    ) {
+      const fn = this.resolveCount;
+      this.resolveCount = undefined;
+      fn();
+    }
+  }
+
+  /** Wait until `count` requests have been captured (or fail-fast). */
+  async waitForCount(count: number, timeoutMs = 10_000): Promise<void> {
+    if (this.captured.length >= count) return;
+    this.targetCount = count;
+    const captured = await new Promise<true>((resolve, reject) => {
+      this.resolveCount = () => resolve(true);
+      const timer = setTimeout(() => {
+        this.resolveCount = undefined;
+        reject(
+          new Error(
+            `timed out waiting for ${count} requests (got ${this.captured.length})`,
+          ),
+        );
+      }, timeoutMs);
+      // Resolve clears the timer.
+      const wrapped = this.resolveCount;
+      this.resolveCount = () => {
+        clearTimeout(timer);
+        wrapped();
+      };
+    });
+    assert(captured);
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+Deno.test("EscalateChannel: 200 concurrent requests correlate by request_id", async () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  const N = 200;
+
+  // Fire all N requests truly concurrently.
+  const promises: Promise<EscalateOkResponse | null>[] = [];
+  for (let i = 0; i < N; i++) {
+    promises.push(
+      channel.request({
+        op: "test_correlation",
+        // Stash an identifier the responder can echo back.
+        _worker_idx: i,
+      } as unknown as Parameters<EscalateChannel["request"]>[0]),
+    );
+  }
+
+  // Wait for all requests to land in the fake bridge before responding.
+  await bridge.waitForCount(N);
+
+  // Echo responses in REVERSE capture order to surface any FIFO
+  // assumption regression in the demuxer.
+  const reversed = [...bridge.captured].reverse();
+  for (const req of reversed) {
+    channel.handleIncoming({
+      rpc: "escalate_response",
+      request_id: req.request_id,
+      result: "ok",
+      echo_idx: (req.payload._worker_idx as number),
+    });
+  }
+
+  const results = await Promise.all(promises);
+  for (let i = 0; i < N; i++) {
+    const r = results[i];
+    assert(r !== null, `request ${i} resolved to null contended sentinel`);
+    const echoed = (r as unknown as Record<string, unknown>).echo_idx;
+    assertEquals(
+      echoed,
+      i,
+      `cross-talk: request ${i} got echo_idx ${echoed}`,
+    );
+  }
+});
+
+Deno.test("EscalateChannel: handleIncoming ignores frames without request_id", () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  // Lifecycle frames (cmd: ...) have no rpc field, so handleIncoming
+  // returns false → caller routes to the lifecycle path.
+  assertEquals(
+    channel.handleIncoming({ cmd: "on_pause", capability: "limited" }),
+    false,
+  );
+  // A malformed escalate response with no request_id is consumed but
+  // doesn't throw — it should not propagate to the lifecycle dispatch.
+  assertEquals(
+    channel.handleIncoming({ rpc: "escalate_response" }),
+    true,
+  );
+});
+
+Deno.test("EscalateChannel: cancelAll wakes in-flight requests with EscalateError", async () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  const promises: Promise<unknown>[] = [];
+  for (let i = 0; i < 10; i++) {
+    promises.push(
+      channel.request({
+        op: "stranded",
+        _idx: i,
+      } as unknown as Parameters<EscalateChannel["request"]>[0])
+        .then(() => "resolved")
+        .catch((e: unknown) => {
+          if (e instanceof EscalateError) return e.message;
+          return `unexpected: ${e}`;
+        }),
+    );
+  }
+  await bridge.waitForCount(10);
+
+  channel.cancelAll("test shutdown");
+
+  const outcomes = await Promise.all(promises);
+  for (const o of outcomes) {
+    assertEquals(o, "test shutdown");
+  }
+});
+
+Deno.test("EscalateChannel: contended response on non-allowContended request rejects", async () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  const p = channel.request({
+    op: "expects_blocking",
+  } as unknown as Parameters<EscalateChannel["request"]>[0]);
+  await bridge.waitForCount(1);
+
+  channel.handleIncoming({
+    rpc: "escalate_response",
+    request_id: bridge.captured[0].request_id,
+    result: "contended",
+  });
+
+  let caught: unknown = null;
+  try {
+    await p;
+  } catch (e) {
+    caught = e;
+  }
+  assert(caught instanceof EscalateError, "expected EscalateError on contended");
+});
+
+Deno.test("EscalateChannel: contended response on allowContended request resolves to null", async () => {
+  const bridge = new FakeBridge();
+  const channel = new EscalateChannel((msg) => bridge.write(msg));
+
+  const p = channel.request(
+    { op: "try_op" } as unknown as Parameters<EscalateChannel["request"]>[0],
+    { allowContended: true },
+  );
+  await bridge.waitForCount(1);
+
+  channel.handleIncoming({
+    rpc: "escalate_response",
+    request_id: bridge.captured[0].request_id,
+    result: "contended",
+  });
+
+  const result = await p;
+  assertEquals(result, null);
+});

--- a/libs/streamlib-deno/subprocess_runner.ts
+++ b/libs/streamlib-deno/subprocess_runner.ts
@@ -394,21 +394,17 @@ async function main(): Promise<void> {
           running = true;
           log.info("Entering execution loop", { mode: executionMode });
 
-          if (executionMode === "manual") {
-            // Manual mode: start() is a resource-lifecycle op → full access
-            const manualProc = processor as ManualProcessor;
-            try {
-              await manualProc.start(fullCtx);
-            } catch (e) {
-              log.error("start() error", { error: String(e) });
-            }
-            break;
-          }
-
-          // Reactive/continuous: the processing loop blocks the outer command
-          // loop. Read stdin commands concurrently so teardown can be received
-          // during processing. The processing loop yields at await points,
-          // allowing the event loop to progress the stdin reader.
+          // The escalate FD demuxer runs for every execution mode now —
+          // including manual (#604). Without a concurrent reader, a worker
+          // task that issues an escalate request `await`s a Promise that
+          // only resolves when someone reads its `escalate_response` from
+          // the FD. Manual mode used to break out of `case "run"` after
+          // `start()` returned, leaving the outer loop as the only reader;
+          // if the worker fired escalate after start() returned but before
+          // the outer loop iterated again, the response sat in the
+          // socketpair buffer and the worker's Promise never resolved
+          // (deadlock). Spawning the same reader pattern reactive/
+          // continuous already use closes that gap.
           let teardownReceived = false;
           const _stdinReader = (async () => {
             try {
@@ -428,6 +424,22 @@ async function main(): Promise<void> {
                 if (nextCmd === "stop") {
                   assertCapability(processorId, nextCmd, nextMsg, "full");
                   running = false;
+                  // Manual mode: stop the processor + reply here so the
+                  // outer command loop never sees this `stop`. Reactive/
+                  // continuous don't have a `stop()` lifecycle hook —
+                  // they reply `stopped` from the outer loop after the
+                  // processing loop exits. Keep the wire shape identical:
+                  // one `{rpc: "stopped"}` reply per `stop` request.
+                  if (executionMode === "manual") {
+                    const manualProc = processor as ManualProcessor;
+                    if (manualProc.stop) {
+                      try {
+                        await manualProc.stop(fullCtx);
+                      } catch (e) {
+                        log.error("stop() error", { error: String(e) });
+                      }
+                    }
+                  }
                   try {
                     await bridgeSendJson({ rpc: "stopped" });
                   } catch {
@@ -452,11 +464,50 @@ async function main(): Promise<void> {
                 }
               }
             } catch {
-              // stdin closed (pipe broken) — treat as shutdown signal
+              // escalate fd closed (pipe broken) — treat as shutdown signal
               running = false;
               teardownReceived = true;
             }
           })();
+
+          if (executionMode === "manual") {
+            // Manual mode: start() is a resource-lifecycle op → full access.
+            // Contract: start() returns promptly; long-lived work goes in a
+            // worker task. Worker tasks may now call ctx.escalate_*
+            // concurrently — the `_stdinReader` above demuxes responses by
+            // request_id. Wait for the reader to observe a stop/teardown
+            // before falling through; in manual mode it's the only thing
+            // that flips `running` to false.
+            const manualProc = processor as ManualProcessor;
+            try {
+              await manualProc.start(fullCtx);
+            } catch (e) {
+              log.error("start() error", { error: String(e) });
+            }
+            await _stdinReader;
+            if (teardownReceived) {
+              if (processor?.teardown && fullCtx) {
+                try {
+                  await processor.teardown(fullCtx);
+                } catch (e) {
+                  log.error("teardown() error", { error: String(e) });
+                }
+              }
+              try {
+                await bridgeSendJson({ rpc: "done" });
+              } catch {
+                // stdout may be closed if escalate fd EOF triggered shutdown
+              }
+              lib.symbols.sldn_context_destroy(ctxPtr);
+              lib.close();
+              closeLibcHandle();
+              await log.shutdown();
+              Deno.exit(0);
+            }
+            // stop without teardown: _stdinReader already replied; fall
+            // through and let the outer loop pick up the next command.
+            break;
+          }
 
           // Enter execution loop based on mode. process() always receives
           // the limited ctx — no path in the hot loop can reach full access.

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -117,7 +117,7 @@ macro_rules! export_plugin {
             )*
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static STREAMLIB_PLUGIN: $crate::PluginDeclaration = $crate::PluginDeclaration {
             abi_version: $crate::STREAMLIB_ABI_VERSION,
             register: __streamlib_plugin_register,

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
+use std::sync::Mutex;
 
 use iceoryx2::port::listener::Listener;
 use iceoryx2::port::notifier::Notifier;
@@ -30,9 +31,25 @@ const READ_MODE_SKIP_TO_LATEST: i32 = 0;
 const READ_MODE_READ_NEXT_IN_ORDER: i32 = 1;
 
 /// Per-processor native context holding iceoryx2 node and port state.
+///
+/// Mutable interior state lives behind [`Self::inner`]'s [`Mutex`] so that
+/// concurrent FFI calls from different Python threads cannot alias `&mut`
+/// against each other (#604). Python's `ctypes` releases the GIL on FFI
+/// dispatch by default — without this lock, two threads in
+/// `slpn_output_write` against the same context would each materialize a
+/// `&mut PythonNativeContext` and instantly violate Rust's aliasing rules.
+///
+/// `node` is immutable after construction (its `service_builder` only
+/// borrows `&self`) so it sits outside the lock to keep the locked region
+/// small.
 pub struct PythonNativeContext {
     processor_id: String,
     node: Node<ipc::Service>,
+    inner: Mutex<PythonNativeContextInner>,
+}
+
+/// Mutable iceoryx2 port state guarded by [`PythonNativeContext::inner`].
+struct PythonNativeContextInner {
     subscribers: HashMap<String, SubscriberState>,
     publishers: HashMap<String, PublisherState>,
     /// Per-port read mode (port_name → READ_MODE_*). Default is SkipToLatest.
@@ -63,10 +80,12 @@ impl PythonNativeContext {
         Ok(Self {
             processor_id: processor_id.to_string(),
             node,
-            subscribers: HashMap::new(),
-            publishers: HashMap::new(),
-            port_read_modes: HashMap::new(),
-            notify_listener: None,
+            inner: Mutex::new(PythonNativeContextInner {
+                subscribers: HashMap::new(),
+                publishers: HashMap::new(),
+                port_read_modes: HashMap::new(),
+                notify_listener: None,
+            }),
         })
     }
 }
@@ -308,7 +327,7 @@ pub unsafe extern "C" fn slpn_input_subscribe(
     ctx: *mut PythonNativeContext,
     service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -357,7 +376,11 @@ pub unsafe extern "C" fn slpn_input_subscribe(
         }
     };
 
-    ctx.subscribers.insert(
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.subscribers.insert(
         service_name.to_string(),
         SubscriberState {
             subscriber,
@@ -380,7 +403,7 @@ pub unsafe extern "C" fn slpn_input_set_read_mode(
     port_name: *const c_char,
     mode: i32,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -389,7 +412,11 @@ pub unsafe extern "C" fn slpn_input_set_read_mode(
         None => return -1,
     };
 
-    ctx.port_read_modes.insert(port_name.to_string(), mode);
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.port_read_modes.insert(port_name.to_string(), mode);
     0
 }
 
@@ -398,14 +425,19 @@ pub unsafe extern "C" fn slpn_input_set_read_mode(
 /// Returns 1 if any data was received, 0 if none, -1 on error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_input_poll(ctx: *mut PythonNativeContext) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
 
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
     let mut has_data = false;
 
-    for (_service_name, state) in ctx.subscribers.iter_mut() {
+    for (_service_name, state) in inner.subscribers.iter_mut() {
         while let Ok(Some(sample)) = state.subscriber.receive() {
             let buf: &[u8] = sample.payload();
             if buf.len() < FRAME_HEADER_SIZE {
@@ -453,7 +485,7 @@ pub unsafe extern "C" fn slpn_input_read(
     out_len: *mut u32,
     out_ts: *mut i64,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -462,14 +494,19 @@ pub unsafe extern "C" fn slpn_input_read(
         None => return -1,
     };
 
-    let read_mode = ctx
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
+    let read_mode = inner
         .port_read_modes
         .get(port_name)
         .copied()
         .unwrap_or(READ_MODE_SKIP_TO_LATEST);
 
     // Search all subscribers for pending data on this port
-    for (_service_name, state) in ctx.subscribers.iter_mut() {
+    for (_service_name, state) in inner.subscribers.iter_mut() {
         if let Some(queue) = state.pending.get_mut(port_name) {
             if queue.is_empty() {
                 continue;
@@ -530,7 +567,7 @@ pub unsafe extern "C" fn slpn_output_publish(
     max_payload_bytes: usize,
     notify_service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -630,7 +667,11 @@ pub unsafe extern "C" fn slpn_output_publish(
         _ => None,
     };
 
-    ctx.publishers.insert(
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    inner.publishers.insert(
         port_name.to_string(),
         PublisherState {
             publisher,
@@ -645,6 +686,12 @@ pub unsafe extern "C" fn slpn_output_publish(
 
 /// Write data to a specific output port.
 ///
+/// Safe to call from any thread, including concurrently with other
+/// `slpn_*` ops on the same context — the inner [`Mutex`] serializes
+/// access to the iceoryx2 publisher map (#604). The lock is held through
+/// `loan_slice_uninit` + `send` + `notify`; iceoryx2's publisher path is
+/// lock-free zero-copy so the held duration is short.
+///
 /// Returns 0 on success, -1 on failure.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_output_write(
@@ -654,7 +701,7 @@ pub unsafe extern "C" fn slpn_output_write(
     data_len: u32,
     timestamp_ns: i64,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
@@ -663,7 +710,12 @@ pub unsafe extern "C" fn slpn_output_write(
         None => return -1,
     };
 
-    let state = match ctx.publishers.get(port_name) {
+    let inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+
+    let state = match inner.publishers.get(port_name) {
         Some(s) => s,
         None => {
             tracing::error!(
@@ -732,12 +784,18 @@ pub unsafe extern "C" fn slpn_event_subscribe(
     ctx: *mut PythonNativeContext,
     notify_service_name: *const c_char,
 ) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
-    if ctx.notify_listener.is_some() {
-        return 0;
+    {
+        let inner = match ctx.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if inner.notify_listener.is_some() {
+            return 0;
+        }
     }
     let name = match unsafe { c_str_to_str(notify_service_name) } {
         Some(s) if !s.is_empty() => s,
@@ -780,18 +838,29 @@ pub unsafe extern "C" fn slpn_event_subscribe(
             return -1;
         }
     };
-    ctx.notify_listener = Some(listener);
+    let mut inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    // Re-check under the lock — another thread may have raced ahead.
+    if inner.notify_listener.is_none() {
+        inner.notify_listener = Some(listener);
+    }
     0
 }
 
 /// Returns the underlying listener fd for `select`/`poll`, or -1 if not subscribed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_event_listener_fd(ctx: *mut PythonNativeContext) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
-    match ctx.notify_listener.as_ref() {
+    let inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    match inner.notify_listener.as_ref() {
         // SAFETY: native_handle() is unsafe per iceoryx2-bb-posix because the
         // returned int must not outlive the Listener. We hand it to Python
         // which uses it transiently inside select(); the Listener stays alive
@@ -807,11 +876,15 @@ pub unsafe extern "C" fn slpn_event_listener_fd(ctx: *mut PythonNativeContext) -
 /// Returns 0 on success, -1 if no listener is subscribed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slpn_event_drain(ctx: *mut PythonNativeContext) -> i32 {
-    let ctx = match unsafe { ctx.as_mut() } {
+    let ctx = match unsafe { ctx.as_ref() } {
         Some(c) => c,
         None => return -1,
     };
-    let Some(listener) = ctx.notify_listener.as_ref() else {
+    let inner = match ctx.inner.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let Some(listener) = inner.notify_listener.as_ref() else {
         return -1;
     };
     if let Err(e) = listener.try_wait_all(|_id| {}) {

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -33,6 +33,15 @@ from .processor_context import bridge_read_message, bridge_send_message
 ESCALATE_REQUEST_RPC = "escalate_request"
 ESCALATE_RESPONSE_RPC = "escalate_response"
 
+#: Default upper bound on how long :meth:`EscalateChannel.request` waits for
+#: a correlated response before raising. Generous enough for realistic
+#: escalate ops (compute pipeline-cache cold start, GPU readback under
+#: load) but tight enough that a stuck host or zombie reader thread
+#: surfaces as a clear ``EscalateError("escalate timed out…")`` instead
+#: of a silent hang. Callers can override per-request via the
+#: ``timeout_s`` parameter.
+DEFAULT_REQUEST_TIMEOUT_S: float = 60.0
+
 
 class EscalateError(RuntimeError):
     """Raised when the host returns an ``Err`` escalate response."""
@@ -246,7 +255,11 @@ class EscalateChannel:
     # -------------------- core request/response --------------------
 
     def request(
-        self, op: Dict[str, Any], *, allow_contended: bool = False
+        self,
+        op: Dict[str, Any],
+        *,
+        allow_contended: bool = False,
+        timeout_s: Optional[float] = DEFAULT_REQUEST_TIMEOUT_S,
     ) -> Optional[Dict[str, Any]]:
         """Send an escalate request and block until the correlated response.
 
@@ -262,6 +275,17 @@ class EscalateChannel:
         contention as a protocol violation (raises
         :class:`EscalateError`) so a buggy host can't silently degrade
         an op that was supposed to be blocking.
+
+        ``timeout_s`` caps how long this call waits for the correlated
+        response. ``None`` disables the timeout (waits indefinitely);
+        otherwise on expiry the call raises :class:`EscalateError` and
+        the pending slot is cleared. Defaults to
+        :data:`DEFAULT_REQUEST_TIMEOUT_S`.
+
+        Raises :class:`EscalateError` for: send failures (broken pipe,
+        OS-level write errors), timeouts, channel-closed-mid-flight,
+        and host-reported errors. The exception type is uniform so
+        callers don't have to special-case OSError vs. semantic failures.
         """
         request_id = str(uuid.uuid4())
         slot = _PendingResponse()
@@ -272,14 +296,27 @@ class EscalateChannel:
 
         try:
             req = {"rpc": ESCALATE_REQUEST_RPC, "request_id": request_id, **op}
-            bridge_send_message(self._stdout, req)
-            slot.event.wait()
-            msg = slot.message
+            try:
+                bridge_send_message(self._stdout, req)
+            except OSError as e:
+                raise EscalateError(
+                    f"escalate channel send failed: {e}"
+                ) from e
+            signaled = slot.event.wait(timeout=timeout_s)
         finally:
             with self._pending_lock:
                 self._pending.pop(request_id, None)
 
+        # Race-safe message check: a delivery can land between the
+        # `wait()` returning False (timeout) and the `finally` pop —
+        # `slot.message` reflects the latest state regardless of which
+        # branch the wait took.
+        msg = slot.message
         if msg is None:
+            if not signaled:
+                raise EscalateError(
+                    f"escalate timed out after {timeout_s}s"
+                )
             raise EscalateError("escalate channel closed before response arrived")
         result = msg.get("result")
         if result == "ok":

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -7,25 +7,25 @@ A Python processor running in a subprocess only sees a
 ``GpuContextLimitedAccess`` sandbox (no raw allocations). When it needs the
 privileged ``GpuContextFullAccess`` surface — e.g. to acquire a new-shape
 pixel buffer mid-stream — it sends an ``escalate_request`` to the Rust host
-over the subprocess's stdout, and the host replies with an
-``escalate_response`` on stdin. The host runs the work inside
+over the dedicated escalate socketpair, and the host replies with an
+``escalate_response``. The host runs the work inside
 ``GpuContextLimitedAccess::escalate``, which serializes against every other
 escalation in the runtime.
 
-This module is small on purpose: it owns the request-id bookkeeping and the
-deferred-lifecycle buffer that lets ``EscalateChannel.request()`` step over
-any lifecycle commands (``on_pause``, ``stop``, …) that happen to arrive
-while it's blocked waiting for its correlated response. The outer
-``subprocess_runner`` loop drains those buffered messages through
-``EscalateChannel.take_deferred_lifecycle_messages()`` before polling stdin
-again.
+This module owns the request-id bookkeeping and the response demultiplexer
+that lets multiple worker threads issue escalate calls concurrently. A
+single reader thread (started by :func:`start_reader_thread`) consumes the
+escalate fd, routes ``escalate_response`` messages to their waiting caller
+by ``request_id``, and forwards every other message into a lifecycle queue
+the runner's outer command loop drains.
 """
 
 from __future__ import annotations
 
+import queue
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from .processor_context import bridge_read_message, bridge_send_message
 
@@ -38,22 +38,35 @@ class EscalateError(RuntimeError):
     """Raised when the host returns an ``Err`` escalate response."""
 
 
-class EscalateChannel:
-    """Synchronous request/response channel over the subprocess's stdio pipes.
+class _PendingResponse:
+    """One slot per in-flight escalate request — Event + landing pad."""
 
-    The channel is single-flight: only one escalate request is in flight at
-    a time, matching the single-threaded structure of the Python subprocess
-    runner. Lifecycle messages that the host sends while we're waiting on a
-    correlated response are captured in ``_deferred_lifecycle`` and drained
-    by the outer loop through
-    :meth:`take_deferred_lifecycle_messages`.
+    __slots__ = ("event", "message")
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.message: Optional[Dict[str, Any]] = None
+
+
+class EscalateChannel:
+    """Concurrent-safe request/response channel over the escalate socketpair.
+
+    Multiple worker threads may issue concurrent :meth:`request` calls; each
+    call registers a per-``request_id`` slot keyed off
+    :class:`_PendingResponse` and blocks on its event. The dedicated reader
+    thread (see :func:`start_reader_thread`) demuxes incoming
+    ``escalate_response`` frames against this map and routes anything else
+    into the runner's lifecycle queue.
+
+    Frame writes are serialized by ``bridge_send_message``'s module lock, so
+    request payloads never interleave on the wire.
     """
 
-    def __init__(self, stdin, stdout) -> None:
-        self._stdin = stdin
+    def __init__(self, stdout) -> None:
         self._stdout = stdout
-        self._send_lock = threading.Lock()
-        self._deferred_lifecycle: List[Dict[str, Any]] = []
+        self._pending: Dict[str, _PendingResponse] = {}
+        self._pending_lock = threading.Lock()
+        self._closed = False
 
     # -------------------- public SDK surface --------------------
 
@@ -237,19 +250,47 @@ class EscalateChannel:
     ) -> Optional[Dict[str, Any]]:
         """Send an escalate request and block until the correlated response.
 
+        Safe to call from any thread, including concurrently with other
+        :meth:`request` calls. The reader thread routes incoming
+        ``escalate_response`` frames by ``request_id`` so concurrent calls
+        can't steal each other's responses.
+
         When ``allow_contended`` is true, a ``"contended"`` response is
         returned as ``None`` instead of raising. Used by
-        :meth:`try_acquire_cpu_readback` and any future ``try_*`` op that
+        :meth:`try_run_cpu_readback_copy` and any future ``try_*`` op that
         opts into the contended-skip shape — every other op still treats
         contention as a protocol violation (raises
         :class:`EscalateError`) so a buggy host can't silently degrade
         an op that was supposed to be blocking.
         """
         request_id = str(uuid.uuid4())
-        req = {"rpc": ESCALATE_REQUEST_RPC, "request_id": request_id, **op}
-        with self._send_lock:
+        slot = _PendingResponse()
+        with self._pending_lock:
+            if self._closed:
+                raise EscalateError("escalate channel is closed")
+            self._pending[request_id] = slot
+
+        try:
+            req = {"rpc": ESCALATE_REQUEST_RPC, "request_id": request_id, **op}
             bridge_send_message(self._stdout, req)
-            return self._await_response(request_id, allow_contended=allow_contended)
+            slot.event.wait()
+            msg = slot.message
+        finally:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+
+        if msg is None:
+            raise EscalateError("escalate channel closed before response arrived")
+        result = msg.get("result")
+        if result == "ok":
+            return msg
+        if result == "contended":
+            if allow_contended:
+                return None
+            raise EscalateError(
+                "escalate returned contended for an op that does not allow it"
+            )
+        raise EscalateError(msg.get("message") or "escalate failed")
 
     def log_fire_and_forget(self, payload: Dict[str, Any]) -> None:
         """Send a fire-and-forget escalate op (currently `log`).
@@ -262,38 +303,132 @@ class EscalateChannel:
         req = {"rpc": ESCALATE_REQUEST_RPC, **payload}
         bridge_send_message(self._stdout, req)
 
-    def _await_response(
-        self, request_id: str, *, allow_contended: bool = False
-    ) -> Optional[Dict[str, Any]]:
-        while True:
-            msg = bridge_read_message(self._stdin)
-            rpc = msg.get("rpc", "")
-            if rpc == ESCALATE_RESPONSE_RPC and msg.get("request_id") == request_id:
-                result = msg.get("result")
-                if result == "ok":
-                    return msg
-                if result == "contended":
-                    if allow_contended:
-                        return None
-                    raise EscalateError(
-                        "escalate returned contended for an op that does not allow it"
+    # -------------------- demux + shutdown --------------------
+
+    def deliver_response(self, msg: Dict[str, Any]) -> bool:
+        """Route an incoming ``escalate_response`` to its waiting caller.
+
+        Called from the reader thread for every frame where
+        ``rpc == ESCALATE_RESPONSE_RPC``. Returns ``True`` when the
+        response was delivered to a registered waiter, ``False`` if the
+        ``request_id`` is unknown (orphaned / late response — dropped).
+        """
+        request_id = msg.get("request_id")
+        if not isinstance(request_id, str):
+            return False
+        with self._pending_lock:
+            slot = self._pending.get(request_id)
+        if slot is None:
+            return False
+        slot.message = msg
+        slot.event.set()
+        return True
+
+    def close(self) -> None:
+        """Wake every in-flight ``request`` with a closed-channel error.
+
+        Called from the reader thread when the escalate fd reaches EOF, or
+        from the runner during shutdown. Idempotent.
+        """
+        with self._pending_lock:
+            self._closed = True
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for slot in pending:
+            slot.message = None
+            slot.event.set()
+
+
+# ============================================================================
+# Reader thread — demultiplexes the escalate fd
+# ============================================================================
+
+
+class BridgeReaderThread:
+    """Background thread that owns the escalate fd reader.
+
+    Splits incoming frames between two consumers:
+
+    - ``escalate_response`` frames go to :meth:`EscalateChannel.deliver_response`.
+    - everything else goes to ``lifecycle_queue`` for the runner's outer
+      command loop to dispatch.
+
+    The thread exits on EOF (host closed the fd) or when ``stop()`` is
+    called. EOF is signaled to the lifecycle queue with a sentinel so the
+    runner can shut down.
+    """
+
+    EOF_SENTINEL: Dict[str, Any] = {"__bridge_eof__": True}
+
+    def __init__(
+        self,
+        stdin,
+        escalate_channel: EscalateChannel,
+        lifecycle_queue: "queue.Queue[Dict[str, Any]]",
+    ) -> None:
+        self._stdin = stdin
+        self._escalate_channel = escalate_channel
+        self._lifecycle_queue = lifecycle_queue
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        """Start the reader thread. Idempotent — second call is a no-op."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._loop,
+            name="streamlib-bridge-reader",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, *, join_timeout: float = 1.0) -> None:
+        """Request the reader to exit and join it."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=join_timeout)
+
+    def _loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                try:
+                    msg = bridge_read_message(self._stdin)
+                except EOFError:
+                    break
+                except Exception:
+                    # Defensive: a malformed frame shouldn't kill the runner;
+                    # log via the standard channel and keep going. The host's
+                    # bridge writer is the source of truth — drift here means
+                    # something upstream is wrong, but we don't want to mask
+                    # the issue by silently exiting.
+                    from . import log
+
+                    log.error(
+                        "bridge reader: malformed frame; continuing",
                     )
-                raise EscalateError(msg.get("message") or "escalate failed")
-            # Any other message during our blocking read is a lifecycle
-            # command (stop / teardown / on_pause / on_resume / update_config).
-            # Defer it so the outer loop consumes it in FIFO order.
-            self._deferred_lifecycle.append(msg)
+                    continue
 
-    # -------------------- lifecycle cooperation --------------------
+                if msg.get("rpc") == ESCALATE_RESPONSE_RPC:
+                    if not self._escalate_channel.deliver_response(msg):
+                        # Late / orphan response — log and drop.
+                        from . import log
 
-    def take_deferred_lifecycle_messages(self) -> List[Dict[str, Any]]:
-        """Drain and return buffered lifecycle messages, FIFO."""
-        out = self._deferred_lifecycle
-        self._deferred_lifecycle = []
-        return out
+                        log.warn(
+                            "bridge reader: orphan escalate response",
+                            request_id=msg.get("request_id"),
+                        )
+                    continue
 
-    def has_deferred_lifecycle_messages(self) -> bool:
-        return bool(self._deferred_lifecycle)
+                # Lifecycle command (or unknown rpc) — hand off to the runner.
+                self._lifecycle_queue.put(msg)
+        finally:
+            # Wake every in-flight escalate caller so they don't deadlock,
+            # and signal the runner that no more lifecycle messages will
+            # arrive on this channel.
+            self._escalate_channel.close()
+            self._lifecycle_queue.put(self.EOF_SENTINEL)
 
 
 _channel_singleton: Optional[EscalateChannel] = None

--- a/libs/streamlib-python/python/streamlib/subprocess_runner.py
+++ b/libs/streamlib-python/python/streamlib/subprocess_runner.py
@@ -11,6 +11,13 @@ fd1/fd2 stay as free log pipes that the host captures as `intercepted`
 records in the unified JSONL. Data I/O uses direct iceoryx2 FFI via
 libstreamlib_python_native.
 
+A single :class:`BridgeReaderThread` owns the escalate fd: it demultiplexes
+``escalate_response`` frames into their waiting caller (any thread that
+called ``ctx.escalate_*``) and forwards every other frame into a
+lifecycle queue this runner drains. That decoupling is what lets manual-
+mode worker threads issue concurrent escalate calls while the runner's
+main thread keeps draining lifecycle commands (#604).
+
 Usage:
     python -m streamlib.subprocess_runner
 
@@ -26,18 +33,19 @@ Environment variables:
 
 import importlib
 import os
+import queue
 import select
 import socket
 import sys
+import time
 import traceback
 
 from . import clock, log
-from .escalate import EscalateChannel, install_channel
+from .escalate import BridgeReaderThread, EscalateChannel, install_channel
 from .processor_context import (
     NativeProcessorState,
     NativeRuntimeContextFullAccess,
     NativeRuntimeContextLimitedAccess,
-    bridge_read_message,
     bridge_send_message,
     compute_read_buf_bytes,
     load_native_lib,
@@ -248,39 +256,33 @@ def _assert_capability(processor_id: str, cmd: str, msg: dict, expected: str) ->
         )
 
 
-def _handle_stdin_during_run(
-    stdin, stdout, processor, full_ctx, limited_ctx, processor_id,
-    escalate_channel=None,
+def _drain_lifecycle_during_run(
+    lifecycle_queue, stdout, processor, full_ctx, limited_ctx, processor_id,
 ):
-    """Non-blocking check for lifecycle commands during the run loop.
+    """Non-blocking poll for lifecycle commands during the run loop.
 
-    Also drains any lifecycle commands the escalate channel may have buffered
-    while blocked on a correlated response. Handles on_pause, on_resume, and
-    update_config inline. Returns "stop", "teardown", or None.
+    Drains all queued lifecycle messages (which the bridge reader thread
+    deposited while we were busy processing a frame) and dispatches them.
+    Handles on_pause / on_resume / update_config inline; returns ``"stop"``
+    or ``"teardown"`` (or :data:`BridgeReaderThread.EOF_SENTINEL`'s
+    sentinel form ``"eof"``) as soon as a terminal command is observed,
+    re-queueing any messages we didn't process so a stop/teardown takes
+    precedence in FIFO order.
     """
-    # Drain deferred lifecycle messages first — they arrived while a
-    # process() call was blocked on ctx.escalate_*, so they're older than
-    # anything still in the pipe.
-    if escalate_channel and escalate_channel.has_deferred_lifecycle_messages():
-        deferred = escalate_channel.take_deferred_lifecycle_messages()
-        for dm in deferred:
-            result = _dispatch_lifecycle_msg(
-                dm, stdout, processor, full_ctx, limited_ctx, processor_id,
-            )
-            if result is not None:
-                # Re-queue any messages we didn't process this turn so a
-                # stop/teardown coming from a deferred slot takes precedence.
-                remaining = deferred[deferred.index(dm) + 1 :]
-                escalate_channel._deferred_lifecycle[:0] = remaining
-                return result
+    while True:
+        try:
+            msg = lifecycle_queue.get_nowait()
+        except queue.Empty:
+            return None
 
-    if not select.select([stdin], [], [], 0)[0]:
-        return None
+        if msg.get("__bridge_eof__"):
+            return "eof"
 
-    msg = bridge_read_message(stdin)
-    return _dispatch_lifecycle_msg(
-        msg, stdout, processor, full_ctx, limited_ctx, processor_id,
-    )
+        result = _dispatch_lifecycle_msg(
+            msg, stdout, processor, full_ctx, limited_ctx, processor_id,
+        )
+        if result is not None:
+            return result
 
 
 def _dispatch_lifecycle_msg(
@@ -327,6 +329,18 @@ def _dispatch_lifecycle_msg(
     return None
 
 
+def _next_lifecycle_msg(lifecycle_queue):
+    """Block until the next lifecycle message arrives, returning ``None`` on EOF.
+
+    Used by the outer command loop. The ``__bridge_eof__`` sentinel maps to
+    ``None`` so callers see a clean EOF signal.
+    """
+    msg = lifecycle_queue.get()
+    if msg.get("__bridge_eof__"):
+        return None
+    return msg
+
+
 def main():
     """Main entry point for the subprocess runner."""
     entrypoint = os.environ.get("STREAMLIB_ENTRYPOINT")
@@ -353,10 +367,18 @@ def main():
     stdin, stdout, _escalate_sock = _open_escalate_fd_stream()
 
     # Install the escalate channel so processors can call ctx.escalate_*
-    # during setup() and process(). The channel demultiplexes responses
-    # by request_id.
-    escalate_channel = EscalateChannel(stdin, stdout)
+    # during setup() and process(). The reader thread (started below)
+    # demultiplexes responses by request_id so concurrent calls from
+    # worker threads are safe (#604).
+    escalate_channel = EscalateChannel(stdout)
     install_channel(escalate_channel)
+
+    # Lifecycle commands flow through this queue; the bridge reader thread
+    # is the sole producer, the runner's outer loop (and the run-phase
+    # `_drain_lifecycle_during_run`) are the consumers.
+    lifecycle_queue: "queue.Queue[dict]" = queue.Queue()
+    bridge_reader = BridgeReaderThread(stdin, escalate_channel, lifecycle_queue)
+    bridge_reader.start()
 
     # Install unified logging: writer thread + stdio / logging interceptors.
     # After this point, `print()` / `sys.stderr.write()` / `logging.*` all
@@ -380,7 +402,10 @@ def main():
 
     try:
         while True:
-            msg = bridge_read_message(stdin)
+            msg = _next_lifecycle_msg(lifecycle_queue)
+            if msg is None:
+                log.info("escalate channel closed, shutting down")
+                break
             cmd = msg.get("cmd", "")
 
             if cmd == "setup":
@@ -425,17 +450,11 @@ def main():
                 log.info("Entering execution loop", mode=execution_mode)
 
                 if execution_mode == "reactive":
-                    # Try the destination's listener fd; -1 means no notify
-                    # service was wired (Rust source absent or older host) —
-                    # we fall back to a coarse sleep so the loop still
-                    # progresses without burning idle CPU.
                     listener_fd = native_lib.slpn_event_listener_fd(native_ctx_ptr)
-                    stdin_fd = stdin.fileno()
-                    select_fds = [stdin_fd]
-                    if listener_fd >= 0:
-                        select_fds.append(listener_fd)
-                    # Cap the wait so a closed stdin / shutdown command latency
-                    # stays bounded even if no notify ever arrives.
+                    # Cap the wait so a closed escalate fd / shutdown command
+                    # latency stays bounded even if no notify ever arrives.
+                    # Matches the previous select() timeout — teardown latency
+                    # is bounded by this constant plus per-iteration overhead.
                     SELECT_TIMEOUT_S = 0.1
                     while running:
                         has_data = native_lib.slpn_input_poll(native_ctx_ptr)
@@ -453,13 +472,23 @@ def main():
                             except Exception as e:
                                 log.error("process() error", error=str(e))
                         else:
-                            ready, _, _ = select.select(select_fds, [], [], SELECT_TIMEOUT_S)
-                            if listener_fd >= 0 and listener_fd in ready:
-                                native_lib.slpn_event_drain(native_ctx_ptr)
+                            # No data: block on the input notify fd (when
+                            # wired) or a coarse sleep otherwise. The
+                            # lifecycle queue is drained unconditionally
+                            # below, so the SELECT_TIMEOUT_S cap is what
+                            # bounds teardown latency.
+                            if listener_fd >= 0:
+                                ready, _, _ = select.select(
+                                    [listener_fd], [], [], SELECT_TIMEOUT_S,
+                                )
+                                if listener_fd in ready:
+                                    native_lib.slpn_event_drain(native_ctx_ptr)
+                            else:
+                                time.sleep(SELECT_TIMEOUT_S)
 
-                        lifecycle_cmd = _handle_stdin_during_run(
-                            stdin, stdout, processor, full_ctx, limited_ctx,
-                            processor_id, escalate_channel=escalate_channel,
+                        lifecycle_cmd = _drain_lifecycle_during_run(
+                            lifecycle_queue, stdout, processor, full_ctx, limited_ctx,
+                            processor_id,
                         )
                         if lifecycle_cmd == "teardown":
                             running = False
@@ -473,6 +502,8 @@ def main():
                         elif lifecycle_cmd == "stop":
                             running = False
                             bridge_send_message(stdout, {"rpc": "stopped"})
+                        elif lifecycle_cmd == "eof":
+                            running = False
 
                 elif execution_mode == "continuous":
                     # Drift-free monotonic-clock dispatch via timerfd. Replaces
@@ -512,16 +543,16 @@ def main():
                                     running = False
                                     break
                                 # expirations == 0 -> timeout, fall through to
-                                # the stdin poll. expirations >= 1 -> tick(s)
+                                # the lifecycle drain. expirations >= 1 -> tick(s)
                                 # consumed; the loop body already ran once for
                                 # this iteration so missed-tick catch-up is
                                 # naturally skipped (drift-free, not catch-up).
                             # interval_ms <= 0: no timer; loop runs as fast as
-                            # process() returns, polling stdin between iterations.
+                            # process() returns.
 
-                            lifecycle_cmd = _handle_stdin_during_run(
-                                stdin, stdout, processor, full_ctx, limited_ctx,
-                                processor_id, escalate_channel=escalate_channel,
+                            lifecycle_cmd = _drain_lifecycle_during_run(
+                                lifecycle_queue, stdout, processor, full_ctx, limited_ctx,
+                                processor_id,
                             )
                             if lifecycle_cmd == "teardown":
                                 running = False
@@ -535,12 +566,18 @@ def main():
                             elif lifecycle_cmd == "stop":
                                 running = False
                                 bridge_send_message(stdout, {"rpc": "stopped"})
+                            elif lifecycle_cmd == "eof":
+                                running = False
                     finally:
                         if timer is not None:
                             timer.close()
 
                 elif execution_mode == "manual":
-                    # Manual mode: start() is a resource-lifecycle op → full access
+                    # Manual mode: start() is a resource-lifecycle op → full access.
+                    # The contract is that start() returns promptly (worker
+                    # threads do the long-lived work). Worker threads are now
+                    # safe to call ctx.escalate_* concurrently — the bridge
+                    # reader thread demuxes responses by request_id.
                     if hasattr(processor, "start"):
                         try:
                             processor.start(full_ctx)
@@ -598,14 +635,13 @@ def main():
             else:
                 log.warn("Unknown command", cmd=cmd)
 
-    except EOFError:
-        log.info("stdin closed, shutting down")
     except Exception as e:
         log.error("Fatal error", error=str(e), traceback=traceback.format_exc())
         # finally runs cleanup; exit code is set by sys.exit raising SystemExit
         sys.exit(1)
     finally:
         # Single cleanup site — the FFI free is not idempotent (#469).
+        bridge_reader.stop()
         if native_lib and native_ctx_ptr:
             _cleanup_native(native_lib, native_ctx_ptr, native_handle_ptr, state)
         log.info("Subprocess runner exiting")

--- a/libs/streamlib-python/python/streamlib/tests/test_escalate_concurrency.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_escalate_concurrency.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Concurrency tests for [`EscalateChannel`] (#604).
+
+Pre-#604, ``EscalateChannel.request()`` held a single ``_send_lock``
+through both ``bridge_send_message`` and ``_await_response``. The
+single-flight invariant was: only one request is in flight at a time;
+the runner's outer loop is the sole reader of stdin between escalate
+roundtrips. In manual mode, a worker thread that issued an escalate
+request would compete with the outer loop for stdin reads, sometimes
+stealing a lifecycle command into ``_await_response``'s loop or losing
+its correlated response to the outer loop.
+
+#604 replaced that with:
+
+- a dedicated [`BridgeReaderThread`] that owns the escalate fd reader
+  and demuxes incoming frames by ``rpc``: ``escalate_response`` →
+  [`EscalateChannel.deliver_response`] (looking up the waiter by
+  ``request_id``); everything else → a lifecycle queue the runner
+  drains on its main thread.
+- per-request slots ([`_PendingResponse`]) keyed by ``request_id``
+  inside [`EscalateChannel`], so concurrent ``request()`` calls
+  register non-aliasing waiters and block on per-slot
+  ``threading.Event``s.
+
+These tests drive a fake host over a real ``socket.socketpair`` (so the
+production code path — ``socket.makefile("rb"/"wb")`` + length-prefixed
+JSON framing — is exercised end-to-end) and assert that:
+
+1. 200+ concurrent ``request()`` calls from N worker threads all
+   correlate back to their own caller, even when the host responds
+   out-of-order with respect to send order.
+2. Lifecycle messages interleaved with escalate responses are routed
+   into the lifecycle queue and never observed by ``request()``.
+3. EOF on the escalate fd wakes every in-flight ``request()`` with an
+   ``EscalateError`` instead of hanging the test runner.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import socket
+import struct
+import threading
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from streamlib.escalate import (
+    BridgeReaderThread,
+    EscalateChannel,
+    EscalateError,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_pair() -> Tuple[Any, Any, Any, Any]:
+    """Set up a socketpair representing the (subprocess, host) bridge.
+
+    Returns ``(subprocess_reader, subprocess_writer, host_reader, host_writer)``.
+    The subprocess side is wrapped in unbuffered file objects exactly the
+    way ``subprocess_runner._open_escalate_fd_stream`` does so the
+    framing exercised by [`bridge_read_message`] / [`bridge_send_message`]
+    matches production.
+    """
+    sub_sock, host_sock = socket.socketpair()
+    sub_reader = sub_sock.makefile("rb", buffering=0)
+    sub_writer = sub_sock.makefile("wb", buffering=0)
+    host_reader = host_sock.makefile("rb", buffering=0)
+    host_writer = host_sock.makefile("wb", buffering=0)
+    # Caller is responsible for closing the writers and original sockets;
+    # tests use try/finally to drive that.
+    return sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock
+
+
+def _read_frame(stream) -> Dict[str, Any]:
+    len_buf = stream.read(4)
+    if len(len_buf) < 4:
+        raise EOFError("pair closed")
+    (length,) = struct.unpack(">I", len_buf)
+    body = stream.read(length)
+    if len(body) < length:
+        raise EOFError("pair closed mid-message")
+    return json.loads(body)
+
+
+def _send_frame(stream, msg: Dict[str, Any]) -> None:
+    body = json.dumps(msg, separators=(",", ":")).encode("utf-8")
+    stream.write(struct.pack(">I", len(body)))
+    stream.write(body)
+    stream.flush()
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+def test_concurrent_requests_correlate_correctly():
+    """200 concurrent request/response cycles across 8 worker threads.
+    The host echo loop runs in its own thread and replies immediately,
+    so workers fire their next request as soon as the previous resolves
+    — putting up to 8 requests in flight at once and exercising the
+    cross-talk path that pre-#604 lock-while-reading would corrupt.
+    """
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    THREADS = 8
+    PER_THREAD = 25  # 200 total
+
+    host_stop = threading.Event()
+
+    def _host_loop() -> None:
+        while not host_stop.is_set():
+            try:
+                msg = _read_frame(host_reader)
+            except EOFError:
+                return
+            if msg.get("rpc") != "escalate_request":
+                continue
+            request_id = msg["request_id"]
+            worker_id = msg.get("_worker_id")
+            iter_idx = msg.get("_iter")
+            _send_frame(
+                host_writer,
+                {
+                    "rpc": "escalate_response",
+                    "request_id": request_id,
+                    "result": "ok",
+                    "echo_tag": f"w{worker_id}-i{iter_idx}",
+                },
+            )
+
+    host_thread = threading.Thread(
+        target=_host_loop, name="test-host-loop", daemon=True
+    )
+    host_thread.start()
+
+    failures: List[str] = []
+    failures_lock = threading.Lock()
+
+    def _worker(worker_id: int) -> None:
+        for i in range(PER_THREAD):
+            payload = {
+                "op": "test_correlation",
+                "_worker_id": worker_id,
+                "_iter": i,
+            }
+            try:
+                response = channel.request(payload)
+            except EscalateError as e:
+                with failures_lock:
+                    failures.append(f"worker {worker_id} iter {i}: {e}")
+                return
+            assert response is not None
+            tag = response["echo_tag"]
+            expected = f"w{worker_id}-i{i}"
+            if tag != expected:
+                with failures_lock:
+                    failures.append(
+                        f"worker {worker_id} iter {i}: got tag {tag!r}, expected {expected!r}"
+                    )
+
+    workers = [
+        threading.Thread(
+            target=_worker, args=(w,), name=f"test-worker-{w}", daemon=True
+        )
+        for w in range(THREADS)
+    ]
+    try:
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=20.0)
+            assert not w.is_alive(), "worker hung — likely lost-response regression"
+
+        assert not failures, "concurrent escalate failures: " + "; ".join(failures)
+    finally:
+        host_stop.set()
+        reader.stop()
+        for s in (sub_writer, host_writer, sub_reader, host_reader, sub_sock, host_sock):
+            try:
+                s.close()
+            except Exception:
+                pass
+
+
+def test_out_of_order_responses_correlate_correctly():
+    """50 requests fired truly concurrently (one per thread), batched
+    by the host, then echoed back in reverse order. Any demuxer that
+    accidentally relied on FIFO ordering would mismatch tags — this
+    test catches that regression.
+    """
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    REQUESTS = 50
+
+    received: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+
+    def _host_batch() -> None:
+        for _ in range(REQUESTS):
+            try:
+                msg = _read_frame(host_reader)
+            except EOFError:
+                return
+            received.put(msg)
+
+    host_thread = threading.Thread(
+        target=_host_batch, name="test-host-batch", daemon=True
+    )
+    host_thread.start()
+
+    results: Dict[int, str] = {}
+    results_lock = threading.Lock()
+    failures: List[str] = []
+    failures_lock = threading.Lock()
+    barrier = threading.Barrier(REQUESTS)
+
+    def _worker(worker_id: int) -> None:
+        # Synchronise so all REQUESTS calls go on the wire concurrently.
+        barrier.wait()
+        try:
+            response = channel.request(
+                {"op": "test_oo", "_worker_id": worker_id}
+            )
+        except EscalateError as e:
+            with failures_lock:
+                failures.append(f"worker {worker_id}: {e}")
+            return
+        assert response is not None
+        with results_lock:
+            results[worker_id] = response["echo_tag"]
+
+    workers = [
+        threading.Thread(
+            target=_worker, args=(w,), name=f"test-oo-worker-{w}", daemon=True
+        )
+        for w in range(REQUESTS)
+    ]
+    try:
+        for w in workers:
+            w.start()
+
+        # Collect the batch the host saw, then echo in REVERSE order.
+        collected: List[Dict[str, Any]] = []
+        for _ in range(REQUESTS):
+            collected.append(received.get(timeout=10.0))
+        for msg in reversed(collected):
+            request_id = msg["request_id"]
+            worker_id = msg["_worker_id"]
+            _send_frame(
+                host_writer,
+                {
+                    "rpc": "escalate_response",
+                    "request_id": request_id,
+                    "result": "ok",
+                    "echo_tag": f"w{worker_id}",
+                },
+            )
+
+        for w in workers:
+            w.join(timeout=10.0)
+            assert not w.is_alive(), "worker hung — likely lost-response regression"
+
+        assert not failures, "out-of-order escalate failures: " + "; ".join(failures)
+        assert len(results) == REQUESTS
+        for w_id, tag in results.items():
+            assert tag == f"w{w_id}", f"cross-talk: worker {w_id} got tag {tag!r}"
+    finally:
+        reader.stop()
+        for s in (sub_writer, host_writer, sub_reader, host_reader, sub_sock, host_sock):
+            try:
+                s.close()
+            except Exception:
+                pass
+
+
+def test_lifecycle_messages_routed_to_queue_not_request():
+    """Lifecycle frames the host sends *between* escalate responses must
+    never surface from `request()`. They go to the lifecycle queue."""
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    request_done = threading.Event()
+    request_result: List[Any] = []
+
+    def _worker() -> None:
+        try:
+            request_result.append(channel.request({"op": "ping"}))
+        except Exception as e:
+            request_result.append(e)
+        finally:
+            request_done.set()
+
+    threading.Thread(target=_worker, name="test-ping-worker", daemon=True).start()
+
+    # Wait for the request to actually arrive on the host side.
+    msg = _read_frame(host_reader)
+    request_id = msg["request_id"]
+
+    # Inject a lifecycle frame before the escalate response to prove the
+    # demuxer routes the lifecycle into the queue and the request keeps
+    # waiting on its own slot.
+    _send_frame(
+        host_writer,
+        {"cmd": "on_pause", "capability": "limited"},
+    )
+    # Give the reader a chance to deliver the lifecycle without racing
+    # the response.
+    time.sleep(0.05)
+
+    _send_frame(
+        host_writer,
+        {
+            "rpc": "escalate_response",
+            "request_id": request_id,
+            "result": "ok",
+        },
+    )
+
+    try:
+        assert request_done.wait(timeout=5.0), "request() never returned"
+        assert len(request_result) == 1
+        assert not isinstance(request_result[0], Exception)
+
+        # Lifecycle queue should hold exactly the on_pause we injected.
+        try:
+            queued = lifecycle_queue.get(timeout=2.0)
+        except queue.Empty:
+            pytest.fail("lifecycle frame was lost — should have been routed to queue")
+        assert queued.get("cmd") == "on_pause"
+    finally:
+        reader.stop()
+        for s in (sub_writer, host_writer, sub_reader, host_reader, sub_sock, host_sock):
+            try:
+                s.close()
+            except Exception:
+                pass
+
+
+def test_eof_wakes_in_flight_requests_with_error():
+    """If the host closes the escalate fd while a request is waiting, the
+    request must wake with [`EscalateError`] rather than hang."""
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    raised: List[Any] = []
+    done = threading.Event()
+
+    def _worker() -> None:
+        try:
+            channel.request({"op": "stranded"})
+        except EscalateError as e:
+            raised.append(e)
+        finally:
+            done.set()
+
+    threading.Thread(target=_worker, name="test-eof-worker", daemon=True).start()
+
+    # Wait for the request to land on the host side, then close the host
+    # end without responding. The reader should hit EOF and call
+    # `channel.close()`, which signals the in-flight slot.
+    _ = _read_frame(host_reader)
+    # `socketpair`'s peer doesn't see EOF until every fd referencing the
+    # socket is gone — `makefile("rb", buffering=0)` and
+    # `makefile("wb", buffering=0)` each keep a reference, so we have
+    # to close all of them plus the underlying socket. A SHUT_RDWR on
+    # the socket itself forces the EOF propagation regardless.
+    host_writer.close()
+    host_reader.close()
+    try:
+        host_sock.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    host_sock.close()
+
+    try:
+        assert done.wait(timeout=5.0), "request() did not wake on EOF"
+        assert len(raised) == 1
+        assert isinstance(raised[0], EscalateError)
+    finally:
+        reader.stop()
+        for s in (sub_writer, sub_reader, sub_sock):
+            try:
+                s.close()
+            except Exception:
+                pass

--- a/libs/streamlib-python/python/streamlib/tests/test_escalate_concurrency.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_escalate_concurrency.py
@@ -356,6 +356,148 @@ def test_lifecycle_messages_routed_to_queue_not_request():
                 pass
 
 
+def test_send_failure_surfaces_as_escalate_error():
+    """If `bridge_send_message` raises (broken pipe, fd revoked, etc.),
+    `request()` must convert the OSError into an EscalateError so callers
+    see a single uniform exception type for every channel failure."""
+
+    class _BrokenWriter:
+        """Stream stub whose write() raises BrokenPipeError on first call."""
+
+        def write(self, _b: bytes) -> int:
+            raise BrokenPipeError("simulated broken pipe")
+
+        def flush(self) -> None:
+            pass
+
+    channel = EscalateChannel(_BrokenWriter())
+    raised: list[Exception] = []
+    try:
+        channel.request({"op": "noop"})
+    except Exception as e:  # noqa: BLE001 — we want the type comparison
+        raised.append(e)
+
+    assert len(raised) == 1
+    assert isinstance(raised[0], EscalateError), (
+        f"expected EscalateError, got {type(raised[0]).__name__}: {raised[0]}"
+    )
+    assert "send failed" in str(raised[0])
+
+
+def test_request_timeout_surfaces_as_escalate_error():
+    """If no response arrives within `timeout_s`, the request raises
+    EscalateError with a clear timeout message rather than hanging."""
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    raised: list[Exception] = []
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _worker() -> None:
+        started.set()
+        try:
+            channel.request({"op": "blocked"}, timeout_s=0.2)
+        except Exception as e:  # noqa: BLE001
+            raised.append(e)
+        finally:
+            finished.set()
+
+    threading.Thread(target=_worker, name="test-timeout-worker", daemon=True).start()
+
+    try:
+        # Drain the request frame on the host side without responding.
+        # The worker should hit the 200ms timeout.
+        assert started.wait(timeout=2.0)
+        _ = _read_frame(host_reader)
+        assert finished.wait(timeout=5.0), "request() did not honor timeout"
+        assert len(raised) == 1
+        assert isinstance(raised[0], EscalateError)
+        assert "timed out" in str(raised[0])
+    finally:
+        reader.stop()
+        for s in (sub_writer, host_writer, sub_reader, host_reader, sub_sock, host_sock):
+            try:
+                s.close()
+            except Exception:
+                pass
+
+
+def test_late_response_after_timeout_does_not_lose_data():
+    """Race-safety: if a response arrives between `event.wait(timeout)`
+    returning False and the slot pop, `slot.message` is still populated.
+    The current request will see the timeout error, but the next
+    request's slot must not be corrupted by the orphaned message — the
+    reader's `deliver_response` looks the slot up under the lock and
+    returns False if the entry is gone."""
+    sub_reader, sub_writer, host_reader, host_writer, sub_sock, host_sock = _make_pair()
+    channel = EscalateChannel(sub_writer)
+    lifecycle_queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+    reader = BridgeReaderThread(sub_reader, channel, lifecycle_queue)
+    reader.start()
+
+    try:
+        # First request times out before the host responds.
+        first_raised: list[Exception] = []
+        try:
+            channel.request({"op": "first"}, timeout_s=0.1)
+        except Exception as e:  # noqa: BLE001
+            first_raised.append(e)
+        assert len(first_raised) == 1
+        assert isinstance(first_raised[0], EscalateError)
+
+        # Host now responds to the first request — orphaned, dropped.
+        first_msg = _read_frame(host_reader)
+        _send_frame(
+            host_writer,
+            {
+                "rpc": "escalate_response",
+                "request_id": first_msg["request_id"],
+                "result": "ok",
+                "stale": True,
+            },
+        )
+
+        # Second request should NOT see the orphaned response from the
+        # first — its own slot is registered under a fresh request_id
+        # and the orphan goes through deliver_response → returns False
+        # (no slot found) → logged + dropped.
+        captured: dict[str, Any] = {}
+        done = threading.Event()
+
+        def _second() -> None:
+            captured["response"] = channel.request({"op": "second"})
+            done.set()
+
+        threading.Thread(target=_second, daemon=True).start()
+        second_msg = _read_frame(host_reader)
+        _send_frame(
+            host_writer,
+            {
+                "rpc": "escalate_response",
+                "request_id": second_msg["request_id"],
+                "result": "ok",
+                "second": True,
+            },
+        )
+        assert done.wait(timeout=5.0)
+        # The second request's response is its own — not the stale
+        # first response.
+        assert captured["response"] is not None
+        assert captured["response"].get("second") is True
+        assert "stale" not in captured["response"]
+    finally:
+        reader.stop()
+        for s in (sub_writer, host_writer, sub_reader, host_reader, sub_sock, host_sock):
+            try:
+                s.close()
+            except Exception:
+                pass
+
+
 def test_eof_wakes_in_flight_requests_with_error():
     """If the host closes the escalate fd while a request is waiting, the
     request must wake with [`EscalateError`] rather than hang."""

--- a/libs/streamlib-python/python/streamlib/tests/test_subprocess_runner_cleanup.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_subprocess_runner_cleanup.py
@@ -14,16 +14,21 @@ teardown), mock the FFI lib so the cleanup symbols are countable, and assert
 each FFI cleanup symbol is called *exactly once*. Reverting the fix (re-adding
 the inline `_cleanup_native(...)` in the outer teardown branch) makes both
 counts equal 2 and these tests fail.
+
+Updated for #604 — the runner now reads lifecycle messages from a queue
+filled by `BridgeReaderThread` instead of polling stdin directly. The mock
+reader thread replaces the real one and hands the scripted messages into
+the same queue.
 """
 
 from __future__ import annotations
 
-import sys
 from typing import Any
 
 import pytest
 
 from streamlib import subprocess_runner
+from streamlib.escalate import BridgeReaderThread
 
 
 # ============================================================================
@@ -112,7 +117,7 @@ def _patch_runner(
     scripted messages against the mock FFI without touching real fds."""
 
     # Stub the escalate fd / channel — the runner never actually reads from
-    # them in this test because we replace `bridge_read_message` below.
+    # them in this test because we replace the bridge reader thread below.
     class _DummyStream:
         def write(self, _b: bytes) -> int:
             return 0
@@ -138,16 +143,36 @@ def _patch_runner(
         def __init__(self, *_a: Any, **_kw: Any) -> None:
             pass
 
-        def has_deferred_lifecycle_messages(self) -> bool:
-            return False
-
     monkeypatch.setattr(subprocess_runner, "EscalateChannel", _DummyChannel)
     monkeypatch.setattr(subprocess_runner, "install_channel", lambda _c: None)
+
+    # Replace BridgeReaderThread with a stub that synchronously enqueues the
+    # scripted messages plus the EOF sentinel as soon as `start()` is called.
+    # The runner's outer loop drains the queue exactly as if a real reader
+    # thread had read them off the wire.
+    class _ScriptedBridgeReader:
+        def __init__(self, _stdin: Any, _channel: Any, lifecycle_queue: Any) -> None:
+            self._queue = lifecycle_queue
+
+        def start(self) -> None:
+            for msg in scripted_messages:
+                self._queue.put(msg)
+            self._queue.put(BridgeReaderThread.EOF_SENTINEL)
+
+        def stop(self, *, join_timeout: float = 1.0) -> None:
+            pass
+
+    monkeypatch.setattr(subprocess_runner, "BridgeReaderThread", _ScriptedBridgeReader)
 
     # Logging — the runner installs interceptors that hijack stdout. Skip them.
     monkeypatch.setattr(subprocess_runner.log, "set_processor_id", lambda _p: None)
     monkeypatch.setattr(subprocess_runner.log, "install", lambda _c: None)
     monkeypatch.setattr(subprocess_runner.log, "shutdown", lambda: None)
+    # `_setup_native_state` calls `clock.install_timerfd(lib)` to wire the
+    # MonotonicTimer FFI. The mock doesn't expose ctypes-shaped function
+    # attributes, so skip the install — these tests don't exercise
+    # MonotonicTimer.
+    monkeypatch.setattr(subprocess_runner.clock, "install_timerfd", lambda _lib: None)
 
     monkeypatch.setattr(
         subprocess_runner, "_load_processor_class", lambda _e, _p: _NoopProcessor
@@ -161,23 +186,13 @@ def _patch_runner(
     monkeypatch.setattr(subprocess_runner, "load_native_lib", lambda _path: mock_lib)
     monkeypatch.setattr(pc, "load_native_lib", lambda _path: mock_lib)
 
-    # Script the bridge message sequence.
-    msg_iter = iter(scripted_messages)
-
-    def _fake_read(_stdin: Any) -> dict[str, Any]:
-        try:
-            return next(msg_iter)
-        except StopIteration as e:
-            # Loop is supposed to exit before we run out — surfacing as
-            # EOFError mimics the host closing stdin.
-            raise EOFError("scripted messages exhausted") from e
-
+    # Capture bridge replies the runner sends. The runner uses the imported
+    # `bridge_send_message` symbol re-exported from `processor_context`.
     sent: list[dict[str, Any]] = []
 
     def _fake_send(_stdout: Any, msg: dict[str, Any]) -> None:
         sent.append(msg)
 
-    monkeypatch.setattr(subprocess_runner, "bridge_read_message", _fake_read)
     monkeypatch.setattr(subprocess_runner, "bridge_send_message", _fake_send)
 
 

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -2713,11 +2713,16 @@ mod tests {
             Some(frame_count)
         }
 
+        // Post-#604 the EscalateChannel takes a single writer; the
+        // bridge reader thread (started by subprocess_runner.main)
+        // owns the read side. These log-only tests don't need a
+        // reader thread — they just enqueue records that the writer
+        // thread frames onto stdout.
         const HELPER_PREAMBLE: &str = r#"
 import sys
 from streamlib import log
 from streamlib.escalate import EscalateChannel
-channel = EscalateChannel(sys.stdin.buffer, sys.stdout.buffer)
+channel = EscalateChannel(sys.stdout.buffer)
 log.set_processor_id("pr-test")
 log.set_pipeline_id("pl-test")
 log.install(channel, install_interceptors=False)


### PR DESCRIPTION
## Summary

Closes #604.

Three coordinated fixes that together let polyglot manual processors publish iceoryx2 frames safely from a worker thread / async task:

- **Python `EscalateChannel`: dedicated `BridgeReaderThread` + per-request slots.** The reader thread owns the escalate fd and demuxes incoming frames by `request_id` (responses → per-request `threading.Event` slot) vs. lifecycle commands (queued for the runner's main loop). Replaces the old `_send_lock` that wrapped both send + read, which let manual-mode worker threads race the outer command loop on stdin reads and corrupt response correlation.
- **Deno `_stdinReader` IIFE now spawns in manual mode too.** Pre-fix the IIFE only ran in reactive/continuous; manual mode broke out of `case "run"` before the reader was created, and a worker awaiting an escalate response would deadlock against the un-pumped FD.
- **Both cdylibs (`streamlib-python-native` + `streamlib-deno-native`) wrap mutable iceoryx2 state in a `Mutex`.** `slpn_output_write` / `sldn_output_write` previously took `*mut *NativeContext` and grabbed `&mut` per call — instant UB once Python's ctypes released the GIL or two Deno tasks raced. Iceoryx2's `Publisher` is `Send + Sync` so the lock is released after the loan/send/notify triple, keeping the held duration short.

Plus the pieces that exercise the fixes end-to-end:

- New Rust counting-sink plugin under `examples/polyglot-manual-source/plugin/` (cdylib loaded via `runtime.load_project`).
- Polyglot source rewrite: Python + Deno workers now publish `Videoframe`s via `ctx.outputs.write("frame_out", ...)` instead of writing to a host-visible file (the placeholder PR #602 carved out for this issue).
- Scenario `main.rs` wires source → counting_sink and reads sink stats post-stop.
- Per-runtime concurrency unit tests (200 concurrent requests, out-of-order responses, lifecycle-routing, EOF-wakeup, send-failure conversion, request-timeout, late-response race-safety).

## Closes

Closes #604

## Polyglot coverage

- **Runtimes affected**: rust + python + deno
- **Schema regenerated**: n/a — no escalate-op or wire-format changes; the bug was in the channel demuxer and the cdylib publisher, not the wire types.
- **Python and Deno both covered?** yes — both runtimes' escalate channels and cdylib publisher paths are fixed; both are exercised by the rewritten example and per-runtime concurrency tests.
- **E2E tests run**:
  - [x] Host-Rust unit: `cargo test -p streamlib --lib core::compiler::compiler_ops::subprocess_escalate` (45 passed)
  - [x] Python subprocess unit: `pytest libs/streamlib-python/python/streamlib/tests/` (94 passed; 7 new in `test_escalate_concurrency.py`)
  - [x] Deno subprocess unit: `deno test --no-check libs/streamlib-deno/` (75 passed; 9 new in `escalate_concurrency_test.ts`)
  - [x] E2E integration: `cargo test -p streamlib --test polyglot_linux_execution_modes` (4 passed: manual + continuous, python + deno)
  - [x] E2E by hand: `cargo run -p polyglot-manual-source-scenario -- --runtime=python` → 60 frames in 2s; same for `--runtime=deno`
- **FD-passing path**: n/a — this issue is about the existing escalate channel and the cdylib publisher path; FD passing is unchanged.

## Exit criteria (from #604)

- [x] Polyglot Python + Deno escalate channel safely supports concurrent escalate calls from worker threads alongside the runner's main-thread lifecycle reads.
- [x] Polyglot manual processors can call `outputs.write(port, frame)` from a worker thread, with the underlying `acquire_pixel_buffer` escalate call landing reliably (the cdylib Mutex makes `outputs.write` thread-safe; the new reader-thread architecture makes concurrent escalate calls correlate correctly — verified by the unit tests with 200 concurrent calls and out-of-order responses).
- [x] An updated `examples/polyglot-manual-source` demonstrates a real iceoryx2 publish from the worker thread, replacing the file-based verification PR #602 carved out.

## Note on Python vs Deno test architecture

Python tests use a real `socket.socketpair()` driving a fake host thread; Deno tests use a `FakeBridge` and call `channel.handleIncoming(msg)` directly. The asymmetry tracks the SDK architecture, **not** test coverage gaps:

- Python's `EscalateChannel` owns a `BridgeReaderThread` internally — channel + FD reader are one cohesive unit.
- Deno's `EscalateChannel` deliberately does NOT own the reader. The reader is the `_stdinReader` IIFE in `subprocess_runner.ts`, which calls `escalateChannel.handleIncoming(msg)`. Unit-testing the channel in isolation matches that factoring; the integrated `_stdinReader` is exercised by `polyglot_linux_execution_modes::polyglot_manual_source_deno` end-to-end (60 frames published from a worker → received by the counting sink in <2s).

## Test plan

- [x] Unit: Python + Deno concurrency tests (200 concurrent requests, out-of-order responses, EOF wakeup, lifecycle routing, send-failure conversion, request-timeout, late-response race-safety).
- [x] E2E: scenario binary publishes Videoframes from worker → counting sink reports ≥20 frames received in 2s. Both runtimes pass with 60 frames received.
- [x] Pre-existing tests: full Python SDK suite (94 passed), Deno SDK suite (75 passed), streamlib lib tests (300 passed), polyglot integration suite (4 passed).
- [x] Boundary check: `cargo xtask check-boundaries` — 1948 files, no violations.

## Bundled in this PR

- `streamlib_plugin_abi::export_plugin!` macro updated to `#[unsafe(no_mangle)]` (edition 2024 requirement). Pre-fix the macro only worked when the plugin was platform-`cfg`-gated to non-Linux; the new counting-sink plugin needed it to compile on Linux.
- **Uniform `EscalateError` for every channel failure mode.** `request()` now wraps `OSError` (Python) / generic `Error` (Deno) from the writer in `EscalateError` so callers don't have to special-case OS-level failures vs. semantic ones.
- **Overridable `request()` timeout (default 60s).** Caps the wait for a correlated response so a stuck host or zombie reader-thread surfaces as a clear `EscalateError("escalate timed out…")` rather than an unobservable hang. The timeout handler pops the pending entry under the same map `handleIncoming` / `cancelAll` use, so a late delivery sees no slot and is dropped (race-safe — pinned by dedicated tests in both runtimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)