### PR TITLE
feat(display): PNG sampler captures from texture surfaces via VulkanTextureReadback

### DIFF
--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -199,6 +199,7 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
                     png_sample_dir,
                     png_sample_every,
                     png_samples_saved: 0,
+                    png_texture_readback: None,
                 };
 
                 if let Err(e) = event_loop.run_app(&mut app) {
@@ -364,6 +365,10 @@ struct DisplayEventLoopHandler {
     png_sample_every: u64,
     /// Internal counter for next PNG sample.
     png_samples_saved: u64,
+    /// Lazily-built readback handle for the texture-surface PNG sampling path.
+    /// Pinned to the first sampled texture's format/extent; samples whose
+    /// texture disagrees are skipped with a warning.
+    png_texture_readback: Option<Arc<crate::vulkan::rhi::VulkanTextureReadback>>,
 }
 
 impl ApplicationHandler for DisplayEventLoopHandler {
@@ -938,8 +943,16 @@ impl DisplayEventLoopHandler {
         state.current_frame = (frame_index + 1) % MAX_FRAMES_IN_FLIGHT;
         let frame_idx = self.frame_counter.fetch_add(1, Ordering::Relaxed);
 
-        // Debug feature: sample frame to PNG from HOST_VISIBLE pixel buffer.
-        // Resolve pixel buffer on-demand for sampling (not in hot path).
+        // Debug feature: sample frame to PNG. Two paths:
+        //   1. HOST_VISIBLE pixel-buffer fast path — zero-copy from CPU's
+        //      perspective, fires for surfaces registered as pixel buffers
+        //      (decoded frames, BgraFileSource).
+        //   2. Texture-surface fallback — for surfaces registered via
+        //      `surface_store.register_texture` (DMA-BUF VkImages from
+        //      adapter outputs: AvatarCharacter, Skia, Glitch). Routes
+        //      through the canonical `VulkanTextureReadback` RHI primitive
+        //      (Granite-style `copy_image_to_buffer + vkSemaphoreWaitKHR`,
+        //      reusable persistent staging buffer + command pool).
         //
         // Filename carries BOTH the displayed-frame counter (`frame_idx`)
         // and the INPUT frame index (from `ipc_frame.frame_index`). The
@@ -950,15 +963,15 @@ impl DisplayEventLoopHandler {
         // the same decoded frame while the decoder is stalled.
         if let Some(ref dir) = self.png_sample_dir {
             if frame_idx % self.png_sample_every == 0 {
+                let input_frame_index: u64 = ipc_frame.frame_index.parse().unwrap_or(frame_idx);
+                let path = dir.join(format!(
+                    "display_{:03}_frame_{:06}_input_{:06}.png",
+                    self.window_id, frame_idx, input_frame_index
+                ));
                 if let Ok(buf) = self.gpu_context.resolve_videoframe_buffer(&ipc_frame) {
                     let vk_buf = &buf.buffer_ref().inner;
                     let mapped_ptr = vk_buf.mapped_ptr();
                     if !mapped_ptr.is_null() {
-                        let input_frame_index: u64 = ipc_frame.frame_index.parse().unwrap_or(frame_idx);
-                        let path = dir.join(format!(
-                            "display_{:03}_frame_{:06}_input_{:06}.png",
-                            self.window_id, frame_idx, input_frame_index
-                        ));
                         let len = (src_width as usize) * (src_height as usize) * 4;
                         let rgba = unsafe { std::slice::from_raw_parts(mapped_ptr, len) };
                         if let Err(e) = write_png_rgba(&path, src_width, src_height, rgba) {
@@ -974,7 +987,135 @@ impl DisplayEventLoopHandler {
                             );
                         }
                     }
+                } else {
+                    self.sample_texture_to_png(
+                        &camera_texture,
+                        &path,
+                        frame_idx,
+                        input_frame_index,
+                    );
                 }
+            }
+        }
+    }
+
+    /// Capture an adapter-output texture into a PNG via the RHI's
+    /// `VulkanTextureReadback` primitive. Lazily constructs (and caches)
+    /// the readback handle on first use; format/extent are pinned to the
+    /// first texture sampled. Subsequent samples whose texture disagrees
+    /// are skipped with a warning rather than rebuilding the handle.
+    fn sample_texture_to_png(
+        &mut self,
+        texture: &crate::core::rhi::StreamTexture,
+        path: &std::path::Path,
+        frame_idx: u64,
+        input_frame_index: u64,
+    ) {
+        use crate::core::rhi::{TextureReadbackDescriptor, TextureSourceLayout};
+
+        let format = texture.format();
+        let width = texture.width();
+        let height = texture.height();
+
+        // PNG writer assumes 4-byte RGBA-shape pixels. Skip exotic formats
+        // (NV12, fp16, fp32) — these are valid texture formats but the
+        // handwritten PNG writer can't render them.
+        if format.bytes_per_pixel() != 4 {
+            tracing::warn!(
+                "Display {}: skip PNG sample for input frame {} — texture format {:?} \
+                 (bpp={}) not supported by PNG writer",
+                self.window_id,
+                input_frame_index,
+                format,
+                format.bytes_per_pixel()
+            );
+            return;
+        }
+
+        // Lazy: build the readback handle on first sample.
+        if self.png_texture_readback.is_none() {
+            let descriptor = TextureReadbackDescriptor {
+                label: "display-png-sample",
+                format,
+                width,
+                height,
+            };
+            match crate::vulkan::rhi::VulkanTextureReadback::new_into_stream_error(
+                &self.vulkan_device,
+                &descriptor,
+            ) {
+                Ok(handle) => {
+                    tracing::info!(
+                        "Display {}: created texture-readback handle for PNG sampling \
+                         ({:?}, {}x{}, {} bytes)",
+                        self.window_id,
+                        format,
+                        width,
+                        height,
+                        descriptor.staging_size()
+                    );
+                    self.png_texture_readback = Some(Arc::new(handle));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Display {}: PNG texture-readback handle creation failed: {}",
+                        self.window_id,
+                        e
+                    );
+                    return;
+                }
+            }
+        }
+        let readback = self.png_texture_readback.as_ref().unwrap().clone();
+
+        // `TextureSourceLayout::General` covers adapter-output textures
+        // (OpenGL post-glFinish, Skia, compute kernels) — the canonical
+        // case this fallback exists to support. Native ring textures from
+        // the camera processor register as pixel buffers and take the
+        // fast path above, so they don't reach here in practice.
+        let ticket = match readback.submit(texture, TextureSourceLayout::General) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "Display {}: PNG texture-readback submit failed for input frame {}: {}",
+                    self.window_id,
+                    input_frame_index,
+                    e
+                );
+                return;
+            }
+        };
+        let result = readback.wait_and_read_with(ticket, u64::MAX, |bytes| {
+            write_png_rgba(path, width, height, bytes)
+        });
+        match result {
+            Ok(Ok(())) => {
+                self.png_samples_saved += 1;
+                tracing::info!(
+                    "Display {}: saved PNG sample (texture path) {:?} \
+                     (input {}, displayed {}, total saved {})",
+                    self.window_id,
+                    path,
+                    input_frame_index,
+                    frame_idx,
+                    self.png_samples_saved
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "Display {}: PNG sample (texture path) save failed for input frame {}: {}",
+                    self.window_id,
+                    input_frame_index,
+                    e
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Display {}: PNG texture-readback wait failed for input frame {}: {}",
+                    self.window_id,
+                    input_frame_index,
+                    e
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

- Display PNG sampler now falls back to a texture-path readback when `resolve_videoframe_buffer` fails. Adapter-output surfaces registered via `surface_store.register_texture` (DMA-BUF VkImages from AvatarCharacter, future Skia/Glitch overlays) are now sampled instead of silently skipped.
- Routes through the canonical RHI primitive `VulkanTextureReadback` — Granite-style `copy_image_to_buffer + vkSemaphoreWaitKHR`, persistent staging buffer + command pool + timeline semaphore allocated once at construction. The handle is lazily built on first texture-path sample (format/extent pinned to the resolved texture) and cached on `DisplayEventLoopHandler` for the rest of the run. `TextureSourceLayout::General` covers the canonical adapter-output case the readback enum's docs explicitly cite.
- Buffer-path fast path is unchanged — preserves zero-copy capture for surfaces registered as HOST_VISIBLE pixel buffers (decoded frames, BgraFileSource).

## Closes
Closes #613

## Exit criteria
- [x] Display PNG sampler handles texture surfaces in addition to pixel buffer surfaces.
- [x] No new dependencies (existing handwritten PNG writer in `display.rs` stays in tree; readback primitive already in the RHI).
- [x] Sampling-interval semantics (`STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY`) unchanged.

## Implementation notes

The issue body's original AI Agent Notes suggested hand-rolling the `vkCmdCopyImageToBuffer` + one-shot staging VkBuffer in `display.rs`. That suggestion pre-dated `VulkanTextureReadback` (`libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs`, exposed as `GpuContext::create_texture_readback`), which already solves this exact pattern with reusable resources. Per CLAUDE.md's engine-model rule ("search first, prefer extending a core system"), this PR rides the existing primitive instead. The issue body was updated in place with a strike-through annotation pointing at the supersession.

## Test plan

- [x] `cargo check -p streamlib` — clean, no new warnings (29 pre-existing dead-code/unused-import warnings in unrelated files).
- [x] **Workspace test baseline** (`cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream`): **1210 passed / 0 failed / 34 ignored**. One transient `Lost Device` failure in `streamlib-adapter-skia::skia_adapter_passes_run_conformance` cleared on re-run — flaky under GPU contention, unrelated to this change.
- [x] **Camera-display buffer-path regression** (`cargo run -p camera-display --release` with `STREAMLIB_DISPLAY_PNG_SAMPLE_DIR` set, `/dev/video0` vivid, frame_limit=120, sample_every=30): 4 PNGs saved at frames 0/30/60/90, no errors. Read `display_001_frame_000060_input_000062.png` with the Read tool — vivid green/dark-green vertical bands with scrolling timecode `00:00:12.204.61`, control-line text overlay, scanlines. Pattern matches expected vivid output. All saved log lines used the existing buffer-path message (no `(texture path)` suffix), confirming the fast path is preserved.
- [x] **Underlying readback primitive validation on adapter-output BGRA8 DMA-BUF VkImage** (`cargo run -p polyglot-opengl-fragment-shader-scenario --release -- --runtime=deno`): plasma-waves PNG written successfully via `VulkanTextureReadback` against an `OpenGLContext.acquire_write` surface — same primitive, same call shape, same `TextureSourceLayout::General` as this PR's display path. Read `/tmp/opengl-plasma.png` with the Read tool — characteristic green/yellow/magenta plasma pattern, 512x512, content correct. This is the strongest available indirect evidence that the new texture-path implementation in `display.rs` will work end-to-end on adapter outputs.
- [ ] **Direct adapter-output → display PNG sampler E2E** — blocked by an unrelated upstream bug. AvatarCharacter Linux is the only in-tree example that combines an adapter-output texture surface with a Display processor, and its Python ModernGL `program(...)` call fails with `GLSL Compiler failed` on every frame, so the avatar never emits a frame to the display. Filed as **#626** (`fix(linux-python): AvatarCharacter Linux fails GLSL compile, blocks adapter→display E2E`). Once #626 lands, re-run `camera-python-display` with `STREAMLIB_DISPLAY_PNG_SAMPLE_*` set to close this checkbox.

### E2E Test Report

- **Scenario**: camera+display-only (regression — buffer path)
- **Example**: `camera-display`
- **Codec**: n/a
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=120` (~24s of pipeline run)
- **Build profile**: release
- **Command**:
    ```
    STREAMLIB_CAMERA_DEVICE=/dev/video0 \
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/camdisp-regress-…/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=120 \
    timeout --kill-after=5 30 cargo run -q -p camera-display --release
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `Display 1: saved PNG sample`: 4 (input_frame=2/32/62/92, displayed_frame=0/30/60/90)

#### PNG samples

- Directory: `/tmp/camdisp-regress-…/png_samples/`
- Sample count: 4
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30`
- PNGs read with Read tool: `display_001_frame_000060_input_000062.png`
- What was in the image(s): "vivid test pattern at 1920x1080 — green/dark-green vertical bands with scrolling timecode `00:00:12.204.61` overlaid in the upper-left, plus per-line text indicating brightness/contrast/saturation/hue/autogain values, with the characteristic vivid scanline interlace. Matches the expected vivid pattern."
- Anomalies: none

#### PSNR

- Reference frame: n/a — vivid synthetic source not paired with a checked-in reference for this sampler-path regression.
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass** — buffer path unchanged.

## Follow-ups

- #626 — `fix(linux-python): AvatarCharacter Linux fails GLSL compile, blocks adapter→display E2E`. Once landed, run `camera-python-display` with `STREAMLIB_DISPLAY_PNG_SAMPLE_DIR` set to close the direct adapter→display checkbox in #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)