### PR TITLE
fix(tests): isolate hardware-integration tests behind hardware-tests feature

### DIFF
--- a/docs/testing-baseline.md
+++ b/docs/testing-baseline.md
@@ -1,8 +1,17 @@
 # Workspace test baseline
 
-Canonical command and exclusion list for streamlib's unit + integration
-test suite. Use this when reporting test results for a PR so reviewers
-can spot silent test-coverage loss.
+Canonical command and exclusion list for streamlib's tier-1 unit-test
+suite. Use this when reporting test results for a PR so reviewers can
+spot silent test-coverage loss.
+
+**Two tiers, gated by a Cargo feature.** Tier 1 (this doc) is the
+default `cargo test` and runs in parallel — pure logic, parsers, mock-
+backed integration. Tier 2 is hardware-integration: `cargo test
+--features streamlib/hardware-tests --workspace -- --test-threads=1`,
+documented separately in [`testing-hardware.md`](testing-hardware.md).
+The split is enforced by `#[cfg_attr(not(feature = "hardware-tests"),
+ignore)]` on every test that constructs a real `HostVulkanDevice`,
+so a tier-2 test can never accidentally hang the tier-1 gate.
 
 **Do not use `cargo test -p streamlib` as the workspace baseline.** It
 covers only the top-level `streamlib` crate and misses the bulk of the

