### PR TITLE
fix(linux-python): AvatarCharacter Vulkan-conventional Y in pose overlay (#621)

### DIFF
--- a/examples/camera-python-display/python/pose_overlay_renderer.py
+++ b/examples/camera-python-display/python/pose_overlay_renderer.py
@@ -226,14 +226,20 @@ class PoseOverlayRenderer:
             vertex_shader=_BACKGROUND_VS, fragment_shader=_BACKGROUND_FS,
         )
         # Full-screen quad — pos.xy + texcoord.xy interleaved.
-        # NDC corners + flipped Y in tex coords (camera bytes upload
-        # top-down, OpenGL textures are bottom-up, so we sample with
-        # flipped Y to keep the camera the right way up).
+        # The output FBO wraps an imported GL_TEXTURE_2D backed by a
+        # Vulkan VkImage (the OpenGL adapter's contract). GL writes
+        # with origin bottom-left; Vulkan downstream reads with origin
+        # top-left — so we render with Vulkan-conventional Y: GL bottom
+        # (NDC y=-1) gets the camera's top row (tex y=0). The double
+        # flip (GL render axis + Vulkan read axis) cancels and the
+        # display sees the camera upright. See OpenGlContext docs for
+        # the convention. Don't be tempted to "fix" by inverting the
+        # texcoord Y — that re-introduces #621.
         bg_verts = np.array([
-            -1.0, -1.0, 0.0, 1.0,
-             1.0, -1.0, 1.0, 1.0,
-            -1.0,  1.0, 0.0, 0.0,
-             1.0,  1.0, 1.0, 0.0,
+            -1.0, -1.0, 0.0, 0.0,
+             1.0, -1.0, 1.0, 0.0,
+            -1.0,  1.0, 0.0, 1.0,
+             1.0,  1.0, 1.0, 1.0,
         ], dtype=np.float32)
         self._bg_vbo = ctx.buffer(bg_verts.tobytes())
         self._bg_vao = ctx.vertex_array(
@@ -311,12 +317,17 @@ class PoseOverlayRenderer:
                 # Collapse to origin so the edge takes zero pixels.
                 continue
 
-            # Pixel → NDC (-1..1). Y is flipped because YOLO image-space
-            # has Y growing downwards while NDC Y grows upwards.
+            # Pixel → NDC (-1..1). Y is NOT negated: YOLO image-space
+            # y grows downwards (y=0 at top of camera) and we want
+            # camera-top to render at GL NDC y=-1 (bottom) so that the
+            # VkImage backing this FBO sees row 0 at the top — Vulkan-
+            # conventional. See bg_verts above for the full rationale
+            # and OpenGlContext docs for the convention. Inverting Y
+            # here re-introduces #621.
             ax = (xi / max(self.W, 1)) * 2.0 - 1.0
-            ay = -((yi / max(self.H, 1)) * 2.0 - 1.0)
+            ay = (yi / max(self.H, 1)) * 2.0 - 1.0
             bx = (xj / max(self.W, 1)) * 2.0 - 1.0
-            by = -((yj / max(self.H, 1)) * 2.0 - 1.0)
+            by = (yj / max(self.H, 1)) * 2.0 - 1.0
 
             dx = bx - ax
             dy = by - ay
@@ -370,7 +381,7 @@ class PoseOverlayRenderer:
                 continue
 
             cx = (xp / max(self.W, 1)) * 2.0 - 1.0
-            cy = -((yp / max(self.H, 1)) * 2.0 - 1.0)
+            cy = (yp / max(self.H, 1)) * 2.0 - 1.0
 
             for vi in range(6):
                 cx_corner, cy_corner = corners[vi]

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -95,8 +95,13 @@ pub fn main() -> Result<()> {
     // BGRA-shaped ring textures; mismatched sizes are rejected by the
     // copy processor at the first frame.
     println!("📷 Adding camera processor...");
+    // Match the env-var convention used in `examples/camera-display` so
+    // the same flag (`STREAMLIB_CAMERA_DEVICE=/dev/videoN`) targets vivid
+    // / v4l2loopback fixtures during E2E. Default `None` lets the camera
+    // processor pick by capability.
+    let device_id = std::env::var("STREAMLIB_CAMERA_DEVICE").ok();
     let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
-        device_id: None,
+        device_id,
         ..Default::default()
     }))?;
     println!("✓ Camera added: {camera}\n");

--- a/libs/streamlib-adapter-opengl/src/lib.rs
+++ b/libs/streamlib-adapter-opengl/src/lib.rs
@@ -13,6 +13,14 @@
 //! never reaches them because the host allocator already picked a
 //! tiled, render-target-capable modifier.
 //!
