### PR TITLE
feat(linux): VulkanBlendingCompositor + manual-mode vsync render loop + display_info helper

### DIFF
--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -1,33 +1,76 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Blending Compositor - Multi-layer alpha blending with PiP support.
+//! Blending Compositor — multi-layer alpha-over composite with PiP slide-in.
 //!
-//! Composites multiple video layers using Photoshop-style alpha blending:
-//! - Layer 1 (base): Video from camera
-//! - Layer 2 (middle): Lower third overlay (RGBA with transparency)
-//! - Layer 3: Watermark overlay (RGBA with transparency)
-//! - Layer 4 (top): PiP overlay with slide-in animation (Breaking News style)
+//! Runs as a [`ManualProcessor`] with a render thread paced against the
+//! display's refresh rate (60 Hz fallback). Each tick reads the latest
+//! frame from each input port (older queued frames are dropped by the
+//! port's `SkipToLatest` read mode), composites the four layers, and
+//! emits one output frame.
 //!
-//! The PiP slides in from the right when the avatar processor signals ready.
+//! Layer order (bottom → top): video → lower_third → watermark → PiP.
+//! macOS uses a Metal fragment shader; Linux uses
+//! [`streamlib::vulkan::rhi::VulkanBlendingCompositor`].
 
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
-use streamlib::core::rhi::{PixelFormat, RhiTextureCache, RhiTextureView};
-use streamlib::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+use streamlib::core::display_info;
+use streamlib::core::rhi::PixelFormat;
+use streamlib::core::{
+    GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+    StreamError,
+};
+use streamlib::iceoryx2::{InputMailboxes, OutputWriter};
 use streamlib::Videoframe;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use streamlib::core::rhi::{RhiTextureCache, RhiTextureView};
+
+#[cfg(target_os = "linux")]
+use std::sync::Arc as StdArc;
+#[cfg(target_os = "linux")]
+use streamlib::{BlendingCompositorInputs, VulkanBlendingCompositor};
+
+// Per-platform GPU backend stash. Defined as a single field on the
+// processor (proc-macro `#[streamlib::processor]` strips `#[cfg]` attrs
+// from individual fields, so we collapse the cfg into the type alias).
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+type GpuBackendStash = Option<MetalState>;
+#[cfg(target_os = "linux")]
+type GpuBackendStash = Option<StdArc<VulkanBlendingCompositor>>;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+type GpuBackendStash = ();
+
+/// Iteration cap applied when [`BlendingCompositorConfig::target_fps`]
+/// or the display refresh query produces a non-positive value.
+const FALLBACK_TARGET_FPS: f64 = 60.0;
+
+/// Render-loop iteration count slack: at 60 Hz nominal we tolerate up
+/// to ~5 fps over (drift between sleep granularity + scheduler) before
+/// the loop is considered "out of bound" — issue exit-criterion
+/// "60 → ≤ 65/s on a 60 Hz display".
+#[cfg_attr(not(test), allow(dead_code))]
+const TARGET_FPS_OVERSHOOT_SLACK: f64 = 5.0;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlendingCompositorConfig {
-    /// Default output width (used until video arrives)
+    /// Default output width (used until video arrives).
     pub width: u32,
-    /// Default output height (used until video arrives)
+    /// Default output height (used until video arrives).
     pub height: u32,
-    /// Duration of PiP slide-in animation in seconds
+    /// Duration of PiP slide-in animation, seconds.
     pub pip_slide_duration: f32,
-    /// Delay in seconds after first camera frame before PiP slides in
+    /// Delay after first camera frame before PiP slides in, seconds.
     pub pip_slide_delay: f32,
+    /// Override the render loop's target frame rate. When unset, the
+    /// loop polls [`display_info::get_refresh_rate`]; primarily useful
+    /// for tests that need a deterministic cadence without a window.
+    #[serde(default)]
+    pub target_fps: Option<f64>,
 }
 
 impl Default for BlendingCompositorConfig {
@@ -35,164 +78,60 @@ impl Default for BlendingCompositorConfig {
         Self {
             width: 1920,
             height: 1080,
-            pip_slide_duration: 0.5, // 500ms slide-in
-            pip_slide_delay: 2.5,    // 2.5s after camera starts
+            pip_slide_duration: 0.5,
+            pip_slide_delay: 2.5,
+            target_fps: None,
         }
     }
-}
-
-/// Uniform buffer for blending compositor shader.
-/// Must match the Metal shader struct layout exactly.
-#[repr(C)]
-struct BlendingUniforms {
-    has_video: u32,
-    has_lower_third: u32,
-    has_watermark: u32,
-    has_pip: u32,
-    pip_slide_progress: f32, // 0.0 = off-screen, 1.0 = fully visible
-    _padding1: f32,
-    _padding2: f32,
-    _padding3: f32,
 }
 
 #[streamlib::processor("com.tatolab.blending_compositor")]
 pub struct BlendingCompositorProcessor {
     config: BlendingCompositorConfig,
 
-    gpu_context: Option<GpuContext>,
-    render_pipeline: Option<metal::RenderPipelineState>,
-    render_pass_desc: Option<metal::RenderPassDescriptor>,
-    sampler: Option<metal::SamplerState>,
-    uniforms_buffers: [Option<metal::Buffer>; 3],
-    uniforms_index: usize,
-    frame_count: AtomicU64,
+    gpu_context: Option<GpuContextLimitedAccess>,
+    frame_count: Arc<AtomicU64>,
 
-    // RHI resources
-    texture_cache: Option<RhiTextureCache>,
+    /// Stop signal for the render thread.
+    running: Arc<AtomicBool>,
+    /// Render-thread handle owned by this processor; joined on `stop()`.
+    render_thread: Option<JoinHandle<()>>,
 
-    // Cached texture views
-    cached_video_view: Option<RhiTextureView>,
-    cached_lower_third_view: Option<RhiTextureView>,
-    cached_watermark_view: Option<RhiTextureView>,
-    cached_pip_view: Option<RhiTextureView>,
-    cached_video_dimensions: Option<(u32, u32)>,
-
-    // PiP animation state
-    pip_ready: bool,
-    pip_animation_start: Option<Instant>,
-    first_video_time: Option<Instant>,
-    pip_placeholder_texture: Option<metal::Texture>,
-
-    // Debug timing
-    last_frame_time: Option<Instant>,
+    /// Platform-specific GPU backend instantiated in `setup()` and
+    /// moved into the render thread by `start()`.
+    backend: GpuBackendStash,
 }
 
-impl streamlib::core::ReactiveProcessor for BlendingCompositorProcessor::Processor {
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+struct MetalState {
+    render_pipeline: metal::RenderPipelineState,
+    sampler: metal::SamplerState,
+    render_pass_desc: metal::RenderPassDescriptor,
+    uniforms_buffers: [metal::Buffer; 3],
+    pip_placeholder_texture: metal::Texture,
+}
+
+/// Uniform buffer for the Metal compositor shader. Must match the Metal
+/// struct layout exactly.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[repr(C)]
+struct BlendingUniforms {
+    has_video: u32,
+    has_lower_third: u32,
+    has_watermark: u32,
+    has_pip: u32,
+    pip_slide_progress: f32,
+    _padding1: f32,
+    _padding2: f32,
+    _padding3: f32,
+}
+
+impl streamlib::core::ManualProcessor for BlendingCompositorProcessor::Processor {
     fn setup(
         &mut self,
         ctx: &RuntimeContextFullAccess<'_>,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
-            tracing::info!("BlendingCompositor: Setting up (reactive mode)...");
-
-            self.gpu_context = Some(ctx.gpu_limited_access().clone());
-            self.texture_cache = None;
-
-            let metal_device_ref = ctx.gpu_full_access().device().metal_device_ref();
-
-            // Compile shaders
-            let shader_source = include_str!("shaders/blending_compositor.metal");
-            let library = metal_device_ref
-                .new_library_with_source(shader_source, &metal::CompileOptions::new())
-                .map_err(|e| StreamError::Configuration(format!("Shader compile failed: {}", e)))?;
-
-            let vertex_fn = library
-                .get_function("blending_vertex", None)
-                .map_err(|e| StreamError::Configuration(format!("Vertex not found: {}", e)))?;
-            let fragment_fn = library
-                .get_function("blending_fragment", None)
-                .map_err(|e| StreamError::Configuration(format!("Fragment not found: {}", e)))?;
-
-            // Render pipeline
-            let pipeline_desc = metal::RenderPipelineDescriptor::new();
-            pipeline_desc.set_vertex_function(Some(&vertex_fn));
-            pipeline_desc.set_fragment_function(Some(&fragment_fn));
-
-            let color_attachment = pipeline_desc.color_attachments().object_at(0).unwrap();
-            color_attachment.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-
-            let render_pipeline = metal_device_ref
-                .new_render_pipeline_state(&pipeline_desc)
-                .map_err(|e| StreamError::Configuration(format!("Pipeline failed: {}", e)))?;
-
-            // Sampler
-            let sampler_desc = metal::SamplerDescriptor::new();
-            sampler_desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
-            sampler_desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
-            sampler_desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
-            sampler_desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
-            let sampler = metal_device_ref.new_sampler(&sampler_desc);
-
-            // Render pass descriptor
-            let render_pass_desc_ref = metal::RenderPassDescriptor::new();
-            let color_attachment = render_pass_desc_ref
-                .color_attachments()
-                .object_at(0)
-                .unwrap();
-            color_attachment.set_load_action(metal::MTLLoadAction::Clear);
-            color_attachment.set_clear_color(metal::MTLClearColor::new(0.0, 0.0, 0.0, 1.0));
-            color_attachment.set_store_action(metal::MTLStoreAction::Store);
-
-            // Uniforms ring buffer
-            let uniforms_size = std::mem::size_of::<BlendingUniforms>() as u64;
-            let uniforms_buffers = [
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-            ];
-
-            // Create 1x1 transparent placeholder texture for PiP
-            // Allows the PiP frame (border, title bar) to slide in before avatar frames arrive
-            let pip_placeholder_desc = metal::TextureDescriptor::new();
-            pip_placeholder_desc.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-            pip_placeholder_desc.set_width(1);
-            pip_placeholder_desc.set_height(1);
-            pip_placeholder_desc.set_usage(metal::MTLTextureUsage::ShaderRead);
-            let pip_placeholder = metal_device_ref.new_texture(&pip_placeholder_desc);
-            let zero_data: [u8; 4] = [0, 0, 0, 0];
-            pip_placeholder.replace_region(
-                metal::MTLRegion::new_2d(0, 0, 1, 1),
-                0,
-                zero_data.as_ptr() as *const std::ffi::c_void,
-                4,
-            );
-
-            self.render_pipeline = Some(render_pipeline);
-            self.render_pass_desc = Some(render_pass_desc_ref.to_owned());
-            self.sampler = Some(sampler);
-            self.uniforms_buffers = uniforms_buffers;
-            self.uniforms_index = 0;
-            self.pip_ready = false;
-            self.pip_animation_start = None;
-            self.pip_placeholder_texture = Some(pip_placeholder);
-
-            tracing::info!(
-                "BlendingCompositor: Initialized ({}x{} default, PiP slide: {}s)",
-                self.config.width,
-                self.config.height,
-                self.config.pip_slide_duration
-            );
-            Ok(())
-        })();
+        let result = self.setup_inner(ctx);
         std::future::ready(result)
     }
 
@@ -201,195 +140,610 @@ impl streamlib::core::ReactiveProcessor for BlendingCompositorProcessor::Process
         _ctx: &RuntimeContextFullAccess<'_>,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
         tracing::info!(
-            "BlendingCompositor: Shutdown ({} frames)",
+            "BlendingCompositor: teardown ({} frames)",
             self.frame_count.load(Ordering::Relaxed)
         );
         std::future::ready(Ok(()))
     }
 
-    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
-        let process_start = Instant::now();
-        let frame_count = self.frame_count.load(Ordering::Relaxed);
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let target_fps = self.resolve_target_fps();
+        tracing::info!(
+            "BlendingCompositor: starting render thread @ {:.1} fps",
+            target_fps
+        );
 
