### PR TITLE
feat(polyglot): cdylib FFI for producer-side QFOT release / IPC layout publish (#643)

### DIFF
--- a/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
+++ b/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
@@ -34,7 +34,10 @@ import type {
   RuntimeContextFullAccess,
   RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
-import { VulkanContext } from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+import {
+  VkImageLayout,
+  VulkanContext,
+} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
 
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);
@@ -106,18 +109,32 @@ export default class VulkanComputeProcessor implements ReactiveProcessor {
     const groupX = Math.ceil(this.width / local);
     const groupY = Math.ceil(this.height / local);
 
-    using guard = this.vk.acquireWrite(this.uuid);
+    {
+      using guard = this.vk.acquireWrite(this.uuid);
+      console.error(
+        `[VulkanCompute/deno] acquired vk_image=0x${guard.view.vkImage.toString(16)} ` +
+          `layout=${guard.view.vkImageLayout}`,
+      );
+      this.vk.dispatchCompute(
+        this.uuid,
+        this.spv,
+        pc,
+        groupX,
+        groupY,
+        1,
+      );
+    }
+    // Producer-side cross-process release (#643). The dispatched
+    // compute leaves the image in GENERAL (the kernel writes to a
+    // storage_image binding, which Vulkan keeps in GENERAL); publish
+    // that as the post-release layout so any future host consumer
+    // going through Path 2's `acquire_from_foreign` sees a matching
+    // source layout. Pairs with the QFOT release barrier the adapter
+    // records on this subprocess's `ConsumerVulkanDevice`.
+    this.vk.releaseForCrossProcess(this.uuid, VkImageLayout.General);
     console.error(
-      `[VulkanCompute/deno] acquired vk_image=0x${guard.view.vkImage.toString(16)} ` +
-        `layout=${guard.view.vkImageLayout}`,
-    );
-    this.vk.dispatchCompute(
-      this.uuid,
-      this.spv,
-      pc,
-      groupX,
-      groupY,
-      1,
+      `[VulkanCompute/deno] published cross-process release ` +
+        `layout=General for surface '${this.uuid}'`,
     );
   }
 

--- a/examples/polyglot-vulkan-compute/python/vulkan_compute.py
+++ b/examples/polyglot-vulkan-compute/python/vulkan_compute.py
@@ -49,7 +49,7 @@ import struct
 from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
-from streamlib.adapters.vulkan import VulkanContext
+from streamlib.adapters.vulkan import VkImageLayout, VulkanContext
 
 
 class VulkanComputeProcessor:
@@ -118,6 +118,21 @@ class VulkanComputeProcessor:
                 group_y,
                 1,
             )
+        # Producer-side cross-process release (#643). The dispatched
+        # compute leaves the image in GENERAL (the kernel writes to a
+        # storage_image binding, which Vulkan keeps in GENERAL); publish
+        # that as the post-release layout so any future host consumer
+        # going through Path 2's `acquire_from_foreign` sees a matching
+        # source layout. Pairs with the QFOT release barrier the adapter
+        # records on this subprocess's `ConsumerVulkanDevice`.
+        self._vk.release_for_cross_process(
+            self._uuid, VkImageLayout.GENERAL
+        )
+        print(
+            f"[VulkanCompute/py] published cross-process release "
+            f"layout=GENERAL for surface '{self._uuid}'",
+            flush=True,
+        )
 
     def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print(

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -2163,6 +2163,24 @@ mod surface_client {
         surface_handle_ptr
     }
 
+    /// macOS XPC has no `update_layout` op — the macOS surface-share
+    /// path does not coordinate cross-process Vulkan layouts (#633 is
+    /// Linux-only by construction; macOS uses IOSurface + XPC).
+    /// Returns `-1` so callers see the failure clearly rather than
+    /// silently no-op'ing.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_surface_update_image_layout(
+        _handle: *mut c_void,
+        _pool_id: *const c_char,
+        _layout: i32,
+    ) -> i32 {
+        tracing::error!(
+            "sldn_surface_update_image_layout: not supported on macOS \
+             (cross-process VkImageLayout coordination is Linux-only; #633)"
+        );
+        -1
+    }
+
     unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         if ptr.is_null() {
             return None;
@@ -2714,6 +2732,92 @@ mod surface_client {
         }
     }
 