+//! **Y-axis convention** — the imported `GL_TEXTURE_2D` is backed by a
+//! `VkImage` that downstream Vulkan consumers (display, encoders) read
+//! with origin at top-left, while GL writes to an FBO with origin at
+//! bottom-left. Producers MUST render Vulkan-conventional or the
+//! consumer sees an upside-down image (#621). See [`OpenGlWriteView`]
+//! for the full convention and the `pose_overlay_renderer.py` example
+//! for an in-tree reference.
+//!
 //! See `docs/architecture/surface-adapter.md` for the architecture brief
 //! and `docs/architecture/adapter-authoring.md` for the 3rd-party
 //! authoring guide.

--- a/libs/streamlib-adapter-opengl/src/view.rs
+++ b/libs/streamlib-adapter-opengl/src/view.rs
@@ -70,6 +70,31 @@ impl GlWritable for OpenGlReadView<'_> {
 /// external-OES path is read-only by construction (the underlying
 /// import is sampler-only on NVIDIA per
 /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`).
+///
+/// # Y-axis convention — render Vulkan-conventional
+///
+/// The underlying storage is a Vulkan `VkImage`. GL writes to an FBO
+/// with origin at bottom-left; Vulkan downstream reads the same
+/// `VkImage` with origin at top-left. To avoid the consumer-side
+/// visual flip, **producers must render with Vulkan-conventional Y**:
+/// emit geometry such that the camera/source's top row lands at
+/// `gl_Position.y == -1` (GL bottom of NDC), which is byte row 0 of
+/// the underlying `VkImage` — i.e. Vulkan top.
+///
+/// Concretely, when sampling a top-down source (camera DMA-BUF, image
+/// upload) into a full-screen quad, set the texcoord-Y so that GL
+/// NDC `(−1, −1)` samples tex `(0, 0)` — **don't** flip texcoord-Y to
+/// "make it look upright in a GL window." The double flip (GL render
+/// axis + Vulkan read axis) cancels and the downstream Vulkan
+/// consumer sees the source upright. See `#621` for the bug class
+/// this prevents.
+///
+/// Equivalent fixes if you find Vulkan-conventional geometry awkward
+/// in a given producer: invert `gl_Position.y` in the vertex shader,
+/// or (GL 4.5+) call `glClipControl(GL_UPPER_LEFT, GL_ZERO_TO_ONE)`
+/// once at context init. Don't do a final Y-flip blit in the producer
+/// — that costs a render pass and recreates the same convention
+/// problem one layer down.
 pub struct OpenGlWriteView<'g> {
     pub(crate) texture: u32,
     pub(crate) _marker: PhantomData<&'g ()>,


### PR DESCRIPTION
## Summary

- Renderer was Y-flipping bg-quad texcoords + negating keypoint Y to "look upright in GL view" — but the FBO is an imported `GL_TEXTURE_2D` backed by a Vulkan `VkImage` that downstream display reads top-left, while GL writes bottom-left. So anything upright-in-GL was upside-down at the consumer (the issue's reported symptom: bg + skeleton flipped consistently together — confirms this is a render-axis bug, not an inference-path bug, per the issue's AI Agent Notes).
- Fix is two-layered:
  - **Renderer (consumer)**: `pose_overlay_renderer.py` now renders Vulkan-conventional Y. `bg_verts` texcoord-Y is identity (GL bottom samples camera tex y=0 = top row); skeleton + joint geometry drop the keypoint Y negation. Co-located change so bg + skeleton stay in lockstep.
  - **OpenGL adapter (engine)**: encodes the Y-axis convention as a docstring section on `OpenGlWriteView` plus a paragraph in the crate's module doc. Future producers (#485 watermark/lower-third, #486 cyberpunk glitch, #513 skia adapter) read the contract instead of re-deriving from #621.
- Also wired `STREAMLIB_CAMERA_DEVICE` into `camera-python-display`'s linux entrypoint — matches `examples/camera-display`'s pattern. Test-infrastructure scope: lets v4l2loopback / vivid drive E2E without a physical camera. The reproducer for this PR's regression test depends on it.

## Closes
Closes #621

## Architectural note

Per CLAUDE.md's engine-model rule ("engine-wide bugs get fixed at the engine layer"), the GL ↔ Vulkan Y-axis convention IS engine-level — every future OpenGL adapter producer would otherwise re-derive #621 by reading "the gl_texture_id is a regular GL_TEXTURE_2D" (the existing docstring's contract) and writing GL-natural code. The convention is captured at the engine layer (adapter docstring) but the actual *fix code* lives at the consumer (renderer) because:

- The convention is a producer-side discipline; the adapter has no compile-time enforcement leverage.
- A final Y-flip blit at `release_write` would absorb the convention but cost a render pass per frame and trade an architectural leak for a perf cost — not the right shape.
- A `glClipControl(GL_UPPER_LEFT, GL_ZERO_TO_ONE)` (GL 4.5+) flip in the adapter's EGL setup *would* reverse the convention engine-side, but it requires careful interaction with ModernGL's own context state and isn't worth a P1 in this PR. The docstring lists it as an equivalent option for future producers.