-        // Stutter detection
-        if let Some(last_time) = self.last_frame_time {
-            let interval_ms = last_time.elapsed().as_secs_f64() * 1000.0;
-            if interval_ms > 50.0 {
-                tracing::warn!(
-                    "BlendingCompositor: STUTTER! Frame {} interval: {:.1}ms",
-                    frame_count,
-                    interval_ms
-                );
-            }
-        }
-        self.last_frame_time = Some(process_start);
-
-        let gpu_ctx = self
+        let inputs = std::mem::take(&mut self.inputs);
+        // Outputs are an `Arc<OutputWriter>` in the generated processor —
+        // share the writer with the render thread by cloning the handle.
+        let outputs = Arc::clone(&self.outputs);
+        let running = Arc::clone(&self.running);
+        let frame_count = Arc::clone(&self.frame_count);
+        let gpu_context = self
             .gpu_context
-            .as_ref()
+            .clone()
             .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
+        let config = self.config.clone();
 
-        // Lazy texture cache creation
-        if self.texture_cache.is_none() {
-            self.texture_cache = Some(gpu_ctx.create_texture_cache()?);
+        running.store(true, Ordering::Release);
+
+        let backend = self
+            .backend
+            .take()
+            .ok_or_else(|| StreamError::Configuration("GPU backend not initialized".into()))?;
+
+        let thread = std::thread::Builder::new()
+            .name("blending-compositor-render".into())
+            .spawn(move || {
+                let mut state = LoopState::new(config);
+                manual_render_loop(target_fps, Arc::clone(&running), || {
+                    let _ = compose_one_frame(
+                        &mut state,
+                        &gpu_context,
+                        &inputs,
+                        &outputs,
+                        &frame_count,
+                        &backend,
+                    );
+                });
+            })
+            .map_err(|e| StreamError::Runtime(format!("Failed to spawn render thread: {e}")))?;
+
+        self.render_thread = Some(thread);
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.running.store(false, Ordering::Release);
+        if let Some(handle) = self.render_thread.take() {
+            handle
+                .join()
+                .map_err(|_| StreamError::Runtime("Render thread panicked".into()))?;
         }
-        let texture_cache = self.texture_cache.as_ref().unwrap();
+        tracing::info!(
+            "BlendingCompositor: stopped ({} frames)",
+            self.frame_count.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+}
 
-        // Update cached textures from new input frames
-        if self.inputs.has_data("video_in") {
-            let video_frame: Videoframe = self.inputs.read("video_in")?;
-            let buffer = gpu_ctx.resolve_videoframe_buffer(&video_frame)?;
-            self.cached_video_view = Some(texture_cache.create_view(&buffer)?);
-            self.cached_video_dimensions = Some((video_frame.width, video_frame.height));
-
-            // Record when camera first starts flowing
-            if self.first_video_time.is_none() {
-                self.first_video_time = Some(Instant::now());
-                tracing::info!(
-                    "BlendingCompositor: First camera frame received, PiP slide-in in {:.1}s",
-                    self.config.pip_slide_delay
-                );
-            }
+impl BlendingCompositorProcessor::Processor {
+    fn resolve_target_fps(&self) -> f64 {
+        if let Some(t) = self.config.target_fps {
+            return if t > 0.0 { t } else { FALLBACK_TARGET_FPS };
         }
+        // No window in BlendingCompositor — Linux falls back to 60 Hz; macOS
+        // queries the main display via CoreGraphics, no window needed.
+        let rate = display_info::get_refresh_rate(None);
+        if rate > 0.0 { rate } else { FALLBACK_TARGET_FPS }
+    }
 
-        if self.inputs.has_data("lower_third_in") {
-            let lower_third_frame: Videoframe = self.inputs.read("lower_third_in")?;
-            let buffer = gpu_ctx.resolve_videoframe_buffer(&lower_third_frame)?;
-            self.cached_lower_third_view = Some(texture_cache.create_view(&buffer)?);
-        }
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("BlendingCompositor: setup (Metal)");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
-        if self.inputs.has_data("watermark_in") {
-            let watermark_frame: Videoframe = self.inputs.read("watermark_in")?;
-            let buffer = gpu_ctx.resolve_videoframe_buffer(&watermark_frame)?;
-            self.cached_watermark_view = Some(texture_cache.create_view(&buffer)?);
-        }
+        let metal_device_ref = ctx.gpu_full_access().device().metal_device_ref();
 
-        // Check for PiP frames
-        if self.inputs.has_data("pip_in") {
-            let pip_frame: Videoframe = self.inputs.read("pip_in")?;
-            let buffer = gpu_ctx.resolve_videoframe_buffer(&pip_frame)?;
-            self.cached_pip_view = Some(texture_cache.create_view(&buffer)?);
-        }
+        let shader_source = include_str!("shaders/blending_compositor.metal");
+        let library = metal_device_ref
+            .new_library_with_source(shader_source, &metal::CompileOptions::new())
+            .map_err(|e| StreamError::Configuration(format!("Shader compile failed: {e}")))?;
 
-        // Trigger PiP slide-in after delay from first camera frame
-        if !self.pip_ready {
-            if let Some(first_video) = self.first_video_time {
-                if first_video.elapsed().as_secs_f32() >= self.config.pip_slide_delay {
-                    self.pip_ready = true;
-                    self.pip_animation_start = Some(Instant::now());
-                    tracing::info!("BlendingCompositor: PiP slide-in animation starting!");
-                }
-            }
-        }
+        let vertex_fn = library
+            .get_function("blending_vertex", None)
+            .map_err(|e| StreamError::Configuration(format!("Vertex not found: {e}")))?;
+        let fragment_fn = library
+            .get_function("blending_fragment", None)
+            .map_err(|e| StreamError::Configuration(format!("Fragment not found: {e}")))?;
 
-        // Calculate PiP animation progress
-        let pip_slide_progress = if let Some(start_time) = self.pip_animation_start {
-            let elapsed = start_time.elapsed().as_secs_f32();
-            let progress: f32 = (elapsed / self.config.pip_slide_duration).min(1.0);
-            // Ease-out cubic: 1 - (1-t)^3
-            1.0_f32 - (1.0_f32 - progress).powi(3)
-        } else {
-            0.0
-        };
-
-        // Determine output dimensions
-        let (width, height) = self
-            .cached_video_dimensions
-            .unwrap_or((self.config.width, self.config.height));
-
-        // Acquire output buffer from GpuContext pool
-        let (output_pool_id, output_buffer) =
-            gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Bgra32)?;
-        let output_view = texture_cache.create_view(&output_buffer)?;
-        let output_metal: &metal::TextureRef = output_view.as_metal_texture();
-
-        // Update render pass
-        let render_pass_desc = self.render_pass_desc.as_ref().unwrap();
-        render_pass_desc
+        let pipeline_desc = metal::RenderPipelineDescriptor::new();
+        pipeline_desc.set_vertex_function(Some(&vertex_fn));
+        pipeline_desc.set_fragment_function(Some(&fragment_fn));
+        pipeline_desc
             .color_attachments()
             .object_at(0)
             .unwrap()
-            .set_texture(Some(output_metal));
+            .set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
 
-        // Render
-        let command_queue = gpu_ctx.command_queue().metal_queue_ref();
-        let command_buffer = command_queue.new_command_buffer();
-        let render_enc = command_buffer.new_render_command_encoder(render_pass_desc);
-        render_enc.set_render_pipeline_state(self.render_pipeline.as_ref().unwrap());
+        let render_pipeline = metal_device_ref
+            .new_render_pipeline_state(&pipeline_desc)
+            .map_err(|e| StreamError::Configuration(format!("Pipeline failed: {e}")))?;
 
-        // Bind textures
-        let has_video = self.cached_video_view.is_some();
-        let has_lower_third = self.cached_lower_third_view.is_some();
-        let has_watermark = self.cached_watermark_view.is_some();
-        let has_pip = self.pip_ready;
+        let sampler_desc = metal::SamplerDescriptor::new();
+        sampler_desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
+        sampler_desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
+        sampler_desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
+        sampler_desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
+        let sampler = metal_device_ref.new_sampler(&sampler_desc);
 
-        if let Some(ref video_view) = self.cached_video_view {
-            render_enc.set_fragment_texture(0, Some(video_view.as_metal_texture()));
-        }
-        if let Some(ref lower_third_view) = self.cached_lower_third_view {
-            render_enc.set_fragment_texture(1, Some(lower_third_view.as_metal_texture()));
-        }
-        if let Some(ref watermark_view) = self.cached_watermark_view {
-            render_enc.set_fragment_texture(2, Some(watermark_view.as_metal_texture()));
-        }
-        if let Some(ref pip_view) = self.cached_pip_view {
-            render_enc.set_fragment_texture(3, Some(pip_view.as_metal_texture()));
-        } else if has_pip {
-            if let Some(ref placeholder) = self.pip_placeholder_texture {
-                let tex_ref: &metal::TextureRef = placeholder;
-                render_enc.set_fragment_texture(3, Some(tex_ref));
-            }
-        }
+        let render_pass_desc_ref = metal::RenderPassDescriptor::new();
+        let attachment = render_pass_desc_ref.color_attachments().object_at(0).unwrap();
+        attachment.set_load_action(metal::MTLLoadAction::Clear);
+        attachment.set_clear_color(metal::MTLClearColor::new(0.0, 0.0, 0.0, 1.0));
+        attachment.set_store_action(metal::MTLStoreAction::Store);
 
-        render_enc.set_fragment_sampler_state(0, Some(self.sampler.as_ref().unwrap()));
-
-        // Update uniforms
-        self.uniforms_index = (self.uniforms_index + 1) % 3;
-        let current_uniforms = self.uniforms_buffers[self.uniforms_index].as_ref().unwrap();
-
-        unsafe {
-            let ptr = current_uniforms.contents() as *mut BlendingUniforms;
-            (*ptr).has_video = if has_video { 1 } else { 0 };
-            (*ptr).has_lower_third = if has_lower_third { 1 } else { 0 };
-            (*ptr).has_watermark = if has_watermark { 1 } else { 0 };
-            (*ptr).has_pip = if has_pip { 1 } else { 0 };
-            (*ptr).pip_slide_progress = pip_slide_progress;
-            (*ptr)._padding1 = 0.0;
-            (*ptr)._padding2 = 0.0;
-            (*ptr)._padding3 = 0.0;
-        }
-
-        render_enc.set_fragment_buffer(0, Some(current_uniforms), 0);
-
-        render_enc.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 3);
-        render_enc.end_encoding();
-
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-
-        // Output frame
-        let timestamp_ns = (frame_count as i64) * 16_666_667;
-        let output_frame = Videoframe {
-            surface_id: output_pool_id.to_string(),
-            width,
-            height,
-            timestamp_ns: timestamp_ns.to_string(),
-            frame_index: frame_count.to_string(),
-            fps: None,
+        let uniforms_size = std::mem::size_of::<BlendingUniforms>() as u64;
+        let make_uniforms = || {
+            metal_device_ref.new_buffer(uniforms_size, metal::MTLResourceOptions::CPUCacheModeDefaultCache)
         };
-        self.outputs.write("video_out", &output_frame)?;
+        let uniforms_buffers = [make_uniforms(), make_uniforms(), make_uniforms()];
 
-        self.frame_count.fetch_add(1, Ordering::Relaxed);
+        let pip_placeholder_desc = metal::TextureDescriptor::new();
+        pip_placeholder_desc.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+        pip_placeholder_desc.set_width(1);
+        pip_placeholder_desc.set_height(1);
+        pip_placeholder_desc.set_usage(metal::MTLTextureUsage::ShaderRead);
+        let pip_placeholder = metal_device_ref.new_texture(&pip_placeholder_desc);
+        let zero_data: [u8; 4] = [0, 0, 0, 0];
+        pip_placeholder.replace_region(
+            metal::MTLRegion::new_2d(0, 0, 1, 1),
+            0,
+            zero_data.as_ptr() as *const std::ffi::c_void,
+            4,
+        );
 
-        let total_ms = process_start.elapsed().as_secs_f64() * 1000.0;
-        if total_ms > 20.0 {
-            tracing::warn!(
-                "BlendingCompositor: Frame {} slow: {:.1}ms",
-                frame_count,
-                total_ms
-            );
-        }
+        self.backend = Some(MetalState {
+            render_pipeline,
+            sampler,
+            render_pass_desc: render_pass_desc_ref.to_owned(),
+            uniforms_buffers,
+            pip_placeholder_texture: pip_placeholder,
+        });
 
         Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("BlendingCompositor: setup (Vulkan)");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        let vulkan_device = ctx.gpu_full_access().device().vulkan_device().clone();
+        let compositor = VulkanBlendingCompositor::new(&vulkan_device)?;
+        self.backend = Some(StdArc::new(compositor));
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+    fn setup_inner(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let _ = ctx;
+        Err(StreamError::Configuration(
+            "BlendingCompositor: no GPU backend on this platform".into(),
+        ))
+    }
+}
+
+// ---- Render-loop scaffolding ------------------------------------------------
+
+/// Per-iteration state owned by the spawned render thread. Tracks PiP
+/// animation timing and (on macOS) the cached input texture views.
+struct LoopState {
+    config: BlendingCompositorConfig,
+    pip_ready: bool,
+    pip_animation_start: Option<Instant>,
+    first_video_time: Option<Instant>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    texture_cache: Option<RhiTextureCache>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    cached_video_view: Option<RhiTextureView>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    cached_lower_third_view: Option<RhiTextureView>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    cached_watermark_view: Option<RhiTextureView>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    cached_pip_view: Option<RhiTextureView>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    uniforms_index: usize,
+    cached_video_dimensions: Option<(u32, u32)>,
+}
+
+impl LoopState {
+    fn new(config: BlendingCompositorConfig) -> Self {
+        Self {
+            config,
+            pip_ready: false,
+            pip_animation_start: None,
+            first_video_time: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            texture_cache: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            cached_video_view: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            cached_lower_third_view: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            cached_watermark_view: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            cached_pip_view: None,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            uniforms_index: 0,
+            cached_video_dimensions: None,
+        }
+    }
+
+    fn maybe_promote_pip(&mut self, now: Instant) {
+        if self.pip_ready {
+            return;
+        }
+        if let Some(start) = self.first_video_time {
+            if start.elapsed().as_secs_f32() >= self.config.pip_slide_delay {
+                self.pip_ready = true;
+                self.pip_animation_start = Some(now);
+                tracing::info!("BlendingCompositor: PiP slide-in started");
+            }
+        }
+    }
+
+    fn pip_slide_progress(&self) -> f32 {
+        let Some(start) = self.pip_animation_start else {
+            return 0.0;
+        };
+        let elapsed = start.elapsed().as_secs_f32();
+        let progress = (elapsed / self.config.pip_slide_duration).min(1.0);
+        // Ease-out cubic — preserved verbatim from the Metal Reactive impl.
+        1.0_f32 - (1.0_f32 - progress).powi(3)
+    }
+}
+
+/// Render loop. Sleeps after each tick to maintain `target_fps` cadence;
+/// exits when `running` is cleared. The closure runs once per iteration.
+fn manual_render_loop<F>(target_fps: f64, running: Arc<AtomicBool>, mut tick: F)
+where
+    F: FnMut(),
+{
+    let frame_period = if target_fps > 0.0 {
+        Duration::from_secs_f64(1.0 / target_fps)
+    } else {
+        Duration::from_millis(16)
+    };
+    let mut next_deadline = Instant::now();
+    while running.load(Ordering::Acquire) {
+        tick();
+        next_deadline += frame_period;
+        let now = Instant::now();
+        if next_deadline > now {
+            std::thread::sleep(next_deadline - now);
+        } else {
+            // Falling behind — reset baseline so we don't spiral when a
+            // tick spends longer than `frame_period`.
+            next_deadline = now;
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[allow(clippy::too_many_arguments)]
+fn compose_one_frame(
+    state: &mut LoopState,
+    gpu_ctx: &GpuContextLimitedAccess,
+    inputs: &InputMailboxes,
+    outputs: &Arc<OutputWriter>,
+    frame_count: &Arc<AtomicU64>,
+    backend: &MetalState,
+) -> Result<()> {
+    if state.texture_cache.is_none() {
+        state.texture_cache = Some(gpu_ctx.create_texture_cache()?);
+    }
+    let texture_cache = state.texture_cache.as_ref().unwrap();
+
+    if inputs.has_data("video_in") {
+        let frame: Videoframe = inputs.read("video_in")?;
+        let buffer = gpu_ctx.resolve_videoframe_buffer(&frame)?;
+        state.cached_video_view = Some(texture_cache.create_view(&buffer)?);
+        state.cached_video_dimensions = Some((frame.width, frame.height));
+        if state.first_video_time.is_none() {
+            state.first_video_time = Some(Instant::now());
+        }
+    }
+    if inputs.has_data("lower_third_in") {
+        let frame: Videoframe = inputs.read("lower_third_in")?;
+        let buffer = gpu_ctx.resolve_videoframe_buffer(&frame)?;
+        state.cached_lower_third_view = Some(texture_cache.create_view(&buffer)?);
+    }
+    if inputs.has_data("watermark_in") {
+        let frame: Videoframe = inputs.read("watermark_in")?;
+        let buffer = gpu_ctx.resolve_videoframe_buffer(&frame)?;
+        state.cached_watermark_view = Some(texture_cache.create_view(&buffer)?);
+    }
+    if inputs.has_data("pip_in") {
+        let frame: Videoframe = inputs.read("pip_in")?;
+        let buffer = gpu_ctx.resolve_videoframe_buffer(&frame)?;
+        state.cached_pip_view = Some(texture_cache.create_view(&buffer)?);
+    }
+
+    state.maybe_promote_pip(Instant::now());
+    let pip_slide_progress = state.pip_slide_progress();
+
+    let (width, height) = state
+        .cached_video_dimensions
+        .unwrap_or((state.config.width, state.config.height));
+
+    let (output_pool_id, output_buffer) =
+        gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Bgra32)?;
+    let output_view = texture_cache.create_view(&output_buffer)?;
+    let output_metal: &metal::TextureRef = output_view.as_metal_texture();
+
+    backend
+        .render_pass_desc
+        .color_attachments()
+        .object_at(0)
+        .unwrap()
+        .set_texture(Some(output_metal));
+
+    let command_queue = gpu_ctx.command_queue().metal_queue_ref();
+    let command_buffer = command_queue.new_command_buffer();
+    let render_enc = command_buffer.new_render_command_encoder(&backend.render_pass_desc);
+    render_enc.set_render_pipeline_state(&backend.render_pipeline);
+
+    let has_video = state.cached_video_view.is_some();
+    let has_lower_third = state.cached_lower_third_view.is_some();
+    let has_watermark = state.cached_watermark_view.is_some();
+    let has_pip = state.pip_ready;
+
+    if let Some(ref view) = state.cached_video_view {
+        render_enc.set_fragment_texture(0, Some(view.as_metal_texture()));
+    }
+    if let Some(ref view) = state.cached_lower_third_view {
+        render_enc.set_fragment_texture(1, Some(view.as_metal_texture()));
+    }
+    if let Some(ref view) = state.cached_watermark_view {
+        render_enc.set_fragment_texture(2, Some(view.as_metal_texture()));
+    }
+    if let Some(ref view) = state.cached_pip_view {
+        render_enc.set_fragment_texture(3, Some(view.as_metal_texture()));
+    } else if has_pip {
+        let tex_ref: &metal::TextureRef = &backend.pip_placeholder_texture;
+        render_enc.set_fragment_texture(3, Some(tex_ref));
+    }
+
+    render_enc.set_fragment_sampler_state(0, Some(&backend.sampler));
+
+    state.uniforms_index = (state.uniforms_index + 1) % backend.uniforms_buffers.len();
+    let uniforms = &backend.uniforms_buffers[state.uniforms_index];
+    unsafe {
+        let ptr = uniforms.contents() as *mut BlendingUniforms;
+        (*ptr).has_video = has_video as u32;
+        (*ptr).has_lower_third = has_lower_third as u32;
+        (*ptr).has_watermark = has_watermark as u32;
+        (*ptr).has_pip = has_pip as u32;
+        (*ptr).pip_slide_progress = pip_slide_progress;
+        (*ptr)._padding1 = 0.0;
+        (*ptr)._padding2 = 0.0;
+        (*ptr)._padding3 = 0.0;
+    }
+    render_enc.set_fragment_buffer(0, Some(uniforms), 0);
+    render_enc.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 3);
+    render_enc.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    let count = frame_count.fetch_add(1, Ordering::Relaxed);
+    let timestamp_ns = (count as i64) * 16_666_667;
+    let output_frame = Videoframe {
+        surface_id: output_pool_id.to_string(),
+        width,
+        height,
+        timestamp_ns: timestamp_ns.to_string(),
+        frame_index: count.to_string(),
+        fps: None,
+    };
+    outputs.write("video_out", &output_frame)?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+fn compose_one_frame(
+    state: &mut LoopState,
+    gpu_ctx: &GpuContextLimitedAccess,
+    inputs: &InputMailboxes,
+    outputs: &Arc<OutputWriter>,
+    frame_count: &Arc<AtomicU64>,
+    backend: &StdArc<VulkanBlendingCompositor>,
+) -> Result<()> {
+    let video_buf = if inputs.has_data("video_in") {
+        let frame: Videoframe = inputs.read("video_in")?;
+        let buf = gpu_ctx.resolve_videoframe_buffer(&frame)?;
+        state.cached_video_dimensions = Some((frame.width, frame.height));
+        if state.first_video_time.is_none() {
+            state.first_video_time = Some(Instant::now());
+        }
+        Some(buf)
+    } else {
+        None
+    };
+    let lower_third_buf = inputs
+        .has_data("lower_third_in")
+        .then(|| inputs.read::<Videoframe>("lower_third_in"))
+        .transpose()?
+        .map(|f| gpu_ctx.resolve_videoframe_buffer(&f))
+        .transpose()?;
+    let watermark_buf = inputs
+        .has_data("watermark_in")
+        .then(|| inputs.read::<Videoframe>("watermark_in"))
+        .transpose()?
+        .map(|f| gpu_ctx.resolve_videoframe_buffer(&f))
+        .transpose()?;
+    let pip_buf = inputs
+        .has_data("pip_in")
+        .then(|| inputs.read::<Videoframe>("pip_in"))
+        .transpose()?
+        .map(|f| gpu_ctx.resolve_videoframe_buffer(&f))
+        .transpose()?;
+
+    state.maybe_promote_pip(Instant::now());
+    let pip_slide_progress = state.pip_slide_progress();
+
+    let (width, height) = state
+        .cached_video_dimensions
+        .unwrap_or((state.config.width, state.config.height));
+
+    let (output_pool_id, output_buffer) =
+        gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Bgra32)?;
+
+    backend.dispatch(BlendingCompositorInputs {
+        video: video_buf.as_ref(),
+        lower_third: lower_third_buf.as_ref(),
+        watermark: watermark_buf.as_ref(),
+        pip: if state.pip_ready { pip_buf.as_ref() } else { None },
+        output: &output_buffer,
+        pip_slide_progress,
+    })?;
+
+    let count = frame_count.fetch_add(1, Ordering::Relaxed);
+    let timestamp_ns = (count as i64) * 16_666_667;
+    let output_frame = Videoframe {
+        surface_id: output_pool_id.to_string(),
+        width,
+        height,
+        timestamp_ns: timestamp_ns.to_string(),
+        frame_index: count.to_string(),
+        fps: None,
+    };
+    outputs.write("video_out", &output_frame)?;
+
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+fn compose_one_frame(
+    _state: &mut LoopState,
+    _gpu_ctx: &GpuContextLimitedAccess,
+    _inputs: &InputMailboxes,
+    _outputs: &Arc<OutputWriter>,
+    _frame_count: &Arc<AtomicU64>,
+    _backend: &(),
+) -> Result<()> {
+    Err(StreamError::Configuration(
+        "BlendingCompositor: no GPU backend on this platform".into(),
+    ))
+}
+
+// Keep this compiling for `clippy::let_unit_value` etc. when the loop
+// helpers reference [`RuntimeContextLimitedAccess`] only conceptually
+// (lifecycle methods don't need on_pause / on_resume).
+#[allow(dead_code)]
+fn _ctx_marker(_ctx: &RuntimeContextLimitedAccess<'_>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// Issue exit-criterion: idle invocation count is bounded by display
+    /// refresh + small slack (60 → ≤ 65/s on a 60 Hz display).
+    #[test]
+    fn manual_loop_runs_at_target_fps() {
+        let target_fps: f64 = 60.0;
+        let running = Arc::new(AtomicBool::new(true));
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let counter_clone = Arc::clone(&counter);
+        let running_clone = Arc::clone(&running);
+        let handle = std::thread::spawn(move || {
+            manual_render_loop(target_fps, running_clone, || {
+                counter_clone.fetch_add(1, Ordering::Relaxed);
+            });
+        });
+
+        std::thread::sleep(Duration::from_millis(2000));
+        running.store(false, Ordering::Release);
+        handle.join().expect("loop thread join");
+
+        let observed = counter.load(Ordering::Relaxed) as f64;
+        let nominal = target_fps * 2.0; // 2 seconds at 60 fps = 120
+        let lower = nominal - TARGET_FPS_OVERSHOOT_SLACK * 2.0; // tolerate ±5/s
+        let upper = nominal + TARGET_FPS_OVERSHOOT_SLACK * 2.0;
+        assert!(
+            observed >= lower && observed <= upper,
+            "expected {nominal} ±{} ticks, got {observed}",
+            TARGET_FPS_OVERSHOOT_SLACK * 2.0
+        );
+    }
+
+    /// Issue exit-criterion: stop signal exits the render loop within 250 ms.
+    /// Mirrors the `Arc<AtomicBool>` + explicit-stop pattern used by
+    /// `AppleDisplayProcessor` / `LinuxDisplayProcessor`. The original
+    /// issue body framed this as a PUBSUB shutdown event; the actual
+    /// codebase converged on the bool-based pattern. See in-issue
+    /// annotation dated 2026-05-01.
+    #[test]
+    fn shutdown_exits_loop() {
+        let running = Arc::new(AtomicBool::new(true));
+        let started = Arc::new(AtomicBool::new(false));
+
+        let running_clone = Arc::clone(&running);
+        let started_clone = Arc::clone(&started);
+        let handle = std::thread::spawn(move || {
+            manual_render_loop(60.0, running_clone, || {
+                started_clone.store(true, Ordering::Release);
+                std::thread::sleep(Duration::from_millis(8));
+            });
+        });
+
+        // Wait for the loop to start before signalling stop, so we
+        // measure shutdown latency rather than thread-spawn overhead.
+        let spawn_deadline = Instant::now() + Duration::from_millis(500);
+        while !started.load(Ordering::Acquire) && Instant::now() < spawn_deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(started.load(Ordering::Acquire), "loop never started");
+
+        let stop_at = Instant::now();
+        running.store(false, Ordering::Release);
+        handle.join().expect("loop thread join");
+        let elapsed = stop_at.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "loop took {elapsed:?} to exit after stop signal (cap is 250 ms)"
+        );
+    }
+
+    /// Issue exit-criterion: pushing 5 frames into one input port between
+    /// iterations causes the older 4 to be discarded; only the latest is
+    /// read. This is the contract `PortMailbox::pop_latest` provides; the
+    /// processor's render loop relies on it via `inputs.read()` (the
+    /// frame ports are configured with `ReadMode::SkipToLatest`).
+    #[test]
+    fn pulls_latest_input_skipping_stale() {
+        use streamlib::iceoryx2::PortMailbox;
+
+        let mailbox = PortMailbox::new(8);
+        for i in 0u8..5 {
+            mailbox.push(vec![i]);
+        }
+        let latest = mailbox
+            .pop_latest()
+            .expect("at least one frame should have been pushed");
+        assert_eq!(latest, vec![4], "pop_latest must return the most recent push");
+        assert!(
+            mailbox.is_empty(),
+            "older frames must be drained (skip-stale semantics)"
+        );
+    }
+
+    /// Sanity check the easing curve so the macOS Metal port and the
+    /// Linux Vulkan port stay in lockstep on PiP slide timing.
+    #[test]
+    fn pip_slide_progress_is_ease_out_cubic() {
+        let mut state = LoopState::new(BlendingCompositorConfig {
+            pip_slide_duration: 1.0,
+            ..Default::default()
+        });
+        // No animation → 0.
+        assert_eq!(state.pip_slide_progress(), 0.0);
+
+        state.pip_animation_start = Some(Instant::now() - Duration::from_millis(250));
+        let q1 = state.pip_slide_progress();
+        // ease-out-cubic at t=0.25: 1 - (0.75)^3 ≈ 0.578
+        assert!(
+            (q1 - 0.578).abs() < 0.05,
+            "expected ~0.578 at t=0.25, got {q1}"
+        );
+
+        state.pip_animation_start = Some(Instant::now() - Duration::from_millis(2000));
+        let done = state.pip_slide_progress();
+        assert!((done - 1.0).abs() < 1e-3, "expected 1.0 past duration, got {done}");
     }
 }

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -20,10 +20,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use streamlib::core::display_info;
 use streamlib::core::rhi::PixelFormat;
-use streamlib::core::{
-    GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
-    StreamError,
-};
+use streamlib::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
 use streamlib::iceoryx2::{InputMailboxes, OutputWriter};
 use streamlib::Videoframe;
 
@@ -385,8 +382,20 @@ impl LoopState {
     }
 }
 
+/// Slow-tick threshold restored from the pre-rewrite `STUTTER!` log
+/// (50 ms ≈ three frames at 60 Hz). Exceeding this is a clear hitch
+/// worth surfacing even when the loop's per-tick cadence still
+/// averages out.
+const SLOW_TICK_WARN_THRESHOLD: Duration = Duration::from_millis(50);
+
 /// Render loop. Sleeps after each tick to maintain `target_fps` cadence;
 /// exits when `running` is cleared. The closure runs once per iteration.
+///
+/// When a tick spends longer than `frame_period`, the deadline baseline
+/// is reset to `now` so the loop does not spiral trying to "catch up"
+/// — but each over-budget tick is also surfaced via [`tracing::warn!`]
+/// (gated by [`SLOW_TICK_WARN_THRESHOLD`]) so sustained slowness stays
+/// visible rather than silently masked.
 fn manual_render_loop<F>(target_fps: f64, running: Arc<AtomicBool>, mut tick: F)
 where
     F: FnMut(),
@@ -398,14 +407,24 @@ where
     };
     let mut next_deadline = Instant::now();
     while running.load(Ordering::Acquire) {
+        let tick_start = Instant::now();
         tick();
+        let tick_elapsed = tick_start.elapsed();
+        if tick_elapsed > SLOW_TICK_WARN_THRESHOLD {
+            tracing::warn!(
+                "BlendingCompositor: slow tick {:?} (threshold {:?})",
+                tick_elapsed,
+                SLOW_TICK_WARN_THRESHOLD
+            );
+        }
         next_deadline += frame_period;
         let now = Instant::now();
         if next_deadline > now {
             std::thread::sleep(next_deadline - now);
         } else {
             // Falling behind — reset baseline so we don't spiral when a
-            // tick spends longer than `frame_period`.
+            // tick spends longer than `frame_period`. The slow-tick
+            // tracing above keeps the issue visible despite the reset.
             next_deadline = now;
         }
     }
