### PR TITLE
feat(python): @processor decorator parity with structured SchemaIdent

### DIFF
--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -481,30 +481,52 @@ it in your `streamlib.yaml`; nothing else. Hand-curated match arms
 mapping schema IDs to embedded YAML strings are not allowed — they
 silently drift when a schema renames or is added.
 
-## Why no Python / Deno parity in v1
+## Polyglot SchemaIdent parity
 
-The `streamlib-idents` crate ships Rust-only. Python and Deno do
-not get matching `SchemaIdent` validators / range matchers in v1 —
-deliberately scope-cut.
+The `streamlib-idents` crate's full surface (range matching,
+lockfile read/write, content-hash resolver, codegen pipeline)
+is Rust-only. The Python SDK carries a focused subset matched
+to the authoring path:
 
-The reason is structural, not ergonomic: **structured-everywhere
-eliminates the need for non-Rust callers to validate identifiers.**
-Python and Deno consume `SchemaIdent` records that have already been
-validated upstream (by codegen at build time, or by the Rust host
-on inbound IPC). No subprocess-side parser exists, because no
-subprocess-side parsing happens.
+- **`streamlib.SchemaIdent`** — frozen dataclass mirroring the
+  Rust 4-field shape with the same regex-validating constructors
+  (org / package / type / version follow the same grammar that
+  `streamlib_idents::Org` / `Package` / `TypeName` / `SemVer`
+  enforce). No `parse` / `from_str` API; the joined `__str__` form
+  is render-only and never round-trips through a parser.
+- **`streamlib._manifest`** — hand-rolled minimal YAML reader
+  that extracts the `package: { org, name, version }` block plus
+  the processor-name list. Avoids adding PyYAML as the SDK's first
+  runtime dep. Full manifest deserialization stays Rust-side.
+- **`@streamlib.processor("PascalCase")`** — mirrors Rust's
+  `#[streamlib::processor("Camera")]` proc-macro: positional
+  PascalCase short name resolved at decoration time against the
+  enclosing package's `streamlib.yaml`. The decorator validates
+  that the short name appears in the manifest's `processors:`
+  list and attaches `__streamlib_schema_ident__: SchemaIdent` to
+  the class.
+- **`@streamlib.input(schema=...)` / `@streamlib.output(schema=...)`**
+  — accept a `SchemaIdent` instance or a class that carries
+  `__streamlib_schema_ident__`. Bare-string and joined-string
+  forms are rejected at decoration time, mirroring the no-parse
+  invariant on the Rust side.
 
-If a future non-Rust caller actually needs to validate identifiers
-locally (e.g. a Python tool authoring `streamlib.yaml` programmatically),
-file a follow-up at that point. Building three parser-parity test
-corpora upfront for hypothetical consumers is exactly the burden the
-structured-everywhere decision exists to eliminate.
+The reason for the focused subset rather than full parity:
+structured-everywhere eliminates the need for non-Rust callers to
+*validate identifiers* at runtime. Polyglot SDKs consume already-
+validated records produced by Rust codegen or inbound IPC. The
+Python SDK's local validators run only at authoring time —
+guarding against manifest-vs-decorator drift, not validating
+wire-format input.
 
-This is the same shape as the polyglot rule's escape clause
+Range matching, lockfile resolution, and the codegen pipeline
+stay Rust-side because no non-Rust caller currently exercises
+them. This matches the polyglot rule's escape clause
 (`.claude/workflows/polyglot.md`): *"the only legitimate split is
-schema-only / language-specific by construction"* — here the split is
-"language-specific by construction," because the design eliminates
-the cross-language need.
+schema-only / language-specific by construction"* — the deeper
+crate functionality (range matching, lockfile, codegen) is
+"language-specific by construction" while basic identity
+validation is mirrored across runtimes that need it.
 
 ## Reference
 
@@ -533,6 +555,16 @@ the cross-language need.
   - `.github/workflows/check-schema-versions.yml` — schema-version CI gate.
   - `.github/workflows/check-no-streamlib-metadata.yml` —
     legacy-metadata CI gate.
+  - `libs/streamlib-python/python/streamlib/schema_ident.py` —
+    Python `SchemaIdent` dataclass with regex-validating
+    constructors and render-only joined `__str__`.
+  - `libs/streamlib-python/python/streamlib/_manifest.py` —
+    hand-rolled minimal YAML reader for `package:` block +
+    `processors[].name` list.
+  - `libs/streamlib-python/python/streamlib/decorators.py` —
+    `@processor("PascalCase")` / `@input` / `@output`
+    decorators; manifest-driven structured ident attached at
+    decoration time.
 - **Tests**:
   - `libs/streamlib-idents/src/{ident,semver,manifest,lockfile,resolver}.rs::tests`
     — unit tests covering grammar conformance, semver-range matching,
@@ -554,6 +586,14 @@ the cross-language need.
     lint fixtures.
   - `xtask/src/check_no_streamlib_metadata.rs::tests` —
     legacy-metadata lint fixtures.
+  - `libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py`
+    — `SchemaIdent` validation, `@processor` manifest-driven
+    decoration paths, `@input` / `@output` schema rejection of
+    bare-string and joined-string forms.
+  - `libs/streamlib-python/python/streamlib/tests/test_manifest_reader.py`
+    — minimal YAML reader edge cases (quoted scalars, comments,
+    nested processor bodies, missing fields, name-first ordering
+    constraint).
 - **Sibling architecture docs**:
   - [`compute-kernel.md`](compute-kernel.md), [`graphics-kernel.md`](graphics-kernel.md),
     [`ray-tracing-kernel.md`](ray-tracing-kernel.md) — the kernel-shape

--- a/examples/camera-python-display/python/cyberpunk_processor.py
+++ b/examples/camera-python-display/python/cyberpunk_processor.py
@@ -17,9 +17,12 @@ import math
 
 import skia
 
-from streamlib import processor, input, output
+from streamlib import SchemaIdent, processor, input, output
 
 logger = logging.getLogger(__name__)
+
+# Cross-package schema reference — declared once and reused on every port.
+VIDEO_FRAME = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
 
 # OpenGL constants (not exposed by skia-python)
 GL_RGBA8 = 0x8058
@@ -175,7 +178,7 @@ def draw_spray_paint_tag(canvas, x, y, scale=1.0, time_offset=0.0):
 # Cyberpunk Processor
 # =============================================================================
 
-@processor(name="CyberpunkProcessor", description="Cyberpunk overlay with Skia GPU rendering")
+@processor("CyberpunkProcessor")
 class CyberpunkProcessor:
     """Applies cyberpunk color grading and spray paint watermark using Skia.
 
@@ -187,11 +190,11 @@ class CyberpunkProcessor:
     - Stable GL texture IDs (create once, update per-frame)
     """
 
-    @input(schema="VideoFrame")
+    @input(schema=VIDEO_FRAME)
     def video_in(self):
         pass
 
-    @output(schema="VideoFrame")
+    @output(schema=VIDEO_FRAME)
     def video_out(self):
         pass
 

--- a/examples/camera-python-display/python/streamlib.yaml
+++ b/examples/camera-python-display/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: cyberpunk-processor
   version: "0.1.0"
   description: "Cyberpunk video overlay processors using isolated subprocess architecture"
 
 processors:
-  - name: com.tatolab.avatar_character
+  - name: AvatarCharacter
     version: "1.0.0"
     description: "MediaPipe pose detection + stylized 3D character as PiP overlay"
     runtime: python
@@ -17,7 +18,7 @@ processors:
       - name: video_out
         schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
