### PR TITLE
feat(704): codegen-emitted SchemaIdent on Python dataclasses + remove @schema

### DIFF
--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -510,23 +510,22 @@ to the authoring path:
   `__streamlib_schema_ident__`. Bare-string and joined-string
   forms are rejected at decoration time, mirroring the no-parse
   invariant on the Rust side.
-- **No `@streamlib.schema` decorator.** Schemas only enter Python
-  through codegen-emitted dataclasses produced by `streamlib
-  generate` from the package's JTD/YAML schemas. The codegen
-  Python post-processor injects
+- **Schemas enter Python only through codegen.** Authors import
+  generated dataclasses from `streamlib._generated_.<package>`
+  (or their own package's `_generated_/`); the codegen Python
+  post-processor injects
   `__streamlib_schema_ident__: ClassVar[SchemaIdent] =
   SchemaIdent(org=…, package=…, type_=…, version=…)` as a class
   attribute on every new-shape (`metadata.type` + package
   context) generated dataclass, so `@input(schema=GeneratedClass)`
-  resolves to a structured `SchemaIdent` without an authoring
-  decorator. JTD-in-YAML is the canonical schema source —
-  deriving JTD from Python field declarations would leak
-  Python-native expressivity (custom classes, numpy types,
-  pydantic types) that doesn't translate cross-language. To the
-  best of our current knowledge as of issue #704's landing,
-  no Rust `#[streamlib::schema]` macro and no Deno
-  `@streamlib.schema` decorator exists either — schemas are
-  always YAML-authored, generated code is what authors import.
+  resolves to a structured `SchemaIdent` directly. There is no
+  language-side authoring affordance for declaring schemas —
+  JTD-in-YAML is the canonical schema source, and deriving JTD
+  from Python field declarations would leak Python-native
+  expressivity (custom classes, numpy types, pydantic types)
+  that doesn't translate cross-language. The same constraint
+  applies to Rust and Deno: schemas are always YAML-authored,
+  generated code is what authors import.
 
 The reason for the focused subset rather than full parity:
 structured-everywhere eliminates the need for non-Rust callers to

--- a/docs/architecture/schema-identity-and-packaging.md
+++ b/docs/architecture/schema-identity-and-packaging.md
@@ -510,6 +510,23 @@ to the authoring path:
   `__streamlib_schema_ident__`. Bare-string and joined-string
   forms are rejected at decoration time, mirroring the no-parse
   invariant on the Rust side.
+- **No `@streamlib.schema` decorator.** Schemas only enter Python
+  through codegen-emitted dataclasses produced by `streamlib
+  generate` from the package's JTD/YAML schemas. The codegen
+  Python post-processor injects
+  `__streamlib_schema_ident__: ClassVar[SchemaIdent] =
+  SchemaIdent(org=…, package=…, type_=…, version=…)` as a class
+  attribute on every new-shape (`metadata.type` + package
+  context) generated dataclass, so `@input(schema=GeneratedClass)`
+  resolves to a structured `SchemaIdent` without an authoring
+  decorator. JTD-in-YAML is the canonical schema source —
+  deriving JTD from Python field declarations would leak
+  Python-native expressivity (custom classes, numpy types,
+  pydantic types) that doesn't translate cross-language. To the
+  best of our current knowledge as of issue #704's landing,
+  no Rust `#[streamlib::schema]` macro and no Deno
+  `@streamlib.schema` decorator exists either — schemas are
+  always YAML-authored, generated code is what authors import.
 
 The reason for the focused subset rather than full parity:
 structured-everywhere eliminates the need for non-Rust callers to
@@ -527,6 +544,25 @@ schema-only / language-specific by construction"* — the deeper
 crate functionality (range matching, lockfile, codegen) is
 "language-specific by construction" while basic identity
 validation is mirrored across runtimes that need it.
+
+### Codegen-emitted `SCHEMA_IDENT` (Python today; Rust + TS pending)
+
+Decision 2 above lists "codegen-emitted const records
+(`SCHEMA_IDENT: SchemaIdent { … }`)" as a structured-everywhere
+surface. To the best of our current knowledge as of issue #704,
+the Python post-processor in `streamlib-jtd-codegen` is the only
+one that emits the structured ident on generated types
+(`__streamlib_schema_ident__: ClassVar[SchemaIdent]`). The Rust
+and TypeScript post-processors emit the dataclass / struct /
+interface body but no `SCHEMA_IDENT` const yet. Python is the
+load-bearing case because `@streamlib.input(schema=...)` /
+`@streamlib.output(schema=...)` resolves the structured ident
+*off the class* via `__streamlib_schema_ident__`; Rust and TS
+have no analogous runtime resolution path that requires the
+const today. Bringing those backends to parity (so `Generated
+struct VideoFrame { … }` carries a `pub const SCHEMA_IDENT:
+SchemaIdent = …` and the TS interface analogue) is filed as a
+follow-up to #704.
 
 ## Reference
 

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -518,7 +518,27 @@ fn run_jtd_codegen_python(tasks: &[SchemaTask], output_dir: &Path) -> Result<()>
             )
         })?;
 
-        let processed_code = post_process_python(&python_code, &identity.struct_name);
+        // New-shape schemas (declaring `metadata.type` under a package-flavor
+        // streamlib.yaml) carry a structured `SchemaIdent` on every emitted
+        // class. Legacy `metadata.name`-shape schemas have no enclosing package
+        // context to construct from and are emitted as plain dataclasses;
+        // authors who reference them construct `SchemaIdent` directly until
+        // #702 migrates them off reverse-DNS.
+        let schema_ident_emit: Option<SchemaIdentEmit> = if identity.package_subdir.is_some() {
+            task.package.as_ref().map(|p| SchemaIdentEmit {
+                org: p.org.clone(),
+                package: p.name.clone(),
+                type_name: identity.struct_name.clone(),
+                version: p.version.to_string(),
+            })
+        } else {
+            None
+        };
+        let processed_code = post_process_python(
+            &python_code,
+            &identity.struct_name,
+            schema_ident_emit.as_ref(),
+        );
         let restored_code = sentinel::restore_python(&processed_code, &sentinel_table);
 
         let output_path = identity.output_path(output_dir, "py");
