### PR TITLE
perf(adapter): amortize per-frame command-pool churn in cpu-readback + cuda

### DIFF
--- a/libs/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback/Cargo.toml
@@ -67,5 +67,9 @@ path = "tests/stride_offset_handling.rs"
 name = "subprocess_crash_mid_write"
 path = "tests/subprocess_crash_mid_write.rs"
 
+[[test]]
+name = "persistent_command_pool"
+path = "tests/persistent_command_pool.rs"
+
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -965,8 +965,11 @@ impl<D: VulkanRhiDevice + 'static> InProcessCpuReadbackCopyTrigger<D> {
 /// and completion fence — replaces the create-and-destroy-per-submit
 /// pattern that used to churn `vkCreateCommandPool` /
 /// `vkDestroyCommandPool` once per copy. Same shape lives in
-/// `streamlib-adapter-cuda::adapter::AdapterPersistentSubmitContext`;
-/// fix BOTH if you change EITHER (issue #620 AI Agent Notes).
+/// `streamlib-adapter-cuda::adapter::AdapterPersistentSubmitContext`
+/// and `streamlib-adapter-vulkan::adapter::AdapterPersistentSubmitContext`;
+/// fix ALL THREE if you change ANY (issue #620 + #640 AI Agent
+/// Notes — `streamlib-adapter-abi` deliberately does not depend on
+/// `vulkanalia`, so duplication is the project pattern here).
 ///
 /// The fence is created signaled so the first submit doesn't block
 /// waiting on a previous-submit completion. Subsequent submits wait

--- a/libs/streamlib-adapter-cpu-readback/src/adapter.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/adapter.rs
@@ -31,7 +31,8 @@
 //! the dep graph alone.
 
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use streamlib_consumer_rhi::{
@@ -698,13 +699,46 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CpuReadbackSurfaceAdapter<
 /// in-process trigger is reachable to them only against
 /// `ConsumerVulkanDevice`, which fails at the `image.is_some()`
 /// check.
+///
+/// Holds a single persistent `vk::CommandPool` + command buffer +
+/// completion fence ([`AdapterPersistentSubmitContext`]), reset and
+/// reused on every submit. The pool is lazy-initialised on the first
+/// `run_copy_*` call so `new()` stays infallible. Single-threaded
+/// caller convention; future concurrent callers serialise through
+/// the inner [`Mutex`] (correct, just less concurrent than
+/// thread-local pools — see issue #620 AI Agent Notes).
 pub struct InProcessCpuReadbackCopyTrigger<D: VulkanRhiDevice> {
     device: Arc<D>,
+    #[cfg(target_os = "linux")]
+    submit_ctx: Mutex<Option<AdapterPersistentSubmitContext>>,
+    /// Counts the number of times the persistent submit context was
+    /// (re)created — incremented on lazy-init and on rebuild after
+    /// device loss. Tests assert this stays at 1 after N submits to
+    /// lock the amortisation contract from #620.
+    submit_ctx_create_count: AtomicUsize,
 }
 
 impl<D: VulkanRhiDevice> InProcessCpuReadbackCopyTrigger<D> {
     pub fn new(device: Arc<D>) -> Self {
-        Self { device }
+        Self {
+            device,
+            #[cfg(target_os = "linux")]
+            submit_ctx: Mutex::new(None),
+            submit_ctx_create_count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of times this trigger has materialised its persistent
+    /// command pool. Stays at 0 before the first submit, becomes 1
+    /// after the first submit, and stays at 1 across every subsequent
+    /// submit unless the pool is rebuilt (which never happens today
+    /// — driver-loss recovery would bump it).
+    ///
+    /// Hidden from the public docs because callers shouldn't depend
+    /// on it; tests use it to lock #620's amortisation invariant.
+    #[doc(hidden)]
+    pub fn submit_pool_create_count(&self) -> usize {
+        self.submit_ctx_create_count.load(Ordering::Relaxed)
     }
 }
 
@@ -721,8 +755,7 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackCopyTrigger<D::Privilege>
                 "InProcessCpuReadbackCopyTrigger requires a source VkImage; consumer-flavor surfaces have none"
                     .into(),
         })?;
-        submit_image_buffer_copy(
-            self.device.as_ref(),
+        self.submit_image_buffer_copy(
             image,
             ctx.from_layout,
             vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
@@ -738,14 +771,26 @@ impl<D: VulkanRhiDevice + 'static> CpuReadbackCopyTrigger<D::Privilege>
         let image = ctx.image.ok_or(AdapterError::BackendRejected {
             reason: "InProcessCpuReadbackCopyTrigger requires a source VkImage on flush".into(),
         })?;
-        submit_image_buffer_copy(
-            self.device.as_ref(),
+        self.submit_image_buffer_copy(
             image,
             ctx.from_layout,
             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
             CopyDirection::BufferToImage,
             ctx,
         )
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl<D: VulkanRhiDevice> Drop for InProcessCpuReadbackCopyTrigger<D> {
+    fn drop(&mut self) {
+        let mut guard = match self.submit_ctx.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(ctx) = guard.take() {
+            ctx.destroy(self.device.device());
+        }
     }
 }
 
@@ -766,123 +811,259 @@ enum BridgeDirection {
 }
 
 #[cfg(target_os = "linux")]
-fn submit_image_buffer_copy<D: VulkanRhiDevice, P: DevicePrivilege>(
-    device: &D,
-    image: vk::Image,
-    from_layout: vk::ImageLayout,
-    transfer_layout: vk::ImageLayout,
-    direction: CopyDirection,
-    ctx: &CpuReadbackTriggerContext<'_, P>,
-) -> Result<u64, AdapterError> {
-    let vk_device = device.device();
-    let queue = device.queue();
-    let qf = device.queue_family_index();
-    let combined_aspect = combined_aspect_mask(ctx.format);
+impl<D: VulkanRhiDevice + 'static> InProcessCpuReadbackCopyTrigger<D> {
+    fn submit_image_buffer_copy<P: DevicePrivilege>(
+        &self,
+        image: vk::Image,
+        from_layout: vk::ImageLayout,
+        transfer_layout: vk::ImageLayout,
+        direction: CopyDirection,
+        ctx: &CpuReadbackTriggerContext<'_, P>,
+    ) -> Result<u64, AdapterError> {
+        let vk_device = self.device.device();
+        let queue = self.device.queue();
+        let qf = self.device.queue_family_index();
+        let combined_aspect = combined_aspect_mask(ctx.format);
 
-    let (pool, cmd) = create_one_shot_command_buffer(vk_device, qf)?;
+        let mut guard = self
+            .submit_ctx
+            .lock()
+            .map_err(|_| AdapterError::BackendRejected {
+                reason: "submit_image_buffer_copy: persistent submit context mutex poisoned"
+                    .into(),
+            })?;
+        if guard.is_none() {
+            *guard = Some(AdapterPersistentSubmitContext::new(vk_device, qf)?);
+            self.submit_ctx_create_count.fetch_add(1, Ordering::Relaxed);
+        }
+        let submit_ctx = guard.as_ref().expect("submit_ctx populated above");
+        let cmd = submit_ctx.cmd;
 
-    let begin_info = vk::CommandBufferBeginInfo::builder()
-        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
-        .build();
-    if let Err(e) = unsafe { vk_device.begin_command_buffer(cmd, &begin_info) } {
-        unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::BackendRejected {
-            reason: format!("begin_command_buffer: {e}"),
-        });
+        submit_ctx.reset_for_recording(vk_device)?;
+
+        let begin_info = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        unsafe { vk_device.begin_command_buffer(cmd, &begin_info) }
+            .map_err(|e| AdapterError::BackendRejected {
+                reason: format!("begin_command_buffer: {e}"),
+            })?;
+
+        let pre_barrier =
+            build_image_barrier(image, qf, from_layout, transfer_layout, combined_aspect);
+        let pre_barriers = [pre_barrier];
+        let pre_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&pre_barriers)
+            .build();
+        unsafe { vk_device.cmd_pipeline_barrier2(cmd, &pre_dep) };
+
+        for (plane_idx, plane) in ctx.planes.iter().enumerate() {
+            let aspect = plane_aspect_mask(ctx.format, plane_idx as u32);
+            let copy_region = vk::BufferImageCopy::builder()
+                .buffer_offset(0)
+                .buffer_row_length(plane.width)
+                .buffer_image_height(plane.height)
+                .image_subresource(
+                    vk::ImageSubresourceLayers::builder()
+                        .aspect_mask(aspect)
+                        .mip_level(0)
+                        .base_array_layer(0)
+                        .layer_count(1)
+                        .build(),
+                )
+                .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+                .image_extent(vk::Extent3D {
+                    width: plane.width,
+                    height: plane.height,
+                    depth: 1,
+                })
+                .build();
+            match direction {
+                CopyDirection::ImageToBuffer => unsafe {
+                    vk_device.cmd_copy_image_to_buffer(
+                        cmd,
+                        image,
+                        transfer_layout,
+                        plane.buffer,
+                        &[copy_region],
+                    )
+                },
+                CopyDirection::BufferToImage => unsafe {
+                    vk_device.cmd_copy_buffer_to_image(
+                        cmd,
+                        plane.buffer,
+                        image,
+                        transfer_layout,
+                        &[copy_region],
+                    )
+                },
+            }
+        }
+
+        let post_image_barrier = build_image_barrier(
+            image,
+            qf,
+            transfer_layout,
+            vk::ImageLayout::GENERAL,
+            combined_aspect,
+        );
+        let post_image_barriers = [post_image_barrier];
+        let post_buf_barriers: Vec<vk::BufferMemoryBarrier2> = match direction {
+            CopyDirection::ImageToBuffer => ctx
+                .planes
+                .iter()
+                .map(|p| {
+                    vk::BufferMemoryBarrier2::builder()
+                        .src_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
+                        .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
+                        .dst_stage_mask(vk::PipelineStageFlags2::HOST)
+                        .dst_access_mask(vk::AccessFlags2::HOST_READ)
+                        .buffer(p.buffer)
+                        .offset(0)
+                        .size(vk::WHOLE_SIZE)
+                        .build()
+                })
+                .collect(),
+            CopyDirection::BufferToImage => Vec::new(),
+        };
+        let post_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&post_image_barriers)
+            .buffer_memory_barriers(&post_buf_barriers)
+            .build();
+        unsafe { vk_device.cmd_pipeline_barrier2(cmd, &post_dep) };
+
+        unsafe { vk_device.end_command_buffer(cmd) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("end_command_buffer: {e}"),
+            }
+        })?;
+
+        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cmd)
+            .build()];
+        let signal_infos = [vk::SemaphoreSubmitInfo::builder()
+            .semaphore(ctx.timeline.semaphore())
+            .value(ctx.suggested_signal_value)
+            .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .build()];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cmd_infos)
+            .signal_semaphore_infos(&signal_infos)
+            .build();
+
+        unsafe { self.device.submit_to_queue(queue, &[submit], submit_ctx.fence) }.map_err(
+            |e| AdapterError::BackendRejected {
+                reason: format!("submit_to_queue: {e}"),
+            },
+        )?;
+
+        Ok(ctx.suggested_signal_value)
+    }
+}
+
+/// Persistent per-trigger / per-adapter command pool, command buffer,
+/// and completion fence — replaces the create-and-destroy-per-submit
+/// pattern that used to churn `vkCreateCommandPool` /
+/// `vkDestroyCommandPool` once per copy. Same shape lives in
+/// `streamlib-adapter-cuda::adapter::AdapterPersistentSubmitContext`;
+/// fix BOTH if you change EITHER (issue #620 AI Agent Notes).
+///
+/// The fence is created signaled so the first submit doesn't block
+/// waiting on a previous-submit completion. Subsequent submits wait
+/// on the fence (instant if the prior submit has already drained,
+/// which is the steady state for cpu-readback because the adapter
+/// already CPU-waits on the timeline before the customer reads).
+/// `vkResetCommandPool` is the cheap path per Vulkan spec — recycles
+/// every command buffer's memory in one call.
+#[cfg(target_os = "linux")]
+struct AdapterPersistentSubmitContext {
+    pool: vk::CommandPool,
+    cmd: vk::CommandBuffer,
+    fence: vk::Fence,
+}
+
+#[cfg(target_os = "linux")]
+impl AdapterPersistentSubmitContext {
+    fn new(device: &vulkanalia::Device, qf: u32) -> Result<Self, AdapterError> {
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let pool =
+            unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
+                AdapterError::BackendRejected {
+                    reason: format!("create_command_pool: {e}"),
+                }
+            })?;
+
+        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd = match unsafe { device.allocate_command_buffers(&alloc_info) } {
+            Ok(v) => v[0],
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("allocate_command_buffers: {e}"),
+                });
+            }
+        };
+
+        let fence_info = vk::FenceCreateInfo::builder()
+            .flags(vk::FenceCreateFlags::SIGNALED)
+            .build();
+        let fence = match unsafe { device.create_fence(&fence_info, None) } {
+            Ok(f) => f,
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("create_fence: {e}"),
+                });
+            }
+        };
+
+        Ok(Self { pool, cmd, fence })
     }
 
