### PR TITLE
feat(deno): @streamlib.processor decorator parity with Rust short-name macro (#701)

### DIFF
--- a/examples/camera-deno-subprocess/deno/grayscale_processor.ts
+++ b/examples/camera-deno-subprocess/deno/grayscale_processor.ts
@@ -8,13 +8,15 @@
  * directly for zero-copy processing, and writes output frames.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
-import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/com_tatolab_videoframe.ts";
+import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/tatolab__core/video_frame.ts";
 
+@processor("GrayscaleProcessor", import.meta.url)
 export default class GrayscaleProcessor implements ReactiveProcessor {
   setup(ctx: RuntimeContextFullAccess): void {
     console.error("[GrayscaleProcessor] setup — config:", JSON.stringify(ctx.config));

--- a/examples/camera-deno-subprocess/deno/halftone_processor.ts
+++ b/examples/camera-deno-subprocess/deno/halftone_processor.ts
@@ -13,13 +13,14 @@
 
 import tgpu, { type TgpuRoot } from "npm:typegpu@0.8.2";
 import * as d from "npm:typegpu@0.8.2/data";
-import type {
-  GpuSurface,
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  type GpuSurface,
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
-import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/com_tatolab_videoframe.ts";
+import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/tatolab__core/video_frame.ts";
 
 const HALFTONE_WGSL = /* wgsl */`
 @group(0) @binding(0) var<storage, read> inputPixels: array<u32>;
@@ -102,6 +103,7 @@ interface PoolSlot {
   handleId: string;
 }
 
+@processor("HalftoneProcessor", import.meta.url)
 export default class HalftoneProcessor implements ReactiveProcessor {
   private gpu: GpuResources | null = null;
   private outputPool: PoolSlot[] = [];

--- a/examples/camera-deno-subprocess/deno/streamlib.yaml
+++ b/examples/camera-deno-subprocess/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: camera-deno-subprocess
   version: "0.1.0"
   description: "TypeScript/Deno video processors using subprocess architecture"
 
 processors:
-  - name: com.tatolab.grayscale-ts
+  - name: GrayscaleProcessor
     version: "1.0.0"
     description: "Grayscale processor — TypeScript/Deno"
     runtime: deno
@@ -17,7 +18,7 @@ processors:
       - name: video_out
         schema: { org: tatolab, package: core, type: VideoFrame, version: 1.0.0 }
 
-  - name: com.tatolab.halftone-ts
+  - name: HalftoneProcessor
     version: "1.0.0"
     description: "Halftone dot pattern via TypeGPU/WebGPU compute shader"
     runtime: deno

--- a/examples/camera-deno-subprocess/src/main.rs
+++ b/examples/camera-deno-subprocess/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     }))?;
 
     let halftone = runtime.add_processor(ProcessorSpec::new(
-        "com.tatolab.halftone-ts",
+        "HalftoneProcessor",
         serde_json::json!({}),
     ))?;
 

--- a/examples/polyglot-continuous-processor/deno/continuous_processor.ts
+++ b/examples/polyglot-continuous-processor/deno/continuous_processor.ts
@@ -28,10 +28,12 @@ import {
   type ContinuousProcessor,
   log,
   monotonicNowNs,
+  processor,
   type RuntimeContextFullAccess,
   type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 
+@processor("PolyglotContinuousProcessor", import.meta.url)
 export default class PolyglotContinuousProcessor
   implements ContinuousProcessor {
   private outputFile = "";

--- a/examples/polyglot-continuous-processor/deno/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-continuous-processor-deno
   version: "0.1.0"
   description: "Polyglot continuous processor (#542) — Deno process() driven by monotonic-clock timerfd"
 
 processors:
-  - name: com.tatolab.polyglot_continuous_processor_deno
+  - name: PolyglotContinuousProcessor
     version: "1.0.0"
     description: "Continuous processor: process() called by the runner at interval_ms cadence (now timerfd-paced); each call writes the tick count + a monotonic timestamp into the host cpu-readback surface. Reference example for the no-setTimeout pacing contract."
     runtime: deno

--- a/examples/polyglot-continuous-processor/src/main.rs
+++ b/examples/polyglot-continuous-processor/src/main.rs
@@ -88,7 +88,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "PolyglotContinuousProcessor",
-            Self::Deno => "com.tatolab.polyglot_continuous_processor_deno",
+            Self::Deno => "PolyglotContinuousProcessor",
         }
     }
 }

--- a/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
+++ b/examples/polyglot-cpu-readback-blur/deno/cpu_readback_blur.ts
@@ -26,13 +26,15 @@
  *         Gaussian sigma.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import { CpuReadbackContext } from "../../../libs/streamlib-deno/adapters/cpu_readback.ts";
 
+@processor("CpuReadbackBlurProcessor", import.meta.url)
 export default class CpuReadbackBlurProcessor implements ReactiveProcessor {
   private surfaceId: bigint = 0n;
   private kernelSize = 11;

--- a/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-cpu-readback-blur-deno
   version: "0.1.0"
   description: "Polyglot cpu-readback adapter blur (#529) — Deno twin with hand-rolled separable Gaussian"
 
 processors:
-  - name: com.tatolab.cpu_readback_blur_deno
+  - name: CpuReadbackBlurProcessor
     version: "1.0.0"
     description: "Acquires a host-pre-registered cpu-readback surface, applies a separable Gaussian blur, releases"
     runtime: deno

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -100,7 +100,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "CpuReadbackBlur",
-            Self::Deno => "com.tatolab.cpu_readback_blur_deno",
+            Self::Deno => "CpuReadbackBlurProcessor",
         }
     }
 }

--- a/examples/polyglot-cuda-inference/deno/cuda_inference.ts
+++ b/examples/polyglot-cuda-inference/deno/cuda_inference.ts
@@ -32,10 +32,11 @@
  * is accepted but unused on the Deno side).
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import { CudaContext } from "../../../libs/streamlib-deno/adapters/cuda.ts";
 
@@ -50,6 +51,7 @@ interface CudaInferenceConfig {
 const DEVICE_TYPE_CUDA = 2;
 const DEVICE_TYPE_CUDA_HOST = 3;
 
+@processor("CudaInferenceProcessor", import.meta.url)
 export default class CudaInferenceProcessor implements ReactiveProcessor {
   private surfaceId: bigint = 0n;
   private width = 0;
@@ -60,7 +62,7 @@ export default class CudaInferenceProcessor implements ReactiveProcessor {
   private lastError: string | null = null;
 
   setup(ctx: RuntimeContextFullAccess): void {
-    const cfg = ctx.config as CudaInferenceConfig;
+    const cfg = ctx.config as unknown as CudaInferenceConfig;
     const sidRaw = cfg.cuda_surface_id;
     if (typeof sidRaw !== "number" && typeof sidRaw !== "bigint") {
       throw new Error(

--- a/examples/polyglot-cuda-inference/deno/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-cuda-inference-deno
   version: "0.1.0"
   description: "Polyglot CUDA adapter inference (#591) — Deno DLPack-capsule structural validation against host OPAQUE_FD VkBuffer"
 
 processors:
-  - name: com.tatolab.cuda_inference_deno
+  - name: CudaInferenceProcessor
     version: "1.0.0"
     description: "Acquires a host-pre-registered cuda OPAQUE_FD surface, validates the DLPack capsule shape, logs VALIDATION_PASSED / VALIDATION_FAILED to stderr"
     runtime: deno

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -99,7 +99,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "CudaInference",
-            Self::Deno => "com.tatolab.cuda_inference_deno",
+            Self::Deno => "CudaInferenceProcessor",
         }
     }
 }

--- a/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
+++ b/examples/polyglot-dma-buf-consumer/deno/dma_buf_consumer.ts
@@ -26,15 +26,17 @@
  *         Throttle for periodic resolve-success / resolve-failure log lines.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
-import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/com_tatolab_videoframe.ts";
+import type { VideoFrame } from "../../../libs/streamlib-deno/_generated_/tatolab__core/video_frame.ts";
 
 const BOGUS_SURFACE_ID = "00000000-0000-0000-0000-000000000000";
 
+@processor("DmaBufConsumer", import.meta.url)
 export default class DmaBufConsumer implements ReactiveProcessor {
   private forceBadId = false;
   private logEvery = 60;

--- a/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-dma-buf-consumer-deno
   version: "0.1.0"
   description: "Linux DMA-BUF consumer — Deno twin of the Python polyglot E2E"
 
 processors:
-  - name: com.tatolab.dma_buf_consumer_deno
+  - name: DmaBufConsumer
     version: "1.0.0"
     description: "Resolves an upstream surface_id to a DMA-BUF, locks/reads it, and forwards the frame downstream"
     runtime: deno

--- a/examples/polyglot-dma-buf-consumer/src/main.rs
+++ b/examples/polyglot-dma-buf-consumer/src/main.rs
@@ -60,7 +60,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "DmaBufConsumer",
-            Self::Deno => "com.tatolab.dma_buf_consumer_deno",
+            Self::Deno => "DmaBufConsumer",
         }
     }
 }

--- a/examples/polyglot-manual-source/deno/manual_source.ts
+++ b/examples/polyglot-manual-source/deno/manual_source.ts
@@ -32,14 +32,16 @@
  */
 
 import {
+  log,
   type ManualProcessor,
   monotonicNowNs,
   MonotonicTimer,
-  log,
+  processor,
   type RuntimeContextFullAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import type { OutputPorts } from "../../../libs/streamlib-deno/types.ts";
 
+@processor("PolyglotManualSource", import.meta.url)
 export default class PolyglotManualSource implements ManualProcessor {
   private intervalNs = 33n * 1_000_000n;
   private width = 32;

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-manual-source-deno
   version: "0.1.0"
   description: "Polyglot manual source (#542 / #604) — Deno worker Promise paced by MonotonicTimer publishes Videoframes via iceoryx2"
 
 processors:
-  - name: com.tatolab.polyglot_manual_source_deno
+  - name: PolyglotManualSource
     version: "1.0.0"
     description: "Manual source: spawns a worker Promise in start() that publishes Videoframes on the frame_out port at MonotonicTimer cadence. Reference example for the start()-must-return-promptly contract and #604's worker-task iceoryx2 publish path."
     runtime: deno

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -85,7 +85,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "PolyglotManualSource",
-            Self::Deno => "com.tatolab.polyglot_manual_source_deno",
+            Self::Deno => "PolyglotManualSource",
         }
     }
 }

--- a/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
+++ b/examples/polyglot-opengl-fragment-shader/deno/opengl_fragment_shader.ts
@@ -35,10 +35,11 @@
  *     Surface height in pixels.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import { OpenGLContext } from "../../../libs/streamlib-deno/adapters/opengl.ts";
 import {
@@ -268,6 +269,7 @@ function linkProgram(gl: any, vs: number, fs: number): number {
 // Processor
 // =============================================================================
 
+@processor("OpenGlFragmentShaderProcessor", import.meta.url)
 export default class OpenGlFragmentShaderProcessor implements ReactiveProcessor {
   private uuid = "";
   private width = 0;

--- a/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-opengl-fragment-shader-deno
   version: "0.1.0"
   description: "Polyglot OpenGL adapter scenario (#530) — Deno plasma fragment shader rendered into a host DMA-BUF surface"
 
 processors:
-  - name: com.tatolab.opengl_fragment_shader_deno
+  - name: OpenGlFragmentShaderProcessor
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a GL_TEXTURE_2D, renders a plasma-effect fragment shader, releases"
     runtime: deno

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -74,7 +74,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "OpenGlFragmentShader",
-            Self::Deno => "com.tatolab.opengl_fragment_shader_deno",
+            Self::Deno => "OpenGlFragmentShaderProcessor",
         }
     }
 }

--- a/examples/polyglot-vulkan-compute/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-compute-deno
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#531) — Deno Mandelbrot compute kernel dispatched against a host DMA-BUF VkImage"
 
 processors:
-  - name: com.tatolab.vulkan_compute_deno
+  - name: VulkanComputeProcessor
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, dispatches a Mandelbrot compute shader, releases"
     runtime: deno

--- a/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
+++ b/examples/polyglot-vulkan-compute/deno/vulkan_compute.ts
@@ -29,10 +29,11 @@
  * `examples/polyglot-vulkan-compute/shaders/mandelbrot.comp`).
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import {
   VkImageLayout,
@@ -47,6 +48,7 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
+@processor("VulkanComputeProcessor", import.meta.url)
 export default class VulkanComputeProcessor implements ReactiveProcessor {
   private uuid = "";
   private width = 0;

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -89,7 +89,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "VulkanCompute",
-            Self::Deno => "com.tatolab.vulkan_compute_deno",
+            Self::Deno => "VulkanComputeProcessor",
         }
     }
 }

--- a/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-graphics-deno
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#656) — Deno triangle vertex/fragment graphics kernel rendered into a host DMA-BUF VkImage"
 
 processors:
-  - name: com.tatolab.vulkan_graphics_deno
+  - name: VulkanGraphicsProcessor
     version: "1.0.0"
     description: "Acquires a host-pre-registered render-target DMA-BUF surface as a VkImage, draws a triangle via the host's VulkanGraphicsKernel, releases"
     runtime: deno

--- a/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
+++ b/examples/polyglot-vulkan-graphics/deno/vulkan_graphics.ts
@@ -25,10 +25,11 @@
  * vertex_spv_hex, fragment_spv_hex.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import {
   VkImageLayout,
@@ -80,6 +81,7 @@ function trianglePipelineState():
 // `GraphicsShaderStageFlags`.
 const STAGE_VERTEX = 1;
 
+@processor("VulkanGraphicsProcessor", import.meta.url)
 export default class VulkanGraphicsProcessor implements ReactiveProcessor {
   private uuid = "";
   private width = 0;

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -100,7 +100,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "VulkanGraphics",
-            Self::Deno => "com.tatolab.vulkan_graphics_deno",
+            Self::Deno => "VulkanGraphicsProcessor",
         }
     }
 }

--- a/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
@@ -1,10 +1,11 @@
 package:
+  org: tatolab
   name: polyglot-vulkan-ray-tracing-deno
   version: "0.1.0"
   description: "Polyglot Vulkan adapter scenario (#667) — Deno ray-traced triangle via host VulkanRayTracingKernel + AS escalate IPC"
 
 processors:
-  - name: com.tatolab.vulkan_ray_tracing_deno
+  - name: VulkanRayTracingProcessor
     version: "1.0.0"
     description: "Builds a single-triangle BLAS + identity TLAS via escalate IPC, registers an RT kernel, and dispatches one trace into a host-pre-registered storage image"
     runtime: deno

--- a/examples/polyglot-vulkan-ray-tracing/deno/vulkan_ray_tracing.ts
+++ b/examples/polyglot-vulkan-ray-tracing/deno/vulkan_ray_tracing.ts
@@ -25,10 +25,11 @@
  * rgen_spv_hex, rmiss_spv_hex, rchit_spv_hex.
  */
 
-import type {
-  ReactiveProcessor,
-  RuntimeContextFullAccess,
-  RuntimeContextLimitedAccess,
+import {
+  processor,
+  type ReactiveProcessor,
+  type RuntimeContextFullAccess,
+  type RuntimeContextLimitedAccess,
 } from "../../../libs/streamlib-deno/mod.ts";
 import { VulkanContext } from "../../../libs/streamlib-deno/adapters/vulkan.ts";
 
@@ -86,6 +87,7 @@ function identityTransform(): readonly number[] {
   ];
 }
 
+@processor("VulkanRayTracingProcessor", import.meta.url)
 export default class VulkanRayTracingProcessor implements ReactiveProcessor {
   private uuid = "";
   private width = 0;

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -105,7 +105,7 @@ impl RuntimeKind {
     fn processor_name(self) -> &'static str {
         match self {
             Self::Python => "VulkanRayTracing",
-            Self::Deno => "com.tatolab.vulkan_ray_tracing_deno",
+            Self::Deno => "VulkanRayTracingProcessor",
         }
     }
 }

--- a/libs/streamlib-deno/_manifest.ts
+++ b/libs/streamlib-deno/_manifest.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Decorator-side reader for `streamlib.yaml` package metadata.
+ *
+ * Reads only the shape needed by the `@processor` decorator:
+ *
+ * - top-level `package: { org, name, version, ... }` block
+ * - top-level `processors:` list, returning the `name` of each entry
+ *
+ * The full manifest is parsed by the Rust runtime via `serde_yaml` when
+ * the host loads it; this reader only needs enough fields to validate
+ * the decorator's short name and compose a structured `SchemaIdent`.
+ *
+ * Uses `@std/yaml` (Deno's standard library YAML parser) — no npm shim.
+ *
+ * @module
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+
+/** Resolved `package:` block from streamlib.yaml. */
+export interface ManifestPackage {
+  readonly org: string;
+  readonly name: string;
+  readonly version: string;
+}
+
+/** Decorator-side view of a streamlib.yaml. */
+export interface ManifestSummary {
+  readonly package: ManifestPackage;
+  readonly processorNames: readonly string[];
+}
+
+/** Raised when a streamlib.yaml cannot be parsed for decorator use. */
+export class ManifestParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ManifestParseError";
+  }
+}
+
+/**
+ * Parse the `package:` block + `processors[].name` list from a
+ * streamlib.yaml at `path`.
+ *
+ * Throws `Deno.errors.NotFound` if the file does not exist, and
+ * `ManifestParseError` if the manifest is missing `package:`, missing
+ * any of `org`/`name`/`version`, or otherwise malformed.
+ */
+export function readManifestSummary(path: string): ManifestSummary {
+  let text: string;
+  try {
+    text = Deno.readTextFileSync(path);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw e;
+    }
+    throw new ManifestParseError(
+      `failed to read ${path}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(text);
+  } catch (e) {
+    throw new ManifestParseError(
+      `failed to parse ${path}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ManifestParseError(
+      `streamlib.yaml at ${path} must be a YAML mapping at the top level`,
+    );
+  }
+  const root = parsed as Record<string, unknown>;
+
+  const pkgRaw = root["package"];
+  if (
+    pkgRaw === null || pkgRaw === undefined ||
+    typeof pkgRaw !== "object" || Array.isArray(pkgRaw)
+  ) {
+    throw new ManifestParseError(
+      `streamlib.yaml at ${path} is missing required \`package:\` block. ` +
+        `The decorator requires \`package: { org, name, version }\` to ` +
+        `construct a structured SchemaIdent.`,
+    );
+  }
+  const pkg = pkgRaw as Record<string, unknown>;
+
+  const org = pkg["org"];
+  const name = pkg["name"];
+  const version = pkg["version"];
+  const missing: string[] = [];
+  if (typeof org !== "string") missing.push("org");
+  if (typeof name !== "string") missing.push("name");
+  if (typeof version !== "string") missing.push("version");
+  if (missing.length > 0) {
+    throw new ManifestParseError(
+      `streamlib.yaml at ${path} is missing required \`package:\` field(s): ` +
+        `${missing.join(", ")}. The decorator requires ` +
+        `\`package: { org, name, version }\` to construct a structured SchemaIdent.`,
+    );
+  }
+
+  const processorNames: string[] = [];
+  const procsRaw = root["processors"];
+  if (Array.isArray(procsRaw)) {
+    for (const entry of procsRaw) {
+      if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+        const entryName = (entry as Record<string, unknown>)["name"];
+        if (typeof entryName === "string" && entryName.length > 0) {
+          processorNames.push(entryName);
+        }
+      }
+    }
+  }
+
+  return {
+    package: {
+      org: org as string,
+      name: name as string,
+      version: version as string,
+    },
+    processorNames,
+  };
+}

--- a/libs/streamlib-deno/adapters/cpu_readback.ts
+++ b/libs/streamlib-deno/adapters/cpu_readback.ts
@@ -174,7 +174,10 @@ export class CpuReadbackContext {
   // deno-lint-ignore no-explicit-any
   private readonly symbols: any;
   private readonly rt: Deno.PointerObject;
-  private readonly triggerCallback: Deno.UnsafeCallback;
+  private readonly triggerCallback: Deno.UnsafeCallback<{
+    readonly parameters: readonly ["pointer", "u64", "u32"];
+    readonly result: "u64";
+  }>;
   private readonly surfaceIds = new Map<string, bigint>();
   private readonly resolvedHandles = new Map<
     string,
@@ -352,7 +355,7 @@ export class CpuReadbackContext {
       surfaceId,
       "image_to_buffer",
     );
-    _pendingTimelineValue = BigInt(response.timeline_value);
+    _pendingTimelineValue = BigInt(response.timeline_value ?? 0);
 
     const buf = new Uint8Array(VIEW_STRUCT_SIZE);
     const fn = blocking
@@ -395,7 +398,7 @@ export class CpuReadbackContext {
               surfaceIdSnapshot,
               "buffer_to_image",
             );
-            _pendingTimelineValue = BigInt(flushResponse.timeline_value);
+            _pendingTimelineValue = BigInt(flushResponse.timeline_value ?? 0);
           } catch (e) {
             // Surface flush failure through the polyglot unified
             // logging pathway; the cdylib logs its own context too.

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -34,6 +34,7 @@ import {
 import {
   STREAMLIB_ADAPTER_ABI_VERSION,
   type StreamlibSurface,
+  type SurfaceAccessGuard,
 } from "../surface_adapter.ts";
 
 export { STREAMLIB_ADAPTER_ABI_VERSION };

--- a/libs/streamlib-deno/decorators.ts
+++ b/libs/streamlib-deno/decorators.ts
@@ -1,0 +1,350 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Decorators for defining StreamLib processors in Deno.
+ *
+ * `@processor("PascalCase", import.meta.url)` mirrors Rust's
+ * `#[streamlib::processor("Camera")]` proc-macro and Python's
+ * `@processor("Camera")`: a positional PascalCase short name resolved
+ * against the sibling `streamlib.yaml`'s `package: { org, name, version }`
+ * block at decoration time. The result is a structured
+ * {@linkcode SchemaIdent} attached to the class as
+ * `streamlibSchemaIdent`.
+ *
+ * Deno has no `inspect.getfile` equivalent — TC39 stage-3 decorators
+ * don't surface the source URL in the decorator context. The caller
+ * passes `import.meta.url` explicitly as the second argument; the
+ * decorator resolves it to a filesystem path and looks for a sibling
+ * `streamlib.yaml`.
+ *
+ * Schema references in port declarations (`@input(...)` / `@output(...)`)
+ * are cross-package by definition. The only accepted forms are a
+ * {@linkcode SchemaIdent} instance or a class carrying
+ * `streamlibSchemaIdent` as a static field. String forms (bare type
+ * name or joined `@org/pkg/Type@v`) are rejected — schemas have no
+ * shorthand. See `docs/architecture/schema-identity-and-packaging.md`.
+ *
+ * Timestamps
+ * ----------
+ *
+ * For any timestamp that crosses the host/subprocess boundary or is
+ * compared against another runtime's stamps — frame stamps, log
+ * correlation, escalate request IDs, anything similar — use
+ * `monotonicNowNs()` from `mod.ts`. It calls
+ * `clock_gettime(CLOCK_MONOTONIC)`, the same kernel syscall the host
+ * Rust runtime and the Python SDK make, so values share a system-wide
+ * epoch and are directly comparable.
+ *
+ * Do NOT use `Date.now()` or `performance.now()` for cross-process
+ * timestamps. Wall-clock APIs remain appropriate for ISO8601
+ * formatting and other genuinely human-facing display.
+ *
+ * @module
+ */
+
+import { dirname, fromFileUrl, join } from "@std/path";
+
+import {
+  type ManifestSummary,
+  ManifestParseError,
+  readManifestSummary,
+} from "./_manifest.ts";
+import { SchemaIdent } from "./schema_ident.ts";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/** Carrier shape for a class that has been processed by `@processor`. */
+export interface StreamlibClassMetadata {
+  readonly streamlibSchemaIdent: SchemaIdent;
+  readonly streamlibPorts: {
+    readonly inputs: readonly PortMetadata[];
+    readonly outputs: readonly PortMetadata[];
+  };
+}
+
+/** Per-port metadata attached by `@input` / `@output`. */
+export interface PortMetadata {
+  readonly name: string;
+  readonly schema: SchemaIdent | null;
+  readonly description: string;
+}
+
+/**
+ * Schema carrier accepted by `@input` / `@output`.
+ *
+ * Either a {@linkcode SchemaIdent} instance, or a class that carries
+ * `streamlibSchemaIdent` as a static field (produced by
+ * `streamlib generate` from the package's JTD/YAML schemas).
+ */
+export type SchemaCarrier =
+  | SchemaIdent
+  | { streamlibSchemaIdent: SchemaIdent };
+
+/** Options accepted by `input()` / `output()`. */
+export interface PortOptions {
+  /** Port name. Defaults to the method name. */
+  name?: string;
+  /** Structured schema carrier — strings are rejected. */
+  schema?: SchemaCarrier | null;
+  /** Human-readable description for introspection. */
+  description?: string;
+}
+
+// =============================================================================
+// Processor class decorator
+// =============================================================================
+
+// deno-lint-ignore no-explicit-any
+type ClassConstructor = new (...args: any[]) => any;
+
+/**
+ * Mark a class as a StreamLib processor (PascalCase positional short
+ * name).
+ *
+ * Mirrors Rust's `#[streamlib::processor("Camera")]` macro and Python's
+ * `@processor("Camera")`. At decoration time, the decorator locates the
+ * sibling `streamlib.yaml` (next to the file containing
+ * `import.meta.url`), reads its `package: { org, name, version }` block,
+ * validates that `shortName` appears in the manifest's `processors:`
+ * list, and constructs a structured {@linkcode SchemaIdent} attached to
+ * the class as `streamlibSchemaIdent`. Method-level port metadata
+ * declared by {@linkcode input}/{@linkcode output} is collected onto
+ * `streamlibPorts`.
+ *
+ * @param shortName PascalCase type name. Must match an entry in the
+ *   sibling manifest's `processors:` list.
+ * @param moduleUrl Pass `import.meta.url` from the file containing the
+ *   decorated class. Required because Deno's TC39 decorator context
+ *   does not expose the source URL.
+ *
+ * @example
+ * ```ts
+ * import { processor } from "<deno-streamlib>";
+ *
+ * @processor("CyberpunkProcessor", import.meta.url)
+ * export default class CyberpunkProcessor { … }
+ * ```
+ *
+ * Wire format and IPC always carry the full structured `SchemaIdent`;
+ * the short-name positional is an authoring convenience for the
+ * processor's own identity declaration only — schema references in
+ * port declarations have no analogous shorthand and require a
+ * structured carrier.
+ */
+export function processor(shortName: string, moduleUrl: string) {
+  if (typeof shortName !== "string") {
+    throw new TypeError(
+      `@processor() takes a positional PascalCase short name (string); got ` +
+        `${typeof shortName}. Pass the type name as the first argument: ` +
+        `@processor("Camera", import.meta.url).`,
+    );
+  }
+  if (typeof moduleUrl !== "string") {
+    throw new TypeError(
+      `@processor() requires the module's import.meta.url as the second ` +
+        `argument; got ${typeof moduleUrl}. Pass import.meta.url explicitly: ` +
+        `@processor("Camera", import.meta.url).`,
+    );
+  }
+
+  return <T extends ClassConstructor>(
+    target: T,
+    _context: ClassDecoratorContext,
+  ): T => {
+    const manifestPath = locateSiblingManifest(moduleUrl, shortName);
+    const summary = loadManifestSummary(manifestPath, shortName);
+
+    if (!summary.processorNames.includes(shortName)) {
+      const available = summary.processorNames.length > 0
+        ? summary.processorNames.join("\n    ")
+        : "(none declared)";
+      throw new Error(
+        `@processor(${JSON.stringify(shortName)}): short name not declared ` +
+          `in ${manifestPath}'s \`processors:\` list. Available processors:\n    ` +
+          `${available}`,
+      );
+    }
+
+    const ident = new SchemaIdent(
+      summary.package.org,
+      summary.package.name,
+      shortName,
+      summary.package.version,
+    );
+
+    // Attach as static fields. Mirrors Python's
+    // `cls.__streamlib_schema_ident__` / `cls.__streamlib_ports__`.
+    Object.defineProperty(target, "streamlibSchemaIdent", {
+      value: ident,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+
+    const inputs: PortMetadata[] = [];
+    const outputs: PortMetadata[] = [];
+    const prototype = target.prototype as Record<string, unknown>;
+    if (prototype) {
+      for (const key of Object.getOwnPropertyNames(prototype)) {
+        const value = prototype[key];
+        if (typeof value !== "function") continue;
+        // deno-lint-ignore no-explicit-any
+        const fn = value as any;
+        if (fn.streamlibInputPort) inputs.push(fn.streamlibInputPort);
+        if (fn.streamlibOutputPort) outputs.push(fn.streamlibOutputPort);
+      }
+    }
+    Object.defineProperty(target, "streamlibPorts", {
+      value: Object.freeze({
+        inputs: Object.freeze(inputs),
+        outputs: Object.freeze(outputs),
+      }),
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+
+    return target;
+  };
+}
+
+// =============================================================================
+// Port method decorators
+// =============================================================================
+
+/**
+ * Mark a method as defining an input port.
+ *
+ * @example
+ * ```ts
+ * import { input } from "<deno-streamlib>";
+ * import { VideoFrame } from "<deno-streamlib>/_generated_/tatolab__core/video_frame.ts";
+ *
+ * class MyProcessor {
+ *   @input({ schema: VideoFrame, description: "RGB video input" })
+ *   videoIn() {}
+ * }
+ * ```
+ */
+export function input(opts: PortOptions = {}) {
+  return (
+    // deno-lint-ignore ban-types
+    target: Function,
+    context: ClassMethodDecoratorContext,
+  ): void => {
+    if (context.kind !== "method") {
+      throw new Error("@input must be applied to a method");
+    }
+    const portName = opts.name ??
+      (typeof context.name === "string" ? context.name : String(context.name));
+    // deno-lint-ignore no-explicit-any
+    (target as any).streamlibInputPort = {
+      name: portName,
+      schema: resolveSchemaIdent(opts.schema ?? null),
+      description: opts.description ?? "",
+    } as PortMetadata;
+  };
+}
+
+/**
+ * Mark a method as defining an output port. Same shape as
+ * {@linkcode input}.
+ */
+export function output(opts: PortOptions = {}) {
+  return (
+    // deno-lint-ignore ban-types
+    target: Function,
+    context: ClassMethodDecoratorContext,
+  ): void => {
+    if (context.kind !== "method") {
+      throw new Error("@output must be applied to a method");
+    }
+    const portName = opts.name ??
+      (typeof context.name === "string" ? context.name : String(context.name));
+    // deno-lint-ignore no-explicit-any
+    (target as any).streamlibOutputPort = {
+      name: portName,
+      schema: resolveSchemaIdent(opts.schema ?? null),
+      description: opts.description ?? "",
+    } as PortMetadata;
+  };
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function locateSiblingManifest(
+  moduleUrl: string,
+  shortName: string,
+): string {
+  if (!moduleUrl.startsWith("file://")) {
+    throw new Error(
+      `@processor(${JSON.stringify(shortName)}): module URL must be a ` +
+        `file:// URL (got ${moduleUrl}). Pass import.meta.url from a ` +
+        `regular .ts module file.`,
+    );
+  }
+  const filePath = fromFileUrl(moduleUrl);
+  return join(dirname(filePath), "streamlib.yaml");
+}
+
+function loadManifestSummary(
+  manifestPath: string,
+  shortName: string,
+): ManifestSummary {
+  try {
+    return readManifestSummary(manifestPath);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw new Error(
+        `streamlib.yaml not found at ${manifestPath}. ` +
+          `@processor(${JSON.stringify(shortName)}) requires a sibling ` +
+          `streamlib.yaml with a \`package: { org, name, version }\` block ` +
+          `and a matching \`processors:\` entry.`,
+      );
+    }
+    if (e instanceof ManifestParseError) {
+      throw e;
+    }
+    throw e;
+  }
+}
+
+function resolveSchemaIdent(
+  arg: SchemaCarrier | null | undefined,
+): SchemaIdent | null {
+  if (arg === null || arg === undefined) return null;
+  if (arg instanceof SchemaIdent) return arg;
+  if (typeof arg === "string") {
+    throw new TypeError(
+      `schema=${JSON.stringify(arg)}: string schema references are no ` +
+        `longer accepted. Pass a structured \`SchemaIdent(org, package, type, version)\` ` +
+        `instance instead. Joined-string forms like ` +
+        `'@tatolab/core/VideoFrame@1.0.0' and bare type names like ` +
+        `'VideoFrame' are both rejected — schemas are cross-package ` +
+        `references by definition and have no shorthand. See ` +
+        `docs/architecture/schema-identity-and-packaging.md.`,
+    );
+  }
+  if (typeof arg === "function" || typeof arg === "object") {
+    // deno-lint-ignore no-explicit-any
+    const candidate = (arg as any).streamlibSchemaIdent;
+    if (candidate instanceof SchemaIdent) return candidate;
+    throw new TypeError(
+      `schema=${
+        // deno-lint-ignore no-explicit-any
+        ((arg as any).name ?? String(arg))
+      }: carrier does not expose a structured \`streamlibSchemaIdent\`. ` +
+        `Import a codegen-emitted class from your generated bindings, or ` +
+        `pass a \`SchemaIdent\` instance directly.`,
+    );
+  }
+  throw new TypeError(
+    `schema=${JSON.stringify(arg)}: unsupported type ${typeof arg}. Pass a ` +
+      `\`SchemaIdent\` instance or a codegen-emitted schema class.`,
+  );
+}

--- a/libs/streamlib-deno/decorators_test.ts
+++ b/libs/streamlib-deno/decorators_test.ts
@@ -13,7 +13,7 @@ import {
   assertEquals,
   assertThrows,
 } from "@std/assert";
-import { dirname, fromFileUrl, join } from "@std/path";
+import { join } from "@std/path";
 
 import { SchemaIdent } from "./schema_ident.ts";
 import {
@@ -146,8 +146,6 @@ async function makeFixture(
   await Deno.writeTextFile(modulePath, moduleBody);
   return { dir, manifestPath, modulePath };
 }
-
-const SDK_DIR = dirname(fromFileUrl(import.meta.url));
 
 function moduleHeader(): string {
   const decoratorsUrl = new URL("./decorators.ts", import.meta.url).href;
@@ -460,9 +458,3 @@ Deno.test("@processor collects @input + @output port metadata", async () => {
   }
 });
 
-// Anchor the SDK_DIR test — silences unused-var lint for the constant.
-Deno.test("SDK_DIR is the directory holding decorators.ts", () => {
-  const expected = fromFileUrl(new URL("./", import.meta.url));
-  // join() normalizes trailing slashes; compare via dirname round-trip.
-  assertEquals(SDK_DIR + "/", expected);
-});

--- a/libs/streamlib-deno/decorators_test.ts
+++ b/libs/streamlib-deno/decorators_test.ts
@@ -1,0 +1,468 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for `@processor("PascalCase", import.meta.url)` and structured
+ * `SchemaIdent` parity. Mirrors
+ * `libs/streamlib-python/python/streamlib/tests/test_processor_decorator.py`
+ * shape so a reviewer can diff them line-for-line.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+import { SchemaIdent } from "./schema_ident.ts";
+import {
+  input,
+  output,
+  type PortMetadata,
+  processor,
+  type StreamlibClassMetadata,
+} from "./decorators.ts";
+
+// =============================================================================
+// SchemaIdent class
+// =============================================================================
+
+Deno.test("SchemaIdent constructs with valid segments", () => {
+  const ident = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  assertEquals(ident.org, "tatolab");
+  assertEquals(ident.package, "core");
+  assertEquals(ident.type, "VideoFrame");
+  assertEquals(ident.version, "1.0.0");
+});
+
+Deno.test("SchemaIdent toString renders joined form", () => {
+  const ident = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  assertEquals(String(ident), "@tatolab/core/VideoFrame@1.0.0");
+});
+
+Deno.test("SchemaIdent toWireObject uses 'type' key", () => {
+  const ident = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  assertEquals(ident.toWireObject(), {
+    org: "tatolab",
+    package: "core",
+    type: "VideoFrame",
+    version: "1.0.0",
+  });
+});
+
+Deno.test("SchemaIdent is frozen", () => {
+  const ident = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  assertThrows(
+    () => {
+      // deno-lint-ignore no-explicit-any
+      (ident as any).org = "other";
+    },
+    TypeError,
+  );
+});
+
+Deno.test("SchemaIdent rejects uppercase org", () => {
+  assertThrows(
+    () => new SchemaIdent("Tatolab", "core", "VideoFrame", "1.0.0"),
+    Error,
+    "invalid org",
+  );
+});
+
+Deno.test("SchemaIdent rejects uppercase package", () => {
+  assertThrows(
+    () => new SchemaIdent("tatolab", "Core", "VideoFrame", "1.0.0"),
+    Error,
+    "invalid package",
+  );
+});
+
+Deno.test("SchemaIdent rejects lowercase type", () => {
+  assertThrows(
+    () => new SchemaIdent("tatolab", "core", "videoFrame", "1.0.0"),
+    Error,
+    "invalid type",
+  );
+});
+
+Deno.test("SchemaIdent rejects underscore in org", () => {
+  assertThrows(
+    () => new SchemaIdent("tato_lab", "core", "VideoFrame", "1.0.0"),
+    Error,
+    "invalid org",
+  );
+});
+
+Deno.test("SchemaIdent rejects malformed version", () => {
+  assertThrows(
+    () => new SchemaIdent("tatolab", "core", "VideoFrame", "1.0"),
+    Error,
+    "invalid version",
+  );
+});
+
+Deno.test("SchemaIdent accepts hyphen in package", () => {
+  const ident = new SchemaIdent(
+    "tatolab",
+    "camera-deno-subprocess",
+    "Foo",
+    "0.1.0",
+  );
+  assertEquals(ident.package, "camera-deno-subprocess");
+});
+
+Deno.test("SchemaIdent.equals returns true on structural match", () => {
+  const a = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  const b = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+  assert(a.equals(b));
+  const c = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.1");
+  assert(!a.equals(c));
+});
+
+// =============================================================================
+// @processor decorator — manifest-driven structured-ident emission
+// =============================================================================
+//
+// Each test writes a `streamlib.yaml` + `<fixture>.ts` pair into a
+// fresh tmp dir, then dynamic-imports the fixture and inspects its
+// emitted class metadata. Mirrors `_import_class_from_dir` from the
+// Python test suite.
+
+interface FixturePaths {
+  dir: string;
+  manifestPath: string;
+  modulePath: string;
+}
+
+async function makeFixture(
+  manifestBody: string,
+  moduleBody: string,
+): Promise<FixturePaths> {
+  const dir = await Deno.makeTempDir({ prefix: "streamlib-decorator-" });
+  const manifestPath = join(dir, "streamlib.yaml");
+  const modulePath = join(dir, "fixture.ts");
+  await Deno.writeTextFile(manifestPath, manifestBody);
+  await Deno.writeTextFile(modulePath, moduleBody);
+  return { dir, manifestPath, modulePath };
+}
+
+const SDK_DIR = dirname(fromFileUrl(import.meta.url));
+
+function moduleHeader(): string {
+  const decoratorsUrl = new URL("./decorators.ts", import.meta.url).href;
+  const schemaIdentUrl = new URL("./schema_ident.ts", import.meta.url).href;
+  return (
+    `import { input, output, processor } from "${decoratorsUrl}";\n` +
+    `import { SchemaIdent } from "${schemaIdentUrl}";\n`
+  );
+}
+
+Deno.test("@processor attaches structured SchemaIdent from manifest", async () => {
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: cyberpunk-processor",
+      "  version: 0.1.0",
+      "",
+      "processors:",
+      "  - name: CyberpunkProcessor",
+      "    runtime: deno",
+      "    execution: reactive",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `@processor("CyberpunkProcessor", import.meta.url)\n` +
+      `export default class CyberpunkProcessor {}\n`,
+  );
+  try {
+    const mod = await import(`file://${fixture.modulePath}`);
+    const cls = mod.default as unknown as StreamlibClassMetadata;
+    const ident = cls.streamlibSchemaIdent;
+    assert(ident instanceof SchemaIdent);
+    assertEquals(ident.org, "tatolab");
+    assertEquals(ident.package, "cyberpunk-processor");
+    assertEquals(ident.type, "CyberpunkProcessor");
+    assertEquals(ident.version, "0.1.0");
+    assertEquals(String(ident), "@tatolab/cyberpunk-processor/CyberpunkProcessor@0.1.0");
+    assertEquals(cls.streamlibPorts.inputs.length, 0);
+    assertEquals(cls.streamlibPorts.outputs.length, 0);
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
+Deno.test("@processor errors with expected path when manifest missing", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "streamlib-decorator-" });
+  const modulePath = join(dir, "fixture.ts");
+  // No streamlib.yaml in dir.
+  await Deno.writeTextFile(
+    modulePath,
+    moduleHeader() +
+      `@processor("Anything", import.meta.url)\n` +
+      `export default class Anything {}\n`,
+  );
+  try {
+    let caught: unknown = null;
+    try {
+      await import(`file://${modulePath}`);
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error, "expected an error");
+    const msg = (caught as Error).message;
+    assert(
+      msg.includes("streamlib.yaml not found"),
+      `expected 'streamlib.yaml not found' in error, got: ${msg}`,
+    );
+    assert(
+      msg.includes(join(dir, "streamlib.yaml")),
+      `expected expected manifest path in error, got: ${msg}`,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("@processor short-name not in manifest lists available", async () => {
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: example",
+      "  version: 0.1.0",
+      "",
+      "processors:",
+      "  - name: Camera",
+      "  - name: Display",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `@processor("MissingProcessor", import.meta.url)\n` +
+      `export default class MissingProcessor {}\n`,
+  );
+  try {
+    let caught: unknown = null;
+    try {
+      await import(`file://${fixture.modulePath}`);
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error);
+    const msg = (caught as Error).message;
+    assert(msg.includes("Available processors"), msg);
+    assert(msg.includes("Camera"), msg);
+    assert(msg.includes("Display"), msg);
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
+Deno.test("@processor errors when manifest missing required package fields", async () => {
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  name: example",
+      "  version: 0.1.0",
+      "",
+      "processors:",
+      "  - name: Foo",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `@processor("Foo", import.meta.url)\n` +
+      `export default class Foo {}\n`,
+  );
+  try {
+    let caught: unknown = null;
+    try {
+      await import(`file://${fixture.modulePath}`);
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error);
+    const msg = (caught as Error).message;
+    assert(
+      msg.includes("missing required `package:` field"),
+      `expected missing-fields message, got: ${msg}`,
+    );
+    assert(msg.includes("org"), msg);
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
+Deno.test("@processor rejects non-string short name", () => {
+  assertThrows(
+    () => {
+      // deno-lint-ignore no-explicit-any
+      (processor as any)(123, "file:///dummy.ts");
+    },
+    TypeError,
+    "PascalCase short name",
+  );
+});
+
+Deno.test("@processor rejects missing module URL", () => {
+  assertThrows(
+    () => {
+      // deno-lint-ignore no-explicit-any
+      (processor as any)("Camera");
+    },
+    TypeError,
+    "import.meta.url",
+  );
+});
+
+// =============================================================================
+// @input / @output schema validation
+// =============================================================================
+
+Deno.test("@input accepts a SchemaIdent instance", () => {
+  const ident = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");
+
+  class P {
+    @input({ schema: ident })
+    videoIn() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).videoIn.streamlibInputPort as PortMetadata;
+  assertEquals(meta.name, "videoIn");
+  assert(meta.schema instanceof SchemaIdent);
+  assert(meta.schema!.equals(ident));
+});
+
+Deno.test("@output accepts a class carrying streamlibSchemaIdent", () => {
+  class MySchema {
+    static streamlibSchemaIdent = new SchemaIdent(
+      "tatolab",
+      "core",
+      "VideoFrame",
+      "1.0.0",
+    );
+  }
+
+  class P {
+    @output({ schema: MySchema })
+    videoOut() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).videoOut.streamlibOutputPort as PortMetadata;
+  assert(meta.schema instanceof SchemaIdent);
+  assertEquals(meta.schema!.type, "VideoFrame");
+});
+
+Deno.test("@input rejects bare-string schema", () => {
+  assertThrows(
+    () => {
+      class P {
+        // deno-lint-ignore no-explicit-any
+        @input({ schema: "VideoFrame" as any })
+        videoIn() {}
+      }
+      // Force decorator evaluation via reference.
+      void P;
+    },
+    TypeError,
+    "string schema references are no longer accepted",
+  );
+});
+
+Deno.test("@output rejects joined-string schema", () => {
+  assertThrows(
+    () => {
+      class P {
+        // deno-lint-ignore no-explicit-any
+        @output({ schema: "@tatolab/core/VideoFrame@1.0.0" as any })
+        videoOut() {}
+      }
+      void P;
+    },
+    TypeError,
+    "string schema references",
+  );
+});
+
+Deno.test("@input rejects class without schema metadata", () => {
+  class Plain {}
+  assertThrows(
+    () => {
+      class P {
+        // deno-lint-ignore no-explicit-any
+        @input({ schema: Plain as any })
+        videoIn() {}
+      }
+      void P;
+    },
+    TypeError,
+    "does not expose a structured",
+  );
+});
+
+Deno.test("@input with no schema attaches null schema", () => {
+  class P {
+    @input()
+    control() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).control.streamlibInputPort as PortMetadata;
+  assertEquals(meta.schema, null);
+  assertEquals(meta.name, "control");
+});
+
+Deno.test("@input port name override", () => {
+  class P {
+    @input({ name: "video_in" })
+    handler() {}
+  }
+  // deno-lint-ignore no-explicit-any
+  const meta = (P.prototype as any).handler.streamlibInputPort as PortMetadata;
+  assertEquals(meta.name, "video_in");
+});
+
+Deno.test("@processor collects @input + @output port metadata", async () => {
+  const fixture = await makeFixture(
+    [
+      "package:",
+      "  org: tatolab",
+      "  name: ports-fixture",
+      "  version: 0.1.0",
+      "",
+      "processors:",
+      "  - name: PortsFixture",
+      "    runtime: deno",
+      "    execution: reactive",
+      "",
+    ].join("\n"),
+    moduleHeader() +
+      `const VIDEO = new SchemaIdent("tatolab", "core", "VideoFrame", "1.0.0");\n` +
+      `@processor("PortsFixture", import.meta.url)\n` +
+      `export default class PortsFixture {\n` +
+      `  @input({ name: "video_in", schema: VIDEO, description: "trigger" })\n` +
+      `  handleIn() {}\n` +
+      `  @output({ name: "video_out", schema: VIDEO })\n` +
+      `  handleOut() {}\n` +
+      `}\n`,
+  );
+  try {
+    const mod = await import(`file://${fixture.modulePath}`);
+    const cls = mod.default as unknown as StreamlibClassMetadata;
+    assertEquals(cls.streamlibPorts.inputs.length, 1);
+    assertEquals(cls.streamlibPorts.outputs.length, 1);
+    assertEquals(cls.streamlibPorts.inputs[0].name, "video_in");
+    assertEquals(cls.streamlibPorts.inputs[0].description, "trigger");
+    assert(cls.streamlibPorts.inputs[0].schema instanceof SchemaIdent);
+    assertEquals(cls.streamlibPorts.inputs[0].schema!.type, "VideoFrame");
+    assertEquals(cls.streamlibPorts.outputs[0].name, "video_out");
+  } finally {
+    await Deno.remove(fixture.dir, { recursive: true });
+  }
+});
+
+// Anchor the SDK_DIR test — silences unused-var lint for the constant.
+Deno.test("SDK_DIR is the directory holding decorators.ts", () => {
+  const expected = fromFileUrl(new URL("./", import.meta.url));
+  // join() normalizes trailing slashes; compare via dirname round-trip.
+  assertEquals(SDK_DIR + "/", expected);
+});

--- a/libs/streamlib-deno/deno.json
+++ b/libs/streamlib-deno/deno.json
@@ -4,7 +4,9 @@
   "exports": "./mod.ts",
   "imports": {
     "@msgpack/msgpack": "npm:@msgpack/msgpack@3.0.0-beta2",
-    "@std/assert": "jsr:@std/assert@^1.0.19"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/path": "jsr:@std/path@^1",
+    "@std/yaml": "jsr:@std/yaml@^1"
   },
   "compilerOptions": {
     "strict": true

--- a/libs/streamlib-deno/deno.lock
+++ b/libs/streamlib-deno/deno.lock
@@ -4,6 +4,8 @@
     "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/yaml@1": "1.1.0",
     "npm:@msgpack/msgpack@3.0.0-beta2": "3.0.0-beta2",
     "npm:typegpu@0.8.2": "0.8.2"
   },
@@ -16,6 +18,15 @@
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/yaml@1.1.0": {
+      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
   },
   "npm": {
@@ -40,6 +51,8 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
+      "jsr:@std/path@1",
+      "jsr:@std/yaml@1",
       "npm:@msgpack/msgpack@3.0.0-beta2"
     ]
   }

--- a/libs/streamlib-deno/mod.ts
+++ b/libs/streamlib-deno/mod.ts
@@ -31,6 +31,22 @@ export {
 export { cString, loadNativeLib } from "./native.ts";
 export type { NativeLib } from "./native.ts";
 
+// Schema identity + processor / port decorators (#404 / #701).
+// `SchemaIdent` is the source-side authoring surface — distinct from the
+// wire-side `SchemaIdentEnvelope` in `subprocess_runner.ts` (which
+// parses inbound compiler IPC). `processor`/`input`/`output` mirror the
+// Rust `#[streamlib::processor(...)]` macro and Python's `@processor` /
+// `@input` / `@output` decorators.
+export { SchemaIdent } from "./schema_ident.ts";
+export type { SchemaIdentWire } from "./schema_ident.ts";
+export { input, output, processor } from "./decorators.ts";
+export type {
+  PortMetadata,
+  PortOptions,
+  SchemaCarrier,
+  StreamlibClassMetadata,
+} from "./decorators.ts";
+
 // Unified polyglot logging — see issue #444 / parent #430.
 export * as log from "./log.ts";
 

--- a/libs/streamlib-deno/schema_ident.ts
+++ b/libs/streamlib-deno/schema_ident.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Structured schema identity for the streamlib Deno SDK.
+ *
+ * Mirrors Rust's `streamlib_idents::SchemaIdent` and Python's
+ * `streamlib.schema_ident.SchemaIdent`: 4 validating fields (`org`,
+ * `package`, `type`, `version`) constructed directly. There is no
+ * parse / from-string API — joined-string representations like
+ * `@org/pkg/Type@v` are render-only (`toString()`) and never round-trip
+ * through a parser.
+ *
+ * Distinct from the wire-side `SchemaIdentEnvelope` /
+ * `SchemaIdentSegments` in `subprocess_runner.ts`, which parse the
+ * envelope arriving over inbound compiler IPC. This class is the
+ * source-side authoring surface used by the `@processor` decorator and
+ * by codegen-emitted classes that carry their identity as a static
+ * field.
+ *
+ * @module
+ */
+
+// Validation patterns mirror Rust's `streamlib_idents` newtypes.
+const ORG_PATTERN = /^[a-z][a-z0-9-]*$/;
+const PACKAGE_PATTERN = /^[a-z][a-z0-9-]*$/;
+const TYPE_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/** IPC wire-format dict shape. The `type` key is unquoted on the wire. */
+export interface SchemaIdentWire {
+  org: string;
+  package: string;
+  type: string;
+  version: string;
+}
+
+/**
+ * Structured schema identifier — 4 fields, validated at construction,
+ * frozen.
+ */
+export class SchemaIdent {
+  readonly org: string;
+  readonly package: string;
+  readonly type: string;
+  readonly version: string;
+
+  constructor(org: string, pkg: string, type: string, version: string) {
+    if (typeof org !== "string" || !ORG_PATTERN.test(org)) {
+      throw new Error(
+        `invalid org ${JSON.stringify(org)}: must match [a-z][a-z0-9-]*`,
+      );
+    }
+    if (typeof pkg !== "string" || !PACKAGE_PATTERN.test(pkg)) {
+      throw new Error(
+        `invalid package ${JSON.stringify(pkg)}: must match [a-z][a-z0-9-]*`,
+      );
+    }
+    if (typeof type !== "string" || !TYPE_PATTERN.test(type)) {
+      throw new Error(
+        `invalid type ${JSON.stringify(type)}: must match [A-Z][A-Za-z0-9]* (PascalCase)`,
+      );
+    }
+    if (typeof version !== "string" || !VERSION_PATTERN.test(version)) {
+      throw new Error(
+        `invalid version ${JSON.stringify(version)}: must match major.minor.patch`,
+      );
+    }
+    this.org = org;
+    this.package = pkg;
+    this.type = type;
+    this.version = version;
+    Object.freeze(this);
+  }
+
+  /** Render as the human-facing joined form `@org/package/Type@version`. */
+  toString(): string {
+    return `@${this.org}/${this.package}/${this.type}@${this.version}`;
+  }
+
+  /**
+   * Render as the IPC wire-format dict.
+   *
+   * Matches the shape emitted by the Rust serializer
+   * (`#[serde(rename = "type")]` on `SchemaIdent::r#type`) and the
+   * `SchemaIdent.to_wire_dict()` method on the Python side.
+   */
+  toWireObject(): SchemaIdentWire {
+    return {
+      org: this.org,
+      package: this.package,
+      type: this.type,
+      version: this.version,
+    };
+  }
+
+  /** Structural equality across two idents. */
+  equals(other: SchemaIdent): boolean {
+    return (
+      this.org === other.org &&
+      this.package === other.package &&
+      this.type === other.type &&
+      this.version === other.version
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Greenfield Deno SDK port of the Python `@processor` decorator (#706) and Rust `#[streamlib::processor("…")]` macro (#404). New `SchemaIdent` class (frozen, regex-validated 4-field shape), `_manifest.ts` reader (via `jsr:@std/yaml`), and TC39 stage-3 standard `@processor` / `@input` / `@output` decorators in `libs/streamlib-deno/`.
- Sweep (per "no bad patterns left behind"): all 10 example Deno `streamlib.yaml` files migrated to the structured 4-field shape (`org: tatolab` + PascalCase processor names, dropping `com.tatolab.*` reverse-DNS); all 11 Deno processor `.ts` files adopt `@processor("ClassName", import.meta.url)`; 10 host scenario binaries' `processor_name()` arms updated; 3 stale `_generated_/com_tatolab_videoframe.ts` imports fixed to the post-#704 `_generated_/tatolab__core/video_frame.ts` path.
- Adjacent type-error fixes that were blocking the test gate: `vulkan.ts` now imports `SurfaceAccessGuard`; `cpu_readback.ts`'s `triggerCallback` field carries the explicit `UnsafeCallback` generic and `timeline_value` reads defend against undefined; `cuda_inference.ts` casts through `unknown`.

## Closes
Closes #701

## Exit criteria

- [x] New file in `libs/streamlib-deno/` (`decorators.ts`) exports a `processor(shortName, moduleUrl)` class decorator.
- [x] Decorator at decoration time reads sibling `streamlib.yaml` (resolved via `import.meta.url`), parses the `package: { org, name, version }` block, and attaches the structured `SchemaIdent` to the class as `streamlibSchemaIdent`.
- [x] New `SchemaIdent` TS class in `libs/streamlib-deno/schema_ident.ts` mirrors Rust's `streamlib_idents::SchemaIdent` (4 fields). Distinct from the wire-side `SchemaIdentEnvelope` / `SchemaIdentSegments`.
- [x] Wire format unchanged — host-side Rust runtime continues to read the structured record from the manifest as before. Validated end-to-end via the polyglot-continuous-processor scenario (Deno: `ticks=126 avg_interval_ms=16.000`).
- [x] Every Deno example's `streamlib.yaml` migrates to the 4-field shape (10 files).
- [x] Every Deno polyglot processor class adopts the new decorator (11 .ts files).
- [x] `mod.ts` re-exports `processor`, `input`, `output`, `SchemaIdent`, and companion types.

## Test plan

- [x] Deno tests in `libs/streamlib-deno/decorators_test.ts` — 25 tests covering `SchemaIdent` constructor (valid + every invalid pattern + frozen), `@processor` (manifest-driven structured ident, missing manifest with expected path, short-name-not-in-list lists available, missing required `package:` field, non-string short name, missing module URL), `@input` / `@output` (accepts `SchemaIdent`, accepts class with static `streamlibSchemaIdent`, rejects bare/joined strings, rejects class without metadata, port name override, `@processor` collects port metadata).
- [x] Full Deno SDK suite: `deno test --allow-all` → **100 passed, 0 failed** (with type-checking).
- [x] Polyglot E2E: `polyglot-continuous-processor-scenario --runtime=deno` → `ticks=126 avg_interval_ms=16.000` (cleanly within ±5ms of the 16ms nominal cadence).
- [x] Python regression: `polyglot-continuous-processor-scenario --runtime=python` → unchanged.
- [x] `cargo check` workspace — clean (no errors, only pre-existing dead-code warnings).

## Polyglot coverage

- **Runtimes affected**: deno (this PR is the polyglot follow-up to Python's #706)
- **Schema regenerated**: n/a — wire format unchanged
- **Python and Deno both covered?** yes — Python landed in #706, Deno lands here
- **E2E tests run**:
  - [x] Host-Rust: `polyglot-continuous-processor-scenario --runtime=deno` ✅
  - [x] Python subprocess: regression-check, unchanged ✅
  - [x] Deno subprocess: 26 unit tests + the polyglot E2E above ✅
- **FD-passing path**: n/a (decorator + manifest only)

## Pre-PR review gate

Reviewer returned PASS with two DISCUSS items; both verified independently:
1. `BigInt(response.timeline_value ?? 0)` in `cpu_readback.ts` — verified the existing in-code comment at `cpu_readback.ts:218-220` documents `0` as the "trigger failed" sentinel, so the `?? 0` fallback routes undefined through the documented error path. Strict improvement over the previous `BigInt(undefined) → TypeError`. No change needed.
2. `SDK_DIR` feel-good test — agreed and removed (the constant existed only to silence its own unused-var lint).

## Follow-ups

None. Pre-existing issues unrelated to #701 (and not blocking the test gate) are left for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)