### PR TITLE
feat(adapter-opengl): producer-side QFOT release via dual-registration (#644)

### DIFF
--- a/docs/architecture/adapter-authoring.md
+++ b/docs/architecture/adapter-authoring.md
@@ -474,6 +474,163 @@ subprocesses (which is the default for any new adapter), follow
   language-specific by construction; document the reason in the
   PR if you split.
 
+## Cross-process producer composition
+
+When the producer side (subprocess writing into a host-allocated
+surface) needs spec-correct cross-process layout coordination
+(#633) AND the adapter is **not** the Vulkan adapter, **don't** add
+a Vulkan device handle to the adapter. Compose: the customer
+dual-registers the same surface with the producer adapter (e.g.
+`OpenGlSurfaceAdapter`, `streamlib-adapter-skia` GL backend) AND
+the canonical `VulkanSurfaceAdapter`, and the producer's release
+path delegates to `VulkanSurfaceAdapter::release_to_foreign` for
+the QFOT release barrier + the surface-share `update_image_layout`
+publish.
+
+This is the engine-model answer (per CLAUDE.md → "The RHI is the
+single gateway"): there is one canonical place per API for that
+API's state. The OpenGL adapter does GL only; the Vulkan adapter
+does Vulkan only; cross-API composition lives at the SDK / customer
+layer. Dawn/Chromium's `SharedImageBacking` + per-API
+`*ImageRepresentation` pattern is the same shape; we adopted it
+deliberately rather than rederive it under a different name.
+
+### When this applies
+
+A surface adapter needs producer-side cross-process release wiring
+when **all three** are true:
+
+1. The adapter writes into a host-allocated DMA-BUF / OPAQUE_FD
+   resource. (Read-only adapters never publish layout — they
+   consume it.)
+2. The adapter's underlying API has no native concept of
+   `VkImageLayout` (OpenGL, Skia, future ANGLE/DirectComposition,
+   etc.). The Vulkan adapter trivially handles its own QFOT
+   release; CUDA's path is buffer-only and structurally has no
+   layout to publish (see [CUDA exclusion](#cuda-exclusion)).
+3. Cross-process consumers exist that read the surface via Path 2
+   `acquire_from_foreign`. Same-process consumers go through Path
+   1 and don't need this.
+
+### Implementation pattern
+
+**Host setup hook** — register the surface with surface-share
+**including** an exportable `HostVulkanTimelineSemaphore`, even
+when the producer adapter doesn't use the timeline itself. The
+subprocess's `VulkanSurfaceAdapter::register_host_surface` requires
+a timeline; without it the dual-registration call fails:
+
+```rust
+let timeline = Arc::new(
+    HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)?,
+);
+store.register_texture(
+    SCENARIO_SURFACE_UUID,
+    &texture,
+    Some(timeline.as_ref()),  // required for dual-registration
+    VulkanLayout::GENERAL,    // the producer's post-write layout
+)?;
+```
+
+The `initial_layout` becomes the Vulkan adapter's `current_layout`
+at registration time on the cdylib side, so the QFOT release
+barrier issues from the right source layout.
+
+**Subprocess customer** — obtain both contexts from the same
+runtime in `setup`, then call the producer adapter's
+`release_for_cross_process` after the write block exits:
+
+```python
+# Python
+self._opengl = OpenGLContext.from_runtime(ctx)
+self._vulkan = VulkanContext.from_runtime(ctx)
+# ...
+with self._opengl.acquire_write(uuid) as view:
+    # ... GL writes ...
+# acquire_write's __exit__ runs glFinish — writes drained.
+self._opengl.release_for_cross_process(uuid, self._vulkan, VkImageLayout.GENERAL)
+```
+
+```typescript
+// Deno
+this.opengl = OpenGLContext.fromRuntime(ctx);
+this.vulkan = VulkanContext.fromRuntime(ctx);
+// ...
+{
+  using guard = this.opengl.acquireWrite(uuid);
+  // ... GL writes ...
+}  // dispose runs glFinish — writes drained.
+this.opengl.releaseForCrossProcess(uuid, this.vulkan, VkImageLayout.General);
+```
+
+**Producer adapter SDK method** — a thin delegating wrapper:
+
+```python
+def release_for_cross_process(self, surface, vulkan_ctx, post_release_layout):
+    vulkan_ctx.release_for_cross_process(surface, post_release_layout)
+```
+
+That's the entire implementation. The adapter crate (Rust) doesn't
+change.
+
+**`VulkanContext.release_for_cross_process` lazily registers** the
+surface on its first reference, so the customer doesn't need a
+no-op `acquire_*` first to populate the cdylib's surface-id map.
+The Vulkan adapter's `register_host_surface` consumes the sync_fd
+from the resolved SurfaceHandle and dups its own copies of the
+DMA-BUF FDs — the producer adapter's earlier registration is not
+disturbed (`SurfaceHandle::sync_fd` is `take`n by the Vulkan
+register; the OpenGL register reads only the DMA-BUF FDs and never
+touches the sync_fd).
+
+### Why not add a Vulkan device handle to the producer adapter
+
+Two alternatives were considered and rejected:
+
+- **Construction-time** `OpenGlSurfaceAdapter::new(runtime, device)`
+  — forces every OpenGL adapter user to wire a Vulkan device, even
+  ones that don't need cross-process. Conflates "GL access" with
+  "Vulkan release" at the type level.
+- **Per-call threaded device**
+  `release_for_cross_process<D>(surface, device, …)` — moves the
+  device threading to the API surface and still requires the
+  adapter to stash a `VkImage` (extra `Arc<dyn VulkanTextureLike>`
+  on `HostSurfaceRegistration`). Adapter still has Vulkan
+  obligations.
+
+Both options put Vulkan responsibilities on the OpenGL adapter,
+which is wrong-shaped per the engine-model rule. Composition is
+free; rederivation is expensive.
+
+### CUDA exclusion
+
+The CUDA adapter (`streamlib-adapter-cuda`) does NOT need this
+pattern. CUDA's interop is buffer-only by structural constraint:
+DLPack requires a flat `void*` device pointer, which forces
+`cudaImportExternalMemory(OPAQUE_FD)` →
+`cudaExternalMemoryGetMappedBuffer`, which only accepts a
+`VkBuffer`. `VkBuffer`s have no `VkImageLayout`, so QFOT-for-layout
+is structurally meaningless for CUDA. Cross-process correctness
+is provided by the timeline-semaphore alone (the cuda.py
+docstring: *"there is no per-acquire IPC — the host's pipeline is
+expected to write into the OPAQUE_FD buffer and signal the shared
+timeline ambiently."*).
+
+If a future CUDA-on-VkImage path lands (currently unscoped — no
+open issue contemplates it), it would inherit this dual-
+registration pattern from this section automatically.
+
+### Reference
+
+Implementation: `examples/polyglot-opengl-fragment-shader/`
+demonstrates the pattern end-to-end for both Python and Deno
+runtimes. The host main.rs allocates and registers the timeline;
+the python/deno scenario binaries dual-register and call
+`release_for_cross_process` after each GL write block.
+
+Sibling tickets: #644 (OpenGL, this section's source), #645
+(Skia GL, inherits the pattern when its host crate ships).
+
 ## Conformance & tests
 
 Every adapter passes the conformance suite. The entry point is

--- a/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
+++ b/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
@@ -41,6 +41,10 @@ import type {
   RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import { OpenGLContext } from "../../../libs/streamlib-deno/adapters/opengl.ts";
+import {
+  VkImageLayout,
+  VulkanContext,
+} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
 
 // =============================================================================
 // Minimal libGL.so.1 binding via Deno.dlopen
@@ -269,6 +273,13 @@ export default class OpenGlFragmentShaderProcessor implements ReactiveProcessor 
   private width = 0;
   private height = 0;
   private opengl: OpenGLContext | null = null;
+  // Dual-register the surface with the Vulkan adapter too so the
+  // producer-side QFOT release barrier (#644) can publish layout to
+  // host consumers via OpenGLContext.releaseForCrossProcess. OpenGL
+  // itself does GL writes; the Vulkan adapter owns the cross-process
+  // release barrier — engine-model composition per
+  // docs/architecture/adapter-authoring.md.
+  private vulkan: VulkanContext | null = null;
   private rendered = false;
   private errorMessage: string | null = null;
 
@@ -278,6 +289,7 @@ export default class OpenGlFragmentShaderProcessor implements ReactiveProcessor 
     this.width = Number(cfg["width"] ?? 0);
     this.height = Number(cfg["height"] ?? 0);
     this.opengl = OpenGLContext.fromRuntime(ctx);
+    this.vulkan = VulkanContext.fromRuntime(ctx);
     console.error(
       `[OpenGlFragmentShader/deno] setup uuid=${this.uuid} ` +
         `size=${this.width}x${this.height}`,
@@ -303,91 +315,124 @@ export default class OpenGlFragmentShaderProcessor implements ReactiveProcessor 
   }
 
   private renderOnce(): void {
-    if (this.opengl === null) {
-      throw new Error("OpenGLContext was not initialized in setup");
+    if (this.opengl === null || this.vulkan === null) {
+      throw new Error(
+        "OpenGLContext / VulkanContext were not initialized in setup",
+      );
     }
-    using guard = this.opengl.acquireWrite(this.uuid);
-    const textureId = guard.view.glTextureId;
-    const gl = loadLibGL();
+    // Wrap the GL block in `{ … }` so the `using guard` disposes
+    // (running the adapter's `end_write_access` → `glFinish`) BEFORE
+    // the cross-process release call below — the QFOT release barrier
+    // assumes producer-side hazard coverage upstream.
+    {
+      using guard = this.opengl.acquireWrite(this.uuid);
+      const textureId = guard.view.glTextureId;
+      const gl = loadLibGL();
 
-    // Empty VAO — desktop core requires one bound; geometry comes from
-    // gl_VertexID in the vertex shader.
-    const vao = new Uint32Array(1);
-    gl.symbols.glGenVertexArrays(1, new Uint8Array(vao.buffer));
-    gl.symbols.glBindVertexArray(vao[0]);
-    try {
-      const vs = compileShader(gl, VERTEX_SHADER, GL_VERTEX_SHADER, "vertex");
-      let program: number;
+      // Empty VAO — desktop core requires one bound; geometry comes
+      // from gl_VertexID in the vertex shader.
+      const vao = new Uint32Array(1);
+      gl.symbols.glGenVertexArrays(1, new Uint8Array(vao.buffer));
+      gl.symbols.glBindVertexArray(vao[0]);
       try {
-        const fs = compileShader(
+        const vs = compileShader(
           gl,
-          FRAGMENT_SHADER,
-          GL_FRAGMENT_SHADER,
-          "fragment",
+          VERTEX_SHADER,
+          GL_VERTEX_SHADER,
+          "vertex",
         );
+        let program: number;
         try {
-          program = linkProgram(gl, vs, fs);
+          const fs = compileShader(
+            gl,
+            FRAGMENT_SHADER,
+            GL_FRAGMENT_SHADER,
+            "fragment",
+          );
+          try {
+            program = linkProgram(gl, vs, fs);
+          } finally {
+            gl.symbols.glDeleteShader(fs);
+          }
         } finally {
-          gl.symbols.glDeleteShader(fs);
+          gl.symbols.glDeleteShader(vs);
+        }
+
+        try {
+          // FBO with the imported texture as color attachment.
+          const fbo = new Uint32Array(1);
+          gl.symbols.glGenFramebuffers(1, new Uint8Array(fbo.buffer));
+          gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, fbo[0]);
+          gl.symbols.glFramebufferTexture2D(
+            GL_FRAMEBUFFER,
+            GL_COLOR_ATTACHMENT0,
+            GL_TEXTURE_2D,
+            textureId,
+            0,
+          );
+          const status = gl.symbols.glCheckFramebufferStatus(GL_FRAMEBUFFER);
+          if (status !== GL_FRAMEBUFFER_COMPLETE) {
+            throw new Error(
+              `FBO incomplete (status=0x${
+                status.toString(16)
+              }) — the imported texture may have been bound with an ` +
+                `external_only modifier; the host allocator should pick ` +
+                `a tiled, render-target-capable DRM modifier`,
+            );
+          }
+
+          gl.symbols.glViewport(0, 0, this.width, this.height);
+          gl.symbols.glUseProgram(program);
+
+          const resolutionName = new TextEncoder().encode("resolution\0");
+          const loc = gl.symbols.glGetUniformLocation(program, resolutionName);
+          if (loc >= 0) {
+            gl.symbols.glUniform2f(loc, this.width, this.height);
+          }
+
+          gl.symbols.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+          gl.symbols.glFinish();
+
+          const glErr = gl.symbols.glGetError();
+          if (glErr !== GL_NO_ERROR) {
+            throw new Error(
+              `GL error 0x${glErr.toString(16)} after draw — see ` +
+                `docs/learnings/nvidia-egl-dmabuf-render-target.md`,
+            );
+          }
+
+          gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, 0);
+          gl.symbols.glDeleteFramebuffers(1, new Uint8Array(fbo.buffer));
+        } finally {
+          gl.symbols.glDeleteProgram(program);
         }
       } finally {
-        gl.symbols.glDeleteShader(vs);
+        gl.symbols.glBindVertexArray(0);
+        gl.symbols.glDeleteVertexArrays(1, new Uint8Array(vao.buffer));
       }
-
-      try {
-        // FBO with the imported texture as color attachment.
-        const fbo = new Uint32Array(1);
-        gl.symbols.glGenFramebuffers(1, new Uint8Array(fbo.buffer));
-        gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, fbo[0]);
-        gl.symbols.glFramebufferTexture2D(
-          GL_FRAMEBUFFER,
-          GL_COLOR_ATTACHMENT0,
-          GL_TEXTURE_2D,
-          textureId,
-          0,
-        );
-        const status = gl.symbols.glCheckFramebufferStatus(GL_FRAMEBUFFER);
-        if (status !== GL_FRAMEBUFFER_COMPLETE) {
-          throw new Error(
-            `FBO incomplete (status=0x${status.toString(16)}) — the imported ` +
-              `texture may have been bound with an external_only modifier; ` +
-              `the host allocator should pick a tiled, render-target-capable ` +
-              `DRM modifier`,
-          );
-        }
-
-        gl.symbols.glViewport(0, 0, this.width, this.height);
-        gl.symbols.glUseProgram(program);
-
-        const resolutionName = new TextEncoder().encode("resolution\0");
-        const loc = gl.symbols.glGetUniformLocation(program, resolutionName);
-        if (loc >= 0) {
-          gl.symbols.glUniform2f(loc, this.width, this.height);
-        }
-
-        gl.symbols.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-        gl.symbols.glFinish();
-
-        const glErr = gl.symbols.glGetError();
-        if (glErr !== GL_NO_ERROR) {
-          throw new Error(
-            `GL error 0x${glErr.toString(16)} after draw — see ` +
-              `docs/learnings/nvidia-egl-dmabuf-render-target.md`,
-          );
-        }
-
-        gl.symbols.glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        gl.symbols.glDeleteFramebuffers(1, new Uint8Array(fbo.buffer));
-      } finally {
-        gl.symbols.glDeleteProgram(program);
-      }
-    } finally {
-      gl.symbols.glBindVertexArray(0);
-      gl.symbols.glDeleteVertexArrays(1, new Uint8Array(vao.buffer));
+      // `using guard` runs adapter `end_write_access` at scope exit
+      // which drains GL via glFinish so the host's DMA-BUF readback
+      // sees a fully-flushed image AND the cross-process release
+      // barrier below sees coherent contents through the DMA-BUF.
     }
-    // `using guard` runs adapter `end_write_access` at scope exit which
-    // drains GL via glFinish so the host's DMA-BUF readback sees a
-    // fully-flushed image.
+
+    // Producer-side cross-process release (#644). The OpenGL adapter
+    // has no Vulkan device of its own and never issues a release
+    // barrier on the imported VkImage — delegate to the Vulkan
+    // adapter (dual-registration). General is the right choice for
+    // OpenGL-backed surfaces (the host's pre-stop readback also reads
+    // with TextureSourceLayout::General). Pairs with any future host
+    // consumer's `acquire_from_foreign` via the bridging fallback on
+    // NVIDIA / QFOT-acquire on Mesa.
+    this.opengl.releaseForCrossProcess(
+      this.uuid,
+      this.vulkan,
+      VkImageLayout.General,
+    );
+    console.error(
+      `[OpenGlFragmentShader/deno] published cross-process release ` +
+        `layout=General for surface '${this.uuid}'`,
+    );
   }
 
   teardown(_ctx: RuntimeContextFullAccess): void {

--- a/examples/polyglot-opengl-fragment-shader/python/opengl_fragment_shader.py
+++ b/examples/polyglot-opengl-fragment-shader/python/opengl_fragment_shader.py
@@ -38,6 +38,7 @@ from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
 from streamlib.adapters.opengl import OpenGLContext
+from streamlib.adapters.vulkan import VkImageLayout, VulkanContext
 
 
 # =============================================================================
@@ -284,6 +285,13 @@ class OpenGlFragmentShaderProcessor:
         self._width = int(cfg["width"])
         self._height = int(cfg["height"])
         self._opengl = OpenGLContext.from_runtime(ctx)
+        # Dual-register the surface with the Vulkan adapter too so the
+        # producer-side QFOT release barrier (#644) can publish layout
+        # to host consumers via OpenGLContext.release_for_cross_process.
+        # OpenGL itself does GL writes; the Vulkan adapter owns the
+        # cross-process release barrier — engine-model composition per
+        # docs/architecture/adapter-authoring.md.
+        self._vulkan = VulkanContext.from_runtime(ctx)
         self._gl: Optional[dict] = None
         self._rendered = False
         self._error: Optional[str] = None
@@ -385,6 +393,23 @@ class OpenGlFragmentShaderProcessor:
         # acquire_write's __exit__ runs adapter `end_write_access`
         # which does a final glFinish so the host's DMA-BUF readback
         # sees a fully-flushed image.
+
+        # Producer-side cross-process release (#644). The OpenGL
+        # adapter has no Vulkan device of its own and never issues a
+        # release barrier on the imported VkImage — delegate to the
+        # Vulkan adapter (dual-registration). GENERAL is the right
+        # choice for OpenGL-backed surfaces (the host's pre-stop
+        # readback also reads with TextureSourceLayout::General).
+        # Pairs with any future host consumer's `acquire_from_foreign`
+        # via the bridging fallback on NVIDIA / QFOT-acquire on Mesa.
+        self._opengl.release_for_cross_process(
+            self._uuid, self._vulkan, VkImageLayout.GENERAL
+        )
+        print(
+            f"[OpenGlFragmentShader/py] published cross-process release "
+            f"layout=GENERAL for surface '{self._uuid}'",
+            flush=True,
+        )
 
     def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print(

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -34,7 +34,7 @@ use streamlib::core::rhi::{
     TextureFormat, TextureReadbackDescriptor, TextureSourceLayout,
 };
 use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
-use streamlib::host_rhi::VulkanTextureReadback;
+use streamlib::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
 
 /// UUID the host registers the render-target surface under. The
@@ -111,11 +111,14 @@ fn main() -> Result<()> {
     let texture_slot: Arc<
         Mutex<Option<streamlib::core::rhi::StreamTexture>>,
     > = Arc::new(Mutex::new(None));
+    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
     {
         let texture_slot = Arc::clone(&texture_slot);
+        let timeline_slot = Arc::clone(&timeline_slot);
         let readback_slot = Arc::clone(&readback_slot);
         runtime.install_setup_hook(move |gpu| {
             let texture = gpu.acquire_render_target_dma_buf_image(
@@ -134,22 +137,47 @@ fn main() -> Result<()> {
                         .into(),
                 )
             })?;
-            // OpenGL adapter doesn't need an explicit Vulkan timeline:
+
+            // The OpenGL adapter itself doesn't need a Vulkan timeline:
             // `glFinish` on release plus DMA-BUF kernel-fence semantics
-            // carry visibility for the host's pre-stop readback.
-            //
+            // carry visibility for the host's pre-stop readback. We
+            // register one anyway so the subprocess can dual-register
+            // the same surface with its `VulkanSurfaceAdapter` (#644)
+            // for producer-side QFOT release publishing — the engine-
+            // model answer for cross-process content preservation per
+            // `docs/architecture/adapter-authoring.md`. The Vulkan
+            // adapter's `register_host_surface` requires a timeline,
+            // so the host must allocate one even when the producer is
+            // OpenGL-only.
+            let host_device = Arc::clone(gpu.device().vulkan_device());
+            let timeline = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(
+                    host_device.device(),
+                    0,
+                )
+                .map_err(|e| {
+                    StreamError::Configuration(format!(
+                        "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                    ))
+                })?,
+            );
+
             // GL writes leave the underlying DMA-BUF in GENERAL from
             // Vulkan's point of view (mirrors the host's hard-coded
             // `TextureSourceLayout::General` assumption at the
             // post-stop readback site). Declaring it here means
             // cross-process consumers reaching the surface via Path 2
             // get the right source layout for their first QFOT acquire
-            // barrier (#633).
+            // barrier (#633), AND it sets the subprocess Vulkan
+            // adapter's `current_layout` to GENERAL at registration
+            // time so the producer-side QFOT release barrier issued
+            // via `OpenGLContext.release_for_cross_process` (#644)
+            // pairs from the right source.
             store
                 .register_texture(
                     SCENARIO_SURFACE_UUID,
                     &texture,
-                    None,
+                    Some(timeline.as_ref()),
                     streamlib::core::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
@@ -169,9 +197,10 @@ fn main() -> Result<()> {
             })?;
 
             *texture_slot.lock().unwrap() = Some(texture);
+            *timeline_slot.lock().unwrap() = Some(timeline);
             *readback_slot.lock().unwrap() = Some(readback);
             println!(
-                "✓ render-target DMA-BUF surface registered as '{}'",
+                "✓ render-target DMA-BUF + timeline registered as '{}'",
                 SCENARIO_SURFACE_UUID
             );
             Ok(())

--- a/libs/streamlib-deno/adapters/opengl.ts
+++ b/libs/streamlib-deno/adapters/opengl.ts
@@ -27,6 +27,7 @@ import {
   type StreamlibSurface,
   type SurfaceAccessGuard,
 } from "../surface_adapter.ts";
+import { VulkanContext } from "./vulkan.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };
 
@@ -293,6 +294,52 @@ export class OpenGLContext {
         symbols.sldn_opengl_release_read(rt, surfaceId);
       },
     };
+  }
+
+  /** Publish a producer-side cross-process release for a surface this
+   * OpenGL context has been writing to via `acquireWrite`.
+   *
+   * OpenGL writes don't touch the underlying `VkImage`'s Vulkan
+   * tracker — and the OpenGL adapter has no Vulkan device handle of
+   * its own. The engine-model answer (per
+   * `docs/architecture/adapter-authoring.md` → Cross-process producer
+   * composition) is to let the canonical Vulkan adapter own the QFOT
+   * release barrier: the customer dual-registers the same surface
+   * with both adapters, and OpenGL's release path delegates to
+   * `VulkanContext.releaseForCrossProcess`.
+   *
+   * `vulkanCtx` is the subprocess's `VulkanContext` — typically
+   * obtained alongside this `OpenGLContext` from the same runtime
+   * context inside `setup`. The runtime must have been started with
+   * surface-share registration carrying an exportable timeline
+   * OPAQUE_FD per the host-side
+   * `register_texture(... Some(timeline.as_ref()), ...)` pattern.
+   *
+   * Sequencing — call this *after* the `acquireWrite` `using` block
+   * has exited so the adapter's `glFinish` on release has drained GL
+   * writes through the DMA-BUF kernel backing. The Vulkan adapter's
+   * QFOT release then issues a barrier on its imported `VkImage`
+   * (bound to the same DMA-BUF) and publishes the layout via
+   * surface-share, so any subsequent host-side consumer reaching
+   * this surface through `GpuContext::resolve_videoframe_registration`
+   * Path 2 sees the right source layout.
+   *
+   * `postReleaseLayout` is a Vulkan `VkImageLayout` enumerant as a
+   * number. `GENERAL` is the right choice for OpenGL-backed surfaces.
+   *
+   * See `docs/learnings/cross-process-vkimage-layout.md` for the QFOT
+   * vs bridging-fallback story; on NVIDIA Linux the host consumer
+   * side rides the bridging fallback. */
+  releaseForCrossProcess(
+    surface: StreamlibSurface | string | bigint,
+    vulkanCtx: VulkanContext,
+    postReleaseLayout: number,
+  ): void {
+    // Delegate to VulkanContext.releaseForCrossProcess — that's where
+    // release_to_foreign + surface-share update_layout already live
+    // (#647). VulkanContext lazily registers the surface on its first
+    // reference, so the customer doesn't need a no-op acquire first.
+    vulkanCtx.releaseForCrossProcess(surface, postReleaseLayout);
   }
 
   /** Acquire read access against a surface registered under

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -341,6 +341,15 @@ export class VulkanContext {
    * release barrier carries `srcAccessMask = MEMORY_WRITE_BIT` and
    * assumes producer-side hazard coverage upstream.
    *
+   * Also serves the **dual-registration** path used by non-Vulkan
+   * adapters that need cross-process release wiring (OpenGL via
+   * `OpenGLContext.releaseForCrossProcess`, and Skia GL by
+   * extension). In that mode the surface may not have been touched
+   * by an explicit `acquire*` on this Vulkan context — the release
+   * barrier still issues correctly because the surface-share
+   * registration carries the producer's post-write layout as the
+   * Vulkan adapter's initial layout.
+   *
    * `postReleaseLayout` is a Vulkan `VkImageLayout` enumerant as a
    * number (use `VkImageLayout` constants). Picking `GENERAL` is the
    * safest default for cross-process handoffs — the consumer's
@@ -358,15 +367,11 @@ export class VulkanContext {
     postReleaseLayout: number,
   ): void {
     const poolId = VulkanContext.surfacePoolId(surface);
-    const surfaceId = this.surfaceIds.get(poolId);
-    if (surfaceId === undefined) {
-      throw new Error(
-        `VulkanContext.releaseForCrossProcess: surface '${poolId}' is ` +
-          "not registered — at least one acquireWrite/acquireRead must " +
-          "have run for this surface in this subprocess before publishing " +
-          "a cross-process release.",
-      );
-    }
+    // Lazily resolve+register so dual-registration callers
+    // (OpenGL via OpenGLContext.releaseForCrossProcess, Skia GL by
+    // extension) don't have to issue a no-op acquire first.
+    // Idempotent — repeat calls return the cached id.
+    const surfaceId = this.resolveAndRegister(poolId);
     const rc: number = this.symbols.sldn_vulkan_release_to_foreign(
       this.rt,
       surfaceId,

--- a/libs/streamlib-python/python/streamlib/adapters/opengl.py
+++ b/libs/streamlib-python/python/streamlib/adapters/opengl.py
@@ -391,6 +391,62 @@ class OpenGLContext:
                 self._rt, ctypes.c_uint64(surface_id)
             )
 
+    def release_for_cross_process(
+        self, surface, vulkan_ctx, post_release_layout: int
+    ) -> None:
+        """Publish a producer-side cross-process release for a surface
+        this OpenGL context has been writing to via
+        :meth:`acquire_write`.
+
+        OpenGL writes don't touch the underlying ``VkImage``'s Vulkan
+        tracker — and the OpenGL adapter has no Vulkan device handle
+        of its own. The engine-model answer (per
+        ``docs/architecture/adapter-authoring.md`` → Cross-process
+        producer composition) is to let the canonical Vulkan adapter
+        own the QFOT release barrier: the customer dual-registers the
+        same surface with both adapters, and OpenGL's release path
+        delegates to ``VulkanContext.release_for_cross_process``.
+
+        ``vulkan_ctx`` is the subprocess's
+        :class:`streamlib.adapters.vulkan.VulkanContext` — typically
+        obtained alongside this :class:`OpenGLContext` from the same
+        runtime context inside ``setup``. It must be present (the
+        runtime must have been started with surface-share registration
+        carrying an exportable timeline OPAQUE_FD per the
+        ``register_texture(... Some(timeline.as_ref()), ...)`` host
+        pattern).
+
+        Sequencing — call this *after* the :meth:`acquire_write`
+        ``with`` block has exited so the adapter's ``glFinish`` on
+        release has drained GL writes through the DMA-BUF kernel
+        backing. The Vulkan adapter's QFOT release then issues a
+        barrier on its imported ``VkImage`` (bound to the same
+        DMA-BUF) and publishes the layout via surface-share, so any
+        subsequent host-side consumer reaching this surface through
+        ``GpuContext::resolve_videoframe_registration`` Path 2 sees
+        the right source layout.
+
+        ``post_release_layout`` is a Vulkan ``VkImageLayout``
+        enumerant as an integer (use
+        :class:`streamlib.adapters.vulkan.VkImageLayout` constants).
+        ``GENERAL`` is the right choice for OpenGL-backed surfaces
+        — the host doesn't observe the GL writes' "Vulkan layout" in
+        any meaningful sense, so GENERAL-as-source-of-truth gives the
+        consumer maximum flexibility.
+
+        See ``docs/learnings/cross-process-vkimage-layout.md`` for
+        the full QFOT vs bridging-fallback story; on NVIDIA Linux the
+        host consumer side rides the bridging fallback (NVIDIA does
+        not expose ``VK_EXT_external_memory_acquire_unmodified``) and
+        kernel-side DMA-BUF contents are empirically preserved.
+        """
+        # Delegate to VulkanContext.release_for_cross_process — that's
+        # where release_to_foreign + surface-share update_layout
+        # already live (#647). VulkanContext lazily registers the
+        # surface on its first reference, so the customer doesn't
+        # need a no-op acquire first.
+        vulkan_ctx.release_for_cross_process(surface, post_release_layout)
+
     @contextmanager
     def acquire_read_external_oes(
         self, surface

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -587,6 +587,17 @@ class VulkanContext:
         carries ``srcAccessMask = MEMORY_WRITE_BIT`` and assumes
         producer-side hazard coverage upstream.
 
+        Also serves the **dual-registration** path used by non-Vulkan
+        adapters that need cross-process release wiring (OpenGL via
+        :meth:`streamlib.adapters.opengl.OpenGLContext.release_for_cross_process`,
+        and Skia GL by extension). In that mode the surface may not
+        have been touched by an explicit ``acquire_*`` on this Vulkan
+        context — the release barrier still issues correctly because
+        the surface-share registration carries the producer's
+        post-write layout as the Vulkan adapter's initial layout, so
+        the QFOT source layout matches what the OpenGL writes left
+        the DMA-BUF in.
+
         ``post_release_layout`` is a Vulkan ``VkImageLayout`` enumerant
         as an integer (use :class:`VkImageLayout` constants). Picking
         ``GENERAL`` is the safest default for cross-process handoffs
@@ -602,15 +613,10 @@ class VulkanContext:
         producer-side path here is correct under both modes.
         """
         pool_id = self._surface_pool_id(surface)
-        surface_id = self._surface_ids.get(pool_id)
-        if surface_id is None:
-            raise RuntimeError(
-                f"VulkanContext.release_for_cross_process: surface "
-                f"'{pool_id}' is not registered — at least one "
-                "acquire_write/acquire_read must have run for this "
-                "surface in this subprocess before publishing a "
-                "cross-process release."
-            )
+        # Lazily resolve+register so dual-registration callers
+        # (OpenGL, Skia GL) don't have to issue a no-op acquire first.
+        # Idempotent — repeat calls return the cached id.
+        surface_id = self._resolve_and_register(pool_id)
         rc = self._lib.slpn_vulkan_release_to_foreign(
             self._rt,
             ctypes.c_uint64(surface_id),


### PR DESCRIPTION
## Summary

- Wires up producer-side cross-process VkImageLayout publishing for the OpenGL adapter via the **dual-registration** shape: the customer registers the same surface with both `OpenGlSurfaceAdapter` (for GL access) and `VulkanSurfaceAdapter` (for the QFOT release barrier), and OpenGL's release path delegates to `VulkanContext.release_for_cross_process` (shipped #647).
- The OpenGL adapter Rust crate is unchanged — composition lives at the SDK / customer layer per the engine-model "RHI is the single gateway" rule. Mirrors Chromium Dawn's `SharedImageBacking` + per-API `*ImageRepresentation` pattern: each adapter owns one API's state, cross-API composition is the customer's job.
- Sibling #645 (Skia GL) inherits the pattern from this PR's docs.

## Closes

Closes #644

## Architectural decision

The issue body framed the problem as "where does the Vulkan device handle live in the OpenGL adapter" and enumerated two options: take `Arc<dyn VulkanRhiDevice>` at construction (Option A), or thread it per-call (Option B). After research and discussion, we landed on a third option not enumerated in the body — **Option C: dual-registration, no Rust adapter changes**. The user pre-approved this reframe before implementation. Reasons:

1. **Engine-model purity.** `VulkanSurfaceAdapter::release_to_foreign` is the canonical Vulkan path; building a parallel one inside the OpenGL adapter recreates the "many ways to do the same thing" pattern CLAUDE.md was written to prevent.
2. **Type-system enforcement.** Makes "the OpenGL adapter has zero Vulkan responsibility" a compile-time fact, not a convention.
3. **Future-proofing.** When future adapters need cross-process release (Skia GL via #645, hypothetical CUDA-on-VkImage, etc.), they don't rederive a parallel `release_to_foreign` either — they use the same dual-registration shape.
4. **Aligns with prior art.** Chromium Dawn's `SharedImageBacking` + `*ImageRepresentation` system, Bevy/wgpu's per-backend interop, and Unreal's RHI separation all converge on "one canonical place per API for that API's state" — Option C honors that; A/B don't.

## What landed

### SDK (Python + Deno)

- `OpenGLContext.release_for_cross_process(surface, vulkan_ctx, post_release_layout)` (Python) / `OpenGLContext.releaseForCrossProcess(surface, vulkanCtx, postReleaseLayout)` (Deno) — thin delegating wrappers that call into the Vulkan adapter's existing `release_for_cross_process` after `glFinish` has drained.
- `VulkanContext.release_for_cross_process` / `releaseForCrossProcess` relaxed to lazily resolve+register on first reference (using existing private `_resolve_and_register` / `resolveAndRegister`). Backward-compatible — prior callers that did `acquire_*` first hit the cached id.

### Example

- `examples/polyglot-opengl-fragment-shader/src/main.rs` — host setup hook now allocates a `HostVulkanTimelineSemaphore` and registers it via `surface_store.register_texture(... Some(timeline.as_ref()), VulkanLayout::GENERAL)`. The OpenGL adapter doesn't use the timeline itself, but the subprocess `VulkanSurfaceAdapter::register_host_surface` requires one (its `slpn_vulkan_register_surface` consumes `gpu.sync_fd`).
- Python and Deno scenarios call `release_for_cross_process(surface, vulkan_ctx, GENERAL)` after the GL write block exits.

### Docs

- `docs/architecture/adapter-authoring.md` — new "Cross-process producer composition" section. Documents the pattern, when it applies, the implementation recipe (host setup + subprocess customer + producer SDK method), the rejected alternatives with reasoning, and the CUDA exclusion (buffer-only by structural constraint — DLPack requires flat `void*` → `cudaExternalMemoryGetMappedBuffer` → `VkBuffer`, no `VkImageLayout` to publish).

## CUDA — no follow-up filed (deliberate)

The user asked whether CUDA needs a similar pattern. Verified: **no, CUDA doesn't need it.** CUDA's interop is OPAQUE_FD `VkBuffer`-only by structural constraint (DLPack flat-pointer requirement). `VkBuffer`s have no `VkImageLayout`, so QFOT-for-layout is structurally meaningless. Cross-process correctness is provided by the timeline-semaphore alone (per the cuda.py docstring: *"there is no per-acquire IPC — the host's pipeline is expected to write into the OPAQUE_FD buffer and signal the shared timeline ambiently."*). If a future CUDA-on-VkImage path lands, it would inherit this pattern from the new docs section automatically. Documented in the CUDA exclusion subsection of the new docs.

## Polyglot coverage

- **Runtimes affected**: rust (example) | python (SDK + scenario) | deno (SDK + scenario)
- **Schema regenerated**: n/a (no new escalate ops; uses #647's wire shape unchanged)
- **Python and Deno both covered?** yes — symmetric SDK methods, symmetric scenario invocation, symmetric E2E
- **E2E tests run**:
  - [x] Python E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` — zero VUID-01197, zero validation errors, zero OUT_OF_DEVICE_MEMORY, zero DEVICE_LOST. Mandelbrot Seahorse Valley PNG rendered correctly (visual verification — recursive seahorse fractal structures + cosine palette colors).
  - [x] Deno E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` — same gates clean. Plasma waves PNG rendered correctly (visual verification — interfering sine waves + cosine palette).
  - [x] `polyglot-vulkan-compute` (#647) Python regression — clean (backward compat for the `release_for_cross_process` lazy-register relaxation confirmed).
- **FD-passing path**: n/a (no new surfaces; this PR uses dual-registration on existing surface-share infrastructure; the timeline semaphore added to the example main.rs uses the existing surface-share `register_texture` API)

## Adapter coverage

- **Adapter crate**: `streamlib-adapter-opengl` (no Rust changes; composition pattern only)
- **New adapter or extension?**: extension (new SDK composition pattern + docs)
- **Handle type**: DMA-BUF (unchanged)
- **Per-acquire host work?**: no (the dual-registered Vulkan adapter's `release_to_foreign` is per-publish, not per-acquire)
- **Capability markers impl'd**: n/a (no new markers)
- **Conformance suite**: n/a (no Rust adapter changes; existing OpenGL adapter conformance suite unchanged)
- **Polyglot coverage**:
  - [x] Python E2E: `polyglot-opengl-fragment-shader` Mandelbrot — PASS (validation-clean, PNG correct)
  - [x] Deno E2E: `polyglot-opengl-fragment-shader` plasma — PASS (validation-clean, PNG correct)
- **Dep-graph invariant** (`cargo tree -p streamlib-{python,deno}-native | grep -c "^streamlib v"` returns 0): n/a (no Cargo.toml changes; cargo xtask check-boundaries — 1984 file(s), no violations)

## Test plan

- [x] `cargo check --workspace --all-targets` — clean (no new errors; pre-existing dead_code warnings unchanged)
- [x] `cargo xtask check-boundaries` — 1984 file(s), no violations
- [x] `cargo xtask lint-logging` — 467 file(s), no violations
- [x] `cargo test -p streamlib-adapter-vulkan -p streamlib-adapter-opengl -p streamlib-consumer-rhi` — all green
- [x] `deno check libs/streamlib-deno/mod.ts` — clean (a pre-existing `SurfaceAccessGuard` typo on `main` lights up `vulkan.ts` in stricter check modes — unrelated to this PR, also called out in #647's body)
- [x] Python E2E with validation layers — zero VUID, zero validation errors
- [x] Deno E2E with validation layers — zero VUID, zero validation errors
- [x] `polyglot-vulkan-compute` (#647) Python regression — clean (lazy-register relaxation backward-compat)

## Follow-ups

None — closes #644's exit criteria. Sibling #645 (adapter-skia GL backend) inherits the dual-registration pattern from this PR's docs section and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)