-    let pre_barrier = build_image_barrier(image, qf, from_layout, transfer_layout, combined_aspect);
-    let pre_barriers = [pre_barrier];
-    let pre_dep = vk::DependencyInfo::builder()
-        .image_memory_barriers(&pre_barriers)
-        .build();
-    unsafe { vk_device.cmd_pipeline_barrier2(cmd, &pre_dep) };
+    /// Wait for the previous submit's fence, reset it, then reset the
+    /// command pool so the single command buffer is ready to be
+    /// re-recorded. Steady-state cost is the wait, which is instant
+    /// when the prior submit has already drained.
+    fn reset_for_recording(&self, device: &vulkanalia::Device) -> Result<(), AdapterError> {
+        unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("wait_for_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe { device.reset_fences(&[self.fence]) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("reset_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe {
+            device.reset_command_pool(self.pool, vk::CommandPoolResetFlags::empty())
+        }
+        .map_err(|e| AdapterError::BackendRejected {
+            reason: format!("reset_command_pool (persistent submit pool): {e}"),
+        })?;
+        Ok(())
+    }
 
-    for (plane_idx, plane) in ctx.planes.iter().enumerate() {
-        let aspect = plane_aspect_mask(ctx.format, plane_idx as u32);
-        let copy_region = vk::BufferImageCopy::builder()
-            .buffer_offset(0)
-            .buffer_row_length(plane.width)
-            .buffer_image_height(plane.height)
-            .image_subresource(
-                vk::ImageSubresourceLayers::builder()
-                    .aspect_mask(aspect)
-                    .mip_level(0)
-                    .base_array_layer(0)
-                    .layer_count(1)
-                    .build(),
-            )
-            .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-            .image_extent(vk::Extent3D {
-                width: plane.width,
-                height: plane.height,
-                depth: 1,
-            })
-            .build();
-        match direction {
-            CopyDirection::ImageToBuffer => unsafe {
-                vk_device.cmd_copy_image_to_buffer(cmd, image, transfer_layout, plane.buffer, &[copy_region])
-            },
-            CopyDirection::BufferToImage => unsafe {
-                vk_device.cmd_copy_buffer_to_image(cmd, plane.buffer, image, transfer_layout, &[copy_region])
-            },
+    /// Tear down the pool + fence. Caller must guarantee the fence is
+    /// signaled (no GPU work pending) — `Drop` paths satisfy this by
+    /// either waiting on the fence first or only destroying after a
+    /// known-completed submit.
+    fn destroy(self, device: &vulkanalia::Device) {
+        // Wait for any pending submit to drain so destruction is safe.
+        let _ =
+            unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) };
+        unsafe {
+            device.destroy_fence(self.fence, None);
+            device.destroy_command_pool(self.pool, None);
         }
     }
-
-    let post_image_barrier =
-        build_image_barrier(image, qf, transfer_layout, vk::ImageLayout::GENERAL, combined_aspect);
-    let post_image_barriers = [post_image_barrier];
-    let post_buf_barriers: Vec<vk::BufferMemoryBarrier2> = match direction {
-        CopyDirection::ImageToBuffer => ctx
-            .planes
-            .iter()
-            .map(|p| {
-                vk::BufferMemoryBarrier2::builder()
-                    .src_stage_mask(vk::PipelineStageFlags2::ALL_TRANSFER)
-                    .src_access_mask(vk::AccessFlags2::TRANSFER_WRITE)
-                    .dst_stage_mask(vk::PipelineStageFlags2::HOST)
-                    .dst_access_mask(vk::AccessFlags2::HOST_READ)
-                    .buffer(p.buffer)
-                    .offset(0)
-                    .size(vk::WHOLE_SIZE)
-                    .build()
-            })
-            .collect(),
-        CopyDirection::BufferToImage => Vec::new(),
-    };
-    let post_dep = vk::DependencyInfo::builder()
-        .image_memory_barriers(&post_image_barriers)
-        .buffer_memory_barriers(&post_buf_barriers)
-        .build();
-    unsafe { vk_device.cmd_pipeline_barrier2(cmd, &post_dep) };
-
-    if let Err(e) = unsafe { vk_device.end_command_buffer(cmd) } {
-        unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::BackendRejected {
-            reason: format!("end_command_buffer: {e}"),
-        });
-    }
-
-    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
-        .command_buffer(cmd)
-        .build()];
-    let signal_infos = [vk::SemaphoreSubmitInfo::builder()
-        .semaphore(ctx.timeline.semaphore())
-        .value(ctx.suggested_signal_value)
-        .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .build()];
-    let submit = vk::SubmitInfo2::builder()
-        .command_buffer_infos(&cmd_infos)
-        .signal_semaphore_infos(&signal_infos)
-        .build();
-
-    let submit_result = unsafe { device.submit_to_queue(queue, &[submit], vk::Fence::null()) };
-    unsafe { vk_device.destroy_command_pool(pool, None) };
-    submit_result.map_err(|e| AdapterError::BackendRejected {
-        reason: format!("submit_to_queue: {e}"),
-    })?;
-
-    Ok(ctx.suggested_signal_value)
 }
 
 // =====================================================================
