### PR TITLE
fix(display): adapter-output layout barrier via engine-wide TextureRegistration (#616)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,26 @@ SPIR-V reflection (via `rspirv-reflect`) validates the declared layout
 against the shader at construction. See @docs/architecture/compute-kernel.md
 for the full recipe.
 
+#### TextureRegistration — single canonical per-surface state
+
+Every per-surface lifecycle field lives on `TextureRegistration`,
+keyed by `surface_id` in `GpuContext::texture_cache`. Producers
+declare state at registration (`register_texture_with_layout`);
+consumers read it via `resolve_videoframe_registration` and update on
+transitions. **Never create a parallel `HashMap<surface_id, ...>` for
+new per-surface metadata** — extend the `TextureRegistration` record
+instead. **Never bypass the registration with descriptor-side claims
+that don't match reality** (the bug class #616 fixed). The shape
+mirrors `streamlib-adapter-vulkan::SurfaceState::current_layout`
+lifted from adapter-scope to engine-scope; if you're tempted to
+duplicate that pattern in a third place, stop and read
+@docs/architecture/texture-registration.md before deciding.
+
+When in doubt about whether a new field belongs on `TextureRegistration`
+versus elsewhere (`Videoframe` IPC for per-frame state; adapter
+`SurfaceState` for adapter-internal state; RDG #631 for declared-usage
+hints), read the doc end-to-end first — the boundaries are deliberate.
+
 
 ### Custom Commands
 
@@ -507,5 +527,17 @@ make sense if the surrounding files were renamed or restructured.
   shift the bucketing. Read before adding subprocess-side Vulkan code
   beyond `vkImportMemoryFdInfoKHR` + `vkBindBufferMemory` +
   `vkMapMemory`.
+- @docs/architecture/texture-registration.md — Engine-wide per-surface
+  lifecycle state record (`TextureRegistration`) keyed by `surface_id`
+  in `GpuContext::texture_cache`. Producers declare state at
+  registration; consumers read it via `resolve_videoframe_registration`
+  and update on transitions. Read before adding any new per-surface
+  metadata, before tracking layout state, before wondering if there's a
+  better way than convention to coordinate handoff between a producer
+  and a consumer through a `surface_id`. Same-process consumers benefit
+  today; cross-process consumers wait on a polyglot schema lift (filed
+  as follow-up). Hard rule: never create a parallel
+  `HashMap<surface_id, ...>` for per-surface state; extend
+  `TextureRegistration` instead.
 
 Index: @docs/learnings/README.md

--- a/docs/architecture/texture-registration.md
+++ b/docs/architecture/texture-registration.md
@@ -1,0 +1,386 @@
+# `TextureRegistration` — engine-wide per-surface lifecycle state
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+> Reflects code state as of 2026-05-02 (PR #632, issue #616).
+
+## What this is
+
+`TextureRegistration` is the **single canonical engine-wide record for
+per-surface lifecycle state**, keyed by `surface_id` in
+`GpuContext::texture_cache`. Each registration carries the texture
+plus the typed mutable fields that producers and consumers both need
+to read/write across the surface_id handoff:
+
+- `texture: StreamTexture` — the resource itself.
+- `current_layout: AtomicI32` (Linux only — stores
+  `streamlib_consumer_rhi::VulkanLayout`) — the last-known Vulkan
+  image layout. Producers update on transitions; consumers read for
+  barrier source layouts.
+
+Future additive fields go on this record (see [What goes in / what
+stays out](#what-goes-in--what-stays-out) below). The shape mirrors
+the per-surface state pattern surface adapters already use
+(`streamlib-adapter-vulkan::SurfaceState`,
+`streamlib-adapter-cuda::SurfaceState`,
+`streamlib-adapter-cpu-readback::SurfaceState`) — `TextureRegistration`
+is the same shape lifted from adapter-scope to engine-wide scope.
+
+## Why it exists
+
+Before `TextureRegistration` (pre-#632), `GpuContext::texture_cache`
+was `HashMap<String, StreamTexture>` — a thin lookup with no
+lifecycle metadata. Per-surface state lived in two disjoint places:
+
+- Adapter-scoped `Registry<SurfaceState>` per adapter — visible only
+  to adapter code.
+- Implicit conventions encoded in producer/consumer code — invisible
+  to anyone reading just the engine.
+
+The implicit-convention path broke when a new producer (the OpenGL
+adapter, in #484) shipped an output texture whose Vulkan layout
+didn't match the convention display assumed (`SHADER_READ_ONLY_OPTIMAL`
+from camera). Display's descriptor binding then claimed a layout that
+didn't match reality. NVIDIA tolerated the mismatch; AMD/Intel
+behavior was unverified; Vulkan validation layers warned. See #616
+for the full diagnosis.
+
+The engine-model fix (per
+[CLAUDE.md "Engine-wide bugs get fixed at the engine
+layer"](../../CLAUDE.md#core-operating-principles--read-first)) was to
+make the handoff contract **explicit and typed at the engine
+layer**, not patched at the consumer that surfaced the symptom. That's
+what `TextureRegistration` is.
+
+## How it works
+
+```
+producer:                  consumer:
+  register_texture_with_      resolve_videoframe_
+    layout(id, tex, L)          registration(frame)
+       │                            │
+       ▼                            ▼
+  ┌─────────────────────────────────────────┐
+  │ GpuContext::texture_cache               │
+  │   HashMap<surface_id, Arc<TexReg>>      │
+  │     ├── texture: StreamTexture          │
+  │     └── current_layout: AtomicI32       │
+  └─────────────────────────────────────────┘
+       ▲                            │
+       │                            ▼
+  update_layout(L′) after     barrier(old=current_layout,
+    a producer transition       new=target_layout);
+                              update_layout(target_layout);
+```
+
+The `Arc<TextureRegistration>` is shared across all holders in-process
+— no IPC, no schema changes. `current_layout` reads use
+`Ordering::Acquire`; writes use `Ordering::Release`. Multi-consumer
+races are tolerated (see [Race model](#race-model)).
+
+## What goes in / what stays out
+
+### In: state both producers and consumers care about for handoff
+
+A field belongs in `TextureRegistration` when **all three** are true:
+
+1. The field's value is set by the producer and read by the
+   consumer (or vice-versa) — the handoff is the contract this
+   record encodes.
+2. The field has a stable identity tied to the surface_id (lives
+   from registration through unregistration) — it's not transient
+   per-frame data.
+3. Both producers and consumers run on the same in-process address
+   space, OR the cross-process IPC layer round-trips the field
+   (see [Cross-process limitation](#cross-process-limitation)).
+
+Examples that fit:
+
+- ✓ `current_layout` — present today.
+- ✓ `last_writer_id` — debugging "where did this surface come from?";
+  set on registration, read by anyone tracing the pipeline.
+- ✓ `last_written_frame_index: AtomicU64` — staleness detection;
+  producer increments per write, consumer compares to its expected
+  frame.
+- ✓ `format`, `width`, `height` — could be hoisted from `StreamTexture`
+  for cheaper validation; arguably already covered by `texture`.
+- ✓ Exportable timeline-semaphore handle — for consumers that need to
+  GPU-wait without a side-channel.
+
+### Out: state that doesn't fit any one of the criteria
+
+- ✗ **Adapter-internal state** (e.g., the OpenGL adapter's cached
+  `EGLImage` + GL texture id, or the cuda adapter's `cudaExternalMemory`
+  handle). Stays in the adapter's own `SurfaceState`. Engine doesn't
+  need to see it; other consumers don't either.
+- ✗ **Per-frame transient state** (the timestamp of *this* frame, the
+  encoder's `is_keyframe` bit, etc.). These belong on the `Videoframe`
+  IPC message, not on the surface registration. The registration
+  outlives any single frame.
+- ✗ **RDG-style declared-usage hints** ("I'll read this as a SAMPLED_READ
+  in pass N+1"). That's a different layer entirely — see
+  [Boundary with RDG](#boundary-with-rdg-631) below. Adding declared
+  usage here without the graph compiler to interpret it is just dead
+  metadata.
+- ✗ **Cross-process-only state without a same-process consumer.** Use
+  the surface-share daemon's own state or extend its IPC schema. The
+  `texture_cache` is for in-process consumers reaching textures via
+  `resolve_videoframe_registration` Path 1.
+
+When you find yourself wanting to add a field that doesn't fit cleanly,
+**stop and ask**:
+
+- "Is this really per-surface, or is it per-frame?" → if per-frame, use
+  `Videoframe` IPC fields.
+- "Does the engine need to see this, or only the adapter?" → if only
+  the adapter, keep it in `SurfaceState`.
+- "Am I tracking declared usage?" → if so, that's RDG territory (#631).
+
+## Producer rules
+
+1. **Declare your post-publish layout at registration time.**
+   ```rust
+   gpu.register_texture_with_layout(
+       &surface_id,
+       texture,
+       VulkanLayout::SHADER_READ_ONLY_OPTIMAL,  // or whatever you actually leave it in
+   );
+   ```
+   The "post-publish" layout is the layout the texture is in **at the
+   moment any consumer dereferences the surface_id**. For producers
+   that write IPC frames, this is the layout immediately after the
+   transition that precedes the IPC write.
+
+2. **Use the back-compat shim only when the layout is genuinely
+   `UNDEFINED`.**
+   ```rust
+   gpu.register_texture(&id, texture);  // defaults to UNDEFINED
+   ```
+   This is correct for a freshly-allocated texture that no one has
+   touched (e.g. `acquire_output_texture`). It is **not** a "I don't
+   know, just pick something" escape hatch. If you actually do know
+   the layout, declare it. If you genuinely don't, that's a code smell
+   — the texture should have a knowable post-allocation state.
+
+3. **Update on mid-pipeline transitions.**
+   ```rust
+   // After issuing a barrier that moves the texture to a new layout:
+   reg.update_layout(VulkanLayout::TRANSFER_SRC_OPTIMAL);
+   ```
+   Producers that transition the texture multiple times during a frame
+   only need to update the field after the *last* transition before the
+   IPC publish — intermediate layouts aren't observed by consumers.
+
+4. **Don't lie.** A registration that claims `SHADER_READ_ONLY_OPTIMAL`
+   when the Vulkan tracker is in `GENERAL` re-creates the exact bug
+   `TextureRegistration` exists to fix. If your producer doesn't
+   transition the Vulkan tracker (e.g., the OpenGL adapter, which
+   writes via GL without issuing Vulkan barriers), declare what's
+   actually true: `UNDEFINED` initially, then whatever the last
+   consumer's barrier left it in (read it back from the registration
+   if the producer needs to reason about it).
+
+## Consumer rules
+
+1. **Resolve the registration, not just the texture.**
+   ```rust
+   let reg = gpu.resolve_videoframe_registration(&frame)?;
+   let texture = reg.texture();
+   let current = reg.current_layout();
+   ```
+   `resolve_videoframe_texture` is back-compat for callers that don't
+   need the metadata — but if you're issuing a barrier, use the
+   registration form.
+
+2. **Barrier from `current_layout` to your target.**
+   ```rust
+   if current != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+       device.cmd_pipeline_barrier2(cmd, &dep_info(/* old=current, new=target */));
+       reg.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+   }
+   ```
+   Skip the barrier when source equals target — Vulkan permits no-op
+   transitions but they emit validation warnings on some drivers.
+
+3. **Update after the barrier records.** The
+   `update_layout` call should be the source-of-record for the next
+   reader; race tolerance is documented but not magic. If you skip the
+   update after a real transition, the next consumer will issue a
+   barrier from the wrong source layout.
+
+4. **Don't cache `current_layout` across frames.** A future frame may
+   have a different producer, or the layout may have been changed by
+   another consumer. Read it fresh per frame.
+
+## Anti-patterns
+
+These are the failure modes the engine-model rule exists to prevent.
+Each was either tried and rejected, or is the foreseeable workaround
+that future agents would attempt without this doc.
+
+1. **Parallel `HashMap<surface_id, FooState>`.** If you find yourself
+   wanting to track new per-surface metadata in a separate HashMap,
+   stop. Extend `TextureRegistration`. The whole point of the engine-
+   wide cache is that there's *one* keyed registry; multiple parallel
+   ones recreate the implicit-convention problem one layer up.
+
+2. **Descriptor-side claims that don't match registration.** Display's
+   pre-#632 bug was claiming `SHADER_READ_ONLY_OPTIMAL` in a
+   `VkDescriptorImageInfo::imageLayout` field while the actual texture
+   was in `GENERAL`. The fix is to barrier first, not to claim
+   something else and hope the driver tolerates it. Never use the
+   descriptor's `imageLayout` field as a workaround for an unknown
+   source layout — barrier the texture into the layout you're going
+   to claim.
+
+3. **Side-channel "I know better" code paths.** If a consumer thinks
+   it knows the source layout better than the registration claims,
+   the answer is to fix the producer's declaration, not to ignore the
+   registration and barrier from a hardcoded layout. The registration
+   is the source of truth; if it's wrong, fix it at the source.
+
+4. **Reaching through private fields to bypass the API.** No
+   `_lib._texture_cache._inner` reach-through code paths. If you need
+   the registration's internals, add a public method on
+   `TextureRegistration` itself.
+
+5. **"Just unconditionally barrier from `GENERAL`"** as a way to dodge
+   tracking. This was considered for #616 (Option A in the design
+   discussion) and rejected: it trades one validation warning class
+   for another (camera-display now warns instead of AvatarCharacter).
+   The right answer is typed tracking.
+
+6. **Adding declared-usage hints onto `TextureRegistration`.** "I'll
+   need this as SAMPLED_READ next" is RDG-shape information; without
+   the graph compiler to read it, it's dead metadata that producers
+   and consumers can both lie about. See next section.
+
+## Boundary with RDG (#631)
+
+`TextureRegistration` is **typed state that consumers manually read +
+typed transitions consumers manually issue**. RDG-style automatic
+barrier inference would be **consumers declaratively name their
+access type and the engine derives transitions** from a graph of
+read/write edges. They are different layers:
+
+| Layer | What consumers do | What the engine does |
+|---|---|---|
+| Direct RHI (today) | Issue explicit `cmd_pipeline_barrier2` calls | Nothing |
+| `TextureRegistration` (this doc) | Read `current_layout`, issue barrier, update | Track typed state per surface_id |
+| RDG (#631 — future) | Declare access type via pass parameters | Build graph, derive barriers, schedule async-compute, alias memory |
+
+If you find yourself wanting consumers to declare "I want this as a
+SAMPLED_READ" *without* writing a barrier, that's an RDG-shape need.
+Don't bolt declared usage onto `TextureRegistration` — escalate to
+#631. The engine doesn't have a graph layer to interpret the
+declaration, so the field would be dead metadata that masks rather
+than solves the problem.
+
+The substrate `TextureRegistration` provides (typed per-surface state
+keyed by stable id) is exactly what an eventual RDG layer would build
+on top of — but RDG is a new layer above this one, not a replacement.
+
+## Race model
+
+`current_layout` is `AtomicI32` with `Acquire` reads and `Release`
+writes. The Arc itself is `Send + Sync`. Consequences:
+
+- **Single producer + single consumer** (the dominant pattern today —
+  one camera writes, one display reads): clean, layout claims always
+  match GPU reality after the consumer's barrier records.
+- **Single producer + multiple consumers in the same frame** (e.g.
+  display + encoder both consuming a camera ring texture): the second
+  consumer's `current_layout` read may see the first consumer's
+  updated value, in which case it issues a no-op barrier; or it may
+  race and both consumers issue barriers from the same source layout,
+  in which case the queue mutex serializes the submissions and the
+  GPU work is correct. **Documented as race-tolerant**, not race-free.
+- **Multiple producers in the same frame**: not a supported pattern.
+  `register_texture_with_layout` overwrites the registration; if a
+  producer needs to share a surface with another producer it has to
+  coordinate out-of-band.
+
+The race model is good enough today because streamlib pipelines are
+predominantly single-consumer-per-frame. If a future pipeline genuinely
+needs multi-consumer coordination beyond what queue serialization
+provides, escalate to RDG (#631) — that's the layer where coordination
+is the engine's job, not the consumer's.
+
+## Cross-process limitation
+
+`TextureRegistration` solves the same-process handoff. **It does not
+yet propagate to cross-process / cross-language consumers.**
+
+Today, when a subprocess producer registers a texture via
+`surface-share`, the host consumer's `resolve_videoframe_registration`
+hits Path 2 (cross-process import) which synthesizes a fresh
+`Arc<TextureRegistration>` with `current_layout = UNDEFINED`. The
+host consumer barriers from UNDEFINED → its target, which is correct
+but conservative (Vulkan spec permits content discard on
+UNDEFINED → X, though NVIDIA preserves in practice).
+
+The wire-format gap is mechanical, not architectural. Two extension
+shapes are possible (and probably both belong long-term):
+
+1. **Per-surface schema extension (`surface-share` IPC).** Add
+   `current_layout` to the `register` / `check_in` / `lookup`
+   messages. Subprocess producer declares layout at registration; host
+   consumer reads it. Handles "static layout, never changes" — matches
+   today's same-process producer pattern.
+2. **Per-frame schema extension (`Videoframe`).** Add `texture_layout`
+   (optional) to the `Videoframe` IPC message. Producers can vary
+   layout per frame. Bigger lift — `Videoframe` is a polyglot schema,
+   so all three runtimes (Rust + Python + Deno) ship together per
+   [`.claude/workflows/polyglot.md`](../../.claude/workflows/polyglot.md).
+
+The "right" shape is probably both — registration carries a default,
+`Videoframe` overrides per-frame. Tracked as follow-up issues; see
+the [Reference](#reference) section.
+
+There's also a quieter constraint: cdylibs depend on
+`streamlib-consumer-rhi`, NOT the full `streamlib`, so they can't
+construct `TextureRegistration` directly (it lives in
+`streamlib::core::context`). To give subprocess producers the same
+typed contract, the registration record itself probably needs to live
+in `consumer-rhi`. Separate ticket.
+
+**Until those land, cross-process consumers should keep barriering
+defensively from `UNDEFINED`** — don't paper over the gap consumer-
+side.
+
+## Tests
+
+When a new field lands on `TextureRegistration`:
+
+1. **Unit test in `texture_registration.rs::tests`**: exercise
+   round-trip (set → read), concurrent updates from N threads (no
+   torn values), and any field-specific invariants.
+2. **Unit test in `gpu_context.rs::tests`**: exercise the resolve
+   path — register with the new field, resolve via
+   `resolve_videoframe_registration`, assert visibility.
+3. **Mentally revert the field's update logic** — does the test still
+   pass? If yes, the test is feel-good and doesn't lock the contract.
+   Strengthen it: a test that doesn't fail when the impl is reverted
+   isn't locking anything.
+4. **E2E with `VK_LOADER_LAYERS_ENABLE=*validation*`** for any field
+   that affects GPU behavior. The unit tests lock the data structure;
+   validation-layer E2E locks the actual Vulkan-side correctness.
+
+## Reference
+
+- **Implementation**: `libs/streamlib/src/core/context/texture_registration.rs`,
+  `GpuContext::register_texture_with_layout` /
+  `GpuContext::resolve_videoframe_registration` in
+  `libs/streamlib/src/core/context/gpu_context.rs`.
+- **First consumer**: `LinuxDisplayProcessor::render_frame` in
+  `libs/streamlib/src/linux/processors/display.rs`.
+- **First adapter-output producer**: `register_opengl_output_surface`
+  in `examples/camera-python-display/src/linux.rs`.
+- **First in-tree producer**: `LinuxCameraProcessor` in
+  `libs/streamlib/src/linux/processors/camera.rs`.
+- **Mirror pattern**: `streamlib-adapter-vulkan::SurfaceState` in
+  `libs/streamlib-adapter-vulkan/src/state.rs:48` (and the parallel
+  cuda + cpu-readback adapter state structs).
+- **PR**: #632.
+- **Issue**: #616.
+- **Future research**: #631 (RDG / automatic barrier inference).

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -37,6 +37,7 @@ use streamlib::{
     CameraProcessor, DisplayProcessor, ProcessorSpec, Result, StreamRuntime,
 };
 use streamlib_adapter_abi::SurfaceId;
+use streamlib_consumer_rhi::VulkanLayout;
 
 use crate::camera_to_cuda_copy::{CameraToCudaCopyProcessor, CUDA_CAMERA_SURFACE_ID};
 
@@ -210,12 +211,31 @@ fn register_opengl_output_surface(
 
     // Mirror the texture into the GpuContext's local same-process cache
     // so downstream processors (in this case the display) hit Path 1 in
-    // `GpuContext::resolve_videoframe_texture` instead of the cross-
+    // `GpuContext::resolve_videoframe_registration` instead of the cross-
     // process daemon lookup. This matches what `LinuxCameraProcessor`
     // does for its own ring textures (see `linux/processors/camera.rs:857`)
     // — without it, same-process consumers can't find the texture by
     // UUID even though surface-share has it.
-    gpu.register_texture(AVATAR_OUTPUT_SURFACE_UUID, texture);
+    //
+    // Declare `UNDEFINED` as the registration's initial layout: the
+    // OpenGL adapter writes to this VkImage via EGL DMA-BUF import and
+    // does not transition the Vulkan-side layout (it issues `glFinish`
+    // on release; DMA-BUF kernel-fence semantics carry data visibility,
+    // but Vulkan's layout tracker stays at the image's `initialLayout`
+    // which is `UNDEFINED` from `acquire_render_target_dma_buf_image`).
+    // Display's first-frame barrier transitions UNDEFINED →
+    // SHADER_READ_ONLY_OPTIMAL — content is technically allowed to be
+    // discarded by the spec on this transition but NVIDIA preserves
+    // it (verified empirically on RTX 3090). After that first barrier,
+    // display's `update_layout` advances the registration to
+    // SHADER_READ_ONLY_OPTIMAL; subsequent GL writes don't change the
+    // Vulkan tracker, so steady-state barriers are SHADER_READ_ONLY
+    // → SHADER_READ_ONLY no-ops.
+    gpu.register_texture_with_layout(
+        AVATAR_OUTPUT_SURFACE_UUID,
+        texture,
+        VulkanLayout::UNDEFINED,
+    );
 
     Ok(())
 }

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::_generated_::Videoframe;
+use crate::core::context::TextureRegistration;
 use crate::core::rhi::{
     CommandBuffer, GpuDevice, PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, RhiBlitter,
     RhiCommandQueue, RhiPixelBuffer, RhiPixelBufferPool, StreamTexture, TextureDescriptor,
@@ -11,6 +12,8 @@ use crate::core::{Result, StreamError};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
+#[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::VulkanLayout;
 
 /// Number of buffers to pre-allocate per pool.
 const POOL_PRE_ALLOCATE_COUNT: usize = 4;
@@ -378,8 +381,14 @@ pub struct GpuContext {
     surface_store: Arc<Mutex<Option<SurfaceStore>>>,
     /// GPU blitter for efficient buffer-to-buffer copies with texture caching.
     blitter: Arc<dyn RhiBlitter>,
-    /// Same-process texture cache — maps surface_id to StreamTexture.
-    texture_cache: Arc<Mutex<HashMap<String, StreamTexture>>>,
+    /// Same-process texture cache — maps surface_id to a registration
+    /// record carrying the texture plus per-surface lifecycle metadata
+    /// (e.g. last-known Vulkan image layout). Mirrors the per-surface
+    /// state pattern used by `streamlib-adapter-vulkan::SurfaceState`,
+    /// lifted to engine-wide scope so consumers reaching textures via
+    /// `resolve_videoframe_registration` get the same lifecycle metadata
+    /// adapter consumers do.
+    texture_cache: Arc<Mutex<HashMap<String, Arc<TextureRegistration>>>>,
     /// Cache of textures backing surface-share-registered pixel buffers
     /// (`escalate_acquire_pixel_buffer` flow). Refreshed on every resolve so
     /// rotating-pool producers don't render stale contents — kept separate
@@ -579,36 +588,74 @@ impl GpuContext {
     }
 
     /// Register a texture in the same-process texture cache.
+    ///
+    /// On Linux the texture is registered with `VulkanLayout::UNDEFINED`
+    /// as its initial layout — callers that know the texture's actual
+    /// post-allocation layout (e.g. camera ring textures left in
+    /// `SHADER_READ_ONLY_OPTIMAL` after compute) should use
+    /// [`Self::register_texture_with_layout`] instead so consumers
+    /// reaching the texture via [`Self::resolve_videoframe_registration`]
+    /// can issue correct layout transitions.
     pub fn register_texture(&self, id: &str, texture: StreamTexture) {
+        #[cfg(target_os = "linux")]
+        let registration = TextureRegistration::new(texture, VulkanLayout::UNDEFINED);
+        #[cfg(not(target_os = "linux"))]
+        let registration = TextureRegistration::new(texture);
         let mut cache = self.texture_cache.lock().unwrap();
-        cache.insert(id.to_string(), texture);
+        cache.insert(id.to_string(), registration);
     }
 
-    /// Resolve a Videoframe's texture — unified entry point for consumers.
+    /// Register a texture with a declared initial Vulkan image layout.
     ///
-    /// Tries the fastest available path in order:
-    /// 1. Same-process texture cache (zero-copy, direct ring texture)
-    /// 2. Cross-process DMA-BUF VkImage import via SurfaceStore (GPU-to-GPU)
-    /// 3. Cross-process pixel buffer fallback — copy buffer contents into a
-    ///    private cached texture every call so rotating-pool producers (polyglot
-    ///    subprocess processors using `escalate_acquire_pixel_buffer`) see fresh
-    ///    contents per frame.
-    pub fn resolve_videoframe_texture(&self, frame: &Videoframe) -> Result<StreamTexture> {
+    /// Producers call this when they know the layout the texture is in
+    /// at the moment it becomes visible to consumers — e.g. camera
+    /// processors that finish their compute pipeline with a transition
+    /// to `SHADER_READ_ONLY_OPTIMAL` (so the next display frame's
+    /// barrier source layout is correct), or adapter setup hooks that
+    /// pre-allocate a render target the adapter writes to without
+    /// transitioning the Vulkan layout (declare `UNDEFINED`).
+    #[cfg(target_os = "linux")]
+    pub fn register_texture_with_layout(
+        &self,
+        id: &str,
+        texture: StreamTexture,
+        initial_layout: VulkanLayout,
+    ) {
+        let registration = TextureRegistration::new(texture, initial_layout);
+        let mut cache = self.texture_cache.lock().unwrap();
+        cache.insert(id.to_string(), registration);
+    }
+
+    /// Resolve a Videoframe's full registration record (texture + layout).
+    ///
+    /// Same lookup path as [`Self::resolve_videoframe_texture`] but
+    /// returns the registration so consumers can read `current_layout`
+    /// for barrier-source correctness. Cross-process imports (Path 2/3)
+    /// synthesize a fresh registration with `VulkanLayout::UNDEFINED`
+    /// because Vulkan import semantics leave the layout unspecified;
+    /// the consumer's barrier discards prior contents and transitions
+    /// to its target layout.
+    pub fn resolve_videoframe_registration(
+        &self,
+        frame: &Videoframe,
+    ) -> Result<Arc<TextureRegistration>> {
         // Path 1: same-process texture cache (fastest)
         {
             let cache = self.texture_cache.lock().unwrap();
-            if let Some(texture) = cache.get(&frame.surface_id) {
-                return Ok(texture.clone());
+            if let Some(reg) = cache.get(&frame.surface_id) {
+                return Ok(Arc::clone(reg));
             }
         }
 
-        // Path 2: cross-process DMA-BUF VkImage import via surface-share service
+        // Path 2: cross-process DMA-BUF VkImage import via surface-share service.
+        // Synthesized registration is not cached — Path 2 reimports per-call by
+        // design, and caching would defeat that.
         #[cfg(target_os = "linux")]
         {
             let surface_store = self.surface_store.lock().unwrap();
             if let Some(store) = surface_store.as_ref() {
                 if let Ok(texture) = store.lookup_texture(&frame.surface_id) {
-                    return Ok(texture);
+                    return Ok(TextureRegistration::new(texture, VulkanLayout::UNDEFINED));
                 }
             }
         }
@@ -627,12 +674,18 @@ impl GpuContext {
                     .and_then(|store| store.lookup_buffer(&frame.surface_id).ok())
             };
             if let Some(buffer) = buffer {
-                return self.refresh_pixel_buffer_texture(
+                let texture = self.refresh_pixel_buffer_texture(
                     &frame.surface_id,
                     &buffer,
                     frame.width,
                     frame.height,
-                );
+                )?;
+                // upload_buffer_to_image leaves the texture in
+                // SHADER_READ_ONLY_OPTIMAL (see vulkan_device.rs:1851).
+                return Ok(TextureRegistration::new(
+                    texture,
+                    VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+                ));
             }
         }
 
@@ -640,6 +693,17 @@ impl GpuContext {
             "No texture or pixel buffer found for surface_id '{}'",
             frame.surface_id
         )))
+    }
+
+    /// Resolve a Videoframe's texture — unified entry point for consumers
+    /// that don't need layout metadata.
+    ///
+    /// Thin projection over [`Self::resolve_videoframe_registration`].
+    /// Layout-aware consumers (display, future encoders) should call
+    /// `resolve_videoframe_registration` directly so they can issue
+    /// correct barriers.
+    pub fn resolve_videoframe_texture(&self, frame: &Videoframe) -> Result<StreamTexture> {
+        Ok(self.resolve_videoframe_registration(frame)?.texture().clone())
     }
 
     /// Acquire a new output texture with a UUID, register it in the cache.
@@ -752,7 +816,13 @@ impl GpuContext {
             )?;
         }
 
-        self.register_texture(surface_id, texture);
+        // upload_buffer_to_image leaves the image in SHADER_READ_ONLY_OPTIMAL
+        // (see vulkan_device.rs:1851).
+        self.register_texture_with_layout(
+            surface_id,
+            texture,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
         Ok(())
     }
 
@@ -1405,6 +1475,27 @@ impl GpuContextLimitedAccess {
         self.inner.register_texture(id, texture);
     }
 
+    /// Register a texture with a declared initial Vulkan image layout.
+    /// See [`GpuContext::register_texture_with_layout`].
+    #[cfg(target_os = "linux")]
+    pub fn register_texture_with_layout(
+        &self,
+        id: &str,
+        texture: StreamTexture,
+        initial_layout: VulkanLayout,
+    ) {
+        self.inner
+            .register_texture_with_layout(id, texture, initial_layout);
+    }
+
+    /// Resolve a [`Videoframe`]'s full registration record (texture + layout).
+    pub fn resolve_videoframe_registration(
+        &self,
+        frame: &Videoframe,
+    ) -> Result<Arc<TextureRegistration>> {
+        self.inner.resolve_videoframe_registration(frame)
+    }
+
     /// Resolve a [`Videoframe`]'s texture (Split: cache hit).
     pub fn resolve_videoframe_texture(&self, frame: &Videoframe) -> Result<StreamTexture> {
         self.inner.resolve_videoframe_texture(frame)
@@ -1525,6 +1616,27 @@ impl GpuContextFullAccess {
     /// Register a texture in the same-process texture cache.
     pub fn register_texture(&self, id: &str, texture: StreamTexture) {
         self.inner.register_texture(id, texture);
+    }
+
+    /// Register a texture with a declared initial Vulkan image layout.
+    /// See [`GpuContext::register_texture_with_layout`].
+    #[cfg(target_os = "linux")]
+    pub fn register_texture_with_layout(
+        &self,
+        id: &str,
+        texture: StreamTexture,
+        initial_layout: VulkanLayout,
+    ) {
+        self.inner
+            .register_texture_with_layout(id, texture, initial_layout);
+    }
+
+    /// Resolve a [`Videoframe`]'s full registration record (texture + layout).
+    pub fn resolve_videoframe_registration(
+        &self,
+        frame: &Videoframe,
+    ) -> Result<Arc<TextureRegistration>> {
+        self.inner.resolve_videoframe_registration(frame)
     }
 
     /// Resolve a [`Videoframe`]'s texture.
@@ -1723,6 +1835,82 @@ mod tests {
         assert_eq!(resolved.height(), 480);
 
         println!("Texture cache: register + resolve OK");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_register_texture_with_layout_round_trip() {
+        let gpu = match GpuContext::init_for_platform() {
+            Ok(g) => g,
+            Err(_) => {
+                println!("Skipping - no GPU device available");
+                return;
+            }
+        };
+
+        let desc = TextureDescriptor::new(640, 480, TextureFormat::Rgba8Unorm)
+            .with_usage(TextureUsages::TEXTURE_BINDING);
+        let texture = gpu
+            .device()
+            .create_texture(&desc)
+            .expect("texture creation failed");
+        let surface_id = "test-surface-with-layout";
+
+        gpu.register_texture_with_layout(
+            surface_id,
+            texture,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
+
+        let frame = crate::_generated_::Videoframe {
+            surface_id: surface_id.to_string(),
+            width: 640,
+            height: 480,
+            timestamp_ns: "0".to_string(),
+            frame_index: "1".to_string(),
+            fps: None,
+        };
+
+        let registration = gpu
+            .resolve_videoframe_registration(&frame)
+            .expect("registration cache miss");
+        assert_eq!(
+            registration.current_layout(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            "declared initial layout should be visible to consumers"
+        );
+
+        // Update flow — consumer barriers transition + advance layout.
+        registration.update_layout(VulkanLayout::TRANSFER_SRC_OPTIMAL);
+        let registration2 = gpu
+            .resolve_videoframe_registration(&frame)
+            .expect("second resolve");
+        assert_eq!(
+            registration2.current_layout(),
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            "later resolves see the updated layout (Arc share)"
+        );
+
+        // Default register_texture path declares UNDEFINED.
+        let texture2 = gpu
+            .device()
+            .create_texture(&desc)
+            .expect("second texture creation failed");
+        gpu.register_texture("test-surface-default-layout", texture2);
+        let frame2 = crate::_generated_::Videoframe {
+            surface_id: "test-surface-default-layout".to_string(),
+            ..frame
+        };
+        let registration3 = gpu
+            .resolve_videoframe_registration(&frame2)
+            .expect("default-layout resolve");
+        assert_eq!(
+            registration3.current_layout(),
+            VulkanLayout::UNDEFINED,
+            "register_texture without explicit layout defaults to UNDEFINED"
+        );
+
+        println!("register_texture_with_layout + resolve_videoframe_registration: OK");
     }
 
     #[test]

--- a/libs/streamlib/src/core/context/mod.rs
+++ b/libs/streamlib/src/core/context/mod.rs
@@ -10,6 +10,7 @@ mod gpu_context;
 mod runtime_context;
 mod surface_store;
 pub mod texture_pool;
+mod texture_registration;
 mod time_context;
 
 pub use audio_clock::{
@@ -26,4 +27,5 @@ pub use runtime_context::{
 };
 pub use surface_store::SurfaceStore;
 pub use texture_pool::*;
+pub use texture_registration::TextureRegistration;
 pub use time_context::TimeContext;

--- a/libs/streamlib/src/core/context/texture_registration.rs
+++ b/libs/streamlib/src/core/context/texture_registration.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Engine-wide per-surface texture registration record.
+//!
+//! Stored in [`crate::core::context::GpuContext`]'s same-process texture
+//! cache, keyed by `surface_id`. Mirrors the per-surface state pattern
+//! the surface adapters already use (see
+//! `streamlib-adapter-vulkan::SurfaceState::current_layout`) but lifted
+//! to the engine-wide cache so consumers reaching textures via
+//! `resolve_videoframe_registration` get the same lifecycle metadata
+//! adapter consumers do.
+//!
+//! On Linux the registration carries the texture's last-known
+//! `VkImageLayout` so consumers can issue a correct
+//! `vkCmdPipelineBarrier2` source layout. On other platforms only the
+//! texture is held — Metal manages texture state automatically and
+//! Vulkan layouts don't apply.
+
+use std::sync::Arc;
+
+use crate::core::rhi::StreamTexture;
+
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicI32, Ordering};
+#[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::VulkanLayout;
+
+/// Per-surface registration record held by [`crate::core::context::GpuContext`]'s
+/// texture cache.
+pub struct TextureRegistration {
+    texture: StreamTexture,
+    /// Last-known Vulkan image layout. Producers update after their
+    /// final layout transition; consumers read before issuing their
+    /// own barrier and update after.
+    ///
+    /// Multi-consumer races are tolerated: Vulkan barriers are
+    /// serialized by the queue mutex, so the GPU work each consumer
+    /// submits is correct regardless of which one wins the atomic
+    /// update; the field tracks "best-known stable layout for the
+    /// next reader."
+    #[cfg(target_os = "linux")]
+    current_layout: AtomicI32,
+}
+
+impl TextureRegistration {
+    /// Construct a registration with an initial layout.
+    #[cfg(target_os = "linux")]
+    pub fn new(texture: StreamTexture, initial_layout: VulkanLayout) -> Arc<Self> {
+        Arc::new(Self {
+            texture,
+            current_layout: AtomicI32::new(initial_layout.0),
+        })
+    }
+
+    /// Construct a registration on platforms without Vulkan layout tracking.
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(texture: StreamTexture) -> Arc<Self> {
+        Arc::new(Self { texture })
+    }
+
+    /// Borrow the underlying texture.
+    pub fn texture(&self) -> &StreamTexture {
+        &self.texture
+    }
+
+    /// Last-known `VkImageLayout` the texture is in.
+    #[cfg(target_os = "linux")]
+    pub fn current_layout(&self) -> VulkanLayout {
+        VulkanLayout(self.current_layout.load(Ordering::Acquire))
+    }
+
+    /// Record a new last-known layout.
+    #[cfg(target_os = "linux")]
+    pub fn update_layout(&self, new_layout: VulkanLayout) {
+        self.current_layout.store(new_layout.0, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+    use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
+    use crate::core::context::GpuContext;
+    use std::thread;
+
+    fn fresh_texture() -> Option<StreamTexture> {
+        let gpu = GpuContext::init_for_platform().ok()?;
+        let desc = TextureDescriptor::new(64, 64, TextureFormat::Rgba8Unorm)
+            .with_usage(TextureUsages::TEXTURE_BINDING);
+        gpu.device().create_texture(&desc).ok()
+    }
+
+    #[test]
+    fn current_layout_round_trip() {
+        let Some(texture) = fresh_texture() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let reg = TextureRegistration::new(texture, VulkanLayout::UNDEFINED);
+        assert_eq!(reg.current_layout(), VulkanLayout::UNDEFINED);
+        reg.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        assert_eq!(reg.current_layout(), VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        reg.update_layout(VulkanLayout::GENERAL);
+        assert_eq!(reg.current_layout(), VulkanLayout::GENERAL);
+    }
+
+    #[test]
+    fn concurrent_updates_dont_tear() {
+        let Some(texture) = fresh_texture() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let reg = TextureRegistration::new(texture, VulkanLayout::UNDEFINED);
+        let layouts = [
+            VulkanLayout::GENERAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            VulkanLayout::TRANSFER_DST_OPTIMAL,
+            VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
+        ];
+        let handles: Vec<_> = layouts
+            .iter()
+            .map(|&layout| {
+                let reg = Arc::clone(&reg);
+                thread::spawn(move || {
+                    for _ in 0..1000 {
+                        reg.update_layout(layout);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread join");
+        }
+        // Final value is one of the written layouts — atomic guarantees no torn reads.
+        let final_layout = reg.current_layout();
+        assert!(
+            layouts.iter().any(|&l| l == final_layout),
+            "final layout {:?} is not one of the written values",
+            final_layout
+        );
+    }
+}

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -10,6 +10,7 @@ use crate::core::rhi::{PixelFormat, StreamTexture, TextureDescriptor, TextureFor
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
 use crate::iceoryx2::OutputWriter;
 use crate::vulkan::rhi::HostVulkanTexture;
+use streamlib_consumer_rhi::VulkanLayout;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use v4l::buffer::Type;
@@ -834,7 +835,24 @@ fn capture_thread_loop(
             }
         }
 
-        gpu_context.register_texture(&texture_id, stream_texture.clone());
+        // Ring textures are left in SHADER_READ_ONLY_OPTIMAL after every
+        // compute submit (see the post-copy barrier near the end of
+        // process()) — declare that as the registration's initial layout so
+        // consumers reaching the texture via
+        // `GpuContext::resolve_videoframe_registration` issue correct
+        // barriers. The texture is technically UNDEFINED at the moment of
+        // this register call (no compute pass has run yet), but the camera
+        // only writes the corresponding Videoframe to its output port AFTER
+        // the post-compute barrier transitions the texture to
+        // SHADER_READ_ONLY_OPTIMAL — so by the time any consumer
+        // dereferences the surface_id, the registered layout matches
+        // reality. The cross-frame steady state is also SHADER_READ_ONLY
+        // (every compute submit ends with the same transition).
+        gpu_context.register_texture_with_layout(
+            &texture_id,
+            stream_texture.clone(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
         ring_texture_ids.push(texture_id);
         ring_textures.push(stream_texture);
     }
@@ -1312,8 +1330,16 @@ fn capture_thread_loop(
         let output_vk_buffer = pooled_buffer.buffer_ref().inner.buffer();
 
         // Register ring texture in cache under the pixel buffer's pool_id so
-        // display resolves the texture via the same surface_id used for pixel buffer IPC.
-        gpu_context.register_texture(&pool_id.to_string(), ring_textures[ring_index].clone());
+        // display resolves the texture via the same surface_id used for pixel
+        // buffer IPC. The same Arc<HostVulkanTexture> registered up-front
+        // with SHADER_READ_ONLY_OPTIMAL is published here under a fresh
+        // pool_id — re-declare the layout so the registration record under
+        // this pool_id matches the steady-state contract.
+        gpu_context.register_texture_with_layout(
+            &pool_id.to_string(),
+            ring_textures[ring_index].clone(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
 
         // ---- Step 3: Update descriptor set — input SSBO + ring texture ----
         let input_buffer_descriptor = vk::DescriptorBufferInfo::builder()

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -3,6 +3,7 @@
 
 use crate::_generated_::com_tatolab_display_config::ScalingMode;
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
+use streamlib_consumer_rhi::VulkanLayout;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 use vulkanalia::vk::KhrSurfaceExtensionInstanceCommands as _;
@@ -570,8 +571,15 @@ impl DisplayEventLoopHandler {
         // Unified texture resolution — GpuContext picks the fastest path:
         // 1. Same-process texture cache (zero-copy ring texture)
         // 2. Cross-process DMA-BUF VkImage import via surface-share service (GPU-to-GPU)
-        let camera_texture = match self.gpu_context.resolve_videoframe_texture(&ipc_frame) {
-            Ok(tex) => tex,
+        //
+        // We resolve the full registration (not just the texture) so we can
+        // read `current_layout` and issue a correct source-layout barrier
+        // before sampling — adapter-output textures (OpenGL, Skia, Vulkan
+        // adapter outputs) may arrive in a layout other than the descriptor
+        // binding's claimed `SHADER_READ_ONLY_OPTIMAL`, and the wrong
+        // claim is the bug #616 fixes.
+        let registration = match self.gpu_context.resolve_videoframe_registration(&ipc_frame) {
+            Ok(reg) => reg,
             Err(e) => {
                 tracing::warn!(
                     "Display {}: Failed to resolve texture for '{}': {}",
@@ -582,12 +590,23 @@ impl DisplayEventLoopHandler {
                 return;
             }
         };
+        let camera_texture = registration.texture().clone();
 
         let device = self.vulkan_device.device();
         let queue = self.vulkan_device.queue();
 
         let frame_index = state.current_frame;
 
+        let camera_image = match camera_texture.inner.image() {
+            Some(img) => img,
+            None => {
+                tracing::warn!(
+                    "Display {}: camera texture has no VkImage handle",
+                    self.window_id
+                );
+                return;
+            }
+        };
         let camera_image_view = match camera_texture.inner.image_view() {
             Ok(view) => view,
             Err(e) => {
@@ -708,31 +727,69 @@ impl DisplayEventLoopHandler {
                 return;
             }
 
-            // Camera texture is already in SHADER_READ_ONLY_OPTIMAL (set by camera
-            // after compute dispatch). Only need swapchain barrier.
-            // Camera timeline semaphore wait in queue_submit2 ensures the texture is ready.
+            // Swapchain image: UNDEFINED → COLOR_ATTACHMENT_OPTIMAL.
             // UNDEFINED old_layout: on first use each swapchain image is in UNDEFINED,
             // and on subsequent uses the previous contents are unconditionally discarded
             // by the CLEAR load_op below — so declaring UNDEFINED (which permits any
             // current layout) is valid for every frame and avoids a VUID-vkCmdDraw-None-09600
             // mismatch on the first submit for each image.
-            let swapchain_barrier = vk::ImageMemoryBarrier2::builder()
-                .src_stage_mask(vk::PipelineStageFlags2::NONE)
-                .src_access_mask(vk::AccessFlags2::NONE)
-                .dst_stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
-                .dst_access_mask(vk::AccessFlags2::COLOR_ATTACHMENT_WRITE)
-                .old_layout(vk::ImageLayout::UNDEFINED)
-                .new_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
-                .image(swapchain_image)
-                .subresource_range(color_subresource_range)
-                .build();
-            let swapchain_barriers = [swapchain_barrier];
+            //
+            // Camera-input texture: source layout depends on producer. Camera ring
+            // textures are left in SHADER_READ_ONLY_OPTIMAL after every compute submit;
+            // adapter-output textures (e.g. AvatarCharacter via streamlib-adapter-opengl)
+            // arrive in whatever layout the registration declares (typically UNDEFINED
+            // for adapters that don't transition the Vulkan tracker, or whatever the
+            // last consumer's `update_layout` set). The barrier here transitions from
+            // the registered current layout → SHADER_READ_ONLY_OPTIMAL so the
+            // descriptor binding's claimed `image_layout` matches reality. The camera
+            // timeline-semaphore wait in queue_submit2 covers the producer-finished
+            // GPU sync (independent of layout); this barrier covers the layout
+            // contract Vulkan validation enforces. Skipped when already in
+            // SHADER_READ_ONLY_OPTIMAL to avoid a no-op submission.
+            let camera_current_layout = registration.current_layout();
+            let mut image_barriers: Vec<vk::ImageMemoryBarrier2> = Vec::with_capacity(2);
+            image_barriers.push(
+                vk::ImageMemoryBarrier2::builder()
+                    .src_stage_mask(vk::PipelineStageFlags2::NONE)
+                    .src_access_mask(vk::AccessFlags2::NONE)
+                    .dst_stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)
+                    .dst_access_mask(vk::AccessFlags2::COLOR_ATTACHMENT_WRITE)
+                    .old_layout(vk::ImageLayout::UNDEFINED)
+                    .new_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                    .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                    .image(swapchain_image)
+                    .subresource_range(color_subresource_range)
+                    .build(),
+            );
+            if camera_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+                image_barriers.push(
+                    vk::ImageMemoryBarrier2::builder()
+                        // ALL_COMMANDS / MEMORY_WRITE in the source masks is the
+                        // tolerant pattern that covers any producer (camera compute,
+                        // OpenGL adapter glFinish, future Vulkan/Skia adapters).
+                        // Mirrors the source-side masks `VulkanTextureReadback`
+                        // uses for the same producer-agnostic purpose.
+                        .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                        .src_access_mask(vk::AccessFlags2::MEMORY_WRITE)
+                        .dst_stage_mask(vk::PipelineStageFlags2::FRAGMENT_SHADER)
+                        .dst_access_mask(vk::AccessFlags2::SHADER_SAMPLED_READ)
+                        .old_layout(camera_current_layout.as_vk())
+                        .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+                        .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                        .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                        .image(camera_image)
+                        .subresource_range(color_subresource_range)
+                        .build(),
+                );
+            }
             let dep = vk::DependencyInfo::builder()
-                .image_memory_barriers(&swapchain_barriers)
+                .image_memory_barriers(&image_barriers)
                 .build();
             device.cmd_pipeline_barrier2(command_buffer, &dep);
+            if camera_current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
+                registration.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+            }
 
             // Begin dynamic rendering on swapchain image
             let color_attachment = vk::RenderingAttachmentInfo::builder()


### PR DESCRIPTION
> **tl;dr in three words: show, don't tell.**
>
> ![show don't tell — Cosima, Orphan Black](https://gh-artifact.tatolab.com/pr-632/show-dont-tell.gif)
>
> *(The PR fixes display's "I'll just claim a layout in the descriptor" approach by making producers declare and consumers read — typed state instead of implicit assumption. Same spirit applies to PR evidence: the screenshots above are embedded, not described.)*

## Summary

- Adds an engine-wide `TextureRegistration` record in `GpuContext::texture_cache` keyed by `surface_id`, carrying the texture plus its last-known Vulkan image layout (`AtomicI32` storing `streamlib_consumer_rhi::VulkanLayout`). Mirrors the per-surface state pattern surface adapters already use (`streamlib-adapter-vulkan::SurfaceState::current_layout`) lifted to the engine-wide cache.
- Display now resolves the registration, issues a conditional `cmd_pipeline_barrier2` from `registration.current_layout()` to `SHADER_READ_ONLY_OPTIMAL` before sampling, and updates the registration. Producers declare the layout they leave the texture in: camera ring textures register with `SHADER_READ_ONLY_OPTIMAL`; the AvatarCharacter OpenGL-adapter output registers with `UNDEFINED`.
- `register_texture` keeps its existing one-arg signature (defaults to `UNDEFINED` on Linux) for back-compat; `register_texture_with_layout` is the layout-aware variant. `resolve_videoframe_texture` is a thin projection over the new `resolve_videoframe_registration`.
- Establishes the architectural rule via `docs/architecture/texture-registration.md` + a new "single canonical abstraction" entry in CLAUDE.md (parallel to `VulkanComputeKernel`'s rule). Hard rule: never create a parallel `HashMap<surface_id, ...>` for per-surface state; extend `TextureRegistration` instead.

## Closes
Closes #616

## Architectural note

Engine-wide-cache → per-resource state struct → atomic hot-path field is what every production GPU engine surveyed for this work uses (Unreal `FRHIResource::CurrentAccess`, wgpu `TextureTracker<UsageScope>`, Granite's `ResourceTracker`). RDG-style automatic barrier inference — where each pass declares its read/write access type and the engine derives transitions — is filed as future research at #631; the boundary between this PR's substrate and that future layer is documented in `texture-registration.md`'s "Boundary with RDG" section.

## Exit criteria

- [x] Display issues a layout barrier for adapter-texture inputs before sampling.
- [x] Run with `VK_LOADER_LAYERS_ENABLE=*validation*` produces zero layout-mismatch warnings against AvatarCharacter Linux pipeline.
- [x] AvatarCharacter Linux pipeline rendering unchanged on NVIDIA (current verified behavior preserved).

## Test plan

### Workspace baseline (`docs/testing-baseline.md`)

Result: `passed=1214 failed=1 ignored=34`. The single failure is `streamlib-adapter-cpu-readback::round_trip_write_partial_modification_leaves_rest_untouched` — verified flaky on `main` (DEVICE_LOST under workspace-test contention) and passes when run in isolation. Pre-existing, not a regression from this PR.

### E2E Test Report

#### AvatarCharacter Linux (the bug repro pipeline)

- **Scenario**: camera+display-only with OpenGL adapter
- **Example**: `camera-python-display`
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=180`, 60 s timeout
- **Build profile**: release

##### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- **Layout-mismatch validation errors** (the metric this PR fixes): **0**
- All Validation Errors: 22 (categorized: 10× `VUID-VkSemaphoreSignalInfo-value-03258` cuda-adapter timeline race, 10× `VUID-vkDestroyCommandPool-commandPool-00041` shutdown teardown race, 2× `VUID-vkGetImageSubresourceLayout-image-07790` tiled-image queries — all pre-existing, none layout-barrier-related)

##### PNG samples

- Sample count: 6
- PNG read with Read tool: `display_001_frame_000060_input_000251.png`
- **What was in the image**: Real-camera scene (dark room with chair-back tag and wood door visible) composited with the avatar mesh-render output area (cyan-outlined rectangle on the right) — the OpenGL-adapter-produced VkImage flowed through the new layout-barrier path without garbling, confirming the bug fix produces a correct visual.

  ![AvatarCharacter Linux pipeline frame 60 — real-camera composited with avatar mesh-render overlay area](https://gh-artifact.tatolab.com/pr-632/avatar-frame60.jpg)
- Anomalies: none

##### Outcome

**Pass.** Zero layout-mismatch validation errors. AvatarCharacter pipeline runs end-to-end and produces correct compositing.

#### camera-display Linux (no-regression check)

- **Scenario**: camera+display-only, `camera-display` example
- **Camera device**: `/dev/video0` (vivid), 1920x1080
- **Frame limit / build**: 150 / release

##### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0; `DEVICE_LOST`: 0; `process() failed`: 0
- **Layout-mismatch validation errors**: 0
- All Validation Errors: 2 (both `VUID-vkGetImageSubresourceLayout-image-07790`, pre-existing)

##### PNG samples

- 5 samples; read `display_001_frame_000060_input_000062.png`
- **What was in the image**: Vivid test pattern — vertical green color bands with the test-card metadata overlay (timecode `00:00:12.204 61`, format/brightness/contrast metadata). Matches expected vivid output, no regression.

  ![camera-display Linux frame 60 — vivid test pattern with timecode overlay](https://gh-artifact.tatolab.com/pr-632/camdisp-vivid-frame60.jpg)

##### Outcome

**Pass.** Camera→display still renders cleanly because camera registers with `SHADER_READ_ONLY_OPTIMAL` matching the post-compute transition; display's new conditional barrier short-circuits to the no-op branch.

## Follow-ups

- **#631** — RDG-style automatic barrier inference (research / maybe-never).
- **#633** — Cross-process layout coordination via `surface-share` IPC + `Videoframe` schema extensions (polyglot, all three runtimes ship together).
- **#634** — Lift `TextureRegistration` into `streamlib-consumer-rhi` so subprocess producers can construct registrations from the typed contract.
- AMD / Intel hardware visual-check from the issue body — no AMD/Intel hardware in this dev environment; deferred per the issue's "explicit follow-up if no such hardware in CI".

## Pre-PR review

- `pr-review-gate` skill: VERDICT PASS, three DISCUSS items (multi-consumer race tolerance — already documented as intentional in `texture_registration.rs`; camera-comment imprecision — fixed in the second commit; test fidelity vs. E2E split — by design per issue exit criteria, addressed by E2E run above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