The docstring length on `OpenGlWriteView` is intentionally above CLAUDE.md's "minimal autocomplete" baseline because this is an engine-wide invariant that prevents a bug class. `pr-review-gate` flagged it as DISCUSS / borderline-but-defensible; I agree.

## Exit criteria

- [x] AvatarCharacter Linux's display output is vertically upright against v4l2loopback testsrc2 with a known orientation marker.
- [x] YOLO skeleton tracking still aligns with the user's body in the un-flipped image — the keypoint Y mapping was changed in lockstep with the bg-quad texcoord-Y, so bg + skeleton stay co-located. testsrc2 has no human pose to inspect, but the math is symmetric: both un-negate together, the skeleton's relative position to the bg is preserved.

## Test plan

### Unit (cargo)

- `cargo test -p streamlib-adapter-opengl --tests` — **11 passed**, 0 failed, 0 ignored.
- `cargo doc -p streamlib-adapter-opengl --no-deps` — no new warnings (one pre-existing `argv[1]` warning in `opengl_adapter_subprocess_helper`, unrelated).

### E2E Test Report

- **Scenario**: camera+display-only (Python avatar processor)
- **Example**: `camera-python-display`
- **Codec**: n/a
- **Camera device**: `/dev/video10` (v4l2loopback streaming `ffmpeg testsrc2`)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=100`, ~7s
- **Build profile**: release
- **Command**:
    ```
    # In a separate terminal:
    ffmpeg -re -f lavfi -i 'testsrc2=size=1920x1080:rate=30,format=nv12' -f v4l2 /dev/video10

    STREAMLIB_CAMERA_DEVICE=/dev/video10 \
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/avatar-flip-testsrc2/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=20 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=100 \
    timeout --kill-after=5 35 cargo run --release -p camera-python-display
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame processed`: 02:05:51.593 (~3s after start)
- Camera Virtual_Camera: 194 frames captured

#### PNG samples

- Directory: `/tmp/avatar-flip-testsrc2-…/png_samples/`
- Sample count: 5 (frames 0/20/40/60/80)
- Sample interval: `STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=20`
- PNGs read with Read tool: `display_001_frame_000000`, `display_001_frame_000060`, `display_001_frame_000080`
- **What was in the image(s)**: `testsrc2` test pattern with vertical color bars (R, G, Y, B, M, C left-to-right) ✓, dynamic checkerboard test patch in **lower-right corner** in all 3 sampled frames ✓, animated diagonal sweep line, center alignment cross, smaller marker squares — all rendered through the cyberpunk shader (cyan grade + chromatic aberration + scanlines + vignette). The checkerboard's lower-right placement is the load-bearing orientation marker: `testsrc2` puts it there in the source image, so its appearance in the lower-right of the display output confirms orientation is correct. With the bug, the checkerboard would be in the upper-left.

  **Frame 0** (input frame 74):
  ![display frame 0 — testsrc2 with checkerboard lower-right](https://gh-artifact.tatolab.com/pr-636/frame-000.jpg)

  **Frame 60** (input frame 154):
  ![display frame 60 — center cross visible, checkerboard lower-right](https://gh-artifact.tatolab.com/pr-636/frame-060.jpg)

  **Frame 80** (input frame 174):
  ![display frame 80 — frame-counter rectangle middle-left, checkerboard lower-right](https://gh-artifact.tatolab.com/pr-636/frame-080.jpg)
- Anomalies: none. The cyberpunk shader's chromatic aberration on edges is intentional (this is the AvatarCharacter Linux render style, not a bug).

#### PSNR

- Reference frame: n/a — synthetic source but no checked-in reference for this orientation regression.
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass.** Orientation correct, no regressions, pipeline runs end-to-end at ~30fps for 194 frames.
- Caveats / follow-ups: none filed by this PR.

## Polyglot coverage

- **Runtimes affected**: Python (the renderer change). Rust (adapter docstring + linux example wire).
- **Schema regenerated**: n/a (no IPC schema change).
- **Python and Deno both covered?** AvatarCharacter Linux is Python-only by construction (the cdylib uses ModernGL + Ultralytics YOLOv8); a Deno port doesn't exist and isn't load-bearing for this issue. The OpenGL adapter docstring change is Rust-side and applies to both Python and Deno consumers transparently — when Deno OpenGL producers eventually arrive (none in tree today), they read the same `OpenGlWriteView` documentation.

## Pre-PR review

- `pr-review-gate` skill: **VERDICT PASS**, two DISCUSS items (no Rust unit test — agreed, E2E is the right shape since the convention is producer-side discipline; docstring length above CLAUDE.md baseline — agreed, justified by the engine-wide invariant it captures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