@@ -916,39 +1097,6 @@ unsafe impl<P: DevicePrivilege> Sync for AcquireSnapshot<P> {}
 
 struct AcquireOutcome<P: DevicePrivilege> {
     snap: AcquireSnapshot<P>,
-}
-
-#[cfg(target_os = "linux")]
-fn create_one_shot_command_buffer(
-    device: &vulkanalia::Device,
-    qf: u32,
-) -> Result<(vk::CommandPool, vk::CommandBuffer), AdapterError> {
-    let pool_info = vk::CommandPoolCreateInfo::builder()
-        .queue_family_index(qf)
-        .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-        .build();
-    let pool =
-        unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
-            AdapterError::BackendRejected {
-                reason: format!("create_command_pool: {e}"),
-            }
-        })?;
-
-    let alloc_info = vk::CommandBufferAllocateInfo::builder()
-        .command_pool(pool)
-        .level(vk::CommandBufferLevel::PRIMARY)
-        .command_buffer_count(1)
-        .build();
-    let cmd_buffers = match unsafe { device.allocate_command_buffers(&alloc_info) } {
-        Ok(v) => v,
-        Err(e) => {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
-                reason: format!("allocate_command_buffers: {e}"),
-            });
-        }
-    };
-    Ok((pool, cmd_buffers[0]))
 }
 
 fn build_image_barrier(

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -60,6 +60,11 @@ pub struct HostFixture {
     pub gpu: Arc<GpuContext>,
     pub adapter: Arc<HostAdapter>,
     pub ctx: HostContext,
+    /// Typed handle to the in-process trigger so tests can read its
+    /// `submit_pool_create_count()` (e.g. for #620's amortisation
+    /// invariant). The adapter holds the `dyn`-erased `Arc`; this
+    /// keeps the typed `Arc` alongside it.
+    pub trigger: Arc<InProcessCpuReadbackCopyTrigger<HostVulkanDevice>>,
 }
 
 impl HostFixture {
@@ -68,13 +73,19 @@ impl HostFixture {
         let host_device = Arc::clone(gpu.device().vulkan_device());
         let trigger = Arc::new(InProcessCpuReadbackCopyTrigger::new(Arc::clone(
             &host_device,
-        ))) as Arc<dyn CpuReadbackCopyTrigger<HostMarker>>;
+        )));
+        let trigger_dyn = Arc::clone(&trigger) as Arc<dyn CpuReadbackCopyTrigger<HostMarker>>;
         let adapter = Arc::new(CpuReadbackSurfaceAdapter::new(
             Arc::clone(&host_device),
-            trigger,
+            trigger_dyn,
         ));
         let ctx = CpuReadbackContext::new(Arc::clone(&adapter));
-        Some(Self { gpu, adapter, ctx })
+        Some(Self {
+            gpu,
+            adapter,
+            ctx,
+            trigger,
+        })
     }
 
     /// Allocate a host BGRA8 `VkImage` + per-plane staging buffer +

