### PR TITLE
feat(moq): plumb structured SchemaIdent through MoqSessions::published_tracks

### DIFF
--- a/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::core::context::RuntimeContext;
+#[cfg(feature = "moq")]
+use crate::core::descriptors::SchemaIdent;
 use crate::core::embedded_schemas::max_payload_bytes_for_port_spec;
 use crate::core::error::{Result, StreamError};
 use crate::core::graph::{
@@ -53,6 +55,43 @@ fn schema_ident_wire_for_producer(spec: &PortSchemaSpec) -> SchemaIdentWire {
 
 use super::spawn_deno_subprocess_op::DenoSubprocessHostProcessor;
 use super::spawn_python_native_subprocess_op::PythonNativeSubprocessHostProcessor;
+
+/// If the destination of a wired link is `MoqPublishTrack`, register the
+/// link's structured schema and the upstream processor's structured type
+/// into `sessions`. Runs while opening the iceoryx2 service — strictly
+/// before the destination's `setup()` — so the `/api/moq/catalog`
+/// endpoint reflects every wired track from the moment its publisher is
+/// wired.
+#[cfg(feature = "moq")]
+fn register_moq_track_if_dest_is_moq_publisher(
+    dest_processor: &Arc<Mutex<ProcessorInstance>>,
+    dest_proc_id: &ProcessorUniqueId,
+    source_proc_type: Option<&SchemaIdent>,
+    output_schema: &PortSchemaSpec,
+    source_port: &str,
+    sessions: &crate::core::streaming::SharedMoqSessions,
+) {
+    use crate::core::processors::moq_publish_track::MoqPublishTrackProcessor;
+    let track_name = {
+        let mut guard = dest_processor.lock();
+        match guard
+            .as_any_mut()
+            .downcast_mut::<MoqPublishTrackProcessor::Processor>()
+        {
+            Some(p) => p
+                .config
+                .track_name
+                .clone()
+                .unwrap_or_else(|| dest_proc_id.to_string()),
+            None => return,
+        }
+    };
+    let schema = match output_schema {
+        PortSchemaSpec::Specific(s) => Some(s),
+        PortSchemaSpec::Any => None,
+    };
+    sessions.register_published_track(&track_name, schema, source_proc_type, source_port);
+}
 
 /// Check if a processor is a subprocess (Python, TypeScript, etc.)
 fn is_subprocess_processor(graph: &mut Graph, proc_id: &ProcessorUniqueId) -> bool {
@@ -312,26 +351,26 @@ fn open_iceoryx2_pubsub(
         dest_proc_id
     );
 
-    // Look up schema for the output port before creating the publisher so we can size
-    // the shared memory slot correctly via max_payload_bytes_for_schema.
-    let output_schema = {
-        let source_proc_type = graph
-            .traversal_mut()
-            .v(source_proc_id)
-            .first()
-            .map(|node| node.processor_type().clone());
-
-        source_proc_type
-            .as_ref()
-            .and_then(|ident| PROCESSOR_REGISTRY.port_info(ident))
-            .and_then(|(_, outputs)| {
-                outputs
-                    .iter()
-                    .find(|p| p.name == source_port)
-                    .map(|p| p.data_type.clone())
-            })
-            .unwrap_or_default()
-    };
+    // Resolve the source processor's structured type and the output port's
+    // schema spec. Both are needed downstream — the schema sizes the
+    // iceoryx2 publisher's shared-memory slot, and the source ident +
+    // schema together feed the MoQ catalog when the destination is a
+    // `MoqPublishTrack`.
+    let source_proc_type = graph
+        .traversal_mut()
+        .v(source_proc_id)
+        .first()
+        .map(|node| node.processor_type().clone());
+    let output_schema = source_proc_type
+        .as_ref()
+        .and_then(|ident| PROCESSOR_REGISTRY.port_info(ident))
+        .and_then(|(_, outputs)| {
+            outputs
+                .iter()
+                .find(|p| p.name == source_port)
+                .map(|p| p.data_type.clone())
+        })
+        .unwrap_or_default();
 
     tracing::debug!(
         "Output port '{}' has schema '{}'",
@@ -413,6 +452,18 @@ fn open_iceoryx2_pubsub(
             }
         }
     }
+
+    // Catalog hook: register this link's source ident + schema if the
+    // destination is a MoQ publisher.
+    #[cfg(feature = "moq")]
+    register_moq_track_if_dest_is_moq_publisher(
+        dest_processor,
+        dest_proc_id,
+        source_proc_type.as_ref(),
+        &output_schema,
+        source_port,
+        runtime_ctx.moq_sessions(),
+    );
 
     // Set link state to Wired
     let link = graph
@@ -580,29 +631,28 @@ fn open_iceoryx2_subprocess_to_rust(
     let service = iceoryx2_node.open_or_create_service(&service_name)?;
     let notify_service = iceoryx2_node.open_or_create_notify_service(&notify_service_name)?;
 
+    // Resolve source processor's structured type and the output port's
+    // schema spec — both feed both the iceoryx2 wiring and the MoQ
+    // catalog hook below.
+    let source_proc_type = graph
+        .traversal_mut()
+        .v(source_proc_id)
+        .first()
+        .map(|node| node.processor_type().clone());
+    let output_schema = source_proc_type
+        .as_ref()
+        .and_then(|ident| PROCESSOR_REGISTRY.port_info(ident))
+        .and_then(|(_, outputs)| {
+            outputs
+                .iter()
+                .find(|p| p.name == source_port)
+                .map(|p| p.data_type.clone())
+        })
+        .unwrap_or_default();
+
     // Source is subprocess - it creates its own publisher and notifier via FFI.
     // Store output wiring info on the subprocess processor so it can publish via FFI.
     {
-        // Look up schema for the output port from the registry
-        let output_schema = {
-            let source_proc_type = graph
-                .traversal_mut()
-                .v(source_proc_id)
-                .first()
-                .map(|node| node.processor_type().clone());
-
-            source_proc_type
-                .as_ref()
-                .and_then(|ident| PROCESSOR_REGISTRY.port_info(ident))
-                .and_then(|(_, outputs)| {
-                    outputs
-                        .iter()
-                        .find(|p| p.name == source_port)
-                        .map(|p| p.data_type.clone())
-                })
-                .unwrap_or_default()
-        };
-
         let max_payload = max_payload_bytes_for_port_spec(&output_schema);
         let source_proc_arc = get_single_processor(graph, source_proc_id)?;
         let mut source_guard = source_proc_arc.lock();
@@ -671,6 +721,19 @@ fn open_iceoryx2_subprocess_to_rust(
             }
         }
     }
+
+    // Catalog hook: register this link's source ident + schema if the
+    // destination is a MoQ publisher. Subprocess sources contribute their
+    // structured processor type from the graph node — same as Rust→Rust.
+    #[cfg(feature = "moq")]
+    register_moq_track_if_dest_is_moq_publisher(
+        dest_processor,
+        dest_proc_id,
+        source_proc_type.as_ref(),
+        &output_schema,
+        source_port,
+        runtime_ctx.moq_sessions(),
+    );
 
     // Set link state to Wired
     let link = graph
@@ -919,5 +982,129 @@ mod tests {
         let dest_uid: ProcessorUniqueId = dest_id.as_str().into();
         reject_overcap_destination_fanin(&mut graph, &dest_uid)
             .expect("fan-in == cap must succeed");
+    }
+
+    #[cfg(feature = "moq")]
+    mod moq_catalog_hook {
+        use super::*;
+        use crate::core::descriptors::{Org, Package, SemVer, TypeName};
+        use crate::core::graph::ProcessorNode;
+        use crate::core::streaming::SharedMoqSessions;
+        use crate::core::PortInfo;
+
+        fn ident(org: &str, pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+            SchemaIdent::new(
+                Org::new(org).unwrap(),
+                Package::new(pkg).unwrap(),
+                TypeName::new(ty).unwrap(),
+                v,
+            )
+        }
+
+        fn make_processor_instance(short_name: &str) -> Arc<Mutex<ProcessorInstance>> {
+            let processor_type = lookup_registered_ident(short_name);
+            let node = ProcessorNode::new(
+                processor_type,
+                short_name,
+                None,
+                Vec::<PortInfo>::new(),
+                Vec::<PortInfo>::new(),
+            );
+            let instance = PROCESSOR_REGISTRY
+                .create(&node)
+                .expect("processor must instantiate from default config");
+            Arc::new(Mutex::new(instance))
+        }
+
+        #[test]
+        fn registers_track_when_destination_is_moq_publisher() {
+            let sessions = SharedMoqSessions::new("test-runtime");
+            let dest = make_processor_instance("MoqPublishTrack");
+            let dest_id: ProcessorUniqueId = "moq_publisher_node".into();
+            let source_proc_type = ident("tatolab", "h264", "H264Encoder", SemVer::new(1, 0, 0));
+            let schema_ident = ident("tatolab", "core", "EncodedVideoFrame", SemVer::new(1, 0, 0));
+            let output_schema = PortSchemaSpec::Specific(schema_ident.clone());
+
+            register_moq_track_if_dest_is_moq_publisher(
+                &dest,
+                &dest_id,
+                Some(&source_proc_type),
+                &output_schema,
+                "video_out",
+                &sessions,
+            );
+
+            let tracks = sessions.published_tracks();
+            assert_eq!(tracks.len(), 1, "MoqPublishTrack destination must register one track");
+            let entry = &tracks[0];
+            assert_eq!(
+                entry.track_name, "moq_publisher_node",
+                "track_name defaults to dest_proc_id when config has no override"
+            );
+            assert_eq!(entry.source_port_name, "video_out");
+            let s = entry.schema.as_ref().expect("structured schema must be carried");
+            assert_eq!(s.type_name, "EncodedVideoFrame");
+            let p = entry
+                .source_processor_type
+                .as_ref()
+                .expect("structured source processor type must be carried");
+            assert_eq!(p.type_name, "H264Encoder");
+        }
+
+        #[test]
+        fn skips_registration_when_destination_is_not_moq_publisher() {
+            let sessions = SharedMoqSessions::new("test-runtime");
+            // TestMockInputOnlyProcessor isn't a MoqPublishTrack — the
+            // helper must early-return without registering anything.
+            let dest = make_processor_instance("TestMockInputOnlyProcessor");
+            let dest_id: ProcessorUniqueId = "non_moq_dest".into();
+            let source_proc_type = ident("tatolab", "h264", "H264Encoder", SemVer::new(1, 0, 0));
+            let schema_ident = ident("tatolab", "core", "EncodedVideoFrame", SemVer::new(1, 0, 0));
+            let output_schema = PortSchemaSpec::Specific(schema_ident);
+
+            register_moq_track_if_dest_is_moq_publisher(
+                &dest,
+                &dest_id,
+                Some(&source_proc_type),
+                &output_schema,
+                "video_out",
+                &sessions,
+            );
+
+            assert!(
+                sessions.published_tracks().is_empty(),
+                "non-MoqPublishTrack destination must not register a track"
+            );
+        }
+
+        #[test]
+        fn omits_schema_when_output_port_is_wildcard() {
+            let sessions = SharedMoqSessions::new("test-runtime");
+            let dest = make_processor_instance("MoqPublishTrack");
+            let dest_id: ProcessorUniqueId = "wildcard_publisher".into();
+            let source_proc_type =
+                ident("tatolab", "streamlib", "SimplePassthrough", SemVer::new(1, 0, 0));
+
+            register_moq_track_if_dest_is_moq_publisher(
+                &dest,
+                &dest_id,
+                Some(&source_proc_type),
+                &PortSchemaSpec::Any,
+                "passthrough_out",
+                &sessions,
+            );
+
+            let tracks = sessions.published_tracks();
+            assert_eq!(tracks.len(), 1);
+            assert!(
+                tracks[0].schema.is_none(),
+                "wildcard upstream port must register with schema=None"
+            );
+            let p = tracks[0]
+                .source_processor_type
+                .as_ref()
+                .expect("source processor type still flows through wildcard");
+            assert_eq!(p.type_name, "SimplePassthrough");
+        }
     }
 }

--- a/libs/streamlib/src/core/processors/api_server.rs
+++ b/libs/streamlib/src/core/processors/api_server.rs
@@ -589,20 +589,17 @@ async fn get_openapi_spec(State(state): State<AppState>) -> Json<utoipa::openapi
 
 /// Returns the MoQ broadcast catalog with active published tracks.
 ///
-/// The schema and source-processor identity for each track are not yet
-/// plumbed through `MoqSessions::published_track_names`; they're emitted
-/// as `None` until a future ticket extends the session API to carry the
-/// structured ident alongside the track name. The track entries still
-/// serialize cleanly — `schema` and `source_processor_type` are
-/// `skip_serializing_if = Option::is_none`.
+/// Each track carries the structured `SchemaIdent` for its wire schema and
+/// the producer's structured processor type, populated at iceoryx2 link
+/// wiring time (see `compiler_ops::open_iceoryx2_service_op`).
 #[cfg(feature = "moq")]
 async fn get_moq_catalog(State(state): State<AppState>) -> Json<crate::core::streaming::MoqBroadcastCatalog> {
     let sessions = state.runtime_ctx.moq_sessions();
-    let mut catalog = crate::core::streaming::MoqBroadcastCatalog::new();
-    for track_name in sessions.published_track_names() {
-        catalog.add_track(&track_name, None, None, &track_name);
-    }
-    Json(catalog)
+    let tracks = sessions.published_tracks();
+    Json(crate::core::streaming::MoqBroadcastCatalog {
+        tracks,
+        ..Default::default()
+    })
 }
 
 // ============================================================================

--- a/libs/streamlib/src/core/processors/moq_publish_track.rs
+++ b/libs/streamlib/src/core/processors/moq_publish_track.rs
@@ -40,8 +40,9 @@ impl crate::core::ReactiveProcessor for MoqPublishTrackProcessor::Processor {
         // Get the shared publish session from the runtime (one QUIC connection, N tracks)
         let session = ctx.moq_sessions().get_publish_session().await?;
 
-        // Register this track in the catalog
-        ctx.moq_sessions().register_published_track(&self.track_name);
+        // Catalog registration runs at the iceoryx2 op boundary
+        // (`open_iceoryx2_service_op`), where the upstream's structured
+        // schema and processor type are in scope. Setup runs after that.
 
         tracing::info!(
             broadcast = %ctx.moq_sessions().broadcast_path(),

--- a/libs/streamlib/src/core/processors/moq_subscribe_track.rs
+++ b/libs/streamlib/src/core/processors/moq_subscribe_track.rs
@@ -9,9 +9,10 @@
 //
 // Automatically retries on connection loss with exponential backoff.
 
+use crate::core::context::RuntimeContext;
 use crate::core::media_clock::MediaClock;
 use crate::core::streaming::{MoqSubscribeSession, MoqTrackReader};
-use crate::core::{Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
 use crate::iceoryx2::OutputWriter;
 use std::future::Future;
 use std::sync::Arc;
@@ -40,20 +41,31 @@ pub struct MoqSubscribeTrackProcessor {
 }
 
 impl crate::core::ManualProcessor for MoqSubscribeTrackProcessor::Processor {
-    fn setup(&mut self, ctx: RuntimeContext) -> impl Future<Output = Result<()>> + Send {
-        self.runtime_context = Some(ctx.clone());
+    fn setup(
+        &mut self,
+        ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl Future<Output = Result<()>> + Send {
+        // Stash a cloned RuntimeContext so the long-lived async receive
+        // loop spawned in start() can reach tokio_handle + moq_sessions
+        // without holding the borrowed FullAccess view.
+        self.runtime_context = Some(ctx.clone_runtime_context());
 
+        let broadcast_path = ctx.moq_sessions().broadcast_path().to_string();
+        let track_name = self.config.track_name.clone();
         async move {
             tracing::info!(
-                broadcast = %ctx.moq_sessions().broadcast_path(),
-                track = %self.config.track_name,
+                broadcast = %broadcast_path,
+                track = %track_name,
                 "[MoqSubscribeTrack] Configured (will connect on start)"
             );
             Ok(())
         }
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(
+        &mut self,
+        _ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl Future<Output = Result<()>> + Send {
         tracing::info!("[MoqSubscribeTrack] Shutting down");
 
         if let Some(tx) = self.shutdown_signal_sender.take() {
@@ -62,14 +74,20 @@ impl crate::core::ManualProcessor for MoqSubscribeTrackProcessor::Processor {
 
         self.runtime_context.take();
         tracing::info!("[MoqSubscribeTrack] Shutdown complete");
-        Ok(())
-    }
-
-    fn on_pause(&mut self) -> impl Future<Output = Result<()>> + Send {
         std::future::ready(Ok(()))
     }
 
-    fn on_resume(&mut self) -> impl Future<Output = Result<()>> + Send {
+    fn on_pause(
+        &mut self,
+        _ctx: &RuntimeContextLimitedAccess<'_>,
+    ) -> impl Future<Output = Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+
+    fn on_resume(
+        &mut self,
+        _ctx: &RuntimeContextLimitedAccess<'_>,
+    ) -> impl Future<Output = Result<()>> + Send {
         std::future::ready(Ok(()))
     }
 

--- a/libs/streamlib/src/core/streaming/moq_session.rs
+++ b/libs/streamlib/src/core/streaming/moq_session.rs
@@ -7,6 +7,8 @@
 // Uses moq-transport (cloudflare/moq-rs) for the MoQ protocol and
 // web-transport-quinn for the underlying QUIC/WebTransport connection.
 
+use crate::core::descriptors::SchemaIdent;
+use crate::core::streaming::moq_catalog::MoqCatalogTrackEntry;
 use crate::core::{Result, StreamError};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -517,8 +519,11 @@ pub struct SharedMoqSessions {
     broadcast_path: String,
     publish_session: Arc<tokio::sync::OnceCell<Arc<Mutex<MoqPublishSession>>>>,
     subscribe_session: Arc<tokio::sync::OnceCell<Arc<MoqSubscribeSession>>>,
-    /// Track names currently being published (for catalog).
-    published_tracks: Arc<Mutex<Vec<String>>>,
+    /// Tracks currently being published, with their structured catalog
+    /// metadata. Keyed by `track_name`; reinserting an existing track
+    /// replaces the prior entry so a re-wired link picks up updated
+    /// schema / source-processor identity.
+    published_tracks: Arc<Mutex<Vec<MoqCatalogTrackEntry>>>,
 }
 
 impl SharedMoqSessions {
@@ -564,21 +569,134 @@ impl SharedMoqSessions {
         Ok(Arc::clone(session))
     }
 
-    /// Register a track name as published (for catalog).
-    pub fn register_published_track(&self, track_name: &str) {
+    /// Register a track as published, capturing the structured catalog
+    /// metadata. `schema` is the wire schema flowing on this track;
+    /// `source_processor_type` is the producer's structured type. `None`
+    /// for either is permitted when the upstream link can't supply it
+    /// (e.g. a wildcard `Any` port). Reinserting an existing
+    /// `track_name` replaces the prior entry.
+    pub fn register_published_track(
+        &self,
+        track_name: &str,
+        schema: Option<&SchemaIdent>,
+        source_processor_type: Option<&SchemaIdent>,
+        source_port_name: &str,
+    ) {
+        use crate::core::json_schema::SchemaIdentOutput;
+        let entry = MoqCatalogTrackEntry {
+            track_name: track_name.to_string(),
+            schema: schema.map(SchemaIdentOutput::from),
+            source_processor_type: source_processor_type.map(SchemaIdentOutput::from),
+            source_port_name: source_port_name.to_string(),
+        };
         let mut tracks = self.published_tracks.lock();
-        if !tracks.contains(&track_name.to_string()) {
-            tracks.push(track_name.to_string());
+        if let Some(slot) = tracks.iter_mut().find(|t| t.track_name == track_name) {
+            *slot = entry;
+        } else {
+            tracks.push(entry);
         }
     }
 
-    /// Get all published track names.
-    pub fn published_track_names(&self) -> Vec<String> {
+    /// Get all published tracks with their structured catalog metadata.
+    pub fn published_tracks(&self) -> Vec<MoqCatalogTrackEntry> {
         self.published_tracks.lock().clone()
     }
 
     /// Get the broadcast path (for logging/discovery).
     pub fn broadcast_path(&self) -> &str {
         &self.broadcast_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::descriptors::{Org, Package, SemVer, TypeName};
+
+    fn ident(org: &str, pkg: &str, ty: &str, v: SemVer) -> SchemaIdent {
+        SchemaIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(pkg).unwrap(),
+            TypeName::new(ty).unwrap(),
+            v,
+        )
+    }
+
+    #[test]
+    fn register_published_track_round_trips_structured_fields() {
+        let sessions = SharedMoqSessions::new("test-runtime");
+        let schema = ident("tatolab", "core", "EncodedVideoFrame", SemVer::new(1, 0, 0));
+        let proc_type = ident("tatolab", "h264", "H264Encoder", SemVer::new(1, 0, 0));
+
+        sessions.register_published_track(
+            "encoder/video_out",
+            Some(&schema),
+            Some(&proc_type),
+            "video_out",
+        );
+
+        let tracks = sessions.published_tracks();
+        assert_eq!(tracks.len(), 1);
+        let entry = &tracks[0];
+        assert_eq!(entry.track_name, "encoder/video_out");
+        assert_eq!(entry.source_port_name, "video_out");
+        let s = entry.schema.as_ref().expect("schema must be carried");
+        assert_eq!(s.org, "tatolab");
+        assert_eq!(s.package, "core");
+        assert_eq!(s.type_name, "EncodedVideoFrame");
+        assert_eq!(s.version.major, 1);
+        let p = entry
+            .source_processor_type
+            .as_ref()
+            .expect("source processor type must be carried");
+        assert_eq!(p.type_name, "H264Encoder");
+    }
+
+    #[test]
+    fn register_published_track_omits_optional_fields_when_unknown() {
+        let sessions = SharedMoqSessions::new("test-runtime");
+
+        // Wildcard upstream — no schema, no source processor type.
+        sessions.register_published_track("wildcard_track", None, None, "out");
+
+        let tracks = sessions.published_tracks();
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_name, "wildcard_track");
+        assert!(tracks[0].schema.is_none());
+        assert!(tracks[0].source_processor_type.is_none());
+    }
+
+    #[test]
+    fn register_published_track_replaces_entry_for_same_track_name() {
+        let sessions = SharedMoqSessions::new("test-runtime");
+        let initial = ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0));
+        let updated = ident("tatolab", "core", "EncodedVideoFrame", SemVer::new(1, 0, 0));
+
+        sessions.register_published_track("video", Some(&initial), None, "video_out");
+        sessions.register_published_track("video", Some(&updated), None, "video_out");
+
+        let tracks = sessions.published_tracks();
+        assert_eq!(tracks.len(), 1, "duplicate track names must dedup, not stack");
+        let s = tracks[0].schema.as_ref().expect("schema carried");
+        assert_eq!(
+            s.type_name, "EncodedVideoFrame",
+            "second registration must overwrite the first"
+        );
+    }
+
+    #[test]
+    fn register_published_track_keeps_distinct_entries_for_distinct_track_names() {
+        let sessions = SharedMoqSessions::new("test-runtime");
+        let video_schema = ident("tatolab", "core", "EncodedVideoFrame", SemVer::new(1, 0, 0));
+        let audio_schema = ident("tatolab", "core", "EncodedAudioFrame", SemVer::new(1, 0, 0));
+
+        sessions.register_published_track("video", Some(&video_schema), None, "video_out");
+        sessions.register_published_track("audio", Some(&audio_schema), None, "audio_out");
+
+        let tracks = sessions.published_tracks();
+        assert_eq!(tracks.len(), 2);
+        let names: Vec<&str> = tracks.iter().map(|t| t.track_name.as_str()).collect();
+        assert!(names.contains(&"video"));
+        assert!(names.contains(&"audio"));
     }
 }


### PR DESCRIPTION
## Summary

- `MoqSessions::published_tracks` storage swaps from `Vec<String>` to `Vec<MoqCatalogTrackEntry>`. `register_published_track` takes the structured `SchemaIdent` for both the wire schema and the source processor type; `published_track_names()` is removed and the single in-tree caller migrated.
- Capture moves from `MoqPublishTrackProcessor::setup()` to the iceoryx2 op boundary in `open_iceoryx2_service_op` — both source proc type and output port `PortSchemaSpec` are already in scope there. A small helper detects when a wired link's destination is a `MoqPublishTrack` and registers with the structured fields. Wired into both Rust→Rust and Subprocess→Rust paths.
- `api_server::get_moq_catalog` walks the new accessor and constructs `MoqBroadcastCatalog` with the structured entries directly — no more `None` placeholders.

Includes prerequisite commit `a6ce26e` that fixes pre-existing breakage in `moq_subscribe_track.rs` so the `moq` feature compiles. Default `cargo check -p streamlib` did not surface this because `moq` is not in `default = []`. The user explicitly approved fixing in this PR rather than in a separate prerequisite PR.

## Closes

Closes #720

## Exit criteria

- [x] `MoqSessions::published_track_names` (or a successor accessor) carries the structured `(schema, source_processor_type)` for every published track. — `published_tracks() -> Vec<MoqCatalogTrackEntry>` carries all four typed fields.
- [x] `api_server::get_moq_catalog` passes the real values (no `None` placeholders). — Constructs `MoqBroadcastCatalog` directly from the structured entries.
- [x] Track publication call sites populate the structured fields at publish time. — Single call site (`MoqPublishTrackProcessor::setup`) replaced by compiler-op-boundary registration; structured idents are in scope there at link-wiring time.

## Test plan

- [x] `cargo check -p streamlib` (default features): clean.
- [x] `cargo check -p streamlib --features moq`: clean (was previously broken on `main`).
- [x] `cargo test -p streamlib --features moq --lib`: 323 passed, 0 failed.
- [x] `cargo test -p streamlib --lib`: 311 passed, 0 failed.
- [x] Session round-trip unit tests in `moq_session.rs::tests` — 4 new tests covering structured-field round-trip, optional-field omission, dedup-by-track-name, and distinct-name preservation.
- [x] Compiler-op helper tests in `open_iceoryx2_service_op::tests::moq_catalog_hook` — 3 new tests covering MoqPublishTrack-vs-other-dest dispatch, the wildcard `PortSchemaSpec::Any` path, and structured field round-trip through the helper.
- [x] Pre-existing wire-format lock test `moq_catalog::tests::catalog_json_shape_is_structured_not_joined_string` continues to pass.
- [ ] HTTP integration test for `GET /api/moq/catalog` — deferred (no reusable HTTP integration scaffolding in tree). Filed as #723.

## Follow-ups

- #723 — HTTP integration test for `/api/moq/catalog` structured fields (deferred from this PR's test plan).
- #724 — Unregister catalog tracks when their feeding link disconnects (preserves pre-existing behavior; surfaced by the registration-site move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)