### PR TITLE
feat(packaging): processor short-name macros + structured PortDescriptor.schema (#404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ When presenting design choices for engine work, recommend the production-grade o
 
 **Issues are goals, not specs.** An issue captures the *intent* of the work — the problem to solve, why it matters, and roughly how done looks. The specific exit-criteria checkboxes, file paths, suggested orderings, and AI Agent Notes inside an issue body are the best understanding *as of when the issue was filed*; they go stale fast as code lands, dependencies close, or the surrounding architecture shifts. **When you pick up a task, treat the issue as the goal but research current state before locking the plan.** Re-read the referenced files, check whether referenced code still exists in the shape claimed, verify whether listed follow-ups have already been filed, confirm whether flagged "defects" are still defects. Then announce a *fresh* task plan that supersedes the issue body where evidence has shifted — and update the issue body in place per the markdown-editing rules below (strike through stale items with reasoning, don't silently rewrite). Don't be dogmatic about checking off every original criterion if the world has moved; do hit the goal.
 
-**Writing issues:** every new issue follows the template in @docs/issue-template.md — Description / Context / Exit criteria / Tests or validation / Related / AI Agent Notes. **Keep issues low-resolution by default.** State the goal, the constraints, and what "done" looks like in broad strokes; do *not* try to capture every file path, exact test name, suggested implementation order, or detailed plan in the issue body. That high-resolution detail decays as code shifts, and a future agent picking up the issue will re-derive it anyway. The picker's job is to research current state and produce the implementation plan; the filer's job is to capture the goal cleanly. Cross-cutting concerns (linux, macos, polyglot, ci, frozen) are labels, not milestones. Test harnesses are their own issues. Dependency edges (`blocked by` / `blocks` / `parent`) are native GitHub relationships, not text. Use the `/amos-file` skill to draft new issues — it handles the template, milestone inference, and relationships in one pass.
+**Writing issues:** every new issue follows the template in @docs/issue-template.md — Description / Context / Exit criteria / Tests or validation / Related / AI Agent Notes. **Issue bodies carry the architecture content for proposed work.** Architecture docs (`docs/architecture/*.md`) reflect merged-in code only and never describe upcoming changes; mermaid diagrams, BNF grammars, decision matrices, ADR-style trade-off discussions, sequenced migration plans, and any other design content for not-yet-shipped work all live in the relevant issue / milestone body until merged. Keep implementation specifics (exact file paths, test function names, suggested ordering) **out** of the issue body — those rot fast and the picker re-derives them at pickup time. The picker's job is to research current state and produce the implementation plan; the filer's job is to capture the goal AND the architecture proposal cleanly enough that a competent agent can pick the issue up cold without re-litigating the design. Cross-cutting concerns (linux, macos, polyglot, ci, frozen) are labels, not milestones. Test harnesses are their own issues. Dependency edges (`blocked by` / `blocks` / `parent`) are native GitHub relationships, not text. Use the `/amos-file` skill to draft new issues — it handles the template, milestone inference, and relationships in one pass.
 
 **Specialty workflows** live at `.claude/workflows/<label>.md`. Add a new one by dropping a file there and labeling relevant issues. `/amos:next` loads every matching file into context before starting work. Current workflows:
 - `.claude/workflows/ci.md` — for `ci`-labeled issues (negative test + green baseline evidence required)
@@ -411,6 +411,55 @@ hints), read the doc end-to-end first — the boundaries are deliberate.
 - `/refine-name <current_name>` - Get MORE explicit naming suggestions (never shorter)
 
 ---
+
+## Architecture documentation discipline
+
+**`docs/architecture/*.md` describes the current known state of the
+system, subject to staleness or drift.** A reader who has never seen
+the code should be able to skim an arch doc and walk away with a
+working mental model of how the system is shaped right now —
+identifier grammars the validators enforce, manifest formats the
+parsers accept, invariants the `compile_fail` doctests lock, files
+that exist on disk. Drift is expected and tolerated: a doc claim is
+the best understanding when last edited, nothing more. Verify
+against the code before relying on anything load-bearing.
+
+What architecture docs are **not**:
+
+- Not GitHub-aware. They don't reference issues, milestones, PRs, or
+  any project-management tracker. The codebase is the only thing
+  they describe; tracker references rot the moment the tracker
+  changes hands.
+- Not dated. No "as of YYYY-MM-DD," no "last updated," no embedded
+  timestamps. Git history covers freshness — embedding the date in
+  the doc just adds a second field that goes stale on every edit.
+- Not authoritative. They're a convenience read; a doc that says
+  "do X" is a hypothesis about the current code, not a command (per
+  "Editing markdown documentation" below).
+- Not enforcement. Architecture docs do not validate or gate
+  functionality — code, tests, type-system invariants, and CI lints
+  do that. A doc claim is never the reason something is correct.
+- Not history. They don't describe superseded designs, never-merged
+  proposals, or "this used to be X." The git log holds history.
+- Not a roadmap. They don't describe proposed work, planned
+  migrations, upcoming PR sequences, or "this will become X after
+  some change lands." Forward-looking content creates
+  false-current-state confusion when a future agent picks up a
+  fresh branch and can't tell whether X is what the code does or
+  what the code might do.
+
+Proposed architecture lives in **issue / milestone bodies** while
+in flight. Mermaid diagrams, BNF grammars, ADR-style trade-off
+discussions, sequenced migration plans, decision matrices — all of
+that goes in the issue body until the work merges. When the work
+merges, the architecture moves into a `docs/architecture/*.md` file
+describing the shipped state in current tense; the issue closes and
+the doc takes over. The arch doc itself never references the
+originating issue.
+
+This applies retroactively: existing architecture docs that carry
+proposed-work, GitHub-tracker, or historical-supersession content
+should be cleaned up to current-known-state.
 
 ## Editing markdown documentation
 

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -458,9 +458,13 @@ structured boundary.
 
 The two allowed construction pathways:
 
-- **Codegen-emitted const literals** — `SCHEMA_IDENT: SchemaIdent =
-  SchemaIdent::new(Org::new("tatolab").unwrap(), …)` lands in the
-  generated `_generated_/` files at build time.
+- **Codegen-emitted const literals** — `SchemaIdent::new(Org::new("tatolab").unwrap(), …)`
+  lands in the macro-generated processor module at build time, exposed via
+  a `pub fn schema_ident() -> SchemaIdent` on each `#[streamlib::processor("Camera")]`-
+  decorated module. (Originally specified as a top-level `SCHEMA_IDENT: SchemaIdent`
+  const; the function form ships in #404 because `SchemaIdent`'s validating
+  constructors don't fit a `const` context. The function call is the same
+  one-line read at every call site, fully resolved at codegen.)
 - **Typed YAML / JSON deserialization** — each segment is its own
   field in the source document; `serde` reads the structured shape
   directly into `SchemaIdent { org, package, r#type, version }`.
@@ -491,11 +495,21 @@ use tatolab_core::VIDEO_FRAME_IDENT;
 graph.add_edge(VIDEO_FRAME_IDENT, …);   // No org/package on the wire
 ```
 
-The package-internal short-name pattern (`#[streamlib::processor(name =
-"Camera")]`) is the **only** shorthand mechanism in the architecture.
-Cross-package references in graph JSON, IPC envelopes, generated
-code, and lockfiles carry a fully-qualified `SchemaIdent { org,
+The package-internal short-name pattern (`#[streamlib::processor("Camera")]`
+— positional PascalCase short name) is the **only** shorthand mechanism
+in the architecture. Cross-package references in graph JSON, IPC envelopes,
+generated code, and lockfiles carry a fully-qualified `SchemaIdent { org,
 package, type, version }` structured record.
+
+> ~~Earlier revisions of this section showed the named-arg form
+> `#[streamlib::processor(name = "Camera")]`.~~ — Superseded 2026-05-05 by
+> #404. The macro takes a positional PascalCase short name (`"Camera"`),
+> resolves `org`/`package`/`version` from the enclosing
+> `streamlib.yaml`'s `package:` block, and emits a function returning the
+> full structured `SchemaIdent` per processor module
+> (`Processor::schema_ident()`). The named-arg form was the doc's
+> aspirational shape; the positional form is what landed and what every
+> in-tree call site uses today.
 
 When the macro emits per-package consts, those consts hold a
 *structured* `SchemaIdent` — the consumer can read its fields, but

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -1,23 +1,16 @@
 # Schema identity & packaging
 
-> **Living document.** Validate, update, critique freely per
-> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
-> Reflects code state as of 2026-05-05. Initial doc landed with #399;
-> #400 extracted `streamlib-jtd-codegen` and added `streamlib generate`;
-> #402 landed the resolver + lockfile + sentinel-substitution codegen
-> + cutover off legacy `[package.metadata.streamlib]` etc. The 12
-> carve-out packages and the wire-format migration (#404) remain ahead;
-> claims about *current* code are point-in-time and stale fast.
+> Current known state of the schema-identity surface. Subject to
+> staleness or drift — verify against the code before relying on any
+> claim. Not authoritative, not enforcement.
 
-## Status
+## What this document describes
 
-This document is the canonical architecture brief for milestone 10. It
-ships alongside the `streamlib-idents` Rust crate (the first code-level
-expression of the design); future agents should read this doc for
-design context and the [milestone-10 description][m10] for current
-pickup ordering.
-
-[m10]: https://github.com/tatolab/streamlib/milestone/10
+The architecture surface shared across the `streamlib-idents` and
+`streamlib-jtd-codegen` crates: identifier grammar, package manifest
+formats, dependency resolver, lockfile, the codegen pipeline, and the
+anti-patterns the design rules out. Every claim below describes
+behavior that ships in current code.
 
 ## Why this exists
 
@@ -40,20 +33,19 @@ three independent strands:
 
 The fix is one cohesive architecture covering identifier grammar,
 package manifest, dependency resolution, code generation, and
-distribution. The rest of milestone 10 implements it.
+distribution.
 
 ## Architectural decisions
 
-These are load-bearing — relaxing any of them brings back the failure
-mode that motivated the whole milestone.
+These are the load-bearing design choices the current code rests on.
+Relaxing any of them brings back the failure mode this architecture
+was shaped against.
 
 ### Decision 1 — `@org/package/Type@version` identifier grammar
 
-Replaces `com.tatolab.videoframe@1.0.0` (reverse-DNS, lowercase, no
-package boundary in the name) with `@tatolab/core/VideoFrame@1.0.0`
-(npm-style scope, explicit package, PascalCase type name, semver).
-
-The grammar (BNF):
+Schema identifiers take the npm-style form `@tatolab/core/VideoFrame@1.0.0`:
+scoped org, explicit package, PascalCase type name, semver. The
+grammar (BNF):
 
 ```ebnf
 identifier   ::= "@" org "/" package "/" type "@" version
@@ -151,9 +143,7 @@ collapse this to a single dimension per package.
 
 A CI lint (`cargo xtask check-schema-versions`, wired into
 `.github/workflows/check-schema-versions.yml`) rejects any schema
-YAML declaring a top-level `version` key. The wider lint that also
-rejects `metadata.version` ships when the schema files are migrated
-to the new shape (in #401 / #402).
+YAML declaring a top-level `version` key.
 
 ### Decision 4 — `streamlib.lock` for content-hash resolution
 
@@ -173,42 +163,18 @@ Discipline (mirrors `Cargo.lock`):
 
 The four wire-stable types every other package depends on
 (`VideoFrame`, `AudioFrame`, `EncodedVideoFrame`, `EncodedAudioFrame`)
-live in a single `@tatolab/core` package. This is streamlib's
-`google.protobuf` analogue. `@tatolab/core` ships at `1.0.0` from day
-one; breaking changes require a deliberate v2 bump and downstream
-migration.
-
-Twelve carve-out packages live under `packages/` and depend on
-`@tatolab/core`:
-
-| Package | Owner of |
-|---|---|
-| `@tatolab/audio` | audio capture / output / mixer / channel-converter / resampler / chord-generator / buffer-rechunker |
-| `@tatolab/camera` | camera capture |
-| `@tatolab/display` | display / window / swapchain |
-| `@tatolab/h264` | H.264 encoder + decoder |
-| `@tatolab/h265` | H.265 encoder + decoder |
-| `@tatolab/opus` | Opus encoder + decoder |
-| `@tatolab/mp4` | MP4 writer (Apple + Linux variants) |
-| `@tatolab/webrtc` | WHEP + WHIP |
-| `@tatolab/moq` | MoQ publish + subscribe tracks |
-| `@tatolab/api-server` | runtime API server |
-| `@tatolab/clap` | CLAP audio plugin host |
-| `@tatolab/screen-capture` | screen capture |
+live in a single `@tatolab/core` package at `packages/core/`. This is
+streamlib's `google.protobuf` analogue. `@tatolab/core` ships at
+`1.0.0` from day one; breaking changes require a deliberate v2 bump
+and downstream migration.
 
 ### Decision 6 — universal `streamlib generate` CLI
 
 Code generation goes through `streamlib generate` (a subcommand on
 the `streamlib` CLI). Non-Rust developers regenerate bindings without
 ever installing rustup. `cargo xtask generate-schemas` remains as a
-thin contributor-only wrapper.
-
-The library crate behind both — `streamlib-jtd-codegen` — is what #400
-extracts from the current `xtask/src/generate_schemas.rs`. (Originally
-proposed name `streamlib-codegen` was renamed during #400's PR to
-avoid collision with the existing `streamlib-codegen-shared` crate,
-which itself was renamed to `streamlib-processor-schema` to better
-describe its role — see the PR for naming-clarity rationale.)
+thin contributor-only wrapper. The library crate behind both is
+`streamlib-jtd-codegen`.
 
 ### Decision 7 — sentinel-substitution codegen + deterministic ordering
 
@@ -226,17 +192,6 @@ field orderings + name manglings across runs and across backends
 
 Together these eliminate the per-backend mangling drift that bled
 silent fix-PRs every quarter.
-
-### Decision 8 — `streamlib verify-schemas` CI determinism gate
-
-A CI gate (`streamlib verify-schemas`, wired on every PR) runs
-`streamlib generate` and asserts the generated bindings are
-byte-identical to what's checked in. If they aren't, the PR fails
-and the author re-runs `streamlib generate` locally.
-
-This is where the `streamlib.lock` content hash becomes load-bearing:
-the gate proves that committed `_generated_/` matches the lockfile's
-inputs.
 
 ## Manifest formats
 
@@ -349,10 +304,9 @@ packages:
 | `content_hash` | Namespace-prefixed (`sha256:…`) so future hash-algorithm migrations don't break parsing. |
 
 The content hash is computed over the resolved package's contents
-(deterministic pass over schemas + manifest). This is what the
-`verify-schemas` CI gate compares against — the gate catches both
-"someone hand-edited generated code" and "someone bumped a dep
-without re-locking."
+(deterministic pass over schemas + manifest). It's the load-bearing
+primitive that lets a determinism gate prove committed `_generated_/`
+matches the lockfile's inputs.
 
 ## Sentinel-substitution codegen contract
 
@@ -375,18 +329,16 @@ Code generation runs in three passes:
    backends and across runs).
 
 Then the generated files are written to each consumer's `_generated_/`
-directory. The `verify-schemas` gate re-runs the whole pipeline on
-CI and asserts byte-identical output.
+directory.
 
-The `streamlib-jtd-codegen` crate (extracted by #400, sentinel +
-ordering passes added in #402) owns this pipeline. The `streamlib-idents`
-crate owns the structured types the pipeline reads and writes
-(`SchemaIdent`, `SemVer`, `Manifest`, `PackageMetadata`, `Lockfile`)
-and the resolver that walks `streamlib.yaml` (`resolve`,
-`ResolvedPackages`, added in #402; superseded the original
-`PackageManifest` + `ProjectManifest` split with one unified
-`Manifest` type that tolerates runtime-side fields like `processors:`
-without `deny_unknown_fields` rejection).
+The `streamlib-jtd-codegen` crate owns this pipeline. The
+`streamlib-idents` crate owns the structured types the pipeline reads
+and writes (`SchemaIdent`, `SemVer`, `Manifest`, `PackageMetadata`,
+`Lockfile`) and the resolver that walks `streamlib.yaml` (`resolve`,
+`ResolvedPackages`). `Manifest` deserialization tolerates runtime-side
+fields (`processors:`, `env:`) without `deny_unknown_fields` rejection
+so one `streamlib.yaml` carries both the schema-identity surface and
+the runtime configuration.
 
 ### Root-name sentinel — sibling pattern at the `--root-name` boundary
 
@@ -409,15 +361,13 @@ end with a single `code.replace(ROOT_NAME_SENTINEL, expected_name)`
 pass. The `ROOT_NAME_SENTINEL` value is a transport detail — it
 never appears in committed `_generated_/` output.
 
-The earlier proposal in #143 (`__ROOT__`) was disproven empirically
-during #541's pickup: `jtd-codegen` v0.4.1 normalizes
-underscore-prefixed identifiers, collapsing `__ROOT__` to `Root`
-across all three backends. Any sentinel must satisfy two
-constraints:
+Any sentinel must satisfy two constraints:
 
 - **Survive byte-identically** through all three backends (no
   case-folding, no underscore stripping, no acronym up/down-casing).
-  CamelCase identifiers do; `__ROOT__`-shape identifiers do not.
+  CamelCase identifiers do; `__ROOT__`-shape identifiers do not
+  (`jtd-codegen` v0.4.1 normalizes underscore-prefixed identifiers,
+  collapsing `__ROOT__` to `Root` across all three backends).
 - **Be distinct enough that no real schema would emit it.**
   `StreamlibCanonRoot` is internally namespaced; a `s/Streamlib/`
   grep finds the implementation rather than user code.
@@ -427,14 +377,10 @@ The sub-type prefix-strip pass in Rust's `post_process_rust` runs
 `ROOT_NAME_SENTINEL`-prefixed names (e.g., `StreamlibCanonRootRateControl`
 → `RateControl`). Names that don't get stripped retain their
 sentinel prefix until the final `code.replace`, at which point
-`StreamlibCanonRootBar` becomes `EscalateRequestBar` — exactly the
-existing committed shape. Sub-type renames do **not** use a separate
-sentinel today; the prefix-strip heuristic still runs because
-sub-type identifiers aren't declared in `streamlib.yaml`. Replacing
-the sub-type prefix-strip heuristic with a per-sub-type sentinel
-is a follow-up if the heuristic ever surfaces a bug; today it works
-correctly because the input always has the
-`ROOT_NAME_SENTINEL`-prefixed shape.
+`StreamlibCanonRootBar` becomes `EscalateRequestBar` — the existing
+committed shape. Sub-type renames don't use a separate sentinel; the
+prefix-strip heuristic operates on `ROOT_NAME_SENTINEL`-prefixed
+input, which the upstream sentinel pass guarantees.
 
 The two sentinel passes — cross-package `__STREAMLIB_REF_<hash>__`
 and `ROOT_NAME_SENTINEL` — operate on disjoint parts of the input
@@ -458,13 +404,13 @@ structured boundary.
 
 The two allowed construction pathways:
 
-- **Codegen-emitted const literals** — `SchemaIdent::new(Org::new("tatolab").unwrap(), …)`
+- **Codegen-emitted construction** — `SchemaIdent::new(Org::new("tatolab").unwrap(), …)`
   lands in the macro-generated processor module at build time, exposed via
   a `pub fn schema_ident() -> SchemaIdent` on each `#[streamlib::processor("Camera")]`-
-  decorated module. (Originally specified as a top-level `SCHEMA_IDENT: SchemaIdent`
-  const; the function form ships in #404 because `SchemaIdent`'s validating
-  constructors don't fit a `const` context. The function call is the same
-  one-line read at every call site, fully resolved at codegen.)
+  decorated module. The function form (rather than a `const`) is forced
+  by `SchemaIdent`'s validating constructors — `Org::new` / `Package::new`
+  / `TypeName::new` aren't `const fn`. The function call is fully
+  resolved at codegen and reads as a single line at every call site.
 - **Typed YAML / JSON deserialization** — each segment is its own
   field in the source document; `serde` reads the structured shape
   directly into `SchemaIdent { org, package, r#type, version }`.
@@ -496,25 +442,15 @@ graph.add_edge(VIDEO_FRAME_IDENT, …);   // No org/package on the wire
 ```
 
 The package-internal short-name pattern (`#[streamlib::processor("Camera")]`
-— positional PascalCase short name) is the **only** shorthand mechanism
-in the architecture. Cross-package references in graph JSON, IPC envelopes,
-generated code, and lockfiles carry a fully-qualified `SchemaIdent { org,
-package, type, version }` structured record.
-
-> ~~Earlier revisions of this section showed the named-arg form
-> `#[streamlib::processor(name = "Camera")]`.~~ — Superseded 2026-05-05 by
-> #404. The macro takes a positional PascalCase short name (`"Camera"`),
-> resolves `org`/`package`/`version` from the enclosing
-> `streamlib.yaml`'s `package:` block, and emits a function returning the
-> full structured `SchemaIdent` per processor module
-> (`Processor::schema_ident()`). The named-arg form was the doc's
-> aspirational shape; the positional form is what landed and what every
-> in-tree call site uses today.
-
-When the macro emits per-package consts, those consts hold a
-*structured* `SchemaIdent` — the consumer can read its fields, but
-serializing across a wire surface always emits the full structured
-record.
+— positional PascalCase short name resolved against the enclosing
+`streamlib.yaml`'s `package:` block, exposed via
+`Processor::schema_ident()`) is the **only** shorthand mechanism in the
+architecture. Cross-package references in graph JSON, IPC envelopes,
+generated code, and lockfiles carry a fully-qualified
+`SchemaIdent { org, package, type, version }` structured record. The
+macro-emitted `schema_ident()` returns the structured record; consumers
+can read its fields, but serializing across a wire surface always emits
+the full structured shape.
 
 ### 3. Per-schema `version` field
 