--- a/libs/streamlib-adapter-cpu-readback/tests/persistent_command_pool.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/persistent_command_pool.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cpu_readback::tests::persistent_command_pool` —
+//! locks the #620 amortisation invariant.
+//!
+//! Before #620 the in-process trigger created and destroyed a
+//! `vk::CommandPool` on every read / write release, churning
+//! `vkCreateCommandPool` + `vkDestroyCommandPool` once per acquire on
+//! the steady-state hot path. The fix introduced
+//! `AdapterPersistentSubmitContext` — a single pool + command buffer +
+//! completion fence reset and reused across every submit. This test
+//! locks that invariant: after N>1 acquire/release cycles the
+//! in-process trigger's `submit_pool_create_count()` must stay at 1.
+//!
+//! Mentally revert the fix (e.g. force the lazy-init branch on every
+//! call) and the assertion fires — that's how this test stays
+//! load-bearing rather than feel-good.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use crate::common::HostFixture;
+
+#[test]
+fn persistent_pool_count_stays_at_one_across_repeated_acquires() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "persistent_command_pool: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+
+    let descriptor = fixture.register_surface(1, 16, 16);
+
+    // Pre-condition: lazy-init hasn't fired yet.
+    assert_eq!(
+        fixture.trigger.submit_pool_create_count(),
+        0,
+        "trigger should not have created its persistent pool before the first acquire"
+    );
+
+    // First acquire materialises the pool exactly once.
+    {
+        let _guard = fixture
+            .ctx
+            .acquire_read(&descriptor)
+            .expect("first acquire_read");
+    }
+    assert_eq!(
+        fixture.trigger.submit_pool_create_count(),
+        1,
+        "first submit must materialise the persistent pool exactly once"
+    );
+
+    // N additional acquires + write-release cycles must not grow the
+    // live pool count. Each `acquire_read` triggers an image→buffer
+    // submit; each `acquire_write` + drop triggers a buffer→image
+    // submit. Both go through the persistent pool — neither should
+    // re-materialise it.
+    let cycles = 32usize;
+    for i in 0..cycles {
+        {
+            let _r = fixture
+                .ctx
+                .acquire_read(&descriptor)
+                .unwrap_or_else(|e| panic!("acquire_read cycle {i}: {e:?}"));
+        }
+        {
+            let _w = fixture
+                .ctx
+                .acquire_write(&descriptor)
+                .unwrap_or_else(|e| panic!("acquire_write cycle {i}: {e:?}"));
+        }
+    }
+    assert_eq!(
+        fixture.trigger.submit_pool_create_count(),
+        1,
+        "after {cycles} additional acquire cycles, pool count grew — \
+         the persistent pool is being re-created per submit"
+    );
+}

--- a/libs/streamlib-adapter-cuda/Cargo.toml
+++ b/libs/streamlib-adapter-cuda/Cargo.toml
@@ -63,5 +63,9 @@ tracing-subscriber.workspace = true
 name = "conformance"
 path = "tests/conformance.rs"
 
+[[test]]
+name = "persistent_command_pool"
+path = "tests/persistent_command_pool.rs"
+
 [lints]
 workspace = true

--- a/libs/streamlib-adapter-cuda/src/adapter.rs
+++ b/libs/streamlib-adapter-cuda/src/adapter.rs
@@ -534,8 +534,11 @@ where
 /// pattern that used to churn `vkCreateCommandPool` /
 /// `vkDestroyCommandPool` on every host-pipeline copy. Same shape
 /// lives in
-/// `streamlib-adapter-cpu-readback::adapter::AdapterPersistentSubmitContext`;
-/// fix BOTH if you change EITHER (issue #620 AI Agent Notes).
+/// `streamlib-adapter-cpu-readback::adapter::AdapterPersistentSubmitContext`
+/// and `streamlib-adapter-vulkan::adapter::AdapterPersistentSubmitContext`;
+/// fix ALL THREE if you change ANY (issue #620 + #640 AI Agent
+/// Notes — `streamlib-adapter-abi` deliberately does not depend on
+/// `vulkanalia`, so duplication is the project pattern here).
 ///
 /// The fence is created signaled so the first submit doesn't block.
 /// Subsequent submits wait on it (instant when the prior submit has

--- a/libs/streamlib-adapter-cuda/src/adapter.rs
+++ b/libs/streamlib-adapter-cuda/src/adapter.rs
@@ -33,7 +33,8 @@
 //! is GPU-signaled and stays out of the per-acquire codepath.
 
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use streamlib_adapter_abi::{
@@ -66,6 +67,20 @@ pub struct CudaSurfaceAdapter<D: VulkanRhiDevice> {
     /// Per-acquire timeline-wait timeout. Adjustable via
     /// [`Self::with_acquire_timeout`].
     acquire_timeout: Duration,
+    /// Persistent command pool + buffer + completion fence for the
+    /// host-pipeline producer copy path
+    /// ([`Self::submit_host_copy_image_to_buffer`]). Lazy-init on
+    /// first submit; reused with `vkResetCommandPool` after each
+    /// submission's fence has signaled. See
+    /// [`AdapterPersistentSubmitContext`] for the full contract.
+    /// Single-threaded caller convention; multi-threaded callers
+    /// serialize through this mutex.
+    #[cfg(target_os = "linux")]
+    submit_ctx: Mutex<Option<AdapterPersistentSubmitContext>>,
+    /// Counts how many times the persistent submit context was
+    /// (re)created — used by tests to lock the amortisation invariant
+    /// from #620 (steady-state submits must not grow live pools).
+    submit_ctx_create_count: AtomicUsize,
 }
 
 impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
@@ -75,7 +90,23 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
             device,
             surfaces: Registry::new(),
             acquire_timeout: DEFAULT_TIMELINE_WAIT,
+            #[cfg(target_os = "linux")]
+            submit_ctx: Mutex::new(None),
+            submit_ctx_create_count: AtomicUsize::new(0),
         }
+    }
+
+    /// Number of times the adapter has materialised its persistent
+    /// command pool. Stays at 0 before the first
+    /// [`Self::submit_host_copy_image_to_buffer`] call, becomes 1 on
+    /// first invocation, and stays at 1 across every subsequent
+    /// submit.
+    ///
+    /// Hidden from the public docs because callers shouldn't depend
+    /// on it; tests use it to lock #620's amortisation invariant.
+    #[doc(hidden)]
+    pub fn submit_pool_create_count(&self) -> usize {
+        self.submit_ctx_create_count.load(Ordering::Relaxed)
     }
 
     /// Override the per-acquire timeline-wait timeout. Default 5 s.
@@ -254,8 +285,7 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                 holder: self.surfaces.describe_contention(id),
             })?;
 
-        if let Err(e) = submit_image_to_buffer_copy_signal_timeline::<D>(
-            self.device.as_ref(),
+        if let Err(e) = self.submit_image_to_buffer_copy_signal_timeline(
             image,
             image_layout.as_vk(),
             session.buffer,
@@ -374,10 +404,12 @@ struct HostCopySession<P: DevicePrivilege> {
     signal_value: u64,
 }
 
-/// Build a one-shot command buffer that transitions `image` into
-/// `TRANSFER_SRC_OPTIMAL`, copies its full color plane into `buffer`,
-/// transitions back to `image_layout`, and submits with a GPU-side
-/// timeline signal at `signal_value`.
+/// Records and submits the host-pipeline producer copy
+/// (`vkCmdCopyImageToBuffer`) using the adapter's persistent command
+/// pool ([`AdapterPersistentSubmitContext`]). Transitions `image`
+/// into `TRANSFER_SRC_OPTIMAL`, copies its full color plane into
+/// `buffer`, transitions back to `image_layout`, and submits with a
+/// GPU-side timeline signal at `signal_value`.
 ///
 /// The post-copy buffer barrier is intentionally absent: cuda imports
 /// the buffer's memory once at registration and reads it through
@@ -385,116 +417,227 @@ struct HostCopySession<P: DevicePrivilege> {
 /// `vkMapMemory`, so a HOST_READ barrier would be both unnecessary
 /// and wrong.
 #[cfg(target_os = "linux")]
-fn submit_image_to_buffer_copy_signal_timeline<D>(
-    device: &D,
-    image: vk::Image,
-    image_layout: vk::ImageLayout,
-    buffer: vk::Buffer,
-    image_extent: vk::Extent3D,
-    timeline: &<D::Privilege as DevicePrivilege>::TimelineSemaphore,
-    signal_value: u64,
-) -> Result<(), AdapterError>
+impl<D> CudaSurfaceAdapter<D>
 where
     D: VulkanRhiDevice,
 {
-    let vk_device = device.device();
-    let queue = device.queue();
-    let qf = device.queue_family_index();
-    let transfer_layout = vk::ImageLayout::TRANSFER_SRC_OPTIMAL;
+    fn submit_image_to_buffer_copy_signal_timeline(
+        &self,
+        image: vk::Image,
+        image_layout: vk::ImageLayout,
+        buffer: vk::Buffer,
+        image_extent: vk::Extent3D,
+        timeline: &<D::Privilege as DevicePrivilege>::TimelineSemaphore,
+        signal_value: u64,
+    ) -> Result<(), AdapterError> {
+        let vk_device = self.device.device();
+        let queue = self.device.queue();
+        let qf = self.device.queue_family_index();
+        let transfer_layout = vk::ImageLayout::TRANSFER_SRC_OPTIMAL;
 
-    let pool_info = vk::CommandPoolCreateInfo::builder()
-        .queue_family_index(qf)
-        .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-        .build();
-    let pool = unsafe { vk_device.create_command_pool(&pool_info, None) }.map_err(|e| {
-        AdapterError::BackendRejected {
-            reason: format!("create_command_pool: {e}"),
+        let mut guard = self
+            .submit_ctx
+            .lock()
+            .map_err(|_| AdapterError::BackendRejected {
+                reason:
+                    "submit_image_to_buffer_copy_signal_timeline: persistent submit context mutex poisoned"
+                        .into(),
+            })?;
+        if guard.is_none() {
+            *guard = Some(AdapterPersistentSubmitContext::new(vk_device, qf)?);
+            self.submit_ctx_create_count.fetch_add(1, Ordering::Relaxed);
         }
-    })?;
+        let submit_ctx = guard.as_ref().expect("submit_ctx populated above");
+        let cmd = submit_ctx.cmd;
 
-    let alloc_info = vk::CommandBufferAllocateInfo::builder()
-        .command_pool(pool)
-        .level(vk::CommandBufferLevel::PRIMARY)
-        .command_buffer_count(1)
-        .build();
-    let cmd = match unsafe { vk_device.allocate_command_buffers(&alloc_info) } {
-        Ok(v) => v[0],
-        Err(e) => {
-            unsafe { vk_device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
-                reason: format!("allocate_command_buffers: {e}"),
-            });
+        submit_ctx.reset_for_recording(vk_device)?;
+
+        let begin_info = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        unsafe { vk_device.begin_command_buffer(cmd, &begin_info) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("begin_command_buffer: {e}"),
+            }
+        })?;
+
+        let pre_barrier = build_color_image_barrier(image, qf, image_layout, transfer_layout);
+        let pre_barriers = [pre_barrier];
+        let pre_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&pre_barriers)
+            .build();
+        unsafe { vk_device.cmd_pipeline_barrier2(cmd, &pre_dep) };
+
+        let copy_region = vk::BufferImageCopy::builder()
+            .buffer_offset(0)
+            .buffer_row_length(image_extent.width)
+            .buffer_image_height(image_extent.height)
+            .image_subresource(
+                vk::ImageSubresourceLayers::builder()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .mip_level(0)
+                    .base_array_layer(0)
+                    .layer_count(1)
+                    .build(),
+            )
+            .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+            .image_extent(image_extent)
+            .build();
+        unsafe {
+            vk_device.cmd_copy_image_to_buffer(
+                cmd,
+                image,
+                transfer_layout,
+                buffer,
+                &[copy_region],
+            );
         }
-    };
 
-    let begin_info = vk::CommandBufferBeginInfo::builder()
-        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
-        .build();
-    if let Err(e) = unsafe { vk_device.begin_command_buffer(cmd, &begin_info) } {
-        unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::BackendRejected {
-            reason: format!("begin_command_buffer: {e}"),
-        });
+        let post_barrier = build_color_image_barrier(image, qf, transfer_layout, image_layout);
+        let post_barriers = [post_barrier];
+        let post_dep = vk::DependencyInfo::builder()
+            .image_memory_barriers(&post_barriers)
+            .build();
+        unsafe { vk_device.cmd_pipeline_barrier2(cmd, &post_dep) };
+
+        unsafe { vk_device.end_command_buffer(cmd) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("end_command_buffer: {e}"),
+            }
+        })?;
+
+        let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cmd)
+            .build()];
+        let signal_infos = [vk::SemaphoreSubmitInfo::builder()
+            .semaphore(timeline.semaphore())
+            .value(signal_value)
+            .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+            .build()];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cmd_infos)
+            .signal_semaphore_infos(&signal_infos)
+            .build();
+
+        unsafe { self.device.submit_to_queue(queue, &[submit], submit_ctx.fence) }.map_err(
+            |e| AdapterError::BackendRejected {
+                reason: format!("submit_to_queue: {e}"),
+            },
+        )?;
+
+        Ok(())
+    }
+}
+
+/// Persistent per-adapter command pool, command buffer, and
+/// completion fence — replaces the create-and-destroy-per-submit
+/// pattern that used to churn `vkCreateCommandPool` /
+/// `vkDestroyCommandPool` on every host-pipeline copy. Same shape
+/// lives in
+/// `streamlib-adapter-cpu-readback::adapter::AdapterPersistentSubmitContext`;
+/// fix BOTH if you change EITHER (issue #620 AI Agent Notes).
+///
+/// The fence is created signaled so the first submit doesn't block.
+/// Subsequent submits wait on it (instant when the prior submit has
+/// already drained, which is the steady state). `vkResetCommandPool`
+/// is the cheap path per Vulkan spec — recycles every command
+/// buffer's memory in one call.
+#[cfg(target_os = "linux")]
+struct AdapterPersistentSubmitContext {
+    pool: vk::CommandPool,
+    cmd: vk::CommandBuffer,
+    fence: vk::Fence,
+}
+
+#[cfg(target_os = "linux")]
+impl AdapterPersistentSubmitContext {
+    fn new(device: &vulkanalia::Device, qf: u32) -> Result<Self, AdapterError> {
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let pool =
+            unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
+                AdapterError::BackendRejected {
+                    reason: format!("create_command_pool: {e}"),
+                }
+            })?;
+
+        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd = match unsafe { device.allocate_command_buffers(&alloc_info) } {
+            Ok(v) => v[0],
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("allocate_command_buffers: {e}"),
+                });
+            }
+        };
+
+        let fence_info = vk::FenceCreateInfo::builder()
+            .flags(vk::FenceCreateFlags::SIGNALED)
+            .build();
+        let fence = match unsafe { device.create_fence(&fence_info, None) } {
+            Ok(f) => f,
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("create_fence: {e}"),
+                });
+            }
+        };
+
+        Ok(Self { pool, cmd, fence })
     }
 
-    let pre_barrier = build_color_image_barrier(image, qf, image_layout, transfer_layout);
-    let pre_barriers = [pre_barrier];
-    let pre_dep = vk::DependencyInfo::builder()
-        .image_memory_barriers(&pre_barriers)
-        .build();
-    unsafe { vk_device.cmd_pipeline_barrier2(cmd, &pre_dep) };
-
-    let copy_region = vk::BufferImageCopy::builder()
-        .buffer_offset(0)
-        .buffer_row_length(image_extent.width)
-        .buffer_image_height(image_extent.height)
-        .image_subresource(
-            vk::ImageSubresourceLayers::builder()
-                .aspect_mask(vk::ImageAspectFlags::COLOR)
-                .mip_level(0)
-                .base_array_layer(0)
-                .layer_count(1)
-                .build(),
-        )
-        .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-        .image_extent(image_extent)
-        .build();
-    unsafe {
-        vk_device.cmd_copy_image_to_buffer(cmd, image, transfer_layout, buffer, &[copy_region]);
+    /// Wait for the previous submit's fence, reset it, then reset the
+    /// command pool so the single command buffer is ready to be
+    /// re-recorded. Steady-state cost is the wait, which is instant
+    /// when the prior submit has already drained.
+    fn reset_for_recording(&self, device: &vulkanalia::Device) -> Result<(), AdapterError> {
+        unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("wait_for_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe { device.reset_fences(&[self.fence]) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("reset_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe { device.reset_command_pool(self.pool, vk::CommandPoolResetFlags::empty()) }
+            .map_err(|e| AdapterError::BackendRejected {
+                reason: format!("reset_command_pool (persistent submit pool): {e}"),
+            })?;
+        Ok(())
     }
 
-    let post_barrier = build_color_image_barrier(image, qf, transfer_layout, image_layout);
-    let post_barriers = [post_barrier];
-    let post_dep = vk::DependencyInfo::builder()
-        .image_memory_barriers(&post_barriers)
-        .build();
-    unsafe { vk_device.cmd_pipeline_barrier2(cmd, &post_dep) };
-
-    if let Err(e) = unsafe { vk_device.end_command_buffer(cmd) } {
-        unsafe { vk_device.destroy_command_pool(pool, None) };
-        return Err(AdapterError::BackendRejected {
-            reason: format!("end_command_buffer: {e}"),
-        });
+    /// Tear down the pool + fence. Waits on the fence first to drain
+    /// any pending GPU work so destruction is safe.
+    fn destroy(self, device: &vulkanalia::Device) {
+        let _ = unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) };
+        unsafe {
+            device.destroy_fence(self.fence, None);
+            device.destroy_command_pool(self.pool, None);
+        }
     }
+}
 
-    let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
-        .command_buffer(cmd)
-        .build()];
-    let signal_infos = [vk::SemaphoreSubmitInfo::builder()
-        .semaphore(timeline.semaphore())
-        .value(signal_value)
-        .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
-        .build()];
-    let submit = vk::SubmitInfo2::builder()
-        .command_buffer_infos(&cmd_infos)
-        .signal_semaphore_infos(&signal_infos)
-        .build();
-
-    let submit_result = unsafe { device.submit_to_queue(queue, &[submit], vk::Fence::null()) };
-    unsafe { vk_device.destroy_command_pool(pool, None) };
-    submit_result.map_err(|e| AdapterError::BackendRejected {
-        reason: format!("submit_to_queue: {e}"),
-    })
+#[cfg(target_os = "linux")]
+impl<D: VulkanRhiDevice> Drop for CudaSurfaceAdapter<D> {
+    fn drop(&mut self) {
+        let mut guard = match self.submit_ctx.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(ctx) = guard.take() {
+            ctx.destroy(self.device.device());
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
+++ b/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cuda::tests::persistent_command_pool` — locks
+//! the #620 amortisation invariant for the host-pipeline producer
+//! copy path.
+//!
+//! Before #620 the cuda adapter created and destroyed a
+//! `vk::CommandPool` on every `submit_host_copy_image_to_buffer`
+//! call, churning `vkCreateCommandPool` + `vkDestroyCommandPool`
+//! once per host-pipeline frame. The fix introduced
+//! `AdapterPersistentSubmitContext` — a single pool + command buffer
+//! + completion fence reset and reused across every submit. This
+//! test locks that invariant: after N>1 submits the adapter's
+//! `submit_pool_create_count()` must stay at 1.
+//!
+//! The submit only exercises Vulkan — no CUDA. So the test runs on
+//! any Linux box with a Vulkan device + the OPAQUE_FD pool (the cuda
+//! adapter's registration shape requires OPAQUE_FD-exportable
+//! buffers).
+//!
+//! Mentally revert the fix (e.g. force the lazy-init branch on every
+//! call) and the assertion fires — that's how this test stays
+//! load-bearing rather than feel-good.
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::core::context::GpuContext;
+use streamlib::core::rhi::{PixelFormat, TextureFormat};
+use streamlib::host_rhi::{
+    HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore,
+};
+use streamlib_adapter_abi::SurfaceId;
+use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+
+const W: u32 = 32;
+const H: u32 = 32;
+const SURFACE_ID: SurfaceId = 0xC0DE_0001;
+
+fn try_init_gpu() -> Option<Arc<GpuContext>> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_cuda=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok().map(Arc::new)
+}
+
+#[test]
+fn persistent_pool_count_stays_at_one_across_repeated_submits() {
+    let Some(gpu) = try_init_gpu() else {
+        println!("cuda persistent_pool: skipping — no Vulkan device available");
+        return;
+    };
+    let host_device: Arc<HostVulkanDevice> = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_buffer_pool().is_none() {
+        println!(
+            "cuda persistent_pool: skipping — OPAQUE_FD buffer pool unavailable on this driver"
+        );
+        return;
+    }
+
+    // Allocate the OPAQUE_FD-exportable staging buffer + timeline the
+    // cuda adapter's registration shape requires. DEVICE_LOCAL is the
+    // host-pipeline producer flow `submit_host_copy_image_to_buffer`
+    // is built for; HOST_VISIBLE would also work but DEVICE_LOCAL is
+    // the on-path scenario for this hot-path test.
+    let pixel_buffer = match HostVulkanPixelBuffer::new_opaque_fd_export_device_local(
+        &host_device,
+        W,
+        H,
+        4,
+        PixelFormat::Bgra32,
+    ) {
+        Ok(b) => Arc::new(b),
+        Err(e) => {
+            println!(
+                "cuda persistent_pool: new_opaque_fd_export_device_local failed: {e} — skipping"
+            );
+            return;
+        }
+    };
+    let timeline = match HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0) {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            println!("cuda persistent_pool: new_exportable timeline failed: {e} — skipping");
+            return;
+        }
+    };
+
+    // Source `VkImage` for the copy. The host pipeline producer path
+    // takes any DMA-BUF render-target image; this is the same shape
+    // the camera-to-cuda example registers.
+    let source_texture =
+        match gpu.acquire_render_target_dma_buf_image(W, H, TextureFormat::Bgra8Unorm) {
+            Ok(t) => t,
+            Err(e) => {
+                println!(
+                    "cuda persistent_pool: acquire_render_target_dma_buf_image failed: {e} — skipping"
+                );
+                return;
+            }
+        };
+    let texture_arc = Arc::clone(source_texture.vulkan_inner());
+
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    adapter
+        .register_host_surface(
+            SURFACE_ID,
+            HostSurfaceRegistration {
+                pixel_buffer,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register_host_surface");
+
+    // Pre-condition: lazy-init hasn't fired yet.
+    assert_eq!(
+        adapter.submit_pool_create_count(),
+        0,
+        "adapter should not have created its persistent pool before the first submit"
+    );
+
+    // First submit materialises the pool exactly once.
+    adapter
+        .submit_host_copy_image_to_buffer(SURFACE_ID, texture_arc.as_ref(), VulkanLayout::GENERAL)
+        .expect("first submit_host_copy_image_to_buffer");
+    assert_eq!(
+        adapter.submit_pool_create_count(),
+        1,
+        "first submit must materialise the persistent pool exactly once"
+    );
+
+    // N additional submits must not grow the live pool count.
+    let cycles = 32usize;
+    for i in 0..cycles {
+        adapter
+            .submit_host_copy_image_to_buffer(
+                SURFACE_ID,
+                texture_arc.as_ref(),
+                VulkanLayout::GENERAL,
+            )
+            .unwrap_or_else(|e| panic!("submit cycle {i}: {e:?}"));
+    }
+    assert_eq!(
+        adapter.submit_pool_create_count(),
+        1,
+        "after {cycles} additional submits, pool count grew — \
+         the persistent pool is being re-created per submit"
+    );
+}

--- a/libs/streamlib-adapter-vulkan/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan/Cargo.toml
@@ -73,6 +73,10 @@ path = "tests/concurrent_reads_two_subprocesses.rs"
 name = "subprocess_crash_mid_write"
 path = "tests/subprocess_crash_mid_write.rs"
 
+[[test]]
+name = "persistent_command_pool"
+path = "tests/persistent_command_pool.rs"
+
 # Subprocess test helper lives in `streamlib-adapter-vulkan-helpers`
 # (a dev-dependency of this crate). Tests reach it via
 # `env!("CARGO_BIN_EXE_vulkan_adapter_subprocess_helper")` — Cargo

--- a/libs/streamlib-adapter-vulkan/src/adapter.rs
+++ b/libs/streamlib-adapter-vulkan/src/adapter.rs
@@ -24,7 +24,8 @@
 //!   wakes up.
 
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use streamlib_consumer_rhi::{
@@ -56,6 +57,20 @@ pub struct VulkanSurfaceAdapter<D: VulkanRhiDevice> {
     /// Per-acquire timeline wait timeout. Adjustable via
     /// [`Self::with_acquire_timeout`].
     acquire_timeout: Duration,
+    /// Persistent command pool + buffer + completion fence for the
+    /// per-acquire layout-transition path
+    /// ([`Self::transition_layout_sync`]). Lazy-init on first
+    /// transition; reused with `vkResetCommandPool` after each
+    /// submission's fence has signaled. See
+    /// [`AdapterPersistentSubmitContext`] for the full contract.
+    /// Single-threaded caller convention; multi-threaded callers
+    /// serialize through this mutex.
+    submit_ctx: Mutex<Option<AdapterPersistentSubmitContext>>,
+    /// Counts how many times the persistent submit context was
+    /// (re)created — used by tests to lock the amortisation invariant
+    /// from #620 / #640 (steady-state acquires must not grow live
+    /// pools).
+    submit_ctx_create_count: AtomicUsize,
 }
 
 impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
@@ -65,7 +80,22 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             device,
             surfaces: Registry::new(),
             acquire_timeout: DEFAULT_TIMELINE_WAIT,
+            submit_ctx: Mutex::new(None),
+            submit_ctx_create_count: AtomicUsize::new(0),
         }
+    }
+
+    /// Number of times the adapter has materialised its persistent
+    /// command pool. Stays at 0 before the first acquire, becomes 1
+    /// after the first transition, and stays at 1 across every
+    /// subsequent acquire.
+    ///
+    /// Hidden from the public docs because callers shouldn't depend
+    /// on it; tests use it to lock #620 / #640's amortisation
+    /// invariant.
+    #[doc(hidden)]
+    pub fn submit_pool_create_count(&self) -> usize {
+        self.submit_ctx_create_count.load(Ordering::Relaxed)
     }
 
     /// Override the per-acquire timeline-wait timeout. Default 5 s.
