### PR TITLE
feat(linux): VulkanCrtFilmGrain Metal→Vulkan compute port

### DIFF
--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -9,15 +9,53 @@
 //! - Chromatic aberration (RGB separation)
 //! - Vignette (edge darkening)
 //! - Heavy animated film grain (moving noise)
+//!
+//! macOS uses a Metal vertex+fragment pipeline; Linux uses
+//! [`streamlib::VulkanCrtFilmGrain`] (a compute kernel).
 
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
-use streamlib::core::rhi::{PixelFormat, RhiTextureCache};
-use streamlib::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use streamlib::core::rhi::PixelFormat;
+use streamlib::core::{
+    GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+    StreamError,
+};
 use streamlib::Videoframe;
 
-/// Uniform buffer for CRT + Film Grain shader.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use streamlib::core::rhi::RhiTextureCache;
+
+#[cfg(target_os = "linux")]
+use std::sync::Arc as StdArc;
+#[cfg(target_os = "linux")]
+use streamlib::{CrtFilmGrainInputs, VulkanCrtFilmGrain};
+
+// Per-platform GPU backend stash. Defined as a single field on the
+// processor (proc-macro `#[streamlib::processor]` strips `#[cfg]` attrs
+// from individual fields, so we collapse the cfg into the type alias —
+// same pattern as `BlendingCompositorProcessor`).
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+type GpuBackendStash = Option<MetalState>;
+#[cfg(target_os = "linux")]
+type GpuBackendStash = Option<StdArc<VulkanCrtFilmGrain>>;
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+type GpuBackendStash = ();
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+struct MetalState {
+    render_pipeline: metal::RenderPipelineState,
+    render_pass_desc: metal::RenderPassDescriptor,
+    sampler: metal::SamplerState,
+    /// Ring buffer of uniform buffers to avoid CPU-GPU sync hazards.
+    uniforms_buffers: [metal::Buffer; 3],
+    uniforms_index: usize,
+    /// Lazily populated on the first `process()` call after setup.
+    texture_cache: Option<RhiTextureCache>,
+}
+
+/// Uniform buffer for CRT + Film Grain shader (macOS Metal layout).
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[repr(C)]
 struct CrtFilmGrainUniforms {
     time: f32,
@@ -66,19 +104,10 @@ impl Default for CrtFilmGrainConfig {
 #[streamlib::processor("com.tatolab.crt_film_grain")]
 pub struct CrtFilmGrainProcessor {
     config: CrtFilmGrainConfig,
-
-    gpu_context: Option<GpuContext>,
-    render_pipeline: Option<metal::RenderPipelineState>,
-    render_pass_desc: Option<metal::RenderPassDescriptor>,
-    sampler: Option<metal::SamplerState>,
-    /// Ring buffer of uniform buffers to avoid CPU-GPU sync hazards.
-    uniforms_buffers: [Option<metal::Buffer>; 3],
-    uniforms_index: usize,
+    gpu_context: Option<GpuContextLimitedAccess>,
     frame_count: AtomicU64,
     start_time: Option<Instant>,
-
-    // RHI resources
-    texture_cache: Option<RhiTextureCache>,
+    backend: GpuBackendStash,
 }
 
 impl streamlib::core::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
@@ -86,89 +115,7 @@ impl streamlib::core::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
         &mut self,
         ctx: &RuntimeContextFullAccess<'_>,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
-            tracing::info!("CrtFilmGrain: Setting up...");
-
-            self.gpu_context = Some(ctx.gpu_limited_access().clone());
-            self.start_time = Some(Instant::now());
-            self.texture_cache = None; // Deferred to first process()
-
-            let metal_device_ref = ctx.gpu_full_access().device().metal_device_ref();
-
-            // Compile shaders
-            let shader_source = include_str!("shaders/crt_film_grain.metal");
-            let library = metal_device_ref
-                .new_library_with_source(shader_source, &metal::CompileOptions::new())
-                .map_err(|e| StreamError::Configuration(format!("Shader compile failed: {}", e)))?;
-
-            let vertex_fn = library
-                .get_function("crt_vertex", None)
-                .map_err(|e| StreamError::Configuration(format!("Vertex not found: {}", e)))?;
-            let fragment_fn = library
-                .get_function("crt_film_grain_fragment", None)
-                .map_err(|e| StreamError::Configuration(format!("Fragment not found: {}", e)))?;
-
-            // Render pipeline
-            let pipeline_desc = metal::RenderPipelineDescriptor::new();
-            pipeline_desc.set_vertex_function(Some(&vertex_fn));
-            pipeline_desc.set_fragment_function(Some(&fragment_fn));
-
-            let color_attachment = pipeline_desc.color_attachments().object_at(0).unwrap();
-            color_attachment.set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
-
-            let render_pipeline = metal_device_ref
-                .new_render_pipeline_state(&pipeline_desc)
-                .map_err(|e| StreamError::Configuration(format!("Pipeline failed: {}", e)))?;
-
-            // Sampler with linear filtering
-            let sampler_desc = metal::SamplerDescriptor::new();
-            sampler_desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
-            sampler_desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
-            sampler_desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
-            sampler_desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
-            let sampler = metal_device_ref.new_sampler(&sampler_desc);
-
-            // Create render pass descriptor
-            let render_pass_desc_ref = metal::RenderPassDescriptor::new();
-            let color_attachment = render_pass_desc_ref
-                .color_attachments()
-                .object_at(0)
-                .unwrap();
-            color_attachment.set_load_action(metal::MTLLoadAction::Clear);
-            color_attachment.set_clear_color(metal::MTLClearColor::new(0.0, 0.0, 0.0, 1.0));
-            color_attachment.set_store_action(metal::MTLStoreAction::Store);
-
-            // Uniforms ring buffer (3 buffers)
-            let uniforms_size = std::mem::size_of::<CrtFilmGrainUniforms>() as u64;
-            let uniforms_buffers = [
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-                Some(metal_device_ref.new_buffer(
-                    uniforms_size,
-                    metal::MTLResourceOptions::CPUCacheModeDefaultCache,
-                )),
-            ];
-
-            self.render_pipeline = Some(render_pipeline);
-            self.render_pass_desc = Some(render_pass_desc_ref.to_owned());
-            self.sampler = Some(sampler);
-            self.uniforms_buffers = uniforms_buffers;
-            self.uniforms_index = 0;
-
-            tracing::info!(
-                "CrtFilmGrain: Initialized (curve={:.1}, scanlines={:.1}, grain={:.2})",
-                self.config.crt_curve,
-                self.config.scanline_intensity,
-                self.config.grain_intensity
-            );
-            Ok(())
-        })();
+        let result = self.setup_inner(ctx);
         std::future::ready(result)
     }
 