--- a/docs/testing-hardware.md
+++ b/docs/testing-hardware.md
@@ -1,0 +1,98 @@
+# Hardware-integration test tier
+
+streamlib's test suite is split into two tiers, with the boundary
+enforced by a Cargo feature so the split can't drift:
+
+| Tier | Triggered by | What it covers | Parallel-safe? |
+|---|---|---|---|
+| **1 — Unit** | `cargo test` (default) | Pure logic, parsers, state machines, serialization round-trips, mock-backed integration. | Yes — by construction. |
+| **2 — Hardware integration** | `cargo test --features streamlib/hardware-tests` | Tests that construct a real `HostVulkanDevice`, allocate GPU memory, exercise the swapchain, etc. | No — must run with `--test-threads=1`. |
+
+Tier 1 is the gate that runs on every PR via the [canonical workspace
+baseline](testing-baseline.md). It's parallel-safe by construction — no
+test inside the tier-1 set is allowed to require a GPU device or any
+other exclusive system resource. Tier 1 should always pass cleanly in
+parallel; if it doesn't, the offending test is mis-classified.
+
+Tier 2 is the gate that runs when a change is hardware-relevant — Vulkan
+RHI work, encoder/decoder, display, anything in `vulkan/rhi/`. The
+canonical command:
+
+```bash
+cargo test --features streamlib/hardware-tests --workspace \
+    --exclude api-server-demo \
+    --exclude camera-deno-subprocess \
+    --exclude camera-python-subprocess \
+    --exclude camera-rust-plugin \
+    --exclude webrtc-cloudflare-stream \
+    --no-fail-fast \
+    -- --test-threads=1
+```
+
+The `--test-threads=1` is mandatory: tier-2 tests serialize on the GPU
+device. Running them in parallel deadlocks (most often inside the
+NVIDIA Vulkan driver's per-process kernel state, see
+[`docs/learnings/nvidia-dma-buf-after-swapchain.md`](learnings/nvidia-dma-buf-after-swapchain.md)).
+
+## Why Cargo features instead of `#[ignore]`
+
+The structural defense is `#[cfg_attr(not(feature = "hardware-tests"),
+ignore = "...")]`, not plain `#[ignore]`. The reasoning:
+
+- A plain `#[ignore]` is a single-purpose mute switch. It can drift
+  from "this test belongs to a different tier" to "this test is flaky
+  so I muted it" without anyone noticing — exactly the failure mode
+  the tier separation exists to prevent.
+- A feature-gated ignore is a structural commitment: the test is
+  ignored *only* in tier 1, and runs unconditionally in tier 2. The
+  feature flag makes the tier intent explicit at the call site.
+- Future agents reading the code see "if the `hardware-tests` feature
+  is on, this test runs" rather than just "ignored." That conveys
+  intent, not a band-aid.
+
+If a hardware test is flaky, the right answer is to fix it, not to add
+a plain `#[ignore]` next to its `#[cfg_attr]` line.
+
+## What goes in tier 2
+
+A test belongs in tier 2 if its body, or any helper it transitively
+calls, constructs a real GPU device or otherwise depends on a
+system-exclusive resource. Concretely, today:
+
+- Anything calling `HostVulkanDevice::new()` directly or through a
+  helper like `try_vulkan_device()`, `setup_device()`,
+  `create_test_device()`.
+- Tests in `vulkan/rhi/` that exercise GPU memory, swapchains,
+  pipelines, sync primitives.
+- Future: V4L2 camera capture, audio device probes, display
+  swapchains, anything that holds a kernel-level exclusive lock.
+
+Pure-logic tests in the same file (e.g. cache-path string formatting,
+SPIR-V reflection validators that operate on byte arrays without ever
+constructing a device) stay in tier 1.
+
+## Adding a new hardware test
+
+1. Place the test next to its production code (`vulkan/rhi/foo.rs::tests`).
+2. Tag it with `#[cfg_attr(not(feature = "hardware-tests"), ignore =
+   "hardware integration — set --features streamlib/hardware-tests +
+   run with --test-threads=1. See docs/testing-hardware.md")]`
+   immediately above `#[test]`.
+3. Use a shared `try_vulkan_device()` helper (or equivalent) that
+   gracefully skips when no GPU is available — keeps the test
+   well-behaved when the feature is on but the runner has no GPU.
+4. Don't reach for `#[serial]` from the `serial_test` crate; the
+   `--test-threads=1` invocation in tier 2 already serializes
+   everything.
+
+## CI
+
+Tier 1 runs on every PR via `.github/workflows/test.yml` (the canonical
+parallel command). A tier-2 CI workflow is **future work** — it
+requires a GPU runner, which the
+[testing-baseline doc](testing-baseline.md#ci-gate-pending) tracks as
+pending behind issue #343.
+
+Until the GPU runner lands, run tier 2 locally before merging any
+PR that touches `vulkan/rhi/`, encoders/decoders, or display code.
+The PR template should call this out explicitly when it's relevant.

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -23,6 +23,13 @@ moq = ["dep:moq-transport", "dep:web-transport", "dep:quinn", "dep:url", "dep:ru
 # Strip `debug!` (and `trace!`) from release builds. Opt-in per deployment
 # image. `warn!` / `error!` / `info!` are never stripped. See docs/logging.md.
 strip_debug_logging = ["tracing/release_max_level_info"]
+# Tier 2 — hardware-integration tests (`#[cfg_attr(not(feature =
+# "hardware-tests"), ignore)]` on tests that construct a real
+# `HostVulkanDevice`). Default `cargo test` is the tier-1 unit gate
+# (parallel-safe, mocked). To run hardware tests:
+#   cargo test --features streamlib/hardware-tests --workspace -- --test-threads=1
+# See `docs/testing-hardware.md`.
+hardware-tests = []
 
 [dependencies]
 # Processor schema types (shared with macros for code generation)

--- a/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_blitter.rs
@@ -202,6 +202,7 @@ mod tests {
         })
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_blit_copy_between_equal_size_buffers() {
         let device = match HostVulkanDevice::new() {
@@ -240,6 +241,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_blit_copy_rejects_mismatched_buffer_sizes() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_command_queue.rs
@@ -102,6 +102,7 @@ mod tests {
     use super::*;
     use crate::vulkan::rhi::HostVulkanDevice;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_creates_command_buffer() {
         let device = match HostVulkanDevice::new() {
@@ -117,6 +118,7 @@ mod tests {
         assert!(result.is_ok(), "command buffer allocation must succeed: {:?}", result.err());
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_empty_command_buffer_commit_and_wait_completes() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -1229,26 +1229,31 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_matches_expected_blend_for_one_input() {
         assert_blend_for(1);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_matches_expected_blend_for_two_inputs() {
         assert_blend_for(2);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_matches_expected_blend_for_four_inputs() {
         assert_blend_for(4);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_matches_expected_blend_for_eight_inputs() {
         assert_blend_for(8);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn kernel_bindings_reflect_descriptor() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1276,6 +1281,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn rejects_descriptor_with_mismatched_binding_kind() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1301,6 +1307,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn rejects_descriptor_missing_a_binding_the_shader_declares() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1328,6 +1335,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn rejects_descriptor_with_extra_binding_not_in_shader() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1354,6 +1362,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn rejects_push_constant_size_mismatch() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1375,6 +1384,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_without_setting_bindings_fails_loud() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1398,6 +1408,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_completes_within_reasonable_budget() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1523,6 +1534,7 @@ mod tests {
         let _ = dir; // keep the helper's tempdir name in scope
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     #[serial(streamlib_pipeline_cache_env)]
     fn cache_miss_writes_cache_file_after_kernel_construction() {
@@ -1567,6 +1579,7 @@ mod tests {
         });
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     #[serial(streamlib_pipeline_cache_env)]
     fn cache_hit_does_not_panic_or_break_kernel_construction() {
@@ -1612,6 +1625,7 @@ mod tests {
         });
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     #[serial(streamlib_pipeline_cache_env)]
     fn corrupt_cache_blob_falls_back_to_recompile_and_overwrites() {
@@ -1648,6 +1662,7 @@ mod tests {
         });
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     #[serial(streamlib_pipeline_cache_env)]
     fn read_only_cache_dir_does_not_break_kernel_construction() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_device.rs
@@ -2738,6 +2738,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_device_creation() {
         let device = match try_create_device() {
@@ -2749,6 +2750,7 @@ mod tests {
         println!("Vulkan device created: {}", device.name());
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_queue_family_discovery() {
         let device = match try_create_device() {
@@ -2769,6 +2771,7 @@ mod tests {
     /// vendor-id check; mentally-revertible (delete the
     /// `vendor_id != 0x10DE` check in `new()` and this test fails on
     /// NVIDIA hardware). Skips when no Vulkan device is available.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn supports_cross_device_dma_buf_probe_matches_vendor_blocklist() {
         let device = match try_create_device() {
@@ -2796,6 +2799,7 @@ mod tests {
     /// Issue #633 — `supports_qfot_acquire_unmodified` must equal the
     /// `has_acquire_unmodified` extension probe from `new()`.
     /// Trait-method route must agree with the inherent method.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn supports_qfot_acquire_unmodified_consistent_across_inherent_and_trait() {
         let device = match try_create_device() {
@@ -2822,6 +2826,7 @@ mod tests {
     /// drivers may tolerate it silently. Real GPU-correctness for
     /// QFOT comes from E2E scenarios run with
     /// `VK_LOADER_LAYERS_ENABLE=*validation*`.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn host_acquire_from_foreign_undefined_target_is_noop() {
         let device = match try_create_device() {
@@ -2836,6 +2841,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_vma_allocator_created() {
         let device = match try_create_device() {
@@ -2860,6 +2866,7 @@ mod tests {
     /// structure level so CI catches it without needing the manual
     /// Cam Link 4K reproducer.
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn opaque_fd_export_sentinels_retained_for_each_supported_pool() {
         let device = match try_create_device() {
@@ -2935,6 +2942,7 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_import_round_trip() {
         use vulkanalia::vk::KhrExternalMemoryFdExtensionDeviceCommands;
@@ -3005,6 +3013,7 @@ mod tests {
         unsafe { device.allocator().destroy_buffer(buffer, allocation) };
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_physical_device_supports_vulkan_1_4() {
         let device = match try_create_device() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_format_converter.rs
@@ -166,6 +166,7 @@ mod tests {
         out
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn nv12_full_range_to_bgra_matches_cpu_reference() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -238,6 +239,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn convert_rejects_size_mismatch() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -249,6 +251,7 @@ mod tests {
         assert!(matches!(err, StreamError::GpuError(_)));
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn convert_rejects_unsupported_formats() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -260,6 +263,7 @@ mod tests {
         assert!(matches!(err, StreamError::NotSupported(_)));
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_new_creates_compute_pipeline_successfully() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -386,6 +390,7 @@ mod tests {
         rgba
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn nv12_to_bgra_matches_committed_png_fixture() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -435,7 +440,7 @@ mod tests {
     /// The fixture path is relative to `libs/streamlib/`. After running, commit
     /// the regenerated `tests/fixtures/nv12_to_bgra/*` files.
     #[test]
-    #[ignore = "regenerate fixture — run explicitly with --ignored"]
+    #[ignore = "regenerate fixture — run explicitly with --ignored. (Always ignored — fixture regen is an explicit operation, not a hardware-tier test.)"]
     fn regenerate_nv12_to_bgra_fixture() {
         let device = try_vulkan_device().expect("Vulkan device required to regenerate fixture");
         let nv12_input = build_fixture_nv12_input();

--- a/libs/streamlib/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -2232,6 +2232,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn new_rejects_zero_descriptor_sets_in_flight() {
         // descriptor_sets_in_flight = 0 must fail before any Vulkan call.
@@ -2257,6 +2258,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn new_rejects_descriptor_without_vertex_stage() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2277,6 +2279,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn new_rejects_descriptor_without_fragment_stage() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2297,6 +2300,7 @@ mod tests {
 
     // ---- Pipeline construction (GPU device required) ----------------------
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn constructs_display_blit_kernel() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2317,6 +2321,7 @@ mod tests {
         assert_eq!(kernel.descriptor_sets_in_flight(), 2);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn constructs_kernel_with_depth_stencil_enabled() {
         // Smoke test: pipeline creation succeeds when both
@@ -2358,6 +2363,7 @@ mod tests {
         assert_eq!(kernel.bindings().len(), 1);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn constructs_kernel_with_alpha_blending() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2377,6 +2383,7 @@ mod tests {
             .expect("alpha-blending kernel must construct");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn constructs_kernel_with_vertex_input_buffers() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2419,6 +2426,7 @@ mod tests {
             .expect("vertex-input kernel must construct");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn frame_index_out_of_range_fails_loud() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -2463,6 +2471,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn dispatch_without_setting_bindings_fails_loud() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -771,6 +771,7 @@ unsafe impl Sync for HostVulkanPixelBuffer {}
 mod tests {
     use super::*;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_pool_buffer_creation_1920x1080_bgra32() {
         let device = match HostVulkanDevice::new() {
@@ -800,6 +801,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_buffer_write_and_readback() {
         let device = match HostVulkanDevice::new() {
@@ -838,6 +840,7 @@ mod tests {
         println!("Write/readback verified for {} bytes", size);
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_export() {
         let device = match HostVulkanDevice::new() {
@@ -864,6 +867,7 @@ mod tests {
     /// export is rejected (calling `export_opaque_fd_memory` on a DMA-BUF
     /// buffer produces an error).
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn opaque_fd_export_round_trip_and_cross_flavor_rejection() {
         let device = match HostVulkanDevice::new() {
@@ -917,6 +921,7 @@ mod tests {
     /// `opaque_fd_export_round_trip_and_cross_flavor_rejection` covering
     /// the GPU-resident path.
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn opaque_fd_device_local_export_round_trip() {
         let device = match HostVulkanDevice::new() {
@@ -958,6 +963,7 @@ mod tests {
     /// `export_external_handle` dispatches to the correct
     /// `RhiExternalHandle` variant for each allocation flavor.
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn export_external_handle_dispatches_on_allocation_flavor() {
         use crate::core::rhi::RhiExternalHandle;
@@ -1013,6 +1019,7 @@ mod tests {
     /// is comfortably below every observed real-device UUID and well
     /// above any plausible constant-write bug.
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn physical_device_uuid_is_populated() {
         let device = match HostVulkanDevice::new() {
@@ -1047,6 +1054,7 @@ mod tests {
         println!("physical_device_uuid: {uuid:02x?}");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_multiple_buffers_coexist() {
         let device = match HostVulkanDevice::new() {
@@ -1081,6 +1089,7 @@ mod tests {
         println!("All dropped successfully");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_drop_frees_without_panic() {
         let device = match HostVulkanDevice::new() {
@@ -1098,6 +1107,7 @@ mod tests {
         println!("Buffer drop completed without panic");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_import_round_trip() {
         let device = match HostVulkanDevice::new() {
@@ -1162,6 +1172,7 @@ mod tests {
     /// `HostVulkanPixelBuffer`, confirm `plane_count()` reports 2, and each
     /// plane's bytes survive intact. Mirrors the symmetry the polyglot
     /// Python and Deno shims provide via `*_gpu_surface_plane_{count,size,mmap,base_address}`.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_import_multi_plane_round_trip() {
         let device = match HostVulkanDevice::new() {
@@ -1253,6 +1264,7 @@ mod tests {
     /// more planes than the surface-share `MAX_DMA_BUF_PLANES` cap (4 today).
     /// Covers the Rust half of the consistency the wire helpers already
     /// enforce on sends/receives.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_import_rejects_oversize_plane_vec() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
@@ -148,6 +148,7 @@ mod tests {
     use super::*;
     use crate::vulkan::rhi::HostVulkanDevice;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_pool_acquire_returns_buffer() {
         let device = match HostVulkanDevice::new() {
@@ -173,6 +174,7 @@ mod tests {
         assert_ne!(pool_id, PixelBufferPoolId::new(), "pool id must be stable, not a fresh zero-id");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_pool_exhaustion_returns_error() {
         let device = match HostVulkanDevice::new() {
@@ -199,6 +201,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_pool_reuses_buffer_after_release() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -1677,12 +1677,14 @@ mod tests {
         )
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn kernel_constructs_against_real_device() {
         let Some(device) = try_ray_tracing_device() else { return };
         let _kernel = make_test_kernel(&device, "rt-construct").expect("kernel creation");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn kernel_rejects_missing_binding_in_descriptor() {
         let Some(device) = try_ray_tracing_device() else { return };
@@ -1722,6 +1724,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn kernel_rejects_kind_mismatch() {
         let Some(device) = try_ray_tracing_device() else { return };
@@ -1766,6 +1769,7 @@ mod tests {
     /// against a 64×64 storage image. Reads the result back and checks
     /// that the centre pixel is hit (barycentric color, mostly red) and
     /// the corner pixels are miss (dark blue from rmiss).
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn trace_rays_produces_hit_and_miss_pixels() {
         let Some(device) = try_ray_tracing_device() else { return };

--- a/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_swapchain_alloc_repro_test.rs
@@ -762,6 +762,7 @@ fn try_create_device() -> Option<Arc<HostVulkanDevice>> {
 
 /// BASELINE: without swapchain, even the broken VMA config works.
 /// Proves the bug requires a swapchain to manifest.
+#[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
 #[test]
 fn test_baseline_no_swapchain_broken_config_works() {
     let device = match try_create_device() {
@@ -812,6 +813,7 @@ fn test_baseline_no_swapchain_broken_config_works() {
 ///   1. BUG REPRO: broken VMA config + swapchain → at least one alloc must fail
 ///   2. FIX (clean VMA): internal allocs via plain VMA → all succeed
 ///   3. FIX (VMA pools): export allocs via custom pools → all succeed
+#[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
 #[test]
 fn test_swapchain_allocation_scenarios() {
     let device = match try_create_device() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_sync.rs
@@ -418,6 +418,7 @@ mod tests {
     use super::*;
     use crate::vulkan::rhi::HostVulkanDevice;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_semaphore_creation() {
         let device = match HostVulkanDevice::new() {
@@ -434,6 +435,7 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn timeline_semaphore_host_signal_advances_counter() {
         let device = match HostVulkanDevice::new() {
@@ -457,6 +459,7 @@ mod tests {
     /// Cross-process import is exercised by the surface-adapter
     /// integration tests in `streamlib-adapter-vulkan`.
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn timeline_semaphore_exports_valid_opaque_fd() {
         let device = match HostVulkanDevice::new() {
@@ -478,6 +481,7 @@ mod tests {
         unsafe { libc::close(fd) };
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_fence_creation() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture.rs
@@ -1238,6 +1238,7 @@ mod tests {
     use super::*;
     use crate::vulkan::rhi::HostVulkanDevice;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_pool_texture_creation_1920x1080_bgra8() {
         let device = match HostVulkanDevice::new() {
@@ -1264,6 +1265,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_texture_drop_frees_memory() {
         let device = match HostVulkanDevice::new() {
@@ -1281,6 +1283,7 @@ mod tests {
         println!("Texture drop completed without panic");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_multiple_textures_coexist() {
         let device = match HostVulkanDevice::new() {
@@ -1313,6 +1316,7 @@ mod tests {
         println!("All dropped successfully");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_dma_buf_export() {
         let device = match HostVulkanDevice::new() {
@@ -1358,6 +1362,7 @@ mod tests {
     /// buffers, textures for IPC) use raw vkAllocateMemory with VkExportMemoryAllocateInfo.
     /// Internal allocations (display camera textures) use raw vkAllocateMemory with
     /// dedicated allocation + multi-type fallback (no export flags).
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_camera_display_allocation_pattern() {
         let device = match HostVulkanDevice::new() {
@@ -1494,6 +1499,7 @@ mod tests {
         println!("All resources cleaned up successfully");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_various_formats() {
         let device = match HostVulkanDevice::new() {
@@ -1517,6 +1523,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_device_local_texture_creation() {
         let device = match HostVulkanDevice::new() {
@@ -1540,6 +1547,7 @@ mod tests {
         println!("Device-local texture created: {}x{}", texture.width(), texture.height());
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_lazy_image_view() {
         let device = match HostVulkanDevice::new() {
@@ -1572,6 +1580,7 @@ mod tests {
     /// 6. Assert plane[0].row_pitch >= 1920 * 4 (BGRA stride is at least
     ///    pixel-tight, possibly aligned up by tiling).
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_render_target_dma_buf_round_trip() {
         use crate::vulkan::rhi::drm_modifier_probe::fourcc;
@@ -1641,6 +1650,7 @@ mod tests {
     /// loudly rather than silently fall back to LINEAR (which is sampler-
     /// only on NVIDIA — see docs/learnings/nvidia-egl-dmabuf-render-target.md).
     #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_render_target_dma_buf_empty_modifiers_rejected() {
         let device = match HostVulkanDevice::new() {
@@ -1664,6 +1674,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_ring_texture_lifecycle() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_cache.rs
@@ -103,6 +103,7 @@ mod tests {
     use crate::vulkan::rhi::{HostVulkanDevice, HostVulkanTexture};
     use std::sync::Arc;
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_creates_image_view_for_valid_image() {
         let device = match HostVulkanDevice::new() {
@@ -131,6 +132,7 @@ mod tests {
         assert_ne!(view, vk::ImageView::null(), "image view handle must be non-null");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_returns_cached_view_for_same_image() {
         let device = match HostVulkanDevice::new() {
@@ -163,6 +165,7 @@ mod tests {
         assert_eq!(view_a, view_b, "same image must return the same cached VkImageView");
     }
 
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn test_flush_destroys_all_cached_views() {
         let device = match HostVulkanDevice::new() {

--- a/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -878,6 +878,7 @@ mod tests {
 
     /// Positive: round-trip a known pattern through the readback
     /// primitive on a 32x32 texture.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn submit_then_wait_returns_expected_bytes() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -924,6 +925,7 @@ mod tests {
     /// Positive: multiple submits sequentially on a single handle. After
     /// each wait, the next submit must succeed and the bytes reflect
     /// the (re-filled) texture.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn multiple_sequential_submits_work() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -967,6 +969,7 @@ mod tests {
     }
 
     /// Negative: descriptor / texture mismatch must error at submit time.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn rejects_descriptor_mismatch() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1015,6 +1018,7 @@ mod tests {
 
     /// Negative: a second submit before the first ticket is waited
     /// returns InFlight.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn second_submit_before_wait_errors_in_flight() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1046,6 +1050,7 @@ mod tests {
     }
 
     /// Negative: a ticket from one handle is rejected by another.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn foreign_ticket_rejected() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1084,6 +1089,7 @@ mod tests {
     }
 
     /// Negative: try_read with no in-flight submission errors NoSubmission.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn try_read_with_no_submission_errors_no_submission() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1108,6 +1114,7 @@ mod tests {
     /// Multiple readback handles can be in flight concurrently.
     /// Validates the design assertion that parallel readbacks are
     /// achieved by holding N handles, not by parallelism on one.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn multiple_handles_can_be_in_flight_concurrently() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1146,6 +1153,7 @@ mod tests {
     }
 
     /// Drop on an idle handle must not panic.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn drop_on_idle_handle_no_panic() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };
@@ -1165,6 +1173,7 @@ mod tests {
     /// Bytes-per-pixel for Bgra8Unorm and Rgba8Unorm: descriptor sizes
     /// match the staging buffer and constructed handles report the
     /// expected dimensions.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn descriptor_sizes_and_metadata_round_trip() {
         let device = match try_vulkan_device() { Some(d) => d, None => return };


### PR DESCRIPTION
## Summary

Introduces a two-tier test structure enforced by a Cargo feature, fixing
a long-standing parallel-execution hang in `cargo test --workspace`.

- **Tier 1 (`cargo test`, parallel)** — pure logic + mocks. 1266 passed,
  0 failed, 124 ignored.
- **Tier 2 (`cargo test --features streamlib/hardware-tests --
  --test-threads=1`)** — hardware-integration. 1356 passed (+90), 0
  failed, 34 ignored.

The structural defense is `#[cfg_attr(not(feature = \"hardware-tests\"),
ignore)]` rather than plain `#[ignore]` — an agent can't accidentally
band-aid a flake by slapping `#[ignore]` on it; the cfg_attr form ties
the ignore to a feature, making the tier-2 intent explicit.

A Python classifier traced each `#[test]` through helper calls (e.g.
`try_vulkan_device()` / `assert_blend_for(N)`) so only tests that
transitively construct a `HostVulkanDevice` were tagged (91 tagged; 10
pure-logic tests in the same files — SPIR-V reflection validators,
cache-path formatting, descriptor-shape tests — stay in tier 1).

## Why

`cargo test --workspace` was deadlocking silently when run in default
parallel mode, producing inconsistent counts (854 / 1214 / 1210 across
recent runs depending on which binaries crashed). Root cause: tests in
`vulkan/rhi/*` each construct a fresh `HostVulkanDevice`, and parallel
GPU device construction races on the NVIDIA per-process DMA-BUF kernel
state, validation-layer mutexes, and VMA allocator init.

`#[serial]` from `serial_test` would have kept hardware tests on the
critical path of every PR's test gate. Tier separation keeps the
default gate fast and parallel-safe; hardware tests run when they
should.

## Closes

(Pre-existing issue surfaced during #402 verification; not formally
filed — file as #N if needed for tracking.)

## Test plan

- [x] Tier 1 (default): `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream --no-fail-fast` → **passed=1266 failed=0 ignored=124, EXIT=0**
- [x] Tier 2 (hardware): `cargo test --features streamlib/hardware-tests --workspace [exclusions] -- --test-threads=1` → **passed=1356 failed=0 ignored=34, EXIT=0**
- [x] No diff in production code; only test attributes + Cargo feature + docs.

## Follow-ups

- Wire a `.github/workflows/hardware-tests.yml` workflow on a GPU
  runner once issue #343's GPU CI infrastructure lands. Until then,
  tier 2 runs locally before merging hardware-relevant PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)