@@ -170,8 +200,13 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
     /// `cmd_pipeline_barrier2`; we use queue-family-foreign transitions
     /// to support cross-process handoff.
     ///
-    /// Synchronous: blocks until the GPU has executed the barrier,
-    /// because the next consumer needs the new layout to be visible.
+    /// Synchronous: blocks on the per-submit fence until the GPU has
+    /// executed the barrier, because the next consumer needs the new
+    /// layout to be visible. Pre-#640 this used `vkQueueWaitIdle` —
+    /// queue-wide drain; #640 narrowed it to a fence on the submit
+    /// itself, which composes correctly with concurrent unrelated
+    /// activity sharing the same queue (mirrors the cpu-readback
+    /// `vkQueueWaitIdle` → fence migration in #532).
     fn transition_layout_sync(
         &self,
         image: vk::Image,
@@ -185,39 +220,30 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
         let queue = self.device.queue();
         let qf = self.device.queue_family_index();
 
-        // Single-shot command pool + buffer.
-        let pool_info = vk::CommandPoolCreateInfo::builder()
-            .queue_family_index(qf)
-            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
-            .build();
-        let pool = unsafe { device.create_command_pool(&pool_info, None) }
-            .map_err(|e| AdapterError::BackendRejected {
-                reason: format!("create_command_pool: {e}"),
+        let mut guard = self
+            .submit_ctx
+            .lock()
+            .map_err(|_| AdapterError::BackendRejected {
+                reason: "transition_layout_sync: persistent submit context mutex poisoned"
+                    .into(),
             })?;
+        if guard.is_none() {
+            *guard = Some(AdapterPersistentSubmitContext::new(device, qf)?);
+            self.submit_ctx_create_count.fetch_add(1, Ordering::Relaxed);
+        }
+        let submit_ctx = guard.as_ref().expect("submit_ctx populated above");
+        let cmd = submit_ctx.cmd;
 
-        let alloc_info = vk::CommandBufferAllocateInfo::builder()
-            .command_pool(pool)
-            .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1)
-            .build();
-        let cmd_buffers = unsafe { device.allocate_command_buffers(&alloc_info) }
-            .map_err(|e| {
-                unsafe { device.destroy_command_pool(pool, None) };
-                AdapterError::BackendRejected {
-                    reason: format!("allocate_command_buffers: {e}"),
-                }
-            })?;
-        let cmd = cmd_buffers[0];
+        submit_ctx.reset_for_recording(device)?;
 
         let begin_info = vk::CommandBufferBeginInfo::builder()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
             .build();
-        if let Err(e) = unsafe { device.begin_command_buffer(cmd, &begin_info) } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
+        unsafe { device.begin_command_buffer(cmd, &begin_info) }.map_err(|e| {
+            AdapterError::BackendRejected {
                 reason: format!("begin_command_buffer: {e}"),
-            });
-        }
+            }
+        })?;
 
         let image_barrier = vk::ImageMemoryBarrier2::builder()
             .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