@@ -542,6 +561,14 @@ fn compose_one_frame(
     frame_count: &Arc<AtomicU64>,
     backend: &StdArc<VulkanBlendingCompositor>,
 ) -> Result<()> {
+    // The loop runs unconditionally at refresh rate (per the issue's
+    // "idle invocation count is bounded by display refresh + small
+    // slack" exit criterion). When no upstream frame has ever arrived
+    // the kernel still dispatches and emits a dark-blue placeholder
+    // — same as the macOS Metal path. The cost (one GPU dispatch on
+    // 1×1 placeholder buffers) is negligible and keeps the pipeline
+    // cadence steady; downstream consumers see a stream of valid
+    // frames from t=0 instead of a stall before the first input.
     let video_buf = if inputs.has_data("video_in") {
         let frame: Videoframe = inputs.read("video_in")?;
         let buf = gpu_ctx.resolve_videoframe_buffer(&frame)?;
@@ -620,12 +647,6 @@ fn compose_one_frame(
     ))
 }
 
-// Keep this compiling for `clippy::let_unit_value` etc. when the loop
-// helpers reference [`RuntimeContextLimitedAccess`] only conceptually
-// (lifecycle methods don't need on_pause / on_resume).
-#[allow(dead_code)]
-fn _ctx_marker(_ctx: &RuntimeContextLimitedAccess<'_>) {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -700,13 +721,26 @@ mod tests {
         );
     }
 
