### PR TITLE
docs(architecture): dual-registration addendum for surfaces flowing to in-process consumers

### DIFF
--- a/docs/architecture/adapter-authoring.md
+++ b/docs/architecture/adapter-authoring.md
@@ -203,6 +203,18 @@ Document the canonical `install_setup_hook` snippet for your
 adapter in the crate's top-level `lib.rs` doc-comment so
 application authors can copy-paste.
 
+When the adapter's surface is expected to flow downstream to an
+**in-process** Rust consumer on the hot path (display, blending
+compositor, encoder), the snippet must dual-register the surface
+— `gpu.surface_store().register_texture(...)` for cross-process
+publishing AND `gpu.register_texture_with_layout(...)` for the
+in-process Path 1 fast path. See
+[Dual-registration for in-process consumers](adapter-runtime-integration.md#dual-registration-for-in-process-consumers)
+in the runtime-integration doc for the rule, the reference
+in-tree producer (`LinuxCameraProcessor`), and the cases where
+the second call is unnecessary (subprocess-only consumers,
+post-stop readback).
+
 ### 7. Cross-links
 
 Add the new adapter to:

--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -368,10 +368,18 @@ The shape of what the hook does varies by seam:
   the host's `StreamTexture` (via
   `gpu.acquire_render_target_dma_buf_image` for render-target-capable
   DMA-BUF), registers it in surface-share with a known UUID via
