### PR TITLE
refactor(engine): downgrade core::* engine internals to pub(crate)

### DIFF
--- a/libs/streamlib-cli/src/commands/pack.rs
+++ b/libs/streamlib-cli/src/commands/pack.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
-use streamlib::engine_internal::core::config::ProjectConfig;
+use streamlib::engine_internal::core::ProjectConfig;
 use streamlib_idents::Manifest;
 
 /// Pack a processor package into a .slpkg bundle.

--- a/libs/streamlib-cli/src/commands/pkg.rs
+++ b/libs/streamlib-cli/src/commands/pkg.rs
@@ -4,7 +4,7 @@
 //! Package management commands.
 
 use anyhow::{Context, Result};
-use streamlib::engine_internal::core::config::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
+use streamlib::engine_internal::core::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
 use streamlib::sdk::runtime::extract_slpkg_to_cache;
 
 /// Install a .slpkg package from a local path or HTTP URL.
@@ -60,7 +60,7 @@ pub async fn install(source: &str) -> Result<()> {
             streamlib_processor_schema::ProcessorLanguage::Python
         ) {
             println!("  Setting up Python venv for {}...", processor.name);
-            streamlib::engine_internal::core::compiler::compiler_ops::ensure_processor_venv(
+            streamlib::engine_internal::core::ensure_processor_venv(
                 &processor.name,
                 &cache_dir,
             )
@@ -132,7 +132,7 @@ pub fn inspect(path: &std::path::Path) -> Result<()> {
         buf
     };
 
-    let config: streamlib::engine_internal::core::config::ProjectConfig =
+    let config: ProjectConfig =
         serde_yaml::from_str(&yaml_content).with_context(|| "Failed to parse streamlib.yaml")?;
 
     let package = config
@@ -234,7 +234,7 @@ pub fn remove(name: &str) -> Result<()> {
     };
 
     // Delete cache directory
-    let cache_dir = streamlib::engine_internal::core::streamlib_home::get_cached_package_dir(&entry.cache_dir);
+    let cache_dir = streamlib::engine_internal::core::get_cached_package_dir(&entry.cache_dir);
     if cache_dir.exists() {
         std::fs::remove_dir_all(&cache_dir)
             .with_context(|| format!("Failed to remove cache dir {}", cache_dir.display()))?;

--- a/libs/streamlib-engine/benches/logging.rs
+++ b/libs/streamlib-engine/benches/logging.rs
@@ -32,11 +32,11 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tempfile::TempDir;
 use tracing::subscriber::{DefaultGuard, NoSubscriber};
 
-use streamlib_engine::core::logging::{
+use streamlib_engine::core::runtime::RuntimeUniqueId;
+use streamlib_engine::logging::{
     init_for_tests, LogLevel, LoggingTunables, RuntimeLogEvent, StreamlibLoggingConfig,
     StreamlibLoggingGuard,
 };
-use streamlib_engine::core::runtime::RuntimeUniqueId;
 
 fn install_pathway(tmp: &TempDir, runtime_id: &str) -> StreamlibLoggingGuard {
     unsafe {

--- a/libs/streamlib-engine/src/core/compiler/mod.rs
+++ b/libs/streamlib-engine/src/core/compiler/mod.rs
@@ -22,11 +22,5 @@ mod pending_operation_queue;
 mod processor_config_change;
 pub(crate) mod scheduling;
 
-pub use compile_phase::CompilePhase;
-pub use compile_result::CompileResult;
 pub use compiler::Compiler;
-pub use compiler_transaction::CompilerTransactionHandle;
-pub use link_config_change::LinkConfigChange;
 pub use pending_operation::PendingOperation;
-pub use pending_operation_queue::PendingOperationQueue;
-pub use processor_config_change::ProcessorConfigChange;

--- a/libs/streamlib-engine/src/core/config/mod.rs
+++ b/libs/streamlib-engine/src/core/config/mod.rs
@@ -6,7 +6,5 @@
 mod installed_packages_manifest;
 mod project_config;
 
-pub use installed_packages_manifest::{
-    get_installed_packages_manifest_path, InstalledPackageEntry, InstalledPackageManifest,
-};
+pub use installed_packages_manifest::{InstalledPackageEntry, InstalledPackageManifest};
 pub use project_config::ProjectConfig;

--- a/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/integration_tests.rs
@@ -18,11 +18,11 @@
 
 use std::time::{Duration, Instant};
 
-use iceoryx2::prelude::*;
-use streamlib_engine::core::embedded_schemas::max_payload_bytes_for_schema;
-use streamlib_engine::iceoryx2::{
+use super::max_payload_bytes_for_schema;
+use crate::iceoryx2::{
     FrameHeader, Iceoryx2Node, SchemaIdentWire, FRAME_HEADER_SIZE, MAX_PAYLOAD_SIZE,
 };
+use iceoryx2::prelude::*;
 
 // =============================================================================
 // A) Direct iceoryx2 slice limit tests

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -12,6 +12,9 @@
 //! Lookups tolerate either the unversioned form or the versioned suffix
 //! `@MAJOR.MINOR.PATCH`; the version is stripped before comparing.
 
+#[cfg(test)]
+mod integration_tests;
+
 include!(concat!(env!("OUT_DIR"), "/embedded_schemas_table.rs"));
 
 /// Get the embedded JTD YAML definition for a built-in schema.

--- a/libs/streamlib-engine/src/core/mod.rs
+++ b/libs/streamlib-engine/src/core/mod.rs
@@ -1,56 +1,75 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-pub mod clap;
-pub mod codec;
-pub mod compiler;
-pub mod config;
+// Engine-internal modules. Module-path is `pub(crate)` so consumers
+// cannot reach `streamlib_engine::core::<name>` (or
+// `streamlib::engine_internal::core::<name>`) — the boundary is
+// type-system-enforced at the engine source-of-truth. Items that
+// genuinely need to cross the boundary are re-exported below as
+// narrow `pub use` selections; items not re-exported stay
+// engine-internal.
+pub(crate) mod clap;
+pub(crate) mod codec;
+pub(crate) mod compiler;
+pub(crate) mod config;
+pub(crate) mod embedded_schemas;
+pub(crate) mod logging;
+pub(crate) mod observability;
+pub(crate) mod pubsub;
+pub(crate) mod runtime_hooks;
+pub(crate) mod signals;
+pub(crate) mod streamlib_home;
+
+// Customer-facing modules. Module-path stays `pub` so consumers
+// can reach `streamlib::sdk::<name>` via the SDK's per-module
+// re-exports.
 pub mod context;
 pub mod descriptors;
 pub mod display_info;
-pub mod embedded_schemas;
 pub mod error;
 pub mod execution;
-pub mod rhi;
-
 pub mod graph;
 pub mod graph_file;
 pub mod json_schema;
-pub mod logging;
 pub mod media_clock;
-pub mod observability;
 pub mod prelude;
 pub mod processors;
-pub mod pubsub;
+pub mod rhi;
 pub mod runtime;
-pub mod runtime_hooks;
-pub mod signals;
 pub mod streaming;
-pub mod streamlib_home;
 pub mod sync;
 pub mod texture;
 pub mod utils;
 
+// Customer-facing items from engine-internal modules. These
+// modules' contents include items that ARE customer-facing (e.g.
+// `H264Profile`, `LfoWaveform`); the wildcard re-export keeps
+// those reachable at `streamlib_engine::core::*` so the engine's
+// crate-root list (in `lib.rs`) can re-export them. The module
+// path itself stays closed.
 pub use clap::*;
 pub use codec::*;
-pub use compiler::*;
-pub use config::ProjectConfig;
+
+// Customer-facing modules (wildcard re-exports stay).
 pub use context::*;
 pub use descriptors::*;
 pub use error::*;
 pub use rhi::{gl_constants, GlContext, GlTextureBinding, NativeTextureHandle, RhiBackend};
-
 pub use graph::*;
 pub use graph_file::*;
 pub use processors::*;
-pub use pubsub::*;
 pub use utils::*;
-
 pub use execution::*;
-pub use observability::*;
 pub use runtime::*;
-pub use runtime_hooks::*;
 pub use streaming::*;
-pub use streamlib_home::*;
 pub use sync::*;
 pub use texture::*;
+
+// Narrow re-exports of engine-internal items that have sanctioned
+// external consumers. Each line below is a deliberate boundary
+// crossing — items not listed here stay engine-internal.
+//
+// CLI tooling (`streamlib-cli`):
+pub use compiler::compiler_ops::ensure_processor_venv;
+pub use config::{InstalledPackageEntry, InstalledPackageManifest, ProjectConfig};
+pub use streamlib_home::get_cached_package_dir;

--- a/libs/streamlib-engine/src/core/observability/mod.rs
+++ b/libs/streamlib-engine/src/core/observability/mod.rs
@@ -5,6 +5,3 @@
 
 mod inspector;
 mod snapshots;
-
-pub use inspector::GraphInspector;
-pub use snapshots::{GraphHealth, LatencyStats, LinkSnapshot, ProcessorSnapshot};

--- a/libs/streamlib-engine/src/core/pubsub/integration_tests.rs
+++ b/libs/streamlib-engine/src/core/pubsub/integration_tests.rs
@@ -1,30 +1,40 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-// Integration test for pubsub module — tests the full iceoryx2 transport layer.
-//
-// Each test that requires iceoryx2 creates its own PubSub::new() + Iceoryx2Node::new()
-// instance with a unique runtime_id for isolation (no global state).
-//
-// IMPORTANT: PubSub::subscribe() takes ownership of the Arc but only stores a Weak ref
-// internally. Callers MUST keep a strong reference alive for the subscriber thread to run.
-// Always use `bus.subscribe(topic, listener.clone())` and keep `listener` on the stack.
-//
-// Synchronization strategy:
-// - Uses std::sync::mpsc channels for delivery notification (no sleep-based waits)
-// - Uses retry-publish pattern to handle the race between subscriber thread startup
-//   and the first publish (PubSub provides no readiness signal)
+//! Integration tests for the pubsub module — exercises the full
+//! iceoryx2 transport layer.
+//!
+//! Each test that requires iceoryx2 creates its own `PubSub::new()` +
+//! `Iceoryx2Node::new()` instance with a unique runtime_id for
+//! isolation (no global state).
+//!
+//! `PubSub::subscribe()` takes ownership of the `Arc` but only stores
+//! a `Weak` ref internally. Callers MUST keep a strong reference
+//! alive for the subscriber thread to run. Always use
+//! `bus.subscribe(topic, listener.clone())` and keep `listener` on
+//! the stack.
+//!
+//! Synchronization strategy:
+//! - Uses `std::sync::mpsc` channels for delivery notification (no
+//!   sleep-based waits)
+//! - Uses retry-publish pattern to handle the race between subscriber
+//!   thread startup and the first publish (PubSub provides no
+//!   readiness signal)
+//!
+//! Lives in-source (rather than `tests/`) because the pubsub module
+//! is `pub(crate)` — see `core/mod.rs`.
 
+use super::bus::PubSub;
+use super::events::{
+    topics, Event, EventListener, KeyCode, KeyState, Modifiers, MouseButton, MouseState,
+    ProcessorEvent, RuntimeEvent,
+};
+use crate::iceoryx2::{Iceoryx2Node, MAX_EVENT_PAYLOAD_SIZE};
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use streamlib_engine::core::pubsub::{
-    topics, Event, EventListener, KeyCode, KeyState, Modifiers, MouseButton, MouseState,
-    ProcessorEvent, PubSub, RuntimeEvent,
-};
-use streamlib_engine::iceoryx2::{Iceoryx2Node, MAX_EVENT_PAYLOAD_SIZE};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -47,7 +57,7 @@ impl CountingListener {
 }
 
 impl EventListener for CountingListener {
-    fn on_event(&mut self, _event: &Event) -> streamlib_engine::core::error::Result<()> {
+    fn on_event(&mut self, _event: &Event) -> crate::core::error::Result<()> {
         self.count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -59,7 +69,7 @@ struct ChannelListener {
 }
 
 impl EventListener for ChannelListener {
-    fn on_event(&mut self, event: &Event) -> streamlib_engine::core::error::Result<()> {
+    fn on_event(&mut self, event: &Event) -> crate::core::error::Result<()> {
         let _ = self.sender.send(event.clone());
         Ok(())
     }
@@ -187,7 +197,7 @@ fn test_iceoryx2_direct_delivery() {
     // Publish
     let event = Event::keyboard(KeyCode::A, Modifiers::default(), KeyState::Pressed);
     let bytes = rmp_serde::to_vec_named(&event).unwrap();
-    let payload = streamlib_engine::iceoryx2::EventPayload::new("test", 12345, &bytes);
+    let payload = crate::iceoryx2::EventPayload::new("test", 12345, &bytes);
 
     let sample = publisher.loan_uninit().expect("loan");
     let sample = sample.write_payload(payload);
@@ -196,7 +206,7 @@ fn test_iceoryx2_direct_delivery() {
     // Receive
     match subscriber.receive() {
         Ok(Some(sample)) => {
-            let p: &streamlib_engine::iceoryx2::EventPayload = &*sample;
+            let p: &crate::iceoryx2::EventPayload = &*sample;
             let received: Event = rmp_serde::from_slice(p.data()).unwrap();
             assert_eq!(received.topic(), event.topic());
         }
@@ -253,7 +263,7 @@ fn test_iceoryx2_cross_thread_delivery() {
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline {
-        let payload = streamlib_engine::iceoryx2::EventPayload::new("test", 12345, b"hello");
+        let payload = crate::iceoryx2::EventPayload::new("test", 12345, b"hello");
         let sample = publisher.loan_uninit().expect("loan");
         let sample = sample.write_payload(payload);
         sample.send().expect("send");
@@ -314,7 +324,7 @@ fn test_iceoryx2_pubsub_pattern_mimic() {
 
         let event = Event::keyboard(KeyCode::A, Modifiers::default(), KeyState::Pressed);
         let bytes = rmp_serde::to_vec_named(&event).unwrap();
-        let payload = streamlib_engine::iceoryx2::EventPayload::new(topic, 12345, &bytes);
+        let payload = crate::iceoryx2::EventPayload::new(topic, 12345, &bytes);
 
         let sample = publisher.loan_uninit().expect("loan");
         let sample = sample.write_payload(payload);
@@ -342,10 +352,6 @@ fn test_pubsub_publish_sends_to_iceoryx2() {
     //
     // This bypasses PubSub's subscriber thread to isolate whether the bug
     // is in publish (send side) or subscribe (receive side).
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter("trace")
-        .with_test_writer()
-        .try_init();
 
     let runtime_id = format!("test-pub-sends-{}", uuid::Uuid::new_v4());
     let node = Iceoryx2Node::new().expect("Failed to create iceoryx2 node");
@@ -435,7 +441,7 @@ fn test_pubsub_publish_sends_to_iceoryx2() {
         .expect("c-pub service");
     let c_publisher = c_pub_service.create_publisher().expect("c-publisher");
     let bytes = rmp_serde::to_vec_named(&event).unwrap();
-    let c_payload = streamlib_engine::iceoryx2::EventPayload::new("input:window", 12345, &bytes);
+    let c_payload = crate::iceoryx2::EventPayload::new("input:window", 12345, &bytes);
     let c_sample = c_publisher.loan_uninit().expect("loan");
     let c_sample = c_sample.write_payload(c_payload);
     c_sample.send().expect("send");
@@ -485,7 +491,7 @@ fn test_oncelock_node_delivery() {
 
     let event = Event::keyboard(KeyCode::A, Modifiers::default(), KeyState::Pressed);
     let bytes = rmp_serde::to_vec_named(&event).unwrap();
-    let payload = streamlib_engine::iceoryx2::EventPayload::new("input:keyboard", 12345, &bytes);
+    let payload = crate::iceoryx2::EventPayload::new("input:keyboard", 12345, &bytes);
 
     // Use *&payload to mimic PubSub's `write_payload(*payload)` (copy from reference)
     let sample = publisher.loan_uninit().expect("loan");

--- a/libs/streamlib-engine/src/core/pubsub/mod.rs
+++ b/libs/streamlib-engine/src/core/pubsub/mod.rs
@@ -4,8 +4,8 @@
 mod bus;
 mod events;
 
-pub use bus::{PubSub, PUBSUB};
-pub use events::{
-    topics, Event, EventListener, KeyCode, KeyState, LinkPortDirection, Modifiers, MouseButton,
-    MouseState, ProcessorEvent, ProcessorState, RuntimeEvent, WindowEventType,
-};
+#[cfg(test)]
+mod integration_tests;
+
+pub use bus::PUBSUB;
+pub use events::{topics, Event, EventListener, ProcessorEvent, RuntimeEvent};

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -174,9 +174,9 @@ impl Runner {
         tracing::info!("Creating Runner with ID: {}", runtime_id);
 
         // Get STREAMLIB_HOME and run init hooks (once per process)
-        let streamlib_home = crate::core::get_streamlib_home();
+        let streamlib_home = crate::core::streamlib_home::get_streamlib_home();
         tracing::debug!("STREAMLIB_HOME: {}", streamlib_home.display());
-        crate::core::run_init_hooks(&streamlib_home)?;
+        crate::core::runtime_hooks::run_init_hooks(&streamlib_home)?;
 
         // Register all processors from inventory before any add_processor calls.
         // This populates the global registry with link-time registered processors.

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -22,8 +22,14 @@ pub use serde_json;
 pub mod core;
 pub mod iceoryx2;
 
-/// Unified logging pathway — public re-export of [`core::logging`].
-pub use core::logging;
+/// Unified logging pathway. Wraps the engine-internal
+/// [`core::logging`] module so customer code can reach the
+/// pathway via `streamlib_engine::logging::*` while the
+/// `streamlib_engine::core::logging` module path stays
+/// engine-private.
+pub mod logging {
+    pub use crate::core::logging::*;
+}
 
 /// Generated types from JTD schemas.
 /// Run `cargo xtask generate-schemas` to regenerate.

--- a/libs/streamlib-engine/tests/bin/log_emit_1000.rs
+++ b/libs/streamlib-engine/tests/bin/log_emit_1000.rs
@@ -17,8 +17,8 @@
 
 use std::sync::Arc;
 
-use streamlib_engine::core::logging::{init_for_tests, LoggingTunables, StreamlibLoggingConfig};
 use streamlib_engine::core::runtime::RuntimeUniqueId;
+use streamlib_engine::logging::{init_for_tests, LoggingTunables, StreamlibLoggingConfig};
 
 fn raw_write_stdout(bytes: &[u8]) {
     unsafe {

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -249,7 +249,10 @@ pub mod sdk {
 ///
 /// ```compile_fail
 /// // `core::observability` is `pub(crate)` in streamlib-engine.
-/// use streamlib::engine_internal::core::observability::GraphInspector;
+/// // Importing the module path itself fails because the module is
+/// // crate-private — locks the visibility downgrade independent of
+/// // which items the module currently re-exports.
+/// use streamlib::engine_internal::core::observability;
 /// ```
 ///
 /// ```compile_fail

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -32,20 +32,21 @@
 //! ```
 //!
 //! **Tier 3 — `streamlib::engine_internal::*`** — direct passthrough
-//! to the entire `streamlib-engine` crate. For very rare cases where
-//! the SDK's curated `sdk::engine` surface doesn't expose what's
-//! needed AND extending the SDK isn't right. Reads as "I'm reaching
-//! past the curated boundary; I know what I'm doing."
+//! to the `pub` surface of the `streamlib-engine` crate. For very
+//! rare cases where the SDK's curated `sdk::engine` surface doesn't
+//! expose what's needed AND extending the SDK isn't right. Reads as
+//! "I'm reaching past the curated boundary; I know what I'm doing."
 //!
-//! ```ignore
-//! // Rare — should only be used in very specific circumstances.
-//! use streamlib::engine_internal::core::compiler::SomeInternalThing;
-//! ```
-//!
-//! If you find yourself importing from `engine_internal` for an item
-//! that would benefit other consumers, that's a signal: either extend
-//! the SDK's curated surface (`sdk::engine::*` or one of the topical
-//! sub-namespaces) or open an issue.
+//! Engine-internal `core::*` modules (`compiler`, `embedded_schemas`,
+//! `pubsub`, `runtime_hooks`, etc.) are `pub(crate)` in the engine,
+//! so `streamlib::engine_internal::core::<internal>` does not
+//! compile by construction — even Tier 3 cannot reach module paths
+//! the engine has marked private. Items inside those modules that
+//! genuinely need cross-crate access are explicitly re-exported
+//! item-by-item at `streamlib_engine::core::*` or at the engine
+//! crate root. The set of those re-exports IS the engine's external
+//! surface; if one is missing, file an issue rather than reaching
+//! around the boundary.
 //!
 //! Direct `streamlib_engine::*` imports outside the engine itself and
 //! this facade source are forbidden by `cargo xtask check-boundaries`
@@ -65,10 +66,16 @@ pub mod sdk {
 
     // ---- Engine `core::*` sub-modules that are SDK-public ----
     //
-    // Engine internals (`compiler`, `embedded_schemas`, `runtime_hooks`,
-    // `observability`, `streamlib_home`, `pubsub`, `signals`, `display_info`)
-    // are deliberately NOT re-exported here. Consumers needing them
-    // reach via `streamlib::engine_internal::core::<name>::*` (rare).
+    // Engine internals (`clap`, `codec`, `compiler`, `config`,
+    // `embedded_schemas`, `logging`, `observability`, `pubsub`,
+    // `runtime_hooks`, `signals`, `streamlib_home`) are
+    // `pub(crate)` in the engine crate (see `core/mod.rs`) — those
+    // module paths are not reachable here OR via `engine_internal::*`
+    // (Tier 3) by construction. Items inside that ARE customer-facing
+    // (e.g. `H264Profile` from `codec`, `LfoWaveform` from `clap`) are
+    // re-exported by the engine at its crate root and travel into the
+    // SDK via the top-level `pub use streamlib_engine::*` items below
+    // and the Tier-3 `engine_internal` namespace.
 
     pub use streamlib_engine::core::context;
     pub use streamlib_engine::core::descriptors;
@@ -219,12 +226,42 @@ pub mod sdk {
 // Tier 3 — direct passthrough to streamlib-engine
 // =============================================================================
 
-/// Direct passthrough to the entire `streamlib-engine` crate.
+/// Direct passthrough to the `pub` surface of the `streamlib-engine`
+/// crate.
 ///
 /// **Use sparingly.** This exists for the rare case where the SDK's
 /// curated [`sdk::engine`] surface doesn't expose what's needed AND
 /// extending the SDK isn't right. The path itself signals "I'm
 /// reaching past the curated boundary."
+///
+/// Engine-internal `core::*` modules are `pub(crate)` in the engine
+/// — those module paths cannot be reached from here:
+///
+/// ```compile_fail
+/// // `core::compiler` is `pub(crate)` in streamlib-engine.
+/// use streamlib::engine_internal::core::compiler::Compiler;
+/// ```
+///
+/// ```compile_fail
+/// // `core::pubsub` is `pub(crate)` in streamlib-engine.
+/// use streamlib::engine_internal::core::pubsub::PUBSUB;
+/// ```
+///
+/// ```compile_fail
+/// // `core::observability` is `pub(crate)` in streamlib-engine.
+/// use streamlib::engine_internal::core::observability::GraphInspector;
+/// ```
+///
+/// ```compile_fail
+/// // `core::runtime_hooks` is `pub(crate)` in streamlib-engine.
+/// use streamlib::engine_internal::core::runtime_hooks::RuntimeInitHook;
+/// ```
+///
+/// Items inside engine-internal modules that genuinely need
+/// cross-crate access are explicitly re-exported item-by-item at
+/// `streamlib_engine::core::*` (e.g. `ensure_processor_venv`,
+/// `ProjectConfig`) or at the engine crate root. The set of those
+/// re-exports IS the engine's external surface.
 ///
 /// If you find yourself importing from this namespace for an item
 /// that would benefit other consumers, that's a signal: either extend


### PR DESCRIPTION
## Summary

- Downgrades 11 engine-internal `core::*` modules to `pub(crate)` so `streamlib::engine_internal::core::<internal>` (Tier-3 escape hatch) cannot reach internals by construction — the boundary is now type-system-enforced at the engine source-of-truth.
- Drops wildcard `pub use {compiler,observability,pubsub,runtime_hooks,streamlib_home}::*;` re-exports at `core/mod.rs`; replaces with **narrow** item re-exports for genuinely-needed external consumers (CLI tooling).
- Adds 4 `compile_fail` doctests in `streamlib-sdk` that lock the boundary against future regressions.

## Closes

Closes #735

## What changed

**Engine-internal modules downgraded** in `libs/streamlib-engine/src/core/mod.rs`:
`clap`, `codec`, `compiler`, `config`, `embedded_schemas`, `logging`, `observability`, `pubsub`, `runtime_hooks`, `signals`, `streamlib_home`.

`display_info` stays `pub` — `examples/camera-python-display` consumes `streamlib::sdk::display_info::get_refresh_rate`. Audited the SDK comment that listed it as engine-internal — that was the wrong half of the contradiction.

**Narrow re-exports** added (sanctioned cross-crate items):
- `pub use compiler::compiler_ops::ensure_processor_venv;` (CLI)
- `pub use config::{InstalledPackageEntry, InstalledPackageManifest};` (CLI; `ProjectConfig` already there)
- `pub use streamlib_home::get_cached_package_dir;` (CLI)

**Customer-facing items from engine-internal modules** continue to flow through the existing wildcard `pub use clap::*;` / `pub use codec::*;` re-exports — `H264Profile`, `LfoWaveform`, `AudioCodec`, etc. are still customer-facing, just reached via flat re-exports, not via `core::clap::*` module path.

**SDK changes** (`libs/streamlib-sdk/src/lib.rs`):
- Drops the `display_info` SDK contradiction (kept `pub` since example uses it; updates comment).
- Updates Tier-3 doc comment to reflect that engine-internal module paths are unreachable.
- Adds 4 `compile_fail` doctests for `compiler`, `pubsub`, `observability`, `runtime_hooks`.

**Engine `lib.rs`**: replaces `pub use core::logging;` with a wrapper module so `streamlib_engine::logging::*` stays customer-accessible via the SDK while the underlying `core::logging` is `pub(crate)`.

**CLI updates** (`libs/streamlib-cli/src/commands/{pkg,pack}.rs`): 5 import paths updated to use the new narrow re-exports.

**Engine integration tests moved in-source** (where the modules they exercise are now `pub(crate)`):
- `tests/pubsub_integration_test.rs` → `core/pubsub/integration_tests.rs` (1071 LOC, mechanical)
- `tests/ipc_payload_size_test.rs` → `core/embedded_schemas/integration_tests.rs` (346 LOC; converted `embedded_schemas.rs` to `embedded_schemas/mod.rs`)
- Side-fix: removed a stray `tracing_subscriber::fmt().try_init()` from one pubsub test that worked when the test was its own binary but races with `Runner::new()` calls now that it shares the lib test binary.

**Bin + bench import updates**:
- `tests/bin/log_emit_1000.rs`: `core::logging::*` → `logging::*`
- `benches/logging.rs`: same

**Engine-internal flat-path callers** updated in `runtime/runtime.rs` (`crate::core::run_init_hooks` → `crate::core::runtime_hooks::run_init_hooks`, etc.) since those flat re-exports were dropped.

**Pre-existing dead `pub use` lines** inside engine-internal mod.rs files (compiler, config, observability, pubsub) cleaned up — they were re-exporting items no caller used, masked by the wildcard re-exports at `core/mod.rs`.

## Exit criteria (from issue)

- [x] Each engine-internal `pub mod X;` in `libs/streamlib-engine/src/core/mod.rs` downgraded to `pub(crate) mod X;`.
- [x] Engine-internal callers of those modules updated where the dropped wildcard re-exports broke flat paths.
- [x] SDK customer code can no longer reach `streamlib::engine_internal::core::compiler::*` etc. — verified by 4 `compile_fail` doctests.
- [x] Workspace test gate green; all `cargo xtask check-*` lints pass.

## Test plan

- [x] `cargo check --workspace --all-targets` — no errors
- [x] `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — all green
- [x] `cargo test --doc -p streamlib` — 4 `compile_fail` doctests pass (locking the boundary)
- [x] `cargo xtask check-boundaries` — 3280 files, no violations
- [x] `cargo xtask check-no-streamlib-metadata` — pass
- [x] `cargo xtask check-schema-versions` — pass
- [x] `cargo xtask lint-logging` — 475 files, no violations

## Notes

- The issue body claimed the SDK does `pub mod core { pub use streamlib_engine::core::*; }`. That was stale — the SDK now does selective per-module re-exports + Tier-3 `engine_internal` passthrough (likely from the recent #737 SDK extraction). The downgrade is still the right fix; the leak surface today is `streamlib::engine_internal::core::*` and direct `streamlib_engine::core::*`.
- pr-review-gate flagged that one of my original `compile_fail` doctests (observability::GraphInspector) failed for the wrong reason — `GraphInspector` was no longer `pub use`d at `observability/mod.rs` so the test failed regardless of `mod observability` visibility. Fixed in a follow-up commit by switching that doctest to import the module path itself, which actually locks the visibility downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)