-  - name: com.tatolab.cyberpunk_lower_third
+  - name: CyberpunkLowerThird
     version: "1.0.0"
     description: "Cyberpunk animated lower third overlay — continuous RGBA generator"
     runtime: python
@@ -29,7 +30,7 @@ processors:
       - name: video_out
         schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
-  - name: com.tatolab.cyberpunk_watermark
+  - name: CyberpunkWatermark
     version: "1.0.0"
     description: "Spray paint style watermark overlay — continuous RGBA generator"
     runtime: python
@@ -41,12 +42,25 @@ processors:
       - name: video_out
         schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
-  - name: com.tatolab.cyberpunk_glitch
+  - name: CyberpunkGlitch
     version: "1.0.0"
     description: "Glitch post-processing — RGB separation, scanlines, slice displacement"
     runtime: python
     execution: reactive
     entrypoint: "cyberpunk_glitch:CyberpunkGlitch"
+    inputs:
+      - name: video_in
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
+    outputs:
+      - name: video_out
+        schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
+
+  - name: CyberpunkProcessor
+    version: "1.0.0"
+    description: "Cyberpunk overlay with Skia GPU rendering — reference @processor adopter"
+    runtime: python
+    execution: reactive
+    entrypoint: "cyberpunk_processor:CyberpunkProcessor"
     inputs:
       - name: video_in
         schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -227,7 +227,7 @@ pub fn main() -> Result<()> {
     // opengl DMA-BUF surface, emits the surface UUID downstream.
     println!("🐍 Adding Python avatar character (subprocess, PyTorch pose + ModernGL)...");
     let avatar = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.avatar_character",
+        "AvatarCharacter",
         serde_json::json!({
             "cuda_camera_surface_id": AVATAR_CAMERA_CUDA_SURFACE_ID,
             "opengl_output_surface_uuid": AVATAR_OUTPUT_SURFACE_UUID,
@@ -243,7 +243,7 @@ pub fn main() -> Result<()> {
     // SkiaContext.acquire_write.
     println!("🐍 Adding Python cyberpunk lower third (subprocess, Skia-on-GL)...");
     let lower_third = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.cyberpunk_lower_third",
+        "CyberpunkLowerThird",
         serde_json::json!({
             "output_surface_uuid": LOWER_THIRD_OUTPUT_SURFACE_UUID,
             "width": SURFACE_WIDTH,
@@ -256,7 +256,7 @@ pub fn main() -> Result<()> {
     // as lower-third — distinct UUID, same allocation pattern.
     println!("🐍 Adding Python cyberpunk watermark (subprocess, Skia-on-GL)...");
     let watermark = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.cyberpunk_watermark",
+        "CyberpunkWatermark",
         serde_json::json!({
             "output_surface_uuid": WATERMARK_OUTPUT_SURFACE_UUID,
             "width": SURFACE_WIDTH,
@@ -300,7 +300,7 @@ pub fn main() -> Result<()> {
     // `cyberpunk_glitch.py::GlitchState`).
     println!("🐍 Adding Python cyberpunk glitch (subprocess, OpenGL fragment shader)...");
     let glitch = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.cyberpunk_glitch",
+        "CyberpunkGlitch",
         serde_json::json!({
             "output_surface_uuid": GLITCH_OUTPUT_SURFACE_UUID,
             "width": SURFACE_WIDTH,

--- a/examples/camera-python-subprocess/python/streamlib.yaml
+++ b/examples/camera-python-subprocess/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: camera-python-subprocess
   version: "0.1.0"
   description: "Grayscale processor — converts video frames to grayscale via Python subprocess"
 
 processors:
-  - name: com.tatolab.grayscale
+  - name: Grayscale
     version: "1.0.0"
     description: "Grayscale processor — converts video frames to grayscale via Python subprocess"
     runtime: python

--- a/examples/camera-python-subprocess/src/main.rs
+++ b/examples/camera-python-subprocess/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
     }))?;
 
     let grayscale = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.grayscale",
+        "Grayscale",
         serde_json::json!({}),
     ))?;
 

--- a/examples/polyglot-continuous-processor/python/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-continuous-processor
   version: "0.1.0"
   description: "Polyglot continuous processor (#542) — Python process() driven by monotonic-clock timerfd"
 
 processors:
-  - name: com.tatolab.polyglot_continuous_processor
+  - name: PolyglotContinuousProcessor
     version: "1.0.0"
     description: "Continuous processor: process() called by the runner at interval_ms cadence (now timerfd-paced); each call writes the tick count + a monotonic timestamp into the host cpu-readback surface. Reference example for the no-time.sleep pacing contract."
     runtime: python

--- a/examples/polyglot-continuous-processor/src/main.rs
+++ b/examples/polyglot-continuous-processor/src/main.rs
@@ -87,7 +87,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.polyglot_continuous_processor",
+            Self::Python => "PolyglotContinuousProcessor",
             Self::Deno => "com.tatolab.polyglot_continuous_processor_deno",
         }
     }

--- a/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-cpu-readback-blur
   version: "0.1.0"
   description: "Polyglot cpu-readback adapter blur (#529) — Python cv2.GaussianBlur with numpy fallback"
 
 processors:
-  - name: com.tatolab.cpu_readback_blur
+  - name: CpuReadbackBlur
     version: "1.0.0"
     description: "Acquires a host-pre-registered cpu-readback surface, applies a Gaussian blur, releases"
     runtime: python

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -99,7 +99,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.cpu_readback_blur",
+            Self::Python => "CpuReadbackBlur",
             Self::Deno => "com.tatolab.cpu_readback_blur_deno",
         }
     }

--- a/examples/polyglot-cuda-inference/python/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-cuda-inference
   version: "0.1.0"
   description: "Polyglot CUDA adapter inference (#591) — YOLOv8n on a host OPAQUE_FD VkBuffer via DLPack zero-copy"
 
 processors:
-  - name: com.tatolab.cuda_inference
+  - name: CudaInference
     version: "1.0.0"
     description: "Acquires a host-pre-registered cuda OPAQUE_FD surface, uploads a test image, runs YOLOv8n via torch.from_dlpack, writes annotated PNG"
     runtime: python

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -98,7 +98,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.cuda_inference",
+            Self::Python => "CudaInference",
             Self::Deno => "com.tatolab.cuda_inference_deno",
         }
     }

--- a/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-dma-buf-consumer
   version: "0.1.0"
   description: "Linux DMA-BUF consumer — resolves host camera surfaces via the surface-share service"
 
 processors:
-  - name: com.tatolab.dma_buf_consumer
+  - name: DmaBufConsumer
     version: "1.0.0"
     description: "Resolves an upstream surface_id to a DMA-BUF, locks/reads it, and forwards the frame downstream"
     runtime: python

--- a/examples/polyglot-dma-buf-consumer/src/main.rs
+++ b/examples/polyglot-dma-buf-consumer/src/main.rs
@@ -59,7 +59,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.dma_buf_consumer",
+            Self::Python => "DmaBufConsumer",
             Self::Deno => "com.tatolab.dma_buf_consumer_deno",
         }
     }

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-manual-source
   version: "0.1.0"
   description: "Polyglot manual source (#542 / #604) — Python worker thread paced by MonotonicTimer publishes Videoframes via iceoryx2"
 
 processors:
-  - name: com.tatolab.polyglot_manual_source
+  - name: PolyglotManualSource
     version: "1.0.0"
     description: "Manual source: spawns a worker thread in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-thread iceoryx2 publish path."
     runtime: python

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -84,7 +84,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.polyglot_manual_source",
+            Self::Python => "PolyglotManualSource",
             Self::Deno => "com.tatolab.polyglot_manual_source_deno",
         }
     }