-    /// Issue exit-criterion: pushing 5 frames into one input port between
-    /// iterations causes the older 4 to be discarded; only the latest is
-    /// read. This is the contract `PortMailbox::pop_latest` provides; the
-    /// processor's render loop relies on it via `inputs.read()` (the
-    /// frame ports are configured with `ReadMode::SkipToLatest`).
+    /// Locks down the contract the render loop's drain-latest behavior
+    /// inherits from the iceoryx2 `SkipToLatest` read mode (the schema
+    /// default for video input ports — see
+    /// `libs/streamlib-macros/src/codegen.rs` `read_mode_tokens`).
+    /// `inputs.read()` calls into `PortMailbox::pop_latest`; if a future
+    /// refactor changed this primitive to FIFO behavior, the loop
+    /// would silently drift to consuming stale frames.
+    ///
+    /// **Scope note.** This test exercises the iceoryx2 primitive
+    /// directly, not the processor's call into it. A processor-level
+    /// integration test would require constructing valid
+    /// `FrameHeader`-prefixed wire bytes and pushing them through an
+    /// `InputMailboxes` / iceoryx2 subscriber — neither has a public
+    /// constructor accessible to an out-of-tree test. The combination
+    /// of (a) this primitive test, (b) the schema YAML omitting a
+    /// `read_mode` override (so codegen picks `SkipToLatest`), and
+    /// (c) the loop calling `inputs.read()` once per tick is what
+    /// satisfies the issue's exit criterion.
     #[test]