@@ -199,50 +146,172 @@ impl streamlib::core::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
-
-        // Lazy texture cache creation
-        if self.texture_cache.is_none() {
-            self.texture_cache = Some(gpu_ctx.create_texture_cache()?);
-        }
-        let texture_cache = self.texture_cache.as_ref().unwrap();
+            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?
+            .clone();
 
         let input_buffer = gpu_ctx.resolve_videoframe_buffer(&frame)?;
-        let input_view = texture_cache.create_view(&input_buffer)?;
-        let input_metal: &metal::TextureRef = input_view.as_metal_texture();
-
-        let command_queue = gpu_ctx.command_queue().metal_queue_ref();
-
-        // Acquire output buffer from GpuContext pool
         let (output_pool_id, output_buffer) =
             gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Bgra32)?;
-        let output_view = texture_cache.create_view(&output_buffer)?;
+
+        self.process_frame_inner(elapsed, &gpu_ctx, &input_buffer, &output_buffer)?;
+
+        let output_frame = Videoframe {
+            surface_id: output_pool_id.to_string(),
+            width,
+            height,
+            timestamp_ns: frame.timestamp_ns.clone(),
+            frame_index: frame.frame_index.clone(),
+            fps: frame.fps,
+        };
+        self.outputs.write("video_out", &output_frame)?;
+        self.frame_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl CrtFilmGrainProcessor::Processor {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("CrtFilmGrain: setup (Metal)");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        self.start_time = Some(Instant::now());
+
+        let metal_device_ref = ctx.gpu_full_access().device().metal_device_ref();
+
+        let shader_source = include_str!("shaders/crt_film_grain.metal");
+        let library = metal_device_ref
+            .new_library_with_source(shader_source, &metal::CompileOptions::new())
+            .map_err(|e| StreamError::Configuration(format!("Shader compile failed: {e}")))?;
+
+        let vertex_fn = library
+            .get_function("crt_vertex", None)
+            .map_err(|e| StreamError::Configuration(format!("Vertex not found: {e}")))?;
+        let fragment_fn = library
+            .get_function("crt_film_grain_fragment", None)
+            .map_err(|e| StreamError::Configuration(format!("Fragment not found: {e}")))?;
+
+        let pipeline_desc = metal::RenderPipelineDescriptor::new();
+        pipeline_desc.set_vertex_function(Some(&vertex_fn));
+        pipeline_desc.set_fragment_function(Some(&fragment_fn));
+        pipeline_desc
+            .color_attachments()
+            .object_at(0)
+            .unwrap()
+            .set_pixel_format(metal::MTLPixelFormat::BGRA8Unorm);
+
+        let render_pipeline = metal_device_ref
+            .new_render_pipeline_state(&pipeline_desc)
+            .map_err(|e| StreamError::Configuration(format!("Pipeline failed: {e}")))?;
+
+        let sampler_desc = metal::SamplerDescriptor::new();
+        sampler_desc.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
+        sampler_desc.set_mag_filter(metal::MTLSamplerMinMagFilter::Linear);
+        sampler_desc.set_address_mode_s(metal::MTLSamplerAddressMode::ClampToEdge);
+        sampler_desc.set_address_mode_t(metal::MTLSamplerAddressMode::ClampToEdge);
+        let sampler = metal_device_ref.new_sampler(&sampler_desc);
+
+        let render_pass_desc_ref = metal::RenderPassDescriptor::new();
+        let attachment = render_pass_desc_ref
+            .color_attachments()
+            .object_at(0)
+            .unwrap();
+        attachment.set_load_action(metal::MTLLoadAction::Clear);
+        attachment.set_clear_color(metal::MTLClearColor::new(0.0, 0.0, 0.0, 1.0));
+        attachment.set_store_action(metal::MTLStoreAction::Store);
+
+        let uniforms_size = std::mem::size_of::<CrtFilmGrainUniforms>() as u64;
+        let make_uniforms = || {
+            metal_device_ref
+                .new_buffer(uniforms_size, metal::MTLResourceOptions::CPUCacheModeDefaultCache)
+        };
+        let uniforms_buffers = [make_uniforms(), make_uniforms(), make_uniforms()];
+
+        self.backend = Some(MetalState {
+            render_pipeline,
+            render_pass_desc: render_pass_desc_ref.to_owned(),
+            sampler,
+            uniforms_buffers,
+            uniforms_index: 0,
+            texture_cache: None,
+        });
+
+        tracing::info!(
+            "CrtFilmGrain: Initialized (curve={:.1}, scanlines={:.1}, grain={:.2})",
+            self.config.crt_curve,
+            self.config.scanline_intensity,
+            self.config.grain_intensity
+        );
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn setup_inner(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::info!("CrtFilmGrain: setup (Vulkan)");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        self.start_time = Some(Instant::now());
+        let vulkan_device = ctx.gpu_full_access().device().vulkan_device().clone();
+        let kernel = VulkanCrtFilmGrain::new(&vulkan_device)?;
+        self.backend = Some(StdArc::new(kernel));
+
+        tracing::info!(
+            "CrtFilmGrain: Initialized (curve={:.1}, scanlines={:.1}, grain={:.2})",
+            self.config.crt_curve,
+            self.config.scanline_intensity,
+            self.config.grain_intensity
+        );
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+    fn setup_inner(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Err(StreamError::Configuration(
+            "CrtFilmGrain: no GPU backend on this platform".into(),
+        ))
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    fn process_frame_inner(
+        &mut self,
+        elapsed: f32,
+        gpu_ctx: &GpuContextLimitedAccess,
+        input_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+        output_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+    ) -> Result<()> {
+        let backend = self
+            .backend
+            .as_mut()
+            .ok_or_else(|| StreamError::Configuration("GPU backend not initialized".into()))?;
+
+        if backend.texture_cache.is_none() {
+            backend.texture_cache = Some(gpu_ctx.create_texture_cache()?);
+        }
+        let texture_cache = backend.texture_cache.as_ref().unwrap();
+
+        let input_view = texture_cache.create_view(input_buffer)?;
+        let input_metal: &metal::TextureRef = input_view.as_metal_texture();
+
+        let output_view = texture_cache.create_view(output_buffer)?;
         let output_metal: &metal::TextureRef = output_view.as_metal_texture();
 
-        // Update render pass attachment
-        let render_pass_desc = self.render_pass_desc.as_ref().unwrap();
-        render_pass_desc
+        backend
+            .render_pass_desc
             .color_attachments()
             .object_at(0)
             .unwrap()
             .set_texture(Some(output_metal));
 
-        // Render
+        let command_queue = gpu_ctx.command_queue().metal_queue_ref();
         let command_buffer = command_queue.new_command_buffer();
-        let render_enc = command_buffer.new_render_command_encoder(render_pass_desc);
-        render_enc.set_render_pipeline_state(self.render_pipeline.as_ref().unwrap());
+        let render_enc = command_buffer.new_render_command_encoder(&backend.render_pass_desc);
+        render_enc.set_render_pipeline_state(&backend.render_pipeline);
 
-        // Bind input texture
         render_enc.set_fragment_texture(0, Some(input_metal));
-        render_enc.set_fragment_sampler_state(0, Some(self.sampler.as_ref().unwrap()));
+        render_enc.set_fragment_sampler_state(0, Some(&backend.sampler));
 
-        // Rotate to next uniform buffer
-        self.uniforms_index = (self.uniforms_index + 1) % 3;
-        let current_uniforms = self.uniforms_buffers[self.uniforms_index].as_ref().unwrap();
-
-        // Update uniforms
+        backend.uniforms_index = (backend.uniforms_index + 1) % backend.uniforms_buffers.len();
+        let uniforms = &backend.uniforms_buffers[backend.uniforms_index];
         unsafe {
-            let ptr = current_uniforms.contents() as *mut CrtFilmGrainUniforms;
+            let ptr = uniforms.contents() as *mut CrtFilmGrainUniforms;
             (*ptr).time = elapsed;
             (*ptr).crt_curve = self.config.crt_curve;
             (*ptr).scanline_intensity = self.config.scanline_intensity;
@@ -253,25 +322,50 @@ impl streamlib::core::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
             (*ptr).brightness = self.config.brightness;
         }
 
-        render_enc.set_fragment_buffer(0, Some(current_uniforms), 0);
+        render_enc.set_fragment_buffer(0, Some(uniforms), 0);
         render_enc.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 3);
         render_enc.end_encoding();
-
         command_buffer.commit();
         command_buffer.wait_until_completed();
-
-        // Output frame
-        let output_frame = Videoframe {
-            surface_id: output_pool_id.to_string(),
-            width,
-            height,
-            timestamp_ns: frame.timestamp_ns.clone(),
-            frame_index: frame.frame_index.clone(),
-            fps: frame.fps,
-        };
-        self.outputs.write("video_out", &output_frame)?;
-
-        self.frame_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn process_frame_inner(
+        &mut self,
+        elapsed: f32,
+        _gpu_ctx: &GpuContextLimitedAccess,
+        input_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+        output_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+    ) -> Result<()> {
+        let backend = self
+            .backend
+            .as_ref()
+            .ok_or_else(|| StreamError::Configuration("GPU backend not initialized".into()))?;
+        backend.dispatch(CrtFilmGrainInputs {
+            input: input_buffer,
+            output: output_buffer,
+            time_seconds: elapsed,
+            crt_curve: self.config.crt_curve,
+            scanline_intensity: self.config.scanline_intensity,
+            chromatic_aberration: self.config.chromatic_aberration,
+            grain_intensity: self.config.grain_intensity,
+            grain_speed: self.config.grain_speed,
+            vignette_intensity: self.config.vignette_intensity,
+            brightness: self.config.brightness,
+        })
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
+    fn process_frame_inner(
+        &mut self,
+        _elapsed: f32,
+        _gpu_ctx: &GpuContextLimitedAccess,
+        _input_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+        _output_buffer: &streamlib::core::rhi::RhiPixelBuffer,
+    ) -> Result<()> {
+        Err(StreamError::Configuration(
+            "CrtFilmGrain: no GPU backend on this platform".into(),
+        ))
     }
 }

--- a/examples/camera-python-display/src/main.rs
+++ b/examples/camera-python-display/src/main.rs
@@ -45,12 +45,11 @@ fn main() {
     std::process::exit(2);
 }
 
-// `blending_compositor` is cross-platform (macOS Metal + Linux Vulkan); the
-// rest of the example pipeline still requires macOS until #483 (CRT/film-
-// grain), #484 (AvatarCharacter), #485 (Skia overlays), and #486 (Glitch)
-// land for Linux.
+// `blending_compositor` and `crt_film_grain` are cross-platform (macOS
+// Metal + Linux Vulkan); the rest of the example pipeline still requires
+// macOS until #484 (AvatarCharacter), #485 (Skia overlays), and #486
+// (Glitch) land for Linux.
 mod blending_compositor;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod crt_film_grain;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/libs/streamlib/build.rs
+++ b/libs/streamlib/build.rs
@@ -33,6 +33,10 @@ fn compile_compute_shaders() {
             "src/vulkan/rhi/shaders/blending_compositor.comp",
             "blending_compositor.spv",
         ),
+        (
+            "src/vulkan/rhi/shaders/crt_film_grain.comp",
+            "crt_film_grain.spv",
+        ),
     ];
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -167,7 +167,7 @@ pub use linux::{
 #[cfg(target_os = "linux")]
 pub use vulkan::rhi::{
     blending_compositor_flags, BlendingCompositorInputs, BlendingCompositorPushConstants,
-    VulkanBlendingCompositor,
+    CrtFilmGrainInputs, CrtFilmGrainPushConstants, VulkanBlendingCompositor, VulkanCrtFilmGrain,
 };
 
 /// Per-runtime surface-share service primitives. Exposed for adapter

--- a/libs/streamlib/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib/src/vulkan/rhi/mod.rs
@@ -72,6 +72,11 @@ pub use vulkan_blending_compositor::{
     BlendingCompositorPushConstants, VulkanBlendingCompositor,
 };
 
+mod vulkan_crt_film_grain;
+pub use vulkan_crt_film_grain::{
+    CrtFilmGrainInputs, CrtFilmGrainPushConstants, VulkanCrtFilmGrain,
+};
+
 #[cfg(target_os = "linux")]
 pub mod drm_modifier_probe;
 

--- a/libs/streamlib/src/vulkan/rhi/shaders/crt_film_grain.comp
+++ b/libs/streamlib/src/vulkan/rhi/shaders/crt_film_grain.comp
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// 80s Blade Runner CRT + film grain post-effect. Mirrors the macOS Metal
+// fragment shader at examples/camera-python-display/src/shaders/crt_film_grain.metal —
+// barrel distortion, animated scanlines, chromatic aberration with ghost
+// taps, vignette, phosphor tint, flicker, RGB pixel grid, and a 3-octave
+// hash-based film grain quantized to 24 fps.
+//
+// Input + output are packed BGRA8 little-endian uint32 storage buffers
+// (same packing as nv12_to_bgra.comp / blending_compositor.comp). The
+// kernel reads input via a manual bilinear sampler with clamp-to-edge
+// addressing — matches the Metal sampler's Linear / ClampToEdge config so
+// the chromatic-aberration UV offsets land in the same place.
+
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+layout(set = 0, binding = 0) readonly  buffer VideoIn { uint data[]; } video_in;
+layout(set = 0, binding = 1) writeonly buffer Output  { uint data[]; } output_buf;
+
+layout(push_constant) uniform PushConstants {
+    uint  width;
+    uint  height;
+    float time;
+    float crt_curve;
+    float scanline_intensity;
+    float chromatic_aberration;
+    float grain_intensity;
+    float grain_speed;
+    float vignette_intensity;
+    float brightness;
+} pc;
+
+vec4 unpack_bgra(uint p) {
+    float b = float((p >>  0u) & 0xFFu) / 255.0;
+    float g = float((p >>  8u) & 0xFFu) / 255.0;
+    float r = float((p >> 16u) & 0xFFu) / 255.0;
+    float a = float((p >> 24u) & 0xFFu) / 255.0;
+    return vec4(r, g, b, a);
+}
+
+uint pack_bgra(vec4 c) {
+    uint b = uint(clamp(c.b, 0.0, 1.0) * 255.0 + 0.5);
+    uint g = uint(clamp(c.g, 0.0, 1.0) * 255.0 + 0.5);
+    uint r = uint(clamp(c.r, 0.0, 1.0) * 255.0 + 0.5);
+    uint a = uint(clamp(c.a, 0.0, 1.0) * 255.0 + 0.5);
+    return b | (g << 8u) | (r << 16u) | (a << 24u);
+}
+
+vec4 read_input_texel(ivec2 p) {
+    p = clamp(p, ivec2(0), ivec2(int(pc.width) - 1, int(pc.height) - 1));
+    uint idx = uint(p.y) * pc.width + uint(p.x);
+    return unpack_bgra(video_in.data[idx]);
+}
+
+// Bilinear UV sample with clamp-to-edge. Mirrors Metal's
+// MTLSamplerMinMagFilter::Linear + ClampToEdge — chromatic-aberration
+// offsets pull samples a fraction of a pixel away from the integer grid,
+// so without bilinear the RGB taps quantize to discrete jumps.
+vec4 sample_input_bilinear(vec2 uv) {
+    vec2 size = vec2(float(pc.width), float(pc.height));
+    vec2 sample_pos = uv * size - vec2(0.5);
+    ivec2 base = ivec2(floor(sample_pos));
+    vec2 frac_pos = fract(sample_pos);
+
+    vec4 c00 = read_input_texel(base + ivec2(0, 0));
+    vec4 c10 = read_input_texel(base + ivec2(1, 0));
+    vec4 c01 = read_input_texel(base + ivec2(0, 1));
+    vec4 c11 = read_input_texel(base + ivec2(1, 1));
+
+    vec4 top    = mix(c00, c10, frac_pos.x);
+    vec4 bottom = mix(c01, c11, frac_pos.x);
+    return mix(top, bottom, frac_pos.y);
+}
+
+// Barrel distortion — simulates CRT screen curvature. UV in/out 0..1.
+vec2 crt_curve(vec2 uv, float curve_amount) {
+    uv = (uv - 0.5) * 2.0;
+    uv *= 1.0 + curve_amount * 0.1;
+    uv.x *= 1.0 + pow(abs(uv.y) / 5.0, 2.0) * curve_amount;
+    uv.y *= 1.0 + pow(abs(uv.x) / 4.0, 2.0) * curve_amount;
+    uv = (uv / 2.0) + 0.5;
+    uv = uv * (0.92 + 0.08 * (1.0 - curve_amount)) + (0.04 * curve_amount);
+    return uv;
+}
+
+float hash13(vec3 p3) {
+    p3 = fract(p3 * 0.1031);
+    p3 += dot(p3, p3.zyx + 31.32);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+// 3-octave per-frame speckle grain quantized to 24 fps — real film grain
+// doesn't scroll, it re-randomizes per discrete frame. Weights sum to
+// 1.75; result is normalized into 0..1.
+float film_grain(vec2 uv, float time, float speed) {
+    float frame = floor(time * speed * 24.0);
+    float grain = hash13(vec3(uv * 1000.0, frame));
+    grain += hash13(vec3(uv * 500.0  + 0.5,  frame + 0.33)) * 0.5;
+    grain += hash13(vec3(uv * 250.0  + 0.25, frame + 0.66)) * 0.25;
+    grain /= 1.75;
+    return grain;
+}
+
+void main() {
+    uvec2 pos = gl_GlobalInvocationID.xy;
+    if (pos.x >= pc.width || pos.y >= pc.height) return;
+
+    vec2 size = vec2(float(pc.width), float(pc.height));
+    vec2 uv = (vec2(float(pos.x), float(pos.y)) + vec2(0.5)) / size;
+    vec2 original_uv = uv;
+
+    // === CRT BARREL DISTORTION ===
+    uv = crt_curve(uv, pc.crt_curve);
+    bool outside_bounds = (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0);
+
+    // === CHROMATIC ABERRATION ===
+    float aberration = pc.chromatic_aberration;
+    float scan_wobble = sin(0.3        * pc.time + uv.y * 21.0) *
+                        sin(0.7        * pc.time + uv.y * 29.0) *
+                        sin(0.3 + 0.33 * pc.time + uv.y * 31.0) * 0.0017;
+
+    vec3 col;
+    col.r = sample_input_bilinear(vec2(scan_wobble + uv.x + aberration,       uv.y + aberration * 0.5)).r;
+    col.g = sample_input_bilinear(vec2(scan_wobble + uv.x,                    uv.y - aberration)).g;
+    col.b = sample_input_bilinear(vec2(scan_wobble + uv.x - aberration,       uv.y + aberration * 0.3)).b;
+
+    // Ghost / bloom from chromatic aberration — second tap per channel
+    // weighted lightly. Offsets reproduce the Metal version verbatim.
+    col.r += 0.08 * sample_input_bilinear(0.75 * vec2(scan_wobble + 0.025, -0.027) + vec2(uv.x + aberration, uv.y + aberration * 0.5)).r;
+    col.g += 0.05 * sample_input_bilinear(0.75 * vec2(scan_wobble - 0.022, -0.02 ) + vec2(uv.x,              uv.y - aberration)).g;
+    col.b += 0.08 * sample_input_bilinear(0.75 * vec2(scan_wobble - 0.02,  -0.018) + vec2(uv.x - aberration, uv.y + aberration * 0.3)).b;
+
+    // === S-CURVE CONTRAST ===
+    col = clamp(col * 0.6 + 0.4 * col * col, 0.0, 1.0);
+
+    // === VIGNETTE ===
+    float vig = 16.0 * uv.x * uv.y * (1.0 - uv.x) * (1.0 - uv.y);
+    vig = pow(max(vig, 0.0), 0.3 + pc.vignette_intensity * 0.4);
+    col *= vig;
+
+    // === PHOSPHOR TINT ===
+    col *= vec3(0.95, 1.05, 0.95);
+
+    // === BRIGHTNESS ===
+    col *= pc.brightness;
+
+    // === SCANLINES ===
+    // Phase factor was hardcoded to 1080 in the Metal version (assuming
+    // 1080p); using `pc.height` keeps the cycles-per-pixel ratio
+    // resolution-independent — at 1080p the phase is identical.
+    float scanline_phase = 3.5 * pc.time + uv.y * float(pc.height) * 1.5;
+    float scans = clamp(0.35 + 0.35 * sin(scanline_phase), 0.0, 1.0);
+    scans = pow(scans, 1.7);
+    col *= 0.4 + (1.0 - pc.scanline_intensity) * 0.6 + pc.scanline_intensity * 0.6 * scans;
+
+    // === FLICKER ===
+    col *= 1.0 + 0.01 * sin(110.0 * pc.time);
+
+    // === RGB PIXEL GRID ===
+    // Metal samples this from `in.position.x` (screen-space pixel coord);
+    // the equivalent in compute is `gl_GlobalInvocationID.x`.
+    float pixel_grid = clamp((mod(float(pos.x), 2.0) - 1.0) * 2.0, 0.0, 1.0);
+    col *= 1.0 - 0.3 * pc.scanline_intensity * pixel_grid;
+
+    // === FILM GRAIN ===
+    float grain = film_grain(original_uv, pc.time, pc.grain_speed);
+    float luminance = dot(col, vec3(0.299, 0.587, 0.114));
+    float grain_mask = 1.0 - luminance * 0.5;
+    col += (grain - 0.5) * pc.grain_intensity * grain_mask;
+
+    // === OUTSIDE BOUNDS ===
+    if (outside_bounds) {
+        col = vec3(0.0);
+    }
+
+    output_buf.data[pos.y * pc.width + pos.x] = pack_bgra(vec4(clamp(col, 0.0, 1.0), 1.0));
+}

--- a/libs/streamlib/src/vulkan/rhi/vulkan_crt_film_grain.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_crt_film_grain.rs
@@ -1,0 +1,326 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! 80s CRT + film-grain post-effect via [`VulkanComputeKernel`].
+//!
+//! Linux counterpart to the macOS Metal kernel at
+//! `examples/camera-python-display/src/shaders/crt_film_grain.metal`.
+
+use std::sync::Arc;
+
+use crate::core::rhi::{ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer};
+use crate::core::{Result, StreamError};
+
+use super::{HostVulkanDevice, VulkanComputeKernel};
+
+/// Push-constants layout matching `crt_film_grain.comp`'s
+/// `layout(push_constant)` block.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CrtFilmGrainPushConstants {
+    pub width: u32,
+    pub height: u32,
+    pub time: f32,
+    pub crt_curve: f32,
+    pub scanline_intensity: f32,
+    pub chromatic_aberration: f32,
+    pub grain_intensity: f32,
+    pub grain_speed: f32,
+    pub vignette_intensity: f32,
+    pub brightness: f32,
+}
+
+const CRT_FILM_GRAIN_BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::storage_buffer(0), // input
+    ComputeBindingSpec::storage_buffer(1), // output
+];
+
+const WORKGROUP_SIZE: u32 = 16;
+
+/// Inputs for one CRT/film-grain dispatch. Both buffers are BGRA8 packed
+/// little-endian and must share the same dimensions — the kernel writes
+/// the output 1:1 with the input grid.
+pub struct CrtFilmGrainInputs<'a> {
+    pub input: &'a RhiPixelBuffer,
+    pub output: &'a RhiPixelBuffer,
+    pub time_seconds: f32,
+    pub crt_curve: f32,
+    pub scanline_intensity: f32,
+    pub chromatic_aberration: f32,
+    pub grain_intensity: f32,
+    pub grain_speed: f32,
+    pub vignette_intensity: f32,
+    pub brightness: f32,
+}
+
+/// CRT + film-grain post-effect compute kernel.
+pub struct VulkanCrtFilmGrain {
+    kernel: VulkanComputeKernel,
+}
+
+impl VulkanCrtFilmGrain {
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Self> {
+        let spv = include_bytes!(concat!(env!("OUT_DIR"), "/crt_film_grain.spv"));
+        let kernel = VulkanComputeKernel::new(
+            vulkan_device,
+            &ComputeKernelDescriptor {
+                label: "crt_film_grain",
+                spv,
+                bindings: CRT_FILM_GRAIN_BINDINGS,
+                push_constant_size: std::mem::size_of::<CrtFilmGrainPushConstants>() as u32,
+            },
+        )?;
+        Ok(Self { kernel })
+    }
+
+    /// Apply the CRT/film-grain effect from `inputs.input` into
+    /// `inputs.output`. The output's dimensions drive the dispatch grid;
+    /// input must match the output 1:1 (the shader assumes a shared grid
+    /// for its UV sampling and per-pixel composite).
+    pub fn dispatch(&self, inputs: CrtFilmGrainInputs<'_>) -> Result<()> {
+        let width = inputs.output.width;
+        let height = inputs.output.height;
+
+        if inputs.input.width != width || inputs.input.height != height {
+            return Err(StreamError::GpuError(format!(
+                "CrtFilmGrain: input is {}×{}, expected {w}×{h} (must match output)",
+                inputs.input.width,
+                inputs.input.height,
+                w = width,
+                h = height,
+            )));
+        }
+
+        let push = CrtFilmGrainPushConstants {
+            width,
+            height,
+            time: inputs.time_seconds,
+            crt_curve: inputs.crt_curve,
+            scanline_intensity: inputs.scanline_intensity,
+            chromatic_aberration: inputs.chromatic_aberration,
+            grain_intensity: inputs.grain_intensity,
+            grain_speed: inputs.grain_speed,
+            vignette_intensity: inputs.vignette_intensity,
+            brightness: inputs.brightness,
+        };
+
+        self.kernel.set_storage_buffer(0, inputs.input)?;
+        self.kernel.set_storage_buffer(1, inputs.output)?;
+        self.kernel.set_push_constants_value(&push)?;
+
+        let dispatch_x = width.div_ceil(WORKGROUP_SIZE);
+        let dispatch_y = height.div_ceil(WORKGROUP_SIZE);
+        self.kernel.dispatch(dispatch_x, dispatch_y, 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::rhi::{PixelFormat, RhiPixelBufferRef};
+    use crate::vulkan::rhi::HostVulkanPixelBuffer;
+
+    fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
+        match HostVulkanDevice::new() {
+            Ok(d) => Some(Arc::new(d)),
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                None
+            }
+        }
+    }
+
+    fn make_buf(device: &Arc<HostVulkanDevice>, w: u32, h: u32) -> RhiPixelBuffer {
+        let vk = HostVulkanPixelBuffer::new(device, w, h, 4, PixelFormat::Bgra32)
+            .expect("pixel buffer");
+        RhiPixelBuffer::new(RhiPixelBufferRef {
+            inner: Arc::new(vk),
+        })
+    }
+
+    /// Default config matches the Metal `CrtFilmGrainConfig` in
+    /// `examples/camera-python-display/src/crt_film_grain.rs`.
+    fn default_inputs<'a>(input: &'a RhiPixelBuffer, output: &'a RhiPixelBuffer) -> CrtFilmGrainInputs<'a> {
+        CrtFilmGrainInputs {
+            input,
+            output,
+            time_seconds: 0.0,
+            crt_curve: 0.7,
+            scanline_intensity: 0.6,
+            chromatic_aberration: 0.004,
+            grain_intensity: 0.18,
+            grain_speed: 1.0,
+            vignette_intensity: 0.5,
+            brightness: 2.2,
+        }
+    }
+
+    fn read_pixel(buf: &RhiPixelBuffer, x: u32, y: u32) -> (u8, u8, u8, u8) {
+        unsafe {
+            let ptr = buf.buffer_ref().inner.mapped_ptr() as *const u32;
+            let p = *ptr.add((y * buf.width + x) as usize);
+            (
+                (p & 0xFF) as u8,
+                ((p >> 8) & 0xFF) as u8,
+                ((p >> 16) & 0xFF) as u8,
+                ((p >> 24) & 0xFF) as u8,
+            )
+        }
+    }
+
+    fn fill_solid(buf: &RhiPixelBuffer, b: u8, g: u8, r: u8, a: u8) {
+        let pixel = (b as u32) | ((g as u32) << 8) | ((r as u32) << 16) | ((a as u32) << 24);
+        let count = (buf.width * buf.height) as usize;
+        unsafe {
+            let ptr = buf.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for i in 0..count {
+                *ptr.add(i) = pixel;
+            }
+        }
+    }
+
+    #[test]
+    fn new_compiles_kernel() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let result = VulkanCrtFilmGrain::new(&device);
+        assert!(result.is_ok(), "kernel creation must succeed: {:?}", result.err());
+    }
+
+    #[test]
+    fn rejects_size_mismatch() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let kernel = VulkanCrtFilmGrain::new(&device).expect("kernel");
+        let input = make_buf(&device, 32, 32);
+        let output = make_buf(&device, 64, 32);
+        let err = kernel
+            .dispatch(default_inputs(&input, &output))
+            .expect_err("size mismatch must error");
+        assert!(matches!(err, StreamError::GpuError(_)));
+    }
+
+    /// Runs the kernel against a uniform mid-grey input. The center of the
+    /// output (well inside the barrel-distorted screen rect) must be
+    /// non-black after CRT processing, and the far corners must be black
+    /// (outside the curved bounds → explicitly zeroed).
+    #[test]
+    fn solid_input_produces_curved_bounds() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let kernel = VulkanCrtFilmGrain::new(&device).expect("kernel");
+
+        let w: u32 = 256;
+        let h: u32 = 192;
+        let input = make_buf(&device, w, h);
+        let output = make_buf(&device, w, h);
+        // Mid-grey opaque BGRA = (128, 128, 128, 255).
+        fill_solid(&input, 128, 128, 128, 255);
+
+        let mut inputs = default_inputs(&input, &output);
+        // Disable grain so we can make deterministic assertions about the
+        // center pixel; barrel curve stays in to test the bounds carve-out.
+        inputs.grain_intensity = 0.0;
+        kernel.dispatch(inputs).expect("dispatch");
+
+        // Center should pass through CRT processing → non-zero output. The
+        // S-curve / scanline / brightness chain can drop a channel below
+        // mid-grey but the result should be non-black.
+        let (cb, cg, cr, _ca) = read_pixel(&output, w / 2, h / 2);
+        assert!(
+            cb as u32 + cg as u32 + cr as u32 > 0,
+            "center pixel must not be fully black after CRT pass: BGR=({cb},{cg},{cr})"
+        );
+
+        // Far corner should be outside the barrel-curved screen → black.
+        let (b0, g0, r0, _a0) = read_pixel(&output, 0, 0);
+        assert_eq!(
+            (b0, g0, r0),
+            (0, 0, 0),
+            "top-left corner must be zeroed by outside-bounds carve-out"
+        );
+    }
+
+    /// Visual smoke: feeds a checkerboard + bright square into the kernel,
+    /// dispatches, and writes a PNG of the result for human review (PR
+    /// embedding via `attach-images`). Mirrors the `visual_smoke_emits_png`
+    /// shape used by `vulkan_blending_compositor`.
+    #[test]
+    fn visual_smoke_emits_png() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+        let kernel = VulkanCrtFilmGrain::new(&device).expect("kernel");
+
+        let w: u32 = 480;
+        let h: u32 = 320;
+        let input = make_buf(&device, w, h);
+        let output = make_buf(&device, w, h);
+
+        // Compose a synthetic input: an 8×8 checkerboard with a bright
+        // magenta square in the upper-left and a green diagonal so the
+        // output's CRT processing is visually evaluable.
+        unsafe {
+            let ptr = input.buffer_ref().inner.mapped_ptr() as *mut u32;
+            for y in 0..h {
+                for x in 0..w {
+                    let cell = ((x / 32) + (y / 32)) % 2 == 0;
+                    let mut b = if cell { 200u32 } else { 60u32 };
+                    let mut g = if cell { 200u32 } else { 60u32 };
+                    let mut r = if cell { 200u32 } else { 60u32 };
+                    // Bright magenta block for color separation visibility.
+                    if x < 96 && y < 96 {
+                        b = 255;
+                        g = 0;
+                        r = 255;
+                    }
+                    // Green diagonal stripe.
+                    let on_diag = (x as i32 - y as i32).abs() < 8;
+                    if on_diag {
+                        b = 0;
+                        g = 240;
+                        r = 0;
+                    }
+                    let pixel = b | (g << 8) | (r << 16) | (255u32 << 24);
+                    *ptr.add((y * w + x) as usize) = pixel;
+                }
+            }
+        }
+
+        let mut inputs = default_inputs(&input, &output);
+        // Pick a non-zero animation phase so scanlines + grain are visible
+        // in the rendered PNG; deterministic enough for inspection.
+        inputs.time_seconds = 0.4;
+        kernel.dispatch(inputs).expect("dispatch must succeed");
+
+        let bgra_size = (w * h * 4) as usize;
+        let mut bgra_bytes = vec![0u8; bgra_size];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                output.buffer_ref().inner.mapped_ptr(),
+                bgra_bytes.as_mut_ptr(),
+                bgra_size,
+            );
+        }
+        let mut rgba = vec![0u8; bgra_size];
+        for chunk in 0..(bgra_size / 4) {
+            let i = chunk * 4;
+            rgba[i] = bgra_bytes[i + 2];
+            rgba[i + 1] = bgra_bytes[i + 1];
+            rgba[i + 2] = bgra_bytes[i];
+            rgba[i + 3] = bgra_bytes[i + 3];
+        }
+
+        let out_path = std::env::var("STREAMLIB_CRT_FILM_GRAIN_PNG_OUT")
+            .unwrap_or_else(|_| "target/crt_film_grain_smoke.png".to_string());
+        let _ = std::fs::create_dir_all(
+            std::path::Path::new(&out_path)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let file = std::fs::File::create(&out_path)
+            .unwrap_or_else(|e| panic!("create {out_path}: {e}"));
+        let bw = std::io::BufWriter::new(file);
+        let mut encoder = png::Encoder::new(bw, w, h);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().expect("PNG header");
+        writer.write_image_data(&rgba).expect("PNG data");
+        eprintln!("crt_film_grain visual smoke wrote {out_path}");
+    }
+}