@@ -948,17 +968,230 @@ fn camel_to_snake(s: &str) -> String {
     result
 }
 
+/// Codegen-emit shape for a structured schema identifier. Carries the four
+/// segments the post-processors weave into generated language sources so a
+/// generated class is self-identifying without an authoring decorator.
+///
+/// Constructed at the run-codegen call site from the schema's enclosing
+/// `PackageContext` (org / package / version) and the schema's
+/// `metadata.type` (PascalCase). Legacy `metadata.name`-shape schemas have
+/// no enclosing package context and therefore no `SchemaIdentEmit`.
+#[derive(Debug, Clone)]
+struct SchemaIdentEmit {
+    org: String,
+    package: String,
+    type_name: String,
+    version: String,
+}
+
 /// Post-process jtd-codegen Python output.
-fn post_process_python(code: &str, expected_class_name: &str) -> String {
+///
+/// Always strips the `ROOT_NAME_SENTINEL` placeholder and prepends the
+/// project header. When `schema_ident` is `Some` (new-shape schemas with a
+/// `metadata.type` and an enclosing package-flavor `streamlib.yaml`),
+/// additionally injects a `__streamlib_schema_ident__: ClassVar[SchemaIdent]`
+/// class attribute so `@input(schema=GeneratedClass)` resolves to a
+/// structured `SchemaIdent` without an authoring `@schema` decorator (which
+/// is intentionally not part of the SDK; see issue #704).
+fn post_process_python(
+    code: &str,
+    expected_class_name: &str,
+    schema_ident: Option<&SchemaIdentEmit>,
+) -> String {
     let rewritten = code.replace(ROOT_NAME_SENTINEL, expected_class_name);
 
-    format!(
+    let with_header = format!(
         "# Copyright (c) 2025 Jonathan Fontanez\n\
          # SPDX-License-Identifier: BUSL-1.1\n\
          #\n\
          # Generated from JTD schema using jtd-codegen. DO NOT EDIT.\n\n{}",
         rewritten
-    )
+    );
+
+    match schema_ident {
+        Some(ident) => inject_schema_ident_python(&with_header, expected_class_name, ident),
+        None => with_header,
+    }
+}
+
+/// Rewrite the generated Python code so the `from typing import …` line
+/// imports `ClassVar` (adding it alphabetically when absent) and a
+/// `from streamlib.schema_ident import SchemaIdent` line follows it.
+///
+/// jtd-codegen v0.4.1 emits a single `from typing import …` line whose
+/// import set varies per schema (e.g. some include `List`, most don't).
+/// Parsing the line preserves whatever set the codegen produced rather
+/// than depending on a literal string match.
+///
+/// Falls back to prepending fresh imports below the project header when
+/// no `from typing import` line is present (defensive — every jtd-codegen
+/// v0.4.1 emit currently has one).
+fn inject_typing_imports(code: &str) -> String {
+    const SCHEMA_IDENT_IMPORT: &str = "from streamlib.schema_ident import SchemaIdent";
+    let typing_prefix = "from typing import ";
+    let mut output = String::with_capacity(code.len() + 64);
+    let mut handled = false;
+
+    for line in code.split_inclusive('\n') {
+        if !handled && line.trim_start().starts_with(typing_prefix) {
+            let trim_start = line.find(typing_prefix).unwrap();
+            let prefix_end = trim_start + typing_prefix.len();
+            // Keep any trailing `\n` (or trailing whitespace) on the original line.
+            let (imports_str, line_tail) = match line[prefix_end..].find('\n') {
+                Some(nl_idx) => (
+                    &line[prefix_end..prefix_end + nl_idx],
+                    &line[prefix_end + nl_idx..],
+                ),
+                None => (&line[prefix_end..], ""),
+            };
+            let mut names: Vec<String> = imports_str
+                .split(',')
+                .map(|n| n.trim().to_string())
+                .filter(|n| !n.is_empty())
+                .collect();
+            if !names.iter().any(|n| n == "ClassVar") {
+                names.push("ClassVar".to_string());
+            }
+            names.sort();
+            names.dedup();
+            output.push_str(&line[..trim_start]);
+            output.push_str(typing_prefix);
+            output.push_str(&names.join(", "));
+            output.push_str(line_tail);
+            // Emit the SchemaIdent import on the next physical line.
+            // `line_tail` already carries the original line's `\n`; if it
+            // didn't, append one so the SchemaIdent import isn't glued to
+            // the typing line.
+            if !line_tail.contains('\n') {
+                output.push('\n');
+            }
+            output.push_str(SCHEMA_IDENT_IMPORT);
+            output.push('\n');
+            handled = true;
+            continue;
+        }
+        output.push_str(line);
+    }
+
+    if !handled {
+        // Fallback: prepend imports immediately after the project header.
+        let marker = "# Generated from JTD schema using jtd-codegen. DO NOT EDIT.\n";
+        if let Some(idx) = output.find(marker) {
+            let insert_at = idx + marker.len();
+            let injection = format!("\nfrom typing import ClassVar\n{}\n", SCHEMA_IDENT_IMPORT);
+            output.insert_str(insert_at, &injection);
+        } else {
+            // No project header either — prepend at the very top.
+            output.insert_str(
+                0,
+                &format!("from typing import ClassVar\n{}\n", SCHEMA_IDENT_IMPORT),
+            );
+        }
+    }
+
+    output
+}
+
+/// Inject `__streamlib_schema_ident__` onto a generated Python dataclass.
+///
+/// Two surgeries on the post-`ROOT_NAME_SENTINEL`-substitution code:
+///
+/// 1. Extend the existing `from typing import …` line to include `ClassVar`
+///    and add a `from streamlib.schema_ident import SchemaIdent` line right
+///    after it. The typing import is always emitted by jtd-codegen v0.4.1
+///    for new-shape schemas (they all have `Optional` fields).
+/// 2. Find the first `class <expected_class_name>:` declaration and inject
+///    the class attribute right after the optional class docstring (or
+///    directly after the class line when there's no docstring), so the
+///    attribute is the first non-docstring statement in the class body.
+///    `ClassVar[SchemaIdent]` opts the attribute out of dataclass field
+///    treatment.
+fn inject_schema_ident_python(
+    code: &str,
+    class_name: &str,
+    ident: &SchemaIdentEmit,
+) -> String {
+    // 1. Extend the existing `from typing import …` line to include `ClassVar`
+    //    and inject `from streamlib.schema_ident import SchemaIdent` right
+    //    after it. The exact set of imports varies per schema (some include
+    //    `List`, some don't, etc.), so parse the line and rewrite it rather
+    //    than literal-matching one specific shape.
+    let with_imports = inject_typing_imports(code);
+
+    // 2. Inject the class attribute after the class declaration + optional
+    //    docstring. Locate the class declaration first.
+    let class_marker = format!("class {}:", class_name);
+    let class_idx = match with_imports.find(&class_marker) {
+        Some(idx) => idx,
+        None => return with_imports, // class line not found; emit unchanged
+    };
+
+    // Cursor sits at the newline that ends the `class X:` line.
+    let mut cursor = class_idx + class_marker.len();
+    let bytes = with_imports.as_bytes();
+
+    // Advance past the trailing newline of the class declaration.
+    if cursor < bytes.len() && bytes[cursor] == b'\n' {
+        cursor += 1;
+    }
+
+    // Skip blank / whitespace-only lines between class line and any docstring.
+    while cursor < bytes.len() {
+        let line_end = with_imports[cursor..]
+            .find('\n')
+            .map(|n| cursor + n)
+            .unwrap_or(bytes.len());
+        let line = &with_imports[cursor..line_end];
+        if line.trim().is_empty() {
+            cursor = if line_end < bytes.len() { line_end + 1 } else { line_end };
+        } else {
+            break;
+        }
+    }
+
+    // Detect and skip an optional triple-quoted docstring.
+    if cursor + 3 <= bytes.len() {
+        let leading = &with_imports[cursor..];
+        let trimmed = leading.trim_start();
+        let leading_ws_len = leading.len() - trimmed.len();
+        let triple = if trimmed.starts_with("\"\"\"") {
+            Some("\"\"\"")
+        } else if trimmed.starts_with("'''") {
+            Some("'''")
+        } else {
+            None
+        };
+        if let Some(triple) = triple {
+            // Position of the docstring opener.
+            let opener_start = cursor + leading_ws_len;
+            let after_opener = opener_start + 3;
+            // Find the matching closing triple-quote.
+            if let Some(close_rel) = with_imports[after_opener..].find(triple) {
+                let close_end = after_opener + close_rel + 3;
+                // Advance cursor past the docstring's trailing newline.
+                let line_end = with_imports[close_end..]
+                    .find('\n')
+                    .map(|n| close_end + n + 1)
+                    .unwrap_or(bytes.len());
+                cursor = line_end;
+            }
+        }
+    }
+
+    // Inject the class attribute at `cursor`. Indented to four spaces,
+    // matching the dataclass body. Wrapped on multiple lines so the version
+    // string and structural commas read cleanly even for the longest
+    // identifiers.
+    let injection = format!(
+        "    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(\n        org=\"{}\",\n        package=\"{}\",\n        type_=\"{}\",\n        version=\"{}\",\n    )\n\n",
+        ident.org, ident.package, ident.type_name, ident.version,
+    );
+
+    let mut result = String::with_capacity(with_imports.len() + injection.len());
+    result.push_str(&with_imports[..cursor]);
+    result.push_str(&injection);
+    result.push_str(&with_imports[cursor..]);
+    result
 }
 
 /// Post-process jtd-codegen TypeScript output.
@@ -1230,7 +1463,7 @@ mod tests {
     #[test]
     fn post_process_python_substitutes_root_sentinel() {
         let code = "@dataclass\nclass StreamlibCanonRoot:\n    @classmethod\n    def from_json_data(cls, data) -> 'StreamlibCanonRoot':\n        return cls()\n";
-        let out = post_process_python(code, "H264DecoderConfig");
+        let out = post_process_python(code, "H264DecoderConfig", None);
         assert!(out.contains("class H264DecoderConfig:"));
         assert!(out.contains("-> 'H264DecoderConfig':"));
         assert!(!out.contains("StreamlibCanonRoot"));
@@ -1239,10 +1472,80 @@ mod tests {
     #[test]
     fn post_process_python_substitutes_sub_types_via_prefix() {
         let code = "class StreamlibCanonRootWhep:\n    pass\nclass StreamlibCanonRoot:\n    pass\n";
-        let out = post_process_python(code, "WebrtcWhepConfig");
+        let out = post_process_python(code, "WebrtcWhepConfig", None);
         assert!(out.contains("class WebrtcWhepConfigWhep:"));
         assert!(out.contains("class WebrtcWhepConfig:"));
         assert!(!out.contains("StreamlibCanonRoot"));
+    }
+
+    #[test]
+    fn post_process_python_legacy_schema_omits_schema_ident() {
+        // Legacy `metadata.name`-shape schemas have no enclosing package
+        // context. The Python emit stays a plain dataclass — no
+        // `__streamlib_schema_ident__` injection, no `ClassVar`/`SchemaIdent`
+        // imports added.
+        let code = "from typing import Any, Dict, Optional, Union, get_args, get_origin\n\n@dataclass\nclass StreamlibCanonRoot:\n    \"\"\"Legacy schema\"\"\"\n\n    field_a: 'str'\n";
+        let out = post_process_python(code, "LegacyConfig", None);
+        assert!(!out.contains("__streamlib_schema_ident__"));
+        assert!(!out.contains("ClassVar"));
+        assert!(!out.contains("from streamlib.schema_ident"));
+        assert!(out.contains("class LegacyConfig:"));
+    }
+
+    #[test]
+    fn post_process_python_new_shape_emits_schema_ident_after_docstring() {
+        // New-shape (`metadata.type` + package context) schemas grow a
+        // ClassVar-typed `__streamlib_schema_ident__` attribute right after
+        // the class docstring, plus the matching imports. Inserts BEFORE
+        // the original blank line so the field annotations stay where they
+        // were — preserving the visual separation.
+        let code = "from typing import Any, Dict, Optional, Union, get_args, get_origin\n\n@dataclass\nclass StreamlibCanonRoot:\n    \"\"\"\n    Multi-line\n    description\n    \"\"\"\n\n    width: 'int'\n    \"\"\"width docstring\"\"\"\n";
+        let ident = SchemaIdentEmit {
+            org: "tatolab".to_string(),
+            package: "core".to_string(),
+            type_name: "VideoFrame".to_string(),
+            version: "1.0.0".to_string(),
+        };
+        let out = post_process_python(code, "VideoFrame", Some(&ident));
+        assert!(out.contains("from typing import Any, ClassVar, Dict, Optional, Union, get_args, get_origin"));
+        assert!(out.contains("from streamlib.schema_ident import SchemaIdent"));
+        assert!(out.contains("__streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent("));
+        assert!(out.contains("org=\"tatolab\""));
+        assert!(out.contains("package=\"core\""));
+        assert!(out.contains("type_=\"VideoFrame\""));
+        assert!(out.contains("version=\"1.0.0\""));
+        // The injection lands inside the class body — the SchemaIdent
+        // construction sits between the docstring and the `width` field
+        // (no `width:` line falls between the close-quote and the
+        // injection start).
+        let ident_idx = out.find("__streamlib_schema_ident__").unwrap();
+        let docstring_close_idx = out
+            .rfind("description\n    \"\"\"")
+            .map(|idx| idx + "description\n    \"\"\"".len())
+            .unwrap();
+        let width_field_idx = out.find("width: 'int'").unwrap();
+        assert!(docstring_close_idx < ident_idx);
+        assert!(ident_idx < width_field_idx);
+    }
+
+    #[test]
+    fn post_process_python_new_shape_handles_no_docstring() {
+        // Defensive: if a future jtd-codegen emit drops the class docstring
+        // for some reason, the schema_ident attribute lands directly after
+        // the class line.
+        let code = "from typing import Any, Dict, Optional, Union, get_args, get_origin\n\n@dataclass\nclass StreamlibCanonRoot:\n    width: 'int'\n";
+        let ident = SchemaIdentEmit {
+            org: "tatolab".to_string(),
+            package: "core".to_string(),
+            type_name: "VideoFrame".to_string(),
+            version: "1.0.0".to_string(),
+        };
+        let out = post_process_python(code, "VideoFrame", Some(&ident));
+        let class_line_idx = out.find("class VideoFrame:").unwrap();
+        let ident_idx = out.find("__streamlib_schema_ident__").unwrap();
+        let width_field_idx = out.find("width: 'int'").unwrap();
+        assert!(class_line_idx < ident_idx);
+        assert!(ident_idx < width_field_idx);
     }
 
     #[test]

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -990,9 +990,9 @@ struct SchemaIdentEmit {
 /// project header. When `schema_ident` is `Some` (new-shape schemas with a
 /// `metadata.type` and an enclosing package-flavor `streamlib.yaml`),
 /// additionally injects a `__streamlib_schema_ident__: ClassVar[SchemaIdent]`
-/// class attribute so `@input(schema=GeneratedClass)` resolves to a
-/// structured `SchemaIdent` without an authoring `@schema` decorator (which
-/// is intentionally not part of the SDK; see issue #704).
+/// class attribute so `@input(schema=GeneratedClass)` /
+/// `@output(schema=GeneratedClass)` in the Python SDK resolves the
+/// structured ident off the class without any authoring affordance.
 fn post_process_python(
     code: &str,
     expected_class_name: &str,

--- a/libs/streamlib-jtd-codegen/src/lib.rs
+++ b/libs/streamlib-jtd-codegen/src/lib.rs
@@ -1181,11 +1181,22 @@ fn inject_schema_ident_python(
     // Inject the class attribute at `cursor`. Indented to four spaces,
     // matching the dataclass body. Wrapped on multiple lines so the version
     // string and structural commas read cleanly even for the longest
-    // identifiers.
-    let injection = format!(
-        "    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(\n        org=\"{}\",\n        package=\"{}\",\n        type_=\"{}\",\n        version=\"{}\",\n    )\n\n",
+    // identifiers. The injection ends with the closing-`)` line's newline
+    // only — a separator blank line is emitted only when the source code
+    // doesn't already have one at `cursor` (i.e., when there's no
+    // class-docstring contributing the blank line). This keeps the
+    // post-docstring case from accumulating two blank lines on every
+    // regen.
+    let injection_body = format!(
+        "    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(\n        org=\"{}\",\n        package=\"{}\",\n        type_=\"{}\",\n        version=\"{}\",\n    )\n",
         ident.org, ident.package, ident.type_name, ident.version,
     );
+    let needs_blank_separator = cursor < bytes.len() && bytes[cursor] != b'\n';
+    let injection = if needs_blank_separator {
+        format!("{}\n", injection_body)
+    } else {
+        injection_body
+    };
 
     let mut result = String::with_capacity(with_imports.len() + injection.len());
     result.push_str(&with_imports[..cursor]);

--- a/libs/streamlib-python/python/streamlib/__init__.py
+++ b/libs/streamlib-python/python/streamlib/__init__.py
@@ -39,23 +39,14 @@ from . import log
 from . import clock
 from .clock import MonotonicTimer, monotonic_now_ns
 
-# Re-export decorators and schema API
+# Processor + port decorators. Schemas are not author-decorated in Python —
+# JTD-in-YAML is the canonical schema source and `streamlib generate` emits
+# Python dataclasses carrying `__streamlib_schema_ident__` directly. See
+# `docs/architecture/schema-identity-and-packaging.md`.
 from .decorators import (
-    # Processor decorators
     processor,
     input,
     output,
-    # Schema decorator
-    schema,
-    # Field descriptors
-    SchemaField,
-    f32,
-    f64,
-    i32,
-    i64,
-    u32,
-    u64,
-    bool_field,
 )
 
 # Structured schema identity (mirrors Rust's streamlib_idents::SchemaIdent)
@@ -82,20 +73,10 @@ __all__ = [
     "clock",
     "monotonic_now_ns",
     "MonotonicTimer",
-    # Processor decorators
+    # Processor + port decorators
     "processor",
     "input",
     "output",
-    # Schema API
-    "schema",
-    "SchemaField",
-    "f32",
-    "f64",
-    "i32",
-    "i64",
-    "u32",
-    "u64",
-    "bool_field",
     # Structured schema identity
     "SchemaIdent",
     "PixelFormat",

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/audio_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/audio_frame.py
@@ -8,7 +8,8 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Union, get_args, get_origin
+from typing import Any, ClassVar, Dict, List, Optional, Union, get_args, get_origin
+from streamlib.schema_ident import SchemaIdent
 
 
 @dataclass
@@ -16,6 +17,13 @@ class AudioFrame:
     """
     Audio frame with interleaved samples (1-8 channels)
     """
+    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(
+        org="tatolab",
+        package="core",
+        type_="AudioFrame",
+        version="1.0.0",
+    )
+
 
     channels: 'int'
     """

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/audio_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/audio_frame.py
@@ -24,7 +24,6 @@ class AudioFrame:
         version="1.0.0",
     )
 
-
     channels: 'int'
     """
     Number of audio channels (1-8)

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_audio_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_audio_frame.py
@@ -24,7 +24,6 @@ class EncodedAudioFrame:
         version="1.0.0",
     )
 
-
     data: 'List[int]'
     """
     Encoded audio bitstream data (Opus/AAC)

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_audio_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_audio_frame.py
@@ -8,7 +8,8 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Union, get_args, get_origin
+from typing import Any, ClassVar, Dict, List, Optional, Union, get_args, get_origin
+from streamlib.schema_ident import SchemaIdent
 
 
 @dataclass
@@ -16,6 +17,13 @@ class EncodedAudioFrame:
     """
     Encoded audio frame with Opus/AAC bitstream data
     """
+    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(
+        org="tatolab",
+        package="core",
+        type_="EncodedAudioFrame",
+        version="1.0.0",
+    )
+
 
     data: 'List[int]'
     """

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_video_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_video_frame.py
@@ -24,7 +24,6 @@ class EncodedVideoFrame:
         version="1.0.0",
     )
 
-
     data: 'List[int]'
     """
     Encoded NAL units (H.264/H.265 bitstream data)

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_video_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/encoded_video_frame.py
@@ -8,7 +8,8 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Union, get_args, get_origin
+from typing import Any, ClassVar, Dict, List, Optional, Union, get_args, get_origin
+from streamlib.schema_ident import SchemaIdent
 
 
 @dataclass
@@ -16,6 +17,13 @@ class EncodedVideoFrame:
     """
     Encoded video frame with H.264/H.265 NAL unit data
     """
+    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(
+        org="tatolab",
+        package="core",
+        type_="EncodedVideoFrame",
+        version="1.0.0",
+    )
+
 
     data: 'List[int]'
     """

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/video_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/video_frame.py
@@ -8,7 +8,8 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Union, get_args, get_origin
+from typing import Any, ClassVar, Dict, Optional, Union, get_args, get_origin
+from streamlib.schema_ident import SchemaIdent
 
 
 @dataclass
@@ -16,6 +17,13 @@ class VideoFrame:
     """
     Video frame for IPC - references GPU surface by ID
     """
+    __streamlib_schema_ident__: ClassVar[SchemaIdent] = SchemaIdent(
+        org="tatolab",
+        package="core",
+        type_="VideoFrame",
+        version="1.0.0",
+    )
+
 
     frame_index: 'str'
     """

--- a/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/video_frame.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/tatolab__core/video_frame.py
@@ -24,7 +24,6 @@ class VideoFrame:
         version="1.0.0",
     )
 
-
     frame_index: 'str'
     """
     Sequential frame counter (uint64 as string - parse to native uint64)

--- a/libs/streamlib-python/python/streamlib/_manifest.py
+++ b/libs/streamlib-python/python/streamlib/_manifest.py
@@ -3,7 +3,7 @@
 
 """Minimal hand-rolled YAML reader for `streamlib.yaml` package metadata.
 
-Reads only the shape needed by the `@processor` / `@schema` decorators:
+Reads only the shape needed by the `@processor` decorator:
 
 - top-level `package: { org, name, version, ... }` block
 - top-level `processors:` list, returning the `name` of each entry

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -240,10 +240,9 @@ def _resolve_schema_ident(schema_arg) -> Optional[SchemaIdent]:
     Accepts:
         - `None` (port has no declared schema)
         - `SchemaIdent` instance (returned as-is)
-        - a class with `__streamlib_schema_ident__` attribute carrying a
-          `SchemaIdent` (codegen-emitted classes from `streamlib generate`
-          carry this automatically; authors do not write the attribute by
-          hand and there is no `@schema` authoring decorator)
+        - a codegen-emitted class carrying `__streamlib_schema_ident__`
+          as a `ClassVar[SchemaIdent]` attribute (produced by
+          `streamlib generate` from the package's JTD/YAML schemas)
 
     Rejects:
         - any string (bare type name OR joined `@org/pkg/Type@v` form)

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -182,20 +182,18 @@ def input(
 
     Args:
         name: Port name. Defaults to the method name.
-        schema: A structured carrier — either a `SchemaIdent` instance
-            (cross-package or same-package) or a class decorated with
-            `@schema` (whose `__streamlib_schema_ident__` is read).
-            String forms (bare type name or joined `@org/pkg/Type@v`)
-            are rejected with a clear error.
+        schema: A structured carrier — either a `SchemaIdent` instance or
+            a codegen-emitted class that carries `__streamlib_schema_ident__`
+            as a class attribute (produced by `streamlib generate` from the
+            package's JTD/YAML schemas). String forms (bare type name or
+            joined `@org/pkg/Type@v`) are rejected with a clear error.
         description: Human-readable description for introspection.
 
     Example:
         ```python
-        from streamlib import input, SchemaIdent
+        from streamlib._generated_.tatolab__core import VideoFrame
 
-        VIDEO_FRAME = SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0")
-
-        @input(schema=VIDEO_FRAME, description="RGB video input")
+        @input(schema=VideoFrame, description="RGB video input")
         def video_in(self): pass
         ```
     """

--- a/libs/streamlib-python/python/streamlib/decorators.py
+++ b/libs/streamlib-python/python/streamlib/decorators.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Jonathan Fontanez
 # SPDX-License-Identifier: BUSL-1.1
 
-"""Decorators for defining StreamLib processors and schemas in Python.
+"""Decorators for defining StreamLib processors in Python.
 
 `@processor("PascalCase")` mirrors Rust's `#[streamlib::processor("Camera")]`
 proc-macro: a positional PascalCase short name that the decorator resolves
@@ -12,9 +12,14 @@ as `__streamlib_schema_ident__`.
 
 Schema references in port declarations (`@input(schema=...)` /
 `@output(schema=...)`) are cross-package by definition. The only accepted
-forms are a `SchemaIdent` instance or a `@schema`-decorated class. Bare
-type names and joined-string identifiers are rejected — see the
-architecture preamble in issue #700 and
+forms are a [`SchemaIdent`][streamlib.schema_ident.SchemaIdent] instance
+or a codegen-emitted class carrying `__streamlib_schema_ident__` as a
+class attribute (produced by `streamlib generate` from the package's
+JTD/YAML schemas). There is no Python-side authoring decorator for
+declaring new schemas — JTD-in-YAML is the canonical schema source, and
+deriving JTD from Python field declarations would leak Python-native
+expressivity that doesn't translate cross-language. See the architecture
+preamble in issue #704 and
 `docs/architecture/schema-identity-and-packaging.md`.
 
 Timestamps
@@ -38,125 +43,11 @@ human-facing display.
 from __future__ import annotations
 
 import inspect
-import sys
 from pathlib import Path
-from typing import List, Optional, Type, Union
+from typing import Optional, Type, Union
 
 from ._manifest import ManifestParseError, read_manifest_summary
 from .schema_ident import SchemaIdent
-
-
-# =============================================================================
-# Schema Field Descriptors
-# =============================================================================
-
-
-class SchemaField:
-    """Descriptor for a field in a schema.
-
-    Used by the field descriptor functions (f32, i64, etc.) to define
-    schema fields. The @schema decorator collects these into a
-    Rust-backed DynamicDataFrameSchema.
-    """
-
-    def __init__(
-        self,
-        primitive_type: str,
-        shape: Optional[List[int]] = None,
-        description: str = "",
-    ):
-        self.primitive_type = primitive_type
-        self.shape = shape or []
-        self.description = description
-
-    def __repr__(self) -> str:
-        if self.shape:
-            return f"SchemaField({self.primitive_type}, shape={self.shape})"
-        return f"SchemaField({self.primitive_type})"
-
-
-def f32(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 32-bit float field."""
-    return SchemaField("f32", shape, description)
-
-
-def f64(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 64-bit float field."""
-    return SchemaField("f64", shape, description)
-
-
-def i32(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 32-bit signed integer field."""
-    return SchemaField("i32", shape, description)
-
-
-def i64(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 64-bit signed integer field."""
-    return SchemaField("i64", shape, description)
-
-
-def u32(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 32-bit unsigned integer field."""
-    return SchemaField("u32", shape, description)
-
-
-def u64(shape: Optional[List[int]] = None, description: str = "") -> SchemaField:
-    """Define a 64-bit unsigned integer field."""
-    return SchemaField("u64", shape, description)
-
-
-def bool_field(description: str = "") -> SchemaField:
-    """Define a boolean field.
-
-    Named ``bool_field`` to avoid shadowing Python's ``bool`` builtin.
-    """
-    return SchemaField("bool", None, description)
-
-
-# =============================================================================
-# Schema Decorator (untouched here; structured-ident parity tracked in #704)
-# =============================================================================
-
-
-def schema(name: Optional[str] = None):
-    """Define a custom data schema backed by Rust.
-
-    The decorated class should have class attributes that are SchemaField
-    instances (created via f32, i64, bool_field, etc.). The decorator
-    collects these fields and creates a Rust-backed DynamicDataFrameSchema.
-
-    NOTE: The structured-`SchemaIdent` parity migration for `@schema`
-    tracks in issue #704 (filed alongside #700). This decorator's shape
-    is unchanged in #700 — it still attaches a `__streamlib_schema__` dict
-    carrier; #704 replaces that with `__streamlib_schema_ident__: SchemaIdent`.
-    """
-
-    def decorator(cls):
-        schema_name = name or cls.__name__
-
-        fields = []
-        for attr_name in dir(cls):
-            if attr_name.startswith("_"):
-                continue
-            attr_value = getattr(cls, attr_name, None)
-            if isinstance(attr_value, SchemaField):
-                fields.append(
-                    {
-                        "name": attr_name,
-                        "primitive_type": attr_value.primitive_type,
-                        "shape": attr_value.shape,
-                        "description": attr_value.description,
-                    }
-                )
-
-        cls.__streamlib_schema__ = {
-            "name": schema_name,
-            "fields": fields,
-        }
-
-        return cls
-
-    return decorator
 
 
 # =============================================================================
@@ -351,10 +242,10 @@ def _resolve_schema_ident(schema_arg) -> Optional[SchemaIdent]:
     Accepts:
         - `None` (port has no declared schema)
         - `SchemaIdent` instance (returned as-is)
-        - a class with `__streamlib_schema_ident__` attribute (a
-          `@schema`-decorated class once #704 lands; today these classes
-          carry `__streamlib_schema__` legacy dict — that path is rejected
-          with guidance until #704)
+        - a class with `__streamlib_schema_ident__` attribute carrying a
+          `SchemaIdent` (codegen-emitted classes from `streamlib generate`
+          carry this automatically; authors do not write the attribute by
+          hand and there is no `@schema` authoring decorator)
 
     Rejects:
         - any string (bare type name OR joined `@org/pkg/Type@v` form)
@@ -377,18 +268,13 @@ def _resolve_schema_ident(schema_arg) -> Optional[SchemaIdent]:
         ident = getattr(schema_arg, "__streamlib_schema_ident__", None)
         if isinstance(ident, SchemaIdent):
             return ident
-        if hasattr(schema_arg, "__streamlib_schema__"):
-            raise TypeError(
-                f"schema={schema_arg.__name__}: this class is decorated with the "
-                f"legacy `@schema(name=...)` form whose structured-ident parity "
-                f"lands in #704. Pass a `SchemaIdent` instance directly until then."
-            )
         raise TypeError(
             f"schema={schema_arg.__name__}: class does not carry a structured "
-            f"SchemaIdent. Decorate it with `@schema(\"PascalCase\")` (post-#704) "
-            f"or pass a `SchemaIdent` instance directly."
+            f"SchemaIdent. Import a codegen-emitted class from "
+            f"streamlib._generated_.<package>, or pass a `SchemaIdent` "
+            f"instance directly."
         )
     raise TypeError(
         f"schema={schema_arg!r}: unsupported type {type(schema_arg).__name__}. "
-        f"Pass a `SchemaIdent` instance or a `@schema`-decorated class."
+        f"Pass a `SchemaIdent` instance or a codegen-emitted schema class."
     )

--- a/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py
@@ -239,15 +239,6 @@ class TestPortSchemaResolution:
         assert isinstance(video_in._streamlib_input_port["schema"], SchemaIdent)
         assert video_in._streamlib_input_port["schema"].type_ == "VideoFrame"
 
-    def test_legacy_at_schema_class_directs_to_followup(self) -> None:
-        class LegacySchema:
-            __streamlib_schema__ = {"name": "VideoFrame", "fields": []}
-
-        with pytest.raises(TypeError, match="#704"):
-            @input(schema=LegacySchema)
-            def video_in(self):
-                pass
-
     def test_class_without_schema_metadata_rejected(self) -> None:
         class Plain:
             pass
@@ -263,3 +254,44 @@ class TestPortSchemaResolution:
             pass
 
         assert control._streamlib_input_port["schema"] is None
+
+
+# =============================================================================
+# Codegen-emitted classes carry __streamlib_schema_ident__
+# =============================================================================
+
+
+class TestGeneratedSchemaIdents:
+    """Lock the codegen → `@input(schema=GeneratedClass)` path end-to-end.
+
+    Imports a real codegen-emitted class from the in-tree `_generated_/`
+    tree and asserts the structured `SchemaIdent` attribute it carries
+    matches the manifest-declared identity. If `streamlib generate` is
+    rerun, this test catches a regression in the post-processor's
+    SchemaIdent injection.
+    """
+
+    def test_video_frame_carries_structured_schema_ident(self) -> None:
+        from streamlib._generated_.tatolab__core import VideoFrame
+
+        ident = getattr(VideoFrame, "__streamlib_schema_ident__", None)
+        assert isinstance(ident, SchemaIdent), (
+            "VideoFrame must carry __streamlib_schema_ident__: SchemaIdent. "
+            "If this fails, rerun `cargo xtask generate-schemas --runtime python "
+            "--project-dir libs/streamlib --output libs/streamlib-python/python/streamlib/_generated_`."
+        )
+        assert ident.org == "tatolab"
+        assert ident.package == "core"
+        assert ident.type_ == "VideoFrame"
+        assert ident.version == "1.0.0"
+
+    def test_input_port_resolves_codegen_emitted_class(self) -> None:
+        from streamlib._generated_.tatolab__core import AudioFrame
+
+        @input(schema=AudioFrame)
+        def audio_in(self):
+            pass
+
+        resolved = audio_in._streamlib_input_port["schema"]
+        assert isinstance(resolved, SchemaIdent)
+        assert resolved == SchemaIdent("tatolab", "core", "AudioFrame", "1.0.0")


### PR DESCRIPTION
## Summary

- Extend `streamlib-jtd-codegen`'s Python post-processor to inject `__streamlib_schema_ident__: ClassVar[SchemaIdent]` as a class attribute on every new-shape (`metadata.type` + package context) generated dataclass. `@input(schema=GeneratedClass)` / `@output(schema=GeneratedClass)` now resolve to a structured `SchemaIdent` via the codegen-emitted attribute, no authoring decorator needed.
- Remove the Python `@streamlib.schema` decorator and the `SchemaField` / `f32` / `f64` / `i32` / `i64` / `u32` / `u64` / `bool_field` field-descriptor helpers entirely. JTD-in-YAML is the canonical schema source — letting Python derive JTD from `SchemaField` declarations would inevitably leak Python-native expressivity that doesn't translate cross-language. No other language has an equivalent (verified: zero `#[streamlib::schema]` macros in Rust, zero `@schema` callsites in Deno).
- Regenerate `libs/streamlib-python/python/streamlib/_generated_/tatolab__core/{video_frame,audio_frame,encoded_video_frame,encoded_audio_frame}.py` with the new SchemaIdent attribute. Legacy `metadata.name`-shape schemas are intentionally skipped (no enclosing package context to construct from; they pick up SchemaIdent automatically via #702's reverse-DNS rename).

## Closes

Closes #704

## Direction inversion (vs. issue body's original framing)

The original #704 was scoped as "bring `@schema` to parity with `@processor`." During pickup, two facts surfaced that invalidated the parity direction:

1. **JTDs generate code, not the other way.** Allowing `@schema` to synthesize JTD from Python `SchemaField` descriptors would let authors reach for Python-native types (custom classes, numpy types, pydantic models) that can't survive translation to a `.proto`-style cross-language artifact.
2. **Python's `@schema` was a half-finished asymmetric outlier.** No host-side reader for `__streamlib_schema__` (`DynamicDataFrameSchema` referenced in docstrings doesn't ship in `libs/streamlib`); zero callsites in the codebase outside the decorator definition itself; no equivalent in Rust or Deno.

So `@schema` is removed, not migrated. Issue body rewritten in place per markdown rules — original framing preserved struck-through with reasoning.

## Exit criteria

- [x] `@schema()`, `SchemaField`, and field-descriptor helpers removed from `decorators.py` + re-exports + `__all__`.
- [x] `_resolve_schema_ident()` simplified — legacy `__streamlib_schema__` branch dropped; error message points at codegen-emitted classes.
- [x] Python post-processor injects `from streamlib.schema_ident import SchemaIdent` + `__streamlib_schema_ident__: ClassVar[SchemaIdent]` on every new-shape generated dataclass; legacy reverse-DNS schemas untouched.
- [x] Four `tatolab__core/*.py` files regenerated with the SchemaIdent attribute; `verify-schemas` (idempotency test) green.
- [x] No `@schema` / `__streamlib_schema__` references remain in live Python code or tests.

## Test plan

- [x] `cargo test -p streamlib-jtd-codegen` — 50/50 pass (46 unit + 1 cross-language + 3 idempotency). New unit tests cover legacy-schema skip, new-shape-with-docstring injection, and new-shape-without-docstring fallback.
- [x] `python3 -m pytest libs/streamlib-python/python/streamlib/tests/` — 123/123 pass. New `TestGeneratedSchemaIdents` class imports real codegen-emitted `VideoFrame` and `AudioFrame` and asserts the structured ident plus `@input(schema=…)` resolution. Mental-revert test: removing the post-processor injection makes both new tests fail.
- [x] `cargo check -p streamlib-jtd-codegen -p streamlib-python-native -p streamlib-idents -p xtask` — clean.

## Polyglot coverage

- **Runtimes affected**: rust (codegen tooling) + python (SDK + generated output)
- **Schema regenerated**: yes — Python `_generated_/` for the four `@tatolab/core` schemas
- **Python and Deno both covered?** Schema-only / language-specific by construction. `@schema` only ever existed in Python; nothing to remove on the Rust or Deno side. Codegen extension to Rust + TS post-processors is filed as a follow-up.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib-jtd-codegen` — pass
  - [x] Python subprocess: `python3 -m pytest libs/streamlib-python/python/streamlib/tests/` — pass
  - [ ] Deno subprocess: n/a (no schema decorator existed in Deno)
- **FD-passing path**: n/a (authoring-time + tooling, not IPC)

## Follow-ups

- Rust + TS codegen extension to emit `pub const SCHEMA_IDENT: SchemaIdent = …` (and the TS interface analogue) on generated types — bring Decision 2 of the architecture doc to truth across all three languages, not just Python. Will file a follow-up issue.

## PR review gate

Ran `pr-review-gate` skill (Opus reviewer). Verdict: FIX with 2 items, both verified and fixed in commit `66f3f1d`:

1. `decorators.py` `@input` docstring still referenced "a class decorated with `@schema`" — updated to point at codegen-emitted classes.
2. Generated files had a double blank line between SchemaIdent block and first field — `inject_schema_ident_python` switched to single-newline injection plus a conditional blank-separator.

Re-ran tests after fixes — all 50 + 123 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)