### PR TITLE
feat(adapter-skia): producer-side QFOT release via dual-registration (#645)

### DIFF
--- a/examples/polyglot-skia-canvas/python/skia_canvas.py
+++ b/examples/polyglot-skia-canvas/python/skia_canvas.py
@@ -42,6 +42,7 @@ from typing import Optional
 
 from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
 from streamlib.adapters.skia import SkiaContext
+from streamlib.adapters.vulkan import VkImageLayout, VulkanContext
 from streamlib.surface_adapter import StreamlibSurface, SurfaceFormat, SurfaceUsage
 
 
@@ -53,6 +54,14 @@ class SkiaCanvasProcessor:
         self._height = int(cfg["height"])
         self._fps = int(cfg.get("fps", 60))
         self._skia_ctx = SkiaContext.from_runtime(ctx)
+        # Dual-register the surface with the Vulkan adapter too so the
+        # producer-side QFOT release barrier (#645) can publish layout
+        # to host consumers via SkiaContext.release_for_cross_process.
+        # Skia composes on the OpenGL adapter, which has no Vulkan
+        # device of its own; the Vulkan adapter owns the cross-process
+        # release barrier — engine-model composition per
+        # docs/architecture/adapter-authoring.md.
+        self._vulkan = VulkanContext.from_runtime(ctx)
         self._frame_count = 0
         self._error: Optional[str] = None
         self._surface = StreamlibSurface(
@@ -91,6 +100,17 @@ class SkiaCanvasProcessor:
             sk_surface = guard.surface
             canvas = sk_surface.getCanvas()
             _draw_animated_frame(canvas, t, self._width, self._height)
+        # Producer-side cross-process release (#645). Skia composes on
+        # the OpenGL adapter which has no Vulkan device of its own —
+        # delegate to the Vulkan adapter (dual-registration). GENERAL
+        # mirrors the OpenGL adapter's release-side convention; the
+        # host's pre-stop readback also reads with
+        # TextureSourceLayout::General. Pairs with any future host
+        # consumer's `acquire_from_foreign` via the bridging fallback
+        # on NVIDIA / QFOT-acquire on Mesa.
+        self._skia_ctx.release_for_cross_process(
+            self._surface, self._vulkan, VkImageLayout.GENERAL
+        )
 
     def teardown(self, ctx: RuntimeContextFullAccess) -> None:
         print(

--- a/libs/streamlib-python/python/streamlib/adapters/skia.py
+++ b/libs/streamlib-python/python/streamlib/adapters/skia.py
@@ -116,6 +116,10 @@ class SkiaContextProtocol(Protocol):
 
     def acquire_write(self, surface): ...
 
+    def release_for_cross_process(
+        self, surface, vulkan_ctx, post_release_layout: int
+    ) -> None: ...
+
 
 class SkiaContext:
     """Subprocess-side Skia adapter runtime.
@@ -345,6 +349,49 @@ class SkiaContext:
                 # Drop the Surface refcount so the DirectContext is
                 # not pinned across the inner release.
                 del sk_surface
+
+    def release_for_cross_process(
+        self, surface, vulkan_ctx, post_release_layout: int
+    ) -> None:
+        """Publish a producer-side cross-process release for a surface
+        this Skia context has been writing to via :meth:`acquire_write`.
+
+        Skia composes on the OpenGL adapter; Skia's GL writes don't
+        touch the underlying ``VkImage``'s Vulkan tracker, and neither
+        the Skia nor the OpenGL adapter has a Vulkan device handle of
+        its own. The engine-model answer (per
+        ``docs/architecture/adapter-authoring.md`` → Cross-process
+        producer composition) is to let the canonical Vulkan adapter
+        own the QFOT release barrier: the customer dual-registers the
+        same surface with both adapters, and the Skia/OpenGL release
+        path delegates to ``VulkanContext.release_for_cross_process``.
+
+        ``vulkan_ctx`` is the subprocess's
+        :class:`streamlib.adapters.vulkan.VulkanContext` — typically
+        obtained alongside this :class:`SkiaContext` from the same
+        runtime context inside ``setup``. It must be present (the
+        runtime must have been started with surface-share registration
+        carrying an exportable timeline OPAQUE_FD per the
+        ``register_texture(... Some(timeline.as_ref()), ...)`` host
+        pattern).
+
+        Sequencing — call this *after* the :meth:`acquire_write`
+        ``with`` block has exited so Skia's ``flushAndSubmit`` and the
+        inner OpenGL release's ``glFinish`` have drained GL writes
+        through the DMA-BUF kernel backing.
+
+        ``post_release_layout`` is a Vulkan ``VkImageLayout``
+        enumerant as an integer (use
+        :class:`streamlib.adapters.vulkan.VkImageLayout` constants).
+        ``GENERAL`` is the right choice for Skia/GL-backed surfaces
+        for the same reason it is for the OpenGL adapter — the host
+        doesn't observe the GL writes' "Vulkan layout" in any
+        meaningful sense, so GENERAL-as-source-of-truth gives the
+        consumer maximum flexibility.
+        """
+        self._opengl.release_for_cross_process(
+            surface, vulkan_ctx, post_release_layout
+        )
 
     @contextmanager
     def acquire_read(self, surface) -> Iterator[SkiaReadView]:


### PR DESCRIPTION
## Summary

- Wire up producer-side cross-process `VkImageLayout` publishing for the Python Skia adapter via dual-registration, mirroring #644's OpenGL pattern one delegation level higher (`Skia → OpenGL → Vulkan`).
- The `streamlib-adapter-skia` Rust crate is unchanged — composition lives at the SDK / customer layer per the engine-model "RHI is the single gateway" rule, same as #644. Pattern documented in `docs/architecture/adapter-authoring.md:477-632`.
- Polyglot scope is Python only — the rare "schema-only / language-specific by construction" exception per `.claude/workflows/polyglot.md`. `skia-python` is the only maintained cross-language Skia binding for the runtimes streamlib supports; `examples/polyglot-skia-canvas/` ships Python only by design (the `skia.py` docstring at lines 16-41 records the upstream constraint).

## Closes

Closes #645

## Exit criteria

- [x] `SkiaContext.release_for_cross_process(surface, vulkan_ctx, post_release_layout)` lands in `libs/streamlib-python/python/streamlib/adapters/skia.py` as a thin delegating method to `OpenGLContext.release_for_cross_process`.
- [x] `examples/polyglot-skia-canvas/python/skia_canvas.py` dual-registers `VulkanContext` and calls `release_for_cross_process(surface, vulkan_ctx, VkImageLayout.GENERAL)` after each `acquire_write` block exits.
- [x] E2E with `VK_LOADER_LAYERS_ENABLE=*validation*` against `polyglot-skia-canvas` runs validation-clean (no QFOT-related VUIDs).

## Test plan

### E2E Test Report

- **Scenario**: camera+display-only (subprocess Skia producer + host readback consumer)
- **Example**: `polyglot-skia-canvas`
- **Codec**: n/a
- **Camera device**: n/a (BGRA file source feeding the trigger pipeline)
- **Resolution**: 512x512
- **Duration / frame limit**: 60fps × 30s = 1800 frames
- **Build profile**: debug
- **Command**:
    ```
    OUT=/tmp/skia-canvas-py-645
    mkdir -p "$OUT"
    VK_LOADER_LAYERS_ENABLE='*validation*' \
    timeout --kill-after=5 90 \
        cargo run -q -p polyglot-skia-canvas-scenario -- --output-dir="$OUT"
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: 0 (validation layer enabled)
- `VUID-*`: 0
- `[SkiaCanvas/py] drew frame N`: fired every 120 frames through 1800/1800
- `[BgraFileSource] 1800/1800 frames (30.0s)`: clean stop

#### PNG samples

![skia_canvas hero PNG — frame 900, t=15s](https://gh-artifact.tatolab.com/pr-650/skia_canvas_hero.jpg)

*Frame 900 (t=15.00s) of the 1800-frame run.*

- Hero PNG: `/tmp/skia-canvas-py-645/skia_canvas_hero.png` (frame 900, t=15.00s)
- PNGs read with Read tool: `skia_canvas_hero.png`
- **What was in the image(s)**: frame 900 — HSL-modulated linear gradient background (purple top → magenta-pink bottom), animated stroked green/teal ring centered, five orbiting discs (red, green, blue, magenta, yellow visible), 16-spoke wheel rotating at center, white sine curve along the lower edge, color strip of 7 small rotating tiles in the bottom-left corner. Matches the `_draw_animated_frame` description verbatim — same scene the in-process Rust stress test renders.
- Anomalies: none
- Full 30s MP4 (all 1800 frames): [skia_canvas.mp4 (4.4 MB, 30s)](https://gh-artifact.tatolab.com/pr-650/skia_canvas.mp4)

#### PSNR

- Reference frame: n/a — no ground-truth reference PNG for the animated procedural scene.
- Y / U / V PSNR: n/a
- Command used: n/a

#### Outcome

- **Pass**
- Caveats / follow-ups filed: None

## Polyglot coverage

- **Runtimes affected**: python
- **Schema regenerated**: n/a
- **Python and Deno both covered?**: schema-only / language-specific by construction (justified: skia-python is the only maintained cross-language Skia binding for the runtimes streamlib supports; no Deno equivalent exists. `libs/streamlib-python/python/streamlib/adapters/skia.py:36-41` documents this. `examples/polyglot-skia-canvas/` ships Python only by design.)
- **E2E tests run**:
  - [ ] Host-Rust: n/a — pure SDK delegation
  - [x] Python subprocess: `polyglot-skia-canvas` 1800 frames, validation-clean
  - [ ] Deno subprocess: n/a (no Deno Skia binding)
- **FD-passing path**: DMA-BUF FD (host pre-allocates render-target-capable DMA-BUF + exportable timeline OPAQUE_FD; subprocess imports via the existing surface-share path)

## Adapter coverage

- **Adapter crate**: `streamlib-adapter-skia` (Rust crate unchanged; SDK-layer-only change in `streamlib-python`)
- **New adapter or extension?**: extension (producer-side cross-process release wiring on existing adapter)
- **Handle type**: DMA-BUF (delegated through OpenGL → Vulkan)
- **Per-acquire host work?**: no (surface-share-only — release publishes layout via the existing surface-share `update_image_layout` path inside `VulkanContext.release_for_cross_process`)
- **Capability markers impl'd**: n/a (no new traits)
- **Conformance suite**: n/a (Rust crate unchanged)
- **Polyglot coverage**: see above
- **Dep-graph invariant** (`cargo tree -p streamlib-{python,deno}-native | grep -c "^streamlib v"` returns 0): n/a — no Cargo deps changed

## Follow-ups

None. The Rust `SkiaSurfaceAdapter<D: VulkanRhiDevice>` (Vulkan-backend) does not need a similar method per the dual-registration pattern: in-tree Rust users of that adapter call `vulkan_adapter.release_to_foreign(...)` from #633 directly, since they're already operating with full RHI access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