--- a/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-opengl-fragment-shader
   version: "0.1.0"
   description: "Polyglot OpenGL adapter scenario (#530) — Python Mandelbrot fragment shader rendered into a host DMA-BUF surface"
 
 processors:
-  - name: com.tatolab.opengl_fragment_shader
+  - name: OpenGlFragmentShader
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a Mandelbrot fragment shader, releases"
     runtime: python

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -73,7 +73,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.opengl_fragment_shader",
+            Self::Python => "OpenGlFragmentShader",
             Self::Deno => "com.tatolab.opengl_fragment_shader_deno",
         }
     }

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-skia-canvas
   version: "0.1.0"
   description: "Polyglot Skia adapter scenario (#577) — Python Skia processor (composed on the OpenGL adapter via skia-python's GrDirectContext.MakeGL) draws a canvas into a host DMA-BUF VkImage via streamlib.adapters.skia.SkiaContext"
 
 processors:
-  - name: com.tatolab.skia_canvas
+  - name: SkiaCanvas
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a skia.Surface, draws a known shape, releases"
     runtime: python

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
         "fps": FPS,
     });
     let canvas = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.skia_canvas",
+        "SkiaCanvas",
         canvas_config,
     ))?;
     println!("+ Skia canvas processor: {canvas}");

--- a/examples/polyglot-vulkan-compute/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-compute
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#531) — Python Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage"
 
 processors:
-  - name: com.tatolab.vulkan_compute
+  - name: VulkanCompute
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
     runtime: python

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -88,7 +88,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.vulkan_compute",
+            Self::Python => "VulkanCompute",
             Self::Deno => "com.tatolab.vulkan_compute_deno",
         }
     }

--- a/examples/polyglot-vulkan-graphics/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-graphics
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#656) — Python triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage"
 
 processors:
-  - name: com.tatolab.vulkan_graphics
+  - name: VulkanGraphics
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
     runtime: python

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -99,7 +99,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.vulkan_graphics",
+            Self::Python => "VulkanGraphics",
             Self::Deno => "com.tatolab.vulkan_graphics_deno",
         }
     }

--- a/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-ray-tracing
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#667) — Python ray-traced triangle via host VulkanRayTracingKernel + AS escalate IPC"
 
 processors:
-  - name: com.tatolab.vulkan_ray_tracing
+  - name: VulkanRayTracing
     version: "1.0.0"
     description: "Builds a single-triangle BLAS + identity TLAS via escalate IPC, registers an RT kernel, and dispatches one trace into a host-pre-registered storage image"
     runtime: python

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -104,7 +104,7 @@ impl RuntimeKind {
 
     fn processor_name(self) -> &'static str {
         match self {
-            Self::Python => "com.tatolab.vulkan_ray_tracing",
+            Self::Python => "VulkanRayTracing",
             Self::Deno => "com.tatolab.vulkan_ray_tracing_deno",
         }
     }

--- a/libs/streamlib-python/python/streamlib/__init__.py
+++ b/libs/streamlib-python/python/streamlib/__init__.py
@@ -56,10 +56,10 @@ from .decorators import (
     u32,
     u64,
     bool_field,
-    # Deprecated aliases
-    input_port,
-    output_port,
 )