-    fn pulls_latest_input_skipping_stale() {
+    fn iceoryx2_pop_latest_skips_stale_frames() {
         use streamlib::iceoryx2::PortMailbox;
 
         let mailbox = PortMailbox::new(8);
@@ -720,6 +754,64 @@ mod tests {
         assert!(
             mailbox.is_empty(),
             "older frames must be drained (skip-stale semantics)"
+        );
+    }
+
+    /// Verifies the render loop's call shape: each tick pulls **one**
+    /// payload from the input source and ignores any that arrived
+    /// between ticks. Uses an in-memory queue mock (`Mutex<Vec<u32>>`)
+    /// in place of `InputMailboxes::read()` so the test exercises the
+    /// loop's per-tick consume model rather than the iceoryx2 primitive.
+    #[test]
+    fn render_loop_consumes_one_payload_per_tick() {
+        use std::sync::Mutex;
+
+        let target_fps: f64 = 60.0;
+        let running = Arc::new(AtomicBool::new(true));
+        // Pre-seed five "stale" payloads + a marker for the test thread
+        // to push the latest one between iterations.
+        let queue: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(vec![10, 11, 12, 13, 14]));
+        let consumed: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let queue_for_loop = Arc::clone(&queue);
+        let consumed_clone = Arc::clone(&consumed);
+        let running_clone = Arc::clone(&running);
+
+        let handle = std::thread::spawn(move || {
+            manual_render_loop(target_fps, running_clone, || {
+                // Mirror `inputs.read()` with `SkipToLatest`: drain any
+                // stale entries and consume only the most recent one.
+                let mut q = queue_for_loop.lock().unwrap();
+                if let Some(latest) = q.pop() {
+                    q.clear();
+                    drop(q);
+                    consumed_clone.lock().unwrap().push(latest);
+                }
+            });
+        });
+
+        // First tick should consume only the latest of the seeded five.
+        std::thread::sleep(Duration::from_millis(40));
+        // Push one more between iterations; the next tick should pick
+        // it up directly with no buffering of the prior consumed frame.
+        queue.lock().unwrap().push(99);
+        std::thread::sleep(Duration::from_millis(40));
+
+        running.store(false, Ordering::Release);
+        handle.join().expect("loop join");
+
+        let observed = consumed.lock().unwrap().clone();
+        assert!(
+            observed.contains(&14),
+            "loop must consume the latest pre-seeded frame, got {observed:?}"
+        );
+        assert!(
+            observed.contains(&99),
+            "loop must pick up the post-seed frame, got {observed:?}"
+        );
+        assert!(
+            !observed.contains(&10) && !observed.contains(&11) && !observed.contains(&12),
+            "stale frames must NOT be consumed, got {observed:?}"
         );
     }
 

--- a/examples/camera-python-display/src/main.rs
+++ b/examples/camera-python-display/src/main.rs
@@ -45,7 +45,10 @@ fn main() {
     std::process::exit(2);
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+// `blending_compositor` is cross-platform (macOS Metal + Linux Vulkan); the
+// rest of the example pipeline still requires macOS until #483 (CRT/film-
+// grain), #484 (AvatarCharacter), #485 (Skia overlays), and #486 (Glitch)
+// land for Linux.
 mod blending_compositor;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod crt_film_grain;

--- a/examples/camera-python-display/streamlib.yaml
+++ b/examples/camera-python-display/streamlib.yaml
@@ -18,7 +18,7 @@ processors:
   - name: com.tatolab.blending_compositor
     version: 1.0.0
     description: "Multi-layer alpha blending compositor with PiP support"
-    execution: reactive
+    execution: manual
     runtime:
       options:
         unsafe_send: true

--- a/libs/streamlib/build.rs
+++ b/libs/streamlib/build.rs
@@ -29,6 +29,10 @@ fn compile_compute_shaders() {
     // Add new compute kernels here.
     let shaders: &[(&str, &str)] = &[
         ("src/vulkan/rhi/shaders/nv12_to_bgra.comp", "nv12_to_bgra.spv"),
+        (
+            "src/vulkan/rhi/shaders/blending_compositor.comp",
+            "blending_compositor.spv",
+        ),
     ];
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");

--- a/libs/streamlib/src/apple/processors/camera.rs
+++ b/libs/streamlib/src/apple/processors/camera.rs
@@ -81,33 +81,6 @@ impl CMTime {
     }
 }
 
-#[link(name = "CoreGraphics", kind = "framework")]
-extern "C" {
-    fn CGMainDisplayID() -> u32;
-    fn CGDisplayCopyDisplayMode(display: u32) -> *const c_void;
-    fn CGDisplayModeGetRefreshRate(mode: *const c_void) -> f64;
-    fn CGDisplayModeRelease(mode: *const c_void);
-}
-
-/// Get the refresh rate of the main display in Hz.
-/// Returns 60.0 as fallback if detection fails.
-fn get_main_display_refresh_rate() -> f64 {
-    unsafe {
-        let display_id = CGMainDisplayID();
-        let mode = CGDisplayCopyDisplayMode(display_id);
-        if mode.is_null() {
-            return 60.0;
-        }
-        let rate = CGDisplayModeGetRefreshRate(mode);
-        CGDisplayModeRelease(mode);
-        // Some displays report 0 for "as fast as possible" - default to 60
-        if rate <= 0.0 {
-            60.0
-        } else {
-            rate
-        }
-    }
-}
 
 /// Shared state for AVFoundation initialization (async pattern).
 struct CaptureSessionInitState {
@@ -517,7 +490,9 @@ impl AppleCameraProcessor::Processor {
 
             // Get frame rate settings from config (default: 60fps min, display refresh rate max)
             let requested_min_fps = config.min_fps.unwrap_or(60.0);
-            let requested_max_fps = config.max_fps.unwrap_or_else(get_main_display_refresh_rate);
+            let requested_max_fps = config
+                .max_fps
+                .unwrap_or_else(|| crate::core::display_info::get_refresh_rate(None));
 
             // Query camera's supported frame rate range from active format
             let active_format = device.activeFormat();

--- a/libs/streamlib/src/core/display_info.rs
+++ b/libs/streamlib/src/core/display_info.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-platform display refresh-rate query.
+
+use winit::window::Window;
+
+/// Default fallback refresh rate when the platform query fails or the
+/// driver reports an unusable value.
+pub const DEFAULT_REFRESH_RATE_HZ: f64 = 60.0;
+
+/// Refresh rate of the monitor this window belongs to, in Hz.
+///
+/// On Linux the rate comes from `winit::MonitorHandle::refresh_rate_millihertz`
+/// (returns `None` on Wayland compositors that do not advertise a rate —
+/// fallback applied). On macOS / iOS the rate comes from the main display
+/// via `CGDisplayModeGetRefreshRate` and the `window` argument is ignored
+/// (CoreGraphics is global, no per-window query needed).
+#[cfg(target_os = "linux")]
+pub fn get_refresh_rate(window: Option<&Window>) -> f64 {
+    let monitor = window
+        .and_then(|w| w.current_monitor())
+        .or_else(|| window.and_then(|w| w.available_monitors().next()));
+    match monitor.and_then(|m| m.refresh_rate_millihertz()) {
+        Some(mhz) if mhz > 0 => f64::from(mhz) / 1000.0,
+        _ => {
+            tracing::warn!(
+                "display_info: monitor refresh rate unavailable; falling back to {DEFAULT_REFRESH_RATE_HZ} Hz"
+            );
+            DEFAULT_REFRESH_RATE_HZ
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod apple_link {
+    use std::ffi::c_void;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        pub fn CGMainDisplayID() -> u32;
+        pub fn CGDisplayCopyDisplayMode(display: u32) -> *const c_void;
+        pub fn CGDisplayModeGetRefreshRate(mode: *const c_void) -> f64;
+        pub fn CGDisplayModeRelease(mode: *const c_void);
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn get_refresh_rate(_window: Option<&Window>) -> f64 {
+    use apple_link::*;
+    unsafe {
+        let display_id = CGMainDisplayID();
+        let mode = CGDisplayCopyDisplayMode(display_id);
+        if mode.is_null() {
+            return DEFAULT_REFRESH_RATE_HZ;
+        }
+        let rate = CGDisplayModeGetRefreshRate(mode);
+        CGDisplayModeRelease(mode);
+        if rate <= 0.0 {
+            DEFAULT_REFRESH_RATE_HZ
+        } else {
+            rate
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "ios")))]
+pub fn get_refresh_rate(_window: Option<&Window>) -> f64 {
+    DEFAULT_REFRESH_RATE_HZ
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_refresh_rate_is_60() {
+        assert_eq!(DEFAULT_REFRESH_RATE_HZ, 60.0);
+    }
+
+    #[test]
+    fn get_refresh_rate_with_no_window_returns_positive() {
+        // Linux: warns + falls back to 60. macOS: queries main display.
+        // Either way the result must be a positive Hz value.
+        let rate = get_refresh_rate(None);
+        assert!(rate > 0.0, "refresh rate must be > 0, got {rate}");
+    }
+}

--- a/libs/streamlib/src/core/mod.rs
+++ b/libs/streamlib/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod compiler;
 pub mod config;
 pub mod context;
 pub mod descriptors;
+pub mod display_info;
 pub mod embedded_schemas;
 pub mod error;
 pub mod execution;

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -162,6 +162,14 @@ pub use linux::{
     LinuxDisplayProcessor as DisplayProcessor,
 };
 
+// Vulkan compositor re-exports for in-tree examples that drive the kernel
+// directly. Linux-only because the Vulkan module itself is Linux-gated.
+#[cfg(target_os = "linux")]
+pub use vulkan::rhi::{
+    blending_compositor_flags, BlendingCompositorInputs, BlendingCompositorPushConstants,
+    VulkanBlendingCompositor,
+};
+
 /// Per-runtime surface-share service primitives. Exposed for adapter
 /// integration tests and 3rd-party tooling that needs to drive the
 /// service in isolation; production callers go through [`StreamRuntime`].

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -66,6 +66,12 @@ pub use vulkan_texture_readback::VulkanTextureReadback;
 mod vulkan_format_converter;
 pub use vulkan_format_converter::VulkanFormatConverter;
 
+mod vulkan_blending_compositor;
+pub use vulkan_blending_compositor::{
+    flag_bits as blending_compositor_flags, BlendingCompositorInputs,
+    BlendingCompositorPushConstants, VulkanBlendingCompositor,
+};
+
 #[cfg(target_os = "linux")]
 pub mod drm_modifier_probe;
 

--- a/libs/streamlib/src/vulkan/rhi/shaders/blending_compositor.comp
+++ b/libs/streamlib/src/vulkan/rhi/shaders/blending_compositor.comp
@@ -1,0 +1,221 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// Multi-layer alpha-over compositor (Porter-Duff "over" with premultiplied
+// alpha). Mirrors the macOS Metal fragment shader at
+// examples/camera-python-display/src/shaders/blending_compositor.metal —
+// 4-layer composite (video → lower_third → watermark → PiP) with the same
+// Cyberpunk N54 News PiP chrome and bilinear sampling for the PiP content.
+//
+// All buffers are packed BGRA8 in little-endian uint32: byte0=B, byte1=G,
+// byte2=R, byte3=A. Same packing as nv12_to_bgra.comp.
+
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+layout(set = 0, binding = 0) readonly buffer VideoIn      { uint data[]; } video_in;
+layout(set = 0, binding = 1) readonly buffer LowerThirdIn { uint data[]; } lower_third_in;
+layout(set = 0, binding = 2) readonly buffer WatermarkIn  { uint data[]; } watermark_in;
+layout(set = 0, binding = 3) readonly buffer PipIn        { uint data[]; } pip_in;
+layout(set = 0, binding = 4) writeonly buffer Output      { uint data[]; } output_buf;
+
+layout(push_constant) uniform PushConstants {
+    uint width;
+    uint height;
+    uint pip_width;
+    uint pip_height;
+    uint flags;            // bit 0 has_video, bit 1 has_lower_third,
+                           // bit 2 has_watermark, bit 3 has_pip
+    float pip_slide_progress;
+} pc;
+
+// Cyberpunk palette (matches Metal kernel verbatim).
+const vec4 CYBER_CYAN   = vec4(0.0,   0.94,  1.0,   1.0);   // #00f0ff
+const vec4 CYBER_YELLOW = vec4(0.988, 0.933, 0.039, 1.0);   // #fcee0a
+const vec4 CYBER_WHITE  = vec4(1.0,   1.0,   1.0,   1.0);
+const vec4 CYBER_DARK   = vec4(0.06,  0.06,  0.08,  0.95);
+
+// PiP geometry (UV space, fraction of screen).
+const float PIP_WIDTH        = 0.28;
+const float PIP_HEIGHT       = 0.35;
+const float PIP_MARGIN       = 0.02;
+const float PIP_BORDER       = 0.004;
+const float TITLE_BAR_HEIGHT = 0.045;
+
+vec4 unpack_bgra(uint p) {
+    float b = float((p >>  0u) & 0xFFu) / 255.0;
+    float g = float((p >>  8u) & 0xFFu) / 255.0;
+    float r = float((p >> 16u) & 0xFFu) / 255.0;
+    float a = float((p >> 24u) & 0xFFu) / 255.0;
+    return vec4(r, g, b, a);
+}
+
+uint pack_bgra(vec4 c) {
+    uint b = uint(clamp(c.b, 0.0, 1.0) * 255.0 + 0.5);
+    uint g = uint(clamp(c.g, 0.0, 1.0) * 255.0 + 0.5);
+    uint r = uint(clamp(c.r, 0.0, 1.0) * 255.0 + 0.5);
+    uint a = uint(clamp(c.a, 0.0, 1.0) * 255.0 + 0.5);
+    return b | (g << 8u) | (r << 16u) | (a << 24u);
+}
+
+// Sample a screen-sized layer at integer pixel `pos`. Layers are aligned
+// 1:1 with the output (the upstream Skia/Python/etc. processors produce
+// canvases at the camera resolution — same shape as the Metal version).
+vec4 sample_layer_pixel(uint binding_idx, uvec2 pos) {
+    uint idx = pos.y * pc.width + pos.x;
+    if (binding_idx == 0u) return unpack_bgra(video_in.data[idx]);
+    if (binding_idx == 1u) return unpack_bgra(lower_third_in.data[idx]);
+    return unpack_bgra(watermark_in.data[idx]);
+}
+
+vec4 read_pip_texel(ivec2 p) {
+    p = clamp(p, ivec2(0), ivec2(int(pc.pip_width) - 1, int(pc.pip_height) - 1));
+    uint idx = uint(p.y) * pc.pip_width + uint(p.x);
+    return unpack_bgra(pip_in.data[idx]);
+}
+
+// Bilinear sample of the PiP source at UV (0..1, 0..1). Matches Metal's
+// linear sampler with clamp-to-edge addressing; without bilinear the
+// downsample to ~28% of screen width looks pixelated.
+vec4 sample_pip_bilinear(vec2 uv) {
+    vec2 size = vec2(float(pc.pip_width), float(pc.pip_height));
+    vec2 sample_pos = uv * size - vec2(0.5);
+    ivec2 base = ivec2(floor(sample_pos));
+    vec2 frac_pos = fract(sample_pos);
+
+    vec4 c00 = read_pip_texel(base + ivec2(0, 0));
+    vec4 c10 = read_pip_texel(base + ivec2(1, 0));
+    vec4 c01 = read_pip_texel(base + ivec2(0, 1));
+    vec4 c11 = read_pip_texel(base + ivec2(1, 1));
+
+    vec4 top    = mix(c00, c10, frac_pos.x);
+    vec4 bottom = mix(c01, c11, frac_pos.x);
+    return mix(top, bottom, frac_pos.y);
+}
+
+bool in_rect(vec2 uv, vec2 lo, vec2 hi) {
+    return uv.x >= lo.x && uv.x <= hi.x && uv.y >= lo.y && uv.y <= hi.y;
+}
+
+// Cyberpunk N54 News PiP frame (border + title bar + content + corner techmarks).
+// Slides in from the right; `slideProgress` 0 → fully off-screen, 1 → docked.
+vec4 draw_pip_frame(vec2 uv, float slide_progress, vec4 base) {
+    float slide_offset = (1.0 - slide_progress) * (PIP_WIDTH + PIP_MARGIN + 0.1);
+
+    float pip_left   = 1.0 - PIP_MARGIN - PIP_WIDTH + slide_offset;
+    float pip_right  = 1.0 - PIP_MARGIN + slide_offset;
+    float pip_top    = PIP_MARGIN;
+    float pip_bottom = PIP_MARGIN + PIP_HEIGHT;
+
+    float title_top    = pip_bottom;
+    float title_bottom = pip_bottom + TITLE_BAR_HEIGHT;
+
+    float frame_left   = pip_left   - PIP_BORDER;
+    float frame_right  = pip_right  + PIP_BORDER;
+    float frame_top    = pip_top    - PIP_BORDER;
+    float frame_bottom = title_bottom + PIP_BORDER;
+
+    if (!in_rect(uv, vec2(frame_left, frame_top), vec2(frame_right, frame_bottom))) {
+        return base;
+    }
+
+    // Outer cyan border.
+    bool outer_inner = in_rect(uv,
+        vec2(frame_left + PIP_BORDER, frame_top + PIP_BORDER),
+        vec2(frame_right - PIP_BORDER, frame_bottom - PIP_BORDER));
+    if (!outer_inner) {
+        return CYBER_CYAN;
+    }
+
+    // Inner white border (half thickness).
+    float inner_border = PIP_BORDER * 0.5;
+    bool inner_inner = in_rect(uv,
+        vec2(frame_left + PIP_BORDER + inner_border, frame_top + PIP_BORDER + inner_border),
+        vec2(frame_right - PIP_BORDER - inner_border, frame_bottom - PIP_BORDER - inner_border));
+    if (!inner_inner) {
+        return CYBER_WHITE;
+    }
+
+    // Title bar (yellow with subtle scanline darkening).
+    if (in_rect(uv, vec2(pip_left, title_top), vec2(pip_right, title_bottom))) {
+        vec4 title = CYBER_YELLOW;
+        title.a = 0.95;
+        float scan = fract(uv.y * 200.0);
+        if (scan < 0.1) {
+            title.rgb *= 0.9;
+        }
+        return title;
+    }
+
+    // Content area: PiP texture with corner techmarks.
+    if (in_rect(uv, vec2(pip_left, pip_top), vec2(pip_right, pip_bottom))) {
+        vec4 result = CYBER_DARK;
+
+        vec2 pip_uv = vec2(
+            (uv.x - pip_left) / (pip_right - pip_left),
+            (uv.y - pip_top)  / (pip_bottom - pip_top)
+        );
+
+        vec4 pip_color = sample_pip_bilinear(pip_uv);
+        result.rgb = pip_color.rgb + result.rgb * (1.0 - pip_color.a);
+        result.a   = pip_color.a   + result.a   * (1.0 - pip_color.a);
+
+        const float corner_size  = 0.015;
+        const float tech_thick   = 0.002;
+        float cs_x = corner_size / PIP_WIDTH;
+        float cs_y = corner_size / PIP_HEIGHT;
+        float tt_x = tech_thick  / PIP_WIDTH;
+        float tt_y = tech_thick  / PIP_HEIGHT;
+
+        if ((pip_uv.x < cs_x && pip_uv.y < tt_y) || (pip_uv.x < tt_x && pip_uv.y < cs_y)) {
+            result = CYBER_CYAN;
+        }
+        if ((pip_uv.x > 1.0 - cs_x && pip_uv.y < tt_y) || (pip_uv.x > 1.0 - tt_x && pip_uv.y < cs_y)) {
+            result = CYBER_CYAN;
+        }
+        if ((pip_uv.x < cs_x && pip_uv.y > 1.0 - tt_y) || (pip_uv.x < tt_x && pip_uv.y > 1.0 - cs_y)) {
+            result = CYBER_CYAN;
+        }
+        if ((pip_uv.x > 1.0 - cs_x && pip_uv.y > 1.0 - tt_y) || (pip_uv.x > 1.0 - tt_x && pip_uv.y > 1.0 - cs_y)) {
+            result = CYBER_CYAN;
+        }
+        return result;
+    }
+
+    return base;
+}
+
+void main() {
+    uvec2 pos = gl_GlobalInvocationID.xy;
+    if (pos.x >= pc.width || pos.y >= pc.height) return;
+
+    bool has_video        = (pc.flags & 1u) != 0u;
+    bool has_lower_third  = (pc.flags & 2u) != 0u;
+    bool has_watermark    = (pc.flags & 4u) != 0u;
+    bool has_pip          = (pc.flags & 8u) != 0u;
+
+    // Base layer: video, or the dark-blue placeholder the Metal version uses
+    // before any camera frame has arrived.
+    vec4 result = has_video
+        ? sample_layer_pixel(0u, pos)
+        : vec4(0.05, 0.05, 0.12, 1.0);
+
+    if (has_lower_third) {
+        vec4 src = sample_layer_pixel(1u, pos);
+        result.rgb = src.rgb + result.rgb * (1.0 - src.a);
+        result.a   = src.a   + result.a   * (1.0 - src.a);
+    }
+    if (has_watermark) {
+        vec4 src = sample_layer_pixel(2u, pos);
+        result.rgb = src.rgb + result.rgb * (1.0 - src.a);
+        result.a   = src.a   + result.a   * (1.0 - src.a);
+    }
+    if (has_pip && pc.pip_slide_progress > 0.0) {
+        vec2 uv = vec2(float(pos.x) + 0.5, float(pos.y) + 0.5)
+                / vec2(float(pc.width), float(pc.height));
+        result = draw_pip_frame(uv, pc.pip_slide_progress, result);
+    }
+
+    output_buf.data[pos.y * pc.width + pos.x] = pack_bgra(result);
+}

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
@@ -45,8 +45,17 @@ const BLENDING_BINDINGS: &[ComputeBindingSpec] = &[
 const WORKGROUP_SIZE: u32 = 16;
 
 /// Inputs for one compositor dispatch. All buffers are BGRA8 packed
-/// little-endian; `video`, `lower_third`, `watermark`, and `output` share
-/// the same dimensions; `pip` is its own (typically smaller) source size.
+/// little-endian.
+///
+/// **Layer-size contract.** `video`, `lower_third`, and `watermark`
+/// must match `output`'s dimensions exactly — the GLSL kernel samples
+/// them at integer pixel coordinates with no resampling, so a size
+/// mismatch is rejected at dispatch time with [`StreamError::GpuError`].
+/// `pip` may be any size; it is bilinearly sampled inside the PiP
+/// rect. This is stricter than the macOS Metal version (which silently
+/// resamples mismatched layers via the linear sampler); when porting
+/// upstream overlay processors to Linux, ensure they emit at the
+/// camera resolution.
 pub struct BlendingCompositorInputs<'a> {
     pub video: Option<&'a RhiPixelBuffer>,
     pub lower_third: Option<&'a RhiPixelBuffer>,

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
@@ -304,4 +304,151 @@ mod tests {
             .expect_err("size mismatch must error");
         assert!(matches!(err, StreamError::GpuError(_)));
     }
+
+    /// Visual smoke for the 4-layer composite. Builds synthetic inputs
+    /// (gradient video, semi-transparent magenta lower-third strip,
+    /// opaque cyan watermark in the upper-left, checkerboard PiP),
+    /// dispatches the kernel, writes the result as a PNG to
+    /// `STREAMLIB_BLENDING_COMPOSITOR_PNG_OUT` (or
+    /// `target/blending_compositor_smoke.png` by default), and asserts
+    /// the dispatch succeeded. The PNG is for human review (and PR
+    /// embedding via `attach-images`); the test passes on any
+    /// successful kernel run + well-formed PNG write.
+    ///
+    /// **Scope.** This is a smoke test, not a fixture-locked one. It
+    /// catches kernel-construction regressions and gross
+    /// alpha-over / PiP-geometry breakage that would render an
+    /// obviously-wrong image. A bit-exact fixture comparison (cf.
+    /// `nv12_to_bgra_matches_committed_png_fixture`) is a follow-up
+    /// once the layer composition has settled.
+    #[test]
+    fn visual_smoke_emits_png() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let compositor = VulkanBlendingCompositor::new(&device).expect("compositor");
+
+        let w: u32 = 320;
+        let h: u32 = 240;
+        let pip_w: u32 = 96;
+        let pip_h: u32 = 64;
+
+        let video = make_buf(&device, w, h);
+        let lower_third = make_buf(&device, w, h);
+        let watermark = make_buf(&device, w, h);
+        let pip = make_buf(&device, pip_w, pip_h);
+        let out = make_buf(&device, w, h);
+
+        // ---- video: BGRA gradient. R varies left→right, G varies
+        // top→bottom, B fixed at 64, opaque alpha. -----------------
+        unsafe {
+            let ptr = video.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for y in 0..h {
+                for x in 0..w {
+                    let r = ((x * 255 / w.saturating_sub(1).max(1)) & 0xFF) as u32;
+                    let g = ((y * 255 / h.saturating_sub(1).max(1)) & 0xFF) as u32;
+                    let b: u32 = 64;
+                    let a: u32 = 255;
+                    *ptr.add((y * w + x) as usize) = b | (g << 8) | (r << 16) | (a << 24);
+                }
+            }
+        }
+
+        // ---- lower_third: semi-transparent magenta strip across the
+        // bottom 25% (premultiplied alpha — α=0.5, BGRA = 64,0,64,128).
+        unsafe {
+            let ptr = lower_third.buffer_ref().inner.mapped_ptr() as *mut u32;
+            // Default to fully transparent.
+            for i in 0..(w * h) as usize {
+                *ptr.add(i) = 0;
+            }
+            let strip_top = (h * 75) / 100;
+            // Premultiplied: rgb = source_rgb * α. α=0.5, magenta source
+            // (255, 0, 255) → premul (128, 0, 128).
+            let pixel: u32 = 128 | (0 << 8) | (128 << 16) | (128 << 24);
+            for y in strip_top..h {
+                for x in 0..w {
+                    *ptr.add((y * w + x) as usize) = pixel;
+                }
+            }
+        }
+
+        // ---- watermark: opaque cyan square (32×32) in the upper-left
+        // corner (mirrors a brand-mark in the corner). -----------
+        unsafe {
+            let ptr = watermark.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for i in 0..(w * h) as usize {
+                *ptr.add(i) = 0;
+            }
+            let pixel: u32 = 255 | (255 << 8) | (0 << 16) | (255 << 24); // BGRA cyan
+            for y in 8..40 {
+                for x in 8..40 {
+                    *ptr.add((y * w + x) as usize) = pixel;
+                }
+            }
+        }
+
+        // ---- PiP: 8×8 checkerboard, opaque white / transparent. ----
+        unsafe {
+            let ptr = pip.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for y in 0..pip_h {
+                for x in 0..pip_w {
+                    let cell_x = x / 8;
+                    let cell_y = y / 8;
+                    let on = (cell_x + cell_y) % 2 == 0;
+                    let pixel = if on {
+                        0xFFFFFFFFu32 // opaque white (BGRA: 255,255,255,255)
+                    } else {
+                        0
+                    };
+                    *ptr.add((y * pip_w + x) as usize) = pixel;
+                }
+            }
+        }
+
+        compositor
+            .dispatch(BlendingCompositorInputs {
+                video: Some(&video),
+                lower_third: Some(&lower_third),
+                watermark: Some(&watermark),
+                pip: Some(&pip),
+                output: &out,
+                pip_slide_progress: 1.0,
+            })
+            .expect("dispatch must succeed");
+
+        // Read back BGRA and convert to RGBA for the PNG encoder.
+        let bgra_size = (w * h * 4) as usize;
+        let mut bgra_bytes = vec![0u8; bgra_size];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                out.buffer_ref().inner.mapped_ptr(),
+                bgra_bytes.as_mut_ptr(),
+                bgra_size,
+            );
+        }
+        let mut rgba = vec![0u8; bgra_size];
+        for chunk in 0..(bgra_size / 4) {
+            let i = chunk * 4;
+            rgba[i] = bgra_bytes[i + 2];
+            rgba[i + 1] = bgra_bytes[i + 1];
+            rgba[i + 2] = bgra_bytes[i];
+            rgba[i + 3] = bgra_bytes[i + 3];
+        }
+
+        let out_path = std::env::var("STREAMLIB_BLENDING_COMPOSITOR_PNG_OUT")
+            .unwrap_or_else(|_| "target/blending_compositor_smoke.png".to_string());
+        let _ = std::fs::create_dir_all(
+            std::path::Path::new(&out_path)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let file = std::fs::File::create(&out_path)
+            .unwrap_or_else(|e| panic!("create {out_path}: {e}"));
+        let bw = std::io::BufWriter::new(file);
+        let mut encoder = png::Encoder::new(bw, w, h);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().expect("PNG header");
+        writer.write_image_data(&rgba).expect("PNG data");
+        eprintln!("blending_compositor visual smoke wrote {out_path}");
+    }
 }

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
@@ -1,0 +1,298 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! 4-layer alpha-over compositor via [`VulkanComputeKernel`].
+//!
+//! Linux counterpart to the macOS Metal kernel at
+//! `examples/camera-python-display/src/shaders/blending_compositor.metal`.
+
+use std::sync::Arc;
+
+use crate::core::rhi::{ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer};
+use crate::core::{Result, StreamError};
+
+use super::{HostVulkanDevice, VulkanComputeKernel};
+
+/// Push-constants layout matching `blending_compositor.comp`'s
+/// `layout(push_constant)` block.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BlendingCompositorPushConstants {
+    pub width: u32,
+    pub height: u32,
+    pub pip_width: u32,
+    pub pip_height: u32,
+    pub flags: u32,
+    pub pip_slide_progress: f32,
+}
+
+/// `flags` bit positions for [`BlendingCompositorPushConstants`].
+pub mod flag_bits {
+    pub const HAS_VIDEO: u32 = 1 << 0;
+    pub const HAS_LOWER_THIRD: u32 = 1 << 1;
+    pub const HAS_WATERMARK: u32 = 1 << 2;
+    pub const HAS_PIP: u32 = 1 << 3;
+}
+
+const BLENDING_BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::storage_buffer(0), // video
+    ComputeBindingSpec::storage_buffer(1), // lower_third
+    ComputeBindingSpec::storage_buffer(2), // watermark
+    ComputeBindingSpec::storage_buffer(3), // pip
+    ComputeBindingSpec::storage_buffer(4), // output
+];
+
+const WORKGROUP_SIZE: u32 = 16;
+
+/// Inputs for one compositor dispatch. All buffers are BGRA8 packed
+/// little-endian; `video`, `lower_third`, `watermark`, and `output` share
+/// the same dimensions; `pip` is its own (typically smaller) source size.
+pub struct BlendingCompositorInputs<'a> {
+    pub video: Option<&'a RhiPixelBuffer>,
+    pub lower_third: Option<&'a RhiPixelBuffer>,
+    pub watermark: Option<&'a RhiPixelBuffer>,
+    pub pip: Option<&'a RhiPixelBuffer>,
+    pub output: &'a RhiPixelBuffer,
+    pub pip_slide_progress: f32,
+}
+
+/// 4-layer Porter-Duff "over" compositor with animated PiP frame.
+pub struct VulkanBlendingCompositor {
+    kernel: VulkanComputeKernel,
+    /// 1×1 transparent BGRA buffer used as a placeholder for any input
+    /// that the caller leaves unbound — descriptor sets must be fully
+    /// populated even when the corresponding `has_*` flag is false.
+    placeholder: RhiPixelBuffer,
+}
+
+impl VulkanBlendingCompositor {
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+        let spv = include_bytes!(concat!(env!("OUT_DIR"), "/blending_compositor.spv"));
+        let kernel = VulkanComputeKernel::new(
+            vulkan_device,
+            &ComputeKernelDescriptor {
+                label: "blending_compositor",
+                spv,
+                bindings: BLENDING_BINDINGS,
+                push_constant_size: std::mem::size_of::<BlendingCompositorPushConstants>() as u32,
+            },
+        )?;
+
+        let placeholder = make_placeholder(vulkan_device)?;
+
+        Ok(Self { kernel, placeholder })
+    }
+
+    /// Composite `inputs` into `inputs.output`. The output's dimensions
+    /// drive the dispatch size; missing layer inputs short-circuit via
+    /// the `has_*` flags inside the shader.
+    pub fn dispatch(&self, inputs: BlendingCompositorInputs<'_>) -> Result<()> {
+        let width = inputs.output.width;
+        let height = inputs.output.height;
+
+        let mut flags = 0u32;
+        if inputs.video.is_some()        { flags |= flag_bits::HAS_VIDEO; }
+        if inputs.lower_third.is_some()  { flags |= flag_bits::HAS_LOWER_THIRD; }
+        if inputs.watermark.is_some()    { flags |= flag_bits::HAS_WATERMARK; }
+        if inputs.pip.is_some()          { flags |= flag_bits::HAS_PIP; }
+
+        let video       = inputs.video.unwrap_or(&self.placeholder);
+        let lower_third = inputs.lower_third.unwrap_or(&self.placeholder);
+        let watermark   = inputs.watermark.unwrap_or(&self.placeholder);
+        let pip         = inputs.pip.unwrap_or(&self.placeholder);
+
+        // Screen-aligned layers must match the output's dimensions — the
+        // shader assumes 1:1 pixel alignment for layers 0..2 (mirroring
+        // the Metal version, which samples them at screen UV).
+        if let Some(video) = inputs.video {
+            check_match("video", video, width, height)?;
+        }
+        if let Some(lt) = inputs.lower_third {
+            check_match("lower_third", lt, width, height)?;
+        }
+        if let Some(wm) = inputs.watermark {
+            check_match("watermark", wm, width, height)?;
+        }
+
+        let push = BlendingCompositorPushConstants {
+            width,
+            height,
+            pip_width: pip.width,
+            pip_height: pip.height,
+            flags,
+            pip_slide_progress: inputs.pip_slide_progress.clamp(0.0, 1.0),
+        };
+
+        self.kernel.set_storage_buffer(0, video)?;
+        self.kernel.set_storage_buffer(1, lower_third)?;
+        self.kernel.set_storage_buffer(2, watermark)?;
+        self.kernel.set_storage_buffer(3, pip)?;
+        self.kernel.set_storage_buffer(4, inputs.output)?;
+        self.kernel.set_push_constants_value(&push)?;
+
+        let dispatch_x = width.div_ceil(WORKGROUP_SIZE);
+        let dispatch_y = height.div_ceil(WORKGROUP_SIZE);
+        self.kernel.dispatch(dispatch_x, dispatch_y, 1)
+    }
+}
+
+fn check_match(name: &str, buf: &RhiPixelBuffer, w: u32, h: u32) -> Result<()> {
+    if buf.width != w || buf.height != h {
+        return Err(StreamError::GpuError(format!(
+            "BlendingCompositor: {name} input is {}×{}, expected {w}×{h} (must match output)",
+            buf.width, buf.height
+        )));
+    }
+    Ok(())
+}
+
+fn make_placeholder(vulkan_device: &Arc<HostVulkanDevice>) -> Result<RhiPixelBuffer> {
+    use crate::core::rhi::{PixelFormat, RhiPixelBufferRef};
+    use crate::vulkan::rhi::HostVulkanPixelBuffer;
+
+    let buf = HostVulkanPixelBuffer::new(vulkan_device, 1, 1, 4, PixelFormat::Bgra32)?;
+    // Zero out so any unbound layer reads as fully transparent.
+    unsafe {
+        std::ptr::write_bytes(buf.mapped_ptr(), 0, 4);
+    }
+    Ok(RhiPixelBuffer::new(RhiPixelBufferRef {
+        inner: Arc::new(buf),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::rhi::{PixelFormat, RhiPixelBufferRef};
+    use crate::vulkan::rhi::HostVulkanPixelBuffer;
+
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
+            Ok(d) => Some(Arc::new(d)),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                None
+            }
+        }
+    }
+
+    fn make_buf(device: &Arc<HostVulkanDevice>, w: u32, h: u32) -> RhiPixelBuffer {
+        let vk = HostVulkanPixelBuffer::new(device, w, h, 4, PixelFormat::Bgra32)
+            .expect("pixel buffer");
+        RhiPixelBuffer::new(RhiPixelBufferRef {
+            inner: Arc::new(vk),
+        })
+    }
+
+    fn fill(buf: &RhiPixelBuffer, b: u8, g: u8, r: u8, a: u8) {
+        let pixel = (b as u32) | ((g as u32) << 8) | ((r as u32) << 16) | ((a as u32) << 24);
+        let count = (buf.width * buf.height) as usize;
+        unsafe {
+            let ptr = buf.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for i in 0..count {
+                *ptr.add(i) = pixel;
+            }
+        }
+    }
+
+    fn read_pixel(buf: &RhiPixelBuffer, x: u32, y: u32) -> (u8, u8, u8, u8) {
+        unsafe {
+            let ptr = buf.buffer_ref().inner.mapped_ptr() as *const u32;
+            let p = *ptr.add((y * buf.width + x) as usize);
+            (
+                (p & 0xFF) as u8,
+                ((p >> 8) & 0xFF) as u8,
+                ((p >> 16) & 0xFF) as u8,
+                ((p >> 24) & 0xFF) as u8,
+            )
+        }
+    }
+
+    #[test]
+    fn new_compiles_kernel() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let result = VulkanBlendingCompositor::new(&device);
+        assert!(result.is_ok(), "compositor creation must succeed: {:?}", result.err());
+    }
+
+    #[test]
+    fn output_matches_video_when_only_video_bound() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let compositor = VulkanBlendingCompositor::new(&device).expect("compositor");
+
+        let video = make_buf(&device, 64, 32);
+        let out = make_buf(&device, 64, 32);
+        // BGRA = (10, 200, 50, 255) → opaque green-ish.
+        fill(&video, 10, 200, 50, 255);
+
+        compositor
+            .dispatch(BlendingCompositorInputs {
+                video: Some(&video),
+                lower_third: None,
+                watermark: None,
+                pip: None,
+                output: &out,
+                pip_slide_progress: 0.0,
+            })
+            .expect("dispatch");
+
+        // Sample a center pixel — should round-trip the input bytes.
+        let (b, g, r, a) = read_pixel(&out, 16, 16);
+        // ±1 tolerance per channel for float→u8 rounding paths.
+        assert!((b as i32 - 10).abs() <= 1, "B={b}");
+        assert!((g as i32 - 200).abs() <= 1, "G={g}");
+        assert!((r as i32 - 50).abs() <= 1, "R={r}");
+        assert!((a as i32 - 255).abs() <= 1, "A={a}");
+    }
+
+    #[test]
+    fn no_video_falls_back_to_dark_blue() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let compositor = VulkanBlendingCompositor::new(&device).expect("compositor");
+
+        let out = make_buf(&device, 32, 32);
+
+        compositor
+            .dispatch(BlendingCompositorInputs {
+                video: None,
+                lower_third: None,
+                watermark: None,
+                pip: None,
+                output: &out,
+                pip_slide_progress: 0.0,
+            })
+            .expect("dispatch");
+
+        // Shader's no-video fallback is vec4(0.05, 0.05, 0.12, 1.0) →
+        // BGRA roughly (31, 13, 13, 255). PiP and overlay flags are off,
+        // so the entire frame should be the fallback.
+        let (b, g, r, a) = read_pixel(&out, 8, 8);
+        let expected_b = (0.12_f32 * 255.0).round() as i32; // 31
+        let expected_g = (0.05_f32 * 255.0).round() as i32; // 13
+        let expected_r = (0.05_f32 * 255.0).round() as i32; // 13
+        assert!((b as i32 - expected_b).abs() <= 1, "B={b}");
+        assert!((g as i32 - expected_g).abs() <= 1, "G={g}");
+        assert!((r as i32 - expected_r).abs() <= 1, "R={r}");
+        assert_eq!(a, 255, "alpha must be opaque on fallback");
+    }
+
+    #[test]
+    fn rejects_layer_size_mismatch() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let compositor = VulkanBlendingCompositor::new(&device).expect("compositor");
+        let video = make_buf(&device, 32, 32);
+        let out = make_buf(&device, 64, 32);
+
+        let err = compositor
+            .dispatch(BlendingCompositorInputs {
+                video: Some(&video),
+                lower_third: None,
+                watermark: None,
+                pip: None,
+                output: &out,
+                pip_slide_progress: 0.0,
+            })
+            .expect_err("size mismatch must error");
+        assert!(matches!(err, StreamError::GpuError(_)));
+    }
+}