### PR DESCRIPTION
## Summary

- Restructures the macOS Metal vertex+fragment CRT/film-grain effect as a Vulkan compute kernel matching the `VulkanBlendingCompositor` pattern from #607. Single-input post-effect via storage buffers + manual bilinear-clamp sampler that mirrors Metal's `Linear`/`ClampToEdge`.
- Refactors `examples/camera-python-display/src/crt_film_grain.rs` to a single cross-platform file (Metal + Vulkan paths) using the same `GpuBackendStash` cfg-collapse trick `BlendingCompositor` introduced. Also fixes the pre-existing `Option<GpuContext>` field type to the canonical `Option<GpuContextLimitedAccess>`.
- `mod crt_film_grain;` in the example's `main.rs` is no longer cfg-gated.

## Closes

Closes #483

## Exit criteria

- [x] Vulkan GLSL compute kernel matching the Metal kernel's effects (barrel + scanlines + chromatic aberration + grain + vignette).
- [x] `VulkanCrtFilmGrain` RHI struct + processor wiring on Linux.
- [x] macOS keeps the Metal path.

## Tests / validation

- [x] Unit: smoke test of the compute kernel against a known input texture (`new_compiles_kernel`, `rejects_size_mismatch`, `solid_input_produces_curved_bounds`, `visual_smoke_emits_png` — all 4 pass).
- [x] E2E: visual confirmation via PNG sampling — see screenshot below. The example's full pipeline still requires #484/#485/#486 to land before it runs end-to-end on Linux; the smoke PNG is the visual-confirmation deliverable for this issue.

