### PR TITLE
test(codegen): regen idempotency + cross-language field-order tests

### DIFF
--- a/libs/streamlib-jtd-codegen/tests/common/mod.rs
+++ b/libs/streamlib-jtd-codegen/tests/common/mod.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Shared helpers for the integration tests under `tests/`.
+//!
+//! Cargo treats `tests/common/mod.rs` as a non-test module — files at
+//! `tests/<name>.rs` declare `mod common;` to pull these helpers in
+//! without spawning a separate test binary for the helpers themselves.
+
+#![allow(dead_code)] // each integration-test file pulls in only the helpers it uses
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use streamlib_jtd_codegen::{generate, GenerateOptions, RuntimeTarget};
+
+/// True when `jtd-codegen --version` succeeds. The codegen pipeline shells
+/// out to the binary, so tests that exercise the real pipeline are no-ops
+/// without it.
+pub fn jtd_codegen_available() -> bool {
+    Command::new("jtd-codegen")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Returns `true` and prints a stderr skip message when `jtd-codegen` is
+/// missing; otherwise returns `false`. Tests should `return` early on a
+/// `true` result.
+///
+/// `eprintln!` here is the test-skip escape hatch that
+/// `docs/logging.md` explicitly carves out — the goal is to surface the
+/// skip reason to the developer reading `cargo test` output, regardless
+/// of whether a tracing subscriber is configured.
+#[allow(clippy::disallowed_macros)]
+pub fn skip_unless_jtd_codegen_available(test_name: &str) -> bool {
+    if jtd_codegen_available() {
+        return false;
+    }
+    eprintln!("{test_name}: jtd-codegen not on PATH — skipping");
+    true
+}
+
+/// Workspace root resolved from the test crate's `CARGO_MANIFEST_DIR`.
+pub fn workspace_root() -> PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by cargo");
+    PathBuf::from(manifest_dir)
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("workspace root canonicalize")
+}
+
+/// `libs/streamlib` — directory holding the in-tree `streamlib.yaml`
+/// manifest and `schemas/` directory.
+pub fn streamlib_yaml_dir() -> PathBuf {
+    workspace_root().join("libs/streamlib")
+}
+
+/// Run the full project codegen against the in-tree `streamlib.yaml`.
+pub fn run_project_codegen(runtime: RuntimeTarget, output: &Path) {
+    generate(GenerateOptions {
+        runtime,
+        output: output.to_path_buf(),
+        project_dir: Some(streamlib_yaml_dir()),
+        schema_file: None,
+        schema_dir: None,
+        workspace_root: workspace_root(),
+        write_lockfile: false,
+    })
+    .expect("generate project codegen");
+}
+
+/// Run codegen for a single schema file (used by the cross-language test
+/// to keep the loop tight against one representative schema).
+pub fn run_single_schema_codegen(
+    runtime: RuntimeTarget,
+    schema_file: &Path,
+    output: &Path,
+) {
+    generate(GenerateOptions {
+        runtime,
+        output: output.to_path_buf(),
+        project_dir: None,
+        schema_file: Some(schema_file.to_path_buf()),
+        schema_dir: None,
+        workspace_root: workspace_root(),
+        write_lockfile: false,
+    })
+    .expect("generate single-schema codegen");
+}
+
+/// Recursively collect every file in `dir`, returning paths relative to
+/// `dir`. Skips any directory or file whose basename appears in
+/// `exclude_basenames` (e.g. Python's `__pycache__`).
+pub fn collect_files(dir: &Path, exclude_basenames: &[&str]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(dir, dir, &mut out, exclude_basenames);
+    out.sort();
+    out
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut Vec<PathBuf>, exclude_basenames: &[&str]) {
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        let basename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if exclude_basenames.contains(&basename) {
+            continue;
+        }
+        if path.is_dir() {
+            walk(root, &path, out, exclude_basenames);
+        } else {
+            out.push(
+                path.strip_prefix(root)
+                    .expect("strip_prefix")
+                    .to_path_buf(),
+            );
+        }
+    }
+}
+
+/// Compare two directories and return a list of human-readable
+/// difference descriptions. Empty vec means the trees are byte-identical.
+pub fn diff_dirs(a: &Path, b: &Path, exclude_basenames: &[&str]) -> Vec<String> {
+    let a_files = collect_files(a, exclude_basenames);
+    let b_files = collect_files(b, exclude_basenames);
+
+    let mut differences = Vec::new();
+
+    if a_files != b_files {
+        let only_in_a: Vec<_> = a_files.iter().filter(|p| !b_files.contains(p)).collect();
+        let only_in_b: Vec<_> = b_files.iter().filter(|p| !a_files.contains(p)).collect();
+        if !only_in_a.is_empty() {
+            differences.push(format!("only in {}: {:?}", a.display(), only_in_a));
+        }
+        if !only_in_b.is_empty() {
+            differences.push(format!("only in {}: {:?}", b.display(), only_in_b));
+        }
+    }
+
+    for rel in &a_files {
+        if !b_files.contains(rel) {
+            continue;
+        }
+        let av = std::fs::read(a.join(rel)).expect("read a");
+        let bv = std::fs::read(b.join(rel)).expect("read b");
+        if av != bv {
+            differences.push(format!("{} differs", rel.display()));
+        }
+    }
+
+    differences
+}