-  `gpu.surface_store().register_texture(uuid, &texture)`, and stashes
-  any per-runtime sync state the adapter needs (timeline semaphores,
-  DRM modifier records). No bridge — every subprocess acquire is a
-  one-shot `check_out`.
+  `gpu.surface_store().register_texture(uuid, &texture, timeline,
+  current_image_layout)` (4-arg signature post-#633: `timeline` is
+  an `Option<&HostVulkanTimelineSemaphore>` for cross-process sync,
+  `current_image_layout` is the producer's post-write `VulkanLayout`
+  consumed by Path 2 QFOT acquire), and stashes any per-runtime
+  sync state the adapter needs (timeline semaphores, DRM modifier
+  records). When the same surface flows downstream to an
+  **in-process** Rust consumer on the hot path, the hook also calls
+  `gpu.register_texture_with_layout(uuid, texture.clone(), layout)`
+  — see [Dual-registration for in-process
+  consumers](#dual-registration-for-in-process-consumers) below. No
+  bridge — every subprocess acquire is a one-shot `check_out`.
 - **Escalate-IPC seam** (cpu-readback). The hook constructs the
   `CpuReadbackSurfaceAdapter`, allocates + registers the host
   surface(s) it serves, and registers a `CpuReadbackBridge`
@@ -406,6 +414,104 @@ need per-acquire host work should also expose a `set_*_bridge` setter
 on `GpuContext` mirroring `set_cpu_readback_bridge`. Application
 authors call `install_setup_hook` exactly once per adapter they want
 to expose to subprocesses.
+
+### Dual-registration for in-process consumers
+
+> Added 2026-05-03 (#614). Originally framed as a silent-failure
+> bug from the #484 debugging session. Path 2 (`gpu_context.rs:689-705`)
+> resolves surface_store-only registrations now (#633), so the
+> failure mode no longer reproduces — but the dual-registration
+> rule survives with a different rationale: **performance**.
+
+`gpu.surface_store().register_texture(...)` publishes the surface
+to the cross-process surface-share daemon. It does NOT populate
+`GpuContext`'s in-process `texture_cache`. Same-process consumers
+calling `gpu.resolve_videoframe_registration(&frame)` therefore
+miss Path 1 (`texture_cache` HashMap lookup) and fall through to
+Path 2 (`surface_store.lookup_texture` + DMA-BUF FD import + QFOT
+acquire submit per call). Path 2 explicitly does NOT cache its
+synthesized `TextureRegistration` (`gpu_context.rs:658-660`:
+*"Synthesized registration is not cached — Path 2 reimports
+per-call by design"*) — so an in-process consumer reading the
+same surface every frame would pay a fresh import + QFOT acquire
+on every render.
+
+For hot-path in-process consumers (e.g. `LinuxDisplayProcessor`,
+the `BlendingCompositor`, video encoders), populate Path 1 by
+**dual-registering** in the setup hook:
+
+```rust
+// 1. Cross-process publish (subprocess customers):
+gpu.surface_store()
+    .ok_or(...)?
+    .register_texture(
+        SCENARIO_SURFACE_UUID,
+        &texture,
+        Some(timeline.as_ref()),
+        VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+    )?;
+
+// 2. In-process Path 1 fast path (same-process consumers):
+gpu.register_texture_with_layout(
+    &SCENARIO_SURFACE_UUID,
+    texture.clone(),
+    VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+);
+```
+
+Both calls take the same `current_layout`. The producer is
+responsible for keeping the two declarations consistent — one is
+read by Path 2 (cross-process, via `surface_store.lookup_texture`),
+the other by Path 1 (in-process, via the registry held in
+`GpuContext`). Lying in either is the
+[`TextureRegistration` anti-pattern #2 — descriptor-side claims
+that don't match registration](texture-registration.md#anti-patterns).
+
+The reference in-tree producer is `LinuxCameraProcessor` —
+`libs/streamlib/src/linux/processors/camera.rs` calls both
+`store.register_texture(...)` (around line 833) and
+`gpu_context.register_texture_with_layout(...)` (around line 862)
+for every ring texture it allocates, with the same
+`VulkanLayout::SHADER_READ_ONLY_OPTIMAL` declaration on both
+sides.
+
+#### When the second call is unnecessary
+
+When the surface is consumed **only** by subprocess customers (or
+by a post-stop one-shot like `gpu.create_texture_readback`), the
+in-process call is redundant — Path 1 is never consulted. The
+canonical example is
+[`examples/polyglot-opengl-fragment-shader/src/main.rs`](../../examples/polyglot-opengl-fragment-shader/src/main.rs):
+the host registers via `surface_store.register_texture` only and
+relies on `gpu.create_texture_readback` for its post-stop pixel
+capture. Don't dual-register surfaces with no in-process hot-path
+consumer — every entry in `texture_cache` lives until the
+producer explicitly unregisters, and over-populating it muddies
+the cache's purpose (per-surface lifecycle state for in-process
+fast-path resolution; see
+[`texture-registration.md`](texture-registration.md#what-goes-in--what-stays-out)).
+
+#### Why not auto-couple the two registrations
+
+Considered and rejected: making `surface_store.register_texture`
+populate `texture_cache` automatically. Two reasons it doesn't fit:
+
+- The two registries have different scopes by design.
+  `texture_cache` is for in-process consumers reaching textures
+  via Path 1; `surface_store` is for cross-process consumers
+  reaching them via the surface-share daemon. Auto-coupling them
+  re-introduces the stale-content risk when adapters re-register
+  the same UUID — `texture_cache` would silently rebind to a
+  different texture, while `Path 2` resolves through a separate
+  IPC roundtrip that already encodes per-call freshness.
+- The doc-only path is the conservative fix. The dual-registration
+  call is one line per setup hook; the engine-level coupling is a
+  layered API change with non-local consequences.
+
+If a future adapter genuinely needs both registrations to stay in
+lock-step (e.g. a producer that re-registers on every layout
+transition), revisit — but the current shape is two explicit
+calls.
 
 ### Trade-off — explicit registration vs. Cargo-feature ambient availability
 

--- a/docs/architecture/texture-registration.md
+++ b/docs/architecture/texture-registration.md
@@ -220,6 +220,17 @@ When you find yourself wanting to add a field that doesn't fit cleanly,
    consumer's barrier left it in (read it back from the registration
    if the producer needs to reason about it).
 
+5. **Dual-register when the surface flows to both subprocess and
+   in-process hot-path consumers.** Adapter `install_setup_hook`
+   wirings that publish a surface to `surface_store` (cross-process)
+   AND have a same-process consumer reading it every frame must also
+   call `register_texture_with_layout` — Path 2 explicitly does not
+   cache its synthesized registration, so a Path-1 miss on the hot
+   path costs a fresh DMA-BUF import + QFOT acquire submit per frame.
+   See [`adapter-runtime-integration.md` →
+   Dual-registration](adapter-runtime-integration.md#dual-registration-for-in-process-consumers)
+   for the recipe and the in-tree reference producer.
+
 ## Consumer rules
 
 1. **Resolve the registration, not just the texture.**


### PR DESCRIPTION
## Summary

- Document the dual-registration rule for adapter `install_setup_hook` wirings: when a published surface flows to a hot-path in-process Rust consumer (display, blending compositor, encoder), call both `gpu.surface_store().register_texture(...)` AND `gpu.register_texture_with_layout(...)`.
- Re-derived the rationale during pickup — the issue's original "silent failure" framing was stale. Path 2 (`gpu_context.rs:689-705`, post-#633) resolves surface_store-only registrations, so the silent-failure mode no longer reproduces. The dual-registration rule survives with a different rationale: **performance** — Path 2 explicitly does not cache its synthesized registration (`gpu_context.rs:658-660`), so a Path-1 miss on a hot path costs a fresh DMA-BUF import + QFOT acquire submit per frame.
- Fixed a stale 2-arg `gpu.surface_store().register_texture(uuid, &texture)` snippet in `adapter-runtime-integration.md` to the current 4-arg signature `(surface_id, &texture, timeline, current_image_layout)` introduced by #633.

## Closes
Closes #614

## What changed vs. issue body
The issue's "silent empty render" diagnosis was correct *for the code at the time of #484*; #633 retired that failure mode at the engine layer. Issue body updated in place with strike-through supersession notes per CLAUDE.md's markdown editing rules. Plan re-derived around the corrected (performance) rationale.

## Exit criteria
- [x] `docs/architecture/adapter-runtime-integration.md` covers the dual-registration requirement under the `install_setup_hook` section, with the corrected (performance-shaped) rationale.
- [x] `docs/architecture/adapter-authoring.md` cross-references it from section 6 ("Runtime wiring").
- [x] The stale 2-arg `gpu.surface_store().register_texture(uuid, &texture)` snippet in `adapter-runtime-integration.md` is updated to the current 4-arg signature.
- [x] (Bonus) Cross-reference added from `texture-registration.md`'s "Producer rules" so future agents reading the engine-side doc find the adapter-authoring rule.

## Test plan
- [x] No tests — pure docs change. `cargo doc -p streamlib --no-deps` is unaffected (no doc-comments touched).

## Follow-ups
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)