@@ -528,207 +464,22 @@ versions collapse this to a single dimension per package.
 
 ### 4. Legacy metadata blocks in language-native manifests
 
-After #402 lands, `Cargo.toml` does not contain
-`[package.metadata.streamlib]`, `pyproject.toml` does not contain
-`[tool.streamlib]`, and `deno.json` has no `streamlib` block. The
-single source of truth is `streamlib.yaml` for every runtime; the
-resolver feeds the resolved set into each language's codegen
-pipeline.
-
-CI lint (added in #402) rejects re-introductions.
+`Cargo.toml` does not contain `[package.metadata.streamlib]`,
+`pyproject.toml` does not contain `[tool.streamlib]`, and `deno.json`
+has no `streamlib` block. The single source of truth is
+`streamlib.yaml` for every runtime; the resolver feeds the resolved
+set into each language's codegen pipeline. A CI lint
+(`cargo xtask check-no-streamlib-metadata`) rejects re-introductions.
 
 ### 5. Hand-curated `embedded_schemas.rs`-style match statements
 
-Pre-#402, `libs/streamlib/src/core/embedded_schemas.rs` had a
-hand-curated `match` mapping schema IDs to embedded YAML strings.
-Two failure modes: (a) easy to forget to add a new schema; (b)
-silent drift when a schema renamed but the match arm didn't.
-
-The replacement is resolver-driven: the resolved package set
-populates a `SchemaIdent`-keyed lookup table at build time. Adding
-a schema means declaring it in your `streamlib.yaml`; nothing else.
-
-## Rosetta — current → new identifier mapping
-
-Every current `com.streamlib.*` / `com.tatolab.*` identifier maps to
-a `@org/package/Type@version` form below. The migration is staged:
-
-- **Wire types** (`@tatolab/core`) migrate in **#404**.
-- **Processor names + their config schemas** migrate in **#401**
-  (the macro rewrite is what makes the short-name pattern available)
-  and the carve-out package issues (one per package).
-- **Polyglot escalate IPC** migrates in #404 alongside the wire-type
-  migration (it's the same wire surface).
-
-### Wire vocabulary → `@tatolab/core@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.tatolab.videoframe@1.0.0` | `@tatolab/core/VideoFrame@1.0.0` |
-| `com.tatolab.audioframe@1.0.0` | `@tatolab/core/AudioFrame@1.0.0` |
-| `com.tatolab.encodedvideoframe@1.0.0` | `@tatolab/core/EncodedVideoFrame@1.0.0` |
-| `com.tatolab.encodedaudioframe@1.0.0` | `@tatolab/core/EncodedAudioFrame@1.0.0` |
-
-### Audio package → `@tatolab/audio@1.0.0`
-
-| Current processor / schema | New |
-|---|---|
-| `com.tatolab.audio_capture` | `@tatolab/audio/AudioCapture@1.0.0` |
-| `com.tatolab.audio_capture.config@1.0.0` | `@tatolab/audio/AudioCaptureConfig@1.0.0` |
-| `com.tatolab.audio_output` | `@tatolab/audio/AudioOutput@1.0.0` |
-| `com.tatolab.audio_output.config@1.0.0` | `@tatolab/audio/AudioOutputConfig@1.0.0` |
-| `com.tatolab.audio_mixer` | `@tatolab/audio/AudioMixer@1.0.0` |
-| `com.tatolab.audio_mixer.config@1.0.0` | `@tatolab/audio/AudioMixerConfig@1.0.0` |
-| `com.tatolab.audio_channel_converter` | `@tatolab/audio/AudioChannelConverter@1.0.0` |
-| `com.tatolab.audio_channel_converter.config@1.0.0` | `@tatolab/audio/AudioChannelConverterConfig@1.0.0` |
-| `com.tatolab.audio_resampler` | `@tatolab/audio/AudioResampler@1.0.0` |
-| `com.tatolab.audio_resampler.config@1.0.0` | `@tatolab/audio/AudioResamplerConfig@1.0.0` |
-| `com.tatolab.buffer_rechunker` | `@tatolab/audio/BufferRechunker@1.0.0` |
-| `com.tatolab.buffer_rechunker.config@1.0.0` | `@tatolab/audio/BufferRechunkerConfig@1.0.0` |
-| `com.tatolab.chord_generator` | `@tatolab/audio/ChordGenerator@1.0.0` |
-| `com.tatolab.chord_generator.config@1.0.0` | `@tatolab/audio/ChordGeneratorConfig@1.0.0` |
-
-### Camera package → `@tatolab/camera@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.tatolab.camera` | `@tatolab/camera/Camera@1.0.0` |
-| `com.tatolab.camera.config@1.0.0` | `@tatolab/camera/CameraConfig@1.0.0` |
-
-### Display package → `@tatolab/display@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.tatolab.display` | `@tatolab/display/Display@1.0.0` |
-| `com.tatolab.display.config@1.0.0` | `@tatolab/display/DisplayConfig@1.0.0` |
-
-### H.264 package → `@tatolab/h264@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.h264_encoder` | `@tatolab/h264/H264Encoder@1.0.0` |
-| `com.streamlib.h264_encoder.config@1.0.0` | `@tatolab/h264/H264EncoderConfig@1.0.0` |
-| `com.streamlib.h264_decoder` | `@tatolab/h264/H264Decoder@1.0.0` |
-| `com.streamlib.h264_decoder.config@1.0.0` | `@tatolab/h264/H264DecoderConfig@1.0.0` |
-
-### H.265 package → `@tatolab/h265@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.h265_encoder` | `@tatolab/h265/H265Encoder@1.0.0` |
-| `com.streamlib.h265_encoder.config@1.0.0` | `@tatolab/h265/H265EncoderConfig@1.0.0` |
-| `com.streamlib.h265_decoder` | `@tatolab/h265/H265Decoder@1.0.0` |
-| `com.streamlib.h265_decoder.config@1.0.0` | `@tatolab/h265/H265DecoderConfig@1.0.0` |
-
-### Opus package → `@tatolab/opus@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.opus_encoder` | `@tatolab/opus/OpusEncoder@1.0.0` |
-| `com.streamlib.opus_encoder.config@1.0.0` | `@tatolab/opus/OpusEncoderConfig@1.0.0` |
-| `com.streamlib.opus_decoder` | `@tatolab/opus/OpusDecoder@1.0.0` |
-| `com.streamlib.opus_decoder.config@1.0.0` | `@tatolab/opus/OpusDecoderConfig@1.0.0` |
-
-### MP4 package → `@tatolab/mp4@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.tatolab.mp4_writer` | `@tatolab/mp4/Mp4Writer@1.0.0` |
-| `com.tatolab.mp4_writer.config@1.0.0` | `@tatolab/mp4/Mp4WriterConfig@1.0.0` |
-| `com.streamlib.linux_mp4_writer` | `@tatolab/mp4/LinuxMp4Writer@1.0.0` |
-| `com.streamlib.linux_mp4_writer.config@1.0.0` | `@tatolab/mp4/LinuxMp4WriterConfig@1.0.0` |
-
-### WebRTC package → `@tatolab/webrtc@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.webrtc_whep` | `@tatolab/webrtc/WhepReceiver@1.0.0` |
-| `com.streamlib.webrtc_whep.config@1.0.0` | `@tatolab/webrtc/WhepReceiverConfig@1.0.0` |
-| `com.streamlib.webrtc_whip` | `@tatolab/webrtc/WhipSender@1.0.0` |
-| `com.streamlib.webrtc_whip.config@1.0.0` | `@tatolab/webrtc/WhipSenderConfig@1.0.0` |
-
-### MoQ package → `@tatolab/moq@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.moq_publish_track` | `@tatolab/moq/PublishTrack@1.0.0` |
-| `com.streamlib.moq_publish_track.config@1.0.0` | `@tatolab/moq/PublishTrackConfig@1.0.0` |
-| `com.streamlib.moq_subscribe_track` | `@tatolab/moq/SubscribeTrack@1.0.0` |
-| `com.streamlib.moq_subscribe_track.config@1.0.0` | `@tatolab/moq/SubscribeTrackConfig@1.0.0` |
-
-### API server package → `@tatolab/api-server@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.api_server` | `@tatolab/api-server/ApiServer@1.0.0` |
-| `com.streamlib.api_server.config@1.0.0` | `@tatolab/api-server/ApiServerConfig@1.0.0` |
-
-### CLAP package → `@tatolab/clap@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.streamlib.clap.effect` | `@tatolab/clap/ClapEffect@1.0.0` |
-| `com.streamlib.clap.effect.config@1.0.0` | `@tatolab/clap/ClapEffectConfig@1.0.0` |
-
-### Screen-capture package → `@tatolab/screen-capture@1.0.0`
-
-| Current | New |
-|---|---|
-| `com.tatolab.screen_capture` | `@tatolab/screen-capture/ScreenCapture@1.0.0` |
-| `com.tatolab.screen_capture.config@1.0.0` | `@tatolab/screen-capture/ScreenCaptureConfig@1.0.0` |
-
-### Internal / not-yet-packaged
-
-These don't fit one of the 12 carve-outs but exist in the current
-schema set. They'll either land in their own carve-out package or
-be folded into an existing one — TBD per the per-carve-out issues.
-
-| Current | Likely destination |
-|---|---|
-| `com.streamlib.bgra_file_source` | `@tatolab/sources/BgraFileSource@1.0.0` (new package) |
-| `com.streamlib.escalate_request@1.0.0` | `@streamlib/escalate/EscalateRequest@1.0.0` (escalate IPC; #404) |
-| `com.streamlib.escalate_response@1.0.0` | `@streamlib/escalate/EscalateResponse@1.0.0` (#404) |
-| `com.tatolab.simple_passthrough` | test-only — likely stays under a `@streamlib/test` namespace |
-| `com.streamlib.test.*` | test-only — `@streamlib/test/...@0.1.0` (kept off the public registry) |
-
-## Pickup order (multi-PR migration plan)
-
-The architecture lands across many PRs. The dependency graph (per
-GitHub `Blocked by` edges) drives the order:
-
-1. **#541** + **#684** + **#399** — bug fixes (codegen idempotency,
-   field ordering) and this foundation. Sibling-ready.
-2. **#400** — extract `streamlib-jtd-codegen` crate + add
-   `streamlib generate` CLI. Needs #399 for the structured types.
-3. **#402** — `streamlib.yaml` resolver + `streamlib.lock` + cutover
-   off legacy `[package.metadata.streamlib]` etc. (atomic — absorbs
-   #403 and #405).
-4. **#401** — `@tatolab/core` package + first end-to-end dogfooding
-   of the package format + sweep hardcoded reverse-DNS literals for
-   the four wire types across Rust + Python + Deno + IPC envelopes
-   for the four wire types.
-5. **#404** — processor short-name macros (Rust + Python + Deno
-   decorators) so processor source code stops hand-writing free-form
-   identifier strings.
-6. **#406** + **#408** + the **12 carve-out packages** — the long
-   tail. By this point the architecture is proven and the carve-outs
-   are mechanical.
-
-> ~~Earlier revision swapped #401 and #404 here: #401 was described
-> as "processor short-name macros + sweep" and #404 as "@tatolab/core
-> + IPC wire migration."~~ — Superseded 2026-05-05 during #401's
-> pickup (PR `feat/tatolab-core-package-401`). The issue bodies on
-> GitHub, the dependency graph (`#401 blocks #404`), and the issue
-> titles (`feat(packages): @tatolab/core ...` vs.
-> `feat(macros): processor short-name macros ...`) consistently say
-> the opposite of what this section originally claimed. The doc text
-> was stale; the issues are the source of truth and were left
-> unchanged.
-
-Each later issue is a planned consumer of this PR's foundation. The
-"no bad patterns left behind on engine changes" rule (CLAUDE.md) is
-explicitly relaxed across the milestone — the migration is staged
-across PRs by design, not bandaided on top of one giant PR.
+The embedded-schemas table at `libs/streamlib/src/core/embedded_schemas.rs`
+is build-script-driven: `build.rs` walks the resolver's full dependency
+graph and emits the `(canonical_identifier, yaml_body)` pairs into
+`OUT_DIR/embedded_schemas_table.rs`. Adding a schema means declaring
+it in your `streamlib.yaml`; nothing else. Hand-curated match arms
+mapping schema IDs to embedded YAML strings are not allowed — they
+silently drift when a schema renames or is added.
 
 ## Why no Python / Deno parity in v1
 
@@ -763,28 +514,25 @@ the cross-language need.
     resolver (`resolve`, `resolve_with`, `ResolvedPackages`) lives here
     too and walks path / git / `.slpkg` sources; the lockfile writer
     (`write_lockfile`, `read_lockfile`) and `compute_content_hash`
-    helper are siblings of the resolver (#402).
+    helper are siblings of the resolver.
   - `libs/streamlib-jtd-codegen/` — three-pass codegen pipeline.
     `sentinel.rs` substitutes cross-package refs with deterministic
     sentinels and restores them as native imports; `ordering.rs`
-    stable-sorts every JSON object key before invoking `jtd-codegen`
-    (#402). Public entry `generate(GenerateOptions { project_dir, ... })`
+    stable-sorts every JSON object key before invoking `jtd-codegen`.
+    Public entry `generate(GenerateOptions { project_dir, ... })`
     drives `streamlib.yaml`-mode end-to-end; `generate_from_resolved`
-    is the lower-level entry for callers that already ran the resolver.
+    is the lower-level entry for callers that already ran the
+    resolver.
   - `libs/streamlib/build.rs` — generates `embedded_schemas_table.rs`
-    in `OUT_DIR` from `streamlib.yaml`'s `schemas:` list, replacing
-    the hand-curated 21-arm match in `core/embedded_schemas.rs` (#402).
+    in `OUT_DIR` from `streamlib.yaml`'s `schemas:` list.
   - `xtask/src/check_schema_versions.rs` — CI lint (no per-schema
-    `version` keys in YAML, #399).
+    `version` keys in YAML).
   - `xtask/src/check_no_streamlib_metadata.rs` — CI lint
     (no `[package.metadata.streamlib]`, no `[tool.streamlib]`, no
-    top-level `streamlib` key in `deno.json` / `deno.jsonc`, #402).
-  - `.github/workflows/check-schema-versions.yml` — #399 CI gate.
-  - `.github/workflows/check-no-streamlib-metadata.yml` — #402 CI gate.
-- **Issues**: #399 (foundation), #400 (codegen extraction), #402
-  (resolver + cutover).
-- **Milestone**: [Schema Identity & Packaging (10)][m10] — freshness
-  anchor for in-flight design.
+    top-level `streamlib` key in `deno.json` / `deno.jsonc`).
+  - `.github/workflows/check-schema-versions.yml` — schema-version CI gate.
+  - `.github/workflows/check-no-streamlib-metadata.yml` —
+    legacy-metadata CI gate.
 - **Tests**:
   - `libs/streamlib-idents/src/{ident,semver,manifest,lockfile,resolver}.rs::tests`
     — unit tests covering grammar conformance, semver-range matching,
@@ -802,32 +550,17 @@ the cross-language need.
     (Rust / Python / TypeScript).
   - `libs/streamlib/src/core/embedded_schemas.rs::tests` — table
     populated from `streamlib.yaml`, no duplicate names, sorted output.
-  - `xtask/src/check_schema_versions.rs::tests` — #399 lint fixtures.
-  - `xtask/src/check_no_streamlib_metadata.rs::tests` — #402 lint
-    fixtures (passes-on-clean, fails-on-each-of-the-three-block-types,
-    skips `target/` and `_generated_/`).
-- **Closed**:
-  - #399 — foundation (`SchemaIdent`, `SemVer`, structural manifest /
-    lockfile types, no-`parse`-API doctests, schema-version CI lint).
-  - #400 — `streamlib-jtd-codegen` crate extraction + `streamlib generate`
-    CLI.
-  - #402 — resolver + lockfile + sentinel-substitution codegen +
-    cutover off legacy `[package.metadata.streamlib]`.
-- **Future research / follow-ups**:
-  - #401 (macros + example string migration).
-  - #404 (`@tatolab/core` + IPC wire migration).
-  - 12 carve-out package issues.
-  - Decision 8's `streamlib verify-schemas` CI determinism gate is
-    not yet implemented — separate follow-up. The resolver +
-    content-hashed lockfile (#402) are the load-bearing primitive
-    the gate will sit on.
+  - `xtask/src/check_schema_versions.rs::tests` — schema-version
+    lint fixtures.
+  - `xtask/src/check_no_streamlib_metadata.rs::tests` —
+    legacy-metadata lint fixtures.
 - **Sibling architecture docs**:
   - [`compute-kernel.md`](compute-kernel.md), [`graphics-kernel.md`](graphics-kernel.md),
     [`ray-tracing-kernel.md`](ray-tracing-kernel.md) — the kernel-shape
     doc family.
-  - [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md) — the polyglot
-    capability split this milestone fits alongside.
+  - [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md) — the
+    polyglot capability split this surface fits alongside.
   - [`texture-registration.md`](texture-registration.md) — engine-wide
     record pattern (`TextureRegistration`) that mirrors the same
-    "single canonical record per concern" shape this milestone applies
+    "single canonical record per concern" shape this surface applies
     to identifiers.

--- a/docs/issue-template.md
+++ b/docs/issue-template.md
@@ -4,27 +4,39 @@ GitHub is the source of truth for work in this repo. Milestones group deliverabl
 
 This doc is the template every new issue should follow, and the contract agents (and humans) are expected to honor.
 
-## Keep issues low-resolution
+## Issue bodies carry the architecture for proposed work
 
-An issue captures the *goal* of a piece of work — the problem to
-solve, why it matters, and roughly how done looks. The high-resolution
-plan (specific file paths, exact test names, suggested implementation
-ordering, ruled-out approaches) decays as the surrounding code shifts,
-so capturing it in the issue body just creates staleness for the next
-agent to clean up. Resist the urge to be exhaustive.
+Architecture docs (`docs/architecture/*.md`) reflect merged-in code
+only. They never describe upcoming changes — a doc that says "after
+#404 the wire format will become X" creates false-current-state
+confusion when a future agent picks up a fresh branch.
 
-The picker's job is to research current state at pickup time and
-produce a fresh implementation plan; the filer's job is to capture
-the goal cleanly enough that a competent agent can pick it up cold
-and figure the rest out.
+That means **all proposed architecture lives in issue / milestone
+bodies until merged**: mermaid diagrams, BNF grammars, decision
+matrices, ADR-style trade-off discussions, sequenced migration
+plans, and any other design content for not-yet-shipped work goes
+into the issue that drives it. When the work merges, the
+architecture moves into a `docs/architecture/*.md` file describing
+the shipped state in current tense; the issue closes and the doc
+takes over.
+
+What that does **not** mean: high-resolution implementation
+specifics still don't belong in the issue body. Specific file
+paths, exact test function names, suggested implementation
+ordering, and ruled-out approaches decay as the surrounding code
+shifts, so capturing them in the issue body just creates staleness
+for the next agent to clean up. The picker re-derives the
+implementation plan at pickup time from current code state.
 
 What this means in practice:
 
 - **Description** is a short paragraph stating the goal, not a
   pre-implementation plan.
 - **Context** explains *why* the work matters and what constraints
-  bound it. It does not summarize an investigation that the picker
-  could redo themselves.
+  bound it. It carries the architectural commitment that makes
+  this the right shape — including any mermaid / BNF / decision
+  matrix needed for the picker to understand the design without
+  re-litigating it.
 - **Exit criteria** are 2–4 high-level deliverables that define
   "done," not a checklist of file edits.
 - **Tests / validation** describes the *shape* of validation needed
@@ -32,7 +44,8 @@ What this means in practice:
   function names.
 - **AI Agent Notes** are reserved for things the picker genuinely
   cannot derive from current code (a hidden invariant, a ruled-out
-  approach with a reason). When in doubt, leave it as "None."
+  approach with a reason, a load-bearing constraint not visible in
+  the code yet). When in doubt, leave it as "None."
 - **Phrase claims as "to the best of our current knowledge"** when
   the issue body must reference specific code or behavior. This
   signals to the picker that the claim deserves verification.
@@ -111,9 +124,13 @@ also", "context from #N", etc.).
 1. **GitHub is the source of truth.** Every issue — description, exit
    criteria, tests, dependency edges, AI-agent notes — lives in the
    issue itself. Local plan files are deprecated; don't create new ones.
-2. **Keep it low-resolution.** When in doubt, leave detail out. The
-   picker will research current state and produce the high-resolution
-   plan; specifics in the issue body just create staleness.
+2. **Architecture in, implementation specifics out.** Carry the
+   design content needed to understand the work (mermaid, BNF,
+   decision matrices, trade-off rationale) — that's what the issue
+   body is for now that architecture docs only describe shipped
+   code. But keep file paths, exact test function names, and
+   suggested ordering out — the picker re-derives those from
+   current code at pickup time and they rot fast.
 3. **Every issue includes an AI Agent Notes section** (wrapped in the
    `<!-- amos:ai-notes-begin -->` / `<!-- amos:ai-notes-end -->` markers
    so tooling can update it safely). Default to "None."; only add
@@ -155,7 +172,7 @@ ends up writing must pass in CI before the PR can merge. Test
 harnesses land first, tests land inside the issue that drives them,
 and the merge signal is automatic.
 
-## Example — a well-formed (low-resolution) issue
+## Example — a well-formed issue
 
 ```markdown
 ## Description

--- a/examples/camera-deno-subprocess/deno/streamlib.yaml
+++ b/examples/camera-deno-subprocess/deno/streamlib.yaml
@@ -12,10 +12,10 @@ processors:
     entrypoint: "grayscale_processor.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
   - name: com.tatolab.halftone-ts
     version: "1.0.0"
@@ -25,7 +25,7 @@ processors:
     entrypoint: "halftone_processor.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/camera-python-display/python/streamlib.yaml
+++ b/examples/camera-python-display/python/streamlib.yaml
@@ -12,10 +12,10 @@ processors:
     entrypoint: "avatar_character:AvatarCharacter"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
   - name: com.tatolab.cyberpunk_lower_third
     version: "1.0.0"
@@ -27,7 +27,7 @@ processors:
     entrypoint: "cyberpunk_lower_third:CyberpunkLowerThird"
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
   - name: com.tatolab.cyberpunk_watermark
     version: "1.0.0"
@@ -39,7 +39,7 @@ processors:
     entrypoint: "cyberpunk_watermark:CyberpunkWatermark"
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
   - name: com.tatolab.cyberpunk_glitch
     version: "1.0.0"
@@ -49,7 +49,7 @@ processors:
     entrypoint: "cyberpunk_glitch:CyberpunkGlitch"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -120,7 +120,7 @@ struct GpuBackend {
     output_ring: Vec<OutputSlot>,
 }
 
-#[streamlib::processor("com.tatolab.blending_compositor")]
+#[streamlib::processor("BlendingCompositor")]
 pub struct BlendingCompositorProcessor {
     config: BlendingCompositorConfig,
 

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -89,7 +89,7 @@ impl Default for CameraToCudaCopyConfig {
     }
 }
 
-#[streamlib::processor("com.tatolab.camera_to_cuda_copy")]
+#[streamlib::processor("CameraToCudaCopy")]
 pub struct CameraToCudaCopyProcessor {
     config: CameraToCudaCopyConfig,
     backend: GpuBackendStash,

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -104,7 +104,7 @@ impl Default for CrtFilmGrainConfig {
     }
 }
 
-#[streamlib::processor("com.tatolab.crt_film_grain")]
+#[streamlib::processor("CrtFilmGrain")]
 pub struct CrtFilmGrainProcessor {
     config: CrtFilmGrainConfig,
     gpu_context: Option<GpuContextLimitedAccess>,

--- a/examples/camera-python-display/streamlib.yaml
+++ b/examples/camera-python-display/streamlib.yaml
@@ -1,5 +1,11 @@
+package:
+  org: tatolab
+  name: camera-python-display
+  version: 0.1.0
+  description: "Camera + Python processor + Display example with CRT/film-grain, CUDA copy, and blending compositor processors"
+
 processors:
-  - name: com.tatolab.crt_film_grain
+  - name: CrtFilmGrain
     version: 1.0.0
     description: "CRT display + 80s film grain effect"
     execution: reactive
@@ -8,27 +14,27 @@ processors:
         unsafe_send: true
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Video frames to process"
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Processed video frames"
 
-  - name: com.tatolab.camera_to_cuda_copy
+  - name: CameraToCudaCopy
     version: 1.0.0
     description: "Host-pipeline producer: camera VkImage -> cuda OPAQUE_FD VkBuffer with timeline signal (#612)"
     execution: reactive
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Camera ring texture (RGBA8 DMA-BUF) frame metadata"
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Camera frame forwarded verbatim; cuda surface side-effect happens during process()"
 
-  - name: com.tatolab.blending_compositor
+  - name: BlendingCompositor
     version: 1.0.0
     description: "Multi-layer alpha blending compositor with PiP support"
     execution: manual
@@ -37,18 +43,18 @@ processors:
         unsafe_send: true
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Video frames (base layer)"
       - name: lower_third_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Lower third overlay (RGBA with transparency)"
       - name: watermark_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Watermark overlay (RGBA with transparency)"
       - name: pip_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "PiP overlay (avatar character with transparent background)"
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: "Composited video frames"

--- a/examples/camera-python-subprocess/python/streamlib.yaml
+++ b/examples/camera-python-subprocess/python/streamlib.yaml
@@ -12,7 +12,7 @@ processors:
     entrypoint: "grayscale_processor:GrayscaleProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/camera-rust-plugin/plugin/src/lib.rs
+++ b/examples/camera-rust-plugin/plugin/src/lib.rs
@@ -24,7 +24,7 @@ unsafe extern "C" {
     fn CVPixelBufferGetBytesPerRow(pixel_buffer: *mut c_void) -> usize;
 }
 
-#[streamlib::processor("com.tatolab.grayscale_rust")]
+#[streamlib::processor("GrayscaleRust")]
 pub struct GrayscaleProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,
     running: Arc<AtomicBool>,

--- a/examples/camera-rust-plugin/plugin/streamlib.yaml
+++ b/examples/camera-rust-plugin/plugin/streamlib.yaml
@@ -1,17 +1,18 @@
 package:
+  org: tatolab
   name: camera-rust-plugin
-  version: "0.1.0"
+  version: 0.1.0
   description: "Grayscale video effect as Rust dylib plugin"
 
 processors:
-  - name: com.tatolab.grayscale_rust
-    version: "1.0.0"
+  - name: GrayscaleRust
+    version: 1.0.0
     description: "Grayscale video effect (Rust dylib plugin)"
     runtime: rust
     execution: manual
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "cpu_readback_blur.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "cpu_readback_blur:CpuReadbackBlurProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-cuda-inference/deno/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "cuda_inference.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-cuda-inference/python/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "cuda_inference:CudaInferenceProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
@@ -12,7 +12,7 @@ processors:
     entrypoint: "dma_buf_consumer.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
@@ -12,7 +12,7 @@ processors:
     entrypoint: "dma_buf_consumer:DmaBufConsumer"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "manual_source.ts:default"
     outputs:
       - name: frame_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-manual-source/plugin/src/lib.rs
+++ b/examples/polyglot-manual-source/plugin/src/lib.rs
@@ -27,7 +27,7 @@ use streamlib_plugin_abi::export_plugin;
 
 const OUTPUT_ENV_VAR: &str = "STREAMLIB_POLYGLOT_MANUAL_SOURCE_SINK_OUTPUT";
 
-#[streamlib::processor("com.tatolab.polyglot_manual_source_counting_sink")]
+#[streamlib::processor("PolyglotManualSourceCountingSink")]
 pub struct PolyglotManualSourceCountingSink {
     output_file: Option<PathBuf>,
     frame_counter: u64,

--- a/examples/polyglot-manual-source/plugin/streamlib.yaml
+++ b/examples/polyglot-manual-source/plugin/streamlib.yaml
@@ -2,16 +2,17 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 package:
+  org: tatolab
   name: polyglot-manual-source-counting-sink
-  version: "0.1.0"
+  version: 0.1.0
   description: "Rust counting sink for the polyglot-manual-source example (#604) — counts Videoframes received over iceoryx2 and writes JSON stats on teardown"
 
 processors:
-  - name: com.tatolab.polyglot_manual_source_counting_sink
-    version: "1.0.0"
+  - name: PolyglotManualSourceCountingSink
+    version: 1.0.0
     description: "Reactive sink that counts Videoframes and writes count + first/last timestamp to a stats file on teardown. Used to validate that polyglot manual sources can publish via iceoryx2 from a worker thread (#604)."
     runtime: rust
     execution: reactive
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "manual_source:PolyglotManualSource"
     outputs:
       - name: frame_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -51,7 +51,7 @@ const INTERVAL_MS: u32 = 33;
 /// gate robust against CI jitter.
 const MIN_FRAMES_RECEIVED: u32 = 20;
 
-const COUNTING_SINK_PROCESSOR: &str = "com.tatolab.polyglot_manual_source_counting_sink";
+const COUNTING_SINK_PROCESSOR: &str = "PolyglotManualSourceCountingSink";
 const COUNTING_SINK_PLUGIN_DYLIB: &str = "libpolyglot_manual_source_counting_sink_plugin.so";
 /// Env var the counting sink reads to know where to write JSON stats.
 /// Set unconditionally before `runtime.start()` so the sink picks it up

--- a/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "opengl_fragment_shader.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "opengl_fragment_shader:OpenGlFragmentShaderProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "skia_canvas:SkiaCanvasProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-compute/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_compute.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-compute/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_compute:VulkanComputeProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_graphics.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-graphics/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_graphics:VulkanGraphicsProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_ray_tracing.ts:default"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
@@ -12,4 +12,4 @@ processors:
     entrypoint: "vulkan_ray_tracing:VulkanRayTracingProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -13,15 +13,51 @@
 use crate::analysis::AnalysisResult;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use streamlib_processor_schema::ProcessorSchema;
+use streamlib_processor_schema::{PortSchemaSpec, ProcessorSchema, SchemaIdent};
 use syn::ItemStruct;
+
+/// Emit a `SchemaIdent` literal expression. Inputs are pre-validated by the
+/// manifest parser so the `expect("validated")` calls are infallible.
+fn schema_ident_tokens(ident: &SchemaIdent) -> TokenStream {
+    let org = ident.org.as_str();
+    let pkg = ident.package.as_str();
+    let ty = ident.r#type.as_str();
+    let major = ident.version.major;
+    let minor = ident.version.minor;
+    let patch = ident.version.patch;
+    quote! {
+        ::streamlib::core::SchemaIdent::new(
+            ::streamlib::core::Org::new(#org).expect("validated by manifest parser"),
+            ::streamlib::core::Package::new(#pkg).expect("validated by manifest parser"),
+            ::streamlib::core::TypeName::new(#ty).expect("validated by manifest parser"),
+            ::streamlib::core::SemVer::new(#major, #minor, #patch),
+        )
+    }
+}
+
+/// Emit a `PortSchemaSpec` literal expression.
+fn port_schema_spec_tokens(spec: &PortSchemaSpec) -> TokenStream {
+    match spec {
+        PortSchemaSpec::Any => quote! { ::streamlib::core::PortSchemaSpec::Any },
+        PortSchemaSpec::Specific(ident) => {
+            let inner = schema_ident_tokens(ident);
+            quote! { ::streamlib::core::PortSchemaSpec::Specific(#inner) }
+        }
+    }
+}
 
 // ============================================================================
 // YAML-based code generation
 // ============================================================================
 
-/// Generate a processor module from a YAML ProcessorSchema.
-pub fn generate_from_processor_schema(item: &ItemStruct, schema: &ProcessorSchema) -> TokenStream {
+/// Generate a processor module from a YAML ProcessorSchema and the resolved
+/// structured [`SchemaIdent`] (org/package/type/version composed from the
+/// enclosing `streamlib.yaml`'s `package:` block + processor short name).
+pub fn generate_from_processor_schema(
+    item: &ItemStruct,
+    schema: &ProcessorSchema,
+    schema_ident: &SchemaIdent,
+) -> TokenStream {
     let module_name = &item.ident;
 
     // Derive config type from schema reference if present
@@ -45,10 +81,25 @@ pub fn generate_from_processor_schema(item: &ItemStruct, schema: &ProcessorSchem
     let output_link_module = generate_output_link_module_from_schema(schema);
     let processor_impl = generate_processor_impl_from_schema(
         schema,
+        schema_ident,
         &config_type,
         &config_field_name,
         &custom_fields,
     );
+
+    let schema_ident_const = {
+        let ident_tokens = schema_ident_tokens(schema_ident);
+        quote! {
+            /// Structured wire identity for this processor —
+            /// `@<org>/<package>/<Type>@<version>` resolved at codegen
+            /// from sibling `streamlib.yaml`'s `package:` block plus
+            /// the processor's PascalCase short name.
+            #[allow(dead_code)]
+            pub fn schema_ident() -> ::streamlib::core::SchemaIdent {
+                #ident_tokens
+            }
+        }
+    };
 
     // Generate unsafe Send impl if required (for !Send types like AVFoundation)
     let unsafe_send_impl = if schema.runtime.options.unsafe_send {
@@ -78,6 +129,8 @@ pub fn generate_from_processor_schema(item: &ItemStruct, schema: &ProcessorSchem
 
             /// Configuration type for this processor.
             pub type Config = #config_type;
+
+            #schema_ident_const
 
             /// Create a [`ProcessorSpec`] for adding this processor to a runtime.
             ///
@@ -272,6 +325,7 @@ fn generate_output_link_module_from_schema(schema: &ProcessorSchema) -> TokenStr
 /// Generate Processor trait implementation from schema.
 fn generate_processor_impl_from_schema(
     schema: &ProcessorSchema,
+    schema_ident: &SchemaIdent,
     config_type: &TokenStream,
     config_field_name: &Option<Ident>,
     custom_fields: &[CustomField],
@@ -351,7 +405,8 @@ fn generate_processor_impl_from_schema(
 
     let from_config_body =
         generate_from_config_from_schema(schema, config_field_name, custom_fields);
-    let descriptor_impl = generate_descriptor_from_schema(schema, description, version);
+    let descriptor_impl =
+        generate_descriptor_from_schema(schema, schema_ident, description, version);
     let iceoryx2_accessors = generate_iceoryx2_accessors_from_schema(schema);
 
     let update_config = config_field_name.as_ref().map(|name| {
@@ -540,6 +595,7 @@ fn generate_from_config_from_schema(
 /// Generate descriptor method from schema.
 fn generate_descriptor_from_schema(
     schema: &ProcessorSchema,
+    _schema_ident: &SchemaIdent,
     description: &str,
     version: &str,
 ) -> TokenStream {
@@ -552,13 +608,13 @@ fn generate_descriptor_from_schema(
         .iter()
         .map(|p| {
             let port_name = &p.name;
-            let port_schema = &p.schema;
+            let port_schema_tokens = port_schema_spec_tokens(&p.schema);
             let port_desc = p.description.as_deref().unwrap_or("");
             quote! {
                 .with_input(::streamlib::core::PortDescriptor {
                     name: #port_name.to_string(),
                     description: #port_desc.to_string(),
-                    schema: #port_schema.to_string(),
+                    schema: #port_schema_tokens,
                     required: true,
                     is_iceoryx2: true,
                 })
@@ -572,13 +628,13 @@ fn generate_descriptor_from_schema(
         .iter()
         .map(|p| {
             let port_name = &p.name;
-            let port_schema = &p.schema;
+            let port_schema_tokens = port_schema_spec_tokens(&p.schema);
             let port_desc = p.description.as_deref().unwrap_or("");
             quote! {
                 .with_output(::streamlib::core::PortDescriptor {
                     name: #port_name.to_string(),
                     description: #port_desc.to_string(),
-                    schema: #port_schema.to_string(),
+                    schema: #port_schema_tokens,
                     required: true,
                     is_iceoryx2: true,
                 })
@@ -586,7 +642,8 @@ fn generate_descriptor_from_schema(
         })
         .collect();
 
-    // Config schema reference (if present)
+    // Config schema reference (if present) — config schemas keep the legacy
+    // reverse-DNS string form until #702 renames the schema files on disk.
     let config_schema = schema.config.as_ref().map(|c| {
         let schema_ref = &c.schema;
         quote! {

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -81,7 +81,6 @@ pub fn generate_from_processor_schema(
     let output_link_module = generate_output_link_module_from_schema(schema);
     let processor_impl = generate_processor_impl_from_schema(
         schema,
-        schema_ident,
         &config_type,
         &config_field_name,
         &custom_fields,
@@ -325,7 +324,6 @@ fn generate_output_link_module_from_schema(schema: &ProcessorSchema) -> TokenStr
 /// Generate Processor trait implementation from schema.
 fn generate_processor_impl_from_schema(
     schema: &ProcessorSchema,
-    schema_ident: &SchemaIdent,
     config_type: &TokenStream,
     config_field_name: &Option<Ident>,
     custom_fields: &[CustomField],
@@ -405,8 +403,7 @@ fn generate_processor_impl_from_schema(
 
     let from_config_body =
         generate_from_config_from_schema(schema, config_field_name, custom_fields);
-    let descriptor_impl =
-        generate_descriptor_from_schema(schema, schema_ident, description, version);
+    let descriptor_impl = generate_descriptor_from_schema(schema, description, version);
     let iceoryx2_accessors = generate_iceoryx2_accessors_from_schema(schema);
 
     let update_config = config_field_name.as_ref().map(|name| {
@@ -595,7 +592,6 @@ fn generate_from_config_from_schema(
 /// Generate descriptor method from schema.
 fn generate_descriptor_from_schema(
     schema: &ProcessorSchema,
-    _schema_ident: &SchemaIdent,
     description: &str,
     version: &str,
 ) -> TokenStream {

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -1,14 +1,13 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Procedural macros for streamlib
+//! Procedural macros for streamlib.
 //!
-//! YAML-based processor definition macro:
-//!
-//! - `#[streamlib::processor("com.tatolab.camera")]` - Processor definition by name lookup
-//!
-//! The macro reads `CARGO_MANIFEST_DIR/streamlib.yaml` and finds the processor entry
-//! matching the given name.
+//! - `#[streamlib::processor("Camera")]` — processor definition by
+//!   PascalCase short name. The macro reads `CARGO_MANIFEST_DIR/streamlib.yaml`
+//!   and resolves the full structured [`SchemaIdent`] from the package's
+//!   `package: { org, name, version }` block plus the matching entry in
+//!   the `processors:` list.
 
 mod analysis;
 mod attributes;
@@ -17,49 +16,54 @@ mod config_descriptor;
 
 use proc_macro::TokenStream;
 use std::path::Path;
-use streamlib_processor_schema::ProjectConfigMinimal;
+use streamlib_processor_schema::{
+    PackageMetadata, ProcessorSchema, ProjectConfigMinimal, SchemaIdent, TypeName,
+};
 use syn::{parse_macro_input, DeriveInput, ItemStruct, LitStr};
 
 /// Main processor attribute macro.
 ///
-/// Transforms a struct definition into a processor module by looking up a processor
-/// name in `streamlib.yaml`.
+/// Transforms a struct definition into a processor module by looking up a
+/// PascalCase short name in `streamlib.yaml`'s `processors:` list and
+/// composing the full structured `SchemaIdent` from the package's
+/// `package: { org, name, version }` block.
 ///
-/// The macro reads `CARGO_MANIFEST_DIR/streamlib.yaml` and finds the processor entry
-/// matching the given name.
+/// Example: `#[streamlib::processor("Camera")]` resolves to
+/// `SchemaIdent { org: tatolab, package: streamlib, type: Camera,
+/// version: <package.version> }` when used inside a manifest declaring
+/// `package: { org: tatolab, name: streamlib, ... }`.
 #[proc_macro_attribute]
 pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item_struct = parse_macro_input!(item as ItemStruct);
 
-    // Parse processor name from attribute
-    let processor_name = match parse_processor_name(attr) {
+    let short_name = match parse_processor_short_name(attr) {
         Ok(name) => name,
         Err(err) => return err.to_compile_error().into(),
     };
 
-    // Load and parse the YAML schema
-    let schema = match load_processor_schema(&processor_name, &item_struct) {
-        Ok(schema) => schema,
+    let (schema, schema_ident) = match load_processor_schema(&short_name, &item_struct) {
+        Ok(pair) => pair,
         Err(err) => return err.to_compile_error().into(),
     };
 
-    // Generate code from the schema
-    let generated = codegen::generate_from_processor_schema(&item_struct, &schema);
+    let generated = codegen::generate_from_processor_schema(&item_struct, &schema, &schema_ident);
 
     TokenStream::from(generated)
 }
 
-/// Parse the processor name from the attribute arguments.
-fn parse_processor_name(attr: TokenStream) -> syn::Result<String> {
+/// Parse the processor short name from the attribute argument.
+fn parse_processor_short_name(attr: TokenStream) -> syn::Result<String> {
     let lit: LitStr = syn::parse(attr)?;
     Ok(lit.value())
 }
 
-/// Load a processor schema by name from `streamlib.yaml`.
+/// Locate `CARGO_MANIFEST_DIR/streamlib.yaml`, resolve the package metadata
+/// + matching processor entry by short name, and compose the full
+/// [`SchemaIdent`].
 fn load_processor_schema(
-    processor_name: &str,
+    short_name: &str,
     item: &ItemStruct,
-) -> syn::Result<streamlib_processor_schema::ProcessorSchema> {
+) -> syn::Result<(ProcessorSchema, SchemaIdent)> {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").map_err(|_| {
         syn::Error::new_spanned(
             item,
@@ -74,8 +78,8 @@ fn load_processor_schema(
             item,
             format!(
                 "streamlib.yaml not found at {}\n\
-                 The #[streamlib::processor(\"name\")] macro requires a streamlib.yaml\n\
-                 next to Cargo.toml with processor definitions.",
+                 The #[streamlib::processor(\"<ShortName>\")] macro requires a streamlib.yaml\n\
+                 next to Cargo.toml with a `package:` block and a matching processor entry.",
                 config_path.display()
             ),
         ));
@@ -89,17 +93,27 @@ fn load_processor_schema(
         syn::Error::new_spanned(item, format!("Failed to parse streamlib.yaml: {}", e))
     })?;
 
+    let pkg: PackageMetadata = config.package.ok_or_else(|| {
+        syn::Error::new_spanned(
+            item,
+            format!(
+                "streamlib.yaml at {} is missing a `package:` block. The processor macro requires `package: {{ org, name, version }}` to construct a full SchemaIdent for `{}`.",
+                config_path.display(),
+                short_name
+            ),
+        )
+    })?;
+
     let available_names: Vec<String> = config.processors.iter().map(|p| p.name.clone()).collect();
 
-    config
+    let schema = config
         .processors
         .into_iter()
-        .find(|p| p.name == processor_name)
+        .find(|p| p.name == short_name)
         .ok_or_else(|| {
             let mut msg = format!(
-                "Processor '{}' not found in streamlib.yaml\n\
-                 Expected at: {}",
-                processor_name,
+                "Processor '{}' not found in streamlib.yaml at {}",
+                short_name,
                 config_path.display()
             );
             if !available_names.is_empty() {
@@ -109,7 +123,21 @@ fn load_processor_schema(
                 }
             }
             syn::Error::new_spanned(item, msg)
-        })
+        })?;
+
+    let type_name = TypeName::new(short_name).map_err(|e| {
+        syn::Error::new_spanned(
+            item,
+            format!(
+                "processor short name `{}` is not valid PascalCase: {}",
+                short_name, e
+            ),
+        )
+    })?;
+
+    let ident = SchemaIdent::new(pkg.org, pkg.name, type_name, pkg.version);
+
+    Ok((schema, ident))
 }
 
 /// Derive macro for ConfigDescriptor trait.

--- a/libs/streamlib-processor-schema/Cargo.toml
+++ b/libs/streamlib-processor-schema/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
+streamlib-idents = { path = "../streamlib-idents" }
 thiserror = { workspace = true }
 
 [lints]

--- a/libs/streamlib-processor-schema/src/lib.rs
+++ b/libs/streamlib-processor-schema/src/lib.rs
@@ -18,15 +18,25 @@ pub use thread_priority::ThreadPriority;
 // Processor schema re-exports
 pub use error::{SchemaError, SchemaResult};
 pub use processor_schema::{
-    compute_schema_id, to_pascal_case, to_snake_case, ProcessorConfigSchema, ProcessorLanguage,
-    ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution, ProcessorStateField,
-    RuntimeConfig, RuntimeOptions,
+    compute_schema_id, to_pascal_case, to_snake_case, PortSchemaSpec, ProcessorConfigSchema,
+    ProcessorLanguage, ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution,
+    ProcessorStateField, RuntimeConfig, RuntimeOptions,
 };
 pub use processor_schema_parser::{parse_processor_yaml, parse_processor_yaml_file};
 
-/// Minimal project config for parsing only the `processors` field from `streamlib.yaml`.
+// Re-export structured-identity types so consumers (the macro, runtime
+// loaders) reach `SchemaIdent`, `Org`, `Package`, etc. through this crate
+// without depending on `streamlib-idents` directly.
+pub use streamlib_idents::{Org, Package, PackageMetadata, SchemaIdent, SemVer, TypeName};
+
+/// Minimal project config for the macro: surfaces the `package:` block (so
+/// processor short names can be resolved to a structured [`SchemaIdent`])
+/// and the `processors:` list. The resolver in `streamlib-idents` handles
+/// the full dependency graph; this is a focused view for codegen.
 #[derive(serde::Deserialize)]
 pub struct ProjectConfigMinimal {
+    #[serde(default)]
+    pub package: Option<PackageMetadata>,
     #[serde(default)]
     pub processors: Vec<ProcessorSchema>,
 }

--- a/libs/streamlib-processor-schema/src/processor_schema.rs
+++ b/libs/streamlib-processor-schema/src/processor_schema.rs
@@ -3,10 +3,83 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use streamlib_idents::SchemaIdent;
 
 // ============================================================================
 // Processor Schema Types
 // ============================================================================
+
+/// Schema spec for a port — either a fully-qualified [`SchemaIdent`] or the
+/// `Any` wildcard for ports that accept arbitrary serialized payloads (used
+/// today by MoQ publish/subscribe tracks).
+///
+/// YAML accepts only two shapes:
+/// - `schema: any` — wildcard
+/// - `schema: { org, package, type, version }` — 4-field structured map
+///
+/// Joined-string `'@org/pkg/Type@version'` shorthand is rejected per the
+/// `joined_string_is_not_a_valid_yaml_shape` invariant in
+/// `streamlib-idents`.
+///
+/// `Default` resolves to [`PortSchemaSpec::Any`] — the most permissive
+/// shape. Used by callers that build a `PortInfo` before the routing tag
+/// is known (e.g. graph-builder fallbacks); a default `Any` carries no
+/// false specificity.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PortSchemaSpec {
+    #[default]
+    Any,
+    Specific(SchemaIdent),
+}
+
+impl Serialize for PortSchemaSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PortSchemaSpec::Any => serializer.serialize_str("any"),
+            PortSchemaSpec::Specific(ident) => ident.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PortSchemaSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+        match value {
+            serde_yaml::Value::String(s) if s == "any" => Ok(PortSchemaSpec::Any),
+            serde_yaml::Value::String(s) => Err(D::Error::custom(format!(
+                "port schema must be either `any` or a 4-field structured map \
+                 ({{ org, package, type, version }}); got string `{}`. Joined-string \
+                 shorthand is not allowed (`docs/architecture/schema-identity-and-packaging.md`).",
+                s
+            ))),
+            mapping @ serde_yaml::Value::Mapping(_) => {
+                let ident: SchemaIdent =
+                    serde_yaml::from_value(mapping).map_err(D::Error::custom)?;
+                Ok(PortSchemaSpec::Specific(ident))
+            }
+            other => Err(D::Error::custom(format!(
+                "port schema must be either `any` or a 4-field structured map; got {:?}",
+                other
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for PortSchemaSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PortSchemaSpec::Any => f.write_str("any"),
+            PortSchemaSpec::Specific(ident) => ident.fmt(f),
+        }
+    }
+}
 
 /// Runtime language for a processor.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -242,8 +315,8 @@ impl<'de> Deserialize<'de> for ProcessorSchemaExecution {
 pub struct ProcessorPortSchema {
     /// Port name (e.g., "video_in").
     pub name: String,
-    /// Schema reference with version (e.g., "com.tatolab.videoframe@1.0.0").
-    pub schema: String,
+    /// Structured schema spec — either `any` or a 4-field [`SchemaIdent`].
+    pub schema: PortSchemaSpec,
     /// Human-readable description.
     #[serde(default)]
     pub description: Option<String>,

--- a/libs/streamlib-processor-schema/src/processor_schema_parser.rs
+++ b/libs/streamlib-processor-schema/src/processor_schema_parser.rs
@@ -77,21 +77,14 @@ fn validate_processor_schema(schema: &ProcessorSchema) -> SchemaResult<()> {
         }
     }
 
-    // Validate input port schema references
+    // Validate input port schema references — port name presence + buffer
+    // size sanity. Schema shape is locked by [`PortSchemaSpec`]'s typed
+    // deserializer (rejects joined-string and other non-structured forms).
     for input in &schema.inputs {
         if input.name.is_empty() {
             return Err(SchemaError::InvalidName {
                 name: schema.name.clone(),
                 reason: "input port name cannot be empty".to_string(),
-            });
-        }
-        if !input.schema.contains('@') {
-            return Err(SchemaError::InvalidName {
-                name: input.schema.clone(),
-                reason: format!(
-                    "input '{}' schema must include version (e.g., com.example.frame@1.0.0)",
-                    input.name
-                ),
             });
         }
         if input.buffer_size == Some(0) {
@@ -105,21 +98,12 @@ fn validate_processor_schema(schema: &ProcessorSchema) -> SchemaResult<()> {
         }
     }
 
-    // Validate output port schema references
+    // Validate output port schema references — port name presence only.
     for output in &schema.outputs {
         if output.name.is_empty() {
             return Err(SchemaError::InvalidName {
                 name: schema.name.clone(),
                 reason: "output port name cannot be empty".to_string(),
-            });
-        }
-        if !output.schema.contains('@') {
-            return Err(SchemaError::InvalidName {
-                name: output.schema.clone(),
-                reason: format!(
-                    "output '{}' schema must include version (e.g., com.example.frame@1.0.0)",
-                    output.name
-                ),
             });
         }
     }
@@ -164,12 +148,12 @@ config:
 
 inputs:
   - name: image_in
-    schema: com.streamlib.video.frame@1.0.0
+    schema: { org: streamlib, package: video, type: Frame, version: 1.0.0 }
     description: "Input video frame"
 
 outputs:
   - name: image_out
-    schema: com.streamlib.video.frame@1.0.0
+    schema: { org: streamlib, package: video, type: Frame, version: 1.0.0 }
     description: "Blurred video frame"
 "#;
 
@@ -192,7 +176,10 @@ outputs:
 
         assert_eq!(schema.inputs.len(), 1);
         assert_eq!(schema.inputs[0].name, "image_in");
-        assert_eq!(schema.inputs[0].schema, "com.streamlib.video.frame@1.0.0");
+        assert_eq!(
+            schema.inputs[0].schema.to_string(),
+            "@streamlib/video/Frame@1.0.0"
+        );
 
         assert_eq!(schema.outputs.len(), 1);
         assert_eq!(schema.outputs[0].name, "image_out");
@@ -208,11 +195,11 @@ entrypoint: detector:ObjectDetector
 
 inputs:
   - name: frame
-    schema: com.streamlib.video.frame@1.0.0
+    schema: { org: streamlib, package: video, type: Frame, version: 1.0.0 }
 
 outputs:
   - name: detections
-    schema: com.example.detections@1.0.0
+    schema: { org: example, package: detector, type: Detections, version: 1.0.0 }
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
@@ -247,7 +234,10 @@ version: invalid
     }
 
     #[test]
-    fn test_processor_schema_input_missing_version() {
+    fn test_processor_schema_rejects_joined_string_port_schema() {
+        // Joined-string `com.streamlib.video.frame` (and the @-versioned
+        // variant) must be rejected — only `any` or 4-field structured
+        // maps are accepted (`PortSchemaSpec`'s typed deserializer).
         let yaml = r#"
 name: com.example.test
 version: 1.0.0
@@ -260,7 +250,27 @@ inputs:
         let result = parse_processor_yaml(yaml);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("must include version"));
+        assert!(
+            err.contains("4-field structured map") || err.contains("Joined-string"),
+            "expected structured-map rejection error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_processor_schema_accepts_any_port_schema() {
+        // `any` is the wildcard for ports that accept arbitrary serialized
+        // payloads (e.g. MoQ tracks).
+        let yaml = r#"
+name: com.example.test
+version: 1.0.0
+
+inputs:
+  - name: data
+    schema: any
+"#;
+
+        let schema = parse_processor_yaml(yaml).unwrap();
+        assert_eq!(schema.inputs[0].schema.to_string(), "any");
     }
 
     #[test]
@@ -310,7 +320,7 @@ version: 1.0.0
 
 inputs:
   - name: encoded_video_in
-    schema: com.tatolab.encodedvideoframe@1.0.0
+    schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
     read_mode: read_next_in_order
     buffer_size: 16
 "#;
@@ -332,7 +342,7 @@ version: 1.0.0
 
 inputs:
   - name: video
-    schema: com.streamlib.video.frame@1.0.0
+    schema: { org: streamlib, package: video, type: Frame, version: 1.0.0 }
 "#;
 
         let schema = parse_processor_yaml(yaml).unwrap();
@@ -349,7 +359,7 @@ version: 1.0.0
 
 inputs:
   - name: video
-    schema: com.streamlib.video.frame@1.0.0
+    schema: { org: streamlib, package: video, type: Frame, version: 1.0.0 }
     buffer_size: 0
 "#;
 

--- a/libs/streamlib-processor-schema/src/processor_schema_parser.rs
+++ b/libs/streamlib-processor-schema/src/processor_schema_parser.rs
@@ -29,17 +29,14 @@ pub fn parse_processor_yaml_file(path: &Path) -> SchemaResult<ProcessorSchema> {
 
 /// Validate a parsed processor schema.
 fn validate_processor_schema(schema: &ProcessorSchema) -> SchemaResult<()> {
-    // Validate name format (reverse domain notation)
+    // Name must be present. Both reverse-DNS (`com.example.foo`, used by
+    // legacy CLI inputs) and PascalCase short names (`Camera`, the new
+    // canonical shape resolved by the macro from `streamlib.yaml`'s
+    // `package:` block) are accepted — the standalone CLI validator
+    // doesn't have package context to enforce the new shape.
     if schema.name.is_empty() {
         return Err(SchemaError::MissingField {
             field: "name".to_string(),
-        });
-    }
-
-    if !schema.name.contains('.') {
-        return Err(SchemaError::InvalidName {
-            name: schema.name.clone(),
-            reason: "must use reverse domain notation (e.g., com.example.myprocessor)".to_string(),
         });
     }
 
@@ -210,16 +207,28 @@ outputs:
     }
 
     #[test]
-    fn test_processor_schema_invalid_name() {
+    fn test_processor_schema_accepts_pascal_case_short_name() {
+        // The CLI validator accepts both legacy reverse-DNS names and the
+        // new PascalCase short-name shape. Package-context validation is
+        // the macro's job; the standalone parser stays permissive.
         let yaml = r#"
-name: invalidname
+name: Camera
+version: 1.0.0
+"#;
+
+        let schema = parse_processor_yaml(yaml).unwrap();
+        assert_eq!(schema.name, "Camera");
+    }
+
+    #[test]
+    fn test_processor_schema_rejects_empty_name() {
+        let yaml = r#"
+name: ""
 version: 1.0.0
 "#;
 
         let result = parse_processor_yaml(yaml);
         assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("reverse domain notation"));
     }
 
     #[test]

--- a/libs/streamlib/build.rs
+++ b/libs/streamlib/build.rs
@@ -23,26 +23,24 @@ fn main() {
 }
 
 /// Walk `streamlib.yaml`'s `schemas:` list AND its `dependencies:` block
-/// (per #401) to emit two generated tables in `OUT_DIR/embedded_schemas_table.rs`:
+/// (per #401) to emit `EMBEDDED_SCHEMAS: &[(canonical_identifier, yaml_body)]`
+/// in `OUT_DIR/embedded_schemas_table.rs`.
 ///
-/// 1. `EMBEDDED_SCHEMAS: &[(canonical_identifier, yaml_body)]` — covers
-///    both legacy reverse-DNS and new structured identifiers.
-/// 2. `EMBEDDED_SCHEMA_IDENT_SEGMENTS: &[(joined_versioned_key, org, package,
-///    type, version_major, version_minor, version_patch)]` — covers ONLY
-///    new-shape schemas declaring `metadata.type` inside a package-flavor
-///    manifest. Legacy reverse-DNS schemas have no structured segment
-///    representation and are deliberately excluded (#401 phase 2).
-///
-/// The canonical identifier in table 1 is:
-/// - For legacy schemas declaring `metadata.name` (reverse-DNS): the
+/// Canonical identifiers carry the unversioned form (no `@<semver>` suffix):
+/// - Legacy schemas declaring `metadata.name` (reverse-DNS): the
 ///   `metadata.name` value verbatim.
-/// - For new-shape schemas declaring `metadata.type` inside a package-flavor
-///   manifest: the joined `@<org>/<package>/<Type>` (no version suffix).
+/// - New-shape schemas declaring `metadata.type` inside a package-flavor
+///   manifest: the joined `@<org>/<package>/<Type>`.
 ///
-/// Both tables are sorted by their first column for diff-stable output and
-/// to support binary-search lookups. The file is `include!`ed by
-/// `src/core/embedded_schemas.rs`, replacing the hand-curated match that
-/// historically drifted against the on-disk set.
+/// Sorted by canonical identifier for diff-stable output and binary-search
+/// lookups. The file is `include!`ed by `src/core/embedded_schemas.rs`.
+///
+/// The previous build also emitted `EMBEDDED_SCHEMA_IDENT_SEGMENTS` (a
+/// joined-versioned → structured-segments table for the wire boundary).
+/// That table was deleted with #404 — the macro now emits structured
+/// `PortDescriptor.schema: PortSchemaSpec` natively, so producers reach
+/// `SchemaIdentWire::from_segments(...)` with structured fields directly,
+/// without any joined-string→segments lookup.
 fn generate_embedded_schemas_table() {
     use std::path::PathBuf;
     use streamlib_idents::resolve;
@@ -61,7 +59,6 @@ fn generate_embedded_schemas_table() {
     });
 
     let mut name_entries: Vec<(String, String)> = Vec::new();
-    let mut segment_entries: Vec<SegmentRow> = Vec::new();
 
     for pkg in resolved.iter_all() {
         for schema_path in &pkg.schema_files {
@@ -75,18 +72,13 @@ fn generate_embedded_schemas_table() {
                     panic!("Failed to parse schema {}: {}", schema_path.display(), e)
                 });
 
-            let resolved_schema = resolve_schema_identity(&schema_yaml, pkg, schema_path);
+            let canonical = resolve_canonical_identifier(&schema_yaml, pkg, schema_path);
             let include_path_literal = include_path_literal(&manifest_dir_path, schema_path);
-            name_entries.push((resolved_schema.canonical.clone(), include_path_literal));
-
-            if let Some(seg) = resolved_schema.segments {
-                segment_entries.push(seg);
-            }
+            name_entries.push((canonical, include_path_literal));
         }
     }
 
     name_entries.sort_by(|a, b| a.0.cmp(&b.0));
-    segment_entries.sort_by(|a, b| a.joined_versioned.cmp(&b.joined_versioned));
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let out_path = PathBuf::from(out_dir).join("embedded_schemas_table.rs");
@@ -108,77 +100,20 @@ fn generate_embedded_schemas_table() {
     for (name, include_lit) in &name_entries {
         buf.push_str(&format!("    (\"{}\", {}),\n", name, include_lit));
     }
-    buf.push_str("];\n\n");
-
-    buf.push_str(
-        "/// Structured segments for every new-shape schema in the resolver dep graph.\n",
-    );
-    buf.push_str("///\n");
-    buf.push_str(
-        "/// Tuple shape: `(joined_versioned_key, org, package, type, major, minor, patch)`.\n",
-    );
-    buf.push_str(
-        "/// Sorted by `joined_versioned_key` for binary-search lookups + diff-stable output.\n",
-    );
-    buf.push_str(
-        "/// Legacy reverse-DNS schemas (those declaring `metadata.name` only) are excluded\n",
-    );
-    buf.push_str(
-        "/// — they have no structured `(org, package, type)` representation by design.\n",
-    );
-    buf.push_str("/// Consumed at the wire boundary by `lookup_schema_ident_segments` to convert\n");
-    buf.push_str(
-        "/// a joined-string identifier into structured segments without a parser (#401 phase 2).\n",
-    );
-    buf.push_str(
-        "pub(crate) const EMBEDDED_SCHEMA_IDENT_SEGMENTS:\n    \
-        &[(&str, &str, &str, &str, u32, u32, u32)] = &[\n",
-    );
-    for seg in &segment_entries {
-        buf.push_str(&format!(
-            "    (\"{}\", \"{}\", \"{}\", \"{}\", {}, {}, {}),\n",
-            seg.joined_versioned,
-            seg.org,
-            seg.package,
-            seg.type_name,
-            seg.major,
-            seg.minor,
-            seg.patch,
-        ));
-    }
     buf.push_str("];\n");
 
     std::fs::write(&out_path, &buf).expect("Failed to write embedded_schemas_table.rs");
 }
 
-/// Resolved identity for a schema: the canonical (unversioned) lookup key,
-/// plus — for new-shape schemas only — the structured segments and version.
-struct ResolvedSchemaIdentity {
-    canonical: String,
-    segments: Option<SegmentRow>,
-}
-
-struct SegmentRow {
-    joined_versioned: String,
-    org: String,
-    package: String,
-    type_name: String,
-    major: u32,
-    minor: u32,
-    patch: u32,
-}
-
-/// Resolve a schema's identity from its parsed YAML + the package context.
-///
-/// New-shape schemas (declaring `metadata.type` inside a package-flavor
-/// manifest) get both a canonical unversioned key and a structured segment
-/// row. Legacy reverse-DNS schemas (declaring `metadata.name`) get only the
-/// canonical key — there's no structured segment representation for them.
-fn resolve_schema_identity(
+/// Resolve a schema's canonical (unversioned) lookup key from its parsed
+/// YAML + the package context. New-shape schemas (declaring `metadata.type`
+/// inside a package-flavor manifest) yield `@<org>/<package>/<Type>`; legacy
+/// reverse-DNS schemas declaring `metadata.name` yield the name verbatim.
+fn resolve_canonical_identifier(
     schema_yaml: &serde_yaml::Value,
     pkg: &streamlib_idents::ResolvedPackage,
     schema_path: &std::path::Path,
-) -> ResolvedSchemaIdentity {
+) -> String {
     let metadata = schema_yaml.get("metadata").unwrap_or_else(|| {
         panic!("schema {} missing `metadata` block", schema_path.display())
     });
@@ -191,33 +126,17 @@ fn resolve_schema_identity(
                 schema_path.display()
             )
         });
-        let org = pkg_meta.org.as_str().to_string();
-        let package = pkg_meta.name.as_str().to_string();
-        let major = pkg_meta.version.major;
-        let minor = pkg_meta.version.minor;
-        let patch = pkg_meta.version.patch;
-        let canonical = format!("@{}/{}/{}", org, package, type_name);
-        let joined_versioned = format!("{}@{}.{}.{}", canonical, major, minor, patch);
-        return ResolvedSchemaIdentity {
-            canonical,
-            segments: Some(SegmentRow {
-                joined_versioned,
-                org,
-                package,
-                type_name: type_name.to_string(),
-                major,
-                minor,
-                patch,
-            }),
-        };
+        return format!(
+            "@{}/{}/{}",
+            pkg_meta.org.as_str(),
+            pkg_meta.name.as_str(),
+            type_name
+        );
     }
 
     if let Some(name) = metadata.get("name").and_then(|n| n.as_str()) {
         // Legacy reverse-DNS — strip any trailing @<semver> for canonical form.
-        return ResolvedSchemaIdentity {
-            canonical: strip_semver_suffix(name).to_string(),
-            segments: None,
-        };
+        return strip_semver_suffix(name).to_string();
     }
 
     panic!(

--- a/libs/streamlib/src/apple/processors/audio_capture.rs
+++ b/libs/streamlib/src/apple/processors/audio_capture.rs
@@ -17,7 +17,7 @@ pub struct AppleAudioInputDevice {
     pub is_default: bool,
 }
 
-#[crate::processor("com.tatolab.audio_capture")]
+#[crate::processor("AudioCapture")]
 pub struct AppleAudioCaptureProcessor {
     device_info: Option<AppleAudioInputDevice>,
     _device: Option<Device>,

--- a/libs/streamlib/src/apple/processors/audio_output.rs
+++ b/libs/streamlib/src/apple/processors/audio_output.rs
@@ -58,7 +58,7 @@ pub struct AppleAudioDevice {
     pub is_default: bool,
 }
 
-#[crate::processor("com.tatolab.audio_output")]
+#[crate::processor("AudioOutput")]
 pub struct AppleAudioOutputProcessor {
     device_id: Option<usize>,
     device_name: String,

--- a/libs/streamlib/src/apple/processors/camera.rs
+++ b/libs/streamlib/src/apple/processors/camera.rs
@@ -326,7 +326,7 @@ unsafe fn forward_camera_iosurface_directly(
     }
 }
 
-#[crate::processor("com.tatolab.camera")]
+#[crate::processor("Camera")]
 pub struct AppleCameraProcessor {
     camera_name: String,
     /// Async init state - None means init not started yet.

--- a/libs/streamlib/src/apple/processors/display.rs
+++ b/libs/streamlib/src/apple/processors/display.rs
@@ -25,7 +25,7 @@ pub struct AppleWindowId(pub u64);
 
 static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(1);
 
-#[crate::processor("com.tatolab.display")]
+#[crate::processor("Display")]
 pub struct AppleDisplayProcessor {
     /// Window address stored as usize (NSWindow is !Send, but we leak it anyway)
     window_addr: AtomicUsize,

--- a/libs/streamlib/src/apple/processors/mp4_writer.rs
+++ b/libs/streamlib/src/apple/processors/mp4_writer.rs
@@ -26,7 +26,7 @@ extern "C" {
     fn CVPixelBufferGetIOSurface(pixelBuffer: *const CVPixelBuffer) -> *mut IOSurface;
 }
 
-#[crate::processor("com.tatolab.mp4_writer")]
+#[crate::processor("Mp4Writer")]
 pub struct AppleMp4WriterProcessor {
     // RuntimeContext for main thread dispatch
     ctx: Option<crate::core::RuntimeContext>,

--- a/libs/streamlib/src/apple/processors/screen_capture.rs
+++ b/libs/streamlib/src/apple/processors/screen_capture.rs
@@ -262,7 +262,7 @@ unsafe fn forward_iosurface_directly(
     }
 }
 
-#[crate::processor("com.tatolab.screen_capture")]
+#[crate::processor("ScreenCapture")]
 pub struct AppleScreenCaptureProcessor {
     /// GPU context for surface pooling (set in setup).
     gpu_context: Option<GpuContext>,

--- a/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::core::context::RuntimeContext;
-use crate::core::embedded_schemas::{max_payload_bytes_for_schema, schema_ident_wire_from_joined};
+use crate::core::embedded_schemas::max_payload_bytes_for_port_spec;
 use crate::core::error::{Result, StreamError};
 use crate::core::graph::{
     Graph, GraphEdgeWithComponents, GraphNodeWithComponents, LinkState, LinkStateComponent,
@@ -18,39 +18,36 @@ use crate::core::graph::{
 };
 use crate::core::json_schema::SchemaIdentOutput;
 use crate::core::processors::{ProcessorInstance, PROCESSOR_REGISTRY};
+use crate::core::PortSchemaSpec;
 use crate::core::ProcessorUniqueId;
 use crate::iceoryx2::{SchemaIdentWire, MAX_FANIN_PER_DESTINATION};
 
-/// Resolve a joined-versioned schema string (e.g. `"@tatolab/core/VideoFrame@1.0.0"`)
-/// into a JSON value: a structured `SchemaIdentOutput` object on success, or
-/// `Value::Null` for legacy reverse-DNS / unknown identifiers. Callers that
-/// need both shapes (legacy and new) include the result with a `null` fallback
-/// so subprocess-side parsers can branch on presence.
-fn schema_ident_json(joined: &str) -> serde_json::Value {
-    SchemaIdentOutput::try_from_joined(joined)
-        .map(|s| {
-            serde_json::to_value(s).expect("SchemaIdentOutput must serialize cleanly")
-        })
+/// Render a port's structured schema spec as the JSON value embedded in the
+/// subprocess wiring envelope: a structured `SchemaIdentOutput` object for
+/// `Specific(...)`, or `Value::Null` for `Any` (the wildcard MoQ-style port).
+/// Subprocess-side parsers branch on `null` to detect wildcard ports.
+fn schema_ident_json(spec: &PortSchemaSpec) -> serde_json::Value {
+    SchemaIdentOutput::from_port_spec(spec)
+        .map(|s| serde_json::to_value(s).expect("SchemaIdentOutput must serialize cleanly"))
         .unwrap_or(serde_json::Value::Null)
 }
 
-/// Resolve a joined-versioned schema string into structured wire bytes for
-/// the iceoryx2 producer. For new-shape `@org/pkg/Type@v` identifiers the
-/// build-time segment table provides the structured form. For empty /
-/// legacy reverse-DNS strings (where no structured representation exists),
-/// emits a default zero-segment `SchemaIdentWire` and a `tracing::debug` —
-/// downstream consumers see an unset routing tag, matching the behaviour
-/// of the joined-string predecessor when fed those inputs.
-fn schema_ident_wire_for_producer(joined: &str) -> SchemaIdentWire {
-    match schema_ident_wire_from_joined(joined) {
-        Ok(wire) => wire,
-        Err(e) => {
-            tracing::debug!(
-                "schema {:?} has no structured wire form, using default zero-segment wire bytes: {}",
-                joined, e
-            );
-            SchemaIdentWire::default()
-        }
+/// Resolve a port's structured schema spec into the iceoryx2 wire-routing
+/// tag. `Any` ports yield the default zero-segment wire bytes (unset routing
+/// tag — preserves the existing wildcard semantics). `Specific(...)` ports
+/// build the wire bytes directly from the validated structured fields.
+fn schema_ident_wire_for_producer(spec: &PortSchemaSpec) -> SchemaIdentWire {
+    match spec {
+        PortSchemaSpec::Any => SchemaIdentWire::default(),
+        PortSchemaSpec::Specific(ident) => SchemaIdentWire::from_segments(
+            ident.org.as_str(),
+            ident.package.as_str(),
+            ident.r#type.as_str(),
+            ident.version.major,
+            ident.version.minor,
+            ident.version.patch,
+        )
+        .expect("validated SchemaIdent fits in SchemaIdentWire bounds"),
     }
 }
 
@@ -347,7 +344,7 @@ fn open_iceoryx2_pubsub(
     let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
-    let publisher = service.create_publisher(max_payload_bytes_for_schema(&output_schema))?;
+    let publisher = service.create_publisher(max_payload_bytes_for_port_spec(&output_schema))?;
     let notifier = notify_service.create_notifier()?;
     tracing::debug!(
         "Created iceoryx2 Publisher+Notifier for '{}' -> service '{}'",
@@ -474,7 +471,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
             })
             .unwrap_or_default()
     };
-    let max_payload = max_payload_bytes_for_schema(&output_schema);
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema);
 
     // Store output wiring info on the source subprocess
     {
@@ -605,7 +602,7 @@ fn open_iceoryx2_subprocess_to_rust(
                 .unwrap_or_default()
         };
 
-        let max_payload = max_payload_bytes_for_schema(&output_schema);
+        let max_payload = max_payload_bytes_for_port_spec(&output_schema);
         let source_proc_arc = get_single_processor(graph, source_proc_id)?;
         let mut source_guard = source_proc_arc.lock();
         if let Some(deno_host) = source_guard
@@ -737,7 +734,7 @@ fn open_iceoryx2_rust_to_subprocess(
     let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
     // Create Publisher sized for this schema's declared max payload.
-    let max_payload = max_payload_bytes_for_schema(&output_schema);
+    let max_payload = max_payload_bytes_for_port_spec(&output_schema);
     let publisher = service.create_publisher(max_payload)?;
     let notifier = notify_service.create_notifier()?;
 
@@ -830,7 +827,7 @@ mod tests {
         graph
             .traversal_mut()
             .add_v(ProcessorSpec::new(
-                "com.streamlib.test.mock_output_only_processor",
+                "TestMockOutputOnlyProcessor",
                 serde_json::Value::Null,
             ))
             .first()
@@ -843,7 +840,7 @@ mod tests {
         graph
             .traversal_mut()
             .add_v(ProcessorSpec::new(
-                "com.streamlib.test.mock_input_only_processor",
+                "TestMockInputOnlyProcessor",
                 serde_json::Value::Null,
             ))
             .first()

--- a/libs/streamlib/src/core/config/project_config.rs
+++ b/libs/streamlib/src/core/config/project_config.rs
@@ -238,7 +238,7 @@ env:
   MY_VAR: value
 
 processors:
-  - name: com.test.grayscale
+  - name: Grayscale
     version: "1.0.0"
     description: Grayscale processor
     runtime: python
@@ -246,10 +246,10 @@ processors:
     entrypoint: "grayscale_processor:GrayscaleProcessor"
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: {{ org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }}
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: {{ org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }}
 "#
         )
         .unwrap();
@@ -261,7 +261,7 @@ processors:
         assert_eq!(pkg.version, "0.1.0");
         assert_eq!(config.env.get("MY_VAR"), Some(&"value".to_string()));
         assert_eq!(config.processors.len(), 1);
-        assert_eq!(config.processors[0].name, "com.test.grayscale");
+        assert_eq!(config.processors[0].name, "Grayscale");
         assert_eq!(config.processors[0].inputs.len(), 1);
         assert_eq!(config.processors[0].outputs.len(), 1);
     }

--- a/libs/streamlib/src/core/descriptors.rs
+++ b/libs/streamlib/src/core/descriptors.rs
@@ -4,6 +4,7 @@
 //! Processor and port descriptor types for introspection.
 
 use serde::{Deserialize, Serialize};
+pub use streamlib_processor_schema::{Org, Package, PortSchemaSpec, SchemaIdent, SemVer, TypeName};
 
 /// Runtime environment for a processor.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -21,8 +22,9 @@ pub enum ProcessorRuntime {
 pub struct PortDescriptor {
     pub name: String,
     pub description: String,
-    /// Reference to a schema by name.
-    pub schema: String,
+    /// Structured schema spec — `Any` (wildcard for MoQ-style ports) or a
+    /// fully-qualified [`SchemaIdent`].
+    pub schema: PortSchemaSpec,
     pub required: bool,
     /// Whether this port uses iceoryx2 IPC.
     #[serde(default)]
@@ -33,13 +35,13 @@ impl PortDescriptor {
     pub fn new(
         name: impl Into<String>,
         description: impl Into<String>,
-        schema: impl Into<String>,
+        schema: PortSchemaSpec,
         required: bool,
     ) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
-            schema: schema.into(),
+            schema,
             required,
             is_iceoryx2: false,
         }
@@ -49,12 +51,12 @@ impl PortDescriptor {
     pub fn iceoryx2(
         name: impl Into<String>,
         description: impl Into<String>,
-        schema: impl Into<String>,
+        schema: PortSchemaSpec,
     ) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
-            schema: schema.into(),
+            schema,
             required: true,
             is_iceoryx2: true,
         }

--- a/libs/streamlib/src/core/embedded_schemas.rs
+++ b/libs/streamlib/src/core/embedded_schemas.rs
@@ -47,120 +47,19 @@ pub fn max_payload_bytes_for_schema(schema_name: &str) -> usize {
     MAX_PAYLOAD_SIZE as usize
 }
 
+/// Resolve `max_payload_bytes` from a structured port-schema spec by
+/// rendering it to its canonical lookup form via `Display`. Returns the
+/// iceoryx2 default for `Any` and for unknown schemas.
+pub fn max_payload_bytes_for_port_spec(
+    schema_spec: &streamlib_processor_schema::PortSchemaSpec,
+) -> usize {
+    max_payload_bytes_for_schema(&schema_spec.to_string())
+}
+
 /// List every embedded schema's canonical identifier (unversioned). Sorted
 /// alphabetically so consumers (API server) get diff-stable output.
 pub fn list_embedded_schema_names() -> Vec<&'static str> {
     EMBEDDED_SCHEMAS.iter().map(|(name, _)| *name).collect()
-}
-
-/// Structured segments for a schema identifier, derived at build time from
-/// the resolver's package metadata. Returned by [`lookup_schema_ident_segments`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SchemaIdentSegments {
-    pub org: &'static str,
-    pub package: &'static str,
-    pub type_name: &'static str,
-    pub version_major: u32,
-    pub version_minor: u32,
-    pub version_patch: u32,
-}
-
-/// Look up the structured segments for a schema, given its joined-versioned
-/// identifier (e.g. `"@tatolab/core/VideoFrame@1.0.0"`).
-///
-/// This is the wire-boundary helper that lets producers convert a joined
-/// `String` into a `SchemaIdentWire` without ever invoking a parser
-/// (#401 phase 2 — Path C). The lookup table is populated at build time
-/// from the resolver's structured `(org, package, type, version)` records,
-/// so no string-splitting logic exists anywhere in the runtime path.
-///
-/// Returns `None` for:
-/// - Legacy reverse-DNS schemas (e.g. `com.streamlib.h264_encoder.config@1.0.0`)
-///   — they have no structured-segment representation by design.
-/// - Unknown identifiers — the schema wasn't in `streamlib.yaml`'s dep graph.
-///
-/// The accepted input form is the **versioned** joined string. The unversioned
-/// form is rejected (returns `None`) because the version is part of the wire
-/// identity — a producer that doesn't know the version isn't ready to write
-/// a fully-qualified wire frame.
-pub fn lookup_schema_ident_segments(joined_versioned: &str) -> Option<SchemaIdentSegments> {
-    EMBEDDED_SCHEMA_IDENT_SEGMENTS
-        .binary_search_by(|(k, ..)| (*k).cmp(joined_versioned))
-        .ok()
-        .map(|i| {
-            let (_key, org, package, type_name, major, minor, patch) =
-                EMBEDDED_SCHEMA_IDENT_SEGMENTS[i];
-            SchemaIdentSegments {
-                org,
-                package,
-                type_name,
-                version_major: major,
-                version_minor: minor,
-                version_patch: patch,
-            }
-        })
-}
-
-/// Errors returned when materializing a [`SchemaIdentWire`] from a joined
-/// string at the wire boundary.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SchemaIdentWireBuildError {
-    /// The joined identifier wasn't in the build-time embedded segment table.
-    /// Either it's a legacy reverse-DNS schema (no structured representation
-    /// by design) or it isn't part of `streamlib.yaml`'s dep graph at all.
-    UnknownSchema { joined: String },
-    /// The structured segments resolved cleanly from the table but exceeded
-    /// the wire format's per-segment length bounds — propagated from
-    /// [`SchemaIdentWire::from_segments`].
-    Wire(crate::iceoryx2::SchemaIdentWireError),
-}
-
-impl std::fmt::Display for SchemaIdentWireBuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnknownSchema { joined } => write!(
-                f,
-                "no structured segments registered for schema {joined:?} (legacy reverse-DNS or not in streamlib.yaml dep graph)"
-            ),
-            Self::Wire(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl std::error::Error for SchemaIdentWireBuildError {}
-
-/// Materialize a [`SchemaIdentWire`] from a joined-versioned identifier, in
-/// one step: looks up the structured segments, then constructs the wire
-/// struct. The host-side adapter that wire-format producers in `streamlib`
-/// use to bridge the `String`-shaped `PortDescriptor.schema` to the
-/// structured wire bytes.
-///
-/// No parser runs anywhere — the segments come from the build-time table
-/// populated by `build.rs` walking the resolver's structured metadata.
-///
-/// This adapter intentionally lives in the `streamlib` host crate (not on
-/// `SchemaIdentWire` itself) so the cdylib dep graph (`streamlib-python-native`,
-/// `streamlib-deno-native`) stays minimal — those crates receive structured
-/// segments directly from the Surface 2 IPC envelope and call
-/// `SchemaIdentWire::from_segments` without needing this lookup or
-/// `streamlib-idents` as a dep.
-pub fn schema_ident_wire_from_joined(
-    joined_versioned: &str,
-) -> Result<crate::iceoryx2::SchemaIdentWire, SchemaIdentWireBuildError> {
-    let segs = lookup_schema_ident_segments(joined_versioned).ok_or_else(|| {
-        SchemaIdentWireBuildError::UnknownSchema {
-            joined: joined_versioned.to_string(),
-        }
-    })?;
-    crate::iceoryx2::SchemaIdentWire::from_segments(
-        segs.org,
-        segs.package,
-        segs.type_name,
-        segs.version_major,
-        segs.version_minor,
-        segs.version_patch,
-    )
-    .map_err(SchemaIdentWireBuildError::Wire)
 }
 
 /// Strip a trailing `@MAJOR.MINOR.PATCH` suffix from an identifier. The
@@ -302,92 +201,4 @@ mod tests {
         assert_eq!(strip_semver_suffix("com.tatolab.foo"), "com.tatolab.foo");
     }
 
-    #[test]
-    fn segments_table_is_populated() {
-        // Sanity: the resolver dep graph includes @tatolab/core, so the
-        // segments table must contain at least the four wire types.
-        assert!(
-            !EMBEDDED_SCHEMA_IDENT_SEGMENTS.is_empty(),
-            "build.rs must populate the segments table from new-shape schemas"
-        );
-    }
-
-    #[test]
-    fn segments_table_is_sorted() {
-        // Binary search in lookup_schema_ident_segments depends on this
-        // ordering; build.rs sorts before emit.
-        let keys: Vec<&str> = EMBEDDED_SCHEMA_IDENT_SEGMENTS
-            .iter()
-            .map(|(k, ..)| *k)
-            .collect();
-        let mut sorted = keys.clone();
-        sorted.sort();
-        assert_eq!(keys, sorted, "build.rs sorts segment entries — diff stability");
-    }
-
-    #[test]
-    fn segments_table_no_duplicates() {
-        let keys: Vec<&str> = EMBEDDED_SCHEMA_IDENT_SEGMENTS
-            .iter()
-            .map(|(k, ..)| *k)
-            .collect();
-        let unique: std::collections::HashSet<&&str> = keys.iter().collect();
-        assert_eq!(
-            keys.len(),
-            unique.len(),
-            "duplicate joined-versioned key in segments table"
-        );
-    }
-
-    #[test]
-    fn lookup_schema_ident_segments_resolves_video_frame() {
-        let segs = lookup_schema_ident_segments("@tatolab/core/VideoFrame@1.0.0");
-        let segs = segs.expect("@tatolab/core/VideoFrame@1.0.0 must be in the segments table");
-        assert_eq!(segs.org, "tatolab");
-        assert_eq!(segs.package, "core");
-        assert_eq!(segs.type_name, "VideoFrame");
-        assert_eq!(segs.version_major, 1);
-        assert_eq!(segs.version_minor, 0);
-        assert_eq!(segs.version_patch, 0);
-    }
-
-    #[test]
-    fn lookup_schema_ident_segments_resolves_all_core_wire_types() {
-        // The four wire vocabulary types must all round-trip cleanly. If
-        // any of these fail, the producer-side wire boundary will fall back
-        // to default-zero segments and ship malformed frames.
-        for (joined, expected_type) in [
-            ("@tatolab/core/VideoFrame@1.0.0", "VideoFrame"),
-            ("@tatolab/core/AudioFrame@1.0.0", "AudioFrame"),
-            ("@tatolab/core/EncodedVideoFrame@1.0.0", "EncodedVideoFrame"),
-            ("@tatolab/core/EncodedAudioFrame@1.0.0", "EncodedAudioFrame"),
-        ] {
-            let segs = lookup_schema_ident_segments(joined)
-                .unwrap_or_else(|| panic!("missing segments for {joined}"));
-            assert_eq!(segs.org, "tatolab", "{joined}");
-            assert_eq!(segs.package, "core", "{joined}");
-            assert_eq!(segs.type_name, expected_type, "{joined}");
-        }
-    }
-
-    #[test]
-    fn lookup_schema_ident_segments_returns_none_for_unversioned() {
-        // Unversioned form is deliberately rejected — the wire boundary
-        // requires a fully-qualified joined-versioned identifier.
-        assert!(lookup_schema_ident_segments("@tatolab/core/VideoFrame").is_none());
-    }
-
-    #[test]
-    fn lookup_schema_ident_segments_returns_none_for_legacy_reverse_dns() {
-        // Legacy reverse-DNS schemas have no structured segment representation.
-        assert!(
-            lookup_schema_ident_segments("com.streamlib.h264_encoder.config@1.0.0").is_none()
-        );
-    }
-
-    #[test]
-    fn lookup_schema_ident_segments_returns_none_for_unknown() {
-        assert!(lookup_schema_ident_segments("@nonexistent/pkg/Type@1.0.0").is_none());
-        assert!(lookup_schema_ident_segments("garbage").is_none());
-    }
 }

--- a/libs/streamlib/src/core/graph/graph_tests.rs
+++ b/libs/streamlib/src/core/graph/graph_tests.rs
@@ -20,7 +20,7 @@ use crate::core::JsonSerializableComponent;
 // =============================================================================
 
 /// Mock processor for testing graph operations.
-#[crate::processor("com.streamlib.test.mock_processor")]
+#[crate::processor("TestMockProcessor")]
 struct MockProcessor;
 
 impl crate::core::ManualProcessor for MockProcessor::Processor {
@@ -45,7 +45,7 @@ impl crate::core::ManualProcessor for MockProcessor::Processor {
 }
 
 /// Processor with only output ports.
-#[crate::processor("com.streamlib.test.mock_output_only_processor")]
+#[crate::processor("TestMockOutputOnlyProcessor")]
 struct MockOutputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
@@ -70,7 +70,7 @@ impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
 }
 
 /// Processor with only input ports.
-#[crate::processor("com.streamlib.test.mock_input_only_processor")]
+#[crate::processor("TestMockInputOnlyProcessor")]
 struct MockInputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {
@@ -248,7 +248,7 @@ mod query_ops {
         assert!(found.is_some());
         assert_eq!(
             found.unwrap().processor_type,
-            "com.streamlib.test.mock_processor"
+            "TestMockProcessor"
         );
     }
 
@@ -346,9 +346,9 @@ mod query_ops {
             .collect();
 
         assert_eq!(types.len(), 3);
-        assert!(types.contains(&"com.streamlib.test.mock_processor".to_string()));
-        assert!(types.contains(&"com.streamlib.test.mock_output_only_processor".to_string()));
-        assert!(types.contains(&"com.streamlib.test.mock_input_only_processor".to_string()));
+        assert!(types.contains(&"TestMockProcessor".to_string()));
+        assert!(types.contains(&"TestMockOutputOnlyProcessor".to_string()));
+        assert!(types.contains(&"TestMockInputOnlyProcessor".to_string()));
     }
 }
 
@@ -497,7 +497,7 @@ mod filter_ops {
         let mock_processors: Vec<_> = graph
             .traversal()
             .v(())
-            .filter(|n| n.processor_type == "com.streamlib.test.mock_processor")
+            .filter(|n| n.processor_type == "TestMockProcessor")
             .ids();
 
         assert_eq!(mock_processors.len(), 2);

--- a/libs/streamlib/src/core/graph/nodes/port_info.rs
+++ b/libs/streamlib/src/core/graph/nodes/port_info.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use serde::{Deserialize, Serialize};
+use streamlib_processor_schema::PortSchemaSpec;
 
 use super::PortKind;
 
@@ -9,7 +10,7 @@ use super::PortKind;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PortInfo {
     pub name: String,
-    pub data_type: String,
+    pub data_type: PortSchemaSpec,
     #[serde(default)]
     pub port_kind: PortKind,
 }

--- a/libs/streamlib/src/core/json_schema.rs
+++ b/libs/streamlib/src/core/json_schema.rs
@@ -263,25 +263,31 @@ pub struct SchemaIdentOutput {
     pub version: SemanticVersionOutput,
 }
 
+impl From<&crate::core::SchemaIdent> for SchemaIdentOutput {
+    fn from(ident: &crate::core::SchemaIdent) -> Self {
+        Self {
+            org: ident.org.as_str().to_string(),
+            package: ident.package.as_str().to_string(),
+            type_name: ident.r#type.as_str().to_string(),
+            version: SemanticVersionOutput {
+                major: ident.version.major,
+                minor: ident.version.minor,
+                patch: ident.version.patch,
+            },
+        }
+    }
+}
+
 impl SchemaIdentOutput {
-    /// Resolve a joined-versioned identifier (e.g.
-    /// `"@tatolab/core/VideoFrame@1.0.0"`) into structured form via the
-    /// build-time embedded-schema segment table. Returns `None` for legacy
-    /// reverse-DNS schemas and unknown identifiers — the caller decides
-    /// whether to emit `null` or fail loudly.
-    pub fn try_from_joined(joined_versioned: &str) -> Option<Self> {
-        crate::core::embedded_schemas::lookup_schema_ident_segments(joined_versioned).map(|s| {
-            Self {
-                org: s.org.to_string(),
-                package: s.package.to_string(),
-                type_name: s.type_name.to_string(),
-                version: SemanticVersionOutput {
-                    major: s.version_major,
-                    minor: s.version_minor,
-                    patch: s.version_patch,
-                },
-            }
-        })
+    /// Resolve a structured port schema spec into the JSON-wire output
+    /// shape. `Any` ports yield `None` (the field is omitted on the wire).
+    pub fn from_port_spec(
+        spec: &crate::core::PortSchemaSpec,
+    ) -> Option<Self> {
+        match spec {
+            crate::core::PortSchemaSpec::Any => None,
+            crate::core::PortSchemaSpec::Specific(ident) => Some(Self::from(ident)),
+        }
     }
 }
 
@@ -346,7 +352,7 @@ impl From<&crate::core::graph::PortInfo> for PortInfoOutput {
     fn from(port: &crate::core::graph::PortInfo) -> Self {
         Self {
             name: port.name.clone(),
-            data_type: SchemaIdentOutput::try_from_joined(&port.data_type),
+            data_type: SchemaIdentOutput::from_port_spec(&port.data_type),
             port_kind: PortKindOutput::from(port.port_kind),
         }
     }
@@ -452,7 +458,7 @@ impl From<&crate::core::PortDescriptor> for PortDescriptorOutput {
         Self {
             name: port.name.clone(),
             description: port.description.clone(),
-            schema: SchemaIdentOutput::try_from_joined(&port.schema),
+            schema: SchemaIdentOutput::from_port_spec(&port.schema),
             required: port.required,
         }
     }
@@ -471,11 +477,27 @@ impl From<&crate::core::CodeExamples> for CodeExamplesOutput {
 #[cfg(test)]
 mod schema_ident_output_tests {
     use super::*;
+    use crate::core::{Org, Package, PortSchemaSpec, SchemaIdent, SemVer, TypeName};
+
+    fn ident(org: &str, pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(pkg).unwrap(),
+            TypeName::new(ty).unwrap(),
+            v,
+        )
+    }
 
     #[test]
-    fn try_from_joined_resolves_video_frame() {
-        let s = SchemaIdentOutput::try_from_joined("@tatolab/core/VideoFrame@1.0.0")
-            .expect("VideoFrame must be in the embedded segment table");
+    fn from_port_spec_resolves_specific_to_structured() {
+        let spec = PortSchemaSpec::Specific(ident(
+            "tatolab",
+            "core",
+            "VideoFrame",
+            SemVer::new(1, 0, 0),
+        ));
+        let s = SchemaIdentOutput::from_port_spec(&spec)
+            .expect("Specific must yield a structured output");
         assert_eq!(s.org, "tatolab");
         assert_eq!(s.package, "core");
         assert_eq!(s.type_name, "VideoFrame");
@@ -485,18 +507,10 @@ mod schema_ident_output_tests {
     }
 
     #[test]
-    fn try_from_joined_returns_none_for_legacy_reverse_dns() {
-        // Legacy reverse-DNS schemas have no structured-segment representation.
-        // The JSON wire shape is `null` for these.
-        assert!(
-            SchemaIdentOutput::try_from_joined("com.streamlib.h264_encoder.config@1.0.0")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn try_from_joined_returns_none_for_unversioned() {
-        assert!(SchemaIdentOutput::try_from_joined("@tatolab/core/VideoFrame").is_none());
+    fn from_port_spec_returns_none_for_any() {
+        // `Any` is the wildcard for ports accepting arbitrary payloads.
+        // The JSON wire shape is `null` (skip_serializing_if = Option::is_none).
+        assert!(SchemaIdentOutput::from_port_spec(&PortSchemaSpec::Any).is_none());
     }
 
     #[test]
@@ -522,19 +536,24 @@ mod schema_ident_output_tests {
 
     #[test]
     fn port_info_output_emits_structured_data_type() {
-        // The graph JSON wire format lock — given a PortInfo carrying the
-        // joined-versioned form, the JSON output is a structured 4-key
-        // record matching `SchemaIdentOutput`.
+        // The graph JSON wire format lock — given a PortInfo carrying a
+        // structured `Specific(...)` spec, the JSON output is a structured
+        // 4-key record matching `SchemaIdentOutput`.
         let port = crate::core::graph::PortInfo {
             name: "video".to_string(),
-            data_type: "@tatolab/core/VideoFrame@1.0.0".to_string(),
+            data_type: PortSchemaSpec::Specific(ident(
+                "tatolab",
+                "core",
+                "VideoFrame",
+                SemVer::new(1, 0, 0),
+            )),
             port_kind: crate::core::graph::PortKind::Data,
         };
         let out = PortInfoOutput::from(&port);
         let s = out
             .data_type
             .as_ref()
-            .expect("known wire schema must resolve");
+            .expect("Specific must resolve");
         assert_eq!(s.org, "tatolab");
         assert_eq!(s.package, "core");
         assert_eq!(s.type_name, "VideoFrame");
@@ -550,20 +569,21 @@ mod schema_ident_output_tests {
     }
 
     #[test]
-    fn port_info_output_emits_null_for_legacy_schema() {
+    fn port_info_output_emits_null_for_any_wildcard() {
+        // `Any` ports (e.g. MoQ tracks) omit the `data_type` field on the
+        // wire — `skip_serializing_if = Option::is_none`.
         let port = crate::core::graph::PortInfo {
-            name: "config".to_string(),
-            data_type: "com.streamlib.h264_encoder.config@1.0.0".to_string(),
+            name: "data".to_string(),
+            data_type: PortSchemaSpec::Any,
             port_kind: crate::core::graph::PortKind::Data,
         };
         let out = PortInfoOutput::from(&port);
         assert!(out.data_type.is_none());
 
         let json = serde_json::to_value(&out).unwrap();
-        // Field is skipped when None (skip_serializing_if).
         assert!(
             json.get("data_type").is_none(),
-            "legacy schemas must omit the data_type field, not serialize as null/empty"
+            "Any-wildcard ports must omit the data_type field, not serialize as null/empty"
         );
     }
 
@@ -572,14 +592,19 @@ mod schema_ident_output_tests {
         let pd = crate::core::PortDescriptor::new(
             "video",
             "Video output",
-            "@tatolab/core/EncodedVideoFrame@1.0.0",
+            PortSchemaSpec::Specific(ident(
+                "tatolab",
+                "core",
+                "EncodedVideoFrame",
+                SemVer::new(1, 0, 0),
+            )),
             true,
         );
         let out = PortDescriptorOutput::from(&pd);
         let s = out
             .schema
             .as_ref()
-            .expect("known wire schema must resolve");
+            .expect("Specific must resolve");
         assert_eq!(s.org, "tatolab");
         assert_eq!(s.package, "core");
         assert_eq!(s.type_name, "EncodedVideoFrame");

--- a/libs/streamlib/src/core/processors/api_server.rs
+++ b/libs/streamlib/src/core/processors/api_server.rs
@@ -183,7 +183,7 @@ struct ApiDoc;
 // Processor Definition
 // ============================================================================
 
-#[crate::processor("com.streamlib.api_server")]
+#[crate::processor("ApiServer")]
 pub struct ApiServerProcessor {
     runtime_ctx: Option<RuntimeContext>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,

--- a/libs/streamlib/src/core/processors/audio_channel_converter.rs
+++ b/libs/streamlib/src/core/processors/audio_channel_converter.rs
@@ -5,7 +5,7 @@ use crate::_generated_::com_tatolab_audio_channel_converter_config::Mode;
 use crate::_generated_::AudioFrame;
 use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
 
-#[crate::processor("com.tatolab.audio_channel_converter")]
+#[crate::processor("AudioChannelConverter")]
 pub struct AudioChannelConverterProcessor {
     frame_counter: u64,
 }

--- a/libs/streamlib/src/core/processors/audio_mixer.rs
+++ b/libs/streamlib/src/core/processors/audio_mixer.rs
@@ -5,7 +5,7 @@ use crate::_generated_::com_tatolab_audio_mixer_config::Strategy;
 use crate::_generated_::AudioFrame;
 use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
 
-#[crate::processor("com.tatolab.audio_mixer")]
+#[crate::processor("AudioMixer")]
 pub struct AudioMixerProcessor {
     sample_rate: u32,
     buffer_size: usize,

--- a/libs/streamlib/src/core/processors/audio_resampler.rs
+++ b/libs/streamlib/src/core/processors/audio_resampler.rs
@@ -15,7 +15,7 @@ fn quality_to_resampling_quality(quality: &Quality) -> ResamplingQuality {
     }
 }
 
-#[crate::processor("com.tatolab.audio_resampler")]
+#[crate::processor("AudioResampler")]
 pub struct AudioResamplerProcessor {
     resampler: Option<AudioResampler>,
     output_sample_rate: u32,

--- a/libs/streamlib/src/core/processors/buffer_rechunker.rs
+++ b/libs/streamlib/src/core/processors/buffer_rechunker.rs
@@ -4,7 +4,7 @@
 use crate::_generated_::AudioFrame;
 use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 
-#[crate::processor("com.tatolab.buffer_rechunker")]
+#[crate::processor("BufferRechunker")]
 pub struct BufferRechunkerProcessor {
     buffer: Vec<f32>,
     sample_rate: u32,

--- a/libs/streamlib/src/core/processors/chord_generator.rs
+++ b/libs/streamlib/src/core/processors/chord_generator.rs
@@ -53,7 +53,7 @@ struct OscillatorState {
     osc_g4: SineOscillator,
 }
 
-#[crate::processor("com.tatolab.chord_generator")]
+#[crate::processor("ChordGenerator")]
 pub struct ChordGeneratorProcessor {
     /// Shared oscillator state for the audio clock callback.
     oscillators: Arc<Mutex<Option<OscillatorState>>>,

--- a/libs/streamlib/src/core/processors/clap_effect.rs
+++ b/libs/streamlib/src/core/processors/clap_effect.rs
@@ -58,7 +58,7 @@ impl SendableClapHostPtr {
     }
 }
 
-#[crate::processor("com.streamlib.clap.effect")]
+#[crate::processor("ClapEffect")]
 pub struct ClapEffectProcessor {
     host: Option<ClapPluginHost>,
     buffer_size: usize,

--- a/libs/streamlib/src/core/processors/moq_publish_track.rs
+++ b/libs/streamlib/src/core/processors/moq_publish_track.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.moq_publish_track")]
+#[crate::processor("MoqPublishTrack")]
 pub struct MoqPublishTrackProcessor {
     /// Shared MoQ publish session (from RuntimeContext).
     shared_publish_session: Option<Arc<Mutex<MoqPublishSession>>>,

--- a/libs/streamlib/src/core/processors/moq_subscribe_track.rs
+++ b/libs/streamlib/src/core/processors/moq_subscribe_track.rs
@@ -30,7 +30,7 @@ const MAX_RETRY_DELAY_MS: u64 = 10_000;
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.moq_subscribe_track")]
+#[crate::processor("MoqSubscribeTrack")]
 pub struct MoqSubscribeTrackProcessor {
     /// Runtime context for tokio handle and shared sessions.
     runtime_context: Option<RuntimeContext>,

--- a/libs/streamlib/src/core/processors/opus_decoder.rs
+++ b/libs/streamlib/src/core/processors/opus_decoder.rs
@@ -13,7 +13,7 @@ use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.opus_decoder")]
+#[crate::processor("OpusDecoder")]
 pub struct OpusDecoderProcessor {
     /// Opus decoder.
     opus_decoder: Option<OpusDecoder>,

--- a/libs/streamlib/src/core/processors/opus_encoder.rs
+++ b/libs/streamlib/src/core/processors/opus_encoder.rs
@@ -13,7 +13,7 @@ use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.opus_encoder")]
+#[crate::processor("OpusEncoder")]
 pub struct OpusEncoderProcessor {
     /// Opus encoder.
     opus_encoder: Option<OpusEncoder>,

--- a/libs/streamlib/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib/src/core/processors/processor_instance_factory.rs
@@ -142,7 +142,7 @@ impl ProcessorInstanceFactory {
         {
             let mut schemas = self.schemas.write();
             for port in inputs.iter().chain(outputs.iter()) {
-                schemas.insert(port.data_type.clone());
+                schemas.insert(port.data_type.to_string());
             }
         }
 
@@ -241,7 +241,7 @@ impl ProcessorInstanceFactory {
         {
             let mut schemas = self.schemas.write();
             for port in inputs.iter().chain(outputs.iter()) {
-                schemas.insert(port.data_type.clone());
+                schemas.insert(port.data_type.to_string());
             }
         }
 
@@ -310,7 +310,7 @@ impl ProcessorInstanceFactory {
         {
             let mut schemas = self.schemas.write();
             for port in inputs.iter().chain(outputs.iter()) {
-                schemas.insert(port.data_type.clone());
+                schemas.insert(port.data_type.to_string());
             }
         }
 

--- a/libs/streamlib/src/core/processors/simple_passthrough.rs
+++ b/libs/streamlib/src/core/processors/simple_passthrough.rs
@@ -4,7 +4,7 @@
 use crate::_generated_::VideoFrame;
 use crate::core::{Result, RuntimeContextFullAccess};
 
-#[crate::processor("com.tatolab.simple_passthrough")]
+#[crate::processor("SimplePassthrough")]
 pub struct SimplePassthroughProcessor;
 
 impl crate::core::ManualProcessor for SimplePassthroughProcessor::Processor {

--- a/libs/streamlib/src/core/processors/webrtc_whep.rs
+++ b/libs/streamlib/src/core/processors/webrtc_whep.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.webrtc_whep")]
+#[crate::processor("WebrtcWhep")]
 pub struct WebRtcWhepProcessor {
     // WHEP client (owns WebRTC session)
     whep_client: Option<WhepClient>,

--- a/libs/streamlib/src/core/processors/webrtc_whip.rs
+++ b/libs/streamlib/src/core/processors/webrtc_whip.rs
@@ -28,7 +28,7 @@ enum WhipClientMessage {
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.webrtc_whip")]
+#[crate::processor("WebrtcWhip")]
 pub struct WebRtcWhipProcessor {
     // Session state
     session_started: bool,

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -527,7 +527,7 @@ impl StreamRuntime {
                     PortDescriptor::new(
                         &p.name,
                         p.description.as_deref().unwrap_or(""),
-                        &p.schema,
+                        p.schema.clone(),
                         true,
                     )
                 })
@@ -540,7 +540,7 @@ impl StreamRuntime {
                     PortDescriptor::new(
                         &p.name,
                         p.description.as_deref().unwrap_or(""),
-                        &p.schema,
+                        p.schema.clone(),
                         true,
                     )
                 })

--- a/libs/streamlib/src/iceoryx2/output.rs
+++ b/libs/streamlib/src/iceoryx2/output.rs
@@ -55,9 +55,9 @@ impl OutputWriter {
     ///
     /// `schema_ident` is the structured wire identifier the publisher will
     /// stamp into every [`FrameHeader`] for this connection. Callers
-    /// resolve it once at wiring time via
-    /// [`crate::core::embedded_schemas::schema_ident_wire_from_joined`]
-    /// and pass the result here — no parser runs on the per-frame hot path.
+    /// build it once at wiring time from the port's structured
+    /// `PortSchemaSpec` via [`SchemaIdentWire::from_segments`] — no
+    /// parser runs on the per-frame hot path.
     pub fn add_connection(
         &self,
         output_port: &str,

--- a/libs/streamlib/src/lib.rs
+++ b/libs/streamlib/src/lib.rs
@@ -33,7 +33,7 @@ pub mod _generated_;
 pub use _generated_::{ApiServerConfig, EncodedAudioFrame, EncodedVideoFrame, VideoFrame};
 
 // Re-export attribute macros for processor syntax:
-// - #[streamlib::processor("com.tatolab.camera")] - Processor definition by name lookup in streamlib.yaml
+// - #[streamlib::processor("Camera")] - Processor definition by name lookup in streamlib.yaml
 // - #[derive(ConfigDescriptor)] - Config field metadata derive macro
 pub use streamlib_macros::{processor, ConfigDescriptor};
 

--- a/libs/streamlib/src/linux/processors/audio_capture.rs
+++ b/libs/streamlib/src/linux/processors/audio_capture.rs
@@ -17,7 +17,7 @@ pub struct LinuxAudioInputDevice {
     pub is_default: bool,
 }
 
-#[crate::processor("com.tatolab.audio_capture")]
+#[crate::processor("AudioCapture")]
 pub struct LinuxAudioCaptureProcessor {
     device_info: Option<LinuxAudioInputDevice>,
     _device: Option<Device>,

--- a/libs/streamlib/src/linux/processors/audio_output.rs
+++ b/libs/streamlib/src/linux/processors/audio_output.rs
@@ -58,7 +58,7 @@ pub struct LinuxAudioDevice {
     pub is_default: bool,
 }
 
-#[crate::processor("com.tatolab.audio_output")]
+#[crate::processor("AudioOutput")]
 pub struct LinuxAudioOutputProcessor {
     device_id: Option<usize>,
     device_name: String,

--- a/libs/streamlib/src/linux/processors/bgra_file_source.rs
+++ b/libs/streamlib/src/linux/processors/bgra_file_source.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.bgra_file_source")]
+#[crate::processor("BgraFileSource")]
 pub struct BgraFileSourceProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,
     is_running: Arc<AtomicBool>,

--- a/libs/streamlib/src/linux/processors/camera.rs
+++ b/libs/streamlib/src/linux/processors/camera.rs
@@ -34,7 +34,7 @@ pub struct LinuxCameraDevice {
     pub name: String,
 }
 
-#[crate::processor("com.tatolab.camera")]
+#[crate::processor("Camera")]
 pub struct LinuxCameraProcessor {
     camera_name: String,
     gpu_context: Option<GpuContextLimitedAccess>,

--- a/libs/streamlib/src/linux/processors/display.rs
+++ b/libs/streamlib/src/linux/processors/display.rs
@@ -35,7 +35,7 @@ pub struct LinuxWindowId(pub u64);
 
 static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(1);
 
-#[crate::processor("com.tatolab.display")]
+#[crate::processor("Display")]
 pub struct LinuxDisplayProcessor {
     gpu_context: Option<GpuContextLimitedAccess>,
     window_id: LinuxWindowId,

--- a/libs/streamlib/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_decoder.rs
@@ -17,7 +17,7 @@ use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.h264_decoder")]
+#[crate::processor("H264Decoder")]
 pub struct H264DecoderProcessor {
     /// Vulkan Video hardware decoder (shares RHI device).
     decoder: Option<SimpleDecoder>,

--- a/libs/streamlib/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h264_encoder.rs
@@ -20,7 +20,7 @@ use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.h264_encoder")]
+#[crate::processor("H264Encoder")]
 pub struct H264EncoderProcessor {
     /// Vulkan Video hardware encoder (shares RHI device).
     encoder: Option<SimpleEncoder>,

--- a/libs/streamlib/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_decoder.rs
@@ -17,7 +17,7 @@ use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.h265_decoder")]
+#[crate::processor("H265Decoder")]
 pub struct H265DecoderProcessor {
     /// Vulkan Video hardware decoder (shares RHI device).
     decoder: Option<SimpleDecoder>,

--- a/libs/streamlib/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib/src/linux/processors/h265_encoder.rs
@@ -20,7 +20,7 @@ use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.h265_encoder")]
+#[crate::processor("H265Encoder")]
 pub struct H265EncoderProcessor {
     /// Vulkan Video hardware encoder (shares RHI device).
     encoder: Option<SimpleEncoder>,

--- a/libs/streamlib/src/linux/processors/mp4_writer.rs
+++ b/libs/streamlib/src/linux/processors/mp4_writer.rs
@@ -18,7 +18,7 @@ use std::process::{Child, Command, Stdio};
 // PROCESSOR
 // ============================================================================
 
-#[crate::processor("com.streamlib.linux_mp4_writer")]
+#[crate::processor("LinuxMp4Writer")]
 pub struct LinuxMp4WriterProcessor {
     /// GPU context for resolving VideoFrame pixel buffers.
     gpu_context: Option<GpuContextLimitedAccess>,

--- a/libs/streamlib/streamlib.yaml
+++ b/libs/streamlib/streamlib.yaml
@@ -4,6 +4,12 @@
 # Wire vocabulary now lives in @tatolab/core (#401). The four canonical
 # wire types (VideoFrame, AudioFrame, EncodedVideoFrame, EncodedAudioFrame)
 # are pulled in via this dependency rather than declared inline.
+package:
+  org: tatolab
+  name: streamlib
+  version: 0.4.28
+  description: "Cross-platform real-time media framework"
+
 dependencies:
   "@tatolab/core":
     path: ../../packages/core
@@ -47,7 +53,7 @@ schemas:
 processors:
   # === Apple platform processors ===
 
-  - name: com.tatolab.camera
+  - name: Camera
     version: 1.0.0
     description: "Captures video from macOS cameras using AVFoundation"
     execution: manual
@@ -56,10 +62,10 @@ processors:
       schema: com.tatolab.camera.config@1.0.0
     outputs:
       - name: video
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Live video frames from the camera
 
-  - name: com.tatolab.display
+  - name: Display
     version: 1.0.0
     description: "Displays video frames in a window using Metal with vsync"
     execution: manual
@@ -68,12 +74,12 @@ processors:
       schema: com.tatolab.display.config@1.0.0
     inputs:
       - name: video
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Video frames to display in the window
         read_mode: skip_to_latest
         buffer_size: 4
 
-  - name: com.tatolab.audio_capture
+  - name: AudioCapture
     version: 1.0.0
     description: "Captures mono audio from macOS microphones in device-native format"
     execution: manual
@@ -86,10 +92,10 @@ processors:
       schema: com.tatolab.audio_capture.config@1.0.0
     outputs:
       - name: audio
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Captured mono audio frames in device-native sample rate
 
-  - name: com.tatolab.audio_output
+  - name: AudioOutput
     version: 1.0.0
     description: "Plays audio through speakers/headphones using CoreAudio"
     execution: manual
@@ -102,12 +108,12 @@ processors:
       schema: com.tatolab.audio_output.config@1.0.0
     inputs:
       - name: audio
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Stereo audio frame to play through speakers
         read_mode: read_next_in_order
         buffer_size: 32
 
-  - name: com.tatolab.mp4_writer
+  - name: Mp4Writer
     version: 1.0.0
     description: "Writes stereo audio and video to MP4 file with A/V synchronization"
     execution: reactive
@@ -120,17 +126,17 @@ processors:
       schema: com.tatolab.mp4_writer.config@1.0.0
     inputs:
       - name: audio
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Stereo audio frames to write to MP4
         read_mode: read_next_in_order
         buffer_size: 32
       - name: video
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Video frames to write to MP4
         read_mode: skip_to_latest
         buffer_size: 4
 
-  - name: com.tatolab.screen_capture
+  - name: ScreenCapture
     version: 1.0.0
     description: "Captures display, window, or application content using ScreenCaptureKit (macOS 12.3+)"
     execution: manual
@@ -142,12 +148,12 @@ processors:
       schema: com.tatolab.screen_capture.config@1.0.0
     outputs:
       - name: video
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Captured video frames from screen content
 
   # === Core processors ===
 
-  - name: com.streamlib.api_server
+  - name: ApiServer
     version: 1.0.0
     description: "Runtime api server for streamlib"
     execution: manual
@@ -155,7 +161,7 @@ processors:
       name: config
       schema: com.streamlib.api_server.config@1.0.0
 
-  - name: com.tatolab.simple_passthrough
+  - name: SimplePassthrough
     version: 1.0.0
     description: "Passes video frames through unchanged (for testing)"
     execution: manual
@@ -164,16 +170,16 @@ processors:
       schema: com.tatolab.simple_passthrough.config@1.0.0
     inputs:
       - name: input
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Video frame input
         read_mode: skip_to_latest
         buffer_size: 4
     outputs:
       - name: output
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Video frame output (unchanged)
 
-  - name: com.tatolab.audio_channel_converter
+  - name: AudioChannelConverter
     version: 1.0.0
     description: "Converts mono audio to stereo using configurable channel mapping"
     execution: reactive
@@ -182,16 +188,16 @@ processors:
       schema: com.tatolab.audio_channel_converter.config@1.0.0
     inputs:
       - name: audio_in
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Audio input (validates channel count at runtime)
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: audio_out
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Audio output with converted channel count
 
-  - name: com.tatolab.audio_mixer
+  - name: AudioMixer
     version: 1.0.0
     description: "Mixes two mono signals (left and right) into a stereo signal"
     execution: reactive
@@ -200,21 +206,21 @@ processors:
       schema: com.tatolab.audio_mixer.config@1.0.0
     inputs:
       - name: left
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Left channel mono audio (validates 1 channel at runtime)
         read_mode: read_next_in_order
         buffer_size: 32
       - name: right
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Right channel mono audio (validates 1 channel at runtime)
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: audio
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Mixed stereo audio output (2 channels)
 
-  - name: com.tatolab.audio_resampler
+  - name: AudioResampler
     version: 1.0.0
     description: "Resamples audio from source to target sample rate (preserves channel count)"
     execution: reactive
@@ -223,16 +229,16 @@ processors:
       schema: com.tatolab.audio_resampler.config@1.0.0
     inputs:
       - name: audio_in
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Audio input (any channel count)
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: audio_out
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Resampled audio output (same channel count as input)
 
-  - name: com.tatolab.buffer_rechunker
+  - name: BufferRechunker
     version: 1.0.0
     description: "Rechunks variable-sized audio buffers into fixed-size chunks (preserves channel count)"
     execution: reactive
@@ -241,16 +247,16 @@ processors:
       schema: com.tatolab.buffer_rechunker.config@1.0.0
     inputs:
       - name: audio_in
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Variable-sized audio input (any channel count)
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: audio_out
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Fixed-size audio output (same channel count as input)
 
-  - name: com.tatolab.chord_generator
+  - name: ChordGenerator
     version: 1.0.0
     description: "Generates a C major chord (C4, E4, G4) pre-mixed into a stereo output"
     execution:
@@ -260,10 +266,10 @@ processors:
       schema: com.tatolab.chord_generator.config@1.0.0
     outputs:
       - name: chord
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Stereo audio output with C major chord (2 channels)
 
-  - name: com.streamlib.clap.effect
+  - name: ClapEffect
     version: 1.0.0
     description: "CLAP audio plugin processor with parameter control and automation"
     execution: manual
@@ -272,16 +278,16 @@ processors:
       schema: com.streamlib.clap.effect.config@1.0.0
     inputs:
       - name: audio_in
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Stereo audio frame to process through CLAP plugin (2 channels)
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: audio_out
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Processed stereo audio frame from CLAP plugin (2 channels)
 
-  - name: com.streamlib.webrtc_whep
+  - name: WebrtcWhep
     version: 1.0.0
     description: "Receives video and audio from WHEP endpoint (WebRTC egress)"
     execution: manual
@@ -292,13 +298,13 @@ processors:
       schema: com.streamlib.webrtc_whep.config@1.0.0
     outputs:
       - name: encoded_video_out
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.264 encoded video frames from WHEP stream
       - name: encoded_audio_out
-        schema: '@tatolab/core/EncodedAudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedAudioFrame, version: 1.0.0 }
         description: Opus encoded audio frames from WHEP stream
 
-  - name: com.streamlib.webrtc_whip
+  - name: WebrtcWhip
     version: 1.0.0
     description: "Streams pre-encoded video and audio via WebRTC WHIP"
     execution: reactive
@@ -309,19 +315,19 @@ processors:
       schema: com.streamlib.webrtc_whip.config@1.0.0
     inputs:
       - name: encoded_video_in
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.264 encoded video frames to stream
         read_mode: read_next_in_order
         buffer_size: 16
       - name: encoded_audio_in
-        schema: '@tatolab/core/EncodedAudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedAudioFrame, version: 1.0.0 }
         description: Opus encoded audio frames to stream
         read_mode: skip_to_latest
         buffer_size: 8
 
   # === Linux File Source ===
 
-  - name: com.streamlib.bgra_file_source
+  - name: BgraFileSource
     version: 1.0.0
     description: "Streams raw BGRA frames from a file as Videoframes"
     execution: manual
@@ -332,12 +338,12 @@ processors:
       schema: com.streamlib.bgra_file_source.config@1.0.0
     outputs:
       - name: video
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Video frames read from the BGRA file
 
   # === Linux MP4 Writer ===
 
-  - name: com.streamlib.linux_mp4_writer
+  - name: LinuxMp4Writer
     version: 1.0.0
     description: "Writes video frames to MP4 via ffmpeg encode + mux with silent audio track"
     execution: reactive
@@ -348,14 +354,14 @@ processors:
       schema: com.streamlib.linux_mp4_writer.config@1.0.0
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Decoded video frames (raw pixels) to encode and write
         read_mode: skip_to_latest
         buffer_size: 4
 
   # === Codecs ===
 
-  - name: com.streamlib.h264_encoder
+  - name: H264Encoder
     version: 1.0.0
     description: "Encodes VideoFrame to EncodedVideoFrame (H.264) via Vulkan Video"
     execution: reactive
@@ -366,16 +372,16 @@ processors:
       schema: com.streamlib.h264_encoder.config@1.0.0
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Raw video frames to encode
         read_mode: read_next_in_order
         buffer_size: 8
     outputs:
       - name: encoded_video_out
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.264 encoded video frames
 
-  - name: com.streamlib.h264_decoder
+  - name: H264Decoder
     version: 1.0.0
     description: "Decodes EncodedVideoFrame (H.264) to VideoFrame via Vulkan Video"
     execution: reactive
@@ -386,16 +392,16 @@ processors:
       schema: com.streamlib.h264_decoder.config@1.0.0
     inputs:
       - name: encoded_video_in
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.264 encoded video frames to decode
         read_mode: read_next_in_order
         buffer_size: 16
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Decoded video frames
 
-  - name: com.streamlib.h265_encoder
+  - name: H265Encoder
     version: 1.0.0
     description: "Encodes VideoFrame to EncodedVideoFrame (H.265) via Vulkan Video"
     execution: reactive
@@ -406,16 +412,16 @@ processors:
       schema: com.streamlib.h265_encoder.config@1.0.0
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Raw video frames to encode
         read_mode: read_next_in_order
         buffer_size: 8
     outputs:
       - name: encoded_video_out
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.265 encoded video frames
 
-  - name: com.streamlib.h265_decoder
+  - name: H265Decoder
     version: 1.0.0
     description: "Decodes EncodedVideoFrame (H.265) to VideoFrame via Vulkan Video"
     execution: reactive
@@ -426,16 +432,16 @@ processors:
       schema: com.streamlib.h265_decoder.config@1.0.0
     inputs:
       - name: encoded_video_in
-        schema: '@tatolab/core/EncodedVideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedVideoFrame, version: 1.0.0 }
         description: H.265 encoded video frames to decode
         read_mode: read_next_in_order
         buffer_size: 16
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Decoded video frames
 
-  - name: com.streamlib.opus_encoder
+  - name: OpusEncoder
     version: 1.0.0
     description: "Encodes AudioFrame to EncodedAudioFrame (Opus)"
     execution: reactive
@@ -446,16 +452,16 @@ processors:
       schema: com.streamlib.opus_encoder.config@1.0.0
     inputs:
       - name: audio_in
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Raw audio frames to encode
         read_mode: read_next_in_order
         buffer_size: 32
     outputs:
       - name: encoded_audio_out
-        schema: '@tatolab/core/EncodedAudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedAudioFrame, version: 1.0.0 }
         description: Opus encoded audio frames
 
-  - name: com.streamlib.opus_decoder
+  - name: OpusDecoder
     version: 1.0.0
     description: "Decodes EncodedAudioFrame (Opus) to AudioFrame"
     execution: reactive
@@ -466,18 +472,18 @@ processors:
       schema: com.streamlib.opus_decoder.config@1.0.0
     inputs:
       - name: encoded_audio_in
-        schema: '@tatolab/core/EncodedAudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: EncodedAudioFrame, version: 1.0.0 }
         description: Opus encoded audio frames to decode
         read_mode: skip_to_latest
         buffer_size: 8
     outputs:
       - name: audio_out
-        schema: '@tatolab/core/AudioFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: AudioFrame, version: 1.0.0 }
         description: Decoded audio frames
 
   # === MoQ Streaming ===
 
-  - name: com.streamlib.moq_publish_track
+  - name: MoqPublishTrack
     version: 1.0.0
     description: "Publishes raw bytes from a single graph input to a named MoQ track"
     execution: reactive
@@ -491,7 +497,7 @@ processors:
         schema: any
         description: Input data to publish to MoQ track (any serialized type)
 
-  - name: com.streamlib.moq_subscribe_track
+  - name: MoqSubscribeTrack
     version: 1.0.0
     description: "Subscribes to a named MoQ track and outputs raw bytes to the graph"
     execution: manual
@@ -507,63 +513,63 @@ processors:
 
   # === Test mock processors ===
 
-  - name: com.streamlib.test.mock_processor
+  - name: TestMockProcessor
     version: 1.0.0
     description: "Mock processor for testing graph operations"
     execution: manual
     inputs:
       - name: in1
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test input port 1
       - name: in2
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test input port 2
     outputs:
       - name: out1
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test output port 1
       - name: out2
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test output port 2
 
-  - name: com.streamlib.test.mock_input_only_processor
+  - name: TestMockInputOnlyProcessor
     version: 1.0.0
     description: "Mock processor with only input ports for testing"
     execution: manual
     inputs:
       - name: in1
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test input port 1
       - name: in2
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test input port 2
 
-  - name: com.streamlib.test.mock_output_only_processor
+  - name: TestMockOutputOnlyProcessor
     version: 1.0.0
     description: "Mock processor with only output ports for testing"
     execution: manual
     outputs:
       - name: out1
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test output port 1
       - name: out2
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
         description: Test output port 2
 
   # === Test attribute macro processors ===
 
-  - name: com.streamlib.test.processor
+  - name: TestProcessor
     version: 1.0.0
     description: "Test processor for attribute macro tests"
     execution: manual
     inputs:
       - name: video_in
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
     outputs:
       - name: video_out
-        schema: '@tatolab/core/VideoFrame@1.0.0'
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
-  - name: com.streamlib.test.configured_processor
+  - name: TestConfiguredProcessor
     version: 1.0.0
     description: "Test processor with config for attribute macro tests"
     execution: continuous

--- a/libs/streamlib/tests/attribute_macro_test.rs
+++ b/libs/streamlib/tests/attribute_macro_test.rs
@@ -83,6 +83,37 @@ fn test_processor_instantiation() {
     assert_eq!(processor.name(), "TestProcessor");
 }
 
+#[test]
+fn test_processor_schema_ident_resolves_from_package_block() {
+    // The macro emits `Processor::schema_ident()` returning the structured
+    // SchemaIdent composed from `streamlib.yaml`'s `package:` block plus
+    // the processor's PascalCase short name. This locks the codegen
+    // contract end-to-end: package metadata read, structured const emit,
+    // SchemaIdent::new + segment validators all wired through the
+    // generated module.
+    //
+    // Reverting the macro's `package:` resolution (e.g. hardcoding org)
+    // would flip this assertion — that's the regression the test guards.
+    let ident = TestProcessor::schema_ident();
+    assert_eq!(ident.org.as_str(), "tatolab");
+    assert_eq!(ident.package.as_str(), "streamlib");
+    assert_eq!(ident.r#type.as_str(), "TestProcessor");
+    assert_eq!(ident.version.major, 0);
+    assert_eq!(ident.version.minor, 4);
+    assert_eq!(ident.version.patch, 28);
+}
+
+#[test]
+fn test_processor_schema_ident_renders_canonical_joined_form() {
+    // The structured SchemaIdent's Display impl produces the canonical
+    // `@<org>/<package>/<Type>@<major.minor.patch>` joined form used by
+    // `max_payload_bytes_for_schema` and other lookup paths.
+    assert_eq!(
+        TestProcessor::schema_ident().to_string(),
+        "@tatolab/streamlib/TestProcessor@0.4.28"
+    );
+}
+
 // Test with config field
 #[derive(
     Debug,

--- a/libs/streamlib/tests/attribute_macro_test.rs
+++ b/libs/streamlib/tests/attribute_macro_test.rs
@@ -10,7 +10,7 @@ use streamlib::core::GeneratedProcessor;
 use streamlib::core::{EmptyConfig, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 
 // Define a simple processor using YAML schema
-#[streamlib::processor("com.streamlib.test.processor")]
+#[streamlib::processor("TestProcessor")]
 pub struct TestProcessor;
 
 // User implements the Processor trait on the generated Processor struct
@@ -80,7 +80,7 @@ fn test_processor_instantiation() {
     let processor = TestProcessor::Processor::from_config(EmptyConfig).unwrap();
 
     // Verify it has the expected name from YAML schema
-    assert_eq!(processor.name(), "com.streamlib.test.processor");
+    assert_eq!(processor.name(), "TestProcessor");
 }
 
 // Test with config field
@@ -103,7 +103,7 @@ mod _generated_ {
     pub use super::ConfiguredProcessorConfig;
 }
 
-#[streamlib::processor("com.streamlib.test.configured_processor")]
+#[streamlib::processor("TestConfiguredProcessor")]
 pub struct ConfiguredProcessor;
 
 impl streamlib::ContinuousProcessor for ConfiguredProcessor::Processor {

--- a/libs/streamlib/tests/ipc_payload_size_test.rs
+++ b/libs/streamlib/tests/ipc_payload_size_test.rs
@@ -19,9 +19,7 @@
 use std::time::{Duration, Instant};
 
 use iceoryx2::prelude::*;
-use streamlib::core::embedded_schemas::{
-    max_payload_bytes_for_schema, schema_ident_wire_from_joined,
-};
+use streamlib::core::embedded_schemas::max_payload_bytes_for_schema;
 use streamlib::iceoryx2::{
     FrameHeader, Iceoryx2Node, SchemaIdentWire, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE,
 };
@@ -250,8 +248,9 @@ fn test_frame_header_plus_256kb_roundtrip_through_slice_service() {
 
     let total_len = FRAME_HEADER_SIZE + data_size;
     let mut frame = vec![0u8; total_len];
-    let schema_ident = schema_ident_wire_from_joined("@tatolab/core/EncodedVideoFrame@1.0.0")
-        .expect("EncodedVideoFrame must resolve to structured wire bytes");
+    let schema_ident =
+        SchemaIdentWire::from_segments("tatolab", "core", "EncodedVideoFrame", 1, 0, 0)
+            .expect("EncodedVideoFrame segments fit SchemaIdentWire bounds");
     FrameHeader::new("dest_port", schema_ident, 42, data_size as u32)
         .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
     frame[FRAME_HEADER_SIZE..].copy_from_slice(&data);


### PR DESCRIPTION
## Summary

- Rewrites `#[streamlib::processor("Camera")]` to take a positional PascalCase short name; resolves `org`/`package`/`version` from sibling `streamlib.yaml`'s `package:` block; emits `Processor::schema_ident() -> SchemaIdent` plus structured `PortDescriptor.schema` literals.
- Migrates the engine type system: `PortDescriptor.schema`, `PortInfo.data_type`, `ProcessorPortSchema.schema` → new `PortSchemaSpec` enum (`Any | Specific(SchemaIdent)`). Manifest YAML accepts only `any` or 4-field structured maps; joined-string shorthand rejected at parse time.
- Sweeps every Rust processor decorator (~37 sites), `libs/streamlib/streamlib.yaml`, every Rust-side example manifest, and every Python/Deno polyglot manifest's port-schema declarations.
- Deletes the #401-phase-2 transitional adapter: `EMBEDDED_SCHEMA_IDENT_SEGMENTS` table, `lookup_schema_ident_segments`, `schema_ident_wire_from_joined`, `schema_ident_wire_for_producer`, `SchemaIdentSegments`, `SchemaIdentWireBuildError`. Producers now reach `SchemaIdentWire::from_segments` with structured fields directly.
- Architecture doc corrected via strike-through-and-supersession (`docs/architecture/schema-identity-and-packaging.md` — the previously-aspirational `#[streamlib::processor(name = "Camera")]` form was never the shipping shape).

## Closes
Closes #404

## Polyglot relaxation (deliberate)

The polyglot lockstep rule (`.claude/workflows/polyglot.md`) is relaxed for this PR after explicit user approval. Rationale:

- IPC wire format **unchanged** — engine-side serialization paths construct `SchemaIdentWire::from_segments(...)` from the new structured types, producing identical bytes on the wire.
- Python and Deno polyglot examples currently bypass their decorators entirely (only `cyberpunk_processor.py` uses the existing `@streamlib.processor(...)` decorator, and its `__streamlib_metadata__` dict has zero readers).
- Python (#700) and Deno (#701) decorator parity tickets are filed and blocked-by #404. The relaxation is bounded to authoring-side ergonomics; runtime behavior is identical across all three languages today and will remain so as #700/#701 land.
- Polyglot manifest YAMLs **were** migrated for runtime compatibility (engine parses them via the same parser that rejects joined strings). Their `package:` blocks lack `org:` and processor `name:` fields stay reverse-DNS — those migrate when #700/#701 land their decorator-side resolution.

## Sub-issues filed

- #700 — Python `@streamlib.processor` decorator parity with the Rust short-name macro
- #701 — Deno `@streamlib.processor` decorator parity with the Rust short-name macro
- #702 — Migrate `libs/streamlib/schemas/com.{tatolab,streamlib}.*@*.yaml` off reverse-DNS filenames

All three are blocked-by #404 in the *Schema Identity & Packaging* milestone.

## Deliberate scope cuts (documented for the trail)

- `ProcessorConfigSchema.schema` stays `String` because the on-disk schema files in `libs/streamlib/schemas/` keep their reverse-DNS filenames (deferred to #702). Once those rename, the type can join `PortSchemaSpec`-shaped structure.
- `processor_instance_factory.rs::schemas: HashSet<String>` keeps storing the `Display` form of `PortSchemaSpec` rather than holding `PortSchemaSpec` natively. The public surface (`known_schemas() -> Vec<String>`, `is_schema_known(&str)`) is preserved — internal cache shape is a non-load-bearing scope cut.
- `max_payload_bytes_for_schema(&str)` retained alongside the new `max_payload_bytes_for_port_spec(&PortSchemaSpec)`. Test code uses the `&str` form; production callers use the typed form.

## Polyglot coverage

- **Runtimes affected**: rust + manifest YAMLs across all three runtimes (decorator parity for python/deno is in #700/#701).
- **Schema regenerated**: n/a (no schema changes).
- **Python and Deno both covered?** Paired tickets #700 + #701, blocked-by this PR, in the same milestone.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test --workspace --all-targets` — 132 test suites, 0 failures
  - [x] Python subprocess: covered by `polyglot_manual_source_python` integration test (passes)
  - [x] Deno subprocess: covered by `polyglot_manual_source_deno` integration test (passes)
- **FD-passing path**: n/a (no surface-share / FD changes).

## Test plan

- [x] Macro unit tests: short name + manifest fixture → expected structured const (`test_processor_schema_ident_resolves_from_package_block`, `test_processor_schema_ident_renders_canonical_joined_form` in `attribute_macro_test.rs`).
- [x] `streamlib-idents` 4-field manifest port-shape parser tests; `joined_string_is_not_a_valid_yaml_shape` continues to pass.
- [x] `cargo build --workspace`: clean.
- [x] `cargo test --workspace --all-targets`: 132 test suites pass, 0 failures (full output captured at `/tmp/final-test-2.log` during the final test gate).
- [x] Workspace grep gate: zero live-code reverse-DNS schema literals in Rust source outside (a) doc comments referencing legacy schema files, (b) macOS `DispatchQueue` labels (Cocoa platform conventions, not StreamLib semantics), (c) `_generated_::com_tatolab_*` paths from JTD codegen of the still-reverse-DNS schemas (#702).

## Pre-PR review gate

`pr-review-gate` was run with verdict DISCUSS surfacing 5 items. Three were verified and addressed in commit `17a8d21`:

1. Removed dead `_schema_ident: &SchemaIdent` parameter threaded through `generate_processor_impl_from_schema` → `generate_descriptor_from_schema`.
2. Added the missing macro-emission tests (`test_processor_schema_ident_*`) the issue's exit criterion called for.
3. Relaxed `parse_processor_yaml`'s reverse-DNS gate so the CLI accepts both legacy and the new PascalCase shape.

The remaining two DISCUSS items (the `HashSet<String>` schema cache and the polyglot manifest `org:` deferral) are documented as deliberate scope cuts above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)