### PR TITLE
feat(polyglot): subprocess escalate IPC for VulkanGraphicsKernel (#656)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "examples/polyglot-continuous-processor", # Example: Polyglot continuous processor — Python/Deno process() driven by monotonic-clock timerfd (#542)
     "examples/polyglot-opengl-fragment-shader", # Example: Polyglot OpenGL adapter — Python Mandelbrot / Deno plasma fragment shader rendered into a host DMA-BUF (#530)
     "examples/polyglot-vulkan-compute",   # Example: Polyglot Vulkan adapter — Python/Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage (#531)
+    "examples/polyglot-vulkan-graphics",  # Example: Polyglot Vulkan adapter — Python/Deno triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage (#656)
     "examples/polyglot-skia-canvas",      # Example: Polyglot Skia adapter — Python skia-python draws into a host DMA-BUF VkImage via composing on the Vulkan adapter (#513)
     "examples/polyglot-cuda-inference",   # Example: Polyglot CUDA adapter — Python YOLO inference / Deno DLPack capsule validation against a host OPAQUE_FD VkBuffer (#591)
     "examples/camera-rust-plugin",       # Example: Camera → Rust dylib plugin → Display pipeline

--- a/examples/polyglot-vulkan-graphics/Cargo.toml
+++ b/examples/polyglot-vulkan-graphics/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "polyglot-vulkan-graphics-scenario"
+version = "0.1.0"
+edition = "2024"
+publish = false
+build = "build.rs"
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib" }
+streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
+serde_json = "1.0"
+png = "0.17"
+parking_lot = "0.12"
+sha2 = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+streamlib-adapter-vulkan = { path = "../../libs/streamlib-adapter-vulkan" }

--- a/examples/polyglot-vulkan-graphics/build.rs
+++ b/examples/polyglot-vulkan-graphics/build.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![allow(clippy::disallowed_macros)] // build.rs uses println!/eprintln! for `cargo:` directives
+
+//! Compile `shaders/triangle.{vert,frag}` to SPIR-V via `glslc`. The
+//! example's `main.rs` embeds the resulting `.spv` blobs via
+//! `include_bytes!` and ships them to the polyglot processor as hex
+//! strings in the processor config.
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    compile_graphics_shaders();
+}
+
+#[cfg(target_os = "linux")]
+fn compile_graphics_shaders() {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    let shaders: &[(&str, &str)] = &[
+        ("shaders/triangle.vert", "triangle.vert.spv"),
+        ("shaders/triangle.frag", "triangle.frag.spv"),
+    ];
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    for (src, dst) in shaders {
+        let src_path = Path::new(src);
+        let dst_path: PathBuf = Path::new(&out_dir).join(dst);
+
+        println!("cargo:rerun-if-changed={}", src);
+
+        let glslc = std::env::var("GLSLC").unwrap_or_else(|_| "glslc".to_string());
+        let status = Command::new(&glslc)
+            .arg("-O")
+            .arg("--target-env=vulkan1.2")
+            .arg("-o")
+            .arg(&dst_path)
+            .arg(src_path)
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to invoke `{}` to compile {}: {}. Install shaderc-tools / vulkan-tools.",
+                    glslc, src, e
+                );
+            });
+        assert!(
+            status.success(),
+            "{} compilation failed (exit: {:?})",
+            src,
+            status.code()
+        );
+    }
+}

--- a/examples/polyglot-vulkan-graphics/deno/deno.json
+++ b/examples/polyglot-vulkan-graphics/deno/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2"
+  }
+}

