### PR TITLE
feat(idents): SchemaIdent crate + architecture doc + CI lint (closes #399)

### DIFF
--- a/.github/workflows/check-schema-versions.yml
+++ b/.github/workflows/check-schema-versions.yml
@@ -1,0 +1,48 @@
+name: Check Schema Versions
+
+# CI gate for the package-as-publication-unit rule from milestone 10.
+# `cargo xtask check-schema-versions` walks every YAML under any `schemas/`
+# directory in `libs/`, `packages/`, or `examples/` and fails if any file
+# declares a top-level `version` key.
+#
+# Versioning lives in `streamlib.yaml`, not in individual schemas — bumping
+# any type bumps the whole package. See
+# `docs/architecture/schema-identity-and-packaging.md`.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-schema-versions:
+    name: xtask check-schema-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-schema-versions
+        run: cargo xtask check-schema-versions
+
+      - name: cargo test -p xtask check_schema_versions (fixture tests)
+        run: cargo test -p xtask check_schema_versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "libs/streamlib-cli",       # Command-line interface for StreamLib runtime
     "libs/streamlib-runtime",   # Standalone runtime binary (spawned by CLI)
     "libs/streamlib-codegen-shared", # Execution types shared between streamlib and streamlib-macros
+    "libs/streamlib-idents",    # Structured schema identifiers, semver, manifest/lockfile types (#399)
     "libs/streamlib-macros",    # Procedural macros for reducing boilerplate
     "libs/streamlib-plugin-abi", # ABI-stable FFI types for dynamic plugins
     "libs/streamlib-adapter-abi", # ABI-stable surface adapter contract (in-tree + 3rd-party adapters)

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -1,0 +1,685 @@
+# Schema identity & packaging
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+> Reflects code state as of 2026-05-04 (PR for issue #399 — first
+> deliverable of milestone 10, *Schema Identity & Packaging*). The full
+> migration is staged across multiple PRs (#400, #401, #402, #404, plus
+> the 12 carve-out package issues); claims about *current* code are
+> point-in-time and stale fast.
+
+## Status
+
+This document is the canonical architecture brief for milestone 10. It
+ships alongside the `streamlib-idents` Rust crate (the first code-level
+expression of the design); future agents should read this doc for
+design context and the [milestone-10 description][m10] for current
+pickup ordering.
+
+[m10]: https://github.com/tatolab/streamlib/milestone/10
+
+## Why this exists
+
+Through 2025–early 2026 the schema-identity surface drifted across
+three independent strands:
+
+- **Reverse-DNS schema IDs** (`com.tatolab.videoframe@1.0.0`) embedded
+  in YAML metadata blocks, parsed by ad-hoc `from_str` impls in
+  Rust + Python + TypeScript. Each runtime had its own parser; minor
+  variations in tolerated whitespace / case / trailing data accumulated
+  silently.
+- **Per-language manifest extensions** (`[package.metadata.streamlib]`
+  in `Cargo.toml`, `[tool.streamlib]` in `pyproject.toml`, an
+  ungoverned `streamlib` block in `deno.json`). Three sources of truth
+  describing the same set of facts.
+- **Incomplete distribution attempts** (`embedded_schemas.rs`'s
+  hand-curated match statement, ad-hoc `.slpkg` archive experiments,
+  schemas that lived only in `libs/streamlib/schemas/` with no
+  publication story).
+
+The fix is one cohesive architecture covering identifier grammar,
+package manifest, dependency resolution, code generation, and
+distribution. The rest of milestone 10 implements it.
+
+## Architectural decisions
+
+These are load-bearing — relaxing any of them brings back the failure
+mode that motivated the whole milestone.
+
+### Decision 1 — `@org/package/Type@version` identifier grammar
+
+Replaces `com.tatolab.videoframe@1.0.0` (reverse-DNS, lowercase, no
+package boundary in the name) with `@tatolab/core/VideoFrame@1.0.0`
+(npm-style scope, explicit package, PascalCase type name, semver).
+
+The grammar (BNF):
+
+```ebnf
+identifier   ::= "@" org "/" package "/" type "@" version
+org          ::= [a-z] [a-z0-9-]*
+package      ::= [a-z] [a-z0-9-]*
+type         ::= [A-Z] [A-Za-z0-9]*
+version      ::= major "." minor "." patch
+major        ::= [0-9]+
+minor        ::= [0-9]+
+patch        ::= [0-9]+
+```
+
+Worked examples:
+
+| Identifier | org | package | type | version |
+|---|---|---|---|---|
+| `@tatolab/core/VideoFrame@1.0.0` | `tatolab` | `core` | `VideoFrame` | `1.0.0` |
+| `@tatolab/h264/EncodedVideoFrame@1.0.0` | `tatolab` | `h264` | `EncodedVideoFrame` | `1.0.0` |
+| `@tatolab/camera/CameraConfig@1.0.0` | `tatolab` | `camera` | `CameraConfig` | `1.0.0` |
+| `@streamlib/escalate/EscalateRequest@1.0.0` | `streamlib` | `escalate` | `EscalateRequest` | `1.0.0` |
+
+Pre-release / build metadata (the `1.0.0-rc.1+sha.deadbeef` shape) is
+deliberately not supported in v1. Re-introduce when a real consumer
+needs them — adding now creates parser surface that has no caller.
+
+### Decision 2 — structured-everywhere wire format
+
+**Every reference to a schema identifier is a structured record on
+every wire surface.** No joined string is ever the source of truth.
+
+```yaml
+# Wire shape (typed YAML / JSON) — four fields, never a single string:
+org: tatolab
+package: core
+type: VideoFrame
+version: 1.0.0
+```
+
+Surfaces this rule covers:
+
+- IPC envelopes (`escalate_request` / `escalate_response`, surface-
+  share, iceoryx2 payloads).
+- Codegen-emitted const records (`SCHEMA_IDENT: SchemaIdent { … }`).
+- Graph JSON (the runtime's serialized pipeline graph).
+- Embedded-schema lookup keys (replaces `embedded_schemas.rs`'s
+  `match` on string).
+- Lockfile entries (`streamlib.lock`).
+
+The `Display` impl on `SchemaIdent` produces the joined `@org/pkg/Type@v`
+form for human-facing surfaces (logs, error messages, CLI output).
+**The joined form is render-only — it never round-trips back through
+a parser at the structured boundary.**
+
+#### Why structured everywhere
+
+Three independent reasons converged on this answer:
+
+- **AI determinism.** Future agents (and current ones) read code to
+  derive contracts. A `parse("@org/pkg/Type@v")` API is one more
+  place where an LLM has to guess about whitespace / Unicode /
+  trailing-data tolerance. A struct literal with four named fields
+  is unambiguous-by-construction.
+- **Web-UI / API-server readability.** External consumers reading
+  the runtime's API responses get four typed fields; they don't
+  have to pattern-match strings to figure out which package owns
+  which type.
+- **Type-system over convention.** A `Org` newtype with a private
+  constructor + a validating `new()` makes "invalid org" *unrepresentable
+  in the type system after the validation gate*. Convention-driven
+  parsing routes around this.
+
+#### Carve-out: `SemVer` parses from `"1.2.3"`
+
+The structured-everywhere rule applies to *identifiers*, not to
+every primitive. `SemVer` has a single canonical string form
+(`1.2.3`) that's universally agreed across cargo / npm / pip /
+deno; representing it as `{major: 1, minor: 2, patch: 3}` in YAML
+would be surprising. `SemVer` is therefore deserialized from a
+string via the typed-deserialization pathway. This is not a
+weasel-out — `SchemaIdent` is multi-field-glued-by-punctuation;
+`SemVer` is single-canonical-string — the design line falls
+between the two.
+
+### Decision 3 — package-as-publication-unit
+
+`streamlib.yaml` is the only place a `version` field lives. Schema
+files declare `type` and content fields; **they do not declare a
+version anywhere**. Bumping any type in a package bumps the whole
+package's version (npm-style; Cargo-style; cargo-workspace-style).
+
+Why: per-schema versions create N-dimensional matrices of "which
+versions of which schemas are mutually compatible" that no consumer
+ever actually reasons about. Publication-unit-scoped versions
+collapse this to a single dimension per package.
+
+A CI lint (`cargo xtask check-schema-versions`, wired into
+`.github/workflows/check-schema-versions.yml`) rejects any schema
+YAML declaring a top-level `version` key. The wider lint that also
+rejects `metadata.version` ships when the schema files are migrated
+to the new shape (in #401 / #402).
+
+### Decision 4 — `streamlib.lock` for content-hash resolution
+
+Every project that consumes packages (applications, examples) writes
+a `streamlib.lock` next to its `streamlib.yaml`. The lockfile is
+content-hash-pinned and diff-stable (sorted `BTreeMap` keys), so a
+fresh checkout reconstructs the same generated bindings byte-for-byte.
+
+Discipline (mirrors `Cargo.lock`):
+
+- **Commit `streamlib.lock`** in applications, examples, and any
+  non-publishable consumer.
+- **Don't commit `streamlib.lock`** in publishable libraries — they
+  inherit their consumer's lock.
+
+### Decision 5 — `@tatolab/core` is the canonical wire vocabulary
+
+The four wire-stable types every other package depends on
+(`VideoFrame`, `AudioFrame`, `EncodedVideoFrame`, `EncodedAudioFrame`)
+live in a single `@tatolab/core` package. This is streamlib's
+`google.protobuf` analogue. `@tatolab/core` ships at `1.0.0` from day
+one; breaking changes require a deliberate v2 bump and downstream
+migration.
+
+Twelve carve-out packages live under `packages/` and depend on
+`@tatolab/core`:
+
+| Package | Owner of |
+|---|---|
+| `@tatolab/audio` | audio capture / output / mixer / channel-converter / resampler / chord-generator / buffer-rechunker |
+| `@tatolab/camera` | camera capture |
+| `@tatolab/display` | display / window / swapchain |
+| `@tatolab/h264` | H.264 encoder + decoder |
+| `@tatolab/h265` | H.265 encoder + decoder |
+| `@tatolab/opus` | Opus encoder + decoder |
+| `@tatolab/mp4` | MP4 writer (Apple + Linux variants) |
+| `@tatolab/webrtc` | WHEP + WHIP |
+| `@tatolab/moq` | MoQ publish + subscribe tracks |
+| `@tatolab/api-server` | runtime API server |
+| `@tatolab/clap` | CLAP audio plugin host |
+| `@tatolab/screen-capture` | screen capture |
+
+### Decision 6 — universal `streamlib generate` CLI
+
+Code generation goes through `streamlib generate` (a subcommand on
+the `streamlib` CLI). Non-Rust developers regenerate bindings without
+ever installing rustup. `cargo xtask generate-schemas` remains as a
+thin contributor-only wrapper.
+
+The library crate behind both — `streamlib-codegen` — is what #400
+extracts from the current `xtask/src/generate_schemas.rs`.
+
+### Decision 7 — sentinel-substitution codegen + deterministic ordering
+
+Backend codegen (`jtd-codegen`) historically produced subtly different
+field orderings + name manglings across runs and across backends
+(rust / python / typescript). The fix is two passes:
+
+1. **Sentinel substitution.** Replace cross-package type references
+   with deterministic placeholder sentinels *before* invoking the
+   per-backend codegen, then substitute back after. The backend
+   never sees real cross-package references and can't disagree
+   about how to mangle them.
+2. **Deterministic field ordering.** A normalization pass that
+   stable-sorts properties by name across all backends.
+
+Together these eliminate the per-backend mangling drift that bled
+silent fix-PRs every quarter.
+
+### Decision 8 — `streamlib verify-schemas` CI determinism gate
+
+A CI gate (`streamlib verify-schemas`, wired on every PR) runs
+`streamlib generate` and asserts the generated bindings are
+byte-identical to what's checked in. If they aren't, the PR fails
+and the author re-runs `streamlib generate` locally.
+
+This is where the `streamlib.lock` content hash becomes load-bearing:
+the gate proves that committed `_generated_/` matches the lockfile's
+inputs.
+
+## Manifest formats
+
+`streamlib.yaml` has two flavors. The top-level shape distinguishes
+them; pick by what your crate is.
+
+### Package flavor
+
+A publishable package — has its own `package` block.
+
+```yaml
+package:
+  org: tatolab
+  name: core
+  version: 1.0.0
+  description: Canonical wire vocabulary
+
+dependencies: {}
+```
+
+Package metadata fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `org` | yes | Validated against the `org` grammar. |
+| `name` | yes | Validated against the `package` grammar. The full identifier prefix is `@{org}/{name}`. |
+| `version` | yes | SemVer. The only place a version field lives. |
+| `description` | no | Free-form prose. |
+
+### Project flavor
+
+A consumer project (application, example) — depends on packages but
+isn't itself publishable.
+
+```yaml
+dependencies:
+  "@tatolab/core": "^1.0.0"
+  "@tatolab/h264":
+    path: ../h264
+  "@tatolab/moq":
+    git: https://github.com/tatolab/moq
+    rev: abc123def456
+```
+
+Three dependency source flavors are supported:
+
+- **Registry** (string form `"^1.0.0"` or `{ version: "^1.0.0" }`).
+  Resolved against a registry; the v1 design assumes a Cloudflare R2
+  / GitHub Releases-backed registry, but the resolver is source-
+  agnostic.
+- **Path** (`{ path: ../foo }`). Local-filesystem dependency, used
+  inside the streamlib monorepo for pre-publish work.
+- **Git** (`{ git: <url>, rev: <commit-sha> }`). Pinned-commit-only;
+  branch / tag refs are deliberately not supported, mirroring the
+  workspace dep-pinning rule from `CLAUDE.md` (Conventions →
+  Dependencies). Resolver fails loudly on a missing `rev`.
+
+### Semver-range matching
+
+The supported range operators are an npm-flavored subset:
+
+| Operator | Example | Matches |
+|---|---|---|
+| Exact | `=1.2.3` or bare `1.2.3` | exactly 1.2.3 |
+| At least | `>=1.2.3` | 1.2.3 or any later |
+| Caret (post-1.0) | `^1.2.3` | same major, version ≥ input |
+| Caret (0.minor) | `^0.2.3` | same minor (`0.2.x`), version ≥ input |
+| Caret (0.0.patch) | `^0.0.3` | exactly 0.0.3 |
+| Tilde | `~1.2.3` | same major.minor (`1.2.x`), version ≥ input |
+
+These are exactly what `streamlib.yaml` declarations need today —
+adding more operators is straightforward when a real consumer
+appears.
+
+## Lockfile shape
+
+`streamlib.lock` is the resolved-set companion to `streamlib.yaml`.
+Wire shape:
+
+```yaml
+version: 1
+packages:
+  "@tatolab/core":
+    version: 1.0.0
+    source:
+      kind: registry
+      url: https://packages.streamlib.dev
+    content_hash: "sha256:0123456789abcdef…"
+  "@tatolab/h264":
+    version: 0.4.2
+    source:
+      kind: path
+      path: ../h264
+    content_hash: "sha256:fedcba9876543210…"
+  "@tatolab/moq":
+    version: 0.2.0
+    source:
+      kind: git
+      url: https://github.com/tatolab/moq
+      rev: abc123def456
+    content_hash: "sha256:1111222233334444…"
+```
+
+| Field | Notes |
+|---|---|
+| `version` | Lockfile schema version. Currently `1`. Future format-incompatible bumps are explicit. |
+| `packages` | `BTreeMap` keyed by `"@org/name"` — sorted iteration is what makes the lockfile diff-stable. |
+| `version` (entry) | The concrete resolved SemVer (not a range). |
+| `source` | Discriminated union: `registry` / `path` / `git` (`tag = kind`, snake-case). |
+| `content_hash` | Namespace-prefixed (`sha256:…`) so future hash-algorithm migrations don't break parsing. |
+
+The content hash is computed over the resolved package's contents
+(deterministic pass over schemas + manifest). This is what the
+`verify-schemas` CI gate compares against — the gate catches both
+"someone hand-edited generated code" and "someone bumped a dep
+without re-locking."
+
+## Sentinel-substitution codegen contract
+
+Code generation runs in three passes:
+
+1. **Resolve** — read `streamlib.yaml` + `streamlib.lock`, walk the
+   dependency graph, produce the full set of `(SchemaIdent, JtdSchema)`
+   pairs to generate.
+2. **Substitute → generate → substitute back.**
+   - Pre-pass: replace every cross-package `SchemaIdent` reference in
+     each schema's JTD definition with a deterministic placeholder
+     sentinel (`__STREAMLIB_REF_<hash>__`).
+   - Per-backend codegen: invoke `jtd-codegen --target {rust,python,typescript}`
+     against the sentinel-substituted schemas. The backend never sees
+     a real cross-package reference and can't mangle one inconsistently.
+   - Post-pass: substitute the sentinels back to native cross-package
+     `import`s in each backend's emitted code.
+3. **Order** — stable-sort properties by name in all generated types
+   (a normalization pass that makes the output diff-stable across
+   backends and across runs).
+
+Then the generated files are written to each consumer's `_generated_/`
+directory. The `verify-schemas` gate re-runs the whole pipeline on
+CI and asserts byte-identical output.
+
+The `streamlib-codegen` crate (extracted by #400) owns this pipeline.
+The `streamlib-idents` crate (this PR) owns the structured types
+the pipeline reads and writes (`SchemaIdent`, `SemVer`,
+`PackageManifest`, `Lockfile`).
+
+## Anti-patterns
+
+These are explicit rejections — re-introducing any of them
+re-introduces the drift mode the design exists to eliminate.
+
+### 1. `Identifier::parse(&str) -> Self` (or any equivalent)
+
+There is no public `parse` constructor on `SchemaIdent`, `Org`,
+`Package`, `TypeName`, or any future identifier type. A joined
+identifier string never travels back through a parser at the
+structured boundary.
+
+The two allowed construction pathways:
+
+- **Codegen-emitted const literals** — `SCHEMA_IDENT: SchemaIdent =
+  SchemaIdent::new(Org::new("tatolab").unwrap(), …)` lands in the
+  generated `_generated_/` files at build time.
+- **Typed YAML / JSON deserialization** — each segment is its own
+  field in the source document; `serde` reads the structured shape
+  directly into `SchemaIdent { org, package, r#type, version }`.
+
+A `tests/no_parse_api.rs` integration test in `streamlib-idents` is
+the compile-time witness that no `parse` method has been smuggled
+back in. If you find yourself wanting one — even for a "tiny"
+helper, even "just for tests" — stop. The drift starts that way.
+
+### 2. Cross-package import-then-shorthand
+
+In Rust source, this is the failure mode:
+
+```rust
+// ❌ WRONG — package-internal short name "leaks" cross-package
+use tatolab_core::VIDEO_FRAME_IDENT;
+graph.add_edge(VIDEO_FRAME_IDENT, …);   // No org/package on the wire
+```
+
+The package-internal short-name pattern (`#[streamlib::processor(name =
+"Camera")]`) is the **only** shorthand mechanism in the architecture.
+Cross-package references in graph JSON, IPC envelopes, generated
+code, and lockfiles carry a fully-qualified `SchemaIdent { org,
+package, type, version }` structured record.
+
+When the macro emits per-package consts, those consts hold a
+*structured* `SchemaIdent` — the consumer can read its fields, but
+serializing across a wire surface always emits the full structured
+record.
+
+### 3. Per-schema `version` field
+
+Schema files declare `type` and content fields. They do **not**
+declare a version. The CI lint catches re-introductions; the
+architecture rejects them by design.
+
+Why: per-schema versions create N-dimensional compatibility matrices
+that consumers don't actually reason about. Publication-unit-scoped
+versions collapse this to a single dimension per package.
+
+### 4. Legacy metadata blocks in language-native manifests
+
+After #402 lands, `Cargo.toml` does not contain
+`[package.metadata.streamlib]`, `pyproject.toml` does not contain
+`[tool.streamlib]`, and `deno.json` has no `streamlib` block. The
+single source of truth is `streamlib.yaml` for every runtime; the
+resolver feeds the resolved set into each language's codegen
+pipeline.
+
+CI lint (added in #402) rejects re-introductions.
+
+### 5. Hand-curated `embedded_schemas.rs`-style match statements
+
+Pre-#402, `libs/streamlib/src/core/embedded_schemas.rs` had a
+hand-curated `match` mapping schema IDs to embedded YAML strings.
+Two failure modes: (a) easy to forget to add a new schema; (b)
+silent drift when a schema renamed but the match arm didn't.
+
+The replacement is resolver-driven: the resolved package set
+populates a `SchemaIdent`-keyed lookup table at build time. Adding
+a schema means declaring it in your `streamlib.yaml`; nothing else.
+
+## Rosetta — current → new identifier mapping
+
+Every current `com.streamlib.*` / `com.tatolab.*` identifier maps to
+a `@org/package/Type@version` form below. The migration is staged:
+
+- **Wire types** (`@tatolab/core`) migrate in **#404**.
+- **Processor names + their config schemas** migrate in **#401**
+  (the macro rewrite is what makes the short-name pattern available)
+  and the carve-out package issues (one per package).
+- **Polyglot escalate IPC** migrates in #404 alongside the wire-type
+  migration (it's the same wire surface).
+
+### Wire vocabulary → `@tatolab/core@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.tatolab.videoframe@1.0.0` | `@tatolab/core/VideoFrame@1.0.0` |
+| `com.tatolab.audioframe@1.0.0` | `@tatolab/core/AudioFrame@1.0.0` |
+| `com.tatolab.encodedvideoframe@1.0.0` | `@tatolab/core/EncodedVideoFrame@1.0.0` |
+| `com.tatolab.encodedaudioframe@1.0.0` | `@tatolab/core/EncodedAudioFrame@1.0.0` |
+
+### Audio package → `@tatolab/audio@1.0.0`
+
+| Current processor / schema | New |
+|---|---|
+| `com.tatolab.audio_capture` | `@tatolab/audio/AudioCapture@1.0.0` |
+| `com.tatolab.audio_capture.config@1.0.0` | `@tatolab/audio/AudioCaptureConfig@1.0.0` |
+| `com.tatolab.audio_output` | `@tatolab/audio/AudioOutput@1.0.0` |
+| `com.tatolab.audio_output.config@1.0.0` | `@tatolab/audio/AudioOutputConfig@1.0.0` |
+| `com.tatolab.audio_mixer` | `@tatolab/audio/AudioMixer@1.0.0` |
+| `com.tatolab.audio_mixer.config@1.0.0` | `@tatolab/audio/AudioMixerConfig@1.0.0` |
+| `com.tatolab.audio_channel_converter` | `@tatolab/audio/AudioChannelConverter@1.0.0` |
+| `com.tatolab.audio_channel_converter.config@1.0.0` | `@tatolab/audio/AudioChannelConverterConfig@1.0.0` |
+| `com.tatolab.audio_resampler` | `@tatolab/audio/AudioResampler@1.0.0` |
+| `com.tatolab.audio_resampler.config@1.0.0` | `@tatolab/audio/AudioResamplerConfig@1.0.0` |
+| `com.tatolab.buffer_rechunker` | `@tatolab/audio/BufferRechunker@1.0.0` |
+| `com.tatolab.buffer_rechunker.config@1.0.0` | `@tatolab/audio/BufferRechunkerConfig@1.0.0` |
+| `com.tatolab.chord_generator` | `@tatolab/audio/ChordGenerator@1.0.0` |
+| `com.tatolab.chord_generator.config@1.0.0` | `@tatolab/audio/ChordGeneratorConfig@1.0.0` |
+
+### Camera package → `@tatolab/camera@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.tatolab.camera` | `@tatolab/camera/Camera@1.0.0` |
+| `com.tatolab.camera.config@1.0.0` | `@tatolab/camera/CameraConfig@1.0.0` |
+
+### Display package → `@tatolab/display@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.tatolab.display` | `@tatolab/display/Display@1.0.0` |
+| `com.tatolab.display.config@1.0.0` | `@tatolab/display/DisplayConfig@1.0.0` |
+
+### H.264 package → `@tatolab/h264@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.h264_encoder` | `@tatolab/h264/H264Encoder@1.0.0` |
+| `com.streamlib.h264_encoder.config@1.0.0` | `@tatolab/h264/H264EncoderConfig@1.0.0` |
+| `com.streamlib.h264_decoder` | `@tatolab/h264/H264Decoder@1.0.0` |
+| `com.streamlib.h264_decoder.config@1.0.0` | `@tatolab/h264/H264DecoderConfig@1.0.0` |
+
+### H.265 package → `@tatolab/h265@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.h265_encoder` | `@tatolab/h265/H265Encoder@1.0.0` |
+| `com.streamlib.h265_encoder.config@1.0.0` | `@tatolab/h265/H265EncoderConfig@1.0.0` |
+| `com.streamlib.h265_decoder` | `@tatolab/h265/H265Decoder@1.0.0` |
+| `com.streamlib.h265_decoder.config@1.0.0` | `@tatolab/h265/H265DecoderConfig@1.0.0` |
+
+### Opus package → `@tatolab/opus@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.opus_encoder` | `@tatolab/opus/OpusEncoder@1.0.0` |
+| `com.streamlib.opus_encoder.config@1.0.0` | `@tatolab/opus/OpusEncoderConfig@1.0.0` |
+| `com.streamlib.opus_decoder` | `@tatolab/opus/OpusDecoder@1.0.0` |
+| `com.streamlib.opus_decoder.config@1.0.0` | `@tatolab/opus/OpusDecoderConfig@1.0.0` |
+
+### MP4 package → `@tatolab/mp4@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.tatolab.mp4_writer` | `@tatolab/mp4/Mp4Writer@1.0.0` |
+| `com.tatolab.mp4_writer.config@1.0.0` | `@tatolab/mp4/Mp4WriterConfig@1.0.0` |
+| `com.streamlib.linux_mp4_writer` | `@tatolab/mp4/LinuxMp4Writer@1.0.0` |
+| `com.streamlib.linux_mp4_writer.config@1.0.0` | `@tatolab/mp4/LinuxMp4WriterConfig@1.0.0` |
+
+### WebRTC package → `@tatolab/webrtc@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.webrtc_whep` | `@tatolab/webrtc/WhepReceiver@1.0.0` |
+| `com.streamlib.webrtc_whep.config@1.0.0` | `@tatolab/webrtc/WhepReceiverConfig@1.0.0` |
+| `com.streamlib.webrtc_whip` | `@tatolab/webrtc/WhipSender@1.0.0` |
+| `com.streamlib.webrtc_whip.config@1.0.0` | `@tatolab/webrtc/WhipSenderConfig@1.0.0` |
+
+### MoQ package → `@tatolab/moq@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.moq_publish_track` | `@tatolab/moq/PublishTrack@1.0.0` |
+| `com.streamlib.moq_publish_track.config@1.0.0` | `@tatolab/moq/PublishTrackConfig@1.0.0` |
+| `com.streamlib.moq_subscribe_track` | `@tatolab/moq/SubscribeTrack@1.0.0` |
+| `com.streamlib.moq_subscribe_track.config@1.0.0` | `@tatolab/moq/SubscribeTrackConfig@1.0.0` |
+
+### API server package → `@tatolab/api-server@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.api_server` | `@tatolab/api-server/ApiServer@1.0.0` |
+| `com.streamlib.api_server.config@1.0.0` | `@tatolab/api-server/ApiServerConfig@1.0.0` |
+
+### CLAP package → `@tatolab/clap@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.streamlib.clap.effect` | `@tatolab/clap/ClapEffect@1.0.0` |
+| `com.streamlib.clap.effect.config@1.0.0` | `@tatolab/clap/ClapEffectConfig@1.0.0` |
+
+### Screen-capture package → `@tatolab/screen-capture@1.0.0`
+
+| Current | New |
+|---|---|
+| `com.tatolab.screen_capture` | `@tatolab/screen-capture/ScreenCapture@1.0.0` |
+| `com.tatolab.screen_capture.config@1.0.0` | `@tatolab/screen-capture/ScreenCaptureConfig@1.0.0` |
+
+### Internal / not-yet-packaged
+
+These don't fit one of the 12 carve-outs but exist in the current
+schema set. They'll either land in their own carve-out package or
+be folded into an existing one — TBD per the per-carve-out issues.
+
+| Current | Likely destination |
+|---|---|
+| `com.streamlib.bgra_file_source` | `@tatolab/sources/BgraFileSource@1.0.0` (new package) |
+| `com.streamlib.escalate_request@1.0.0` | `@streamlib/escalate/EscalateRequest@1.0.0` (escalate IPC; #404) |
+| `com.streamlib.escalate_response@1.0.0` | `@streamlib/escalate/EscalateResponse@1.0.0` (#404) |
+| `com.tatolab.simple_passthrough` | test-only — likely stays under a `@streamlib/test` namespace |
+| `com.streamlib.test.*` | test-only — `@streamlib/test/...@0.1.0` (kept off the public registry) |
+
+## Pickup order (multi-PR migration plan)
+
+The architecture lands across many PRs. The dependency graph (per
+GitHub `Blocked by` edges) drives the order:
+
+1. **#541** + **#684** + **#399** — bug fixes (codegen idempotency,
+   field ordering) and this foundation. Sibling-ready.
+2. **#400** — extract `streamlib-codegen` crate + add
+   `streamlib generate` CLI. Needs #399 for the structured types.
+3. **#402** — `streamlib.yaml` resolver + `streamlib.lock` + cutover
+   off legacy `[package.metadata.streamlib]` etc. (atomic — absorbs
+   #403 and #405).
+4. **#401** — processor short-name macros + sweep hardcoded
+   reverse-DNS literals across Rust + Python + Deno.
+5. **#404** — `@tatolab/core` package + IPC wire-format migration
+   to structured records. First end-to-end dogfooding of the
+   architecture.
+6. **#406** + **#408** + the **12 carve-out packages** — the long
+   tail. By this point the architecture is proven and the carve-outs
+   are mechanical.
+
+Each later issue is a planned consumer of this PR's foundation. The
+"no bad patterns left behind on engine changes" rule (CLAUDE.md) is
+explicitly relaxed across the milestone — the migration is staged
+across PRs by design, not bandaided on top of one giant PR.
+
+## Why no Python / Deno parity in v1
+
+The `streamlib-idents` crate ships Rust-only. Python and Deno do
+not get matching `SchemaIdent` validators / range matchers in v1 —
+deliberately scope-cut.
+
+The reason is structural, not ergonomic: **structured-everywhere
+eliminates the need for non-Rust callers to validate identifiers.**
+Python and Deno consume `SchemaIdent` records that have already been
+validated upstream (by codegen at build time, or by the Rust host
+on inbound IPC). No subprocess-side parser exists, because no
+subprocess-side parsing happens.
+
+If a future non-Rust caller actually needs to validate identifiers
+locally (e.g. a Python tool authoring `streamlib.yaml` programmatically),
+file a follow-up at that point. Building three parser-parity test
+corpora upfront for hypothetical consumers is exactly the burden the
+structured-everywhere decision exists to eliminate.
+
+This is the same shape as the polyglot rule's escape clause
+(`.claude/workflows/polyglot.md`): *"the only legitimate split is
+schema-only / language-specific by construction"* — here the split is
+"language-specific by construction," because the design eliminates
+the cross-language need.
+
+## Reference
+
+- **Implementation**:
+  - `libs/streamlib-idents/` — `SchemaIdent`, `SemVer`, `SemVerRange`,
+    `PackageManifest`, `ProjectManifest`, `Lockfile`.
+  - `xtask/src/check_schema_versions.rs` — CI lint.
+  - `.github/workflows/check-schema-versions.yml` — CI gate.
+- **Issue**: #399 — this PR.
+- **Milestone**: [Schema Identity & Packaging (10)][m10] — freshness
+  anchor for in-flight design.
+- **Tests**:
+  - `libs/streamlib-idents/src/{ident,semver,manifest,lockfile}.rs::tests`
+  - `libs/streamlib-idents/tests/no_parse_api.rs` — public-API
+    surface guard.
+  - `xtask/src/check_schema_versions.rs::tests` — fixture tests +
+    workspace smoke test.
+- **Future research / follow-ups**:
+  - #400 (`streamlib-codegen` crate + CLI).
+  - #401 (macros + example string migration).
+  - #402 (resolver + lockfile + cutover off legacy metadata).
+  - #404 (`@tatolab/core` + IPC wire migration).
+  - 12 carve-out package issues.
+- **Sibling architecture docs**:
+  - [`compute-kernel.md`](compute-kernel.md), [`graphics-kernel.md`](graphics-kernel.md),
+    [`ray-tracing-kernel.md`](ray-tracing-kernel.md) — the kernel-shape
+    doc family.
+  - [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md) — the polyglot
+    capability split this milestone fits alongside.
+  - [`texture-registration.md`](texture-registration.md) — engine-wide
+    record pattern (`TextureRegistration`) that mirrors the same
+    "single canonical record per concern" shape this milestone applies
+    to identifiers.

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -399,10 +399,21 @@ The two allowed construction pathways:
   field in the source document; `serde` reads the structured shape
   directly into `SchemaIdent { org, package, r#type, version }`.
 
-A `tests/no_parse_api.rs` integration test in `streamlib-idents` is
-the compile-time witness that no `parse` method has been smuggled
-back in. If you find yourself wanting one — even for a "tiny"
-helper, even "just for tests" — stop. The drift starts that way.
+The compile-time witness is a set of `compile_fail` doctests on each
+public identifier type (`SchemaIdent`, `Org`, `Package`, `TypeName`)
+in `streamlib-idents` — the doctests assert the forbidden snippets
+MUST fail to compile. If a `parse` method (or `FromStr` impl) is
+ever added, the doctests would compile cleanly, the `compile_fail`
+assertion flips, and `cargo test --doc -p streamlib-idents` surfaces
+the regression. Each type locks both `Type::parse(...)` and
+`"…".parse::<Type>()` so adding either entry point trips the gate.
+The `tests/no_parse_api.rs` integration test is the positive
+counterpart: it locks the *allowed* construction pathways
+(validating `Type::new` constructors, typed YAML/JSON deserialization,
+and explicitly that the joined Display form does NOT round-trip
+back through deserialization). If you find yourself wanting a
+parse method — even for a "tiny" helper, even "just for tests" —
+stop. The drift starts that way.
 
 ### 2. Cross-package import-then-shorthand
 
@@ -663,8 +674,16 @@ the cross-language need.
   anchor for in-flight design.
 - **Tests**:
   - `libs/streamlib-idents/src/{ident,semver,manifest,lockfile}.rs::tests`
-  - `libs/streamlib-idents/tests/no_parse_api.rs` — public-API
-    surface guard.
+    — unit tests covering grammar conformance, semver-range matching,
+    typed deserialization, lockfile round-trip + diff stability.
+  - `libs/streamlib-idents/src/ident.rs` — `compile_fail` doctests on
+    each identifier type that lock the no-`parse`-API invariant
+    (proven real: temporarily add `pub fn parse(_: &str) -> Self` to
+    `SchemaIdent` and `cargo test --doc` reports
+    "Test compiled successfully, but it's marked `compile_fail`").
+  - `libs/streamlib-idents/tests/no_parse_api.rs` — positive
+    counterpart: locks the *allowed* construction pathways and
+    asserts joined-string deserialization fails.
   - `xtask/src/check_schema_versions.rs::tests` — fixture tests +
     workspace smoke test.
 - **Future research / follow-ups**:

--- a/libs/streamlib-idents/Cargo.toml
+++ b/libs/streamlib-idents/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-idents"
+description = "Structured schema identifiers, semver, and manifest/lockfile types for streamlib"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_yaml = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/libs/streamlib-idents/src/error.rs
+++ b/libs/streamlib-idents/src/error.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use thiserror::Error;
+
+pub type IdentResult<T> = Result<T, IdentError>;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IdentError {
+    #[error("org segment is empty")]
+    EmptyOrg,
+
+    #[error("package segment is empty")]
+    EmptyPackage,
+
+    #[error("type segment is empty")]
+    EmptyType,
+
+    #[error("org `{0}` contains invalid character `{1}` (allowed: a-z, 0-9, hyphen, must start with a-z)")]
+    InvalidOrgCharacter(String, char),
+
+    #[error("package `{0}` contains invalid character `{1}` (allowed: a-z, 0-9, hyphen, must start with a-z)")]
+    InvalidPackageCharacter(String, char),
+
+    #[error("type `{0}` contains invalid character `{1}` (allowed: a-z, A-Z, 0-9, must start with A-Z)")]
+    InvalidTypeCharacter(String, char),
+
+    #[error("org `{0}` must start with a-z")]
+    OrgMustStartWithLowercase(String),
+
+    #[error("package `{0}` must start with a-z")]
+    PackageMustStartWithLowercase(String),
+
+    #[error("type `{0}` must start with A-Z (PascalCase)")]
+    TypeMustStartWithUppercase(String),
+
+    #[error("invalid semver `{0}`: {1}")]
+    InvalidSemVer(String, String),
+
+    #[error("invalid semver range `{0}`: {1}")]
+    InvalidSemVerRange(String, String),
+}

--- a/libs/streamlib-idents/src/ident.rs
+++ b/libs/streamlib-idents/src/ident.rs
@@ -8,6 +8,19 @@ use crate::error::{IdentError, IdentResult};
 use crate::semver::SemVer;
 
 /// Org segment of an identifier (the `@org` part).
+///
+/// Constructed via [`Org::new`] (validating) or typed deserialization. No
+/// `parse` API — gated below with a `compile_fail` doctest.
+///
+/// ```compile_fail
+/// use streamlib_idents::Org;
+/// let _ = Org::parse("tatolab");
+/// ```
+///
+/// ```compile_fail
+/// use streamlib_idents::Org;
+/// let _: Org = "tatolab".parse().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Org(String);
 
@@ -43,6 +56,19 @@ impl<'de> Deserialize<'de> for Org {
 }
 
 /// Package segment.
+///
+/// Constructed via [`Package::new`] (validating) or typed deserialization.
+/// No `parse` API — gated below with a `compile_fail` doctest.
+///
+/// ```compile_fail
+/// use streamlib_idents::Package;
+/// let _ = Package::parse("core");
+/// ```
+///
+/// ```compile_fail
+/// use streamlib_idents::Package;
+/// let _: Package = "core".parse().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Package(String);
 
@@ -78,6 +104,19 @@ impl<'de> Deserialize<'de> for Package {
 }
 
 /// Type segment (PascalCase).
+///
+/// Constructed via [`TypeName::new`] (validating) or typed deserialization.
+/// No `parse` API — gated below with a `compile_fail` doctest.
+///
+/// ```compile_fail
+/// use streamlib_idents::TypeName;
+/// let _ = TypeName::parse("VideoFrame");
+/// ```
+///
+/// ```compile_fail
+/// use streamlib_idents::TypeName;
+/// let _: TypeName = "VideoFrame".parse().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TypeName(String);
 
@@ -118,6 +157,25 @@ impl<'de> Deserialize<'de> for TypeName {
 /// deserialization (each field as its own YAML key). There is no `parse`
 /// constructor on this type or any of its segments, by deliberate design —
 /// see `docs/architecture/schema-identity-and-packaging.md`.
+///
+/// # No `parse` API — compile-fail doctest gate
+///
+/// Calling `SchemaIdent::parse` must not compile. If a `parse` method is
+/// ever added, the doctest below would compile, the `compile_fail`
+/// assertion would flip, and `cargo test --doc` would surface the
+/// regression. Same gate as [`Org`], [`Package`], [`TypeName`].
+///
+/// ```compile_fail
+/// use streamlib_idents::SchemaIdent;
+/// let _ = SchemaIdent::parse("@tatolab/core/VideoFrame@1.0.0");
+/// ```
+///
+/// `FromStr` would also let `"…".parse::<SchemaIdent>()` work — locked too:
+///
+/// ```compile_fail
+/// use streamlib_idents::SchemaIdent;
+/// let _: SchemaIdent = "@tatolab/core/VideoFrame@1.0.0".parse().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct SchemaIdent {
     pub org: Org,

--- a/libs/streamlib-idents/src/ident.rs
+++ b/libs/streamlib-idents/src/ident.rs
@@ -1,0 +1,368 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+use crate::error::{IdentError, IdentResult};
+use crate::semver::SemVer;
+
+/// Org segment of an identifier (the `@org` part).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Org(String);
+
+impl Org {
+    pub fn new(s: impl Into<String>) -> IdentResult<Self> {
+        let s = s.into();
+        validate_org(&s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Org {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for Org {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Org {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Package segment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Package(String);
+
+impl Package {
+    pub fn new(s: impl Into<String>) -> IdentResult<Self> {
+        let s = s.into();
+        validate_package(&s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Package {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for Package {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Package {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Type segment (PascalCase).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TypeName(String);
+
+impl TypeName {
+    pub fn new(s: impl Into<String>) -> IdentResult<Self> {
+        let s = s.into();
+        validate_type(&s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TypeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for TypeName {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeName {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::new(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Structured schema identifier — `@org/package/Type@version`.
+///
+/// Constructed via codegen-emitted const literals or via typed YAML/JSON
+/// deserialization (each field as its own YAML key). There is no `parse`
+/// constructor on this type or any of its segments, by deliberate design —
+/// see `docs/architecture/schema-identity-and-packaging.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SchemaIdent {
+    pub org: Org,
+    pub package: Package,
+    #[serde(rename = "type")]
+    pub r#type: TypeName,
+    pub version: SemVer,
+}
+
+impl SchemaIdent {
+    /// Construct from already-validated structured fields. Callers in
+    /// non-codegen positions should use [`Org::new`], [`Package::new`],
+    /// [`TypeName::new`] to validate the inputs first.
+    pub fn new(org: Org, package: Package, r#type: TypeName, version: SemVer) -> Self {
+        Self {
+            org,
+            package,
+            r#type,
+            version,
+        }
+    }
+}
+
+impl fmt::Display for SchemaIdent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "@{}/{}/{}@{}",
+            self.org, self.package, self.r#type, self.version
+        )
+    }
+}
+
+/// Validate an org segment per the grammar: `[a-z][a-z0-9-]*`.
+pub fn validate_org(s: &str) -> IdentResult<()> {
+    if s.is_empty() {
+        return Err(IdentError::EmptyOrg);
+    }
+    let mut chars = s.chars();
+    let first = chars.next().expect("non-empty");
+    if !first.is_ascii_lowercase() {
+        return Err(IdentError::OrgMustStartWithLowercase(s.to_string()));
+    }
+    for c in chars {
+        if !is_lower_alnum_or_hyphen(c) {
+            return Err(IdentError::InvalidOrgCharacter(s.to_string(), c));
+        }
+    }
+    Ok(())
+}
+
+/// Validate a package segment per the grammar: `[a-z][a-z0-9-]*`.
+pub fn validate_package(s: &str) -> IdentResult<()> {
+    if s.is_empty() {
+        return Err(IdentError::EmptyPackage);
+    }
+    let mut chars = s.chars();
+    let first = chars.next().expect("non-empty");
+    if !first.is_ascii_lowercase() {
+        return Err(IdentError::PackageMustStartWithLowercase(s.to_string()));
+    }
+    for c in chars {
+        if !is_lower_alnum_or_hyphen(c) {
+            return Err(IdentError::InvalidPackageCharacter(s.to_string(), c));
+        }
+    }
+    Ok(())
+}
+
+/// Validate a type segment per the grammar: `[A-Z][A-Za-z0-9]*` (PascalCase).
+pub fn validate_type(s: &str) -> IdentResult<()> {
+    if s.is_empty() {
+        return Err(IdentError::EmptyType);
+    }
+    let mut chars = s.chars();
+    let first = chars.next().expect("non-empty");
+    if !first.is_ascii_uppercase() {
+        return Err(IdentError::TypeMustStartWithUppercase(s.to_string()));
+    }
+    for c in chars {
+        if !c.is_ascii_alphanumeric() {
+            return Err(IdentError::InvalidTypeCharacter(s.to_string(), c));
+        }
+    }
+    Ok(())
+}
+
+fn is_lower_alnum_or_hyphen(c: char) -> bool {
+    matches!(c, 'a'..='z' | '0'..='9' | '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(org: &str, pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(pkg).unwrap(),
+            TypeName::new(ty).unwrap(),
+            v,
+        )
+    }
+
+    #[test]
+    fn display_round_trip_via_yaml() {
+        let id = ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0));
+        assert_eq!(id.to_string(), "@tatolab/core/VideoFrame@1.0.0");
+
+        // Round-trip via typed YAML (the structured-everywhere wire shape):
+        // each field is its own YAML key, no joined string.
+        let yaml = serde_yaml::to_string(&id).unwrap();
+        let back: SchemaIdent = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(id, back);
+        assert_eq!(id.to_string(), back.to_string());
+    }
+
+    #[test]
+    fn display_round_trip_via_json() {
+        let id = ident("tatolab", "h264", "EncodedVideoFrame", SemVer::new(2, 5, 1));
+        let json = serde_json::to_string(&id).unwrap();
+        let back: SchemaIdent = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+        assert_eq!(id.to_string(), back.to_string());
+    }
+
+    #[test]
+    fn typed_yaml_keys_are_separate_fields() {
+        // Asserts the wire shape — fields, not a joined string. If this ever
+        // breaks because someone added a custom Deserialize impl that
+        // accepts `"@org/pkg/Type@1.0.0"`, the structured-everywhere rule has
+        // been violated. The architecture doc forbids this.
+        let yaml = "
+org: tatolab
+package: core
+type: VideoFrame
+version: 1.0.0
+";
+        let id: SchemaIdent = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(id.org.as_str(), "tatolab");
+        assert_eq!(id.package.as_str(), "core");
+        assert_eq!(id.r#type.as_str(), "VideoFrame");
+        assert_eq!(id.version, SemVer::new(1, 0, 0));
+    }
+
+    #[test]
+    fn validators_accept_canonical() {
+        validate_org("tatolab").unwrap();
+        validate_org("acme-co").unwrap();
+        validate_org("a1b2").unwrap();
+        validate_package("core").unwrap();
+        validate_package("vulkan-video").unwrap();
+        validate_type("VideoFrame").unwrap();
+        validate_type("H264").unwrap();
+        validate_type("X").unwrap();
+    }
+
+    #[test]
+    fn validators_reject_empty() {
+        assert!(matches!(validate_org(""), Err(IdentError::EmptyOrg)));
+        assert!(matches!(validate_package(""), Err(IdentError::EmptyPackage)));
+        assert!(matches!(validate_type(""), Err(IdentError::EmptyType)));
+    }
+
+    #[test]
+    fn org_rejects_uppercase_start() {
+        assert!(matches!(
+            validate_org("Tatolab"),
+            Err(IdentError::OrgMustStartWithLowercase(_))
+        ));
+    }
+
+    #[test]
+    fn org_rejects_leading_digit() {
+        assert!(matches!(
+            validate_org("1tatolab"),
+            Err(IdentError::OrgMustStartWithLowercase(_))
+        ));
+    }
+
+    #[test]
+    fn org_rejects_invalid_chars() {
+        assert!(matches!(
+            validate_org("tato_lab"),
+            Err(IdentError::InvalidOrgCharacter(_, '_'))
+        ));
+        assert!(matches!(
+            validate_org("tato.lab"),
+            Err(IdentError::InvalidOrgCharacter(_, '.'))
+        ));
+        assert!(matches!(
+            validate_org("tato/lab"),
+            Err(IdentError::InvalidOrgCharacter(_, '/'))
+        ));
+    }
+
+    #[test]
+    fn package_rejects_uppercase_start() {
+        assert!(matches!(
+            validate_package("Core"),
+            Err(IdentError::PackageMustStartWithLowercase(_))
+        ));
+    }
+
+    #[test]
+    fn type_rejects_lowercase_start() {
+        assert!(matches!(
+            validate_type("videoFrame"),
+            Err(IdentError::TypeMustStartWithUppercase(_))
+        ));
+    }
+
+    #[test]
+    fn type_rejects_underscores_and_hyphens() {
+        assert!(matches!(
+            validate_type("Video_Frame"),
+            Err(IdentError::InvalidTypeCharacter(_, '_'))
+        ));
+        assert!(matches!(
+            validate_type("Video-Frame"),
+            Err(IdentError::InvalidTypeCharacter(_, '-'))
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_invalid_org() {
+        let yaml = "
+org: Tatolab
+package: core
+type: VideoFrame
+version: 1.0.0
+";
+        let res: Result<SchemaIdent, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_invalid_type() {
+        let yaml = "
+org: tatolab
+package: core
+type: video_frame
+version: 1.0.0
+";
+        let res: Result<SchemaIdent, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+}

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Structured schema identifiers, semver, and manifest/lockfile types.
+//!
+//! The structured-everywhere rule: identifiers are constructed by codegen or
+//! by typed YAML/JSON deserialization. There is no public `parse` API and
+//! none should be added — see `docs/architecture/schema-identity-and-packaging.md`.
+
+mod error;
+mod ident;
+mod lockfile;
+mod manifest;
+mod semver;
+
+pub use error::{IdentError, IdentResult};
+pub use ident::{validate_org, validate_package, validate_type, Org, Package, SchemaIdent, TypeName};
+pub use lockfile::{Lockfile, LockfileEntry, LockfileSource};
+pub use manifest::{
+    DependencySpec, GitDependency, PackageManifest, PathDependency, ProjectManifest,
+    RegistryDependency,
+};
+pub use semver::{SemVer, SemVerRange};

--- a/libs/streamlib-idents/src/lockfile.rs
+++ b/libs/streamlib-idents/src/lockfile.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::semver::SemVer;
+
+/// `streamlib.lock` — content-hash-pinned resolved package set.
+///
+/// Wire shape: a single `version: 1` followed by a `packages` map keyed by
+/// the canonical `"@org/name"` string. Each entry is the resolved
+/// concrete location + content hash so a fresh checkout reconstructs the
+/// same generated bindings byte-for-byte. `BTreeMap` (not `HashMap`)
+/// keeps the lockfile diff-stable across regenerations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Lockfile {
+    /// Lockfile schema version. Currently `1`.
+    pub version: u32,
+
+    pub packages: BTreeMap<String, LockfileEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockfileEntry {
+    pub version: SemVer,
+    pub source: LockfileSource,
+    /// Content hash of the resolved package contents (typically sha256:hex).
+    /// Includes the namespacing prefix so future hash algorithms can land
+    /// without breaking lockfile parsing.
+    pub content_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum LockfileSource {
+    Registry { url: String },
+    Path { path: PathBuf },
+    Git { url: String, rev: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lockfile_round_trip() {
+        let yaml = r#"
+version: 1
+packages:
+  "@tatolab/core":
+    version: 1.0.0
+    source:
+      kind: registry
+      url: https://packages.streamlib.dev
+    content_hash: "sha256:0123456789abcdef"
+  "@tatolab/h264":
+    version: 0.4.2
+    source:
+      kind: path
+      path: ../h264
+    content_hash: "sha256:fedcba9876543210"
+  "@tatolab/moq":
+    version: 0.2.0
+    source:
+      kind: git
+      url: https://github.com/tatolab/moq
+      rev: abc123def456
+    content_hash: "sha256:1111222233334444"
+"#;
+        let lock: Lockfile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(lock.version, 1);
+        assert_eq!(lock.packages.len(), 3);
+
+        let core = lock.packages.get("@tatolab/core").unwrap();
+        assert_eq!(core.version, SemVer::new(1, 0, 0));
+        assert!(matches!(core.source, LockfileSource::Registry { .. }));
+
+        let h264 = lock.packages.get("@tatolab/h264").unwrap();
+        assert!(matches!(h264.source, LockfileSource::Path { .. }));
+
+        let moq = lock.packages.get("@tatolab/moq").unwrap();
+        match &moq.source {
+            LockfileSource::Git { url, rev } => {
+                assert_eq!(url, "https://github.com/tatolab/moq");
+                assert_eq!(rev, "abc123def456");
+            }
+            other => panic!("expected Git source, got {:?}", other),
+        }
+
+        // Re-serialize and re-parse — same shape.
+        let s = serde_yaml::to_string(&lock).unwrap();
+        let back: Lockfile = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back.packages.len(), 3);
+        assert_eq!(back.packages.get("@tatolab/core").unwrap().version, SemVer::new(1, 0, 0));
+    }
+
+    #[test]
+    fn lockfile_rejects_unknown_source_kind() {
+        let yaml = r#"
+version: 1
+packages:
+  "@tatolab/core":
+    version: 1.0.0
+    source:
+      kind: ftp
+      url: ftp://example.com
+    content_hash: "sha256:abcd"
+"#;
+        let res: Result<Lockfile, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn lockfile_keys_are_diff_stable() {
+        // BTreeMap iteration is sorted; ensure two builds produce the same
+        // textual lockfile no matter what order packages were inserted.
+        let mut a = Lockfile {
+            version: 1,
+            packages: BTreeMap::new(),
+        };
+        a.packages.insert(
+            "@tatolab/zzz".into(),
+            LockfileEntry {
+                version: SemVer::new(1, 0, 0),
+                source: LockfileSource::Path { path: "z".into() },
+                content_hash: "sha256:1".into(),
+            },
+        );
+        a.packages.insert(
+            "@tatolab/aaa".into(),
+            LockfileEntry {
+                version: SemVer::new(1, 0, 0),
+                source: LockfileSource::Path { path: "a".into() },
+                content_hash: "sha256:2".into(),
+            },
+        );
+
+        let yaml_a = serde_yaml::to_string(&a).unwrap();
+        // The "aaa" key must come before "zzz" in the serialized form.
+        let aaa_pos = yaml_a.find("@tatolab/aaa").unwrap();
+        let zzz_pos = yaml_a.find("@tatolab/zzz").unwrap();
+        assert!(aaa_pos < zzz_pos, "BTreeMap must produce sorted output");
+    }
+}

--- a/libs/streamlib-idents/src/manifest.rs
+++ b/libs/streamlib-idents/src/manifest.rs
@@ -1,0 +1,214 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::ident::{Org, Package};
+use crate::semver::{SemVer, SemVerRange};
+
+/// Package-flavor `streamlib.yaml` — declares a publishable package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageManifest {
+    pub package: PackageMetadata,
+
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, DependencySpec>,
+}
+
+/// Project-flavor `streamlib.yaml` — declares a consumer project.
+///
+/// No `package:` block; only declares `dependencies`. Use this for
+/// applications and examples that depend on packages but aren't themselves
+/// publishable.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectManifest {
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, DependencySpec>,
+}
+
+/// Package metadata. `version` lives here and ONLY here — per the
+/// package-as-publication-unit rule (CI lint rejects per-schema versions).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageMetadata {
+    pub org: Org,
+    pub name: Package,
+    pub version: SemVer,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Dependency declaration. Three sources:
+///
+/// - String form `^1.2.3` → registry dependency with a semver range
+/// - `{ path: ../foo }` → path dependency
+/// - `{ git: ..., rev: ... }` → git dependency
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum DependencySpec {
+    Registry(RegistryDependency),
+    Path(PathDependency),
+    Git(GitDependency),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryDependency {
+    pub version: SemVerRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PathDependency {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GitDependency {
+    pub git: String,
+    /// Pinned commit. Branch / tag refs are deliberately not supported —
+    /// pinning is required for reproducible resolution. Mirrors the
+    /// workspace rule from `CLAUDE.md` (`Conventions → Dependencies`).
+    pub rev: String,
+}
+
+// Custom Deserialize: a bare string `^1.2.3` is sugar for a Registry
+// dependency. A map is one of the structured variants.
+impl<'de> Deserialize<'de> for DependencySpec {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            // Bare string: `dep-name: ^1.2.3`.
+            Range(SemVerRange),
+            // Structured map: `dep-name: { ... }`.
+            Map(StructuredRepr),
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged, deny_unknown_fields)]
+        enum StructuredRepr {
+            Registry(RegistryDependency),
+            Path(PathDependency),
+            Git(GitDependency),
+        }
+
+        let repr = Repr::deserialize(d)?;
+        Ok(match repr {
+            Repr::Range(v) => Self::Registry(RegistryDependency { version: v }),
+            Repr::Map(StructuredRepr::Registry(r)) => Self::Registry(r),
+            Repr::Map(StructuredRepr::Path(p)) => Self::Path(p),
+            Repr::Map(StructuredRepr::Git(g)) => Self::Git(g),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_manifest_round_trip() {
+        let yaml = "
+package:
+  org: tatolab
+  name: core
+  version: 1.0.0
+  description: Canonical wire vocabulary
+dependencies: {}
+";
+        let m: PackageManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(m.package.org.as_str(), "tatolab");
+        assert_eq!(m.package.name.as_str(), "core");
+        assert_eq!(m.package.version, SemVer::new(1, 0, 0));
+        assert!(m.dependencies.is_empty());
+    }
+
+    #[test]
+    fn project_manifest_with_three_dep_flavors() {
+        let yaml = r#"
+dependencies:
+  "@tatolab/core": "^1.0.0"
+  "@tatolab/h264":
+    path: ../h264
+  "@tatolab/moq":
+    git: https://github.com/tatolab/moq
+    rev: abc123def456
+"#;
+        let m: ProjectManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(m.dependencies.len(), 3);
+
+        match m.dependencies.get("@tatolab/core").unwrap() {
+            DependencySpec::Registry(r) => assert_eq!(r.version.to_string(), "^1.0.0"),
+            other => panic!("expected Registry, got {:?}", other),
+        }
+
+        match m.dependencies.get("@tatolab/h264").unwrap() {
+            DependencySpec::Path(p) => assert_eq!(p.path, PathBuf::from("../h264")),
+            other => panic!("expected Path, got {:?}", other),
+        }
+
+        match m.dependencies.get("@tatolab/moq").unwrap() {
+            DependencySpec::Git(g) => {
+                assert_eq!(g.git, "https://github.com/tatolab/moq");
+                assert_eq!(g.rev, "abc123def456");
+            }
+            other => panic!("expected Git, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn package_manifest_rejects_invalid_org() {
+        let yaml = "
+package:
+  org: Tatolab
+  name: core
+  version: 1.0.0
+";
+        let res: Result<PackageManifest, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn package_manifest_rejects_invalid_version() {
+        let yaml = "
+package:
+  org: tatolab
+  name: core
+  version: not-a-version
+";
+        let res: Result<PackageManifest, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn manifest_rejects_unknown_field() {
+        // The `deny_unknown_fields` invariant — typos at the manifest top
+        // level should fail loudly, not silently turn into no-ops.
+        let yaml = "
+package:
+  org: tatolab
+  name: core
+  version: 1.0.0
+unknown_top_level_field: oops
+";
+        let res: Result<PackageManifest, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn git_dependency_requires_rev() {
+        let yaml = r#"
+dependencies:
+  "@tatolab/moq":
+    git: https://github.com/tatolab/moq
+"#;
+        let res: Result<ProjectManifest, _> = serde_yaml::from_str(yaml);
+        assert!(res.is_err(), "git dep without rev must fail");
+    }
+}

--- a/libs/streamlib-idents/src/semver.rs
+++ b/libs/streamlib-idents/src/semver.rs
@@ -1,0 +1,266 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::Ordering;
+use std::fmt;
+
+use crate::error::{IdentError, IdentResult};
+
+/// Three-part semantic version. Pre-release / build metadata not supported in
+/// v1 — re-introduce when a real consumer needs them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SemVer {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl SemVer {
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Internal string conversion. Public on the crate boundary so YAML/JSON
+    /// deserialization (the typed-deserialization pathway) can construct a
+    /// `SemVer` from `"1.2.3"`. Not a workaround of the `SchemaIdent`
+    /// "no parse API" rule — `SchemaIdent` glues multiple structured fields
+    /// with punctuation; `SemVer` has a single canonical string form
+    /// universally agreed across cargo / npm / pip.
+    pub(crate) fn from_dotted(s: &str) -> IdentResult<Self> {
+        let mut parts = s.split('.');
+        let major = parse_part(s, parts.next())?;
+        let minor = parse_part(s, parts.next())?;
+        let patch = parse_part(s, parts.next())?;
+        if parts.next().is_some() {
+            return Err(IdentError::InvalidSemVer(
+                s.to_string(),
+                "expected exactly three dot-separated integers".into(),
+            ));
+        }
+        Ok(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+fn parse_part(full: &str, part: Option<&str>) -> IdentResult<u32> {
+    let p = part.ok_or_else(|| {
+        IdentError::InvalidSemVer(
+            full.to_string(),
+            "expected exactly three dot-separated integers".into(),
+        )
+    })?;
+    p.parse::<u32>()
+        .map_err(|e| IdentError::InvalidSemVer(full.to_string(), e.to_string()))
+}
+
+impl fmt::Display for SemVer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl PartialOrd for SemVer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SemVer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+    }
+}
+
+impl Serialize for SemVer {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for SemVer {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::from_dotted(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// SemVer range matcher. Supported operators (npm-flavoured subset chosen for
+/// what `streamlib.yaml` actually needs):
+///
+/// - `=1.2.3` exact
+/// - `>=1.2.3` lower bound
+/// - `^1.2.3` caret — same major, version >= input (npm semantics)
+/// - `~1.2.3` tilde — same major.minor, version >= input
+///
+/// Pre-1.0 caret (`^0.x.y`) follows npm: `^0.2.3` matches `>=0.2.3 <0.3.0`,
+/// and `^0.0.3` matches exactly `0.0.3`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemVerRange {
+    Exact(SemVer),
+    AtLeast(SemVer),
+    Caret(SemVer),
+    Tilde(SemVer),
+}
+
+impl SemVerRange {
+    pub(crate) fn from_str(s: &str) -> IdentResult<Self> {
+        let s = s.trim();
+        if let Some(rest) = s.strip_prefix("^") {
+            return Ok(Self::Caret(SemVer::from_dotted(rest.trim())?));
+        }
+        if let Some(rest) = s.strip_prefix("~") {
+            return Ok(Self::Tilde(SemVer::from_dotted(rest.trim())?));
+        }
+        if let Some(rest) = s.strip_prefix(">=") {
+            return Ok(Self::AtLeast(SemVer::from_dotted(rest.trim())?));
+        }
+        if let Some(rest) = s.strip_prefix("=") {
+            return Ok(Self::Exact(SemVer::from_dotted(rest.trim())?));
+        }
+        // Bare version → exact match.
+        Ok(Self::Exact(SemVer::from_dotted(s)?))
+    }
+
+    pub fn matches(&self, v: SemVer) -> bool {
+        match *self {
+            Self::Exact(req) => v == req,
+            Self::AtLeast(req) => v >= req,
+            Self::Caret(req) => caret_matches(req, v),
+            Self::Tilde(req) => v >= req && v.major == req.major && v.minor == req.minor,
+        }
+    }
+}
+
+fn caret_matches(req: SemVer, v: SemVer) -> bool {
+    if v < req {
+        return false;
+    }
+    if req.major > 0 {
+        v.major == req.major
+    } else if req.minor > 0 {
+        // ^0.minor.patch → same minor
+        v.major == 0 && v.minor == req.minor
+    } else {
+        // ^0.0.patch → exact
+        v == req
+    }
+}
+
+impl fmt::Display for SemVerRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exact(v) => write!(f, "={}", v),
+            Self::AtLeast(v) => write!(f, ">={}", v),
+            Self::Caret(v) => write!(f, "^{}", v),
+            Self::Tilde(v) => write!(f, "~{}", v),
+        }
+    }
+}
+
+impl Serialize for SemVerRange {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for SemVerRange {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::from_str(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_round_trip() {
+        let v = SemVer::new(1, 2, 3);
+        assert_eq!(v.to_string(), "1.2.3");
+        assert_eq!(SemVer::from_dotted("1.2.3").unwrap(), v);
+    }
+
+    #[test]
+    fn semver_rejects_garbage() {
+        assert!(SemVer::from_dotted("1.2").is_err());
+        assert!(SemVer::from_dotted("1.2.3.4").is_err());
+        assert!(SemVer::from_dotted("1.x.3").is_err());
+        assert!(SemVer::from_dotted("").is_err());
+    }
+
+    #[test]
+    fn semver_ordering() {
+        assert!(SemVer::new(1, 0, 0) < SemVer::new(1, 0, 1));
+        assert!(SemVer::new(1, 0, 0) < SemVer::new(1, 1, 0));
+        assert!(SemVer::new(1, 0, 0) < SemVer::new(2, 0, 0));
+        assert!(SemVer::new(0, 9, 9) < SemVer::new(1, 0, 0));
+    }
+
+    #[test]
+    fn range_exact() {
+        let r = SemVerRange::from_str("=1.2.3").unwrap();
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(!r.matches(SemVer::new(1, 2, 4)));
+
+        let bare = SemVerRange::from_str("1.2.3").unwrap();
+        assert_eq!(bare, SemVerRange::Exact(SemVer::new(1, 2, 3)));
+    }
+
+    #[test]
+    fn range_at_least() {
+        let r = SemVerRange::from_str(">=1.2.3").unwrap();
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(r.matches(SemVer::new(2, 0, 0)));
+        assert!(!r.matches(SemVer::new(1, 2, 2)));
+    }
+
+    #[test]
+    fn range_caret_post_1_0() {
+        let r = SemVerRange::from_str("^1.2.3").unwrap();
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(r.matches(SemVer::new(1, 9, 0)));
+        assert!(!r.matches(SemVer::new(2, 0, 0)));
+        assert!(!r.matches(SemVer::new(1, 2, 2)));
+    }
+
+    #[test]
+    fn range_caret_pre_1_0_minor() {
+        let r = SemVerRange::from_str("^0.2.3").unwrap();
+        assert!(r.matches(SemVer::new(0, 2, 3)));
+        assert!(r.matches(SemVer::new(0, 2, 9)));
+        assert!(!r.matches(SemVer::new(0, 3, 0)));
+        assert!(!r.matches(SemVer::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn range_caret_pre_1_0_patch() {
+        let r = SemVerRange::from_str("^0.0.3").unwrap();
+        assert!(r.matches(SemVer::new(0, 0, 3)));
+        assert!(!r.matches(SemVer::new(0, 0, 4)));
+    }
+
+    #[test]
+    fn range_tilde() {
+        let r = SemVerRange::from_str("~1.2.3").unwrap();
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(r.matches(SemVer::new(1, 2, 9)));
+        assert!(!r.matches(SemVer::new(1, 3, 0)));
+    }
+
+    #[test]
+    fn range_round_trip_through_yaml() {
+        let r = SemVerRange::from_str("^1.2.3").unwrap();
+        let s = serde_yaml::to_string(&r).unwrap();
+        let back: SemVerRange = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(r, back);
+    }
+}

--- a/libs/streamlib-idents/tests/no_parse_api.rs
+++ b/libs/streamlib-idents/tests/no_parse_api.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Public-API guard for the structured-everywhere rule.
+//
+// `SchemaIdent`, `Org`, `Package`, `TypeName` must all be constructed via
+// codegen-emitted const literals or via typed YAML/JSON deserialization.
+// There is **no** `parse` constructor on these types; adding one would
+// re-introduce the parser-disagreement drift mode the design eliminates.
+//
+// This file is a compile-time witness: if any of the snippets below ever
+// start compiling, a `parse` (or equivalent) entry point has been added
+// to the public surface and the structured-everywhere invariant has
+// been violated. See `docs/architecture/schema-identity-and-packaging.md`,
+// the "Anti-patterns" section.
+
+use streamlib_idents::{Org, Package, SchemaIdent, TypeName};
+
+/// Each of these must be a compile error. We test that by referencing the
+/// methods through a `cfg(any())` block — the code is type-checked but
+/// dead-eliminated. If a `parse` method were added, this file would error
+/// at type-check time, failing the build.
+#[allow(dead_code)]
+fn _structurally_no_parse_api() {
+    // Negative API surface — these calls must not type-check. Rather than
+    // running them, we reference them inside a `cfg(any())` so the
+    // compiler still sees them but never tries to lower them. If a `parse`
+    // method is added that returns `Result<Self, _>`, the call would
+    // compile and the whole file would build — failing the gate.
+    //
+    // We use a runtime check (`should_not_compile!`) that's only ever
+    // referenced inside `if false { … }` so the asserter sees the methods
+    // but doesn't actually run anything.
+
+    if false {
+        // SchemaIdent
+        let _: () = should_not_compile_schema_ident();
+        // Segments
+        let _: () = should_not_compile_org();
+        let _: () = should_not_compile_package();
+        let _: () = should_not_compile_type();
+    }
+}
+
+/// These functions are never called. Their *existence* is the assertion:
+/// each line below must fail to compile if the API includes a `parse`
+/// method. They are referenced only inside `if false { … }` above so the
+/// compiler type-checks the file but never tries to actually link the
+/// non-existent methods at runtime.
+fn should_not_compile_schema_ident() {
+    // Uncommenting the line below MUST fail to compile. If it ever starts
+    // compiling, the structured-everywhere rule has been violated.
+    //
+    // let _ = SchemaIdent::parse("@tatolab/core/VideoFrame@1.0.0");
+}
+
+fn should_not_compile_org() {
+    // let _ = Org::parse("tatolab");
+}
+
+fn should_not_compile_package() {
+    // let _ = Package::parse("core");
+}
+
+fn should_not_compile_type() {
+    // let _ = TypeName::parse("VideoFrame");
+}
+
+/// Reflective check: list every public method name on the public types and
+/// assert none of them is `parse` or `from_str`. We do this by exercising
+/// the *valid* construction paths to make sure the public surface stays
+/// stable, then asserting the no-parse API in plain prose.
+#[test]
+fn public_surface_uses_only_structured_construction() {
+    // The only public constructors:
+    let org = Org::new("tatolab").unwrap();
+    let package = Package::new("core").unwrap();
+    let type_name = TypeName::new("VideoFrame").unwrap();
+    let version = streamlib_idents::SemVer::new(1, 0, 0);
+    let _id = SchemaIdent::new(org, package, type_name, version);
+
+    // Typed deserialization is the other allowed pathway:
+    let yaml = "
+org: tatolab
+package: core
+type: VideoFrame
+version: 1.0.0
+";
+    let _id: SchemaIdent = serde_yaml::from_str(yaml).unwrap();
+}

--- a/libs/streamlib-idents/tests/no_parse_api.rs
+++ b/libs/streamlib-idents/tests/no_parse_api.rs
@@ -8,83 +8,68 @@
 // There is **no** `parse` constructor on these types; adding one would
 // re-introduce the parser-disagreement drift mode the design eliminates.
 //
-// This file is a compile-time witness: if any of the snippets below ever
-// start compiling, a `parse` (or equivalent) entry point has been added
-// to the public surface and the structured-everywhere invariant has
-// been violated. See `docs/architecture/schema-identity-and-packaging.md`,
-// the "Anti-patterns" section.
+// ## Where the actual gate lives
+//
+// The compile-time witness for "no `parse` API" lives in `compile_fail`
+// doctests on each type definition (`SchemaIdent`, `Org`, `Package`,
+// `TypeName`) — see their rustdoc. Those doctests assert the
+// forbidden snippets MUST fail to compile; if a `parse` (or `FromStr`)
+// API is ever added, the doctests would compile cleanly, the `compile_fail`
+// assertion would flip, and `cargo test --doc -p streamlib-idents` would
+// surface the regression.
+//
+// This integration test is the *positive* counterpart: it locks the
+// allowed construction pathways (`Type::new` validating constructors and
+// typed YAML deserialization) so that whatever change adds a new public
+// constructor has to pass through here too. If a `parse` API were
+// accidentally added in the same change that removed one of the allowed
+// constructors, the doctest would catch the addition and this test would
+// catch the removal — together they bracket the public surface.
 
-use streamlib_idents::{Org, Package, SchemaIdent, TypeName};
+use streamlib_idents::{Org, Package, SchemaIdent, SemVer, TypeName};
 
-/// Each of these must be a compile error. We test that by referencing the
-/// methods through a `cfg(any())` block — the code is type-checked but
-/// dead-eliminated. If a `parse` method were added, this file would error
-/// at type-check time, failing the build.
-#[allow(dead_code)]
-fn _structurally_no_parse_api() {
-    // Negative API surface — these calls must not type-check. Rather than
-    // running them, we reference them inside a `cfg(any())` so the
-    // compiler still sees them but never tries to lower them. If a `parse`
-    // method is added that returns `Result<Self, _>`, the call would
-    // compile and the whole file would build — failing the gate.
-    //
-    // We use a runtime check (`should_not_compile!`) that's only ever
-    // referenced inside `if false { … }` so the asserter sees the methods
-    // but doesn't actually run anything.
-
-    if false {
-        // SchemaIdent
-        let _: () = should_not_compile_schema_ident();
-        // Segments
-        let _: () = should_not_compile_org();
-        let _: () = should_not_compile_package();
-        let _: () = should_not_compile_type();
-    }
-}
-
-/// These functions are never called. Their *existence* is the assertion:
-/// each line below must fail to compile if the API includes a `parse`
-/// method. They are referenced only inside `if false { … }` above so the
-/// compiler type-checks the file but never tries to actually link the
-/// non-existent methods at runtime.
-fn should_not_compile_schema_ident() {
-    // Uncommenting the line below MUST fail to compile. If it ever starts
-    // compiling, the structured-everywhere rule has been violated.
-    //
-    // let _ = SchemaIdent::parse("@tatolab/core/VideoFrame@1.0.0");
-}
-
-fn should_not_compile_org() {
-    // let _ = Org::parse("tatolab");
-}
-
-fn should_not_compile_package() {
-    // let _ = Package::parse("core");
-}
-
-fn should_not_compile_type() {
-    // let _ = TypeName::parse("VideoFrame");
-}
-
-/// Reflective check: list every public method name on the public types and
-/// assert none of them is `parse` or `from_str`. We do this by exercising
-/// the *valid* construction paths to make sure the public surface stays
-/// stable, then asserting the no-parse API in plain prose.
 #[test]
-fn public_surface_uses_only_structured_construction() {
-    // The only public constructors:
+fn allowed_construction_paths_remain_intact() {
+    // Path 1 — codegen-style: validating segment constructors + struct
+    // literal. This is what the rust-side macro emits.
     let org = Org::new("tatolab").unwrap();
     let package = Package::new("core").unwrap();
     let type_name = TypeName::new("VideoFrame").unwrap();
-    let version = streamlib_idents::SemVer::new(1, 0, 0);
-    let _id = SchemaIdent::new(org, package, type_name, version);
+    let version = SemVer::new(1, 0, 0);
+    let id = SchemaIdent::new(org, package, type_name, version);
+    assert_eq!(id.to_string(), "@tatolab/core/VideoFrame@1.0.0");
 
-    // Typed deserialization is the other allowed pathway:
+    // Path 2 — typed YAML deserialization: each segment is its own field.
+    // The wire shape is structured fields, not a joined string.
     let yaml = "
 org: tatolab
 package: core
 type: VideoFrame
 version: 1.0.0
 ";
-    let _id: SchemaIdent = serde_yaml::from_str(yaml).unwrap();
+    let id: SchemaIdent = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(id.org.as_str(), "tatolab");
+    assert_eq!(id.package.as_str(), "core");
+    assert_eq!(id.r#type.as_str(), "VideoFrame");
+    assert_eq!(id.version, SemVer::new(1, 0, 0));
+
+    // Path 3 — typed JSON deserialization: same structured shape over JSON.
+    let json = r#"{"org":"tatolab","package":"core","type":"VideoFrame","version":"1.0.0"}"#;
+    let id: SchemaIdent = serde_json::from_str(json).unwrap();
+    assert_eq!(id.to_string(), "@tatolab/core/VideoFrame@1.0.0");
+}
+
+#[test]
+fn joined_string_is_not_a_valid_yaml_shape() {
+    // The Display form `@org/package/Type@version` is render-only — feeding
+    // it back as a YAML string for a SchemaIdent must NOT round-trip. If
+    // someone added a custom Deserialize impl that accepts the joined form,
+    // this test would start passing-with-the-wrong-id and the assertion
+    // below would fire.
+    let yaml = "\"@tatolab/core/VideoFrame@1.0.0\"";
+    let res: Result<SchemaIdent, _> = serde_yaml::from_str(yaml);
+    assert!(
+        res.is_err(),
+        "joined-string deserialization MUST fail — structured-everywhere rule"
+    );
 }

--- a/xtask/src/check_schema_versions.rs
+++ b/xtask/src/check_schema_versions.rs
@@ -1,0 +1,246 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI lint enforcing the package-as-publication-unit rule from milestone 10.
+//!
+//! Schema YAMLs declare `type` (and content fields); they do NOT declare a
+//! top-level `version`. Versioning lives at the package level
+//! (`streamlib.yaml`'s `package.version`) — bumping any type bumps the
+//! whole package. This lint catches anyone re-introducing a top-level
+//! `version` key in a schema YAML.
+//!
+//! See `docs/architecture/schema-identity-and-packaging.md`.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Directory globs to walk for schema YAMLs. New layout (`packages/*/schemas`)
+/// is included alongside the legacy `libs/*/schemas` so the lint stays
+/// effective during the milestone-10 migration.
+pub const SCHEMA_DIR_PARENTS: &[&str] = &["libs", "packages", "examples"];
+
+/// Files that look like schema YAMLs but are NOT (e.g. `streamlib.yaml`,
+/// `Cargo.toml.orig`). The lint runs only on files matching `*.yaml` /
+/// `*.yml` in a directory whose name is exactly `schemas/`.
+const SCHEMA_DIR_NAME: &str = "schemas";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LintViolation {
+    TopLevelVersion { file: PathBuf },
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let violations = lint_workspace(workspace_root)?;
+
+    if violations.is_empty() {
+        println!("✓ check-schema-versions: no schema YAMLs declare a top-level `version` key");
+        return Ok(());
+    }
+
+    eprintln!("✗ check-schema-versions: {} violation(s)", violations.len());
+    for v in &violations {
+        match v {
+            LintViolation::TopLevelVersion { file } => {
+                eprintln!(
+                    "  {}: schema YAMLs must not declare a top-level `version` key (publication-unit lives in streamlib.yaml; see docs/architecture/schema-identity-and-packaging.md)",
+                    file.display()
+                );
+            }
+        }
+    }
+    anyhow::bail!("check-schema-versions failed");
+}
+
+pub fn lint_workspace(workspace_root: &Path) -> Result<Vec<LintViolation>> {
+    let mut violations = Vec::new();
+    for parent in SCHEMA_DIR_PARENTS {
+        let parent_path = workspace_root.join(parent);
+        if !parent_path.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(&parent_path).follow_links(false) {
+            let entry = entry.with_context(|| format!("walking {}", parent_path.display()))?;
+            let path = entry.path();
+            if !is_schema_yaml(path) {
+                continue;
+            }
+            if has_top_level_version(path)? {
+                violations.push(LintViolation::TopLevelVersion {
+                    file: path.to_path_buf(),
+                });
+            }
+        }
+    }
+    Ok(violations)
+}
+
+fn is_schema_yaml(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    let ext = path.extension().and_then(|e| e.to_str());
+    if !matches!(ext, Some("yaml") | Some("yml")) {
+        return false;
+    }
+    // Must live under a directory literally named `schemas`.
+    path.ancestors()
+        .any(|a| a.file_name().and_then(|n| n.to_str()) == Some(SCHEMA_DIR_NAME))
+}
+
+fn has_top_level_version(path: &Path) -> Result<bool> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+
+    // Empty file is fine.
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let value: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("parsing {} as YAML", path.display()))?;
+
+    let mapping = match value {
+        serde_yaml::Value::Mapping(m) => m,
+        // A non-mapping schema (anchor list, sequence, etc.) has no
+        // top-level keys at all — pass.
+        _ => return Ok(false),
+    };
+
+    Ok(mapping.contains_key(serde_yaml::Value::String("version".into())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_fixture(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn passes_on_canonical_jtd_metadata_block() {
+        // The current schema shape (metadata.version), which the lint must
+        // accept until the milestone-10 sweep migrates schemas off it.
+        let dir = TempDir::new().unwrap();
+        write_fixture(
+            dir.path(),
+            "libs/foo/schemas/com.tatolab.videoframe.yaml",
+            "metadata:\n  name: com.tatolab.videoframe\n  version: 1.0.0\nproperties:\n  width:\n    type: uint32\n",
+        );
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert!(
+            violations.is_empty(),
+            "metadata.version is grandfathered until later issues sweep, but {:?}",
+            violations
+        );
+    }
+
+    #[test]
+    fn rejects_top_level_version_key() {
+        let dir = TempDir::new().unwrap();
+        let bad = write_fixture(
+            dir.path(),
+            "libs/foo/schemas/com.tatolab.videoframe.yaml",
+            "type: VideoFrame\nversion: 1.0.0\nproperties:\n  width:\n    type: uint32\n",
+        );
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert_eq!(violations.len(), 1);
+        match &violations[0] {
+            LintViolation::TopLevelVersion { file } => assert_eq!(file, &bad),
+        }
+    }
+
+    #[test]
+    fn ignores_non_schemas_directory() {
+        // A YAML that lives outside a `schemas/` directory is not a schema —
+        // even if it has a top-level version. (e.g. `streamlib.yaml`,
+        // `release.yml`, `.github/workflows/*.yml`.)
+        let dir = TempDir::new().unwrap();
+        write_fixture(
+            dir.path(),
+            "libs/foo/streamlib.yaml",
+            "package:\n  org: tatolab\n  name: foo\n  version: 1.0.0\n",
+        );
+        write_fixture(
+            dir.path(),
+            ".github/workflows/release.yml",
+            "name: Release\non:\n  push: {}\n",
+        );
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert!(violations.is_empty(), "{:?}", violations);
+    }
+
+    #[test]
+    fn ignores_non_yaml_files() {
+        let dir = TempDir::new().unwrap();
+        write_fixture(
+            dir.path(),
+            "libs/foo/schemas/Cargo.toml",
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        );
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert!(violations.is_empty(), "{:?}", violations);
+    }
+
+    #[test]
+    fn handles_yml_extension() {
+        let dir = TempDir::new().unwrap();
+        write_fixture(
+            dir.path(),
+            "libs/foo/schemas/anything.yml",
+            "type: VideoFrame\nversion: 1.0.0\n",
+        );
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn empty_file_is_a_pass() {
+        let dir = TempDir::new().unwrap();
+        write_fixture(dir.path(), "libs/foo/schemas/empty.yaml", "");
+        let violations = lint_workspace(dir.path()).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn invalid_yaml_is_an_error_not_a_silent_pass() {
+        let dir = TempDir::new().unwrap();
+        write_fixture(
+            dir.path(),
+            "libs/foo/schemas/broken.yaml",
+            ":::: not yaml ::::",
+        );
+        let res = lint_workspace(dir.path());
+        assert!(res.is_err(), "broken YAML must surface, not silently pass");
+    }
+
+    #[test]
+    fn current_workspace_passes() {
+        // Smoke test: run the lint against the actual workspace. Locks in
+        // that no current schema declares a top-level `version` key. If
+        // this fails, either a new schema was added with the wrong shape
+        // or the migration sweep already happened (in which case the
+        // grandfather test above also needs revisiting).
+        let workspace = workspace_root().expect("workspace root");
+        let violations = lint_workspace(&workspace).unwrap();
+        assert!(
+            violations.is_empty(),
+            "current workspace has top-level version keys: {:?}",
+            violations
+        );
+    }
+
+    fn workspace_root() -> Result<PathBuf> {
+        let manifest = env!("CARGO_MANIFEST_DIR"); // .../streamlib/xtask
+        Ok(PathBuf::from(manifest)
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("xtask has no parent"))?
+            .to_path_buf())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 pub mod check_boundaries;
+pub mod check_schema_versions;
 mod generate_schemas;
 pub mod lint_logging;
 
@@ -64,6 +65,12 @@ enum Commands {
     /// on the full `streamlib` crate, or privileged Vulkan calls outside
     /// the RHI. See `docs/architecture/subprocess-rhi-parity.md`.
     CheckBoundaries,
+
+    /// CI gate for the package-as-publication-unit rule from milestone 10.
+    /// Fails when any schema YAML declares a top-level `version` key
+    /// (versioning lives in `streamlib.yaml`, not in individual schemas).
+    /// See `docs/architecture/schema-identity-and-packaging.md`.
+    CheckSchemaVersions,
 }
 
 fn main() -> Result<()> {
@@ -79,6 +86,7 @@ fn main() -> Result<()> {
         } => generate_schemas::run(runtime, output, project_file, schema_file, schema_dir)?,
         Commands::LintLogging => lint_logging::run(&workspace_root()?)?,
         Commands::CheckBoundaries => check_boundaries::run(&workspace_root()?)?,
+        Commands::CheckSchemaVersions => check_schema_versions::run(&workspace_root()?)?,
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Lays the foundation for milestone 10 (*Schema Identity & Packaging*): new `streamlib-idents` Rust crate, `cargo xtask check-schema-versions` CI lint, and the canonical architecture doc anchoring the rest of the milestone.
- Structured-everywhere identifier shape (`SchemaIdent { org, package, type, version }`) — no public `parse` API on the surface, locked by `compile_fail` doctests on each identifier type.
- Migration sweep is staged across follow-ups (#401 / #402 / #404 + the 12 carve-out package issues) per the milestone's pickup order — this PR is foundation only, no consumers migrated yet.

## Closes

Closes #399

## What lands

- **`libs/streamlib-idents/`** — new crate exposing `SchemaIdent`, `SemVer`, `SemVerRange`, `PackageManifest`, `ProjectManifest`, `Lockfile`. Validating constructors on every segment newtype; typed YAML/JSON deserialization runs the validators.
- **`xtask/src/check_schema_versions.rs`** + **`.github/workflows/check-schema-versions.yml`** — CI lint rejecting any schema YAML that declares a top-level `version` key (publication-unit enforcement). Walks `libs/*/schemas/`, `packages/*/schemas/`, `examples/*/schemas/`. Grandfathers existing `metadata.version` blocks until the schema-file sweep in #401/#402.
- **`docs/architecture/schema-identity-and-packaging.md`** — new living doc covering grammar BNF, manifest formats (package + project flavors), lockfile shape, sentinel-substitution codegen contract, anti-patterns, and the rosetta table mapping every current `com.streamlib.*` / `com.tatolab.*` identifier to its `@org/package/Type@version` form.

## Exit criteria (from issue body)

- [x] `streamlib-idents` Rust crate ships `SchemaIdent`, `SemVer`, `Display`, semver-range matcher, validator
- [x] `docs/architecture/schema-identity-and-packaging.md` lands as a tracked living-document — covers grammar BNF, manifest formats, lockfile shape, sentinel-substitution contract, package-as-publication-unit rule, anti-patterns, rosetta table
- [x] CI lint rejects schema YAML files declaring a top-level `version` key (publication-unit enforcement)

## Test plan

All gates green locally. (CI re-runs them on PR.)

- [x] `cargo test -p streamlib-idents` — 32 unit tests + 2 integration tests + 8 `compile_fail` doctests pass
- [x] `cargo test -p xtask check_schema_versions` — 8 fixture tests including a workspace smoke test (current schemas pass)
- [x] `cargo xtask check-schema-versions` against the live workspace — passes ✓
- [x] `cargo xtask check-boundaries` — no regressions (new crate has no Vulkan deps)
- [x] `cargo xtask lint-logging` — no regressions

### How the no-parse-API gate is enforced

Each identifier type (`SchemaIdent`, `Org`, `Package`, `TypeName`) carries `compile_fail` doctests covering both `Type::parse(...)` and `"…".parse::<Type>()` (FromStr) entry points. **Verified the gate fires** by temporarily adding `pub fn parse(_: &str) -> Self` to `SchemaIdent` — `cargo test --doc` reported "Test compiled successfully, but it's marked `compile_fail`" → 1 of 8 doctests failed. The `tests/no_parse_api.rs` integration test is the positive counterpart, locking the allowed construction pathways and explicitly asserting joined-string YAML deserialization fails.

## Polyglot coverage

- **Runtimes affected**: rust only
- **Schema regenerated**: n/a (no new IPC ops)
- **Python and Deno both covered?** schema-only / language-specific by construction — the structured-everywhere rule eliminates the parser-parity burden for non-Rust callers (they receive structured records, never parse identifiers locally). AI Agent Note in the issue body explicitly scope-cuts polyglot validator parity to a follow-up if/when a non-Rust caller actually needs to validate identifiers.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-idents -p xtask` ✓
  - [ ] Python subprocess: n/a — no polyglot surface in this PR
  - [ ] Deno subprocess: n/a — no polyglot surface in this PR
- **FD-passing path**: n/a

## Migration sweep is multi-PR by design

This is the rare case where the milestone explicitly stages "no bad patterns left behind" across PRs:

- **#400** — `streamlib-codegen` extraction + `streamlib generate` CLI
- **#402** — `streamlib.yaml` resolver + `streamlib.lock` + cutover off legacy `[package.metadata.streamlib]` etc. (atomic — absorbs #403 + #405)
- **#401** — processor short-name macros + sweep hardcoded reverse-DNS literals across Rust + Python + Deno
- **#404** — `@tatolab/core` package + IPC wire-format migration to structured records
- **12 carve-out package issues** — long-tail mechanical migration per package

The "no bad patterns left behind" rule from CLAUDE.md is explicitly relaxed for this milestone — see the *Pickup order* section in the new architecture doc.

## Follow-ups (out of scope)

None. The scope cuts that exist (polyglot validator parity, prebuilt-binary distribution for `streamlib generate`) are documented in the architecture doc + issue body / AI Agent Notes; downstream issues already track them.

## Notes for reviewers

- Issue body had a small staleness in the `Blocks:` field (claimed `#400, #402, #404` but graph data shows `#401, #402, #404`); fixed in-place during pickup with a strikethrough + reasoning per CLAUDE.md's markdown-editing rules.
- Reviewer in pre-PR `pr-review-gate` correctly flagged the original `tests/no_parse_api.rs` as a feel-good test (negative API references were inside Rust comments). Fix landed in commit 15960da; gate verified empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)