+
+# Structured schema identity (mirrors Rust's streamlib_idents::SchemaIdent)
+from .schema_ident import SchemaIdent
 
 # Re-export capability-typed runtime context views for processor authors
 from .processor_context import (
@@ -96,9 +96,8 @@ __all__ = [
     "u32",
     "u64",
     "bool_field",
-    # Deprecated aliases
-    "input_port",
-    "output_port",
+    # Structured schema identity
+    "SchemaIdent",
     "PixelFormat",
     # Capability-typed runtime context
     "RuntimeContextFullAccess",

--- a/libs/streamlib-python/python/streamlib/_manifest.py
+++ b/libs/streamlib-python/python/streamlib/_manifest.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Minimal hand-rolled YAML reader for `streamlib.yaml` package metadata.
+
+Reads only the shape needed by the `@processor` / `@schema` decorators:
+
+- top-level `package: { org, name, version, ... }` block
+- top-level `processors:` list, returning the `name` of each entry
+
+A full YAML parser would require PyYAML, which would be the SDK's first
+runtime dep. The streamlib.yaml shape is constrained enough that a focused
+line-oriented reader suffices: 2-space indented mappings, sequence items
+prefixed by `-`, comments, blank lines, optional single/double quotes
+around scalars. Anything more complex (anchors, multi-line strings, flow
+style outside `{ a: b }`) is out of scope for this reader.
+
+The full manifest is parsed by the Rust runtime via `serde_yaml` when the
+host loads it; this reader only needs enough fields to validate the
+decorator's short name and compose a structured `SchemaIdent`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ManifestPackage:
+    """Resolved `package:` block from streamlib.yaml."""
+
+    org: str
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class ManifestSummary:
+    """Decorator-side view of a streamlib.yaml.
+
+    Carries the package metadata and the set of processor names declared
+    in the manifest — enough for the decorator to validate that its
+    short-name argument matches an entry the manifest declares.
+    """
+
+    package: ManifestPackage
+    processor_names: List[str]
+
+
+class ManifestParseError(ValueError):
+    """Raised when a streamlib.yaml cannot be parsed for decorator use."""
+
+
+def read_manifest_summary(path: Path) -> ManifestSummary:
+    """Parse the package block + processors[].name list from a streamlib.yaml.
+
+    Raises:
+        FileNotFoundError: if `path` does not exist.
+        ManifestParseError: if the manifest is missing `package:`, missing
+            any of `org`/`name`/`version`, or malformed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+
+    text = path.read_text(encoding="utf-8")
+    org, name, version, processor_names = _scan(text, path)
+
+    missing = [field for field, val in (("org", org), ("name", name), ("version", version)) if val is None]
+    if missing:
+        raise ManifestParseError(
+            f"streamlib.yaml at {path} is missing required `package:` field(s): "
+            f"{', '.join(missing)}. The decorator requires `package: {{ org, name, version }}` "
+            f"to construct a structured SchemaIdent."
+        )
+
+    return ManifestSummary(
+        package=ManifestPackage(org=org, name=name, version=version),
+        processor_names=processor_names,
+    )
+
+
+def _scan(
+    text: str, path: Path
+) -> Tuple[Optional[str], Optional[str], Optional[str], List[str]]:
+    org: Optional[str] = None
+    name: Optional[str] = None
+    version: Optional[str] = None
+    processor_names: List[str] = []
+
+    section: Optional[str] = None  # "package" | "processors" | None
+
+    for raw in text.splitlines():
+        line = _strip_comment(raw).rstrip()
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip())
+        content = line.lstrip()
+
+        if indent == 0:
+            if content.rstrip(":") == "package" and content.endswith(":"):
+                section = "package"
+            elif content.rstrip(":") == "processors" and content.endswith(":"):
+                section = "processors"
+            else:
+                section = None
+            continue
+
+        if section == "package" and indent == 2 and ":" in content:
+            key, _, val = content.partition(":")
+            key = key.strip()
+            val = _strip_quotes(val.strip())
+            if key == "org":
+                org = val
+            elif key == "name":
+                name = val
+            elif key == "version":
+                version = val
+
+        elif section == "processors" and indent == 2 and content.startswith("- "):
+            # Sequence item start. We assume `name:` is the first key per the
+            # repo convention; if a future manifest reorders, extend this.
+            rest = content[2:].lstrip()
+            if rest.startswith("name:"):
+                _, _, val = rest.partition(":")
+                val = _strip_quotes(val.strip())
+                if val:
+                    processor_names.append(val)
+            else:
+                raise ManifestParseError(
+                    f"streamlib.yaml at {path} has a processor entry whose first "
+                    f"key is not `name:` — the decorator's manifest reader only "
+                    f"supports `name`-first ordering. Got: {content!r}"
+                )
+
+    return org, name, version, processor_names
+
+
+def _strip_quotes(s: str) -> str:
+    """Strip a single surrounding pair of double or single quotes."""
+    if len(s) >= 2 and ((s[0] == s[-1] == '"') or (s[0] == s[-1] == "'")):
+        return s[1:-1]
+    return s
+
+
+def _strip_comment(s: str) -> str:
+    """Strip a trailing `# ...` comment when `#` is whitespace-preceded.
+
+    Plays it safe around `#` characters embedded in string values: only
+    strips when the `#` follows whitespace and is outside of a quoted
+    region.
+    """
+    in_quote: Optional[str] = None
+    for i, c in enumerate(s):
+        if c in ('"', "'"):
+            if in_quote is None:
+                in_quote = c
+            elif in_quote == c:
+                in_quote = None
+        elif c == "#" and in_quote is None:
+            if i == 0 or s[i - 1].isspace():
+                return s[:i].rstrip()
+    return s

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -3,13 +3,19 @@
 
 """Decorators for defining StreamLib processors and schemas in Python.
 
-These decorators mark Python classes as StreamLib processors and define
-their input/output ports. The metadata is extracted by PythonHostProcessor
-to integrate with the Rust runtime.
+`@processor("PascalCase")` mirrors Rust's `#[streamlib::processor("Camera")]`
+proc-macro: a positional PascalCase short name that the decorator resolves
+against the sibling `streamlib.yaml`'s `package: { org, name, version }`
+block at decoration time. The result is a structured
+[`SchemaIdent`][streamlib.schema_ident.SchemaIdent] attached to the class
+as `__streamlib_schema_ident__`.
 
-Schema decorators allow defining custom data schemas that are backed by
-Rust's DynamicDataFrameSchema, enabling seamless data flow between Python
-and Rust processors.
+Schema references in port declarations (`@input(schema=...)` /
+`@output(schema=...)`) are cross-package by definition. The only accepted
+forms are a `SchemaIdent` instance or a `@schema`-decorated class. Bare
+type names and joined-string identifiers are rejected — see the
+architecture preamble in issue #700 and
+`docs/architecture/schema-identity-and-packaging.md`.
 
 Timestamps
 ----------
@@ -29,7 +35,15 @@ APIs are still appropriate for ISO8601 formatting and other genuinely
 human-facing display.
 """
 
-from typing import Optional, Union, List, Type
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+from typing import List, Optional, Type, Union
+
+from ._manifest import ManifestParseError, read_manifest_summary
+from .schema_ident import SchemaIdent
 
 
 # =============================================================================
@@ -40,8 +54,9 @@ from typing import Optional, Union, List, Type
 class SchemaField:
     """Descriptor for a field in a schema.
 
-    Used internally by field descriptor functions (f32, i64, etc.) to define
-    schema fields. The @schema decorator collects these to build the schema.
+    Used by the field descriptor functions (f32, i64, etc.) to define
+    schema fields. The @schema decorator collects these into a
+    Rust-backed DynamicDataFrameSchema.
     """
 
     def __init__(
@@ -61,18 +76,7 @@ class SchemaField:
 
 
 def f32(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 32-bit float field.
-
-    Args:
-        shape: Array dimensions. Empty/None for scalar, [512] for 1D array, [4, 4] for 2D.
-        description: Human-readable description.
-
-    Example:
-        @schema(name="embedding")
-        class EmbeddingSchema:
-            vector = f32(shape=[512], description="Feature vector")
-            confidence = f32(description="Confidence score")
-    """
+    """Define a 32-bit float field."""
     return SchemaField("f32", shape, description)
 
 
@@ -104,13 +108,13 @@ def u64(shape: Optional[List[int]] = None, description: str = "") -> SchemaField
 def bool_field(description: str = "") -> SchemaField:
     """Define a boolean field.
 
-    Note: Named bool_field to avoid shadowing Python's bool builtin.
+    Named ``bool_field`` to avoid shadowing Python's ``bool`` builtin.
     """
     return SchemaField("bool", None, description)
 
 
 # =============================================================================
-# Schema Decorator
+# Schema Decorator (untouched here; structured-ident parity tracked in #704)
 # =============================================================================
 
 
@@ -121,27 +125,15 @@ def schema(name: Optional[str] = None):
     instances (created via f32, i64, bool_field, etc.). The decorator
     collects these fields and creates a Rust-backed DynamicDataFrameSchema.
 
-    Args:
-        name: Schema name for registry. Defaults to class name.
-
-    Example:
-        @schema(name="clip_embedding")
-        class ClipEmbeddingSchema:
-            embedding = f32(shape=[512], description="CLIP embedding vector")
-            timestamp = i64(description="Timestamp in nanoseconds")
-            normalized = bool_field(description="Whether embedding is normalized")
-
-        # Use in processor:
-        @processor(name="EmbeddingProcessor")
-        class EmbeddingProcessor:
-            @output(schema=ClipEmbeddingSchema)
-            def embedding_out(self): pass
+    NOTE: The structured-`SchemaIdent` parity migration for `@schema`
+    tracks in issue #704 (filed alongside #700). This decorator's shape
+    is unchanged in #700 — it still attaches a `__streamlib_schema__` dict
+    carrier; #704 replaces that with `__streamlib_schema_ident__: SchemaIdent`.
     """
 
     def decorator(cls):
         schema_name = name or cls.__name__
 
-        # Collect field definitions from class attributes
         fields = []
         for attr_name in dir(cls):
             if attr_name.startswith("_"):
@@ -157,7 +149,6 @@ def schema(name: Optional[str] = None):
                     }
                 )
 
-        # Store metadata on class
         cls.__streamlib_schema__ = {
             "name": schema_name,
             "fields": fields,
@@ -168,116 +159,89 @@ def schema(name: Optional[str] = None):
     return decorator
 
 
-def _get_schema_name(schema_arg: Union[str, Type, None]) -> Optional[str]:
-    """Extract schema name from string or schema class."""
-    if schema_arg is None:
-        return None
-    if isinstance(schema_arg, str):
-        return schema_arg
-    # Check if it's a schema-decorated class
-    if hasattr(schema_arg, "__streamlib_schema__"):
-        return schema_arg.__streamlib_schema__["name"]
-    # Fallback to class name
-    if isinstance(schema_arg, type):
-        return schema_arg.__name__
-    return None
-
-
 # =============================================================================
-# Processor Decorators
+# Processor Decorator
 # =============================================================================
 
 
-def processor(
-    name: Optional[str] = None,
-    description: str = "",
-    execution: str = "Reactive",
-):
-    """Mark a class as a StreamLib processor.
+def processor(short_name: str):
+    """Mark a class as a StreamLib processor (PascalCase positional short name).
 
-    The decorated class should define input/output ports using @input
-    and @output decorators on methods, and implement the appropriate
-    methods for the execution mode.
+    Mirrors Rust's `#[streamlib::processor("Camera")]` macro. At decoration
+    time, the decorator locates the sibling `streamlib.yaml` (next to the
+    file containing the decorated class), reads its
+    `package: { org, name, version }` block, validates that `short_name`
+    appears in the manifest's `processors:` list, and constructs a
+    structured `SchemaIdent` attached to the class as
+    `__streamlib_schema_ident__`.
 
     Args:
-        name: Processor name for registry. Defaults to class name.
-        description: Human-readable description.
-        execution: Execution mode - one of:
-            - "Reactive": process() called when input data arrives.
-              Use for transforms, filters, effects, encoders, decoders.
-            - "Continuous": process() called repeatedly at a fixed
-              interval. The runner paces calls via a monotonic
-              timerfd (`streamlib.MonotonicTimer`); do NOT use
-              `time.sleep` inside `process()` — return promptly.
-              Use for generators, sources, polling, batch processing.
-            - "Manual": `start()` is called once with full ctx; you
-              own the lifecycle from there.
-              Use for hardware callbacks, display vsync, cameras.
+        short_name: PascalCase type name. Must match an entry in the
+            sibling manifest's `processors:` list.
 
-              **`start()` MUST return promptly.** The subprocess
-              runner's command loop only iterates after `start()`
-              returns; a long-running `while True:` here will
-              block lifecycle messages (`stop` / `teardown`) and
-              the host falls through to a 5-second SIGKILL after
-              timeout. Spawn a worker thread for any ongoing work
-              and return — see
-              ``examples/polyglot-manual-source/`` for the
-              canonical pattern (worker + ``streamlib.MonotonicTimer``
-              for drift-free pacing).
+    Raises:
+        FileNotFoundError: if no sibling `streamlib.yaml` is found.
+        ManifestParseError: if the manifest is malformed or missing
+            required `package:` fields.
+        ValueError: if `short_name` is not declared in the manifest.
 
-    Required methods by execution mode:
-        Reactive/Continuous:
-            - process(self, ctx): Called to process data.
+    Example:
+        ```python
+        from streamlib import processor
 
-        Manual:
-            - start(self, ctx): Called once to start the processor.
-              Must return promptly — spawn a worker thread for any
-              ongoing work.
-            - stop(self, ctx): Optional, called when stopping. Should
-              signal the worker thread to exit and join it.
+        @processor("CyberpunkProcessor")
+        class CyberpunkProcessor:
+            ...
+        ```
 
-    Optional lifecycle methods (all modes):
-        - setup(self, ctx): Called once at startup.
-        - teardown(self, ctx): Called once at shutdown.
-        - on_pause(self, ctx): Called when processor is paused.
-        - on_resume(self, ctx): Called when processor is resumed.
-
-    Example (Reactive):
-        @processor(name="GrayscaleProcessor", execution="Reactive")
-        class GrayscaleProcessor:
-            @input(schema="VideoFrame")
-            def video_in(self): pass
-
-            @output(schema="VideoFrame")
-            def video_out(self): pass
-
-            def process(self, ctx):
-                frame = ctx.input("video_in").get()
-                if frame:
-                    # Process frame...
-                    ctx.output("video_out").set(result)
-
-    Example (Manual):
-        @processor(name="CameraSource", execution="Manual")
-        class CameraSource:
-            @output(schema="VideoFrame")
-            def video_out(self): pass
-
-            def start(self, ctx):
-                # Start camera capture, register callbacks
-                self.camera = Camera()
-                self.camera.on_frame(lambda f: ctx.output("video_out").set(f))
-                self.camera.start()
-
-            def stop(self, ctx):
-                self.camera.stop()
+    Wire format and IPC always carry the full structured `SchemaIdent`;
+    the short-name positional is an authoring convenience for the
+    processor's own identity declaration only — schema references in
+    port declarations (`@input(schema=...)` / `@output(schema=...)`)
+    have no analogous shorthand and require a structured carrier.
     """
+    if not isinstance(short_name, str):
+        raise TypeError(
+            f"@processor() takes a positional PascalCase short name (str); "
+            f"got {type(short_name).__name__}. The legacy `name=`/`description=`/"
+            f"`execution=` kwarg form is removed (pre-1.0 policy)."
+        )
 
     def decorator(cls):
-        # Collect port metadata from decorated methods
+        manifest_path = _locate_sibling_manifest(cls)
+        try:
+            summary = read_manifest_summary(manifest_path)
+        except ManifestParseError:
+            raise
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"streamlib.yaml not found at {manifest_path}. "
+                f"@processor({short_name!r}) requires a sibling streamlib.yaml "
+                f"with a `package: {{ org, name, version }}` block and a matching "
+                f"`processors:` entry."
+            ) from exc
+
+        if short_name not in summary.processor_names:
+            available = "\n    ".join(summary.processor_names) or "(none declared)"
+            raise ValueError(
+                f"@processor({short_name!r}): short name not declared in "
+                f"{manifest_path}'s `processors:` list. Available processors:\n    "
+                f"{available}"
+            )
+
+        ident = SchemaIdent(
+            org=summary.package.org,
+            package=summary.package.name,
+            type_=short_name,
+            version=summary.package.version,
+        )
+        cls.__streamlib_schema_ident__ = ident
+
+        # Collect port metadata declared by @input / @output for runtime
+        # introspection. Port schemas are already SchemaIdent instances at
+        # this point (see _resolve_schema_ident below).
         inputs = []
         outputs = []
-
         for attr_name in dir(cls):
             attr = getattr(cls, attr_name, None)
             if callable(attr):
@@ -285,47 +249,71 @@ def processor(
                     inputs.append(attr._streamlib_input_port)
                 if hasattr(attr, "_streamlib_output_port"):
                     outputs.append(attr._streamlib_output_port)
-
-        # Store metadata on class for extraction by PythonHostProcessor
-        cls.__streamlib_metadata__ = {
-            "name": name or cls.__name__,
-            "description": description,
-            "execution": execution,
-            "inputs": inputs,
-            "outputs": outputs,
-        }
+        cls.__streamlib_ports__ = {"inputs": inputs, "outputs": outputs}
 
         return cls
 
     return decorator
 
 
+def _locate_sibling_manifest(cls) -> Path:
+    """Find the streamlib.yaml next to the file the class lives in.
+
+    Looks at the directory containing the source file of `cls` for a
+    `streamlib.yaml`. If not present there, returns that path anyway —
+    the caller raises FileNotFoundError with the expected location, which
+    is more useful than walking up arbitrarily.
+    """
+    try:
+        source_file = inspect.getfile(cls)
+    except TypeError as exc:
+        # Built-in classes / dynamically-created classes without a source.
+        raise TypeError(
+            f"@processor cannot resolve a source file for {cls!r}; the "
+            f"decorator must be applied to a class defined in a regular "
+            f"Python module."
+        ) from exc
+    return Path(source_file).resolve().parent / "streamlib.yaml"
+
+
+# =============================================================================
+# Port Decorators
+# =============================================================================
+
+
 def input(
     name: Optional[str] = None,
-    schema: Union[str, Type, None] = None,
+    *,
+    schema: Union[SchemaIdent, Type, None] = None,
     description: str = "",
 ):
     """Mark a method as defining an input port.
 
     Args:
-        name: Port name. Defaults to method name.
-        schema: Schema name (str) or schema class decorated with @schema.
-            Examples: "VideoFrame", "AudioFrame", or MyCustomSchema.
+        name: Port name. Defaults to the method name.
+        schema: A structured carrier — either a `SchemaIdent` instance
+            (cross-package or same-package) or a class decorated with
+            `@schema` (whose `__streamlib_schema_ident__` is read).
+            String forms (bare type name or joined `@org/pkg/Type@v`)
+            are rejected with a clear error.
         description: Human-readable description for introspection.
 
     Example:
-        @input(schema="VideoFrame", description="RGB video input")
-        def video_in(self): pass
+        ```python
+        from streamlib import input, SchemaIdent
 
-        @input(schema=MyCustomSchema)
-        def custom_in(self): pass
+        VIDEO_FRAME = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+        @input(schema=VIDEO_FRAME, description="RGB video input")
+        def video_in(self): pass
+        ```
     """
 
     def decorator(method):
         port_name = name or method.__name__
         method._streamlib_input_port = {
             "name": port_name,
-            "schema": _get_schema_name(schema),
+            "schema": _resolve_schema_ident(schema),
             "description": description,
         }
         return method
@@ -335,30 +323,21 @@ def input(
 
 def output(
     name: Optional[str] = None,
-    schema: Union[str, Type, None] = None,
+    *,
+    schema: Union[SchemaIdent, Type, None] = None,
     description: str = "",
 ):
     """Mark a method as defining an output port.
 
-    Args:
-        name: Port name. Defaults to method name.
-        schema: Schema name (str) or schema class decorated with @schema.
-            Examples: "VideoFrame", "AudioFrame", or MyCustomSchema.
-        description: Human-readable description for introspection.
-
-    Example:
-        @output(schema="VideoFrame", description="Processed video output")
-        def video_out(self): pass
-
-        @output(schema=MyCustomSchema)
-        def custom_out(self): pass
+    Same shape as [`input`][streamlib.decorators.input]; see that doc for
+    the accepted `schema` carriers.
     """
 
     def decorator(method):
         port_name = name or method.__name__
         method._streamlib_output_port = {
             "name": port_name,
-            "schema": _get_schema_name(schema),
+            "schema": _resolve_schema_ident(schema),
             "description": description,
         }
         return method
@@ -366,20 +345,50 @@ def output(
     return decorator
 
 
-# Backward compatibility aliases
-def input_port(
-    name: Optional[str] = None,
-    frame_type: str = "VideoFrame",
-    description: str = "",
-):
-    """Deprecated: Use @input(schema=...) instead."""
-    return input(name=name, schema=frame_type, description=description)
+def _resolve_schema_ident(schema_arg) -> Optional[SchemaIdent]:
+    """Resolve a `schema=` argument to a structured `SchemaIdent`.
 
+    Accepts:
+        - `None` (port has no declared schema)
+        - `SchemaIdent` instance (returned as-is)
+        - a class with `__streamlib_schema_ident__` attribute (a
+          `@schema`-decorated class once #704 lands; today these classes
+          carry `__streamlib_schema__` legacy dict — that path is rejected
+          with guidance until #704)
 
-def output_port(
-    name: Optional[str] = None,
-    frame_type: str = "VideoFrame",
-    description: str = "",
-):
-    """Deprecated: Use @output(schema=...) instead."""
-    return output(name=name, schema=frame_type, description=description)
+    Rejects:
+        - any string (bare type name OR joined `@org/pkg/Type@v` form)
+        - classes without structured-ident metadata
+    """
+    if schema_arg is None:
+        return None
+    if isinstance(schema_arg, SchemaIdent):
+        return schema_arg
+    if isinstance(schema_arg, str):
+        raise TypeError(
+            f"schema={schema_arg!r}: string schema references are no longer "
+            f"accepted. Pass a structured `SchemaIdent(org, package, type_, version)` "
+            f"instance instead. Joined-string forms like '@tatolab/core/VideoFrame@1.0.0' "
+            f"and bare type names like 'VideoFrame' are both rejected — schemas are "
+            f"cross-package references by definition and have no shorthand. See "
+            f"docs/architecture/schema-identity-and-packaging.md."
+        )
+    if isinstance(schema_arg, type):
+        ident = getattr(schema_arg, "__streamlib_schema_ident__", None)
+        if isinstance(ident, SchemaIdent):
+            return ident
+        if hasattr(schema_arg, "__streamlib_schema__"):
+            raise TypeError(
+                f"schema={schema_arg.__name__}: this class is decorated with the "
+                f"legacy `@schema(name=...)` form whose structured-ident parity "
+                f"lands in #704. Pass a `SchemaIdent` instance directly until then."
+            )
+        raise TypeError(
+            f"schema={schema_arg.__name__}: class does not carry a structured "
+            f"SchemaIdent. Decorate it with `@schema(\"PascalCase\")` (post-#704) "
+            f"or pass a `SchemaIdent` instance directly."
+        )
+    raise TypeError(
+        f"schema={schema_arg!r}: unsupported type {type(schema_arg).__name__}. "
+        f"Pass a `SchemaIdent` instance or a `@schema`-decorated class."
+    )

--- a/libs/streamlib-python/python/streamlib/schema_ident.py
+++ b/libs/streamlib-python/python/streamlib/schema_ident.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Structured schema identity for the streamlib Python SDK.
+
+Mirrors Rust's `streamlib_idents::SchemaIdent` shape: 4 validating fields
+(`org`, `package`, `type_`, `version`) constructed directly. There is no
+parse / from-string API — joined-string representations like
+`"@org/pkg/Type@v"` are render-only (`__str__`) and never round-trip
+through a parser.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Pattern
+
+# Validation patterns mirror Rust's `streamlib_idents` newtypes.
+_ORG_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_PACKAGE_PATTERN: Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+_TYPE_PATTERN: Pattern[str] = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+_VERSION_PATTERN: Pattern[str] = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+@dataclass(frozen=True)
+class SchemaIdent:
+    """Structured schema identifier — 4 fields, validated at construction."""
+
+    org: str
+    package: str
+    type_: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.org, str) or not _ORG_PATTERN.match(self.org):
+            raise ValueError(
+                f"invalid org {self.org!r}: must match [a-z][a-z0-9-]*"
+            )
+        if not isinstance(self.package, str) or not _PACKAGE_PATTERN.match(self.package):
+            raise ValueError(
+                f"invalid package {self.package!r}: must match [a-z][a-z0-9-]*"
+            )
+        if not isinstance(self.type_, str) or not _TYPE_PATTERN.match(self.type_):
+            raise ValueError(
+                f"invalid type {self.type_!r}: must match [A-Z][A-Za-z0-9]* (PascalCase)"
+            )
+        if not isinstance(self.version, str) or not _VERSION_PATTERN.match(self.version):
+            raise ValueError(
+                f"invalid version {self.version!r}: must match major.minor.patch"
+            )
+
+    def __str__(self) -> str:
+        return f"@{self.org}/{self.package}/{self.type_}@{self.version}"
+
+    def to_wire_dict(self) -> dict:
+        """Render as the IPC wire-format dict.
+
+        Used by callers that need to hand the structured ident to JSON-RPC
+        / iceoryx2 envelopes that already speak the 4-field shape.
+        """
+        return {
+            "org": self.org,
+            "package": self.package,
+            "type": self.type_,
+            "version": self.version,
+        }

--- a/libs/streamlib-python/python/streamlib/tests/test_manifest_reader.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_manifest_reader.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for the hand-rolled streamlib.yaml minimal manifest reader."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from streamlib._manifest import ManifestParseError, read_manifest_summary
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "streamlib.yaml"
+    p.write_text(textwrap.dedent(body).lstrip("\n"))
+    return p
+
+
+class TestManifestReader:
+    def test_parses_package_block_and_processors_list(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: cyberpunk-processor
+              version: 0.1.0
+              description: "Some description"
+
+            processors:
+              - name: AvatarCharacter
+                runtime: python
+                execution: reactive
+              - name: CyberpunkLowerThird
+                runtime: python
+            """,
+        )
+        summary = read_manifest_summary(path)
+        assert summary.package.org == "tatolab"
+        assert summary.package.name == "cyberpunk-processor"
+        assert summary.package.version == "0.1.0"
+        assert summary.processor_names == ["AvatarCharacter", "CyberpunkLowerThird"]
+
+    def test_strips_double_quotes_around_version(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: example
+              version: "1.2.3"
+
+            processors:
+              - name: Foo
+            """,
+        )
+        summary = read_manifest_summary(path)
+        assert summary.package.version == "1.2.3"
+
+    def test_strips_single_quotes(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: 'tatolab'
+              name: 'example'
+              version: '1.2.3'
+
+            processors: []
+            """,
+        )
+        summary = read_manifest_summary(path)
+        assert summary.package.org == "tatolab"
+        assert summary.processor_names == []
+
+    def test_ignores_trailing_comments(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: tatolab  # inline comment
+              name: example
+              version: 0.1.0
+
+            # standalone comment
+            processors:
+              - name: Foo
+            """,
+        )
+        summary = read_manifest_summary(path)
+        assert summary.package.org == "tatolab"
+        assert summary.processor_names == ["Foo"]
+
+    def test_skips_nested_processor_body(self, tmp_path: Path) -> None:
+        # Inner ports/inputs/outputs must NOT show up as processor entries.
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: example
+              version: 0.1.0
+
+            processors:
+              - name: Foo
+                inputs:
+                  - name: video_in
+                    schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
+                outputs:
+                  - name: video_out
+                    schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
+              - name: Bar
+            """,
+        )
+        summary = read_manifest_summary(path)
+        assert summary.processor_names == ["Foo", "Bar"]
+
+    def test_missing_package_block_errors(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            processors:
+              - name: Foo
+            """,
+        )
+        with pytest.raises(ManifestParseError, match="missing required"):
+            read_manifest_summary(path)
+
+    def test_missing_org_field_errors(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            """
+            package:
+              name: example
+              version: 0.1.0
+
+            processors:
+              - name: Foo
+            """,
+        )
+        with pytest.raises(ManifestParseError, match=r"org"):
+            read_manifest_summary(path)
+
+    def test_no_file_raises_filenotfound(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_manifest_summary(tmp_path / "does-not-exist.yaml")
+
+    def test_processor_entry_with_non_name_first_key_errors(self, tmp_path: Path) -> None:
+        # Defends the "name-first ordering" assumption with a clear failure.
+        path = _write(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: example
+              version: 0.1.0
+
+            processors:
+              - runtime: python
+                name: Foo
+            """,
+        )
+        with pytest.raises(ManifestParseError, match="name`-first"):
+            read_manifest_summary(path)

--- a/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for `@processor("PascalCase")` and structured `SchemaIdent` parity."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from streamlib import SchemaIdent, processor, input, output
+
+
+# =============================================================================
+# SchemaIdent dataclass
+# =============================================================================
+
+
+class TestSchemaIdent:
+    def test_constructs_with_valid_segments(self) -> None:
+        ident = SchemaIdent(org="tatolab", package="core", type_="VideoFrame", version="1.0.0")
+        assert ident.org == "tatolab"
+        assert ident.package == "core"
+        assert ident.type_ == "VideoFrame"
+        assert ident.version == "1.0.0"
+
+    def test_str_renders_joined_form(self) -> None:
+        ident = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+        assert str(ident) == "@tatolab/core/VideoFrame@1.0.0"
+
+    def test_to_wire_dict_uses_type_key(self) -> None:
+        ident = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+        assert ident.to_wire_dict() == {
+            "org": "tatolab",
+            "package": "core",
+            "type": "VideoFrame",
+            "version": "1.0.0",
+        }
+
+    def test_frozen(self) -> None:
+        ident = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+        with pytest.raises(Exception):
+            ident.org = "other"  # type: ignore[misc]
+
+    def test_rejects_uppercase_org(self) -> None:
+        with pytest.raises(ValueError, match="invalid org"):
+            SchemaIdent("Tatolab", "core", "VideoFrame", "1.0.0")
+
+    def test_rejects_uppercase_package(self) -> None:
+        with pytest.raises(ValueError, match="invalid package"):
+            SchemaIdent("tatolab", "Core", "VideoFrame", "1.0.0")
+
+    def test_rejects_lowercase_type(self) -> None:
+        with pytest.raises(ValueError, match="invalid type"):
+            SchemaIdent("tatolab", "core", "videoFrame", "1.0.0")
+
+    def test_rejects_underscore_in_org(self) -> None:
+        with pytest.raises(ValueError, match="invalid org"):
+            SchemaIdent("tato_lab", "core", "VideoFrame", "1.0.0")
+
+    def test_rejects_malformed_version(self) -> None:
+        with pytest.raises(ValueError, match="invalid version"):
+            SchemaIdent("tatolab", "core", "VideoFrame", "1.0")
+
+    def test_accepts_hyphen_in_package(self) -> None:
+        ident = SchemaIdent("tatolab", "camera-python-display", "Foo", "0.1.0")
+        assert ident.package == "camera-python-display"
+
+
+# =============================================================================
+# @processor decorator — manifest-driven structured-ident emission
+# =============================================================================
+
+
+def _write_manifest(dir_path: Path, body: str) -> None:
+    (dir_path / "streamlib.yaml").write_text(textwrap.dedent(body).lstrip("\n"))
+
+
+def _import_class_from_dir(dir_path: Path, module_name: str, body: str):
+    """Write `<module_name>.py` containing `body` and import it fresh."""
+    (dir_path / f"{module_name}.py").write_text(textwrap.dedent(body).lstrip("\n"))
+    sys.path.insert(0, str(dir_path))
+    try:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        return importlib.import_module(module_name)
+    finally:
+        sys.path.remove(str(dir_path))
+
+
+class TestProcessorDecorator:
+    def test_attaches_structured_schema_ident_from_manifest(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: cyberpunk-processor
+              version: 0.1.0
+
+            processors:
+              - name: CyberpunkProcessor
+                runtime: python
+                execution: reactive
+            """,
+        )
+        module = _import_class_from_dir(
+            tmp_path,
+            "decorator_pkg_module",
+            """
+            from streamlib import processor
+
+            @processor("CyberpunkProcessor")
+            class CyberpunkProcessor:
+                pass
+            """,
+        )
+        ident = module.CyberpunkProcessor.__streamlib_schema_ident__
+        assert ident.org == "tatolab"
+        assert ident.package == "cyberpunk-processor"
+        assert ident.type_ == "CyberpunkProcessor"
+        assert ident.version == "0.1.0"
+        assert str(ident) == "@tatolab/cyberpunk-processor/CyberpunkProcessor@0.1.0"
+
+    def test_missing_manifest_errors_with_expected_path(self, tmp_path: Path) -> None:
+        # No streamlib.yaml in tmp_path
+        with pytest.raises(FileNotFoundError, match="streamlib.yaml"):
+            _import_class_from_dir(
+                tmp_path,
+                "no_manifest_module",
+                """
+                from streamlib import processor
+
+                @processor("Anything")
+                class Anything:
+                    pass
+                """,
+            )
+
+    def test_short_name_not_in_manifest_lists_available(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            """
+            package:
+              org: tatolab
+              name: example
+              version: 0.1.0
+
+            processors:
+              - name: Camera
+              - name: Display
+            """,
+        )
+        with pytest.raises(ValueError, match=r"Available processors"):
+            _import_class_from_dir(
+                tmp_path,
+                "missing_short_name_module",
+                """
+                from streamlib import processor
+
+                @processor("MissingProcessor")
+                class MissingProcessor:
+                    pass
+                """,
+            )
+
+    def test_manifest_missing_org_errors(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            """
+            package:
+              name: example
+              version: 0.1.0
+
+            processors:
+              - name: Foo
+            """,
+        )
+        with pytest.raises(ValueError, match="missing required `package:` field"):
+            _import_class_from_dir(
+                tmp_path,
+                "missing_org_module",
+                """
+                from streamlib import processor
+
+                @processor("Foo")
+                class Foo:
+                    pass
+                """,
+            )
+
+    def test_legacy_kwarg_form_rejected(self) -> None:
+        # The legacy `name=`/`description=`/`execution=` kwarg form is gone.
+        # `@processor(name="...")` now raises immediately because the first
+        # positional must be a str.
+        with pytest.raises(TypeError):
+            processor(name="Camera")  # type: ignore[arg-type]
+
+
+# =============================================================================
+# @input / @output schema validation
+# =============================================================================
+
+
+class TestPortSchemaResolution:
+    def test_accepts_schema_ident_instance(self) -> None:
+        ident = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+        @input(schema=ident)
+        def video_in(self):
+            pass
+
+        assert video_in._streamlib_input_port["schema"] is ident
+
+    def test_rejects_bare_string_schema(self) -> None:
+        with pytest.raises(TypeError, match="string schema references are no longer accepted"):
+            @input(schema="VideoFrame")
+            def video_in(self):
+                pass
+
+    def test_rejects_joined_string_schema(self) -> None:
+        with pytest.raises(TypeError, match="string schema references"):
+            @output(schema="@tatolab/core/VideoFrame@1.0.0")
+            def video_out(self):
+                pass
+
+    def test_accepts_class_carrying_schema_ident(self) -> None:
+        class MySchema:
+            __streamlib_schema_ident__ = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
+
+        @input(schema=MySchema)
+        def video_in(self):
+            pass
+
+        assert isinstance(video_in._streamlib_input_port["schema"], SchemaIdent)
+        assert video_in._streamlib_input_port["schema"].type_ == "VideoFrame"
+
+    def test_legacy_at_schema_class_directs_to_followup(self) -> None:
+        class LegacySchema:
+            __streamlib_schema__ = {"name": "VideoFrame", "fields": []}
+
+        with pytest.raises(TypeError, match="#704"):
+            @input(schema=LegacySchema)
+            def video_in(self):
+                pass
+
+    def test_class_without_schema_metadata_rejected(self) -> None:
+        class Plain:
+            pass
+
+        with pytest.raises(TypeError, match="does not carry a structured SchemaIdent"):
+            @output(schema=Plain)
+            def video_out(self):
+                pass
+
+    def test_none_schema_ok(self) -> None:
+        @input(schema=None)
+        def control(self):
+            pass
+
+        assert control._streamlib_input_port["schema"] is None


### PR DESCRIPTION
## Summary

- Brings the Python `@streamlib.processor` decorator to parity with Rust's `#[streamlib::processor("Camera")]` macro from #404. New `streamlib.SchemaIdent` dataclass mirrors Rust's `streamlib_idents::SchemaIdent`; the rewritten decorator reads the sibling `streamlib.yaml` at decoration time and attaches a structured `__streamlib_schema_ident__` to the class.
- Migrates every polyglot Python example's `streamlib.yaml` and the Python arms of every example's Rust scenario binary off reverse-DNS naming. Deno-side strings (`Self::Deno =>` arms and `examples/*/deno/streamlib.yaml`) remain unchanged — Deno parity is #701's scope and lands in the same milestone.
- `@input(schema=...)` / `@output(schema=...)` accept a `SchemaIdent` instance or a class carrying `__streamlib_schema_ident__`; bare-string and joined-string forms are rejected with a helpful error.

## Closes

Closes #700

## Exit criteria

- [x] `@streamlib.processor("Camera")` accepts a positional PascalCase short name; `name=` kwarg removed (no deprecated alias per pre-1.0 policy).
- [x] At decoration time the decorator reads sibling `streamlib.yaml`, resolves the `package: { org, name, version }` block, and attaches `__streamlib_schema_ident__: SchemaIdent`.
- [x] New `streamlib.SchemaIdent` Python dataclass mirrors Rust's 4-field shape with validating constructors and a render-only joined `__str__`.
- [x] Every polyglot Python example's `streamlib.yaml` migrates to PascalCase short-name keys + `org: tatolab`. (`processors:` ports already structured per #404.)
- [x] `examples/camera-python-display/python/cyberpunk_processor.py` adopts the new decorator (the lone existing call site).
- [x] No `@processor(name="…")` legacy kwarg form remains in live code.
- [x] Deprecated `input_port` / `output_port` aliases removed.

### Reframed (per author guidance during pickup)

- The original "host-side Rust consumer reads `__streamlib_schema_ident__`" criterion is reshaped per the architecture preamble in #700: `streamlib.yaml` is THE manifest, and the host already loads identity through it via `serde_yaml`. The decorator's class-level attribute exists for Python-side authoring + drift detection (raises immediately if the short name doesn't appear in the manifest's `processors:` list).

## Architecture preamble (copied to #700, #701, #702, and #704)

A multi-paragraph author-guidance preamble was added to the heads of #700, #701, #702, and the new #704 (`@schema` decorator parity). It locks in: schema/processor refs are cross-package by default with no internal-only shorthand; the only allowed reference form is the structured 4-field `SchemaIdent`; `streamlib.yaml` is THE manifest for every package across every language; reverse-DNS dies wherever touched.

## Test plan

- [x] Python SDK tests: 125 passed (31 new — `SchemaIdent` validation, manifest reader edge cases, `@processor` decoration paths, `@input`/`@output` schema rejection).
- [x] Rust workspace check: `cargo check --workspace` clean (pre-existing warnings only).
- [x] Polyglot Linux execution modes: `cargo test -p streamlib --test polyglot_linux_execution_modes` 4/4 passed (Python and Deno arms both work post-migration).
- [x] Hand-rolled YAML reader validated against all 12 migrated example manifests.
- [x] `cargo test --workspace` clean except pre-existing logging test flake (filed as #705 with `bug` label).

## Out of scope

- **#704 (`@schema` decorator parity)** — filed as the symmetric follow-up; mirrors `@processor`'s manifest-driven structured-ident shape onto `@schema`. Blocks #701 (Deno).
- **#701 (Deno decorator parity)** — Deno-side `Self::Deno =>` arms in example `main.rs` files and `examples/*/deno/streamlib.yaml` files still use reverse-DNS. They migrate when Deno parity lands in the same milestone.
- **#702 (reverse-DNS schema file rename)** — on-disk schema filenames in `libs/streamlib/schemas/com.{tatolab,streamlib}.*@*.yaml` and the residual `String`-typed config-schema/registry/MoQ APIs.

## Notes for reviewers

- **Stale local `.slpkg` bundles.** `.slpkg` files are `.gitignore`d (build artifacts) but cached locally. After this PR, anyone with stale slpkgs from before the rename must rebuild via `cargo run -p streamlib-cli -- pack examples/<name>/python` before running the affected examples. Fresh checkouts and CI are unaffected (the slpkgs aren't tracked).
- **Cross-package shorthand follow-up.** Rust example `main.rs` strings (`ProcessorSpec::new("Grayscale", …)`) are still bare PascalCase `String` references — technically a cross-package shorthand the architecture preamble (note 1) discourages. The full migration is `ProcessorSpec.name: String → SchemaIdent` and is a Rust-side engine change beyond #700's scope; this PR only kills the reverse-DNS form per the issue's literal exit criteria. Worth a separate ticket once the milestone's other carve-outs settle.
- **Hand-rolled manifest reader.** `_manifest.py` parses only the `package:` block + `processors[].name` list. Adding PyYAML would have made the SDK runtime-non-empty for the first time. The reader hard-fails (with a clear error) if a future manifest reorders processor entry keys to put a non-`name:` key first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)