--- a/libs/streamlib-jtd-codegen/tests/cross_language_consistency.rs
+++ b/libs/streamlib-jtd-codegen/tests/cross_language_consistency.rs
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-language consistency integration test for the deterministic-
+//! ordering pass (issue #684, test bullet: "Cross-language consistency
+//! test: same schema's fields appear in the same order across the three
+//! generated bindings").
+//!
+//! Runs jtd-codegen for one representative schema across Rust, Python,
+//! and TypeScript, then parses the field-name order out of each emit and
+//! asserts all three match the JTD properties' lexicographic order. The
+//! representative schema is `com.streamlib.h264_encoder.config@1.0.0` —
+//! its eight `optionalProperties` are declared in non-alphabetical order
+//! in the YAML, so a regression that bypasses the ordering pass would
+//! show up as a mismatch.
+//!
+//! Skipped (with a clear stderr message) when `jtd-codegen` is not on PATH.
+
+mod common;
+
+use common::{
+    run_single_schema_codegen, skip_unless_jtd_codegen_available, workspace_root,
+};
+use streamlib_jtd_codegen::RuntimeTarget;
+use tempfile::TempDir;
+
+const REPRESENTATIVE_SCHEMA_REL: &str =
+    "libs/streamlib/schemas/com.streamlib.h264_encoder.config@1.0.0.yaml";
+
+const EXPECTED_FIELDS: &[&str] = &[
+    "bitrate_bps",
+    "effort_level",
+    "fps",
+    "height",
+    "keyframe_interval",
+    "keyframe_interval_seconds",
+    "profile",
+    "width",
+];
+
+#[test]
+fn field_order_consistent_across_runtimes_for_h264_encoder_config() {
+    let test_name = "field_order_consistent_across_runtimes_for_h264_encoder_config";
+    if skip_unless_jtd_codegen_available(test_name) {
+        return;
+    }
+
+    let schema_path = workspace_root().join(REPRESENTATIVE_SCHEMA_REL);
+    assert!(
+        schema_path.exists(),
+        "{test_name}: representative schema missing at {}",
+        schema_path.display()
+    );
+
+    let rust_dir = TempDir::new().expect("rust temp dir");
+    let py_dir = TempDir::new().expect("python temp dir");
+    let ts_dir = TempDir::new().expect("typescript temp dir");
+
+    run_single_schema_codegen(RuntimeTarget::Rust, &schema_path, rust_dir.path());
+    run_single_schema_codegen(RuntimeTarget::Python, &schema_path, py_dir.path());
+    run_single_schema_codegen(RuntimeTarget::Typescript, &schema_path, ts_dir.path());
+
+    let rust_code = std::fs::read_to_string(
+        rust_dir.path().join("com_streamlib_h264_encoder_config.rs"),
+    )
+    .expect("read generated Rust");
+    let py_code = std::fs::read_to_string(
+        py_dir.path().join("com_streamlib_h264_encoder_config.py"),
+    )
+    .expect("read generated Python");
+    let ts_code = std::fs::read_to_string(
+        ts_dir.path().join("com_streamlib_h264_encoder_config.ts"),
+    )
+    .expect("read generated TypeScript");
+
+    let rust_fields = extract_rust_struct_fields(&rust_code);
+    let py_fields = extract_python_dataclass_fields(&py_code);
+    let ts_fields = extract_typescript_interface_fields(&ts_code);
+
+    assert_eq!(
+        rust_fields, EXPECTED_FIELDS,
+        "rust field order differs from JTD lexicographic order"
+    );
+    assert_eq!(
+        py_fields, EXPECTED_FIELDS,
+        "python field order differs from JTD lexicographic order"
+    );
+    assert_eq!(
+        ts_fields, EXPECTED_FIELDS,
+        "typescript field order differs from JTD lexicographic order"
+    );
+}
+
+/// Pull `pub <name>:` lines out of a generated Rust struct body.
+fn extract_rust_struct_fields(code: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut in_struct = false;
+    for line in code.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("pub struct ") && trimmed.trim_end().ends_with('{') {
+            in_struct = true;
+            continue;
+        }
+        if !in_struct {
+            continue;
+        }
+        if line.starts_with('}') {
+            break;
+        }
+        if let Some(rest) = trimmed.strip_prefix("pub ")
+            && let Some(colon) = rest.find(':')
+        {
+            let name = &rest[..colon];
+            if is_ident(name) {
+                fields.push(name.to_string());
+            }
+        }
+    }
+    fields
+}
+
+/// Pull `<name>: '<type>'` lines out of a generated Python `@dataclass`
+/// body. Skips triple-quoted docstrings and stops at the first method.
+fn extract_python_dataclass_fields(code: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut in_class = false;
+    let mut in_docstring = false;
+    for line in code.lines() {
+        if line.starts_with("class ") && line.trim_end().ends_with(':') {
+            in_class = true;
+            continue;
+        }
+        if !in_class {
+            continue;
+        }
+        if line.trim() == "\"\"\"" {
+            in_docstring = !in_docstring;
+            continue;
+        }
+        if in_docstring {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("@classmethod") || trimmed.starts_with("def ") {
+            break;
+        }
+        // Field lines have exactly four leading spaces.
+        if let Some(after_indent) = line.strip_prefix("    ") {
+            if after_indent.starts_with(' ') {
+                continue;
+            }
+            if let Some(colon) = after_indent.find(':') {
+                let name = &after_indent[..colon];
+                if is_ident(name) {
+                    fields.push(name.to_string());
+                }
+            }
+        }
+    }
+    fields
+}
+
+/// Pull `<name>?:` / `<name>:` lines out of a generated TypeScript
+/// `export interface` body. Skips `/** ... */` JSDoc comments.
+fn extract_typescript_interface_fields(code: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut in_interface = false;
+    let mut in_jsdoc = false;
+    for line in code.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("export interface ") {
+            in_interface = true;
+            continue;
+        }
+        if !in_interface {
+            continue;
+        }
+        if line.starts_with('}') {
+            break;
+        }
+        if trimmed.starts_with("/**") {
+            in_jsdoc = true;
+        }
+        if in_jsdoc {
+            if trimmed.ends_with("*/") {
+                in_jsdoc = false;
+            }
+            continue;
+        }
+        if let Some(colon) = trimmed.find(':') {
+            let name_part = trimmed[..colon].trim_end_matches('?').trim();
+            if is_ident(name_part) {
+                fields.push(name_part.to_string());
+            }
+        }
+    }
+    fields
+}
+
+fn is_ident(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}

