### PR TITLE
fix(packaging): reconcile ProjectConfig.dependencies with structured Manifest shape (#716)

### DIFF
--- a/examples/polyglot-continuous-processor/deno/streamlib.yaml
+++ b/examples/polyglot-continuous-processor/deno/streamlib.yaml
@@ -5,6 +5,14 @@ package:
   version: "0.1.0"
   description: "Polyglot continuous processor (#542) — Deno process() driven by monotonic-clock timerfd"
 
+# Reference yaml for the structured-deps shape landed in #716. Declares
+# `@tatolab/core` as a path dep so the runtime parser is exercised end
+# to end against a real consumer manifest. The full sweep across every
+# consumer yaml is owned by #717.
+dependencies:
+  "@tatolab/core":
+    path: ../../../packages/core
+
 processors:
   - name: PolyglotContinuousProcessor
     version: "1.0.0"

--- a/libs/streamlib/Cargo.toml
+++ b/libs/streamlib/Cargo.toml
@@ -35,6 +35,10 @@ hardware-tests = []
 # Processor schema types (shared with macros for code generation)
 streamlib-processor-schema = { path = "../streamlib-processor-schema" }
 
+# Schema identity + manifest types (one source of truth for the
+# structured `dependencies:` shape consumed at runtime).
+streamlib-idents = { path = "../streamlib-idents" }
+
 # Procedural macros
 streamlib-macros = { path = "../streamlib-macros" }
 

--- a/libs/streamlib/src/core/config/project_config.rs
+++ b/libs/streamlib/src/core/config/project_config.rs
@@ -5,8 +5,9 @@
 
 use crate::core::{Result, StreamError};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
+use streamlib_idents::DependencySpec;
 use streamlib_processor_schema::{Org, Package, SemVer};
 
 /// Package-level metadata from `streamlib.yaml`. Structured fields per the
@@ -41,10 +42,13 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub processors: Vec<streamlib_processor_schema::ProcessorSchema>,
 
-    /// Package dependencies (installed package names whose processors/schemas
-    /// must be loaded before this package).
+    /// Package dependencies, keyed by `@org/name`. Mirrors
+    /// [`streamlib_idents::Manifest::dependencies`] and the JSON Schema
+    /// source-of-truth `StreamlibYaml` so a single declaration shape
+    /// flows through the resolver, the editor schema, and the runtime
+    /// loader.
     #[serde(default)]
-    pub dependencies: Vec<String>,
+    pub dependencies: BTreeMap<String, DependencySpec>,
 }
 
 impl ProjectConfig {
@@ -225,6 +229,103 @@ env:
 
         let config = ProjectConfig::load(dir.path()).unwrap();
         assert!(config.env.is_empty());
+    }
+
+    #[test]
+    fn test_load_with_path_dependency() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("streamlib.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+dependencies:
+  "@tatolab/core":
+    path: ../../packages/core
+"#,
+        )
+        .unwrap();
+
+        let config = ProjectConfig::load(dir.path()).unwrap();
+        assert_eq!(config.dependencies.len(), 1);
+        let spec = config
+            .dependencies
+            .get("@tatolab/core")
+            .expect("@tatolab/core dep present");
+        match spec {
+            DependencySpec::Path(p) => {
+                assert_eq!(p.path.to_str().unwrap(), "../../packages/core");
+            }
+            other => panic!("expected Path dep, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_load_with_registry_dependency_short_form() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("streamlib.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+dependencies:
+  "@tatolab/core": "^1.0.0"
+"#,
+        )
+        .unwrap();
+
+        let config = ProjectConfig::load(dir.path()).unwrap();
+        assert_eq!(config.dependencies.len(), 1);
+        match config.dependencies.get("@tatolab/core").unwrap() {
+            DependencySpec::Registry(r) => {
+                assert_eq!(r.version.to_string(), "^1.0.0");
+            }
+            other => panic!("expected Registry dep, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_load_with_git_dependency() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("streamlib.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+dependencies:
+  "@tatolab/moq":
+    git: https://github.com/tatolab/moq
+    rev: abc123def456
+"#,
+        )
+        .unwrap();
+
+        let config = ProjectConfig::load(dir.path()).unwrap();
+        match config.dependencies.get("@tatolab/moq").unwrap() {
+            DependencySpec::Git(g) => {
+                assert_eq!(g.git, "https://github.com/tatolab/moq");
+                assert_eq!(g.rev, "abc123def456");
+            }
+            other => panic!("expected Git dep, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_load_rejects_legacy_sequence_dependencies() {
+        // Pre-#716 ProjectConfig accepted `dependencies: [name1, name2]`. The
+        // shape now matches the JSON Schema source-of-truth and the resolver,
+        // so a bare sequence must error rather than silently parse against a
+        // mismatched type.
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("streamlib.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+dependencies:
+  - some-installed-package
+"#,
+        )
+        .unwrap();
+
+        let result = ProjectConfig::load(dir.path());
+        assert!(result.is_err(), "legacy sequence-shaped deps must error");
     }
 
     #[test]

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -359,13 +359,13 @@ impl StreamRuntime {
         // The dep schema is the same `BTreeMap<String, DependencySpec>` that
         // the resolver and the JSON Schema source-of-truth (`StreamlibYaml`)
         // consume. Path-style deps resolve relative to the manifest dir and
-        // recurse through `load_project`; registry/git deps fall back to the
-        // installed-package cache (or fail with an actionable error).
+        // recurse through `load_project`. Registry/git deps require canonical
+        // `@org/name` install-manifest keys + workspace `[patch]` resolution,
+        // which arrive in #717; until then they error explicitly here so no
+        // string parser sneaks into the lookup site.
         if !config.dependencies.is_empty() {
-            use crate::core::config::InstalledPackageManifest;
             use streamlib_idents::DependencySpec;
 
-            let installed_manifest = InstalledPackageManifest::load()?;
             for (dep_key, spec) in &config.dependencies {
                 let dep_path = match spec {
                     DependencySpec::Path(p) => {
@@ -376,13 +376,12 @@ impl StreamRuntime {
                         }
                     }
                     DependencySpec::Registry(_) | DependencySpec::Git(_) => {
-                        let entry = installed_manifest.find_by_name(dep_key).ok_or_else(|| {
-                            StreamError::Configuration(format!(
-                                "Dependency '{}' is not installed. Install it with: streamlib pkg install <path.slpkg>",
-                                dep_key
-                            ))
-                        })?;
-                        crate::core::streamlib_home::get_cached_package_dir(&entry.cache_dir)
+                        return Err(StreamError::Configuration(format!(
+                            "Registry/git dep '{dep_key}' is not yet supported \
+                             (pending #717: canonical install-manifest keys + \
+                             workspace [patch] resolution). Use a path-style \
+                             declaration in a workspace patch file once #717 lands."
+                        )));
                     }
                 };
                 tracing::info!(
@@ -1585,6 +1584,46 @@ dependencies:
         assert!(
             result.is_err(),
             "load_project must error when a path dep target has no streamlib.yaml"
+        );
+    }
+
+    /// Registry/git deps are not yet supported — the canonical
+    /// install-manifest + workspace `[patch]` resolution chain arrives in
+    /// #717. Until then the runtime errors explicitly so no string parser
+    /// sneaks into the lookup site. The error must surface the canonical
+    /// `@org/name` key the user wrote AND point at #717.
+    #[test]
+    #[serial]
+    fn test_load_project_registry_dep_errors_pending_717() {
+        let runtime = StreamRuntime::new().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let a = tmp.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: "0.1.0"
+dependencies:
+  "@tatolab/missing": "^1.0.0"
+"#,
+        )
+        .unwrap();
+
+        let err = runtime
+            .load_project(&a)
+            .expect_err("registry dep must error explicitly until #717 lands");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("@tatolab/missing"),
+            "error must surface the canonical `@org/name` key, got: {msg}"
+        );
+        assert!(
+            msg.contains("#717"),
+            "error must point at #717 so the picker has a follow-up reference, got: {msg}"
         );
     }
 

--- a/libs/streamlib/src/core/runtime/runtime.rs
+++ b/libs/streamlib/src/core/runtime/runtime.rs
@@ -354,23 +354,40 @@ impl StreamRuntime {
 
         config.check_streamlib_version_compatibility()?;
 
-        // Load dependency packages first (schemas/processors they export)
+        // Load dependency packages first (schemas/processors they export).
+        //
+        // The dep schema is the same `BTreeMap<String, DependencySpec>` that
+        // the resolver and the JSON Schema source-of-truth (`StreamlibYaml`)
+        // consume. Path-style deps resolve relative to the manifest dir and
+        // recurse through `load_project`; registry/git deps fall back to the
+        // installed-package cache (or fail with an actionable error).
         if !config.dependencies.is_empty() {
             use crate::core::config::InstalledPackageManifest;
+            use streamlib_idents::DependencySpec;
 
-            let manifest = InstalledPackageManifest::load()?;
-            for dep_name in &config.dependencies {
-                let entry = manifest.find_by_name(dep_name).ok_or_else(|| {
-                    StreamError::Configuration(format!(
-                        "Dependency '{}' is not installed. Install it with: streamlib pkg install <path.slpkg>",
-                        dep_name
-                    ))
-                })?;
-                let dep_path =
-                    crate::core::streamlib_home::get_cached_package_dir(&entry.cache_dir);
+            let installed_manifest = InstalledPackageManifest::load()?;
+            for (dep_key, spec) in &config.dependencies {
+                let dep_path = match spec {
+                    DependencySpec::Path(p) => {
+                        if p.path.is_absolute() {
+                            p.path.clone()
+                        } else {
+                            project_path.join(&p.path)
+                        }
+                    }
+                    DependencySpec::Registry(_) | DependencySpec::Git(_) => {
+                        let entry = installed_manifest.find_by_name(dep_key).ok_or_else(|| {
+                            StreamError::Configuration(format!(
+                                "Dependency '{}' is not installed. Install it with: streamlib pkg install <path.slpkg>",
+                                dep_key
+                            ))
+                        })?;
+                        crate::core::streamlib_home::get_cached_package_dir(&entry.cache_dir)
+                    }
+                };
                 tracing::info!(
                     "Loading dependency '{}' from {}",
-                    dep_name,
+                    dep_key,
                     dep_path.display()
                 );
                 self.load_project(&dep_path)?;
@@ -1490,6 +1507,85 @@ mod tests {
     fn test_runtime_creation() {
         let _runtime = StreamRuntime::new();
         // Runtime creates successfully
+    }
+
+    /// Path-style dep recursion: `runtime.load_project(A)` must walk into
+    /// `B` (declared as `path: ../b`) and parse its manifest. The negative
+    /// counterpart below proves recursion actually happens — not just that
+    /// the parser tolerates the structured shape.
+    #[test]
+    #[serial]
+    fn test_load_project_recurses_into_path_dep() {
+        let runtime = StreamRuntime::new().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Project A — empty processors, declares path dep to ../b
+        let a = tmp.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: "0.1.0"
+dependencies:
+  "@tatolab/b":
+    path: ../b
+"#,
+        )
+        .unwrap();
+
+        // Project B — leaf, empty processors
+        let b = tmp.path().join("b");
+        std::fs::create_dir(&b).unwrap();
+        std::fs::write(
+            b.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: b
+  version: "0.1.0"
+"#,
+        )
+        .unwrap();
+
+        runtime
+            .load_project(&a)
+            .expect("load_project should recurse into path dep without error");
+    }
+
+    /// Negative pair to the test above: when `B`'s manifest is missing,
+    /// the recursion must fail and propagate the error. Mentally reverting
+    /// the recursion in `load_project` would make this test pass falsely
+    /// — that's why both are needed.
+    #[test]
+    #[serial]
+    fn test_load_project_path_dep_missing_manifest_propagates_error() {
+        let runtime = StreamRuntime::new().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let a = tmp.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::write(
+            a.join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: a
+  version: "0.1.0"
+dependencies:
+  "@tatolab/missing":
+    path: ../does-not-exist
+"#,
+        )
+        .unwrap();
+
+        let result = runtime.load_project(&a);
+        assert!(
+            result.is_err(),
+            "load_project must error when a path dep target has no streamlib.yaml"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Retypes `ProjectConfig::dependencies` from `Vec<String>` to `BTreeMap<String, streamlib_idents::DependencySpec>` so the runtime parser consumes the same shape as the JSON Schema source-of-truth (`StreamlibYaml`) and the resolver (`Manifest`). One source of truth for the dep schema across all three parsers.
- Reworks `runtime.load_project()` to dispatch per dep variant: path-style → resolve relative to the manifest dir → recurse; registry/git → explicit `Configuration` error pointing at #717 (canonical install-manifest keys + workspace `[patch]` resolution land there).
- One example yaml (`examples/polyglot-continuous-processor/deno/streamlib.yaml`) declares `@tatolab/core` as a path dep so the runtime path is exercised end to end. The full sweep across consumer yamls is owned by #717.

## Closes
Closes #716

## Why no registry/git support in this PR

The structured `DependencySpec` enum has three variants — `Path`, `Registry`, `Git`. This PR fully implements `Path` (the only variant any in-tree yaml uses today). `Registry` and `Git` lookups require canonical `@org/name` keys in `InstalledPackageManifest` (today the manifest stores entries keyed on bare `Package::name`) plus a workspace-level `[patch]` resolution layer (cargo-style). That whole chain lands in #717 — pulling pieces of it into this PR would mean either (a) shipping a string-parser at the lookup site as a band-aid (the structured-everywhere anti-pattern the milestone explicitly rejects) or (b) doing #717's work inside #716. The cleanest answer is to error explicitly with a pointer to #717 and let that ticket land the architectural change in one place.

This is permitted by the issue's exit criterion #2 ("git/registry behave per the existing semantic — installed-package lookup *or explicit error*"). Path-style deps work fully; registry/git fail loudly with an actionable pointer.

## Exit criteria

- [x] `ProjectConfig::dependencies` accepts the same structured shape as `streamlib_idents::Manifest::dependencies`.
- [x] `runtime.load_project()` walks the path-style dep variant (resolves relative to the manifest dir + recurses); registry/git error explicitly with an actionable `#717` pointer.
- [x] At least one example yaml in tree declares `@tatolab/core` as a path-style dep and the runtime loads it cleanly.

## Test plan

- [x] Unit tests in `project_config.rs` round-trip the structured deps shape (path / registry-short-form / git) and reject the legacy sequence shape.
- [x] Unit tests in `runtime.rs` exercise `load_project()` with a path-style dep to a sibling tmpdir manifest (positive + negative recursion check) and a registry-style dep that errors explicitly with the canonical key + `#717` reference.
- [x] Polyglot E2E: `cargo run -p polyglot-continuous-processor-scenario -- --runtime=deno` → green (`ticks=126 avg_interval_ms=16.001`); trace confirms `Loading dependency '@tatolab/core'` → recursive `load_project` → parsed `packages/core/streamlib.yaml`.
- [x] `cargo run -p xtask -- check-manifest-schema` → all yamls validated against the JSON Schema source-of-truth.
- [x] `cargo test -p streamlib --lib core::` → 275 passed (no regressions).

## Polyglot coverage

- **Runtimes affected**: rust
- **Schema regenerated**: n/a (`StreamlibYaml` already declared the structured shape; the runtime parser was the lone outlier)
- **Python and Deno both covered?** schema-only / language-specific by construction — only the Rust runtime parses `streamlib.yaml`. Python and Deno SDKs receive descriptors over IPC from the host.
- **E2E tests run**:
  - [x] Host-Rust: `cargo test -p streamlib --lib core::` (275 passed)
  - [x] Deno subprocess: `polyglot-continuous-processor-scenario --runtime=deno` (ticks=126 avg_interval_ms=16.001)
  - [ ] Python subprocess: not run — Python yaml has no deps block, so it exercises the unchanged empty-deps fast path.
- **FD-passing path**: n/a

## Follow-ups

- #717 — `feat(packaging): canonical dep references + workspace [patch] resolution`. Lands the canonical `@org/name` install-manifest keys, cargo-style workspace `[patch]` resolution, full consumer-yaml sweep, and the `@tatolab/core` slpkg dev workflow. Until #717 merges, registry/git dep variants in `streamlib.yaml` will error with an actionable pointer.

Generated with [Claude Code](https://claude.com/claude-code)
