### PR TITLE
fix(linux-python): AvatarCharacter Linux GLSL + EXTERNAL_OES end-to-end

### DIFF
--- a/examples/camera-python-display/python/pose_overlay_renderer.py
+++ b/examples/camera-python-display/python/pose_overlay_renderer.py
@@ -102,11 +102,16 @@ uniform float u_time;
 
 void main() {
     // Subtle chromatic aberration: shift R and B channels horizontally.
+    // Use the GL_OES_EGL_image_external `texture2D(samplerExternalOES,
+    // vec2)` overload — NVIDIA's desktop-GL driver does not register the
+    // unified `texture(samplerExternalOES, vec2)` overload in
+    // `#version 330 core`; that overload is ESSL3-only (would require
+    // `_essl3` + an actual GLES context).
     float shift = 0.0025;
     vec3 col;
-    col.r = texture(u_camera, v_texcoord + vec2(shift, 0.0)).r;
-    col.g = texture(u_camera, v_texcoord).g;
-    col.b = texture(u_camera, v_texcoord - vec2(shift, 0.0)).b;
+    col.r = texture2D(u_camera, v_texcoord + vec2(shift, 0.0)).r;
+    col.g = texture2D(u_camera, v_texcoord).g;
+    col.b = texture2D(u_camera, v_texcoord - vec2(shift, 0.0)).b;
 
     // Cyberpunk grade: lift mids towards cyan, push shadows slightly violet.
     vec3 graded = mix(col, col * vec3(0.78, 1.05, 1.18), 0.55);

--- a/libs/streamlib-adapter-opengl/src/adapter.rs
+++ b/libs/streamlib-adapter-opengl/src/adapter.rs
@@ -94,8 +94,15 @@ impl OpenGlSurfaceAdapter {
     /// Same DMA-BUF import path as [`Self::register_host_surface`],
     /// but binds the resulting `EGLImage` via
     /// `glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, image)`.
-    /// The customer's GLSL must `#extension GL_OES_EGL_image_external_essl3 :
-    /// require` (or the older `_essl1`) and sample via `samplerExternalOES`.
+    /// The customer's GLSL must enable `samplerExternalOES`. On the
+    /// adapter's desktop-GL context (`EGL_OPENGL_API`, see
+    /// [`crate::EglRuntime`]), use `#extension GL_OES_EGL_image_external :
+    /// require` and sample via the `texture2D(samplerExternalOES, vec2)`
+    /// overload — NVIDIA's desktop-GL driver does NOT register the
+    /// unified `texture(samplerExternalOES, vec2)` overload in
+    /// `#version 330 core`. The unified `texture(...)` overload comes
+    /// from `GL_OES_EGL_image_external_essl3`, which requires a GLES
+    /// context and is not what this adapter creates.
     ///
     /// Use this for surfaces the host did not (or could not) allocate
     /// with a render-target-capable modifier — typically camera ring

--- a/libs/streamlib-adapter-opengl/src/egl.rs
+++ b/libs/streamlib-adapter-opengl/src/egl.rs
@@ -224,15 +224,47 @@ impl EglRuntime {
     /// Lock + make-current; returns a guard that releases the context
     /// on drop. Every adapter operation that touches EGL or GL calls
     /// this before doing anything.
+    ///
+    /// **Same-thread reentrance.** If the EGL context is already current
+    /// on the calling thread (an outer `lock_make_current` /
+    /// `arc_lock_make_current` scope on this thread already locked the
+    /// mutex and made-current), this returns a no-op guard that does
+    /// NOT re-take the mutex and does NOT release the context on drop.
+    /// Without this, nested acquire patterns (e.g. an
+    /// `acquire_write` scope that calls into a re-registration path
+    /// which itself calls `lock_make_current`) would deadlock the
+    /// non-reentrant `Mutex`. Reentrance is keyed off
+    /// `eglGetCurrentContext` so it works across borrowed
+    /// (`MakeCurrentGuard`) and owned (`OwnedMakeCurrentGuard`) outer
+    /// holders identically.
     pub fn lock_make_current(&self) -> Result<MakeCurrentGuard<'_>, EglRuntimeError> {
+        if self.is_current_on_this_thread() {
+            return Ok(MakeCurrentGuard {
+                runtime: self,
+                _lock: None,
+            });
+        }
         let lock = self.make_current_lock.lock();
         self.egl
             .make_current(self.display, None, None, Some(self.context))
             .map_err(|e| EglRuntimeError::MakeCurrent(format!("acquire: {e}")))?;
         Ok(MakeCurrentGuard {
             runtime: self,
-            _lock: lock,
+            _lock: Some(lock),
         })
+    }
+
+    /// Returns `true` when the EGL context owned by this runtime is
+    /// currently bound on the calling thread. Used by
+    /// [`Self::lock_make_current`] / [`OwnedMakeCurrentGuard::new`] to
+    /// detect same-thread reentrance and skip the lock + make-current
+    /// + release dance that would otherwise deadlock or tear down the
+    /// outer holder's context state.
+    fn is_current_on_this_thread(&self) -> bool {
+        match self.egl.get_current_context() {
+            Some(ctx) => ctx == self.context,
+            None => false,
+        }
     }
 
     /// Owned-Arc variant of [`Self::lock_make_current`] returning a
@@ -332,14 +364,22 @@ impl Drop for EglRuntime {
 /// RAII guard that holds the runtime's make-current lock and the EGL
 /// current-context state. On drop the context is cleared so a
 /// different thread can re-make-current on its next call.
+///
+/// `_lock = None` is the no-op variant returned when the calling
+/// thread already had the context current (nested `lock_make_current`
+/// scope). The no-op variant intentionally skips the
+/// `eglMakeCurrent(NULL)` on drop so the outer holder's context state
+/// stays intact.
 pub struct MakeCurrentGuard<'r> {
     runtime: &'r EglRuntime,
-    _lock: parking_lot::MutexGuard<'r, ()>,
+    _lock: Option<parking_lot::MutexGuard<'r, ()>>,
 }
 
 impl Drop for MakeCurrentGuard<'_> {
     fn drop(&mut self) {
-        let _ = self.runtime.egl.make_current(self.runtime.display, None, None, None);
+        if self._lock.is_some() {
+            let _ = self.runtime.egl.make_current(self.runtime.display, None, None, None);
+        }
     }
 }
 
@@ -349,11 +389,18 @@ impl Drop for MakeCurrentGuard<'_> {
 /// release happen across separate FFI calls.
 pub struct OwnedMakeCurrentGuard {
     runtime: Arc<EglRuntime>,
-    lock: ManuallyDrop<MutexGuard<'static, ()>>,
+    /// `None` is the same-thread reentrance variant — the outer holder
+    /// already had the context current and the lock taken. We intentionally
+    /// did not re-lock or re-call `eglMakeCurrent`, so drop does nothing
+    /// to avoid clobbering the outer's state.
+    lock: Option<ManuallyDrop<MutexGuard<'static, ()>>>,
 }
 
 impl OwnedMakeCurrentGuard {
     fn new(runtime: Arc<EglRuntime>) -> Result<Self, EglRuntimeError> {
+        if runtime.is_current_on_this_thread() {
+            return Ok(Self { runtime, lock: None });
+        }
         let lock_borrowed = runtime.make_current_lock.lock();
         runtime
             .egl
@@ -374,21 +421,23 @@ impl OwnedMakeCurrentGuard {
         };
         Ok(Self {
             runtime,
-            lock: ManuallyDrop::new(lock),
+            lock: Some(ManuallyDrop::new(lock)),
         })
     }
 }
 
 impl Drop for OwnedMakeCurrentGuard {
     fn drop(&mut self) {
-        let _ = self
-            .runtime
-            .egl
-            .make_current(self.runtime.display, None, None, None);
-        // SAFETY: the lock has not yet been dropped (we never call
-        // `ManuallyDrop::drop` outside this Drop impl). Drop it here to
-        // release the mutex before our Arc reference goes away.
-        unsafe { ManuallyDrop::drop(&mut self.lock) };
+        if let Some(mut lock) = self.lock.take() {
+            let _ = self
+                .runtime
+                .egl
+                .make_current(self.runtime.display, None, None, None);
+            // SAFETY: the lock has not yet been dropped (we never call
+            // `ManuallyDrop::drop` outside this Drop impl). Drop it here to
+            // release the mutex before our Arc reference goes away.
+            unsafe { ManuallyDrop::drop(&mut lock) };
+        }
     }
 }
 

--- a/libs/streamlib-adapter-opengl/src/egl.rs
+++ b/libs/streamlib-adapter-opengl/src/egl.rs
@@ -260,6 +260,20 @@ impl EglRuntime {
     /// detect same-thread reentrance and skip the lock + make-current
     /// + release dance that would otherwise deadlock or tear down the
     /// outer holder's context state.
+    ///
+    /// **Invariant load-bearing for the reentrance fast-path.** This
+    /// shortcut is sound only because *every path in the streamlib
+    /// codebase that makes this runtime's context current goes
+    /// through* [`Self::lock_make_current`] /
+    /// [`Self::arc_lock_make_current`]. Under that invariant
+    /// "context-is-current on this thread" implies "this thread owns
+    /// the `make_current_lock`," so the fast-path can elide the
+    /// re-lock without breaking the single-current-thread contract
+    /// EGL imposes. Third-party code that directly calls
+    /// `eglMakeCurrent` on this runtime's context outside the lock
+    /// would invalidate that implication and let a concurrent thread
+    /// race in to lock + make-current — don't do that, and don't
+    /// expose a public API that lets a caller do it.
     fn is_current_on_this_thread(&self) -> bool {
         match self.egl.get_current_context() {
             Some(ctx) => ctx == self.context,

--- a/libs/streamlib-adapter-opengl/src/view.rs
+++ b/libs/streamlib-adapter-opengl/src/view.rs
@@ -10,8 +10,11 @@
 //! NVIDIA EGL DMA-BUF render-target learning). For sampler-only inputs
 //! imported via [`crate::OpenGlSurfaceAdapter::register_external_oes_host_surface`]
 //! the target is `GL_TEXTURE_EXTERNAL_OES` and the consumer's GLSL must
-//! sample via `samplerExternalOES` with the `GL_OES_EGL_image_external`
-//! family of extensions.
+//! `#extension GL_OES_EGL_image_external : require` and sample via
+//! `texture2D(samplerExternalOES, vec2)` — see
+//! [`crate::OpenGlSurfaceAdapter::register_external_oes_host_surface`]
+//! for why the unified `texture(...)` overload is not available on the
+//! adapter's desktop-GL context.
 
 use std::marker::PhantomData;
 

--- a/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
+++ b/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
@@ -90,10 +90,11 @@ fn nested_arc_lock_make_current_does_not_deadlock() {
         .expect("inner lock_make_current after arc outer");
     drop(inner_borrowed);
 
-    // And the symmetric inner: arc-style after a borrowed outer.
-    // (The avatar's path is technically only the outer-arc + inner-borrowed
-    // direction, but pinning both directions keeps the contract symmetric
-    // for future refactors.)
+    // Now arc-style inner under the same arc-style outer (still
+    // owned). The avatar's path is technically only the
+    // outer-arc + inner-borrowed direction we just exercised, but
+    // pinning the arc-on-arc nest covers the second guard flavor's
+    // reentrance and keeps the contract symmetric for future refactors.
     let inner_arc = fixture
         .egl
         .arc_lock_make_current()

--- a/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
+++ b/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Same-thread reentrance contract for `EglRuntime::lock_make_current`
+//! and `EglRuntime::arc_lock_make_current`.
+//!
+//! Nested acquire patterns surface in real consumers: e.g.
+//! AvatarCharacter Linux's `acquire_write(out)` → `_ensure_render_state`
+//! → `acquire_read_external_oes(camera)` chain takes an outer EGL lock
+//! through the cdylib's per-acquire `arc_lock_make_current`, then the
+//! inner `register_external_oes_host_surface` calls `lock_make_current`
+//! again on the same thread. The non-reentrant `parking_lot::Mutex`
+//! that previously backed `make_current_lock` deadlocked that pattern
+//! before #626's fix.
+//!
+//! These tests pin the same-thread reentrance contract so any future
+//! refactor of the lock primitive surfaces a regression here instead
+//! of in a downstream subprocess pipeline.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use common::HostFixture;
+
+#[test]
+fn nested_lock_make_current_does_not_deadlock() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!("nested_lock_make_current_does_not_deadlock: skipping — no EGL");
+            return;
+        }
+    };
+
+    let outer = fixture
+        .egl
+        .lock_make_current()
+        .expect("outer lock_make_current");
+
+    // The inner call must not deadlock: same-thread reentrance returns
+    // a no-op guard. Without the reentrance check, this hangs forever
+    // on the non-reentrant Mutex.
+    let inner = fixture
+        .egl
+        .lock_make_current()
+        .expect("inner lock_make_current (same thread, must reenter)");
+
+    // Inner drop must NOT release the EGL context — the outer guard
+    // still expects the context to be current. We can't directly observe
+    // "context is still current" through the public API, so we rely on
+    // the next acquire succeeding to confirm the lock state is consistent.
+    drop(inner);
+    drop(outer);
+
+    // After the outer drops, the lock is released and a fresh acquire
+    // succeeds — proves the lock didn't end up permanently held by an
+    // unbalanced reentrance count.
+    let after = fixture
+        .egl
+        .lock_make_current()
+        .expect("post-nested lock_make_current");
+    drop(after);
+}
+
+#[test]
+fn nested_arc_lock_make_current_does_not_deadlock() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!("nested_arc_lock_make_current_does_not_deadlock: skipping — no EGL");
+            return;
+        }
+    };
+
+    // Mixed-style nesting: outer borrowed, inner owned. The cdylib
+    // takes the outer via `arc_lock_make_current` (returns an owned
+    // 'static guard for FFI scope spans); the inner adapter register
+    // path takes a borrowed `lock_make_current`. The reentrance check
+    // must work across the two guard flavors identically.
+    let outer = fixture
+        .egl
+        .arc_lock_make_current()
+        .expect("outer arc_lock_make_current");
+    let inner_borrowed = fixture
+        .egl
+        .lock_make_current()
+        .expect("inner lock_make_current after arc outer");
+    drop(inner_borrowed);
+
+    // And the symmetric inner: arc-style after a borrowed outer.
+    // (The avatar's path is technically only the outer-arc + inner-borrowed
+    // direction, but pinning both directions keeps the contract symmetric
+    // for future refactors.)
+    let inner_arc = fixture
+        .egl
+        .arc_lock_make_current()
+        .expect("inner arc_lock_make_current");
+    drop(inner_arc);
+    drop(outer);
+
+    let after = fixture
+        .egl
+        .lock_make_current()
+        .expect("post-nested lock_make_current");
+    drop(after);
+}

