### PR TITLE
fix(rhi): pre-warm export VMA pools at HostVulkanDevice construction (#624)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ The principles:
 - **Bias toward supporting use-case classes, not single examples.** Real-time engines (Unreal, Bevy, Granite) serve classes — render targets, compute, video decode, audio, IPC. When designing or extending a core system, ask "what shape supports the *class* of use case this system is responsible for?", not "what's the smallest thing that makes the example in front of me work?".
 - **Observability is a design-time concern, not a retrofit.** `tracing::instrument` + metric hooks at trait birth is one line per method; added later it's a refactor across every implementor. Put hooks in when the trait is born.
 - **Concrete consumers are known requirements.** A future consumer is *hypothetical* only when unattested. A filed issue in the same milestone, a documented use case, an in-tree caller in a sibling file — these are *known*, and must be designed for now. The system-prompt's "don't design for hypothetical futures" rule still applies; it does *not* license under-shipping for known concrete futures.
+- **Engine-wide bugs get fixed at the engine layer, not in the consumer that surfaced them.** When debugging surfaces a defect in an engine primitive (RHI, `GpuContext`, runtime hooks, IPC surfaces, escalate ops) that *any* consumer of that primitive would hit — fix it at the engine layer, even when the symptom showed up in one example or processor. Examples are integration tests, not first-class consumers; an example-level bandaid removes the symptom for that example while leaving the bug in the engine for the next consumer (a future composition, a new processor, a third-party adapter) to rediscover. "I'll fix it for me; if you encounter it later, re-derive it" is a footgun. Lead recommendations with the engine-level fix; bandaids only appear when there is an explicit scope-cutting reason and the user gets the call. Restraint still applies (don't refactor neighboring systems just because the engine is now in scope), but the bar is: defect at engine layer ⇒ fix at engine layer.
 
 What this means concretely when designing or extending a core system (RHI, IPC, processor model, public ABI, surface adapters, escalate ops):
 
@@ -91,6 +92,8 @@ When presenting design choices for engine work, recommend the production-grade o
    - Rewriting a file or large section: summarize the plan first.
    - Adding new public API or changing existing signatures: get approval.
    - **Engine-core changes** (RHI, IPC wire format, processor model, public ABI crates, escalate ops): a written plan is required, not optional. The plan covers trait shape, error taxonomy, observability hooks, polyglot mirrors, and tests, before any code lands.
+
+4. **No bad patterns left behind on engine changes.** When an engine change establishes a new canonical way to do something, sweep the repo and migrate every consumer of the old pattern in the same PR — Rust + Python + Deno code, examples, processors, tests, docs, learnings. This is an explicit exception to "files outside scope: ask before editing." The codebase must always encourage the right pattern at every read site, because future AI agents (and humans) read existing code to learn patterns; if half the codebase uses the old shape, the old shape survives forever in onboarding. Examples especially matter: agents treat example code as canonical "how to use the engine." Update every doc/learning that endorsed the old pattern with a strikethrough + dated note per the markdown editing rules. "Scope discipline" still applies (don't refactor *unrelated* systems just because the engine moved) — but every consumer of the old pattern is *related*, not unrelated, when the engine moves.
 
 ### Work Tracking
 
@@ -454,6 +457,10 @@ make sense if the surrounding files were renamed or restructured.
 - @docs/learnings/nvidia-dma-buf-after-swapchain.md — `VK_ERROR_OUT_OF_DEVICE_MEMORY`
   from `vmaCreateImage`/`vkAllocateMemory` on NVIDIA Linux when a swapchain
   has been created. NOT real OOM.
+- @docs/learnings/nvidia-opaque-fd-after-swapchain.md — Same NVIDIA cap as
+  DMA-BUF but for the OPAQUE_FD path used by CUDA / OpenCL interop. The
+  engine pre-warms every export-capable VMA pool at
+  `HostVulkanDevice::new()`; consumers don't need to (and shouldn't) pre-warm.
 - @docs/learnings/nvidia-egl-dmabuf-render-target.md — Linear DMA-BUFs on
   NVIDIA Linux are sampler-only (EGL `external_only=TRUE`); FBO color
   attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`.

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -47,6 +47,9 @@ Avoid the two failure modes:
 - [@docs/learnings/nvidia-dma-buf-after-swapchain.md](nvidia-dma-buf-after-swapchain.md) —
   `VK_ERROR_OUT_OF_DEVICE_MEMORY` from `vmaCreateImage`/`vkAllocateMemory`
   on NVIDIA Linux when a swapchain exists
+- [@docs/learnings/nvidia-opaque-fd-after-swapchain.md](nvidia-opaque-fd-after-swapchain.md) —
+  Same NVIDIA cap as DMA-BUF, but for OPAQUE_FD allocations (CUDA / OpenCL
+  interop); engine pre-warms every export pool at `HostVulkanDevice` construction
 - [@docs/learnings/nvidia-egl-dmabuf-render-target.md](nvidia-egl-dmabuf-render-target.md) —
   Linear DMA-BUFs on NVIDIA are EGL `external_only=TRUE` (sampler-only); FBO color attachments require a tiled DRM modifier from `eglQueryDmaBufModifiersEXT`
 - [@docs/learnings/vma-export-pools.md](vma-export-pools.md) —

--- a/docs/learnings/nvidia-dma-buf-after-swapchain.md
+++ b/docs/learnings/nvidia-dma-buf-after-swapchain.md
@@ -50,13 +50,22 @@ end-to-end via @docs/learnings/camera-display-e2e-validation.md.
 
 2. **The engine pre-warms every export-capable VMA pool at
    `HostVulkanDevice::new()` time** (DMA-BUF buffers, DMA-BUF images
-   linear and tiled, OPAQUE_FD HOST_VISIBLE and DEVICE_LOCAL buffers).
-   The probe allocates a tiny resource through each pool and drops it;
-   VMA retains the underlying `VkDeviceMemory` block for subsequent
-   real allocations. Construction either yields a fully pre-warmed
-   `Arc<HostVulkanDevice>` or fails — there is no half-formed instance
-   for callers to observe. Companion learning for OPAQUE_FD:
-   @docs/learnings/nvidia-opaque-fd-after-swapchain.md.
+   linear and tiled, OPAQUE_FD HOST_VISIBLE and DEVICE_LOCAL buffers)
+   by allocating a tiny probe through each pool and dropping it,
+   strictly before any caller can build a `VkSwapchainKHR`. Empirical
+   observation from issue #624: this keeps the post-swapchain
+   allocation path open for that handle type. Note that the host RHI
+   pixel-buffer and texture constructors all set
+   `vma::AllocationCreateFlags::DEDICATED_MEMORY`, so every export
+   allocation is its own `VkDeviceMemory` and dropping the probe
+   actually issues `vkFreeMemory` — VMA does not "retain a block"
+   for subsequent allocations. The cap-bypass mechanism is internal
+   to NVIDIA's driver (one-way reservation initialized by the first
+   export allocation, surviving the free) rather than VMA-side block
+   retention. Construction either yields a fully pre-warmed
+   `Arc<HostVulkanDevice>` or fails — there is no half-formed
+   instance for callers to observe. Companion learning for
+   OPAQUE_FD: @docs/learnings/nvidia-opaque-fd-after-swapchain.md.
 
    > ~~**Pre-allocate exportable resources BEFORE creating the
    > swapchain.** Camera processors should acquire-and-release a

--- a/docs/learnings/nvidia-dma-buf-after-swapchain.md
+++ b/docs/learnings/nvidia-dma-buf-after-swapchain.md
@@ -42,16 +42,35 @@ compositor DMA-BUF imports — not just a swapchain in idle state.
 Don't waste time trying to reproduce in pure unit tests. Validate the fix
 end-to-end via @docs/learnings/camera-display-e2e-validation.md.
 
-## Fix (combine all three)
+## Fix
 
 1. **Don't set VMA `pTypeExternalMemoryHandleTypes` globally.** Use VMA
    custom pools with `pMemoryAllocateNext` for the specific allocations
    that need DMA-BUF export. See @docs/learnings/vma-export-pools.md.
 
-2. **Pre-allocate exportable resources BEFORE creating the swapchain.**
-   Camera processors should acquire-and-release a pixel buffer in their
-   `start()` to trigger lazy pool creation while the budget is freely
-   available. See `LinuxCameraProcessor::start()` for the exact pattern.
+2. **The engine pre-warms every export-capable VMA pool at
+   `HostVulkanDevice::new()` time** (DMA-BUF buffers, DMA-BUF images
+   linear and tiled, OPAQUE_FD HOST_VISIBLE and DEVICE_LOCAL buffers).
+   The probe allocates a tiny resource through each pool and drops it;
+   VMA retains the underlying `VkDeviceMemory` block for subsequent
+   real allocations. Construction either yields a fully pre-warmed
+   `Arc<HostVulkanDevice>` or fails — there is no half-formed instance
+   for callers to observe. Companion learning for OPAQUE_FD:
+   @docs/learnings/nvidia-opaque-fd-after-swapchain.md.
+
+   > ~~**Pre-allocate exportable resources BEFORE creating the
+   > swapchain.** Camera processors should acquire-and-release a
+   > pixel buffer in their `start()` to trigger lazy pool creation
+   > while the budget is freely available. See
+   > `LinuxCameraProcessor::start()` for the exact pattern.~~ —
+   > Superseded 2026-05-02 by engine-level pre-warm in
+   > `HostVulkanDevice::new()` (issue #624). The consumer-level
+   > pattern was load-bearing only because the engine deferred
+   > block materialization to first use; once the engine pre-warms,
+   > consumers no longer need to. The previous pattern persisted in
+   > `camera.rs`, `display.rs`, `h264_decoder.rs`, and `h265_decoder.rs`
+   > and was swept out in the same PR per the "no bad patterns left
+   > behind on engine changes" rule in CLAUDE.md.
 
 3. **Size per-frame Vulkan resources to MAX_FRAMES_IN_FLIGHT (2), not
    swapchain image_count.** See @docs/learnings/vulkan-frames-in-flight.md.
@@ -59,5 +78,6 @@ end-to-end via @docs/learnings/camera-display-e2e-validation.md.
 ## References
 - Bug fix: `cab6a00` `fix(vulkan): VMA pool isolation for DMA-BUF allocations`
 - Refactor: `6816f54` `refactor(display): decouple frames-in-flight from swapchain image count`
+- Engine pre-warm: issue #624, `fix(rhi): pre-warm export VMA pools at HostVulkanDevice construction`
 - Repro test (does NOT trigger bug, documents attempt):
   `libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs`

--- a/docs/learnings/nvidia-opaque-fd-after-swapchain.md
+++ b/docs/learnings/nvidia-opaque-fd-after-swapchain.md
@@ -25,35 +25,43 @@ display processor's render thread had created its swapchain, and the
 allocation failed with `A device memory allocation has failed`. Issue
 #624.
 
-## Root cause
+## Root cause (empirical)
 
-NVIDIA's Linux driver tracks per-process exportable-memory budget per
-handle-type (DMA-BUF and OPAQUE_FD count separately, but both are
-budgeted). The Wayland/X11 compositor imports the swapchain images
-as DMA-BUFs to display them — that consumes the DMA-BUF budget. The
+NVIDIA's Linux driver tracks per-process exportable-memory state per
+handle-type (DMA-BUF and OPAQUE_FD are budgeted separately, both are
+affected). The Wayland/X11 compositor imports the swapchain images
+as DMA-BUFs to display them — that consumes the DMA-BUF state. The
 swapchain itself reserves additional kernel resources that affect
 fresh `vkAllocateMemory` calls for any other exportable handle type,
-including OPAQUE_FD.
+including OPAQUE_FD: after `vkCreateSwapchainKHR`, the *first* call
+to `vkAllocateMemory` for a handle type that hasn't been allocated
+yet in this process returns `VK_ERROR_OUT_OF_DEVICE_MEMORY`.
 
-VMA pools defer their underlying `VkDeviceMemory` block to first use:
-`vmaCreatePool` reserves no kernel memory; the first
-`vmaCreate{Buffer,Image}` from the pool issues a real
-`vkAllocateMemory` to back the block. If that first allocation lands
-post-swapchain, NVIDIA's exportable budget is already spoken for and
-the call fails.
+The exact mechanism is internal to NVIDIA's driver. What's
+empirically observable: a successful `vkAllocateMemory` for the
+handle type *before* `vkCreateSwapchainKHR` is sufficient to keep
+the post-swapchain allocation path open, even after that allocation
+is freed. The reservation appears to be one-way — first allocation
+initializes some kernel-side state that survives the free.
 
-The fix shape is identical to the DMA-BUF case: materialize the pool's
-backing block while the budget is freely available, then sub-allocate
-from it.
+This is **not** about VMA block retention. The host RHI's pixel-
+buffer and texture constructors all set
+`vma::AllocationCreateFlags::DEDICATED_MEMORY`, so each export
+allocation is its own `VkDeviceMemory`; dropping the probe issues a
+real `vkFreeMemory`. The engine pre-warm works in spite of that, not
+because of it — what survives the free is on NVIDIA's side, not on
+VMA's.
 
 ## Fix
 
-The engine handles this. `HostVulkanDevice::new()` pre-warms every
-export-capable VMA pool — DMA-BUF buffer, DMA-BUF image linear,
-DMA-BUF image tiled, OPAQUE_FD HOST_VISIBLE buffer, OPAQUE_FD
-DEVICE_LOCAL buffer — by allocating a small probe through each one
-and dropping it. VMA retains the block; subsequent real allocations
-from any consumer sub-allocate from it.
+`HostVulkanDevice::new()` pre-warms every export-capable VMA pool —
+DMA-BUF buffer, DMA-BUF image linear, DMA-BUF image tiled, OPAQUE_FD
+HOST_VISIBLE buffer, OPAQUE_FD DEVICE_LOCAL buffer — by allocating
+a small probe through each one and dropping it, strictly before any
+caller can build a `VkSwapchainKHR`. The probes share the standard
+host RHI constructors (so they trigger the same DEDICATED_MEMORY
+allocation codepath that real consumers will hit), guaranteeing that
+whatever NVIDIA-side state needs initializing has been initialized.
 
 `new()` returns `Result<Arc<Self>>` so the pre-warm step can call
 back through the public RHI constructors (which take
@@ -70,25 +78,34 @@ before any of your code ran. See CLAUDE.md's "Engine-wide bugs get
 fixed at the engine layer" and "No bad patterns left behind on engine
 changes" rules.
 
-## When the constraint still bites
+## Verifying / re-deriving the fix
 
-The engine pre-warm sizes blocks via VMA's default heuristic. If a
-consumer needs a single exportable allocation larger than the block
-VMA picked (typically up to ~256 MiB on heaps ≥ 1 GiB), VMA may
-attempt a fresh `vkAllocateMemory` for a new block — which can hit
-the cap. For typical workloads (1080p / 4K / 8K BGRA buffers, ≤ ~133
-MiB) this stays within one block.
+When in doubt about whether the engine pre-warm still works (driver
+update, VMA refactor, new export handle type, etc.), the
+deterministic protocol is:
 
-If a future consumer needs allocations beyond a single block:
-- Don't reach for a consumer-level pre-warm — that's the dead pattern.
-- Extend the engine to set explicit `VmaPoolCreateInfo::blockSize` on
-  the affected pool, or add a typed "pre-allocate this consumer's
-  worst-case footprint" hook the engine runs at construction.
-- Surface the constraint to the user — block-size tuning is an
-  engine-shape decision, not a per-processor workaround.
+1. Edit `vulkan_device.rs` to comment out the
+   `Self::prewarm_export_pools(&device)?;` call in
+   `HostVulkanDevice::new()`.
+2. `cargo build --release -p camera-python-display`.
+3. Run with `STREAMLIB_CAMERA_DEVICE=/dev/video2`,
+   `STREAMLIB_DISPLAY_FRAME_LIMIT=180`, `timeout --kill-after=5 30`.
+4. Without the pre-warm: log shows `Setup failed: ... CameraToCudaCopy:
+   new_opaque_fd_export_device_local: ... A device memory allocation
+   has failed.`
+5. Re-enable, rebuild, re-run: log shows `HostVulkanDevice export
+   pools pre-warmed` followed by `CameraToCudaCopy: registered cuda
+   OPAQUE_FD DEVICE_LOCAL surface_id=...` — no setup failure.
+
+If step 4 stops reproducing the failure on a fresh driver, the
+NVIDIA-side mechanism may have changed and this learning is stale.
+Update accordingly.
 
 ## Reference
 
 - Bug fix: issue #624, `fix(rhi): pre-warm export VMA pools at HostVulkanDevice construction`
 - Sibling learning: @docs/learnings/nvidia-dma-buf-after-swapchain.md
 - VMA pool pattern: @docs/learnings/vma-export-pools.md
+- Empirical verification protocol above documents the reproducer
+  (since the bug doesn't trigger in isolated unit tests, per the
+  DMA-BUF learning).

--- a/docs/learnings/nvidia-opaque-fd-after-swapchain.md
+++ b/docs/learnings/nvidia-opaque-fd-after-swapchain.md
@@ -1,0 +1,94 @@
+# NVIDIA Linux: OPAQUE_FD allocations are capped after swapchain creation
+
+## Symptom
+
+`VK_ERROR_OUT_OF_DEVICE_MEMORY` returned from `vmaCreateBuffer` (or
+the host RHI's `HostVulkanPixelBuffer::new_opaque_fd_export*`) when:
+
+- Running on NVIDIA Linux Vulkan driver
+- A `VkSwapchainKHR` has been created in this process
+- The allocation chains `VkExportMemoryAllocateInfo::handleTypes =
+  OPAQUE_FD` (the export type CUDA / OpenCL `cudaImportExternalMemory`
+  expects)
+
+Error message looks like real OOM but is NOT — the device has plenty
+of free VRAM. The driver is enforcing a quota on OPAQUE_FD-exportable
+memory, just as it does for DMA-BUF (see
+@docs/learnings/nvidia-dma-buf-after-swapchain.md). Different export
+handle type, same kernel-side budget pressure.
+
+**Failure pattern observed in streamlib:**
+`CameraToCudaCopyProcessor::setup_inner` (in
+`examples/camera-python-display`) called
+`HostVulkanPixelBuffer::new_opaque_fd_export_device_local` after the
+display processor's render thread had created its swapchain, and the
+allocation failed with `A device memory allocation has failed`. Issue
+#624.
+
+## Root cause
+
+NVIDIA's Linux driver tracks per-process exportable-memory budget per
+handle-type (DMA-BUF and OPAQUE_FD count separately, but both are
+budgeted). The Wayland/X11 compositor imports the swapchain images
+as DMA-BUFs to display them — that consumes the DMA-BUF budget. The
+swapchain itself reserves additional kernel resources that affect
+fresh `vkAllocateMemory` calls for any other exportable handle type,
+including OPAQUE_FD.
+
+VMA pools defer their underlying `VkDeviceMemory` block to first use:
+`vmaCreatePool` reserves no kernel memory; the first
+`vmaCreate{Buffer,Image}` from the pool issues a real
+`vkAllocateMemory` to back the block. If that first allocation lands
+post-swapchain, NVIDIA's exportable budget is already spoken for and
+the call fails.
+
+The fix shape is identical to the DMA-BUF case: materialize the pool's
+backing block while the budget is freely available, then sub-allocate
+from it.
+
+## Fix
+
+The engine handles this. `HostVulkanDevice::new()` pre-warms every
+export-capable VMA pool — DMA-BUF buffer, DMA-BUF image linear,
+DMA-BUF image tiled, OPAQUE_FD HOST_VISIBLE buffer, OPAQUE_FD
+DEVICE_LOCAL buffer — by allocating a small probe through each one
+and dropping it. VMA retains the block; subsequent real allocations
+from any consumer sub-allocate from it.
+
+`new()` returns `Result<Arc<Self>>` so the pre-warm step can call
+back through the public RHI constructors (which take
+`&Arc<HostVulkanDevice>`). This is the production pattern (Unreal
+`RHICreateDevice`, Bevy renderer init, wgpu-core `request_device`):
+construction either yields a fully-usable instance with all
+init-time invariants run, or fails — there is no half-formed state
+observable to callers.
+
+**Consumers do NOT need to pre-warm.** If you find yourself wanting
+to allocate-and-drop an exportable resource at processor `start()`
+time, you're re-deriving the dead pattern; the engine already did it
+before any of your code ran. See CLAUDE.md's "Engine-wide bugs get
+fixed at the engine layer" and "No bad patterns left behind on engine
+changes" rules.
+
+## When the constraint still bites
+
+The engine pre-warm sizes blocks via VMA's default heuristic. If a
+consumer needs a single exportable allocation larger than the block
+VMA picked (typically up to ~256 MiB on heaps ≥ 1 GiB), VMA may
+attempt a fresh `vkAllocateMemory` for a new block — which can hit
+the cap. For typical workloads (1080p / 4K / 8K BGRA buffers, ≤ ~133
+MiB) this stays within one block.
+
+If a future consumer needs allocations beyond a single block:
+- Don't reach for a consumer-level pre-warm — that's the dead pattern.
+- Extend the engine to set explicit `VmaPoolCreateInfo::blockSize` on
+  the affected pool, or add a typed "pre-allocate this consumer's
+  worst-case footprint" hook the engine runs at construction.
+- Surface the constraint to the user — block-size tuning is an
+  engine-shape decision, not a per-processor workaround.
+
+## Reference
+
+- Bug fix: issue #624, `fix(rhi): pre-warm export VMA pools at HostVulkanDevice construction`
+- Sibling learning: @docs/learnings/nvidia-dma-buf-after-swapchain.md
+- VMA pool pattern: @docs/learnings/vma-export-pools.md

--- a/libs/streamlib-adapter-cuda-helpers/tests/opaque_fd_consumer_rhi_round_trip.rs
+++ b/libs/streamlib-adapter-cuda-helpers/tests/opaque_fd_consumer_rhi_round_trip.rs
@@ -90,7 +90,7 @@ fn opaque_fd_chain_host_export_to_consumer_import_to_adapter_acquire() {
 
     // ── Phase 0: skip if Vulkan or OPAQUE_FD pool unavailable ──────────
     let host_device = match HostVulkanDevice::new() {
-        Ok(d) => Arc::new(d),
+        Ok(d) => d,
         Err(e) => {
             println!("stage6: no Vulkan host device — skipping ({e})");
             return;

--- a/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
@@ -127,7 +127,7 @@ fn run() -> ExitCode {
     // Build our own VkDevice. The parent has no GPU work in flight when
     // it spawns us, so the dual-VkDevice crash on NVIDIA does not apply.
     let device = match HostVulkanDevice::new() {
-        Ok(d) => Arc::new(d),
+        Ok(d) => d,
         Err(e) => return die(Some(&socket), format!("HostVulkanDevice::new: {e}")),
     };
 

--- a/libs/streamlib-adapter-vulkan-helpers/tests/consumer_carve_out.rs
+++ b/libs/streamlib-adapter-vulkan-helpers/tests/consumer_carve_out.rs
@@ -51,7 +51,7 @@ fn try_consumer() -> Option<Arc<ConsumerVulkanDevice>> {
 
 fn try_host() -> Option<Arc<HostVulkanDevice>> {
     match HostVulkanDevice::new() {
-        Ok(d) => Some(Arc::new(d)),
+        Ok(d) => Some(d),
         Err(e) => {
             println!("skip: HostVulkanDevice::new failed: {e}");
             None

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -911,49 +911,6 @@ impl GpuContext {
         Ok(StreamTexture::from_vulkan(texture))
     }
 
-    /// Pre-warm the tiled DMA-BUF VMA pool so the first VMA block lands
-    /// before the display swapchain creates the NVIDIA DMA-BUF cap pressure.
-    ///
-    /// Mirrors [`acquire_pixel_buffer`]'s pre-warm pattern in
-    /// `LinuxCameraProcessor::start()` — allocate a small probe image and
-    /// drop it. Subsequent allocations reuse the pool block.
-    ///
-    /// No-op (returns `Ok(())`) when the EGL probe has no RT modifiers for
-    /// `format` — there's nothing to pre-warm in that case.
-    #[cfg(target_os = "linux")]
-    pub fn pre_warm_render_target_dma_buf_pool(
-        &self,
-        format: TextureFormat,
-    ) -> Result<()> {
-        use crate::vulkan::rhi::drm_modifier_probe::fourcc;
-        let fourcc = match format {
-            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => {
-                fourcc::DRM_FORMAT_ARGB8888
-            }
-            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => {
-                fourcc::DRM_FORMAT_ABGR8888
-            }
-            _ => return Ok(()),
-        };
-        let vulkan_device = &self.device.inner;
-        if vulkan_device
-            .drm_modifier_table()
-            .rt_modifiers(fourcc)
-            .is_empty()
-        {
-            tracing::info!(
-                "pre_warm_render_target_dma_buf_pool: skipping {format:?} — no RT modifiers"
-            );
-            return Ok(());
-        }
-        let probe = self.acquire_render_target_dma_buf_image(64, 64, format)?;
-        drop(probe);
-        tracing::info!(
-            "pre_warm_render_target_dma_buf_pool: {format:?} pool warmed"
-        );
-        Ok(())
-    }
-
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
     ///
     /// Reflects the SPIR-V at creation time and validates that the declared
@@ -1553,16 +1510,6 @@ impl GpuContextFullAccess {
     ) -> Result<StreamTexture> {
         self.inner
             .acquire_render_target_dma_buf_image(width, height, format)
-    }
-
-    /// Pre-warm the tiled DMA-BUF VMA pool. See
-    /// [`GpuContext::pre_warm_render_target_dma_buf_pool`].
-    #[cfg(target_os = "linux")]
-    pub fn pre_warm_render_target_dma_buf_pool(
-        &self,
-        format: TextureFormat,
-    ) -> Result<()> {
-        self.inner.pre_warm_render_target_dma_buf_pool(format)
     }
 
     /// Get a pixel buffer by its pool id.

--- a/libs/streamlib/src/core/rhi/device.rs
+++ b/libs/streamlib/src/core/rhi/device.rs
@@ -94,7 +94,7 @@ impl GpuDevice {
             all(target_os = "linux", not(feature = "backend-metal"))
         ))]
         {
-            let device_arc = std::sync::Arc::new(crate::vulkan::rhi::HostVulkanDevice::new()?);
+            let device_arc = crate::vulkan::rhi::HostVulkanDevice::new()?;
             let vulkan_queue = device_arc.create_command_queue_wrapper();
 
             // On macOS/iOS with Vulkan backend, also create Metal device/queue for Apple services

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -305,27 +305,6 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
             }
         };
 
-        // Pre-allocate the pixel buffer pool BEFORE the display has a chance to
-        // create its swapchain. NVIDIA limits DMA-BUF exportable allocations
-        // after swapchain creation; pre-allocating here ensures the pool buffers
-        // are created while DMA-BUF allocations are still freely available.
-        match gpu_context.acquire_pixel_buffer(capture_width, capture_height, PixelFormat::Rgba32) {
-            Ok((pool_id, buffer)) => {
-                tracing::info!(
-                    "Camera {}: pre-allocated pixel buffer pool ({}x{} RGBA32) — pool_id={}",
-                    self.camera_name, capture_width, capture_height, pool_id
-                );
-                drop(buffer);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Camera {}: failed to pre-allocate pixel buffer pool: {} \
-                     (will retry from capture thread)",
-                    self.camera_name, e
-                );
-            }
-        }
-
         self.is_capturing.store(true, Ordering::Release);
 
         let is_capturing = Arc::clone(&self.is_capturing);

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -744,9 +744,10 @@ fn capture_thread_loop(
 
     // -----------------------------------------------------------------------
     // Create 2-texture DEVICE_LOCAL ring — DMA-BUF exportable for cross-process
-    // GPU-to-GPU sharing. Uses the isolated DMA-BUF image pool in VMA.
-    // Pre-allocated here (before display's swapchain) to get the NVIDIA DMA-BUF
-    // budget before the swapchain consumes it.
+    // GPU-to-GPU sharing. Uses the isolated DMA-BUF image pool in VMA, whose
+    // underlying VkDeviceMemory block is pre-warmed at
+    // `HostVulkanDevice::new()` so the NVIDIA post-swapchain export cap
+    // doesn't bite (see `docs/learnings/nvidia-dma-buf-after-swapchain.md`).
     // -----------------------------------------------------------------------
     let ring_texture_desc = TextureDescriptor::new(width, height, TextureFormat::Rgba8Unorm)
         .with_usage(

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -116,29 +116,6 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
             .clone()
             .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
 
-        // Pre-warm the tiled DMA-BUF VMA pool BEFORE spawning the render
-        // thread that creates the swapchain. NVIDIA caps DMA-BUF
-        // exportable allocations after swapchain creation; pre-warming the
-        // pool now ensures the first VMA block lands while DMA-BUF
-        // allocations are still freely available.
-        // See `docs/learnings/nvidia-dma-buf-after-swapchain.md` and
-        // `docs/learnings/nvidia-egl-dmabuf-render-target.md`.
-        // Failure here is non-fatal: the EGL probe may have returned no
-        // RT-capable modifiers in headless / no-display environments, in
-        // which case render-target adapters will fail loudly with a clear
-        // message at acquire time rather than silently fall back to
-        // sampler-only LINEAR.
-        if let Err(e) = ctx
-            .gpu_full_access()
-            .pre_warm_render_target_dma_buf_pool(crate::core::rhi::TextureFormat::Bgra8Unorm)
-        {
-            tracing::warn!(
-                "Display {}: render-target DMA-BUF pool pre-warm failed: {} \
-                 — surface adapter consumers will see allocation errors",
-                self.window_id.0, e
-            );
-        }
-
         // Pull the Vulkan device handle from the FullAccess lifecycle ctx.
         // The render thread uses it to build its swapchain and rendering
         // pipeline at startup; the Sandbox clone is what the thread keeps

--- a/libs/streamlib/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_decoder.rs
@@ -74,23 +74,13 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to pre-initialize H.264 decoder session: {e}"))
         })?;
 
-        // Eagerly allocate the NV12→RGBA converter before the display swapchain
-        // consumes NVIDIA's post-swapchain DEVICE_LOCAL / DMA-BUF allocation budget
-        // (docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Eagerly allocate the NV12→RGBA converter. Decode-side resources
+        // are real allocations the decoder needs; the engine pre-warms the
+        // exportable VMA pools at `HostVulkanDevice` construction so this
+        // no longer races NVIDIA's post-swapchain exportable cap.
         decoder.prepare_gpu_decode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.264 decode resources: {e}"))
         })?;
-
-        // Pre-allocate the output pixel buffer pool at the codec-aligned extent
-        // derived from the decoder config, also before the swapchain. The pool
-        // is DMA-BUF exportable; sizing it to the decoder's max extent ensures
-        // the underlying VMA block is large enough for any SPS up to that cap.
-        let (aligned_w, aligned_h) = decoder.aligned_extent();
-        let (_probe_id, _probe_buffer) = ctx.gpu_full_access().acquire_pixel_buffer(
-            aligned_w,
-            aligned_h,
-            crate::core::rhi::PixelFormat::Rgba32,
-        )?;
 
         tracing::info!("[H264Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -54,9 +54,10 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             ..Default::default()
         };
 
-        // Create encoder in setup() — MUST happen before the display swapchain.
-        // NVIDIA limits DMA-BUF exportable allocations after swapchain creation
-        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Create the encoder in setup(). The engine pre-warms every
+        // export-capable VMA pool at `HostVulkanDevice` construction
+        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md), so
+        // encoder allocations no longer race the display's swapchain.
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
@@ -86,11 +87,11 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to create H.264 encoder: {e}"))
         })?;
 
-        // Pre-allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage + per-plane
-        // views + compute pipeline) now, before the display's swapchain is created.
-        // On NVIDIA Linux, new DEVICE_LOCAL allocations can fail with
-        // ERROR_OUT_OF_DEVICE_MEMORY once a swapchain has been created and the
-        // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
+        // per-plane views + compute pipeline) eagerly in setup. These are
+        // real resources the encoder needs at first frame; engine pre-warm
+        // already materialized the underlying VMA blocks so this no longer
+        // races NVIDIA's post-swapchain export cap.
         encoder.prepare_gpu_encode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
         })?;

--- a/libs/streamlib/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_decoder.rs
@@ -74,23 +74,13 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to pre-initialize H.265 decoder session: {e}"))
         })?;
 
-        // Eagerly allocate the NV12→RGBA converter before the display swapchain
-        // consumes NVIDIA's post-swapchain DEVICE_LOCAL / DMA-BUF allocation budget
-        // (docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Eagerly allocate the NV12→RGBA converter. Decode-side resources
+        // are real allocations the decoder needs; the engine pre-warms the
+        // exportable VMA pools at `HostVulkanDevice` construction so this
+        // no longer races NVIDIA's post-swapchain exportable cap.
         decoder.prepare_gpu_decode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.265 decode resources: {e}"))
         })?;
-
-        // Pre-allocate the output pixel buffer pool at the codec-aligned extent
-        // derived from the decoder config, also before the swapchain. The pool
-        // is DMA-BUF exportable; sizing it to the decoder's max extent ensures
-        // the underlying VMA block is large enough for any SPS up to that cap.
-        let (aligned_w, aligned_h) = decoder.aligned_extent();
-        let (_probe_id, _probe_buffer) = ctx.gpu_full_access().acquire_pixel_buffer(
-            aligned_w,
-            aligned_h,
-            crate::core::rhi::PixelFormat::Rgba32,
-        )?;
 
         tracing::info!("[H265Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -54,9 +54,10 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             ..Default::default()
         };
 
-        // Create encoder in setup() — MUST happen before the display swapchain.
-        // NVIDIA limits DMA-BUF exportable allocations after swapchain creation
-        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Create the encoder in setup(). The engine pre-warms every
+        // export-capable VMA pool at `HostVulkanDevice` construction
+        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md), so
+        // encoder allocations no longer race the display's swapchain.
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
@@ -86,11 +87,11 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             StreamError::Runtime(format!("Failed to create H.265 encoder: {e}"))
         })?;
 
-        // Pre-allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage + per-plane
-        // views + compute pipeline) now, before the display's swapchain is created.
-        // On NVIDIA Linux, new DEVICE_LOCAL allocations can fail with
-        // ERROR_OUT_OF_DEVICE_MEMORY once a swapchain has been created and the
-        // DMA-BUF budget is consumed (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+        // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
+        // per-plane views + compute pipeline) eagerly in setup. These are
+        // real resources the encoder needs at first frame; engine pre-warm
+        // already materialized the underlying VMA blocks so this no longer
+        // races NVIDIA's post-swapchain export cap.
         encoder.prepare_gpu_encode_resources().map_err(|e| {
             StreamError::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
         })?;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blending_compositor.rs
@@ -177,7 +177,7 @@ mod tests {
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn test_blit_copy_between_equal_size_buffers() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn test_blit_copy_rejects_mismatched_buffer_sizes() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_creates_command_buffer() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn test_empty_command_buffer_commit_and_wait_completes() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -1101,7 +1101,7 @@ mod tests {
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_crt_film_grain.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_crt_film_grain.rs
@@ -122,7 +122,7 @@ mod tests {
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -133,7 +133,18 @@ impl HostVulkanDevice {
     ///
     /// On macOS/iOS, this loads MoltenVK and enables VK_EXT_metal_objects
     /// for Metal interoperability.
-    pub fn new() -> Result<Self> {
+    ///
+    /// Returns the device wrapped in [`Arc`] because construction runs
+    /// engine init-time invariants that need [`Arc<Self>`] to call back
+    /// into the public RHI constructors — most importantly, every
+    /// export-capable VMA pool (DMA-BUF + OPAQUE_FD) is pre-warmed so
+    /// the underlying [`vk::DeviceMemory`] block exists before any
+    /// swapchain is created. NVIDIA's Linux driver caps fresh
+    /// exportable allocations after a swapchain has been bound (see
+    /// [`docs/learnings/nvidia-dma-buf-after-swapchain.md`]
+    /// and `nvidia-opaque-fd-after-swapchain.md`); pre-warming here
+    /// removes that footgun for every consumer at the engine layer.
+    pub fn new() -> Result<Arc<Self>> {
         // 1. Load Vulkan entry points via libloading
         let loader = unsafe { LibloadingLoader::new(LIBRARY) }.map_err(|e| {
             StreamError::GpuError(format!("Failed to load Vulkan library: {e}"))
@@ -835,7 +846,7 @@ impl HostVulkanDevice {
             }
         );
 
-        Ok(Self {
+        let device = Self {
             entry,
             instance,
             physical_device,
@@ -887,7 +898,140 @@ impl HostVulkanDevice {
             video_decode_queue_mutex: Mutex::new(()),
             compute_queue_mutex: Mutex::new(()),
             device_mutex: Mutex::new(()),
-        })
+        };
+
+        // Wrap in `Arc` before pre-warming so the export-pool probes
+        // can call back through the public RHI constructors (which
+        // take `&Arc<HostVulkanDevice>`).
+        let device = Arc::new(device);
+
+        #[cfg(target_os = "linux")]
+        Self::prewarm_export_pools(&device)?;
+
+        Ok(device)
+    }
+
+    /// Allocate-then-drop a small probe through every export-capable
+    /// VMA pool so the underlying [`vk::DeviceMemory`] block is
+    /// materialized while the per-process exportable-memory budget is
+    /// still freely available.
+    ///
+    /// NVIDIA's Linux driver caps fresh `vkAllocateMemory` calls for
+    /// exportable handle types (DMA-BUF and OPAQUE_FD) after a
+    /// `VkSwapchainKHR` has been bound. VMA pools defer block
+    /// allocation to first use, so without this pre-warm the first
+    /// `vmaCreate{Buffer,Image}` from any export pool — wherever in
+    /// the codebase it lands — can hit the cap and return
+    /// `VK_ERROR_OUT_OF_DEVICE_MEMORY`. Materializing the block here,
+    /// before [`Self::new`] returns, removes that race for every
+    /// consumer.
+    ///
+    /// VMA retains the block when the probe allocation drops; later
+    /// real allocations sub-allocate from it. Probe sizes are tiny
+    /// (8×8 images, 64-KiB buffers); VMA picks the actual block size
+    /// by its own heuristic.
+    ///
+    /// Pools that weren't created (external memory unsupported, EGL
+    /// probe failed, etc.) are skipped — the engine never produces a
+    /// device that exposes a pool but won't pre-warm it.
+    #[cfg(target_os = "linux")]
+    fn prewarm_export_pools(device: &Arc<Self>) -> Result<()> {
+        use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
+        use streamlib_consumer_rhi::PixelFormat;
+        use super::{HostVulkanPixelBuffer, HostVulkanTexture};
+
+        const PROBE_W: u32 = 8;
+        const PROBE_H: u32 = 8;
+        const PROBE_BPP: u32 = 4;
+
+        // 1. DMA-BUF buffer pool — HOST_VISIBLE exportable buffer.
+        if device.dma_buf_buffer_pool().is_some() {
+            let probe = HostVulkanPixelBuffer::new(
+                device, PROBE_W, PROBE_H, PROBE_BPP, PixelFormat::Bgra32,
+            )
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "DMA-BUF buffer pool pre-warm failed: {e}"
+                ))
+            })?;
+            drop(probe);
+        }
+
+        // 2. DMA-BUF image pool (linear, OPTIMAL tiling).
+        if device.dma_buf_image_pool().is_some() {
+            let desc = TextureDescriptor::new(PROBE_W, PROBE_H, TextureFormat::Bgra8Unorm)
+                .with_usage(
+                    TextureUsages::TEXTURE_BINDING
+                        | TextureUsages::COPY_SRC
+                        | TextureUsages::COPY_DST,
+                );
+            let probe = HostVulkanTexture::new(device, &desc).map_err(|e| {
+                StreamError::GpuError(format!(
+                    "DMA-BUF image pool pre-warm failed: {e}"
+                ))
+            })?;
+            drop(probe);
+        }
+
+        // 3. Tiled DMA-BUF image pool (DRM modifier). Only when the
+        //    EGL probe found at least one render-target-capable
+        //    modifier for ARGB8888 — that's the same gating
+        //    `create_dma_buf_pools` uses for the tiled pool itself.
+        if device.dma_buf_image_pool_tiled().is_some() {
+            let bgra_modifiers = device
+                .drm_modifier_table()
+                .rt_modifiers(drm_modifier_probe::fourcc::DRM_FORMAT_ARGB8888);
+            if !bgra_modifiers.is_empty() {
+                let desc =
+                    TextureDescriptor::new(PROBE_W, PROBE_H, TextureFormat::Bgra8Unorm)
+                        .with_usage(
+                            TextureUsages::RENDER_ATTACHMENT
+                                | TextureUsages::TEXTURE_BINDING
+                                | TextureUsages::COPY_SRC
+                                | TextureUsages::COPY_DST,
+                        );
+                let probe = HostVulkanTexture::new_render_target_dma_buf(
+                    device,
+                    &desc,
+                    bgra_modifiers,
+                )
+                .map_err(|e| {
+                    StreamError::GpuError(format!(
+                        "tiled DMA-BUF image pool pre-warm failed: {e}"
+                    ))
+                })?;
+                drop(probe);
+            }
+        }
+
+        // 4. OPAQUE_FD HOST_VISIBLE buffer pool.
+        if device.opaque_fd_buffer_pool().is_some() {
+            let probe = HostVulkanPixelBuffer::new_opaque_fd_export(
+                device, PROBE_W, PROBE_H, PROBE_BPP, PixelFormat::Bgra32,
+            )
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "OPAQUE_FD HOST_VISIBLE buffer pool pre-warm failed: {e}"
+                ))
+            })?;
+            drop(probe);
+        }
+
+        // 5. OPAQUE_FD DEVICE_LOCAL buffer pool.
+        if device.opaque_fd_buffer_pool_device_local().is_some() {
+            let probe = HostVulkanPixelBuffer::new_opaque_fd_export_device_local(
+                device, PROBE_W, PROBE_H, PROBE_BPP, PixelFormat::Bgra32,
+            )
+            .map_err(|e| {
+                StreamError::GpuError(format!(
+                    "OPAQUE_FD DEVICE_LOCAL buffer pool pre-warm failed: {e}"
+                ))
+            })?;
+            drop(probe);
+        }
+
+        tracing::info!("HostVulkanDevice export pools pre-warmed");
+        Ok(())
     }
 
 }
@@ -1919,7 +2063,7 @@ mod tests {
     /// Try to create a HostVulkanDevice; return None if GPU/Vulkan is unavailable (CI).
     fn try_create_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(e) => {
                 println!("Skipping test — Vulkan not available: {e}");
                 None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -912,28 +912,51 @@ impl HostVulkanDevice {
     }
 
     /// Allocate-then-drop a small probe through every export-capable
-    /// VMA pool so the underlying [`vk::DeviceMemory`] block is
-    /// materialized while the per-process exportable-memory budget is
-    /// still freely available.
+    /// VMA pool **before any swapchain is bound** so subsequent
+    /// post-swapchain allocations through the same pool don't hit
+    /// NVIDIA's exportable-memory cap.
     ///
-    /// NVIDIA's Linux driver caps fresh `vkAllocateMemory` calls for
-    /// exportable handle types (DMA-BUF and OPAQUE_FD) after a
-    /// `VkSwapchainKHR` has been bound. VMA pools defer block
-    /// allocation to first use, so without this pre-warm the first
-    /// `vmaCreate{Buffer,Image}` from any export pool — wherever in
-    /// the codebase it lands — can hit the cap and return
-    /// `VK_ERROR_OUT_OF_DEVICE_MEMORY`. Materializing the block here,
-    /// before [`Self::new`] returns, removes that race for every
-    /// consumer.
+    /// **What this does empirically:** Run the export-pool allocation
+    /// codepath (`vmaCreateBuffer` / `vmaCreateImage` with the pool's
+    /// chained `VkExportMemoryAllocateInfo`) once per pool, before
+    /// `HostVulkanDevice::new` returns — i.e., before any caller can
+    /// build a `VkSwapchainKHR`. With pre-warm: post-swapchain
+    /// allocations through the same pools succeed. Without pre-warm:
+    /// `CameraToCudaCopyProcessor::setup_inner` (and any equivalent
+    /// post-swapchain allocator) fails with
+    /// `VK_ERROR_OUT_OF_DEVICE_MEMORY` (issue #624).
     ///
-    /// VMA retains the block when the probe allocation drops; later
-    /// real allocations sub-allocate from it. Probe sizes are tiny
-    /// (8×8 images, 64-KiB buffers); VMA picks the actual block size
-    /// by its own heuristic.
+    /// **What this does NOT do:** Retain a long-lived VMA block that
+    /// subsequent real allocations sub-allocate from. Every export-
+    /// pool consumer in tree (host RHI pixel buffers + textures,
+    /// see `vulkan_pixel_buffer.rs` / `vulkan_texture.rs`) sets
+    /// `vma::AllocationCreateFlags::DEDICATED_MEMORY`, so each
+    /// allocation gets its own `VkDeviceMemory` regardless of pool
+    /// configuration. Dropping the probe issues a real
+    /// `vkFreeMemory` and frees the block.
+    ///
+    /// **Why it works anyway:** The exact mechanism is internal to
+    /// NVIDIA's Linux driver and is not publicly documented. Empirical
+    /// observation from issue #624: a successful `vkAllocateMemory`
+    /// for an exportable handle type *before* `vkCreateSwapchainKHR`
+    /// is enough to keep the post-swapchain allocation path open for
+    /// that handle type, even after the probe is freed. The
+    /// reservation appears to be one-way — first export allocation
+    /// initializes some driver state that survives the free.
+    ///
+    /// Probe sizes are tiny (8×8 images, 64-KiB buffers); the cost is
+    /// dominated by `vkAllocateMemory` round-trips, not memory
+    /// footprint.
     ///
     /// Pools that weren't created (external memory unsupported, EGL
     /// probe failed, etc.) are skipped — the engine never produces a
     /// device that exposes a pool but won't pre-warm it.
+    ///
+    /// **Verification:** `examples/camera-python-display` reproduces
+    /// the post-swapchain failure deterministically when this
+    /// function is bypassed and runs cleanly when it isn't. See
+    /// `docs/learnings/nvidia-opaque-fd-after-swapchain.md` for the
+    /// run-and-revert protocol.
     #[cfg(target_os = "linux")]
     fn prewarm_export_pools(device: &Arc<Self>) -> Result<()> {
         use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};

--- a/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
@@ -117,7 +117,7 @@ mod tests {
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -774,7 +774,7 @@ mod tests {
     #[test]
     fn test_pool_buffer_creation_1920x1080_bgra32() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -803,7 +803,7 @@ mod tests {
     #[test]
     fn test_buffer_write_and_readback() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -841,7 +841,7 @@ mod tests {
     #[test]
     fn test_dma_buf_export() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -867,7 +867,7 @@ mod tests {
     #[test]
     fn opaque_fd_export_round_trip_and_cross_flavor_rejection() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -920,7 +920,7 @@ mod tests {
     #[test]
     fn opaque_fd_device_local_export_round_trip() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -963,7 +963,7 @@ mod tests {
         use crate::core::rhi::RhiExternalHandle;
 
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1016,7 +1016,7 @@ mod tests {
     #[test]
     fn physical_device_uuid_is_populated() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1050,7 +1050,7 @@ mod tests {
     #[test]
     fn test_multiple_buffers_coexist() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1084,7 +1084,7 @@ mod tests {
     #[test]
     fn test_drop_frees_without_panic() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1101,7 +1101,7 @@ mod tests {
     #[test]
     fn test_dma_buf_import_round_trip() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1165,7 +1165,7 @@ mod tests {
     #[test]
     fn test_dma_buf_import_multi_plane_round_trip() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1256,7 +1256,7 @@ mod tests {
     #[test]
     fn test_dma_buf_import_rejects_oversize_plane_vec() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn test_pool_acquire_returns_buffer() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn test_pool_exhaustion_returns_error() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn test_pool_reuses_buffer_after_release() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
@@ -748,7 +748,7 @@ fn create_swapchain(
 
 fn try_create_device() -> Option<Arc<HostVulkanDevice>> {
     match HostVulkanDevice::new() {
-        Ok(d) => Some(Arc::new(d)),
+        Ok(d) => Some(d),
         Err(e) => {
             println!("Skipping — Vulkan device unavailable: {e}");
             None

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -1128,7 +1128,7 @@ mod tests {
     #[test]
     fn test_pool_texture_creation_1920x1080_bgra8() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1154,7 +1154,7 @@ mod tests {
     #[test]
     fn test_texture_drop_frees_memory() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1171,7 +1171,7 @@ mod tests {
     #[test]
     fn test_multiple_textures_coexist() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1203,7 +1203,7 @@ mod tests {
     #[test]
     fn test_dma_buf_export() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1248,7 +1248,7 @@ mod tests {
     #[test]
     fn test_camera_display_allocation_pattern() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1384,7 +1384,7 @@ mod tests {
     #[test]
     fn test_various_formats() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1407,7 +1407,7 @@ mod tests {
     #[test]
     fn test_device_local_texture_creation() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1430,7 +1430,7 @@ mod tests {
     #[test]
     fn test_lazy_image_view() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -1464,7 +1464,7 @@ mod tests {
         use crate::vulkan::rhi::drm_modifier_probe::fourcc;
 
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(e) => {
                 println!("Skipping — no Vulkan device: {e}");
                 return;
@@ -1531,7 +1531,7 @@ mod tests {
     #[test]
     fn test_render_target_dma_buf_empty_modifiers_rejected() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(e) => {
                 println!("Skipping — no Vulkan device: {e}");
                 return;
@@ -1554,7 +1554,7 @@ mod tests {
     #[test]
     fn test_ring_texture_lifecycle() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -371,9 +371,10 @@ impl HostVulkanTexture {
 
         // Prefer the dedicated tiled DMA-BUF image pool; fall back to the
         // default allocator (still with the export-info pNext chain) only
-        // when external memory isn't supported. The fallback path may fail
-        // on NVIDIA after swapchain creation — caller is expected to have
-        // pre-warmed the pool to avoid that.
+        // when external memory isn't supported. The pool's underlying
+        // `VkDeviceMemory` block is pre-warmed at `HostVulkanDevice::new()`
+        // (see `nvidia-dma-buf-after-swapchain.md`), so the post-swapchain
+        // NVIDIA cap doesn't apply to the pooled path.
         let (image, allocation) = if let Some(pool) =
             vulkan_device.dma_buf_image_pool_tiled()
         {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_creates_image_view_for_valid_image() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn test_returns_cached_view_for_same_image() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_flush_destroys_all_cached_views() {
         let device = match HostVulkanDevice::new() {
-            Ok(d) => Arc::new(d),
+            Ok(d) => d,
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 return;

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -702,7 +702,7 @@ mod tests {
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
-            Ok(d) => Some(Arc::new(d)),
+            Ok(d) => Some(d),
             Err(_) => {
                 println!("Skipping - no Vulkan device available");
                 None

--- a/libs/vulkan-video/src/decode/session.rs
+++ b/libs/vulkan-video/src/decode/session.rs
@@ -43,10 +43,12 @@ impl SimpleDecoder {
     /// Eagerly allocate the GPU resources used during decode.
     ///
     /// Creates the NV12→RGBA compute converter now (when `rgba_output` is
-    /// enabled) instead of on the first `feed()` call. Callers should invoke
-    /// this during setup — before a display swapchain is created — so the
-    /// converter's DEVICE_LOCAL image isn't subject to NVIDIA's post-swapchain
-    /// allocation cap (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+    /// enabled) instead of on the first `feed()` call. The exportable VMA
+    /// blocks the converter's DEVICE_LOCAL image rides through are
+    /// pre-warmed at `HostVulkanDevice::new()`
+    /// (see docs/learnings/nvidia-dma-buf-after-swapchain.md), so eager
+    /// allocation here is purely for first-frame latency, not for dodging
+    /// the post-swapchain export cap.
     ///
     /// Requires [`pre_initialize_session`](Self::pre_initialize_session) to
     /// have been called first (so `max_width`/`max_height` are known).

--- a/libs/vulkan-video/src/encode/mod.rs
+++ b/libs/vulkan-video/src/encode/mod.rs
@@ -374,10 +374,11 @@ impl SimpleEncoder {
     ///
     /// Creates the RGB→NV12 converter (an NV12 VkImage, per-plane views, compute
     /// pipeline, command pool/buffer) now instead of on the first `encode_image`
-    /// call. Callers that will feed GPU-resident frames should invoke this
-    /// during setup — before a display swapchain is created — so the NV12 image
-    /// allocation isn't subject to NVIDIA's post-swapchain DMA-BUF budget cap
-    /// (see docs/learnings/nvidia-dma-buf-after-swapchain.md).
+    /// call. Eager allocation here is for first-frame latency; the exportable
+    /// VMA blocks the NV12 image rides through are pre-warmed at
+    /// `HostVulkanDevice::new()` (see
+    /// docs/learnings/nvidia-dma-buf-after-swapchain.md), so callers no
+    /// longer need to invoke this before the display swapchain.
     pub fn prepare_gpu_encode_resources(&mut self) -> Result<(), VideoError> {
         self.prepare_gpu_encode_resources_impl()
     }


### PR DESCRIPTION
## Summary

- Engine-level fix for #624 (`CameraToCudaCopyProcessor::setup_inner` failing with `VK_ERROR_OUT_OF_DEVICE_MEMORY` post-swapchain on NVIDIA Linux): `HostVulkanDevice::new()` now returns `Result<Arc<Self>>` and pre-warms every export-capable VMA pool (DMA-BUF buffer / image linear / image tiled, OPAQUE_FD HOST_VISIBLE / DEVICE_LOCAL) before any caller can build a `VkSwapchainKHR`.
- Sweeps four redundant consumer-level pre-warms (`camera.rs`, `display.rs`, `h264_decoder.rs`, `h265_decoder.rs`) and the now-dead `pre_warm_render_target_dma_buf_pool` API on `GpuContext{Full,Limited}Access`. Per the new "No bad patterns left behind on engine changes" rule in CLAUDE.md.
- Adds two durable rules to CLAUDE.md surfaced during the staleness check: "Engine-wide bugs get fixed at the engine layer" and "No bad patterns left behind on engine changes." The same rules are reflected in `~/.claude/skills/amos-next/SKILL.md` and saved as feedback memories.

## Closes
Closes #624

## Mechanism note

Initial review flagged that the docs claimed VMA pool block retention, but every host RHI export-pool consumer sets `vma::AllocationCreateFlags::DEDICATED_MEMORY` — so each allocation is its own `VkDeviceMemory` and dropping the probe issues real `vkFreeMemory`. The fix still works empirically (NVIDIA driver state initialized by the first export allocation survives the free), but the docs were wrong-shaped about *why*. Final commit corrects the explanation in `vulkan_device.rs::prewarm_export_pools`, both learning files, and removes a misleading "block size guidance" section.

## Exit criteria

- [x] `examples/camera-python-display` runs end-to-end without `CameraToCudaCopy` setup failing.
- [x] Allocation strategy documented in `docs/learnings/nvidia-opaque-fd-after-swapchain.md` (new) and `nvidia-dma-buf-after-swapchain.md` (updated with strikethrough on superseded consumer-level guidance).

## Test plan

### Workspace baseline (per `docs/testing-baseline.md`)

```
cargo test --workspace \
    --exclude api-server-demo \
    --exclude camera-deno-subprocess \
    --exclude camera-python-subprocess \
    --exclude camera-rust-plugin \
    --exclude webrtc-cloudflare-stream
```

→ **passed=1210 failed=0 ignored=34**

### A→B reproducer (verifies the fix actually fixes the bug)

**Without `prewarm_export_pools` call** (commented out in `HostVulkanDevice::new()`):

```
ERROR ... Setup failed: Invalid configuration: CameraToCudaCopy:
new_opaque_fd_export_device_local: GPU operation failed: Failed to
create DEVICE_LOCAL OPAQUE_FD exportable buffer:
A device memory allocation has failed.
```

(Bug reproduces as documented in #624.)

**With `prewarm_export_pools` re-enabled:**

```
HostVulkanDevice export pools pre-warmed
CameraToCudaCopy: registered cuda OPAQUE_FD DEVICE_LOCAL surface_id=484001 (1920x1080) — host pipeline will copy camera→cuda per frame
CameraToCudaCopy: shutdown (1579 frames)
```

(Bug gone; pipeline runs cleanly for the timeout window.)

The reproducer protocol is documented in `nvidia-opaque-fd-after-swapchain.md` so future agents can re-derive this when the driver behavior changes.

### E2E run command

```
STREAMLIB_CAMERA_DEVICE=/dev/video2 \
STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-624/png_samples \
STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
STREAMLIB_DISPLAY_FRAME_LIMIT=180 \
timeout --kill-after=5 30 cargo run --release -p camera-python-display
```

(NVIDIA RTX 3090 + Cam Link 4K, 26-second self-terminated run.)

## Follow-ups

- None. The cuda Python avatar bottleneck preventing display-side PNG samples in the E2E run is unrelated to #624 — separate issues track that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)