@@ -248,12 +274,11 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             .build();
         unsafe { device.cmd_pipeline_barrier2(cmd, &dep_info) };
 
-        if let Err(e) = unsafe { device.end_command_buffer(cmd) } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
+        unsafe { device.end_command_buffer(cmd) }.map_err(|e| {
+            AdapterError::BackendRejected {
                 reason: format!("end_command_buffer: {e}"),
-            });
-        }
+            }
+        })?;
 
         let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
             .command_buffer(cmd)
@@ -262,25 +287,23 @@ impl<D: VulkanRhiDevice> VulkanSurfaceAdapter<D> {
             .command_buffer_infos(&cmd_infos)
             .build();
 
-        if let Err(e) = unsafe {
-            self.device.submit_to_queue(queue, &[submit], vk::Fence::null())
-        } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
+        unsafe { self.device.submit_to_queue(queue, &[submit], submit_ctx.fence) }.map_err(
+            |e| AdapterError::BackendRejected {
                 reason: format!("submit_to_queue: {e}"),
-            });
-        }
+            },
+        )?;
 
-        // Block until the layout transition has executed. The next
-        // consumer's view assumes the new layout is visible.
-        if let Err(e) = unsafe { device.queue_wait_idle(queue) } {
-            unsafe { device.destroy_command_pool(pool, None) };
-            return Err(AdapterError::BackendRejected {
-                reason: format!("queue_wait_idle: {e}"),
-            });
-        }
+        // Block until the GPU has executed the barrier — the next
+        // consumer's view assumes the new layout is visible. The wait
+        // is per-submit (not queue-wide like the pre-#640
+        // `vkQueueWaitIdle`), so concurrent unrelated submits on the
+        // same queue aren't drained.
+        unsafe { device.wait_for_fences(&[submit_ctx.fence], true, u64::MAX) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("wait_for_fences (transition_layout_sync): {e}"),
+            }
+        })?;
 
