### PR TITLE
refactor(sdk): rename StreamError to Error (#738)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ Run `cargo doc -p streamlib --no-deps` - fix any unresolved link warnings.
 ## Conventions
 
 ### Error Handling
-- Use `StreamError` enum from `streamlib::core::error`
+- Use `Error` enum from `streamlib::core::error`
 - Return `Result<T>` from all fallible operations
 - Prefer `?` operator over `.unwrap()` in library code
 - `.unwrap()` acceptable in examples and tests

--- a/docs/research/blit-copy-classification.md
+++ b/docs/research/blit-copy-classification.md
@@ -181,12 +181,12 @@ warmer.
 
 Per #320 §8.Q3 (already decided), no `acquire_*_or_escalate` helpers.
 Pool-miss / cold-key paths in Sandbox should return a distinct error
-(`StreamError::SandboxColdKey` or similar), so the compiler-visible
+(`Error::SandboxColdKey` or similar), so the compiler-visible
 shape of an un-pre-warmed call site is an `?` that will propagate a
 clear error at runtime — not a silent escalation.
 
 For the blitter specifically: if callers miss a pre-warm, the first
-`blit_copy` hits a `StreamError::SandboxColdKey`. The caller either
+`blit_copy` hits a `Error::SandboxColdKey`. The caller either
 (a) pre-warms more thoroughly in `setup()` or (b) wraps the blit in
 `escalate(|full| full.blit_copy(…))` at the offending call site. The
 latter is fine as a bridge while pre-warm coverage is completed, so

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -38,7 +38,7 @@ use streamlib::sdk::engine::HostGpuDeviceExt;
 use streamlib::sdk::display_info;
 use streamlib::sdk::rhi::{StreamTexture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
 use streamlib::sdk::_generated_::VideoFrame;
 
@@ -169,12 +169,12 @@ impl streamlib::sdk::processors::ManualProcessor for BlendingCompositorProcessor
         let running = Arc::clone(&self.running);
         let frame_count = Arc::clone(&self.frame_count);
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "BlendingCompositor::start: gpu_context unset (setup() not run)".into(),
             )
         })?;
         let backend = self.backend.take().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "BlendingCompositor::start: backend unset (setup() not run)".into(),
             )
         })?;
@@ -204,7 +204,7 @@ impl streamlib::sdk::processors::ManualProcessor for BlendingCompositorProcessor
                 );
             })
             .map_err(|e| {
-                StreamError::Configuration(format!("spawn render thread: {e}"))
+                Error::Configuration(format!("spawn render thread: {e}"))
             })?;
         self.render_thread = Some(handle);
         Ok(())
@@ -309,7 +309,7 @@ impl BlendingCompositorProcessor::Processor {
             // SHADER_READ_ONLY_OPTIMAL (the steady-state post-render
             // layout) is honest.
             let surface_store = gpu_full.surface_store().ok_or_else(|| {
-                StreamError::Configuration(
+                Error::Configuration(
                     "BlendingCompositor: GpuContext has no surface_store \
                      — cross-process output (Glitch consumer, #486) \
                      unavailable"
@@ -324,7 +324,7 @@ impl BlendingCompositorProcessor::Processor {
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "BlendingCompositor: surface_store.register_texture \
                          slot {slot_idx}: {e}"
                     ))

--- a/examples/camera-python-display/src/blending_compositor_kernel.rs
+++ b/examples/camera-python-display/src/blending_compositor_kernel.rs
@@ -75,7 +75,7 @@ use streamlib::sdk::rhi::{
     Viewport,
     VulkanLayout,
 };
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, HostVulkanPixelBuffer, VulkanGraphicsKernel};
 
 /// Push-constants layout — must match `blending_compositor.frag`'s
@@ -251,7 +251,7 @@ impl SandboxedBlendingCompositor {
         ] {
             if let Some(layer) = layer {
                 if layer.texture.width() != width || layer.texture.height() != height {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "{}: '{name}' layer is {}×{}, expected {width}×{height} (must match output)",
                         self.label,
                         layer.texture.width(),
@@ -296,18 +296,18 @@ impl SandboxedBlendingCompositor {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: wait_for_fences failed: {e}",
                         self.label
                     ))
                 })?;
             self.device.reset_fences(&[self.fence]).map_err(|e| {
-                StreamError::GpuError(format!("{}: reset_fences failed: {e}", self.label))
+                Error::GpuError(format!("{}: reset_fences failed: {e}", self.label))
             })?;
             self.device
                 .reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: reset_command_buffer failed: {e}",
                         self.label
                     ))
@@ -319,7 +319,7 @@ impl SandboxedBlendingCompositor {
             self.device
                 .begin_command_buffer(self.command_buffer, &begin)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: begin_command_buffer failed: {e}",
                         self.label
                     ))
@@ -341,12 +341,12 @@ impl SandboxedBlendingCompositor {
                     continue;
                 }
                 let image = tex.vulkan_inner().image().ok_or_else(|| {
-                    StreamError::GpuError(format!("{}: input texture has no VkImage", self.label))
+                    Error::GpuError(format!("{}: input texture has no VkImage", self.label))
                 })?;
                 barriers.push(input_barrier_to_shader_read_only(image, layout.as_vk()));
             }
             let output_image = inputs.output.texture.vulkan_inner().image().ok_or_else(|| {
-                StreamError::GpuError(format!("{}: output texture has no VkImage", self.label))
+                Error::GpuError(format!("{}: output texture has no VkImage", self.label))
             })?;
             barriers.push(output_barrier_to_color_attachment(
                 output_image,
@@ -424,7 +424,7 @@ impl SandboxedBlendingCompositor {
             self.device
                 .end_command_buffer(self.command_buffer)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: end_command_buffer failed: {e}",
                         self.label
                     ))
@@ -443,7 +443,7 @@ impl SandboxedBlendingCompositor {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: post-submit wait failed: {e}",
                         self.label
                     ))
@@ -485,7 +485,7 @@ fn make_placeholder_texture(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Str
     // it never crosses a process boundary.
     let host_tex = vulkan_device.create_texture_local(&desc)?;
     let image = host_tex.image().ok_or_else(|| {
-        StreamError::GpuError("placeholder texture has no VkImage".into())
+        Error::GpuError("placeholder texture has no VkImage".into())
     })?;
 
     // Upload zeros (transparent BGRA); `upload_buffer_to_image` leaves
@@ -508,7 +508,7 @@ fn create_command_pool(
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .build();
     unsafe { device.create_command_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("create_command_pool: {e}")))
 }
 
 fn allocate_command_buffer(
@@ -521,7 +521,7 @@ fn allocate_command_buffer(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }
-        .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("allocate_command_buffers: {e}")))?;
     Ok(buffers[0])
 }
 
@@ -530,7 +530,7 @@ fn create_signaled_fence(device: &vulkanalia::Device) -> Result<vk::Fence> {
         .flags(vk::FenceCreateFlags::SIGNALED)
         .build();
     unsafe { device.create_fence(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("create_fence: {e}")))
+        .map_err(|e| Error::GpuError(format!("create_fence: {e}")))
 }
 
 fn color_subresource_range() -> vk::ImageSubresourceRange {
@@ -797,7 +797,7 @@ mod tests {
                 pip_slide_progress: 0.0,
             })
             .expect_err("size mismatch must error");
-        assert!(matches!(err, StreamError::GpuError(_)));
+        assert!(matches!(err, Error::GpuError(_)));
     }
 
     /// Multi-layer composite smoke — exercises the full alpha-over

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -19,7 +19,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib::sdk::_generated_::VideoFrame;
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
@@ -138,7 +138,7 @@ impl CameraToCudaCopyProcessor::Processor {
         let width = self.config.width;
         let height = self.config.height;
         if width == 0 || height == 0 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "CameraToCudaCopy: width/height must be non-zero, got {width}x{height}"
             )));
         }
@@ -160,7 +160,7 @@ impl CameraToCudaCopyProcessor::Processor {
             PixelFormat::Bgra32,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "CameraToCudaCopy: new_opaque_fd_export_device_local: {e}"
             ))
         })?;
@@ -173,7 +173,7 @@ impl CameraToCudaCopyProcessor::Processor {
         //    on the GPU signal this processor emits per frame.
         let timeline = Arc::new(
             HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0).map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "CameraToCudaCopy: HostVulkanTimelineSemaphore::new_exportable: {e}"
                 ))
             })?,
@@ -183,7 +183,7 @@ impl CameraToCudaCopyProcessor::Processor {
         //    `check_out` the OPAQUE_FD memory + timeline in one round
         //    trip.
         let surface_store = gpu_full.surface_store().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "CameraToCudaCopy: GpuContext has no surface_store (Linux runtime?)".into(),
             )
         })?;
@@ -195,7 +195,7 @@ impl CameraToCudaCopyProcessor::Processor {
                 Some(timeline.as_ref()),
             )
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "CameraToCudaCopy: register_pixel_buffer_with_timeline: {e}"
                 ))
             })?;
@@ -216,7 +216,7 @@ impl CameraToCudaCopyProcessor::Processor {
                 },
             )
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "CameraToCudaCopy: register_host_surface: {e:?}"
                 ))
             })?;
@@ -241,7 +241,7 @@ impl CameraToCudaCopyProcessor::Processor {
 
     #[cfg(not(target_os = "linux"))]
     fn setup_inner(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "CameraToCudaCopy: only supported on Linux (cuda is Linux-only)".into(),
         ))
     }
@@ -249,7 +249,7 @@ impl CameraToCudaCopyProcessor::Processor {
     #[cfg(target_os = "linux")]
     fn process_frame_inner(&mut self, frame: &VideoFrame) -> Result<()> {
         let backend = self.backend.as_ref().ok_or_else(|| {
-            StreamError::Configuration("CameraToCudaCopy: backend not initialized".into())
+            Error::Configuration("CameraToCudaCopy: backend not initialized".into())
         })?;
 
         // Resolve the camera ring texture. The camera processor
@@ -257,7 +257,7 @@ impl CameraToCudaCopyProcessor::Processor {
         // and rotates through them; `frame.surface_id` carries the
         // current ring slot's UUID.
         let texture = backend.gpu_ctx.resolve_video_frame_texture(frame).map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "CameraToCudaCopy: resolve_video_frame_texture('{}'): {e}",
                 frame.surface_id
             ))
@@ -266,7 +266,7 @@ impl CameraToCudaCopyProcessor::Processor {
         let cam_w = host_texture.width();
         let cam_h = host_texture.height();
         if cam_w != backend.width || cam_h != backend.height {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "CameraToCudaCopy: camera resolution {cam_w}x{cam_h} differs from \
                  cuda surface {}x{}; GPU-side resize is not implemented in this processor \
                  (the cuda buffer is a flat VkBuffer, not a VkImage, so vkCmdBlitImage \
@@ -304,7 +304,7 @@ impl CameraToCudaCopyProcessor::Processor {
                 }
             }
             Err(e) => {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "CameraToCudaCopy: submit_host_copy_image_to_buffer: {e:?}"
                 )));
             }
@@ -314,7 +314,7 @@ impl CameraToCudaCopyProcessor::Processor {
 
     #[cfg(not(target_os = "linux"))]
     fn process_frame_inner(&mut self, _frame: &VideoFrame) -> Result<()> {
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "CameraToCudaCopy: only supported on Linux".into(),
         ))
     }

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -30,7 +30,7 @@ use streamlib::sdk::engine::HostGpuDeviceExt;
 
 use streamlib::sdk::rhi::{StreamTexture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::_generated_::VideoFrame;
 
 use crate::crt_film_grain_kernel::{
@@ -146,11 +146,11 @@ impl streamlib::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Pr
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?
             .clone();
 
         let backend = self.backend.as_mut().ok_or_else(|| {
-            StreamError::Configuration("CrtFilmGrain: backend not initialized".into())
+            Error::Configuration("CrtFilmGrain: backend not initialized".into())
         })?;
 
         // Resolve input texture + its current_layout via Path 1 / Path 2
@@ -243,7 +243,7 @@ impl CrtFilmGrainProcessor::Processor {
         // keep both registrations honest.
         let mut output_ring: Vec<OutputSlot> = Vec::with_capacity(OUTPUT_RING_DEPTH);
         let surface_store = gpu_full.surface_store().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "CrtFilmGrain: GpuContext has no surface_store \
                  — cross-process output (Glitch consumer, #486) unavailable"
                     .into(),
@@ -285,7 +285,7 @@ impl CrtFilmGrainProcessor::Processor {
                     VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "CrtFilmGrain: surface_store.register_texture slot {slot_idx}: {e}"
                     ))
                 })?;

--- a/examples/camera-python-display/src/crt_film_grain_kernel.rs
+++ b/examples/camera-python-display/src/crt_film_grain_kernel.rs
@@ -74,7 +74,7 @@ use streamlib::sdk::rhi::{
     Viewport,
     VulkanLayout,
 };
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanGraphicsKernel};
 
 /// Push-constants layout — must match `crt_film_grain.frag`'s
@@ -209,7 +209,7 @@ impl SandboxedCrtFilmGrain {
         if inputs.input.texture.width() != width
             || inputs.input.texture.height() != height
         {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "{}: input is {}×{}, expected {width}×{height} (must match output)",
                 self.label,
                 inputs.input.texture.width(),
@@ -237,18 +237,18 @@ impl SandboxedCrtFilmGrain {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: wait_for_fences failed: {e}",
                         self.label
                     ))
                 })?;
             self.device.reset_fences(&[self.fence]).map_err(|e| {
-                StreamError::GpuError(format!("{}: reset_fences failed: {e}", self.label))
+                Error::GpuError(format!("{}: reset_fences failed: {e}", self.label))
             })?;
             self.device
                 .reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: reset_command_buffer failed: {e}",
                         self.label
                     ))
@@ -260,7 +260,7 @@ impl SandboxedCrtFilmGrain {
             self.device
                 .begin_command_buffer(self.command_buffer, &begin)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: begin_command_buffer failed: {e}",
                         self.label
                     ))
@@ -271,7 +271,7 @@ impl SandboxedCrtFilmGrain {
             let mut barriers: Vec<vk::ImageMemoryBarrier2> = Vec::with_capacity(2);
             if inputs.input.current_layout != VulkanLayout::SHADER_READ_ONLY_OPTIMAL {
                 let input_image = inputs.input.texture.vulkan_inner().image().ok_or_else(|| {
-                    StreamError::GpuError(format!("{}: input texture has no VkImage", self.label))
+                    Error::GpuError(format!("{}: input texture has no VkImage", self.label))
                 })?;
                 barriers.push(input_barrier_to_shader_read_only(
                     input_image,
@@ -279,7 +279,7 @@ impl SandboxedCrtFilmGrain {
                 ));
             }
             let output_image = inputs.output.texture.vulkan_inner().image().ok_or_else(|| {
-                StreamError::GpuError(format!("{}: output texture has no VkImage", self.label))
+                Error::GpuError(format!("{}: output texture has no VkImage", self.label))
             })?;
             barriers.push(output_barrier_to_color_attachment(
                 output_image,
@@ -354,7 +354,7 @@ impl SandboxedCrtFilmGrain {
             self.device
                 .end_command_buffer(self.command_buffer)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: end_command_buffer failed: {e}",
                         self.label
                     ))
@@ -373,7 +373,7 @@ impl SandboxedCrtFilmGrain {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "{}: post-submit wait failed: {e}",
                         self.label
                     ))
@@ -404,7 +404,7 @@ fn create_command_pool(
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .build();
     unsafe { device.create_command_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("create_command_pool: {e}")))
 }
 
 fn allocate_command_buffer(
@@ -417,7 +417,7 @@ fn allocate_command_buffer(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }
-        .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("allocate_command_buffers: {e}")))?;
     Ok(buffers[0])
 }
 
@@ -426,7 +426,7 @@ fn create_signaled_fence(device: &vulkanalia::Device) -> Result<vk::Fence> {
         .flags(vk::FenceCreateFlags::SIGNALED)
         .build();
     unsafe { device.create_fence(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("create_fence: {e}")))
+        .map_err(|e| Error::GpuError(format!("create_fence: {e}")))
 }
 
 fn color_subresource_range() -> vk::ImageSubresourceRange {
@@ -656,7 +656,7 @@ mod tests {
         let err = kernel
             .dispatch(default_inputs(&input, &output))
             .expect_err("size mismatch must error");
-        assert!(matches!(err, StreamError::GpuError(_)));
+        assert!(matches!(err, Error::GpuError(_)));
     }
 
     /// Runs the kernel against a uniform mid-grey input. The center of

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -64,7 +64,7 @@ use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::rhi::TextureFormat;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::processors::{CameraProcessor, DisplayProcessor, ProcessorSpec};
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
@@ -143,7 +143,7 @@ pub fn main() -> Result<()> {
             "avatar mesh-render output",
         )
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "register avatar surface: {e}"
             ))
         })?;
@@ -156,7 +156,7 @@ pub fn main() -> Result<()> {
             "lower-third Skia output (#485)",
         )
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "register lower-third surface: {e}"
             ))
         })?;
@@ -169,7 +169,7 @@ pub fn main() -> Result<()> {
             "watermark Skia output (#485)",
         )
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "register watermark surface: {e}"
             ))
         })?;
@@ -182,7 +182,7 @@ pub fn main() -> Result<()> {
             "glitch OpenGL output (#486)",
         )
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "register glitch surface: {e}"
             ))
         })?;

--- a/examples/camera-rust-plugin/plugin/src/lib.rs
+++ b/examples/camera-rust-plugin/plugin/src/lib.rs
@@ -15,7 +15,7 @@ use streamlib::sdk::_generated_::VideoFrame;
 use streamlib::sdk::rhi::PixelFormat;
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
 use streamlib::sdk::processors::ManualProcessor;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib_plugin_abi::export_plugin;
 
 #[link(name = "CoreVideo", kind = "framework")]
@@ -50,7 +50,7 @@ impl ManualProcessor for GrayscaleProcessor::Processor {
         let gpu = self
             .gpu_context
             .clone()
-            .ok_or_else(|| StreamError::Configuration("GpuContext not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("GpuContext not initialized".into()))?;
         let running = Arc::clone(&self.running);
 
         running.store(true, Ordering::Release);
@@ -168,7 +168,7 @@ impl ManualProcessor for GrayscaleProcessor::Processor {
                 tracing::info!("GrayscaleProcessor: processing thread stopped");
             })
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to spawn processing thread: {}", e))
+                Error::Configuration(format!("Failed to spawn processing thread: {}", e))
             })?;
 
         self.processing_thread = Some(handle);
@@ -182,7 +182,7 @@ impl ManualProcessor for GrayscaleProcessor::Processor {
         if let Some(handle) = self.processing_thread.take() {
             handle
                 .join()
-                .map_err(|_| StreamError::Runtime("Processing thread panicked".into()))?;
+                .map_err(|_| Error::Runtime("Processing thread panicked".into()))?;
         }
 
         tracing::info!("GrayscaleProcessor: stopped");

--- a/examples/camera-rust-plugin/src/main.rs
+++ b/examples/camera-rust-plugin/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
     let plugin_dir = manifest_dir.join("plugin");
     let lib_dir = plugin_dir.join("lib");
     std::fs::create_dir_all(&lib_dir).map_err(|e| {
-        streamlib::sdk::error::StreamError::Configuration(format!("Failed to create lib dir: {}", e))
+        streamlib::sdk::error::Error::Configuration(format!("Failed to create lib dir: {}", e))
     })?;
 
     // Derive workspace target dir: CARGO_MANIFEST_DIR is examples/camera-rust-plugin/,
@@ -77,7 +77,7 @@ fn main() -> Result<()> {
 
     let dest_dylib = lib_dir.join(dylib_name);
     std::fs::copy(source_dylib, &dest_dylib).map_err(|e| {
-        streamlib::sdk::error::StreamError::Configuration(format!(
+        streamlib::sdk::error::Error::Configuration(format!(
             "Failed to copy dylib from {} to {}: {}",
             source_dylib.display(),
             dest_dylib.display(),

--- a/examples/polyglot-continuous-processor/src/main.rs
+++ b/examples/polyglot-continuous-processor/src/main.rs
@@ -43,7 +43,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
@@ -149,7 +149,7 @@ fn run() -> Result<TickReport> {
     for a in std::env::args().skip(1) {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output-file=") {
             output_file = Some(PathBuf::from(value));
         }
@@ -201,7 +201,7 @@ fn run() -> Result<TickReport> {
     let report = read_tick_report(&output_file)?;
 
     if report.count < MIN_TICK_COUNT || report.count > MAX_TICK_COUNT {
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "tick count {} outside expected [{MIN_TICK_COUNT}, {MAX_TICK_COUNT}]",
             report.count,
         )));
@@ -210,7 +210,7 @@ fn run() -> Result<TickReport> {
         let nominal_ns = (NOMINAL_INTERVAL_MS as f64) * 1_000_000.0;
         let slack_ns = INTERVAL_SLACK_MS * 1_000_000.0;
         if (avg_ns - nominal_ns).abs() > slack_ns {
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "average inter-tick interval {:.3}ms outside nominal {NOMINAL_INTERVAL_MS}ms ± {INTERVAL_SLACK_MS}ms",
                 avg_ns / 1_000_000.0,
             )));
@@ -221,18 +221,18 @@ fn run() -> Result<TickReport> {
 
 fn read_tick_report(path: &std::path::Path) -> Result<TickReport> {
     let raw = std::fs::read_to_string(path).map_err(|e| {
-        StreamError::Runtime(format!(
+        Error::Runtime(format!(
             "polyglot continuous processor did not write {} — teardown may have failed: {e}",
             path.display()
         ))
     })?;
     let v: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
-        StreamError::Runtime(format!("output file is not valid JSON: {e}"))
+        Error::Runtime(format!("output file is not valid JSON: {e}"))
     })?;
     let count = v
         .get("tick_count")
         .and_then(|x| x.as_u64())
-        .ok_or_else(|| StreamError::Runtime("missing tick_count".into()))? as u32;
+        .ok_or_else(|| Error::Runtime("missing tick_count".into()))? as u32;
     // The Python side writes integers, the Deno side writes BigInts as
     // strings (JSON has no native u64). Accept both shapes.
     let first_ns = parse_u64_or_string(&v, "first_tick_ns")?;
@@ -242,17 +242,17 @@ fn read_tick_report(path: &std::path::Path) -> Result<TickReport> {
 
 fn parse_u64_or_string(v: &serde_json::Value, key: &str) -> Result<u64> {
     let field = v.get(key).ok_or_else(|| {
-        StreamError::Runtime(format!("missing {key}"))
+        Error::Runtime(format!("missing {key}"))
     })?;
     if let Some(n) = field.as_u64() {
         return Ok(n);
     }
     if let Some(s) = field.as_str() {
         return s.parse::<u64>().map_err(|e| {
-            StreamError::Runtime(format!("{key} not a u64 string: {e}"))
+            Error::Runtime(format!("{key} not a u64 string: {e}"))
         });
     }
-    Err(StreamError::Runtime(format!(
+    Err(Error::Runtime(format!(
         "{key} has unexpected JSON shape: {field:?}"
     )))
 }

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -52,7 +52,7 @@ use streamlib::sdk::context::{CpuReadbackBridge, CpuReadbackCopyDirection, GpuCo
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
     HostMarker,
     HostVulkanPixelBuffer,
@@ -131,16 +131,16 @@ fn main() -> Result<()> {
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         } else if let Some(value) = a.strip_prefix("--kernel-size=") {
             kernel_size = value.parse().map_err(|e| {
-                StreamError::Configuration(format!("invalid --kernel-size: {e}"))
+                Error::Configuration(format!("invalid --kernel-size: {e}"))
             })?;
         } else if let Some(value) = a.strip_prefix("--sigma=") {
             sigma = value.parse().map_err(|e| {
-                StreamError::Configuration(format!("invalid --sigma: {e}"))
+                Error::Configuration(format!("invalid --sigma: {e}"))
             })?;
         }
     }
@@ -175,7 +175,7 @@ fn main() -> Result<()> {
             );
 
             register_host_surface(&adapter, gpu).map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "register_host_surface: {e}"
                 ))
             })?;
@@ -202,7 +202,7 @@ fn main() -> Result<()> {
             let slpkg_path =
                 manifest_dir.join("python/polyglot-cpu-readback-blur-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-cpu-readback-blur/python",
                     slpkg_path.display()
                 )));
@@ -212,7 +212,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -227,14 +227,14 @@ fn main() -> Result<()> {
     // on the pre-registered cpu-readback surface, not the trigger
     // frame's pixel buffer).
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
 
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -282,7 +282,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "cpu-readback adapter slot is empty — setup hook never ran"
                     .into(),
             )
@@ -426,7 +426,7 @@ fn upload_input_pattern(adapter: &Arc<HostAdapter>) -> Result<()> {
     );
 
     let mut guard = adapter.acquire_write(&surface).map_err(|e| {
-        StreamError::Configuration(format!("upload_input_pattern acquire: {e:?}"))
+        Error::Configuration(format!("upload_input_pattern acquire: {e:?}"))
     })?;
 
     {
@@ -497,7 +497,7 @@ fn write_output_png(
     );
 
     let guard = adapter.acquire_read(&surface).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "acquire_read for output PNG: {e:?}"
         ))
     })?;
@@ -514,7 +514,7 @@ fn write_output_png(
     }
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "create output PNG {}: {e}",
             output.display()
         ))
@@ -524,9 +524,9 @@ fn write_output_png(
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(&rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -54,7 +54,7 @@ use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
     HostMarker,
     HostVulkanPixelBuffer,
@@ -131,12 +131,12 @@ fn main() -> Result<()> {
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         } else if let Some(value) = a.strip_prefix("--timeout-secs=") {
             timeout_secs = value.parse().map_err(|e| {
-                StreamError::Configuration(format!("invalid --timeout-secs: {e}"))
+                Error::Configuration(format!("invalid --timeout-secs: {e}"))
             })?;
         }
     }
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
                 Arc::new(CudaSurfaceAdapter::new(Arc::clone(&host_device)));
 
             register_host_surface(&adapter, gpu).map_err(|e| {
-                StreamError::Configuration(format!("register_host_surface: {e}"))
+                Error::Configuration(format!("register_host_surface: {e}"))
             })?;
 
             *adapter_slot.lock().unwrap() = Some(adapter);
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
             let slpkg_path =
                 manifest_dir.join("python/polyglot-cuda-inference-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-cuda-inference/python",
                     slpkg_path.display()
                 )));
@@ -199,7 +199,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -214,14 +214,14 @@ fn main() -> Result<()> {
     // on the pre-registered cuda OPAQUE_FD surface, not the trigger
     // frame's pixel buffer). Same shape as cpu-readback-blur.
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
 
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?

--- a/examples/polyglot-dma-buf-consumer/src/main.rs
+++ b/examples/polyglot-dma-buf-consumer/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
             negative = true;
         } else if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind = RuntimeKind::parse(value).map_err(|e| {
-                streamlib::sdk::error::StreamError::Configuration(e)
+                streamlib::sdk::error::Error::Configuration(e)
             })?;
         } else {
             positional.push(a);
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
             let slpkg_path =
                 manifest_dir.join("python/polyglot-dma-buf-consumer-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(streamlib::sdk::error::StreamError::Configuration(format!(
+                return Err(streamlib::sdk::error::Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-dma-buf-consumer/python",
                     slpkg_path.display()
                 )));
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(streamlib::sdk::error::StreamError::Configuration(format!(
+                return Err(streamlib::sdk::error::Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));

--- a/examples/polyglot-manual-source/plugin/src/lib.rs
+++ b/examples/polyglot-manual-source/plugin/src/lib.rs
@@ -20,7 +20,7 @@
 
 use std::path::PathBuf;
 use streamlib::sdk::_generated_::VideoFrame;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib_plugin_abi::export_plugin;
 
@@ -89,7 +89,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCount
                     "last_timestamp_ns": self.last_ns.to_string(),
                 });
                 std::fs::write(path, stats.to_string()).map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "[CountingSink] failed to write stats to {}: {}",
                         path.display(),
                         e

--- a/examples/polyglot-manual-source/src/main.rs
+++ b/examples/polyglot-manual-source/src/main.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
@@ -139,7 +139,7 @@ fn run() -> Result<SinkReport> {
     for a in std::env::args().skip(1) {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--sink-stats-file=") {
             sink_stats_file = Some(PathBuf::from(value));
         }
@@ -235,7 +235,7 @@ fn run() -> Result<SinkReport> {
 
     let report = read_sink_report(&sink_stats_file)?;
     if report.frames_received < MIN_FRAMES_RECEIVED {
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "counting sink received only {} frames; expected >= {MIN_FRAMES_RECEIVED}",
             report.frames_received,
         )));
@@ -249,7 +249,7 @@ fn run() -> Result<SinkReport> {
 fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
     let lib_dir = plugin_dir.join("lib");
     std::fs::create_dir_all(&lib_dir).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "failed to create plugin lib dir {}: {e}",
             lib_dir.display(),
         ))
@@ -259,7 +259,7 @@ fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
     let workspace_root = manifest_dir
         .parent()
         .and_then(|p| p.parent())
-        .ok_or_else(|| StreamError::Configuration("workspace root not found".into()))?;
+        .ok_or_else(|| Error::Configuration("workspace root not found".into()))?;
 
     let target_dir = workspace_root.join("target");
     let candidates = [
@@ -267,7 +267,7 @@ fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
         target_dir.join("release").join(COUNTING_SINK_PLUGIN_DYLIB),
     ];
     let source = candidates.iter().find(|p| p.exists()).ok_or_else(|| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "counting-sink plugin dylib not found. Build it first:\n  \
              cargo build -p polyglot-manual-source-counting-sink-plugin\n\
              Looked in:\n  {}\n  {}",
@@ -277,7 +277,7 @@ fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
     })?;
     let dest = lib_dir.join(COUNTING_SINK_PLUGIN_DYLIB);
     std::fs::copy(source, &dest).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "failed to copy {} → {}: {e}",
             source.display(),
             dest.display(),
@@ -288,18 +288,18 @@ fn stage_plugin_dylib(plugin_dir: &std::path::Path) -> Result<()> {
 
 fn read_sink_report(path: &std::path::Path) -> Result<SinkReport> {
     let raw = std::fs::read_to_string(path).map_err(|e| {
-        StreamError::Runtime(format!(
+        Error::Runtime(format!(
             "counting sink did not write {} — sink processor may not have received any frames: {e}",
             path.display()
         ))
     })?;
     let v: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
-        StreamError::Runtime(format!("sink stats file is not valid JSON: {e}"))
+        Error::Runtime(format!("sink stats file is not valid JSON: {e}"))
     })?;
     let frames_received = v
         .get("frames_received")
         .and_then(|x| x.as_u64())
-        .ok_or_else(|| StreamError::Runtime("missing frames_received".into()))?
+        .ok_or_else(|| Error::Runtime("missing frames_received".into()))?
         as u32;
     Ok(SinkReport { frames_received })
 }

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -34,7 +34,7 @@ use streamlib::sdk::engine::HostGpuDeviceExt;
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::sdk::processors::{BgraFileSourceProcessor, ProcessorSpec};
 use streamlib::sdk::error::Result;
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         }
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
             // adapter's `OpenGlSurfaceAdapter` then imports the
             // resulting DMA-BUF FD as an EGLImage + GL_TEXTURE_2D.
             let store = gpu.surface_store().ok_or_else(|| {
-                StreamError::Configuration(
+                Error::Configuration(
                     "surface_store unavailable — host runtime built without \
                      a surface-share service (Linux subprocess flow requires it)"
                         .into(),
@@ -169,7 +169,7 @@ fn main() -> Result<()> {
                     0,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "HostVulkanTimelineSemaphore::new_exportable: {e}"
                     ))
                 })?,
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "register_texture: {e}"
                     ))
                 })?;
@@ -227,7 +227,7 @@ fn main() -> Result<()> {
             let slpkg_path = manifest_dir
                 .join("python/polyglot-opengl-fragment-shader-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-opengl-fragment-shader/python",
                     slpkg_path.display()
                 )));
@@ -237,7 +237,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -251,14 +251,14 @@ fn main() -> Result<()> {
     // ignores frame contents — it works on the pre-registered host
     // surface, not the trigger frame's pixel buffer.
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
 
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -310,7 +310,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
@@ -318,14 +318,14 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+        .ok_or_else(|| Error::Runtime("readback slot is empty".into()))?;
     // OpenGL adapter leaves the image in GENERAL.
     let ticket = readback
         .submit(&texture, TextureSourceLayout::General)
-        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("readback submit: {e}")))?;
     let bgra = readback
         .wait_and_read(ticket, u64::MAX)
-        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .map_err(|e| Error::Runtime(format!("readback wait: {e}")))?
         .to_vec();
     write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
@@ -367,7 +367,7 @@ fn write_png(
     }
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "create output PNG {}: {e}",
             output.display()
         ))
@@ -377,9 +377,9 @@ fn write_png(
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(&rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -56,7 +56,7 @@ use streamlib::sdk::rhi::{
     VulkanLayout,
 };
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::sdk::processors::{BgraFileSourceProcessor, ProcessorSpec};
 use streamlib::sdk::error::Result;
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
         }
     }
     std::fs::create_dir_all(&output_dir).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "create output dir {}: {e}",
             output_dir.display()
         ))
@@ -127,13 +127,13 @@ fn main() -> Result<()> {
                     0,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "HostVulkanTimelineSemaphore::new_exportable: {e}"
                     ))
                 })?,
             );
             let store = gpu.surface_store().ok_or_else(|| {
-                StreamError::Configuration(
+                Error::Configuration(
                     "surface_store unavailable — host runtime built without \
                      a surface-share service (Linux subprocess flow requires it)"
                         .into(),
@@ -152,7 +152,7 @@ fn main() -> Result<()> {
                     VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!("register_texture: {e}"))
+                    Error::Configuration(format!("register_texture: {e}"))
                 })?;
             // No bridge wiring: Skia composes on the OpenGL adapter,
             // which has no per-acquire host work — every line of GPU
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
     let slpkg_path =
         manifest_dir.join("python/polyglot-skia-canvas-0.1.0.slpkg");
     if !slpkg_path.exists() {
-        return Err(StreamError::Configuration(format!(
+        return Err(Error::Configuration(format!(
             "Package not found: {}\n\
              Run: cargo run -p streamlib-cli -- pack examples/polyglot-skia-canvas/python",
             slpkg_path.display()
@@ -193,13 +193,13 @@ fn main() -> Result<()> {
     runtime.load_package(&slpkg_path)?;
 
     let fixture_path =
-        write_trigger_fixture().map_err(StreamError::Configuration)?;
+        write_trigger_fixture().map_err(Error::Configuration)?;
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -274,7 +274,7 @@ fn main() -> Result<()> {
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "ffmpeg spawn (install ffmpeg if missing): {e}"
             ))
         })?;
@@ -288,7 +288,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
@@ -296,7 +296,7 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+        .ok_or_else(|| Error::Runtime("readback slot is empty".into()))?;
 
     // 60Hz readback loop. The Python subprocess draws as fast as it
     // gets trigger frames from BgraFileSource (also 60fps); host
@@ -323,7 +323,7 @@ fn main() -> Result<()> {
         let rb_start = Instant::now();
         let ticket = readback
             .submit(&texture, TextureSourceLayout::General)
-            .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+            .map_err(|e| Error::Runtime(format!("readback submit: {e}")))?;
         let capture_hero = f == HERO_FRAME_INDEX;
         let mut hero_capture: Option<Vec<u8>> = None;
         readback
@@ -333,9 +333,9 @@ fn main() -> Result<()> {
                 }
                 ffmpeg_stdin.write_all(bgra)
             })
-            .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+            .map_err(|e| Error::Runtime(format!("readback wait: {e}")))?
             .map_err(|e| {
-                StreamError::Runtime(format!("ffmpeg stdin write: {e}"))
+                Error::Runtime(format!("ffmpeg stdin write: {e}"))
             })?;
         readback_times.push(rb_start.elapsed());
         if let Some(pixels) = hero_capture {
@@ -360,10 +360,10 @@ fn main() -> Result<()> {
 
     drop(ffmpeg_stdin);
     let ffmpeg_status = ffmpeg.wait().map_err(|e| {
-        StreamError::Runtime(format!("ffmpeg wait: {e}"))
+        Error::Runtime(format!("ffmpeg wait: {e}"))
     })?;
     if !ffmpeg_status.success() {
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "ffmpeg encode failed: {ffmpeg_status:?}"
         )));
     }
@@ -376,7 +376,7 @@ fn main() -> Result<()> {
             hero_path.display()
         );
     } else {
-        return Err(StreamError::Runtime(
+        return Err(Error::Runtime(
             "hero frame was never captured — readback loop exited early".into(),
         ));
     }
@@ -418,7 +418,7 @@ fn write_png(
     }
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "create output PNG {}: {e}",
             output.display()
         ))
@@ -428,9 +428,9 @@ fn write_png(
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(&rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -47,7 +47,7 @@ use streamlib::sdk::rhi::{
     TextureSourceLayout,
 };
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanDevice,
     HostVulkanTimelineSemaphore,
@@ -229,7 +229,7 @@ fn main() -> Result<()> {
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
             runtime_kind =
-                RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+                RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         }
@@ -272,7 +272,7 @@ fn main() -> Result<()> {
             let timeline = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                     .map_err(|e| {
-                        StreamError::Configuration(format!(
+                        Error::Configuration(format!(
                             "HostVulkanTimelineSemaphore::new_exportable: {e}"
                         ))
                     })?,
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
             // and the timeline OPAQUE_FD so the subprocess can wire up
             // the host adapter's `register_host_surface` directly.
             let store = gpu.surface_store().ok_or_else(|| {
-                StreamError::Configuration(
+                Error::Configuration(
                     "surface_store unavailable — host runtime built without \
                      a surface-share service (Linux subprocess flow requires it)"
                         .into(),
@@ -300,7 +300,7 @@ fn main() -> Result<()> {
                     streamlib::sdk::rhi::VulkanLayout::GENERAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "register_texture: {e}"
                     ))
                 })?;
@@ -343,7 +343,7 @@ fn main() -> Result<()> {
             let slpkg_path = manifest_dir
                 .join("python/polyglot-vulkan-compute-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-compute/python",
                     slpkg_path.display()
                 )));
@@ -353,7 +353,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -367,14 +367,14 @@ fn main() -> Result<()> {
     // works on the pre-registered host surface, not the trigger frame's
     // pixel buffer.
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
 
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -427,7 +427,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
@@ -435,13 +435,13 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+        .ok_or_else(|| Error::Runtime("readback slot is empty".into()))?;
     let ticket = readback
         .submit(&texture, TextureSourceLayout::General)
-        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("readback submit: {e}")))?;
     let bgra = readback
         .wait_and_read(ticket, u64::MAX)
-        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .map_err(|e| Error::Runtime(format!("readback wait: {e}")))?
         .to_vec();
     write_png(&bgra, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
@@ -485,7 +485,7 @@ fn write_png(
     let rgba = bgra.to_vec();
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!(
+        Error::Configuration(format!(
             "create output PNG {}: {e}",
             output.display()
         ))
@@ -495,9 +495,9 @@ fn write_png(
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(&rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -76,7 +76,7 @@ use streamlib::sdk::rhi::{
     VertexInputState,
 };
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanDevice,
     HostVulkanTimelineSemaphore,
@@ -565,7 +565,7 @@ fn main() -> Result<()> {
     let mut output_png = PathBuf::from("/tmp/vulkan-triangle.png");
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
-            runtime_kind = RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+            runtime_kind = RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         }
@@ -606,13 +606,13 @@ fn main() -> Result<()> {
             let timeline = Arc::new(
                 HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
                     .map_err(|e| {
-                        StreamError::Configuration(format!(
+                        Error::Configuration(format!(
                             "HostVulkanTimelineSemaphore::new_exportable: {e}"
                         ))
                     })?,
             );
             let store = gpu.surface_store().ok_or_else(|| {
-                StreamError::Configuration(
+                Error::Configuration(
                     "surface_store unavailable — host runtime built without \
                      a surface-share service (Linux subprocess flow requires it)"
                         .into(),
@@ -631,7 +631,7 @@ fn main() -> Result<()> {
                     streamlib::sdk::rhi::VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
                 )
                 .map_err(|e| {
-                    StreamError::Configuration(format!("register_texture: {e}"))
+                    Error::Configuration(format!("register_texture: {e}"))
                 })?;
 
             let bridge = Arc::new(TriangleKernelBridge::new(
@@ -664,7 +664,7 @@ fn main() -> Result<()> {
             let slpkg_path = manifest_dir
                 .join("python/polyglot-vulkan-graphics-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-graphics/python",
                     slpkg_path.display()
                 )));
@@ -674,7 +674,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -684,13 +684,13 @@ fn main() -> Result<()> {
     }
 
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -742,7 +742,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "host texture slot is empty — setup hook never ran".into(),
             )
         })?;
@@ -750,13 +750,13 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+        .ok_or_else(|| Error::Runtime("readback slot is empty".into()))?;
     let ticket = readback
         .submit(&texture, TextureSourceLayout::ColorAttachment)
-        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("readback submit: {e}")))?;
     let rgba = readback
         .wait_and_read(ticket, u64::MAX)
-        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .map_err(|e| Error::Runtime(format!("readback wait: {e}")))?
         .to_vec();
     write_png(&rgba, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
@@ -794,16 +794,16 @@ fn write_png(
     use std::io::BufWriter;
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!("create output PNG {}: {e}", output.display()))
+        Error::Configuration(format!("create output PNG {}: {e}", output.display()))
     })?;
     let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -69,7 +69,7 @@ use streamlib::sdk::rhi::{
     VulkanLayout,
 };
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
     GeometryInstanceFlagsKHR,
     HostVulkanDevice,
@@ -531,7 +531,7 @@ fn main() -> Result<()> {
     let mut output_png = PathBuf::from("/tmp/vulkan-rt.png");
     for a in args {
         if let Some(value) = a.strip_prefix("--runtime=") {
-            runtime_kind = RuntimeKind::parse(value).map_err(StreamError::Configuration)?;
+            runtime_kind = RuntimeKind::parse(value).map_err(Error::Configuration)?;
         } else if let Some(value) = a.strip_prefix("--output=") {
             output_png = PathBuf::from(value);
         }
@@ -585,7 +585,7 @@ fn main() -> Result<()> {
                 },
             )
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "HostVulkanTexture::new_device_local: {e}"
                 ))
             })?;
@@ -595,12 +595,12 @@ fn main() -> Result<()> {
                 .vulkan_inner()
                 .image()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "freshly-created HostVulkanTexture missing VkImage handle".into(),
                     )
                 })?;
             HostVulkanTexture::transition_to_general(&host_device, image).map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "transition output texture to GENERAL: {e}"
                 ))
             })?;
@@ -644,7 +644,7 @@ fn main() -> Result<()> {
             let slpkg_path = manifest_dir
                 .join("python/polyglot-vulkan-ray-tracing-0.1.0.slpkg");
             if !slpkg_path.exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Package not found: {}\nRun: cargo run -p streamlib-cli -- pack examples/polyglot-vulkan-ray-tracing/python",
                     slpkg_path.display()
                 )));
@@ -654,7 +654,7 @@ fn main() -> Result<()> {
         RuntimeKind::Deno => {
             let project_path = manifest_dir.join("deno");
             if !project_path.join("streamlib.yaml").exists() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Deno project not found: {}",
                     project_path.display()
                 )));
@@ -664,13 +664,13 @@ fn main() -> Result<()> {
     }
 
     let fixture_path = write_trigger_fixture()
-        .map_err(StreamError::Configuration)?;
+        .map_err(Error::Configuration)?;
     let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
         BgraFileSourceProcessor::Config {
             file_path: fixture_path
                 .to_str()
                 .ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "fixture path has non-utf8 component".into(),
                     )
                 })?
@@ -723,7 +723,7 @@ fn main() -> Result<()> {
         .unwrap()
         .clone()
         .ok_or_else(|| {
-            StreamError::Runtime(
+            Error::Runtime(
                 "host texture slot is empty — setup hook never ran (likely \
                  because the device lacks RT support; see the earlier log)"
                     .into(),
@@ -733,13 +733,13 @@ fn main() -> Result<()> {
         .lock()
         .unwrap()
         .clone()
-        .ok_or_else(|| StreamError::Runtime("readback slot is empty".into()))?;
+        .ok_or_else(|| Error::Runtime("readback slot is empty".into()))?;
     let ticket = readback
         .submit(&texture, TextureSourceLayout::General)
-        .map_err(|e| StreamError::Runtime(format!("readback submit: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("readback submit: {e}")))?;
     let rgba = readback
         .wait_and_read(ticket, u64::MAX)
-        .map_err(|e| StreamError::Runtime(format!("readback wait: {e}")))?
+        .map_err(|e| Error::Runtime(format!("readback wait: {e}")))?
         .to_vec();
     write_png(&rgba, SURFACE_SIZE, SURFACE_SIZE, &output_png)?;
     println!("✓ Output PNG written: {}", output_png.display());
@@ -777,16 +777,16 @@ fn write_png(
     use std::io::BufWriter;
 
     let file = File::create(output).map_err(|e| {
-        StreamError::Configuration(format!("create output PNG {}: {e}", output.display()))
+        Error::Configuration(format!("create output PNG {}: {e}", output.display()))
     })?;
     let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
-        .map_err(|e| StreamError::Configuration(format!("PNG header: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG header: {e}")))?;
     writer
         .write_image_data(rgba)
-        .map_err(|e| StreamError::Configuration(format!("PNG body: {e}")))?;
+        .map_err(|e| Error::Configuration(format!("PNG body: {e}")))?;
     Ok(())
 }

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -25,7 +25,7 @@ use streamlib::sdk::engine::host_rhi::{
     HostVulkanTimelineSemaphore,
 };
 use streamlib::sdk::context::GpuContext;
-use streamlib::sdk::error::StreamError;
+use streamlib::sdk::error::Error;
 use streamlib::sdk::rhi::{PixelFormat, TextureFormat};
 use streamlib_adapter_abi::{
     StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
@@ -129,7 +129,7 @@ impl HostFixture {
         .expect("register_surface_with_format")
     }
 
-    /// Fallible variant — returns `Err(StreamError)` when the host
+    /// Fallible variant — returns `Err(Error)` when the host
     /// can't allocate a render-target DMA-BUF in `texture_format` on
     /// this driver (typically NV12 RT modifier missing on the EGL
     /// probe). Multi-plane tests use this to skip cleanly.
@@ -140,7 +140,7 @@ impl HostFixture {
         height: u32,
         surface_format: SurfaceFormat,
         texture_format: TextureFormat,
-    ) -> Result<StreamlibSurface, StreamError> {
+    ) -> Result<StreamlibSurface, Error> {
         let stream_texture =
             self.gpu
                 .acquire_render_target_dma_buf_image(width, height, texture_format)?;
@@ -163,14 +163,14 @@ impl HostFixture {
                 pf,
             )
             .map_err(|e| {
-                StreamError::GpuError(format!("staging plane {plane_idx}: {e}"))
+                Error::GpuError(format!("staging plane {plane_idx}: {e}"))
             })?;
             staging_planes.push(Arc::new(pb));
         }
 
         let timeline = Arc::new(
             HostVulkanTimelineSemaphore::new(self.adapter.device().device(), 0)
-                .map_err(|e| StreamError::GpuError(format!("create timeline: {e}")))?,
+                .map_err(|e| Error::GpuError(format!("create timeline: {e}")))?,
         );
         self.adapter
             .register_host_surface(
@@ -186,7 +186,7 @@ impl HostFixture {
                 },
             )
             .map_err(|e| {
-                StreamError::GpuError(format!("register_host_surface: {e:?}"))
+                Error::GpuError(format!("register_host_surface: {e:?}"))
             })?;
         Ok(StreamlibSurface::new(
             surface_id,

--- a/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
+++ b/libs/streamlib-adapter-vulkan-helpers/src/bin/vulkan_adapter_subprocess_helper.rs
@@ -250,7 +250,7 @@ fn subprocess_clear_image(
     image: vk::Image,
     color: [f32; 4],
 ) -> streamlib::sdk::error::Result<()> {
-    use streamlib::sdk::error::StreamError;
+    use streamlib::sdk::error::Error;
     let dev = device.device();
     let queue = device.queue();
     let qf = device.queue_family_index();
@@ -264,7 +264,7 @@ fn subprocess_clear_image(
             None,
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))?;
+    .map_err(|e| Error::GpuError(format!("create_command_pool: {e}")))?;
 
     let cmd = unsafe {
         dev.allocate_command_buffers(
@@ -275,7 +275,7 @@ fn subprocess_clear_image(
                 .build(),
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?[0];
+    .map_err(|e| Error::GpuError(format!("allocate_command_buffers: {e}")))?[0];
 
     unsafe {
         dev.begin_command_buffer(
@@ -285,7 +285,7 @@ fn subprocess_clear_image(
                 .build(),
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("begin_command_buffer: {e}")))?;
+    .map_err(|e| Error::GpuError(format!("begin_command_buffer: {e}")))?;
 
     // UNDEFINED → TRANSFER_DST_OPTIMAL barrier so vkCmdClearColorImage
     // sees a known layout.
@@ -333,7 +333,7 @@ fn subprocess_clear_image(
     };
 
     unsafe { dev.end_command_buffer(cmd) }
-        .map_err(|e| StreamError::GpuError(format!("end_command_buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("end_command_buffer: {e}")))?;
 
     let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
         .command_buffer(cmd)
@@ -343,7 +343,7 @@ fn subprocess_clear_image(
         .build()];
     unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }?;
     unsafe { dev.queue_wait_idle(queue) }
-        .map_err(|e| StreamError::GpuError(format!("queue_wait_idle: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("queue_wait_idle: {e}")))?;
     unsafe { dev.destroy_command_pool(pool, None) };
     Ok(())
 }
@@ -356,7 +356,7 @@ fn subprocess_readback_image(
     width: u32,
     height: u32,
 ) -> streamlib::sdk::error::Result<Vec<u8>> {
-    use streamlib::sdk::error::StreamError;
+    use streamlib::sdk::error::Error;
     let dev = device.device();
     let queue = device.queue();
     let qf = device.queue_family_index();
@@ -370,7 +370,7 @@ fn subprocess_readback_image(
         .sharing_mode(vk::SharingMode::EXCLUSIVE)
         .build();
     let buffer = unsafe { dev.create_buffer(&buffer_info, None) }
-        .map_err(|e| StreamError::GpuError(format!("create_buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("create_buffer: {e}")))?;
     let mem_req = unsafe { dev.get_buffer_memory_requirements(buffer) };
 
     // Find a host-visible memory type from the device's physical
@@ -385,7 +385,7 @@ fn subprocess_readback_image(
             (mem_req.memory_type_bits & bit) != 0
                 && mem_props.memory_types[*i as usize].property_flags.contains(needed)
         })
-        .ok_or_else(|| StreamError::GpuError("no host-visible memory type".into()))?;
+        .ok_or_else(|| Error::GpuError("no host-visible memory type".into()))?;
 
     let alloc_info = vk::MemoryAllocateInfo::builder()
         .allocation_size(mem_req.size)
@@ -394,13 +394,13 @@ fn subprocess_readback_image(
     let mem = unsafe { dev.allocate_memory(&alloc_info, None) }
         .map_err(|e| {
             unsafe { dev.destroy_buffer(buffer, None) };
-            StreamError::GpuError(format!("allocate_memory: {e}"))
+            Error::GpuError(format!("allocate_memory: {e}"))
         })?;
     unsafe { dev.bind_buffer_memory(buffer, mem, 0) }
         .map_err(|e| {
             unsafe { dev.free_memory(mem, None) };
             unsafe { dev.destroy_buffer(buffer, None) };
-            StreamError::GpuError(format!("bind_buffer_memory: {e}"))
+            Error::GpuError(format!("bind_buffer_memory: {e}"))
         })?;
 
     // Command buffer: transition image to TRANSFER_SRC, copy to buffer.
@@ -413,7 +413,7 @@ fn subprocess_readback_image(
             None,
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("create_command_pool: {e}")))?;
+    .map_err(|e| Error::GpuError(format!("create_command_pool: {e}")))?;
     let cmd = unsafe {
         dev.allocate_command_buffers(
             &vk::CommandBufferAllocateInfo::builder()
@@ -423,7 +423,7 @@ fn subprocess_readback_image(
                 .build(),
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("allocate_command_buffers: {e}")))?[0];
+    .map_err(|e| Error::GpuError(format!("allocate_command_buffers: {e}")))?[0];
 
     unsafe {
         dev.begin_command_buffer(
@@ -433,7 +433,7 @@ fn subprocess_readback_image(
                 .build(),
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("begin_command_buffer: {e}")))?;
+    .map_err(|e| Error::GpuError(format!("begin_command_buffer: {e}")))?;
 
     // GENERAL is what the parent's adapter left it in; transition to
     // TRANSFER_SRC_OPTIMAL.
@@ -486,7 +486,7 @@ fn subprocess_readback_image(
     };
 
     unsafe { dev.end_command_buffer(cmd) }
-        .map_err(|e| StreamError::GpuError(format!("end_command_buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("end_command_buffer: {e}")))?;
 
     let cmd_infos = [vk::CommandBufferSubmitInfo::builder()
         .command_buffer(cmd)
@@ -496,10 +496,10 @@ fn subprocess_readback_image(
         .build()];
     unsafe { device.submit_to_queue(queue, &submits, vk::Fence::null()) }?;
     unsafe { dev.queue_wait_idle(queue) }
-        .map_err(|e| StreamError::GpuError(format!("queue_wait_idle: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("queue_wait_idle: {e}")))?;
 
     let mapped = unsafe { dev.map_memory(mem, 0, bytes, vk::MemoryMapFlags::empty()) }
-        .map_err(|e| StreamError::GpuError(format!("map_memory: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("map_memory: {e}")))?;
     let slice = unsafe { std::slice::from_raw_parts(mapped as *const u8, bytes as usize) };
     let out = slice.to_vec();
     unsafe { dev.unmap_memory(mem) };

--- a/libs/streamlib-consumer-rhi/src/error.rs
+++ b/libs/streamlib-consumer-rhi/src/error.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 /// Kept deliberately narrow: the carve-out is small (DMA-BUF FD import
 /// + bind + map, sync wait/signal, layout transitions on imported
 /// handles), so two variants cover everything that can go wrong.
-/// `streamlib::sdk::error::StreamError` provides a `From<ConsumerRhiError>`
+/// `streamlib::sdk::error::Error` provides a `From<ConsumerRhiError>`
 /// impl, so host-side code can wrap consumer errors with `?`.
 #[derive(Debug, Error)]
 pub enum ConsumerRhiError {

--- a/libs/streamlib-consumer-rhi/src/lib.rs
+++ b/libs/streamlib-consumer-rhi/src/lib.rs
@@ -32,7 +32,7 @@
 //!   `streamlib::sdk::rhi::pixel_format` re-export these so existing
 //!   call sites compile unchanged.
 //! - [`ConsumerRhiError`] — thin error taxonomy for the carve-out.
-//!   `streamlib::sdk::error::StreamError` provides a `From` impl, so the
+//!   `streamlib::sdk::error::Error` provides a `From` impl, so the
 //!   host side can wrap consumer errors with `?`.
 //!
 //! What does NOT live here: anything that calls `vkAllocateMemory`

--- a/libs/streamlib-engine/src/apple/audio_clock.rs
+++ b/libs/streamlib-engine/src/apple/audio_clock.rs
@@ -10,7 +10,7 @@
 
 use crate::apple::time::mach_now_ns;
 use crate::core::context::{AudioClock, AudioClockConfig, AudioTickCallback, AudioTickContext};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use parking_lot::Mutex;
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -203,7 +203,7 @@ impl AudioClock for CoreAudioClock {
             unsafe { dispatch_source_create(dispatch_source_type_timer(), 0, 0, self.queue) };
 
         if timer_source.is_null() {
-            return Err(StreamError::Runtime(
+            return Err(Error::Runtime(
                 "Failed to create GCD timer source".into(),
             ));
         }

--- a/libs/streamlib-engine/src/apple/audio_utils.rs
+++ b/libs/streamlib-engine/src/apple/audio_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use crate::core::{AudioDevice, Result, StreamError};
+use crate::core::{AudioDevice, Result, Error};
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, Stream, StreamConfig};
 
@@ -30,16 +30,16 @@ where
         let devices: Vec<_> = host
             .output_devices()
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to enumerate audio devices: {}", e))
+                Error::Configuration(format!("Failed to enumerate audio devices: {}", e))
             })?
             .collect();
         devices
             .get(id)
-            .ok_or_else(|| StreamError::Configuration(format!("Audio device {} not found", id)))?
+            .ok_or_else(|| Error::Configuration(format!("Audio device {} not found", id)))?
             .clone()
     } else {
         host.default_output_device()
-            .ok_or_else(|| StreamError::Configuration("No default audio output device".into()))?
+            .ok_or_else(|| Error::Configuration("No default audio output device".into()))?
     };
 
     let device_name = device
@@ -48,7 +48,7 @@ where
 
     let config = device
         .default_output_config()
-        .map_err(|e| StreamError::Configuration(format!("Failed to get audio config: {}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to get audio config: {}", e)))?;
 
     let sample_rate = config.sample_rate().0;
     let channels = config.channels() as u32;
@@ -92,7 +92,7 @@ where
             },
             None,
         )
-        .map_err(|e| StreamError::Configuration(format!("Failed to build audio stream: {}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to build audio stream: {}", e)))?;
 
     Ok(AudioOutputSetup {
         stream,

--- a/libs/streamlib-engine/src/apple/iosurface.rs
+++ b/libs/streamlib-engine/src/apple/iosurface.rs
@@ -5,7 +5,7 @@
 // Review if these are needed for future texture format support or can be removed
 #![allow(dead_code)]
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -55,7 +55,7 @@ pub fn create_metal_texture_from_iosurface(
     };
 
     texture.ok_or_else(|| {
-        StreamError::TextureError(format!(
+        Error::TextureError(format!(
             "Failed to create Metal texture from IOSurface (width={}, height={}, format={})",
             width, height, pixel_format
         ))
@@ -113,7 +113,7 @@ pub fn create_iosurface(
         unsafe { msg_send![allocated_ptr, initWithProperties: &*properties] };
 
     let surface = unsafe { Retained::from_raw(surface_ptr) }.ok_or_else(|| {
-        StreamError::TextureError(format!(
+        Error::TextureError(format!(
             "Failed to create IOSurface with dimensions {}x{}, format={:?}",
             width, height, pixel_format
         ))
@@ -123,7 +123,7 @@ pub fn create_iosurface(
     let actual_height = surface.height() as usize;
 
     if actual_width != width || actual_height != height {
-        return Err(StreamError::TextureError(format!(
+        return Err(Error::TextureError(format!(
             "IOSurface created with wrong dimensions: expected {}x{}, got {}x{}",
             width, height, actual_width, actual_height
         )));
@@ -136,7 +136,7 @@ fn iosurface_format_to_metal(ios_format: u32) -> Result<MTLPixelFormat> {
     match ios_format {
         0x42475241 => Ok(MTLPixelFormat::BGRA8Unorm), // 'BGRA' - most common on macOS
         0x52474241 => Ok(MTLPixelFormat::RGBA8Unorm), // 'RGBA'
-        _ => Err(StreamError::NotSupported(format!(
+        _ => Err(Error::NotSupported(format!(
             "IOSurface pixel format 0x{:08X} not supported",
             ios_format
         ))),

--- a/libs/streamlib-engine/src/apple/main_thread.rs
+++ b/libs/streamlib-engine/src/apple/main_thread.rs
@@ -23,7 +23,7 @@ where
     });
 
     rx.recv().map_err(|e| {
-        crate::core::StreamError::Runtime(format!("Main thread dispatch failed: {}", e))
+        crate::core::Error::Runtime(format!("Main thread dispatch failed: {}", e))
     })?
 }
 
@@ -34,5 +34,5 @@ where
 {
     tokio::task::spawn_blocking(move || execute_on_main_thread(f))
         .await
-        .map_err(|e| crate::core::StreamError::Runtime(format!("Task join error: {}", e)))?
+        .map_err(|e| crate::core::Error::Runtime(format!("Task join error: {}", e)))?
 }

--- a/libs/streamlib-engine/src/apple/muxer/mod.rs
+++ b/libs/streamlib-engine/src/apple/muxer/mod.rs
@@ -6,7 +6,7 @@
 use crate::_generated_::EncodedVideoFrame;
 use crate::core::codec::Mp4MuxerConfig;
 use crate::_generated_::EncodedAudioFrame;
-use crate::core::{Result, RuntimeContext, StreamError};
+use crate::core::{Result, RuntimeContext, Error};
 
 /// Apple MP4 muxer using AVAssetWriter.
 ///
@@ -28,7 +28,7 @@ impl AppleMp4Muxer {
         // - Create video input with passthrough format description
         // - Create audio input (if audio configured)
         // - Start writing session
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Apple MP4 muxer not yet implemented".into(),
         ))
     }
@@ -39,7 +39,7 @@ impl AppleMp4Muxer {
         // - Create CMBlockBuffer from frame.data
         // - Create CMSampleBuffer with format description
         // - Append to video input
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Apple MP4 muxer not yet implemented".into(),
         ))
     }
@@ -50,7 +50,7 @@ impl AppleMp4Muxer {
         // - Create CMBlockBuffer from frame.data
         // - Create CMSampleBuffer with audio format description
         // - Append to audio input
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Apple MP4 muxer not yet implemented".into(),
         ))
     }
@@ -61,7 +61,7 @@ impl AppleMp4Muxer {
         // - Mark inputs as finished
         // - Finish writing session
         // - Wait for completion
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Apple MP4 muxer not yet implemented".into(),
         ))
     }

--- a/libs/streamlib-engine/src/apple/permissions.rs
+++ b/libs/streamlib-engine/src/apple/permissions.rs
@@ -8,7 +8,7 @@ pub fn request_camera_permission() -> Result<bool> {
     use objc2_av_foundation::{AVCaptureDevice, AVMediaTypeVideo};
 
     let _mtm = MainThreadMarker::new().ok_or_else(|| {
-        crate::core::StreamError::Configuration(
+        crate::core::Error::Configuration(
             "request_camera_permission must be called on main thread".into(),
         )
     })?;
@@ -17,7 +17,7 @@ pub fn request_camera_permission() -> Result<bool> {
 
     let media_type = unsafe {
         AVMediaTypeVideo.ok_or_else(|| {
-            crate::core::StreamError::Configuration("AVMediaTypeVideo not available".into())
+            crate::core::Error::Configuration("AVMediaTypeVideo not available".into())
         })?
     };
 
@@ -55,7 +55,7 @@ pub fn request_audio_permission() -> Result<bool> {
     use objc2_av_foundation::{AVCaptureDevice, AVMediaTypeAudio};
 
     let _mtm = MainThreadMarker::new().ok_or_else(|| {
-        crate::core::StreamError::Configuration(
+        crate::core::Error::Configuration(
             "request_audio_permission must be called on main thread".into(),
         )
     })?;
@@ -64,7 +64,7 @@ pub fn request_audio_permission() -> Result<bool> {
 
     let media_type = unsafe {
         AVMediaTypeAudio.ok_or_else(|| {
-            crate::core::StreamError::Configuration("AVMediaTypeAudio not available".into())
+            crate::core::Error::Configuration("AVMediaTypeAudio not available".into())
         })?
     };
 

--- a/libs/streamlib-engine/src/apple/pixel_transfer.rs
+++ b/libs/streamlib-engine/src/apple/pixel_transfer.rs
@@ -3,7 +3,7 @@
 
 use crate::apple::iosurface;
 use crate::core::rhi::{GpuDevice, RhiCommandQueue, RhiPixelBuffer, StreamTexture};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use metal::foreign_types::ForeignTypeRef;
 use objc2_core_video::CVPixelBuffer;
 use objc2_io_surface::IOSurface;
@@ -72,7 +72,7 @@ impl PixelTransferSession {
             );
 
             if status != ffi::NO_ERR {
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "VTPixelTransferSessionCreate failed: {}",
                     status
                 )));
@@ -179,7 +179,7 @@ impl PixelTransferSession {
             );
 
             if status != 0 {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CVPixelBufferCreate (BGRA) failed: {}",
                     status
                 )));
@@ -190,7 +190,7 @@ impl PixelTransferSession {
         let iosurface_ptr = unsafe { ffi::CVPixelBufferGetIOSurface(pixel_buffer) };
 
         if iosurface_ptr.is_null() {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Failed to get IOSurface from CVPixelBuffer".into(),
             ));
         }
@@ -260,7 +260,7 @@ impl PixelTransferSession {
             );
 
             if status != 0 {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CVPixelBufferCreate (NV12) failed: {}",
                     status
                 )));
@@ -278,7 +278,7 @@ impl PixelTransferSession {
             if status != ffi::NO_ERR {
                 // Clean up destination buffer on error
                 ffi::CFRelease(dest_buffer as *const _);
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "VTPixelTransferSessionTransferImage failed: {}",
                     status
                 )));

--- a/libs/streamlib-engine/src/apple/processors/camera.rs
+++ b/libs/streamlib-engine/src/apple/processors/camera.rs
@@ -5,7 +5,7 @@ use crate::apple::corevideo_ffi::{
     CVPixelBufferGetHeight, CVPixelBufferGetIOSurface, CVPixelBufferGetWidth, IOSurfaceGetID,
 };
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
-use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
@@ -368,7 +368,7 @@ impl crate::core::ManualProcessor for AppleCameraProcessor::Processor {
 
         // Get GPU context (set during setup)
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
-            StreamError::Configuration("GPU context not initialized. Call setup() first.".into())
+            Error::Configuration("GPU context not initialized. Call setup() first.".into())
         })?;
 
         // Create callback context with pointer to OutputWriter and GPU context
@@ -466,7 +466,7 @@ impl AppleCameraProcessor::Processor {
                 let id_str = NSString::from_str(id);
                 let dev = AVCaptureDevice::deviceWithUniqueID(&id_str);
                 if dev.is_none() {
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "Camera not found with ID: {}",
                         id
                     )));
@@ -474,18 +474,18 @@ impl AppleCameraProcessor::Processor {
                 dev.unwrap()
             } else {
                 let media_type = AVMediaTypeVideo.ok_or_else(|| {
-                    StreamError::Configuration("AVMediaTypeVideo not available".into())
+                    Error::Configuration("AVMediaTypeVideo not available".into())
                 })?;
 
                 AVCaptureDevice::defaultDeviceWithMediaType(media_type)
-                    .ok_or_else(|| StreamError::Configuration("No camera found".into()))?
+                    .ok_or_else(|| Error::Configuration("No camera found".into()))?
             }
         };
 
         // Configure frame rate based on config, display refresh rate, and camera capabilities
         unsafe {
             if let Err(e) = device.lockForConfiguration() {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Failed to lock camera device: {:?}",
                     e
                 )));
@@ -572,13 +572,13 @@ impl AppleCameraProcessor::Processor {
 
         let input = unsafe {
             AVCaptureDeviceInput::deviceInputWithDevice_error(&device).map_err(|e| {
-                StreamError::Configuration(format!("Failed to create camera input: {:?}", e))
+                Error::Configuration(format!("Failed to create camera input: {:?}", e))
             })?
         };
 
         let can_add = unsafe { session.canAddInput(&input) };
         if !can_add {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Session cannot add camera input. Camera may be in use.".into(),
             ));
         }
@@ -625,7 +625,7 @@ impl AppleCameraProcessor::Processor {
 
         let can_add_output = unsafe { session.canAddOutput(&output) };
         if !can_add_output {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Cannot add camera output".into(),
             ));
         }
@@ -658,7 +658,7 @@ impl AppleCameraProcessor::Processor {
             use objc2_foundation::NSArray;
 
             let media_type = AVMediaTypeVideo.ok_or_else(|| {
-                StreamError::Configuration("AVMediaTypeVideo not available".into())
+                Error::Configuration("AVMediaTypeVideo not available".into())
             })?;
 
             let builtin_wide =

--- a/libs/streamlib-engine/src/apple/processors/display.rs
+++ b/libs/streamlib-engine/src/apple/processors/display.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::core::rhi::{PixelFormat, RhiTextureCache};
-use crate::core::{Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, Error};
 use crossbeam_channel::{Receiver, Sender};
 use metal;
 use objc2::{rc::Retained, MainThreadMarker};
@@ -94,14 +94,14 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
             let library = metal_device_ref
                 .new_library_with_source(shader_source, &metal::CompileOptions::new())
                 .map_err(|e| {
-                    StreamError::Configuration(format!("Failed to compile Metal shader: {}", e))
+                    Error::Configuration(format!("Failed to compile Metal shader: {}", e))
                 })?;
 
             let vertex_function = library.get_function("vertex_main", None).map_err(|e| {
-                StreamError::Configuration(format!("vertex_main function not found: {}", e))
+                Error::Configuration(format!("vertex_main function not found: {}", e))
             })?;
             let fragment_function = library.get_function("fragment_main", None).map_err(|e| {
-                StreamError::Configuration(format!("fragment_main function not found: {}", e))
+                Error::Configuration(format!("fragment_main function not found: {}", e))
             })?;
 
             // Create render pipeline descriptor
@@ -119,7 +119,7 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
             let pipeline_state = metal_device_ref
                 .new_render_pipeline_state(&pipeline_descriptor)
                 .map_err(|e| {
-                    StreamError::Configuration(format!("Failed to create render pipeline: {}", e))
+                    Error::Configuration(format!("Failed to create render pipeline: {}", e))
                 })?;
 
             // Create sampler for texture sampling with linear filtering
@@ -196,7 +196,7 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
         let gpu_context = self
             .gpu_context
             .clone()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?;
 
         // Clone shared command queue from GpuContext for render thread
         let command_queue = gpu_context.command_queue().clone();
@@ -205,26 +205,26 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
             .metal_render_pipeline
             .as_ref()
             .ok_or_else(|| {
-                StreamError::Configuration("Metal render pipeline not initialized".into())
+                Error::Configuration("Metal render pipeline not initialized".into())
             })?
             .clone();
 
         let sampler = self
             .metal_sampler
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Metal sampler not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Metal sampler not initialized".into()))?
             .clone();
 
         let format_buffer_rgba = self
             .format_buffer_rgba
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Format buffer RGBA not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Format buffer RGBA not initialized".into()))?
             .clone();
 
         let format_buffer_bgra = self
             .format_buffer_bgra
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Format buffer BGRA not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Format buffer BGRA not initialized".into()))?
             .clone();
 
         // Signal that the render thread should run
@@ -381,7 +381,7 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
 
                 tracing::debug!("Display {}: Render thread exiting", window_id);
             })
-            .map_err(|e| StreamError::Runtime(format!("Failed to spawn render thread: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to spawn render thread: {}", e)))?;
 
         self.render_thread = Some(render_thread);
 
@@ -400,7 +400,7 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
         if let Some(handle) = self.render_thread.take() {
             handle
                 .join()
-                .map_err(|_| StreamError::Runtime("Render thread panicked".into()))?;
+                .map_err(|_| Error::Runtime("Render thread panicked".into()))?;
         }
 
         tracing::info!("Display {}: Stopped", self.window_id.0);
@@ -536,7 +536,7 @@ impl AppleDisplayProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?;
         let metal_device = gpu_ctx.metal_device().clone_device();
         let window_id = self.window_id;
         let layer_addr = Arc::clone(&self.layer_addr);

--- a/libs/streamlib-engine/src/apple/processors/mp4_writer.rs
+++ b/libs/streamlib-engine/src/apple/processors/mp4_writer.rs
@@ -3,7 +3,7 @@
 
 use crate::_generated_::{AudioFrame, VideoFrame};
 use crate::core::{
-    sync::DEFAULT_SYNC_TOLERANCE_MS, GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError,
+    sync::DEFAULT_SYNC_TOLERANCE_MS, GpuContextLimitedAccess, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error,
 };
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
@@ -153,7 +153,7 @@ impl crate::core::ReactiveProcessor for AppleMp4WriterProcessor::Processor {
 
             // Start the writing session (all inputs configured)
             let writer = self.writer.as_ref().ok_or_else(|| {
-                StreamError::Configuration("AVAssetWriter not initialized".into())
+                Error::Configuration("AVAssetWriter not initialized".into())
             })?;
 
             info!("🎬 STARTING AVAssetWriter session...");
@@ -166,7 +166,7 @@ impl crate::core::ReactiveProcessor for AppleMp4WriterProcessor::Processor {
                         .map(|e| e.localizedDescription().to_string())
                         .unwrap_or_else(|| "Unknown error".to_string())
                 };
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Failed to start AVAssetWriter: {}",
                     error_msg
                 )));
@@ -369,7 +369,7 @@ impl AppleMp4WriterProcessor::Processor {
         let ctx = self
             .ctx
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("RuntimeContext not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("RuntimeContext not initialized".into()))?;
 
         let path_str = self.config.output_path.clone();
         let video_codec = self
@@ -405,7 +405,7 @@ impl AppleMp4WriterProcessor::Processor {
         // SAFETY: We just created this pointer on the main thread
         let writer = unsafe {
             Retained::retain(writer_ptr as *mut AVAssetWriter).ok_or_else(|| {
-                StreamError::Configuration("Failed to retain AVAssetWriter".into())
+                Error::Configuration("Failed to retain AVAssetWriter".into())
             })?
         };
 
@@ -425,7 +425,7 @@ impl AppleMp4WriterProcessor::Processor {
         if std::path::Path::new(path_str).exists() {
             info!("Deleting existing file: {}", path_str);
             std::fs::remove_file(path_str).map_err(|e| {
-                StreamError::Configuration(format!("Failed to delete existing file: {}", e))
+                Error::Configuration(format!("Failed to delete existing file: {}", e))
             })?;
         }
 
@@ -440,7 +440,7 @@ impl AppleMp4WriterProcessor::Processor {
                 Ok(w) => w,
                 Err(e) => {
                     error!("Failed to create AVAssetWriter: {:?}", e);
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Failed to create AVAssetWriter: {:?}",
                         e
                     )));
@@ -467,12 +467,12 @@ impl AppleMp4WriterProcessor::Processor {
         let ctx = self
             .ctx
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("RuntimeContext not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("RuntimeContext not initialized".into()))?;
 
         let writer = self
             .writer
             .take()
-            .ok_or_else(|| StreamError::Configuration("AVAssetWriter not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("AVAssetWriter not initialized".into()))?;
         let writer_ptr = Retained::into_raw(writer) as usize;
 
         let video_bitrate = self.config.video_bitrate.unwrap_or(5_000_000);
@@ -596,7 +596,7 @@ impl AppleMp4WriterProcessor::Processor {
         // Add input to writer
         let can_add = unsafe { writer.canAddInput(&video_input) };
         if !can_add {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Cannot add video input to AVAssetWriter".into(),
             ));
         }
@@ -626,12 +626,12 @@ impl AppleMp4WriterProcessor::Processor {
         let ctx = self
             .ctx
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("RuntimeContext not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("RuntimeContext not initialized".into()))?;
 
         let writer = self
             .writer
             .take()
-            .ok_or_else(|| StreamError::Configuration("AVAssetWriter not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("AVAssetWriter not initialized".into()))?;
         let writer_ptr = Retained::into_raw(writer) as usize;
 
         // Dispatch to main thread to configure audio input
@@ -749,7 +749,7 @@ impl AppleMp4WriterProcessor::Processor {
         // Add input to writer
         let can_add = unsafe { writer.canAddInput(&audio_input) };
         if !can_add {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Cannot add audio input to AVAssetWriter".into(),
             ));
         }
@@ -788,7 +788,7 @@ impl AppleMp4WriterProcessor::Processor {
             && !self.writer_failed
         {
             let writer = self.writer.as_ref().ok_or_else(|| {
-                StreamError::Configuration("AVAssetWriter not initialized".into())
+                Error::Configuration("AVAssetWriter not initialized".into())
             })?;
 
             info!("Both audio and video inputs configured, starting AVAssetWriter session...");
@@ -802,7 +802,7 @@ impl AppleMp4WriterProcessor::Processor {
                         .map(|e| e.localizedDescription().to_string())
                         .unwrap_or_else(|| "Unknown error".to_string())
                 };
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Failed to start AVAssetWriter: {}",
                     error_msg
                 )));
@@ -860,13 +860,13 @@ impl AppleMp4WriterProcessor::Processor {
 
     fn write_video_frame(&self, frame: &VideoFrame) -> Result<()> {
         let pixel_buffer_adaptor = self.pixel_buffer_adaptor.as_ref().ok_or_else(|| {
-            StreamError::Configuration("Pixel buffer adaptor not initialized".into())
+            Error::Configuration("Pixel buffer adaptor not initialized".into())
         })?;
 
         let video_input = self
             .video_input
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Video input not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("Video input not initialized".into()))?;
 
         // Check if video input is ready for more data
         let is_ready = unsafe { video_input.isReadyForMoreMediaData() };
@@ -876,13 +876,13 @@ impl AppleMp4WriterProcessor::Processor {
         }
 
         let pixel_transfer = self.pixel_transfer.as_ref().ok_or_else(|| {
-            StreamError::Configuration("PixelTransferSession not initialized".into())
+            Error::Configuration("PixelTransferSession not initialized".into())
         })?;
 
         let gpu_context = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?;
 
         // Resolve buffer from surface_id
         let buffer = gpu_context.resolve_video_frame_buffer(frame)?;
@@ -912,7 +912,7 @@ impl AppleMp4WriterProcessor::Processor {
         };
 
         if !success {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Failed to append pixel buffer to adaptor".into(),
             ));
         }
@@ -925,7 +925,7 @@ impl AppleMp4WriterProcessor::Processor {
         let audio_input = self
             .audio_input
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Audio input not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("Audio input not initialized".into()))?;
 
         // Check if audio input is ready for more data
         let is_ready = unsafe { audio_input.isReadyForMoreMediaData() };
@@ -960,7 +960,7 @@ impl AppleMp4WriterProcessor::Processor {
 
         let mut block_buffer_ptr: *mut CMBlockBuffer = std::ptr::null_mut();
         let block_buffer_out = NonNull::new(&mut block_buffer_ptr as *mut _).ok_or_else(|| {
-            StreamError::GpuError("Failed to create NonNull for block buffer".into())
+            Error::GpuError("Failed to create NonNull for block buffer".into())
         })?;
 
         // Create CMBlockBuffer that allocates its own memory and copies our data
@@ -979,7 +979,7 @@ impl AppleMp4WriterProcessor::Processor {
         };
 
         if status != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create CMBlockBuffer: status {}",
                 status
             )));
@@ -987,7 +987,7 @@ impl AppleMp4WriterProcessor::Processor {
 
         let block_buffer = unsafe {
             objc2::rc::Retained::retain(block_buffer_ptr)
-                .ok_or_else(|| StreamError::GpuError("CMBlockBuffer is null".into()))?
+                .ok_or_else(|| Error::GpuError("CMBlockBuffer is null".into()))?
         };
 
         // Copy PCM data into the CMBlockBuffer
@@ -1011,7 +1011,7 @@ impl AppleMp4WriterProcessor::Processor {
         };
 
         if copy_status != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to copy PCM data to CMBlockBuffer: status {}",
                 copy_status
             )));
@@ -1035,7 +1035,7 @@ impl AppleMp4WriterProcessor::Processor {
         let mut sample_buffer_ptr: *mut CMSampleBuffer = std::ptr::null_mut();
         let _sample_buffer_out =
             NonNull::new(&mut sample_buffer_ptr as *mut _).ok_or_else(|| {
-                StreamError::GpuError("Failed to create NonNull for sample buffer".into())
+                Error::GpuError("Failed to create NonNull for sample buffer".into())
             })?;
 
         // We need to use CMAudioSampleBufferCreateWithPacketDescriptions
@@ -1105,7 +1105,7 @@ impl AppleMp4WriterProcessor::Processor {
         };
 
         if status != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create CMAudioFormatDescription: status {}",
                 status
             )));
@@ -1113,7 +1113,7 @@ impl AppleMp4WriterProcessor::Processor {
 
         let _format_desc = unsafe {
             objc2::rc::Retained::retain(format_desc_ptr as *mut CMFormatDescription)
-                .ok_or_else(|| StreamError::GpuError("Format description is null".into()))?
+                .ok_or_else(|| Error::GpuError("Format description is null".into()))?
         };
 
         // Use CMAudioSampleBufferCreateWithPacketDescriptions which is designed for audio
@@ -1156,7 +1156,7 @@ impl AppleMp4WriterProcessor::Processor {
         };
 
         if status != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create audio CMSampleBuffer: status {}",
                 status
             )));
@@ -1164,7 +1164,7 @@ impl AppleMp4WriterProcessor::Processor {
 
         let sample_buffer = unsafe {
             objc2::rc::Retained::retain(sample_buffer_ptr)
-                .ok_or_else(|| StreamError::GpuError("Sample buffer is null".into()))?
+                .ok_or_else(|| Error::GpuError("Sample buffer is null".into()))?
         };
 
         trace!("Appending audio to AVAssetWriter: timestamp={}ns ({:.6}s), samples={}, channels={}, rate={}Hz",
@@ -1175,7 +1175,7 @@ impl AppleMp4WriterProcessor::Processor {
         let success = unsafe { audio_input.appendSampleBuffer(&sample_buffer) };
 
         if !success {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Failed to append audio sample buffer".into(),
             ));
         }

--- a/libs/streamlib-engine/src/apple/processors/screen_capture.rs
+++ b/libs/streamlib-engine/src/apple/processors/screen_capture.rs
@@ -5,7 +5,7 @@ use crate::apple::corevideo_ffi::{
     CVPixelBufferGetHeight, CVPixelBufferGetIOSurface, CVPixelBufferGetWidth, IOSurfaceGetID,
 };
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
-use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use block2::RcBlock;
 use objc2::rc::Retained;
@@ -299,7 +299,7 @@ impl crate::core::ManualProcessor for AppleScreenCaptureProcessor::Processor {
         validate_config(&self.config)?;
 
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
-            StreamError::Configuration("GPU context not initialized. Call setup() first.".into())
+            Error::Configuration("GPU context not initialized. Call setup() first.".into())
         })?;
 
         // Create callback context
@@ -402,7 +402,7 @@ impl AppleScreenCaptureProcessor::Processor {
             TargetType::Display => {
                 let display_index = config.display_index.unwrap_or(0) as usize;
                 if display_index >= displays.len() {
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "Display {} not found (available: {})",
                         display_index,
                         displays.len()
@@ -483,7 +483,7 @@ impl AppleScreenCaptureProcessor::Processor {
             );
 
         if let Err(e) = add_result {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Failed to add stream output: {}",
                 e.localizedDescription()
             )));
@@ -538,7 +538,7 @@ impl AppleScreenCaptureProcessor::Processor {
         }
 
         let window = found_window.ok_or_else(|| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "Window not found (id: {:?}, title: {:?})",
                 config.window_id, config.window_title
             ))
@@ -558,7 +558,7 @@ impl AppleScreenCaptureProcessor::Processor {
         applications: &NSArray<SCRunningApplication>,
     ) -> Result<Retained<SCContentFilter>> {
         let bundle_id = config.app_bundle_id.as_ref().ok_or_else(|| {
-            StreamError::Configuration("Application mode requires app_bundle_id".into())
+            Error::Configuration("Application mode requires app_bundle_id".into())
         })?;
 
         let mut found_app: Option<Retained<SCRunningApplication>> = None;
@@ -573,12 +573,12 @@ impl AppleScreenCaptureProcessor::Processor {
         }
 
         let app = found_app.ok_or_else(|| {
-            StreamError::Configuration(format!("Application not found: {}", bundle_id))
+            Error::Configuration(format!("Application not found: {}", bundle_id))
         })?;
 
         let display_index = config.app_display_index.unwrap_or(0) as usize;
         if display_index >= displays.len() {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Display {} not found for application capture",
                 display_index
             )));
@@ -606,7 +606,7 @@ fn validate_config(config: &ScreenCaptureConfig) -> Result<()> {
         TargetType::Display => Ok(()),
         TargetType::Window => {
             if config.window_title.is_none() && config.window_id.is_none() {
-                return Err(StreamError::Configuration(
+                return Err(Error::Configuration(
                     "Window mode requires window_title or window_id".into(),
                 ));
             }
@@ -614,7 +614,7 @@ fn validate_config(config: &ScreenCaptureConfig) -> Result<()> {
         }
         TargetType::Application => {
             if config.app_bundle_id.is_none() {
-                return Err(StreamError::Configuration(
+                return Err(Error::Configuration(
                     "Application mode requires app_bundle_id".into(),
                 ));
             }

--- a/libs/streamlib-engine/src/apple/runtime_ext.rs
+++ b/libs/streamlib-engine/src/apple/runtime_ext.rs
@@ -126,7 +126,7 @@ pub fn ensure_macos_platform_ready() -> Result<()> {
     use objc2_foundation::{NSDate, NSDefaultRunLoopMode};
 
     let mtm = MainThreadMarker::new().ok_or_else(|| {
-        crate::core::StreamError::Runtime(
+        crate::core::Error::Runtime(
             "ensure_macos_platform_ready must be called from main thread".to_string(),
         )
     })?;
@@ -177,7 +177,7 @@ pub fn ensure_macos_platform_ready() -> Result<()> {
 
         // Timeout check
         if start.elapsed() > timeout {
-            return Err(crate::core::StreamError::Runtime(format!(
+            return Err(crate::core::Error::Runtime(format!(
                 "macOS platform readiness timeout after {:?}: isFinishedLaunching={}",
                 timeout, is_finished_launching
             )));

--- a/libs/streamlib-engine/src/apple/texture.rs
+++ b/libs/streamlib-engine/src/apple/texture.rs
@@ -5,7 +5,7 @@
 // Review if this texture creation utility is needed or can be removed
 #![allow(dead_code)]
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::MTLTextureType;
@@ -31,7 +31,7 @@ pub fn create_metal_texture(
     let texture = device
         .newTextureWithDescriptor(&descriptor)
         .ok_or_else(|| {
-            StreamError::TextureError(format!(
+            Error::TextureError(format!(
                 "Failed to create Metal texture ({}x{}, format={:?})",
                 width, height, format
             ))

--- a/libs/streamlib-engine/src/apple/texture_pool_macos.rs
+++ b/libs/streamlib-engine/src/apple/texture_pool_macos.rs
@@ -13,7 +13,7 @@ use crate::core::context::texture_pool::{
     PoolSlot, TexturePoolDescriptor, TexturePoolInner, TexturePoolKey,
 };
 use crate::core::rhi::{StreamTexture, TextureFormat};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use crate::metal::rhi::MetalTexture;
 
 // FFI binding to get IOSurface ID for cross-process sharing
@@ -33,7 +33,7 @@ fn rhi_format_to_pixel_format(format: TextureFormat) -> Result<PixelFormat> {
     match format {
         TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => Ok(PixelFormat::Bgra32),
         TextureFormat::Rgba8Unorm | TextureFormat::Rgba8UnormSrgb => Ok(PixelFormat::Rgba32),
-        _ => Err(StreamError::TextureError(format!(
+        _ => Err(Error::TextureError(format!(
             "Unsupported texture format for IOSurface: {:?}",
             format
         ))),

--- a/libs/streamlib-engine/src/apple/thread_priority.rs
+++ b/libs/streamlib-engine/src/apple/thread_priority.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::core::execution::ThreadPriority;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Apply thread priority to the current thread based on the specified priority level.
 ///
@@ -68,7 +68,7 @@ fn set_realtime_priority() -> Result<()> {
         );
 
         if result != KERN_SUCCESS {
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "Failed to set real-time thread priority: mach error {}",
                 result
             )));
@@ -128,7 +128,7 @@ fn set_realtime_priority() -> Result<()> {
         );
 
         if result != KERN_SUCCESS {
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "Failed to set real-time thread priority: mach error {}",
                 result
             )));

--- a/libs/streamlib-engine/src/apple/videotoolbox/decoder.rs
+++ b/libs/streamlib-engine/src/apple/videotoolbox/decoder.rs
@@ -18,7 +18,7 @@
 use super::{ffi, format};
 use crate::_generated_::VideoFrame;
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
-use crate::core::{GpuContext, Result, RuntimeContext, StreamError, VideoDecoderConfig};
+use crate::core::{GpuContext, Result, RuntimeContext, Error, VideoDecoderConfig};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
@@ -116,7 +116,7 @@ impl VideoToolboxDecoder {
                     );
 
                     if status != ffi::NO_ERR {
-                        return Err(StreamError::Runtime(format!(
+                        return Err(Error::Runtime(format!(
                             "CMVideoFormatDescriptionCreateFromH264ParameterSets failed: {}",
                             status
                         )));
@@ -179,7 +179,7 @@ impl VideoToolboxDecoder {
                         let _ = Arc::from_raw(
                             callback_context_arc as *const Mutex<VecDeque<DecodedFrame>>,
                         );
-                        return Err(StreamError::Runtime(format!(
+                        return Err(Error::Runtime(format!(
                             "VTDecompressionSessionCreate failed: {}",
                             status
                         )));
@@ -213,7 +213,7 @@ impl VideoToolboxDecoder {
     ) -> Result<Option<VideoFrame>> {
         // Check if we have a decompression session
         let session = self.decompression_session.ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "Decompression session not initialized - call update_format() with SPS/PPS first"
                     .into(),
             )
@@ -221,7 +221,7 @@ impl VideoToolboxDecoder {
 
         let format_desc = self
             .format_description
-            .ok_or_else(|| StreamError::Configuration("Format description not available".into()))?;
+            .ok_or_else(|| Error::Configuration("Format description not available".into()))?;
 
         // Step 1: Convert Annex B → AVCC format (required by VideoToolbox)
         let avcc_data = format::annex_b_to_avcc(nal_units_annex_b)?;
@@ -260,7 +260,7 @@ impl VideoToolboxDecoder {
                             avcc_ptr as *mut u8,
                             avcc_len,
                         ));
-                        return Err(StreamError::Runtime(format!(
+                        return Err(Error::Runtime(format!(
                             "CMBlockBufferCreateWithMemoryBlock failed: {}",
                             status
                         )));
@@ -287,7 +287,7 @@ impl VideoToolboxDecoder {
 
                     if status != ffi::NO_ERR {
                         ffi::CFRelease(block_buffer as *const _);
-                        return Err(StreamError::Runtime(format!(
+                        return Err(Error::Runtime(format!(
                             "CMSampleBufferCreate failed: {}",
                             status
                         )));
@@ -323,7 +323,7 @@ impl VideoToolboxDecoder {
             ffi::CFRelease(sample_buffer as *const _);
 
             if status != ffi::NO_ERR {
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "VTDecompressionSessionDecodeFrame failed: {}",
                     status
                 )));
@@ -344,7 +344,7 @@ impl VideoToolboxDecoder {
         // Step 6: Retrieve decoded frame from queue
         let decoded_frame = {
             let mut queue = self.decoded_frames.lock().map_err(|e| {
-                StreamError::Runtime(format!("Failed to lock decoded frames: {}", e))
+                Error::Runtime(format!("Failed to lock decoded frames: {}", e))
             })?;
             queue.pop_front()
         };
@@ -387,7 +387,7 @@ impl VideoToolboxDecoder {
                 decoded_frame.pixel_buffer as ffi::CVPixelBufferRef,
             )
         }
-        .ok_or_else(|| StreamError::GpuError("Decoded frame has null pixel buffer".into()))?;
+        .ok_or_else(|| Error::GpuError("Decoded frame has null pixel buffer".into()))?;
 
         let source_buffer = RhiPixelBuffer::new(buffer_ref);
 

--- a/libs/streamlib-engine/src/apple/videotoolbox/encoder.rs
+++ b/libs/streamlib-engine/src/apple/videotoolbox/encoder.rs
@@ -9,7 +9,7 @@
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::apple::PixelTransferSession;
 use crate::core::rhi::{PixelBufferPoolId, RhiPixelBuffer};
-use crate::core::{GpuContext, Result, RuntimeContext, StreamError, VideoEncoderConfig};
+use crate::core::{GpuContext, Result, RuntimeContext, Error, VideoEncoderConfig};
 use objc2_core_video::CVPixelBuffer;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -102,7 +102,7 @@ impl VideoToolboxEncoder {
                         let _ = Arc::from_raw(
                             callback_context as *const Mutex<VecDeque<EncodedVideoFrame>>,
                         );
-                        return Err(StreamError::Runtime(format!(
+                        return Err(Error::Runtime(format!(
                             "VTCompressionSessionCreate failed: {}",
                             status
                         )));
@@ -235,7 +235,7 @@ impl VideoToolboxEncoder {
     ) -> Result<*mut CVPixelBuffer> {
         // GPU-accelerated conversion using VTPixelTransferSession
         let pixel_transfer = self.pixel_transfer.as_ref().ok_or_else(|| {
-            StreamError::Configuration("PixelTransferSession not initialized".into())
+            Error::Configuration("PixelTransferSession not initialized".into())
         })?;
 
         pixel_transfer.convert_buffer_to_nv12(buffer)
@@ -244,7 +244,7 @@ impl VideoToolboxEncoder {
     /// Encode a video frame.
     pub fn encode(&mut self, frame: &VideoFrame, gpu: &GpuContext) -> Result<EncodedVideoFrame> {
         let session = self.compression_session.ok_or_else(|| {
-            StreamError::Configuration("Compression session not initialized".into())
+            Error::Configuration("Compression session not initialized".into())
         })?;
 
         // Resolve buffer from surface_id
@@ -310,7 +310,7 @@ impl VideoToolboxEncoder {
             });
 
             if status != ffi::NO_ERR {
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "VTCompressionSessionEncodeFrame failed: {}",
                     status
                 )));
@@ -337,11 +337,11 @@ impl VideoToolboxEncoder {
             .encoded_frames
             .lock()
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to lock encoded frames queue: {}", e))
+                Error::Runtime(format!("Failed to lock encoded frames queue: {}", e))
             })?
             .pop_front()
             .ok_or_else(|| {
-                StreamError::Runtime("No encoded frame available after encoding".into())
+                Error::Runtime("No encoded frame available after encoding".into())
             })?;
 
         // Step 7: Update frame metadata
@@ -393,7 +393,7 @@ impl VideoToolboxEncoder {
                 );
                 ffi::CFRelease(avg_bitrate_num as *const _);
                 if status != ffi::NO_ERR {
-                    return Err(StreamError::Runtime(format!(
+                    return Err(Error::Runtime(format!(
                         "Failed to update encoder bitrate: {}",
                         status
                     )));

--- a/libs/streamlib-engine/src/apple/videotoolbox/format.rs
+++ b/libs/streamlib-engine/src/apple/videotoolbox/format.rs
@@ -187,7 +187,7 @@ pub fn avcc_to_annex_b(avcc_data: &[u8]) -> Vec<u8> {
 
 /// Convert Annex B format to AVCC format.
 pub fn annex_b_to_avcc(annex_b_data: &[u8]) -> crate::core::Result<Vec<u8>> {
-    use crate::core::StreamError;
+    use crate::core::Error;
 
     let mut avcc = Vec::with_capacity(annex_b_data.len());
     let mut pos = 0;
@@ -206,7 +206,7 @@ pub fn annex_b_to_avcc(annex_b_data: &[u8]) -> crate::core::Result<Vec<u8>> {
             tracing::warn!(
                 "[Annex B → AVCC] No start code found at position 0, data may already be AVCC"
             );
-            return Err(StreamError::Runtime(
+            return Err(Error::Runtime(
                 "Invalid Annex B data: no start code at beginning".to_string(),
             ));
         } else {

--- a/libs/streamlib-engine/src/core/clap/host.rs
+++ b/libs/streamlib-engine/src/core/clap/host.rs
@@ -20,7 +20,7 @@ use clack_extensions::params::{ParamInfoBuffer, PluginParams};
 use super::scanner::ClapScanner;
 use crate::_generated_::AudioFrame;
 use crate::core::clap::{ParameterInfo, PluginInfo};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use parking_lot::Mutex as ParkingLotMutex;
 use std::path::Path;
@@ -118,7 +118,7 @@ impl ClapPluginHost {
             descriptors
                 .nth(index)
                 .ok_or_else(|| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Plugin index {} not found in bundle",
                         index
                     ))
@@ -172,7 +172,7 @@ impl ClapPluginHost {
                             all_names.join(", ")
                         };
 
-                        StreamError::Configuration(format!(
+                        Error::Configuration(format!(
                             "Plugin '{}' not found in bundle {}. Available plugins: [{}]",
                             name, path_str, available
                         ))
@@ -184,7 +184,7 @@ impl ClapPluginHost {
                 descriptors
                     .next()
                     .ok_or_else(|| {
-                        StreamError::Configuration("CLAP plugin bundle contains no plugins".into())
+                        Error::Configuration("CLAP plugin bundle contains no plugins".into())
                     })
                     .cloned()
             })
@@ -210,7 +210,7 @@ impl ClapPluginHost {
         // SAFETY: Loading CLAP plugins is inherently unsafe as it loads dynamic libraries
         let bundle = unsafe {
             PluginEntry::load(&binary_path).map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Failed to load CLAP plugin from {:?}: {:?}",
                     path, e
                 ))
@@ -218,23 +218,23 @@ impl ClapPluginHost {
         };
 
         let factory = bundle.get_plugin_factory().ok_or_else(|| {
-            StreamError::Configuration("CLAP plugin has no plugin factory".into())
+            Error::Configuration("CLAP plugin has no plugin factory".into())
         })?;
 
         let descriptor = filter(factory.plugin_descriptors())?;
 
         let plugin_id = descriptor
             .id()
-            .ok_or_else(|| StreamError::Configuration("Plugin descriptor has no ID".into()))?;
+            .ok_or_else(|| Error::Configuration("Plugin descriptor has no ID".into()))?;
 
         let plugin_id_str = plugin_id
             .to_str()
             .ok()
-            .ok_or_else(|| StreamError::Configuration("Invalid plugin ID".into()))?
+            .ok_or_else(|| Error::Configuration("Invalid plugin ID".into()))?
             .to_string();
 
         let plugin_id_cstring = std::ffi::CString::new(plugin_id_str.clone()).map_err(|e| {
-            StreamError::Configuration(format!("Failed to create CString from plugin ID: {}", e))
+            Error::Configuration(format!("Failed to create CString from plugin ID: {}", e))
         })?;
 
         let plugin_info = PluginInfo {
@@ -298,7 +298,7 @@ impl ClapPluginHost {
             .parameters
             .get(&id)
             .copied()
-            .ok_or_else(|| StreamError::Configuration(format!("Parameter ID {} not found", id)))
+            .ok_or_else(|| Error::Configuration(format!("Parameter ID {} not found", id)))
     }
 
     pub fn set_parameter(&mut self, id: u32, value: f64) -> Result<()> {
@@ -343,7 +343,7 @@ impl ClapPluginHost {
             "https://github.com/tatolab/streamlib",
             "0.1.0",
         )
-        .map_err(|e| StreamError::Configuration(format!("Failed to create host info: {:?}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to create host info: {:?}", e)))?;
 
         let shared_state_clone = Arc::clone(&self.shared_state);
 
@@ -357,7 +357,7 @@ impl ClapPluginHost {
             &host_info,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to create plugin instance: {:?}", e))
+            Error::Configuration(format!("Failed to create plugin instance: {:?}", e))
         })?;
 
         {
@@ -453,11 +453,11 @@ impl ClapPluginHost {
         };
 
         let activated = instance.activate(|_, _| (), audio_config).map_err(|e| {
-            StreamError::Configuration(format!("Failed to activate plugin: {:?}", e))
+            Error::Configuration(format!("Failed to activate plugin: {:?}", e))
         })?;
 
         let audio_processor = activated.start_processing().map_err(|e| {
-            StreamError::Configuration(format!("Failed to start audio processing: {:?}", e))
+            Error::Configuration(format!("Failed to start audio processing: {:?}", e))
         })?;
 
         *self.instance.lock() = Some(instance);
@@ -531,7 +531,7 @@ impl ClapPluginHost {
         let mut processor_guard = self.audio_processor.lock();
         let processor = processor_guard
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Audio processor not started".into()))?;
+            .ok_or_else(|| Error::Configuration("Audio processor not started".into()))?;
 
         let mut input_ports_base = AudioPorts::with_capacity(2, 1);
         let mut output_ports_base = AudioPorts::with_capacity(2, 1);
@@ -593,7 +593,7 @@ impl ClapPluginHost {
                 None,
                 None,
             )
-            .map_err(|e| StreamError::Runtime(format!("Plugin processing failed: {:?}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Plugin processing failed: {:?}", e)))?;
 
         Ok(())
     }

--- a/libs/streamlib-engine/src/core/clap/scanner.rs
+++ b/libs/streamlib-engine/src/core/clap/scanner.rs
@@ -3,7 +3,7 @@
 
 use clack_host::entry::PluginEntry;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
@@ -85,10 +85,10 @@ impl ClapScanner {
         let mut plugins = Vec::new();
 
         for entry in std::fs::read_dir(path).map_err(|e| {
-            StreamError::Configuration(format!("Failed to read directory {:?}: {}", path, e))
+            Error::Configuration(format!("Failed to read directory {:?}: {}", path, e))
         })? {
             let entry = entry
-                .map_err(|e| StreamError::Configuration(format!("Failed to read entry: {}", e)))?;
+                .map_err(|e| Error::Configuration(format!("Failed to read entry: {}", e)))?;
             let entry_path = entry.path();
 
             if Self::is_clap_bundle(&entry_path) {
@@ -114,13 +114,13 @@ impl ClapScanner {
         // SAFETY: Loading CLAP plugins is inherently unsafe as it loads dynamic libraries
         let bundle = unsafe {
             PluginEntry::load(&binary_path).map_err(|e| {
-                StreamError::Configuration(format!("Failed to load bundle {:?}: {:?}", path, e))
+                Error::Configuration(format!("Failed to load bundle {:?}: {:?}", path, e))
             })?
         };
 
         let factory = bundle
             .get_plugin_factory()
-            .ok_or_else(|| StreamError::Configuration("Plugin has no factory".into()))?;
+            .ok_or_else(|| Error::Configuration("Plugin has no factory".into()))?;
 
         let mut plugins = Vec::new();
 
@@ -175,14 +175,14 @@ impl ClapScanner {
 
             let binary_name = bundle_path
                 .file_stem()
-                .ok_or_else(|| StreamError::Configuration("Invalid bundle path".into()))?;
+                .ok_or_else(|| Error::Configuration("Invalid bundle path".into()))?;
 
             let binary_path = bundle_path.join("Contents").join("MacOS").join(binary_name);
 
             if binary_path.exists() {
                 Ok(binary_path)
             } else {
-                Err(StreamError::Configuration(format!(
+                Err(Error::Configuration(format!(
                     "Binary not found in bundle: {:?}",
                     binary_path
                 )))

--- a/libs/streamlib-engine/src/core/codec/mp4_muxer.rs
+++ b/libs/streamlib-engine/src/core/codec/mp4_muxer.rs
@@ -54,28 +54,28 @@ impl Mp4Muxer {
 impl Mp4Muxer {
     /// Create a new MP4 muxer (unsupported platform).
     pub fn new(_config: Mp4MuxerConfig, _ctx: &RuntimeContext) -> Result<Self> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "MP4 muxing not supported on this platform".into(),
         ))
     }
 
     /// Write an encoded video frame (unsupported platform).
     pub fn write_video(&mut self, _frame: &EncodedVideoFrame) -> Result<()> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "MP4 muxing not supported on this platform".into(),
         ))
     }
 
     /// Write an encoded audio frame (unsupported platform).
     pub fn write_audio(&mut self, _frame: &EncodedAudioFrame) -> Result<()> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "MP4 muxing not supported on this platform".into(),
         ))
     }
 
     /// Finalize (unsupported platform).
     pub fn finalize(&mut self) -> Result<()> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "MP4 muxing not supported on this platform".into(),
         ))
     }

--- a/libs/streamlib-engine/src/core/codec/video_decoder.rs
+++ b/libs/streamlib-engine/src/core/codec/video_decoder.rs
@@ -59,14 +59,14 @@ impl VideoDecoder {
 impl VideoDecoder {
     /// Create a new video decoder (unsupported platform).
     pub fn new(_config: VideoDecoderConfig, _ctx: &RuntimeContext) -> Result<Self> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "Video decoding not supported on this platform".into(),
         ))
     }
 
     /// Update decoder format (unsupported platform).
     pub fn update_format(&mut self, _sps: &[u8], _pps: &[u8]) -> Result<()> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "Video decoding not supported on this platform".into(),
         ))
     }
@@ -78,7 +78,7 @@ impl VideoDecoder {
         _timestamp_ns: i64,
         _gpu: &GpuContext,
     ) -> Result<Option<VideoFrame>> {
-        Err(crate::core::StreamError::Configuration(
+        Err(crate::core::Error::Configuration(
             "Video decoding not supported on this platform".into(),
         ))
     }

--- a/libs/streamlib-engine/src/core/codec/video_encoder.rs
+++ b/libs/streamlib-engine/src/core/codec/video_encoder.rs
@@ -5,7 +5,7 @@
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-use crate::core::StreamError;
+use crate::core::Error;
 use crate::core::{GpuContext, Result, RuntimeContext};
 
 use super::VideoEncoderConfig;
@@ -60,7 +60,7 @@ impl VideoEncoder {
     /// Encode a video frame (unsupported platform).
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     pub fn encode(&mut self, _frame: &VideoFrame, _gpu: &GpuContext) -> Result<EncodedVideoFrame> {
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Video encoding not supported on this platform".into(),
         ))
     }
@@ -74,7 +74,7 @@ impl VideoEncoder {
     /// Set the target bitrate (unsupported platform).
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     pub fn set_bitrate(&mut self, _bitrate_bps: u32) -> Result<()> {
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "Video encoding not supported on this platform".into(),
         ))
     }

--- a/libs/streamlib-engine/src/core/compiler/compiler.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler.rs
@@ -11,7 +11,7 @@ use crate::core::compiler::compile_result::CompileResult;
 use crate::core::compiler::compiler_transaction::CompilerTransactionHandle;
 use crate::core::compiler::PendingOperation;
 use crate::core::context::RuntimeContext;
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::graph::{
     Graph, GraphEdgeWithComponents, GraphNodeWithComponents, LinkStateComponent,
     ProcessorReadyBarrierHandle, ProcessorUniqueId,
@@ -239,7 +239,7 @@ impl Compiler {
                 // Clean up graph after unwiring
                 let mut graph = graph_arc.write();
                 if graph.traversal_mut().e(link_id).drop().exists() {
-                    return Err(StreamError::GraphError("value was not dropped".into()));
+                    return Err(Error::GraphError("value was not dropped".into()));
                 }
             }
 
@@ -352,7 +352,7 @@ impl Compiler {
                     }
                     // Remove from graph
                     if graph.traversal_mut().v(proc_id).drop().exists() {
-                        return Err(StreamError::GraphError("value was not dropped".into()));
+                        return Err(Error::GraphError("value was not dropped".into()));
                     }
                 }
 
@@ -377,7 +377,7 @@ impl Compiler {
             for proc_id in &plan.processors_to_add {
                 let mut graph = graph_arc.write();
                 let node = graph.traversal().v(proc_id).first().ok_or_else(|| {
-                    StreamError::ProcessorNotFound(format!("Processor '{}' not found", proc_id))
+                    Error::ProcessorNotFound(format!("Processor '{}' not found", proc_id))
                 })?;
 
                 let processor_type = node.processor_type.clone();
@@ -444,7 +444,7 @@ impl Compiler {
                 let mut graph = graph_arc.write();
                 let (from_port, to_port) = {
                     let link = graph.traversal().e(link_id).first().ok_or_else(|| {
-                        StreamError::LinkNotFound(format!("Link '{}' not found", link_id))
+                        Error::LinkNotFound(format!("Link '{}' not found", link_id))
                     })?;
                     (link.from_port().to_string(), link.to_port().to_string())
                 };
@@ -514,7 +514,7 @@ impl Compiler {
                         .map(|i| i.0.clone())
                 })
                 .ok_or_else(|| {
-                    StreamError::ProcessorNotFound(format!(
+                    Error::ProcessorNotFound(format!(
                         "Processor '{}' not found for config update",
                         proc_id
                     ))

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -11,7 +11,7 @@ use parking_lot::Mutex;
 
 use crate::core::context::RuntimeContext;
 use crate::core::embedded_schemas::max_payload_bytes_for_port_spec;
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::graph::{
     Graph, GraphEdgeWithComponents, GraphNodeWithComponents, LinkState, LinkStateComponent,
     LinkUniqueId, ProcessorInstanceComponent, SubprocessHandleComponent,
@@ -124,7 +124,7 @@ pub fn open_iceoryx2_service(
 ) -> Result<()> {
     let (from_port, to_port) = {
         let link = graph.traversal_mut().e(link_id).first().ok_or_else(|| {
-            StreamError::LinkNotFound(format!("Link '{}' not found in graph", link_id))
+            Error::LinkNotFound(format!("Link '{}' not found in graph", link_id))
         })?;
         (link.from_port().clone(), link.to_port().clone())
     };
@@ -253,7 +253,7 @@ fn reject_overcap_destination_fanin(
         .iter()
         .count();
     if fanin > MAX_FANIN_PER_DESTINATION {
-        return Err(StreamError::Configuration(format!(
+        return Err(Error::Configuration(format!(
             "destination processor '{}' would have {} upstream sources, \
              exceeding the per-destination iceoryx2 fan-in cap of {} \
              (max_publishers / max_notifiers).",
@@ -285,7 +285,7 @@ fn get_single_processor(
             node.get::<ProcessorInstanceComponent>()
                 .map(|i| i.0.clone())
         })
-        .ok_or_else(|| StreamError::Configuration(format!("Processor '{}' not found", proc_id)))
+        .ok_or_else(|| Error::Configuration(format!("Processor '{}' not found", proc_id)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -419,7 +419,7 @@ fn open_iceoryx2_pubsub(
         .traversal_mut()
         .e(link_id)
         .first_mut()
-        .ok_or_else(|| StreamError::LinkNotFound(link_id.to_string()))?;
+        .ok_or_else(|| Error::LinkNotFound(link_id.to_string()))?;
     link.insert(LinkStateComponent(LinkState::Wired));
 
     tracing::info!(
@@ -543,7 +543,7 @@ fn open_iceoryx2_subprocess_to_subprocess(
         .traversal_mut()
         .e(link_id)
         .first_mut()
-        .ok_or_else(|| StreamError::LinkNotFound(link_id.to_string()))?;
+        .ok_or_else(|| Error::LinkNotFound(link_id.to_string()))?;
     link.insert(LinkStateComponent(LinkState::Wired));
 
     tracing::info!(
@@ -677,7 +677,7 @@ fn open_iceoryx2_subprocess_to_rust(
         .traversal_mut()
         .e(link_id)
         .first_mut()
-        .ok_or_else(|| StreamError::LinkNotFound(link_id.to_string()))?;
+        .ok_or_else(|| Error::LinkNotFound(link_id.to_string()))?;
     link.insert(LinkStateComponent(LinkState::Wired));
 
     tracing::info!(
@@ -807,7 +807,7 @@ fn open_iceoryx2_rust_to_subprocess(
         .traversal_mut()
         .e(link_id)
         .first_mut()
-        .ok_or_else(|| StreamError::LinkNotFound(link_id.to_string()))?;
+        .ok_or_else(|| Error::LinkNotFound(link_id.to_string()))?;
     link.insert(LinkStateComponent(LinkState::Wired));
 
     tracing::info!(

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/prepare_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/prepare_processor_op.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::graph::{
     Graph, GraphNodeWithComponents, ProcessorPauseGateComponent, ProcessorReadyBarrierComponent,
     ProcessorReadyBarrierHandle, ProcessorUniqueId, ShutdownChannelComponent, StateComponent,
@@ -18,7 +18,7 @@ pub(crate) fn prepare_processor(
         .v(proc_id)
         .first_mut()
         .ok_or_else(|| {
-            StreamError::ProcessorNotFound(format!("Processor '{}' not found", proc_id))
+            Error::ProcessorNotFound(format!("Processor '{}' not found", proc_id))
         })?;
 
     // Create barrier for synchronization with processor thread

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -6,7 +6,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::execution::ExecutionConfig;
 use crate::core::graph::ProcessorNode;
 use crate::core::processors::{DynamicProcessorConstructorFn, ProcessorInstance};
@@ -165,7 +165,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
 
             let mut child = command.spawn()
                 .map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Failed to spawn Deno subprocess for '{}': {}. Deno: '{}'",
                         self.processor_id, e, deno_binary
                     ))
@@ -243,7 +243,7 @@ impl crate::core::processors::DynGeneratedProcessor for DenoSubprocessHostProces
                     .get("error")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "Deno subprocess '{}' setup failed: {}",
                     self.processor_id, error
                 )));
@@ -530,7 +530,7 @@ impl DenoSubprocessHostProcessor {
     /// Send a length-prefixed JSON message to the subprocess stdin.
     fn bridge_send(&mut self, msg: &serde_json::Value) -> Result<()> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge.send(msg)
     }
@@ -538,18 +538,18 @@ impl DenoSubprocessHostProcessor {
     /// Read a length-prefixed JSON message from the subprocess stdout.
     fn bridge_recv(&mut self) -> Result<serde_json::Value> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge.recv_lifecycle()
     }
 
     fn bridge_recv_timeout(&mut self, timeout: Duration) -> Result<serde_json::Value> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge
             .recv_lifecycle_timeout(timeout)
-            .map_err(|e| StreamError::Runtime(format!("bridge recv timed out: {e}")))
+            .map_err(|e| Error::Runtime(format!("bridge recv timed out: {e}")))
     }
 }
 
@@ -607,7 +607,7 @@ fn which_deno() -> Result<String> {
         .arg("deno")
         .output()
         .map_err(|e| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "Failed to locate deno binary: {}. Install with: curl -fsSL https://deno.land/install.sh | sh",
                 e
             ))
@@ -620,7 +620,7 @@ fn which_deno() -> Result<String> {
         }
     }
 
-    Err(StreamError::Runtime(
+    Err(Error::Runtime(
         "deno binary not found on PATH. Install with: curl -fsSL https://deno.land/install.sh | sh"
             .to_string(),
     ))
@@ -641,10 +641,10 @@ fn resolve_deno_sdk_path() -> Result<PathBuf> {
     if dev_path.exists() {
         return dev_path
             .canonicalize()
-            .map_err(|e| StreamError::Runtime(format!("Failed to canonicalize SDK path: {}", e)));
+            .map_err(|e| Error::Runtime(format!("Failed to canonicalize SDK path: {}", e)));
     }
 
-    Err(StreamError::Runtime(
+    Err(Error::Runtime(
         "StreamLib Deno SDK not found. Set STREAMLIB_DENO_SDK_PATH or build from workspace."
             .to_string(),
     ))

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -11,7 +11,7 @@ use parking_lot::{Mutex, RwLock};
 use crate::core::compiler::scheduling::{scheduling_strategy_for_processor, SchedulingStrategy};
 use crate::core::context::{GpuContextLimitedAccess, RuntimeContext, RuntimeContextFullAccess};
 use crate::core::descriptors::ProcessorRuntime;
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::execution::run_processor_loop;
 use crate::core::graph::{
     Graph, GraphNodeWithComponents, ProcessorAudioConverterComponent, ProcessorInstanceComponent,
@@ -75,13 +75,13 @@ pub(crate) fn spawn_processor(
             .v(processor_id)
             .first_mut()
             .ok_or_else(|| {
-                StreamError::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
+                Error::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
             })?;
 
         let barrier = node_mut
             .remove::<ProcessorReadyBarrierComponent>()
             .ok_or_else(|| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Processor '{}' has no ProcessorReadyBarrierComponent",
                     processor_id
                 ))
@@ -96,7 +96,7 @@ pub(crate) fn spawn_processor(
             let strategy = {
                 let graph = graph_arc.read();
                 let node = graph.traversal().v(&proc_id_clone).first().ok_or_else(|| {
-                    StreamError::ProcessorNotFound(format!(
+                    Error::ProcessorNotFound(format!(
                         "Processor '{}' not found",
                         proc_id_clone
                     ))
@@ -131,7 +131,7 @@ pub(crate) fn spawn_processor(
             let strategy = {
                 let graph = graph_arc.read();
                 let node = graph.traversal().v(&proc_id_clone).first().ok_or_else(|| {
-                    StreamError::ProcessorNotFound(format!(
+                    Error::ProcessorNotFound(format!(
                         "Processor '{}' not found",
                         proc_id_clone
                     ))
@@ -166,7 +166,7 @@ pub(crate) fn spawn_processor(
             let strategy = {
                 let graph = graph_arc.read();
                 let node = graph.traversal().v(&proc_id_clone).first().ok_or_else(|| {
-                    StreamError::ProcessorNotFound(format!(
+                    Error::ProcessorNotFound(format!(
                         "Processor '{}' not found",
                         proc_id_clone
                     ))
@@ -215,7 +215,7 @@ fn spawn_dedicated_thread(
     let (processor_arc, audio_converter_status_arc) = {
         let graph = graph_arc.read();
         let node = graph.traversal().v(&processor_id).first().ok_or_else(|| {
-            StreamError::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
+            Error::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
         })?;
         let processor = factory.create(node)?;
         let audio_status = processor.get_audio_converter_status_arc();
@@ -447,7 +447,7 @@ fn spawn_dedicated_thread(
                 processor_context,
             );
         })
-        .map_err(|e| StreamError::Runtime(format!("Failed to spawn thread: {}", e)))?;
+        .map_err(|e| Error::Runtime(format!("Failed to spawn thread: {}", e)))?;
 
     // Attach thread handle
     {
@@ -457,7 +457,7 @@ fn spawn_dedicated_thread(
             .v(&processor_id)
             .first_mut()
             .ok_or_else(|| {
-                StreamError::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
+                Error::ProcessorNotFound(format!("Processor '{}' not found", processor_id))
             })?;
         node.insert(ThreadHandleComponent(thread));
     }

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -6,7 +6,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::execution::ExecutionConfig;
 use crate::core::graph::ProcessorNode;
 use crate::core::processors::{DynamicProcessorConstructorFn, ProcessorInstance};
@@ -148,7 +148,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 
             let mut child = command.spawn()
                 .map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Failed to spawn Python native subprocess for '{}': {}. Python: '{}'",
                         self.processor_id, e, python_executable
                     ))
@@ -228,7 +228,7 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
                     .get("error")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "Python native subprocess '{}' setup failed: {}",
                     self.processor_id, error
                 )));
@@ -521,25 +521,25 @@ impl crate::core::processors::DynGeneratedProcessor for PythonNativeSubprocessHo
 impl PythonNativeSubprocessHostProcessor {
     fn bridge_send(&mut self, msg: &serde_json::Value) -> Result<()> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge.send(msg)
     }
 
     fn bridge_recv(&mut self) -> Result<serde_json::Value> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge.recv_lifecycle()
     }
 
     fn bridge_recv_timeout(&mut self, timeout: Duration) -> Result<serde_json::Value> {
         let bridge = self.bridge.as_ref().ok_or_else(|| {
-            StreamError::Runtime("Subprocess bridge not initialized".to_string())
+            Error::Runtime("Subprocess bridge not initialized".to_string())
         })?;
         bridge
             .recv_lifecycle_timeout(timeout)
-            .map_err(|e| StreamError::Runtime(format!("bridge recv timed out: {e}")))
+            .map_err(|e| Error::Runtime(format!("bridge recv timed out: {e}")))
     }
 }
 
@@ -623,7 +623,7 @@ pub(crate) fn resolve_python_native_lib_path() -> Result<String> {
         }
     }
 
-    Err(StreamError::Runtime(format!(
+    Err(Error::Runtime(format!(
         "Python native FFI library not found. Expected at '{}' or '{}'. Build with: cargo build -p streamlib-python-native",
         default_path.display(),
         release_path.display()

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_subprocess_op.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 
 // ============================================================================
 // Venv management
@@ -37,9 +37,9 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
     // Compute hash for cache key
     let hash_hex = if let Some(ref pyproject) = pyproject_path {
         let contents = std::fs::read_to_string(pyproject)
-            .map_err(|e| StreamError::Runtime(format!("Failed to read pyproject.toml: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to read pyproject.toml: {}", e)))?;
         let canonical = project_path.canonicalize().map_err(|e| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "Failed to canonicalize project_path '{}': {}",
                 project_path.display(),
                 e
@@ -79,7 +79,7 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
     static VENV_CREATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _lock = VENV_CREATION_LOCK
         .lock()
-        .map_err(|e| StreamError::Runtime(format!("Venv creation lock poisoned: {}", e)))?;
+        .map_err(|e| Error::Runtime(format!("Venv creation lock poisoned: {}", e)))?;
 
     // Re-check after acquiring lock — another thread may have created it
     if venv_python.exists() {
@@ -101,7 +101,7 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
     );
 
     std::fs::create_dir_all(venv_dir.parent().unwrap_or(&venv_dir)).map_err(|e| {
-        StreamError::Runtime(format!("Failed to create venv parent directory: {}", e))
+        Error::Runtime(format!("Failed to create venv parent directory: {}", e))
     })?;
 
     let output = run_uv(
@@ -112,7 +112,7 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let _ = std::fs::remove_dir_all(&venv_dir);
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "Failed to create venv for processor '{}': {}",
             processor_id, stderr
         )));
@@ -146,7 +146,7 @@ pub fn ensure_processor_venv(processor_id: &str, project_path: &Path) -> Result<
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let _ = std::fs::remove_dir_all(&venv_dir);
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "Failed to install project deps for processor '{}': {}",
                 processor_id, stderr
             )));
@@ -163,7 +163,7 @@ fn run_uv(args: &[&str], uv_cache_dir: &Path) -> Result<std::process::Output> {
         .env("UV_CACHE_DIR", uv_cache_dir.to_str().unwrap_or(""))
         .output()
         .map_err(|e| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "Failed to run uv (is uv installed?): {}. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh",
                 e
             ))

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_bridge.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_bridge.rs
@@ -37,7 +37,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::core::context::GpuContextLimitedAccess;
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 
 use super::subprocess_escalate::{process_bridge_message, EscalateHandleRegistry};
 
@@ -65,7 +65,7 @@ impl EscalateTransport {
     /// the subprocess retains the child-side fd.
     pub(crate) fn attach(command: &mut Command) -> Result<Self> {
         let (parent_end, child_end) = UnixStream::pair().map_err(|e| {
-            StreamError::Runtime(format!("failed to create escalate socketpair: {e}"))
+            Error::Runtime(format!("failed to create escalate socketpair: {e}"))
         })?;
 
         let child_fd: RawFd = child_end.as_raw_fd();
@@ -136,7 +136,7 @@ impl SubprocessBridge {
         processor_id: String,
     ) -> Result<Self> {
         let read_half = stream.try_clone().map_err(|e| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "failed to clone escalate socketpair for reader: {e}"
             ))
         })?;
@@ -179,7 +179,7 @@ impl SubprocessBridge {
     /// Write a length-prefixed JSON message to the subprocess.
     pub(crate) fn send(&self, msg: &serde_json::Value) -> Result<()> {
         if self.is_dead() {
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "[{}] bridge marked dead, cannot send",
                 self.processor_id
             )));
@@ -187,7 +187,7 @@ impl SubprocessBridge {
         let mut writer = self
             .writer
             .lock()
-            .map_err(|_| StreamError::Runtime("subprocess writer mutex poisoned".to_string()))?;
+            .map_err(|_| Error::Runtime("subprocess writer mutex poisoned".to_string()))?;
         write_frame(&mut *writer, msg).map_err(|e| {
             self.mark_dead();
             e
@@ -198,7 +198,7 @@ impl SubprocessBridge {
     pub(crate) fn recv_lifecycle(&self) -> Result<serde_json::Value> {
         self.lifecycle_rx.recv().map_err(|_| {
             self.mark_dead();
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "[{}] subprocess escalate socket closed before reply",
                 self.processor_id
             ))
@@ -421,17 +421,17 @@ fn thread_name(processor_id: &str) -> String {
 
 fn write_frame<W: Write>(writer: &mut W, msg: &serde_json::Value) -> Result<()> {
     let bytes = serde_json::to_vec(msg)
-        .map_err(|e| StreamError::Runtime(format!("failed to serialize bridge message: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("failed to serialize bridge message: {e}")))?;
     let len = bytes.len() as u32;
     writer
         .write_all(&len.to_be_bytes())
-        .map_err(|e| StreamError::Runtime(format!("failed to write bridge frame: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("failed to write bridge frame: {e}")))?;
     writer
         .write_all(&bytes)
-        .map_err(|e| StreamError::Runtime(format!("failed to write bridge frame: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("failed to write bridge frame: {e}")))?;
     writer
         .flush()
-        .map_err(|e| StreamError::Runtime(format!("failed to flush bridge frame: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("failed to flush bridge frame: {e}")))?;
     Ok(())
 }
 
@@ -439,14 +439,14 @@ fn read_frame<R: Read>(reader: &mut R) -> Result<serde_json::Value> {
     let mut len_buf = [0u8; 4];
     reader
         .read_exact(&mut len_buf)
-        .map_err(|e| StreamError::Runtime(format!("bridge read failed: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("bridge read failed: {e}")))?;
     let len = u32::from_be_bytes(len_buf) as usize;
     let mut buf = vec![0u8; len];
     reader
         .read_exact(&mut buf)
-        .map_err(|e| StreamError::Runtime(format!("bridge read failed: {e}")))?;
+        .map_err(|e| Error::Runtime(format!("bridge read failed: {e}")))?;
     serde_json::from_slice(&buf)
-        .map_err(|e| StreamError::Runtime(format!("bridge frame decode failed: {e}")))
+        .map_err(|e| Error::Runtime(format!("bridge frame decode failed: {e}")))
 }
 
 #[cfg(test)]

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -78,7 +78,7 @@ use crate::core::logging::{push_polyglot_record, LogLevel, LogRecord, Source};
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
 
 #[cfg(test)]
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 
 /// Wire tag marking a message as an escalate request. Bridges demux on this
 /// before falling through to lifecycle dispatch.
@@ -813,7 +813,7 @@ where
 
     let bridge: Arc<dyn CpuReadbackBridge> = match sandbox.escalate(|full| {
         full.cpu_readback_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(format!(
+            crate::core::error::Error::Configuration(format!(
                 "{op_label}: no CpuReadbackBridge registered on GpuContext"
             ))
         })
@@ -896,7 +896,7 @@ fn handle_register_compute_kernel(
 
     let bridge: Arc<dyn ComputeKernelBridge> = match sandbox.escalate(|full| {
         full.compute_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "register_compute_kernel: no ComputeKernelBridge registered on GpuContext"
                     .to_string(),
             )
@@ -969,7 +969,7 @@ fn handle_run_compute_kernel(
 
     let bridge: Arc<dyn ComputeKernelBridge> = match sandbox.escalate(|full| {
         full.compute_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "run_compute_kernel: no ComputeKernelBridge registered on GpuContext"
                     .to_string(),
             )
@@ -1056,7 +1056,7 @@ fn handle_register_graphics_kernel(
 
     let bridge: Arc<dyn GraphicsKernelBridge> = match sandbox.escalate(|full| {
         full.graphics_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "register_graphics_kernel: no GraphicsKernelBridge registered on GpuContext"
                     .to_string(),
             )
@@ -1261,7 +1261,7 @@ fn handle_run_graphics_draw(
 
     let bridge: Arc<dyn GraphicsKernelBridge> = match sandbox.escalate(|full| {
         full.graphics_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "run_graphics_draw: no GraphicsKernelBridge registered on GpuContext".to_string(),
             )
         })
@@ -1372,7 +1372,7 @@ fn handle_register_acceleration_structure_blas(
 
     let bridge: Arc<dyn RayTracingKernelBridge> = match sandbox.escalate(|full| {
         full.ray_tracing_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "register_acceleration_structure_blas: no RayTracingKernelBridge \
                  registered on GpuContext"
                     .to_string(),
@@ -1484,7 +1484,7 @@ fn handle_register_acceleration_structure_tlas(
 
     let bridge: Arc<dyn RayTracingKernelBridge> = match sandbox.escalate(|full| {
         full.ray_tracing_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "register_acceleration_structure_tlas: no RayTracingKernelBridge \
                  registered on GpuContext"
                     .to_string(),
@@ -1615,7 +1615,7 @@ fn handle_register_ray_tracing_kernel(
 
     let bridge: Arc<dyn RayTracingKernelBridge> = match sandbox.escalate(|full| {
         full.ray_tracing_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "register_ray_tracing_kernel: no RayTracingKernelBridge registered on \
                  GpuContext"
                     .to_string(),
@@ -1705,7 +1705,7 @@ fn handle_run_ray_tracing_kernel(
 
     let bridge: Arc<dyn RayTracingKernelBridge> = match sandbox.escalate(|full| {
         full.ray_tracing_kernel_bridge().ok_or_else(|| {
-            crate::core::error::StreamError::Configuration(
+            crate::core::error::Error::Configuration(
                 "run_ray_tracing_kernel: no RayTracingKernelBridge registered on \
                  GpuContext"
                     .to_string(),
@@ -2351,8 +2351,8 @@ pub(crate) fn process_bridge_message(
 #[cfg(test)]
 pub(crate) fn parse_op_for_tests(value: &serde_json::Value) -> Result<EscalateRequest> {
     try_parse_escalate_request(value)
-        .ok_or_else(|| StreamError::Runtime("not an escalate_request".to_string()))?
-        .map_err(|e| StreamError::Runtime(e.message))
+        .ok_or_else(|| Error::Runtime("not an escalate_request".to_string()))?
+        .map_err(|e| Error::Runtime(e.message))
 }
 
 #[cfg(test)]

--- a/libs/streamlib-engine/src/core/config/installed_packages_manifest.rs
+++ b/libs/streamlib-engine/src/core/config/installed_packages_manifest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use streamlib_idents::{PackageRef, SemVer};
 
 use crate::core::streamlib_home::get_streamlib_home;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Format-version of the on-disk installed-package manifest. Bumped when the
 /// shape changes; mismatched files are reset on load with a warning. Pre-#717
@@ -58,7 +58,7 @@ impl InstalledPackageManifest {
         }
 
         let content = std::fs::read_to_string(&path).map_err(|e| {
-            StreamError::Configuration(format!("Failed to read {}: {}", path.display(), e))
+            Error::Configuration(format!("Failed to read {}: {}", path.display(), e))
         })?;
 
         match serde_yaml::from_str::<Self>(&content) {
@@ -97,7 +97,7 @@ impl InstalledPackageManifest {
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Failed to create directory {}: {}",
                     parent.display(),
                     e
@@ -106,11 +106,11 @@ impl InstalledPackageManifest {
         }
 
         let content = serde_yaml::to_string(self).map_err(|e| {
-            StreamError::Configuration(format!("Failed to serialize packages manifest: {}", e))
+            Error::Configuration(format!("Failed to serialize packages manifest: {}", e))
         })?;
 
         std::fs::write(&path, content).map_err(|e| {
-            StreamError::Configuration(format!("Failed to write {}: {}", path.display(), e))
+            Error::Configuration(format!("Failed to write {}: {}", path.display(), e))
         })?;
 
         Ok(())

--- a/libs/streamlib-engine/src/core/config/project_config.rs
+++ b/libs/streamlib-engine/src/core/config/project_config.rs
@@ -3,7 +3,7 @@
 
 //! Project-level configuration via `streamlib.yaml`.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -72,11 +72,11 @@ impl ProjectConfig {
         let config_path = project_path.join(Self::FILE_NAME);
 
         let content = std::fs::read_to_string(&config_path).map_err(|e| {
-            StreamError::Configuration(format!("Failed to read {}: {}", config_path.display(), e))
+            Error::Configuration(format!("Failed to read {}: {}", config_path.display(), e))
         })?;
 
         let config: Self = serde_yaml::from_str(&content).map_err(|e| {
-            StreamError::Configuration(format!("Failed to parse {}: {}", config_path.display(), e))
+            Error::Configuration(format!("Failed to parse {}: {}", config_path.display(), e))
         })?;
 
         tracing::info!("Loaded project config from {}", config_path.display());
@@ -147,7 +147,7 @@ impl ProjectConfig {
         let min_version = constraint
             .strip_prefix(">=")
             .ok_or_else(|| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Unsupported streamlib_version constraint '{}' (only >=X.Y.Z is supported)",
                     constraint
                 ))
@@ -155,7 +155,7 @@ impl ProjectConfig {
             .trim();
 
         if compare_semver(runtime_version, min_version) < 0 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Package requires streamlib {} but running version is {}",
                 constraint, runtime_version
             )));

--- a/libs/streamlib-engine/src/core/context/audio_clock.rs
+++ b/libs/streamlib-engine/src/core/context/audio_clock.rs
@@ -241,7 +241,7 @@ impl AudioClock for SoftwareAudioClock {
                 tracing::info!("[SoftwareAudioClock] Stopped");
             })
             .map_err(|e| {
-                crate::core::StreamError::Runtime(format!(
+                crate::core::Error::Runtime(format!(
                     "Failed to spawn audio clock thread: {}",
                     e
                 ))

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -8,7 +8,7 @@ use crate::core::rhi::{
     RhiCommandQueue, RhiPixelBuffer, RhiPixelBufferPool, StreamTexture, TextureDescriptor,
     TextureFormat, TextureUsages,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 #[cfg(target_os = "linux")]
 use crate::host_rhi::HostStreamTextureExt;
 use std::collections::HashMap;
@@ -33,7 +33,7 @@ struct NoOpBlitter;
 #[cfg(not(target_os = "macos"))]
 impl RhiBlitter for NoOpBlitter {
     fn blit_copy(&self, _src: &RhiPixelBuffer, _dest: &RhiPixelBuffer) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "Blitter not supported on this platform".into(),
         ))
     }
@@ -45,7 +45,7 @@ impl RhiBlitter for NoOpBlitter {
         _width: u32,
         _height: u32,
     ) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "Blitter not supported on this platform".into(),
         ))
     }
@@ -150,7 +150,7 @@ impl PixelBufferPoolManager {
             let _ = desc;
             let underlying_pool = RhiPixelBufferPool {
                 #[cfg(target_os = "macos")]
-                inner: return Err(crate::core::StreamError::Configuration(
+                inner: return Err(crate::core::Error::Configuration(
                     "PixelBufferPool creation via descriptor not yet implemented".into(),
                 )),
                 #[cfg(target_os = "linux")]
@@ -158,7 +158,7 @@ impl PixelBufferPoolManager {
                     let vulkan_device = std::sync::Arc::clone(&self.device.inner);
                     let bytes_per_pixel = format.bits_per_pixel() / 8;
                     if bytes_per_pixel == 0 {
-                        return Err(crate::core::StreamError::Configuration(
+                        return Err(crate::core::Error::Configuration(
                             format!("Cannot create pixel buffer pool: PixelFormat {:?} has 0 bits per pixel", format),
                         ));
                     }
@@ -252,7 +252,7 @@ impl PixelBufferPoolManager {
         let buffer_count = ring_pool.buffers.len();
 
         if buffer_count == 0 {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "No buffers available in pool".into(),
             ));
         }
@@ -352,7 +352,7 @@ impl PixelBufferPoolManager {
             format,
             POOL_MAX_BUFFER_COUNT
         );
-        Err(StreamError::Configuration(
+        Err(Error::Configuration(
             "All pixel buffers are currently in use".into(),
         ))
     }
@@ -516,7 +516,7 @@ impl GpuContext {
         {
             use vulkanalia::vk::DeviceV1_0;
             unsafe { self.device.inner.device().device_wait_idle() }.map_err(|e| {
-                StreamError::GpuError(format!("device_wait_idle failed: {e}"))
+                Error::GpuError(format!("device_wait_idle failed: {e}"))
             })?;
         }
         Ok(())
@@ -600,7 +600,7 @@ impl GpuContext {
 
         let surface_store = self.surface_store.lock().unwrap();
         let store = surface_store.as_ref().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "SurfaceStore not initialized. Call runtime.start() first.".into(),
             )
         })?;
@@ -767,7 +767,7 @@ impl GpuContext {
             }
         }
 
-        Err(StreamError::GpuError(format!(
+        Err(Error::GpuError(format!(
             "No texture or pixel buffer found for surface_id '{}'",
             frame.surface_id
         )))
@@ -847,7 +847,7 @@ impl GpuContext {
 
         unsafe {
             let image = texture.inner.image().ok_or_else(|| {
-                StreamError::GpuError("Texture has no VkImage".into())
+                Error::GpuError("Texture has no VkImage".into())
             })?;
             self.device.inner.upload_buffer_to_image(
                 pixel_buffer.buffer_ref().inner.buffer(),
@@ -884,7 +884,7 @@ impl GpuContext {
 
         unsafe {
             let image = texture.inner.image().ok_or_else(|| {
-                crate::core::StreamError::GpuError("Texture has no VkImage".into())
+                crate::core::Error::GpuError("Texture has no VkImage".into())
             })?;
             self.device.inner.upload_buffer_to_image(
                 pixel_buffer.buffer_ref().inner.buffer(),
@@ -1008,7 +1008,7 @@ impl GpuContext {
             }
             TextureFormat::Nv12 => fourcc::DRM_FORMAT_NV12,
             other => {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "acquire_render_target_dma_buf_image: format {other:?} has no DRM FOURCC mapping"
                 )));
             }
@@ -1021,7 +1021,7 @@ impl GpuContext {
             .to_vec();
 
         if modifiers.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "acquire_render_target_dma_buf_image: no RT-capable DRM modifier for {format:?} (fourcc=0x{fourcc:08x}); EGL probe returned empty list"
             )));
         }
@@ -1227,7 +1227,7 @@ impl GpuContext {
                 .vulkan_inner()
                 .image()
                 .ok_or_else(|| {
-                    crate::core::StreamError::GpuError(
+                    crate::core::Error::GpuError(
                         "transition_storage_image_to_general: texture missing VkImage".to_string(),
                     )
                 })?,
@@ -1287,7 +1287,7 @@ impl GpuContext {
 
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         {
-            Err(StreamError::GpuError(
+            Err(Error::GpuError(
                 "Unsupported platform for GPU initialization".into(),
             ))
         }
@@ -1460,7 +1460,7 @@ impl GpuContext {
     pub fn check_in_surface(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
         let store = self.surface_store.lock().unwrap();
         let store = store.as_ref().ok_or_else(|| {
-            crate::core::StreamError::Configuration(
+            crate::core::Error::Configuration(
                 "SurfaceStore not initialized. Call runtime.start() first.".into(),
             )
         })?;
@@ -1476,7 +1476,7 @@ impl GpuContext {
     pub fn check_out_surface(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
         let store = self.surface_store.lock().unwrap();
         let store = store.as_ref().ok_or_else(|| {
-            crate::core::StreamError::Configuration(
+            crate::core::Error::Configuration(
                 "SurfaceStore not initialized. Call runtime.start() first.".into(),
             )
         })?;
@@ -1486,7 +1486,7 @@ impl GpuContext {
     /// Check in a pixel buffer (non-macOS stub).
     #[cfg(not(target_os = "macos"))]
     pub fn check_in_surface(&self, _pixel_buffer: &RhiPixelBuffer) -> Result<String> {
-        Err(crate::core::StreamError::NotSupported(
+        Err(crate::core::Error::NotSupported(
             "Surface store is only supported on macOS".into(),
         ))
     }
@@ -1494,7 +1494,7 @@ impl GpuContext {
     /// Check out a surface (non-macOS stub).
     #[cfg(not(target_os = "macos"))]
     pub fn check_out_surface(&self, _surface_id: &str) -> Result<RhiPixelBuffer> {
-        Err(crate::core::StreamError::NotSupported(
+        Err(crate::core::Error::NotSupported(
             "Surface store is only supported on macOS".into(),
         ))
     }
@@ -2440,10 +2440,10 @@ mod tests {
 
         let limited = GpuContextLimitedAccess::new(gpu);
         let result: Result<()> = limited.escalate(|_full| {
-            Err(StreamError::Runtime("synthetic failure".to_string()))
+            Err(Error::Runtime("synthetic failure".to_string()))
         });
         match result {
-            Err(StreamError::Runtime(msg)) if msg == "synthetic failure" => {}
+            Err(Error::Runtime(msg)) if msg == "synthetic failure" => {}
             other => panic!("expected synthetic Runtime error, got {other:?}"),
         }
 

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -17,7 +17,7 @@ use std::ffi::c_void;
 use parking_lot::Mutex;
 
 use crate::core::rhi::RhiPixelBuffer;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 #[cfg(target_os = "linux")]
 use crate::host_rhi::HostStreamTextureExt;
 
@@ -163,7 +163,7 @@ impl SurfaceStore {
     #[cfg(target_os = "macos")]
     pub fn connect(&self) -> Result<()> {
         let service_name = CString::new(self.inner.service_name.as_str())
-            .map_err(|e| StreamError::Configuration(format!("Invalid XPC service name: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Invalid XPC service name: {}", e)))?;
 
         let connection = unsafe {
             xpc_connection_create_mach_service(
@@ -174,7 +174,7 @@ impl SurfaceStore {
         };
 
         if connection.is_null() {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Failed to create XPC connection to '{}'",
                 self.inner.service_name
             )));
@@ -241,7 +241,7 @@ impl SurfaceStore {
         // Get the IOSurface ID for deduplication
         let pixel_buffer_ref = pixel_buffer.buffer_ref();
         let iosurface = pixel_buffer_ref.iosurface_ref().ok_or_else(|| {
-            StreamError::Configuration("Pixel buffer is not backed by an IOSurface".into())
+            Error::Configuration("Pixel buffer is not backed by an IOSurface".into())
         })?;
         let iosurface_id = unsafe { IOSurfaceGetID(iosurface) };
 
@@ -352,13 +352,13 @@ impl SurfaceStore {
     fn check_in_to_surface_share(&self, mach_port: u32) -> Result<String> {
         let connection = self.inner.connection.lock();
         let connection = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         // Create request dictionary
         let request = unsafe { xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0) };
         if request.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Failed to create XPC request dictionary".into(),
             ));
         }
@@ -392,7 +392,7 @@ impl SurfaceStore {
         }
 
         if reply.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC check_in: null reply from the surface-share service".into(),
             ));
         }
@@ -402,7 +402,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC check_in: surface-share service returned error".into(),
             ));
         }
@@ -415,7 +415,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC check_in: missing surface_id in reply".into(),
             ));
         }
@@ -436,13 +436,13 @@ impl SurfaceStore {
     fn check_out_from_surface_share(&self, surface_id: &str) -> Result<u32> {
         let connection = self.inner.connection.lock();
         let connection = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         // Create request dictionary
         let request = unsafe { xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0) };
         if request.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Failed to create XPC request dictionary".into(),
             ));
         }
@@ -470,7 +470,7 @@ impl SurfaceStore {
         }
 
         if reply.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC check_out: null reply from the surface-share service".into(),
             ));
         }
@@ -480,7 +480,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC check_out: surface-share service returned error for surface '{}'",
                 surface_id
             )));
@@ -495,7 +495,7 @@ impl SurfaceStore {
         }
 
         if mach_port == 0 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC check_out: invalid mach port for surface '{}'",
                 surface_id
             )));
@@ -538,13 +538,13 @@ impl SurfaceStore {
     fn register_with_surface_share(&self, pool_id: &str, mach_port: u32) -> Result<()> {
         let connection = self.inner.connection.lock();
         let connection = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         // Create request dictionary
         let request = unsafe { xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0) };
         if request.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Failed to create XPC request dictionary".into(),
             ));
         }
@@ -585,7 +585,7 @@ impl SurfaceStore {
         }
 
         if reply.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC register: null reply from the surface-share service".into(),
             ));
         }
@@ -595,7 +595,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC register: surface-share service returned error".into(),
             ));
         }
@@ -610,7 +610,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC register: {}",
                 error_msg
             )));
@@ -647,13 +647,13 @@ impl SurfaceStore {
     fn lookup_from_surface_share(&self, pool_id: &str) -> Result<u32> {
         let connection = self.inner.connection.lock();
         let connection = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         // Create request dictionary
         let request = unsafe { xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0) };
         if request.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Failed to create XPC request dictionary".into(),
             ));
         }
@@ -681,7 +681,7 @@ impl SurfaceStore {
         }
 
         if reply.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "XPC lookup: null reply from the surface-share service".into(),
             ));
         }
@@ -691,7 +691,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC lookup: surface-share service returned error for '{}'",
                 pool_id
             )));
@@ -707,7 +707,7 @@ impl SurfaceStore {
             unsafe {
                 xpc_release(reply);
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC lookup: {}",
                 error_msg
             )));
@@ -722,7 +722,7 @@ impl SurfaceStore {
         }
 
         if mach_port == 0 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "XPC lookup: invalid mach port for '{}'",
                 pool_id
             )));
@@ -749,7 +749,7 @@ impl SurfaceStore {
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = surface_id;
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "SurfaceStore::release is only supported on macOS and Linux".into(),
             ))
         }
@@ -760,13 +760,13 @@ impl SurfaceStore {
     fn release_from_surface_share(&self, surface_id: &str) -> Result<()> {
         let connection = self.inner.connection.lock();
         let connection = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         // Create request dictionary
         let request = unsafe { xpc_dictionary_create(std::ptr::null(), std::ptr::null(), 0) };
         if request.is_null() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "Failed to create XPC request dictionary".into(),
             ));
         }
@@ -810,7 +810,7 @@ impl SurfaceStore {
     pub fn connect(&self) -> Result<()> {
         let stream = std::os::unix::net::UnixStream::connect(&self.inner.service_name)
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Failed to connect to surface-share socket '{}': {}",
                     self.inner.service_name, e
                 ))
@@ -893,7 +893,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let send_result =
@@ -907,7 +907,7 @@ impl SurfaceStore {
         }
 
         let (response, response_fds) = send_result.map_err(|e| {
-            StreamError::Configuration(format!("Unix socket check_in failed: {}", e))
+            Error::Configuration(format!("Unix socket check_in failed: {}", e))
         })?;
         // check_in never returns fds; close any the surface-share service may have attached
         // defensively so a future protocol drift doesn't leak them.
@@ -919,7 +919,7 @@ impl SurfaceStore {
             .get("surface_id")
             .and_then(|v: &serde_json::Value| v.as_str())
             .ok_or_else(|| {
-                StreamError::Configuration("check_in: missing surface_id in response".into())
+                Error::Configuration("check_in: missing surface_id in response".into())
             })?
             .to_string();
 
@@ -963,7 +963,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let (response, received_fds) = streamlib_surface_client::send_request_with_fds(
@@ -973,21 +973,21 @@ impl SurfaceStore {
             streamlib_surface_client::MAX_DMA_BUF_PLANES,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Unix socket check_out failed: {}", e))
+            Error::Configuration(format!("Unix socket check_out failed: {}", e))
         })?;
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
             for fd in &received_fds {
                 unsafe { libc::close(*fd) };
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "check_out: {}",
                 error
             )));
         }
 
         if received_fds.is_empty() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "check_out: no DMA-BUF fd in response".into(),
             ));
         }
@@ -1051,21 +1051,21 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let send_result =
             streamlib_surface_client::send_request_with_fds(stream, &request, &[fd], 0);
         unsafe { libc::close(fd) };
         let (response, response_fds) = send_result.map_err(|e| {
-            StreamError::Configuration(format!("Unix socket register failed: {}", e))
+            Error::Configuration(format!("Unix socket register failed: {}", e))
         })?;
         for f in &response_fds {
             unsafe { libc::close(*f) };
         }
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "register: {}",
                 error
             )));
@@ -1104,7 +1104,7 @@ impl SurfaceStore {
                 Ok(f) => Some(f),
                 Err(e) => {
                     unsafe { libc::close(fd) };
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "register_texture: failed to export timeline opaque fd: {}",
                         e
                     )));
@@ -1149,7 +1149,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let mut fds: Vec<std::os::unix::io::RawFd> = vec![fd];
@@ -1162,14 +1162,14 @@ impl SurfaceStore {
             unsafe { libc::close(*f) };
         }
         let (response, response_fds) = send_result.map_err(|e| {
-            StreamError::Configuration(format!("Unix socket register_texture failed: {}", e))
+            Error::Configuration(format!("Unix socket register_texture failed: {}", e))
         })?;
         for f in &response_fds {
             unsafe { libc::close(*f) };
         }
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "register_texture: {}",
                 error
             )));
@@ -1243,7 +1243,7 @@ impl SurfaceStore {
                     for fd in &plane_fds {
                         unsafe { libc::close(*fd) };
                     }
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "register_pixel_buffer_with_timeline: failed to export timeline opaque fd: {}",
                         e
                     )));
@@ -1268,7 +1268,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let mut fds: Vec<std::os::unix::io::RawFd> = plane_fds.clone();
@@ -1281,7 +1281,7 @@ impl SurfaceStore {
             unsafe { libc::close(*f) };
         }
         let (response, response_fds) = send_result.map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "Unix socket register_pixel_buffer_with_timeline failed: {}",
                 e
             ))
@@ -1291,7 +1291,7 @@ impl SurfaceStore {
         }
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "register_pixel_buffer_with_timeline: {}",
                 error
             )));
@@ -1327,7 +1327,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let (response, received_fds) = streamlib_surface_client::send_request_with_fds(
@@ -1337,21 +1337,21 @@ impl SurfaceStore {
             streamlib_surface_client::MAX_DMA_BUF_PLANES,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Unix socket lookup failed: {}", e))
+            Error::Configuration(format!("Unix socket lookup failed: {}", e))
         })?;
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
             for fd in &received_fds {
                 unsafe { libc::close(*fd) };
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "lookup: {}",
                 error
             )));
         }
 
         if received_fds.is_empty() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "lookup: no memory fd in response".into(),
             ));
         }
@@ -1370,7 +1370,7 @@ impl SurfaceStore {
             for fd in &received_fds {
                 unsafe { libc::close(*fd) };
             }
-            return Err(StreamError::NotSupported(
+            return Err(Error::NotSupported(
                 "SurfaceStore::lookup_buffer: surface registered with \
                  handle_type=\"opaque_fd\"; the host-side RhiPixelBuffer \
                  import path is DMA-BUF-only. Subprocess consumers should \
@@ -1421,7 +1421,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration(
+            Error::Configuration(
                 "SurfaceStore not connected to surface-share service".into(),
             )
         })?;
@@ -1429,7 +1429,7 @@ impl SurfaceStore {
         let (response, response_fds) =
             streamlib_surface_client::send_request_with_fds(stream, &request, &[], 0)
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Unix socket update_layout failed: {}",
                         e
                     ))
@@ -1439,7 +1439,7 @@ impl SurfaceStore {
         }
 
         if let Some(error) = response.get("error").and_then(|v| v.as_str()) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "update_layout: {}",
                 error
             )));
@@ -1447,11 +1447,11 @@ impl SurfaceStore {
 
         match response.get("success").and_then(|v| v.as_bool()) {
             Some(true) => Ok(()),
-            Some(false) => Err(StreamError::Configuration(format!(
+            Some(false) => Err(Error::Configuration(format!(
                 "update_layout: surface_id '{}' not registered",
                 surface_id
             ))),
-            None => Err(StreamError::Configuration(
+            None => Err(Error::Configuration(
                 "update_layout: malformed response (missing `success`)".into(),
             )),
         }
@@ -1474,7 +1474,7 @@ impl SurfaceStore {
 
         let connection = self.inner.connection.lock();
         let stream = connection.as_ref().ok_or_else(|| {
-            StreamError::Configuration("SurfaceStore not connected to surface-share service".into())
+            Error::Configuration("SurfaceStore not connected to surface-share service".into())
         })?;
 
         let (response, received_fds) = streamlib_surface_client::send_request_with_fds(
@@ -1484,21 +1484,21 @@ impl SurfaceStore {
             streamlib_surface_client::MAX_DMA_BUF_PLANES,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Unix socket lookup_texture failed: {}", e))
+            Error::Configuration(format!("Unix socket lookup_texture failed: {}", e))
         })?;
 
         if let Some(error) = response.get("error").and_then(|v: &serde_json::Value| v.as_str()) {
             for fd in &received_fds {
                 unsafe { libc::close(*fd) };
             }
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "lookup_texture: {}",
                 error
             )));
         }
 
         if received_fds.is_empty() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "lookup_texture: no DMA-BUF fd in response".into(),
             ));
         }
@@ -1512,21 +1512,21 @@ impl SurfaceStore {
             .get("width")
             .and_then(|v| v.as_u64())
             .ok_or_else(|| {
-                StreamError::Configuration("lookup_texture: missing width in response".into())
+                Error::Configuration("lookup_texture: missing width in response".into())
             })? as u32;
 
         let height = response
             .get("height")
             .and_then(|v| v.as_u64())
             .ok_or_else(|| {
-                StreamError::Configuration("lookup_texture: missing height in response".into())
+                Error::Configuration("lookup_texture: missing height in response".into())
             })? as u32;
 
         let format_str = response
             .get("format")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                StreamError::Configuration("lookup_texture: missing format in response".into())
+                Error::Configuration("lookup_texture: missing format in response".into())
             })?;
 
         use crate::core::rhi::TextureFormat;
@@ -1540,7 +1540,7 @@ impl SurfaceStore {
             "Rgba32Float" => TextureFormat::Rgba32Float,
             "Nv12" => TextureFormat::Nv12,
             _ => {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "lookup_texture: unknown format '{}'",
                     format_str
                 )));
@@ -1553,7 +1553,7 @@ impl SurfaceStore {
             crate::vulkan::rhi::vulkan_pixel_buffer::VULKAN_DEVICE_FOR_IMPORT
                 .get()
                 .ok_or_else(|| {
-                    StreamError::NotSupported(
+                    Error::NotSupported(
                         "lookup_texture: HostVulkanDevice not initialized for import".into(),
                     )
                 })?;
@@ -1608,7 +1608,7 @@ impl SurfaceStore {
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub fn connect(&self) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
@@ -1620,28 +1620,28 @@ impl SurfaceStore {
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub fn check_in(&self, _pixel_buffer: &RhiPixelBuffer) -> Result<String> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub fn check_out(&self, _surface_id: &str) -> Result<RhiPixelBuffer> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub fn register_buffer(&self, _pool_id: &str, _pixel_buffer: &RhiPixelBuffer) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     pub fn lookup_buffer(&self, _pool_id: &str) -> Result<RhiPixelBuffer> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
@@ -1660,7 +1660,7 @@ impl SurfaceStore {
         _timeline: Option<&()>,
         _current_image_layout: i32,
     ) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "Texture registration not supported on this platform".into(),
         ))
     }
@@ -1670,7 +1670,7 @@ impl SurfaceStore {
         &self,
         _surface_id: &str,
     ) -> Result<(crate::core::rhi::StreamTexture, i32)> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "Texture lookup not supported on this platform".into(),
         ))
     }
@@ -1681,7 +1681,7 @@ impl SurfaceStore {
         _surface_id: &str,
         _layout: i32,
     ) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "update_image_layout not supported on this platform".into(),
         ))
     }

--- a/libs/streamlib-engine/src/core/context/texture_pool.rs
+++ b/libs/streamlib-engine/src/core/context/texture_pool.rs
@@ -12,7 +12,7 @@ use parking_lot::{Condvar, Mutex};
 use crate::core::rhi::{
     GpuDevice, NativeTextureHandle, StreamTexture, TextureDescriptor, TextureFormat, TextureUsages,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Request descriptor for acquiring a pooled texture.
 #[derive(Clone, Debug)]
@@ -378,12 +378,12 @@ impl TexturePool {
                     self.inner.add_slot(Arc::clone(&slot));
                     Ok(self.create_handle_from_slot(&slot))
                 } else {
-                    Err(StreamError::TextureError(
+                    Err(Error::TextureError(
                         "Texture pool exhausted (max size reached)".into(),
                     ))
                 }
             }
-            TexturePoolExhaustionPolicy::ReturnError => Err(StreamError::TextureError(
+            TexturePoolExhaustionPolicy::ReturnError => Err(Error::TextureError(
                 "Texture pool exhausted (no available slots)".into(),
             )),
         }
@@ -406,7 +406,7 @@ impl TexturePool {
             // Check timeout
             let now = std::time::Instant::now();
             if now >= deadline {
-                return Err(StreamError::TextureError(format!(
+                return Err(Error::TextureError(format!(
                     "Texture pool exhausted (timeout after {}ms)",
                     timeout_ms
                 )));
@@ -422,7 +422,7 @@ impl TexturePool {
                 if let Some(slot) = self.inner.find_available_slot(key) {
                     return Ok(self.create_handle_from_slot(&slot));
                 }
-                return Err(StreamError::TextureError(format!(
+                return Err(Error::TextureError(format!(
                     "Texture pool exhausted (timeout after {}ms)",
                     timeout_ms
                 )));

--- a/libs/streamlib-engine/src/core/error.rs
+++ b/libs/streamlib-engine/src/core/error.rs
@@ -1,10 +1,8 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum StreamError {
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
     #[error("GPU operation failed: {0}")]
     GpuError(String),
 
@@ -78,15 +76,15 @@ pub enum StreamError {
     Other(#[from] anyhow::Error),
 }
 
-pub type Result<T> = std::result::Result<T, StreamError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(target_os = "linux")]
-impl From<streamlib_consumer_rhi::ConsumerRhiError> for StreamError {
+impl From<streamlib_consumer_rhi::ConsumerRhiError> for Error {
     fn from(e: streamlib_consumer_rhi::ConsumerRhiError) -> Self {
         match e {
-            streamlib_consumer_rhi::ConsumerRhiError::Gpu(s) => StreamError::GpuError(s),
+            streamlib_consumer_rhi::ConsumerRhiError::Gpu(s) => Error::GpuError(s),
             streamlib_consumer_rhi::ConsumerRhiError::Configuration(s) => {
-                StreamError::Configuration(s)
+                Error::Configuration(s)
             }
         }
     }

--- a/libs/streamlib-engine/src/core/graph/validation.rs
+++ b/libs/streamlib-engine/src/core/graph/validation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::graph::{Link, ProcessorNode};
 use petgraph::algo::is_cyclic_directed;
 use petgraph::graph::DiGraph;
@@ -10,7 +10,7 @@ use petgraph::graph::DiGraph;
 pub fn validate_graph(graph: &DiGraph<ProcessorNode, Link>) -> Result<()> {
     // Check for cycles
     if is_cyclic_directed(graph) {
-        return Err(StreamError::InvalidGraph("Graph contains cycles".into()));
+        return Err(Error::InvalidGraph("Graph contains cycles".into()));
     }
 
     // Future validation:

--- a/libs/streamlib-engine/src/core/graph_file.rs
+++ b/libs/streamlib-engine/src/core/graph_file.rs
@@ -24,7 +24,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::core::descriptors::SchemaIdent;
-use crate::core::{ProcessorSpec, Result, StreamError};
+use crate::core::{ProcessorSpec, Result, Error};
 
 /// Declarative graph definition loaded from JSON/YAML files.
 ///
@@ -100,7 +100,7 @@ impl ConnectionDefinition {
 fn parse_port_ref(s: &str) -> Result<ParsedPortRef<'_>> {
     let parts: Vec<&str> = s.splitn(2, '.').collect();
     if parts.len() != 2 {
-        return Err(StreamError::GraphError(format!(
+        return Err(Error::GraphError(format!(
             "Invalid port reference '{}', expected 'alias.port_name'",
             s
         )));
@@ -122,7 +122,7 @@ impl GraphFileDefinition {
     /// Load from a JSON file path.
     pub fn from_json_file(path: &std::path::Path) -> Result<Self> {
         let file = std::fs::File::open(path).map_err(|e| {
-            StreamError::GraphError(format!(
+            Error::GraphError(format!(
                 "Failed to open graph file '{}': {}",
                 path.display(),
                 e
@@ -130,7 +130,7 @@ impl GraphFileDefinition {
         })?;
 
         serde_json::from_reader(file).map_err(|e| {
-            StreamError::GraphError(format!(
+            Error::GraphError(format!(
                 "Failed to parse graph file '{}': {}",
                 path.display(),
                 e
@@ -141,7 +141,7 @@ impl GraphFileDefinition {
     /// Load from a JSON string.
     pub fn from_json_str(json: &str) -> Result<Self> {
         serde_json::from_str(json)
-            .map_err(|e| StreamError::GraphError(format!("Failed to parse graph JSON: {}", e)))
+            .map_err(|e| Error::GraphError(format!("Failed to parse graph JSON: {}", e)))
     }
 
     /// Validate the graph definition without loading it.
@@ -157,7 +157,7 @@ impl GraphFileDefinition {
         let mut aliases: HashSet<&str> = HashSet::new();
         for proc in &self.processors {
             if !aliases.insert(proc.alias.as_str()) {
-                return Err(StreamError::GraphError(format!(
+                return Err(Error::GraphError(format!(
                     "Duplicate processor alias: '{}'",
                     proc.alias
                 )));
@@ -170,13 +170,13 @@ impl GraphFileDefinition {
             let to = conn.parse_to()?;
 
             if !aliases.contains(&from.alias) {
-                return Err(StreamError::GraphError(format!(
+                return Err(Error::GraphError(format!(
                     "Connection references unknown processor alias: '{}'",
                     from.alias
                 )));
             }
             if !aliases.contains(&to.alias) {
-                return Err(StreamError::GraphError(format!(
+                return Err(Error::GraphError(format!(
                     "Connection references unknown processor alias: '{}'",
                     to.alias
                 )));

--- a/libs/streamlib-engine/src/core/prelude.rs
+++ b/libs/streamlib-engine/src/core/prelude.rs
@@ -5,7 +5,7 @@
 
 pub use crate::core::{
     // Errors
-    error::{Result, StreamError},
+    error::{Result, Error},
 
     // Graph
     graph::{LinkUniqueId, ProcessorUniqueId},

--- a/libs/streamlib-engine/src/core/processors/__generated_private/generated_processor.rs
+++ b/libs/streamlib-engine/src/core/processors/__generated_private/generated_processor.rs
@@ -39,7 +39,7 @@ pub trait GeneratedProcessor: Send + 'static {
         Self: Sized,
     {
         let config: Self::Config = serde_json::from_value(config_json.clone())
-            .map_err(|e| crate::core::StreamError::Config(e.to_string()))?;
+            .map_err(|e| crate::core::Error::Config(e.to_string()))?;
         self.update_config(config)
     }
 
@@ -121,7 +121,7 @@ pub trait GeneratedProcessor: Send + 'static {
     ///
     /// Only valid for Manual execution mode. Returns an error for other modes.
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        Err(crate::core::StreamError::Runtime(
+        Err(crate::core::Error::Runtime(
             "start() is only valid for Manual execution mode".into(),
         ))
     }
@@ -130,7 +130,7 @@ pub trait GeneratedProcessor: Send + 'static {
     ///
     /// Only valid for Manual execution mode. Returns an error for other modes.
     fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        Err(crate::core::StreamError::Runtime(
+        Err(crate::core::Error::Runtime(
             "stop() is only valid for Manual execution mode".into(),
         ))
     }

--- a/libs/streamlib-engine/src/core/processors/api_server.rs
+++ b/libs/streamlib-engine/src/core/processors/api_server.rs
@@ -307,7 +307,7 @@ impl crate::core::ManualProcessor for ApiServerProcessor::Processor {
                         continue;
                     }
                     Err(e) => {
-                        return Err(crate::core::StreamError::Other(anyhow::anyhow!(
+                        return Err(crate::core::Error::Other(anyhow::anyhow!(
                             "Failed to bind to {}: {}",
                             addr,
                             e
@@ -315,7 +315,7 @@ impl crate::core::ManualProcessor for ApiServerProcessor::Processor {
                     }
                 }
             }
-            Err(crate::core::StreamError::Other(anyhow::anyhow!(
+            Err(crate::core::Error::Other(anyhow::anyhow!(
                 "Could not find available port in range {}-{}",
                 base_port,
                 base_port + 9

--- a/libs/streamlib-engine/src/core/processors/clap_effect.rs
+++ b/libs/streamlib-engine/src/core/processors/clap_effect.rs
@@ -68,66 +68,66 @@ pub struct ClapEffectProcessor {
 
 impl ClapEffectProcessor::Processor {
     pub fn plugin_info(&self) -> Result<&PluginInfo> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_ref()
             .map(|h| h.plugin_info())
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))
     }
 
     pub fn list_parameters(&self) -> Result<Vec<ParameterInfo>> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_ref()
             .map(|h| h.list_parameters())
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))
     }
 
     pub fn get_parameter(&self, id: u32) -> Result<f64> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .get_parameter(id)
     }
 
     pub fn set_parameter(&mut self, id: u32, value: f64) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .set_parameter(id, value)
     }
 
     pub fn begin_edit(&mut self, id: u32) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .begin_edit(id)
     }
 
     pub fn end_edit(&mut self, id: u32) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .end_edit(id)
     }
 
     pub fn activate(&mut self, sample_rate: u32, max_frames: usize) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .activate(sample_rate, max_frames)
     }
 
     pub fn deactivate(&mut self) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
         self.host
             .as_mut()
-            .ok_or_else(|| StreamError::Configuration("Plugin not initialized".into()))?
+            .ok_or_else(|| Error::Configuration("Plugin not initialized".into()))?
             .deactivate()
     }
 }

--- a/libs/streamlib-engine/src/core/processors/moq_publish_track.rs
+++ b/libs/streamlib-engine/src/core/processors/moq_publish_track.rs
@@ -8,7 +8,7 @@
 // and publishes the bytes as-is to the shared MoQ relay session.
 
 use crate::core::streaming::MoqPublishSession;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -78,7 +78,7 @@ impl crate::core::ReactiveProcessor for MoqPublishTrackProcessor::Processor {
         let mut session = self
             .shared_publish_session
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("MoQ session not connected".into()))?
+            .ok_or_else(|| Error::Runtime("MoQ session not connected".into()))?
             .lock();
 
         // Detect keyframe by checking the is_keyframe field in the serialized EncodedVideoFrame.

--- a/libs/streamlib-engine/src/core/processors/moq_subscribe_track.rs
+++ b/libs/streamlib-engine/src/core/processors/moq_subscribe_track.rs
@@ -11,7 +11,7 @@
 
 use crate::core::media_clock::MediaClock;
 use crate::core::streaming::{MoqSubscribeSession, MoqTrackReader};
-use crate::core::{Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use std::future::Future;
 use std::sync::Arc;
@@ -77,7 +77,7 @@ impl crate::core::ManualProcessor for MoqSubscribeTrackProcessor::Processor {
         let ctx = self
             .runtime_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("RuntimeContext not available".into()))?
+            .ok_or_else(|| Error::Runtime("RuntimeContext not available".into()))?
             .clone();
 
         let outputs = self.outputs.clone();

--- a/libs/streamlib-engine/src/core/processors/opus_decoder.rs
+++ b/libs/streamlib-engine/src/core/processors/opus_decoder.rs
@@ -7,7 +7,7 @@
 
 use crate::_generated_::{AudioFrame, EncodedAudioFrame};
 use crate::core::streaming::OpusDecoder;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 // ============================================================================
 // PROCESSOR
@@ -57,7 +57,7 @@ impl crate::core::ReactiveProcessor for OpusDecoderProcessor::Processor {
         let decoder = self
             .opus_decoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Opus decoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("Opus decoder not initialized".into()))?;
 
         let timestamp_ns: i64 = encoded.timestamp_ns.parse().unwrap_or(0);
         let frame: AudioFrame = decoder.decode_to_audio_frame(&encoded.data, timestamp_ns)?;

--- a/libs/streamlib-engine/src/core/processors/opus_encoder.rs
+++ b/libs/streamlib-engine/src/core/processors/opus_encoder.rs
@@ -7,7 +7,7 @@
 
 use crate::_generated_::{AudioFrame, EncodedAudioFrame};
 use crate::core::streaming::{AudioEncoderConfig, AudioEncoderOpus, OpusEncoder};
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 // ============================================================================
 // PROCESSOR
@@ -59,7 +59,7 @@ impl crate::core::ReactiveProcessor for OpusEncoderProcessor::Processor {
         let encoder = self
             .opus_encoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("Opus encoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("Opus encoder not initialized".into()))?;
 
         let encoded: EncodedAudioFrame = encoder.encode(&frame)?;
         self.outputs.write("encoded_audio_out", &encoded)?;

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use parking_lot::RwLock;
 
 use crate::core::descriptors::SchemaIdent;
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::graph::{PortInfo, ProcessorNode};
 use crate::core::processors::{DynGeneratedProcessor, GeneratedProcessor};
 use crate::core::pubsub::{topics, Event, RuntimeEvent, PUBSUB};
@@ -94,7 +94,7 @@ impl ProcessorInstanceFactory {
         }
         let count = self.constructors.read().len();
         if count == 0 {
-            return Err(crate::core::StreamError::RegistryFailed(
+            return Err(crate::core::Error::RegistryFailed(
                 "No processors registered. Ensure processor crates are linked and use #[streamlib::sdk::processor]".into()
             ));
         }
@@ -158,7 +158,7 @@ impl ProcessorInstanceFactory {
         let constructor: private::ConstructorFn = Box::new(move |node: &ProcessorNode| {
             let config: P::Config = match &node.config {
                 Some(json) => serde_json::from_value(json.clone()).map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Failed to deserialize config for '{}': {}",
                         node.id, e
                     ))
@@ -212,7 +212,7 @@ impl ProcessorInstanceFactory {
 
         // Check for duplicate registration
         if self.constructors.read().contains_key(&type_name) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Processor '{}' already registered",
                 type_name
             )));
@@ -282,7 +282,7 @@ impl ProcessorInstanceFactory {
         let type_name = descriptor.name.clone();
 
         if self.descriptors.read().contains_key(&type_name) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Processor '{}' already registered",
                 type_name
             )));
@@ -348,7 +348,7 @@ impl ProcessorInstanceFactory {
     pub fn create(&self, node: &ProcessorNode) -> Result<ProcessorInstance> {
         let constructors = self.constructors.read();
         let constructor = constructors.get(&node.processor_type).ok_or_else(|| {
-            StreamError::ProcessorNotFound(format!(
+            Error::ProcessorNotFound(format!(
                 "No factory registered for processor type '{}'",
                 node.processor_type
             ))
@@ -454,7 +454,7 @@ mod tests {
             .expect_err("duplicate 4-tuple must be rejected");
 
         match err {
-            StreamError::Configuration(msg) => {
+            Error::Configuration(msg) => {
                 assert!(
                     msg.contains("already registered"),
                     "error must name the collision; got: {msg}"

--- a/libs/streamlib-engine/src/core/processors/webrtc_whep.rs
+++ b/libs/streamlib-engine/src/core/processors/webrtc_whep.rs
@@ -10,7 +10,7 @@
 use crate::_generated_::{EncodedAudioFrame, EncodedVideoFrame};
 use crate::core::media_clock::MediaClock;
 use crate::core::streaming::{H264RtpDepacketizer, RtpSample, WhepClient, WhepConfig};
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use std::future::Future;
 use std::sync::Arc;
@@ -95,14 +95,14 @@ impl crate::core::ManualProcessor for WebRtcWhepProcessor::Processor {
         let client = self
             .whep_client
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("WhepClient not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("WhepClient not initialized".into()))?;
 
         let video_rx = client
             .take_video_rx()
-            .ok_or_else(|| StreamError::Runtime("Video receiver not available".into()))?;
+            .ok_or_else(|| Error::Runtime("Video receiver not available".into()))?;
         let audio_rx = client
             .take_audio_rx()
-            .ok_or_else(|| StreamError::Runtime("Audio receiver not available".into()))?;
+            .ok_or_else(|| Error::Runtime("Audio receiver not available".into()))?;
 
         let outputs = self.outputs.clone();
         let audio_sample_rate = self.audio_sample_rate.unwrap_or(48000);

--- a/libs/streamlib-engine/src/core/processors/webrtc_whip.rs
+++ b/libs/streamlib-engine/src/core/processors/webrtc_whip.rs
@@ -10,7 +10,7 @@
 use crate::_generated_::{EncodedAudioFrame, EncodedVideoFrame};
 use crate::core::streaming::{convert_audio_to_sample, convert_video_to_samples};
 use crate::core::streaming::{WhipClient, WhipConfig};
-use crate::core::{media_clock::MediaClock, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{media_clock::MediaClock, Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 use std::sync::Arc;
 use tokio::sync::mpsc as tokio_mpsc;
 
@@ -132,7 +132,7 @@ impl WebRtcWhipProcessor::Processor {
         let client = self
             .whip_client
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("WhipClient not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("WhipClient not initialized".into()))?;
 
         tokio_handle.block_on(
             client.connect(self.config.video.bitrate_bps, self.config.audio.bitrate_bps),
@@ -145,7 +145,7 @@ impl WebRtcWhipProcessor::Processor {
         let mut client = self
             .whip_client
             .take()
-            .ok_or_else(|| StreamError::Runtime("WhipClient not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("WhipClient not initialized".into()))?;
 
         let (sender, mut receiver) = tokio_mpsc::channel::<WhipClientMessage>(8);
 
@@ -188,7 +188,7 @@ impl WebRtcWhipProcessor::Processor {
         let samples = convert_video_to_samples(encoded, fps)?;
 
         let sender = self.whip_client_message_sender.as_ref().ok_or_else(|| {
-            StreamError::Runtime("WHIP client channel not initialized".into())
+            Error::Runtime("WHIP client channel not initialized".into())
         })?;
 
         for sample in samples {
@@ -198,7 +198,7 @@ impl WebRtcWhipProcessor::Processor {
                     tracing::warn!("[WebRtcWhip] Video channel full, dropping frame");
                 }
                 Err(tokio_mpsc::error::TrySendError::Closed(_)) => {
-                    return Err(StreamError::Runtime("WHIP client channel closed".into()));
+                    return Err(Error::Runtime("WHIP client channel closed".into()));
                 }
             }
         }
@@ -215,7 +215,7 @@ impl WebRtcWhipProcessor::Processor {
         let sample = convert_audio_to_sample(encoded, self.config.audio.sample_rate)?;
 
         let sender = self.whip_client_message_sender.as_ref().ok_or_else(|| {
-            StreamError::Runtime("WHIP client channel not initialized".into())
+            Error::Runtime("WHIP client channel not initialized".into())
         })?;
 
         match sender.try_send(WhipClientMessage::AudioSample(sample)) {
@@ -224,7 +224,7 @@ impl WebRtcWhipProcessor::Processor {
                 tracing::warn!("[WebRtcWhip] Audio channel full, dropping frame");
             }
             Err(tokio_mpsc::error::TrySendError::Closed(_)) => {
-                return Err(StreamError::Runtime("WHIP client channel closed".into()));
+                return Err(Error::Runtime("WHIP client channel closed".into()));
             }
         }
 

--- a/libs/streamlib-engine/src/core/rhi/compute_kernel.rs
+++ b/libs/streamlib-engine/src/core/rhi/compute_kernel.rs
@@ -10,7 +10,7 @@
 
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Kind of resource bound at a particular slot in a compute kernel's
 /// descriptor set.
@@ -96,17 +96,17 @@ pub fn derive_bindings_from_spirv(
     spv: &[u8],
 ) -> Result<(Vec<ComputeBindingSpec>, u32)> {
     let reflection = Reflection::new_from_spirv(spv).map_err(|e| {
-        StreamError::GpuError(format!("Failed to reflect SPIR-V: {e:?}"))
+        Error::GpuError(format!("Failed to reflect SPIR-V: {e:?}"))
     })?;
 
     let sets = reflection.get_descriptor_sets().map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Failed to extract descriptor sets from SPIR-V: {e:?}"
         ))
     })?;
 
     if sets.len() > 1 {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Only descriptor set 0 is supported; SPIR-V uses sets {:?}",
             sets.keys().collect::<Vec<_>>()
         )));
@@ -122,7 +122,7 @@ pub fn derive_bindings_from_spirv(
         entries.sort_by_key(|(b, _)| *b);
         for (binding, ty) in entries {
             let kind = spirv_type_to_kind(ty).ok_or_else(|| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "SPIR-V binding {binding} has unsupported descriptor type {ty:?}"
                 ))
             })?;
@@ -133,7 +133,7 @@ pub fn derive_bindings_from_spirv(
     let push_size = reflection
         .get_push_constant_range()
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to read push-constant range from SPIR-V: {e:?}"
             ))
         })?

--- a/libs/streamlib-engine/src/core/rhi/external_handle.rs
+++ b/libs/streamlib-engine/src/core/rhi/external_handle.rs
@@ -117,10 +117,10 @@ pub trait RhiPixelBufferImport {
     {
         match handles {
             [only] => Self::from_external_handle(only.clone(), width, height, format),
-            [] => Err(crate::core::StreamError::Configuration(
+            [] => Err(crate::core::Error::Configuration(
                 "from_external_plane_handles: empty plane vec".into(),
             )),
-            _ => Err(crate::core::StreamError::NotSupported(
+            _ => Err(crate::core::Error::NotSupported(
                 "multi-plane import is only implemented on Linux today".into(),
             )),
         }
@@ -157,7 +157,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
         format: super::PixelFormat,
     ) -> Result<Self> {
         if handles.is_empty() {
-            return Err(crate::core::StreamError::Configuration(
+            return Err(crate::core::Error::Configuration(
                 "DMA-BUF import: empty plane vec".into(),
             ));
         }
@@ -167,7 +167,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
         // is unit-testable without a live `HostVulkanDevice`.
         for h in handles {
             if let RhiExternalHandle::OpaqueFd { .. } = h {
-                return Err(crate::core::StreamError::NotSupported(
+                return Err(crate::core::Error::NotSupported(
                     "RhiPixelBufferImport::from_external_plane_handles: \
                      OPAQUE_FD handles must be imported via \
                      ConsumerVulkanPixelBuffer::from_opaque_fd, not \
@@ -181,7 +181,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
             crate::vulkan::rhi::vulkan_pixel_buffer::VULKAN_DEVICE_FOR_IMPORT
                 .get()
                 .ok_or_else(|| {
-                    crate::core::StreamError::NotSupported(
+                    crate::core::Error::NotSupported(
                         "DMA-BUF import: HostVulkanDevice not initialized (GpuDevice::new() not called)"
                             .into(),
                     )
@@ -189,7 +189,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
 
         let bytes_per_pixel = format.bits_per_pixel() / 8;
         if bytes_per_pixel == 0 {
-            return Err(crate::core::StreamError::Configuration(
+            return Err(crate::core::Error::Configuration(
                 "DMA-BUF import: unsupported pixel format (0 bits per pixel)".into(),
             ));
         }
@@ -216,7 +216,7 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
                 // legacy single-plane callers that don't pass a size).
                 (width as u64) * (height as u64) * (bytes_per_pixel as u64)
             } else {
-                return Err(crate::core::StreamError::Configuration(format!(
+                return Err(crate::core::Error::Configuration(format!(
                     "DMA-BUF import: plane {} has size=0 and cannot be derived",
                     idx
                 )));
@@ -283,7 +283,7 @@ mod tests {
                 super::super::PixelFormat::Bgra32,
             );
         match result {
-            Err(crate::core::StreamError::NotSupported(msg)) => {
+            Err(crate::core::Error::NotSupported(msg)) => {
                 assert!(
                     msg.contains("OPAQUE_FD"),
                     "error message must mention OPAQUE_FD: {msg}"

--- a/libs/streamlib-engine/src/core/rhi/format_converter.rs
+++ b/libs/streamlib-engine/src/core/rhi/format_converter.rs
@@ -47,14 +47,14 @@ impl RhiFormatConverter {
         #[cfg(target_os = "linux")]
         {
             let _ = (source_format, dest_format);
-            Err(crate::core::StreamError::NotSupported(
+            Err(crate::core::Error::NotSupported(
                 "RhiFormatConverter::new requires Vulkan device/queue — use VulkanFormatConverter directly".into(),
             ))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = (source_format, dest_format);
-            Err(crate::core::StreamError::Configuration(
+            Err(crate::core::Error::Configuration(
                 "RhiFormatConverter not implemented for this platform".into(),
             ))
         }
@@ -108,14 +108,14 @@ impl RhiFormatConverter {
         #[cfg(target_os = "linux")]
         {
             let _ = (source, dest);
-            Err(crate::core::StreamError::NotSupported(
+            Err(crate::core::Error::NotSupported(
                 "Vulkan format conversion not yet implemented".into(),
             ))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = (source, dest);
-            Err(crate::core::StreamError::Configuration(
+            Err(crate::core::Error::Configuration(
                 "RhiFormatConverter not implemented for this platform".into(),
             ))
         }

--- a/libs/streamlib-engine/src/core/rhi/gl_interop.rs
+++ b/libs/streamlib-engine/src/core/rhi/gl_interop.rs
@@ -12,7 +12,7 @@
 //! - Windows: DXGI → GL texture via `WGL_NV_DX_interop` (future)
 
 use crate::core::rhi::RhiPixelBuffer;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use std::ffi::c_void;
 
 /// OpenGL texture target constants.
@@ -150,7 +150,7 @@ impl GlTextureBinding {
         #[cfg(not(target_os = "macos"))]
         {
             let _ = (gl_ctx, buffer);
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL texture binding not supported on this platform".into(),
             ))
         }
@@ -182,19 +182,19 @@ impl GlContext {
         }
         #[cfg(target_os = "linux")]
         {
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL interop not yet implemented for Linux".into(),
             ))
         }
         #[cfg(target_os = "windows")]
         {
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL interop not yet implemented for Windows".into(),
             ))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         {
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL interop not supported on this platform".into(),
             ))
         }
@@ -213,7 +213,7 @@ impl GlContext {
         }
         #[cfg(not(target_os = "macos"))]
         {
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL interop not supported on this platform".into(),
             ))
         }
@@ -277,7 +277,7 @@ impl GlContext {
         }
         #[cfg(not(target_os = "macos"))]
         {
-            Err(StreamError::NotSupported(
+            Err(Error::NotSupported(
                 "GL texture binding not supported on this platform".into(),
             ))
         }

--- a/libs/streamlib-engine/src/core/rhi/graphics_kernel.rs
+++ b/libs/streamlib-engine/src/core/rhi/graphics_kernel.rs
@@ -14,7 +14,7 @@
 
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::TextureFormat;
 
@@ -573,19 +573,19 @@ pub fn derive_bindings_from_spirv_multistage(
     for stage in stages {
         let stage_flag = stage_to_flag(stage.stage);
         let reflection = Reflection::new_from_spirv(stage.spv).map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel: failed to reflect SPIR-V for {:?} stage: {e:?}",
                 stage.stage
             ))
         })?;
         let sets = reflection.get_descriptor_sets().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel: failed to extract descriptor sets for {:?} stage: {e:?}",
                 stage.stage
             ))
         })?;
         if sets.len() > 1 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel: only descriptor set 0 is supported; SPIR-V {:?} stage uses sets {:?}",
                 stage.stage,
                 sets.keys().collect::<Vec<_>>()
@@ -594,14 +594,14 @@ pub fn derive_bindings_from_spirv_multistage(
         if let Some(set0) = sets.get(&0) {
             for (&binding, info) in set0 {
                 let kind = spirv_type_to_kind(info.ty).ok_or_else(|| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel: SPIR-V {:?} stage binding {binding} has unsupported descriptor type {:?}",
                         stage.stage, info.ty
                     ))
                 })?;
                 let entry = merged.entry(binding).or_insert((kind, GraphicsShaderStageFlags::NONE));
                 if entry.0 != kind {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Graphics kernel: binding {binding} kind conflict — {:?} vs {:?} (introduced by {:?})",
                         entry.0, kind, stage.stage
                     )));
@@ -610,7 +610,7 @@ pub fn derive_bindings_from_spirv_multistage(
             }
         }
         if let Some(info) = reflection.get_push_constant_range().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel: failed to read push-constant range for {:?} stage: {e:?}",
                 stage.stage
             ))

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer_pool.rs
@@ -100,7 +100,7 @@ impl RhiPixelBufferPool {
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
-            Err(crate::core::StreamError::Configuration(
+            Err(crate::core::Error::Configuration(
                 "RhiPixelBufferPool not implemented for this platform".into(),
             ))
         }

--- a/libs/streamlib-engine/src/core/rhi/ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/core/rhi/ray_tracing_kernel.rs
@@ -13,7 +13,7 @@
 //! declarations, and from that point on the caller binds resources by
 //! slot via simple typed setters.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Shader stages that contribute to a ray-tracing pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -278,7 +278,7 @@ pub fn validate_shader_groups(
     groups: &[RayTracingShaderGroup],
 ) -> Result<()> {
     if groups.is_empty() {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Ray-tracing kernel '{label}': at least one shader group is required"
         )));
     }
@@ -291,7 +291,7 @@ pub fn validate_shader_groups(
                     | RayTracingShaderStage::Miss
                     | RayTracingShaderStage::Callable => {}
                     other => {
-                        return Err(StreamError::GpuError(format!(
+                        return Err(Error::GpuError(format!(
                             "Ray-tracing kernel '{label}': group {group_idx} declares General with stage index pointing to {other:?}; must be RayGen / Miss / Callable"
                         )));
                     }
@@ -302,7 +302,7 @@ pub fn validate_shader_groups(
                 any_hit,
             } => {
                 if closest_hit.is_none() && any_hit.is_none() {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Ray-tracing kernel '{label}': group {group_idx} TrianglesHit must set at least one of closest_hit / any_hit"
                     )));
                 }
@@ -377,7 +377,7 @@ fn stage_at(
         .get(stage_idx as usize)
         .map(|s| s.stage)
         .ok_or_else(|| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{label}': group {group_idx} field {field} references stage {stage_idx}, but only {} stages were declared",
                 stages.len()
             ))
@@ -394,7 +394,7 @@ fn expect_stage(
 ) -> Result<()> {
     let actual = stage_at(label, stages, field, group_idx, stage_idx)?;
     if actual != expected {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Ray-tracing kernel '{label}': group {group_idx} field {field} references stage {stage_idx} ({actual:?}); expected {expected:?}"
         )));
     }

--- a/libs/streamlib-engine/src/core/rhi/texture_cache.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture_cache.rs
@@ -38,14 +38,14 @@ impl RhiTextureCache {
             // but RhiPixelBuffer on Linux wraps a VkBuffer (not VkImage).
             // For now, return NotSupported until pixel buffer -> texture path is wired.
             let _ = buffer;
-            Err(crate::core::StreamError::NotSupported(
+            Err(crate::core::Error::NotSupported(
                 "Vulkan texture cache create_view not yet implemented".into(),
             ))
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = buffer;
-            Err(crate::core::StreamError::Configuration(
+            Err(crate::core::Error::Configuration(
                 "RhiTextureCache not implemented for this platform".into(),
             ))
         }

--- a/libs/streamlib-engine/src/core/rhi/texture_readback.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture_readback.rs
@@ -66,7 +66,7 @@ pub struct ReadbackTicket {
 /// Error taxonomy for the texture-readback RHI primitive.
 ///
 /// Named variants — each carries enough context to diagnose without
-/// re-running. `From<TextureReadbackError> for StreamError` (in the
+/// re-running. `From<TextureReadbackError> for Error` (in the
 /// host-side impl module) keeps callers in the existing `Result<T>`
 /// channel.
 #[derive(Debug, thiserror::Error)]

--- a/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -13,7 +13,7 @@ use crate::core::graph::{
 };
 use crate::core::processors::ProcessorSpec;
 use crate::core::pubsub::{topics, Event, RuntimeEvent, PUBSUB};
-use crate::core::{InputLinkPortRef, OutputLinkPortRef, Result, StreamError};
+use crate::core::{InputLinkPortRef, OutputLinkPortRef, Result, Error};
 
 // =============================================================================
 // Core Implementation Functions ('static async fns for spawn compatibility)
@@ -51,7 +51,7 @@ async fn add_processor_impl(
             .inspect(|node| emit_did_add(&node.id))
             .first()
             .map(|node| node.id.clone())
-            .ok_or_else(|| StreamError::GraphError("Could not create node".into()))
+            .ok_or_else(|| Error::GraphError("Could not create node".into()))
     })?;
 
     PUBSUB.publish(
@@ -69,7 +69,7 @@ async fn remove_processor_impl(
 ) -> Result<()> {
     compiler.scope(|graph, tx| {
         if !graph.traversal().v(&processor_id).exists() {
-            return Err(StreamError::ProcessorNotFound(processor_id.to_string()));
+            return Err(Error::ProcessorNotFound(processor_id.to_string()));
         }
 
         if let Some(node) = graph.traversal_mut().v(&processor_id).first_mut() {
@@ -131,9 +131,9 @@ async fn connect_impl(
             .inspect(|link| tx.log(PendingOperation::AddLink(link.id.clone())))
             .first()
             .map(|link| link.id.clone())
-            .ok_or_else(|| StreamError::GraphError("failed to create link".into()))?;
+            .ok_or_else(|| Error::GraphError("failed to create link".into()))?;
 
-        Ok::<_, StreamError>(id)
+        Ok::<_, Error>(id)
     })?;
 
     PUBSUB.publish(
@@ -161,7 +161,7 @@ async fn disconnect_impl(compiler: Arc<Compiler>, link_id: LinkUniqueId) -> Resu
             .e(&link_id)
             .first()
             .map(|l| (l.from_port(), l.to_port()))
-            .ok_or_else(|| StreamError::NotFound(format!("Link '{}' not found", link_id)))?;
+            .ok_or_else(|| Error::NotFound(format!("Link '{}' not found", link_id)))?;
 
         let info = (
             OutputLinkPortRef::new(from_value.processor_id.clone(), to_value.port_name.clone()),
@@ -174,7 +174,7 @@ async fn disconnect_impl(compiler: Arc<Compiler>, link_id: LinkUniqueId) -> Resu
 
         tx.log(PendingOperation::RemoveLink(link_id.clone()));
 
-        Ok::<_, StreamError>(info)
+        Ok::<_, Error>(info)
     })?;
 
     PUBSUB.publish(
@@ -257,7 +257,7 @@ impl RuntimeOperations for Runner {
                     let _ = tx.send(result);
                 });
                 rx.recv()
-                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
             }
         }
     }
@@ -276,7 +276,7 @@ impl RuntimeOperations for Runner {
                     let _ = tx.send(result);
                 });
                 rx.recv()
-                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
             }
         }
     }
@@ -292,7 +292,7 @@ impl RuntimeOperations for Runner {
                     let _ = tx.send(result);
                 });
                 rx.recv()
-                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
             }
         }
     }
@@ -311,7 +311,7 @@ impl RuntimeOperations for Runner {
                     let _ = tx.send(result);
                 });
                 rx.recv()
-                    .map_err(|_| StreamError::Runtime("Task channel closed".into()))?
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
             }
         }
     }

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -25,7 +25,7 @@ use crate::core::graph::{
 use crate::core::processors::ProcessorSpec;
 use crate::core::processors::ProcessorState;
 use crate::core::pubsub::{topics, Event, EventListener, ProcessorEvent, RuntimeEvent, PUBSUB};
-use crate::core::{InputLinkPortRef, OutputLinkPortRef, Result, StreamError};
+use crate::core::{InputLinkPortRef, OutputLinkPortRef, Result, Error};
 use crate::iceoryx2::Iceoryx2Node;
 
 /// Keeps loaded dylib plugin libraries alive for the process lifetime.
@@ -144,7 +144,7 @@ impl Runner {
                     .enable_all()
                     .build()
                     .map_err(|e| {
-                        StreamError::Runtime(format!("Failed to create tokio runtime: {}", e))
+                        Error::Runtime(format!("Failed to create tokio runtime: {}", e))
                     })?;
                 TokioRuntimeVariant::OwnedTokioRuntime(rt)
             }
@@ -170,7 +170,7 @@ impl Runner {
                 Arc::clone(&runtime_id),
             ),
         )
-        .map_err(|e| StreamError::Runtime(format!("Failed to initialize logging: {}", e)))?;
+        .map_err(|e| Error::Runtime(format!("Failed to initialize logging: {}", e)))?;
         tracing::info!("Creating Runner with ID: {}", runtime_id);
 
         // Get STREAMLIB_HOME and run init hooks (once per process)
@@ -284,7 +284,7 @@ impl Runner {
         config: C,
     ) -> Result<()> {
         let config_json = serde_json::to_value(&config)
-            .map_err(|e| crate::core::StreamError::Config(e.to_string()))?;
+            .map_err(|e| crate::core::Error::Config(e.to_string()))?;
 
         // Update config in graph and queue operation
         self.compiler.scope(|graph, tx| {
@@ -415,7 +415,7 @@ impl Runner {
         // registered processor in this manifest uses these typed segments
         // to compose its full structured `SchemaIdent`.
         let package_metadata = config.package.as_ref().ok_or_else(|| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 "{} at {} declares processors but is missing a `package:` block. \
                  The structured-everywhere processor identity rule requires \
                  `package: {{ org, name, version }}` to compose each processor's \
@@ -430,7 +430,7 @@ impl Runner {
             // package metadata + the processor's PascalCase short name.
             let proc_type_name = streamlib_processor_schema::TypeName::new(&proc_schema.name)
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "processor short name `{}` in {} is not valid PascalCase: {}",
                         proc_schema.name,
                         project_path.display(),
@@ -467,7 +467,7 @@ impl Runner {
 
                         let dylib_path = std::fs::read_dir(&lib_dir)
                             .map_err(|e| {
-                                StreamError::Configuration(format!(
+                                Error::Configuration(format!(
                                     "Failed to read lib/ directory at {}: {}",
                                     lib_dir.display(),
                                     e
@@ -477,7 +477,7 @@ impl Runner {
                             .map(|entry| entry.path())
                             .find(|path| path.extension().is_some_and(|ext| ext == dylib_ext))
                             .ok_or_else(|| {
-                                StreamError::Configuration(format!(
+                                Error::Configuration(format!(
                                     "No .{} file found in {}",
                                     dylib_ext,
                                     lib_dir.display()
@@ -491,7 +491,7 @@ impl Runner {
                         // a compatible streamlib-plugin-abi version.
                         let lib = unsafe {
                             libloading::Library::new(&dylib_path).map_err(|e| {
-                                StreamError::Configuration(format!(
+                                Error::Configuration(format!(
                                     "Failed to load dylib {}: {}",
                                     dylib_path.display(),
                                     e
@@ -503,7 +503,7 @@ impl Runner {
                             let symbol = lib
                                 .get::<*const PluginDeclaration>(b"STREAMLIB_PLUGIN\0")
                                 .map_err(|e| {
-                                    StreamError::Configuration(format!(
+                                    Error::Configuration(format!(
                                         "Plugin '{}' missing STREAMLIB_PLUGIN symbol. \
                                          Ensure the plugin uses the export_plugin! macro: {}",
                                         dylib_path.display(),
@@ -514,7 +514,7 @@ impl Runner {
                         };
 
                         if decl.abi_version != PLUGIN_ABI_VERSION {
-                            return Err(StreamError::Configuration(format!(
+                            return Err(Error::Configuration(format!(
                                 "ABI version mismatch for '{}': plugin has v{}, \
                                  runtime expects v{}. Rebuild the plugin with a \
                                  compatible streamlib-plugin-abi version.",
@@ -544,7 +544,7 @@ impl Runner {
                         .iter()
                         .any(|desc| desc.name == proc_schema_ident);
                     if !registered {
-                        return Err(StreamError::Configuration(format!(
+                        return Err(Error::Configuration(format!(
                             "Processor '{}' declared in streamlib.yaml but not \
                              registered by the dylib. Ensure export_plugin!() \
                              includes this processor.",
@@ -729,7 +729,7 @@ impl Runner {
             let surface_store =
                 SurfaceStore::new(socket_path.clone(), self.runtime_id.to_string());
             surface_store.connect().map_err(|e| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Failed to connect to runtime-internal surface-sharing service at {}: {}",
                     socket_path, e
                 ))
@@ -925,10 +925,10 @@ impl Runner {
                 .traversal()
                 .v(processor_id)
                 .first()
-                .ok_or_else(|| StreamError::ProcessorNotFound(processor_id.to_string()))?;
+                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))?;
 
             let pause_gate = node.get::<ProcessorPauseGateComponent>().ok_or_else(|| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Processor '{}' has no ProcessorPauseGate",
                     processor_id
                 ))
@@ -966,10 +966,10 @@ impl Runner {
                 .traversal()
                 .v(processor_id)
                 .first()
-                .ok_or_else(|| StreamError::ProcessorNotFound(processor_id.to_string()))?;
+                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))?;
 
             let pause_gate = node.get::<ProcessorPauseGateComponent>().ok_or_else(|| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Processor '{}' has no ProcessorPauseGate",
                     processor_id
                 ))
@@ -1006,11 +1006,11 @@ impl Runner {
                 .traversal()
                 .v(processor_id)
                 .first()
-                .ok_or_else(|| StreamError::ProcessorNotFound(processor_id.to_string()))?;
+                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))?;
 
             let pause_gate = node
                 .get::<ProcessorPauseGateComponent>()
-                .ok_or_else(|| StreamError::ProcessorNotFound(processor_id.to_string()))?;
+                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))?;
 
             Ok(pause_gate.is_paused())
         })
@@ -1122,7 +1122,7 @@ impl Runner {
     {
         // Install signal handlers
         crate::core::signals::install_signal_handlers().map_err(|e| {
-            crate::core::StreamError::Configuration(format!(
+            crate::core::Error::Configuration(format!(
                 "Failed to install signal handlers: {}",
                 e
             ))
@@ -1229,7 +1229,7 @@ impl Runner {
     pub fn to_json(&self) -> Result<serde_json::Value> {
         self.compiler.scope(|graph, _tx| {
             serde_json::to_value(&*graph)
-                .map_err(|_| StreamError::GraphError("Unable to serialize graph".into()))
+                .map_err(|_| Error::GraphError("Unable to serialize graph".into()))
         })
     }
 
@@ -1273,10 +1273,10 @@ impl Runner {
             let to = conn_def.parse_to()?;
 
             let from_id = alias_to_id.get(from.alias).ok_or_else(|| {
-                StreamError::GraphError(format!("Unknown processor alias: '{}'", from.alias))
+                Error::GraphError(format!("Unknown processor alias: '{}'", from.alias))
             })?;
             let to_id = alias_to_id.get(to.alias).ok_or_else(|| {
-                StreamError::GraphError(format!("Unknown processor alias: '{}'", to.alias))
+                Error::GraphError(format!("Unknown processor alias: '{}'", to.alias))
             })?;
 
             self.connect(
@@ -1357,7 +1357,7 @@ impl Runner {
                 if let Some(installed) = self.lookup_installed_package(dep_ref)? {
                     return Ok(installed);
                 }
-                Err(StreamError::Configuration(format!(
+                Err(Error::Configuration(format!(
                     "Dependency '{dep_ref}' could not be resolved. \
                      No matching `patch:` entry was found in {}/{}, and no matching \
                      package is installed (run `streamlib pkg list` to see \
@@ -1401,7 +1401,7 @@ impl Runner {
                     consumer_dir.join(&p.path)
                 };
                 if !abs.exists() {
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "patch entry for '{dep_ref}' in {}/{} points at \
                          `{}` which does not exist. Path patches are \
                          dev-time overrides — they must resolve to a \
@@ -1423,9 +1423,9 @@ impl Runner {
                     &g.rev,
                     &cache_dir,
                 )
-                .map_err(|e| StreamError::Configuration(e.to_string()))
+                .map_err(|e| Error::Configuration(e.to_string()))
             }
-            DependencySpec::Registry(_) => Err(StreamError::Configuration(format!(
+            DependencySpec::Registry(_) => Err(Error::Configuration(format!(
                 "patch entry for '{dep_ref}' in {}/{} is registry-flavored. \
                  The v1 resolver doesn't ship a registry — declare a \
                  `path:` or `git:` patch entry, or remove the patch and \
@@ -1461,17 +1461,17 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
     use crate::core::config::ProjectConfig;
 
     let slpkg_bytes = std::fs::read(slpkg_path).map_err(|e| {
-        StreamError::Configuration(format!("Failed to read {}: {}", slpkg_path.display(), e))
+        Error::Configuration(format!("Failed to read {}: {}", slpkg_path.display(), e))
     })?;
 
     let cursor = std::io::Cursor::new(&slpkg_bytes);
     let mut archive = zip::ZipArchive::new(cursor)
-        .map_err(|e| StreamError::Configuration(format!("Failed to open .slpkg archive: {}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to open .slpkg archive: {}", e)))?;
 
     // Read streamlib.yaml from archive to get name + version
     let manifest_yaml = {
         let mut manifest_file = archive.by_name(ProjectConfig::FILE_NAME).map_err(|e| {
-            StreamError::Configuration(format!(
+            Error::Configuration(format!(
                 ".slpkg archive missing {}: {}",
                 ProjectConfig::FILE_NAME,
                 e
@@ -1479,15 +1479,15 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
         })?;
         let mut contents = String::new();
         std::io::Read::read_to_string(&mut manifest_file, &mut contents)
-            .map_err(|e| StreamError::Configuration(format!("Failed to read manifest: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to read manifest: {}", e)))?;
         contents
     };
 
     let config: ProjectConfig = serde_yaml::from_str(&manifest_yaml)
-        .map_err(|e| StreamError::Configuration(format!("Failed to parse manifest: {}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to parse manifest: {}", e)))?;
 
     let package = config.package.as_ref().ok_or_else(|| {
-        StreamError::Configuration("streamlib.yaml missing [package] section".to_string())
+        Error::Configuration("streamlib.yaml missing [package] section".to_string())
     })?;
 
     let cache_key = format!("{}-{}", package.name, package.version);
@@ -1496,7 +1496,7 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
     // Always overwrite
     if cache_dir.exists() {
         std::fs::remove_dir_all(&cache_dir)
-            .map_err(|e| StreamError::Configuration(format!("Failed to clear cache dir: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to clear cache dir: {}", e)))?;
     }
 
     tracing::info!(
@@ -1505,24 +1505,24 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
         cache_dir.display()
     );
     std::fs::create_dir_all(&cache_dir)
-        .map_err(|e| StreamError::Configuration(format!("Failed to create cache dir: {}", e)))?;
+        .map_err(|e| Error::Configuration(format!("Failed to create cache dir: {}", e)))?;
 
     // Re-open archive (cursor consumed by manifest read)
     let cursor = std::io::Cursor::new(&slpkg_bytes);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| {
-        StreamError::Configuration(format!("Failed to re-open .slpkg archive: {}", e))
+        Error::Configuration(format!("Failed to re-open .slpkg archive: {}", e))
     })?;
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i).map_err(|e| {
-            StreamError::Configuration(format!("Failed to read archive entry: {}", e))
+            Error::Configuration(format!("Failed to read archive entry: {}", e))
         })?;
 
         let file_name = file.name().to_string();
 
         // Security: reject path traversal
         if file_name.contains("..") || file_name.starts_with('/') {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Invalid path in .slpkg archive: {}",
                 file_name
             )));
@@ -1532,16 +1532,16 @@ pub fn extract_slpkg_to_cache(slpkg_path: &std::path::Path) -> Result<std::path:
 
         if let Some(parent) = output_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                StreamError::Configuration(format!("Failed to create directory: {}", e))
+                Error::Configuration(format!("Failed to create directory: {}", e))
             })?;
         }
 
         let mut output_file = std::fs::File::create(&output_path).map_err(|e| {
-            StreamError::Configuration(format!("Failed to create {}: {}", output_path.display(), e))
+            Error::Configuration(format!("Failed to create {}: {}", output_path.display(), e))
         })?;
 
         std::io::copy(&mut file, &mut output_file).map_err(|e| {
-            StreamError::Configuration(format!("Failed to extract {}: {}", file_name, e))
+            Error::Configuration(format!("Failed to extract {}: {}", file_name, e))
         })?;
     }
 
@@ -1561,7 +1561,7 @@ fn bring_up_surface_service(
     use crate::linux::surface_share::{SurfaceShareState, UnixSocketSurfaceService};
 
     let xdg_runtime_dir = std::env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
-        StreamError::Runtime(
+        Error::Runtime(
             "XDG_RUNTIME_DIR is not set. The runtime needs a writable directory \
              for its per-runtime surface-sharing socket — typically /run/user/<uid>. \
              Set XDG_RUNTIME_DIR or run under a session manager that provides it."
@@ -1575,7 +1575,7 @@ fn bring_up_surface_service(
     if socket_path.exists() {
         match std::os::unix::net::UnixStream::connect(&socket_path) {
             Ok(_) => {
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "Surface-sharing socket {} is already bound by a live process. \
                      Each Runner requires a unique runtime_id; check for a \
                      duplicate STREAMLIB_RUNTIME_ID env var or another runtime in \
@@ -1585,7 +1585,7 @@ fn bring_up_surface_service(
             }
             Err(_) => {
                 std::fs::remove_file(&socket_path).map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Found stale surface-sharing socket {} from a prior crashed \
                          runtime but failed to remove it: {}",
                         socket_path.display(),
@@ -1602,7 +1602,7 @@ fn bring_up_surface_service(
 
     let mut service = UnixSocketSurfaceService::new(SurfaceShareState::new(), socket_path.clone());
     service.start().map_err(|e| {
-        StreamError::Runtime(format!(
+        Error::Runtime(format!(
             "Failed to start runtime-internal surface-sharing service at {}: {}",
             socket_path.display(),
             e

--- a/libs/streamlib-engine/src/core/runtime_hooks.rs
+++ b/libs/streamlib-engine/src/core/runtime_hooks.rs
@@ -78,7 +78,7 @@ pub fn run_init_hooks(streamlib_home: &Path) -> Result<()> {
 
     // If previously failed, return the cached error
     if let Some(err_msg) = INIT_FAILED.get() {
-        return Err(crate::StreamError::Runtime(err_msg.clone()));
+        return Err(crate::Error::Runtime(err_msg.clone()));
     }
 
     // Run hooks (first caller wins due to OnceLock semantics)

--- a/libs/streamlib-engine/src/core/streaming/h264_rtp.rs
+++ b/libs/streamlib-engine/src/core/streaming/h264_rtp.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use bytes::Bytes;
 use std::collections::HashMap;
 
@@ -48,7 +48,7 @@ impl H264RtpDepacketizer {
         seq_num: u16,
     ) -> Result<Vec<Bytes>> {
         if payload.is_empty() {
-            return Err(StreamError::Runtime("Empty RTP payload".into()));
+            return Err(Error::Runtime("Empty RTP payload".into()));
         }
 
         // First byte is NAL header (forbidden_zero_bit | nal_ref_idc | nal_unit_type)
@@ -78,7 +78,7 @@ impl H264RtpDepacketizer {
 
     fn process_fu_a(&mut self, payload: Bytes, timestamp: u32, seq_num: u16) -> Result<Vec<Bytes>> {
         if payload.len() < 2 {
-            return Err(StreamError::Runtime("FU-A packet too small".into()));
+            return Err(Error::Runtime("FU-A packet too small".into()));
         }
 
         let fu_indicator = payload[0];
@@ -213,7 +213,7 @@ impl H264RtpDepacketizer {
             offset += 2;
 
             if offset + nal_size > payload.len() {
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "STAP-A NAL size exceeds packet bounds: {} > {}",
                     offset + nal_size,
                     payload.len()

--- a/libs/streamlib-engine/src/core/streaming/moq_session.rs
+++ b/libs/streamlib-engine/src/core/streaming/moq_session.rs
@@ -7,7 +7,7 @@
 // Uses moq-transport (cloudflare/moq-rs) for the MoQ protocol and
 // web-transport-quinn for the underlying QUIC/WebTransport connection.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -99,7 +99,7 @@ impl MoqRelayConfig {
             self.broadcast_path.trim_start_matches('/')
         );
         url::Url::parse(&raw)
-            .map_err(|e| StreamError::Configuration(format!("Invalid MoQ relay URL '{raw}': {e}")))
+            .map_err(|e| Error::Configuration(format!("Invalid MoQ relay URL '{raw}': {e}")))
     }
 }
 
@@ -116,7 +116,7 @@ fn create_webtransport_client(
         rustls::ClientConfig::builder_with_provider(provider.clone())
             .with_protocol_versions(&[&rustls::version::TLS13])
             .map_err(|e| {
-                StreamError::Runtime(format!("TLS config failed: {e}"))
+                Error::Runtime(format!("TLS config failed: {e}"))
             })?
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(
@@ -128,13 +128,13 @@ fn create_webtransport_client(
         let native_certs = rustls_native_certs::load_native_certs();
         for cert in native_certs.certs {
             roots.add(cert).map_err(|e| {
-                StreamError::Runtime(format!("Failed to add root cert: {e}"))
+                Error::Runtime(format!("Failed to add root cert: {e}"))
             })?;
         }
         rustls::ClientConfig::builder_with_provider(provider)
             .with_protocol_versions(&[&rustls::version::TLS13])
             .map_err(|e| {
-                StreamError::Runtime(format!("TLS config failed: {e}"))
+                Error::Runtime(format!("TLS config failed: {e}"))
             })?
             .with_root_certificates(roots)
             .with_no_client_auth()
@@ -145,7 +145,7 @@ fn create_webtransport_client(
 
     let quic_client_config =
         quinn::crypto::rustls::QuicClientConfig::try_from(crypto).map_err(|e| {
-            StreamError::Runtime(format!("QUIC client config failed: {e}"))
+            Error::Runtime(format!("QUIC client config failed: {e}"))
         })?;
 
     let mut client_config = quinn::ClientConfig::new(Arc::new(quic_client_config));
@@ -155,7 +155,7 @@ fn create_webtransport_client(
     client_config.transport_config(Arc::new(transport));
 
     let endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap()).map_err(|e| {
-        StreamError::Runtime(format!("QUIC endpoint creation failed: {e}"))
+        Error::Runtime(format!("QUIC endpoint creation failed: {e}"))
     })?;
 
     tracing::info!(keep_alive_secs = 4, "QUIC transport configured with keep-alive");
@@ -193,7 +193,7 @@ impl MoqPublishSession {
         let client = create_webtransport_client(config.tls_disable_verify)?;
 
         let wt_session = client.connect(url).await.map_err(|e| {
-            StreamError::Runtime(format!("MoQ WebTransport connect failed: {e}"))
+            Error::Runtime(format!("MoQ WebTransport connect failed: {e}"))
         })?;
 
         // Convert web_transport_quinn::Session → web_transport::Session for moq-transport
@@ -207,7 +207,7 @@ impl MoqPublishSession {
             )
             .await
             .map_err(|e| {
-                StreamError::Runtime(format!("MoQ session connect failed: {e}"))
+                Error::Runtime(format!("MoQ session connect failed: {e}"))
             })?;
 
         // Run session event loop in background
@@ -281,7 +281,7 @@ impl MoqPublishSession {
         if needs_new_subgroup {
             let subgroups_writer = self.ensure_track_subgroups_writer(track_name)?;
             let subgroup = subgroups_writer.append(0).map_err(|e| {
-                StreamError::Runtime(format!("Failed to create MoQ subgroup: {e}"))
+                Error::Runtime(format!("Failed to create MoQ subgroup: {e}"))
             })?;
             self.active_subgroup_writers
                 .insert(track_name.to_string(), subgroup);
@@ -292,7 +292,7 @@ impl MoqPublishSession {
         if let Err(e) = write_result {
             // Remove the stale writer so next call creates a new one
             self.active_subgroup_writers.remove(track_name);
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "Failed to write MoQ frame: {e}"
             )));
         }
@@ -306,14 +306,14 @@ impl MoqPublishSession {
     ) -> Result<&mut moq_transport::serve::SubgroupsWriter> {
         if !self.track_subgroup_writers.contains_key(track_name) {
             let track_writer = self.tracks_writer.create(track_name).ok_or_else(|| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Failed to create MoQ track '{track_name}' (all readers dropped)"
                 ))
             })?;
 
             let subgroups_writer =
                 track_writer.subgroups().map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Failed to enter subgroups mode for track '{track_name}': {e}"
                     ))
                 })?;
@@ -351,7 +351,7 @@ impl MoqSubscribeSession {
         let client = create_webtransport_client(config.tls_disable_verify)?;
 
         let wt_session = client.connect(url).await.map_err(|e| {
-            StreamError::Runtime(format!("MoQ WebTransport connect failed: {e}"))
+            Error::Runtime(format!("MoQ WebTransport connect failed: {e}"))
         })?;
 
         let wt_session: web_transport::Session = wt_session.into();
@@ -364,7 +364,7 @@ impl MoqSubscribeSession {
             )
             .await
             .map_err(|e| {
-                StreamError::Runtime(format!("MoQ session connect failed: {e}"))
+                Error::Runtime(format!("MoQ session connect failed: {e}"))
             })?;
 
         // Run session event loop in background
@@ -460,7 +460,7 @@ impl MoqTrackReader {
         // Lazily initialize the subgroups reader on first call
         if self.subgroups_reader.is_none() {
             let mode = self.track_reader.mode().await.map_err(|e| {
-                StreamError::Runtime(format!("MoQ track mode error: {e}"))
+                Error::Runtime(format!("MoQ track mode error: {e}"))
             })?;
 
             match mode {
@@ -468,7 +468,7 @@ impl MoqTrackReader {
                     self.subgroups_reader = Some(reader);
                 }
                 _ => {
-                    return Err(StreamError::Runtime(
+                    return Err(Error::Runtime(
                         "Unexpected MoQ track mode (expected subgroups)".into(),
                     ));
                 }
@@ -479,7 +479,7 @@ impl MoqTrackReader {
         match reader.next().await {
             Ok(Some(subgroup)) => Ok(Some(MoqSubgroupReader { inner: subgroup })),
             Ok(None) => Ok(None),
-            Err(e) => Err(StreamError::Runtime(format!(
+            Err(e) => Err(Error::Runtime(format!(
                 "MoQ subgroup read error: {e}"
             ))),
         }
@@ -495,7 +495,7 @@ impl MoqSubgroupReader {
     /// Read the next frame from this subgroup. Returns `None` when the subgroup ends.
     pub async fn read_frame(&mut self) -> Result<Option<bytes::Bytes>> {
         self.inner.read_next().await.map_err(|e| {
-            StreamError::Runtime(format!("MoQ frame read error: {e}"))
+            Error::Runtime(format!("MoQ frame read error: {e}"))
         })
     }
 }
@@ -544,7 +544,7 @@ impl SharedMoqSessions {
                 timeout_ms: 10000,
             };
             let session = MoqPublishSession::connect(config).await?;
-            Ok::<_, StreamError>(Arc::new(Mutex::new(session)))
+            Ok::<_, Error>(Arc::new(Mutex::new(session)))
         }).await?;
         Ok(Arc::clone(session))
     }
@@ -559,7 +559,7 @@ impl SharedMoqSessions {
                 timeout_ms: 10000,
             };
             let session = MoqSubscribeSession::connect(config).await?;
-            Ok::<_, StreamError>(Arc::new(session))
+            Ok::<_, Error>(Arc::new(session))
         }).await?;
         Ok(Arc::clone(session))
     }

--- a/libs/streamlib-engine/src/core/streaming/opus.rs
+++ b/libs/streamlib-engine/src/core/streaming/opus.rs
@@ -6,7 +6,7 @@
 // Provides Opus encoding for real-time audio streaming.
 
 use crate::_generated_::{AudioFrame, EncodedAudioFrame};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -76,13 +76,13 @@ impl OpusEncoder {
     pub fn new(config: AudioEncoderConfig) -> Result<Self> {
         // Validate config
         if config.sample_rate != 48000 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Opus encoder only supports 48kHz sample rate, got {}Hz",
                 config.sample_rate
             )));
         }
         if config.channels != 2 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Opus encoder only supports stereo (2 channels), got {}",
                 config.channels
             )));
@@ -98,22 +98,22 @@ impl OpusEncoder {
             opus::Application::Audio, // Use Audio for best quality (music/broadcast)
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to create Opus encoder: {:?}", e))
+            Error::Configuration(format!("Failed to create Opus encoder: {:?}", e))
         })?;
 
         // Configure encoder
         encoder
             .set_bitrate(opus::Bitrate::Bits(config.bitrate_bps as i32))
-            .map_err(|e| StreamError::Configuration(format!("Failed to set bitrate: {:?}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to set bitrate: {:?}", e)))?;
 
         encoder
             .set_vbr(config.vbr)
-            .map_err(|e| StreamError::Configuration(format!("Failed to set VBR: {:?}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to set VBR: {:?}", e)))?;
 
         // Enable FEC (Forward Error Correction) for better packet loss resilience
         encoder
             .set_inband_fec(true)
-            .map_err(|e| StreamError::Configuration(format!("Failed to set FEC: {:?}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to set FEC: {:?}", e)))?;
 
         tracing::info!(
             "OpusEncoder initialized: {}Hz, {} channels, {} kbps, {}ms frames, VBR={}",
@@ -136,7 +136,7 @@ impl AudioEncoderOpus for OpusEncoder {
     fn encode(&mut self, frame: &AudioFrame) -> Result<EncodedAudioFrame> {
         // Validate sample rate
         if frame.sample_rate != 48000 {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 format!(
                     "Expected 48kHz, got {}Hz. Use AudioResamplerProcessor upstream to convert to 48kHz.",
                     frame.sample_rate
@@ -149,7 +149,7 @@ impl AudioEncoderOpus for OpusEncoder {
         let actual_samples = frame.samples.len() / frame.channels as usize;
 
         if actual_samples != expected_samples {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 format!(
                     "Expected {} samples (20ms @ 48kHz), got {}. Use BufferRechunkerProcessor(960) upstream.",
                     expected_samples, actual_samples
@@ -162,7 +162,7 @@ impl AudioEncoderOpus for OpusEncoder {
         let encoded_data = self
             .encoder
             .encode_vec_float(&frame.samples, 4000)
-            .map_err(|e| StreamError::Runtime(format!("Opus encoding failed: {:?}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Opus encoding failed: {:?}", e)))?;
 
         tracing::trace!(
             "Encoded audio frame: {} samples → {} bytes (compression: {:.2}x)",
@@ -185,7 +185,7 @@ impl AudioEncoderOpus for OpusEncoder {
     fn set_bitrate(&mut self, bitrate_bps: u32) -> Result<()> {
         self.encoder
             .set_bitrate(opus::Bitrate::Bits(bitrate_bps as i32))
-            .map_err(|e| StreamError::Configuration(format!("Failed to set bitrate: {:?}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to set bitrate: {:?}", e)))?;
 
         self.config.bitrate_bps = bitrate_bps;
 

--- a/libs/streamlib-engine/src/core/streaming/opus_decoder.rs
+++ b/libs/streamlib-engine/src/core/streaming/opus_decoder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::_generated_::AudioFrame;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Opus audio decoder for real-time WebRTC streaming.
 #[derive(Debug)]
@@ -19,14 +19,14 @@ impl OpusDecoder {
         // Opus supports: 8000, 12000, 16000, 24000, 48000 Hz
         // WebRTC typically uses 48000 Hz
         if ![8000, 12000, 16000, 24000, 48000].contains(&sample_rate) {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Opus decoder requires sample rate of 8/12/16/24/48 kHz, got {}Hz",
                 sample_rate
             )));
         }
 
         if input_channels != 1 && input_channels != 2 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Opus decoder supports 1 (mono) or 2 (stereo) channels, got {}",
                 input_channels
             )));
@@ -40,7 +40,7 @@ impl OpusDecoder {
         };
 
         let decoder = opus::Decoder::new(sample_rate, channels)
-            .map_err(|e| StreamError::Runtime(format!("Failed to create Opus decoder: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to create Opus decoder: {}", e)))?;
 
         // Calculate frame size based on sample rate
         // WebRTC typically uses 20ms frames: (sample_rate * 20) / 1000
@@ -92,7 +92,7 @@ impl OpusDecoder {
                     packet.len(),
                     self.input_channels
                 );
-                StreamError::Runtime(format!("Opus decode failed: {}", e))
+                Error::Runtime(format!("Opus decode failed: {}", e))
             })?;
 
         if decode_num == 0 {

--- a/libs/streamlib-engine/src/core/streaming/rtp.rs
+++ b/libs/streamlib-engine/src/core/streaming/rtp.rs
@@ -3,7 +3,7 @@
 
 use crate::_generated_::EncodedVideoFrame;
 use crate::_generated_::EncodedAudioFrame;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use bytes::Bytes;
 use std::time::Duration;
 
@@ -16,7 +16,7 @@ pub fn convert_video_to_samples(
     let nal_units = parse_nal_units(&frame.data);
 
     if nal_units.is_empty() {
-        return Err(StreamError::Runtime(
+        return Err(Error::Runtime(
             "No NAL units found in H.264 frame".into(),
         ));
     }

--- a/libs/streamlib-engine/src/core/streaming/webrtc_session.rs
+++ b/libs/streamlib-engine/src/core/streaming/webrtc_session.rs
@@ -6,7 +6,7 @@
 // Manages WebRTC PeerConnection, tracks, and RTP packetization using webrtc-rs.
 // Supports both send (WHIP) and receive (WHEP) modes.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use std::sync::Arc;
 use webrtc::track::track_local::TrackLocalWriter;
 
@@ -92,7 +92,7 @@ impl WebRtcSession {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Video,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register H.264 codec: {}", e))
+                Error::Configuration(format!("Failed to register H.264 codec: {}", e))
             })?;
 
         // Register Opus audio codec
@@ -112,7 +112,7 @@ impl WebRtcSession {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Audio,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register Opus codec: {}", e))
+                Error::Configuration(format!("Failed to register Opus codec: {}", e))
             })?;
 
         tracing::info!("[WebRTC] Registered ONLY H.264 (PT=102) and Opus (PT=111) codecs");
@@ -126,7 +126,7 @@ impl WebRtcSession {
             &mut media_engine,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to register interceptors: {}", e))
+            Error::Configuration(format!("Failed to register interceptors: {}", e))
         })?;
 
         tracing::debug!("[WebRTC] Creating WebRTC API...");
@@ -142,7 +142,7 @@ impl WebRtcSession {
         // Create RTCPeerConnection
         let config = webrtc::peer_connection::configuration::RTCConfiguration::default();
         let peer_connection = Arc::new(api.new_peer_connection(config).await.map_err(|e| {
-            StreamError::Configuration(format!("Failed to create PeerConnection: {}", e))
+            Error::Configuration(format!("Failed to create PeerConnection: {}", e))
         })?);
 
         tracing::debug!("[WebRTC] RTCPeerConnection created successfully");
@@ -275,7 +275,7 @@ impl WebRtcSession {
             .add_track(Arc::clone(&video_track)
                 as Arc<dyn webrtc::track::track_local::TrackLocal + Send + Sync>)
             .await
-            .map_err(|e| StreamError::Configuration(format!("Failed to add video track: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to add video track: {}", e)))?;
 
         let video_params = video_rtp_sender.get_parameters().await;
 
@@ -322,7 +322,7 @@ impl WebRtcSession {
             .add_track(Arc::clone(&audio_track)
                 as Arc<dyn webrtc::track::track_local::TrackLocal + Send + Sync>)
             .await
-            .map_err(|e| StreamError::Configuration(format!("Failed to add audio track: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to add audio track: {}", e)))?;
 
         let audio_params = audio_rtp_sender.get_parameters().await;
 
@@ -413,7 +413,7 @@ impl WebRtcSession {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Video,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register H.264 codec: {}", e))
+                Error::Configuration(format!("Failed to register H.264 codec: {}", e))
             })?;
 
         // Register Opus audio codec (same as WHIP)
@@ -433,7 +433,7 @@ impl WebRtcSession {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Audio,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register Opus codec: {}", e))
+                Error::Configuration(format!("Failed to register Opus codec: {}", e))
             })?;
 
         tracing::info!(
@@ -447,7 +447,7 @@ impl WebRtcSession {
             &mut media_engine,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to register interceptors: {}", e))
+            Error::Configuration(format!("Failed to register interceptors: {}", e))
         })?;
 
         // Create API with MediaEngine and InterceptorRegistry
@@ -459,7 +459,7 @@ impl WebRtcSession {
         // Create RTCPeerConnection
         let config = webrtc::peer_connection::configuration::RTCConfiguration::default();
         let peer_connection = Arc::new(api.new_peer_connection(config).await.map_err(|e| {
-            StreamError::Configuration(format!("Failed to create PeerConnection: {}", e))
+            Error::Configuration(format!("Failed to create PeerConnection: {}", e))
         })?);
 
         tracing::debug!("[WebRTC WHEP] RTCPeerConnection created successfully");
@@ -584,7 +584,7 @@ impl WebRtcSession {
                 direction: webrtc::rtp_transceiver::rtp_transceiver_direction::RTCRtpTransceiverDirection::Recvonly,
                 send_encodings: vec![],
             })
-        ).await.map_err(|e| StreamError::Configuration(format!("Failed to add video transceiver: {}", e)))?;
+        ).await.map_err(|e| Error::Configuration(format!("Failed to add video transceiver: {}", e)))?;
 
         peer_connection.add_transceiver_from_kind(
             webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Audio,
@@ -592,7 +592,7 @@ impl WebRtcSession {
                 direction: webrtc::rtp_transceiver::rtp_transceiver_direction::RTCRtpTransceiverDirection::Recvonly,
                 send_encodings: vec![],
             })
-        ).await.map_err(|e| StreamError::Configuration(format!("Failed to add audio transceiver: {}", e)))?;
+        ).await.map_err(|e| Error::Configuration(format!("Failed to add audio transceiver: {}", e)))?;
 
         tracing::info!("[WebRTC WHEP] Added recvonly transceivers for video and audio");
 
@@ -665,7 +665,7 @@ impl WebRtcSession {
             .peer_connection
             .create_offer(None)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to create offer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to create offer: {}", e)))?;
 
         tracing::debug!("[WebRTC] Setting local description (starts ICE gathering)...");
 
@@ -673,7 +673,7 @@ impl WebRtcSession {
         self.peer_connection
             .set_local_description(offer)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to set local description: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to set local description: {}", e)))?;
 
         // Wait for ICE gathering to complete
         tracing::debug!("[WebRTC] Waiting for ICE gathering to complete...");
@@ -688,7 +688,7 @@ impl WebRtcSession {
             .peer_connection
             .local_description()
             .await
-            .ok_or_else(|| StreamError::Runtime("No local description".into()))?;
+            .ok_or_else(|| Error::Runtime("No local description".into()))?;
 
         let candidate_count = local_desc.sdp.matches("a=candidate:").count();
         tracing::debug!(
@@ -711,13 +711,13 @@ impl WebRtcSession {
             webrtc::peer_connection::sdp::session_description::RTCSessionDescription::answer(
                 sdp.to_owned(),
             )
-            .map_err(|e| StreamError::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
 
         self.peer_connection
             .set_remote_description(answer)
             .await
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to set remote description: {}", e))
+                Error::Runtime(format!("Failed to set remote description: {}", e))
             })?;
 
         tracing::debug!("[WebRTC {}] Remote SDP answer set successfully", mode_str);
@@ -900,7 +900,7 @@ impl WebRtcSession {
         let track = self
             .video_track
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Video track not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("Video track not initialized".into()))?;
 
         // Track first write and periodic telemetry
         static VIDEO_SAMPLE_COUNTER: std::sync::atomic::AtomicU64 =
@@ -983,7 +983,7 @@ impl WebRtcSession {
 
                 tokio_handle.block_on(async {
                     track.write_rtp(&rtp_packet).await.map_err(|e| {
-                        StreamError::Runtime(format!("Failed to write video RTP: {}", e))
+                        Error::Runtime(format!("Failed to write video RTP: {}", e))
                     })
                 })?;
 
@@ -1049,7 +1049,7 @@ impl WebRtcSession {
 
                     tokio_handle.block_on(async {
                         track.write_rtp(&rtp_packet).await.map_err(|e| {
-                            StreamError::Runtime(format!("Failed to write video RTP: {}", e))
+                            Error::Runtime(format!("Failed to write video RTP: {}", e))
                         })
                     })?;
 
@@ -1087,7 +1087,7 @@ impl WebRtcSession {
         let track = self
             .audio_track
             .as_ref()
-            .ok_or_else(|| StreamError::Configuration("Audio track not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("Audio track not initialized".into()))?;
 
         // Track first write and periodic telemetry
         static AUDIO_SAMPLE_COUNTER: std::sync::atomic::AtomicU64 =
@@ -1139,7 +1139,7 @@ impl WebRtcSession {
             track
                 .write_rtp(&rtp_packet)
                 .await
-                .map_err(|e| StreamError::Runtime(format!("Failed to write audio RTP: {}", e)))
+                .map_err(|e| Error::Runtime(format!("Failed to write audio RTP: {}", e)))
         });
 
         if let Err(ref e) = result {
@@ -1167,6 +1167,6 @@ impl WebRtcSession {
         self.peer_connection
             .close()
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to close peer connection: {}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to close peer connection: {}", e)))
     }
 }

--- a/libs/streamlib-engine/src/core/streaming/whep_client.rs
+++ b/libs/streamlib-engine/src/core/streaming/whep_client.rs
@@ -6,7 +6,7 @@
 // Unified client that owns both HTTP signaling and WebRTC session management.
 // Implements IETF WHEP specification for WebRTC playback/egress.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -108,7 +108,7 @@ impl WhepClient {
             rustls::crypto::ring::default_provider()
                 .install_default()
                 .map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Failed to install rustls crypto provider: {:?}",
                         e
                     ))
@@ -123,7 +123,7 @@ impl WhepClient {
         // Build HTTPS connector
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
-            .map_err(|e| StreamError::Configuration(format!("Failed to load CA roots: {}", e)))?
+            .map_err(|e| Error::Configuration(format!("Failed to load CA roots: {}", e)))?
             .https_or_http()
             .enable_http1()
             .enable_http2()
@@ -252,7 +252,7 @@ impl WhepClient {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Video,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register H.264 codec: {}", e))
+                Error::Configuration(format!("Failed to register H.264 codec: {}", e))
             })?;
 
         // Register Opus audio codec
@@ -272,7 +272,7 @@ impl WhepClient {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Audio,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register Opus codec: {}", e))
+                Error::Configuration(format!("Failed to register Opus codec: {}", e))
             })?;
 
         tracing::info!("[WhepClient] Registered H.264 (PT=102) and Opus (PT=111) codecs");
@@ -284,7 +284,7 @@ impl WhepClient {
             &mut media_engine,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to register interceptors: {}", e))
+            Error::Configuration(format!("Failed to register interceptors: {}", e))
         })?;
 
         // Create API
@@ -296,7 +296,7 @@ impl WhepClient {
         // Create peer connection
         let config = webrtc::peer_connection::configuration::RTCConfiguration::default();
         let peer_connection = Arc::new(api.new_peer_connection(config).await.map_err(|e| {
-            StreamError::Configuration(format!("Failed to create PeerConnection: {}", e))
+            Error::Configuration(format!("Failed to create PeerConnection: {}", e))
         })?);
 
         // Create channels for ICE candidates and media samples
@@ -395,7 +395,7 @@ impl WhepClient {
             )
             .await
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to add video transceiver: {}", e))
+                Error::Configuration(format!("Failed to add video transceiver: {}", e))
             })?;
 
         peer_connection
@@ -408,7 +408,7 @@ impl WhepClient {
             )
             .await
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to add audio transceiver: {}", e))
+                Error::Configuration(format!("Failed to add audio transceiver: {}", e))
             })?;
 
         Ok((peer_connection, ice_rx, video_rx, audio_rx))
@@ -422,12 +422,12 @@ impl WhepClient {
         let offer = peer_connection
             .create_offer(None)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to create offer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to create offer: {}", e)))?;
 
         peer_connection
             .set_local_description(offer)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to set local description: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to set local description: {}", e)))?;
 
         // Wait for ICE gathering to complete
         let mut done_rx = peer_connection.gathering_complete_promise().await;
@@ -436,7 +436,7 @@ impl WhepClient {
         let local_desc = peer_connection
             .local_description()
             .await
-            .ok_or_else(|| StreamError::Runtime("No local description".into()))?;
+            .ok_or_else(|| Error::Runtime("No local description".into()))?;
 
         Ok(local_desc.sdp)
     }
@@ -451,13 +451,13 @@ impl WhepClient {
             webrtc::peer_connection::sdp::session_description::RTCSessionDescription::answer(
                 sdp.to_owned(),
             )
-            .map_err(|e| StreamError::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
 
         peer_connection
             .set_remote_description(answer)
             .await
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to set remote description: {}", e))
+                Error::Runtime(format!("Failed to set remote description: {}", e))
             })?;
 
         Ok(())
@@ -515,7 +515,7 @@ impl WhepClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build request: {}", e)))?;
 
         tracing::debug!("[WhepClient] POST to {}", self.config.endpoint_url);
 
@@ -525,19 +525,19 @@ impl WhepClient {
         )
         .await
         .map_err(|_| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "WHEP POST timed out after {}ms",
                 self.config.timeout_ms
             ))
         })?
-        .map_err(|e| StreamError::Runtime(format!("WHEP POST failed: {}", e)))?;
+        .map_err(|e| Error::Runtime(format!("WHEP POST failed: {}", e)))?;
 
         let status = response.status();
         let headers = response.headers().clone();
 
         let body_bytes = BodyExt::collect(response.into_body())
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to read response: {}", e)))?
+            .map_err(|e| Error::Runtime(format!("Failed to read response: {}", e)))?
             .to_bytes();
 
         match status {
@@ -547,7 +547,7 @@ impl WhepClient {
                     .get(header::LOCATION)
                     .and_then(|v| v.to_str().ok())
                     .ok_or_else(|| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "WHEP {} without Location header",
                             status.as_u16()
                         ))
@@ -573,14 +573,14 @@ impl WhepClient {
                 );
 
                 let sdp_answer = String::from_utf8(body_bytes.to_vec())
-                    .map_err(|e| StreamError::Runtime(format!("Invalid UTF-8 in SDP: {}", e)))?;
+                    .map_err(|e| Error::Runtime(format!("Invalid UTF-8 in SDP: {}", e)))?;
 
                 Ok(sdp_answer)
             }
             _ => {
                 let error_body = String::from_utf8(body_bytes.to_vec())
                     .unwrap_or_else(|_| format!("HTTP {}", status));
-                Err(StreamError::Runtime(format!(
+                Err(Error::Runtime(format!(
                     "WHEP POST failed ({}): {}",
                     status, error_body
                 )))
@@ -628,15 +628,15 @@ impl WhepClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build PATCH request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build PATCH request: {}", e)))?;
 
         let response = tokio::time::timeout(
             std::time::Duration::from_millis(self.config.timeout_ms),
             self.http_client.request(req),
         )
         .await
-        .map_err(|_| StreamError::Runtime("WHEP PATCH timed out".into()))?
-        .map_err(|e| StreamError::Runtime(format!("WHEP PATCH failed: {}", e)))?;
+        .map_err(|_| Error::Runtime("WHEP PATCH timed out".into()))?
+        .map_err(|e| Error::Runtime(format!("WHEP PATCH failed: {}", e)))?;
 
         match response.status() {
             StatusCode::NO_CONTENT | StatusCode::OK => {
@@ -649,7 +649,7 @@ impl WhepClient {
                     .ok()
                     .and_then(|b| String::from_utf8(b.to_bytes().to_vec()).ok())
                     .unwrap_or_else(|| format!("HTTP {}", status));
-                Err(StreamError::Runtime(format!(
+                Err(Error::Runtime(format!(
                     "WHEP PATCH failed: {}",
                     body_bytes
                 )))
@@ -723,7 +723,7 @@ impl WhepClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build DELETE request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build DELETE request: {}", e)))?;
 
         tracing::debug!("[WhepClient] DELETE to {}", session_url);
 
@@ -732,8 +732,8 @@ impl WhepClient {
             self.http_client.request(req),
         )
         .await
-        .map_err(|_| StreamError::Runtime("WHEP DELETE timed out".into()))?
-        .map_err(|e| StreamError::Runtime(format!("WHEP DELETE failed: {}", e)))?;
+        .map_err(|_| Error::Runtime("WHEP DELETE timed out".into()))?
+        .map_err(|e| Error::Runtime(format!("WHEP DELETE failed: {}", e)))?;
 
         if response.status().is_success() {
             tracing::info!("[WhepClient] WHEP session deleted: {}", session_url);

--- a/libs/streamlib-engine/src/core/streaming/whip_client.rs
+++ b/libs/streamlib-engine/src/core/streaming/whip_client.rs
@@ -6,7 +6,7 @@
 // Unified client that owns both HTTP signaling and WebRTC session management.
 // Implements RFC 9725 WHIP signaling for WebRTC streaming.
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -98,7 +98,7 @@ impl WhipClient {
             rustls::crypto::ring::default_provider()
                 .install_default()
                 .map_err(|e| {
-                    StreamError::Runtime(format!(
+                    Error::Runtime(format!(
                         "Failed to install rustls crypto provider: {:?}",
                         e
                     ))
@@ -113,7 +113,7 @@ impl WhipClient {
         // Build HTTPS connector
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
-            .map_err(|e| StreamError::Configuration(format!("Failed to load CA roots: {}", e)))?
+            .map_err(|e| Error::Configuration(format!("Failed to load CA roots: {}", e)))?
             .https_or_http()
             .enable_http1()
             .enable_http2()
@@ -239,7 +239,7 @@ impl WhipClient {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Video,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register H.264 codec: {}", e))
+                Error::Configuration(format!("Failed to register H.264 codec: {}", e))
             })?;
 
         // Register Opus audio codec
@@ -259,7 +259,7 @@ impl WhipClient {
                 webrtc::rtp_transceiver::rtp_codec::RTPCodecType::Audio,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to register Opus codec: {}", e))
+                Error::Configuration(format!("Failed to register Opus codec: {}", e))
             })?;
 
         tracing::info!("[WhipClient] Registered H.264 (PT=102) and Opus (PT=111) codecs");
@@ -271,7 +271,7 @@ impl WhipClient {
             &mut media_engine,
         )
         .map_err(|e| {
-            StreamError::Configuration(format!("Failed to register interceptors: {}", e))
+            Error::Configuration(format!("Failed to register interceptors: {}", e))
         })?;
 
         // Create API
@@ -283,7 +283,7 @@ impl WhipClient {
         // Create peer connection
         let config = webrtc::peer_connection::configuration::RTCConfiguration::default();
         let peer_connection = Arc::new(api.new_peer_connection(config).await.map_err(|e| {
-            StreamError::Configuration(format!("Failed to create PeerConnection: {}", e))
+            Error::Configuration(format!("Failed to create PeerConnection: {}", e))
         })?);
 
         // Create ICE candidate channel
@@ -345,7 +345,7 @@ impl WhipClient {
             .add_track(Arc::clone(&video_track)
                 as Arc<dyn webrtc::track::track_local::TrackLocal + Send + Sync>)
             .await
-            .map_err(|e| StreamError::Configuration(format!("Failed to add video track: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to add video track: {}", e)))?;
 
         // Drain incoming RTCP on the video sender. Required by webrtc-rs —
         // without this, the interceptor pipeline stalls and RTCP Sender Reports
@@ -381,7 +381,7 @@ impl WhipClient {
             .add_track(Arc::clone(&audio_track)
                 as Arc<dyn webrtc::track::track_local::TrackLocal + Send + Sync>)
             .await
-            .map_err(|e| StreamError::Configuration(format!("Failed to add audio track: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to add audio track: {}", e)))?;
 
         // Drain incoming RTCP on the audio sender (same reason as video above).
         tokio::spawn(async move {
@@ -417,12 +417,12 @@ impl WhipClient {
         let offer = peer_connection
             .create_offer(None)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to create offer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to create offer: {}", e)))?;
 
         peer_connection
             .set_local_description(offer)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to set local description: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to set local description: {}", e)))?;
 
         // Wait for ICE gathering to complete
         let mut done_rx = peer_connection.gathering_complete_promise().await;
@@ -431,7 +431,7 @@ impl WhipClient {
         let local_desc = peer_connection
             .local_description()
             .await
-            .ok_or_else(|| StreamError::Runtime("No local description".into()))?;
+            .ok_or_else(|| Error::Runtime("No local description".into()))?;
 
         Ok(local_desc.sdp)
     }
@@ -446,13 +446,13 @@ impl WhipClient {
             webrtc::peer_connection::sdp::session_description::RTCSessionDescription::answer(
                 sdp.to_owned(),
             )
-            .map_err(|e| StreamError::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to parse SDP answer: {}", e)))?;
 
         peer_connection
             .set_remote_description(answer)
             .await
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to set remote description: {}", e))
+                Error::Runtime(format!("Failed to set remote description: {}", e))
             })?;
 
         Ok(())
@@ -499,7 +499,7 @@ impl WhipClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build request: {}", e)))?;
 
         tracing::debug!("[WhipClient] POST to {}", self.config.endpoint_url);
 
@@ -509,19 +509,19 @@ impl WhipClient {
         )
         .await
         .map_err(|_| {
-            StreamError::Runtime(format!(
+            Error::Runtime(format!(
                 "WHIP POST timed out after {}ms",
                 self.config.timeout_ms
             ))
         })?
-        .map_err(|e| StreamError::Runtime(format!("WHIP POST failed: {}", e)))?;
+        .map_err(|e| Error::Runtime(format!("WHIP POST failed: {}", e)))?;
 
         let status = response.status();
         let headers = response.headers().clone();
 
         let body_bytes = BodyExt::collect(response.into_body())
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to read response: {}", e)))?
+            .map_err(|e| Error::Runtime(format!("Failed to read response: {}", e)))?
             .to_bytes();
 
         match status {
@@ -531,7 +531,7 @@ impl WhipClient {
                     .get(header::LOCATION)
                     .and_then(|v| v.to_str().ok())
                     .ok_or_else(|| {
-                        StreamError::Runtime("WHIP 201 without Location header".into())
+                        Error::Runtime("WHIP 201 without Location header".into())
                     })?;
 
                 // Convert relative to absolute URL
@@ -554,7 +554,7 @@ impl WhipClient {
                 );
 
                 let sdp_answer = String::from_utf8(body_bytes.to_vec())
-                    .map_err(|e| StreamError::Runtime(format!("Invalid UTF-8 in SDP: {}", e)))?;
+                    .map_err(|e| Error::Runtime(format!("Invalid UTF-8 in SDP: {}", e)))?;
 
                 Ok(sdp_answer)
             }
@@ -562,7 +562,7 @@ impl WhipClient {
                 let location = headers
                     .get(header::LOCATION)
                     .and_then(|v| v.to_str().ok())
-                    .ok_or_else(|| StreamError::Runtime("307 without Location header".into()))?;
+                    .ok_or_else(|| Error::Runtime("307 without Location header".into()))?;
 
                 tracing::info!("[WhipClient] Redirecting to: {}", location);
                 self.config.endpoint_url = location.to_owned();
@@ -571,7 +571,7 @@ impl WhipClient {
             _ => {
                 let error_body = String::from_utf8(body_bytes.to_vec())
                     .unwrap_or_else(|_| format!("HTTP {}", status));
-                Err(StreamError::Runtime(format!(
+                Err(Error::Runtime(format!(
                     "WHIP POST failed ({}): {}",
                     status, error_body
                 )))
@@ -617,15 +617,15 @@ impl WhipClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build PATCH request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build PATCH request: {}", e)))?;
 
         let response = tokio::time::timeout(
             std::time::Duration::from_millis(self.config.timeout_ms),
             self.http_client.request(req),
         )
         .await
-        .map_err(|_| StreamError::Runtime("WHIP PATCH timed out".into()))?
-        .map_err(|e| StreamError::Runtime(format!("WHIP PATCH failed: {}", e)))?;
+        .map_err(|_| Error::Runtime("WHIP PATCH timed out".into()))?
+        .map_err(|e| Error::Runtime(format!("WHIP PATCH failed: {}", e)))?;
 
         match response.status() {
             StatusCode::NO_CONTENT | StatusCode::OK => {
@@ -638,7 +638,7 @@ impl WhipClient {
                     .ok()
                     .and_then(|b| String::from_utf8(b.to_bytes().to_vec()).ok())
                     .unwrap_or_else(|| format!("HTTP {}", status));
-                Err(StreamError::Runtime(format!(
+                Err(Error::Runtime(format!(
                     "WHIP PATCH failed: {}",
                     body_bytes
                 )))
@@ -655,7 +655,7 @@ impl WhipClient {
         let track = self
             .video_track
             .clone()
-            .ok_or_else(|| StreamError::Runtime("Video track not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("Video track not initialized".into()))?;
 
         // Log first frame and keyframes at startup to confirm encoding pipeline works
         if self.video_frame_count < 5 {
@@ -669,7 +669,7 @@ impl WhipClient {
         track
             .write_sample(&sample)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to write video sample: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to write video sample: {}", e)))?;
 
         self.video_frame_count += 1;
 
@@ -684,7 +684,7 @@ impl WhipClient {
         let track = self
             .audio_track
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("Audio track not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("Audio track not initialized".into()))?;
 
         const TIMESTAMP_INCREMENT: u32 = 960; // 20ms @ 48kHz
 
@@ -717,7 +717,7 @@ impl WhipClient {
         track
             .write_rtp(&rtp_packet)
             .await
-            .map_err(|e| StreamError::Runtime(format!("Failed to write audio RTP: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to write audio RTP: {}", e)))?;
 
         Ok(())
     }
@@ -771,7 +771,7 @@ impl WhipClient {
 
         let req = req_builder
             .body(boxed_body)
-            .map_err(|e| StreamError::Runtime(format!("Failed to build DELETE request: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to build DELETE request: {}", e)))?;
 
         tracing::debug!("[WhipClient] DELETE to {}", session_url);
 
@@ -780,8 +780,8 @@ impl WhipClient {
             self.http_client.request(req),
         )
         .await
-        .map_err(|_| StreamError::Runtime("WHIP DELETE timed out".into()))?
-        .map_err(|e| StreamError::Runtime(format!("WHIP DELETE failed: {}", e)))?;
+        .map_err(|_| Error::Runtime("WHIP DELETE timed out".into()))?
+        .map_err(|e| Error::Runtime(format!("WHIP DELETE failed: {}", e)))?;
 
         if response.status().is_success() {
             tracing::info!("[WhipClient] WHIP session deleted: {}", session_url);

--- a/libs/streamlib-engine/src/core/utils/audio_resample.rs
+++ b/libs/streamlib-engine/src/core/utils/audio_resample.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use rubato::{
     Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
 };
@@ -81,7 +81,7 @@ impl AudioResampler {
             1 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 1)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 1-channel resampler: {:?}",
                             e
                         ))
@@ -91,7 +91,7 @@ impl AudioResampler {
             2 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 2)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 2-channel resampler: {:?}",
                             e
                         ))
@@ -101,7 +101,7 @@ impl AudioResampler {
             3 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 3)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 3-channel resampler: {:?}",
                             e
                         ))
@@ -111,7 +111,7 @@ impl AudioResampler {
             4 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 4)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 4-channel resampler: {:?}",
                             e
                         ))
@@ -121,7 +121,7 @@ impl AudioResampler {
             5 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 5)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 5-channel resampler: {:?}",
                             e
                         ))
@@ -131,7 +131,7 @@ impl AudioResampler {
             6 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 6)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 6-channel resampler: {:?}",
                             e
                         ))
@@ -141,7 +141,7 @@ impl AudioResampler {
             7 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 7)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 7-channel resampler: {:?}",
                             e
                         ))
@@ -151,7 +151,7 @@ impl AudioResampler {
             8 => {
                 let resampler = SincFixedIn::<f32>::new(ratio, 2.0, params, chunk_size, 8)
                     .map_err(|e| {
-                        StreamError::Runtime(format!(
+                        Error::Runtime(format!(
                             "Failed to create 8-channel resampler: {:?}",
                             e
                         ))
@@ -159,7 +159,7 @@ impl AudioResampler {
                 ResamplerInner::Eight(resampler)
             }
             _ => {
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "Unsupported channel count: {}. Must be 1-8.",
                     channels
                 )))
@@ -200,7 +200,7 @@ impl AudioResampler {
             ResamplerInner::Seven(r) => r.process(&planar_input, None),
             ResamplerInner::Eight(r) => r.process(&planar_input, None),
         }
-        .map_err(|e| StreamError::Runtime(format!("Resampling failed: {:?}", e)))?;
+        .map_err(|e| Error::Runtime(format!("Resampling failed: {:?}", e)))?;
 
         // Convert back to interleaved
         let output_samples_per_channel = planar_output[0].len();

--- a/libs/streamlib-engine/src/iceoryx2/input.rs
+++ b/libs/streamlib-engine/src/iceoryx2/input.rs
@@ -14,7 +14,7 @@ use serde::de::DeserializeOwned;
 use super::mailbox::PortMailbox;
 use super::read_mode::ReadMode;
 use super::{FrameHeader, FRAME_HEADER_SIZE};
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 
 /// Thread-local subscriber wrapper.
 ///
@@ -238,18 +238,18 @@ impl InputMailboxes {
         let port_config = self
             .ports
             .get(port)
-            .ok_or_else(|| StreamError::Link(format!("Unknown input port: {}", port)))?;
+            .ok_or_else(|| Error::Link(format!("Unknown input port: {}", port)))?;
 
         let raw = match port_config.read_mode {
             ReadMode::SkipToLatest => port_config.mailbox.pop_latest(),
             ReadMode::ReadNextInOrder => port_config.mailbox.pop(),
         }
-        .ok_or_else(|| StreamError::Link(format!("No data available on port: {}", port)))?;
+        .ok_or_else(|| Error::Link(format!("No data available on port: {}", port)))?;
 
         let header = FrameHeader::read_from_slice(&raw);
         let data = &raw[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + header.len as usize];
         rmp_serde::from_slice(data)
-            .map_err(|e| StreamError::Link(format!("Failed to deserialize frame: {}", e)))
+            .map_err(|e| Error::Link(format!("Failed to deserialize frame: {}", e)))
     }
 
     /// Read raw bytes and timestamp from the given port without deserialization.
@@ -262,7 +262,7 @@ impl InputMailboxes {
         let port_config = self
             .ports
             .get(port)
-            .ok_or_else(|| StreamError::Link(format!("Unknown input port: {}", port)))?;
+            .ok_or_else(|| Error::Link(format!("Unknown input port: {}", port)))?;
 
         let raw = match port_config.read_mode {
             ReadMode::SkipToLatest => port_config.mailbox.pop_latest(),

--- a/libs/streamlib-engine/src/iceoryx2/node.rs
+++ b/libs/streamlib-engine/src/iceoryx2/node.rs
@@ -12,7 +12,7 @@ use iceoryx2::prelude::*;
 use parking_lot::Mutex;
 
 use super::{EventPayload, FRAME_HEADER_SIZE, MAX_FANIN_PER_DESTINATION};
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 
 /// Thread-safe wrapper for iceoryx2 Node.
 ///
@@ -27,7 +27,7 @@ impl Iceoryx2Node {
     /// Create a new iceoryx2 Node.
     pub fn new() -> Result<Self> {
         let node = NodeBuilder::new().create::<ipc::Service>().map_err(|e| {
-            StreamError::Runtime(format!("Failed to create iceoryx2 node: {:?}", e))
+            Error::Runtime(format!("Failed to create iceoryx2 node: {:?}", e))
         })?;
 
         Ok(Self {
@@ -41,7 +41,7 @@ impl Iceoryx2Node {
     pub fn open_or_create_event_service(&self, service_name: &str) -> Result<Iceoryx2EventService> {
         let node = self.inner.lock();
         let service_name: ServiceName = service_name.try_into().map_err(|e| {
-            StreamError::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
+            Error::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
         })?;
 
         let service = node
@@ -51,7 +51,7 @@ impl Iceoryx2Node {
             .subscriber_max_buffer_size(64)
             .open_or_create()
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to open/create event service: {:?}", e))
+                Error::Runtime(format!("Failed to open/create event service: {:?}", e))
             })?;
 
         Ok(Iceoryx2EventService { inner: service })
@@ -69,7 +69,7 @@ impl Iceoryx2Node {
     ) -> Result<Iceoryx2NotifyService> {
         let node = self.inner.lock();
         let service_name: ServiceName = service_name.try_into().map_err(|e| {
-            StreamError::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
+            Error::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
         })?;
 
         let service = node
@@ -79,7 +79,7 @@ impl Iceoryx2Node {
             .max_listeners(1)
             .open_or_create()
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to open/create notify service: {:?}", e))
+                Error::Runtime(format!("Failed to open/create notify service: {:?}", e))
             })?;
 
         Ok(Iceoryx2NotifyService { inner: service })
@@ -91,7 +91,7 @@ impl Iceoryx2Node {
     pub fn open_or_create_service(&self, service_name: &str) -> Result<Iceoryx2Service> {
         let node = self.inner.lock();
         let service_name: ServiceName = service_name.try_into().map_err(|e| {
-            StreamError::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
+            Error::Configuration(format!("Invalid service name '{}': {:?}", service_name, e))
         })?;
 
         let service = node
@@ -100,7 +100,7 @@ impl Iceoryx2Node {
             .max_publishers(MAX_FANIN_PER_DESTINATION)
             .subscriber_max_buffer_size(16)
             .open_or_create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to open/create service: {:?}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to open/create service: {:?}", e)))?;
 
         Ok(Iceoryx2Service { inner: service })
     }
@@ -129,7 +129,7 @@ impl Iceoryx2Service {
             .publisher_builder()
             .initial_max_slice_len(max_payload_bytes + FRAME_HEADER_SIZE)
             .create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to create publisher: {:?}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to create publisher: {:?}", e)))
     }
 
     /// Create a subscriber for this service.
@@ -140,7 +140,7 @@ impl Iceoryx2Service {
             .subscriber_builder()
             .buffer_size(16)
             .create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to create subscriber: {:?}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to create subscriber: {:?}", e)))
     }
 }
 
@@ -159,7 +159,7 @@ impl Iceoryx2NotifyService {
         self.inner
             .notifier_builder()
             .create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to create notifier: {:?}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to create notifier: {:?}", e)))
     }
 
     /// Create a listener for this service.
@@ -167,7 +167,7 @@ impl Iceoryx2NotifyService {
         self.inner
             .listener_builder()
             .create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to create listener: {:?}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to create listener: {:?}", e)))
     }
 }
 
@@ -188,7 +188,7 @@ impl Iceoryx2EventService {
         self.inner
             .publisher_builder()
             .create()
-            .map_err(|e| StreamError::Runtime(format!("Failed to create event publisher: {:?}", e)))
+            .map_err(|e| Error::Runtime(format!("Failed to create event publisher: {:?}", e)))
     }
 
     /// Create a subscriber for this event service.
@@ -200,7 +200,7 @@ impl Iceoryx2EventService {
             .buffer_size(64)
             .create()
             .map_err(|e| {
-                StreamError::Runtime(format!("Failed to create event subscriber: {:?}", e))
+                Error::Runtime(format!("Failed to create event subscriber: {:?}", e))
             })
     }
 }

--- a/libs/streamlib-engine/src/iceoryx2/output.rs
+++ b/libs/streamlib-engine/src/iceoryx2/output.rs
@@ -12,7 +12,7 @@ use parking_lot::Mutex;
 use serde::Serialize;
 
 use super::{FrameHeader, SchemaIdentWire, FRAME_HEADER_SIZE};
-use crate::core::error::{Result, StreamError};
+use crate::core::error::{Result, Error};
 use crate::core::media_clock::MediaClock;
 
 /// One downstream connection: structured schema identifier, destination
@@ -100,12 +100,12 @@ impl OutputWriter {
         timestamp_ns: i64,
     ) -> Result<()> {
         let data = rmp_serde::to_vec_named(value)
-            .map_err(|e| StreamError::Link(format!("Failed to serialize frame: {}", e)))?;
+            .map_err(|e| Error::Link(format!("Failed to serialize frame: {}", e)))?;
 
         let connections = self.connections.lock();
         let port_connections = connections
             .get(port)
-            .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
+            .ok_or_else(|| Error::Link(format!("Unknown output port: {}", port)))?;
 
         for conn in port_connections {
             let total_len = FRAME_HEADER_SIZE + data.len();
@@ -117,12 +117,12 @@ impl OutputWriter {
             let sample = conn
                 .publisher
                 .loan_slice_uninit(total_len)
-                .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
+                .map_err(|e| Error::Link(format!("Failed to loan slice: {:?}", e)))?;
 
             let sample = sample.write_from_slice(&frame);
             sample
                 .send()
-                .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;
+                .map_err(|e| Error::Link(format!("Failed to send sample: {:?}", e)))?;
 
             // Wake the downstream listener fd. notify() may transiently fail
             // (e.g. listener not yet created) — log and continue rather than
@@ -148,7 +148,7 @@ impl OutputWriter {
         let connections = self.connections.lock();
         let port_connections = connections
             .get(port)
-            .ok_or_else(|| StreamError::Link(format!("Unknown output port: {}", port)))?;
+            .ok_or_else(|| Error::Link(format!("Unknown output port: {}", port)))?;
 
         for conn in port_connections {
             let total_len = FRAME_HEADER_SIZE + data.len();
@@ -160,12 +160,12 @@ impl OutputWriter {
             let sample = conn
                 .publisher
                 .loan_slice_uninit(total_len)
-                .map_err(|e| StreamError::Link(format!("Failed to loan slice: {:?}", e)))?;
+                .map_err(|e| Error::Link(format!("Failed to loan slice: {:?}", e)))?;
 
             let sample = sample.write_from_slice(&frame);
             sample
                 .send()
-                .map_err(|e| StreamError::Link(format!("Failed to send sample: {:?}", e)))?;
+                .map_err(|e| Error::Link(format!("Failed to send sample: {:?}", e)))?;
 
             if let Err(e) = conn.notifier.notify() {
                 tracing::trace!(

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -84,7 +84,7 @@ pub use core::{
     RuntimeContext,
     RuntimeContextFullAccess,
     RuntimeContextLimitedAccess,
-    StreamError,
+    Error,
     StreamTexture,
     TextureDescriptor,
     TextureFormat,

--- a/libs/streamlib-engine/src/linux/audio_clock.rs
+++ b/libs/streamlib-engine/src/linux/audio_clock.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use crate::core::context::{AudioClock, AudioClockConfig, AudioTickCallback, AudioTickContext};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -77,7 +77,7 @@ impl AudioClock for LinuxTimerFdAudioClock {
                 tracing::info!("[LinuxTimerFdAudioClock] Stopped");
             })
             .map_err(|e| {
-                StreamError::Runtime(format!(
+                Error::Runtime(format!(
                     "Failed to spawn audio clock timerfd thread: {}",
                     e
                 ))
@@ -139,7 +139,7 @@ fn run_timerfd_loop(
     let timer_fd = unsafe { libc::timerfd_create(libc::CLOCK_MONOTONIC, libc::TFD_NONBLOCK) };
 
     if timer_fd < 0 {
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "timerfd_create failed: errno {}",
             std::io::Error::last_os_error()
         )));
@@ -153,7 +153,7 @@ fn run_timerfd_loop(
     let clock_ret = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now) };
     if clock_ret < 0 {
         unsafe { libc::close(timer_fd) };
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "clock_gettime failed: errno {}",
             std::io::Error::last_os_error()
         )));
@@ -194,7 +194,7 @@ fn run_timerfd_loop(
     };
     if set_ret < 0 {
         unsafe { libc::close(timer_fd) };
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "timerfd_settime failed: errno {}",
             std::io::Error::last_os_error()
         )));
@@ -204,7 +204,7 @@ fn run_timerfd_loop(
     let epoll_fd = unsafe { libc::epoll_create1(0) };
     if epoll_fd < 0 {
         unsafe { libc::close(timer_fd) };
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "epoll_create1 failed: errno {}",
             std::io::Error::last_os_error()
         )));
@@ -222,7 +222,7 @@ fn run_timerfd_loop(
             libc::close(epoll_fd);
             libc::close(timer_fd);
         }
-        return Err(StreamError::Runtime(format!(
+        return Err(Error::Runtime(format!(
             "epoll_ctl failed: errno {}",
             std::io::Error::last_os_error()
         )));
@@ -249,7 +249,7 @@ fn run_timerfd_loop(
                 libc::close(epoll_fd);
                 libc::close(timer_fd);
             }
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "epoll_wait failed: {}",
                 err
             )));
@@ -279,7 +279,7 @@ fn run_timerfd_loop(
                 libc::close(epoll_fd);
                 libc::close(timer_fd);
             }
-            return Err(StreamError::Runtime(format!(
+            return Err(Error::Runtime(format!(
                 "timerfd read failed: {}",
                 err
             )));

--- a/libs/streamlib-engine/src/linux/processors/bgra_file_source.rs
+++ b/libs/streamlib-engine/src/linux/processors/bgra_file_source.rs
@@ -10,7 +10,7 @@
 use crate::_generated_::VideoFrame;
 use crate::core::context::GpuContextLimitedAccess;
 use crate::core::rhi::PixelFormat;
-use crate::core::{Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 
 use std::io::Read;
@@ -61,7 +61,7 @@ impl crate::core::ManualProcessor for BgraFileSourceProcessor::Processor {
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
-            StreamError::Configuration("GPU context not initialized".into())
+            Error::Configuration("GPU context not initialized".into())
         })?;
 
         self.is_running.store(true, Ordering::Release);
@@ -91,7 +91,7 @@ impl crate::core::ManualProcessor for BgraFileSourceProcessor::Processor {
                 );
             })
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to spawn source thread: {e}"))
+                Error::Configuration(format!("Failed to spawn source thread: {e}"))
             })?;
 
         self.source_thread_handle = Some(handle);

--- a/libs/streamlib-engine/src/linux/processors/camera.rs
+++ b/libs/streamlib-engine/src/linux/processors/camera.rs
@@ -7,7 +7,7 @@ use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
 use crate::core::rhi::{PixelFormat, StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
-use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use crate::host_rhi::HostStreamTextureExt;
 use crate::iceoryx2::OutputWriter;
 use crate::vulkan::rhi::HostVulkanTexture;
@@ -73,7 +73,7 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
 
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
-            StreamError::Configuration("GPU context not initialized. Call setup() first.".into())
+            Error::Configuration("GPU context not initialized. Call setup() first.".into())
         })?;
 
         // Extract the device handle from the FullAccess lifecycle ctx so the
@@ -88,7 +88,7 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
             None => {
                 let devices = Self::list_devices()?;
                 devices.first().map(|d| d.id.clone()).ok_or_else(|| {
-                    StreamError::Configuration(
+                    Error::Configuration(
                         "No V4L2 capture devices found. Check that a camera is connected.".into(),
                     )
                 })?
@@ -97,12 +97,12 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
 
         // Open the V4L2 device
         let mut dev = v4l::Device::with_path(&device_path).map_err(|e| {
-            StreamError::Configuration(format!("Failed to open V4L2 device '{}': {}", device_path, e))
+            Error::Configuration(format!("Failed to open V4L2 device '{}': {}", device_path, e))
         })?;
 
         // Query device capabilities
         let caps = dev.query_caps().map_err(|e| {
-            StreamError::Configuration(format!("Failed to query device capabilities: {}", e))
+            Error::Configuration(format!("Failed to query device capabilities: {}", e))
         })?;
         self.camera_name = caps.card.clone();
         tracing::info!(
@@ -114,7 +114,7 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
 
         // Read the device's current format as a fallback baseline
         let current_fmt = dev.format().map_err(|e| {
-            StreamError::Configuration(format!("Failed to read current format: {}", e))
+            Error::Configuration(format!("Failed to read current format: {}", e))
         })?;
 
         // Negotiate format + resolution: enumerate frame sizes for NV12 (preferred) or
@@ -211,13 +211,13 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
                 try_fmt.width = best_w;
                 try_fmt.height = best_h;
                 let f = dev.set_format(&try_fmt).map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Failed to set camera format (tried NV12, YUYV): {}",
                         e
                     ))
                 })?;
                 if f.fourcc != yuyv_fourcc {
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "Camera does not support NV12 or YUYV (driver negotiated {:?})",
                         f.fourcc
                     )));
@@ -269,7 +269,7 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
         let mut stream =
             v4l::io::mmap::Stream::with_buffers(&mut dev, Type::VideoCapture, V4L2_BUFFER_COUNT)
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Failed to create V4L2 mmap stream: {}",
                         e
                     ))
@@ -333,7 +333,7 @@ impl crate::core::ManualProcessor for LinuxCameraProcessor::Processor {
                 );
             })
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to spawn capture thread: {}", e))
+                Error::Configuration(format!("Failed to spawn capture thread: {}", e))
             })?;
 
         self.capture_thread_handle = Some(handle);
@@ -1808,7 +1808,7 @@ impl LinuxCameraProcessor::Processor {
 
         // Scan /dev/video* devices
         for entry in std::fs::read_dir("/dev").map_err(|e| {
-            StreamError::Configuration(format!("Failed to read /dev: {}", e))
+            Error::Configuration(format!("Failed to read /dev: {}", e))
         })? {
             let entry = match entry {
                 Ok(e) => e,

--- a/libs/streamlib-engine/src/linux/processors/display.rs
+++ b/libs/streamlib-engine/src/linux/processors/display.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::_generated_::com_tatolab_display_config::ScalingMode;
-use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, StreamError};
+use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use streamlib_consumer_rhi::VulkanLayout;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
@@ -115,7 +115,7 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
         let gpu_context = self
             .gpu_context
             .clone()
-            .ok_or_else(|| StreamError::Configuration("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Configuration("GPU context not initialized".into()))?;
 
         // Pull the Vulkan device handle from the FullAccess lifecycle ctx.
         // The render thread uses it to build its swapchain and rendering
@@ -236,7 +236,7 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
 
                 tracing::debug!("Display {}: Render thread exiting", window_id);
             })
-            .map_err(|e| StreamError::Runtime(format!("Failed to spawn render thread: {}", e)))?;
+            .map_err(|e| Error::Runtime(format!("Failed to spawn render thread: {}", e)))?;
 
         self.render_thread = Some(render_thread);
 
@@ -269,7 +269,7 @@ impl crate::core::ManualProcessor for LinuxDisplayProcessor::Processor {
             if handle.is_finished() {
                 handle
                     .join()
-                    .map_err(|_| StreamError::Runtime("Render thread panicked".into()))?;
+                    .map_err(|_| Error::Runtime("Render thread panicked".into()))?;
             } else {
                 tracing::warn!(
                     "Display {}: Render thread did not exit within 2s, detaching",
@@ -1304,7 +1304,7 @@ fn create_swapchain_state(
     let surface = unsafe {
         vulkanalia::window::create_surface(instance, window, window)
     }
-    .map_err(|e| StreamError::GpuError(format!("Failed to create Vulkan surface: {}", e)))?;
+    .map_err(|e| Error::GpuError(format!("Failed to create Vulkan surface: {}", e)))?;
 
     // Check surface support for this queue family
     let surface_supported = unsafe {
@@ -1314,11 +1314,11 @@ fn create_swapchain_state(
             surface,
         )
     }
-    .map_err(|e| StreamError::GpuError(format!("Failed to check surface support: {}", e)))?;
+    .map_err(|e| Error::GpuError(format!("Failed to check surface support: {}", e)))?;
 
     if !surface_supported {
         unsafe { instance.destroy_surface_khr(surface, None) };
-        return Err(StreamError::GpuError(
+        return Err(Error::GpuError(
             "Graphics queue family does not support presentation to this surface".into(),
         ));
     }
@@ -1328,21 +1328,21 @@ fn create_swapchain_state(
         instance.get_physical_device_surface_capabilities_khr(physical_device, surface)
     }
     .map_err(|e| {
-        StreamError::GpuError(format!("Failed to query surface capabilities: {}", e))
+        Error::GpuError(format!("Failed to query surface capabilities: {}", e))
     })?;
 
     let surface_formats = unsafe {
         instance.get_physical_device_surface_formats_khr(physical_device, surface)
     }
     .map_err(|e| {
-        StreamError::GpuError(format!("Failed to query surface formats: {}", e))
+        Error::GpuError(format!("Failed to query surface formats: {}", e))
     })?;
 
     let present_modes = unsafe {
         instance.get_physical_device_surface_present_modes_khr(physical_device, surface)
     }
     .map_err(|e| {
-        StreamError::GpuError(format!("Failed to query present modes: {}", e))
+        Error::GpuError(format!("Failed to query present modes: {}", e))
     })?;
 
     // Choose surface format — prefer B8G8R8A8_UNORM + SRGB_NONLINEAR
@@ -1402,11 +1402,11 @@ fn create_swapchain_state(
         .build();
 
     let swapchain = unsafe { device.create_swapchain_khr(&swapchain_info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create swapchain: {}", e)))?;
+        .map_err(|e| Error::GpuError(format!("Failed to create swapchain: {}", e)))?;
 
     let swapchain_images = unsafe { device.get_swapchain_images_khr(swapchain) }
         .map_err(|e| {
-            StreamError::GpuError(format!("Failed to get swapchain images: {}", e))
+            Error::GpuError(format!("Failed to get swapchain images: {}", e))
         })?;
 
     // Create command pool for this thread
@@ -1416,7 +1416,7 @@ fn create_swapchain_state(
         .build();
 
     let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {}", e)))?;
+        .map_err(|e| Error::GpuError(format!("Failed to create command pool: {}", e)))?;
 
     // image_available: per-frame-in-flight (CPU↔GPU pipelining).
     // render_finished: per-swapchain-image — the present engine keeps a hold
@@ -1429,14 +1429,14 @@ fn create_swapchain_state(
     let mut image_available_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
     for _ in 0..MAX_FRAMES_IN_FLIGHT {
         let image_available = unsafe { device.create_semaphore(&semaphore_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create semaphore: {}", e)))?;
         image_available_semaphores.push(image_available);
     }
 
     let mut render_finished_semaphores = Vec::with_capacity(image_count);
     for _ in 0..image_count {
         let render_finished = unsafe { device.create_semaphore(&semaphore_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create semaphore: {}", e)))?;
         render_finished_semaphores.push(render_finished);
     }
 
@@ -1453,7 +1453,7 @@ fn create_swapchain_state(
     let frame_timeline_semaphore =
         unsafe { device.create_semaphore(&timeline_semaphore_info, None) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create timeline semaphore: {}", e))
+                Error::GpuError(format!("Failed to create timeline semaphore: {}", e))
             })?;
 
     // Pre-allocate command buffers (one per in-flight frame).
@@ -1465,7 +1465,7 @@ fn create_swapchain_state(
 
     let command_buffers = unsafe { device.allocate_command_buffers(&alloc_info) }
         .map_err(|e| {
-            StreamError::GpuError(format!("Failed to allocate command buffers: {}", e))
+            Error::GpuError(format!("Failed to allocate command buffers: {}", e))
         })?;
 
     // Create swapchain image views for dynamic rendering color attachments
@@ -1493,7 +1493,7 @@ fn create_swapchain_state(
             .build();
         let view = unsafe { device.create_image_view(&view_info, None) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create swapchain image view: {}", e))
+                Error::GpuError(format!("Failed to create swapchain image view: {}", e))
             })?;
         swapchain_image_views.push(view);
     }
@@ -1508,7 +1508,7 @@ fn create_swapchain_state(
         vk::Format::R8G8B8A8_UNORM => crate::core::rhi::TextureFormat::Rgba8Unorm,
         vk::Format::R8G8B8A8_SRGB => crate::core::rhi::TextureFormat::Rgba8UnormSrgb,
         other => {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Display swapchain surface format {other:?} not mapped to TextureFormat"
             )));
         }
@@ -1610,7 +1610,7 @@ fn recreate_swapchain(
         instance.get_physical_device_surface_capabilities_khr(physical_device, surface)
     }
     .map_err(|e| {
-        StreamError::GpuError(format!("Failed to query surface capabilities: {}", e))
+        Error::GpuError(format!("Failed to query surface capabilities: {}", e))
     })?;
 
     let extent = if capabilities.current_extent.width != u32::MAX {
@@ -1632,7 +1632,7 @@ fn recreate_swapchain(
         instance.get_physical_device_surface_present_modes_khr(physical_device, surface)
     }
     .map_err(|e| {
-        StreamError::GpuError(format!("Failed to query present modes: {}", e))
+        Error::GpuError(format!("Failed to query present modes: {}", e))
     })?;
 
     let present_mode = if vsync {
@@ -1665,11 +1665,11 @@ fn recreate_swapchain(
         .build();
 
     let swapchain = unsafe { device.create_swapchain_khr(&swapchain_info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to recreate swapchain: {}", e)))?;
+        .map_err(|e| Error::GpuError(format!("Failed to recreate swapchain: {}", e)))?;
 
     let swapchain_images = unsafe { device.get_swapchain_images_khr(swapchain) }
         .map_err(|e| {
-            StreamError::GpuError(format!("Failed to get swapchain images: {}", e))
+            Error::GpuError(format!("Failed to get swapchain images: {}", e))
         })?;
 
     // Create new command pool
@@ -1679,7 +1679,7 @@ fn recreate_swapchain(
         .build();
 
     let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {}", e)))?;
+        .map_err(|e| Error::GpuError(format!("Failed to create command pool: {}", e)))?;
 
     // image_available: per-frame-in-flight. render_finished: per-swapchain-image
     // (see create path for rationale).
@@ -1689,14 +1689,14 @@ fn recreate_swapchain(
     let mut image_available_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
     for _ in 0..MAX_FRAMES_IN_FLIGHT {
         let image_available = unsafe { device.create_semaphore(&semaphore_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create semaphore: {}", e)))?;
         image_available_semaphores.push(image_available);
     }
 
     let mut render_finished_semaphores = Vec::with_capacity(new_image_count);
     for _ in 0..new_image_count {
         let render_finished = unsafe { device.create_semaphore(&semaphore_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {}", e)))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create semaphore: {}", e)))?;
         render_finished_semaphores.push(render_finished);
     }
 
@@ -1711,7 +1711,7 @@ fn recreate_swapchain(
     let frame_timeline_semaphore =
         unsafe { device.create_semaphore(&timeline_semaphore_info, None) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create timeline semaphore: {}", e))
+                Error::GpuError(format!("Failed to create timeline semaphore: {}", e))
             })?;
 
     // Pre-allocate command buffers (one per in-flight frame).
@@ -1723,7 +1723,7 @@ fn recreate_swapchain(
 
     let command_buffers = unsafe { device.allocate_command_buffers(&alloc_info) }
         .map_err(|e| {
-            StreamError::GpuError(format!("Failed to allocate command buffers: {}", e))
+            Error::GpuError(format!("Failed to allocate command buffers: {}", e))
         })?;
 
     // Create swapchain image views for dynamic rendering color attachments
@@ -1751,7 +1751,7 @@ fn recreate_swapchain(
             .build();
         let view = unsafe { device.create_image_view(&view_info, None) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create swapchain image view: {}", e))
+                Error::GpuError(format!("Failed to create swapchain image view: {}", e))
             })?;
         swapchain_image_views.push(view);
     }

--- a/libs/streamlib-engine/src/linux/processors/h264_decoder.rs
+++ b/libs/streamlib-engine/src/linux/processors/h264_decoder.rs
@@ -9,7 +9,7 @@
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::core::context::GpuContextLimitedAccess;
 use crate::core::rhi::PixelFormat;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
 
@@ -44,10 +44,10 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let decode_queue = vulkan_device.video_decode_queue().ok_or_else(|| {
-            StreamError::Runtime("GPU does not support Vulkan Video decode".into())
+            Error::Runtime("GPU does not support Vulkan Video decode".into())
         })?;
         let decode_queue_family = vulkan_device.video_decode_queue_family_index().ok_or_else(|| {
-            StreamError::Runtime("No video decode queue family".into())
+            Error::Runtime("No video decode queue family".into())
         })?;
 
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
@@ -65,13 +65,13 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
             vulkan_device.queue(),
             vulkan_device.queue_family_index(),
         ).map_err(|e| {
-            StreamError::Runtime(format!("Failed to create H.264 decoder: {e}"))
+            Error::Runtime(format!("Failed to create H.264 decoder: {e}"))
         })?;
 
         // Pre-create the video session BEFORE the display swapchain.
         // NVIDIA limits video session creation after swapchain exists.
         decoder.pre_initialize_session().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-initialize H.264 decoder session: {e}"))
+            Error::Runtime(format!("Failed to pre-initialize H.264 decoder session: {e}"))
         })?;
 
         // Eagerly allocate the NV12→RGBA converter. Decode-side resources
@@ -79,7 +79,7 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
         // exportable VMA pools at `HostVulkanDevice` construction so this
         // no longer races NVIDIA's post-swapchain exportable cap.
         decoder.prepare_gpu_decode_resources().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-allocate H.264 decode resources: {e}"))
+            Error::Runtime(format!("Failed to pre-allocate H.264 decode resources: {e}"))
         })?;
 
         tracing::info!("[H264Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
@@ -107,15 +107,15 @@ impl crate::core::ReactiveProcessor for H264DecoderProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
 
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("H.264 decoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.264 decoder not initialized".into()))?;
 
         let decoded_frames = decoder.feed(&encoded.data).map_err(|e| {
-            StreamError::Runtime(format!("H.264 decode failed: {e}"))
+            Error::Runtime(format!("H.264 decode failed: {e}"))
         })?;
 
         for decoded in decoded_frames {

--- a/libs/streamlib-engine/src/linux/processors/h264_encoder.rs
+++ b/libs/streamlib-engine/src/linux/processors/h264_encoder.rs
@@ -12,7 +12,7 @@
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::core::context::GpuContextLimitedAccess;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
@@ -61,10 +61,10 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
-            StreamError::Runtime("GPU does not support Vulkan Video encode".into())
+            Error::Runtime("GPU does not support Vulkan Video encode".into())
         })?;
         let encode_queue_family = vulkan_device.video_encode_queue_family_index().ok_or_else(|| {
-            StreamError::Runtime("No video encode queue family".into())
+            Error::Runtime("No video encode queue family".into())
         })?;
 
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
@@ -84,7 +84,7 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
             vulkan_device.compute_queue().unwrap_or_else(|| vulkan_device.queue()),
             vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
         ).map_err(|e| {
-            StreamError::Runtime(format!("Failed to create H.264 encoder: {e}"))
+            Error::Runtime(format!("Failed to create H.264 encoder: {e}"))
         })?;
 
         // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
@@ -93,7 +93,7 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
         // already materialized the underlying VMA blocks so this no longer
         // races NVIDIA's post-swapchain export cap.
         encoder.prepare_gpu_encode_resources().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
+            Error::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
         })?;
 
         tracing::info!(
@@ -124,23 +124,23 @@ impl crate::core::ReactiveProcessor for H264EncoderProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
 
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("H.264 encoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.264 encoder not initialized".into()))?;
 
         let texture = gpu_ctx.resolve_video_frame_texture(&frame)?;
         let image_view = texture.inner.image_view().map_err(|e| {
-            StreamError::GpuError(format!("Failed to get image view: {e}"))
+            Error::GpuError(format!("Failed to get image view: {e}"))
         })?;
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
 
         let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
-            StreamError::Runtime(format!("H.264 encode failed: {e}"))
+            Error::Runtime(format!("H.264 encode failed: {e}"))
         })?;
 
         for packet in packets {

--- a/libs/streamlib-engine/src/linux/processors/h265_decoder.rs
+++ b/libs/streamlib-engine/src/linux/processors/h265_decoder.rs
@@ -9,7 +9,7 @@
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::core::context::GpuContextLimitedAccess;
 use crate::core::rhi::PixelFormat;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
 
@@ -44,10 +44,10 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let decode_queue = vulkan_device.video_decode_queue().ok_or_else(|| {
-            StreamError::Runtime("GPU does not support Vulkan Video decode".into())
+            Error::Runtime("GPU does not support Vulkan Video decode".into())
         })?;
         let decode_queue_family = vulkan_device.video_decode_queue_family_index().ok_or_else(|| {
-            StreamError::Runtime("No video decode queue family".into())
+            Error::Runtime("No video decode queue family".into())
         })?;
 
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
@@ -65,13 +65,13 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
             vulkan_device.queue(),
             vulkan_device.queue_family_index(),
         ).map_err(|e| {
-            StreamError::Runtime(format!("Failed to create H.265 decoder: {e}"))
+            Error::Runtime(format!("Failed to create H.265 decoder: {e}"))
         })?;
 
         // Pre-create the video session BEFORE the display swapchain.
         // NVIDIA limits video session creation after swapchain exists.
         decoder.pre_initialize_session().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-initialize H.265 decoder session: {e}"))
+            Error::Runtime(format!("Failed to pre-initialize H.265 decoder session: {e}"))
         })?;
 
         // Eagerly allocate the NV12→RGBA converter. Decode-side resources
@@ -79,7 +79,7 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
         // exportable VMA pools at `HostVulkanDevice` construction so this
         // no longer races NVIDIA's post-swapchain exportable cap.
         decoder.prepare_gpu_decode_resources().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-allocate H.265 decode resources: {e}"))
+            Error::Runtime(format!("Failed to pre-allocate H.265 decode resources: {e}"))
         })?;
 
         tracing::info!("[H265Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
@@ -107,15 +107,15 @@ impl crate::core::ReactiveProcessor for H265DecoderProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
 
         let decoder = self
             .decoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("H.265 decoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.265 decoder not initialized".into()))?;
 
         let decoded_frames = decoder.feed(&encoded.data).map_err(|e| {
-            StreamError::Runtime(format!("H.265 decode failed: {e}"))
+            Error::Runtime(format!("H.265 decode failed: {e}"))
         })?;
 
         for decoded in decoded_frames {

--- a/libs/streamlib-engine/src/linux/processors/h265_encoder.rs
+++ b/libs/streamlib-engine/src/linux/processors/h265_encoder.rs
@@ -12,7 +12,7 @@
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::core::context::GpuContextLimitedAccess;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
@@ -61,10 +61,10 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
         let vulkan_device = &ctx.gpu_full_access().device().inner;
 
         let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
-            StreamError::Runtime("GPU does not support Vulkan Video encode".into())
+            Error::Runtime("GPU does not support Vulkan Video encode".into())
         })?;
         let encode_queue_family = vulkan_device.video_encode_queue_family_index().ok_or_else(|| {
-            StreamError::Runtime("No video encode queue family".into())
+            Error::Runtime("No video encode queue family".into())
         })?;
 
         let submitter: std::sync::Arc<dyn vulkan_video::RhiQueueSubmitter> =
@@ -84,7 +84,7 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
             vulkan_device.compute_queue().unwrap_or_else(|| vulkan_device.queue()),
             vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
         ).map_err(|e| {
-            StreamError::Runtime(format!("Failed to create H.265 encoder: {e}"))
+            Error::Runtime(format!("Failed to create H.265 encoder: {e}"))
         })?;
 
         // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
@@ -93,7 +93,7 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
         // already materialized the underlying VMA blocks so this no longer
         // races NVIDIA's post-swapchain export cap.
         encoder.prepare_gpu_encode_resources().map_err(|e| {
-            StreamError::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
+            Error::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
         })?;
 
         tracing::info!(
@@ -124,23 +124,23 @@ impl crate::core::ReactiveProcessor for H265EncoderProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
 
         let encoder = self
             .encoder
             .as_mut()
-            .ok_or_else(|| StreamError::Runtime("H.265 encoder not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("H.265 encoder not initialized".into()))?;
 
         let texture = gpu_ctx.resolve_video_frame_texture(&frame)?;
         let image_view = texture.inner.image_view().map_err(|e| {
-            StreamError::GpuError(format!("Failed to get image view: {e}"))
+            Error::GpuError(format!("Failed to get image view: {e}"))
         })?;
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
 
         let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
-            StreamError::Runtime(format!("H.265 encode failed: {e}"))
+            Error::Runtime(format!("H.265 encode failed: {e}"))
         })?;
 
         for packet in packets {

--- a/libs/streamlib-engine/src/linux/processors/mp4_writer.rs
+++ b/libs/streamlib-engine/src/linux/processors/mp4_writer.rs
@@ -9,7 +9,7 @@
 
 use crate::_generated_::VideoFrame;
 use crate::core::context::GpuContextLimitedAccess;
-use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, StreamError};
+use crate::core::{Result, RuntimeContextFullAccess, RuntimeContextLimitedAccess, Error};
 
 use std::io::Write;
 use std::process::{Child, Command, Stdio};
@@ -47,12 +47,12 @@ impl crate::core::ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
             drop(child.stdin.take());
 
             let output = child.wait_with_output().map_err(|e| {
-                StreamError::Runtime(format!("Failed to wait for ffmpeg: {e}"))
+                Error::Runtime(format!("Failed to wait for ffmpeg: {e}"))
             })?;
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                return Err(StreamError::Runtime(format!(
+                return Err(Error::Runtime(format!(
                     "ffmpeg exited with status {}: {stderr}", output.status
                 )));
             }
@@ -79,7 +79,7 @@ impl crate::core::ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
         let gpu_ctx = self
             .gpu_context
             .as_ref()
-            .ok_or_else(|| StreamError::Runtime("GPU context not initialized".into()))?;
+            .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
 
         // Resolve VideoFrame to pixel buffer for decoded NV12 data.
         // Decoder outputs NV12 (Y + UV = W*H*3/2). ffmpeg converts to display RGB
@@ -139,7 +139,7 @@ impl crate::core::ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())
                 .spawn()
-                .map_err(|e| StreamError::Runtime(format!("Failed to spawn ffmpeg: {e}")))?;
+                .map_err(|e| Error::Runtime(format!("Failed to spawn ffmpeg: {e}")))?;
 
             self.ffmpeg_process = Some(child);
         }
@@ -147,11 +147,11 @@ impl crate::core::ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
         // Write raw RGBA frame to ffmpeg's stdin.
         let child = self.ffmpeg_process.as_mut().unwrap();
         let stdin = child.stdin.as_mut().ok_or_else(|| {
-            StreamError::Runtime("ffmpeg stdin not available".into())
+            Error::Runtime("ffmpeg stdin not available".into())
         })?;
 
         stdin.write_all(raw_data).map_err(|e| {
-            StreamError::Runtime(format!("Failed to write frame to ffmpeg: {e}"))
+            Error::Runtime(format!("Failed to write frame to ffmpeg: {e}"))
         })?;
 
         self.frames_received += 1;

--- a/libs/streamlib-engine/src/metal/rhi/blitter.rs
+++ b/libs/streamlib-engine/src/metal/rhi/blitter.rs
@@ -7,7 +7,7 @@ use crate::apple::iosurface::create_metal_texture_from_iosurface;
 use crate::apple::texture_pool_macos::get_iosurface_id;
 use crate::core::rhi::blitter::RhiBlitter;
 use crate::core::rhi::{RhiCommandQueue, RhiPixelBuffer};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use metal::foreign_types::ForeignTypeRef;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -80,12 +80,12 @@ impl RhiBlitter for MetalBlitter {
         let src_iosurface = src
             .buffer_ref()
             .iosurface_ref()
-            .ok_or_else(|| StreamError::GpuError("Source buffer not backed by IOSurface".into()))?;
+            .ok_or_else(|| Error::GpuError("Source buffer not backed by IOSurface".into()))?;
 
         let dest_iosurface = dest
             .buffer_ref()
             .iosurface_ref()
-            .ok_or_else(|| StreamError::GpuError("Dest buffer not backed by IOSurface".into()))?;
+            .ok_or_else(|| Error::GpuError("Dest buffer not backed by IOSurface".into()))?;
 
         // Cast to objc2 IOSurface references
         let src_iosurface_ref = unsafe { &*(src_iosurface as *const IOSurface) };
@@ -152,7 +152,7 @@ impl RhiBlitter for MetalBlitter {
         let dest_iosurface = dest
             .buffer_ref()
             .iosurface_ref()
-            .ok_or_else(|| StreamError::GpuError("Dest buffer not backed by IOSurface".into()))?;
+            .ok_or_else(|| Error::GpuError("Dest buffer not backed by IOSurface".into()))?;
 
         // Cast pointers to objc2 IOSurface references
         let src_iosurface_ref = &*(src as *const IOSurface);

--- a/libs/streamlib-engine/src/metal/rhi/format_converter.rs
+++ b/libs/streamlib-engine/src/metal/rhi/format_converter.rs
@@ -12,7 +12,7 @@ use crate::apple::vimage_ffi::{
     CVPixelBufferLockBaseAddress, CVPixelBufferUnlockBaseAddress,
 };
 use crate::core::rhi::{PixelFormat, RhiPixelBuffer};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use std::ptr;
 
 /// macOS format converter wrapping vImageConverter.
@@ -37,7 +37,7 @@ impl FormatConverterMacOS {
         };
 
         if src_cv_format.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create vImageCVImageFormat for source format {:?}",
                 source_format
             )));
@@ -55,7 +55,7 @@ impl FormatConverterMacOS {
 
         if dst_cv_format.is_null() {
             unsafe { vImageCVImageFormat_Release(src_cv_format) };
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create vImageCVImageFormat for dest format {:?}",
                 dest_format
             )));
@@ -82,7 +82,7 @@ impl FormatConverterMacOS {
         }
 
         if converter.is_null() || error != kvImageNoError {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create vImageConverter: {} ({:?} -> {:?})",
                 vimage_error_description(error),
                 source_format,
@@ -114,7 +114,7 @@ impl FormatConverterMacOS {
     pub fn convert(&self, source: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
         // Verify dimensions match
         if source.width != dest.width || source.height != dest.height {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Buffer dimension mismatch: source {}x{}, dest {}x{}",
                 source.width, source.height, dest.width, dest.height
             )));
@@ -129,7 +129,7 @@ impl FormatConverterMacOS {
         let src_lock_result =
             unsafe { CVPixelBufferLockBaseAddress(src_ptr, kCVPixelBufferLock_ReadOnly) };
         if src_lock_result != kCVReturnSuccess {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to lock source pixel buffer: {}",
                 src_lock_result
             )));
@@ -139,7 +139,7 @@ impl FormatConverterMacOS {
         let dst_lock_result = unsafe { CVPixelBufferLockBaseAddress(dst_ptr, 0) };
         if dst_lock_result != kCVReturnSuccess {
             unsafe { CVPixelBufferUnlockBaseAddress(src_ptr, kCVPixelBufferLock_ReadOnly) };
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to lock destination pixel buffer: {}",
                 dst_lock_result
             )));
@@ -181,7 +181,7 @@ impl FormatConverterMacOS {
         }
 
         if result != kvImageNoError {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "vImageConvert_AnyToAny failed: {}",
                 vimage_error_description(result)
             )));

--- a/libs/streamlib-engine/src/metal/rhi/gl_interop.rs
+++ b/libs/streamlib-engine/src/metal/rhi/gl_interop.rs
@@ -14,7 +14,7 @@
 
 use crate::apple::corevideo_ffi::CVPixelBufferRef;
 use crate::core::rhi::RhiPixelBuffer;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use std::ffi::c_void;
 
 // =============================================================================
@@ -128,7 +128,7 @@ impl MacOsGlContext {
                 CGLChoosePixelFormat(attributes.as_ptr(), &mut pixel_format, &mut num_formats);
 
             if err != 0 || pixel_format.is_null() {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CGLChoosePixelFormat failed with error: {}",
                     err
                 )));
@@ -140,7 +140,7 @@ impl MacOsGlContext {
 
             if err != 0 || context.is_null() {
                 CGLDestroyPixelFormat(pixel_format);
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CGLCreateContext failed with error: {}",
                     err
                 )));
@@ -160,7 +160,7 @@ impl MacOsGlContext {
         unsafe {
             let err = CGLSetCurrentContext(self.cgl_context);
             if err != 0 {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CGLSetCurrentContext failed with error: {}",
                     err
                 )));
@@ -213,7 +213,7 @@ impl MacOsGlContext {
             // Ensure we have a current context
             let current = CGLGetCurrentContext();
             if current.is_null() {
-                return Err(StreamError::GpuError(
+                return Err(Error::GpuError(
                     "No current GL context. Call make_current() first.".into(),
                 ));
             }
@@ -223,7 +223,7 @@ impl MacOsGlContext {
             glGenTextures(1, &mut texture_id);
 
             if texture_id == 0 {
-                return Err(StreamError::GpuError(
+                return Err(Error::GpuError(
                     "glGenTextures failed to create texture".into(),
                 ));
             }
@@ -240,7 +240,7 @@ impl MacOsGlContext {
             let gl_error = glGetError();
             if gl_error != 0 {
                 glDeleteTextures(1, &texture_id);
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "GL error during texture creation: 0x{:X}",
                     gl_error
                 )));
@@ -276,7 +276,7 @@ impl MacOsGlContext {
             // Ensure we have a current context
             let current = CGLGetCurrentContext();
             if current != self.cgl_context {
-                return Err(StreamError::GpuError(
+                return Err(Error::GpuError(
                     "GL context must be current to rebind texture".into(),
                 ));
             }
@@ -300,7 +300,7 @@ impl MacOsGlContext {
             glBindTexture(GL_TEXTURE_RECTANGLE, 0);
 
             if result != 0 {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "CGLTexImageIOSurface2D failed with error: {}",
                     result
                 )));
@@ -407,7 +407,7 @@ impl GlTextureBinding {
             // Get IOSurface from CVPixelBuffer
             let iosurface = CVPixelBufferGetIOSurface(cv_buffer);
             if iosurface.is_null() {
-                return Err(StreamError::GpuError(
+                return Err(Error::GpuError(
                     "CVPixelBuffer has no IOSurface backing. \
                      Ensure buffer was created with kCVPixelBufferIOSurfacePropertiesKey."
                         .into(),

--- a/libs/streamlib-engine/src/metal/rhi/metal_command_queue.rs
+++ b/libs/streamlib-engine/src/metal/rhi/metal_command_queue.rs
@@ -7,7 +7,7 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::MTLCommandQueue;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::MetalCommandBuffer;
 
@@ -32,7 +32,7 @@ impl MetalCommandQueue {
         let cmd_buffer = self
             .queue
             .commandBuffer()
-            .ok_or_else(|| StreamError::GpuError("Failed to create Metal command buffer".into()))?;
+            .ok_or_else(|| Error::GpuError("Failed to create Metal command buffer".into()))?;
         Ok(MetalCommandBuffer::new(cmd_buffer))
     }
 

--- a/libs/streamlib-engine/src/metal/rhi/metal_device.rs
+++ b/libs/streamlib-engine/src/metal/rhi/metal_device.rs
@@ -8,7 +8,7 @@ use objc2::runtime::ProtocolObject;
 use objc2_metal::{MTLCommandQueue, MTLCreateSystemDefaultDevice, MTLDevice};
 
 use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::{MetalCommandQueue, MetalTexture};
 
@@ -22,7 +22,7 @@ impl MetalDevice {
     /// Create a new Metal device.
     pub fn new() -> Result<Self> {
         let device = MTLCreateSystemDefaultDevice().ok_or_else(|| {
-            StreamError::GpuError(
+            Error::GpuError(
                 "No Metal device available on this system. Metal requires macOS 10.11+ or iOS 8+."
                     .into(),
             )
@@ -30,7 +30,7 @@ impl MetalDevice {
 
         let command_queue = device
             .newCommandQueue()
-            .ok_or_else(|| StreamError::GpuError("Failed to create Metal command queue".into()))?;
+            .ok_or_else(|| Error::GpuError("Failed to create Metal command queue".into()))?;
 
         Ok(Self {
             device,
@@ -57,7 +57,7 @@ impl MetalDevice {
             .device
             .newTextureWithDescriptor(&texture_desc)
             .ok_or_else(|| {
-                StreamError::TextureError(format!(
+                Error::TextureError(format!(
                     "Failed to create Metal texture {}x{} format={:?}",
                     desc.width, desc.height, desc.format
                 ))

--- a/libs/streamlib-engine/src/metal/rhi/pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/metal/rhi/pixel_buffer_pool.rs
@@ -28,7 +28,7 @@ use crate::core::rhi::{
     PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, RhiPixelBuffer, RhiPixelBufferPool,
     RhiPixelBufferRef,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// macOS pixel buffer pool wrapping CVPixelBufferPool.
 pub struct PixelBufferPoolMacOS {
@@ -52,7 +52,7 @@ impl PixelBufferPoolMacOS {
 
         // Reject Unknown format - CV doesn't support format value 0
         if pixel_format == PixelFormat::Unknown {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Cannot create pixel buffer pool with Unknown format".into(),
             ));
         }
@@ -101,7 +101,7 @@ impl PixelBufferPoolMacOS {
         );
 
         if status != kCVReturnSuccess || pixel_buffer.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to acquire pixel buffer from pool: status {}",
                 status
             )));
@@ -110,7 +110,7 @@ impl PixelBufferPoolMacOS {
         // The pool gives us a retained buffer, so use no_retain
         let buffer_ref = unsafe {
             RhiPixelBufferRef::from_cv_pixel_buffer_no_retain(pixel_buffer)
-                .ok_or_else(|| StreamError::GpuError("Null pixel buffer from pool".into()))?
+                .ok_or_else(|| Error::GpuError("Null pixel buffer from pool".into()))?
         };
 
         // Get IOSurfaceID to check if this is a recycled buffer
@@ -321,7 +321,7 @@ fn create_pool_on_main_thread(
     };
 
     if status != kCVReturnSuccess || pool.is_null() {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Failed to create CVPixelBufferPool: status {}",
             status
         )));

--- a/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
@@ -106,7 +106,7 @@ use crate::apple::corevideo_ffi::{
     IOSurfaceLookupFromMachPort,
 };
 use crate::core::rhi::{RhiExternalHandle, RhiPixelBufferExport, RhiPixelBufferImport};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 impl RhiPixelBufferExport for RhiPixelBufferRef {
     /// Export the CVPixelBuffer's IOSurface for cross-process sharing.
@@ -128,7 +128,7 @@ impl RhiPixelBufferExport for RhiPixelBufferRef {
                 cv_buffer,
                 std::process::id()
             );
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "CVPixelBuffer is not backed by an IOSurface".into(),
             ));
         }
@@ -145,7 +145,7 @@ impl RhiPixelBufferExport for RhiPixelBufferRef {
                 iosurface,
                 std::process::id()
             );
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "IOSurface has invalid ID 0".into(),
             ));
         }
@@ -186,7 +186,7 @@ impl RhiPixelBufferRef {
                 cv_buffer,
                 std::process::id()
             );
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "CVPixelBuffer is not backed by an IOSurface".into(),
             ));
         }
@@ -206,7 +206,7 @@ impl RhiPixelBufferRef {
                 id,
                 std::process::id()
             );
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "IOSurfaceCreateMachPort failed".into(),
             ));
         }
@@ -261,7 +261,7 @@ impl RhiPixelBufferImport for RhiPixelBufferRef {
                         id,
                         std::process::id()
                     );
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "IOSurface with ID {} not found",
                         id
                     )));
@@ -297,7 +297,7 @@ impl RhiPixelBufferImport for RhiPixelBufferRef {
                         port,
                         std::process::id()
                     );
-                    return Err(StreamError::Configuration(format!(
+                    return Err(Error::Configuration(format!(
                         "IOSurface mach port {} lookup failed",
                         port
                     )));
@@ -330,7 +330,7 @@ impl RhiPixelBufferImport for RhiPixelBufferRef {
             }
 
             #[allow(unreachable_patterns)]
-            _ => Err(StreamError::NotSupported(
+            _ => Err(Error::NotSupported(
                 "External handle type not supported on macOS".into(),
             )),
         }
@@ -358,7 +358,7 @@ fn create_cv_buffer_from_iosurface(
             result,
             std::process::id()
         );
-        return Err(StreamError::Configuration(format!(
+        return Err(Error::Configuration(format!(
             "Failed to create CVPixelBuffer from IOSurface: error {}",
             result
         )));
@@ -369,7 +369,7 @@ fn create_cv_buffer_from_iosurface(
             "CVPixelBufferCreateWithIOSurface returned null (pid={})",
             std::process::id()
         );
-        return Err(StreamError::Configuration(
+        return Err(Error::Configuration(
             "CVPixelBufferCreateWithIOSurface returned null".into(),
         ));
     }
@@ -383,7 +383,7 @@ fn create_cv_buffer_from_iosurface(
     // The CVPixelBuffer is already retained by CreateWithIOSurface,
     // so use from_cv_pixel_buffer_no_retain
     unsafe { RhiPixelBufferRef::from_cv_pixel_buffer_no_retain(cv_buffer) }
-        .ok_or_else(|| StreamError::Configuration("Failed to wrap CVPixelBuffer".into()))
+        .ok_or_else(|| Error::Configuration("Failed to wrap CVPixelBuffer".into()))
 }
 
 /// Create an RhiPixelBufferRef from a raw IOSurfaceRef.
@@ -396,7 +396,7 @@ pub unsafe fn from_iosurface_ref_impl(
     iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
 ) -> Result<RhiPixelBufferRef> {
     if iosurface.is_null() {
-        return Err(StreamError::Configuration("IOSurfaceRef is null".into()));
+        return Err(Error::Configuration("IOSurfaceRef is null".into()));
     }
 
     let id = IOSurfaceGetID(iosurface);

--- a/libs/streamlib-engine/src/metal/rhi/texture_cache.rs
+++ b/libs/streamlib-engine/src/metal/rhi/texture_cache.rs
@@ -24,7 +24,7 @@ use crate::apple::corevideo_ffi::{
     CVMetalTextureGetTexture, CVMetalTextureRef,
 };
 use crate::core::rhi::{RhiPixelBuffer, RhiTextureCache, RhiTextureView};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// macOS texture cache wrapping CVMetalTextureCache.
 ///
@@ -95,7 +95,7 @@ impl TextureCacheMacOS {
         };
 
         if status != kCVReturnSuccess || texture.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Failed to create texture from CVPixelBuffer: status {}",
                 status
             )));
@@ -217,7 +217,7 @@ fn create_cache_on_main_thread(device_ptr: usize) -> Result<SendableCacheRef> {
     };
 
     if status != kCVReturnSuccess || cache.is_null() {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Failed to create CVMetalTextureCache: status {}",
             status
         )));

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
@@ -21,7 +21,7 @@ use vulkanalia::vk::KhrAccelerationStructureExtensionDeviceCommands as _;
 use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
 
@@ -119,25 +119,25 @@ impl VulkanAccelerationStructure {
         indices: &[u32],
     ) -> Result<Arc<Self>> {
         if !vulkan_device.supports_ray_tracing_pipeline() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': ray-tracing extensions not supported by device"
             )));
         }
         if vertices.is_empty() || indices.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': empty geometry (vertices={}, indices={})",
                 vertices.len(),
                 indices.len()
             )));
         }
         if vertices.len() % 3 != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': vertex slice length {} is not a multiple of 3 (must be flat [x,y,z,...] layout)",
                 vertices.len()
             )));
         }
         if indices.len() % 3 != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': index slice length {} is not a multiple of 3 (must be three indices per triangle)",
                 indices.len()
             )));
@@ -163,7 +163,7 @@ impl VulkanAccelerationStructure {
         )?;
         let vptr = vertex_buffer.mapped_ptr();
         if vptr.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': vertex buffer mapping returned null"
             )));
         }
@@ -185,7 +185,7 @@ impl VulkanAccelerationStructure {
         )?;
         let iptr = index_buffer.mapped_ptr();
         if iptr.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': index buffer mapping returned null"
             )));
         }
@@ -274,18 +274,18 @@ impl VulkanAccelerationStructure {
         instances: &[TlasInstanceDesc],
     ) -> Result<Arc<Self>> {
         if !vulkan_device.supports_ray_tracing_pipeline() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': ray-tracing extensions not supported by device"
             )));
         }
         if instances.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': TLAS must have at least one instance"
             )));
         }
         for (i, inst) in instances.iter().enumerate() {
             if inst.blas.kind != AccelerationStructureKind::BottomLevel {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Acceleration structure '{label}': instance {i} references a TLAS as its BLAS"
                 )));
             }
@@ -313,7 +313,7 @@ impl VulkanAccelerationStructure {
         )?;
         let inst_ptr = instance_buffer.mapped_ptr();
         if inst_ptr.is_null() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Acceleration structure '{label}': instance buffer mapping returned null"
             )));
         }
@@ -421,7 +421,7 @@ impl VulkanAccelerationStructure {
             device.create_acceleration_structure_khr(&as_create_info, None)
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Acceleration structure '{label}': vkCreateAccelerationStructureKHR failed: {e}"
             ))
         })?;
@@ -469,7 +469,7 @@ impl VulkanAccelerationStructure {
             if let Err(e) = unsafe { device.begin_command_buffer(cmd, &begin_info) } {
                 unsafe { device.destroy_command_pool(command_pool, None) };
                 drop(scratch);
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Acceleration structure '{label}': begin_command_buffer failed: {e}"
                 )));
             }
@@ -497,7 +497,7 @@ impl VulkanAccelerationStructure {
             if let Err(e) = unsafe { device.end_command_buffer(cmd) } {
                 unsafe { device.destroy_command_pool(command_pool, None) };
                 drop(scratch);
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Acceleration structure '{label}': end_command_buffer failed: {e}"
                 )));
             }
@@ -508,7 +508,7 @@ impl VulkanAccelerationStructure {
                 Err(e) => {
                     unsafe { device.destroy_command_pool(command_pool, None) };
                     drop(scratch);
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Acceleration structure '{label}': fence creation failed: {e}"
                     )));
                 }
@@ -529,7 +529,7 @@ impl VulkanAccelerationStructure {
                 unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
                     .map(|_| ())
                     .map_err(|e| {
-                        StreamError::GpuError(format!(
+                        Error::GpuError(format!(
                             "Acceleration structure '{label}': wait_for_fences failed: {e}"
                         ))
                     })
@@ -672,7 +672,7 @@ impl AsBuffer {
         };
         let (buffer, allocation) =
             unsafe { allocator.create_buffer(buffer_info, &alloc_opts) }.map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "AS buffer '{label}': vmaCreateBuffer (size={size}) failed: {e}"
                 ))
             })?;
@@ -725,7 +725,7 @@ impl AsBuffer {
         };
         let (buffer, allocation) =
             unsafe { allocator.create_buffer(buffer_info, &alloc_opts) }.map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "AS buffer (host-visible) '{label}': vmaCreateBuffer (size={size}) failed: {e}"
                 ))
             })?;
@@ -794,7 +794,7 @@ fn create_one_shot_pool(
         .flags(vk::CommandPoolCreateFlags::TRANSIENT)
         .build();
     unsafe { device.create_command_pool(&info, None) }.map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "AS one-shot pool '{label}': create_command_pool failed: {e}"
         ))
     })
@@ -810,7 +810,7 @@ fn allocate_one_shot_cmd(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }.map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "AS one-shot cmd: allocate_command_buffers failed: {e}"
         ))
     })?;

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_blitter.rs
@@ -8,7 +8,7 @@ use vulkanalia::vk;
 
 use crate::core::rhi::blitter::RhiBlitter;
 use crate::core::rhi::RhiPixelBuffer;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
 
@@ -33,7 +33,7 @@ impl VulkanBlitter {
 
         let command_pool =
             unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
-                StreamError::GpuError(format!("Failed to create blitter command pool: {e}"))
+                Error::GpuError(format!("Failed to create blitter command pool: {e}"))
             })?;
 
         Ok(Self {
@@ -54,7 +54,7 @@ impl RhiBlitter for VulkanBlitter {
         let dest_size = dest.buffer_ref().inner.size();
 
         if src_size != dest_size {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "blit_copy requires same-size buffers: src={} bytes, dest={} bytes",
                 src_size, dest_size
             )));
@@ -69,7 +69,7 @@ impl RhiBlitter for VulkanBlitter {
             .build();
 
         let command_buffer = unsafe { self.device.allocate_command_buffers(&alloc_info) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to allocate blit command buffer: {e}")))?[0];
+            .map_err(|e| Error::GpuError(format!("Failed to allocate blit command buffer: {e}")))?[0];
 
         let begin_info = vk::CommandBufferBeginInfo::builder()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
@@ -79,7 +79,7 @@ impl RhiBlitter for VulkanBlitter {
             self.device
                 .begin_command_buffer(command_buffer, &begin_info)
                 .map(|_| ())
-                .map_err(|e| StreamError::GpuError(format!("Failed to begin blit command buffer: {e}")))?;
+                .map_err(|e| Error::GpuError(format!("Failed to begin blit command buffer: {e}")))?;
 
             let region = vk::BufferCopy2::builder()
                 .src_offset(0)
@@ -97,7 +97,7 @@ impl RhiBlitter for VulkanBlitter {
             self.device
                 .end_command_buffer(command_buffer)
                 .map(|_| ())
-                .map_err(|e| StreamError::GpuError(format!("Failed to end blit command buffer: {e}")))?;
+                .map_err(|e| Error::GpuError(format!("Failed to end blit command buffer: {e}")))?;
 
             // Timeline semaphore (Vulkan 1.2 core) for targeted blit synchronization.
             // More efficient than fences for GPU-GPU ordering.
@@ -111,7 +111,7 @@ impl RhiBlitter for VulkanBlitter {
             let timeline_semaphore = self
                 .device
                 .create_semaphore(&timeline_semaphore_info, None)
-                .map_err(|e| StreamError::GpuError(format!("Failed to create blit timeline semaphore: {e}")))?;
+                .map_err(|e| Error::GpuError(format!("Failed to create blit timeline semaphore: {e}")))?;
 
             let signal_semaphore = vk::SemaphoreSubmitInfo::builder()
                 .semaphore(timeline_semaphore)
@@ -145,7 +145,7 @@ impl RhiBlitter for VulkanBlitter {
                 .wait_semaphores(&wait_info, u64::MAX)
                 .map_err(|e| {
                     self.device.destroy_semaphore(timeline_semaphore, None);
-                    StreamError::GpuError(format!("Failed to wait for blit timeline semaphore: {e}"))
+                    Error::GpuError(format!("Failed to wait for blit timeline semaphore: {e}"))
                 })
                 .map(|_| ())?;
 
@@ -164,7 +164,7 @@ impl RhiBlitter for VulkanBlitter {
         _width: u32,
         _height: u32,
     ) -> Result<()> {
-        Err(StreamError::NotSupported(
+        Err(Error::NotSupported(
             "IOSurface not available on Linux".into(),
         ))
     }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_queue.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_queue.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::{VulkanCommandBuffer, HostVulkanDevice};
 
@@ -54,7 +54,7 @@ impl VulkanCommandQueue {
 
         let command_buffers = unsafe { self.device.allocate_command_buffers(&alloc_info) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to allocate command buffer: {e}"))
+                Error::GpuError(format!("Failed to allocate command buffer: {e}"))
             })?;
 
         let command_buffer = command_buffers[0];
@@ -68,7 +68,7 @@ impl VulkanCommandQueue {
             self.device
                 .begin_command_buffer(command_buffer, &begin_info)
         }
-        .map_err(|e| StreamError::GpuError(format!("Failed to begin command buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to begin command buffer: {e}")))?;
 
         Ok(VulkanCommandBuffer::new(
             Arc::clone(&self.vulkan_device),

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -27,7 +27,7 @@ use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 use crate::core::rhi::{
     ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer, StreamTexture,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Env var that overrides the default pipeline-cache directory. Used by tests
 /// and headless / CI scenarios that need a writable, isolated cache root.
@@ -229,7 +229,7 @@ impl VulkanComputeKernel {
                     device.destroy_descriptor_set_layout(descriptor_set_layout, None);
                     device.destroy_shader_module(shader_module, None);
                 }
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Failed to create compute fence: {e}"
                 )));
             }
@@ -318,7 +318,7 @@ impl VulkanComputeKernel {
     /// declared `push_constant_size` (and be 4-byte aligned per Vulkan).
     pub fn set_push_constants(&self, bytes: &[u8]) -> Result<()> {
         if bytes.len() as u32 != self.push_constant_size {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': push-constant size mismatch — got {} bytes, kernel declares {}",
                 self.label,
                 bytes.len(),
@@ -357,14 +357,14 @@ impl VulkanComputeKernel {
 
         for spec in &self.bindings {
             if !pending.bindings.contains_key(&spec.binding) {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Compute kernel '{}': binding {} ({:?}) not set before dispatch",
                     self.label, spec.binding, spec.kind
                 )));
             }
         }
         if self.push_constant_size > 0 && pending.push_constants.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': push constants not set before dispatch",
                 self.label
             )));
@@ -376,12 +376,12 @@ impl VulkanComputeKernel {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to wait for compute fence: {e}"))
+                    Error::GpuError(format!("Failed to wait for compute fence: {e}"))
                 })?;
             self.device
                 .reset_fences(&[self.fence])
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to reset compute fence: {e}"))
+                    Error::GpuError(format!("Failed to reset compute fence: {e}"))
                 })?;
         }
 
@@ -391,7 +391,7 @@ impl VulkanComputeKernel {
             self.device
                 .reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to reset command buffer: {e}"))
+                    Error::GpuError(format!("Failed to reset command buffer: {e}"))
                 })?;
 
             let begin_info = vk::CommandBufferBeginInfo::builder()
@@ -401,7 +401,7 @@ impl VulkanComputeKernel {
             self.device
                 .begin_command_buffer(self.command_buffer, &begin_info)
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to begin command buffer: {e}"))
+                    Error::GpuError(format!("Failed to begin command buffer: {e}"))
                 })?;
 
             self.device.cmd_bind_pipeline(
@@ -439,7 +439,7 @@ impl VulkanComputeKernel {
             self.device
                 .end_command_buffer(self.command_buffer)
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to end command buffer: {e}"))
+                    Error::GpuError(format!("Failed to end command buffer: {e}"))
                 })?;
 
             let cmd_info = vk::CommandBufferSubmitInfo::builder()
@@ -456,7 +456,7 @@ impl VulkanComputeKernel {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!("Failed to wait for compute fence: {e}"))
+                    Error::GpuError(format!("Failed to wait for compute fence: {e}"))
                 })?;
         }
 
@@ -475,13 +475,13 @@ impl VulkanComputeKernel {
 
     fn expect_kind(&self, binding: u32, expected: ComputeBindingKind) -> Result<()> {
         let spec = self.bindings.iter().find(|b| b.binding == binding).ok_or_else(|| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Compute kernel '{}': binding {} not declared",
                 self.label, binding
             ))
         })?;
         if spec.kind != expected {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': binding {} declared as {:?}, but {:?} was set",
                 self.label, binding, spec.kind, expected
             )));
@@ -507,7 +507,7 @@ impl VulkanComputeKernel {
             .unnormalized_coordinates(false)
             .build();
         let sampler = unsafe { self.device.create_sampler(&info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create default sampler: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create default sampler: {e}")))?;
         *guard = Some(sampler);
         Ok(sampler)
     }
@@ -597,7 +597,7 @@ impl VulkanComputeKernel {
                     });
                 }
                 _ => {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Compute kernel '{}': binding {} kind/resource mismatch (declared {:?})",
                         self.label, spec.binding, spec.kind
                     )));
@@ -669,14 +669,14 @@ impl std::fmt::Debug for VulkanComputeKernel {
 
 fn validate_against_spirv(descriptor: &ComputeKernelDescriptor<'_>) -> Result<()> {
     let reflection = Reflection::new_from_spirv(descriptor.spv).map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Compute kernel '{}': failed to reflect SPIR-V: {e:?}",
             descriptor.label
         ))
     })?;
 
     let sets = reflection.get_descriptor_sets().map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Compute kernel '{}': failed to extract descriptor sets: {e:?}",
             descriptor.label
         ))
@@ -684,7 +684,7 @@ fn validate_against_spirv(descriptor: &ComputeKernelDescriptor<'_>) -> Result<()
 
     // Reject multi-set kernels — out of scope.
     if sets.len() > 1 {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Compute kernel '{}': only descriptor set 0 is supported; SPIR-V uses sets {:?}",
             descriptor.label,
             sets.keys().collect::<Vec<_>>()
@@ -698,14 +698,14 @@ fn validate_against_spirv(descriptor: &ComputeKernelDescriptor<'_>) -> Result<()
         let info = set0
             .and_then(|m| m.get(&spec.binding))
             .ok_or_else(|| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Compute kernel '{}': binding {} declared but missing in SPIR-V",
                     descriptor.label, spec.binding
                 ))
             })?;
         let expected = expected_spirv_type(spec.kind);
         if info.ty != expected {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': binding {} declared {:?} ({:?}), but SPIR-V has {:?}",
                 descriptor.label, spec.binding, spec.kind, expected, info.ty
             )));
@@ -717,7 +717,7 @@ fn validate_against_spirv(descriptor: &ComputeKernelDescriptor<'_>) -> Result<()
     if let Some(set0) = set0 {
         for (&binding, info) in set0 {
             if !descriptor.bindings.iter().any(|s| s.binding == binding) {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Compute kernel '{}': SPIR-V declares binding {} ({:?}, name `{}`) but it is missing from the descriptor",
                     descriptor.label, binding, info.ty, info.name
                 )));
@@ -727,20 +727,20 @@ fn validate_against_spirv(descriptor: &ComputeKernelDescriptor<'_>) -> Result<()
 
     // Push-constant size must match if the shader uses any.
     let push = reflection.get_push_constant_range().map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Compute kernel '{}': failed to read push-constant range: {e:?}",
             descriptor.label
         ))
     })?;
     match (push, descriptor.push_constant_size) {
         (Some(info), declared) if info.size != declared => {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': push-constant size mismatch — SPIR-V says {}, descriptor declares {}",
                 descriptor.label, info.size, declared
             )));
         }
         (None, declared) if declared > 0 => {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Compute kernel '{}': descriptor declares {} push-constant bytes but SPIR-V has none",
                 descriptor.label, declared
             )));
@@ -776,7 +776,7 @@ fn create_shader_module(
 ) -> Result<vk::ShaderModule> {
     let info = vk::ShaderModuleCreateInfo::builder().code(spirv).build();
     unsafe { device.create_shader_module(&info, None) }.map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Compute kernel '{label}': failed to create shader module: {e}"
         ))
     })
@@ -802,7 +802,7 @@ fn create_descriptor_set_layout(
         .bindings(&layout_bindings)
         .build();
     unsafe { device.create_descriptor_set_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create descriptor set layout: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create descriptor set layout: {e}")))
 }
 
 fn create_pipeline_layout(
@@ -827,7 +827,7 @@ fn create_pipeline_layout(
         .build();
 
     unsafe { device.create_pipeline_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create pipeline layout: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create pipeline layout: {e}")))
 }
 
 /// Build a compute pipeline, transparently using an on-disk pipeline cache
@@ -878,7 +878,7 @@ fn create_compute_pipeline_with_cache(
     }
 
     let pipelines = pipelines_result.map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Compute kernel '{label}': failed to create compute pipeline: {e}"
         ))
     })?;
@@ -1040,7 +1040,7 @@ fn create_descriptor_pool(
         .pool_sizes(&pool_sizes)
         .build();
     unsafe { device.create_descriptor_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create descriptor pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create descriptor pool: {e}")))
 }
 
 fn allocate_descriptor_set(
@@ -1054,7 +1054,7 @@ fn allocate_descriptor_set(
         .set_layouts(&set_layouts)
         .build();
     let sets = unsafe { device.allocate_descriptor_sets(&info) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to allocate descriptor set: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to allocate descriptor set: {e}")))?;
     Ok(sets[0])
 }
 
@@ -1067,7 +1067,7 @@ fn create_command_pool(
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .build();
     unsafe { device.create_command_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create command pool: {e}")))
 }
 
 fn allocate_command_buffer(
@@ -1080,7 +1080,7 @@ fn allocate_command_buffer(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to allocate command buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to allocate command buffer: {e}")))?;
     Ok(buffers[0])
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -14,7 +14,7 @@ use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
 use crate::core::rhi::TextureDescriptor;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 #[cfg(target_os = "linux")]
 use super::drm_modifier_probe::{self, DrmModifierTable};
@@ -243,10 +243,10 @@ impl HostVulkanDevice {
     pub fn new() -> Result<Arc<Self>> {
         // 1. Load Vulkan entry points via libloading
         let loader = unsafe { LibloadingLoader::new(LIBRARY) }.map_err(|e| {
-            StreamError::GpuError(format!("Failed to load Vulkan library: {e}"))
+            Error::GpuError(format!("Failed to load Vulkan library: {e}"))
         })?;
         let entry = unsafe { vulkanalia::Entry::new(loader) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to load Vulkan. On macOS, ensure MoltenVK is installed: {e}"
             ))
         })?;
@@ -254,7 +254,7 @@ impl HostVulkanDevice {
         // 2. Enumerate available instance extensions
         let available_extensions = unsafe { entry.enumerate_instance_extension_properties(None) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to enumerate extensions: {e}"))
+                Error::GpuError(format!("Failed to enumerate extensions: {e}"))
             })?;
 
         let available_ext_names: Vec<&CStr> = available_extensions
@@ -375,14 +375,14 @@ impl HostVulkanDevice {
             .build();
 
         let instance = unsafe { entry.create_instance(&instance_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create Vulkan instance: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create Vulkan instance: {e}")))?;
 
         // 5. Select physical device
         let physical_devices = unsafe { instance.enumerate_physical_devices() }
-            .map_err(|e| StreamError::GpuError(format!("Failed to enumerate devices: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to enumerate devices: {e}")))?;
 
         if physical_devices.is_empty() {
-            return Err(StreamError::GpuError("No Vulkan devices found".into()));
+            return Err(Error::GpuError("No Vulkan devices found".into()));
         }
 
         // Prefer discrete GPU, fall back to first available
@@ -448,7 +448,7 @@ impl HostVulkanDevice {
             .enumerate()
             .find(|(_, props)| props.queue_flags.contains(vk::QueueFlags::GRAPHICS))
             .map(|(idx, _)| idx as u32)
-            .ok_or_else(|| StreamError::GpuError("No graphics queue family found".into()))?;
+            .ok_or_else(|| Error::GpuError("No graphics queue family found".into()))?;
 
         // 6b. Find dedicated transfer queue family (TRANSFER-only, no GRAPHICS/COMPUTE).
         //     Dedicated transfer queues use independent DMA engines for parallel data movement.
@@ -946,7 +946,7 @@ impl HostVulkanDevice {
             .build();
 
         let device = unsafe { instance.create_device(physical_device, &device_create_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create logical device: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create logical device: {e}")))?;
 
         // 8. Get the graphics queue
         let queue = unsafe { device.get_device_queue(queue_family_index, 0) };
@@ -1008,7 +1008,7 @@ impl HostVulkanDevice {
 
         let allocator = Arc::new(
             unsafe { vma::Allocator::new(&alloc_options) }
-                .map_err(|e| StreamError::GpuError(format!("Failed to create VMA allocator: {e}")))?,
+                .map_err(|e| Error::GpuError(format!("Failed to create VMA allocator: {e}")))?,
         );
 
         // Run the EGL probe BEFORE creating pools — the tiled pool needs the
@@ -1266,7 +1266,7 @@ impl HostVulkanDevice {
                 device, PROBE_W, PROBE_H, PROBE_BPP, PixelFormat::Bgra32,
             )
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "DMA-BUF buffer pool pre-warm failed: {e}"
                 ))
             })?;
@@ -1282,7 +1282,7 @@ impl HostVulkanDevice {
                         | TextureUsages::COPY_DST,
                 );
             let probe = HostVulkanTexture::new(device, &desc).map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "DMA-BUF image pool pre-warm failed: {e}"
                 ))
             })?;
@@ -1313,7 +1313,7 @@ impl HostVulkanDevice {
                     bgra_modifiers,
                 )
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "tiled DMA-BUF image pool pre-warm failed: {e}"
                     ))
                 })?;
@@ -1418,7 +1418,7 @@ fn make_opaque_fd_buffer_sentinel(
 
     let (buffer, allocation) = unsafe { pool.create_buffer(buffer_info, &alloc_opts) }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "OPAQUE_FD export pool '{label}' sentinel allocation failed \
                  (size={size}): {e}"
             ))
@@ -1470,7 +1470,7 @@ fn probe_tiled_dma_buf_memory_type(
 
     let probe_image = unsafe { device.create_image(&probe_image_info, None) }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "tiled-DMA-BUF probe vkCreateImage failed: {e}"
             ))
         })?;
@@ -1495,7 +1495,7 @@ fn probe_tiled_dma_buf_memory_type(
             return Ok(i);
         }
     }
-    Err(StreamError::GpuError(format!(
+    Err(Error::GpuError(format!(
         "no DEVICE_LOCAL memory type accepts tiled DMA-BUF probe image (memory_type_bits=0x{:x})",
         mem_reqs.memory_type_bits
     )))
@@ -1563,7 +1563,7 @@ impl HostVulkanDevice {
             )
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "find memory type for DMA-BUF buffer pool: {e}"
             ))
         })?;
@@ -1602,7 +1602,7 @@ impl HostVulkanDevice {
             )
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "find memory type for DMA-BUF image pool: {e}"
             ))
         })?;
@@ -1629,14 +1629,14 @@ impl HostVulkanDevice {
         buffer_pool_options.memory_type_index = buffer_mem_type_idx;
         let buffer_pool = allocator
             .create_pool(&buffer_pool_options)
-            .map_err(|e| StreamError::GpuError(format!("create DMA-BUF buffer pool: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("create DMA-BUF buffer pool: {e}")))?;
 
         let mut image_pool_options = vma::PoolOptions::default();
         image_pool_options = image_pool_options.push_next(image_export_info.as_mut());
         image_pool_options.memory_type_index = image_mem_type_idx;
         let image_pool = allocator
             .create_pool(&image_pool_options)
-            .map_err(|e| StreamError::GpuError(format!("create DMA-BUF image pool: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("create DMA-BUF image pool: {e}")))?;
 
         // ── Tiled (DRM_FORMAT_MODIFIER) image pool ────────────────────────
         // Only created when the EGL probe returned at least one
@@ -1752,7 +1752,7 @@ impl HostVulkanDevice {
             )
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "find memory type for OPAQUE_FD buffer pool: {e}"
             ))
         })?;
@@ -1767,7 +1767,7 @@ impl HostVulkanDevice {
         pool_options.memory_type_index = mem_type_idx;
         let pool = allocator
             .create_pool(&pool_options)
-            .map_err(|e| StreamError::GpuError(format!("create OPAQUE_FD buffer pool: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("create OPAQUE_FD buffer pool: {e}")))?;
 
         tracing::info!(
             "OPAQUE_FD VMA buffer pool created — mem_type={}",
@@ -1813,7 +1813,7 @@ impl HostVulkanDevice {
             )
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "find memory type for DEVICE_LOCAL OPAQUE_FD buffer pool: {e}"
             ))
         })?;
@@ -1827,7 +1827,7 @@ impl HostVulkanDevice {
         pool_options = pool_options.push_next(export_info.as_mut());
         pool_options.memory_type_index = mem_type_idx;
         let pool = allocator.create_pool(&pool_options).map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "create DEVICE_LOCAL OPAQUE_FD buffer pool: {e}"
             ))
         })?;
@@ -1882,7 +1882,7 @@ impl HostVulkanDevice {
                 return Ok(i);
             }
         }
-        Err(StreamError::GpuError(format!(
+        Err(Error::GpuError(format!(
             "No suitable memory type found (filter: 0x{:x}, required: {:?})",
             type_filter, required_properties
         )))
@@ -2071,7 +2071,7 @@ impl HostVulkanDevice {
             .unwrap_or_else(|e| e.into_inner());
         unsafe { self.device.queue_submit2(queue, submits, fence) }
             .map(|_| ())
-            .map_err(|e| StreamError::GpuError(format!("queue_submit2 failed: {e}")))
+            .map_err(|e| Error::GpuError(format!("queue_submit2 failed: {e}")))
     }
 
     /// Present to a queue with per-queue mutex synchronization.
@@ -2177,7 +2177,7 @@ impl HostVulkanDevice {
         width: u32,
         height: u32,
     ) -> crate::core::Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
 
         let device = self.device();
         let queue = self.queue;
@@ -2190,7 +2190,7 @@ impl HostVulkanDevice {
                     .flags(vk::CommandPoolCreateFlags::TRANSIENT),
                 None,
             )
-        }.map_err(|e| StreamError::GpuError(format!("upload cmd pool: {e}")))?;
+        }.map_err(|e| Error::GpuError(format!("upload cmd pool: {e}")))?;
 
         let cb = unsafe {
             device.allocate_command_buffers(
@@ -2199,10 +2199,10 @@ impl HostVulkanDevice {
                     .level(vk::CommandBufferLevel::PRIMARY)
                     .command_buffer_count(1),
             )
-        }.map_err(|e| StreamError::GpuError(format!("upload cmd buf: {e}")))?[0];
+        }.map_err(|e| Error::GpuError(format!("upload cmd buf: {e}")))?[0];
 
         let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }
-            .map_err(|e| StreamError::GpuError(format!("upload fence: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("upload fence: {e}")))?;
 
         unsafe {
             device.begin_command_buffer(
@@ -2210,7 +2210,7 @@ impl HostVulkanDevice {
                 &vk::CommandBufferBeginInfo::builder()
                     .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
             )
-        }.map_err(|e| StreamError::GpuError(format!("begin cb: {e}")))?;
+        }.map_err(|e| Error::GpuError(format!("begin cb: {e}")))?;
 
         // Barrier: UNDEFINED → TRANSFER_DST
         let barrier_to_dst = vk::ImageMemoryBarrier2::builder()
@@ -2280,7 +2280,7 @@ impl HostVulkanDevice {
         unsafe { device.cmd_pipeline_barrier2(cb, &dep_to_read) };
 
         unsafe { device.end_command_buffer(cb) }
-            .map_err(|e| StreamError::GpuError(format!("end cb: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("end cb: {e}")))?;
 
         let cb_submit = vk::CommandBufferSubmitInfo::builder()
             .command_buffer(cb)
@@ -2291,7 +2291,7 @@ impl HostVulkanDevice {
             .build();
         unsafe { self.submit_to_queue(queue, &[submit], fence) }?;
         unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
-            .map_err(|e| StreamError::GpuError(format!("wait: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("wait: {e}")))?;
 
         unsafe { device.destroy_fence(fence, None) };
         unsafe { device.destroy_command_pool(pool, None) };
@@ -2451,7 +2451,7 @@ impl HostVulkanDevice {
         &self,
         barriers: &[vk::ImageMemoryBarrier2],
     ) -> Result<()> {
-        use crate::core::StreamError;
+        use crate::core::Error;
 
         let device = self.device();
         let queue = self.queue;
@@ -2465,7 +2465,7 @@ impl HostVulkanDevice {
                 None,
             )
         }
-        .map_err(|e| StreamError::GpuError(format!("qfot cmd pool: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("qfot cmd pool: {e}")))?;
 
         let cb = unsafe {
             device.allocate_command_buffers(
@@ -2477,13 +2477,13 @@ impl HostVulkanDevice {
         }
         .map_err(|e| {
             unsafe { device.destroy_command_pool(pool, None) };
-            StreamError::GpuError(format!("qfot cmd buf: {e}"))
+            Error::GpuError(format!("qfot cmd buf: {e}"))
         })?[0];
 
         let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }
             .map_err(|e| {
                 unsafe { device.destroy_command_pool(pool, None) };
-                StreamError::GpuError(format!("qfot fence: {e}"))
+                Error::GpuError(format!("qfot fence: {e}"))
             })?;
 
         unsafe {
@@ -2493,13 +2493,13 @@ impl HostVulkanDevice {
                     .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
             )
         }
-        .map_err(|e| StreamError::GpuError(format!("begin qfot cb: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("begin qfot cb: {e}")))?;
 
         let dep = vk::DependencyInfo::builder().image_memory_barriers(barriers);
         unsafe { device.cmd_pipeline_barrier2(cb, &dep) };
 
         unsafe { device.end_command_buffer(cb) }
-            .map_err(|e| StreamError::GpuError(format!("end qfot cb: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("end qfot cb: {e}")))?;
 
         let cb_submit = vk::CommandBufferSubmitInfo::builder()
             .command_buffer(cb)
@@ -2510,7 +2510,7 @@ impl HostVulkanDevice {
             .build();
         unsafe { self.submit_to_queue(queue, &[submit], fence) }?;
         unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
-            .map_err(|e| StreamError::GpuError(format!("qfot wait: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("qfot wait: {e}")))?;
 
         unsafe { device.destroy_fence(fence, None) };
         unsafe { device.destroy_command_pool(pool, None) };
@@ -2549,7 +2549,7 @@ impl HostVulkanDevice {
             .build();
 
         let memory = unsafe { self.device.allocate_memory(&alloc_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to import DMA-BUF memory: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to import DMA-BUF memory: {e}")))?;
 
         let count = self.live_allocation_count.fetch_add(1, Ordering::Relaxed) + 1;
         tracing::debug!(
@@ -2648,7 +2648,7 @@ impl HostVulkanDevice {
         let ptr = unsafe {
             self.device.map_memory(memory, 0, size, vk::MemoryMapFlags::empty())
         }
-        .map_err(|e| StreamError::GpuError(format!("Failed to map device memory: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to map device memory: {e}")))?;
         Ok(ptr as *mut u8)
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_format_converter.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::core::rhi::{
     ComputeBindingSpec, ComputeKernelDescriptor, PixelFormat, RhiPixelBuffer,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::{VulkanComputeKernel, HostVulkanDevice};
 
@@ -65,7 +65,7 @@ impl VulkanFormatConverter {
         let width = source.width;
         let height = source.height;
         if width != dest.width || height != dest.height {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Source and destination buffers must have the same dimensions".into(),
             ));
         }
@@ -82,7 +82,7 @@ impl VulkanFormatConverter {
                 (is_bgra as u32) | ((full_range as u32) << 1)
             }
             _ => {
-                return Err(StreamError::NotSupported(format!(
+                return Err(Error::NotSupported(format!(
                     "Unsupported format conversion: {:?} → {:?}",
                     src_format, dst_format
                 )));
@@ -112,7 +112,7 @@ impl VulkanFormatConverter {
 mod tests {
     use super::*;
     use crate::core::rhi::RhiPixelBufferRef;
-    use crate::core::StreamError;
+    use crate::core::Error;
     use crate::vulkan::rhi::HostVulkanPixelBuffer;
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
@@ -248,7 +248,7 @@ mod tests {
         let converter =
             VulkanFormatConverter::new(&device, 2, 4).expect("converter creation");
         let err = converter.convert(&nv12, &bgra).err().expect("expected error");
-        assert!(matches!(err, StreamError::GpuError(_)));
+        assert!(matches!(err, Error::GpuError(_)));
     }
 
     #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
@@ -260,7 +260,7 @@ mod tests {
         let converter =
             VulkanFormatConverter::new(&device, 4, 4).expect("converter creation");
         let err = converter.convert(&src, &dst).err().expect("expected error");
-        assert!(matches!(err, StreamError::NotSupported(_)));
+        assert!(matches!(err, Error::NotSupported(_)));
     }
 
     #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -50,7 +50,7 @@ use crate::core::rhi::{
     PrimitiveTopology, RhiPixelBuffer, ScissorRect, StreamTexture, TextureFormat,
     VertexAttributeFormat, VertexInputRate, VertexInputState, Viewport,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
 
@@ -166,13 +166,13 @@ impl VulkanGraphicsKernel {
         descriptor: &GraphicsKernelDescriptor<'_>,
     ) -> Result<Self> {
         if descriptor.descriptor_sets_in_flight == 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': descriptor_sets_in_flight must be ≥ 1",
                 descriptor.label
             )));
         }
         if descriptor.stages.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': no shader stages provided",
                 descriptor.label
             )));
@@ -191,7 +191,7 @@ impl VulkanGraphicsKernel {
             .filter(|s| s.stage == GraphicsShaderStage::Vertex)
             .count();
         if vertex_count != 1 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': expected exactly 1 Vertex stage, got {vertex_count}",
                 descriptor.label
             )));
@@ -204,7 +204,7 @@ impl VulkanGraphicsKernel {
             .filter(|s| s.stage == GraphicsShaderStage::Fragment)
             .count();
         if fragment_count != 1 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': expected exactly 1 Fragment stage, got {fragment_count}",
                 descriptor.label
             )));
@@ -418,7 +418,7 @@ impl VulkanGraphicsKernel {
     /// declared `push_constants.size`.
     pub fn set_push_constants(&self, frame_index: u32, bytes: &[u8]) -> Result<()> {
         if bytes.len() as u32 != self.push_constant_size {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': push-constant size mismatch — got {} bytes, kernel declares {}",
                 self.label,
                 bytes.len(),
@@ -456,14 +456,14 @@ impl VulkanGraphicsKernel {
     ) -> Result<()> {
         match &self.pipeline_state.vertex_input {
             VertexInputState::None => {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Graphics kernel '{}': set_vertex_buffer called but pipeline has no vertex input bindings",
                     self.label
                 )));
             }
             VertexInputState::Buffers { bindings, .. } => {
                 if !bindings.iter().any(|b| b.binding == binding) {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Graphics kernel '{}': vertex binding {binding} not declared in pipeline",
                         self.label
                     )));
@@ -548,7 +548,7 @@ impl VulkanGraphicsKernel {
         draw: OffscreenDraw,
     ) -> Result<()> {
         if color_targets.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': offscreen_render called with no color targets",
                 self.label
             )));
@@ -567,13 +567,13 @@ impl VulkanGraphicsKernel {
             self.device
                 .wait_for_fences(&[fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': wait_for_fences failed: {e}",
                         self.label
                     ))
                 })?;
             self.device.reset_fences(&[fence]).map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Graphics kernel '{}': reset_fences failed: {e}",
                     self.label
                 ))
@@ -582,7 +582,7 @@ impl VulkanGraphicsKernel {
             self.device
                 .reset_command_buffer(command_buffer, vk::CommandBufferResetFlags::empty())
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': reset_command_buffer failed: {e}",
                         self.label
                     ))
@@ -594,7 +594,7 @@ impl VulkanGraphicsKernel {
             self.device
                 .begin_command_buffer(command_buffer, &begin_info)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': begin_command_buffer failed: {e}",
                         self.label
                     ))
@@ -607,7 +607,7 @@ impl VulkanGraphicsKernel {
             let mut barriers: Vec<vk::ImageMemoryBarrier2> = Vec::with_capacity(color_targets.len());
             for target in color_targets {
                 let image = target.texture.inner.image().ok_or_else(|| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': offscreen color target has no VkImage",
                         self.label
                     ))
@@ -696,7 +696,7 @@ impl VulkanGraphicsKernel {
             self.device
                 .end_command_buffer(command_buffer)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': end_command_buffer failed: {e}",
                         self.label
                     ))
@@ -715,7 +715,7 @@ impl VulkanGraphicsKernel {
             self.device
                 .wait_for_fences(&[fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': post-submit wait failed: {e}",
                         self.label
                     ))
@@ -731,7 +731,7 @@ impl VulkanGraphicsKernel {
         draw: DrawKind,
     ) -> Result<()> {
         if frame_index >= self.descriptor_sets_in_flight {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': frame_index {frame_index} out of range (ring depth {})",
                 self.label, self.descriptor_sets_in_flight
             )));
@@ -751,14 +751,14 @@ impl VulkanGraphicsKernel {
 
         for spec in &self.bindings {
             if !pending.bindings.contains_key(&spec.binding) {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Graphics kernel '{}': binding {} ({:?}) not set before draw",
                     self.label, spec.binding, spec.kind
                 )));
             }
         }
         if self.push_constant_size > 0 && pending.push_constants.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': push constants not set before draw",
                 self.label
             )));
@@ -766,7 +766,7 @@ impl VulkanGraphicsKernel {
         if let VertexInputState::Buffers { bindings, .. } = &self.pipeline_state.vertex_input {
             for vb in bindings {
                 if !pending.vertex_buffers.contains_key(&vb.binding) {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Graphics kernel '{}': vertex buffer at binding {} not set before draw",
                         self.label, vb.binding
                     )));
@@ -774,7 +774,7 @@ impl VulkanGraphicsKernel {
             }
         }
         if matches!(draw, DrawKind::DrawIndexed(_)) && pending.index_buffer.is_none() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': indexed draw requested but no index buffer set",
                 self.label
             )));
@@ -797,13 +797,13 @@ impl VulkanGraphicsKernel {
                     DrawKind::DrawIndexed(d) => (d.viewport, d.scissor),
                 };
                 let viewport = viewport_opt.ok_or_else(|| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': pipeline has dynamic viewport but DrawCall has none",
                         self.label
                     ))
                 })?;
                 let scissor = scissor_opt.ok_or_else(|| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Graphics kernel '{}': pipeline has dynamic scissor but DrawCall has none",
                         self.label
                     ))
@@ -933,13 +933,13 @@ impl VulkanGraphicsKernel {
             .iter()
             .find(|b| b.binding == binding)
             .ok_or_else(|| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Graphics kernel '{}': binding {binding} not declared",
                     self.label
                 ))
             })?;
         if spec.kind != expected {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': binding {binding} declared as {:?}, but {expected:?} was set",
                 self.label, spec.kind
             )));
@@ -953,7 +953,7 @@ impl VulkanGraphicsKernel {
         f: impl FnOnce(&mut PendingState) -> Result<R>,
     ) -> Result<R> {
         if frame_index >= self.descriptor_sets_in_flight {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': frame_index {frame_index} out of range (ring depth {})",
                 self.label, self.descriptor_sets_in_flight
             )));
@@ -980,7 +980,7 @@ impl VulkanGraphicsKernel {
             .unnormalized_coordinates(false)
             .build();
         let sampler = unsafe { self.device.create_sampler(&info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create default sampler: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create default sampler: {e}")))?;
         *guard = Some(sampler);
         Ok(sampler)
     }
@@ -1008,7 +1008,7 @@ impl VulkanGraphicsKernel {
             Ok(f) => f,
             Err(e) => {
                 unsafe { self.device.destroy_command_pool(command_pool, None) };
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Failed to create offscreen fence: {e}"
                 )));
             }
@@ -1113,7 +1113,7 @@ impl VulkanGraphicsKernel {
                     });
                 }
                 _ => {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Graphics kernel '{}': binding {} kind/resource mismatch (declared {:?})",
                         self.label, spec.binding, spec.kind
                     )));
@@ -1215,19 +1215,19 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
     for stage in descriptor.stages {
         let stage_flag = stage_to_flag(stage.stage);
         let reflection = Reflection::new_from_spirv(stage.spv).map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel '{}': failed to reflect SPIR-V for {:?} stage: {e:?}",
                 descriptor.label, stage.stage
             ))
         })?;
         let sets = reflection.get_descriptor_sets().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel '{}': failed to extract descriptor sets for {:?} stage: {e:?}",
                 descriptor.label, stage.stage
             ))
         })?;
         if sets.len() > 1 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': only descriptor set 0 is supported; SPIR-V {:?} stage uses sets {:?}",
                 descriptor.label,
                 stage.stage,
@@ -1240,7 +1240,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
                     .entry(binding)
                     .or_insert((info.ty, GraphicsShaderStageFlags::NONE));
                 if entry.0 != info.ty {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Graphics kernel '{}': binding {binding} type conflict — {:?} vs {:?} (in {:?})",
                         descriptor.label, entry.0, info.ty, stage.stage
                     )));
@@ -1249,7 +1249,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
             }
         }
         if let Some(info) = reflection.get_push_constant_range().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel '{}': failed to read push-constant range for {:?} stage: {e:?}",
                 descriptor.label, stage.stage
             ))
@@ -1262,14 +1262,14 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
     // Each declared binding must agree with merged shader declaration.
     for spec in descriptor.bindings {
         let merged_entry = merged.get(&spec.binding).ok_or_else(|| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Graphics kernel '{}': binding {} declared but missing in SPIR-V",
                 descriptor.label, spec.binding
             ))
         })?;
         let expected = expected_spirv_type(spec.kind);
         if merged_entry.0 != expected {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': binding {} declared {:?} ({:?}), but SPIR-V has {:?}",
                 descriptor.label, spec.binding, spec.kind, expected, merged_entry.0
             )));
@@ -1279,7 +1279,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
         // fragment but declared visible only to vertex would be a Vulkan
         // validation error at draw time; reject up front.
         if (merged_entry.1.bits() & !spec.stages.bits()) != 0 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': binding {} stage visibility mismatch — declared {:?}, SPIR-V uses bits {:#b}",
                 descriptor.label,
                 spec.binding,
@@ -1292,7 +1292,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
     // Conversely, every SPIR-V binding must be declared.
     for (&binding, (ty, stages)) in &merged {
         if !descriptor.bindings.iter().any(|s| s.binding == binding) {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{}': SPIR-V declares binding {} ({:?}, stages {:#b}) but it is missing from the descriptor",
                 descriptor.label, binding, ty, stages.bits()
             )));
@@ -1301,7 +1301,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
 
     // Push-constant size must match.
     if spirv_push_size != descriptor.push_constants.size {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Graphics kernel '{}': push-constant size mismatch — SPIR-V has {} bytes (stages {:#b}), descriptor declares {} bytes",
             descriptor.label,
             spirv_push_size,
@@ -1311,7 +1311,7 @@ fn validate_against_spirv(descriptor: &GraphicsKernelDescriptor<'_>) -> Result<(
     }
     if spirv_push_size > 0 && (spirv_push_stages.bits() & !descriptor.push_constants.stages.bits()) != 0
     {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Graphics kernel '{}': push-constant stage visibility mismatch — declared {:#b}, SPIR-V uses {:#b}",
             descriptor.label,
             descriptor.push_constants.stages.bits(),
@@ -1532,7 +1532,7 @@ fn create_shader_modules(
             Ok(m) => out.push((stage.stage, m)),
             Err(e) => {
                 destroy_shader_modules(device, &out);
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Graphics kernel '{}': failed to create {:?} shader module: {e}",
                     descriptor.label, stage.stage
                 )));
@@ -1570,7 +1570,7 @@ fn create_descriptor_set_layout(
         .bindings(&layout_bindings)
         .build();
     unsafe { device.create_descriptor_set_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create descriptor set layout: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create descriptor set layout: {e}")))
 }
 
 fn create_pipeline_layout(
@@ -1593,7 +1593,7 @@ fn create_pipeline_layout(
         .push_constant_ranges(&push_ranges)
         .build();
     unsafe { device.create_pipeline_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create pipeline layout: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create pipeline layout: {e}")))
 }
 
 fn create_descriptor_pool(
@@ -1619,7 +1619,7 @@ fn create_descriptor_pool(
         .pool_sizes(&pool_sizes)
         .build();
     unsafe { device.create_descriptor_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create descriptor pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create descriptor pool: {e}")))
 }
 
 fn allocate_descriptor_sets(
@@ -1634,7 +1634,7 @@ fn allocate_descriptor_sets(
         .set_layouts(&layouts)
         .build();
     let sets = unsafe { device.allocate_descriptor_sets(&info) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to allocate descriptor sets: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to allocate descriptor sets: {e}")))?;
     Ok(sets)
 }
 
@@ -1647,7 +1647,7 @@ fn create_command_pool(
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .build();
     unsafe { device.create_command_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to create command pool: {e}")))
+        .map_err(|e| Error::GpuError(format!("Failed to create command pool: {e}")))
 }
 
 fn allocate_command_buffer(
@@ -1660,7 +1660,7 @@ fn allocate_command_buffer(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }
-        .map_err(|e| StreamError::GpuError(format!("Failed to allocate command buffer: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("Failed to allocate command buffer: {e}")))?;
     Ok(buffers[0])
 }
 
@@ -1681,13 +1681,13 @@ fn create_graphics_pipeline_with_cache(
     // graphics-pipeline target).
     for (i, fmt) in state.attachment_formats.color.iter().enumerate() {
         if matches!(fmt, TextureFormat::Nv12) {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Graphics kernel '{label}': color attachment {i} format {fmt:?} is not a valid render target"
             )));
         }
     }
     if state.multisample.samples != 1 {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Graphics kernel '{label}': multisample.samples = {} is not supported (only 1)",
             state.multisample.samples
         )));
@@ -1847,7 +1847,7 @@ fn create_graphics_pipeline_with_cache(
     }
 
     let pipelines = pipelines_result.map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Graphics kernel '{label}': failed to create graphics pipeline: {e}"
         ))
     })?;

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer.rs
@@ -9,7 +9,7 @@ use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
 use crate::core::rhi::PixelFormat;
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
 
@@ -126,7 +126,7 @@ impl HostVulkanPixelBuffer {
             #[cfg(not(target_os = "linux"))]
             let result = unsafe { allocator.create_buffer(buffer_info, &alloc_opts) };
             result.map_err(|e| {
-                StreamError::GpuError(format!("Failed to create exportable buffer: {e}"))
+                Error::GpuError(format!("Failed to create exportable buffer: {e}"))
             })?
         };
 
@@ -136,7 +136,7 @@ impl HostVulkanPixelBuffer {
 
         if mapped_ptr.is_null() {
             unsafe { allocator.destroy_buffer(buffer, allocation) };
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "VMA staging buffer mapped pointer is null — expected persistent mapping".into(),
             ));
         }
@@ -327,7 +327,7 @@ impl HostVulkanPixelBuffer {
         };
 
         let pool = vulkan_device.opaque_fd_buffer_pool().ok_or_else(|| {
-            StreamError::GpuError(
+            Error::GpuError(
                 "OPAQUE_FD buffer pool unavailable — external memory unsupported \
                  or pool construction failed; CUDA / OpenCL interop requires this pool"
                     .into(),
@@ -335,7 +335,7 @@ impl HostVulkanPixelBuffer {
         })?;
         let (buffer, allocation) = unsafe { pool.create_buffer(buffer_info, &alloc_opts) }
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Failed to create OPAQUE_FD exportable buffer: {e}"
                 ))
             })?;
@@ -345,7 +345,7 @@ impl HostVulkanPixelBuffer {
         let mapped_ptr = alloc_info.pMappedData.cast::<u8>();
         if mapped_ptr.is_null() {
             unsafe { allocator.destroy_buffer(buffer, allocation) };
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "VMA OPAQUE_FD staging buffer mapped pointer is null — expected persistent mapping".into(),
             ));
         }
@@ -416,7 +416,7 @@ impl HostVulkanPixelBuffer {
         let pool = vulkan_device
             .opaque_fd_buffer_pool_device_local()
             .ok_or_else(|| {
-                StreamError::GpuError(
+                Error::GpuError(
                     "DEVICE_LOCAL OPAQUE_FD buffer pool unavailable — external memory \
                      unsupported or pool construction failed; GPU-resident CUDA interop \
                      requires this pool"
@@ -425,7 +425,7 @@ impl HostVulkanPixelBuffer {
             })?;
         let (buffer, allocation) = unsafe { pool.create_buffer(buffer_info, &alloc_opts) }
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Failed to create DEVICE_LOCAL OPAQUE_FD exportable buffer: {e}"
                 ))
             })?;
@@ -458,7 +458,7 @@ impl HostVulkanPixelBuffer {
     /// `dup` again on receipt).
     pub fn export_opaque_fd_memory(&self) -> Result<std::os::unix::io::RawFd> {
         if !self.is_opaque_fd_export {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "HostVulkanPixelBuffer::export_opaque_fd_memory: buffer was not created \
                  with `new_opaque_fd_export`; the underlying memory carries DMA_BUF_EXT \
                  (or no) export flags and OPAQUE_FD export will fail at the driver"
@@ -466,7 +466,7 @@ impl HostVulkanPixelBuffer {
             ));
         }
         let allocation = self.allocation.as_ref().ok_or_else(|| {
-            StreamError::GpuError(
+            Error::GpuError(
                 "HostVulkanPixelBuffer::export_opaque_fd_memory: buffer has no VMA allocation"
                     .into(),
             )
@@ -482,7 +482,7 @@ impl HostVulkanPixelBuffer {
         use vulkanalia::vk::KhrExternalMemoryFdExtensionDeviceCommands;
         let fd = unsafe { self.vulkan_device.device().get_memory_fd_khr(&get_fd_info) }
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to export OPAQUE_FD memory fd: {e}"))
+                Error::GpuError(format!("Failed to export OPAQUE_FD memory fd: {e}"))
             })?;
         Ok(fd)
     }
@@ -496,7 +496,7 @@ impl HostVulkanPixelBuffer {
         } else if let Some(memory) = self.imported_memory {
             memory
         } else {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Cannot export DMA-BUF: buffer has no allocation or imported memory".into(),
             ));
         };
@@ -509,7 +509,7 @@ impl HostVulkanPixelBuffer {
         use vulkanalia::vk::KhrExternalMemoryFdExtensionDeviceCommands;
         let fd = unsafe { self.vulkan_device.device().get_memory_fd_khr(&get_fd_info) }
             .map(|r| r)
-            .map_err(|e| StreamError::GpuError(format!("Failed to export DMA-BUF fd: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to export DMA-BUF fd: {e}")))?;
 
         Ok(fd)
     }
@@ -584,19 +584,19 @@ impl HostVulkanPixelBuffer {
         format: PixelFormat,
     ) -> Result<Self> {
         if fds.is_empty() {
-            return Err(StreamError::Configuration(
+            return Err(Error::Configuration(
                 "DMA-BUF import: fd vec must be non-empty".into(),
             ));
         }
         if fds.len() != plane_sizes.len() {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "DMA-BUF import: plane_sizes length ({}) must match fds length ({})",
                 plane_sizes.len(),
                 fds.len()
             )));
         }
         if fds.len() > streamlib_surface_client::MAX_DMA_BUF_PLANES {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "DMA-BUF import: plane count {} exceeds MAX_DMA_BUF_PLANES ({})",
                 fds.len(),
                 streamlib_surface_client::MAX_DMA_BUF_PLANES
@@ -622,7 +622,7 @@ impl HostVulkanPixelBuffer {
                 for plane in imported.into_iter() {
                     teardown_imported_plane(vulkan_device, plane);
                 }
-                return Err(StreamError::Configuration(format!(
+                return Err(Error::Configuration(format!(
                     "DMA-BUF import: plane {} has size=0 and cannot be derived from width*height",
                     idx
                 )));
@@ -687,7 +687,7 @@ fn import_single_plane(
         .build();
 
     let buffer = unsafe { device.create_buffer(&buffer_info, None) }.map_err(|e| {
-        StreamError::GpuError(format!("Failed to create buffer for DMA-BUF import: {e}"))
+        Error::GpuError(format!("Failed to create buffer for DMA-BUF import: {e}"))
     })?;
 
     let mem_requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
@@ -708,7 +708,7 @@ fn import_single_plane(
     unsafe { device.bind_buffer_memory(buffer, memory, 0) }.map_err(|e| {
         vulkan_device.free_imported_memory(memory);
         unsafe { device.destroy_buffer(buffer, None) };
-        StreamError::GpuError(format!("Failed to bind imported memory: {e}"))
+        Error::GpuError(format!("Failed to bind imported memory: {e}"))
     })?;
 
     let mapped_ptr = vulkan_device
@@ -903,7 +903,7 @@ mod tests {
         let dma_buf = HostVulkanPixelBuffer::new(&device, 64, 64, 4, PixelFormat::Bgra32)
             .expect("dma-buf buffer failed");
         match dma_buf.export_opaque_fd_memory() {
-            Err(crate::core::StreamError::GpuError(msg)) => {
+            Err(crate::core::Error::GpuError(msg)) => {
                 assert!(
                     msg.contains("not created with `new_opaque_fd_export`"),
                     "error must call out the cross-flavor mismatch, got: {msg}"

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::core::rhi::{PixelBufferPoolId, PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::{HostVulkanDevice, HostVulkanPixelBuffer};
 
@@ -39,7 +39,7 @@ impl VulkanPixelBufferPool {
     ) -> Result<Self> {
         let mut buffers = Vec::with_capacity(pre_allocate);
         let mut buffer_to_pool_id = HashMap::with_capacity(pre_allocate);
-        let mut last_err: Option<StreamError> = None;
+        let mut last_err: Option<Error> = None;
 
         for i in 0..pre_allocate {
             match HostVulkanPixelBuffer::new(&device, width, height, bytes_per_pixel, format) {
@@ -61,7 +61,7 @@ impl VulkanPixelBufferPool {
 
         if buffers.is_empty() {
             return Err(last_err.unwrap_or_else(|| {
-                StreamError::BufferError(
+                Error::BufferError(
                     "VulkanPixelBufferPool: failed to allocate any buffers".into(),
                 )
             }));
@@ -103,7 +103,7 @@ impl VulkanPixelBufferPool {
     pub fn acquire(&self) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
         let len = self.buffers.len();
         if len == 0 {
-            return Err(StreamError::BufferError(
+            return Err(Error::BufferError(
                 "VulkanPixelBufferPool has no buffers".into(),
             ));
         }
@@ -133,7 +133,7 @@ impl VulkanPixelBufferPool {
             }
         }
 
-        Err(StreamError::BufferError(
+        Err(Error::BufferError(
             "All VulkanPixelBufferPool buffers are in use".into(),
         ))
     }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -34,7 +34,7 @@ use crate::core::rhi::{
     RayTracingKernelDescriptor, RayTracingShaderGroup, RayTracingShaderStage,
     RayTracingShaderStageFlags, RayTracingStage, RhiPixelBuffer, StreamTexture,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::{HostVulkanDevice, VulkanAccelerationStructure};
 
@@ -107,19 +107,19 @@ impl VulkanRayTracingKernel {
         descriptor: &RayTracingKernelDescriptor<'_>,
     ) -> Result<Self> {
         if !vulkan_device.supports_ray_tracing_pipeline() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': ray-tracing extensions not supported by device",
                 descriptor.label
             )));
         }
         let rt_props = vulkan_device.ray_tracing_pipeline_properties().ok_or_else(|| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': device reports RT supported but properties unavailable",
                 descriptor.label
             ))
         })?;
         if descriptor.max_recursion_depth > rt_props.max_ray_recursion_depth {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': declared max_recursion_depth={} exceeds device max ({})",
                 descriptor.label,
                 descriptor.max_recursion_depth,
@@ -150,7 +150,7 @@ impl VulkanRayTracingKernel {
                     for m in shader_modules.drain(..) {
                         unsafe { device.destroy_shader_module(m, None) };
                     }
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Ray-tracing kernel '{}': failed to create shader module for stage {:?}: {e}",
                         descriptor.label, stage.stage
                     )));
@@ -240,7 +240,7 @@ impl VulkanRayTracingKernel {
                 for m in shader_modules.drain(..) {
                     unsafe { device.destroy_shader_module(m, None) };
                 }
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Ray-tracing kernel '{}': vkCreateRayTracingPipelinesKHR failed: {e}",
                     descriptor.label
                 )));
@@ -358,7 +358,7 @@ impl VulkanRayTracingKernel {
                 for m in shader_modules.drain(..) {
                     unsafe { device.destroy_shader_module(m, None) };
                 }
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Ray-tracing kernel '{}': fence creation failed: {e}",
                     descriptor.label
                 )));
@@ -400,7 +400,7 @@ impl VulkanRayTracingKernel {
     ) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::AccelerationStructure)?;
         if tlas.kind() != super::AccelerationStructureKind::TopLevel {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': binding {} expects a top-level AS, got {:?}",
                 self.label, binding, tlas.kind()
             )));
@@ -464,7 +464,7 @@ impl VulkanRayTracingKernel {
 
     pub fn set_push_constants(&self, bytes: &[u8]) -> Result<()> {
         if bytes.len() as u32 != self.push_constant_size {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': push-constant size mismatch — got {} bytes, kernel declares {}",
                 self.label,
                 bytes.len(),
@@ -495,14 +495,14 @@ impl VulkanRayTracingKernel {
 
         for spec in &self.bindings {
             if !pending.bindings.contains_key(&spec.binding) {
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "Ray-tracing kernel '{}': binding {} ({:?}) not set before trace_rays",
                     self.label, spec.binding, spec.kind
                 )));
             }
         }
         if self.push_constant_size > 0 && pending.push_constants.is_empty() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': push constants not set before trace_rays",
                 self.label
             )));
@@ -512,13 +512,13 @@ impl VulkanRayTracingKernel {
             self.device
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': wait_for_fences failed: {e}",
                         self.label
                     ))
                 })?;
             self.device.reset_fences(&[self.fence]).map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Ray-tracing kernel '{}': reset_fences failed: {e}",
                     self.label
                 ))
@@ -531,7 +531,7 @@ impl VulkanRayTracingKernel {
             self.device
                 .reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': reset_command_buffer failed: {e}",
                         self.label
                     ))
@@ -542,7 +542,7 @@ impl VulkanRayTracingKernel {
             self.device
                 .begin_command_buffer(self.command_buffer, &begin_info)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': begin_command_buffer failed: {e}",
                         self.label
                     ))
@@ -585,7 +585,7 @@ impl VulkanRayTracingKernel {
             self.device
                 .end_command_buffer(self.command_buffer)
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': end_command_buffer failed: {e}",
                         self.label
                     ))
@@ -610,7 +610,7 @@ impl VulkanRayTracingKernel {
                 .wait_for_fences(&[self.fence], true, u64::MAX)
                 .map(|_| ())
                 .map_err(|e| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': wait_for_fences (post-submit) failed: {e}",
                         self.label
                     ))
@@ -634,13 +634,13 @@ impl VulkanRayTracingKernel {
             .iter()
             .find(|b| b.binding == binding)
             .ok_or_else(|| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Ray-tracing kernel '{}': binding {} not declared",
                     self.label, binding
                 ))
             })?;
         if spec.kind != expected {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': binding {} declared as {:?}, but {:?} was set",
                 self.label, binding, spec.kind, expected
             )));
@@ -666,7 +666,7 @@ impl VulkanRayTracingKernel {
             .unnormalized_coordinates(false)
             .build();
         let sampler = unsafe { self.device.create_sampler(&info, None) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': failed to create default sampler: {e}",
                 self.label
             ))
@@ -779,7 +779,7 @@ impl VulkanRayTracingKernel {
                     });
                 }
                 _ => {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Ray-tracing kernel '{}': binding {} kind/resource mismatch (declared {:?})",
                         self.label, spec.binding, spec.kind
                     )));
@@ -893,19 +893,19 @@ fn validate_bindings_against_spirv(descriptor: &RayTracingKernelDescriptor<'_>) 
 
     for stage in descriptor.stages {
         let reflection = Reflection::new_from_spirv(stage.spv).map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': failed to reflect SPIR-V for stage {:?}: {e:?}",
                 descriptor.label, stage.stage
             ))
         })?;
         let sets = reflection.get_descriptor_sets().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': failed to extract descriptor sets for stage {:?}: {e:?}",
                 descriptor.label, stage.stage
             ))
         })?;
         if sets.len() > 1 {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': only descriptor set 0 supported; stage {:?} uses sets {:?}",
                 descriptor.label,
                 stage.stage,
@@ -916,7 +916,7 @@ fn validate_bindings_against_spirv(descriptor: &RayTracingKernelDescriptor<'_>) 
         if let Some(set0) = sets.get(&0) {
             for (&binding, info) in set0 {
                 let kind = spirv_type_to_kind(info.ty).ok_or_else(|| {
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "Ray-tracing kernel '{}': SPIR-V binding {} in stage {:?} has unsupported descriptor type {:?}",
                         descriptor.label, binding, stage.stage, info.ty
                     ))
@@ -925,7 +925,7 @@ fn validate_bindings_against_spirv(descriptor: &RayTracingKernelDescriptor<'_>) 
                     .entry(binding)
                     .or_insert((kind, RayTracingShaderStageFlags::NONE));
                 if entry.0 != kind {
-                    return Err(StreamError::GpuError(format!(
+                    return Err(Error::GpuError(format!(
                         "Ray-tracing kernel '{}': SPIR-V binding {} declared as {:?} in one stage and {:?} in another",
                         descriptor.label, binding, entry.0, kind
                     )));
@@ -938,19 +938,19 @@ fn validate_bindings_against_spirv(descriptor: &RayTracingKernelDescriptor<'_>) 
     // Every declared binding must exist in the merged SPIR-V map.
     for spec in descriptor.bindings {
         let (spirv_kind, spirv_stages) = merged.get(&spec.binding).ok_or_else(|| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': binding {} declared but missing in SPIR-V",
                 descriptor.label, spec.binding
             ))
         })?;
         if *spirv_kind != spec.kind {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': binding {} declared {:?}, but SPIR-V has {:?}",
                 descriptor.label, spec.binding, spec.kind, spirv_kind
             )));
         }
         if !spec.stages.contains(*spirv_stages) {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': binding {} stages {:?} miss SPIR-V usage in {:?}",
                 descriptor.label, spec.binding, spec.stages, spirv_stages
             )));
@@ -960,7 +960,7 @@ fn validate_bindings_against_spirv(descriptor: &RayTracingKernelDescriptor<'_>) 
     // Conversely, every SPIR-V binding must be declared.
     for (&binding, &(kind, _)) in &merged {
         if !descriptor.bindings.iter().any(|s| s.binding == binding) {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Ray-tracing kernel '{}': SPIR-V declares binding {} ({:?}) but it is missing from the descriptor",
                 descriptor.label, binding, kind
             )));
@@ -976,13 +976,13 @@ fn validate_push_constants_against_spirv(
     let mut max_size = 0u32;
     for stage in descriptor.stages {
         let reflection = Reflection::new_from_spirv(stage.spv).map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': failed to reflect SPIR-V (push) for stage {:?}: {e:?}",
                 descriptor.label, stage.stage
             ))
         })?;
         if let Some(info) = reflection.get_push_constant_range().map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': failed to read push-constant range for stage {:?}: {e:?}",
                 descriptor.label, stage.stage
             ))
@@ -991,7 +991,7 @@ fn validate_push_constants_against_spirv(
         }
     }
     if max_size != descriptor.push_constants.size {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Ray-tracing kernel '{}': push-constant size mismatch — SPIR-V says {}, descriptor declares {}",
             descriptor.label, max_size, descriptor.push_constants.size
         )));
@@ -1033,7 +1033,7 @@ fn create_descriptor_set_layout(
         .bindings(&layout_bindings)
         .build();
     unsafe { device.create_descriptor_set_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("RT descriptor-set-layout creation failed: {e}")))
+        .map_err(|e| Error::GpuError(format!("RT descriptor-set-layout creation failed: {e}")))
 }
 
 fn create_pipeline_layout(
@@ -1057,7 +1057,7 @@ fn create_pipeline_layout(
         .push_constant_ranges(&push_constant_ranges)
         .build();
     unsafe { device.create_pipeline_layout(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("RT pipeline-layout creation failed: {e}")))
+        .map_err(|e| Error::GpuError(format!("RT pipeline-layout creation failed: {e}")))
 }
 
 fn create_descriptor_pool(
@@ -1082,7 +1082,7 @@ fn create_descriptor_pool(
         .pool_sizes(&pool_sizes)
         .build();
     unsafe { device.create_descriptor_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("RT descriptor-pool creation failed: {e}")))
+        .map_err(|e| Error::GpuError(format!("RT descriptor-pool creation failed: {e}")))
 }
 
 fn allocate_descriptor_set(
@@ -1096,7 +1096,7 @@ fn allocate_descriptor_set(
         .set_layouts(&set_layouts)
         .build();
     let sets = unsafe { device.allocate_descriptor_sets(&info) }
-        .map_err(|e| StreamError::GpuError(format!("RT descriptor-set allocation failed: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("RT descriptor-set allocation failed: {e}")))?;
     Ok(sets[0])
 }
 
@@ -1109,7 +1109,7 @@ fn create_command_pool(
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .build();
     unsafe { device.create_command_pool(&info, None) }
-        .map_err(|e| StreamError::GpuError(format!("RT command-pool creation failed: {e}")))
+        .map_err(|e| Error::GpuError(format!("RT command-pool creation failed: {e}")))
 }
 
 fn allocate_command_buffer(
@@ -1122,7 +1122,7 @@ fn allocate_command_buffer(
         .command_buffer_count(1)
         .build();
     let buffers = unsafe { device.allocate_command_buffers(&info) }
-        .map_err(|e| StreamError::GpuError(format!("RT command-buffer allocation failed: {e}")))?;
+        .map_err(|e| Error::GpuError(format!("RT command-buffer allocation failed: {e}")))?;
     Ok(buffers[0])
 }
 
@@ -1284,7 +1284,7 @@ fn build_sbt(
         }
     }
     if raygen_indices.is_empty() {
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Ray-tracing kernel '{}': pipeline must have at least one RayGen group",
             descriptor.label
         )));
@@ -1324,7 +1324,7 @@ fn build_sbt(
         )
     }
     .map_err(|e| {
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Ray-tracing kernel '{}': vkGetRayTracingShaderGroupHandlesKHR failed: {e}",
             descriptor.label
         ))
@@ -1386,7 +1386,7 @@ fn build_sbt(
     };
     let (sbt_buffer, sbt_allocation) =
         unsafe { allocator.create_buffer(buffer_info, &alloc_opts) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{}': SBT vmaCreateBuffer (size={total_size}) failed: {e}",
                 descriptor.label
             ))
@@ -1488,7 +1488,7 @@ fn upload_bytes_to_buffer(
     };
     let (staging_buffer, staging_allocation) =
         unsafe { allocator.create_buffer(staging_info, &staging_opts) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Ray-tracing kernel '{label}': SBT staging vmaCreateBuffer ({size}) failed: {e}"
             ))
         })?;
@@ -1496,7 +1496,7 @@ fn upload_bytes_to_buffer(
     let dst_ptr = info.pMappedData as *mut u8;
     if dst_ptr.is_null() {
         unsafe { allocator.destroy_buffer(staging_buffer, staging_allocation) };
-        return Err(StreamError::GpuError(format!(
+        return Err(Error::GpuError(format!(
             "Ray-tracing kernel '{label}': SBT staging mapping returned null"
         )));
     }
@@ -1526,7 +1526,7 @@ fn upload_bytes_to_buffer(
             device.destroy_command_pool(command_pool, None);
             allocator.destroy_buffer(staging_buffer, staging_allocation);
         }
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Ray-tracing kernel '{label}': SBT begin_command_buffer failed: {e}"
         ))
     })?;
@@ -1541,7 +1541,7 @@ fn upload_bytes_to_buffer(
             device.destroy_command_pool(command_pool, None);
             allocator.destroy_buffer(staging_buffer, staging_allocation);
         }
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Ray-tracing kernel '{label}': SBT end_command_buffer failed: {e}"
         ))
     })?;
@@ -1552,7 +1552,7 @@ fn upload_bytes_to_buffer(
             device.destroy_command_pool(command_pool, None);
             allocator.destroy_buffer(staging_buffer, staging_allocation);
         }
-        StreamError::GpuError(format!(
+        Error::GpuError(format!(
             "Ray-tracing kernel '{label}': SBT fence creation failed: {e}"
         ))
     })?;
@@ -1572,7 +1572,7 @@ fn upload_bytes_to_buffer(
         unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
             .map(|_| ())
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "Ray-tracing kernel '{label}': SBT wait_for_fences failed: {e}"
                 ))
             })

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs
@@ -8,7 +8,7 @@ use vulkanalia::vk;
 #[cfg(target_os = "linux")]
 use vulkanalia::vk::KhrExternalSemaphoreFdExtensionDeviceCommands;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Vulkan semaphore wrapper for synchronization.
 ///
@@ -30,7 +30,7 @@ impl VulkanSemaphore {
         let semaphore_info = vk::SemaphoreCreateInfo::builder().build();
 
         let semaphore = unsafe { device.create_semaphore(&semaphore_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create semaphore: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create semaphore: {e}")))?;
 
         Ok(Self {
             device: device.clone(),
@@ -53,7 +53,7 @@ impl VulkanSemaphore {
         mtl_shared_event: *const std::ffi::c_void,
     ) -> Result<Self> {
         if mtl_shared_event.is_null() {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Cannot import null MTLSharedEvent".into(),
             ));
         }
@@ -71,7 +71,7 @@ impl VulkanSemaphore {
         };
 
         let semaphore = unsafe { device.create_semaphore(&semaphore_info, None) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to create semaphore from MTLSharedEvent: {e}"
             ))
         })?;
@@ -127,7 +127,7 @@ impl VulkanFence {
         let fence_info = vk::FenceCreateInfo::builder().flags(flags).build();
 
         let fence = unsafe { device.create_fence(&fence_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create fence: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create fence: {e}")))?;
 
         Ok(Self {
             device: device.clone(),
@@ -142,14 +142,14 @@ impl VulkanFence {
     pub fn wait(&self, timeout_ns: u64) -> Result<()> {
         unsafe { self.device.wait_for_fences(&[self.fence], true, timeout_ns) }
             .map(|_| ())
-            .map_err(|e| StreamError::GpuError(format!("Failed to wait for fence: {e}")))
+            .map_err(|e| Error::GpuError(format!("Failed to wait for fence: {e}")))
     }
 
     /// Reset the fence to unsignaled state.
     pub fn reset(&self) -> Result<()> {
         unsafe { self.device.reset_fences(&[self.fence]) }
             .map(|_| ())
-            .map_err(|e| StreamError::GpuError(format!("Failed to reset fence: {e}")))
+            .map_err(|e| Error::GpuError(format!("Failed to reset fence: {e}")))
     }
 
     /// Get the underlying Vulkan fence handle.
@@ -244,7 +244,7 @@ impl HostVulkanTimelineSemaphore {
         };
 
         let semaphore = unsafe { device.create_semaphore(&info, None) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to create timeline semaphore (exportable={exportable}): {e}"
             ))
         })?;
@@ -281,7 +281,7 @@ impl HostVulkanTimelineSemaphore {
             .push_next(&mut type_info)
             .build();
         let semaphore = unsafe { device.create_semaphore(&info, None) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to create receiving timeline semaphore for import: {e}"
             ))
         })?;
@@ -296,7 +296,7 @@ impl HostVulkanTimelineSemaphore {
         let import_result = unsafe { device.import_semaphore_fd_khr(&import_info) };
         if let Err(e) = import_result {
             unsafe { device.destroy_semaphore(semaphore, None) };
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "vkImportSemaphoreFdKHR failed: {e}"
             )));
         }
@@ -314,7 +314,7 @@ impl HostVulkanTimelineSemaphore {
     /// subprocess has imported its own copy).
     pub fn export_opaque_fd(&self) -> Result<std::os::unix::io::RawFd> {
         if !self.exportable {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "HostVulkanTimelineSemaphore::export_opaque_fd: semaphore was not created with `new_exportable`".into(),
             ));
         }
@@ -323,7 +323,7 @@ impl HostVulkanTimelineSemaphore {
             .handle_type(vk::ExternalSemaphoreHandleTypeFlags::OPAQUE_FD)
             .build();
         let fd = unsafe { self.device.get_semaphore_fd_khr(&info) }.map_err(|e| {
-            StreamError::GpuError(format!("vkGetSemaphoreFdKHR failed: {e}"))
+            Error::GpuError(format!("vkGetSemaphoreFdKHR failed: {e}"))
         })?;
         Ok(fd)
     }
@@ -332,7 +332,7 @@ impl HostVulkanTimelineSemaphore {
     ///
     /// `timeout_ns` is the per-call timeout; pass `u64::MAX` for "no
     /// timeout". Returns `Ok(())` on success and
-    /// [`StreamError::GpuError`] (containing the underlying VkResult) on
+    /// [`Error::GpuError`] (containing the underlying VkResult) on
     /// timeout or driver failure.
     pub fn wait(&self, value: u64, timeout_ns: u64) -> Result<()> {
         let semaphores = [self.semaphore];
@@ -345,7 +345,7 @@ impl HostVulkanTimelineSemaphore {
         unsafe { self.device.wait_semaphores(&info, timeout_ns) }
             .map(|_| ())
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "vkWaitSemaphores(value={value}, timeout_ns={timeout_ns}): {e}"
                 ))
             })
@@ -363,7 +363,7 @@ impl HostVulkanTimelineSemaphore {
             .value(value)
             .build();
         unsafe { self.device.signal_semaphore(&info) }.map_err(|e| {
-            StreamError::GpuError(format!("vkSignalSemaphore(value={value}): {e}"))
+            Error::GpuError(format!("vkSignalSemaphore(value={value}): {e}"))
         })
     }
 
@@ -371,7 +371,7 @@ impl HostVulkanTimelineSemaphore {
     /// `vkGetSemaphoreCounterValue`. Used by tests and progress reporting.
     pub fn current_value(&self) -> Result<u64> {
         unsafe { self.device.get_semaphore_counter_value(self.semaphore) }.map_err(|e| {
-            StreamError::GpuError(format!("vkGetSemaphoreCounterValue: {e}"))
+            Error::GpuError(format!("vkGetSemaphoreCounterValue: {e}"))
         })
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
@@ -11,7 +11,7 @@ use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
 use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
 
@@ -208,7 +208,7 @@ impl HostVulkanTexture {
                 unsafe { allocator.create_image(image_info, &alloc_opts) }
             };
             result.map_err(|e| {
-                StreamError::GpuError(format!("Failed to create exportable image: {e}"))
+                Error::GpuError(format!("Failed to create exportable image: {e}"))
             })?
         };
 
@@ -274,7 +274,7 @@ impl HostVulkanTexture {
         let allocator = vulkan_device.allocator();
         let (image, allocation) =
             unsafe { allocator.create_image(image_info, &alloc_opts) }.map_err(|e| {
-                StreamError::GpuError(format!("Failed to create device-local image: {e}"))
+                Error::GpuError(format!("Failed to create device-local image: {e}"))
             })?;
 
         Ok(Self {
@@ -327,7 +327,7 @@ impl HostVulkanTexture {
         modifier_candidates: &[u64],
     ) -> Result<Self> {
         if modifier_candidates.is_empty() {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "new_render_target_dma_buf: empty modifier list — EGL did not advertise an external_only=FALSE modifier for this format. Linear DMA-BUF is sampler-only on NVIDIA; refusing to allocate.".into(),
             ));
         }
@@ -384,7 +384,7 @@ impl HostVulkanTexture {
             unsafe { allocator.create_image(image_info, &alloc_opts) }
         }
         .map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "Failed to create render-target DMA-BUF image (modifiers={:?}): {e}",
                 modifier_candidates
             ))
@@ -400,7 +400,7 @@ impl HostVulkanTexture {
                     // Image leaks on this branch — the allocator owns it. We
                     // destroy it explicitly so the caller doesn't need to.
                     unsafe { vulkan_device.allocator().destroy_image(image, allocation) };
-                    StreamError::GpuError(format!(
+                    Error::GpuError(format!(
                         "vkGetImageDrmFormatModifierPropertiesEXT failed: {e}"
                     ))
                 })?;
@@ -409,7 +409,7 @@ impl HostVulkanTexture {
 
         if !modifier_candidates.contains(&chosen) {
             unsafe { vulkan_device.allocator().destroy_image(image, allocation) };
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "Driver picked modifier 0x{:016x} that wasn't in our candidate list {:?} — VUID violation",
                 chosen, modifier_candidates
             )));
@@ -464,7 +464,7 @@ impl HostVulkanTexture {
         format: TextureFormat,
     ) -> Result<Self> {
         if iosurface_ref.is_null() {
-            return Err(StreamError::TextureError(
+            return Err(Error::TextureError(
                 "Cannot import null IOSurface".into(),
             ));
         }
@@ -502,7 +502,7 @@ impl HostVulkanTexture {
         let image = unsafe { device.create_image(&image_info, None) }
             .map(|r| r)
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create image from IOSurface: {e}"))
+                Error::GpuError(format!("Failed to create image from IOSurface: {e}"))
             })?;
 
         tracing::debug!(
@@ -586,10 +586,10 @@ impl HostVulkanTexture {
         }
 
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("Cannot create image view: no HostVulkanDevice stored".into())
+            Error::GpuError("Cannot create image view: no HostVulkanDevice stored".into())
         })?;
         let image = self.image.ok_or_else(|| {
-            StreamError::GpuError("Cannot create image view: no image".into())
+            Error::GpuError("Cannot create image view: no image".into())
         })?;
 
         let vk_format = texture_format_to_vk(self.format);
@@ -609,7 +609,7 @@ impl HostVulkanTexture {
             .build();
 
         let view = unsafe { vk_dev.device().create_image_view(&view_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create image view: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create image view: {e}")))?;
 
         let _ = self.cached_image_view.set(view);
         Ok(*self.cached_image_view.get().unwrap())
@@ -636,7 +636,7 @@ impl HostVulkanTexture {
             .flags(vk::CommandPoolCreateFlags::TRANSIENT)
             .build();
         let pool = unsafe { device.create_command_pool(&pool_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("transition_to_general: create_command_pool: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("transition_to_general: create_command_pool: {e}")))?;
         let cb_info = vk::CommandBufferAllocateInfo::builder()
             .command_pool(pool)
             .level(vk::CommandBufferLevel::PRIMARY)
@@ -646,7 +646,7 @@ impl HostVulkanTexture {
             Ok(c) => c[0],
             Err(e) => {
                 unsafe { device.destroy_command_pool(pool, None) };
-                return Err(StreamError::GpuError(format!(
+                return Err(Error::GpuError(format!(
                     "transition_to_general: allocate_command_buffers: {e}"
                 )));
             }
@@ -655,7 +655,7 @@ impl HostVulkanTexture {
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
             .build();
         unsafe { device.begin_command_buffer(cmd, &begin) }.map_err(|e| {
-            StreamError::GpuError(format!("transition_to_general: begin_command_buffer: {e}"))
+            Error::GpuError(format!("transition_to_general: begin_command_buffer: {e}"))
         })?;
         let barrier = vk::ImageMemoryBarrier2::builder()
             .src_stage_mask(vk::PipelineStageFlags2::NONE)
@@ -683,7 +683,7 @@ impl HostVulkanTexture {
             .build();
         unsafe { device.cmd_pipeline_barrier2(cmd, &dep) };
         unsafe { device.end_command_buffer(cmd) }.map_err(|e| {
-            StreamError::GpuError(format!("transition_to_general: end_command_buffer: {e}"))
+            Error::GpuError(format!("transition_to_general: end_command_buffer: {e}"))
         })?;
 
         let cmd_info = vk::CommandBufferSubmitInfo::builder()
@@ -695,7 +695,7 @@ impl HostVulkanTexture {
             .build();
         let fence_info = vk::FenceCreateInfo::default();
         let fence = unsafe { device.create_fence(&fence_info, None) }.map_err(|e| {
-            StreamError::GpuError(format!("transition_to_general: create_fence: {e}"))
+            Error::GpuError(format!("transition_to_general: create_fence: {e}"))
         })?;
         let submits = [submit];
         let submit_result = unsafe {
@@ -716,7 +716,7 @@ impl HostVulkanTexture {
         let wait_result = unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
             .map(|_| ())
             .map_err(|e| {
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "transition_to_general: wait_for_fences: {e}"
                 ))
             });
@@ -754,10 +754,10 @@ impl HostVulkanTexture {
     /// build.
     pub fn dma_buf_plane_layout(&self) -> Result<Vec<(u64, u64)>> {
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("dma_buf_plane_layout: no HostVulkanDevice".into())
+            Error::GpuError("dma_buf_plane_layout: no HostVulkanDevice".into())
         })?;
         let image = self.image.ok_or_else(|| {
-            StreamError::GpuError("dma_buf_plane_layout: no image".into())
+            Error::GpuError("dma_buf_plane_layout: no image".into())
         })?;
 
         let plane_count = match self.format {
@@ -775,7 +775,7 @@ impl HostVulkanTexture {
                     1 => vk::ImageAspectFlags::MEMORY_PLANE_1_EXT,
                     2 => vk::ImageAspectFlags::MEMORY_PLANE_2_EXT,
                     3 => vk::ImageAspectFlags::MEMORY_PLANE_3_EXT,
-                    _ => return Err(StreamError::GpuError(format!(
+                    _ => return Err(Error::GpuError(format!(
                         "dma_buf_plane_layout: plane index {plane_idx} out of range"
                     ))),
                 }
@@ -783,7 +783,7 @@ impl HostVulkanTexture {
                 match plane_idx {
                     0 => vk::ImageAspectFlags::PLANE_0,
                     1 => vk::ImageAspectFlags::PLANE_1,
-                    _ => return Err(StreamError::GpuError(format!(
+                    _ => return Err(Error::GpuError(format!(
                         "dma_buf_plane_layout: NV12 plane {plane_idx} out of range"
                     ))),
                 }
@@ -814,7 +814,7 @@ impl HostVulkanTexture {
         }
 
         let vk_dev = self.vulkan_device.as_ref().ok_or_else(|| {
-            StreamError::GpuError("Cannot export DMA-BUF: no HostVulkanDevice stored".into())
+            Error::GpuError("Cannot export DMA-BUF: no HostVulkanDevice stored".into())
         })?;
 
         // Get DeviceMemory from raw allocation (export/import path) or VMA allocation
@@ -824,7 +824,7 @@ impl HostVulkanTexture {
             let alloc_info = vk_dev.allocator().get_allocation_info(*allocation);
             alloc_info.deviceMemory
         } else {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "Cannot export DMA-BUF from texture without memory".into(),
             ));
         };
@@ -837,7 +837,7 @@ impl HostVulkanTexture {
         use vulkanalia::vk::KhrExternalMemoryFdExtensionDeviceCommands;
         let fd = unsafe { vk_dev.device().get_memory_fd_khr(&get_fd_info) }
             .map(|r| r)
-            .map_err(|e| StreamError::GpuError(format!("Failed to export DMA-BUF fd: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to export DMA-BUF fd: {e}")))?;
 
         let _ = self.cached_dma_buf_fd.set(fd);
         Ok(fd)
@@ -876,12 +876,12 @@ impl HostVulkanTexture {
         allocation_size: vk::DeviceSize,
     ) -> Result<Self> {
         if fds.is_empty() {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "import_render_target_dma_buf: empty fd vec".into(),
             ));
         }
         if plane_offsets.len() != fds.len() || plane_strides.len() != fds.len() {
-            return Err(StreamError::GpuError(format!(
+            return Err(Error::GpuError(format!(
                 "import_render_target_dma_buf: plane arrays length mismatch — fds={} offsets={} strides={}",
                 fds.len(),
                 plane_offsets.len(),
@@ -889,7 +889,7 @@ impl HostVulkanTexture {
             )));
         }
         if drm_format_modifier == 0 {
-            return Err(StreamError::GpuError(
+            return Err(Error::GpuError(
                 "import_render_target_dma_buf: zero (LINEAR) modifier — host should have allocated a tiled modifier; LINEAR DMA-BUFs are sampler-only on NVIDIA"
                     .into(),
             ));
@@ -949,7 +949,7 @@ impl HostVulkanTexture {
             .push_next(&mut external_image_info);
 
         let image = unsafe { device.create_image(&image_info, None) }.map_err(|e| {
-            StreamError::GpuError(format!(
+            Error::GpuError(format!(
                 "import_render_target_dma_buf: create_image failed (modifier=0x{:016x}): {e}",
                 drm_format_modifier
             ))
@@ -979,7 +979,7 @@ impl HostVulkanTexture {
             .map_err(|e| {
                 vulkan_device.free_imported_memory(memory);
                 unsafe { device.destroy_image(image, None) };
-                StreamError::GpuError(format!(
+                Error::GpuError(format!(
                     "import_render_target_dma_buf: bind_image_memory failed: {e}"
                 ))
             })?;
@@ -1040,7 +1040,7 @@ impl HostVulkanTexture {
         let image = unsafe { device.create_image(&image_info, None) }
             .map(|r| r)
             .map_err(|e| {
-                StreamError::GpuError(format!("Failed to create image for DMA-BUF import: {e}"))
+                Error::GpuError(format!("Failed to create image for DMA-BUF import: {e}"))
             })?;
 
         let mem_requirements = unsafe { device.get_image_memory_requirements(image) };
@@ -1064,7 +1064,7 @@ impl HostVulkanTexture {
             .map_err(|e| {
                 vulkan_device.free_imported_memory(memory);
                 unsafe { device.destroy_image(image, None) };
-                StreamError::GpuError(format!("Failed to bind imported memory: {e}"))
+                Error::GpuError(format!("Failed to bind imported memory: {e}"))
             })?;
 
         Ok(Self {

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_cache.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_cache.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 
 /// Vulkan texture cache — creates and caches VkImageView from VkImage.
 ///
@@ -39,7 +39,7 @@ impl VulkanTextureCache {
         let mut cache = self
             .view_cache
             .lock()
-            .map_err(|e| StreamError::GpuError(format!("Failed to lock texture cache: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to lock texture cache: {e}")))?;
 
         if let Some(&existing_view) = cache.get(&key) {
             return Ok(existing_view);
@@ -68,7 +68,7 @@ impl VulkanTextureCache {
         let _ = height;
 
         let view = unsafe { self.device.create_image_view(&view_info, None) }
-            .map_err(|e| StreamError::GpuError(format!("Failed to create VkImageView: {e}")))?;
+            .map_err(|e| Error::GpuError(format!("Failed to create VkImageView: {e}")))?;
 
         cache.insert(key, view);
         Ok(view)

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -31,7 +31,7 @@ use crate::core::rhi::{
     ReadbackTicket, StreamTexture, TextureFormat, TextureReadbackDescriptor, TextureReadbackError,
     TextureSourceLayout,
 };
-use crate::core::{Result, StreamError};
+use crate::core::{Result, Error};
 use crate::host_rhi::HostStreamTextureExt;
 
 use super::HostVulkanDevice;
@@ -680,19 +680,19 @@ impl std::fmt::Debug for VulkanTextureReadback {
     }
 }
 
-impl From<TextureReadbackError> for StreamError {
+impl From<TextureReadbackError> for Error {
     fn from(e: TextureReadbackError) -> Self {
-        StreamError::GpuError(e.to_string())
+        Error::GpuError(e.to_string())
     }
 }
 
-/// Convenience for callers that already work in `Result<T, StreamError>`.
+/// Convenience for callers that already work in `Result<T, Error>`.
 impl VulkanTextureReadback {
     pub fn new_into_stream_error(
         vulkan_device: &Arc<HostVulkanDevice>,
         descriptor: &TextureReadbackDescriptor<'_>,
     ) -> Result<Self> {
-        Self::new(vulkan_device, descriptor).map_err(StreamError::from)
+        Self::new(vulkan_device, descriptor).map_err(Error::from)
     }
 }
 

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -464,12 +464,12 @@ fn generate_processor_impl_from_schema(
                 <Self as ::streamlib::sdk::processors::ReactiveProcessor>::process(self, ctx)
             },
             quote! {
-                Err(::streamlib::sdk::error::StreamError::Runtime(
+                Err(::streamlib::sdk::error::Error::Runtime(
                     "start() is only valid for Manual execution mode.".into()
                 ))
             },
             quote! {
-                Err(::streamlib::sdk::error::StreamError::Runtime(
+                Err(::streamlib::sdk::error::Error::Runtime(
                     "stop() is only valid for Manual execution mode.".into()
                 ))
             },
@@ -480,7 +480,7 @@ fn generate_processor_impl_from_schema(
             quote! { ::streamlib::sdk::processors::ManualProcessor },
             quote! {
                 let _ = ctx;
-                Err(::streamlib::sdk::error::StreamError::Runtime(
+                Err(::streamlib::sdk::error::Error::Runtime(
                     "process() is only valid for Reactive/Continuous execution modes.".into()
                 ))
             },
@@ -501,12 +501,12 @@ fn generate_processor_impl_from_schema(
                     <Self as ::streamlib::sdk::processors::ContinuousProcessor>::process(self, ctx)
                 },
                 quote! {
-                    Err(::streamlib::sdk::error::StreamError::Runtime(
+                    Err(::streamlib::sdk::error::Error::Runtime(
                         "start() is only valid for Manual execution mode.".into()
                     ))
                 },
                 quote! {
-                    Err(::streamlib::sdk::error::StreamError::Runtime(
+                    Err(::streamlib::sdk::error::Error::Runtime(
                         "stop() is only valid for Manual execution mode.".into()
                     ))
                 },

--- a/packages/audio/src/apple/audio_capture.rs
+++ b/packages/audio/src/apple/audio_capture.rs
@@ -5,7 +5,7 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, Stream, StreamConfig};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::RuntimeContextFullAccess;
 use streamlib::sdk::iceoryx2::OutputWriter;
 
@@ -83,7 +83,7 @@ impl AppleAudioCaptureProcessor::Processor {
             let devices: Vec<Device> = host
                 .input_devices()
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Failed to enumerate audio input devices: {}",
                         e
                     ))
@@ -100,14 +100,14 @@ impl AppleAudioCaptureProcessor::Processor {
                     }
                 })
                 .ok_or_else(|| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Audio input device '{}' not found",
                         device_name_str
                     ))
                 })?
         } else {
             host.default_input_device()
-                .ok_or_else(|| StreamError::Configuration("No default audio input device".into()))?
+                .ok_or_else(|| Error::Configuration("No default audio input device".into()))?
         };
 
         let device_name = device
@@ -115,7 +115,7 @@ impl AppleAudioCaptureProcessor::Processor {
             .unwrap_or_else(|_| "Unknown Device".to_string());
 
         let default_config = device.default_input_config().map_err(|e| {
-            StreamError::Configuration(format!("Failed to get audio config: {}", e))
+            Error::Configuration(format!("Failed to get audio config: {}", e))
         })?;
 
         let device_sample_rate = default_config.sample_rate().0;
@@ -137,7 +137,7 @@ impl AppleAudioCaptureProcessor::Processor {
         };
 
         if device_channels != 1 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "Audio input device '{}' is not mono (has {} channels). Only mono devices are supported.",
                 device_name, device_channels
             )));
@@ -188,13 +188,13 @@ impl AppleAudioCaptureProcessor::Processor {
                 None,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to build audio stream: {}", e))
+                Error::Configuration(format!("Failed to build audio stream: {}", e))
             })?;
 
         tracing::info!("[AudioCapture] Starting stream...");
 
         stream.play().map_err(|e| {
-            StreamError::Configuration(format!("Failed to start audio stream: {}", e))
+            Error::Configuration(format!("Failed to start audio stream: {}", e))
         })?;
 
         self.is_capturing.store(true, Ordering::Relaxed);
@@ -219,7 +219,7 @@ impl AppleAudioCaptureProcessor::Processor {
         let devices: Result<Vec<AppleAudioInputDevice>> = host
             .input_devices()
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Failed to enumerate audio input devices: {}",
                     e
                 ))

--- a/packages/audio/src/apple/audio_output.rs
+++ b/packages/audio/src/apple/audio_output.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use streamlib::sdk::_generated_::AudioFrame;
 use streamlib::sdk::utils::ProcessorAudioConverterTargetFormat;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::RuntimeContextFullAccess;
 
 /// Wrapper for InputMailboxes pointer that is Send.
@@ -109,23 +109,23 @@ impl streamlib::sdk::processors::ManualProcessor for AppleAudioOutputProcessor::
             let devices: Vec<_> = host
                 .output_devices()
                 .map_err(|e| {
-                    StreamError::Configuration(format!("Failed to enumerate audio devices: {}", e))
+                    Error::Configuration(format!("Failed to enumerate audio devices: {}", e))
                 })?
                 .collect();
             devices
                 .get(id)
                 .ok_or_else(|| {
-                    StreamError::Configuration(format!("Audio device {} not found", id))
+                    Error::Configuration(format!("Audio device {} not found", id))
                 })?
                 .clone()
         } else {
             host.default_output_device().ok_or_else(|| {
-                StreamError::Configuration("No default audio output device".into())
+                Error::Configuration("No default audio output device".into())
             })?
         };
 
         let device_config = device.default_output_config().map_err(|e| {
-            StreamError::Configuration(format!("Failed to get audio config: {}", e))
+            Error::Configuration(format!("Failed to get audio config: {}", e))
         })?;
 
         let device_sample_rate = device_config.sample_rate().0;
@@ -190,13 +190,13 @@ impl streamlib::sdk::processors::ManualProcessor for AppleAudioOutputProcessor::
                 None,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to build audio stream: {}", e))
+                Error::Configuration(format!("Failed to build audio stream: {}", e))
             })?;
 
         tracing::info!("AudioOutput: Starting cpal stream playback");
         stream
             .play()
-            .map_err(|e| StreamError::Configuration(format!("Failed to start stream: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to start stream: {}", e)))?;
 
         tracing::info!("AudioOutput: cpal stream.play() succeeded");
 

--- a/packages/audio/src/audio_channel_converter.rs
+++ b/packages/audio/src/audio_channel_converter.rs
@@ -3,7 +3,7 @@
 
 use crate::_generated_::tatolab__audio::audio_channel_converter_config::Mode;
 use streamlib::sdk::_generated_::AudioFrame;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 
 #[streamlib::sdk::processor("AudioChannelConverter")]
@@ -42,7 +42,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for AudioChannelConverterProc
         let input_frame: AudioFrame = self.inputs.read("audio_in")?;
 
         if input_frame.channels != 1 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "AudioChannelConverter expects mono input (1 channel), got {} channels",
                 input_frame.channels
             )));

--- a/packages/audio/src/audio_mixer.rs
+++ b/packages/audio/src/audio_mixer.rs
@@ -3,7 +3,7 @@
 
 use crate::_generated_::tatolab__audio::audio_mixer_config::Strategy;
 use streamlib::sdk::_generated_::AudioFrame;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 
 #[streamlib::sdk::processor("AudioMixer")]
@@ -49,13 +49,13 @@ impl streamlib::sdk::processors::ReactiveProcessor for AudioMixerProcessor::Proc
         let right_frame: AudioFrame = self.inputs.read("right")?;
 
         if left_frame.channels != 1 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "AudioMixer expects mono left input (1 channel), got {} channels",
                 left_frame.channels
             )));
         }
         if right_frame.channels != 1 {
-            return Err(StreamError::Configuration(format!(
+            return Err(Error::Configuration(format!(
                 "AudioMixer expects mono right input (1 channel), got {} channels",
                 right_frame.channels
             )));

--- a/packages/audio/src/linux/audio_capture.rs
+++ b/packages/audio/src/linux/audio_capture.rs
@@ -5,7 +5,7 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, Stream, StreamConfig};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::RuntimeContextFullAccess;
 use streamlib::sdk::iceoryx2::OutputWriter;
 
@@ -83,7 +83,7 @@ impl LinuxAudioCaptureProcessor::Processor {
             let devices: Vec<Device> = host
                 .input_devices()
                 .map_err(|e| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Failed to enumerate audio input devices: {}",
                         e
                     ))
@@ -100,14 +100,14 @@ impl LinuxAudioCaptureProcessor::Processor {
                     }
                 })
                 .ok_or_else(|| {
-                    StreamError::Configuration(format!(
+                    Error::Configuration(format!(
                         "Audio input device '{}' not found",
                         device_name_str
                     ))
                 })?
         } else {
             host.default_input_device()
-                .ok_or_else(|| StreamError::Configuration("No default audio input device".into()))?
+                .ok_or_else(|| Error::Configuration("No default audio input device".into()))?
         };
 
         let device_name = device
@@ -115,7 +115,7 @@ impl LinuxAudioCaptureProcessor::Processor {
             .unwrap_or_else(|_| "Unknown Device".to_string());
 
         let default_config = device.default_input_config().map_err(|e| {
-            StreamError::Configuration(format!("Failed to get audio config: {}", e))
+            Error::Configuration(format!("Failed to get audio config: {}", e))
         })?;
 
         let device_sample_rate = default_config.sample_rate().0;
@@ -179,13 +179,13 @@ impl LinuxAudioCaptureProcessor::Processor {
                 None,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to build audio stream: {}", e))
+                Error::Configuration(format!("Failed to build audio stream: {}", e))
             })?;
 
         tracing::info!("[AudioCapture] Starting stream...");
 
         stream.play().map_err(|e| {
-            StreamError::Configuration(format!("Failed to start audio stream: {}", e))
+            Error::Configuration(format!("Failed to start audio stream: {}", e))
         })?;
 
         self.is_capturing.store(true, Ordering::Relaxed);
@@ -210,7 +210,7 @@ impl LinuxAudioCaptureProcessor::Processor {
         let devices: Result<Vec<LinuxAudioInputDevice>> = host
             .input_devices()
             .map_err(|e| {
-                StreamError::Configuration(format!(
+                Error::Configuration(format!(
                     "Failed to enumerate audio input devices: {}",
                     e
                 ))

--- a/packages/audio/src/linux/audio_output.rs
+++ b/packages/audio/src/linux/audio_output.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use streamlib::sdk::_generated_::AudioFrame;
 use streamlib::sdk::utils::ProcessorAudioConverterTargetFormat;
-use streamlib::sdk::error::{Result, StreamError};
+use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::RuntimeContextFullAccess;
 
 /// Wrapper for InputMailboxes pointer that is Send.
@@ -109,23 +109,23 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::
             let devices: Vec<_> = host
                 .output_devices()
                 .map_err(|e| {
-                    StreamError::Configuration(format!("Failed to enumerate audio devices: {}", e))
+                    Error::Configuration(format!("Failed to enumerate audio devices: {}", e))
                 })?
                 .collect();
             devices
                 .get(id)
                 .ok_or_else(|| {
-                    StreamError::Configuration(format!("Audio device {} not found", id))
+                    Error::Configuration(format!("Audio device {} not found", id))
                 })?
                 .clone()
         } else {
             host.default_output_device().ok_or_else(|| {
-                StreamError::Configuration("No default audio output device".into())
+                Error::Configuration("No default audio output device".into())
             })?
         };
 
         let device_config = device.default_output_config().map_err(|e| {
-            StreamError::Configuration(format!("Failed to get audio config: {}", e))
+            Error::Configuration(format!("Failed to get audio config: {}", e))
         })?;
 
         let device_sample_rate = device_config.sample_rate().0;
@@ -194,13 +194,13 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::
                 None,
             )
             .map_err(|e| {
-                StreamError::Configuration(format!("Failed to build audio stream: {}", e))
+                Error::Configuration(format!("Failed to build audio stream: {}", e))
             })?;
 
         tracing::info!("AudioOutput: Starting cpal stream playback");
         stream
             .play()
-            .map_err(|e| StreamError::Configuration(format!("Failed to start stream: {}", e)))?;
+            .map_err(|e| Error::Configuration(format!("Failed to start stream: {}", e)))?;
 
         tracing::info!("AudioOutput: cpal stream.play() succeeded");
 


### PR DESCRIPTION
## Summary
- Rename `StreamError` enum → `Error` so the SDK path becomes `streamlib::sdk::error::Error`, matching the Rust idiom (`std::io::Error`, `tokio::io::Error`).
- Pure rename, no behavior change. `Result` alias unchanged at `streamlib::sdk::error::Result`. `From<ConsumerRhiError>` impl preserved.
- The `thiserror::Error` derive collision at the definition site is resolved by switching to fully-qualified `#[derive(thiserror::Error, Debug)]`.

## Closes
Closes #738

## Exit criteria
- [x] `StreamError` enum renamed to `Error` in `libs/streamlib-engine/src/core/error.rs`.
- [x] All consumers updated: `streamlib::sdk::error::StreamError` references become `streamlib::sdk::error::Error` (140 files, 1374 insertions / 1376 deletions).
- [x] `Result` alias unchanged.
- [x] All `cargo xtask check-*` lints pass.
- [x] Workspace test gate green.

## Test plan
- `cargo check --workspace`: ✅ (3 pre-existing unused-import warnings in `screen-recorder`, `microphone-reverb-speaker`, `camera-audio-recorder` — `Result` and `Runner` imports unaffected by this rename, left alone per "no auto-fixing on the side").
- `cargo xtask check-boundaries`: ✅ 3280 files scanned, no violations.
- `cargo xtask lint-logging`: ✅ 475 files, no violations.
- `cargo xtask check-schema-versions`: ✅
- `cargo xtask check-no-streamlib-metadata`: ✅
- `cargo xtask check-processor-spec-new`: ✅
- `cargo xtask check-manifest-schema`: ✅ 28 streamlib.yaml files validated.
- Workspace test baseline (`docs/testing-baseline.md`): ✅ 149 test result blocks, 0 failures.

## Follow-ups
None. Pairs with #739 (`StreamTexture` → `Texture`) and #740 (`RhiPixelBuffer*` → `PixelBuffer*`) — same shape, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)