### Visual smoke

![CrtFilmGrain Vulkan compute smoke output — checkerboard with magenta block and green diagonal showing barrel curve, scanlines, vignette, chromatic aberration, grain speckle](https://gh-artifact.tatolab.com/pr-608/crt_film_grain_smoke.jpg)

*`target/crt_film_grain_smoke.png` (full-resolution 480×320 BGRA→RGBA), written by the `visual_smoke_emits_png` test. Override path with `STREAMLIB_CRT_FILM_GRAIN_PNG_OUT`. Visible effects: barrel curve (rounded corners with outside-bounds carve-out), horizontal scanlines, vignette darkening at edges, chromatic aberration (RGB separation around the green diagonal and magenta block), phosphor tint, film-grain speckle.*

### Notable behavioral choice

GLSL scanline phase uses `pc.height` instead of the Metal version's hardcoded `1080.0`. At 1080p (the example's actual resolution) the two formulas are pixel-identical; at other resolutions the GLSL keeps the cycles-per-pixel ratio resolution-independent rather than diverging.

## Polyglot coverage

- **Runtimes affected**: rust
- **Schema regenerated**: n/a
- **Python and Deno both covered?** n/a — host-Rust effect processor; no SDK surface change. The `polyglot` label tracks the encompassing milestone (Polyglot SDK Realignment), not a wire-format change.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib --lib vulkan_crt_film_grain` — 4/4 pass
  - [x] Host-Rust: `cargo test -p streamlib --lib` — 311/311 pass, 0 regressions
  - [ ] Python subprocess: n/a
  - [ ] Deno subprocess: n/a
- **FD-passing path**: n/a — same-process RhiPixelBuffer in/out

## Follow-ups

- #484 / #485 / #486 still need to land before the full `camera-python-display` pipeline runs end-to-end on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