+    /// Publish a producer-side post-release `VkImageLayout` for the
+    /// given `pool_id` over the surface-share `update_layout` op (#633).
+    /// Pairs with [`sldn_vulkan_release_to_foreign`]: a producer
+    /// subprocess issues the QFOT release barrier on its consumer
+    /// `VkDevice` and then publishes the resulting layout so the next
+    /// host-side consumer's `acquire_from_foreign` sees it.
+    ///
+    /// Returns `0` on success, `-1` on socket failure or wire
+    /// rejection (e.g. unknown surface_id).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_surface_update_image_layout(
+        handle: *mut SurfaceShareHandle,
+        pool_id: *const c_char,
+        layout: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_ref() } {
+            Some(h) => h,
+            None => {
+                tracing::error!("sldn_surface_update_image_layout: null handle");
+                return -1;
+            }
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                tracing::error!(
+                    "sldn_surface_update_image_layout: null or empty pool_id"
+                );
+                return -1;
+            }
+        };
+        let guard = match handle.lazy_connect() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_surface_update_image_layout: connect to '{}' failed: {}",
+                    handle.socket_path, e
+                );
+                return -1;
+            }
+        };
+        let stream = guard.as_ref().expect("connection just populated");
+        let request = serde_json::json!({
+            "op": "update_layout",
+            "surface_id": pool_id_str,
+            "current_image_layout": layout,
+        });
+        let (response, response_fds) =
+            match wire::send_request_with_fds(stream, &request, &[], 0) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_surface_update_image_layout: update_layout for '{}' failed: {}",
+                        pool_id_str, e
+                    );
+                    return -1;
+                }
+            };
+        for fd in &response_fds {
+            unsafe { libc::close(*fd) };
+        }
+        if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
+            tracing::error!(
+                "sldn_surface_update_image_layout: '{}': {}",
+                pool_id_str, err
+            );
+            return -1;
+        }
+        match response.get("success").and_then(|v| v.as_bool()) {
+            Some(true) => 0,
+            Some(false) => {
+                tracing::error!(
+                    "sldn_surface_update_image_layout: surface_id '{}' not registered",
+                    pool_id_str
+                );
+                -1
+            }
+            None => {
+                tracing::error!(
+                    "sldn_surface_update_image_layout: malformed response (missing `success`) for '{}'",
+                    pool_id_str
+                );
+                -1
+            }
+        }
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -2735,6 +2839,16 @@ mod surface_client {
         _pool_id: *const c_char,
     ) -> *mut c_void {
         std::ptr::null_mut()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_surface_update_image_layout(
+        _handle: *mut c_void,
+        _pool_id: *const c_char,
+        _layout: i32,
+    ) -> i32 {
+        tracing::error!("Surface-share operations not supported on this platform");
+        -1
     }
 
     #[unsafe(no_mangle)]
@@ -3515,6 +3629,70 @@ mod vulkan {
         surface_id: u64,
     ) -> i32 {
         release_inner(rt, surface_id, AcquireKind::Read)
+    }
+
+    /// Issue a producer-side queue-family-ownership-transfer release
+    /// barrier to `VK_QUEUE_FAMILY_EXTERNAL` against the surface's
+    /// imported `VkImage`, transitioning to `post_release_layout` (#633).
+    /// Pairs with the host-side consumer's `acquire_from_foreign`
+    /// (Path 2 of `GpuContext::resolve_videoframe_registration`).
+    ///
+    /// Caller responsibilities:
+    /// 1. The surface must already be registered (via
+    ///    `sldn_vulkan_register_surface`) and NOT currently held in a
+    ///    read or write acquire — call this **after** the matching
+    ///    `sldn_vulkan_release_write`/`_read` returns. The adapter's
+    ///    single-producer-per-surface contract is what makes the
+    ///    snapshot-then-submit pattern in
+    ///    `VulkanSurfaceAdapter::release_to_foreign` safe.
+    /// 2. The producer must have completed all writes / reads against
+    ///    the image (i.e. their own queue submission has signalled or
+    ///    `vkQueueWaitIdle` has returned) before calling this; the
+    ///    adapter's QFOT release barrier carries an
+    ///    `srcAccessMask = MEMORY_WRITE_BIT` and assumes hazard
+    ///    coverage upstream.
+    /// 3. After this returns successfully, the producer should
+    ///    publish `post_release_layout` to surface-share via
+    ///    [`sldn_surface_update_image_layout`] so the next consumer's
+    ///    `acquire_from_foreign` sees the right source layout.
+    ///
+    /// `post_release_layout` is the `VkImageLayout` enumerant value
+    /// (an `i32`, e.g. `VK_IMAGE_LAYOUT_GENERAL = 1`,
+    /// `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = 5`).
+    ///
+    /// Returns `0` on success, `-1` on failure (null runtime,
+    /// unregistered surface, or GPU submit error). On a missing
+    /// `VK_EXT_external_memory_acquire_unmodified` extension at
+    /// device construction the adapter records a same-family layout
+    /// transition instead of a true QFOT — the result is still
+    /// validation-clean against the consumer's bridging fallback;
+    /// see `docs/learnings/cross-process-vkimage-layout.md`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_to_foreign(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        post_release_layout: i32,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_vulkan_release_to_foreign: null runtime");
+                return -1;
+            }
+        };
+        match rt
+            .adapter
+            .release_to_foreign(surface_id, VulkanLayout(post_release_layout))
+        {
+            Ok(_) => 0,
+            Err(e) => {
+                tracing::error!(
+                    "sldn_vulkan_release_to_foreign({}): {:?}",
+                    surface_id, e
+                );
+                -1
+            }
+        }
     }
 
     #[unsafe(no_mangle)]