--- a/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
+++ b/libs/streamlib-adapter-opengl/tests/lock_make_current_reentrance.rs
@@ -74,11 +74,12 @@ fn nested_arc_lock_make_current_does_not_deadlock() {
         }
     };
 
-    // Mixed-style nesting: outer borrowed, inner owned. The cdylib
-    // takes the outer via `arc_lock_make_current` (returns an owned
-    // 'static guard for FFI scope spans); the inner adapter register
-    // path takes a borrowed `lock_make_current`. The reentrance check
-    // must work across the two guard flavors identically.
+    // Mixed-style nesting: outer owned, inner borrowed — matches the
+    // avatar's failing path. The cdylib takes the outer via
+    // `arc_lock_make_current` (returns an owned `'static` guard for
+    // FFI scope spans), then the inner adapter register path takes a
+    // borrowed `lock_make_current`. The reentrance check must work
+    // across the two guard flavors identically.
     let outer = fixture
         .egl
         .arc_lock_make_current()

--- a/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
+++ b/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
@@ -196,17 +196,18 @@ fn sample_external_oes_round_trip() {
             .lock_make_current()
             .expect("lock_make_current");
         unsafe {
-            let prog = match compile_program(FRAGMENT_SRC_EXTERNAL_OES) {
-                Ok(p) => p,
-                Err(e) => {
-                    println!(
-                        "sample_external_oes_round_trip: skipping — driver \
-                         rejected GL_OES_EGL_image_external in #version 330 \
-                         core fragment shader: {e}"
-                    );
-                    return;
-                }
-            };
+            // The shader uses `texture2D(samplerExternalOES, vec2)` — the
+            // GLES2-era overload that NVIDIA's desktop-GL driver honors in
+            // `#version 330 core`. A compile failure here means a real
+            // regression in either the test shader or the adapter's
+            // EXTERNAL_OES contract; do NOT skip past it. Drivers that
+            // genuinely lack `GL_OES_EGL_image_external` would already have
+            // rejected `EglRuntime::new` upstream of this point.
+            let prog = compile_program(FRAGMENT_SRC_EXTERNAL_OES)
+                .expect("FRAGMENT_SRC_EXTERNAL_OES must compile on a driver \
+                         that exposed GL_OES_EGL_image_external during EglRuntime \
+                         construction — failure here is a regression in either \
+                         the shader or the adapter's EXTERNAL_OES contract");
 
             // Build a probe RGBA8 texture + FBO of width×height.
             let mut probe_tex: u32 = 0;

--- a/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
+++ b/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
@@ -51,13 +51,19 @@ void main() {
 }
 "#;
 
+// `texture2D(samplerExternalOES, vec2)` — the GL_OES_EGL_image_external
+// (GLES2-era) overload, which NVIDIA's desktop-GL driver honors in
+// `#version 330 core`. The unified `texture(samplerExternalOES, vec2)`
+// overload is ESSL3-only (`_essl3` extension + GLES context), and the
+// adapter binds `EGL_OPENGL_API`, not `EGL_OPENGL_ES_API` — so consumers
+// targeting this adapter must use `texture2D` for EXTERNAL_OES samples.
 const FRAGMENT_SRC_EXTERNAL_OES: &str = r#"#version 330 core
 #extension GL_OES_EGL_image_external : require
 in vec2 v_uv;
 out vec4 frag_color;
 uniform samplerExternalOES u_tex;
 void main() {
-    frag_color = texture(u_tex, v_uv);
+    frag_color = texture2D(u_tex, v_uv);
 }
 "#;
 

--- a/libs/streamlib-deno-native/Cargo.toml
+++ b/libs/streamlib-deno-native/Cargo.toml
@@ -21,6 +21,14 @@ rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+# Cdylib runs in its own subprocess and has no host-side `tracing`
+# subscriber by default — `tracing::error!` events would otherwise be
+# silently dropped, leaving FFI rc=-1 returns unaccompanied by any
+# diagnostic in the host's intercepted `[/deno]` log namespace.
+# `init_subprocess_logging` (lib.rs) installs a stderr-writing fmt
+# subscriber once at first FFI entry; the host's stdio interceptor
+# then forwards it as fd2 lines.
+tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-surface-client = { path = "../streamlib-surface-client" }

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -2830,11 +2830,18 @@ mod opengl {
     /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`); typical
     /// consumer is a per-frame camera ring texture.
     ///
-    /// The customer's GLSL must `#extension GL_OES_EGL_image_external_essl3 :
-    /// require` and sample via `samplerExternalOES`. Acquire/release uses
-    /// the same [`sldn_opengl_acquire_read`] / [`sldn_opengl_release_read`]
-    /// pair as the 2D path; only `acquire_write` is rejected (the
-    /// EXTERNAL_OES binding is sample-only by GL spec).
+    /// The customer's GLSL must enable `samplerExternalOES`. On the
+    /// adapter's desktop-GL context, declare
+    /// `#extension GL_OES_EGL_image_external : require` and sample via
+    /// `texture2D(samplerExternalOES, vec2)` — NVIDIA's desktop-GL
+    /// driver does NOT register the unified `texture(...)` overload
+    /// for `samplerExternalOES` in `#version 330 core`; that overload
+    /// comes from `GL_OES_EGL_image_external_essl3`, which requires a
+    /// GLES context (not what this adapter creates). Acquire/release
+    /// uses the same [`sldn_opengl_acquire_read`] /
+    /// [`sldn_opengl_release_read`] pair as the 2D path; only
+    /// `acquire_write` is rejected (the EXTERNAL_OES binding is
+    /// sample-only by GL spec).
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_opengl_register_external_oes_surface(
         rt: *mut OpenGlRuntimeHandle,

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -3080,8 +3080,15 @@ mod opengl {
 
     fn drm_fourcc_for_format(format: &str) -> Option<u32> {
         match format {
+            // TextureFormat-derived strings (host-allocated render-target
+            // surfaces emit these in the surface-share wire format).
             "Bgra8Unorm" | "Bgra8UnormSrgb" => Some(DRM_FORMAT_ARGB8888),
             "Rgba8Unorm" | "Rgba8UnormSrgb" => Some(DRM_FORMAT_ABGR8888),
+            // PixelFormat-derived strings (host-allocated HOST_VISIBLE
+            // pixel buffers emit these — camera ring `acquire_pixel_buffer`,
+            // CPU-readback adapter, etc.).
+            "Bgra32" | "Argb32" => Some(DRM_FORMAT_ARGB8888),
+            "Rgba32" => Some(DRM_FORMAT_ABGR8888),
             _ => None,
         }
     }

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use iceoryx2::port::listener::Listener;
@@ -21,6 +21,30 @@ use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
 use streamlib_ipc_types::{FrameHeader, FRAME_HEADER_SIZE, MAX_FANIN_PER_DESTINATION};
+
+// ============================================================================
+// Tracing subscriber init
+// ============================================================================
+
+/// Install a fmt subscriber on first FFI entry so the cdylib's
+/// `tracing::error!` / `tracing::warn!` events surface to subprocess
+/// stderr, where the host's `spawn_fd_line_reader` picks them up and
+/// forwards them under the `[/deno]` log namespace via fd2.
+///
+/// Idempotent — subsequent calls hit the `OnceLock` and no-op. Filter
+/// honors `RUST_LOG` if set, otherwise defaults to `info`.
+fn init_subprocess_logging() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
 
 // ============================================================================
 // Context
@@ -99,6 +123,7 @@ impl DenoNativeContext {
 pub unsafe extern "C" fn sldn_context_create(
     processor_id: *const c_char,
 ) -> *mut DenoNativeContext {
+    init_subprocess_logging();
     let id = if processor_id.is_null() {
         "unknown"
     } else {
@@ -2728,6 +2753,7 @@ mod opengl {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_opengl_runtime_new() -> *mut OpenGlRuntimeHandle {
+        super::init_subprocess_logging();
         let egl = match EglRuntime::new() {
             Ok(r) => r,
             Err(e) => {
@@ -3227,6 +3253,7 @@ mod vulkan {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
@@ -3710,6 +3737,7 @@ mod cpu_readback {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_cpu_readback_runtime_new() -> *mut CpuReadbackRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
@@ -4467,6 +4495,7 @@ mod cuda {
     #[unsafe(no_mangle)]
     #[tracing::instrument(level = "info")]
     pub unsafe extern "C" fn sldn_cuda_runtime_new() -> *mut CudaRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {

--- a/libs/streamlib-deno/adapters/opengl.ts
+++ b/libs/streamlib-deno/adapters/opengl.ts
@@ -38,8 +38,10 @@ export const GL_TEXTURE_2D = 0x0DE1 as const;
 /** `GL_TEXTURE_EXTERNAL_OES` enumerant from `GL_OES_EGL_image_external`.
  * Returned in `view.target` for surfaces acquired via
  * `OpenGLContext.acquireReadExternalOes` — the consumer's GLSL must
- * `#extension GL_OES_EGL_image_external_essl3 : require` and sample
- * via `samplerExternalOES`. */
+ * `#extension GL_OES_EGL_image_external : require` and sample via
+ * `texture2D(samplerExternalOES, vec2)` (the adapter's desktop-GL
+ * context does not provide the ESSL3 unified `texture(...)` overload).
+ * See `OpenGLContext.acquireReadExternalOes` for the full reasoning. */
 export const GL_TEXTURE_EXTERNAL_OES = 0x8D65 as const;
 
 /** Read-side view inside an `acquireRead` / `acquireReadExternalOes`
@@ -305,8 +307,14 @@ export class OpenGLContext {
    *
    * `view.target` is `GL_TEXTURE_EXTERNAL_OES` — bind manually via
    * `glBindTexture(GL_TEXTURE_EXTERNAL_OES, view.glTextureId)` and
-   * sample via `samplerExternalOES` in GLSL with
-   * `#extension GL_OES_EGL_image_external_essl3 : require`. */
+   * sample via `samplerExternalOES` in GLSL. On the adapter's desktop-
+   * GL context, declare `#extension GL_OES_EGL_image_external : require`
+   * and use the `texture2D(samplerExternalOES, vec2)` overload —
+   * NVIDIA's desktop-GL driver does NOT register the unified
+   * `texture(...)` overload for `samplerExternalOES` in
+   * `#version 330 core`; that overload comes from
+   * `GL_OES_EGL_image_external_essl3`, which requires a GLES context
+   * (which this adapter does not create). */
   acquireReadExternalOes(
     surface: StreamlibSurface | string | bigint,
   ): OpenGLAccessGuard<OpenGLReadView> {

--- a/libs/streamlib-python-native/Cargo.toml
+++ b/libs/streamlib-python-native/Cargo.toml
@@ -22,6 +22,14 @@ rmp-serde = "1.3"
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+# Cdylib runs in its own subprocess and has no host-side `tracing`
+# subscriber by default — `tracing::error!` events would otherwise be
+# silently dropped, leaving FFI rc=-1 returns unaccompanied by any
+# diagnostic in the host's intercepted `[/python]` log namespace.
+# `init_subprocess_logging` (lib.rs) installs a stderr-writing fmt
+# subscriber once at first FFI entry; the host's stdio interceptor
+# then forwards it as fd2 lines.
+tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib-surface-client = { path = "../streamlib-surface-client" }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use iceoryx2::port::listener::Listener;
 use iceoryx2::port::notifier::Notifier;
@@ -20,6 +20,30 @@ use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::prelude::*;
 use streamlib_ipc_types::{FrameHeader, FRAME_HEADER_SIZE, MAX_FANIN_PER_DESTINATION};
+
+// ============================================================================
+// Tracing subscriber init
+// ============================================================================
+
+/// Install a fmt subscriber on first FFI entry so the cdylib's
+/// `tracing::error!` / `tracing::warn!` events surface to subprocess
+/// stderr, where the host's `spawn_fd_line_reader` picks them up and
+/// forwards them under the `[/python]` log namespace via fd2.
+///
+/// Idempotent — subsequent calls hit the `OnceLock` and no-op. Filter
+/// honors `RUST_LOG` if set, otherwise defaults to `info`.
+fn init_subprocess_logging() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
 
 // ============================================================================
 // Context
@@ -101,6 +125,7 @@ impl PythonNativeContext {
 pub unsafe extern "C" fn slpn_context_create(
     processor_id: *const c_char,
 ) -> *mut PythonNativeContext {
+    init_subprocess_logging();
     let id = if processor_id.is_null() {
         "unknown"
     } else {
@@ -2922,6 +2947,7 @@ mod opengl {
     /// driver doesn't support `EGL_EXT_image_dma_buf_import_modifiers`).
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_opengl_runtime_new() -> *mut OpenGlRuntimeHandle {
+        super::init_subprocess_logging();
         let egl = match EglRuntime::new() {
             Ok(r) => r,
             Err(e) => {
@@ -3077,12 +3103,12 @@ mod opengl {
         let fd = match gpu.fds.first().copied() {
             Some(f) if f >= 0 => f,
             _ => {
-                eprintln!(
-                    "slpn_opengl_register_external_oes_surface: surface has no DMA-BUF fd \
-                     (fds={:?} format={} {}x{} modifier=0x{:016x})",
-                    gpu.fds, gpu.format, gpu.width, gpu.height, gpu.drm_format_modifier,
-                );
                 tracing::error!(
+                    fds = ?gpu.fds,
+                    format = %gpu.format,
+                    width = gpu.width,
+                    height = gpu.height,
+                    modifier = format_args!("0x{:016x}", gpu.drm_format_modifier),
                     "slpn_opengl_register_external_oes_surface: surface has no DMA-BUF fd"
                 );
                 return -1;
@@ -3091,13 +3117,9 @@ mod opengl {
         let drm_fourcc = match drm_fourcc_for_format(&gpu.format) {
             Some(c) => c,
             None => {
-                eprintln!(
-                    "slpn_opengl_register_external_oes_surface: unsupported format '{}'",
-                    gpu.format,
-                );
                 tracing::error!(
-                    "slpn_opengl_register_external_oes_surface: unsupported format '{}'",
-                    gpu.format
+                    format = %gpu.format,
+                    "slpn_opengl_register_external_oes_surface: unsupported format"
                 );
                 return -1;
             }
@@ -3124,27 +3146,17 @@ mod opengl {
         {
             Ok(()) => 0,
             Err(e) => {
-                // Subprocess has no `tracing_subscriber` by default, so
-                // `tracing::error!` events are dropped. Mirror to stderr
-                // so the host stdio interceptor surfaces the actual EGL
-                // failure instead of swallowing it behind rc=-1.
-                eprintln!(
-                    "slpn_opengl_register_external_oes_surface failed: \
-                     surface_id={} fourcc=0x{:08x} modifier=0x{:016x} \
-                     {}x{} fd={} stride={} offset={} err={:?}",
+                tracing::error!(
                     surface_id,
-                    drm_fourcc,
-                    gpu.drm_format_modifier,
-                    gpu.width,
-                    gpu.height,
+                    fourcc = format_args!("0x{:08x}", drm_fourcc),
+                    modifier = format_args!("0x{:016x}", gpu.drm_format_modifier),
+                    width = gpu.width,
+                    height = gpu.height,
                     fd,
                     stride,
                     offset,
-                    e,
-                );
-                tracing::error!(
-                    "slpn_opengl_register_external_oes_surface: register_external_oes_host_surface failed: {:?}",
-                    e
+                    error = ?e,
+                    "slpn_opengl_register_external_oes_surface: register_external_oes_host_surface failed"
                 );
                 -1
             }
@@ -3536,6 +3548,7 @@ mod vulkan {
     /// DMA-BUF / external-semaphore extensions).
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_vulkan_runtime_new() -> *mut VulkanRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
@@ -4161,6 +4174,7 @@ mod cpu_readback {
     /// the first acquire; until then every acquire returns -1.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_cpu_readback_runtime_new() -> *mut CpuReadbackRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {
@@ -4946,6 +4960,7 @@ mod cuda {
     #[unsafe(no_mangle)]
     #[tracing::instrument(level = "info")]
     pub unsafe extern "C" fn slpn_cuda_runtime_new() -> *mut CudaRuntimeHandle {
+        super::init_subprocess_logging();
         let device = match ConsumerVulkanDevice::new() {
             Ok(d) => Arc::new(d),
             Err(e) => {

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -3077,6 +3077,11 @@ mod opengl {
         let fd = match gpu.fds.first().copied() {
             Some(f) if f >= 0 => f,
             _ => {
+                eprintln!(
+                    "slpn_opengl_register_external_oes_surface: surface has no DMA-BUF fd \
+                     (fds={:?} format={} {}x{} modifier=0x{:016x})",
+                    gpu.fds, gpu.format, gpu.width, gpu.height, gpu.drm_format_modifier,
+                );
                 tracing::error!(
                     "slpn_opengl_register_external_oes_surface: surface has no DMA-BUF fd"
                 );
@@ -3086,6 +3091,10 @@ mod opengl {
         let drm_fourcc = match drm_fourcc_for_format(&gpu.format) {
             Some(c) => c,
             None => {
+                eprintln!(
+                    "slpn_opengl_register_external_oes_surface: unsupported format '{}'",
+                    gpu.format,
+                );
                 tracing::error!(
                     "slpn_opengl_register_external_oes_surface: unsupported format '{}'",
                     gpu.format
@@ -3115,6 +3124,24 @@ mod opengl {
         {
             Ok(()) => 0,
             Err(e) => {
+                // Subprocess has no `tracing_subscriber` by default, so
+                // `tracing::error!` events are dropped. Mirror to stderr
+                // so the host stdio interceptor surfaces the actual EGL
+                // failure instead of swallowing it behind rc=-1.
+                eprintln!(
+                    "slpn_opengl_register_external_oes_surface failed: \
+                     surface_id={} fourcc=0x{:08x} modifier=0x{:016x} \
+                     {}x{} fd={} stride={} offset={} err={:?}",
+                    surface_id,
+                    drm_fourcc,
+                    gpu.drm_format_modifier,
+                    gpu.width,
+                    gpu.height,
+                    fd,
+                    stride,
+                    offset,
+                    e,
+                );
                 tracing::error!(
                     "slpn_opengl_register_external_oes_surface: register_external_oes_host_surface failed: {:?}",
                     e
@@ -3311,8 +3338,15 @@ mod opengl {
     /// is bytes `[B, G, R, A]` in memory, which is `DRM_FORMAT_ARGB8888`.
     fn drm_fourcc_for_format(format: &str) -> Option<u32> {
         match format {
+            // TextureFormat-derived strings (host-allocated render-target
+            // surfaces emit these in the surface-share wire format).
             "Bgra8Unorm" | "Bgra8UnormSrgb" => Some(DRM_FORMAT_ARGB8888),
             "Rgba8Unorm" | "Rgba8UnormSrgb" => Some(DRM_FORMAT_ABGR8888),
+            // PixelFormat-derived strings (host-allocated HOST_VISIBLE
+            // pixel buffers emit these — camera ring `acquire_pixel_buffer`,
+            // CPU-readback adapter, etc.).
+            "Bgra32" | "Argb32" => Some(DRM_FORMAT_ARGB8888),
+            "Rgba32" => Some(DRM_FORMAT_ABGR8888),
             _ => None,
         }
     }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -3038,11 +3038,18 @@ mod opengl {
     /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`); typical
     /// consumer is a per-frame camera ring texture.
     ///
-    /// The customer's GLSL must `#extension GL_OES_EGL_image_external_essl3 :
-    /// require` and sample via `samplerExternalOES`. Acquire/release uses
-    /// the same [`slpn_opengl_acquire_read`] / [`slpn_opengl_release_read`]
-    /// pair as the 2D path; only `acquire_write` is rejected (the
-    /// EXTERNAL_OES binding is sample-only by GL spec).
+    /// The customer's GLSL must enable `samplerExternalOES`. On the
+    /// adapter's desktop-GL context, declare
+    /// `#extension GL_OES_EGL_image_external : require` and sample via
+    /// `texture2D(samplerExternalOES, vec2)` — NVIDIA's desktop-GL
+    /// driver does NOT register the unified `texture(...)` overload
+    /// for `samplerExternalOES` in `#version 330 core`; that overload
+    /// comes from `GL_OES_EGL_image_external_essl3`, which requires a
+    /// GLES context (not what this adapter creates). Acquire/release
+    /// uses the same [`slpn_opengl_acquire_read`] /
+    /// [`slpn_opengl_release_read`] pair as the 2D path; only
+    /// `acquire_write` is rejected (the EXTERNAL_OES binding is
+    /// sample-only by GL spec).
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_opengl_register_external_oes_surface(
         rt: *mut OpenGlRuntimeHandle,

--- a/libs/streamlib-python/python/streamlib/adapters/opengl.py
+++ b/libs/streamlib-python/python/streamlib/adapters/opengl.py
@@ -81,9 +81,12 @@ GL_TEXTURE_2D: int = 0x0DE1
 # `GL_TEXTURE_EXTERNAL_OES` enumerant from `GL_OES_EGL_image_external`.
 # Returned in `view.target` for surfaces acquired via
 # :meth:`OpenGLContext.acquire_read_external_oes` — the consumer's GLSL
-# must `#extension GL_OES_EGL_image_external_essl3 : require` and
-# sample via `samplerExternalOES`. Matches the Rust crate's
-# `GL_TEXTURE_EXTERNAL_OES` constant.
+# must `#extension GL_OES_EGL_image_external : require` and sample via
+# `texture2D(samplerExternalOES, vec2)` (the adapter's desktop-GL
+# context does not provide the ESSL3 unified `texture(...)` overload).
+# See :meth:`OpenGLContext.acquire_read_external_oes` for the full
+# reasoning. Matches the Rust crate's `GL_TEXTURE_EXTERNAL_OES`
+# constant.
 GL_TEXTURE_EXTERNAL_OES: int = 0x8D65
 
 
@@ -414,10 +417,15 @@ class OpenGLContext:
                 GL.glBindTexture(view.target, view.gl_texture_id)
                 # ... draw with samplerExternalOES shader ...
 
-        The shader must declare
-        ``#extension GL_OES_EGL_image_external_essl3 : require`` (or
-        ``GL_OES_EGL_image_external`` for older GLSL profiles) and
-        sample the texture via ``samplerExternalOES``.
+        The shader must enable ``samplerExternalOES``. On the adapter's
+        desktop-GL context, declare
+        ``#extension GL_OES_EGL_image_external : require`` and sample
+        via ``texture2D(samplerExternalOES, vec2)`` — NVIDIA's desktop-
+        GL driver does NOT register the unified ``texture(...)``
+        overload for ``samplerExternalOES`` in ``#version 330 core``;
+        that overload comes from ``GL_OES_EGL_image_external_essl3``,
+        which requires a GLES context (which this adapter does not
+        create).
         """
         pool_id = self._surface_pool_id(surface)
         surface_id = self._resolve_and_register(pool_id, GL_TEXTURE_EXTERNAL_OES)

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -1011,7 +1011,7 @@ impl DisplayEventLoopHandler {
         frame_idx: u64,
         input_frame_index: u64,
     ) {
-        use crate::core::rhi::{TextureReadbackDescriptor, TextureSourceLayout};
+        use crate::core::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
 
         let format = texture.format();
         let width = texture.width();
@@ -1085,8 +1085,29 @@ impl DisplayEventLoopHandler {
                 return;
             }
         };
+        // VulkanTextureReadback hands the staging bytes back in the
+        // texture's native channel order. The PNG writer treats every
+        // input as RGBA-in-memory, so source textures whose memory
+        // layout is BGRA need an R↔B swizzle before the PNG encode —
+        // otherwise blue and red swap and (e.g.) a dark blue wall
+        // renders as orange. The OpenGL adapter picks Bgra8Unorm for
+        // its render-target DMA-BUFs to match the swapchain's native
+        // format and avoid a swizzle in the display path; that
+        // optimization just doesn't carry to the PNG export.
+        let needs_swizzle = matches!(
+            format,
+            TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb,
+        );
         let result = readback.wait_and_read_with(ticket, u64::MAX, |bytes| {
-            write_png_rgba(path, width, height, bytes)
+            if needs_swizzle {
+                let mut rgba = bytes.to_vec();
+                for chunk in rgba.chunks_exact_mut(4) {
+                    chunk.swap(0, 2);
+                }
+                write_png_rgba(path, width, height, &rgba)
+            } else {
+                write_png_rgba(path, width, height, bytes)
+            }
         });
         match result {
             Ok(Ok(())) => {


### PR DESCRIPTION
## Summary

- **Closes #626**: AvatarCharacter Linux processes camera frames end-to-end (`First frame processed (1920x1080)` log + display PNG samples confirm camera→adapter→shader→display flow).
- The originally reported symptom (GLSL compile failure) was the entry point; investigation surfaced two coupled latent defects that masked behind it: (a) cdylib `drm_fourcc_for_format` only knew TextureFormat strings, not PixelFormat strings (camera publishes `PixelFormat::Rgba32` wire string); (b) EGL `lock_make_current` was non-reentrant, deadlocking nested same-thread acquires (`acquire_write` → `_ensure_render_state` → `acquire_read_external_oes`).
- Three engine-layer fixes — pose_overlay_renderer GLSL switch + adapter docstring sweep across the polyglot stack (Rust adapter+view, Python+Deno SDK, Python+Deno cdylib); `Rgba32`/`Bgra32`/`Argb32` added to `drm_fourcc_for_format` in BOTH cdylibs; EGL `lock_make_current` + `OwnedMakeCurrentGuard::new` consult `eglGetCurrentContext` to detect same-thread reentrance and return a no-op guard.

## Closes

Closes #626

## Exit criteria

- [x] AvatarCharacter Linux processes frames without `opengl acquire / render failed: GLSL Compiler failed` (verified via release E2E run, see test report below).
- [x] At least one frame reaches the display processor downstream (verified via PNG samples in the display sampler dir).
- [x] `sample_external_oes_round_trip` actually exercises the EXTERNAL_OES round-trip on this driver (no longer skipping with the C1115 error — now uses `expect(...)` so any compile failure is a hard test failure).

## Test plan

### Unit / integration (cargo)

- `cargo test -p streamlib-adapter-opengl --tests` — **11 passed**, 0 failed, 0 ignored. Includes:
  - `sample_external_oes_round_trip` — now actually compiles + runs the EXTERNAL_OES sampler shader (was skipping before; the `texture(samplerExternalOES, vec2)` overload was rejected by NVIDIA's desktop-GL GLSL compiler with `C1115`).
  - `nested_lock_make_current_does_not_deadlock` (new) — pins the same-thread reentrance contract; without the fix this would hang forever on the non-reentrant `parking_lot::Mutex`.
  - `nested_arc_lock_make_current_does_not_deadlock` (new) — covers the borrowed/owned guard cross-flavor case (the avatar's actual failing pattern: outer arc, inner borrowed).
- `cargo check --workspace` — clean.

### E2E Test Report

- **Scenario**: camera+display-only (Python avatar processor)
- **Example**: `camera-python-display`
- **Codec**: n/a
- **Camera device**: `/dev/video0` (Cam Link 4K)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=120`, ~7 s
- **Build profile**: release
- **Command**:
    ```
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/avatar-e2e/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=20 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=120 \
    STREAMLIB_CAMERA_DEVICE=/dev/video0 \
    timeout --kill-after=5 30 cargo run --release -p camera-python-display
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame processed`: 18:11:36.282 (~3 s after camera setup)
- `First frame captured` (camera): seq=0 via GPU compute (MMAP + memcpy mode)
- `Encode/Decode progress`: n/a (no codec in this scenario)

#### PNG samples

- Directory: `/tmp/avatar-e2e/png_samples/`
- Sample count: 6
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=20`
- PNGs read with Read tool: `display_001_frame_000040_input_000231.png`, `display_001_frame_000100_input_000299.png`
- **What was in the image(s)**: live Cam Link 4K scene rendered through the cyberpunk-grade `_BACKGROUND_FS` shader — dark blue wall (the renderer's cyan-tinged grade preserves the wall's blue tone with subtle violet shadow lift), wood door bottom-right with door handle visible, wall outlet on the left, vignette darkening the corners, soft chromatic-aberration on edges. Two consecutive samples show the same scene with subtle live frame-to-frame variation. Confirms the EGL DMA-BUF EXTERNAL_OES camera-bg path renders end-to-end through ModernGL into the imported `GL_TEXTURE_2D` output FBO with correct channel order.

  ![display sample frame 40 — dark blue wall, wood door through cyberpunk shader](https://gh-artifact.tatolab.com/pr-629/display_001_frame_000040_input_000231.jpg)

  *Frame 40 — dark blue wall, wood door + handle, wall outlet, vignette + chromatic aberration applied by `_BACKGROUND_FS` over the EGL DMA-BUF EXTERNAL_OES camera sample. Cyan grade preserves the wall's true blue.*

  ![display sample frame 100 — same scene, later frame](https://gh-artifact.tatolab.com/pr-629/display_001_frame_000100_input_000299.jpg)

  *Frame 100 — same scene 60 frames later, demonstrating live per-frame sampling through the adapter (not a static cached texture).*
- Anomalies: image is rotated 90° / orientation-skewed — that is the separate ticket #621, **out of scope** for this PR.
- **PNG sampler color fix**: an earlier draft of this PR shipped PNG samples with the dark blue wall rendered as orange/red. Root cause was `display.rs::sample_texture_to_png` interpreting BGRA-source readback bytes as RGBA when calling the PNG writer (introduced by #613, separate from #626's diagnosis). On-screen swapchain rendering was always correct — only the readback→PNG export was R↔B-swapped. Fixed in commit on this PR (R↔B swizzle when texture format is `Bgra8Unorm`/`Bgra8UnormSrgb`); the screenshots above now match what the display window shows. Picked up in scope at user request because the misleading PNG evidence would have confused future reviewers of this PR.

#### PSNR

- Reference frame: n/a — real-camera source, no ground-truth reference available.
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass**
- Caveats / follow-ups filed: #621 (output orientation/flip, separate ticket, pre-existing), #630 (regression test for the `sample_texture_to_png` R↔B swizzle landed in this PR — round-3 review flagged the missing coverage).

## Polyglot coverage

- **Runtimes affected**: rust + python + deno (cdylib parity required because the camera EXTERNAL_OES path goes through `drm_fourcc_for_format` in both natives)
- **Schema regenerated**: n/a (no escalate IPC schema change)
- **Python and Deno both covered?** **yes** — `streamlib-python-native` and `streamlib-deno-native` both got the `Rgba32` / `Bgra32` / `Argb32` entries in `drm_fourcc_for_format`. Adapter docstring sweep covers the Python SDK (`opengl.py`), Deno SDK (`opengl.ts`), and both native lib.rs FFI doc-comments. Round-1 review caught a sync gap on this — fixed in commit 6428ff6.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-adapter-opengl --tests` — 11 passed.
  - [x] Python subprocess: `cargo run --release -p camera-python-display` — runs end-to-end.
  - [ ] Deno subprocess: not exercised — there is no Deno consumer of the EXTERNAL_OES camera path yet (the AvatarCharacter Linux example is Python-only by construction). Deno-side `drm_fourcc_for_format` is fixed defensively so the next Deno consumer (e.g. a future Deno port of camera-bg sampling) doesn't re-trigger the format gap.
- **FD-passing path**: DMA-BUF FD via surface-share + `register_external_oes_host_surface` (linear pixel-buffer DMA-BUF imported as EGL `EXTERNAL_OES`).

## Follow-ups

- #621 — `fix(linux-python)`: AvatarCharacter output is vertically flipped at display. Pre-existing, separate symptom not in scope here.
- #630 — `test(display)`: cover the `sample_texture_to_png` R↔B swizzle for `Bgra8Unorm` source textures. Round-3 review flagged the missing automated regression guard for the swizzle fix landed in this PR. Test-only follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