--- a/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-vulkan-graphics-deno
+  version: "0.1.0"
+  description: "Polyglot Vulkan adapter scenario (#656) — Deno triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage"
+
+processors:
+  - name: com.tatolab.vulkan_graphics_deno
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
+    runtime: deno
+    execution: reactive
+    entrypoint: "vulkan_graphics.ts:default"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
+++ b/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Polyglot Vulkan graphics processor — Deno twin of
+ * `examples/polyglot-vulkan-graphics/python/vulkan_graphics.py`.
+ *
+ * End-to-end gate for the subprocess `VulkanContext.dispatchGraphics`
+ * runtime (#656). The host pre-allocates a render-target-capable
+ * DMA-BUF surface AND an exportable `VulkanTimelineSemaphore`,
+ * registers both with surface-share, and installs a
+ * `GraphicsKernelBridge` wired to its `VulkanGraphicsKernel`. This
+ * processor receives a trigger Videoframe, opens the host surface
+ * through `VulkanContext.acquireWrite`, and calls
+ * `VulkanContext.dispatchGraphics` — which routes through escalate
+ * IPC's `register_graphics_kernel` + `run_graphics_draw` ops to the
+ * host's `VulkanGraphicsKernel.offscreen_render`.
+ *
+ * Same vertex+fragment shaders as the Python twin, with
+ * `variant = 1` so the triangle is drawn in cyan/magenta/yellow
+ * instead of red/green/blue — visually distinct PNGs make reviewer
+ * comparisons easy.
+ *
+ * Config keys: vulkan_surface_uuid, width, height, variant,
+ * vertex_spv_hex, fragment_spv_hex.
+ */
+
+import type {
+  ReactiveProcessor,
+  RuntimeContextFullAccess,
+  RuntimeContextLimitedAccess,
+} from "../../../libs/streamlib-deno/mod.ts";
+import {
+  VkImageLayout,
+  VulkanContext,
+} from "../../../libs/streamlib-deno/adapters/vulkan.ts";
+import type { EscalateRequestRegisterGraphicsKernelPipelineState } from "../../../libs/streamlib-deno/escalate.ts";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function trianglePipelineState():
+  EscalateRequestRegisterGraphicsKernelPipelineState {
+  // jtd-codegen produces string-valued enums (`Topology.TriangleList =
+  // "triangle_list"`), and the wire JSON shape is the string. Build
+  // the literal then cast — the runtime serializer accepts any field
+  // whose value matches the expected string discriminator.
+  // deno-lint-ignore no-explicit-any
+  return {
+    topology: "triangle_list",
+    vertex_input_bindings: [],
+    vertex_input_attributes: [],
+    rasterization_polygon_mode: "fill",
+    rasterization_cull_mode: "none",
+    rasterization_front_face: "counter_clockwise",
+    rasterization_line_width: 1.0,
+    multisample_samples: 1,
+    depth_stencil_enabled: false,
+    depth_compare_op: "always",
+    depth_write: false,
+    color_blend_enabled: false,
+    color_write_mask: 0b1111,
+    color_blend_src_color_factor: "one",
+    color_blend_dst_color_factor: "zero",
+    color_blend_color_op: "add",
+    color_blend_src_alpha_factor: "one",
+    color_blend_dst_alpha_factor: "zero",
+    color_blend_alpha_op: "add",
+    attachment_color_formats: ["rgba8_unorm"],
+    dynamic_state: "viewport_scissor",
+  } as unknown as EscalateRequestRegisterGraphicsKernelPipelineState;
+}
+
+// Vertex stage visibility for push constants — bit 0 in
+// `GraphicsShaderStageFlags`.
+const STAGE_VERTEX = 1;
+
+export default class VulkanGraphicsProcessor implements ReactiveProcessor {
+  private uuid = "";
+  private width = 0;
+  private height = 0;
+  private variant = 1; // Default to Deno palette.
+  private vertSpv: Uint8Array | null = null;
+  private fragSpv: Uint8Array | null = null;
+  private vk: VulkanContext | null = null;
+  private dispatched = false;
+  private errorMessage: string | null = null;
+
+  setup(ctx: RuntimeContextFullAccess): void {
+    const cfg = ctx.config;
+    this.uuid = String(cfg["vulkan_surface_uuid"]);
+    this.width = Number(cfg["width"] ?? 0);
+    this.height = Number(cfg["height"] ?? 0);
+    this.variant = Number(cfg["variant"] ?? 1);
+    this.vertSpv = hexToBytes(String(cfg["vertex_spv_hex"] ?? ""));
+    this.fragSpv = hexToBytes(String(cfg["fragment_spv_hex"] ?? ""));
+    this.vk = VulkanContext.fromRuntime(ctx);
+    console.error(
+      `[VulkanGraphics/deno] setup uuid=${this.uuid} ` +
+        `size=${this.width}x${this.height} ` +
+        `vert_bytes=${this.vertSpv.byteLength} ` +
+        `frag_bytes=${this.fragSpv.byteLength} variant=${this.variant}`,
+    );
+  }
+
+  process(ctx: RuntimeContextLimitedAccess): void {
+    const result = ctx.inputs.read("video_in");
+    if (!result) return;
+    if (this.dispatched) return;
+    try {
+      this.dispatchOnce();
+      this.dispatched = true;
+      console.error(
+        `[VulkanGraphics/deno] triangle drawn into surface '${this.uuid}'`,
+      );
+    } catch (e) {
+      this.errorMessage = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[VulkanGraphics/deno] dispatch failed: ${this.errorMessage}`,
+      );
+    }
+  }
+
+  private async dispatchOnce(): Promise<void> {
+    if (this.vk === null || this.vertSpv === null || this.fragSpv === null) {
+      throw new Error("VulkanContext / SPIR-V not initialized in setup");
+    }
+    // Push constants: layout is `{u32 variant}` (vertex stage only).
+    const pc = new Uint8Array(4);
+    new DataView(pc.buffer).setUint32(0, this.variant, true);
+
+    {
+      using guard = this.vk.acquireWrite(this.uuid);
+      console.error(
+        `[VulkanGraphics/deno] acquired vk_image=0x${
+          guard.view.vkImage.toString(16)
+        } layout=${guard.view.vkImageLayout}`,
+      );
+      await this.vk.dispatchGraphics({
+        colorTarget: this.uuid,
+        extentWidth: this.width,
+        extentHeight: this.height,
+        vertexSpv: this.vertSpv,
+        fragmentSpv: this.fragSpv,
+        pipelineState: trianglePipelineState(),
+        bindings: [],
+        bindingDecls: [],
+        vertexBuffers: [],
+        pushConstants: pc,
+        pushConstantStages: STAGE_VERTEX,
+        descriptorSetsInFlight: 2,
+        frameIndex: 0,
+        viewport: {
+          x: 0.0,
+          y: 0.0,
+          width: this.width,
+          height: this.height,
+          min_depth: 0.0,
+          max_depth: 1.0,
+        },
+        scissor: {
+          x: 0,
+          y: 0,
+          width: this.width,
+          height: this.height,
+        },
+        label: "polyglot-triangle-deno",
+      });
+    }
+    // Producer-side cross-process release (#643). The graphics
+    // kernel's offscreen_render leaves the image in
+    // COLOR_ATTACHMENT_OPTIMAL after the render pass.
+    this.vk.releaseForCrossProcess(
+      this.uuid,
+      VkImageLayout.ColorAttachmentOptimal,
+    );
+    console.error(
+      `[VulkanGraphics/deno] published cross-process release ` +
+        `layout=ColorAttachmentOptimal for surface '${this.uuid}'`,
+    );
+  }
+
+  teardown(_ctx: RuntimeContextFullAccess): void {
+    console.error(
+      `[VulkanGraphics/deno] teardown dispatched=${this.dispatched} ` +
+        `error=${this.errorMessage}`,
+    );
+  }
+}

--- a/examples/polyglot-vulkan-graphics/python/pyproject.toml
+++ b/examples/polyglot-vulkan-graphics/python/pyproject.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[project]
+name = "polyglot-vulkan-graphics"
+version = "0.1.0"
+description = "Polyglot Vulkan adapter scenario — Python triangle graphics kernel"
+requires-python = ">=3.10"
+dependencies = [
+    "iceoryx2>=0.8.1",
+    "msgpack>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/examples/polyglot-vulkan-graphics/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/python/streamlib.yaml
@@ -1,0 +1,15 @@
+package:
+  name: polyglot-vulkan-graphics
+  version: "0.1.0"
+  description: "Polyglot Vulkan adapter scenario (#656) — Python triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage"
+
+processors:
+  - name: com.tatolab.vulkan_graphics
+    version: "1.0.0"
+    description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
+    runtime: python
+    execution: reactive
+    entrypoint: "vulkan_graphics:VulkanGraphicsProcessor"
+    inputs:
+      - name: video_in
+        schema: com.tatolab.videoframe@1.0.0

--- a/examples/polyglot-vulkan-graphics/python/vulkan_graphics.py
+++ b/examples/polyglot-vulkan-graphics/python/vulkan_graphics.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Polyglot Vulkan graphics processor — Python.
+
+End-to-end gate for the subprocess `VulkanContext.dispatch_graphics`
+runtime (#656). The host pre-allocates a render-target-capable
+DMA-BUF surface AND an exportable `VulkanTimelineSemaphore`,
+registers both with surface-share, and installs a
+``GraphicsKernelBridge`` wired to its ``VulkanGraphicsKernel``. This
+processor receives a trigger Videoframe, opens the host surface
+through ``VulkanContext.acquire_write``, and calls
+``VulkanContext.dispatch_graphics`` — which routes through escalate
+IPC's ``register_graphics_kernel`` + ``run_graphics_draw`` ops to
+the host's ``VulkanGraphicsKernel.offscreen_render``. The triangle
+is fabricated by the vertex shader from ``gl_VertexIndex`` (no
+vertex buffer required), with a per-vertex color picked by the
+``variant`` push constant.
+
+Config keys:
+    vulkan_surface_uuid (str, required)
+        Surface-share UUID the host registered the render-target image
+        + timeline semaphore under.
+    width (int, required)
+        Surface width in pixels.
+    height (int, required)
+        Surface height in pixels.
+    variant (int, required)
+        0 → Python palette (R/G/B), 1 → Deno palette (cyan/magenta/yellow).
+    vertex_spv_hex (str, required)
+        Hex-encoded SPIR-V bytecode for the triangle vertex shader.
+    fragment_spv_hex (str, required)
+        Hex-encoded SPIR-V bytecode for the triangle fragment shader.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+from streamlib import RuntimeContextFullAccess, RuntimeContextLimitedAccess
+from streamlib.adapters.vulkan import VkImageLayout, VulkanContext
+
+
+def _triangle_pipeline_state() -> dict:
+    """The pipeline state the host's `VulkanGraphicsKernel` is built
+    with. Single Rgba8Unorm color attachment, no depth, no blend, no
+    vertex inputs (gl_VertexIndex pattern), TriangleList topology,
+    dynamic viewport+scissor.
+    """
+    return {
+        "topology": "triangle_list",
+        "vertex_input_bindings": [],
+        "vertex_input_attributes": [],
+        "rasterization_polygon_mode": "fill",
+        "rasterization_cull_mode": "none",
+        "rasterization_front_face": "counter_clockwise",
+        "rasterization_line_width": 1.0,
+        "multisample_samples": 1,
+        "depth_stencil_enabled": False,
+        "depth_compare_op": "always",
+        "depth_write": False,
+        "color_blend_enabled": False,
+        "color_write_mask": 0b1111,
+        "color_blend_src_color_factor": "one",
+        "color_blend_dst_color_factor": "zero",
+        "color_blend_color_op": "add",
+        "color_blend_src_alpha_factor": "one",
+        "color_blend_dst_alpha_factor": "zero",
+        "color_blend_alpha_op": "add",
+        "attachment_color_formats": ["rgba8_unorm"],
+        "dynamic_state": "viewport_scissor",
+    }
+
+
+# Vertex stage visibility for push constants — bit 0 in the
+# `GraphicsShaderStageFlags` newtype.
+_STAGE_VERTEX = 1
+
+
+class VulkanGraphicsProcessor:
+    def setup(self, ctx: RuntimeContextFullAccess) -> None:
+        cfg = ctx.config
+        self._uuid = str(cfg["vulkan_surface_uuid"])
+        self._width = int(cfg["width"])
+        self._height = int(cfg["height"])
+        self._variant = int(cfg["variant"])
+        self._vert: bytes = bytes.fromhex(str(cfg["vertex_spv_hex"]))
+        self._frag: bytes = bytes.fromhex(str(cfg["fragment_spv_hex"]))
+        self._vk = VulkanContext.from_runtime(ctx)
+        self._dispatched = False
+        self._error: Optional[str] = None
+        print(
+            f"[VulkanGraphics/py] setup uuid={self._uuid} "
+            f"size={self._width}x{self._height} "
+            f"vert_bytes={len(self._vert)} frag_bytes={len(self._frag)} "
+            f"variant={self._variant}",
+            flush=True,
+        )
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None:
+        frame = ctx.inputs.read("video_in")
+        if frame is None:
+            return
+        if self._dispatched:
+            return
+        try:
+            self._dispatch_once()
+            self._dispatched = True
+            print(
+                f"[VulkanGraphics/py] triangle drawn into surface '{self._uuid}'",
+                flush=True,
+            )
+        except Exception as e:
+            self._error = str(e)
+            print(
+                f"[VulkanGraphics/py] dispatch failed: {e}", flush=True,
+            )
+
+    def _dispatch_once(self) -> None:
+        # Push constants: layout is `{u32 variant}` (vertex stage only).
+        push_consts = struct.pack("<I", self._variant)
+
+        with self._vk.acquire_write(self._uuid) as view:
+            print(
+                f"[VulkanGraphics/py] acquired vk_image=0x{view.vk_image:x} "
+                f"layout={view.vk_image_layout}",
+                flush=True,
+            )
+            self._vk.dispatch_graphics(
+                color_target=self._uuid,
+                extent_width=self._width,
+                extent_height=self._height,
+                vertex_spv=self._vert,
+                fragment_spv=self._frag,
+                pipeline_state=_triangle_pipeline_state(),
+                bindings=[],
+                binding_decls=[],
+                vertex_buffers=[],
+                push_constants=push_consts,
+                push_constant_stages=_STAGE_VERTEX,
+                descriptor_sets_in_flight=2,
+                frame_index=0,
+                viewport={
+                    "x": 0.0,
+                    "y": 0.0,
+                    "width": float(self._width),
+                    "height": float(self._height),
+                    "min_depth": 0.0,
+                    "max_depth": 1.0,
+                },
+                scissor={
+                    "x": 0,
+                    "y": 0,
+                    "width": self._width,
+                    "height": self._height,
+                },
+                draw={
+                    "kind": "draw",
+                    "vertex_count": 3,
+                    "instance_count": 1,
+                    "first_vertex": 0,
+                    "first_instance": 0,
+                    "index_count": 0,
+                    "first_index": 0,
+                    "vertex_offset": 0,
+                },
+                label="polyglot-triangle-py",
+            )
+        # Producer-side cross-process release (#643). The graphics
+        # kernel's offscreen_render leaves the image in
+        # COLOR_ATTACHMENT_OPTIMAL after the render pass.
+        self._vk.release_for_cross_process(
+            self._uuid, VkImageLayout.COLOR_ATTACHMENT_OPTIMAL
+        )
+        print(
+            f"[VulkanGraphics/py] published cross-process release "
+            f"layout=COLOR_ATTACHMENT_OPTIMAL for surface '{self._uuid}'",
+            flush=True,
+        )
+
+    def teardown(self, ctx: RuntimeContextFullAccess) -> None:
+        print(
+            f"[VulkanGraphics/py] teardown dispatched={self._dispatched} "
+            f"error={self._error}",
+            flush=True,
+        )

--- a/examples/polyglot-vulkan-graphics/shaders/triangle.frag
+++ b/examples/polyglot-vulkan-graphics/shaders/triangle.frag
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Polyglot Vulkan adapter graphics scenario (#656) — fragment stage.
+// Pass-through of the interpolated per-vertex color from the vertex
+// stage. Single Rgba8Unorm color attachment.
+
+#version 450
+
+layout(location = 0) in vec3 v_color;
+layout(location = 0) out vec4 out_color;
+
+void main() {
+    out_color = vec4(v_color, 1.0);
+}

--- a/examples/polyglot-vulkan-graphics/shaders/triangle.vert
+++ b/examples/polyglot-vulkan-graphics/shaders/triangle.vert
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Polyglot Vulkan adapter graphics scenario (#656) — vertex stage.
+// Fabricates a centered triangle from gl_VertexIndex (no vertex buffer
+// required). Pushes a per-vertex color the fragment stage interpolates.
+
+#version 450
+
+layout(push_constant) uniform Pc {
+    uint variant;
+} pc;
+
+layout(location = 0) out vec3 v_color;
+
+void main() {
+    // Centered triangle, ~60% of viewport.
+    vec2 positions[3] = vec2[3](
+        vec2( 0.0, -0.6),
+        vec2(-0.6,  0.6),
+        vec2( 0.6,  0.6)
+    );
+
+    // Variant 0: Python palette (R / G / B). Variant 1: Deno palette
+    // (cyan / magenta / yellow). Different palettes give the host's PNG
+    // readback a visually distinct gate per runtime so the Read-tool
+    // check confirms which subprocess actually ran.
+    vec3 colors;
+    if (pc.variant == 0u) {
+        vec3 py[3] = vec3[3](
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+            vec3(0.0, 0.0, 1.0)
+        );
+        colors = py[gl_VertexIndex];
+    } else {
+        vec3 dn[3] = vec3[3](
+            vec3(0.0, 1.0, 1.0),
+            vec3(1.0, 0.0, 1.0),
+            vec3(1.0, 1.0, 0.0)
+        );
+        colors = dn[gl_VertexIndex];
+    }
+
+    gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+    v_color = colors;
+}

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -1,0 +1,768 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Polyglot Vulkan adapter graphics scenario (#656).
+//!
+//! End-to-end gate for the subprocess `VulkanContext.dispatch_graphics`
+//! path: the host pre-allocates ONE render-target-capable DMA-BUF
+//! surface AND an exportable `HostVulkanTimelineSemaphore`, registers
+//! both with surface-share under a known UUID, and installs a
+//! `GraphicsKernelBridge` wired to its `VulkanGraphicsKernel`. A
+//! Python or Deno polyglot processor opens the surface through
+//! `VulkanContext.acquire_write` and calls `dispatch_graphics`, which
+//! routes through escalate IPC's `register_graphics_kernel` +
+//! `run_graphics_draw` ops to the host's
+//! `VulkanGraphicsKernel::offscreen_render`. This binary then reads
+//! the surface back via Vulkan and writes a PNG; reading the PNG
+//! with the Read tool is the visual gate.
+//!
+//! The shaders (`shaders/triangle.{vert,frag}`) are compiled to
+//! SPIR-V at build time via `build.rs`, embedded as bytes here, and
+//! shipped to the polyglot processor via the processor config as hex
+//! strings.
+//!
+//! Build the Python `.slpkg` first:
+//!   cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-graphics/python
+//!
+//! Run:
+//!   cargo run -p polyglot-vulkan-graphics-scenario -- \
+//!       --runtime=python --output=/tmp/vulkan-triangle-py.png
+//!   cargo run -p polyglot-vulkan-graphics-scenario -- \
+//!       --runtime=deno   --output=/tmp/vulkan-triangle-deno.png
+
+#![cfg(target_os = "linux")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use streamlib::core::context::{
+    BlendFactorWire, BlendOpWire, CullModeWire, DynamicStateWire, FrontFaceWire,
+    GraphicsBindingDecl, GraphicsKernelBridge, GraphicsKernelRegisterDecl,
+    GraphicsKernelRunDraw, GraphicsPipelineStateWire, PolygonModeWire,
+    PrimitiveTopologyWire,
+};
+use streamlib::core::rhi::{
+    AttachmentFormats, ColorBlendState, ColorWriteMask, DepthStencilState,
+    GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor,
+    GraphicsPipelineState, GraphicsPushConstants, GraphicsShaderStage,
+    GraphicsShaderStageFlags, GraphicsStage, MultisampleState, PrimitiveTopology,
+    RasterizationState, StreamTexture, TextureFormat, TextureReadbackDescriptor,
+    TextureSourceLayout, VertexInputState,
+};
+use streamlib::core::{InputLinkPortRef, OutputLinkPortRef, StreamError};
+use streamlib::host_rhi::{
+    HostVulkanDevice, HostVulkanTimelineSemaphore, OffscreenColorTarget, OffscreenDraw,
+    VulkanGraphicsKernel, VulkanTextureReadback,
+};
+use streamlib::{BgraFileSourceProcessor, ProcessorSpec, Result, StreamRuntime};
+
+/// Compiled SPIR-V for the triangle vertex shader.
+const TRIANGLE_VERT_SPV: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/triangle.vert.spv"));
+
+/// Compiled SPIR-V for the triangle fragment shader.
+const TRIANGLE_FRAG_SPV: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/triangle.frag.spv"));
+
+/// UUID the host registers the render-target surface under.
+const SCENARIO_SURFACE_UUID: &str = "00000000-0000-0000-0000-0000000006a1";
+
+/// Side length of the surface (square keeps the reader-tool gate easy
+/// to interpret; 512 is large enough to be visually obvious).
+const SURFACE_SIZE: u32 = 512;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeKind {
+    Python,
+    Deno,
+}
+
+impl RuntimeKind {
+    fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s {
+            "python" => Ok(Self::Python),
+            "deno" => Ok(Self::Deno),
+            other => Err(format!(
+                "unknown --runtime value '{other}' (expected 'python' or 'deno')"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Deno => "deno",
+        }
+    }
+
+    fn processor_name(self) -> &'static str {
+        match self {
+            Self::Python => "com.tatolab.vulkan_graphics",
+            Self::Deno => "com.tatolab.vulkan_graphics_deno",
+        }
+    }
+}
+
+/// Bridge between the host runtime's `set_graphics_kernel_bridge` and
+/// the host's `VulkanGraphicsKernel`. Lives in this example because
+/// the `GraphicsKernelBridge` trait lives in `streamlib` and the
+/// `streamlib-adapter-vulkan` crate cannot depend on the full
+/// `streamlib` (the consumer-rhi capability boundary forbids it).
+///
+/// Holds a UUID → `StreamTexture` map populated at setup time so
+/// `run_graphics_draw(color_target_uuids[…], ...)` can resolve to the
+/// host's `VkImage` for the offscreen color target. The kernel cache
+/// is keyed by SHA-256 over a canonical byte representation of the
+/// register-time descriptor.
+struct TriangleKernelBridge {
+    device: Arc<HostVulkanDevice>,
+    surfaces: HashMap<String, StreamTexture>,
+    kernels: parking_lot::Mutex<HashMap<String, Arc<VulkanGraphicsKernel>>>,
+}
+
+impl TriangleKernelBridge {
+    fn new(
+        device: Arc<HostVulkanDevice>,
+        surfaces: Vec<(String, StreamTexture)>,
+    ) -> Self {
+        Self {
+            device,
+            surfaces: surfaces.into_iter().collect(),
+            kernels: parking_lot::Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn canonical_kernel_id(decl: &GraphicsKernelRegisterDecl) -> String {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(b"v=");
+        h.update(&decl.vertex_spv);
+        h.update(b"|f=");
+        h.update(&decl.fragment_spv);
+        h.update(b"|ve=");
+        h.update(decl.vertex_entry_point.as_bytes());
+        h.update(b"|fe=");
+        h.update(decl.fragment_entry_point.as_bytes());
+        h.update(b"|pc=");
+        h.update(&decl.push_constant_size.to_le_bytes());
+        h.update(b"|pcs=");
+        h.update(&decl.push_constant_stages.to_le_bytes());
+        h.update(b"|dsi=");
+        h.update(&decl.descriptor_sets_in_flight.to_le_bytes());
+        h.update(b"|nb=");
+        h.update(&(decl.bindings.len() as u32).to_le_bytes());
+        // Pipeline state — distil enums to enum discriminants to avoid
+        // pulling in serde just for the canonicalization step.
+        let p = &decl.pipeline_state;
+        h.update(b"|t=");
+        h.update(&(p.topology as u32).to_le_bytes());
+        h.update(b"|cb=");
+        h.update(&[p.color_blend_enabled as u8]);
+        h.update(b"|cm=");
+        h.update(&p.color_write_mask.to_le_bytes());
+        h.update(b"|nf=");
+        h.update(&(p.attachment_color_formats.len() as u32).to_le_bytes());
+        for f in &p.attachment_color_formats {
+            h.update(f.as_bytes());
+            h.update(b"|");
+        }
+        format!("{:x}", h.finalize())
+    }
+}
+
+fn map_topology(t: PrimitiveTopologyWire) -> PrimitiveTopology {
+    match t {
+        PrimitiveTopologyWire::PointList => PrimitiveTopology::PointList,
+        PrimitiveTopologyWire::LineList => PrimitiveTopology::LineList,
+        PrimitiveTopologyWire::LineStrip => PrimitiveTopology::LineStrip,
+        PrimitiveTopologyWire::TriangleList => PrimitiveTopology::TriangleList,
+        PrimitiveTopologyWire::TriangleStrip => PrimitiveTopology::TriangleStrip,
+        PrimitiveTopologyWire::TriangleFan => PrimitiveTopology::TriangleFan,
+    }
+}
+
+fn map_polygon_mode(m: PolygonModeWire) -> streamlib::core::rhi::PolygonMode {
+    use streamlib::core::rhi::PolygonMode;
+    match m {
+        PolygonModeWire::Fill => PolygonMode::Fill,
+        PolygonModeWire::Line => PolygonMode::Line,
+        PolygonModeWire::Point => PolygonMode::Point,
+    }
+}
+
+fn map_cull(m: CullModeWire) -> streamlib::core::rhi::CullMode {
+    use streamlib::core::rhi::CullMode;
+    match m {
+        CullModeWire::None => CullMode::None,
+        CullModeWire::Front => CullMode::Front,
+        CullModeWire::Back => CullMode::Back,
+        CullModeWire::FrontAndBack => CullMode::FrontAndBack,
+    }
+}
+
+fn map_front_face(m: FrontFaceWire) -> streamlib::core::rhi::FrontFace {
+    use streamlib::core::rhi::FrontFace;
+    match m {
+        FrontFaceWire::CounterClockwise => FrontFace::CounterClockwise,
+        FrontFaceWire::Clockwise => FrontFace::Clockwise,
+    }
+}
+
+fn map_blend_factor(f: BlendFactorWire) -> streamlib::core::rhi::BlendFactor {
+    use streamlib::core::rhi::BlendFactor;
+    match f {
+        BlendFactorWire::Zero => BlendFactor::Zero,
+        BlendFactorWire::One => BlendFactor::One,
+        BlendFactorWire::SrcColor => BlendFactor::SrcColor,
+        BlendFactorWire::OneMinusSrcColor => BlendFactor::OneMinusSrcColor,
+        BlendFactorWire::DstColor => BlendFactor::DstColor,
+        BlendFactorWire::OneMinusDstColor => BlendFactor::OneMinusDstColor,
+        BlendFactorWire::SrcAlpha => BlendFactor::SrcAlpha,
+        BlendFactorWire::OneMinusSrcAlpha => BlendFactor::OneMinusSrcAlpha,
+        BlendFactorWire::DstAlpha => BlendFactor::DstAlpha,
+        BlendFactorWire::OneMinusDstAlpha => BlendFactor::OneMinusDstAlpha,
+        BlendFactorWire::ConstantColor => BlendFactor::ConstantColor,
+        BlendFactorWire::OneMinusConstantColor => BlendFactor::OneMinusConstantColor,
+        BlendFactorWire::ConstantAlpha => BlendFactor::ConstantAlpha,
+        BlendFactorWire::OneMinusConstantAlpha => BlendFactor::OneMinusConstantAlpha,
+        BlendFactorWire::SrcAlphaSaturate => BlendFactor::SrcAlphaSaturate,
+    }
+}
+
+fn map_blend_op(o: BlendOpWire) -> streamlib::core::rhi::BlendOp {
+    use streamlib::core::rhi::BlendOp;
+    match o {
+        BlendOpWire::Add => BlendOp::Add,
+        BlendOpWire::Subtract => BlendOp::Subtract,
+        BlendOpWire::ReverseSubtract => BlendOp::ReverseSubtract,
+        BlendOpWire::Min => BlendOp::Min,
+        BlendOpWire::Max => BlendOp::Max,
+    }
+}
+
+fn parse_texture_format(s: &str) -> std::result::Result<TextureFormat, String> {
+    match s {
+        "rgba8_unorm" => Ok(TextureFormat::Rgba8Unorm),
+        "rgba8_unorm_srgb" => Ok(TextureFormat::Rgba8UnormSrgb),
+        "bgra8_unorm" => Ok(TextureFormat::Bgra8Unorm),
+        "bgra8_unorm_srgb" => Ok(TextureFormat::Bgra8UnormSrgb),
+        other => Err(format!("unknown attachment color format '{other}'")),
+    }
+}
+
+fn build_pipeline_state(
+    p: &GraphicsPipelineStateWire,
+) -> std::result::Result<GraphicsPipelineState, String> {
+    use streamlib::core::rhi::ColorBlendAttachment;
+
+    if p.multisample_samples != 1 {
+        return Err(format!(
+            "MSAA samples != 1 not supported (got {})",
+            p.multisample_samples
+        ));
+    }
+    if p.attachment_color_formats.len() != 1 {
+        return Err(format!(
+            "expected exactly one attachment color format (got {})",
+            p.attachment_color_formats.len()
+        ));
+    }
+    if p.attachment_depth_format.is_some() || p.depth_stencil_enabled {
+        return Err(
+            "depth attachments are not supported in v1 of the bridge".into(),
+        );
+    }
+    if !p.vertex_input_bindings.is_empty() || !p.vertex_input_attributes.is_empty() {
+        // The triangle example uses gl_VertexIndex (no vertex buffers); a
+        // production bridge can fold these in via VertexInputState::Buffers.
+        return Err(
+            "v1 example bridge supports only vertex-fabricating shaders \
+             (gl_VertexIndex pattern) — empty vertex_input_bindings"
+                .into(),
+        );
+    }
+
+    let color_blend = if p.color_blend_enabled {
+        let mask = ColorWriteMask::R
+            | ColorWriteMask::G
+            | ColorWriteMask::B
+            | ColorWriteMask::A;
+        ColorBlendState::Enabled(ColorBlendAttachment {
+            src_color_blend_factor: map_blend_factor(p.color_blend_src_color_factor),
+            dst_color_blend_factor: map_blend_factor(p.color_blend_dst_color_factor),
+            color_blend_op: map_blend_op(p.color_blend_color_op),
+            src_alpha_blend_factor: map_blend_factor(p.color_blend_src_alpha_factor),
+            dst_alpha_blend_factor: map_blend_factor(p.color_blend_dst_alpha_factor),
+            alpha_blend_op: map_blend_op(p.color_blend_alpha_op),
+            // Wire mask is a flat u32; the host `ColorWriteMask` accepts
+            // RGBA as a preset and any subset here would degrade visibility
+            // for the triangle anyway.
+            color_write_mask: if (p.color_write_mask & 0b1111) == 0b1111 {
+                ColorWriteMask::RGBA
+            } else {
+                mask
+            },
+        })
+    } else {
+        ColorBlendState::Disabled {
+            color_write_mask: ColorWriteMask::RGBA,
+        }
+    };
+
+    Ok(GraphicsPipelineState {
+        topology: map_topology(p.topology),
+        vertex_input: VertexInputState::None,
+        rasterization: RasterizationState {
+            polygon_mode: map_polygon_mode(p.rasterization_polygon_mode),
+            cull_mode: map_cull(p.rasterization_cull_mode),
+            front_face: map_front_face(p.rasterization_front_face),
+            line_width: p.rasterization_line_width,
+        },
+        multisample: MultisampleState { samples: 1 },
+        depth_stencil: DepthStencilState::Disabled,
+        color_blend,
+        attachment_formats: AttachmentFormats {
+            color: vec![parse_texture_format(&p.attachment_color_formats[0])?],
+            depth: None,
+        },
+        dynamic_state: match p.dynamic_state {
+            DynamicStateWire::None => GraphicsDynamicState::None,
+            DynamicStateWire::ViewportScissor => GraphicsDynamicState::ViewportScissor,
+        },
+    })
+}
+
+fn build_bindings(decls: &[GraphicsBindingDecl]) -> Vec<GraphicsBindingSpec> {
+    use streamlib::core::context::GraphicsBindingKindWire as W;
+    use streamlib::core::rhi::GraphicsBindingKind;
+    decls
+        .iter()
+        .map(|d| GraphicsBindingSpec {
+            binding: d.binding,
+            kind: match d.kind {
+                W::SampledTexture => GraphicsBindingKind::SampledTexture,
+                W::StorageBuffer => GraphicsBindingKind::StorageBuffer,
+                W::UniformBuffer => GraphicsBindingKind::UniformBuffer,
+                W::StorageImage => GraphicsBindingKind::StorageImage,
+            },
+            stages: GraphicsShaderStageFlags::from_bits_or_zero(d.stages),
+        })
+        .collect()
+}
+
+trait FlagsFromBits {
+    fn from_bits_or_zero(bits: u32) -> GraphicsShaderStageFlags;
+}
+
+impl FlagsFromBits for GraphicsShaderStageFlags {
+    fn from_bits_or_zero(bits: u32) -> GraphicsShaderStageFlags {
+        // Hand-roll a flags constructor — `GraphicsShaderStageFlags` is a
+        // newtype around u32 with no public from_bits, so reconstruct via
+        // the public consts.
+        let mut out = GraphicsShaderStageFlags::NONE;
+        if bits & 0b01 != 0 {
+            out |= GraphicsShaderStageFlags::VERTEX;
+        }
+        if bits & 0b10 != 0 {
+            out |= GraphicsShaderStageFlags::FRAGMENT;
+        }
+        out
+    }
+}
+
+impl GraphicsKernelBridge for TriangleKernelBridge {
+    fn register(
+        &self,
+        decl: &GraphicsKernelRegisterDecl,
+    ) -> std::result::Result<String, String> {
+        let kernel_id = Self::canonical_kernel_id(decl);
+        let mut kernels = self.kernels.lock();
+        if !kernels.contains_key(&kernel_id) {
+            let pipeline_state = build_pipeline_state(&decl.pipeline_state)?;
+            let bindings = build_bindings(&decl.bindings);
+            let stages = [
+                GraphicsStage {
+                    stage: GraphicsShaderStage::Vertex,
+                    spv: &decl.vertex_spv,
+                    entry_point: if decl.vertex_entry_point.is_empty() {
+                        "main"
+                    } else {
+                        decl.vertex_entry_point.as_str()
+                    },
+                },
+                GraphicsStage {
+                    stage: GraphicsShaderStage::Fragment,
+                    spv: &decl.fragment_spv,
+                    entry_point: if decl.fragment_entry_point.is_empty() {
+                        "main"
+                    } else {
+                        decl.fragment_entry_point.as_str()
+                    },
+                },
+            ];
+            let push_constants = if decl.push_constant_size == 0 {
+                GraphicsPushConstants::NONE
+            } else {
+                GraphicsPushConstants {
+                    size: decl.push_constant_size,
+                    stages: GraphicsShaderStageFlags::from_bits_or_zero(
+                        decl.push_constant_stages,
+                    ),
+                }
+            };
+            let descriptor = GraphicsKernelDescriptor {
+                label: if decl.label.is_empty() {
+                    "polyglot-triangle"
+                } else {
+                    decl.label.as_str()
+                },
+                stages: &stages,
+                bindings: &bindings,
+                push_constants,
+                pipeline_state,
+                descriptor_sets_in_flight: decl.descriptor_sets_in_flight,
+            };
+            let kernel = VulkanGraphicsKernel::new(&self.device, &descriptor)
+                .map_err(|e| format!("VulkanGraphicsKernel::new: {e}"))?;
+            kernels.insert(kernel_id.clone(), Arc::new(kernel));
+        }
+        Ok(kernel_id)
+    }
+
+    fn run_draw(
+        &self,
+        draw: &GraphicsKernelRunDraw,
+    ) -> std::result::Result<(), String> {
+        let kernel = self
+            .kernels
+            .lock()
+            .get(&draw.kernel_id)
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "kernel_id '{}' not registered with this bridge",
+                    draw.kernel_id
+                )
+            })?;
+        if draw.color_target_uuids.len() != 1 {
+            return Err(format!(
+                "v1 bridge requires exactly one color target (got {})",
+                draw.color_target_uuids.len()
+            ));
+        }
+        let target_uuid = &draw.color_target_uuids[0];
+        let texture = self.surfaces.get(target_uuid).ok_or_else(|| {
+            format!(
+                "color_target_uuid '{target_uuid}' not registered with this bridge"
+            )
+        })?;
+        if !draw.push_constants.is_empty() {
+            kernel
+                .set_push_constants(draw.frame_index, &draw.push_constants)
+                .map_err(|e| format!("set_push_constants: {e}"))?;
+        }
+        let _ = (&draw.bindings, &draw.vertex_buffers, &draw.index_buffer);
+        // The triangle scenario has no descriptor bindings, no vertex
+        // buffers, and is non-indexed — so we don't need to forward any
+        // of those paths to the kernel. A production bridge would loop
+        // over `draw.bindings` and call `set_sampled_texture` /
+        // `set_storage_buffer` etc., loop over `draw.vertex_buffers`
+        // and call `set_vertex_buffer`, and forward `draw.index_buffer`
+        // to `set_index_buffer` for indexed draws.
+        let offscreen_draw = match draw.draw {
+            streamlib::core::context::GraphicsDrawSpec::Draw {
+                vertex_count,
+                instance_count,
+                first_vertex,
+                first_instance,
+            } => OffscreenDraw::Draw(streamlib::core::rhi::DrawCall {
+                vertex_count,
+                instance_count,
+                first_vertex,
+                first_instance,
+                viewport: None,
+                scissor: None,
+            }),
+            streamlib::core::context::GraphicsDrawSpec::DrawIndexed {
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            } => OffscreenDraw::DrawIndexed(
+                streamlib::core::rhi::DrawIndexedCall {
+                    index_count,
+                    instance_count,
+                    first_index,
+                    vertex_offset,
+                    first_instance,
+                    viewport: None,
+                    scissor: None,
+                },
+            ),
+        };
+        kernel
+            .offscreen_render(
+                draw.frame_index,
+                &[OffscreenColorTarget {
+                    texture,
+                    clear_color: Some([0.05, 0.05, 0.05, 1.0]),
+                }],
+                draw.extent,
+                offscreen_draw,
+            )
+            .map_err(|e| format!("offscreen_render: {e}"))?;
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1);
+    let mut runtime_kind = RuntimeKind::Python;
+    let mut output_png = PathBuf::from("/tmp/vulkan-triangle.png");
+    for a in args {
+        if let Some(value) = a.strip_prefix("--runtime=") {
+            runtime_kind = RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+        } else if let Some(value) = a.strip_prefix("--output=") {
+            output_png = PathBuf::from(value);
+        }
+    }
+
+    println!("=== Polyglot Vulkan adapter graphics scenario (#656) ===");
+    println!("Runtime:     {}", runtime_kind.as_str());
+    println!(
+        "Surface:     {SURFACE_SIZE}x{SURFACE_SIZE} RGBA8 (uuid {SCENARIO_SURFACE_UUID})"
+    );
+    println!(
+        "SPIR-V:      vert={} bytes, frag={} bytes",
+        TRIANGLE_VERT_SPV.len(),
+        TRIANGLE_FRAG_SPV.len()
+    );
+    println!("Output PNG:  {}", output_png.display());
+    println!();
+
+    let runtime = StreamRuntime::new()?;
+
+    let texture_slot: Arc<Mutex<Option<StreamTexture>>> = Arc::new(Mutex::new(None));
+    let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
+        Arc::new(Mutex::new(None));
+    let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
+        Arc::new(Mutex::new(None));
+
+    {
+        let texture_slot = Arc::clone(&texture_slot);
+        let timeline_slot = Arc::clone(&timeline_slot);
+        let readback_slot = Arc::clone(&readback_slot);
+        runtime.install_setup_hook(move |gpu| {
+            let texture = gpu.acquire_render_target_dma_buf_image(
+                SURFACE_SIZE,
+                SURFACE_SIZE,
+                TextureFormat::Rgba8Unorm,
+            )?;
+            let host_device = Arc::clone(gpu.device().vulkan_device());
+            let timeline = Arc::new(
+                HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+                    .map_err(|e| {
+                        StreamError::Configuration(format!(
+                            "HostVulkanTimelineSemaphore::new_exportable: {e}"
+                        ))
+                    })?,
+            );
+            let store = gpu.surface_store().ok_or_else(|| {
+                StreamError::Configuration(
+                    "surface_store unavailable — host runtime built without \
+                     a surface-share service (Linux subprocess flow requires it)"
+                        .into(),
+                )
+            })?;
+            // The graphics kernel's offscreen_render leaves the image in
+            // COLOR_ATTACHMENT_OPTIMAL after the render pass. Declare
+            // that as the post-release layout so any future Path 2
+            // consumer's acquire_from_foreign sees a matching source
+            // layout.
+            store
+                .register_texture(
+                    SCENARIO_SURFACE_UUID,
+                    &texture,
+                    Some(timeline.as_ref()),
+                    streamlib::core::rhi::VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
+                )
+                .map_err(|e| {
+                    StreamError::Configuration(format!("register_texture: {e}"))
+                })?;
+
+            let bridge = Arc::new(TriangleKernelBridge::new(
+                Arc::clone(&host_device),
+                vec![(SCENARIO_SURFACE_UUID.to_string(), texture.clone())],
+            ));
+            gpu.set_graphics_kernel_bridge(bridge);
+
+            let readback = gpu.create_texture_readback(&TextureReadbackDescriptor {
+                label: "polyglot-vulkan-graphics/readback",
+                format: TextureFormat::Rgba8Unorm,
+                width: SURFACE_SIZE,
+                height: SURFACE_SIZE,
+            })?;
+
+            *texture_slot.lock().unwrap() = Some(texture);
+            *timeline_slot.lock().unwrap() = Some(timeline);
+            *readback_slot.lock().unwrap() = Some(readback);
+            println!(
+                "✓ render-target DMA-BUF + timeline registered as '{}'",
+                SCENARIO_SURFACE_UUID
+            );
+            Ok(())
+        });
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match runtime_kind {
+        RuntimeKind::Python => {
+            let slpkg_path = manifest_dir
+                .join("python/polyglot-vulkan-graphics-0.1.0.slpkg");
+            if !slpkg_path.exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-graphics/python",
+                    slpkg_path.display()
+                )));
+            }
+            runtime.load_package(&slpkg_path)?;
+        }
+        RuntimeKind::Deno => {
+            let project_path = manifest_dir.join("deno");
+            if !project_path.join("streamlib.yaml").exists() {
+                return Err(StreamError::Configuration(format!(
+                    "Deno project not found: {}",
+                    project_path.display()
+                )));
+            }
+            runtime.load_project(&project_path)?;
+        }
+    }
+
+    let fixture_path = write_trigger_fixture()
+        .map_err(StreamError::Configuration)?;
+    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
+        BgraFileSourceProcessor::Config {
+            file_path: fixture_path
+                .to_str()
+                .ok_or_else(|| {
+                    StreamError::Configuration(
+                        "fixture path has non-utf8 component".into(),
+                    )
+                })?
+                .to_string(),
+            width: 4,
+            height: 4,
+            fps: 5,
+            frame_count: 3,
+        },
+    ))?;
+    println!("+ BgraFileSource: {source}");
+
+    let variant: u32 = match runtime_kind {
+        RuntimeKind::Python => 0,
+        RuntimeKind::Deno => 1,
+    };
+    let graphics_config = serde_json::json!({
+        "vulkan_surface_uuid": SCENARIO_SURFACE_UUID,
+        "width": SURFACE_SIZE,
+        "height": SURFACE_SIZE,
+        "variant": variant,
+        "vertex_spv_hex": bytes_to_hex(TRIANGLE_VERT_SPV),
+        "fragment_spv_hex": bytes_to_hex(TRIANGLE_FRAG_SPV),
+    });
+    let graphics = runtime.add_processor(ProcessorSpec::new(
+        runtime_kind.processor_name(),
+        graphics_config,
+    ))?;
+    println!("+ Vulkan graphics processor: {graphics}");
+
+    runtime.connect(
+        OutputLinkPortRef::new(&source, "video"),
+        InputLinkPortRef::new(&graphics, "video_in"),
+    )?;
+    println!(
+        "\nPipeline: BgraFileSource → {} vulkan-graphics\n",
+        runtime_kind.as_str()
+    );
+
+    println!("Starting pipeline...");
+    runtime.start()?;
+    std::thread::sleep(Duration::from_secs(4));
+    println!("Stopping pipeline...");
+    runtime.stop()?;
+
+    println!("\nReading host surface back via Vulkan...");
+    let texture = texture_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| {
+            StreamError::Runtime(
+                "host texture slot is empty — setup hook never ran".into(),
+            )
+        })?;
+    let readback = readback_slot
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+    let ticket = readback
+        .submit(&texture, TextureSourceLayout::ColorAttachment)
+        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+    let rgba = readback
+        .wait_and_read(ticket, u64::MAX)
+        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .to_vec();
+    write_png(&rgba, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
+    println!("✓ Output PNG written: {}", output_png.display());
+
+    Ok(())
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn write_trigger_fixture() -> std::result::Result<PathBuf, String> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let path = std::env::temp_dir().join("vulkan-graphics-trigger.bgra");
+    let mut f = File::create(&path)
+        .map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(&[0u8; 4 * 4 * 4 * 3])
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+fn write_png(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    output: &std::path::Path,
+) -> Result<()> {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    let file = File::create(output).map_err(|e| {
+        StreamError::Configuration(format!("create output PNG {}: {e}", output.display()))
+    })?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+    writer
+        .write_image_data(rgba)
+        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+    Ok(())
+}

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -8,7 +8,7 @@
 /**
  * Polyglot subprocess escalate-on-behalf request (subprocess → host)
  */
-export type EscalateRequest = EscalateRequestAcquireImage | EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestRegisterComputeKernel | EscalateRequestReleaseHandle | EscalateRequestRunComputeKernel | EscalateRequestRunCpuReadbackCopy | EscalateRequestTryRunCpuReadbackCopy;
+export type EscalateRequest = EscalateRequestAcquireImage | EscalateRequestAcquirePixelBuffer | EscalateRequestAcquireTexture | EscalateRequestLog | EscalateRequestRegisterComputeKernel | EscalateRequestRegisterGraphicsKernel | EscalateRequestReleaseHandle | EscalateRequestRunComputeKernel | EscalateRequestRunCpuReadbackCopy | EscalateRequestRunGraphicsDraw | EscalateRequestTryRunCpuReadbackCopy;
 
 export interface EscalateRequestAcquireImage {
   op: "acquire_image";
@@ -222,6 +222,379 @@ export interface EscalateRequestRegisterComputeKernel {
   spv_hex: string;
 }
 
+/**
+ * Resource kind for this binding slot.
+ */
+export enum EscalateRequestRegisterGraphicsKernelBindingKind {
+  SampledTexture = "sampled_texture",
+  StorageBuffer = "storage_buffer",
+  StorageImage = "storage_image",
+  UniformBuffer = "uniform_buffer",
+}
+
+export interface EscalateRequestRegisterGraphicsKernelBinding {
+  binding: number;
+
+  /**
+   * Resource kind for this binding slot.
+   */
+  kind: EscalateRequestRegisterGraphicsKernelBindingKind;
+
+  /**
+   * Bitmask of stages the binding is visible to. `1 = VERTEX`, `2 = FRAGMENT`,
+   * `3 = VERTEX_FRAGMENT`.
+   */
+  stages: number;
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp {
+  Add = "add",
+  Max = "max",
+  Min = "min",
+  ReverseSubtract = "reverse_subtract",
+  Subtract = "subtract",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp {
+  Add = "add",
+  Max = "max",
+  Min = "min",
+  ReverseSubtract = "reverse_subtract",
+  Subtract = "subtract",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor {
+  ConstantAlpha = "constant_alpha",
+  ConstantColor = "constant_color",
+  DstAlpha = "dst_alpha",
+  DstColor = "dst_color",
+  One = "one",
+  OneMinusConstantAlpha = "one_minus_constant_alpha",
+  OneMinusConstantColor = "one_minus_constant_color",
+  OneMinusDstAlpha = "one_minus_dst_alpha",
+  OneMinusDstColor = "one_minus_dst_color",
+  OneMinusSrcAlpha = "one_minus_src_alpha",
+  OneMinusSrcColor = "one_minus_src_color",
+  SrcAlpha = "src_alpha",
+  SrcAlphaSaturate = "src_alpha_saturate",
+  SrcColor = "src_color",
+  Zero = "zero",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor {
+  ConstantAlpha = "constant_alpha",
+  ConstantColor = "constant_color",
+  DstAlpha = "dst_alpha",
+  DstColor = "dst_color",
+  One = "one",
+  OneMinusConstantAlpha = "one_minus_constant_alpha",
+  OneMinusConstantColor = "one_minus_constant_color",
+  OneMinusDstAlpha = "one_minus_dst_alpha",
+  OneMinusDstColor = "one_minus_dst_color",
+  OneMinusSrcAlpha = "one_minus_src_alpha",
+  OneMinusSrcColor = "one_minus_src_color",
+  SrcAlpha = "src_alpha",
+  SrcAlphaSaturate = "src_alpha_saturate",
+  SrcColor = "src_color",
+  Zero = "zero",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor {
+  ConstantAlpha = "constant_alpha",
+  ConstantColor = "constant_color",
+  DstAlpha = "dst_alpha",
+  DstColor = "dst_color",
+  One = "one",
+  OneMinusConstantAlpha = "one_minus_constant_alpha",
+  OneMinusConstantColor = "one_minus_constant_color",
+  OneMinusDstAlpha = "one_minus_dst_alpha",
+  OneMinusDstColor = "one_minus_dst_color",
+  OneMinusSrcAlpha = "one_minus_src_alpha",
+  OneMinusSrcColor = "one_minus_src_color",
+  SrcAlpha = "src_alpha",
+  SrcAlphaSaturate = "src_alpha_saturate",
+  SrcColor = "src_color",
+  Zero = "zero",
+}
+
+/**
+ * Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+ * value (e.g. `one`) regardless.
+ */
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor {
+  ConstantAlpha = "constant_alpha",
+  ConstantColor = "constant_color",
+  DstAlpha = "dst_alpha",
+  DstColor = "dst_color",
+  One = "one",
+  OneMinusConstantAlpha = "one_minus_constant_alpha",
+  OneMinusConstantColor = "one_minus_constant_color",
+  OneMinusDstAlpha = "one_minus_dst_alpha",
+  OneMinusDstColor = "one_minus_dst_color",
+  OneMinusSrcAlpha = "one_minus_src_alpha",
+  OneMinusSrcColor = "one_minus_src_color",
+  SrcAlpha = "src_alpha",
+  SrcAlphaSaturate = "src_alpha_saturate",
+  SrcColor = "src_color",
+  Zero = "zero",
+}
+
+/**
+ * Depth compare op. Ignored when `depth_stencil_enabled` is false; the wire
+ * field must still carry a valid value (use `always` as the default placeholder
+ * when disabled).
+ */
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp {
+  Always = "always",
+  Equal = "equal",
+  Greater = "greater",
+  GreaterOrEqual = "greater_or_equal",
+  Less = "less",
+  LessOrEqual = "less_or_equal",
+  Never = "never",
+  NotEqual = "not_equal",
+}
+
+/**
+ * Which pipeline state is set dynamically per draw vs baked into the pipeline
+ * at creation. `none` bakes a default 1×1 viewport (offscreen fixed-size only);
+ * `viewport_scissor` lets the same pipeline serve varying extents.
+ */
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState {
+  None = "none",
+  ViewportScissor = "viewport_scissor",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode {
+  Back = "back",
+  Front = "front",
+  FrontAndBack = "front_and_back",
+  None = "none",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace {
+  Clockwise = "clockwise",
+  CounterClockwise = "counter_clockwise",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode {
+  Fill = "fill",
+  Line = "line",
+  Point = "point",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateTopology {
+  LineList = "line_list",
+  LineStrip = "line_strip",
+  PointList = "point_list",
+  TriangleFan = "triangle_fan",
+  TriangleList = "triangle_list",
+  TriangleStrip = "triangle_strip",
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat {
+  R32Float = "r32_float",
+  R32Sint = "r32_sint",
+  R32Uint = "r32_uint",
+  Rg32Float = "rg32_float",
+  Rg32Sint = "rg32_sint",
+  Rg32Uint = "rg32_uint",
+  Rgb32Float = "rgb32_float",
+  Rgb32Sint = "rgb32_sint",
+  Rgb32Uint = "rgb32_uint",
+  Rgba32Float = "rgba32_float",
+  Rgba32Sint = "rgba32_sint",
+  Rgba32Uint = "rgba32_uint",
+  Rgba8Snorm = "rgba8_snorm",
+  Rgba8Unorm = "rgba8_unorm",
+}
+
+export interface EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute {
+  binding: number;
+  format: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat;
+  location: number;
+  offset: number;
+}
+
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate {
+  Instance = "instance",
+  Vertex = "vertex",
+}
+
+export interface EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding {
+  binding: number;
+  input_rate: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate;
+  stride: number;
+}
+
+/**
+ * Depth attachment format. Absent disables depth attachments — the
+ * depth_stencil flags must be consistent (`depth_stencil_enabled = false` when
+ * this is absent).
+ */
+export enum EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat {
+  D16Unorm = "d16_unorm",
+  D24UnormS8Uint = "d24_unorm_s8_uint",
+  D32Sfloat = "d32_sfloat",
+}
+
+/**
+ * Fixed-function pipeline state plus attachment formats for the graphics
+ * pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+ * combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+ * rejected with an `err` response.
+ */
+export interface EscalateRequestRegisterGraphicsKernelPipelineState {
+  /**
+   * Color attachment texture formats (lowercase snake-case names matching
+   * `acquire_texture.format`). v1 supports a single color attachment; arrays of
+   * length other than 1 are rejected.
+   */
+  attachment_color_formats: string[];
+  color_blend_alpha_op: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp;
+  color_blend_color_op: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp;
+  color_blend_dst_alpha_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor;
+  color_blend_dst_color_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor;
+  color_blend_enabled: boolean;
+  color_blend_src_alpha_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor;
+
+  /**
+   * Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+   * value (e.g. `one`) regardless.
+   */
+  color_blend_src_color_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor;
+
+  /**
+   * Color write mask bits — `1=R`, `2=G`, `4=B`, `8=A`. `15` (`0b1111`) writes
+   * RGBA. Used both when blending is disabled and as the blend attachment's
+   * `color_write_mask` when enabled.
+   */
+  color_write_mask: number;
+
+  /**
+   * Depth compare op. Ignored when `depth_stencil_enabled` is false; the
+   * wire field must still carry a valid value (use `always` as the default
+   * placeholder when disabled).
+   */
+  depth_compare_op: EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp;
+  depth_stencil_enabled: boolean;
+  depth_write: boolean;
+
+  /**
+   * Which pipeline state is set dynamically per draw vs baked into the pipeline
+   * at creation. `none` bakes a default 1×1 viewport (offscreen fixed-size
+   * only); `viewport_scissor` lets the same pipeline serve varying extents.
+   */
+  dynamic_state: EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState;
+
+  /**
+   * MSAA sample count. Only `1` is supported in v1; any other value returns an
+   * `err` response.
+   */
+  multisample_samples: number;
+  rasterization_cull_mode: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode;
+  rasterization_front_face: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace;
+  rasterization_line_width: number;
+  rasterization_polygon_mode: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode;
+  topology: EscalateRequestRegisterGraphicsKernelPipelineStateTopology;
+
+  /**
+   * Vertex attributes pulled from the bindings. Must be empty when
+   * `vertex_input_bindings` is empty.
+   */
+  vertex_input_attributes: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute[];
+
+  /**
+   * Vertex buffer binding slots — stride and step rate per binding. Empty
+   * array selects the `VertexInputState::None` (gl_VertexIndex-driven) shape;
+   * non-empty selects `VertexInputState::Buffers` with the given bindings
+   * + attributes.
+   */
+  vertex_input_bindings: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding[];
+
+  /**
+   * Depth attachment format. Absent disables depth attachments — the
+   * depth_stencil flags must be consistent (`depth_stencil_enabled = false`
+   * when this is absent).
+   */
+  attachment_depth_format?: EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat;
+}
+
+export interface EscalateRequestRegisterGraphicsKernel {
+  op: "register_graphics_kernel";
+
+  /**
+   * Descriptor-set-0 bindings the host pipeline declares. Validated against
+   * `rspirv-reflect` of the supplied SPIR-V at register time — mismatches
+   * return an `err` response. Empty array means no bindings.
+   */
+  bindings: EscalateRequestRegisterGraphicsKernelBinding[];
+
+  /**
+   * Depth of the descriptor-set ring. Render-loop callers pass `frame_index ∈
+   * [0, descriptor_sets_in_flight)` per draw. Must be ≥ 1.
+   */
+  descriptor_sets_in_flight: number;
+
+  /**
+   * Entry-point name for the fragment stage. Empty string is normalized to
+   * `"main"` host-side.
+   */
+  fragment_entry_point: string;
+
+  /**
+   * Compiled SPIR-V bytecode for the fragment stage, encoded as lowercase hex.
+   * Today exactly one fragment stage is required (matching the host kernel's
+   * v1 contract).
+   */
+  fragment_spv_hex: string;
+
+  /**
+   * Human-readable label used in error messages and tracing on the host. Echoed
+   * in `kernel_id` derivation only via its bytes — purely diagnostic.
+   */
+  label: string;
+
+  /**
+   * Fixed-function pipeline state plus attachment formats for the graphics
+   * pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+   * combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+   * rejected with an `err` response.
+   */
+  pipeline_state: EscalateRequestRegisterGraphicsKernelPipelineState;
+
+  /**
+   * Push-constant range size in bytes, validated against the merged shader
+   * reflection. Set 0 if the shaders use no push constants.
+   */
+  push_constant_size: number;
+
+  /**
+   * Bitmask of stages the push-constant range is visible to. `1 = VERTEX`, `2 =
+   * FRAGMENT`. Ignored when `push_constant_size == 0`.
+   */
+  push_constant_stages: number;
+
+  /**
+   * Correlates request with response. UUID string.
+   */
+  request_id: string;
+
+  /**
+   * Entry-point name for the vertex stage. Empty string is normalized to
+   * `"main"` host-side.
+   */
+  vertex_entry_point: string;
+
+  /**
+   * Compiled SPIR-V bytecode for the vertex stage, encoded as lowercase hex
+   * (no `0x` prefix, no whitespace). Today exactly one vertex stage is required
+   * (the host kernel rejects zero or multiple vertex stages). Geometry /
+   * tessellation / mesh / task stages are not yet supported.
+   */
+  vertex_spv_hex: string;
+}
+
 export interface EscalateRequestReleaseHandle {
   op: "release_handle";
 
@@ -329,6 +702,184 @@ export interface EscalateRequestRunCpuReadbackCopy {
    * back into u64 by the host before dispatch.
    */
   surface_id: string;
+}
+
+export enum EscalateRequestRunGraphicsDrawBindingKind {
+  SampledTexture = "sampled_texture",
+  StorageBuffer = "storage_buffer",
+  StorageImage = "storage_image",
+  UniformBuffer = "uniform_buffer",
+}
+
+export interface EscalateRequestRunGraphicsDrawBinding {
+  binding: number;
+  kind: EscalateRequestRunGraphicsDrawBindingKind;
+  surface_uuid: string;
+}
+
+export enum EscalateRequestRunGraphicsDrawDrawKind {
+  Draw = "draw",
+  DrawIndexed = "draw_indexed",
+}
+
+/**
+ * Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven), `kind
+ * = "draw_indexed"` requires `index_buffer` to be set and uses `index_count`
+ * / `first_index` / `vertex_offset`. Fields not used by the selected kind are
+ * ignored host-side; subprocesses should still send valid placeholder values
+ * (zero is fine) to keep the wire shape regular.
+ */
+export interface EscalateRequestRunGraphicsDrawDraw {
+  first_index: number;
+  first_instance: number;
+  first_vertex: number;
+  index_count: number;
+  instance_count: number;
+  kind: EscalateRequestRunGraphicsDrawDrawKind;
+  vertex_count: number;
+  vertex_offset: number;
+}
+
+export interface EscalateRequestRunGraphicsDrawVertexBuffer {
+  binding: number;
+  offset: string;
+  surface_uuid: string;
+}
+
+export enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
+  Uint16 = "uint16",
+  Uint32 = "uint32",
+}
+
+/**
+ * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+ * `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+ * into it.
+ */
+export interface EscalateRequestRunGraphicsDrawIndexBuffer {
+  index_type: EscalateRequestRunGraphicsDrawIndexBufferIndexType;
+  offset: string;
+  surface_uuid: string;
+}
+
+/**
+ * Dynamic scissor rect for this draw. Required when the kernel declared
+ * `dynamic_state = "viewport_scissor"`; ignored otherwise.
+ */
+export interface EscalateRequestRunGraphicsDrawScissor {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+/**
+ * Dynamic viewport for this draw. Required when the kernel's pipeline state
+ * declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+ */
+export interface EscalateRequestRunGraphicsDrawViewport {
+  height: number;
+  max_depth: number;
+  min_depth: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+export interface EscalateRequestRunGraphicsDraw {
+  op: "run_graphics_draw";
+
+  /**
+   * Per-draw bindings — each slot's `surface_uuid` must resolve through the
+   * host bridge's UUID → resource map. `kind` must match the binding's declared
+   * kind from register time.
+   */
+  bindings: EscalateRequestRunGraphicsDrawBinding[];
+
+  /**
+   * UUIDs of color attachment textures. v1 requires exactly one entry — multi-
+   * attachment is a future extension. Each UUID must resolve to a host-side
+   * `StreamTexture` registered as a render target.
+   */
+  color_target_uuids: string[];
+
+  /**
+   * Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven),
+   * `kind = "draw_indexed"` requires `index_buffer` to be set and uses
+   * `index_count` / `first_index` / `vertex_offset`. Fields not used by the
+   * selected kind are ignored host-side; subprocesses should still send valid
+   * placeholder values (zero is fine) to keep the wire shape regular.
+   */
+  draw: EscalateRequestRunGraphicsDrawDraw;
+
+  /**
+   * Render-area height in pixels.
+   */
+  extent_height: number;
+
+  /**
+   * Render-area width in pixels.
+   */
+  extent_width: number;
+
+  /**
+   * Slot in the kernel's descriptor-set ring. Must satisfy `frame_index <
+   * descriptor_sets_in_flight` declared at register time. Render-loop callers
+   * cycle this through `MAX_FRAMES_IN_FLIGHT` so concurrent frames don't
+   * scribble each other's bindings.
+   */
+  frame_index: number;
+
+  /**
+   * Handle returned by a prior `register_graphics_kernel` response. The host
+   * looks up the cached `Arc<VulkanGraphicsKernel>` and dispatches against it.
+   * Dispatching with an unrecognized kernel_id returns an `err` response.
+   */
+  kernel_id: string;
+
+  /**
+   * Push-constant payload for this draw, lowercase hex. Must decode to exactly
+   * the kernel's declared `push_constant_size` (or empty if zero).
+   */
+  push_constants_hex: string;
+
+  /**
+   * Correlates request with response. UUID string.
+   */
+  request_id: string;
+
+  /**
+   * Per-draw vertex buffer bindings. Each entry's `surface_uuid` must resolve
+   * to a host-side `RhiPixelBuffer`. `offset` is the byte offset into the
+   * buffer where vertex data starts (decimal-encoded u64 — JTD has no native
+   * u64). Empty for vertex-fabricating shaders (`gl_VertexIndex` patterns).
+   */
+  vertex_buffers: EscalateRequestRunGraphicsDrawVertexBuffer[];
+
+  /**
+   * UUID of a depth attachment texture. Reserved for future use — v1 rejects
+   * depth attachments with an `err` response.
+   */
+  depth_target_uuid?: string;
+
+  /**
+   * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+   * `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+   * into it.
+   */
+  index_buffer?: EscalateRequestRunGraphicsDrawIndexBuffer;
+
+  /**
+   * Dynamic scissor rect for this draw. Required when the kernel declared
+   * `dynamic_state = "viewport_scissor"`; ignored otherwise.
+   */
+  scissor?: EscalateRequestRunGraphicsDrawScissor;
+
+  /**
+   * Dynamic viewport for this draw. Required when the kernel's pipeline state
+   * declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+   */
+  viewport?: EscalateRequestRunGraphicsDrawViewport;
 }
 
 /**

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -27,7 +27,10 @@
  *    customers driving Vulkan directly.
  */
 
-import { getChannel as getEscalateChannel } from "../escalate.ts";
+import {
+  EscalateRequestRunGraphicsDrawDrawKind,
+  getChannel as getEscalateChannel,
+} from "../escalate.ts";
 import {
   STREAMLIB_ADAPTER_ABI_VERSION,
   type StreamlibSurface,
@@ -167,6 +170,15 @@ export class VulkanContext {
    * IPC payload is sent again).
    */
   private readonly computeKernelIds = new WeakMap<Uint8Array, string>();
+  /** Identity-keyed graphics kernel-id cache. Composite keys (vertex
+   * SPIR-V + fragment SPIR-V) require a 2-level WeakMap: the outer
+   * keyed on the vertex Uint8Array, the inner keyed on the fragment
+   * Uint8Array. Same auto-clearing semantics as the compute cache.
+   */
+  private readonly graphicsKernelIds = new WeakMap<
+    Uint8Array,
+    WeakMap<Uint8Array, string>
+  >();
   private readonly resolvedHandles = new Map<
     string,
     ReturnType<VulkanGpuLimitedAccess["resolveSurface"]>
@@ -446,6 +458,111 @@ export class VulkanContext {
       groupCountY,
       groupCountZ,
     );
+  }
+
+  /** Dispatch a graphics draw against the surface's host-side
+   * `VkImage` via escalate IPC. The surface MUST currently be held
+   * in WRITE mode (call inside an `acquireWrite` `using` block).
+   *
+   * On the first call with a given `(vertexSpv, fragmentSpv)` pair
+   * this registers the kernel through escalate IPC; subsequent
+   * calls with the same `Uint8Array` references hit the local
+   * kernel-id cache and skip registration.
+   *
+   * `bindings` is the per-draw binding-value list (slot →
+   * `surface_uuid`); `bindingDecls` is the register-time binding
+   * declaration validated against SPIR-V reflection on the host.
+   * Both default to empty arrays for fullscreen-triangle / first-
+   * render shapes that use neither textures nor uniform buffers.
+   *
+   * Graphics dispatch is synchronous host-side: when this resolves,
+   * the host's writes to the color target are visible to subsequent
+   * submissions.
+   */
+  async dispatchGraphics(args: {
+    colorTarget: StreamlibSurface | string | bigint;
+    vertexSpv: Uint8Array;
+    fragmentSpv: Uint8Array;
+    pipelineState: import("../escalate.ts").EscalateRequestRegisterGraphicsKernelPipelineState;
+    bindings?: readonly import("../escalate.ts").EscalateRequestRunGraphicsDrawBinding[];
+    bindingDecls?: readonly import("../escalate.ts").EscalateRequestRegisterGraphicsKernelBinding[];
+    vertexBuffers?: readonly import("../escalate.ts").EscalateRequestRunGraphicsDrawVertexBuffer[];
+    pushConstants?: Uint8Array;
+    pushConstantStages?: number;
+    descriptorSetsInFlight?: number;
+    frameIndex?: number;
+    indexBuffer?: import("../escalate.ts").EscalateRequestRunGraphicsDrawIndexBuffer;
+    depthTargetUuid?: string;
+    viewport?: import("../escalate.ts").EscalateRequestRunGraphicsDrawViewport;
+    scissor?: import("../escalate.ts").EscalateRequestRunGraphicsDrawScissor;
+    draw?: import("../escalate.ts").EscalateRequestRunGraphicsDrawDraw;
+    label?: string;
+    extentWidth: number;
+    extentHeight: number;
+  }): Promise<void> {
+    const poolId = VulkanContext.surfacePoolId(args.colorTarget);
+    const cached = this.surfaceIds.get(poolId);
+    if (cached === undefined) {
+      throw new Error(
+        `VulkanContext.dispatchGraphics: surface '${poolId}' is not registered ` +
+          "— call acquireWrite inside a `using` block first.",
+      );
+    }
+    const ch = getEscalateChannel();
+    const pushConstants = args.pushConstants ?? new Uint8Array();
+
+    // Identity-keyed two-level WeakMap lookup keeps the hot path O(1)
+    // per dispatch — no hashing, no copying.
+    let inner = this.graphicsKernelIds.get(args.vertexSpv);
+    let kernelId = inner?.get(args.fragmentSpv);
+    if (kernelId === undefined) {
+      const response = await ch.registerGraphicsKernel({
+        label: args.label ?? "polyglot-graphics",
+        vertexSpv: args.vertexSpv,
+        fragmentSpv: args.fragmentSpv,
+        bindings: args.bindingDecls ?? [],
+        pushConstantSize: pushConstants.byteLength,
+        pushConstantStages: args.pushConstantStages ?? 0,
+        descriptorSetsInFlight: args.descriptorSetsInFlight ?? 2,
+        pipelineState: args.pipelineState,
+      });
+      kernelId = response.handle_id;
+      if (inner === undefined) {
+        inner = new WeakMap<Uint8Array, string>();
+        this.graphicsKernelIds.set(args.vertexSpv, inner);
+      }
+      inner.set(args.fragmentSpv, kernelId);
+    }
+
+    // Default to a 3-vertex non-indexed draw for first-render shapes.
+    const draw: import("../escalate.ts").EscalateRequestRunGraphicsDrawDraw =
+      args.draw ?? {
+        kind: EscalateRequestRunGraphicsDrawDrawKind.Draw,
+        vertex_count: 3,
+        instance_count: 1,
+        first_vertex: 0,
+        first_instance: 0,
+        index_count: 0,
+        first_index: 0,
+        vertex_offset: 0,
+      };
+
+    void cached;
+    await ch.runGraphicsDraw({
+      kernelId,
+      frameIndex: args.frameIndex ?? 0,
+      bindings: args.bindings ?? [],
+      vertexBuffers: args.vertexBuffers ?? [],
+      colorTargetUuids: [poolId],
+      extentWidth: Math.trunc(args.extentWidth),
+      extentHeight: Math.trunc(args.extentHeight),
+      pushConstants,
+      draw,
+      indexBuffer: args.indexBuffer,
+      depthTargetUuid: args.depthTargetUuid,
+      viewport: args.viewport,
+      scissor: args.scissor,
+    });
   }
 
   /** Return the cdylib runtime's raw Vulkan handles — same shape as

--- a/libs/streamlib-deno/escalate.ts
+++ b/libs/streamlib-deno/escalate.ts
@@ -23,13 +23,24 @@ import type {
   EscalateRequestAcquireTexture,
   EscalateRequestLog,
   EscalateRequestRegisterComputeKernel,
+  EscalateRequestRegisterGraphicsKernel,
+  EscalateRequestRegisterGraphicsKernelBinding,
+  EscalateRequestRegisterGraphicsKernelPipelineState,
   EscalateRequestReleaseHandle,
   EscalateRequestRunComputeKernel,
   EscalateRequestRunCpuReadbackCopy,
+  EscalateRequestRunGraphicsDraw,
+  EscalateRequestRunGraphicsDrawBinding,
+  EscalateRequestRunGraphicsDrawDraw,
+  EscalateRequestRunGraphicsDrawIndexBuffer,
+  EscalateRequestRunGraphicsDrawScissor,
+  EscalateRequestRunGraphicsDrawVertexBuffer,
+  EscalateRequestRunGraphicsDrawViewport,
   EscalateRequestTryRunCpuReadbackCopy,
 } from "./_generated_/com_streamlib_escalate_request.ts";
 import {
   EscalateRequestRunCpuReadbackCopyDirection,
+  EscalateRequestRunGraphicsDrawDrawKind,
   EscalateRequestTryRunCpuReadbackCopyDirection,
 } from "./_generated_/com_streamlib_escalate_request.ts";
 import type {
@@ -46,9 +57,19 @@ export type {
   EscalateRequestAcquireTexture,
   EscalateRequestLog,
   EscalateRequestRegisterComputeKernel,
+  EscalateRequestRegisterGraphicsKernel,
+  EscalateRequestRegisterGraphicsKernelBinding,
+  EscalateRequestRegisterGraphicsKernelPipelineState,
   EscalateRequestReleaseHandle,
   EscalateRequestRunComputeKernel,
   EscalateRequestRunCpuReadbackCopy,
+  EscalateRequestRunGraphicsDraw,
+  EscalateRequestRunGraphicsDrawBinding,
+  EscalateRequestRunGraphicsDrawDraw,
+  EscalateRequestRunGraphicsDrawIndexBuffer,
+  EscalateRequestRunGraphicsDrawScissor,
+  EscalateRequestRunGraphicsDrawVertexBuffer,
+  EscalateRequestRunGraphicsDrawViewport,
   EscalateRequestTryRunCpuReadbackCopy,
   EscalateResponse,
   EscalateResponseContended,
@@ -57,6 +78,7 @@ export type {
 };
 export {
   EscalateRequestRunCpuReadbackCopyDirection,
+  EscalateRequestRunGraphicsDrawDrawKind,
   EscalateRequestTryRunCpuReadbackCopyDirection,
 };
 
@@ -88,9 +110,11 @@ export type EscalateOpPayload =
   | Omit<EscalateRequestAcquirePixelBuffer, "request_id">
   | Omit<EscalateRequestAcquireTexture, "request_id">
   | Omit<EscalateRequestRegisterComputeKernel, "request_id">
+  | Omit<EscalateRequestRegisterGraphicsKernel, "request_id">
   | Omit<EscalateRequestReleaseHandle, "request_id">
   | Omit<EscalateRequestRunComputeKernel, "request_id">
   | Omit<EscalateRequestRunCpuReadbackCopy, "request_id">
+  | Omit<EscalateRequestRunGraphicsDraw, "request_id">
   | Omit<EscalateRequestTryRunCpuReadbackCopy, "request_id">;
 
 /**
@@ -276,6 +300,99 @@ export class EscalateChannel {
       group_count_y: Math.trunc(groupCountY),
       group_count_z: Math.trunc(groupCountZ),
     }) as EscalateOkResponse;
+  }
+
+  /**
+   * Register a graphics kernel on the host. Resolves to the
+   * `ok`-payload whose `handle_id` is the bridge-assigned kernel_id
+   * (typically a stable hash over a canonical representation of all
+   * register-time inputs — re-registering an identical descriptor hits
+   * the host-side cache and returns the same id).
+   *
+   * `vertexSpv` and `fragmentSpv` are raw SPIR-V bytes. The host
+   * derives the binding shape from `rspirv-reflect`, validates the
+   * declared `bindings` match the merged shader declaration, and
+   * persists driver-compiled pipeline state to the same on-disk
+   * pipeline cache compute uses.
+   */
+  async registerGraphicsKernel(args: {
+    label: string;
+    vertexSpv: Uint8Array;
+    fragmentSpv: Uint8Array;
+    bindings: readonly EscalateRequestRegisterGraphicsKernelBinding[];
+    pushConstantSize: number;
+    pushConstantStages: number;
+    descriptorSetsInFlight: number;
+    pipelineState: EscalateRequestRegisterGraphicsKernelPipelineState;
+    vertexEntryPoint?: string;
+    fragmentEntryPoint?: string;
+  }): Promise<EscalateOkResponse> {
+    return await this.request({
+      op: "register_graphics_kernel",
+      label: args.label,
+      vertex_spv_hex: bytesToHex(args.vertexSpv),
+      fragment_spv_hex: bytesToHex(args.fragmentSpv),
+      vertex_entry_point: args.vertexEntryPoint ?? "main",
+      fragment_entry_point: args.fragmentEntryPoint ?? "main",
+      bindings: [...args.bindings],
+      push_constant_size: Math.trunc(args.pushConstantSize),
+      push_constant_stages: Math.trunc(args.pushConstantStages),
+      descriptor_sets_in_flight: Math.trunc(args.descriptorSetsInFlight),
+      pipeline_state: args.pipelineState,
+    }) as EscalateOkResponse;
+  }
+
+  /**
+   * Issue one draw against a previously-registered graphics kernel.
+   *
+   * Graphics dispatch is synchronous host-side: this resolves once
+   * the host's own command buffer + fence have retired and the host's
+   * writes to the color attachments are visible to subsequent
+   * submissions. `frameIndex` indexes the kernel's descriptor-set
+   * ring (`0 ≤ frameIndex < descriptorSetsInFlight`).
+   */
+  async runGraphicsDraw(args: {
+    kernelId: string;
+    frameIndex: number;
+    bindings: readonly EscalateRequestRunGraphicsDrawBinding[];
+    vertexBuffers: readonly EscalateRequestRunGraphicsDrawVertexBuffer[];
+    colorTargetUuids: readonly string[];
+    extentWidth: number;
+    extentHeight: number;
+    pushConstants: Uint8Array;
+    draw: EscalateRequestRunGraphicsDrawDraw;
+    indexBuffer?: EscalateRequestRunGraphicsDrawIndexBuffer;
+    depthTargetUuid?: string;
+    viewport?: EscalateRequestRunGraphicsDrawViewport;
+    scissor?: EscalateRequestRunGraphicsDrawScissor;
+  }): Promise<EscalateOkResponse> {
+    const payload = {
+      op: "run_graphics_draw" as const,
+      kernel_id: args.kernelId,
+      frame_index: Math.trunc(args.frameIndex),
+      bindings: [...args.bindings],
+      vertex_buffers: [...args.vertexBuffers],
+      color_target_uuids: [...args.colorTargetUuids],
+      extent_width: Math.trunc(args.extentWidth),
+      extent_height: Math.trunc(args.extentHeight),
+      push_constants_hex: bytesToHex(args.pushConstants),
+      draw: args.draw,
+    } as Record<string, unknown>;
+    if (args.indexBuffer !== undefined) {
+      payload.index_buffer = args.indexBuffer;
+    }
+    if (args.depthTargetUuid !== undefined) {
+      payload.depth_target_uuid = args.depthTargetUuid;
+    }
+    if (args.viewport !== undefined) {
+      payload.viewport = args.viewport;
+    }
+    if (args.scissor !== undefined) {
+      payload.scissor = args.scissor;
+    }
+    return await this.request(
+      payload as unknown as EscalateOpPayload,
+    ) as EscalateOkResponse;
   }
 
   async releaseHandle(handleId: string): Promise<EscalateOkResponse> {

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -28,9 +28,11 @@ class EscalateRequest:
             "acquire_texture": EscalateRequestAcquireTexture,
             "log": EscalateRequestLog,
             "register_compute_kernel": EscalateRequestRegisterComputeKernel,
+            "register_graphics_kernel": EscalateRequestRegisterGraphicsKernel,
             "release_handle": EscalateRequestReleaseHandle,
             "run_compute_kernel": EscalateRequestRunComputeKernel,
             "run_cpu_readback_copy": EscalateRequestRunCPUReadbackCopy,
+            "run_graphics_draw": EscalateRequestRunGraphicsDraw,
             "try_run_cpu_readback_copy": EscalateRequestTryRunCPUReadbackCopy,
         }
 
@@ -358,6 +360,598 @@ class EscalateRequestRegisterComputeKernel(EscalateRequest):
         data["spv_hex"] = _to_json_data(self.spv_hex)
         return data
 
+class EscalateRequestRegisterGraphicsKernelBindingKind(Enum):
+    """
+    Resource kind for this binding slot.
+    """
+
+    SAMPLED_TEXTURE = "sampled_texture"
+    STORAGE_BUFFER = "storage_buffer"
+    STORAGE_IMAGE = "storage_image"
+    UNIFORM_BUFFER = "uniform_buffer"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelBindingKind':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRegisterGraphicsKernelBinding:
+    binding: 'int'
+    kind: 'EscalateRequestRegisterGraphicsKernelBindingKind'
+    """
+    Resource kind for this binding slot.
+    """
+
+    stages: 'int'
+    """
+    Bitmask of stages the binding is visible to. `1 = VERTEX`, `2 = FRAGMENT`,
+    `3 = VERTEX_FRAGMENT`.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelBinding':
+        return cls(
+            _from_json_data(int, data.get("binding")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelBindingKind, data.get("kind")),
+            _from_json_data(int, data.get("stages")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["binding"] = _to_json_data(self.binding)
+        data["kind"] = _to_json_data(self.kind)
+        data["stages"] = _to_json_data(self.stages)
+        return data
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp(Enum):
+    ADD = "add"
+    MAX = "max"
+    MIN = "min"
+    REVERSE_SUBTRACT = "reverse_subtract"
+    SUBTRACT = "subtract"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp(Enum):
+    ADD = "add"
+    MAX = "max"
+    MIN = "min"
+    REVERSE_SUBTRACT = "reverse_subtract"
+    SUBTRACT = "subtract"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor(Enum):
+    CONSTANT_ALPHA = "constant_alpha"
+    CONSTANT_COLOR = "constant_color"
+    DST_ALPHA = "dst_alpha"
+    DST_COLOR = "dst_color"
+    ONE = "one"
+    ONE_MINUS_CONSTANT_ALPHA = "one_minus_constant_alpha"
+    ONE_MINUS_CONSTANT_COLOR = "one_minus_constant_color"
+    ONE_MINUS_DST_ALPHA = "one_minus_dst_alpha"
+    ONE_MINUS_DST_COLOR = "one_minus_dst_color"
+    ONE_MINUS_SRC_ALPHA = "one_minus_src_alpha"
+    ONE_MINUS_SRC_COLOR = "one_minus_src_color"
+    SRC_ALPHA = "src_alpha"
+    SRC_ALPHA_SATURATE = "src_alpha_saturate"
+    SRC_COLOR = "src_color"
+    ZERO = "zero"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor(Enum):
+    CONSTANT_ALPHA = "constant_alpha"
+    CONSTANT_COLOR = "constant_color"
+    DST_ALPHA = "dst_alpha"
+    DST_COLOR = "dst_color"
+    ONE = "one"
+    ONE_MINUS_CONSTANT_ALPHA = "one_minus_constant_alpha"
+    ONE_MINUS_CONSTANT_COLOR = "one_minus_constant_color"
+    ONE_MINUS_DST_ALPHA = "one_minus_dst_alpha"
+    ONE_MINUS_DST_COLOR = "one_minus_dst_color"
+    ONE_MINUS_SRC_ALPHA = "one_minus_src_alpha"
+    ONE_MINUS_SRC_COLOR = "one_minus_src_color"
+    SRC_ALPHA = "src_alpha"
+    SRC_ALPHA_SATURATE = "src_alpha_saturate"
+    SRC_COLOR = "src_color"
+    ZERO = "zero"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor(Enum):
+    CONSTANT_ALPHA = "constant_alpha"
+    CONSTANT_COLOR = "constant_color"
+    DST_ALPHA = "dst_alpha"
+    DST_COLOR = "dst_color"
+    ONE = "one"
+    ONE_MINUS_CONSTANT_ALPHA = "one_minus_constant_alpha"
+    ONE_MINUS_CONSTANT_COLOR = "one_minus_constant_color"
+    ONE_MINUS_DST_ALPHA = "one_minus_dst_alpha"
+    ONE_MINUS_DST_COLOR = "one_minus_dst_color"
+    ONE_MINUS_SRC_ALPHA = "one_minus_src_alpha"
+    ONE_MINUS_SRC_COLOR = "one_minus_src_color"
+    SRC_ALPHA = "src_alpha"
+    SRC_ALPHA_SATURATE = "src_alpha_saturate"
+    SRC_COLOR = "src_color"
+    ZERO = "zero"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor(Enum):
+    """
+    Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+    value (e.g. `one`) regardless.
+    """
+
+    CONSTANT_ALPHA = "constant_alpha"
+    CONSTANT_COLOR = "constant_color"
+    DST_ALPHA = "dst_alpha"
+    DST_COLOR = "dst_color"
+    ONE = "one"
+    ONE_MINUS_CONSTANT_ALPHA = "one_minus_constant_alpha"
+    ONE_MINUS_CONSTANT_COLOR = "one_minus_constant_color"
+    ONE_MINUS_DST_ALPHA = "one_minus_dst_alpha"
+    ONE_MINUS_DST_COLOR = "one_minus_dst_color"
+    ONE_MINUS_SRC_ALPHA = "one_minus_src_alpha"
+    ONE_MINUS_SRC_COLOR = "one_minus_src_color"
+    SRC_ALPHA = "src_alpha"
+    SRC_ALPHA_SATURATE = "src_alpha_saturate"
+    SRC_COLOR = "src_color"
+    ZERO = "zero"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp(Enum):
+    """
+    Depth compare op. Ignored when `depth_stencil_enabled` is false; the
+    wire field must still carry a valid value (use `always` as the default
+    placeholder when disabled).
+    """
+
+    ALWAYS = "always"
+    EQUAL = "equal"
+    GREATER = "greater"
+    GREATER_OR_EQUAL = "greater_or_equal"
+    LESS = "less"
+    LESS_OR_EQUAL = "less_or_equal"
+    NEVER = "never"
+    NOT_EQUAL = "not_equal"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState(Enum):
+    """
+    Which pipeline state is set dynamically per draw vs baked into the pipeline
+    at creation. `none` bakes a default 1×1 viewport (offscreen fixed-size
+    only); `viewport_scissor` lets the same pipeline serve varying extents.
+    """
+
+    NONE = "none"
+    VIEWPORT_SCISSOR = "viewport_scissor"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode(Enum):
+    BACK = "back"
+    FRONT = "front"
+    FRONT_AND_BACK = "front_and_back"
+    NONE = "none"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace(Enum):
+    CLOCKWISE = "clockwise"
+    COUNTER_CLOCKWISE = "counter_clockwise"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode(Enum):
+    FILL = "fill"
+    LINE = "line"
+    POINT = "point"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateTopology(Enum):
+    LINE_LIST = "line_list"
+    LINE_STRIP = "line_strip"
+    POINT_LIST = "point_list"
+    TRIANGLE_FAN = "triangle_fan"
+    TRIANGLE_LIST = "triangle_list"
+    TRIANGLE_STRIP = "triangle_strip"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateTopology':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat(Enum):
+    R32_FLOAT = "r32_float"
+    R32_SINT = "r32_sint"
+    R32_UINT = "r32_uint"
+    RG32_FLOAT = "rg32_float"
+    RG32_SINT = "rg32_sint"
+    RG32_UINT = "rg32_uint"
+    RGB32_FLOAT = "rgb32_float"
+    RGB32_SINT = "rgb32_sint"
+    RGB32_UINT = "rgb32_uint"
+    RGBA32_FLOAT = "rgba32_float"
+    RGBA32_SINT = "rgba32_sint"
+    RGBA32_UINT = "rgba32_uint"
+    RGBA8_SNORM = "rgba8_snorm"
+    RGBA8_UNORM = "rgba8_unorm"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute:
+    binding: 'int'
+    format: 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat'
+    location: 'int'
+    offset: 'int'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute':
+        return cls(
+            _from_json_data(int, data.get("binding")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat, data.get("format")),
+            _from_json_data(int, data.get("location")),
+            _from_json_data(int, data.get("offset")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["binding"] = _to_json_data(self.binding)
+        data["format"] = _to_json_data(self.format)
+        data["location"] = _to_json_data(self.location)
+        data["offset"] = _to_json_data(self.offset)
+        return data
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate(Enum):
+    INSTANCE = "instance"
+    VERTEX = "vertex"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding:
+    binding: 'int'
+    input_rate: 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate'
+    stride: 'int'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding':
+        return cls(
+            _from_json_data(int, data.get("binding")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate, data.get("input_rate")),
+            _from_json_data(int, data.get("stride")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["binding"] = _to_json_data(self.binding)
+        data["input_rate"] = _to_json_data(self.input_rate)
+        data["stride"] = _to_json_data(self.stride)
+        return data
+
+class EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat(Enum):
+    """
+    Depth attachment format. Absent disables depth attachments — the
+    depth_stencil flags must be consistent (`depth_stencil_enabled = false` when
+    this is absent).
+    """
+
+    D16_UNORM = "d16_unorm"
+    D24_UNORM_S8_UINT = "d24_unorm_s8_uint"
+    D32_SFLOAT = "d32_sfloat"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRegisterGraphicsKernelPipelineState:
+    """
+    Fixed-function pipeline state plus attachment formats for the graphics
+    pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+    combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+    rejected with an `err` response.
+    """
+
+    attachment_color_formats: 'List[str]'
+    """
+    Color attachment texture formats (lowercase snake-case names matching
+    `acquire_texture.format`). v1 supports a single color attachment; arrays of
+    length other than 1 are rejected.
+    """
+
+    color_blend_alpha_op: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp'
+    color_blend_color_op: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp'
+    color_blend_dst_alpha_factor: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor'
+    color_blend_dst_color_factor: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor'
+    color_blend_enabled: 'bool'
+    color_blend_src_alpha_factor: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor'
+    color_blend_src_color_factor: 'EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor'
+    """
+    Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+    value (e.g. `one`) regardless.
+    """
+
+    color_write_mask: 'int'
+    """
+    Color write mask bits — `1=R`, `2=G`, `4=B`, `8=A`. `15` (`0b1111`) writes
+    RGBA. Used both when blending is disabled and as the blend attachment's
+    `color_write_mask` when enabled.
+    """
+
+    depth_compare_op: 'EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp'
+    """
+    Depth compare op. Ignored when `depth_stencil_enabled` is false; the
+    wire field must still carry a valid value (use `always` as the default
+    placeholder when disabled).
+    """
+
+    depth_stencil_enabled: 'bool'
+    depth_write: 'bool'
+    dynamic_state: 'EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState'
+    """
+    Which pipeline state is set dynamically per draw vs baked into the pipeline
+    at creation. `none` bakes a default 1×1 viewport (offscreen fixed-size
+    only); `viewport_scissor` lets the same pipeline serve varying extents.
+    """
+
+    multisample_samples: 'int'
+    """
+    MSAA sample count. Only `1` is supported in v1; any other value returns an
+    `err` response.
+    """
+
+    rasterization_cull_mode: 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode'
+    rasterization_front_face: 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace'
+    rasterization_line_width: 'float'
+    rasterization_polygon_mode: 'EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode'
+    topology: 'EscalateRequestRegisterGraphicsKernelPipelineStateTopology'
+    vertex_input_attributes: 'List[EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute]'
+    """
+    Vertex attributes pulled from the bindings. Must be empty when
+    `vertex_input_bindings` is empty.
+    """
+
+    vertex_input_bindings: 'List[EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding]'
+    """
+    Vertex buffer binding slots — stride and step rate per binding. Empty
+    array selects the `VertexInputState::None` (gl_VertexIndex-driven) shape;
+    non-empty selects `VertexInputState::Buffers` with the given bindings
+    + attributes.
+    """
+
+    attachment_depth_format: 'Optional[EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat]'
+    """
+    Depth attachment format. Absent disables depth attachments — the
+    depth_stencil flags must be consistent (`depth_stencil_enabled = false` when
+    this is absent).
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernelPipelineState':
+        return cls(
+            _from_json_data(List[str], data.get("attachment_color_formats")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp, data.get("color_blend_alpha_op")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp, data.get("color_blend_color_op")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor, data.get("color_blend_dst_alpha_factor")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor, data.get("color_blend_dst_color_factor")),
+            _from_json_data(bool, data.get("color_blend_enabled")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor, data.get("color_blend_src_alpha_factor")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor, data.get("color_blend_src_color_factor")),
+            _from_json_data(int, data.get("color_write_mask")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp, data.get("depth_compare_op")),
+            _from_json_data(bool, data.get("depth_stencil_enabled")),
+            _from_json_data(bool, data.get("depth_write")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState, data.get("dynamic_state")),
+            _from_json_data(int, data.get("multisample_samples")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode, data.get("rasterization_cull_mode")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace, data.get("rasterization_front_face")),
+            _from_json_data(float, data.get("rasterization_line_width")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode, data.get("rasterization_polygon_mode")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineStateTopology, data.get("topology")),
+            _from_json_data(List[EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute], data.get("vertex_input_attributes")),
+            _from_json_data(List[EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding], data.get("vertex_input_bindings")),
+            _from_json_data(Optional[EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat], data.get("attachment_depth_format")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["attachment_color_formats"] = _to_json_data(self.attachment_color_formats)
+        data["color_blend_alpha_op"] = _to_json_data(self.color_blend_alpha_op)
+        data["color_blend_color_op"] = _to_json_data(self.color_blend_color_op)
+        data["color_blend_dst_alpha_factor"] = _to_json_data(self.color_blend_dst_alpha_factor)
+        data["color_blend_dst_color_factor"] = _to_json_data(self.color_blend_dst_color_factor)
+        data["color_blend_enabled"] = _to_json_data(self.color_blend_enabled)
+        data["color_blend_src_alpha_factor"] = _to_json_data(self.color_blend_src_alpha_factor)
+        data["color_blend_src_color_factor"] = _to_json_data(self.color_blend_src_color_factor)
+        data["color_write_mask"] = _to_json_data(self.color_write_mask)
+        data["depth_compare_op"] = _to_json_data(self.depth_compare_op)
+        data["depth_stencil_enabled"] = _to_json_data(self.depth_stencil_enabled)
+        data["depth_write"] = _to_json_data(self.depth_write)
+        data["dynamic_state"] = _to_json_data(self.dynamic_state)
+        data["multisample_samples"] = _to_json_data(self.multisample_samples)
+        data["rasterization_cull_mode"] = _to_json_data(self.rasterization_cull_mode)
+        data["rasterization_front_face"] = _to_json_data(self.rasterization_front_face)
+        data["rasterization_line_width"] = _to_json_data(self.rasterization_line_width)
+        data["rasterization_polygon_mode"] = _to_json_data(self.rasterization_polygon_mode)
+        data["topology"] = _to_json_data(self.topology)
+        data["vertex_input_attributes"] = _to_json_data(self.vertex_input_attributes)
+        data["vertex_input_bindings"] = _to_json_data(self.vertex_input_bindings)
+        if self.attachment_depth_format is not None:
+             data["attachment_depth_format"] = _to_json_data(self.attachment_depth_format)
+        return data
+
+@dataclass
+class EscalateRequestRegisterGraphicsKernel(EscalateRequest):
+    bindings: 'List[EscalateRequestRegisterGraphicsKernelBinding]'
+    """
+    Descriptor-set-0 bindings the host pipeline declares. Validated against
+    `rspirv-reflect` of the supplied SPIR-V at register time — mismatches return
+    an `err` response. Empty array means no bindings.
+    """
+
+    descriptor_sets_in_flight: 'int'
+    """
+    Depth of the descriptor-set ring. Render-loop callers pass `frame_index ∈
+    [0, descriptor_sets_in_flight)` per draw. Must be ≥ 1.
+    """
+
+    fragment_entry_point: 'str'
+    """
+    Entry-point name for the fragment stage. Empty string is normalized to
+    `"main"` host-side.
+    """
+
+    fragment_spv_hex: 'str'
+    """
+    Compiled SPIR-V bytecode for the fragment stage, encoded as lowercase hex.
+    Today exactly one fragment stage is required (matching the host kernel's
+    v1 contract).
+    """
+
+    label: 'str'
+    """
+    Human-readable label used in error messages and tracing on the host. Echoed
+    in `kernel_id` derivation only via its bytes — purely diagnostic.
+    """
+
+    pipeline_state: 'EscalateRequestRegisterGraphicsKernelPipelineState'
+    """
+    Fixed-function pipeline state plus attachment formats for the graphics
+    pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+    combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+    rejected with an `err` response.
+    """
+
+    push_constant_size: 'int'
+    """
+    Push-constant range size in bytes, validated against the merged shader
+    reflection. Set 0 if the shaders use no push constants.
+    """
+
+    push_constant_stages: 'int'
+    """
+    Bitmask of stages the push-constant range is visible to. `1 = VERTEX`, `2 =
+    FRAGMENT`. Ignored when `push_constant_size == 0`.
+    """
+
+    request_id: 'str'
+    """
+    Correlates request with response. UUID string.
+    """
+
+    vertex_entry_point: 'str'
+    """
+    Entry-point name for the vertex stage. Empty string is normalized to
+    `"main"` host-side.
+    """
+
+    vertex_spv_hex: 'str'
+    """
+    Compiled SPIR-V bytecode for the vertex stage, encoded as lowercase hex (no
+    `0x` prefix, no whitespace). Today exactly one vertex stage is required (the
+    host kernel rejects zero or multiple vertex stages). Geometry / tessellation
+    / mesh / task stages are not yet supported.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRegisterGraphicsKernel':
+        return cls(
+            "register_graphics_kernel",
+            _from_json_data(List[EscalateRequestRegisterGraphicsKernelBinding], data.get("bindings")),
+            _from_json_data(int, data.get("descriptor_sets_in_flight")),
+            _from_json_data(str, data.get("fragment_entry_point")),
+            _from_json_data(str, data.get("fragment_spv_hex")),
+            _from_json_data(str, data.get("label")),
+            _from_json_data(EscalateRequestRegisterGraphicsKernelPipelineState, data.get("pipeline_state")),
+            _from_json_data(int, data.get("push_constant_size")),
+            _from_json_data(int, data.get("push_constant_stages")),
+            _from_json_data(str, data.get("request_id")),
+            _from_json_data(str, data.get("vertex_entry_point")),
+            _from_json_data(str, data.get("vertex_spv_hex")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "register_graphics_kernel" }
+        data["bindings"] = _to_json_data(self.bindings)
+        data["descriptor_sets_in_flight"] = _to_json_data(self.descriptor_sets_in_flight)
+        data["fragment_entry_point"] = _to_json_data(self.fragment_entry_point)
+        data["fragment_spv_hex"] = _to_json_data(self.fragment_spv_hex)
+        data["label"] = _to_json_data(self.label)
+        data["pipeline_state"] = _to_json_data(self.pipeline_state)
+        data["push_constant_size"] = _to_json_data(self.push_constant_size)
+        data["push_constant_stages"] = _to_json_data(self.push_constant_stages)
+        data["request_id"] = _to_json_data(self.request_id)
+        data["vertex_entry_point"] = _to_json_data(self.vertex_entry_point)
+        data["vertex_spv_hex"] = _to_json_data(self.vertex_spv_hex)
+        return data
+
 @dataclass
 class EscalateRequestReleaseHandle(EscalateRequest):
     handle_id: 'str'
@@ -522,6 +1116,352 @@ class EscalateRequestRunCPUReadbackCopy(EscalateRequest):
         data["direction"] = _to_json_data(self.direction)
         data["request_id"] = _to_json_data(self.request_id)
         data["surface_id"] = _to_json_data(self.surface_id)
+        return data
+
+class EscalateRequestRunGraphicsDrawBindingKind(Enum):
+    SAMPLED_TEXTURE = "sampled_texture"
+    STORAGE_BUFFER = "storage_buffer"
+    STORAGE_IMAGE = "storage_image"
+    UNIFORM_BUFFER = "uniform_buffer"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawBindingKind':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRunGraphicsDrawBinding:
+    binding: 'int'
+    kind: 'EscalateRequestRunGraphicsDrawBindingKind'
+    surface_uuid: 'str'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawBinding':
+        return cls(
+            _from_json_data(int, data.get("binding")),
+            _from_json_data(EscalateRequestRunGraphicsDrawBindingKind, data.get("kind")),
+            _from_json_data(str, data.get("surface_uuid")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["binding"] = _to_json_data(self.binding)
+        data["kind"] = _to_json_data(self.kind)
+        data["surface_uuid"] = _to_json_data(self.surface_uuid)
+        return data
+
+class EscalateRequestRunGraphicsDrawDrawKind(Enum):
+    DRAW = "draw"
+    DRAW_INDEXED = "draw_indexed"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawDrawKind':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRunGraphicsDrawDraw:
+    """
+    Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven),
+    `kind = "draw_indexed"` requires `index_buffer` to be set and uses
+    `index_count` / `first_index` / `vertex_offset`. Fields not used by the
+    selected kind are ignored host-side; subprocesses should still send valid
+    placeholder values (zero is fine) to keep the wire shape regular.
+    """
+
+    first_index: 'int'
+    first_instance: 'int'
+    first_vertex: 'int'
+    index_count: 'int'
+    instance_count: 'int'
+    kind: 'EscalateRequestRunGraphicsDrawDrawKind'
+    vertex_count: 'int'
+    vertex_offset: 'int'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawDraw':
+        return cls(
+            _from_json_data(int, data.get("first_index")),
+            _from_json_data(int, data.get("first_instance")),
+            _from_json_data(int, data.get("first_vertex")),
+            _from_json_data(int, data.get("index_count")),
+            _from_json_data(int, data.get("instance_count")),
+            _from_json_data(EscalateRequestRunGraphicsDrawDrawKind, data.get("kind")),
+            _from_json_data(int, data.get("vertex_count")),
+            _from_json_data(int, data.get("vertex_offset")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["first_index"] = _to_json_data(self.first_index)
+        data["first_instance"] = _to_json_data(self.first_instance)
+        data["first_vertex"] = _to_json_data(self.first_vertex)
+        data["index_count"] = _to_json_data(self.index_count)
+        data["instance_count"] = _to_json_data(self.instance_count)
+        data["kind"] = _to_json_data(self.kind)
+        data["vertex_count"] = _to_json_data(self.vertex_count)
+        data["vertex_offset"] = _to_json_data(self.vertex_offset)
+        return data
+
+@dataclass
+class EscalateRequestRunGraphicsDrawVertexBuffer:
+    binding: 'int'
+    offset: 'str'
+    surface_uuid: 'str'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawVertexBuffer':
+        return cls(
+            _from_json_data(int, data.get("binding")),
+            _from_json_data(str, data.get("offset")),
+            _from_json_data(str, data.get("surface_uuid")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["binding"] = _to_json_data(self.binding)
+        data["offset"] = _to_json_data(self.offset)
+        data["surface_uuid"] = _to_json_data(self.surface_uuid)
+        return data
+
+class EscalateRequestRunGraphicsDrawIndexBufferIndexType(Enum):
+    UINT16 = "uint16"
+    UINT32 = "uint32"
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawIndexBufferIndexType':
+        return cls(data)
+
+    def to_json_data(self) -> Any:
+        return self.value
+
+@dataclass
+class EscalateRequestRunGraphicsDrawIndexBuffer:
+    """
+    Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+    `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+    into it.
+    """
+
+    index_type: 'EscalateRequestRunGraphicsDrawIndexBufferIndexType'
+    offset: 'str'
+    surface_uuid: 'str'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawIndexBuffer':
+        return cls(
+            _from_json_data(EscalateRequestRunGraphicsDrawIndexBufferIndexType, data.get("index_type")),
+            _from_json_data(str, data.get("offset")),
+            _from_json_data(str, data.get("surface_uuid")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["index_type"] = _to_json_data(self.index_type)
+        data["offset"] = _to_json_data(self.offset)
+        data["surface_uuid"] = _to_json_data(self.surface_uuid)
+        return data
+
+@dataclass
+class EscalateRequestRunGraphicsDrawScissor:
+    """
+    Dynamic scissor rect for this draw. Required when the kernel declared
+    `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    """
+
+    height: 'int'
+    width: 'int'
+    x: 'int'
+    y: 'int'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawScissor':
+        return cls(
+            _from_json_data(int, data.get("height")),
+            _from_json_data(int, data.get("width")),
+            _from_json_data(int, data.get("x")),
+            _from_json_data(int, data.get("y")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["height"] = _to_json_data(self.height)
+        data["width"] = _to_json_data(self.width)
+        data["x"] = _to_json_data(self.x)
+        data["y"] = _to_json_data(self.y)
+        return data
+
+@dataclass
+class EscalateRequestRunGraphicsDrawViewport:
+    """
+    Dynamic viewport for this draw. Required when the kernel's pipeline state
+    declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    """
+
+    height: 'float'
+    max_depth: 'float'
+    min_depth: 'float'
+    width: 'float'
+    x: 'float'
+    y: 'float'
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDrawViewport':
+        return cls(
+            _from_json_data(float, data.get("height")),
+            _from_json_data(float, data.get("max_depth")),
+            _from_json_data(float, data.get("min_depth")),
+            _from_json_data(float, data.get("width")),
+            _from_json_data(float, data.get("x")),
+            _from_json_data(float, data.get("y")),
+        )
+
+    def to_json_data(self) -> Any:
+        data: Dict[str, Any] = {}
+        data["height"] = _to_json_data(self.height)
+        data["max_depth"] = _to_json_data(self.max_depth)
+        data["min_depth"] = _to_json_data(self.min_depth)
+        data["width"] = _to_json_data(self.width)
+        data["x"] = _to_json_data(self.x)
+        data["y"] = _to_json_data(self.y)
+        return data
+
+@dataclass
+class EscalateRequestRunGraphicsDraw(EscalateRequest):
+    bindings: 'List[EscalateRequestRunGraphicsDrawBinding]'
+    """
+    Per-draw bindings — each slot's `surface_uuid` must resolve through the host
+    bridge's UUID → resource map. `kind` must match the binding's declared kind
+    from register time.
+    """
+
+    color_target_uuids: 'List[str]'
+    """
+    UUIDs of color attachment textures. v1 requires exactly one entry — multi-
+    attachment is a future extension. Each UUID must resolve to a host-side
+    `StreamTexture` registered as a render target.
+    """
+
+    draw: 'EscalateRequestRunGraphicsDrawDraw'
+    """
+    Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven),
+    `kind = "draw_indexed"` requires `index_buffer` to be set and uses
+    `index_count` / `first_index` / `vertex_offset`. Fields not used by the
+    selected kind are ignored host-side; subprocesses should still send valid
+    placeholder values (zero is fine) to keep the wire shape regular.
+    """
+
+    extent_height: 'int'
+    """
+    Render-area height in pixels.
+    """
+
+    extent_width: 'int'
+    """
+    Render-area width in pixels.
+    """
+
+    frame_index: 'int'
+    """
+    Slot in the kernel's descriptor-set ring. Must satisfy `frame_index <
+    descriptor_sets_in_flight` declared at register time. Render-loop callers
+    cycle this through `MAX_FRAMES_IN_FLIGHT` so concurrent frames don't
+    scribble each other's bindings.
+    """
+
+    kernel_id: 'str'
+    """
+    Handle returned by a prior `register_graphics_kernel` response. The host
+    looks up the cached `Arc<VulkanGraphicsKernel>` and dispatches against it.
+    Dispatching with an unrecognized kernel_id returns an `err` response.
+    """
+
+    push_constants_hex: 'str'
+    """
+    Push-constant payload for this draw, lowercase hex. Must decode to exactly
+    the kernel's declared `push_constant_size` (or empty if zero).
+    """
+
+    request_id: 'str'
+    """
+    Correlates request with response. UUID string.
+    """
+
+    vertex_buffers: 'List[EscalateRequestRunGraphicsDrawVertexBuffer]'
+    """
+    Per-draw vertex buffer bindings. Each entry's `surface_uuid` must resolve
+    to a host-side `RhiPixelBuffer`. `offset` is the byte offset into the buffer
+    where vertex data starts (decimal-encoded u64 — JTD has no native u64).
+    Empty for vertex-fabricating shaders (`gl_VertexIndex` patterns).
+    """
+
+    depth_target_uuid: 'Optional[str]'
+    """
+    UUID of a depth attachment texture. Reserved for future use — v1 rejects
+    depth attachments with an `err` response.
+    """
+
+    index_buffer: 'Optional[EscalateRequestRunGraphicsDrawIndexBuffer]'
+    """
+    Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+    `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+    into it.
+    """
+
+    scissor: 'Optional[EscalateRequestRunGraphicsDrawScissor]'
+    """
+    Dynamic scissor rect for this draw. Required when the kernel declared
+    `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    """
+
+    viewport: 'Optional[EscalateRequestRunGraphicsDrawViewport]'
+    """
+    Dynamic viewport for this draw. Required when the kernel's pipeline state
+    declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    """
+
+
+    @classmethod
+    def from_json_data(cls, data: Any) -> 'EscalateRequestRunGraphicsDraw':
+        return cls(
+            "run_graphics_draw",
+            _from_json_data(List[EscalateRequestRunGraphicsDrawBinding], data.get("bindings")),
+            _from_json_data(List[str], data.get("color_target_uuids")),
+            _from_json_data(EscalateRequestRunGraphicsDrawDraw, data.get("draw")),
+            _from_json_data(int, data.get("extent_height")),
+            _from_json_data(int, data.get("extent_width")),
+            _from_json_data(int, data.get("frame_index")),
+            _from_json_data(str, data.get("kernel_id")),
+            _from_json_data(str, data.get("push_constants_hex")),
+            _from_json_data(str, data.get("request_id")),
+            _from_json_data(List[EscalateRequestRunGraphicsDrawVertexBuffer], data.get("vertex_buffers")),
+            _from_json_data(Optional[str], data.get("depth_target_uuid")),
+            _from_json_data(Optional[EscalateRequestRunGraphicsDrawIndexBuffer], data.get("index_buffer")),
+            _from_json_data(Optional[EscalateRequestRunGraphicsDrawScissor], data.get("scissor")),
+            _from_json_data(Optional[EscalateRequestRunGraphicsDrawViewport], data.get("viewport")),
+        )
+
+    def to_json_data(self) -> Any:
+        data = { "op": "run_graphics_draw" }
+        data["bindings"] = _to_json_data(self.bindings)
+        data["color_target_uuids"] = _to_json_data(self.color_target_uuids)
+        data["draw"] = _to_json_data(self.draw)
+        data["extent_height"] = _to_json_data(self.extent_height)
+        data["extent_width"] = _to_json_data(self.extent_width)
+        data["frame_index"] = _to_json_data(self.frame_index)
+        data["kernel_id"] = _to_json_data(self.kernel_id)
+        data["push_constants_hex"] = _to_json_data(self.push_constants_hex)
+        data["request_id"] = _to_json_data(self.request_id)
+        data["vertex_buffers"] = _to_json_data(self.vertex_buffers)
+        if self.depth_target_uuid is not None:
+             data["depth_target_uuid"] = _to_json_data(self.depth_target_uuid)
+        if self.index_buffer is not None:
+             data["index_buffer"] = _to_json_data(self.index_buffer)
+        if self.scissor is not None:
+             data["scissor"] = _to_json_data(self.scissor)
+        if self.viewport is not None:
+             data["viewport"] = _to_json_data(self.viewport)
         return data
 
 class EscalateRequestTryRunCPUReadbackCopyDirection(Enum):

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -36,7 +36,7 @@ import ctypes
 import itertools
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
-from typing import Iterator, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Iterator, Optional, Protocol, Sequence, runtime_checkable
 
 from streamlib.surface_adapter import (
     STREAMLIB_ADAPTER_ABI_VERSION,
@@ -312,6 +312,14 @@ class VulkanContext:
         # re-register through escalate IPC (host-side cache hit, but the
         # IPC payload is sent again).
         self._compute_kernel_ids: dict[int, tuple[bytes, str]] = {}
+        # Graphics-kernel cache: `(id(vertex_spv), id(fragment_spv))` →
+        # `(vertex_strong_ref, fragment_strong_ref, kernel_id)`. Same
+        # identity-keyed pattern as `_compute_kernel_ids` — strong refs
+        # pin both byte buffers so Python can't recycle either id while
+        # the cached kernel_id is still in flight.
+        self._graphics_kernel_ids: dict[
+            tuple[int, int], tuple[bytes, bytes, str]
+        ] = {}
 
     def _wire_signatures(self) -> None:
         """Set ctypes signatures on every `slpn_vulkan_*` entry point.
@@ -568,6 +576,118 @@ class VulkanContext:
             group_count_x=int(group_count_x),
             group_count_y=int(group_count_y),
             group_count_z=int(group_count_z),
+        )
+
+    def dispatch_graphics(
+        self,
+        *,
+        color_target,
+        extent_width: int,
+        extent_height: int,
+        vertex_spv: bytes,
+        fragment_spv: bytes,
+        pipeline_state: Dict[str, Any],
+        bindings: Sequence[Dict[str, Any]] = (),
+        binding_decls: Sequence[Dict[str, Any]] = (),
+        vertex_buffers: Sequence[Dict[str, Any]] = (),
+        push_constants: bytes = b"",
+        push_constant_stages: int = 0,
+        descriptor_sets_in_flight: int = 2,
+        frame_index: int = 0,
+        index_buffer: Optional[Dict[str, Any]] = None,
+        depth_target_uuid: Optional[str] = None,
+        viewport: Optional[Dict[str, Any]] = None,
+        scissor: Optional[Dict[str, Any]] = None,
+        draw: Optional[Dict[str, Any]] = None,
+        label: str = "polyglot-graphics",
+    ) -> None:
+        """Dispatch a graphics draw against ``color_target``'s host-side
+        ``VkImage`` via escalate IPC.
+
+        ``color_target`` is the surface acquired via :meth:`acquire_write`
+        (a ``StreamlibSurface``). The surface's ``pool_id`` (the host
+        surface-share UUID) is sent to the host bridge for resolution.
+
+        The first call with a given ``(vertex_spv, fragment_spv)`` pair
+        registers the kernel through escalate IPC; subsequent calls with
+        the same byte objects hit the local kernel-id cache and skip
+        registration. ``binding_decls`` is the register-time binding
+        declaration list (validated against SPIR-V reflection on the
+        host); ``bindings`` is the per-draw binding-value list. They
+        share the same ``{"binding", "kind"[, "stages"|"surface_uuid"]}``
+        shape but with different field sets — the customer authors both
+        because the host can't infer per-draw values from declarations
+        alone.
+
+        ``draw`` defaults to a 3-vertex non-indexed draw (the canonical
+        fullscreen-triangle / first-render shape). Pass an explicit
+        ``{"kind": "draw" | "draw_indexed", ...}`` for anything else.
+
+        Graphics dispatch is synchronous host-side: when this returns,
+        the host's writes to the color target are visible to subsequent
+        submissions.
+        """
+        from streamlib.escalate import channel as _escalate_channel
+
+        pool_id = self._surface_pool_id(color_target)
+        cached = self._surface_ids.get(pool_id)
+        if cached is None:
+            raise RuntimeError(
+                f"VulkanContext.dispatch_graphics: surface '{pool_id}' is not "
+                "registered — call acquire_write inside a `with` block first."
+            )
+        ch = _escalate_channel()
+        cache_key = (id(vertex_spv), id(fragment_spv))
+        cached_entry = self._graphics_kernel_ids.get(cache_key)
+        if (
+            cached_entry is not None
+            and cached_entry[0] is vertex_spv
+            and cached_entry[1] is fragment_spv
+        ):
+            kernel_id = cached_entry[2]
+        else:
+            response = ch.register_graphics_kernel(
+                label=label,
+                vertex_spv=vertex_spv,
+                fragment_spv=fragment_spv,
+                bindings=binding_decls,
+                push_constant_size=len(push_constants),
+                push_constant_stages=int(push_constant_stages),
+                descriptor_sets_in_flight=int(descriptor_sets_in_flight),
+                pipeline_state=pipeline_state,
+            )
+            kernel_id = response["handle_id"]
+            self._graphics_kernel_ids[cache_key] = (vertex_spv, fragment_spv, kernel_id)
+
+        if draw is None:
+            draw = {
+                "kind": "draw",
+                "vertex_count": 3,
+                "instance_count": 1,
+                "first_vertex": 0,
+                "first_instance": 0,
+                "index_count": 0,
+                "first_index": 0,
+                "vertex_offset": 0,
+            }
+
+        # Use `pool_id` (surface-share UUID) for the color target — same
+        # convention as compute. Host bridge resolves UUID → host-side
+        # `StreamTexture`.
+        ch.run_graphics_draw(
+            kernel_id=kernel_id,
+            frame_index=int(frame_index),
+            bindings=bindings,
+            vertex_buffers=vertex_buffers,
+            color_target_uuids=[pool_id],
+            extent_width=int(extent_width),
+            extent_height=int(extent_height),
+            push_constants=push_constants,
+            draw=draw,
+            index_buffer=index_buffer,
+            depth_target_uuid=depth_target_uuid,
+            viewport=viewport,
+            scissor=scissor,
         )
 
     def release_for_cross_process(

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -243,6 +243,129 @@ class EscalateChannel:
             }
         )
 
+    def register_graphics_kernel(
+        self,
+        *,
+        label: str,
+        vertex_spv: bytes,
+        fragment_spv: bytes,
+        bindings: Sequence[Dict[str, Any]],
+        push_constant_size: int,
+        push_constant_stages: int,
+        descriptor_sets_in_flight: int,
+        pipeline_state: Dict[str, Any],
+        vertex_entry_point: str = "main",
+        fragment_entry_point: str = "main",
+    ) -> Dict[str, Any]:
+        """Register a graphics kernel on the host.
+
+        Returns the ``ok``-payload whose ``handle_id`` is the
+        bridge-assigned kernel_id (typically SHA-256 over a canonical
+        representation of all register-time inputs — re-registering an
+        identical descriptor hits the host-side cache and returns the
+        same id).
+
+        ``vertex_spv`` and ``fragment_spv`` are raw SPIR-V bytes. The
+        host derives the binding shape from `rspirv-reflect`,
+        validates the declared ``bindings`` match the merged shader
+        declaration, and persists driver-compiled pipeline state to
+        the same on-disk pipeline cache compute uses.
+
+        ``bindings`` is a list of ``{"binding": int, "kind": str,
+        "stages": int}`` dicts where ``kind`` is one of
+        ``sampled_texture | storage_buffer | uniform_buffer |
+        storage_image`` and ``stages`` is a bitmask
+        (``1=VERTEX``, ``2=FRAGMENT``).
+
+        ``pipeline_state`` mirrors the host
+        ``GraphicsPipelineState`` shape — see the schema YAML for the
+        complete field list.
+
+        On failure raises :class:`EscalateError`.
+        """
+        return self.request(
+            {
+                "op": "register_graphics_kernel",
+                "label": str(label),
+                "vertex_spv_hex": vertex_spv.hex(),
+                "fragment_spv_hex": fragment_spv.hex(),
+                "vertex_entry_point": vertex_entry_point,
+                "fragment_entry_point": fragment_entry_point,
+                "bindings": list(bindings),
+                "push_constant_size": int(push_constant_size),
+                "push_constant_stages": int(push_constant_stages),
+                "descriptor_sets_in_flight": int(descriptor_sets_in_flight),
+                "pipeline_state": dict(pipeline_state),
+            }
+        )
+
+    def run_graphics_draw(
+        self,
+        *,
+        kernel_id: str,
+        frame_index: int,
+        bindings: Sequence[Dict[str, Any]],
+        vertex_buffers: Sequence[Dict[str, Any]],
+        color_target_uuids: Sequence[str],
+        extent_width: int,
+        extent_height: int,
+        push_constants: bytes,
+        draw: Dict[str, Any],
+        index_buffer: Optional[Dict[str, Any]] = None,
+        depth_target_uuid: Optional[str] = None,
+        viewport: Optional[Dict[str, Any]] = None,
+        scissor: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Issue one draw against a previously-registered graphics kernel.
+
+        Resolves binding ``surface_uuid``s through the host bridge's
+        UUID → resource map, records bind + push + draw, submits the
+        kernel's command buffer, and waits on its fence — graphics
+        dispatch is synchronous host-side, so when this returns, the
+        host's writes to the color attachments are visible.
+
+        ``frame_index`` indexes the kernel's descriptor-set ring
+        (``0 ≤ frame_index < descriptor_sets_in_flight``).
+        ``bindings`` carries per-slot ``surface_uuid`` references for
+        sampled textures + storage/uniform buffers + storage images.
+        ``vertex_buffers`` is a list of ``{"binding": int,
+        "surface_uuid": str, "offset": str}`` (offset is decimal-
+        encoded u64).
+
+        ``draw`` is one of:
+
+        - ``{"kind": "draw", "vertex_count": int, "instance_count": int,
+          "first_vertex": int, "first_instance": int, "index_count": 0,
+          "first_index": 0, "vertex_offset": 0}``
+        - ``{"kind": "draw_indexed", "vertex_count": 0,
+          "instance_count": int, "first_vertex": 0,
+          "first_instance": int, "index_count": int, "first_index":
+          int, "vertex_offset": int}``
+
+        On failure raises :class:`EscalateError`.
+        """
+        payload: Dict[str, Any] = {
+            "op": "run_graphics_draw",
+            "kernel_id": str(kernel_id),
+            "frame_index": int(frame_index),
+            "bindings": list(bindings),
+            "vertex_buffers": list(vertex_buffers),
+            "color_target_uuids": list(color_target_uuids),
+            "extent_width": int(extent_width),
+            "extent_height": int(extent_height),
+            "push_constants_hex": push_constants.hex(),
+            "draw": dict(draw),
+        }
+        if index_buffer is not None:
+            payload["index_buffer"] = dict(index_buffer)
+        if depth_target_uuid is not None:
+            payload["depth_target_uuid"] = str(depth_target_uuid)
+        if viewport is not None:
+            payload["viewport"] = dict(viewport)
+        if scissor is not None:
+            payload["scissor"] = dict(scissor)
+        return self.request(payload)
+
     def release_handle(self, handle_id: str) -> Dict[str, Any]:
         """Tell the host to drop its strong reference to ``handle_id``."""
         return self.request(

--- a/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -236,6 +236,451 @@ mapping:
         metadata:
           description: "vkCmdDispatch groupCountZ."
         type: uint32
+  register_graphics_kernel:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      label:
+        metadata:
+          description: >
+            Human-readable label used in error messages and tracing
+            on the host. Echoed in `kernel_id` derivation only via
+            its bytes — purely diagnostic.
+        type: string
+      vertex_spv_hex:
+        metadata:
+          description: >
+            Compiled SPIR-V bytecode for the vertex stage, encoded
+            as lowercase hex (no `0x` prefix, no whitespace). Today
+            exactly one vertex stage is required (the host kernel
+            rejects zero or multiple vertex stages). Geometry /
+            tessellation / mesh / task stages are not yet supported.
+        type: string
+      fragment_spv_hex:
+        metadata:
+          description: >
+            Compiled SPIR-V bytecode for the fragment stage, encoded
+            as lowercase hex. Today exactly one fragment stage is
+            required (matching the host kernel's v1 contract).
+        type: string
+      vertex_entry_point:
+        metadata:
+          description: >
+            Entry-point name for the vertex stage. Empty string is
+            normalized to `"main"` host-side.
+        type: string
+      fragment_entry_point:
+        metadata:
+          description: >
+            Entry-point name for the fragment stage. Empty string is
+            normalized to `"main"` host-side.
+        type: string
+      bindings:
+        metadata:
+          description: >
+            Descriptor-set-0 bindings the host pipeline declares.
+            Validated against `rspirv-reflect` of the supplied
+            SPIR-V at register time — mismatches return an `err`
+            response. Empty array means no bindings.
+        elements:
+          properties:
+            binding:
+              type: uint32
+            kind:
+              metadata:
+                description: >
+                  Resource kind for this binding slot.
+              enum:
+                - sampled_texture
+                - storage_buffer
+                - uniform_buffer
+                - storage_image
+            stages:
+              metadata:
+                description: >
+                  Bitmask of stages the binding is visible to.
+                  `1 = VERTEX`, `2 = FRAGMENT`, `3 = VERTEX_FRAGMENT`.
+              type: uint32
+      push_constant_size:
+        metadata:
+          description: >
+            Push-constant range size in bytes, validated against
+            the merged shader reflection. Set 0 if the shaders use
+            no push constants.
+        type: uint32
+      push_constant_stages:
+        metadata:
+          description: >
+            Bitmask of stages the push-constant range is visible to.
+            `1 = VERTEX`, `2 = FRAGMENT`. Ignored when
+            `push_constant_size == 0`.
+        type: uint32
+      descriptor_sets_in_flight:
+        metadata:
+          description: >
+            Depth of the descriptor-set ring. Render-loop callers
+            pass `frame_index ∈ [0, descriptor_sets_in_flight)` per
+            draw. Must be ≥ 1.
+        type: uint32
+      pipeline_state:
+        metadata:
+          description: >
+            Fixed-function pipeline state plus attachment formats
+            for the graphics pipeline. Mirrors the host
+            `GraphicsPipelineState` shape; unsupported combinations
+            (multi-attachment color blend, MSAA samples > 1, etc.)
+            are rejected with an `err` response.
+        properties:
+          topology:
+            enum:
+              - point_list
+              - line_list
+              - line_strip
+              - triangle_list
+              - triangle_strip
+              - triangle_fan
+          vertex_input_bindings:
+            metadata:
+              description: >
+                Vertex buffer binding slots — stride and step rate
+                per binding. Empty array selects the
+                `VertexInputState::None` (gl_VertexIndex-driven)
+                shape; non-empty selects `VertexInputState::Buffers`
+                with the given bindings + attributes.
+            elements:
+              properties:
+                binding:
+                  type: uint32
+                stride:
+                  type: uint32
+                input_rate:
+                  enum:
+                    - vertex
+                    - instance
+          vertex_input_attributes:
+            metadata:
+              description: >
+                Vertex attributes pulled from the bindings. Must be
+                empty when `vertex_input_bindings` is empty.
+            elements:
+              properties:
+                location:
+                  type: uint32
+                binding:
+                  type: uint32
+                format:
+                  enum:
+                    - r32_float
+                    - rg32_float
+                    - rgb32_float
+                    - rgba32_float
+                    - r32_uint
+                    - rg32_uint
+                    - rgb32_uint
+                    - rgba32_uint
+                    - r32_sint
+                    - rg32_sint
+                    - rgb32_sint
+                    - rgba32_sint
+                    - rgba8_unorm
+                    - rgba8_snorm
+                offset:
+                  type: uint32
+          rasterization_polygon_mode:
+            enum:
+              - fill
+              - line
+              - point
+          rasterization_cull_mode:
+            enum:
+              - none
+              - front
+              - back
+              - front_and_back
+          rasterization_front_face:
+            enum:
+              - counter_clockwise
+              - clockwise
+          rasterization_line_width:
+            type: float32
+          multisample_samples:
+            metadata:
+              description: >
+                MSAA sample count. Only `1` is supported in v1; any
+                other value returns an `err` response.
+            type: uint32
+          depth_stencil_enabled:
+            type: boolean
+          depth_compare_op:
+            metadata:
+              description: >
+                Depth compare op. Ignored when
+                `depth_stencil_enabled` is false; the wire field
+                must still carry a valid value (use `always` as the
+                default placeholder when disabled).
+            enum:
+              - never
+              - less
+              - equal
+              - less_or_equal
+              - greater
+              - not_equal
+              - greater_or_equal
+              - always
+          depth_write:
+            type: boolean
+          color_blend_enabled:
+            type: boolean
+          color_write_mask:
+            metadata:
+              description: >
+                Color write mask bits — `1=R`, `2=G`, `4=B`, `8=A`.
+                `15` (`0b1111`) writes RGBA. Used both when blending
+                is disabled and as the blend attachment's
+                `color_write_mask` when enabled.
+            type: uint32
+          color_blend_src_color_factor:
+            metadata:
+              description: >
+                Blend factor. Ignored when `color_blend_enabled` is
+                false; carry a valid value (e.g. `one`) regardless.
+              ref: "blend_factor_enum"
+            enum: &blend_factor
+              - zero
+              - one
+              - src_color
+              - one_minus_src_color
+              - dst_color
+              - one_minus_dst_color
+              - src_alpha
+              - one_minus_src_alpha
+              - dst_alpha
+              - one_minus_dst_alpha
+              - constant_color
+              - one_minus_constant_color
+              - constant_alpha
+              - one_minus_constant_alpha
+              - src_alpha_saturate
+          color_blend_dst_color_factor:
+            enum: *blend_factor
+          color_blend_color_op:
+            enum: &blend_op
+              - add
+              - subtract
+              - reverse_subtract
+              - min
+              - max
+          color_blend_src_alpha_factor:
+            enum: *blend_factor
+          color_blend_dst_alpha_factor:
+            enum: *blend_factor
+          color_blend_alpha_op:
+            enum: *blend_op
+          attachment_color_formats:
+            metadata:
+              description: >
+                Color attachment texture formats (lowercase
+                snake-case names matching `acquire_texture.format`).
+                v1 supports a single color attachment; arrays of
+                length other than 1 are rejected.
+            elements:
+              type: string
+          dynamic_state:
+            metadata:
+              description: >
+                Which pipeline state is set dynamically per draw vs
+                baked into the pipeline at creation. `none` bakes a
+                default 1×1 viewport (offscreen fixed-size only);
+                `viewport_scissor` lets the same pipeline serve
+                varying extents.
+            enum:
+              - none
+              - viewport_scissor
+        optionalProperties:
+          attachment_depth_format:
+            metadata:
+              description: >
+                Depth attachment format. Absent disables depth
+                attachments — the depth_stencil flags must be
+                consistent (`depth_stencil_enabled = false` when
+                this is absent).
+              ref: "depth_format_enum"
+            enum:
+              - d16_unorm
+              - d32_sfloat
+              - d24_unorm_s8_uint
+  run_graphics_draw:
+    properties:
+      request_id:
+        metadata:
+          description: "Correlates request with response. UUID string."
+        type: string
+      kernel_id:
+        metadata:
+          description: >
+            Handle returned by a prior `register_graphics_kernel`
+            response. The host looks up the cached
+            `Arc<VulkanGraphicsKernel>` and dispatches against it.
+            Dispatching with an unrecognized kernel_id returns an
+            `err` response.
+        type: string
+      frame_index:
+        metadata:
+          description: >
+            Slot in the kernel's descriptor-set ring. Must satisfy
+            `frame_index < descriptor_sets_in_flight` declared at
+            register time. Render-loop callers cycle this through
+            `MAX_FRAMES_IN_FLIGHT` so concurrent frames don't
+            scribble each other's bindings.
+        type: uint32
+      bindings:
+        metadata:
+          description: >
+            Per-draw bindings — each slot's `surface_uuid` must
+            resolve through the host bridge's UUID → resource map.
+            `kind` must match the binding's declared kind from
+            register time.
+        elements:
+          properties:
+            binding:
+              type: uint32
+            kind:
+              enum:
+                - sampled_texture
+                - storage_buffer
+                - uniform_buffer
+                - storage_image
+            surface_uuid:
+              type: string
+      vertex_buffers:
+        metadata:
+          description: >
+            Per-draw vertex buffer bindings. Each entry's
+            `surface_uuid` must resolve to a host-side
+            `RhiPixelBuffer`. `offset` is the byte offset into the
+            buffer where vertex data starts (decimal-encoded u64 —
+            JTD has no native u64). Empty for vertex-fabricating
+            shaders (`gl_VertexIndex` patterns).
+        elements:
+          properties:
+            binding:
+              type: uint32
+            surface_uuid:
+              type: string
+            offset:
+              type: string
+      color_target_uuids:
+        metadata:
+          description: >
+            UUIDs of color attachment textures. v1 requires exactly
+            one entry — multi-attachment is a future extension. Each
+            UUID must resolve to a host-side `StreamTexture`
+            registered as a render target.
+        elements:
+          type: string
+      extent_width:
+        metadata:
+          description: "Render-area width in pixels."
+        type: uint32
+      extent_height:
+        metadata:
+          description: "Render-area height in pixels."
+        type: uint32
+      push_constants_hex:
+        metadata:
+          description: >
+            Push-constant payload for this draw, lowercase hex. Must
+            decode to exactly the kernel's declared
+            `push_constant_size` (or empty if zero).
+        type: string
+      draw:
+        metadata:
+          description: >
+            Draw call. `kind = "draw"` selects non-indexed
+            (`vertex_count`-driven), `kind = "draw_indexed"` requires
+            `index_buffer` to be set and uses `index_count` /
+            `first_index` / `vertex_offset`. Fields not used by the
+            selected kind are ignored host-side; subprocesses
+            should still send valid placeholder values (zero is
+            fine) to keep the wire shape regular.
+        properties:
+          kind:
+            enum:
+              - draw
+              - draw_indexed
+          vertex_count:
+            type: uint32
+          index_count:
+            type: uint32
+          instance_count:
+            type: uint32
+          first_vertex:
+            type: uint32
+          first_instance:
+            type: uint32
+          first_index:
+            type: uint32
+          vertex_offset:
+            type: int32
+    optionalProperties:
+      index_buffer:
+        metadata:
+          description: >
+            Required when `draw.kind == "draw_indexed"`, must be
+            absent otherwise. `surface_uuid` resolves to an
+            `RhiPixelBuffer`; `offset` is the byte offset into it.
+        properties:
+          surface_uuid:
+            type: string
+          offset:
+            type: string
+          index_type:
+            enum:
+              - uint16
+              - uint32
+      depth_target_uuid:
+        metadata:
+          description: >
+            UUID of a depth attachment texture. Reserved for future
+            use — v1 rejects depth attachments with an `err`
+            response.
+        type: string
+      viewport:
+        metadata:
+          description: >
+            Dynamic viewport for this draw. Required when the
+            kernel's pipeline state declared
+            `dynamic_state = "viewport_scissor"`; ignored otherwise.
+        properties:
+          x:
+            type: float32
+          y:
+            type: float32
+          width:
+            type: float32
+          height:
+            type: float32
+          min_depth:
+            type: float32
+          max_depth:
+            type: float32
+      scissor:
+        metadata:
+          description: >
+            Dynamic scissor rect for this draw. Required when the
+            kernel declared `dynamic_state = "viewport_scissor"`;
+            ignored otherwise.
+        properties:
+          x:
+            type: int32
+          y:
+            type: int32
+          width:
+            type: uint32
+          height:
+            type: uint32
   release_handle:
     properties:
       request_id:

--- a/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib/src/_generated_/com_streamlib_escalate_request.rs
@@ -27,6 +27,9 @@ pub enum EscalateRequest {
     #[serde(rename = "register_compute_kernel")]
     RegisterComputeKernel(EscalateRequestRegisterComputeKernel),
 
+    #[serde(rename = "register_graphics_kernel")]
+    RegisterGraphicsKernel(EscalateRequestRegisterGraphicsKernel),
+
     #[serde(rename = "release_handle")]
     ReleaseHandle(EscalateRequestReleaseHandle),
 
@@ -35,6 +38,9 @@ pub enum EscalateRequest {
 
     #[serde(rename = "run_cpu_readback_copy")]
     RunCpuReadbackCopy(EscalateRequestRunCpuReadbackCopy),
+
+    #[serde(rename = "run_graphics_draw")]
+    RunGraphicsDraw(EscalateRequestRunGraphicsDraw),
 
     #[serde(rename = "try_run_cpu_readback_copy")]
     TryRunCpuReadbackCopy(EscalateRequestTryRunCpuReadbackCopy),
@@ -238,6 +244,646 @@ pub struct EscalateRequestRegisterComputeKernel {
     pub spv_hex: String,
 }
 
+/// Resource kind for this binding slot.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelBindingKind {
+    #[serde(rename = "sampled_texture")]
+    #[default]
+    SampledTexture,
+
+    #[serde(rename = "storage_buffer")]
+    StorageBuffer,
+
+    #[serde(rename = "storage_image")]
+    StorageImage,
+
+    #[serde(rename = "uniform_buffer")]
+    UniformBuffer,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRegisterGraphicsKernelBinding {
+    #[serde(rename = "binding")]
+    pub binding: u32,
+
+    /// Resource kind for this binding slot.
+    #[serde(rename = "kind")]
+    pub kind: EscalateRequestRegisterGraphicsKernelBindingKind,
+
+    /// Bitmask of stages the binding is visible to. `1 = VERTEX`, `2 =
+    /// FRAGMENT`, `3 = VERTEX_FRAGMENT`.
+    #[serde(rename = "stages")]
+    pub stages: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp {
+    #[serde(rename = "add")]
+    #[default]
+    Add,
+
+    #[serde(rename = "max")]
+    Max,
+
+    #[serde(rename = "min")]
+    Min,
+
+    #[serde(rename = "reverse_subtract")]
+    ReverseSubtract,
+
+    #[serde(rename = "subtract")]
+    Subtract,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp {
+    #[serde(rename = "add")]
+    #[default]
+    Add,
+
+    #[serde(rename = "max")]
+    Max,
+
+    #[serde(rename = "min")]
+    Min,
+
+    #[serde(rename = "reverse_subtract")]
+    ReverseSubtract,
+
+    #[serde(rename = "subtract")]
+    Subtract,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor {
+    #[serde(rename = "constant_alpha")]
+    #[default]
+    ConstantAlpha,
+
+    #[serde(rename = "constant_color")]
+    ConstantColor,
+
+    #[serde(rename = "dst_alpha")]
+    DstAlpha,
+
+    #[serde(rename = "dst_color")]
+    DstColor,
+
+    #[serde(rename = "one")]
+    One,
+
+    #[serde(rename = "one_minus_constant_alpha")]
+    OneMinusConstantAlpha,
+
+    #[serde(rename = "one_minus_constant_color")]
+    OneMinusConstantColor,
+
+    #[serde(rename = "one_minus_dst_alpha")]
+    OneMinusDstAlpha,
+
+    #[serde(rename = "one_minus_dst_color")]
+    OneMinusDstColor,
+
+    #[serde(rename = "one_minus_src_alpha")]
+    OneMinusSrcAlpha,
+
+    #[serde(rename = "one_minus_src_color")]
+    OneMinusSrcColor,
+
+    #[serde(rename = "src_alpha")]
+    SrcAlpha,
+
+    #[serde(rename = "src_alpha_saturate")]
+    SrcAlphaSaturate,
+
+    #[serde(rename = "src_color")]
+    SrcColor,
+
+    #[serde(rename = "zero")]
+    Zero,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor {
+    #[serde(rename = "constant_alpha")]
+    #[default]
+    ConstantAlpha,
+
+    #[serde(rename = "constant_color")]
+    ConstantColor,
+
+    #[serde(rename = "dst_alpha")]
+    DstAlpha,
+
+    #[serde(rename = "dst_color")]
+    DstColor,
+
+    #[serde(rename = "one")]
+    One,
+
+    #[serde(rename = "one_minus_constant_alpha")]
+    OneMinusConstantAlpha,
+
+    #[serde(rename = "one_minus_constant_color")]
+    OneMinusConstantColor,
+
+    #[serde(rename = "one_minus_dst_alpha")]
+    OneMinusDstAlpha,
+
+    #[serde(rename = "one_minus_dst_color")]
+    OneMinusDstColor,
+
+    #[serde(rename = "one_minus_src_alpha")]
+    OneMinusSrcAlpha,
+
+    #[serde(rename = "one_minus_src_color")]
+    OneMinusSrcColor,
+
+    #[serde(rename = "src_alpha")]
+    SrcAlpha,
+
+    #[serde(rename = "src_alpha_saturate")]
+    SrcAlphaSaturate,
+
+    #[serde(rename = "src_color")]
+    SrcColor,
+
+    #[serde(rename = "zero")]
+    Zero,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor {
+    #[serde(rename = "constant_alpha")]
+    #[default]
+    ConstantAlpha,
+
+    #[serde(rename = "constant_color")]
+    ConstantColor,
+
+    #[serde(rename = "dst_alpha")]
+    DstAlpha,
+
+    #[serde(rename = "dst_color")]
+    DstColor,
+
+    #[serde(rename = "one")]
+    One,
+
+    #[serde(rename = "one_minus_constant_alpha")]
+    OneMinusConstantAlpha,
+
+    #[serde(rename = "one_minus_constant_color")]
+    OneMinusConstantColor,
+
+    #[serde(rename = "one_minus_dst_alpha")]
+    OneMinusDstAlpha,
+
+    #[serde(rename = "one_minus_dst_color")]
+    OneMinusDstColor,
+
+    #[serde(rename = "one_minus_src_alpha")]
+    OneMinusSrcAlpha,
+
+    #[serde(rename = "one_minus_src_color")]
+    OneMinusSrcColor,
+
+    #[serde(rename = "src_alpha")]
+    SrcAlpha,
+
+    #[serde(rename = "src_alpha_saturate")]
+    SrcAlphaSaturate,
+
+    #[serde(rename = "src_color")]
+    SrcColor,
+
+    #[serde(rename = "zero")]
+    Zero,
+}
+
+/// Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+/// value (e.g. `one`) regardless.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor {
+    #[serde(rename = "constant_alpha")]
+    #[default]
+    ConstantAlpha,
+
+    #[serde(rename = "constant_color")]
+    ConstantColor,
+
+    #[serde(rename = "dst_alpha")]
+    DstAlpha,
+
+    #[serde(rename = "dst_color")]
+    DstColor,
+
+    #[serde(rename = "one")]
+    One,
+
+    #[serde(rename = "one_minus_constant_alpha")]
+    OneMinusConstantAlpha,
+
+    #[serde(rename = "one_minus_constant_color")]
+    OneMinusConstantColor,
+
+    #[serde(rename = "one_minus_dst_alpha")]
+    OneMinusDstAlpha,
+
+    #[serde(rename = "one_minus_dst_color")]
+    OneMinusDstColor,
+
+    #[serde(rename = "one_minus_src_alpha")]
+    OneMinusSrcAlpha,
+
+    #[serde(rename = "one_minus_src_color")]
+    OneMinusSrcColor,
+
+    #[serde(rename = "src_alpha")]
+    SrcAlpha,
+
+    #[serde(rename = "src_alpha_saturate")]
+    SrcAlphaSaturate,
+
+    #[serde(rename = "src_color")]
+    SrcColor,
+
+    #[serde(rename = "zero")]
+    Zero,
+}
+
+/// Depth compare op. Ignored when `depth_stencil_enabled` is false; the
+/// wire field must still carry a valid value (use `always` as the default
+/// placeholder when disabled).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp {
+    #[serde(rename = "always")]
+    #[default]
+    Always,
+
+    #[serde(rename = "equal")]
+    Equal,
+
+    #[serde(rename = "greater")]
+    Greater,
+
+    #[serde(rename = "greater_or_equal")]
+    GreaterOrEqual,
+
+    #[serde(rename = "less")]
+    Less,
+
+    #[serde(rename = "less_or_equal")]
+    LessOrEqual,
+
+    #[serde(rename = "never")]
+    Never,
+
+    #[serde(rename = "not_equal")]
+    NotEqual,
+}
+
+/// Which pipeline state is set dynamically per draw vs baked into the pipeline
+/// at creation. `none` bakes a default 1×1 viewport (offscreen fixed-size
+/// only); `viewport_scissor` lets the same pipeline serve varying extents.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState {
+    #[serde(rename = "none")]
+    #[default]
+    None,
+
+    #[serde(rename = "viewport_scissor")]
+    ViewportScissor,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode {
+    #[serde(rename = "back")]
+    #[default]
+    Back,
+
+    #[serde(rename = "front")]
+    Front,
+
+    #[serde(rename = "front_and_back")]
+    FrontAndBack,
+
+    #[serde(rename = "none")]
+    None,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace {
+    #[serde(rename = "clockwise")]
+    #[default]
+    Clockwise,
+
+    #[serde(rename = "counter_clockwise")]
+    CounterClockwise,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode {
+    #[serde(rename = "fill")]
+    #[default]
+    Fill,
+
+    #[serde(rename = "line")]
+    Line,
+
+    #[serde(rename = "point")]
+    Point,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateTopology {
+    #[serde(rename = "line_list")]
+    #[default]
+    LineList,
+
+    #[serde(rename = "line_strip")]
+    LineStrip,
+
+    #[serde(rename = "point_list")]
+    PointList,
+
+    #[serde(rename = "triangle_fan")]
+    TriangleFan,
+
+    #[serde(rename = "triangle_list")]
+    TriangleList,
+
+    #[serde(rename = "triangle_strip")]
+    TriangleStrip,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat {
+    #[serde(rename = "r32_float")]
+    #[default]
+    R32Float,
+
+    #[serde(rename = "r32_sint")]
+    R32Sint,
+
+    #[serde(rename = "r32_uint")]
+    R32Uint,
+
+    #[serde(rename = "rg32_float")]
+    Rg32Float,
+
+    #[serde(rename = "rg32_sint")]
+    Rg32Sint,
+
+    #[serde(rename = "rg32_uint")]
+    Rg32Uint,
+
+    #[serde(rename = "rgb32_float")]
+    Rgb32Float,
+
+    #[serde(rename = "rgb32_sint")]
+    Rgb32Sint,
+
+    #[serde(rename = "rgb32_uint")]
+    Rgb32Uint,
+
+    #[serde(rename = "rgba32_float")]
+    Rgba32Float,
+
+    #[serde(rename = "rgba32_sint")]
+    Rgba32Sint,
+
+    #[serde(rename = "rgba32_uint")]
+    Rgba32Uint,
+
+    #[serde(rename = "rgba8_snorm")]
+    Rgba8Snorm,
+
+    #[serde(rename = "rgba8_unorm")]
+    Rgba8Unorm,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute {
+    #[serde(rename = "binding")]
+    pub binding: u32,
+
+    #[serde(rename = "format")]
+    pub format: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat,
+
+    #[serde(rename = "location")]
+    pub location: u32,
+
+    #[serde(rename = "offset")]
+    pub offset: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate {
+    #[serde(rename = "instance")]
+    #[default]
+    Instance,
+
+    #[serde(rename = "vertex")]
+    Vertex,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding {
+    #[serde(rename = "binding")]
+    pub binding: u32,
+
+    #[serde(rename = "input_rate")]
+    pub input_rate: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate,
+
+    #[serde(rename = "stride")]
+    pub stride: u32,
+}
+
+/// Depth attachment format. Absent disables depth attachments — the
+/// depth_stencil flags must be consistent (`depth_stencil_enabled = false` when
+/// this is absent).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat {
+    #[serde(rename = "d16_unorm")]
+    #[default]
+    D16Unorm,
+
+    #[serde(rename = "d24_unorm_s8_uint")]
+    D24UnormS8Uint,
+
+    #[serde(rename = "d32_sfloat")]
+    D32Sfloat,
+}
+
+/// Fixed-function pipeline state plus attachment formats for the graphics
+/// pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+/// combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+/// rejected with an `err` response.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRegisterGraphicsKernelPipelineState {
+    /// Color attachment texture formats (lowercase snake-case names matching
+    /// `acquire_texture.format`). v1 supports a single color attachment; arrays
+    /// of length other than 1 are rejected.
+    #[serde(rename = "attachment_color_formats")]
+    pub attachment_color_formats: Vec<String>,
+
+    #[serde(rename = "color_blend_alpha_op")]
+    pub color_blend_alpha_op: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp,
+
+    #[serde(rename = "color_blend_color_op")]
+    pub color_blend_color_op: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp,
+
+    #[serde(rename = "color_blend_dst_alpha_factor")]
+    pub color_blend_dst_alpha_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor,
+
+    #[serde(rename = "color_blend_dst_color_factor")]
+    pub color_blend_dst_color_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor,
+
+    #[serde(rename = "color_blend_enabled")]
+    pub color_blend_enabled: bool,
+
+    #[serde(rename = "color_blend_src_alpha_factor")]
+    pub color_blend_src_alpha_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor,
+
+    /// Blend factor. Ignored when `color_blend_enabled` is false; carry a valid
+    /// value (e.g. `one`) regardless.
+    #[serde(rename = "color_blend_src_color_factor")]
+    pub color_blend_src_color_factor: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor,
+
+    /// Color write mask bits — `1=R`, `2=G`, `4=B`, `8=A`. `15` (`0b1111`)
+    /// writes RGBA. Used both when blending is disabled and as the blend
+    /// attachment's `color_write_mask` when enabled.
+    #[serde(rename = "color_write_mask")]
+    pub color_write_mask: u32,
+
+    /// Depth compare op. Ignored when `depth_stencil_enabled` is false; the
+    /// wire field must still carry a valid value (use `always` as the default
+    /// placeholder when disabled).
+    #[serde(rename = "depth_compare_op")]
+    pub depth_compare_op: EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp,
+
+    #[serde(rename = "depth_stencil_enabled")]
+    pub depth_stencil_enabled: bool,
+
+    #[serde(rename = "depth_write")]
+    pub depth_write: bool,
+
+    /// Which pipeline state is set dynamically per draw vs baked into the
+    /// pipeline at creation. `none` bakes a default 1×1 viewport (offscreen
+    /// fixed-size only); `viewport_scissor` lets the same pipeline serve
+    /// varying extents.
+    #[serde(rename = "dynamic_state")]
+    pub dynamic_state: EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState,
+
+    /// MSAA sample count. Only `1` is supported in v1; any other value returns
+    /// an `err` response.
+    #[serde(rename = "multisample_samples")]
+    pub multisample_samples: u32,
+
+    #[serde(rename = "rasterization_cull_mode")]
+    pub rasterization_cull_mode: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode,
+
+    #[serde(rename = "rasterization_front_face")]
+    pub rasterization_front_face: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace,
+
+    #[serde(rename = "rasterization_line_width")]
+    pub rasterization_line_width: f32,
+
+    #[serde(rename = "rasterization_polygon_mode")]
+    pub rasterization_polygon_mode: EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode,
+
+    #[serde(rename = "topology")]
+    pub topology: EscalateRequestRegisterGraphicsKernelPipelineStateTopology,
+
+    /// Vertex attributes pulled from the bindings. Must be empty when
+    /// `vertex_input_bindings` is empty.
+    #[serde(rename = "vertex_input_attributes")]
+    pub vertex_input_attributes: Vec<EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute>,
+
+    /// Vertex buffer binding slots — stride and step rate per binding. Empty
+    /// array selects the `VertexInputState::None` (gl_VertexIndex-driven)
+    /// shape; non-empty selects `VertexInputState::Buffers` with the given
+    /// bindings + attributes.
+    #[serde(rename = "vertex_input_bindings")]
+    pub vertex_input_bindings: Vec<EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding>,
+
+    /// Depth attachment format. Absent disables depth attachments — the
+    /// depth_stencil flags must be consistent (`depth_stencil_enabled = false`
+    /// when this is absent).
+    #[serde(rename = "attachment_depth_format")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_depth_format: Option<EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRegisterGraphicsKernel {
+    /// Descriptor-set-0 bindings the host pipeline declares. Validated against
+    /// `rspirv-reflect` of the supplied SPIR-V at register time — mismatches
+    /// return an `err` response. Empty array means no bindings.
+    #[serde(rename = "bindings")]
+    pub bindings: Vec<EscalateRequestRegisterGraphicsKernelBinding>,
+
+    /// Depth of the descriptor-set ring. Render-loop callers pass `frame_index
+    /// ∈ [0, descriptor_sets_in_flight)` per draw. Must be ≥ 1.
+    #[serde(rename = "descriptor_sets_in_flight")]
+    pub descriptor_sets_in_flight: u32,
+
+    /// Entry-point name for the fragment stage. Empty string is normalized to
+    /// `"main"` host-side.
+    #[serde(rename = "fragment_entry_point")]
+    pub fragment_entry_point: String,
+
+    /// Compiled SPIR-V bytecode for the fragment stage, encoded as lowercase
+    /// hex. Today exactly one fragment stage is required (matching the host
+    /// kernel's v1 contract).
+    #[serde(rename = "fragment_spv_hex")]
+    pub fragment_spv_hex: String,
+
+    /// Human-readable label used in error messages and tracing on the host.
+    /// Echoed in `kernel_id` derivation only via its bytes — purely diagnostic.
+    #[serde(rename = "label")]
+    pub label: String,
+
+    /// Fixed-function pipeline state plus attachment formats for the graphics
+    /// pipeline. Mirrors the host `GraphicsPipelineState` shape; unsupported
+    /// combinations (multi-attachment color blend, MSAA samples > 1, etc.) are
+    /// rejected with an `err` response.
+    #[serde(rename = "pipeline_state")]
+    pub pipeline_state: EscalateRequestRegisterGraphicsKernelPipelineState,
+
+    /// Push-constant range size in bytes, validated against the merged shader
+    /// reflection. Set 0 if the shaders use no push constants.
+    #[serde(rename = "push_constant_size")]
+    pub push_constant_size: u32,
+
+    /// Bitmask of stages the push-constant range is visible to. `1 = VERTEX`,
+    /// `2 = FRAGMENT`. Ignored when `push_constant_size == 0`.
+    #[serde(rename = "push_constant_stages")]
+    pub push_constant_stages: u32,
+
+    /// Correlates request with response. UUID string.
+    #[serde(rename = "request_id")]
+    pub request_id: String,
+
+    /// Entry-point name for the vertex stage. Empty string is normalized to
+    /// `"main"` host-side.
+    #[serde(rename = "vertex_entry_point")]
+    pub vertex_entry_point: String,
+
+    /// Compiled SPIR-V bytecode for the vertex stage, encoded as lowercase
+    /// hex (no `0x` prefix, no whitespace). Today exactly one vertex stage
+    /// is required (the host kernel rejects zero or multiple vertex stages).
+    /// Geometry / tessellation / mesh / task stages are not yet supported.
+    #[serde(rename = "vertex_spv_hex")]
+    pub vertex_spv_hex: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EscalateRequestReleaseHandle {
@@ -339,6 +985,247 @@ pub struct EscalateRequestRunCpuReadbackCopy {
     /// representation, parsed back into u64 by the host before dispatch.
     #[serde(rename = "surface_id")]
     pub surface_id: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRunGraphicsDrawBindingKind {
+    #[serde(rename = "sampled_texture")]
+    #[default]
+    SampledTexture,
+
+    #[serde(rename = "storage_buffer")]
+    StorageBuffer,
+
+    #[serde(rename = "storage_image")]
+    StorageImage,
+
+    #[serde(rename = "uniform_buffer")]
+    UniformBuffer,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawBinding {
+    #[serde(rename = "binding")]
+    pub binding: u32,
+
+    #[serde(rename = "kind")]
+    pub kind: EscalateRequestRunGraphicsDrawBindingKind,
+
+    #[serde(rename = "surface_uuid")]
+    pub surface_uuid: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRunGraphicsDrawDrawKind {
+    #[serde(rename = "draw")]
+    #[default]
+    Draw,
+
+    #[serde(rename = "draw_indexed")]
+    DrawIndexed,
+}
+
+/// Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven),
+/// `kind = "draw_indexed"` requires `index_buffer` to be set and uses
+/// `index_count` / `first_index` / `vertex_offset`. Fields not used by the
+/// selected kind are ignored host-side; subprocesses should still send valid
+/// placeholder values (zero is fine) to keep the wire shape regular.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawDraw {
+    #[serde(rename = "first_index")]
+    pub first_index: u32,
+
+    #[serde(rename = "first_instance")]
+    pub first_instance: u32,
+
+    #[serde(rename = "first_vertex")]
+    pub first_vertex: u32,
+
+    #[serde(rename = "index_count")]
+    pub index_count: u32,
+
+    #[serde(rename = "instance_count")]
+    pub instance_count: u32,
+
+    #[serde(rename = "kind")]
+    pub kind: EscalateRequestRunGraphicsDrawDrawKind,
+
+    #[serde(rename = "vertex_count")]
+    pub vertex_count: u32,
+
+    #[serde(rename = "vertex_offset")]
+    pub vertex_offset: i32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawVertexBuffer {
+    #[serde(rename = "binding")]
+    pub binding: u32,
+
+    #[serde(rename = "offset")]
+    pub offset: String,
+
+    #[serde(rename = "surface_uuid")]
+    pub surface_uuid: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
+    #[serde(rename = "uint16")]
+    #[default]
+    Uint16,
+
+    #[serde(rename = "uint32")]
+    Uint32,
+}
+
+/// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+/// `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+/// into it.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawIndexBuffer {
+    #[serde(rename = "index_type")]
+    pub index_type: EscalateRequestRunGraphicsDrawIndexBufferIndexType,
+
+    #[serde(rename = "offset")]
+    pub offset: String,
+
+    #[serde(rename = "surface_uuid")]
+    pub surface_uuid: String,
+}
+
+/// Dynamic scissor rect for this draw. Required when the kernel declared
+/// `dynamic_state = "viewport_scissor"`; ignored otherwise.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawScissor {
+    #[serde(rename = "height")]
+    pub height: u32,
+
+    #[serde(rename = "width")]
+    pub width: u32,
+
+    #[serde(rename = "x")]
+    pub x: i32,
+
+    #[serde(rename = "y")]
+    pub y: i32,
+}
+
+/// Dynamic viewport for this draw. Required when the kernel's pipeline state
+/// declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDrawViewport {
+    #[serde(rename = "height")]
+    pub height: f32,
+
+    #[serde(rename = "max_depth")]
+    pub max_depth: f32,
+
+    #[serde(rename = "min_depth")]
+    pub min_depth: f32,
+
+    #[serde(rename = "width")]
+    pub width: f32,
+
+    #[serde(rename = "x")]
+    pub x: f32,
+
+    #[serde(rename = "y")]
+    pub y: f32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalateRequestRunGraphicsDraw {
+    /// Per-draw bindings — each slot's `surface_uuid` must resolve through
+    /// the host bridge's UUID → resource map. `kind` must match the binding's
+    /// declared kind from register time.
+    #[serde(rename = "bindings")]
+    pub bindings: Vec<EscalateRequestRunGraphicsDrawBinding>,
+
+    /// UUIDs of color attachment textures. v1 requires exactly one entry —
+    /// multi-attachment is a future extension. Each UUID must resolve to a
+    /// host-side `StreamTexture` registered as a render target.
+    #[serde(rename = "color_target_uuids")]
+    pub color_target_uuids: Vec<String>,
+
+    /// Draw call. `kind = "draw"` selects non-indexed (`vertex_count`-driven),
+    /// `kind = "draw_indexed"` requires `index_buffer` to be set and uses
+    /// `index_count` / `first_index` / `vertex_offset`. Fields not used by
+    /// the selected kind are ignored host-side; subprocesses should still send
+    /// valid placeholder values (zero is fine) to keep the wire shape regular.
+    #[serde(rename = "draw")]
+    pub draw: EscalateRequestRunGraphicsDrawDraw,
+
+    /// Render-area height in pixels.
+    #[serde(rename = "extent_height")]
+    pub extent_height: u32,
+
+    /// Render-area width in pixels.
+    #[serde(rename = "extent_width")]
+    pub extent_width: u32,
+
+    /// Slot in the kernel's descriptor-set ring. Must satisfy `frame_index
+    /// < descriptor_sets_in_flight` declared at register time. Render-loop
+    /// callers cycle this through `MAX_FRAMES_IN_FLIGHT` so concurrent frames
+    /// don't scribble each other's bindings.
+    #[serde(rename = "frame_index")]
+    pub frame_index: u32,
+
+    /// Handle returned by a prior `register_graphics_kernel` response. The
+    /// host looks up the cached `Arc<VulkanGraphicsKernel>` and dispatches
+    /// against it. Dispatching with an unrecognized kernel_id returns an `err`
+    /// response.
+    #[serde(rename = "kernel_id")]
+    pub kernel_id: String,
+
+    /// Push-constant payload for this draw, lowercase hex. Must decode to
+    /// exactly the kernel's declared `push_constant_size` (or empty if zero).
+    #[serde(rename = "push_constants_hex")]
+    pub push_constants_hex: String,
+
+    /// Correlates request with response. UUID string.
+    #[serde(rename = "request_id")]
+    pub request_id: String,
+
+    /// Per-draw vertex buffer bindings. Each entry's `surface_uuid` must
+    /// resolve to a host-side `RhiPixelBuffer`. `offset` is the byte offset
+    /// into the buffer where vertex data starts (decimal-encoded u64 — JTD has
+    /// no native u64). Empty for vertex-fabricating shaders (`gl_VertexIndex`
+    /// patterns).
+    #[serde(rename = "vertex_buffers")]
+    pub vertex_buffers: Vec<EscalateRequestRunGraphicsDrawVertexBuffer>,
+
+    /// UUID of a depth attachment texture. Reserved for future use — v1 rejects
+    /// depth attachments with an `err` response.
+    #[serde(rename = "depth_target_uuid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depth_target_uuid: Option<String>,
+
+    /// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
+    /// `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte
+    /// offset into it.
+    #[serde(rename = "index_buffer")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_buffer: Option<EscalateRequestRunGraphicsDrawIndexBuffer>,
+
+    /// Dynamic scissor rect for this draw. Required when the kernel declared
+    /// `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    #[serde(rename = "scissor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scissor: Option<EscalateRequestRunGraphicsDrawScissor>,
+
+    /// Dynamic viewport for this draw. Required when the kernel's pipeline
+    /// state declared `dynamic_state = "viewport_scissor"`; ignored otherwise.
+    #[serde(rename = "viewport")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub viewport: Option<EscalateRequestRunGraphicsDrawViewport>,
 }
 
 /// Same shape as `run_cpu_readback_copy.direction`.

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -2703,6 +2703,9 @@ mod tests {
         use std::sync::{Arc, Mutex};
 
         use crate::_generated_::com_streamlib_escalate_request::{
+            EscalateRequestRegisterGraphicsKernelBinding,
+            EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute,
+            EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding,
             EscalateRequestRunGraphicsDrawBinding, EscalateRequestRunGraphicsDrawDraw,
             EscalateRequestRunGraphicsDrawIndexBuffer, EscalateRequestRunGraphicsDrawScissor,
             EscalateRequestRunGraphicsDrawVertexBuffer, EscalateRequestRunGraphicsDrawViewport,
@@ -2731,6 +2734,12 @@ mod tests {
 
             fn registered_count(&self) -> usize {
                 self.registered.lock().unwrap().len()
+            }
+
+            fn last_registered(&self) -> Option<GraphicsKernelRegisterDecl> {
+                // The tests register at most one descriptor each so
+                // returning a snapshot of the first entry is enough.
+                self.registered.lock().unwrap().values().next().cloned()
             }
 
             fn runs(&self) -> Vec<GraphicsKernelRunDraw> {
@@ -3148,6 +3157,181 @@ mod tests {
                 other => panic!("expected Ok, got {other:?}"),
             };
             assert_ne!(id_a, id_b, "different vertex SPIR-V must produce different kernel_ids");
+        }
+
+        /// Lock in the wire→domain pipeline-state translation. Mentally
+        /// reverting any single arm of `graphics_pipeline_state_from_wire`
+        /// (e.g. swapping `BlendOpWire::Add ↔ Subtract`) must fail this
+        /// test — the synthetic `RecordingGraphicsBridge` accepts the
+        /// translated `GraphicsPipelineStateWire` value but doesn't itself
+        /// validate any arm, so without this test the ~200 lines of enum
+        /// mapping in the handler would have no regression coverage.
+        #[test]
+        fn pipeline_state_translates_every_enum_arm() {
+            use crate::core::context::{
+                BlendFactorWire, BlendOpWire, CullModeWire, DepthCompareOpWire,
+                DepthFormatWire, DynamicStateWire, FrontFaceWire, GraphicsBindingKindWire,
+                PolygonModeWire, PrimitiveTopologyWire, VertexAttributeFormatWire,
+                VertexInputRateWire,
+            };
+
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "pipeline_state_translates_every_enum_arm: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+
+            // Build a request that uses non-default values for every
+            // pipeline-state arm we want to lock down. Each value is
+            // chosen to be DIFFERENT from the matching default so a
+            // wrong arm in the translation would land in the wrong
+            // wire-mirror variant and the assertion would fail.
+            let mut req = make_register_req(
+                "req-translate", "deadbeef", "cafebabe",
+            );
+            req.bindings = vec![EscalateRequestRegisterGraphicsKernelBinding {
+                binding: 7,
+                kind: EscalateRequestRegisterGraphicsKernelBindingKind::UniformBuffer,
+                stages: 3, // VERTEX | FRAGMENT
+            }];
+            req.pipeline_state.topology =
+                EscalateRequestRegisterGraphicsKernelPipelineStateTopology::TriangleStrip;
+            req.pipeline_state.vertex_input_bindings = vec![
+                EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBinding {
+                    binding: 2,
+                    stride: 28,
+                    input_rate:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate::Instance,
+                },
+            ];
+            req.pipeline_state.vertex_input_attributes = vec![
+                EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttribute {
+                    location: 5,
+                    binding: 2,
+                    format:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat::Rgb32Float,
+                    offset: 12,
+                },
+            ];
+            req.pipeline_state.rasterization_polygon_mode =
+                EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode::Line;
+            req.pipeline_state.rasterization_cull_mode =
+                EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::Back;
+            req.pipeline_state.rasterization_front_face =
+                EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace::Clockwise;
+            req.pipeline_state.rasterization_line_width = 2.5;
+            req.pipeline_state.depth_stencil_enabled = true;
+            req.pipeline_state.depth_compare_op =
+                EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp::LessOrEqual;
+            req.pipeline_state.depth_write = true;
+            req.pipeline_state.color_blend_enabled = true;
+            req.pipeline_state.color_write_mask = 0b0101; // R | B only
+            req.pipeline_state.color_blend_src_color_factor =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor::SrcAlpha;
+            req.pipeline_state.color_blend_dst_color_factor =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor::OneMinusSrcAlpha;
+            req.pipeline_state.color_blend_color_op =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp::Subtract;
+            req.pipeline_state.color_blend_src_alpha_factor =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor::ConstantAlpha;
+            req.pipeline_state.color_blend_dst_alpha_factor =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor::OneMinusConstantAlpha;
+            req.pipeline_state.color_blend_alpha_op =
+                EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp::Max;
+            req.pipeline_state.attachment_color_formats =
+                vec!["bgra8_unorm_srgb".to_string()];
+            req.pipeline_state.attachment_depth_format = Some(
+                EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat::D32Sfloat,
+            );
+            req.pipeline_state.dynamic_state =
+                EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState::None;
+            req.push_constant_size = 16;
+            req.push_constant_stages = 3;
+            req.descriptor_sets_in_flight = 4;
+
+            let response = handle_escalate_op(
+                &sandbox,
+                &registry,
+                EscalateRequest::RegisterGraphicsKernel(req),
+            )
+            .expect("must produce a response");
+            match response {
+                EscalateResponse::Ok(ok) => assert_eq!(ok.request_id, "req-translate"),
+                other => panic!("expected Ok, got {other:?}"),
+            }
+
+            let registered = bridge
+                .last_registered()
+                .expect("bridge should have stored the descriptor");
+
+            // Top-level fields.
+            assert_eq!(registered.label, "test-graphics");
+            assert_eq!(registered.vertex_spv, vec![0xde, 0xad, 0xbe, 0xef]);
+            assert_eq!(registered.fragment_spv, vec![0xca, 0xfe, 0xba, 0xbe]);
+            assert_eq!(registered.push_constant_size, 16);
+            assert_eq!(registered.push_constant_stages, 3);
+            assert_eq!(registered.descriptor_sets_in_flight, 4);
+
+            // Bindings translation.
+            assert_eq!(registered.bindings.len(), 1);
+            assert_eq!(registered.bindings[0].binding, 7);
+            assert_eq!(
+                registered.bindings[0].kind,
+                GraphicsBindingKindWire::UniformBuffer
+            );
+            assert_eq!(registered.bindings[0].stages, 3);
+
+            let p = &registered.pipeline_state;
+            assert_eq!(p.topology, PrimitiveTopologyWire::TriangleStrip);
+            assert_eq!(p.vertex_input_bindings.len(), 1);
+            assert_eq!(p.vertex_input_bindings[0].binding, 2);
+            assert_eq!(p.vertex_input_bindings[0].stride, 28);
+            assert_eq!(
+                p.vertex_input_bindings[0].input_rate,
+                VertexInputRateWire::Instance
+            );
+            assert_eq!(p.vertex_input_attributes.len(), 1);
+            assert_eq!(p.vertex_input_attributes[0].location, 5);
+            assert_eq!(p.vertex_input_attributes[0].binding, 2);
+            assert_eq!(
+                p.vertex_input_attributes[0].format,
+                VertexAttributeFormatWire::Rgb32Float
+            );
+            assert_eq!(p.vertex_input_attributes[0].offset, 12);
+            assert_eq!(p.rasterization_polygon_mode, PolygonModeWire::Line);
+            assert_eq!(p.rasterization_cull_mode, CullModeWire::Back);
+            assert_eq!(p.rasterization_front_face, FrontFaceWire::Clockwise);
+            assert_eq!(p.rasterization_line_width, 2.5);
+            assert_eq!(p.multisample_samples, 1);
+            assert!(p.depth_stencil_enabled);
+            assert_eq!(p.depth_compare_op, DepthCompareOpWire::LessOrEqual);
+            assert!(p.depth_write);
+            assert!(p.color_blend_enabled);
+            assert_eq!(p.color_write_mask, 0b0101);
+            assert_eq!(p.color_blend_src_color_factor, BlendFactorWire::SrcAlpha);
+            assert_eq!(
+                p.color_blend_dst_color_factor,
+                BlendFactorWire::OneMinusSrcAlpha
+            );
+            assert_eq!(p.color_blend_color_op, BlendOpWire::Subtract);
+            assert_eq!(
+                p.color_blend_src_alpha_factor,
+                BlendFactorWire::ConstantAlpha
+            );
+            assert_eq!(
+                p.color_blend_dst_alpha_factor,
+                BlendFactorWire::OneMinusConstantAlpha
+            );
+            assert_eq!(p.color_blend_alpha_op, BlendOpWire::Max);
+            assert_eq!(p.attachment_color_formats, vec!["bgra8_unorm_srgb"]);
+            assert_eq!(p.attachment_depth_format, Some(DepthFormatWire::D32Sfloat));
+            assert_eq!(p.dynamic_state, DynamicStateWire::None);
         }
 
         #[test]

--- a/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -23,10 +23,29 @@ use uuid::Uuid;
 use crate::_generated_::com_streamlib_escalate_request::{
     EscalateRequestAcquireImage, EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
     EscalateRequestLog, EscalateRequestLogLevel, EscalateRequestLogSource,
-    EscalateRequestRegisterComputeKernel, EscalateRequestReleaseHandle,
-    EscalateRequestRunComputeKernel, EscalateRequestRunCpuReadbackCopy,
-    EscalateRequestRunCpuReadbackCopyDirection, EscalateRequestTryRunCpuReadbackCopy,
-    EscalateRequestTryRunCpuReadbackCopyDirection,
+    EscalateRequestRegisterComputeKernel, EscalateRequestRegisterGraphicsKernel,
+    EscalateRequestRegisterGraphicsKernelBindingKind,
+    EscalateRequestRegisterGraphicsKernelPipelineState,
+    EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor,
+    EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor,
+    EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp,
+    EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState,
+    EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode,
+    EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace,
+    EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode,
+    EscalateRequestRegisterGraphicsKernelPipelineStateTopology,
+    EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat,
+    EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate,
+    EscalateRequestReleaseHandle, EscalateRequestRunComputeKernel,
+    EscalateRequestRunCpuReadbackCopy, EscalateRequestRunCpuReadbackCopyDirection,
+    EscalateRequestRunGraphicsDraw, EscalateRequestRunGraphicsDrawBindingKind,
+    EscalateRequestRunGraphicsDrawDrawKind, EscalateRequestRunGraphicsDrawIndexBufferIndexType,
+    EscalateRequestTryRunCpuReadbackCopy, EscalateRequestTryRunCpuReadbackCopyDirection,
 };
 use crate::_generated_::com_streamlib_escalate_response::{
     EscalateResponseContended, EscalateResponseErr, EscalateResponseOk,
@@ -35,7 +54,16 @@ use crate::_generated_::{EscalateRequest, EscalateResponse};
 use crate::core::context::{PooledTextureHandle, TexturePoolDescriptor};
 use crate::core::context::GpuContextLimitedAccess;
 #[cfg(target_os = "linux")]
-use crate::core::context::{ComputeKernelBridge, CpuReadbackBridge, CpuReadbackCopyDirection};
+use crate::core::context::{
+    BlendFactorWire, BlendOpWire, ComputeKernelBridge, CpuReadbackBridge,
+    CpuReadbackCopyDirection, CullModeWire, DepthCompareOpWire, DepthFormatWire,
+    DynamicStateWire, FrontFaceWire, GraphicsBindingDecl, GraphicsBindingKindWire,
+    GraphicsBindingValue, GraphicsDrawSpec, GraphicsIndexBufferBinding, GraphicsKernelBridge,
+    GraphicsKernelRegisterDecl, GraphicsKernelRunDraw, GraphicsPipelineStateWire,
+    GraphicsVertexBufferBinding, IndexTypeWire, PolygonModeWire, PrimitiveTopologyWire,
+    ScissorRectWire, VertexAttributeFormatWire, VertexInputAttributeDecl,
+    VertexInputBindingDecl, VertexInputRateWire, ViewportWire,
+};
 use crate::core::logging::{push_polyglot_record, LogLevel, LogRecord, Source};
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
 
@@ -61,6 +89,8 @@ fn request_id(op: &EscalateRequest) -> Option<&str> {
         EscalateRequest::TryRunCpuReadbackCopy(p) => Some(&p.request_id),
         EscalateRequest::RegisterComputeKernel(p) => Some(&p.request_id),
         EscalateRequest::RunComputeKernel(p) => Some(&p.request_id),
+        EscalateRequest::RegisterGraphicsKernel(p) => Some(&p.request_id),
+        EscalateRequest::RunGraphicsDraw(p) => Some(&p.request_id),
         EscalateRequest::ReleaseHandle(p) => Some(&p.request_id),
         EscalateRequest::Log(_) => None,
     }
@@ -396,6 +426,34 @@ pub(crate) fn handle_escalate_op(
                 Some(EscalateResponse::Err(EscalateResponseErr {
                     request_id: rid,
                     message: "run_compute_kernel is only available on Linux".to_string(),
+                }))
+            }
+        }
+        EscalateRequest::RegisterGraphicsKernel(req) => {
+            #[cfg(target_os = "linux")]
+            {
+                Some(handle_register_graphics_kernel(sandbox, rid, req))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = req;
+                Some(EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: "register_graphics_kernel is only available on Linux".to_string(),
+                }))
+            }
+        }
+        EscalateRequest::RunGraphicsDraw(req) => {
+            #[cfg(target_os = "linux")]
+            {
+                Some(handle_run_graphics_draw(sandbox, rid, req))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = req;
+                Some(EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: "run_graphics_draw is only available on Linux".to_string(),
                 }))
             }
         }
@@ -875,6 +933,581 @@ fn handle_run_compute_kernel(
             message: format!("run_compute_kernel bridge call failed: {msg}"),
         }),
     }
+}
+
+/// Map a wire-format `register_graphics_kernel` request through the
+/// registered [`GraphicsKernelBridge`].
+///
+/// Decodes the per-stage SPIR-V hex blobs, translates the wire-format
+/// pipeline-state enums into the bridge's typed [`GraphicsPipelineStateWire`],
+/// and asks the bridge to register the kernel. The bridge returns a
+/// stable `kernel_id` (recommended: SHA-256 over a canonical
+/// representation of all register-time inputs); identical re-registration
+/// hits the bridge's cache and returns the same id.
+///
+/// Failure modes (each surfaced as an [`EscalateResponse::Err`] keyed
+/// by the original request_id):
+/// 1. `vertex_spv_hex` / `fragment_spv_hex` doesn't decode as hex bytes.
+/// 2. No bridge is registered.
+/// 3. Bridge `register` returned an error — typically reflection
+///    failure, push-constant size mismatch, pipeline-state validation
+///    failure, or pipeline build failure.
+#[cfg(target_os = "linux")]
+fn handle_register_graphics_kernel(
+    sandbox: &GpuContextLimitedAccess,
+    rid: String,
+    req: EscalateRequestRegisterGraphicsKernel,
+) -> EscalateResponse {
+    use std::sync::Arc;
+
+    let vertex_spv = match decode_hex(&req.vertex_spv_hex) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!("register_graphics_kernel: vertex_spv_hex decode: {e}"),
+            });
+        }
+    };
+    let fragment_spv = match decode_hex(&req.fragment_spv_hex) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!("register_graphics_kernel: fragment_spv_hex decode: {e}"),
+            });
+        }
+    };
+
+    let bridge: Arc<dyn GraphicsKernelBridge> = match sandbox.escalate(|full| {
+        full.graphics_kernel_bridge().ok_or_else(|| {
+            crate::core::error::StreamError::Configuration(
+                "register_graphics_kernel: no GraphicsKernelBridge registered on GpuContext"
+                    .to_string(),
+            )
+        })
+    }) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: e.to_string(),
+            });
+        }
+    };
+
+    let bindings: Vec<GraphicsBindingDecl> = req
+        .bindings
+        .into_iter()
+        .map(|b| GraphicsBindingDecl {
+            binding: b.binding,
+            kind: graphics_register_binding_kind_from_wire(b.kind),
+            stages: b.stages,
+        })
+        .collect();
+
+    let pipeline_state = match graphics_pipeline_state_from_wire(req.pipeline_state) {
+        Ok(p) => p,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!("register_graphics_kernel: pipeline_state: {e}"),
+            });
+        }
+    };
+
+    let decl = GraphicsKernelRegisterDecl {
+        label: req.label,
+        vertex_spv,
+        fragment_spv,
+        vertex_entry_point: req.vertex_entry_point,
+        fragment_entry_point: req.fragment_entry_point,
+        bindings,
+        push_constant_size: req.push_constant_size,
+        push_constant_stages: req.push_constant_stages,
+        descriptor_sets_in_flight: req.descriptor_sets_in_flight,
+        pipeline_state,
+    };
+
+    match bridge.register(&decl) {
+        Ok(kernel_id) => EscalateResponse::Ok(EscalateResponseOk {
+            request_id: rid,
+            handle_id: kernel_id,
+            width: None,
+            height: None,
+            format: None,
+            usage: None,
+            timeline_value: None,
+        }),
+        Err(msg) => EscalateResponse::Err(EscalateResponseErr {
+            request_id: rid,
+            message: format!("register_graphics_kernel bridge call failed: {msg}"),
+        }),
+    }
+}
+
+/// Map a wire-format `run_graphics_draw` request through the registered
+/// [`GraphicsKernelBridge`].
+///
+/// Graphics dispatch on the host is synchronous (the bridge calls
+/// [`crate::vulkan::rhi::VulkanGraphicsKernel::offscreen_render`] which
+/// submits + waits on its own command buffer + fence), so by the time
+/// this function returns `Ok`, the GPU work has retired and the host's
+/// writes to the color attachments are visible.
+///
+/// Failure modes (each surfaced as an [`EscalateResponse::Err`] keyed
+/// by the original request_id):
+/// 1. `push_constants_hex` doesn't decode as hex bytes.
+/// 2. Vertex/index buffer offset doesn't parse as decimal u64.
+/// 3. No bridge is registered.
+/// 4. Bridge `run_draw` returned an error — typically unrecognized
+///    `kernel_id`, surface lookup failure, or Vulkan submit failure.
+#[cfg(target_os = "linux")]
+fn handle_run_graphics_draw(
+    sandbox: &GpuContextLimitedAccess,
+    rid: String,
+    req: EscalateRequestRunGraphicsDraw,
+) -> EscalateResponse {
+    use std::sync::Arc;
+
+    let push_constants = match decode_hex(&req.push_constants_hex) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: format!("run_graphics_draw: push_constants_hex decode: {e}"),
+            });
+        }
+    };
+
+    let bindings: Vec<GraphicsBindingValue> = req
+        .bindings
+        .into_iter()
+        .map(|b| GraphicsBindingValue {
+            binding: b.binding,
+            kind: graphics_run_binding_kind_from_wire(b.kind),
+            surface_uuid: b.surface_uuid,
+        })
+        .collect();
+
+    let mut vertex_buffers: Vec<GraphicsVertexBufferBinding> =
+        Vec::with_capacity(req.vertex_buffers.len());
+    for vb in req.vertex_buffers.into_iter() {
+        let offset = match vb.offset.parse::<u64>() {
+            Ok(v) => v,
+            Err(e) => {
+                return EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: format!(
+                        "run_graphics_draw: vertex_buffer.offset '{}' is not a decimal u64: {e}",
+                        vb.offset
+                    ),
+                });
+            }
+        };
+        vertex_buffers.push(GraphicsVertexBufferBinding {
+            binding: vb.binding,
+            surface_uuid: vb.surface_uuid,
+            offset,
+        });
+    }
+
+    let index_buffer = if let Some(ib) = req.index_buffer {
+        let offset = match ib.offset.parse::<u64>() {
+            Ok(v) => v,
+            Err(e) => {
+                return EscalateResponse::Err(EscalateResponseErr {
+                    request_id: rid,
+                    message: format!(
+                        "run_graphics_draw: index_buffer.offset '{}' is not a decimal u64: {e}",
+                        ib.offset
+                    ),
+                });
+            }
+        };
+        Some(GraphicsIndexBufferBinding {
+            surface_uuid: ib.surface_uuid,
+            offset,
+            index_type: match ib.index_type {
+                EscalateRequestRunGraphicsDrawIndexBufferIndexType::Uint16 => IndexTypeWire::Uint16,
+                EscalateRequestRunGraphicsDrawIndexBufferIndexType::Uint32 => IndexTypeWire::Uint32,
+            },
+        })
+    } else {
+        None
+    };
+
+    let viewport = req.viewport.map(|v| ViewportWire {
+        x: v.x,
+        y: v.y,
+        width: v.width,
+        height: v.height,
+        min_depth: v.min_depth,
+        max_depth: v.max_depth,
+    });
+    let scissor = req.scissor.map(|s| ScissorRectWire {
+        x: s.x,
+        y: s.y,
+        width: s.width,
+        height: s.height,
+    });
+
+    let draw = match req.draw.kind {
+        EscalateRequestRunGraphicsDrawDrawKind::Draw => GraphicsDrawSpec::Draw {
+            vertex_count: req.draw.vertex_count,
+            instance_count: req.draw.instance_count,
+            first_vertex: req.draw.first_vertex,
+            first_instance: req.draw.first_instance,
+        },
+        EscalateRequestRunGraphicsDrawDrawKind::DrawIndexed => GraphicsDrawSpec::DrawIndexed {
+            index_count: req.draw.index_count,
+            instance_count: req.draw.instance_count,
+            first_index: req.draw.first_index,
+            vertex_offset: req.draw.vertex_offset,
+            first_instance: req.draw.first_instance,
+        },
+    };
+
+    let kernel_id = req.kernel_id;
+    let domain = GraphicsKernelRunDraw {
+        kernel_id: kernel_id.clone(),
+        frame_index: req.frame_index,
+        bindings,
+        vertex_buffers,
+        index_buffer,
+        color_target_uuids: req.color_target_uuids,
+        depth_target_uuid: req.depth_target_uuid,
+        extent: (req.extent_width, req.extent_height),
+        push_constants,
+        viewport,
+        scissor,
+        draw,
+    };
+
+    let bridge: Arc<dyn GraphicsKernelBridge> = match sandbox.escalate(|full| {
+        full.graphics_kernel_bridge().ok_or_else(|| {
+            crate::core::error::StreamError::Configuration(
+                "run_graphics_draw: no GraphicsKernelBridge registered on GpuContext".to_string(),
+            )
+        })
+    }) {
+        Ok(b) => b,
+        Err(e) => {
+            return EscalateResponse::Err(EscalateResponseErr {
+                request_id: rid,
+                message: e.to_string(),
+            });
+        }
+    };
+
+    match bridge.run_draw(&domain) {
+        Ok(()) => EscalateResponse::Ok(EscalateResponseOk {
+            request_id: rid,
+            handle_id: kernel_id,
+            width: None,
+            height: None,
+            format: None,
+            usage: None,
+            timeline_value: None,
+        }),
+        Err(msg) => EscalateResponse::Err(EscalateResponseErr {
+            request_id: rid,
+            message: format!("run_graphics_draw bridge call failed: {msg}"),
+        }),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn graphics_register_binding_kind_from_wire(
+    kind: EscalateRequestRegisterGraphicsKernelBindingKind,
+) -> GraphicsBindingKindWire {
+    match kind {
+        EscalateRequestRegisterGraphicsKernelBindingKind::SampledTexture => {
+            GraphicsBindingKindWire::SampledTexture
+        }
+        EscalateRequestRegisterGraphicsKernelBindingKind::StorageBuffer => {
+            GraphicsBindingKindWire::StorageBuffer
+        }
+        EscalateRequestRegisterGraphicsKernelBindingKind::UniformBuffer => {
+            GraphicsBindingKindWire::UniformBuffer
+        }
+        EscalateRequestRegisterGraphicsKernelBindingKind::StorageImage => {
+            GraphicsBindingKindWire::StorageImage
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn graphics_run_binding_kind_from_wire(
+    kind: EscalateRequestRunGraphicsDrawBindingKind,
+) -> GraphicsBindingKindWire {
+    match kind {
+        EscalateRequestRunGraphicsDrawBindingKind::SampledTexture => {
+            GraphicsBindingKindWire::SampledTexture
+        }
+        EscalateRequestRunGraphicsDrawBindingKind::StorageBuffer => {
+            GraphicsBindingKindWire::StorageBuffer
+        }
+        EscalateRequestRunGraphicsDrawBindingKind::UniformBuffer => {
+            GraphicsBindingKindWire::UniformBuffer
+        }
+        EscalateRequestRunGraphicsDrawBindingKind::StorageImage => {
+            GraphicsBindingKindWire::StorageImage
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn graphics_pipeline_state_from_wire(
+    p: EscalateRequestRegisterGraphicsKernelPipelineState,
+) -> std::result::Result<GraphicsPipelineStateWire, String> {
+    let topology = match p.topology {
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::PointList => {
+            PrimitiveTopologyWire::PointList
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::LineList => {
+            PrimitiveTopologyWire::LineList
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::LineStrip => {
+            PrimitiveTopologyWire::LineStrip
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::TriangleList => {
+            PrimitiveTopologyWire::TriangleList
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::TriangleStrip => {
+            PrimitiveTopologyWire::TriangleStrip
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateTopology::TriangleFan => {
+            PrimitiveTopologyWire::TriangleFan
+        }
+    };
+    let vertex_input_bindings = p
+        .vertex_input_bindings
+        .into_iter()
+        .map(|b| VertexInputBindingDecl {
+            binding: b.binding,
+            stride: b.stride,
+            input_rate: match b.input_rate {
+                EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate::Vertex => {
+                    VertexInputRateWire::Vertex
+                }
+                EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputBindingInputRate::Instance => {
+                    VertexInputRateWire::Instance
+                }
+            },
+        })
+        .collect::<Vec<_>>();
+    let vertex_input_attributes = p
+        .vertex_input_attributes
+        .into_iter()
+        .map(|a| {
+            Ok::<_, String>(VertexInputAttributeDecl {
+                location: a.location,
+                binding: a.binding,
+                format: vertex_attribute_format_from_wire(a.format),
+                offset: a.offset,
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let rasterization_polygon_mode = match p.rasterization_polygon_mode {
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode::Fill => {
+            PolygonModeWire::Fill
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode::Line => {
+            PolygonModeWire::Line
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode::Point => {
+            PolygonModeWire::Point
+        }
+    };
+    let rasterization_cull_mode = match p.rasterization_cull_mode {
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::None => {
+            CullModeWire::None
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::Front => {
+            CullModeWire::Front
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::Back => {
+            CullModeWire::Back
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::FrontAndBack => {
+            CullModeWire::FrontAndBack
+        }
+    };
+    let rasterization_front_face = match p.rasterization_front_face {
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace::CounterClockwise => {
+            FrontFaceWire::CounterClockwise
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace::Clockwise => {
+            FrontFaceWire::Clockwise
+        }
+    };
+    let depth_compare_op = depth_compare_op_from_wire(p.depth_compare_op);
+    let color_blend_src_color_factor = blend_factor_from_wire_src_color(p.color_blend_src_color_factor);
+    let color_blend_dst_color_factor = blend_factor_from_wire_dst_color(p.color_blend_dst_color_factor);
+    let color_blend_color_op = blend_op_from_wire_color(p.color_blend_color_op);
+    let color_blend_src_alpha_factor = blend_factor_from_wire_src_alpha(p.color_blend_src_alpha_factor);
+    let color_blend_dst_alpha_factor = blend_factor_from_wire_dst_alpha(p.color_blend_dst_alpha_factor);
+    let color_blend_alpha_op = blend_op_from_wire_alpha(p.color_blend_alpha_op);
+    let attachment_depth_format = p.attachment_depth_format.map(|d| match d {
+        EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat::D16Unorm => {
+            DepthFormatWire::D16Unorm
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat::D32Sfloat => {
+            DepthFormatWire::D32Sfloat
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateAttachmentDepthFormat::D24UnormS8Uint => {
+            DepthFormatWire::D24UnormS8Uint
+        }
+    });
+    let dynamic_state = match p.dynamic_state {
+        EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState::None => {
+            DynamicStateWire::None
+        }
+        EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState::ViewportScissor => {
+            DynamicStateWire::ViewportScissor
+        }
+    };
+
+    Ok(GraphicsPipelineStateWire {
+        topology,
+        vertex_input_bindings,
+        vertex_input_attributes,
+        rasterization_polygon_mode,
+        rasterization_cull_mode,
+        rasterization_front_face,
+        rasterization_line_width: p.rasterization_line_width,
+        multisample_samples: p.multisample_samples,
+        depth_stencil_enabled: p.depth_stencil_enabled,
+        depth_compare_op,
+        depth_write: p.depth_write,
+        color_blend_enabled: p.color_blend_enabled,
+        color_write_mask: p.color_write_mask,
+        color_blend_src_color_factor,
+        color_blend_dst_color_factor,
+        color_blend_color_op,
+        color_blend_src_alpha_factor,
+        color_blend_dst_alpha_factor,
+        color_blend_alpha_op,
+        attachment_color_formats: p.attachment_color_formats,
+        attachment_depth_format,
+        dynamic_state,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn vertex_attribute_format_from_wire(
+    fmt: EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat,
+) -> VertexAttributeFormatWire {
+    use EscalateRequestRegisterGraphicsKernelPipelineStateVertexInputAttributeFormat as W;
+    match fmt {
+        W::R32Float => VertexAttributeFormatWire::R32Float,
+        W::Rg32Float => VertexAttributeFormatWire::Rg32Float,
+        W::Rgb32Float => VertexAttributeFormatWire::Rgb32Float,
+        W::Rgba32Float => VertexAttributeFormatWire::Rgba32Float,
+        W::R32Uint => VertexAttributeFormatWire::R32Uint,
+        W::Rg32Uint => VertexAttributeFormatWire::Rg32Uint,
+        W::Rgb32Uint => VertexAttributeFormatWire::Rgb32Uint,
+        W::Rgba32Uint => VertexAttributeFormatWire::Rgba32Uint,
+        W::R32Sint => VertexAttributeFormatWire::R32Sint,
+        W::Rg32Sint => VertexAttributeFormatWire::Rg32Sint,
+        W::Rgb32Sint => VertexAttributeFormatWire::Rgb32Sint,
+        W::Rgba32Sint => VertexAttributeFormatWire::Rgba32Sint,
+        W::Rgba8Unorm => VertexAttributeFormatWire::Rgba8Unorm,
+        W::Rgba8Snorm => VertexAttributeFormatWire::Rgba8Snorm,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn depth_compare_op_from_wire(
+    op: EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp,
+) -> DepthCompareOpWire {
+    use EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp as W;
+    match op {
+        W::Never => DepthCompareOpWire::Never,
+        W::Less => DepthCompareOpWire::Less,
+        W::Equal => DepthCompareOpWire::Equal,
+        W::LessOrEqual => DepthCompareOpWire::LessOrEqual,
+        W::Greater => DepthCompareOpWire::Greater,
+        W::NotEqual => DepthCompareOpWire::NotEqual,
+        W::GreaterOrEqual => DepthCompareOpWire::GreaterOrEqual,
+        W::Always => DepthCompareOpWire::Always,
+    }
+}
+
+#[cfg(target_os = "linux")]
+macro_rules! blend_factor_match {
+    ($enum:ident, $val:expr) => {{
+        use $enum as W;
+        match $val {
+            W::Zero => BlendFactorWire::Zero,
+            W::One => BlendFactorWire::One,
+            W::SrcColor => BlendFactorWire::SrcColor,
+            W::OneMinusSrcColor => BlendFactorWire::OneMinusSrcColor,
+            W::DstColor => BlendFactorWire::DstColor,
+            W::OneMinusDstColor => BlendFactorWire::OneMinusDstColor,
+            W::SrcAlpha => BlendFactorWire::SrcAlpha,
+            W::OneMinusSrcAlpha => BlendFactorWire::OneMinusSrcAlpha,
+            W::DstAlpha => BlendFactorWire::DstAlpha,
+            W::OneMinusDstAlpha => BlendFactorWire::OneMinusDstAlpha,
+            W::ConstantColor => BlendFactorWire::ConstantColor,
+            W::OneMinusConstantColor => BlendFactorWire::OneMinusConstantColor,
+            W::ConstantAlpha => BlendFactorWire::ConstantAlpha,
+            W::OneMinusConstantAlpha => BlendFactorWire::OneMinusConstantAlpha,
+            W::SrcAlphaSaturate => BlendFactorWire::SrcAlphaSaturate,
+        }
+    }};
+}
+
+#[cfg(target_os = "linux")]
+macro_rules! blend_op_match {
+    ($enum:ident, $val:expr) => {{
+        use $enum as W;
+        match $val {
+            W::Add => BlendOpWire::Add,
+            W::Subtract => BlendOpWire::Subtract,
+            W::ReverseSubtract => BlendOpWire::ReverseSubtract,
+            W::Min => BlendOpWire::Min,
+            W::Max => BlendOpWire::Max,
+        }
+    }};
+}
+
+#[cfg(target_os = "linux")]
+fn blend_factor_from_wire_src_color(
+    f: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor,
+) -> BlendFactorWire {
+    blend_factor_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor, f)
+}
+#[cfg(target_os = "linux")]
+fn blend_factor_from_wire_dst_color(
+    f: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor,
+) -> BlendFactorWire {
+    blend_factor_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor, f)
+}
+#[cfg(target_os = "linux")]
+fn blend_factor_from_wire_src_alpha(
+    f: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor,
+) -> BlendFactorWire {
+    blend_factor_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor, f)
+}
+#[cfg(target_os = "linux")]
+fn blend_factor_from_wire_dst_alpha(
+    f: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor,
+) -> BlendFactorWire {
+    blend_factor_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor, f)
+}
+#[cfg(target_os = "linux")]
+fn blend_op_from_wire_color(
+    o: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp,
+) -> BlendOpWire {
+    blend_op_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp, o)
+}
+#[cfg(target_os = "linux")]
+fn blend_op_from_wire_alpha(
+    o: EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp,
+) -> BlendOpWire {
+    blend_op_match!(EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp, o)
 }
 
 /// Decode lowercase hex into bytes, returning a clean error message on
@@ -2054,6 +2687,628 @@ mod tests {
             assert_eq!(r.surface_uuid, "surface-xyz");
             assert_eq!(r.push_len, 8, "push_constants_hex decoded to 8 bytes");
             assert_eq!(r.groups, (4, 5, 6));
+        }
+    }
+
+    /// Host-Rust unit tests for the `register_graphics_kernel` /
+    /// `run_graphics_draw` escalate handlers. Mirrors the
+    /// `compute_kernel_dispatch` shape — the synthetic
+    /// `RecordingGraphicsBridge` keeps tests independent of a working
+    /// VkDevice, so handler-shape regressions surface even on
+    /// machines without a GPU.
+    #[cfg(target_os = "linux")]
+    mod graphics_kernel_dispatch {
+        use super::super::*;
+        use super::EscalateHandleRegistry;
+        use std::sync::{Arc, Mutex};
+
+        use crate::_generated_::com_streamlib_escalate_request::{
+            EscalateRequestRunGraphicsDrawBinding, EscalateRequestRunGraphicsDrawDraw,
+            EscalateRequestRunGraphicsDrawIndexBuffer, EscalateRequestRunGraphicsDrawScissor,
+            EscalateRequestRunGraphicsDrawVertexBuffer, EscalateRequestRunGraphicsDrawViewport,
+        };
+        use crate::core::context::{
+            GpuContext, GpuContextLimitedAccess, GraphicsKernelBridge,
+            GraphicsKernelRegisterDecl, GraphicsKernelRunDraw,
+        };
+
+        /// Synthetic bridge — registers any caller-provided vertex+fragment
+        /// SPIR-V (no SPV reflection or pipeline build), keys the kernel id by
+        /// SHA-256 over the canonicalized inputs so identical descriptors
+        /// hit the cache, and records each `run_draw` for later assertion.
+        struct RecordingGraphicsBridge {
+            registered: Mutex<std::collections::HashMap<String, GraphicsKernelRegisterDecl>>,
+            runs: Mutex<Vec<GraphicsKernelRunDraw>>,
+        }
+
+        impl RecordingGraphicsBridge {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    registered: Mutex::new(std::collections::HashMap::new()),
+                    runs: Mutex::new(Vec::new()),
+                })
+            }
+
+            fn registered_count(&self) -> usize {
+                self.registered.lock().unwrap().len()
+            }
+
+            fn runs(&self) -> Vec<GraphicsKernelRunDraw> {
+                self.runs.lock().unwrap().clone()
+            }
+
+            fn key(decl: &GraphicsKernelRegisterDecl) -> String {
+                use sha2::{Digest, Sha256};
+                let mut h = Sha256::new();
+                h.update(b"v=");
+                h.update(&decl.vertex_spv);
+                h.update(b"|f=");
+                h.update(&decl.fragment_spv);
+                h.update(b"|ve=");
+                h.update(decl.vertex_entry_point.as_bytes());
+                h.update(b"|fe=");
+                h.update(decl.fragment_entry_point.as_bytes());
+                h.update(b"|pcs=");
+                h.update(&decl.push_constant_size.to_le_bytes());
+                h.update(b"|pcst=");
+                h.update(&decl.push_constant_stages.to_le_bytes());
+                h.update(b"|dsi=");
+                h.update(&decl.descriptor_sets_in_flight.to_le_bytes());
+                h.update(b"|nb=");
+                h.update(&(decl.bindings.len() as u32).to_le_bytes());
+                format!("{:x}", h.finalize())
+            }
+        }
+
+        impl GraphicsKernelBridge for RecordingGraphicsBridge {
+            fn register(
+                &self,
+                decl: &GraphicsKernelRegisterDecl,
+            ) -> std::result::Result<String, String> {
+                let id = Self::key(decl);
+                self.registered
+                    .lock()
+                    .unwrap()
+                    .entry(id.clone())
+                    .or_insert_with(|| decl.clone());
+                Ok(id)
+            }
+
+            fn run_draw(
+                &self,
+                draw: &GraphicsKernelRunDraw,
+            ) -> std::result::Result<(), String> {
+                if !self.registered.lock().unwrap().contains_key(&draw.kernel_id) {
+                    return Err(format!(
+                        "kernel_id '{}' not registered with this bridge",
+                        draw.kernel_id
+                    ));
+                }
+                self.runs.lock().unwrap().push(draw.clone());
+                Ok(())
+            }
+        }
+
+        fn make_sandbox_with_bridge(
+            bridge: Option<Arc<dyn GraphicsKernelBridge>>,
+        ) -> Option<GpuContextLimitedAccess> {
+            let gpu = match GpuContext::init_for_platform_sync() {
+                Ok(g) => g,
+                Err(_) => return None,
+            };
+            if let Some(b) = bridge {
+                gpu.set_graphics_kernel_bridge(b);
+            }
+            Some(GpuContextLimitedAccess::new(gpu))
+        }
+
+        /// Build a baseline `register_graphics_kernel` request — vertex
+        /// + fragment SPIR-V hex, default-shaped TriangleList pipeline
+        /// state with no blending and no depth. Tests that need a
+        /// specific shape mutate fields after calling.
+        fn make_register_req(
+            request_id: &str,
+            vertex_hex: &str,
+            fragment_hex: &str,
+        ) -> EscalateRequestRegisterGraphicsKernel {
+            EscalateRequestRegisterGraphicsKernel {
+                request_id: request_id.to_string(),
+                label: "test-graphics".to_string(),
+                vertex_spv_hex: vertex_hex.to_string(),
+                fragment_spv_hex: fragment_hex.to_string(),
+                vertex_entry_point: "main".to_string(),
+                fragment_entry_point: "main".to_string(),
+                bindings: Vec::new(),
+                push_constant_size: 0,
+                push_constant_stages: 0,
+                descriptor_sets_in_flight: 2,
+                pipeline_state: EscalateRequestRegisterGraphicsKernelPipelineState {
+                    topology: EscalateRequestRegisterGraphicsKernelPipelineStateTopology::TriangleList,
+                    vertex_input_bindings: Vec::new(),
+                    vertex_input_attributes: Vec::new(),
+                    rasterization_polygon_mode:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationPolygonMode::Fill,
+                    rasterization_cull_mode:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationCullMode::None,
+                    rasterization_front_face:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateRasterizationFrontFace::CounterClockwise,
+                    rasterization_line_width: 1.0,
+                    multisample_samples: 1,
+                    depth_stencil_enabled: false,
+                    depth_compare_op:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateDepthCompareOp::Always,
+                    depth_write: false,
+                    color_blend_enabled: false,
+                    color_write_mask: 0b1111,
+                    color_blend_src_color_factor:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcColorFactor::One,
+                    color_blend_dst_color_factor:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstColorFactor::Zero,
+                    color_blend_color_op:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendColorOp::Add,
+                    color_blend_src_alpha_factor:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendSrcAlphaFactor::One,
+                    color_blend_dst_alpha_factor:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendDstAlphaFactor::Zero,
+                    color_blend_alpha_op:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateColorBlendAlphaOp::Add,
+                    attachment_color_formats: vec!["rgba8_unorm".to_string()],
+                    dynamic_state:
+                        EscalateRequestRegisterGraphicsKernelPipelineStateDynamicState::ViewportScissor,
+                    attachment_depth_format: None,
+                },
+            }
+        }
+
+        /// Baseline `run_graphics_draw` request — vertex-fabricating
+        /// (no vertex buffers, no index buffer), single color target,
+        /// 320x240 extent, simple Draw of 3 vertices.
+        fn make_run_req(
+            request_id: &str,
+            kernel_id: &str,
+            surface_uuid: &str,
+        ) -> EscalateRequestRunGraphicsDraw {
+            EscalateRequestRunGraphicsDraw {
+                request_id: request_id.to_string(),
+                kernel_id: kernel_id.to_string(),
+                frame_index: 0,
+                bindings: Vec::new(),
+                vertex_buffers: Vec::new(),
+                color_target_uuids: vec![surface_uuid.to_string()],
+                extent_width: 320,
+                extent_height: 240,
+                push_constants_hex: String::new(),
+                draw: EscalateRequestRunGraphicsDrawDraw {
+                    kind: EscalateRequestRunGraphicsDrawDrawKind::Draw,
+                    vertex_count: 3,
+                    index_count: 0,
+                    instance_count: 1,
+                    first_vertex: 0,
+                    first_instance: 0,
+                    first_index: 0,
+                    vertex_offset: 0,
+                },
+                index_buffer: None,
+                depth_target_uuid: None,
+                viewport: None,
+                scissor: None,
+            }
+        }
+
+        #[test]
+        fn register_without_bridge_returns_err() {
+            let sandbox = match make_sandbox_with_bridge(None) {
+                Some(s) => s,
+                None => {
+                    println!("register_without_bridge_returns_err: no GPU — skipping");
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "req-reg-1", "deadbeef", "cafebabe",
+            ));
+            let response = handle_escalate_op(&sandbox, &registry, req)
+                .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-reg-1");
+                    assert!(
+                        err.message.contains("GraphicsKernelBridge"),
+                        "expected bridge-not-registered error, got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err when no bridge registered, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn run_without_bridge_returns_err() {
+            let sandbox = match make_sandbox_with_bridge(None) {
+                Some(s) => s,
+                None => {
+                    println!("run_without_bridge_returns_err: no GPU — skipping");
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req = EscalateRequest::RunGraphicsDraw(make_run_req(
+                "req-run-1", "kernel-x", "surface-y",
+            ));
+            let response = handle_escalate_op(&sandbox, &registry, req)
+                .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-run-1");
+                    assert!(
+                        err.message.contains("GraphicsKernelBridge"),
+                        "expected bridge-not-registered error, got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err when no bridge registered, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn register_with_invalid_vertex_hex_returns_err() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!("register_with_invalid_vertex_hex_returns_err: no GPU — skipping");
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "req-bad-v", "xyz123", "cafebabe",
+            ));
+            let response = handle_escalate_op(&sandbox, &registry, req)
+                .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-bad-v");
+                    assert!(
+                        err.message.contains("vertex_spv_hex"),
+                        "got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err for malformed vertex hex, got {other:?}"),
+            }
+            assert_eq!(
+                bridge.registered_count(),
+                0,
+                "bridge.register must not have been called on the parse-error path"
+            );
+        }
+
+        #[test]
+        fn register_with_invalid_fragment_hex_returns_err() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!("register_with_invalid_fragment_hex_returns_err: no GPU — skipping");
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "req-bad-f", "deadbeef", "qq",
+            ));
+            let response = handle_escalate_op(&sandbox, &registry, req)
+                .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-bad-f");
+                    assert!(
+                        err.message.contains("fragment_spv_hex"),
+                        "got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err for malformed fragment hex, got {other:?}"),
+            }
+            assert_eq!(bridge.registered_count(), 0);
+        }
+
+        #[test]
+        fn run_with_invalid_push_constants_hex_returns_err() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "run_with_invalid_push_constants_hex_returns_err: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let mut req = make_run_req("req-bad-push", "kernel-x", "surface-y");
+            req.push_constants_hex = "xyz".to_string();
+            let response = handle_escalate_op(
+                &sandbox,
+                &registry,
+                EscalateRequest::RunGraphicsDraw(req),
+            )
+            .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-bad-push");
+                    assert!(
+                        err.message.contains("push_constants_hex"),
+                        "got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err for malformed push hex, got {other:?}"),
+            }
+            assert!(bridge.runs().is_empty());
+        }
+
+        #[test]
+        fn run_with_malformed_vertex_buffer_offset_returns_err() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "run_with_malformed_vertex_buffer_offset_returns_err: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let mut req = make_run_req("req-bad-vb", "kernel-x", "surface-y");
+            req.vertex_buffers = vec![EscalateRequestRunGraphicsDrawVertexBuffer {
+                binding: 0,
+                surface_uuid: "vb-uuid".to_string(),
+                offset: "not-a-number".to_string(),
+            }];
+            let response = handle_escalate_op(
+                &sandbox,
+                &registry,
+                EscalateRequest::RunGraphicsDraw(req),
+            )
+            .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-bad-vb");
+                    assert!(
+                        err.message.contains("vertex_buffer.offset"),
+                        "got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err for malformed vb.offset, got {other:?}"),
+            }
+            assert!(bridge.runs().is_empty());
+        }
+
+        #[test]
+        fn register_returns_stable_kernel_id_for_identical_descriptor() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "register_returns_stable_kernel_id_for_identical_descriptor: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let make_req = |rid: &str| {
+                EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                    rid,
+                    "deadbeefcafebabe",
+                    "00112233445566778899aabbccddeeff",
+                ))
+            };
+            let id1 = match handle_escalate_op(&sandbox, &registry, make_req("a")).unwrap() {
+                EscalateResponse::Ok(ok) => ok.handle_id,
+                other => panic!("first register expected Ok, got {other:?}"),
+            };
+            let id2 = match handle_escalate_op(&sandbox, &registry, make_req("b")).unwrap() {
+                EscalateResponse::Ok(ok) => ok.handle_id,
+                other => panic!("second register expected Ok, got {other:?}"),
+            };
+            assert_eq!(id1, id2, "identical descriptor must produce the same kernel_id");
+        }
+
+        #[test]
+        fn register_returns_distinct_kernel_ids_for_different_spirv() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "register_returns_distinct_kernel_ids_for_different_spirv: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req_a = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "a", "deadbeef", "cafebabe",
+            ));
+            let req_b = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "b", "11223344", "cafebabe",
+            ));
+            let id_a = match handle_escalate_op(&sandbox, &registry, req_a).unwrap() {
+                EscalateResponse::Ok(ok) => ok.handle_id,
+                other => panic!("expected Ok, got {other:?}"),
+            };
+            let id_b = match handle_escalate_op(&sandbox, &registry, req_b).unwrap() {
+                EscalateResponse::Ok(ok) => ok.handle_id,
+                other => panic!("expected Ok, got {other:?}"),
+            };
+            assert_ne!(id_a, id_b, "different vertex SPIR-V must produce different kernel_ids");
+        }
+
+        #[test]
+        fn run_with_unregistered_kernel_id_returns_err() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "run_with_unregistered_kernel_id_returns_err: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+            let req = EscalateRequest::RunGraphicsDraw(make_run_req(
+                "req-bad-id",
+                "never-registered",
+                "surface-y",
+            ));
+            let response = handle_escalate_op(&sandbox, &registry, req)
+                .expect("must produce a response");
+            match response {
+                EscalateResponse::Err(err) => {
+                    assert_eq!(err.request_id, "req-bad-id");
+                    assert!(
+                        err.message.contains("not registered")
+                            || err.message.contains("never-registered"),
+                        "got: {}",
+                        err.message
+                    );
+                }
+                other => panic!("expected Err for unregistered kernel_id, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn run_forwards_payload_to_bridge_and_echoes_kernel_id() {
+            let bridge = RecordingGraphicsBridge::new();
+            let sandbox = match make_sandbox_with_bridge(Some(bridge.clone())) {
+                Some(s) => s,
+                None => {
+                    println!(
+                        "run_forwards_payload_to_bridge_and_echoes_kernel_id: no GPU — skipping"
+                    );
+                    return;
+                }
+            };
+            let registry = EscalateHandleRegistry::new();
+
+            // Register first so the bridge has the kernel_id cached.
+            let reg = EscalateRequest::RegisterGraphicsKernel(make_register_req(
+                "reg",
+                "abcdef0123456789",
+                "fedcba9876543210",
+            ));
+            let kernel_id = match handle_escalate_op(&sandbox, &registry, reg).unwrap() {
+                EscalateResponse::Ok(ok) => ok.handle_id,
+                other => panic!("register expected Ok, got {other:?}"),
+            };
+
+            // Indexed draw with a vertex buffer + push constants — exercises
+            // every translation arm in the wire→domain mapper.
+            let mut run = make_run_req("run", &kernel_id, "color-target-uuid");
+            run.frame_index = 1;
+            run.bindings = vec![EscalateRequestRunGraphicsDrawBinding {
+                binding: 0,
+                kind: EscalateRequestRunGraphicsDrawBindingKind::SampledTexture,
+                surface_uuid: "tex-uuid".to_string(),
+            }];
+            run.vertex_buffers = vec![EscalateRequestRunGraphicsDrawVertexBuffer {
+                binding: 0,
+                surface_uuid: "vb-uuid".to_string(),
+                offset: "128".to_string(),
+            }];
+            run.index_buffer = Some(EscalateRequestRunGraphicsDrawIndexBuffer {
+                surface_uuid: "ib-uuid".to_string(),
+                offset: "64".to_string(),
+                index_type: EscalateRequestRunGraphicsDrawIndexBufferIndexType::Uint32,
+            });
+            run.push_constants_hex = "00112233aabbccdd".to_string();
+            run.draw = EscalateRequestRunGraphicsDrawDraw {
+                kind: EscalateRequestRunGraphicsDrawDrawKind::DrawIndexed,
+                vertex_count: 0,
+                index_count: 6,
+                instance_count: 2,
+                first_vertex: 0,
+                first_instance: 1,
+                first_index: 3,
+                vertex_offset: -4,
+            };
+            run.viewport = Some(EscalateRequestRunGraphicsDrawViewport {
+                x: 0.0,
+                y: 0.0,
+                width: 320.0,
+                height: 240.0,
+                min_depth: 0.0,
+                max_depth: 1.0,
+            });
+            run.scissor = Some(EscalateRequestRunGraphicsDrawScissor {
+                x: 0,
+                y: 0,
+                width: 320,
+                height: 240,
+            });
+
+            let response = handle_escalate_op(
+                &sandbox,
+                &registry,
+                EscalateRequest::RunGraphicsDraw(run),
+            )
+            .unwrap();
+            match response {
+                EscalateResponse::Ok(ok) => {
+                    assert_eq!(ok.request_id, "run");
+                    assert_eq!(
+                        ok.handle_id, kernel_id,
+                        "run response handle_id must echo the kernel_id"
+                    );
+                    assert!(
+                        ok.timeline_value.is_none(),
+                        "run_graphics_draw responses carry no timeline"
+                    );
+                }
+                other => panic!("run expected Ok, got {other:?}"),
+            }
+            let runs = bridge.runs();
+            assert_eq!(runs.len(), 1, "bridge.run_draw must have been called once");
+            let r = &runs[0];
+            assert_eq!(r.kernel_id, kernel_id);
+            assert_eq!(r.frame_index, 1);
+            assert_eq!(r.color_target_uuids, vec!["color-target-uuid".to_string()]);
+            assert_eq!(r.extent, (320, 240));
+            assert_eq!(r.bindings.len(), 1);
+            assert_eq!(r.bindings[0].surface_uuid, "tex-uuid");
+            assert_eq!(r.vertex_buffers.len(), 1);
+            assert_eq!(r.vertex_buffers[0].surface_uuid, "vb-uuid");
+            assert_eq!(r.vertex_buffers[0].offset, 128);
+            let ib = r.index_buffer.as_ref().expect("index_buffer present");
+            assert_eq!(ib.surface_uuid, "ib-uuid");
+            assert_eq!(ib.offset, 64);
+            assert_eq!(ib.index_type, IndexTypeWire::Uint32);
+            assert_eq!(r.push_constants.len(), 8);
+            assert!(r.viewport.is_some());
+            assert!(r.scissor.is_some());
+            match r.draw {
+                GraphicsDrawSpec::DrawIndexed {
+                    index_count,
+                    instance_count,
+                    first_index,
+                    vertex_offset,
+                    first_instance,
+                } => {
+                    assert_eq!(index_count, 6);
+                    assert_eq!(instance_count, 2);
+                    assert_eq!(first_index, 3);
+                    assert_eq!(vertex_offset, -4);
+                    assert_eq!(first_instance, 1);
+                }
+                other => panic!("expected DrawIndexed, got {other:?}"),
+            }
         }
     }
 

--- a/libs/streamlib/src/core/context/gpu_context.rs
+++ b/libs/streamlib/src/core/context/gpu_context.rs
@@ -54,6 +54,8 @@ impl RhiBlitter for NoOpBlitter {
 #[cfg(target_os = "linux")]
 use super::compute_kernel_bridge::ComputeKernelBridge;
 #[cfg(target_os = "linux")]
+use super::graphics_kernel_bridge::GraphicsKernelBridge;
+#[cfg(target_os = "linux")]
 use super::cpu_readback_bridge::CpuReadbackBridge;
 use super::surface_store::SurfaceStore;
 use super::texture_pool::{
@@ -417,6 +419,14 @@ pub struct GpuContext {
     /// handler responds with an `Err` in that case).
     #[cfg(target_os = "linux")]
     compute_kernel_bridge: Arc<Mutex<Option<Arc<dyn ComputeKernelBridge>>>>,
+    /// Host-side bridge for the graphics-kernel escalate ops
+    /// (`register_graphics_kernel`, `run_graphics_draw`). Wired by
+    /// application code that exposes the host's
+    /// [`crate::vulkan::rhi::VulkanGraphicsKernel`] to subprocess customers;
+    /// left unset on hosts that don't expose graphics dispatch (the
+    /// escalate handler responds with an `Err` in that case).
+    #[cfg(target_os = "linux")]
+    graphics_kernel_bridge: Arc<Mutex<Option<Arc<dyn GraphicsKernelBridge>>>>,
 }
 
 impl GpuContext {
@@ -439,6 +449,8 @@ impl GpuContext {
             cpu_readback_bridge: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "linux")]
             compute_kernel_bridge: Arc::new(Mutex::new(None)),
+            #[cfg(target_os = "linux")]
+            graphics_kernel_bridge: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -461,6 +473,8 @@ impl GpuContext {
             cpu_readback_bridge: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "linux")]
             compute_kernel_bridge: Arc::new(Mutex::new(None)),
+            #[cfg(target_os = "linux")]
+            graphics_kernel_bridge: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1252,6 +1266,26 @@ impl GpuContext {
         self.compute_kernel_bridge.lock().unwrap().clone()
     }
 
+    // =========================================================================
+    // GraphicsKernelBridge — host-side dispatch for the graphics-kernel escalate ops
+    // =========================================================================
+
+    /// Register a [`GraphicsKernelBridge`] implementation. The escalate handler
+    /// dispatches `register_graphics_kernel` and `run_graphics_draw` requests
+    /// through this bridge; until it is set, those requests fail with an
+    /// "unsupported" error response. Linux-only: graphics escalate uses the
+    /// Linux-side `VulkanGraphicsKernel`.
+    #[cfg(target_os = "linux")]
+    pub fn set_graphics_kernel_bridge(&self, bridge: Arc<dyn GraphicsKernelBridge>) {
+        *self.graphics_kernel_bridge.lock().unwrap() = Some(bridge);
+    }
+
+    /// Get the registered [`GraphicsKernelBridge`], if any.
+    #[cfg(target_os = "linux")]
+    pub fn graphics_kernel_bridge(&self) -> Option<Arc<dyn GraphicsKernelBridge>> {
+        self.graphics_kernel_bridge.lock().unwrap().clone()
+    }
+
     /// Check in a pixel buffer to the surface-share service, returning a surface ID.
     ///
     /// The surface ID can be shared with other processes (e.g., Python subprocesses)
@@ -1861,6 +1895,13 @@ impl GpuContextFullAccess {
     #[cfg(target_os = "linux")]
     pub fn compute_kernel_bridge(&self) -> Option<Arc<dyn ComputeKernelBridge>> {
         self.inner.compute_kernel_bridge()
+    }
+
+    /// Get the registered graphics-kernel bridge, if any. Reachable only inside
+    /// `escalate(|full| ...)` since it requires `FullAccess`.
+    #[cfg(target_os = "linux")]
+    pub fn graphics_kernel_bridge(&self) -> Option<Arc<dyn GraphicsKernelBridge>> {
+        self.inner.graphics_kernel_bridge()
     }
 }
 

--- a/libs/streamlib/src/core/context/graphics_kernel_bridge.rs
+++ b/libs/streamlib/src/core/context/graphics_kernel_bridge.rs
@@ -1,0 +1,358 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side dispatch trait the escalate handler uses to drive graphics
+//! kernel registration and per-draw invocation on behalf of subprocess
+//! customers.
+//!
+//! Mirrors the [`super::compute_kernel_bridge::ComputeKernelBridge`]
+//! shape (#550): the subprocess sends a typed IPC, the host runs
+//! privileged Vulkan work via its [`crate::core::context::GpuContextFullAccess`],
+//! and the bridge keeps the FullAccess capability boundary on the host
+//! side of the IPC seam.
+//!
+//! Graphics is register-once-draw-many: the subprocess sends the
+//! vertex + fragment SPIR-V plus the full pipeline state once; the
+//! host reflects bindings + builds the
+//! [`crate::vulkan::rhi::VulkanGraphicsKernel`] (with on-disk pipeline
+//! cache persistence — same `STREAMLIB_PIPELINE_CACHE_DIR` knob as
+//! compute), and caches it keyed by SHA-256 of a canonical
+//! description blob. Subsequent `run_draw` calls reference the cached
+//! kernel by handle.
+//!
+//! Subprocesses cannot pass `vk::CommandBuffer` across IPC, so the
+//! bridge's `run_draw` always renders one offscreen pass into the
+//! caller-provided color targets and submits + waits on the kernel's
+//! own command buffer + fence. This matches
+//! [`crate::vulkan::rhi::VulkanGraphicsKernel::offscreen_render`].
+//!
+//! The trait lives here (in `streamlib`) because the escalate IPC
+//! handler is here. Implementations live in application setup glue
+//! (or in `streamlib-adapter-vulkan` test utilities) — those can
+//! depend on `streamlib`; the reverse cannot. Register an impl via
+//! [`crate::core::context::GpuContext::set_graphics_kernel_bridge`]
+//! before spawning subprocesses that issue
+//! `register_graphics_kernel` / `run_graphics_draw`.
+
+#![cfg(target_os = "linux")]
+
+/// Resource kind for a binding slot in the graphics kernel's
+/// descriptor set 0. Wire-format mirror of
+/// [`crate::core::rhi::GraphicsBindingKind`] decoupled from the
+/// generated JTD types so the bridge surface is stable across schema
+/// regenerations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsBindingKindWire {
+    SampledTexture,
+    StorageBuffer,
+    UniformBuffer,
+    StorageImage,
+}
+
+/// One binding declaration for register-time validation against
+/// SPIR-V reflection.
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsBindingDecl {
+    pub binding: u32,
+    pub kind: GraphicsBindingKindWire,
+    /// Stage-visibility bitmask: `1 = VERTEX`, `2 = FRAGMENT`.
+    pub stages: u32,
+}
+
+/// Per-vertex attribute format. Mirrors
+/// [`crate::core::rhi::VertexAttributeFormat`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexAttributeFormatWire {
+    R32Float,
+    Rg32Float,
+    Rgb32Float,
+    Rgba32Float,
+    R32Uint,
+    Rg32Uint,
+    Rgb32Uint,
+    Rgba32Uint,
+    R32Sint,
+    Rg32Sint,
+    Rgb32Sint,
+    Rgba32Sint,
+    Rgba8Unorm,
+    Rgba8Snorm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexInputRateWire {
+    Vertex,
+    Instance,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputBindingDecl {
+    pub binding: u32,
+    pub stride: u32,
+    pub input_rate: VertexInputRateWire,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputAttributeDecl {
+    pub location: u32,
+    pub binding: u32,
+    pub format: VertexAttributeFormatWire,
+    pub offset: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveTopologyWire {
+    PointList,
+    LineList,
+    LineStrip,
+    TriangleList,
+    TriangleStrip,
+    TriangleFan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolygonModeWire {
+    Fill,
+    Line,
+    Point,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CullModeWire {
+    None,
+    Front,
+    Back,
+    FrontAndBack,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontFaceWire {
+    CounterClockwise,
+    Clockwise,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthCompareOpWire {
+    Never,
+    Less,
+    Equal,
+    LessOrEqual,
+    Greater,
+    NotEqual,
+    GreaterOrEqual,
+    Always,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendFactorWire {
+    Zero,
+    One,
+    SrcColor,
+    OneMinusSrcColor,
+    DstColor,
+    OneMinusDstColor,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    DstAlpha,
+    OneMinusDstAlpha,
+    ConstantColor,
+    OneMinusConstantColor,
+    ConstantAlpha,
+    OneMinusConstantAlpha,
+    SrcAlphaSaturate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendOpWire {
+    Add,
+    Subtract,
+    ReverseSubtract,
+    Min,
+    Max,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthFormatWire {
+    D16Unorm,
+    D32Sfloat,
+    D24UnormS8Uint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynamicStateWire {
+    None,
+    ViewportScissor,
+}
+
+/// Pipeline-state mirror used by the bridge `register` call. Owned (no
+/// borrows) so the bridge can stash it in its kernel cache.
+#[derive(Debug, Clone)]
+pub struct GraphicsPipelineStateWire {
+    pub topology: PrimitiveTopologyWire,
+    pub vertex_input_bindings: Vec<VertexInputBindingDecl>,
+    pub vertex_input_attributes: Vec<VertexInputAttributeDecl>,
+    pub rasterization_polygon_mode: PolygonModeWire,
+    pub rasterization_cull_mode: CullModeWire,
+    pub rasterization_front_face: FrontFaceWire,
+    pub rasterization_line_width: f32,
+    pub multisample_samples: u32,
+    pub depth_stencil_enabled: bool,
+    pub depth_compare_op: DepthCompareOpWire,
+    pub depth_write: bool,
+    pub color_blend_enabled: bool,
+    /// Color write-mask bits — `1=R`, `2=G`, `4=B`, `8=A`.
+    pub color_write_mask: u32,
+    pub color_blend_src_color_factor: BlendFactorWire,
+    pub color_blend_dst_color_factor: BlendFactorWire,
+    pub color_blend_color_op: BlendOpWire,
+    pub color_blend_src_alpha_factor: BlendFactorWire,
+    pub color_blend_dst_alpha_factor: BlendFactorWire,
+    pub color_blend_alpha_op: BlendOpWire,
+    /// Color attachment formats — wire-format strings (`"bgra8_unorm"`,
+    /// `"rgba8_unorm"`, …). The bridge translates these to
+    /// [`crate::core::rhi::TextureFormat`] before construction.
+    pub attachment_color_formats: Vec<String>,
+    pub attachment_depth_format: Option<DepthFormatWire>,
+    pub dynamic_state: DynamicStateWire,
+}
+
+/// Full register-time descriptor passed to
+/// [`GraphicsKernelBridge::register`]. Owned mirror of the wire shape.
+#[derive(Debug, Clone)]
+pub struct GraphicsKernelRegisterDecl {
+    pub label: String,
+    pub vertex_spv: Vec<u8>,
+    pub fragment_spv: Vec<u8>,
+    pub vertex_entry_point: String,
+    pub fragment_entry_point: String,
+    pub bindings: Vec<GraphicsBindingDecl>,
+    pub push_constant_size: u32,
+    pub push_constant_stages: u32,
+    pub descriptor_sets_in_flight: u32,
+    pub pipeline_state: GraphicsPipelineStateWire,
+}
+
+/// Per-draw binding value.
+#[derive(Debug, Clone)]
+pub struct GraphicsBindingValue {
+    pub binding: u32,
+    pub kind: GraphicsBindingKindWire,
+    pub surface_uuid: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphicsVertexBufferBinding {
+    pub binding: u32,
+    pub surface_uuid: String,
+    pub offset: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexTypeWire {
+    Uint16,
+    Uint32,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphicsIndexBufferBinding {
+    pub surface_uuid: String,
+    pub offset: u64,
+    pub index_type: IndexTypeWire,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ViewportWire {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub min_depth: f32,
+    pub max_depth: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ScissorRectWire {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Draw-call discriminator + parameters. Indexed and non-indexed share
+/// the wire shape; the host bridge dispatches the right
+/// `vkCmdDraw` / `vkCmdDrawIndexed` based on `kind`.
+#[derive(Debug, Clone, Copy)]
+pub enum GraphicsDrawSpec {
+    Draw {
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    },
+    DrawIndexed {
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    },
+}
+
+/// Full per-draw input passed to [`GraphicsKernelBridge::run_draw`].
+#[derive(Debug, Clone)]
+pub struct GraphicsKernelRunDraw {
+    pub kernel_id: String,
+    pub frame_index: u32,
+    pub bindings: Vec<GraphicsBindingValue>,
+    pub vertex_buffers: Vec<GraphicsVertexBufferBinding>,
+    pub index_buffer: Option<GraphicsIndexBufferBinding>,
+    pub color_target_uuids: Vec<String>,
+    pub depth_target_uuid: Option<String>,
+    pub extent: (u32, u32),
+    pub push_constants: Vec<u8>,
+    pub viewport: Option<ViewportWire>,
+    pub scissor: Option<ScissorRectWire>,
+    pub draw: GraphicsDrawSpec,
+}
+
+/// Dispatch trait the host runtime uses to drive graphics kernel
+/// registration and per-draw invocation for subprocess customers.
+///
+/// Graphics dispatch on the host is synchronous: the bridge's
+/// `run_draw` blocks on the kernel's fence inside
+/// [`crate::vulkan::rhi::VulkanGraphicsKernel::offscreen_render`]
+/// before returning, so by the time this returns, the GPU work has
+/// retired and the host's writes to the color attachments are visible
+/// to any subsequent submission against the same VkDevice. The
+/// subprocess can safely advance its surface-share timeline on
+/// receipt of the `ok` response.
+pub trait GraphicsKernelBridge: Send + Sync {
+    /// Register a graphics kernel. Returns a stable `kernel_id` —
+    /// re-registering an identical descriptor (same SPIR-V, same
+    /// pipeline state, same bindings) hits the host-side cache and
+    /// returns the same id without re-reflecting or rebuilding the
+    /// pipeline.
+    ///
+    /// The bridge is responsible for hashing `decl` into a
+    /// content-addressed kernel id; SHA-256 over a canonical byte
+    /// representation is the recommended pattern (mirrors the
+    /// compute-kernel approach but extended to cover stage SPIR-V +
+    /// pipeline state).
+    fn register(
+        &self,
+        decl: &GraphicsKernelRegisterDecl,
+    ) -> Result<String, String>;
+
+    /// Run one draw against a previously-registered kernel.
+    ///
+    /// Resolves binding `surface_uuid`s through the application-
+    /// provided UUID → resource map, then submits + waits on the
+    /// kernel's own command buffer + fence (offscreen-render shape).
+    /// Errors include unrecognized `kernel_id`, surface lookup
+    /// failure, push-constant size mismatch, and Vulkan submit
+    /// failure.
+    fn run_draw(
+        &self,
+        draw: &GraphicsKernelRunDraw,
+    ) -> Result<(), String>;
+}

--- a/libs/streamlib/src/core/context/graphics_kernel_bridge.rs
+++ b/libs/streamlib/src/core/context/graphics_kernel_bridge.rs
@@ -333,11 +333,18 @@ pub trait GraphicsKernelBridge: Send + Sync {
     /// returns the same id without re-reflecting or rebuilding the
     /// pipeline.
     ///
-    /// The bridge is responsible for hashing `decl` into a
-    /// content-addressed kernel id; SHA-256 over a canonical byte
-    /// representation is the recommended pattern (mirrors the
-    /// compute-kernel approach but extended to cover stage SPIR-V +
-    /// pipeline state).
+    /// The `kernel_id` shape is **implementation-defined** — the
+    /// escalate handler treats it as an opaque string and the
+    /// subprocess uses it only as a `run_draw` reference, so
+    /// implementations are free to canonicalize whichever subset of
+    /// `decl` makes sense for their cache shape. The recommended
+    /// pattern is SHA-256 hex over a canonical byte representation
+    /// of the inputs that *materially* determine the host-side
+    /// `VulkanGraphicsKernel` (mirroring compute's SHA-256(spv)
+    /// approach but extended to stage SPIR-V + pipeline state).
+    /// Identical descriptors must collide on `kernel_id` for the
+    /// register-cache to work; differing descriptors should not
+    /// collide, but the bridge — not the trait — owns that contract.
     fn register(
         &self,
         decl: &GraphicsKernelRegisterDecl,

--- a/libs/streamlib/src/core/context/mod.rs
+++ b/libs/streamlib/src/core/context/mod.rs
@@ -7,6 +7,8 @@ mod compute_kernel_bridge;
 #[cfg(target_os = "linux")]
 mod cpu_readback_bridge;
 mod gpu_context;
+#[cfg(target_os = "linux")]
+mod graphics_kernel_bridge;
 mod runtime_context;
 mod surface_store;
 pub mod texture_pool;
@@ -21,6 +23,16 @@ pub use audio_clock::{
 pub use compute_kernel_bridge::ComputeKernelBridge;
 #[cfg(target_os = "linux")]
 pub use cpu_readback_bridge::{CpuReadbackBridge, CpuReadbackCopyDirection};
+#[cfg(target_os = "linux")]
+pub use graphics_kernel_bridge::{
+    BlendFactorWire, BlendOpWire, CullModeWire, DepthCompareOpWire, DepthFormatWire,
+    DynamicStateWire, FrontFaceWire, GraphicsBindingDecl, GraphicsBindingKindWire,
+    GraphicsBindingValue, GraphicsDrawSpec, GraphicsIndexBufferBinding, GraphicsKernelBridge,
+    GraphicsKernelRegisterDecl, GraphicsKernelRunDraw, GraphicsPipelineStateWire,
+    GraphicsVertexBufferBinding, IndexTypeWire, PolygonModeWire, PrimitiveTopologyWire,
+    ScissorRectWire, VertexAttributeFormatWire, VertexInputAttributeDecl,
+    VertexInputBindingDecl, VertexInputRateWire, ViewportWire,
+};
 pub use gpu_context::{GpuContext, GpuContextFullAccess, GpuContextLimitedAccess};
 pub use runtime_context::{
     RuntimeContext, RuntimeContextFullAccess, RuntimeContextLimitedAccess,

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -200,7 +200,8 @@ pub mod linux_surface_share {
 pub mod host_rhi {
     pub use crate::vulkan::rhi::{
         HostMarker, HostVulkanDevice, HostVulkanPixelBuffer, HostVulkanTexture,
-        HostVulkanTimelineSemaphore, VulkanComputeKernel, VulkanTextureReadback,
+        HostVulkanTimelineSemaphore, OffscreenColorTarget, OffscreenDraw,
+        VulkanComputeKernel, VulkanGraphicsKernel, VulkanTextureReadback,
     };
 
     /// EGL DRM-modifier probe — exposed so adapter conformance tests


### PR DESCRIPTION
## Summary

- Add `RegisterGraphicsKernel` + `RunGraphicsDraw` escalate-IPC ops so Python/Deno subprocess customers can drive the host's `VulkanGraphicsKernel` (#655). Counterpart to compute's `RegisterComputeKernel` / `RunComputeKernel` (#550) — register-once-draw-many.
- New `GraphicsKernelBridge` trait + owned wire-mirror types in `core::context`; host-Rust handler with 11 unit tests (10 dispatch + error-path + 1 wire→domain pipeline-state translation lock-in).
- Polyglot SDK parity: `EscalateChannel.{register_graphics_kernel,run_graphics_draw}` (Python + Deno) and `VulkanContext.dispatch_graphics` / `dispatchGraphics` high-level wrappers with identity-keyed kernel-id caches.
- New `examples/polyglot-vulkan-graphics` scenario — vertex+fragment triangle shaders, host `TriangleKernelBridge` impl, post-stop PNG readback. Both Python and Deno scenarios verified via Read tool.

## Closes

Closes #656

## Exit criteria

- [x] `RegisterGraphicsKernel` op accepts the same shape as the host's `GraphicsKernelDescriptor` (multi-stage SPIR-V, bindings, push constants, full `GraphicsPipelineState`, descriptor-sets-in-flight) and returns a stable handle.
- [x] `RunGraphicsDraw` op records bind + push + draw against a registered kernel, with bindings resolved through the bridge's UUID → resource map. Subprocesses cannot pass `vk::CommandBuffer` across IPC, so the bridge runs `VulkanGraphicsKernel::offscreen_render` (kernel-owned command buffer + fence — submits + waits).
- [x] Python and Deno SDKs both expose the kernel API with parity.

## Test plan

- [x] **Host-Rust unit tests**: `cargo test -p streamlib --lib subprocess_escalate` — 56 passed (11 new graphics-kernel-dispatch tests + 45 existing). New tests cover: bridge-not-registered (register + run), invalid hex (vertex + fragment + push), malformed vertex-buffer offset (decimal u64 parse), kernel_id stability for identical descriptor, distinct kernel_ids for different SPIR-V, unregistered kernel_id, full payload forwarding (bindings + vertex/index buffers + viewport/scissor + DrawIndexed), and the new `pipeline_state_translates_every_enum_arm` lock-in covering ~200 lines of wire→domain translation across topology/blend/depth/raster/dynamic-state/vertex-input/attachment-format arms (mentally reverting any single arm fails the test — verified by patching source and re-running).
- [x] **Python subprocess E2E**: `cargo run -p polyglot-vulkan-graphics-scenario -- --runtime=python --output=/tmp/vulkan-triangle-py.png`. Triangle visible with R/G/B per-vertex colors (Python palette via `variant=0` push constant), gradients across the body, dark background.

  ![Python E2E — R/G/B triangle rendered into host DMA-BUF VkImage via escalate IPC](https://gh-artifact.tatolab.com/pr-666/vulkan-triangle-py.png)

- [x] **Deno subprocess E2E**: same with `--runtime=deno`. Triangle visible with cyan/magenta/yellow per-vertex colors (Deno palette via `variant=1`).

  ![Deno E2E — cyan/magenta/yellow triangle rendered into host DMA-BUF VkImage via escalate IPC](https://gh-artifact.tatolab.com/pr-666/vulkan-triangle-deno.png)

- [x] **Boundary check**: `cargo run -q -p xtask -- check-boundaries` — 2002 files, 0 violations.
- [x] **Workspace build**: `cargo build --workspace` — clean.

## Polyglot coverage

- **Runtimes affected**: rust + python + deno.
- **Schema regenerated**: yes — `escalate_request@1.0.0` for all three runtimes (only the changed file was retained; other generated files reverted to keep the diff minimal).
- **Python and Deno both covered?** yes — same shape end-to-end. Both runtimes ship `register_graphics_kernel` + `run_graphics_draw` low-level methods on `EscalateChannel` and `dispatch_graphics` / `dispatchGraphics` high-level wrappers with identity-keyed kernel-id caches.
- **E2E tests run**:
  - [x] Host-Rust: `subprocess_escalate::tests::graphics_kernel_dispatch::*` — 11 passed.
  - [x] Python subprocess: `polyglot-vulkan-graphics-scenario --runtime=python` — R/G/B triangle PNG verified via Read tool.
  - [x] Deno subprocess: `polyglot-vulkan-graphics-scenario --runtime=deno` — cyan/magenta/yellow triangle PNG verified via Read tool.
- **FD-passing path**: surface-share UUID. Single render-target DMA-BUF + timeline pre-registered at host setup; per-call escalate IPC carries no FDs — only the kernel_id, frame_index, surface UUIDs, and the draw payload.

## Test-validation note

Per the issue's "Tests / validation" section, the Python/Deno subprocess gates were exit criteria. The pr-review-gate flagged that no `#[test]`-style harness spawns Python/Deno subprocesses with assertion-based verification — but this matches the convention established by the compute reference (#550 / #571), where the example scenario binary IS the integration test with a PNG-readback gate verified via the Read tool. Both runtimes were exercised end-to-end during the test gate and produced visually distinct triangles. A future polyglot subprocess test harness with automated assertions would be its own follow-up issue (the ".claude/workflows/polyglot.md" doc already calls out the harness pattern as a candidate for a dedicated ticket).

## Follow-ups

- v1 wire format limits the example bridge to a single color attachment, no MSAA, no depth, and gl_VertexIndex-only vertex input. The schema and bridge trait support the full host `VulkanGraphicsKernel` shape (multi-stage SPIR-V, full pipeline state, multi-binding bindings, vertex/index buffer references, push constants, viewport/scissor) — a future bridge implementation can lift the example's "v1 limit" `Err`s. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