-        unsafe { device.destroy_command_pool(pool, None) };
         Ok(())
     }
 
@@ -576,3 +599,113 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for VulkanSurfaceAdapter<D> {
     }
 }
 
+/// Persistent per-adapter command pool, command buffer, and
+/// completion fence — replaces the create-and-destroy-per-acquire
+/// pattern that used to churn `vkCreateCommandPool` /
+/// `vkDestroyCommandPool` on every layout transition. Same shape
+/// lives in `streamlib-adapter-cpu-readback::adapter::AdapterPersistentSubmitContext`
+/// and `streamlib-adapter-cuda::adapter::AdapterPersistentSubmitContext`;
+/// fix ALL THREE if you change ANY (issue #620 + #640 AI Agent
+/// Notes — `streamlib-adapter-abi` deliberately does not depend on
+/// `vulkanalia`, so duplication is the project pattern here).
+///
+/// The fence is created signaled so the first submit doesn't block.
+/// Subsequent submits wait on it (instant when the prior submit has
+/// already drained — `transition_layout_sync` always drains
+/// synchronously at the end so the next call's wait is always
+/// instant). `vkResetCommandPool` is the cheap path per Vulkan spec
+/// — recycles every command buffer's memory in one call.
+struct AdapterPersistentSubmitContext {
+    pool: vk::CommandPool,
+    cmd: vk::CommandBuffer,
+    fence: vk::Fence,
+}
+
+impl AdapterPersistentSubmitContext {
+    fn new(device: &vulkanalia::Device, qf: u32) -> Result<Self, AdapterError> {
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(qf)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let pool =
+            unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
+                AdapterError::BackendRejected {
+                    reason: format!("create_command_pool: {e}"),
+                }
+            })?;
+
+        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cmd = match unsafe { device.allocate_command_buffers(&alloc_info) } {
+            Ok(v) => v[0],
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("allocate_command_buffers: {e}"),
+                });
+            }
+        };
+
+        let fence_info = vk::FenceCreateInfo::builder()
+            .flags(vk::FenceCreateFlags::SIGNALED)
+            .build();
+        let fence = match unsafe { device.create_fence(&fence_info, None) } {
+            Ok(f) => f,
+            Err(e) => {
+                unsafe { device.destroy_command_pool(pool, None) };
+                return Err(AdapterError::BackendRejected {
+                    reason: format!("create_fence: {e}"),
+                });
+            }
+        };
+
+        Ok(Self { pool, cmd, fence })
+    }
+
+    /// Wait for the previous submit's fence, reset it, then reset the
+    /// command pool so the single command buffer is ready to be
+    /// re-recorded. Steady-state cost is the wait, which is instant
+    /// when the prior submit has already drained.
+    fn reset_for_recording(&self, device: &vulkanalia::Device) -> Result<(), AdapterError> {
+        unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("wait_for_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe { device.reset_fences(&[self.fence]) }.map_err(|e| {
+            AdapterError::BackendRejected {
+                reason: format!("reset_fences (persistent submit fence): {e}"),
+            }
+        })?;
+        unsafe { device.reset_command_pool(self.pool, vk::CommandPoolResetFlags::empty()) }
+            .map_err(|e| AdapterError::BackendRejected {
+                reason: format!("reset_command_pool (persistent submit pool): {e}"),
+            })?;
+        Ok(())
+    }
+
+    /// Tear down the pool + fence. Waits on the fence first to drain
+    /// any pending GPU work so destruction is safe.
+    fn destroy(self, device: &vulkanalia::Device) {
+        let _ = unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) };
+        unsafe {
+            device.destroy_fence(self.fence, None);
+            device.destroy_command_pool(self.pool, None);
+        }
+    }
+}
+
+impl<D: VulkanRhiDevice> Drop for VulkanSurfaceAdapter<D> {
+    fn drop(&mut self) {
+        let mut guard = match self.submit_ctx.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(ctx) = guard.take() {
+            ctx.destroy(self.device.device());
+        }
+    }
+}