@@ -5498,6 +5676,15 @@ mod vulkan {
     pub unsafe extern "C" fn sldn_vulkan_release_read(
         _rt: *mut c_void,
         _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_vulkan_release_to_foreign(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _post_release_layout: i32,
     ) -> i32 {
         -1
     }

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -113,6 +113,11 @@ export interface VulkanGpuLimitedAccess {
     readonly nativeHandlePtr: Deno.PointerObject | null;
     release(): void;
   };
+  /** Publish a producer-side post-release `VkImageLayout` for `poolId`
+   * via the surface-share `update_layout` op (#633). Called by
+   * `VulkanContext.releaseForCrossProcess` after the QFOT release
+   * barrier records. */
+  updateImageLayout(poolId: string, layout: number): void;
   // deno-lint-ignore no-explicit-any
   readonly nativeLib: { readonly symbols: any };
 }
@@ -321,6 +326,63 @@ export class VulkanContext {
         symbols.sldn_vulkan_release_read(rt, surfaceId);
       },
     };
+  }
+
+  /** Issue a producer-side queue-family-ownership-transfer (QFOT)
+   * release barrier on this subprocess's `ConsumerVulkanDevice` and
+   * publish the post-release `VkImageLayout` to surface-share so the
+   * next cross-process consumer's `acquire_from_foreign` sees the
+   * right source layout (#633).
+   *
+   * Call this *after* the matching `acquireWrite`/`acquireRead`
+   * `using` block has exited and after the producer's queue
+   * submission has actually retired (e.g. the customer has signalled
+   * their own timeline or `vkQueueWaitIdle`-ed). The adapter's QFOT
+   * release barrier carries `srcAccessMask = MEMORY_WRITE_BIT` and
+   * assumes producer-side hazard coverage upstream.
+   *
+   * `postReleaseLayout` is a Vulkan `VkImageLayout` enumerant as a
+   * number (use `VkImageLayout` constants). Picking `GENERAL` is the
+   * safest default for cross-process handoffs — the consumer's
+   * `acquire_from_foreign` re-transitions to whatever layout it
+   * actually needs.
+   *
+   * On NVIDIA Linux drivers without
+   * `VK_EXT_external_memory_acquire_unmodified` (current state as of
+   * 2026-05-03), the host consumer side falls back to a bridging
+   * `UNDEFINED → target` transition; content preservation is
+   * empirical (see `docs/learnings/cross-process-vkimage-layout.md`).
+   * The producer-side path here is correct under both modes. */
+  releaseForCrossProcess(
+    surface: StreamlibSurface | string | bigint,
+    postReleaseLayout: number,
+  ): void {
+    const poolId = VulkanContext.surfacePoolId(surface);
+    const surfaceId = this.surfaceIds.get(poolId);
+    if (surfaceId === undefined) {
+      throw new Error(
+        `VulkanContext.releaseForCrossProcess: surface '${poolId}' is ` +
+          "not registered — at least one acquireWrite/acquireRead must " +
+          "have run for this surface in this subprocess before publishing " +
+          "a cross-process release.",
+      );
+    }
+    const rc: number = this.symbols.sldn_vulkan_release_to_foreign(
+      this.rt,
+      surfaceId,
+      postReleaseLayout,
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `VulkanContext.releaseForCrossProcess: ` +
+          `sldn_vulkan_release_to_foreign returned ${rc} for surface ` +
+          `'${poolId}' (check subprocess log for the underlying adapter error)`,
+      );
+    }
+    // Pair the QFOT release with the surface-share `update_layout`
+    // publish so the next host-side consumer's `acquire_from_foreign`
+    // picks up the new layout instead of the cached registration one.
+    this.gpu.updateImageLayout(poolId, postReleaseLayout);
   }
 
   /** Dispatch a compute shader against the surface's host-side `VkImage`

--- a/libs/streamlib-deno/context.ts
+++ b/libs/streamlib-deno/context.ts
@@ -422,6 +422,28 @@ class NativeGpuContextLimitedAccess implements GpuContextLimitedAccess {
     }
     return new NativeGpuSurface(this.lib, handlePtr, iosurfaceId);
   }
+
+  updateImageLayout(poolId: string, layout: number): void {
+    if (this.surfaceHandlePtr === null) {
+      throw new Error(
+        "updateImageLayout requires a surface-share connection (Linux-only; " +
+          "macOS uses IOSurface + XPC and has no VkImageLayout coordination op)",
+      );
+    }
+    const poolIdBuf = cString(poolId);
+    const rc: number = this.lib.symbols.sldn_surface_update_image_layout(
+      this.surfaceHandlePtr,
+      poolIdBuf,
+      layout,
+    );
+    if (rc !== 0) {
+      throw new Error(
+        `updateImageLayout failed for poolId='${poolId}' (rc=${rc}). ` +
+          "Check the subprocess log; the daemon may have rejected an " +
+          "unknown surface_id, or the socket may be broken.",
+      );
+    }
+  }
 }
 
 /**

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -144,6 +144,15 @@ const symbols = {
     parameters: ["pointer", "buffer"] as const,
     result: "void" as const,
   },
+  // Producer-side cross-process layout publish (#633, Linux). Pairs
+  // with `sldn_vulkan_release_to_foreign`: a producer subprocess
+  // issues the QFOT release on its consumer device, then publishes
+  // the post-release `VkImageLayout` so the next host consumer's
+  // `acquire_from_foreign` sees the right source layout.
+  sldn_surface_update_image_layout: {
+    parameters: ["pointer", "buffer", "i32"] as const,
+    result: "i32" as const,
+  },
 
   // Per-plane surface-share accessors (#530). The OpenGL adapter needs
   // `plane_stride` (EGL_DMA_BUF_PLANE{N}_PITCH_EXT) and
@@ -253,6 +262,13 @@ const symbols = {
   },
   sldn_vulkan_release_read: {
     parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  // Producer-side cross-process release. Pairs with
+  // `sldn_surface_update_image_layout` — see VulkanContext
+  // `releaseForCrossProcess` (#633).
+  sldn_vulkan_release_to_foreign: {
+    parameters: ["pointer", "u64", "i32"] as const,
     result: "i32" as const,
   },
   sldn_vulkan_raw_handles: {

--- a/libs/streamlib-deno/types.ts
+++ b/libs/streamlib-deno/types.ts
@@ -92,6 +92,16 @@ export interface GpuContextLimitedAccess {
   resolveSurface(poolId: string): GpuSurface;
 
   /**
+   * Publish a producer-side post-release `VkImageLayout` for `poolId`
+   * over the surface-share `update_layout` op (#633). Pairs with the
+   * cross-process QFOT release a producer subprocess issues via
+   * `VulkanContext.releaseForCrossProcess` — without this publish, the
+   * next host consumer's `acquire_from_foreign` falls back to the
+   * cached registration layout. Linux-only.
+   */
+  updateImageLayout(poolId: string, layout: number): void;
+
+  /**
    * The cdylib handle this view's surfaces resolve against. Used by
    * in-tree adapter SDKs to call additional `sldn_*` FFI ops without
    * re-loading the cdylib.

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -2291,6 +2291,24 @@ mod surface_client {
         xpc_release(request);
     }
 
+    /// macOS XPC has no `update_layout` op — the macOS surface-share
+    /// path does not coordinate cross-process Vulkan layouts (#633 is
+    /// Linux-only by construction; macOS uses IOSurface + XPC).
+    /// Returns `-1` so callers see the failure clearly rather than
+    /// silently no-op'ing.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_surface_update_image_layout(
+        _handle: *mut SurfaceShareHandle,
+        _pool_id: *const c_char,
+        _layout: i32,
+    ) -> i32 {
+        tracing::error!(
+            "slpn_surface_update_image_layout: not supported on macOS \
+             (cross-process VkImageLayout coordination is Linux-only; #633)"
+        );
+        -1
+    }
+
     unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         if ptr.is_null() {
             return None;
@@ -2882,7 +2900,92 @@ mod surface_client {
         }
     }
 
-
+    /// Publish a producer-side post-release `VkImageLayout` for the
+    /// given `pool_id` over the surface-share `update_layout` op (#633).
+    /// Pairs with [`slpn_vulkan_release_to_foreign`]: a producer
+    /// subprocess issues the QFOT release barrier on its consumer
+    /// `VkDevice` and then publishes the resulting layout so the next
+    /// host-side consumer's `acquire_from_foreign` sees it.
+    ///
+    /// Returns `0` on success, `-1` on socket failure or wire
+    /// rejection (e.g. unknown surface_id).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_surface_update_image_layout(
+        handle: *mut SurfaceShareHandle,
+        pool_id: *const c_char,
+        layout: i32,
+    ) -> i32 {
+        let handle = match unsafe { handle.as_ref() } {
+            Some(h) => h,
+            None => {
+                tracing::error!("slpn_surface_update_image_layout: null handle");
+                return -1;
+            }
+        };
+        let pool_id_str = match c_str_to_string(pool_id) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                tracing::error!(
+                    "slpn_surface_update_image_layout: null or empty pool_id"
+                );
+                return -1;
+            }
+        };
+        let guard = match handle.lazy_connect() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_surface_update_image_layout: connect to '{}' failed: {}",
+                    handle.socket_path, e
+                );
+                return -1;
+            }
+        };
+        let stream = guard.as_ref().expect("connection just populated");
+        let request = serde_json::json!({
+            "op": "update_layout",
+            "surface_id": pool_id_str,
+            "current_image_layout": layout,
+        });
+        let (response, response_fds) =
+            match wire::send_request_with_fds(stream, &request, &[], 0) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_surface_update_image_layout: update_layout for '{}' failed: {}",
+                        pool_id_str, e
+                    );
+                    return -1;
+                }
+            };
+        for fd in &response_fds {
+            unsafe { libc::close(*fd) };
+        }
+        if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
+            tracing::error!(
+                "slpn_surface_update_image_layout: '{}': {}",
+                pool_id_str, err
+            );
+            return -1;
+        }
+        match response.get("success").and_then(|v| v.as_bool()) {
+            Some(true) => 0,
+            Some(false) => {
+                tracing::error!(
+                    "slpn_surface_update_image_layout: surface_id '{}' not registered",
+                    pool_id_str
+                );
+                -1
+            }
+            None => {
+                tracing::error!(
+                    "slpn_surface_update_image_layout: malformed response (missing `success`) for '{}'",
+                    pool_id_str
+                );
+                -1
+            }
+        }
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -2926,6 +3029,16 @@ mod surface_client {
         _handle: *mut c_void,
         _pool_id: *const c_char,
     ) {
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_surface_update_image_layout(
+        _handle: *mut c_void,
+        _pool_id: *const c_char,
+        _layout: i32,
+    ) -> i32 {
+        tracing::error!("Surface-share operations not supported on this platform");
+        -1
     }
 
 }
@@ -3843,6 +3956,70 @@ mod vulkan {
         surface_id: u64,
     ) -> i32 {
         release_inner(rt, surface_id, AcquireKind::Read)
+    }
+
+    /// Issue a producer-side queue-family-ownership-transfer release
+    /// barrier to `VK_QUEUE_FAMILY_EXTERNAL` against the surface's
+    /// imported `VkImage`, transitioning to `post_release_layout` (#633).
+    /// Pairs with the host-side consumer's `acquire_from_foreign`
+    /// (Path 2 of `GpuContext::resolve_videoframe_registration`).
+    ///
+    /// Caller responsibilities:
+    /// 1. The surface must already be registered (via
+    ///    `slpn_vulkan_register_surface`) and NOT currently held in
+    ///    a read or write acquire — call this **after** the matching
+    ///    `slpn_vulkan_release_write`/`_read` returns. The adapter's
+    ///    single-producer-per-surface contract is what makes the
+    ///    snapshot-then-submit pattern in
+    ///    `VulkanSurfaceAdapter::release_to_foreign` safe.
+    /// 2. The producer must have completed all writes / reads against
+    ///    the image (i.e. their own queue submission has signalled or
+    ///    `vkQueueWaitIdle` has returned) before calling this; the
+    ///    adapter's QFOT release barrier carries an
+    ///    `srcAccessMask = MEMORY_WRITE_BIT` and assumes hazard
+    ///    coverage upstream.
+    /// 3. After this returns successfully, the producer should
+    ///    publish `post_release_layout` to surface-share via
+    ///    [`slpn_surface_update_image_layout`] so the next consumer's
+    ///    `acquire_from_foreign` sees the right source layout.
+    ///
+    /// `post_release_layout` is the `VkImageLayout` enumerant value
+    /// (an `i32`, e.g. `VK_IMAGE_LAYOUT_GENERAL = 1`,
+    /// `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = 5`).
+    ///
+    /// Returns `0` on success, `-1` on failure (null runtime,
+    /// unregistered surface, or GPU submit error). On a missing
+    /// `VK_EXT_external_memory_acquire_unmodified` extension at
+    /// device construction the adapter records a same-family layout
+    /// transition instead of a true QFOT — the result is still
+    /// validation-clean against the consumer's bridging fallback;
+    /// see `docs/learnings/cross-process-vkimage-layout.md`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_to_foreign(
+        rt: *mut VulkanRuntimeHandle,
+        surface_id: u64,
+        post_release_layout: i32,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_vulkan_release_to_foreign: null runtime");
+                return -1;
+            }
+        };
+        match rt
+            .adapter
+            .release_to_foreign(surface_id, VulkanLayout(post_release_layout))
+        {
+            Ok(_) => 0,
+            Err(e) => {
+                tracing::error!(
+                    "slpn_vulkan_release_to_foreign({}): {:?}",
+                    surface_id, e
+                );
+                -1
+            }
+        }
     }
 
     /// Power-user surface — the same handles `streamlib_adapter_vulkan::raw_handles`
@@ -5982,6 +6159,15 @@ mod vulkan {
     pub unsafe extern "C" fn slpn_vulkan_release_read(
         _rt: *mut c_void,
         _surface_id: u64,
+    ) -> i32 {
+        -1
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_vulkan_release_to_foreign(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _post_release_layout: i32,
     ) -> i32 {
         -1
     }

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -361,6 +361,13 @@ class VulkanContext:
             fn.restype = ctypes.c_int32
             fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
 
+        lib.slpn_vulkan_release_to_foreign.restype = ctypes.c_int32
+        lib.slpn_vulkan_release_to_foreign.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_int32,
+        ]
+
         lib.slpn_vulkan_raw_handles.restype = ctypes.c_int32
         lib.slpn_vulkan_raw_handles.argtypes = [
             ctypes.c_void_p,
@@ -562,6 +569,64 @@ class VulkanContext:
             group_count_y=int(group_count_y),
             group_count_z=int(group_count_z),
         )
+
+    def release_for_cross_process(
+        self, surface, post_release_layout: int
+    ) -> None:
+        """Issue a producer-side queue-family-ownership-transfer (QFOT)
+        release barrier on this subprocess's ``ConsumerVulkanDevice`` and
+        publish the post-release ``VkImageLayout`` to surface-share so
+        the next cross-process consumer's ``acquire_from_foreign`` sees
+        the right source layout.
+
+        Call this *after* the matching :meth:`acquire_write` /
+        :meth:`acquire_read` ``with`` block has exited and after the
+        producer's queue submission has actually retired (e.g. the
+        customer has signalled their own timeline or
+        ``vkQueueWaitIdle``-ed). The adapter's QFOT release barrier
+        carries ``srcAccessMask = MEMORY_WRITE_BIT`` and assumes
+        producer-side hazard coverage upstream.
+
+        ``post_release_layout`` is a Vulkan ``VkImageLayout`` enumerant
+        as an integer (use :class:`VkImageLayout` constants). Picking
+        ``GENERAL`` is the safest default for cross-process handoffs
+        — the consumer's ``acquire_from_foreign`` re-transitions to
+        whatever layout it actually needs.
+
+        On NVIDIA Linux drivers without
+        ``VK_EXT_external_memory_acquire_unmodified`` (current state
+        as of 2026-05-03), the host consumer side falls back to a
+        bridging ``UNDEFINED → target`` transition; content
+        preservation is empirical (see
+        ``docs/learnings/cross-process-vkimage-layout.md``). The
+        producer-side path here is correct under both modes.
+        """
+        pool_id = self._surface_pool_id(surface)
+        surface_id = self._surface_ids.get(pool_id)
+        if surface_id is None:
+            raise RuntimeError(
+                f"VulkanContext.release_for_cross_process: surface "
+                f"'{pool_id}' is not registered — at least one "
+                "acquire_write/acquire_read must have run for this "
+                "surface in this subprocess before publishing a "
+                "cross-process release."
+            )
+        rc = self._lib.slpn_vulkan_release_to_foreign(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.c_int32(int(post_release_layout)),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"VulkanContext.release_for_cross_process: "
+                f"slpn_vulkan_release_to_foreign returned {rc} for "
+                f"surface '{pool_id}' (check subprocess log for the "
+                "underlying adapter error)"
+            )
+        # Pair the QFOT release with the surface-share `update_layout`
+        # publish so the next host-side consumer's `acquire_from_foreign`
+        # picks up the new layout instead of the cached registration one.
+        self._gpu.update_image_layout(pool_id, int(post_release_layout))
 
     def raw_handles(self) -> RawVulkanHandles:
         """Return the cdylib runtime's raw Vulkan handles — same shape

--- a/libs/streamlib-python/python/streamlib/processor_context.py
+++ b/libs/streamlib-python/python/streamlib/processor_context.py
@@ -202,6 +202,15 @@ def load_native_lib(lib_path):
     lib.slpn_surface_acquire_surface.restype = ctypes.c_void_p
     lib.slpn_surface_unregister_surface.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     lib.slpn_surface_unregister_surface.restype = None
+    # Producer-side cross-process layout publish (#633, Linux). Pairs
+    # with `slpn_vulkan_release_to_foreign`: a producer subprocess
+    # issues the QFOT release on its consumer device, then publishes
+    # the post-release `VkImageLayout` so the next host consumer's
+    # `acquire_from_foreign` sees the right source layout.
+    lib.slpn_surface_update_image_layout.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int32,
+    ]
+    lib.slpn_surface_update_image_layout.restype = ctypes.c_int32
 
     # OpenGL adapter runtime (#530, Linux). Uses the host adapter crate's
     # EglRuntime + OpenGlSurfaceAdapter for EGL bring-up + DMA-BUF→GL
@@ -482,6 +491,36 @@ class NativeGpuContextLimitedAccess:
         if not handle_ptr:
             raise RuntimeError(f"IOSurface not found: {surface_id}")
         return NativeGpuSurfaceHandle(self._lib, handle_ptr)
+
+    def update_image_layout(self, surface_id: str, layout: int) -> None:
+        """Publish a producer-side post-release ``VkImageLayout`` for
+        ``surface_id`` over the surface-share ``update_layout`` op (#633).
+        Pairs with the cross-process QFOT release a producer subprocess
+        issues via :meth:`streamlib.adapters.vulkan.VulkanContext.release_for_cross_process`
+        — without this publish, the next host consumer's ``acquire_from_foreign``
+        falls back to the cached registration layout.
+
+        Linux-only: macOS surface-share doesn't ship a layout-coordination
+        op (cross-process VkImageLayout coordination is Linux-by-construction).
+        """
+        if not self._handle_ptr:
+            raise RuntimeError(
+                "update_image_layout requires a surface-share connection "
+                "(Linux-only; macOS uses IOSurface + XPC and has no "
+                "VkImageLayout coordination op)"
+            )
+        rc = self._lib.slpn_surface_update_image_layout(
+            self._handle_ptr,
+            surface_id.encode("utf-8"),
+            int(layout),
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"update_image_layout failed for surface_id='{surface_id}' "
+                f"(rc={rc}). Check the subprocess log; the daemon may have "
+                "rejected an unknown surface_id, or the socket may be "
+                "broken."
+            )
 
 
 class NativeGpuContextFullAccess(NativeGpuContextLimitedAccess):


### PR DESCRIPTION
## Summary

- Wire `VulkanSurfaceAdapter::release_to_foreign` + `SurfaceStore::update_image_layout` (both shipped in #646 / #633) through the Python and Deno cdylibs so subprocess producers can publish a post-release `VkImageLayout` to host consumers going through Path 2's `acquire_from_foreign`.
- Adds two FFI symbols per cdylib + a single composed `VulkanContext.release_for_cross_process(surface, post_release_layout)` method on each SDK that pairs the QFOT release barrier (subprocess-side) with the surface-share `update_layout` IPC publish atomically.
- Exercises the new path end-to-end in `examples/polyglot-vulkan-compute` for both runtimes with `VK_LOADER_LAYERS_ENABLE=*validation*`.

## Closes

Closes #643

## Polyglot coverage

- **Runtimes affected**: rust (cdylibs) | python | deno
- **Schema regenerated**: n/a (the surface-share `update_layout` op already shipped in #633; this PR wires the existing wire format through new cdylib symbols)
- **Python and Deno both covered?** yes — same FFI symbol pair, same composed adapter method, same example invocation
- **E2E tests run**:
  - [x] Python subprocess: `polyglot-vulkan-compute --runtime=python` with validation layers — zero VUID-01197, zero `Validation Error`, zero `OUT_OF_DEVICE_MEMORY`, zero `DEVICE_LOST`. PNG output:

    ![python-mandelbrot](https://gh-artifact.tatolab.com/pr-643/20260503-155009/vulkan-mandelbrot-py-643.jpg)

  - [x] Deno subprocess: `polyglot-vulkan-compute --runtime=deno` with validation layers — same gates clean. PNG output:

    ![deno-mandelbrot](https://gh-artifact.tatolab.com/pr-643/20260503-155009/vulkan-mandelbrot-deno-643.jpg)
- **FD-passing path**: n/a (no new surfaces; this PR publishes layout state for already-registered surfaces)

## What landed

### Cdylib FFI (Python `slpn_*`, Deno `sldn_*`)

- `*_vulkan_release_to_foreign(rt, surface_id: u64, post_release_layout: i32) -> i32` — calls `VulkanSurfaceAdapter::release_to_foreign(...)` on the subprocess's `ConsumerVulkanDevice`. Records the QFOT release barrier (or bridging fallback when `VK_EXT_external_memory_acquire_unmodified` is missing — see `docs/learnings/cross-process-vkimage-layout.md`) and updates the adapter's per-surface `current_layout`.
- `*_surface_update_image_layout(handle, pool_id: *const c_char, layout: i32) -> i32` — sends the surface-share `update_layout` op (`{"op": "update_layout", "surface_id", "current_image_layout"}`) over the existing Unix-socket transport, mirroring the wire shape `SurfaceStore::update_image_layout` already speaks. macOS gets a `-1`-returning stub with a tracing error (cross-process VkImageLayout coordination is Linux-by-construction).

### SDK wrappers

- **Python** (`libs/streamlib-python/python/streamlib/adapters/vulkan.py`, `processor_context.py`): `NativeGpuContextLimitedAccess.update_image_layout(surface_id, layout)` + `VulkanContext.release_for_cross_process(surface, post_release_layout)`. The composed method validates the surface is registered, calls the QFOT FFI, then publishes via the surface-share handle.
- **Deno** (`libs/streamlib-deno/{types.ts,context.ts,adapters/vulkan.ts,native.ts}`): `GpuContextLimitedAccess.updateImageLayout` is added to the public interface; `NativeGpuContextLimitedAccess.updateImageLayout` implements it; `VulkanContext.releaseForCrossProcess(surface, postReleaseLayout)` composes the two FFI calls.

### Example

`examples/polyglot-vulkan-compute/{python/vulkan_compute.py,deno/vulkan_compute.ts}` calls `release_for_cross_process(uuid, GENERAL)` after the `acquire_write`/`dispatch_compute` block exits, exercising the new producer-side path end-to-end.

## Architectural notes

- **Layer of fix**: consumer/cdylib SDK plumbing. The engine work (QFOT pair, bridging fallback, capability probe) landed correctly in #646; this PR connects it to subprocess code.
- **Pattern sweep**: this is the first cdylib producer-side QFOT user — nothing to sweep. Sibling adapter wiring for OpenGL (#644) and Skia (#645) are split out by design.
- **Capability boundary preserved**: the new cdylib symbols only call into `streamlib-adapter-vulkan` and the surface-share Unix-socket transport — no `vulkanalia` reach-throughs, no full-`streamlib` import. `cargo xtask check-boundaries` passes (1984 files, no violations).

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo xtask check-boundaries` — 1984 file(s), no violations
- [x] `cargo xtask lint-logging` — 467 file(s), no violations
- [x] `cargo test -p streamlib-adapter-vulkan -p streamlib-consumer-rhi -p streamlib-surface-client` — all green
- [x] `deno check libs/streamlib-deno/mod.ts` — clean (a pre-existing `SurfaceAccessGuard` typo on `main` lights up `vulkan.ts` in stricter check modes — unrelated to this PR)
- [x] Python E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` — zero VUID-01197, zero validation errors
- [x] Deno E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` — zero VUID-01197, zero validation errors

## Follow-ups

None — this PR closes #643's exit criteria. Sibling tickets #644 (adapter-opengl producer-side QFOT) and #645 (adapter-skia producer-side QFOT) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)