### PR TITLE
test(adapter-opengl): linear-modifier conformance for register_external_oes_host_surface (#623)

### DIFF
--- a/libs/streamlib-adapter-opengl/tests/common.rs
+++ b/libs/streamlib-adapter-opengl/tests/common.rs
@@ -11,7 +11,8 @@
 use std::sync::Arc;
 
 use streamlib::core::context::GpuContext;
-use streamlib::core::rhi::{StreamTexture, TextureFormat};
+use streamlib::core::rhi::{StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
+use streamlib::host_rhi::HostVulkanTexture;
 use streamlib_adapter_abi::{
     StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
     SurfaceUsage,
@@ -75,6 +76,86 @@ impl HostFixture {
         height: u32,
     ) -> RegisteredSurface {
         self.register_surface_inner(surface_id, width, height, /*external_oes=*/ true)
+    }
+
+    /// Allocate a host VkImage with an explicit DRM modifier (typically a
+    /// sampler-only `external_only=TRUE` modifier discovered via
+    /// [`streamlib::host_rhi::drm_modifier_probe`]) and register it via
+    /// [`OpenGlSurfaceAdapter::register_external_oes_host_surface`].
+    ///
+    /// Unlike [`Self::register_external_oes_surface`] (which goes through
+    /// `acquire_render_target_dma_buf_image` and gets a tiled,
+    /// render-target-capable modifier), this variant lets a test exercise
+    /// the path real-world camera DMA-BUFs hit on NVIDIA — where the EGL
+    /// driver flags the only available modifier as `external_only=TRUE`.
+    /// Usage flags are [`TextureUsages::TEXTURE_BINDING`] +
+    /// [`TextureUsages::COPY_DST`] + [`TextureUsages::COPY_SRC`] (no
+    /// `RENDER_ATTACHMENT`) — matches the sampler-only contract of
+    /// `GL_TEXTURE_EXTERNAL_OES`.
+    pub fn register_external_oes_surface_with_modifier(
+        &self,
+        surface_id: SurfaceId,
+        width: u32,
+        height: u32,
+        modifier: u64,
+    ) -> Result<RegisteredSurface, String> {
+        let vulkan_device = self.gpu.device().vulkan_device();
+        let desc = TextureDescriptor::new(width, height, TextureFormat::Bgra8Unorm).with_usage(
+            TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_DST
+                | TextureUsages::COPY_SRC,
+        );
+        let host_texture = HostVulkanTexture::new_render_target_dma_buf(
+            vulkan_device,
+            &desc,
+            &[modifier],
+        )
+        .map_err(|e| format!("HostVulkanTexture::new_render_target_dma_buf failed: {e}"))?;
+
+        let dma_buf_fd = host_texture
+            .export_dma_buf_fd()
+            .map_err(|e| format!("export_dma_buf_fd failed: {e}"))?;
+        let plane_layout = host_texture
+            .dma_buf_plane_layout()
+            .map_err(|e| format!("dma_buf_plane_layout failed: {e}"))?;
+        let chosen_modifier = host_texture.chosen_drm_format_modifier();
+        assert_eq!(
+            chosen_modifier, modifier,
+            "driver picked modifier 0x{chosen_modifier:016x}, but the candidate \
+             list contained only 0x{modifier:016x} — VUID violation in the RHI"
+        );
+
+        let texture = StreamTexture::from_vulkan(host_texture);
+
+        let registration = HostSurfaceRegistration {
+            dma_buf_fd,
+            width,
+            height,
+            drm_fourcc: DRM_FORMAT_ARGB8888,
+            drm_format_modifier: modifier,
+            plane_offset: plane_layout[0].0,
+            plane_stride: plane_layout[0].1,
+        };
+
+        self.adapter
+            .register_external_oes_host_surface(surface_id, registration)
+            .map_err(|e| format!("register_external_oes_host_surface failed: {e:?}"))?;
+
+        let descriptor = StreamlibSurface::new(
+            surface_id,
+            width,
+            height,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        );
+        Ok(RegisteredSurface {
+            descriptor,
+            texture,
+            width,
+            height,
+        })
     }
 
     fn register_surface_inner(

--- a/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
+++ b/libs/streamlib-adapter-opengl/tests/sample_external_oes.rs
@@ -27,10 +27,11 @@
 #[path = "common.rs"]
 mod common;
 
+use streamlib::host_rhi::drm_modifier_probe;
 use streamlib_adapter_abi::{AdapterError, SurfaceAdapter};
 use streamlib_adapter_opengl::GL_TEXTURE_EXTERNAL_OES;
 
-use common::{host_write_clear_color, HostFixture};
+use common::{host_write_clear_color, HostFixture, RegisteredSurface};
 
 const VERTEX_SRC: &str = r#"#version 330 core
 out vec2 v_uv;
@@ -165,6 +166,134 @@ fn external_oes_view_target_and_write_rejection() {
     }
 }
 
+/// Run the `samplerExternalOES` GLSL roundtrip against a registered
+/// surface and return the read-back BGRA bytes. The surface MUST already
+/// have been seeded by the host (e.g. via [`host_write_clear_color`]).
+///
+/// Factored out of [`sample_external_oes_round_trip`] so the linear-
+/// modifier conformance test can reuse the same GL probe path —
+/// the only thing that varies between the two tests is the modifier of
+/// the underlying DMA-BUF.
+fn sample_external_oes_through_surface(
+    fixture: &HostFixture,
+    surface: &RegisteredSurface,
+) -> Vec<u8> {
+    let width = surface.width;
+    let height = surface.height;
+    let guard = fixture
+        .adapter
+        .acquire_read(&surface.descriptor)
+        .expect("acquire_read");
+    let texture_id = guard.view().gl_texture_id();
+
+    let _current = fixture
+        .egl
+        .lock_make_current()
+        .expect("lock_make_current");
+    unsafe {
+        // The shader uses `texture2D(samplerExternalOES, vec2)` — the
+        // GLES2-era overload that NVIDIA's desktop-GL driver honors in
+        // `#version 330 core`. A compile failure here means a real
+        // regression in either the test shader or the adapter's
+        // EXTERNAL_OES contract; do NOT skip past it. Drivers that
+        // genuinely lack `GL_OES_EGL_image_external` would already have
+        // rejected `EglRuntime::new` upstream of this point.
+        let prog = compile_program(FRAGMENT_SRC_EXTERNAL_OES)
+            .expect("FRAGMENT_SRC_EXTERNAL_OES must compile on a driver \
+                     that exposed GL_OES_EGL_image_external during EglRuntime \
+                     construction — failure here is a regression in either \
+                     the shader or the adapter's EXTERNAL_OES contract");
+
+        // Build a probe RGBA8 texture + FBO of width×height.
+        let mut probe_tex: u32 = 0;
+        gl::GenTextures(1, &mut probe_tex);
+        gl::BindTexture(gl::TEXTURE_2D, probe_tex);
+        gl::TexImage2D(
+            gl::TEXTURE_2D,
+            0,
+            gl::RGBA8 as i32,
+            width as i32,
+            height as i32,
+            0,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            std::ptr::null(),
+        );
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::NEAREST as i32);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::NEAREST as i32);
+
+        let mut probe_fbo: u32 = 0;
+        gl::GenFramebuffers(1, &mut probe_fbo);
+        gl::BindFramebuffer(gl::FRAMEBUFFER, probe_fbo);
+        gl::FramebufferTexture2D(
+            gl::FRAMEBUFFER,
+            gl::COLOR_ATTACHMENT0,
+            gl::TEXTURE_2D,
+            probe_tex,
+            0,
+        );
+        assert_eq!(
+            gl::CheckFramebufferStatus(gl::FRAMEBUFFER),
+            gl::FRAMEBUFFER_COMPLETE,
+            "probe FBO must complete"
+        );
+
+        gl::UseProgram(prog);
+        let loc = gl::GetUniformLocation(prog, b"u_tex\0".as_ptr() as *const _);
+        gl::Uniform1i(loc, 0);
+        gl::ActiveTexture(gl::TEXTURE0);
+        // Bind under the EXTERNAL_OES target — this is the binding the
+        // samplerExternalOES uniform reads from.
+        gl::BindTexture(GL_TEXTURE_EXTERNAL_OES, texture_id);
+
+        let mut vao: u32 = 0;
+        gl::GenVertexArrays(1, &mut vao);
+        gl::BindVertexArray(vao);
+
+        gl::Viewport(0, 0, width as i32, height as i32);
+        gl::ClearColor(0.0, 0.0, 0.0, 0.0);
+        gl::Clear(gl::COLOR_BUFFER_BIT);
+        gl::DrawArrays(gl::TRIANGLES, 0, 3);
+        gl::Finish();
+
+        let mut probe = vec![0u8; (width as usize) * (height as usize) * 4];
+        gl::ReadPixels(
+            0,
+            0,
+            width as i32,
+            height as i32,
+            gl::RGBA,
+            gl::UNSIGNED_BYTE,
+            probe.as_mut_ptr() as *mut _,
+        );
+
+        gl::BindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
+        gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
+        gl::DeleteVertexArrays(1, &vao);
+        gl::DeleteFramebuffers(1, &probe_fbo);
+        gl::DeleteTextures(1, &probe_tex);
+        gl::DeleteProgram(prog);
+        probe
+    }
+}
+
+/// Assert that the read-back probe buffer matches the expected
+/// `RGBA(0.25, 0.5, 0.75, 1.0)` clear color (memory-byte order
+/// `[64, 128, 191, 255]`). Tolerates ±6 LSB to absorb sampler /
+/// format-conversion rounding.
+fn assert_probe_pixels_match_clear_color(probe_pixels: &[u8]) {
+    let mismatch = probe_pixels.chunks_exact(4).enumerate().find(|(_, px)| {
+        (px[0] as i32 - 64).abs() > 6
+            || (px[1] as i32 - 128).abs() > 6
+            || (px[2] as i32 - 191).abs() > 6
+            || (px[3] as i32 - 255).abs() > 6
+    });
+    assert!(
+        mismatch.is_none(),
+        "GL EXTERNAL_OES sample saw unexpected pixel: {mismatch:?}"
+    );
+}
+
 #[test]
 fn sample_external_oes_round_trip() {
     let fixture = match HostFixture::try_new() {
@@ -184,131 +313,91 @@ fn sample_external_oes_round_trip() {
     // so the assertion math is symmetrical: RGBA(0.25, 0.5, 0.75, 1.0).
     host_write_clear_color(&fixture.gpu, &surface, [0.25, 0.5, 0.75, 1.0]);
 
-    let probe_pixels: Option<Vec<u8>> = {
-        let guard = fixture
-            .adapter
-            .acquire_read(&surface.descriptor)
-            .expect("acquire_read");
-        let texture_id = guard.view().gl_texture_id();
+    let probe_pixels = sample_external_oes_through_surface(&fixture, &surface);
+    assert_probe_pixels_match_clear_color(&probe_pixels);
+}
 
-        let _current = fixture
-            .egl
-            .lock_make_current()
-            .expect("lock_make_current");
-        unsafe {
-            // The shader uses `texture2D(samplerExternalOES, vec2)` — the
-            // GLES2-era overload that NVIDIA's desktop-GL driver honors in
-            // `#version 330 core`. A compile failure here means a real
-            // regression in either the test shader or the adapter's
-            // EXTERNAL_OES contract; do NOT skip past it. Drivers that
-            // genuinely lack `GL_OES_EGL_image_external` would already have
-            // rejected `EglRuntime::new` upstream of this point.
-            let prog = compile_program(FRAGMENT_SRC_EXTERNAL_OES)
-                .expect("FRAGMENT_SRC_EXTERNAL_OES must compile on a driver \
-                         that exposed GL_OES_EGL_image_external during EglRuntime \
-                         construction — failure here is a regression in either \
-                         the shader or the adapter's EXTERNAL_OES contract");
-
-            // Build a probe RGBA8 texture + FBO of width×height.
-            let mut probe_tex: u32 = 0;
-            gl::GenTextures(1, &mut probe_tex);
-            gl::BindTexture(gl::TEXTURE_2D, probe_tex);
-            gl::TexImage2D(
-                gl::TEXTURE_2D,
-                0,
-                gl::RGBA8 as i32,
-                width as i32,
-                height as i32,
-                0,
-                gl::RGBA,
-                gl::UNSIGNED_BYTE,
-                std::ptr::null(),
+/// Linear-modifier conformance for `register_external_oes_host_surface`
+/// (#623 / #615 follow-up). Imports a DMA-BUF whose modifier EGL flagged
+/// `external_only=TRUE` — the exact path real-world camera DMA-BUFs hit
+/// on NVIDIA Linux, where the only available modifier for `ARGB8888` is
+/// `DRM_FORMAT_MOD_LINEAR` and `eglQueryDmaBufModifiersEXT` reports it as
+/// sampler-only.
+///
+/// Sibling to [`sample_external_oes_round_trip`]: same `samplerExternalOES`
+/// GLSL probe, same expected pixels, but the underlying VkImage uses a
+/// sampler-only modifier (typically linear) instead of a tiled
+/// render-target-capable one. Skips with `println!` on drivers that do
+/// NOT advertise any sampler-only modifier for `ARGB8888` (e.g. Mesa,
+/// where linear is typically `external_only=FALSE`).
+#[test]
+fn sample_external_oes_round_trip_sampler_only_modifier() {
+    let fixture = match HostFixture::try_new() {
+        Some(f) => f,
+        None => {
+            println!(
+                "sample_external_oes_round_trip_sampler_only_modifier: \
+                 skipping — no Vulkan or no EGL"
             );
-            gl::TexParameteri(
-                gl::TEXTURE_2D,
-                gl::TEXTURE_MIN_FILTER,
-                gl::NEAREST as i32,
-            );
-            gl::TexParameteri(
-                gl::TEXTURE_2D,
-                gl::TEXTURE_MAG_FILTER,
-                gl::NEAREST as i32,
-            );
-
-            let mut probe_fbo: u32 = 0;
-            gl::GenFramebuffers(1, &mut probe_fbo);
-            gl::BindFramebuffer(gl::FRAMEBUFFER, probe_fbo);
-            gl::FramebufferTexture2D(
-                gl::FRAMEBUFFER,
-                gl::COLOR_ATTACHMENT0,
-                gl::TEXTURE_2D,
-                probe_tex,
-                0,
-            );
-            assert_eq!(
-                gl::CheckFramebufferStatus(gl::FRAMEBUFFER),
-                gl::FRAMEBUFFER_COMPLETE,
-                "probe FBO must complete"
-            );
-
-            gl::UseProgram(prog);
-            let loc =
-                gl::GetUniformLocation(prog, b"u_tex\0".as_ptr() as *const _);
-            gl::Uniform1i(loc, 0);
-            gl::ActiveTexture(gl::TEXTURE0);
-            // Bind under the EXTERNAL_OES target — this is the binding
-            // the samplerExternalOES uniform reads from.
-            gl::BindTexture(GL_TEXTURE_EXTERNAL_OES, texture_id);
-
-            let mut vao: u32 = 0;
-            gl::GenVertexArrays(1, &mut vao);
-            gl::BindVertexArray(vao);
-
-            gl::Viewport(0, 0, width as i32, height as i32);
-            gl::ClearColor(0.0, 0.0, 0.0, 0.0);
-            gl::Clear(gl::COLOR_BUFFER_BIT);
-            gl::DrawArrays(gl::TRIANGLES, 0, 3);
-            gl::Finish();
-
-            let mut probe = vec![0u8; (width as usize) * (height as usize) * 4];
-            gl::ReadPixels(
-                0,
-                0,
-                width as i32,
-                height as i32,
-                gl::RGBA,
-                gl::UNSIGNED_BYTE,
-                probe.as_mut_ptr() as *mut _,
-            );
-
-            gl::BindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
-            gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
-            gl::DeleteVertexArrays(1, &vao);
-            gl::DeleteFramebuffers(1, &probe_fbo);
-            gl::DeleteTextures(1, &probe_tex);
-            gl::DeleteProgram(prog);
-            Some(probe)
+            return;
         }
     };
 
-    let probe_pixels = match probe_pixels {
-        Some(p) => p,
-        None => return, // skipped above
+    // Read sampler-only modifiers from the table cached on
+    // `HostVulkanDevice` at construction. Re-running
+    // `drm_modifier_probe::probe_default_display()` here would
+    // `eglInitialize` + `eglTerminate` on the same EGL display the
+    // adapter's `EglRuntime` is bound to — NVIDIA's driver tears down
+    // the shared display rather than refcounting it, breaking every
+    // subsequent `lock_make_current()` on the adapter context.
+    let device = fixture.gpu.device().vulkan_device();
+    let table = device.drm_modifier_table();
+    let modifier = match table
+        .sampler_only_modifiers(drm_modifier_probe::fourcc::DRM_FORMAT_ARGB8888)
+        .first()
+        .copied()
+    {
+        Some(m) => m,
+        None => {
+            println!(
+                "sample_external_oes_round_trip_sampler_only_modifier: \
+                 skipping — no external_only=TRUE modifier advertised for \
+                 ARGB8888 on this driver (expected on Mesa, where linear is \
+                 external_only=FALSE)"
+            );
+            return;
+        }
+    };
+    println!(
+        "sample_external_oes_round_trip_sampler_only_modifier: \
+         using sampler-only modifier 0x{modifier:016x}"
+    );
+
+    let width = 64;
+    let height = 64;
+    let surface = match fixture.register_external_oes_surface_with_modifier(
+        9, width, height, modifier,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            // Allocation against this specific sampler-only modifier may
+            // legitimately fail (e.g. driver advertises the modifier for
+            // EGL import but Vulkan's
+            // `VkImageDrmFormatModifierListCreateInfoEXT` cannot honor it
+            // for SAMPLED+TRANSFER usage). Skip rather than fail — the
+            // path the issue cares about is the GL-side import, not the
+            // Vulkan-side allocator's modifier acceptance.
+            println!(
+                "sample_external_oes_round_trip_sampler_only_modifier: \
+                 skipping — host VkImage allocation refused modifier \
+                 0x{modifier:016x}: {e}"
+            );
+            return;
+        }
     };
 
-    // Same expected pixels as `sample_from_surface` — host wrote
-    // logical RGBA(0.25, 0.5, 0.75, 1.0); GL sampler returns the same
-    // logical values regardless of binding target. Probe FBO stores
-    // RGBA8 in memory byte order [R, G, B, A], so glReadPixels gives
-    // [64, 128, 191, 255]. Tolerate ±6 LSB.
-    let mismatch = probe_pixels.chunks_exact(4).enumerate().find(|(_, px)| {
-        (px[0] as i32 - 64).abs() > 6
-            || (px[1] as i32 - 128).abs() > 6
-            || (px[2] as i32 - 191).abs() > 6
-            || (px[3] as i32 - 255).abs() > 6
-    });
-    assert!(
-        mismatch.is_none(),
-        "GL EXTERNAL_OES sample saw unexpected pixel: {mismatch:?}"
-    );
+    host_write_clear_color(&fixture.gpu, &surface, [0.25, 0.5, 0.75, 1.0]);
+
+    let probe_pixels = sample_external_oes_through_surface(&fixture, &surface);
+    assert_probe_pixels_match_clear_color(&probe_pixels);
 }

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -202,6 +202,12 @@ pub mod host_rhi {
         HostMarker, HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTexture,
         HostVulkanTimelineSemaphore, VulkanComputeKernel, VulkanTextureReadback,
     };
+
+    /// EGL DRM-modifier probe — exposed so adapter conformance tests
+    /// can pick a sampler-only modifier (`external_only=TRUE`) that
+    /// would otherwise be discarded by the higher-level
+    /// `acquire_render_target_dma_buf_image` path.
+    pub use crate::vulkan::rhi::drm_modifier_probe;
 }
 
 // WebRTC streaming (cross-platform)

--- a/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
+++ b/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
@@ -250,6 +250,32 @@ const DEFAULT_PROBE_FORMATS: &[u32] = &[
     fourcc::DRM_FORMAT_NV12,
 ];
 
+/// Partition the EGL `eglQueryDmaBufModifiersEXT` output into render-target
+/// (`external_only=FALSE`) and sampler-only (`external_only=TRUE`) lists.
+/// Pure function so the partitioning is unit-testable without driving a
+/// live EGL display — locks the contract structurally rather than only
+/// empirically against the local driver.
+fn partition_modifiers_by_external_only(
+    modifiers: &[u64],
+    external_only: &[egl::EGLBoolean],
+    returned: usize,
+) -> (Vec<u64>, Vec<u64>) {
+    let mut rt: Vec<u64> = Vec::new();
+    let mut sampler_only: Vec<u64> = Vec::new();
+    for (m, ext) in modifiers
+        .iter()
+        .zip(external_only.iter())
+        .take(returned)
+    {
+        if *ext == egl::EGL_FALSE {
+            rt.push(*m);
+        } else {
+            sampler_only.push(*m);
+        }
+    }
+    (rt, sampler_only)
+}
+
 /// Run the EGL probe on `EGL_DEFAULT_DISPLAY` and return a populated
 /// [`DrmModifierTable`].
 ///
@@ -366,23 +392,11 @@ pub fn probe_with_formats(formats: &[u32]) -> Result<DrmModifierTable, ProbeErro
             return Err(ProbeError::QueryFailed(fourcc, err));
         }
 
-        // Partition by external_only: EGL_FALSE → render-target-capable
-        // (`GL_TEXTURE_2D` + FBO color attachment), EGL_TRUE → sampler-only
-        // (`GL_TEXTURE_EXTERNAL_OES` + `samplerExternalOES`). The two lists
-        // are disjoint and together cover every modifier EGL returned.
-        let mut rt: Vec<u64> = Vec::new();
-        let mut sampler_only: Vec<u64> = Vec::new();
-        for (m, ext) in modifiers
-            .iter()
-            .zip(external_only.iter())
-            .take(returned as usize)
-        {
-            if *ext == egl::EGL_FALSE {
-                rt.push(*m);
-            } else {
-                sampler_only.push(*m);
-            }
-        }
+        let (rt, sampler_only) = partition_modifiers_by_external_only(
+            &modifiers,
+            &external_only,
+            returned as usize,
+        );
 
         tracing::info!(
             "drm_modifier_probe: fourcc 0x{:08x} → {} modifier(s) total, {} render-target-capable, {} sampler-only",
@@ -434,6 +448,59 @@ mod tests {
         assert!(table
             .sampler_only_modifiers(fourcc::DRM_FORMAT_ABGR8888)
             .is_empty());
+    }
+
+    /// Synthetic-input partition test: exercises the
+    /// `partition_modifiers_by_external_only` helper directly with a fake
+    /// EGL output stream so the partitioning's `else` branch is locked
+    /// structurally — independent of which driver the test runs on. A
+    /// regression that drops `external_only=TRUE` entries instead of
+    /// routing them to the sampler-only list would fail this test even on
+    /// Mesa / headless CI, where the live-probe paths skip vacuously.
+    #[test]
+    fn partition_modifiers_routes_external_only_true_to_sampler_only_list() {
+        let modifiers: [u64; 4] = [
+            DRM_FORMAT_MOD_LINEAR,        // sampler-only on NVIDIA
+            0x0030_0000_0000_0000,        // arbitrary tiled — RT
+            0x0030_0000_1234_5678,        // arbitrary tiled — RT
+            0x0030_0000_dead_beef,        // arbitrary — sampler-only
+        ];
+        let external_only = [
+            egl::EGL_TRUE,
+            egl::EGL_FALSE,
+            egl::EGL_FALSE,
+            egl::EGL_TRUE,
+        ];
+        let (rt, sampler_only) =
+            partition_modifiers_by_external_only(&modifiers, &external_only, 4);
+        assert_eq!(
+            rt,
+            vec![0x0030_0000_0000_0000, 0x0030_0000_1234_5678],
+            "external_only=FALSE entries must land in the RT list, in order"
+        );
+        assert_eq!(
+            sampler_only,
+            vec![DRM_FORMAT_MOD_LINEAR, 0x0030_0000_dead_beef],
+            "external_only=TRUE entries must land in the sampler-only list, in order"
+        );
+    }
+
+    /// `returned` truncates the partition pass — EGL may report fewer
+    /// modifiers than the buffer length on a second-pass query, and the
+    /// helper must honor that count.
+    #[test]
+    fn partition_modifiers_honors_returned_count() {
+        let modifiers: [u64; 4] = [1, 2, 3, 4];
+        let external_only = [
+            egl::EGL_FALSE,
+            egl::EGL_TRUE,
+            egl::EGL_FALSE, // ignored
+            egl::EGL_TRUE,  // ignored
+        ];
+        let (rt, sampler_only) =
+            partition_modifiers_by_external_only(&modifiers, &external_only, 2);
+        assert_eq!(rt, vec![1]);
+        assert_eq!(sampler_only, vec![2]);
     }
 
     /// Live EGL probe — when the probe runs, the RT and sampler-only lists

--- a/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
+++ b/libs/streamlib/src/vulkan/rhi/drm_modifier_probe.rs
@@ -1,16 +1,19 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! EGL probe for render-target-capable DRM format modifiers.
+//! EGL probe for DRM format modifiers (render-target-capable and
+//! sampler-only).
 //!
-//! Queries `eglQueryDmaBufModifiersEXT` on a host EGL display and filters out
-//! `external_only=TRUE` modifiers. Returned modifiers are safe to pass to a
-//! consumer-side EGL `EGL_DMA_BUF_PLANE0_MODIFIER_LO/HI_EXT` import for use as
-//! a `GL_TEXTURE_2D` color attachment.
+//! Queries `eglQueryDmaBufModifiersEXT` on a host EGL display and partitions
+//! the returned modifiers by the `external_only` flag — `external_only=FALSE`
+//! lands in the render-target list (safe to bind as `GL_TEXTURE_2D` and use
+//! as an FBO color attachment), `external_only=TRUE` lands in the
+//! sampler-only list (must be bound as `GL_TEXTURE_EXTERNAL_OES` and consumed
+//! through `samplerExternalOES`).
 //!
 //! See `docs/learnings/nvidia-egl-dmabuf-render-target.md` — linear DMA-BUFs
-//! are sampler-only on NVIDIA Linux; tiled modifiers picked from this probe
-//! are render-target-capable.
+//! are sampler-only on NVIDIA Linux; tiled modifiers from this probe are
+//! render-target-capable.
 //!
 //! `libEGL.so.1` is loaded dynamically. When EGL is unavailable (headless CI,
 //! systems without `libEGL`, or display servers that decline to initialize),
@@ -64,16 +67,23 @@ pub enum ProbeError {
     QueryFailed(u32, u32),
 }
 
-/// Render-target-capable DRM modifiers for each probed format.
+/// DRM modifiers reported by the EGL probe, partitioned by binding capability.
 ///
-/// Empty for formats EGL didn't return any `external_only=FALSE` modifier
-/// for. Callers asking for a format that isn't in the table get an empty
-/// slice — the convention is: empty list ⇒ no render-target path is
+/// `rt_modifiers` holds modifiers EGL flagged `external_only=FALSE` — safe
+/// to import as `GL_TEXTURE_2D` and use as an FBO color attachment.
+/// `sampler_only_modifiers` holds modifiers EGL flagged `external_only=TRUE`
+/// — must be imported as `GL_TEXTURE_EXTERNAL_OES` and consumed through
+/// `samplerExternalOES`. The two lists are disjoint and together cover every
+/// modifier EGL returned for the format.
+///
+/// Callers asking for a format that isn't in the table get an empty slice.
+/// The convention for the RT list is: empty ⇒ no render-target path is
 /// available for this format on this driver, fall back to linear with a
 /// `tracing::warn!`.
 #[derive(Debug, Clone, Default)]
 pub struct DrmModifierTable {
     rt_modifiers: HashMap<u32, Vec<u64>>,
+    sampler_only_modifiers: HashMap<u32, Vec<u64>>,
 }
 
 impl DrmModifierTable {
@@ -104,6 +114,24 @@ impl DrmModifierTable {
             .values()
             .filter(|v| !v.is_empty())
             .count()
+    }
+
+    /// Sampler-only modifiers for a DRM FOURCC (EGL `external_only=TRUE`),
+    /// in probe order. Imports against these must use
+    /// `GL_TEXTURE_EXTERNAL_OES`; binding as `GL_TEXTURE_2D` produces a
+    /// `GL_INVALID_OPERATION` (see
+    /// `docs/learnings/nvidia-egl-dmabuf-render-target.md`).
+    pub fn sampler_only_modifiers(&self, fourcc: u32) -> &[u64] {
+        self.sampler_only_modifiers
+            .get(&fourcc)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Whether the probe found at least one sampler-only modifier for
+    /// `fourcc`.
+    pub fn has_sampler_only_modifier(&self, fourcc: u32) -> bool {
+        !self.sampler_only_modifiers(fourcc).is_empty()
     }
 }
 
@@ -338,23 +366,37 @@ pub fn probe_with_formats(formats: &[u32]) -> Result<DrmModifierTable, ProbeErro
             return Err(ProbeError::QueryFailed(fourcc, err));
         }
 
-        // Filter to render-target-capable: external_only must be EGL_FALSE.
-        let rt: Vec<u64> = modifiers
+        // Partition by external_only: EGL_FALSE → render-target-capable
+        // (`GL_TEXTURE_2D` + FBO color attachment), EGL_TRUE → sampler-only
+        // (`GL_TEXTURE_EXTERNAL_OES` + `samplerExternalOES`). The two lists
+        // are disjoint and together cover every modifier EGL returned.
+        let mut rt: Vec<u64> = Vec::new();
+        let mut sampler_only: Vec<u64> = Vec::new();
+        for (m, ext) in modifiers
             .iter()
             .zip(external_only.iter())
             .take(returned as usize)
-            .filter_map(|(m, ext)| if *ext == egl::EGL_FALSE { Some(*m) } else { None })
-            .collect();
+        {
+            if *ext == egl::EGL_FALSE {
+                rt.push(*m);
+            } else {
+                sampler_only.push(*m);
+            }
+        }
 
         tracing::info!(
-            "drm_modifier_probe: fourcc 0x{:08x} → {} modifier(s) total, {} render-target-capable",
+            "drm_modifier_probe: fourcc 0x{:08x} → {} modifier(s) total, {} render-target-capable, {} sampler-only",
             fourcc,
             returned,
             rt.len(),
+            sampler_only.len(),
         );
 
         if !rt.is_empty() {
             table.rt_modifiers.insert(fourcc, rt);
+        }
+        if !sampler_only.is_empty() {
+            table.sampler_only_modifiers.insert(fourcc, sampler_only);
         }
     }
 
@@ -380,6 +422,45 @@ mod tests {
         assert_eq!(table.formats_with_rt_modifier(), 0);
         assert!(!table.has_rt_modifier(fourcc::DRM_FORMAT_ABGR8888));
         assert!(table.rt_modifiers(fourcc::DRM_FORMAT_ABGR8888).is_empty());
+    }
+
+    /// Empty table also reports zero sampler-only modifiers — the
+    /// `external_only=TRUE` accessor mirrors the RT side and never panics
+    /// on an unprobed FOURCC.
+    #[test]
+    fn empty_table_reports_no_sampler_only_modifiers() {
+        let table = DrmModifierTable::empty();
+        assert!(!table.has_sampler_only_modifier(fourcc::DRM_FORMAT_ABGR8888));
+        assert!(table
+            .sampler_only_modifiers(fourcc::DRM_FORMAT_ABGR8888)
+            .is_empty());
+    }
+
+    /// Live EGL probe — when the probe runs, the RT and sampler-only lists
+    /// are disjoint per FOURCC (every modifier EGL returned lands in
+    /// exactly one bucket, never both). This is the invariant the
+    /// `register_external_oes_host_surface` linear-modifier conformance
+    /// test relies on to pick a sampler-only candidate without colliding
+    /// with the RT path.
+    #[test]
+    fn rt_and_sampler_only_lists_are_disjoint_when_probed() {
+        let table = match probe_default_display() {
+            Ok(t) => t,
+            Err(e) => {
+                println!("EGL probe skipped: {e}");
+                return;
+            }
+        };
+        for &fourcc in DEFAULT_PROBE_FORMATS {
+            let rt = table.rt_modifiers(fourcc);
+            let sampler_only = table.sampler_only_modifiers(fourcc);
+            for m in rt {
+                assert!(
+                    !sampler_only.contains(m),
+                    "modifier 0x{m:016x} appears in both RT and sampler-only lists for fourcc 0x{fourcc:08x}"
+                );
+            }
+        }
     }
 
     /// Live EGL probe — best-effort, skips when no EGL is available.


### PR DESCRIPTION
## Summary

- Adds `sample_external_oes_round_trip_sampler_only_modifier` — a sibling to the existing `sample_external_oes_round_trip` that exercises the `samplerExternalOES` GLSL roundtrip against a DMA-BUF whose modifier EGL flags `external_only=TRUE` (the path real-world camera DMA-BUFs hit on NVIDIA Linux, where `DRM_FORMAT_MOD_LINEAR` is the only ARGB8888 modifier and is sampler-only).
- Extends `DrmModifierTable` with parallel `sampler_only_modifiers(fourcc)` / `has_sampler_only_modifier(fourcc)` accessors, mirroring the existing `rt_modifiers` shape. The probe loop already collected `external_only` flags but discarded the `=TRUE` entries; the partition is now total. Existing `rt_modifiers` semantics unchanged.
- Refactors the partition into a pure `partition_modifiers_by_external_only` helper with synthetic-input unit tests, so the partitioning's `else`-branch is locked structurally and not just empirically against the local NVIDIA driver.

## Closes

Closes #623

## Exit criteria

- [x] Conformance test imports a DMA-BUF whose modifier is sampler-only (`external_only=TRUE`) on the test platform.
- [x] Test asserts the EXTERNAL_OES binding succeeds and a `samplerExternalOES` GLSL probe reads the expected pixels.

## Tests / validation

- [x] Unit test alongside the existing `sample_external_oes_round_trip` in `libs/streamlib-adapter-opengl/tests/sample_external_oes.rs`.
- [x] Plus structural partition tests in `drm_modifier_probe.rs` so a regression of the `external_only=TRUE` routing fails deterministically on every driver — not just NVIDIA.

## Test plan

- [x] `cargo test -p streamlib --lib drm_modifier_probe` — 7 passed (5 original + 2 new structural partition tests).
- [x] `cargo test -p streamlib-adapter-opengl --test sample_external_oes` — 3 passed (including the new `sample_external_oes_round_trip_sampler_only_modifier`, which exercised modifier `0x0000…0000` (`DRM_FORMAT_MOD_LINEAR`) end-to-end on the local NVIDIA driver — `using sampler-only modifier 0x0000000000000000` with full GL probe; no skip path hit).
- [x] `cargo run -p xtask -- check-boundaries` — 1984 file(s) scanned, no violations.
- [x] Mental-revert check: deleting the `else { sampler_only.push(*m); }` branch in `partition_modifiers_by_external_only` now fails `partition_modifiers_routes_external_only_true_to_sampler_only_list` deterministically.

## Implementation notes

- The new test reads the cached `DrmModifierTable` from `HostVulkanDevice` rather than re-running `drm_modifier_probe::probe_default_display()` directly. NVIDIA's EGL doesn't refcount `eglInitialize` on the shared default display, so a second probe from the test would tear down the display the adapter's `EglRuntime` is bound to, breaking every subsequent `lock_make_current()`. Comment inline explains.
- Skips with `println!` on drivers that don't advertise any sampler-only modifier for ARGB8888 (Mesa, where linear is typically `external_only=FALSE`). The structural partition tests still lock the routing on those drivers — this is the load-bearing change driven by pre-PR review.

## Polyglot coverage

- **Runtimes affected**: rust (host-side test only — no Python/Deno surface; the OpenGL adapter is consumed by polyglot, but the conformance contract under test is the host adapter's own EGL import path).
- **Schema regenerated**: n/a
- **Python and Deno both covered?** schema-only / language-specific by construction — this is a host-Rust conformance test for a code path shared by every runtime that consumes `streamlib-adapter-opengl`.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-adapter-opengl --test sample_external_oes` — 3 passed (NVIDIA Linux 570.211.01, modifier 0x0000…0000 / LINEAR exercised end-to-end).
  - [x] Host-Rust: `cargo test -p streamlib --lib drm_modifier_probe` — 7 passed (incl. 2 new structural partition tests).
- **FD-passing path**: DMA-BUF FD (existing `register_external_oes_host_surface` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)