### PR DESCRIPTION
## Summary

- Port `BlendingCompositor`'s 4-layer alpha-over composite from Metal to a Vulkan compute kernel and switch the processor from `ReactiveProcessor` to `ManualProcessor` with a render thread paced at display refresh rate.
- Lift `apple/processors/camera.rs`'s private `get_main_display_refresh_rate()` into a cross-platform `core::display_info::get_refresh_rate(window)` helper backed by `CGDisplayModeGetRefreshRate` (macOS) and `winit::MonitorHandle::refresh_rate_millihertz` (Linux, with a 60 Hz Wayland fallback).
- Drop the example's non-macOS hard-exit so `BlendingCompositor` can be exercised on Linux. The full pipeline E2E remains gated until siblings #483–#486 land (CRT/film-grain, AvatarCharacter, Skia overlays, Glitch).

## Closes

Closes #482

## Exit criteria

- [x] New Vulkan GLSL compute kernel implementing the same alpha-over composite + animated PiP offset as the Metal kernel (`libs/streamlib/src/vulkan/rhi/shaders/blending_compositor.comp`).
- [x] `VulkanBlendingCompositor` RHI struct using `VulkanComputeKernel` directly with N storage-buffer bindings (issue body's "multi-input dispatch helper" was stale phrasing for `VulkanComputeKernel` itself; in-issue annotation dated 2026-05-01).
- [x] Cross-platform `display_info::get_refresh_rate(window)` helper; `apple/processors/camera.rs`'s private helper lifted and routed through it.
- [x] `BlendingCompositor` switched from `ReactiveProcessor` to `ManualProcessor`; `start()` spawns a render thread that ticks at refresh rate, drains latest input frames per iteration, emits one composited frame.
- [x] `target_fps: Option<f64>` config override on `BlendingCompositorConfig`.
- [x] macOS keeps Metal path; Linux uses new Vulkan path. Single processor with cfg-gated kernel selection (proc macro strips cfg attrs from struct fields, so the GPU backend lives in a cfg-typed alias `GpuBackendStash`).
- [x] Idle invocation count bounded by display refresh + small slack (test asserts 60 fps target, 2 s, ±10 ticks).

## Tests / validation

- [x] Unit: `manual_loop_runs_at_target_fps` (60 Hz target, 2 s, ±10 iterations).
- [x] Unit: `shutdown_exits_loop` — `stop()` exits the thread within 250 ms (`Arc<AtomicBool>` + `JoinHandle` pattern; PUBSUB shutdown framing in the original issue body was per-codebase-reality replaced — annotated in-issue 2026-05-01).
- [x] Unit: `iceoryx2_pop_latest_skips_stale_frames` (renamed from `pulls_latest_input_skipping_stale` to honestly scope to the iceoryx2 primitive that the loop relies on; deeper coverage isn't viable from an out-of-tree test since `FrameHeader` and the iceoryx2 `Subscriber` have no public test constructors).
- [x] Unit: `render_loop_consumes_one_payload_per_tick` — exercises the loop's per-tick consume-latest model with a `Mutex<Vec<u32>>` mock.
- [x] Bonus unit: `pip_slide_progress_is_ease_out_cubic` — locks down the easing curve so the macOS Metal port and the Linux Vulkan port stay in lockstep.
- [x] Vulkan kernel correctness: `new_compiles_kernel`, `output_matches_video_when_only_video_bound`, `no_video_falls_back_to_dark_blue`, `rejects_layer_size_mismatch`. All pass on local NVIDIA RTX 3090 / 570.211.01.
- [x] Workspace baseline (`docs/testing-baseline.md`): **1201 passed, 0 failed, 34 ignored**.
- [ ] Linux full-pipeline visual-smoke E2E — **deferred**. Blocked on #483 (CRT/film-grain), #484 (AvatarCharacter / PiP source), #485 (Skia LowerThird + Watermark), #486 (Glitch); the example pipeline doesn't run end-to-end on Linux until those land. The Vulkan kernel correctness + render-loop integration tests above are the in-isolation validation.
- [ ] macOS cross-compile — **code review only**. No `*-apple-darwin` target installed locally. Touched macOS files (`apple/processors/camera.rs`, the macOS branch of `blending_compositor.rs`) are mostly mechanical refactors (move `process()` body into `compose_one_frame()`, switch helper call site).
- [x] Visual smoke (added in `a62532c`): synthetic 4-layer PNG via `cargo test -p streamlib --lib visual_smoke_emits_png`. See "Visual smoke" section below.

## Visual smoke

![Vulkan blending compositor 4-layer composite output, 320x240](https://gh-artifact.tatolab.com/pr-607/blending_compositor_smoke.png)

*4-layer composite output (320×240): gradient video base + semi-transparent magenta lower-third strip + opaque cyan watermark in the upper-left + Cyberpunk PiP frame (cyan outer border, white inner border, yellow title bar) with bilinearly-sampled checkerboard content in the upper-right. Generated by `cargo test -p streamlib --lib visual_smoke_emits_png` on local NVIDIA RTX 3090 (570.211.01).*

What this confirms about the kernel port:
- **Premultiplied alpha-over math** matches the Metal version (lower-third strip blends with the gradient cleanly; opaque watermark fully covers the gradient underneath).
- **PiP geometry** — the cyan outer border, white inner border, yellow title bar at the bottom, and corner techmarks all match the Metal `drawPipFrame` shape.
- **Bilinear PiP sampling** — the checkerboard inside the PiP rect downsamples from 96×64 source to ~96×84 frame slot smoothly, no nearest-neighbor pixelation.
- **`pip_slide_progress = 1.0`** docks the PiP fully (no horizontal offset).

## PR-review-gate notes

Pre-open `pr-review-gate` returned FIX with one real concern + several DISCUSS items. Addressed in commit `073cf55`:
- **FIX:** Renamed `pulls_latest_input_skipping_stale` to `iceoryx2_pop_latest_skips_stale_frames` (honest scope) + added `render_loop_consumes_one_payload_per_tick` as the genuine loop-integration test.
- **DISCUSS (addressed):** Dropped the dead `_ctx_marker` and unused `RuntimeContextLimitedAccess` import.
- **DISCUSS (addressed):** Restored slow-tick observability — `manual_render_loop` now emits a `tracing::warn!` per tick exceeding 50 ms (recovers the pre-rewrite `STUTTER!` threshold without spamming on normal jitter).
- **DISCUSS (documented):** Added a doc comment to `BlendingCompositorInputs` calling out the layer-size strictness (Linux hard-errors on size mismatch; Metal silently resamples).
- **DISCUSS (documented):** Inline comment on the Linux `compose_one_frame` explaining the deliberate "dispatch every tick even with no inputs" behavior — within spec per the idle-invocation exit criterion; cost is one GPU dispatch on 1×1 placeholders.
- **DISCUSS (skipped with rationale):** `flag_bits` → `blending_compositor_flags` re-export asymmetry — defensible: generic-named modules get a prefix on re-export to avoid collision; type names don't because they're already prefixed.

## Polyglot coverage

- **Runtimes affected**: rust
- **Schema regenerated**: n/a (no schema changes; `streamlib.yaml`'s `execution: reactive` → `manual` is a per-processor config flip, not a wire-format change)
- **Python and Deno both covered?** schema-only / language-specific by construction — the `BlendingCompositorProcessor` is pure Rust on both platforms; no escalate-IPC change, no FD-passing change, no Python or Deno surface to touch. The `polyglot` label is on this issue because the wider example pipeline exercises Python overlays (LowerThird, Watermark, AvatarCharacter), but those processors are unchanged here.
- **E2E tests run**:
  - [x] Host-Rust: workspace cargo test baseline (1201 passed, 0 failed, 34 ignored)
  - [N/A] Python subprocess: no Python code touched
  - [N/A] Deno subprocess: no Deno code touched
- **FD-passing path**: n/a

## Follow-ups

- Linux full-pipeline E2E lands once #483 / #484 / #485 / #486 are merged — `BlendingCompositor` becomes consumable end-to-end at that point.
- macOS verification: cross-compile in CI or a real macOS runner should validate the apple-side helper lift + Metal-path Manual conversion before any macOS release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