--- a/libs/streamlib-jtd-codegen/tests/cross_language_consistency.rs
+++ b/libs/streamlib-jtd-codegen/tests/cross_language_consistency.rs
@@ -77,6 +77,22 @@ fn field_order_consistent_across_runtimes_for_h264_encoder_config() {
     let py_fields = extract_python_dataclass_fields(&py_code);
     let ts_fields = extract_typescript_interface_fields(&ts_code);
 
+    // Catch a parser regression separately from an ordering regression: an
+    // empty list means the line-based extractor stopped matching the emit
+    // shape, not that the codegen produced an empty struct.
+    assert!(
+        !rust_fields.is_empty(),
+        "rust field-name parser found no fields — emit shape may have changed"
+    );
+    assert!(
+        !py_fields.is_empty(),
+        "python field-name parser found no fields — emit shape may have changed"
+    );
+    assert!(
+        !ts_fields.is_empty(),
+        "typescript field-name parser found no fields — emit shape may have changed"
+    );
+
     assert_eq!(
         rust_fields, EXPECTED_FIELDS,
         "rust field order differs from JTD lexicographic order"

--- a/libs/streamlib-jtd-codegen/tests/idempotency.rs
+++ b/libs/streamlib-jtd-codegen/tests/idempotency.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Idempotency integration tests for the deterministic-ordering pass
+//! (issue #684, exit criterion: "Regenerating any in-tree schema is a no-op
+//! against a clean tree"; test bullet: "Idempotency test: regenerate twice
+//! in a row, diff is empty").
+//!
+//! For each runtime (Rust, Python, TypeScript), runs the full project
+//! codegen against the in-tree `libs/streamlib/streamlib.yaml` manifest
+//! into two separate temp dirs and asserts the trees are byte-identical.
+//! The sibling unit tests in `ordering.rs` lock the sort function in
+//! isolation; this file locks the end-to-end pipeline.
+//!
+//! Skipped (with a clear stderr message) when `jtd-codegen` v0.4.1 is not
+//! on PATH — there is no value in running the rest of the test framework
+//! against a missing binary.
+
+mod common;
+
+use common::{diff_dirs, run_project_codegen, skip_unless_jtd_codegen_available};
+use streamlib_jtd_codegen::RuntimeTarget;
+use tempfile::TempDir;
+
+fn assert_regen_twice_byte_identical(test_name: &str, runtime: RuntimeTarget) {
+    if skip_unless_jtd_codegen_available(test_name) {
+        return;
+    }
+
+    let first = TempDir::new().expect("temp dir 1");
+    let second = TempDir::new().expect("temp dir 2");
+
+    run_project_codegen(runtime, first.path());
+    run_project_codegen(runtime, second.path());
+
+    let diffs = diff_dirs(first.path(), second.path(), &[]);
+    assert!(
+        diffs.is_empty(),
+        "{test_name}: regen-twice not byte-identical:\n{}",
+        diffs.join("\n")
+    );
+}
+
+#[test]
+fn regen_twice_is_byte_identical_rust() {
+    assert_regen_twice_byte_identical("regen_twice_is_byte_identical_rust", RuntimeTarget::Rust);
+}
+
+#[test]
+fn regen_twice_is_byte_identical_python() {
+    assert_regen_twice_byte_identical(
+        "regen_twice_is_byte_identical_python",
+        RuntimeTarget::Python,
+    );
+}
+
+#[test]
+fn regen_twice_is_byte_identical_typescript() {
+    assert_regen_twice_byte_identical(
+        "regen_twice_is_byte_identical_typescript",
+        RuntimeTarget::Typescript,
+    );
+}


### PR DESCRIPTION
## Summary

Adds the integration test coverage that issue #684 calls for. The deterministic-ordering pass itself (post-processor that lexicographically sorts JTD properties before invoking `jtd-codegen`) **already shipped bundled into PR #696 / commit `44000d8`** — `libs/streamlib-jtd-codegen/src/ordering.rs` (`sort_object_keys_recursively`), wired in `lib.rs:247`, locked by 5 unit tests in the same file. This PR adds the missing end-to-end coverage that the issue's exit criteria + tests-validation section asked for and closes the ticket.

- **`tests/idempotency.rs`** — for each runtime (Rust, Python, TypeScript), regen the full in-tree `libs/streamlib/streamlib.yaml` manifest twice into separate temp dirs and assert the trees are byte-identical. Locks "Regenerating any in-tree schema is a no-op against a clean tree" without depending on #406's CI gate.
- **`tests/cross_language_consistency.rs`** — generate `com.streamlib.h264_encoder.config@1.0.0` for all three runtimes, parse the field-name order out of each emit, assert all three match the JTD properties' lexicographic order. The schema's eight `optionalProperties` are declared in non-alphabetical order in YAML, so a regression that bypasses the ordering pass would surface as a mismatch.
- **`tests/common/mod.rs`** — shared helpers (jtd-codegen probe, workspace-root resolution, codegen drivers, dir-diff). The skip-when-jtd-codegen-missing message uses the `eprintln!` test-skip escape hatch documented in `docs/logging.md` (test-skip messages must surface to `cargo test` stderr regardless of tracing-subscriber state); the helper is annotated `#[allow(clippy::disallowed_macros)]` accordingly.

Tests skip with a clear stderr message when `jtd-codegen` is not on PATH; otherwise run end-to-end against the in-tree manifest.

## Closes

Closes #684

## Exit criteria (from updated issue body)

- [x] Post-processor sorts struct fields lexicographically across Rust, Python, and TypeScript backends — *shipped in PR #696 (`44000d8`).*
- [x] Regenerating any in-tree schema is a no-op against a clean tree — *locked by the regen-twice-byte-identical integration tests in this PR (Rust + Python + TypeScript).*
- [ ] CI gate from #406 stays green after this lands — *covered by #406's separate work.*

## Test plan

```bash
cargo test -p streamlib-jtd-codegen
```

Results:
- 32 lib unit tests: pass
- 1 cross-language consistency test: pass
- 3 idempotency tests (Rust, Python, TypeScript): pass

`cargo clippy -p streamlib-jtd-codegen --tests`: clean for new files (5 pre-existing warnings in `lib.rs` are out of scope per the "no auto-fixing on the side" rule).

## Polyglot coverage

- **Runtimes affected**: rust (host) — codegen tooling that exercises all three backends through the Rust API
- **Schema regenerated**: n/a (tests use the existing manifest unchanged)
- **Python and Deno both covered?** schema-only / language-specific by construction — this is host-Rust test infrastructure that exercises all three jtd-codegen backends through `streamlib_jtd_codegen::generate(RuntimeTarget::{Rust,Python,Typescript}, ...)`. There is no Python/Deno SDK code change to sync.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-jtd-codegen` — all pass
  - [ ] Python subprocess: n/a — test exercises Python codegen output, not Python runtime
  - [ ] Deno subprocess: n/a — test exercises TypeScript codegen output, not Deno runtime
- **FD-passing path**: n/a

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)