--- a/libs/streamlib-adapter-vulkan/tests/persistent_command_pool.rs
+++ b/libs/streamlib-adapter-vulkan/tests/persistent_command_pool.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_vulkan::tests::persistent_command_pool` — locks
+//! the #640 amortisation invariant for `transition_layout_sync`.
+//!
+//! Before #640 the Vulkan adapter created and destroyed a
+//! `vk::CommandPool` on every read / write acquire that needed a
+//! layout transition, churning `vkCreateCommandPool` +
+//! `vkDestroyCommandPool` on the steady-state per-acquire path. The
+//! fix introduced `AdapterPersistentSubmitContext` (same shape as the
+//! cpu-readback + cuda adapters from #620) — a single pool + command
+//! buffer + completion fence reset and reused across every layout
+//! transition. This test locks that invariant: after N>1
+//! acquire/release cycles the adapter's `submit_pool_create_count()`
+//! must stay at 1.
+//!
+//! The test alternates read and write acquires so each transition is
+//! a real `from != to` swap: read targets `SHADER_READ_ONLY_OPTIMAL`
+//! and write targets `GENERAL`, so consecutive acquires of different
+//! flavors always trigger a transition (the `from == to` short-
+//! circuit doesn't fire).
+//!
+//! Mentally revert the fix (e.g. force the lazy-init branch on every
+//! call) and the assertion fires — that's how this test stays
+//! load-bearing rather than feel-good.
+
+#![cfg(target_os = "linux")]
+
+#[path = "common.rs"]
+mod common;
+
+use crate::common::HostFixture;
+
+#[test]
+fn persistent_pool_count_stays_at_one_across_repeated_acquires() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "vulkan persistent_command_pool: skipping — no Vulkan device available"
+            );
+            return;
+        }
+    };
+
+    let surface = fixture.register_surface(1, 16, 16);
+
+    // Pre-condition: lazy-init hasn't fired yet.
+    assert_eq!(
+        fixture.adapter.submit_pool_create_count(),
+        0,
+        "adapter should not have created its persistent pool before the first acquire"
+    );
+
+    // First acquire materialises the pool exactly once. The first
+    // transition is UNDEFINED → SHADER_READ_ONLY_OPTIMAL, which is a
+    // real (non-no-op) transition.
+    {
+        let _r = fixture
+            .ctx
+            .acquire_read(&surface.descriptor)
+            .expect("first acquire_read");
+    }
+    assert_eq!(
+        fixture.adapter.submit_pool_create_count(),
+        1,
+        "first transition must materialise the persistent pool exactly once"
+    );
+
+    // N additional alternating read/write acquires. Each transition is
+    // a real swap (SHADER_READ_ONLY_OPTIMAL ↔ GENERAL) so the
+    // `from == to` short-circuit doesn't fire — every one drives the
+    // persistent pool's record + submit + wait path.
+    let cycles = 32usize;
+    for i in 0..cycles {
+        {
+            let _w = fixture
+                .ctx
+                .acquire_write(&surface.descriptor)
+                .unwrap_or_else(|e| panic!("acquire_write cycle {i}: {e:?}"));
+        }
+        {
+            let _r = fixture
+                .ctx
+                .acquire_read(&surface.descriptor)
+                .unwrap_or_else(|e| panic!("acquire_read cycle {i}: {e:?}"));
+        }
+    }
+    assert_eq!(
+        fixture.adapter.submit_pool_create_count(),
+        1,
+        "after {cycles} additional acquire cycles, pool count grew — \
+         the persistent pool is being re-created per submit"
+    );
+}


### PR DESCRIPTION
## Summary

- **All three adapter crates** that had the create-and-destroy-per-submit `vk::CommandPool` pattern (`cpu-readback`, `cuda`, `vulkan`) now hold a single persistent `AdapterPersistentSubmitContext` (pool + command buffer + completion fence), reset and reused per submit via `vkResetCommandPool`. Lazy-init on first call (constructors stay infallible); `Drop` waits on the fence and tears down. Single-threaded caller convention; concurrent callers serialise correctly through an inner `Mutex`.
- The vulkan adapter's `transition_layout_sync` post-submit `vkQueueWaitIdle` (queue-wide drain) is replaced with `vkWaitForFences` on the per-submit fence — same synchronicity for the next consumer's layout-visible guarantee, but composes correctly with concurrent unrelated activity sharing the queue (mirrors cpu-readback's analogous queue-wait → fence migration in #532).
- Same private struct duplicated in all three crates per `streamlib-adapter-abi` not depending on `vulkanalia`. Shape-parity comments updated to "fix ALL THREE if you change ANY".

## Closes

Closes #620
Closes #640

## Exit criteria

- [x] All three adapters submit per-frame copies / per-acquire transitions through a persistent command pool; no `vkCreateCommandPool` / `vkDestroyCommandPool` on the steady-state submit path.
- [x] Thread-safety story documented — see the doc comments on `AdapterPersistentSubmitContext` and the `submit_ctx` field on each adapter / trigger ("Single-threaded caller convention; multi-threaded callers serialize through this mutex").

## Test plan

- [x] **New `persistent_command_pool` integration test in each of the three adapter crates** — runs N>1 acquire/submit cycles and asserts `submit_pool_create_count() == 1`. Vulkan adapter test alternates read↔write acquires so every transition is a real swap (no `from == to` short-circuit). All mentally revertable: drop the lazy-init guard and the assertion fails (count grows to N+1).
- [x] **cpu-readback existing test suite** — all 13 tests across `conformance`, `round_trip_read`, `round_trip_write`, `multi_plane_round_trip`, `cpu_readable_plane_aware`, `stride_offset_handling`, `subprocess_crash_mid_write`, `try_acquire_contention`, `queue_isolation` continue to pass.
- [x] **cuda existing test suite** — 3 conformance + 10 dlpack unit tests continue to pass. cuda-helpers OPAQUE_FD round-trip also passes.
- [x] **vulkan adapter existing test suite** — all 9 tests across `conformance`, `sync_correctness`, `write_excludes_read`, `round_trip_host_writes_subprocess_reads`, `round_trip_subprocess_writes_host_reads`, `concurrent_reads_two_subprocesses`, `subprocess_crash_mid_write` continue to pass with no regressions.
- [x] **`cargo xtask check-boundaries`** — clean (no new RHI-boundary violations).
- [x] **`cargo build`** of `polyglot-cpu-readback-blur-scenario` and `camera-python-display` (the on-tree consumers of these adapters) — clean.

E2E note: the issue's "E2E camera→cuda / camera→cpu-readback" exit criterion refers to the conformance + round-trip tests (see issue body), all of which run cleanly. The vulkan adapter's subprocess round-trip + crash tests cover the equivalent scenario for `transition_layout_sync`.

## Follow-ups

- **#642** — `AdapterPersistentSubmitContext` can hang `Drop` / next-call `wait_for_fences` if a submit errors after `reset_fences` runs. Pre-existing property of the #620 shape now applied to a third surface; surfaced in pr-review-gate. Three plausible fix shapes documented in the issue body.

## Adapter coverage

- **Adapter crates**: `streamlib-adapter-cpu-readback` + `streamlib-adapter-cuda` + `streamlib-adapter-vulkan`
- **New adapter or extension?**: extension (perf refactor of existing submit / layout-transition helpers in three crates)
- **Handle type**: n/a (no FD / handle changes)
- **Per-acquire host work?**: yes (all three adapters' submit paths now ride a persistent pool)
- **Capability markers impl'd**: unchanged
- **Conformance suite**: ✅ all three adapters pass
- **Polyglot coverage**: n/a — Rust-only host-side change, no SDK surface affected
- **Dep-graph invariant** (`cargo tree -p streamlib-{python,deno}-native | grep -c "^streamlib v"` returns 0): n/a — change is contained to adapter crates that already satisfy this; no transitive change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
