### PR TITLE
refactor(sdk): rename StreamTexture to Texture (#739)

### DIFF
--- a/docs/architecture/adapter-runtime-integration.md
+++ b/docs/architecture/adapter-runtime-integration.md
@@ -365,7 +365,7 @@ surfaces have to be in place.
 The shape of what the hook does varies by seam:
 
 - **Surface-share seam** (Vulkan, OpenGL, Skia). The hook allocates
-  the host's `StreamTexture` (via
+  the host's `Texture` (via
   `gpu.acquire_render_target_dma_buf_image` for render-target-capable
   DMA-BUF), registers it in surface-share with a known UUID via
   `gpu.surface_store().register_texture(uuid, &texture, timeline,

--- a/docs/architecture/compute-kernel.md
+++ b/docs/architecture/compute-kernel.md
@@ -36,7 +36,7 @@ Given a SPIR-V blob and a small typed declaration, the kernel:
 3. **Stages bindings as data** through `set_storage_buffer`,
    `set_uniform_buffer`, `set_sampled_texture`, `set_storage_image`,
    and `set_push_constants`. Each setter takes RHI-level types
-   (`RhiPixelBuffer`, `StreamTexture`, `&[u8]`).
+   (`RhiPixelBuffer`, `Texture`, `&[u8]`).
 4. **Flushes + dispatches + waits** in `dispatch(x, y, z)`. The fence is
    pre-signaled so the first dispatch doesn't block, and consecutive
    dispatches against the same kernel are serial (one in flight at a time).

--- a/docs/architecture/graphics-kernel.md
+++ b/docs/architecture/graphics-kernel.md
@@ -39,7 +39,7 @@ declaration, the kernel:
 3. **Stages bindings as data** through `set_sampled_texture`,
    `set_storage_buffer`, `set_uniform_buffer`, `set_storage_image`,
    `set_push_constants`, `set_vertex_buffer`, `set_index_buffer`. Each
-   setter takes RHI-level types (`StreamTexture`, `RhiPixelBuffer`,
+   setter takes RHI-level types (`Texture`, `RhiPixelBuffer`,
    `&[u8]`).
 
 4. **Records bind + push + draw into the caller's command buffer.**
@@ -190,7 +190,7 @@ follow-ups under the **Graphics Kernel Buildout** milestone:
   public API is shaped so the backend can migrate later without
   breaking callers; the descriptor pool is an internal detail today.
 - **Depth attachment allocation.** Depth `TextureFormat` variants
-  and `StreamTexture` allocation for depth attachments are not yet
+  and `Texture` allocation for depth attachments are not yet
   in `streamlib-consumer-rhi` — depth-stencil pipeline-creation is
   validated by unit test, but depth-correctness rendering tests are
   pending depth-format support.

--- a/docs/architecture/ray-tracing-kernel.md
+++ b/docs/architecture/ray-tracing-kernel.md
@@ -58,7 +58,7 @@ binding declaration, the kernel:
 3. **Stages bindings as data** through `set_storage_buffer`,
    `set_uniform_buffer`, `set_sampled_texture`, `set_storage_image`,
    `set_acceleration_structure`, `set_push_constants`. Each setter
-   takes RHI-level types (`RhiPixelBuffer`, `StreamTexture`,
+   takes RHI-level types (`RhiPixelBuffer`, `Texture`,
    `Arc<VulkanAccelerationStructure>`, `&[u8]`).
 
 4. **Records bind + push + trace + waits** in `trace_rays(width,

--- a/docs/architecture/texture-readback.md
+++ b/docs/architecture/texture-readback.md
@@ -1,7 +1,7 @@
 # Host-side texture readback in the RHI
 
 streamlib's RHI exposes one canonical primitive for reading a host
-`StreamTexture` back into CPU memory: `VulkanTextureReadback` (Linux)
+`Texture` back into CPU memory: `VulkanTextureReadback` (Linux)
 plus the public binding-shape types in `core::rhi`
 (`TextureReadbackDescriptor`, `TextureSourceLayout`, `ReadbackTicket`,
 `TextureReadbackError`). **Every callsite that needs to copy GPU pixels

--- a/docs/architecture/texture-registration.md
+++ b/docs/architecture/texture-registration.md
@@ -19,7 +19,7 @@ per-surface lifecycle state**, keyed by `surface_id` in
 plus the typed mutable fields that producers and consumers both need
 to read/write across the surface_id handoff:
 
-- `texture: StreamTexture` — the resource itself.
+- `texture: Texture` — the resource itself.
 - `current_layout: AtomicI32` (Linux only — stores
   `streamlib_consumer_rhi::VulkanLayout`) — the last-known Vulkan
   image layout. Producers update on transitions; consumers read for
@@ -36,7 +36,7 @@ is the same shape lifted from adapter-scope to engine-wide scope.
 ## Why it exists
 
 Before `TextureRegistration` (pre-#632), `GpuContext::texture_cache`
-was `HashMap<String, StreamTexture>` — a thin lookup with no
+was `HashMap<String, Texture>` — a thin lookup with no
 lifecycle metadata. Per-surface state lived in two disjoint places:
 
 - Adapter-scoped `Registry<SurfaceState>` per adapter — visible only
@@ -103,7 +103,7 @@ producer:                  consumer:
   ┌─────────────────────────────────────────┐
   │ GpuContext::texture_cache               │
   │   HashMap<surface_id, Arc<TexReg>>      │
-  │     ├── texture: StreamTexture          │
+  │     ├── texture: Texture          │
   │     └── current_layout: AtomicI32       │
   └─────────────────────────────────────────┘
        ▲                            │
@@ -142,7 +142,7 @@ Examples that fit:
 - ✓ `last_written_frame_index: AtomicU64` — staleness detection;
   producer increments per write, consumer compares to its expected
   frame.
-- ✓ `format`, `width`, `height` — could be hoisted from `StreamTexture`
+- ✓ `format`, `width`, `height` — could be hoisted from `Texture`
   for cheaper validation; arguably already covered by `texture`.
 - ✓ Exportable timeline-semaphore handle — for consumers that need to
   GPU-wait without a side-channel.

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -8,9 +8,9 @@
 //! display's refresh rate (60 Hz fallback). Each tick reads the latest
 //! frame from each input port (older queued frames are dropped by the
 //! port's `SkipToLatest` read mode), resolves the input frames'
-//! [`StreamTexture`]s via `GpuContext::resolve_video_frame_registration`
+//! [`Texture`]s via `GpuContext::resolve_video_frame_registration`
 //! (Path 1 — same-process texture cache), picks the next slot in a
-//! ring of pre-allocated render-target output `StreamTexture`s,
+//! ring of pre-allocated render-target output `Texture`s,
 //! dispatches the compositor's graphics kernel into it, and emits the
 //! slot's surface UUID downstream.
 //!
@@ -36,7 +36,7 @@ use std::time::{Duration, Instant};
 use streamlib::sdk::engine::HostGpuDeviceExt;
 
 use streamlib::sdk::display_info;
-use streamlib::sdk::rhi::{StreamTexture, TextureFormat, VulkanLayout};
+use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
 use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
@@ -106,7 +106,7 @@ impl Default for BlendingCompositorConfig {
 /// it is registered under in `GpuContext::texture_cache`.
 struct OutputSlot {
     surface_id: String,
-    texture: StreamTexture,
+    texture: Texture,
 }
 
 /// GPU backend bundle owned by the processor and moved into the
@@ -576,7 +576,7 @@ fn compose_one_frame(
 /// completes.
 struct ResolvedLayer {
     registration: Arc<streamlib::sdk::context::TextureRegistration>,
-    texture: StreamTexture,
+    texture: Texture,
 }
 
 impl ResolvedLayer {

--- a/examples/camera-python-display/src/blending_compositor_kernel.rs
+++ b/examples/camera-python-display/src/blending_compositor_kernel.rs
@@ -35,7 +35,7 @@
 //!
 //! ## Lifecycle
 //!
-//! Caller pre-allocates a ring of output `StreamTexture`s (typically
+//! Caller pre-allocates a ring of output `Texture`s (typically
 //! `MAX_FRAMES_IN_FLIGHT = 2`), hands one to [`SandboxedBlendingCompositor::dispatch`]
 //! per frame along with the four layer textures + their current
 //! Vulkan layouts, and `dispatch` returns once the GPU has signaled
@@ -44,7 +44,7 @@
 //! ready for the next consumer to sample without re-barriering.
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
@@ -67,7 +67,7 @@ use streamlib::sdk::rhi::{
     PrimitiveTopology,
     RasterizationState,
     ScissorRect,
-    StreamTexture,
+    Texture,
     TextureDescriptor,
     TextureFormat,
     TextureUsages,
@@ -105,7 +105,7 @@ pub mod flag_bits {
 /// in that layout afterward.
 #[derive(Clone, Copy)]
 pub struct BlendingLayer<'a> {
-    pub texture: &'a StreamTexture,
+    pub texture: &'a Texture,
     pub current_layout: VulkanLayout,
 }
 
@@ -115,7 +115,7 @@ pub struct BlendingLayer<'a> {
 /// `UNDEFINED` on the first dispatch into this slot).
 #[derive(Clone, Copy)]
 pub struct BlendingOutput<'a> {
-    pub texture: &'a StreamTexture,
+    pub texture: &'a Texture,
     pub current_layout: VulkanLayout,
 }
 
@@ -154,7 +154,7 @@ pub struct SandboxedBlendingCompositor {
     /// graphics-kernel descriptor sets must be fully populated even
     /// when the corresponding `has_*` flag is false. Pre-uploaded once
     /// at construction; ends in `SHADER_READ_ONLY_OPTIMAL`.
-    placeholder: StreamTexture,
+    placeholder: Texture,
 }
 
 impl SandboxedBlendingCompositor {
@@ -455,7 +455,7 @@ impl SandboxedBlendingCompositor {
     fn layer_or_placeholder<'a>(
         &'a self,
         layer: Option<BlendingLayer<'a>>,
-    ) -> (&'a StreamTexture, VulkanLayout) {
+    ) -> (&'a Texture, VulkanLayout) {
         match layer {
             Some(BlendingLayer { texture, current_layout }) => (texture, current_layout),
             None => (&self.placeholder, VulkanLayout::SHADER_READ_ONLY_OPTIMAL),
@@ -477,7 +477,7 @@ impl Drop for SandboxedBlendingCompositor {
     }
 }
 
-fn make_placeholder_texture(vulkan_device: &Arc<HostVulkanDevice>) -> Result<StreamTexture> {
+fn make_placeholder_texture(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Texture> {
     let desc = TextureDescriptor::new(1, 1, TextureFormat::Bgra8Unorm).with_usage(
         TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
     );
@@ -496,7 +496,7 @@ fn make_placeholder_texture(vulkan_device: &Arc<HostVulkanDevice>) -> Result<Str
         vulkan_device.upload_buffer_to_image(staging.buffer(), image, 1, 1)?;
     }
 
-    Ok(StreamTexture::from_vulkan(host_tex))
+    Ok(Texture::from_vulkan(host_tex))
 }
 
 fn create_command_pool(
@@ -607,7 +607,7 @@ mod tests {
         device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
-    ) -> StreamTexture {
+    ) -> Texture {
         let desc = TextureDescriptor::new(width, height, TextureFormat::Bgra8Unorm).with_usage(
             TextureUsages::RENDER_ATTACHMENT
                 | TextureUsages::TEXTURE_BINDING
@@ -615,7 +615,7 @@ mod tests {
                 | TextureUsages::COPY_SRC,
         );
         let host_tex = device.create_texture_local(&desc).expect("texture");
-        StreamTexture::from_vulkan(host_tex)
+        Texture::from_vulkan(host_tex)
     }
 
     /// Fill a texture with a single BGRA color via host-visible staging
@@ -623,7 +623,7 @@ mod tests {
     /// SHADER_READ_ONLY_OPTIMAL.
     fn fill_texture_solid(
         device: &Arc<HostVulkanDevice>,
-        texture: &StreamTexture,
+        texture: &Texture,
         b: u8,
         g: u8,
         r: u8,
@@ -651,7 +651,7 @@ mod tests {
     /// Read one pixel from a texture via the RHI's readback primitive.
     fn read_pixel(
         device: &Arc<HostVulkanDevice>,
-        texture: &StreamTexture,
+        texture: &Texture,
         x: u32,
         y: u32,
     ) -> (u8, u8, u8, u8) {

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib::sdk::_generated_::VideoFrame;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 #[cfg(target_os = "linux")]
 use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer};

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use streamlib::sdk::engine::HostGpuDeviceExt;
 
-use streamlib::sdk::rhi::{StreamTexture, TextureFormat, VulkanLayout};
+use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::_generated_::VideoFrame;
@@ -53,7 +53,7 @@ const CRT_OUTPUT_SURFACE_UUIDS: [&str; OUTPUT_RING_DEPTH] = [
 /// surface_id (the UUID it is dual-registered under).
 struct OutputSlot {
     surface_id: String,
-    texture: StreamTexture,
+    texture: Texture,
 }
 
 struct LinuxBackend {

--- a/examples/camera-python-display/src/crt_film_grain_kernel.rs
+++ b/examples/camera-python-display/src/crt_film_grain_kernel.rs
@@ -37,7 +37,7 @@
 //!
 //! ## Lifecycle
 //!
-//! Caller pre-allocates a ring of output `StreamTexture`s (mirrors
+//! Caller pre-allocates a ring of output `Texture`s (mirrors
 //! `BlendingCompositor`'s `OUTPUT_RING_DEPTH = 2`), hands one to
 //! [`SandboxedCrtFilmGrain::dispatch`] per frame along with the input
 //! texture + its current Vulkan layout, and `dispatch` returns once
@@ -46,7 +46,7 @@
 //! ready for the next consumer to sample without re-barriering.
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
@@ -68,7 +68,7 @@ use streamlib::sdk::rhi::{
     PrimitiveTopology,
     RasterizationState,
     ScissorRect,
-    StreamTexture,
+    Texture,
     TextureFormat,
     VertexInputState,
     Viewport,
@@ -100,7 +100,7 @@ pub struct CrtFilmGrainPushConstants {
 /// afterward.
 #[derive(Clone, Copy)]
 pub struct CrtFilmGrainInput<'a> {
-    pub texture: &'a StreamTexture,
+    pub texture: &'a Texture,
     pub current_layout: VulkanLayout,
 }
 
@@ -108,7 +108,7 @@ pub struct CrtFilmGrainInput<'a> {
 /// `BlendingOutput` in the sibling kernel.
 #[derive(Clone, Copy)]
 pub struct CrtFilmGrainOutput<'a> {
-    pub texture: &'a StreamTexture,
+    pub texture: &'a Texture,
     pub current_layout: VulkanLayout,
 }
 
@@ -501,7 +501,7 @@ mod tests {
         device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
-    ) -> StreamTexture {
+    ) -> Texture {
         let desc = TextureDescriptor::new(width, height, TextureFormat::Bgra8Unorm).with_usage(
             TextureUsages::RENDER_ATTACHMENT
                 | TextureUsages::TEXTURE_BINDING
@@ -509,12 +509,12 @@ mod tests {
                 | TextureUsages::COPY_SRC,
         );
         let host_tex = device.create_texture_local(&desc).expect("texture");
-        StreamTexture::from_vulkan(host_tex)
+        Texture::from_vulkan(host_tex)
     }
 
     fn fill_texture_solid(
         device: &Arc<HostVulkanDevice>,
-        texture: &StreamTexture,
+        texture: &Texture,
         b: u8,
         g: u8,
         r: u8,
@@ -542,7 +542,7 @@ mod tests {
     /// Read a single BGRA pixel via the RHI readback primitive.
     fn read_pixel(
         device: &Arc<HostVulkanDevice>,
-        texture: &StreamTexture,
+        texture: &Texture,
         x: u32,
         y: u32,
     ) -> (u8, u8, u8, u8) {
@@ -576,7 +576,7 @@ mod tests {
     /// Read the full BGRA buffer from a texture for visual-smoke tests.
     fn read_bgra_buffer(
         device: &Arc<HostVulkanDevice>,
-        texture: &StreamTexture,
+        texture: &Texture,
     ) -> Vec<u8> {
         let w = texture.width();
         let h = texture.height();
@@ -605,8 +605,8 @@ mod tests {
     }
 
     fn default_inputs<'a>(
-        input: &'a StreamTexture,
-        output: &'a StreamTexture,
+        input: &'a Texture,
+        output: &'a Texture,
     ) -> CrtFilmGrainInputs<'a> {
         CrtFilmGrainInputs {
             input: CrtFilmGrainInput {

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -46,7 +46,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::context::{CpuReadbackBridge, CpuReadbackCopyDirection, GpuContext};
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> Result<()> {
     // `&GpuContext` borrow past the hook, so we Arc-clone the bits we
     // need.
     let texture_slot: Arc<
-        Mutex<Option<streamlib::sdk::rhi::StreamTexture>>,
+        Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
     let runtime = Runner::new()?;
 
     let texture_slot: Arc<
-        Mutex<Option<streamlib::sdk::rhi::StreamTexture>>,
+        Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -41,7 +41,7 @@ use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
 use streamlib::sdk::rhi::{
     derive_bindings_from_spirv,
     ComputeKernelDescriptor,
-    StreamTexture,
+    Texture,
     TextureFormat,
     TextureReadbackDescriptor,
     TextureSourceLayout,
@@ -122,21 +122,21 @@ impl RuntimeKind {
 /// `streamlib-adapter-vulkan` crate cannot depend on the full
 /// `streamlib` (the consumer-rhi capability boundary forbids it).
 ///
-/// Holds a UUID → `StreamTexture` map populated at setup time so
+/// Holds a UUID → `Texture` map populated at setup time so
 /// `run_compute_kernel(surface_uuid, ...)` can resolve to the host's
 /// `VkImage` for the storage_image binding. The kernel cache is
 /// keyed by SHA-256(spv) hex (the same key the wire format returns
 /// to the subprocess).
 struct MandelbrotKernelBridge {
     device: Arc<HostVulkanDevice>,
-    surfaces: HashMap<String, StreamTexture>,
+    surfaces: HashMap<String, Texture>,
     kernels: parking_lot::Mutex<HashMap<String, Arc<VulkanComputeKernel>>>,
 }
 
 impl MandelbrotKernelBridge {
     fn new(
         device: Arc<HostVulkanDevice>,
-        surfaces: Vec<(String, StreamTexture)>,
+        surfaces: Vec<(String, Texture)>,
     ) -> Self {
         Self {
             device,
@@ -247,7 +247,7 @@ fn main() -> Result<()> {
     let runtime = Runner::new()?;
 
     let texture_slot: Arc<
-        Mutex<Option<streamlib::sdk::rhi::StreamTexture>>,
+        Mutex<Option<streamlib::sdk::rhi::Texture>>,
     > = Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
@@ -309,7 +309,7 @@ fn main() -> Result<()> {
             // `register_compute_kernel` + `run_compute_kernel` IPCs
             // are routed through this bridge to the host's
             // `VulkanComputeKernel`. The bridge holds a
-            // UUID→`StreamTexture` map populated here at setup time.
+            // UUID→`Texture` map populated here at setup time.
             let bridge = Arc::new(MandelbrotKernelBridge::new(
                 Arc::clone(&host_device),
                 vec![(SCENARIO_SURFACE_UUID.to_string(), texture.clone())],

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -69,7 +69,7 @@ use streamlib::sdk::rhi::{
     MultisampleState,
     PrimitiveTopology,
     RasterizationState,
-    StreamTexture,
+    Texture,
     TextureFormat,
     TextureReadbackDescriptor,
     TextureSourceLayout,
@@ -152,21 +152,21 @@ impl RuntimeKind {
 /// `streamlib-adapter-vulkan` crate cannot depend on the full
 /// `streamlib` (the consumer-rhi capability boundary forbids it).
 ///
-/// Holds a UUID → `StreamTexture` map populated at setup time so
+/// Holds a UUID → `Texture` map populated at setup time so
 /// `run_graphics_draw(color_target_uuids[…], ...)` can resolve to the
 /// host's `VkImage` for the offscreen color target. The kernel cache
 /// is keyed by SHA-256 over a canonical byte representation of the
 /// register-time descriptor.
 struct TriangleKernelBridge {
     device: Arc<HostVulkanDevice>,
-    surfaces: HashMap<String, StreamTexture>,
+    surfaces: HashMap<String, Texture>,
     kernels: parking_lot::Mutex<HashMap<String, Arc<VulkanGraphicsKernel>>>,
 }
 
 impl TriangleKernelBridge {
     fn new(
         device: Arc<HostVulkanDevice>,
-        surfaces: Vec<(String, StreamTexture)>,
+        surfaces: Vec<(String, Texture)>,
     ) -> Self {
         Self {
             device,
@@ -586,7 +586,7 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    let texture_slot: Arc<Mutex<Option<StreamTexture>>> = Arc::new(Mutex::new(None));
+    let texture_slot: Arc<Mutex<Option<Texture>>> = Arc::new(Mutex::new(None));
     let timeline_slot: Arc<Mutex<Option<Arc<HostVulkanTimelineSemaphore>>>> =
         Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::context::{
     BlasRegisterDecl,
@@ -60,7 +60,7 @@ use streamlib::sdk::rhi::{
     RayTracingShaderGroup,
     RayTracingShaderStageFlags,
     RayTracingStage,
-    StreamTexture,
+    Texture,
     TextureDescriptor,
     TextureFormat,
     TextureReadbackDescriptor,
@@ -152,7 +152,7 @@ impl RuntimeKind {
 /// boundary forbids it).
 ///
 /// Holds three caches:
-/// - UUID → `StreamTexture` for resolving non-AS run-time bindings to
+/// - UUID → `Texture` for resolving non-AS run-time bindings to
 ///   host-side images (storage_image, sampled_texture).
 /// - `as_id` → `Arc<VulkanAccelerationStructure>` for resolving AS
 ///   bindings AND for chaining BLAS → TLAS construction (TLAS instance
@@ -162,13 +162,13 @@ impl RuntimeKind {
 ///   cache hit.
 struct SceneKernelBridge {
     device: Arc<HostVulkanDevice>,
-    surfaces: HashMap<String, StreamTexture>,
+    surfaces: HashMap<String, Texture>,
     as_handles: parking_lot::Mutex<HashMap<String, Arc<VulkanAccelerationStructure>>>,
     kernels: parking_lot::Mutex<HashMap<String, Arc<VulkanRayTracingKernel>>>,
 }
 
 impl SceneKernelBridge {
-    fn new(device: Arc<HostVulkanDevice>, surfaces: Vec<(String, StreamTexture)>) -> Self {
+    fn new(device: Arc<HostVulkanDevice>, surfaces: Vec<(String, Texture)>) -> Self {
         Self {
             device,
             surfaces: surfaces.into_iter().collect(),
@@ -553,7 +553,7 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    let texture_slot: Arc<Mutex<Option<StreamTexture>>> = Arc::new(Mutex::new(None));
+    let texture_slot: Arc<Mutex<Option<Texture>>> = Arc::new(Mutex::new(None));
     let readback_slot: Arc<Mutex<Option<Arc<VulkanTextureReadback>>>> =
         Arc::new(Mutex::new(None));
 
@@ -589,7 +589,7 @@ fn main() -> Result<()> {
                     "HostVulkanTexture::new_device_local: {e}"
                 ))
             })?;
-            let stream_texture = StreamTexture::from_vulkan(texture);
+            let stream_texture = Texture::from_vulkan(texture);
             // Storage-image binding requires `VK_IMAGE_LAYOUT_GENERAL`.
             let image = stream_texture
                 .vulkan_inner()

--- a/examples/raytracing-showcase/src/main.rs
+++ b/examples/raytracing-showcase/src/main.rs
@@ -17,7 +17,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use anyhow::{Context, Result};
 use streamlib::sdk::rhi::{
@@ -27,7 +27,7 @@ use streamlib::sdk::rhi::{
     RayTracingShaderGroup,
     RayTracingShaderStageFlags,
     RayTracingStage,
-    StreamTexture,
+    Texture,
     TextureDescriptor,
     TextureFormat,
     TextureReadbackDescriptor,
@@ -119,7 +119,7 @@ fn main() -> Result<()> {
             usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC,
         },
     )?;
-    let stream_texture = StreamTexture::from_vulkan(texture);
+    let stream_texture = Texture::from_vulkan(texture);
     let image = stream_texture
         .vulkan_inner()
         .image()

--- a/libs/streamlib-adapter-cpu-readback-helpers/tests/consumer_carve_out.rs
+++ b/libs/streamlib-adapter-cpu-readback-helpers/tests/consumer_carve_out.rs
@@ -22,7 +22,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use serial_test::serial;
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-adapter-cpu-readback/tests/common.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/common.rs
@@ -16,7 +16,7 @@
 #![allow(dead_code)] // each test file uses a different subset
 
 use std::sync::{Arc, OnceLock};
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::engine::host_rhi::{
     HostMarker,

--- a/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
+++ b/libs/streamlib-adapter-cpu-readback/tests/conformance.rs
@@ -18,7 +18,7 @@
 mod common;
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use streamlib::sdk::engine::host_rhi::{HostMarker, HostVulkanPixelBuffer, HostVulkanTimelineSemaphore};
 use streamlib::sdk::rhi::{PixelFormat, TextureFormat};

--- a/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
+++ b/libs/streamlib-adapter-cuda/tests/persistent_command_pool.rs
@@ -26,7 +26,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::rhi::{PixelFormat, TextureFormat};

--- a/libs/streamlib-adapter-opengl/tests/common.rs
+++ b/libs/streamlib-adapter-opengl/tests/common.rs
@@ -9,10 +9,10 @@
 #![allow(dead_code)] // each test file uses a different subset
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::context::GpuContext;
-use streamlib::sdk::rhi::{StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
+use streamlib::sdk::rhi::{Texture, TextureDescriptor, TextureFormat, TextureUsages};
 use streamlib::sdk::engine::host_rhi::HostVulkanTexture;
 use streamlib_adapter_abi::{
     StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
@@ -126,7 +126,7 @@ impl HostFixture {
              list contained only 0x{modifier:016x} — VUID violation in the RHI"
         );
 
-        let texture = StreamTexture::from_vulkan(host_texture);
+        let texture = Texture::from_vulkan(host_texture);
 
         let registration = HostSurfaceRegistration {
             dma_buf_fd,
@@ -229,7 +229,7 @@ impl HostFixture {
 
 pub struct RegisteredSurface {
     pub descriptor: StreamlibSurface,
-    pub texture: StreamTexture,
+    pub texture: Texture,
     pub width: u32,
     pub height: u32,
 }

--- a/libs/streamlib-adapter-opengl/tests/conformance.rs
+++ b/libs/streamlib-adapter-opengl/tests/conformance.rs
@@ -23,7 +23,7 @@ use streamlib::sdk::rhi::TextureFormat;
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
 use streamlib_adapter_abi::{AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceId};
 use streamlib_adapter_opengl::{HostSurfaceRegistration, DRM_FORMAT_ARGB8888};
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use common::HostFixture;
 

--- a/libs/streamlib-adapter-opengl/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-opengl/tests/subprocess_crash_mid_write.rs
@@ -28,7 +28,7 @@ use std::os::fd::IntoRawFd;
 use std::os::unix::net::UnixStream;
 use std::process::{Command, Stdio};
 use std::time::Duration;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use streamlib_adapter_abi::testing::{CrashTiming, SubprocessCrashHarness};
 

--- a/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
+++ b/libs/streamlib-adapter-skia/tests/concurrent_skia_and_vulkan_read.rs
@@ -15,7 +15,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-adapter-skia/tests/conformance_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/conformance_gl.rs
@@ -17,10 +17,10 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::{Arc, Mutex};
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use streamlib::sdk::context::GpuContext;
-use streamlib::sdk::rhi::{StreamTexture, TextureFormat};
+use streamlib::sdk::rhi::{Texture, TextureFormat};
 use streamlib_adapter_abi::testing::{empty_surface, run_conformance};
 use streamlib_adapter_abi::{
     AdapterError, StreamlibSurface, SurfaceAdapter, SurfaceFormat, SurfaceId, SurfaceSyncState,
@@ -49,7 +49,7 @@ fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
     Some((gpu, egl))
 }
 
-/// Factory that owns the per-surface `StreamTexture`s for the
+/// Factory that owns the per-surface `Texture`s for the
 /// duration of the conformance run. The GL adapter imports each
 /// texture's DMA-BUF FD into an EGLImage at registration time; the
 /// host-side `VkImage` backing must outlive every guard the
@@ -58,7 +58,7 @@ fn try_init() -> Option<(GpuContext, Arc<EglRuntime>)> {
 struct ConformanceFactory<'a> {
     inner: &'a OpenGlSurfaceAdapter,
     gpu: &'a GpuContext,
-    textures: Mutex<Vec<StreamTexture>>,
+    textures: Mutex<Vec<Texture>>,
 }
 
 impl<'a> ConformanceFactory<'a> {

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas.rs
@@ -16,7 +16,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{Color, Color4f, Paint, Point};
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};

--- a/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/round_trip_skia_canvas_gl.rs
@@ -15,7 +15,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{Color, Color4f, Paint, Point};
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_animated_stress.rs
@@ -42,7 +42,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{
     gradient_shader, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,

--- a/libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_animated_stress_gl.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{
     gradient_shader, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,

--- a/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_visual_evidence.rs
@@ -27,7 +27,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{
     gradient_shader, Color, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,

--- a/libs/streamlib-adapter-skia/tests/skia_visual_evidence_gl.rs
+++ b/libs/streamlib-adapter-skia/tests/skia_visual_evidence_gl.rs
@@ -22,7 +22,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use skia_safe::{
     gradient_shader, Color, Color4f, Paint, PaintStyle, Path, Point, Rect, TileMode,

--- a/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-skia/tests/subprocess_crash_mid_write.rs
@@ -37,7 +37,7 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, Stdio};
 use std::time::Duration;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::rhi::TextureFormat;

--- a/libs/streamlib-adapter-vulkan/tests/common.rs
+++ b/libs/streamlib-adapter-vulkan/tests/common.rs
@@ -12,7 +12,7 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 /// Locate the `vulkan_adapter_subprocess_helper` binary built by the
 /// `streamlib-adapter-vulkan-helpers` dev-dependency. Cargo doesn't
@@ -38,7 +38,7 @@ pub fn vulkan_adapter_subprocess_helper_path() -> PathBuf {
 
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::sdk::context::GpuContext;
-use streamlib::sdk::rhi::{StreamTexture, TextureFormat};
+use streamlib::sdk::rhi::{Texture, TextureFormat};
 use streamlib_adapter_abi::{
     StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState, SurfaceTransportHandle,
     SurfaceUsage,
@@ -116,7 +116,7 @@ impl HostFixture {
 
 pub struct RegisteredSurface {
     pub descriptor: StreamlibSurface,
-    pub texture: StreamTexture,
+    pub texture: Texture,
     pub timeline: Arc<HostVulkanTimelineSemaphore>,
     pub width: u32,
     pub height: u32,

--- a/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
+++ b/libs/streamlib-adapter-vulkan/tests/concurrent_reads_two_subprocesses.rs
@@ -11,7 +11,7 @@
 mod common;
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 #[test]
 fn two_subprocesses_concurrently_read_same_surface() {

--- a/libs/streamlib-adapter-vulkan/tests/conformance.rs
+++ b/libs/streamlib-adapter-vulkan/tests/conformance.rs
@@ -15,7 +15,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, HostVulkanTimelineSemaphore};
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_host_writes_subprocess_reads.rs
@@ -12,7 +12,7 @@
 mod common;
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;

--- a/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
+++ b/libs/streamlib-adapter-vulkan/tests/round_trip_subprocess_writes_host_reads.rs
@@ -11,7 +11,7 @@
 mod common;
 
 use std::sync::Arc;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;

--- a/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
+++ b/libs/streamlib-adapter-vulkan/tests/subprocess_crash_mid_write.rs
@@ -25,7 +25,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use streamlib::sdk::engine::HostStreamTextureExt;
+use streamlib::sdk::engine::HostTextureExt;
 
 use streamlib_adapter_abi::testing::{CrashTiming, SubprocessCrashHarness};
 

--- a/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
+++ b/libs/streamlib-adapter-vulkan/tests/sync_correctness.rs
@@ -9,7 +9,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
+++ b/libs/streamlib-adapter-vulkan/tests/write_excludes_read.rs
@@ -13,7 +13,7 @@
 #![cfg(target_os = "linux")]
 
 use std::sync::Arc;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostStreamTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
 use streamlib::sdk::context::GpuContext;

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -909,13 +909,13 @@ export interface EscalateRequestRunComputeKernel {
   request_id: string;
 
   /**
-   * UUID string of a render-target surface previously registered with
-   * the surface-share service via `register_texture`. The host bridge
-   * holds an application-provided UUID→`StreamTexture` map (populated in
-   * `install_setup_hook`) and binds the looked-up `VkImage` as a storage_image
-   * at slot 0 (the single-output convention enforced for v1 — multi-binding
-   * kernels are a future extension). UUID rather than u64 so the host can
-   * resolve the surface without subprocess-side counter coordination.
+   * UUID string of a render-target surface previously registered with the
+   * surface-share service via `register_texture`. The host bridge holds an
+   * application-provided UUID→`Texture` map (populated in `install_setup_hook`)
+   * and binds the looked-up `VkImage` as a storage_image at slot 0 (the single-
+   * output convention enforced for v1 — multi-binding kernels are a future
+   * extension). UUID rather than u64 so the host can resolve the surface
+   * without subprocess-side counter coordination.
    */
   surface_uuid: string;
 }
@@ -1061,7 +1061,7 @@ export interface EscalateRequestRunGraphicsDraw {
   /**
    * UUIDs of color attachment textures. v1 requires exactly one entry — multi-
    * attachment is a future extension. Each UUID must resolve to a host-side
-   * `StreamTexture` registered as a render target.
+   * `Texture` registered as a render target.
    */
   color_target_uuids: string[];
 
@@ -1167,7 +1167,7 @@ export interface EscalateRequestRunRayTracingKernel {
    * `acceleration_structure`: `target_id` is an `as_id`
    *   from a prior `register_acceleration_structure_tlas`.
    * - all other kinds: `target_id` is the surface-share UUID
-   *   of a host-side `RhiPixelBuffer` / `StreamTexture`
+   *   of a host-side `RhiPixelBuffer` / `Texture`
    *   (same convention compute and graphics use).
    */
   bindings: EscalateRequestRunRayTracingKernelBinding[];

--- a/libs/streamlib-deno/adapters/vulkan.ts
+++ b/libs/streamlib-deno/adapters/vulkan.ts
@@ -461,7 +461,7 @@ export class VulkanContext {
     }
     // Send the surface-share UUID, not the cdylib's local u64
     // surfaceId — the host bridge resolves UUID → host
-    // `StreamTexture` via an application-provided map.
+    // `Texture` via an application-provided map.
     void cached;
     await ch.runComputeKernel(
       kernelId,

--- a/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -208,7 +208,7 @@ mapping:
             UUID string of a render-target surface previously
             registered with the surface-share service via
             `register_texture`. The host bridge holds an
-            application-provided UUID→`StreamTexture` map (populated
+            application-provided UUID→`Texture` map (populated
             in `install_setup_hook`) and binds the looked-up
             `VkImage` as a storage_image at slot 0 (the single-output
             convention enforced for v1 — multi-binding kernels are a
@@ -576,7 +576,7 @@ mapping:
           description: >
             UUIDs of color attachment textures. v1 requires exactly
             one entry — multi-attachment is a future extension. Each
-            UUID must resolve to a host-side `StreamTexture`
+            UUID must resolve to a host-side `Texture`
             registered as a render target.
         elements:
           type: string
@@ -949,7 +949,7 @@ mapping:
             - `acceleration_structure`: `target_id` is an `as_id`
               from a prior `register_acceleration_structure_tlas`.
             - all other kinds: `target_id` is the surface-share UUID
-              of a host-side `RhiPixelBuffer` / `StreamTexture`
+              of a host-side `RhiPixelBuffer` / `Texture`
               (same convention compute and graphics use).
         elements:
           properties:

--- a/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
@@ -1211,9 +1211,9 @@ pub struct EscalateRequestRunComputeKernel {
     #[serde(rename = "request_id")]
     pub request_id: String,
 
-    /// UUID string of a render-target surface previously registered with
-    /// the surface-share service via `register_texture`. The host bridge
-    /// holds an application-provided UUID→`StreamTexture` map (populated
+    /// UUID string of a render-target surface previously registered
+    /// with the surface-share service via `register_texture`. The host
+    /// bridge holds an application-provided UUID→`Texture` map (populated
     /// in `install_setup_hook`) and binds the looked-up `VkImage` as a
     /// storage_image at slot 0 (the single-output convention enforced for v1
     /// — multi-binding kernels are a future extension). UUID rather than u64
@@ -1433,7 +1433,7 @@ pub struct EscalateRequestRunGraphicsDraw {
 
     /// UUIDs of color attachment textures. v1 requires exactly one entry —
     /// multi-attachment is a future extension. Each UUID must resolve to a
-    /// host-side `StreamTexture` registered as a render target.
+    /// host-side `Texture` registered as a render target.
     #[serde(rename = "color_target_uuids")]
     pub color_target_uuids: Vec<String>,
 
@@ -1550,7 +1550,7 @@ pub struct EscalateRequestRunRayTracingKernel {
     /// `acceleration_structure`: `target_id` is an `as_id`
     ///   from a prior `register_acceleration_structure_tlas`.
     /// - all other kinds: `target_id` is the surface-share UUID
-    ///   of a host-side `RhiPixelBuffer` / `StreamTexture`
+    ///   of a host-side `RhiPixelBuffer` / `Texture`
     ///   (same convention compute and graphics use).
     #[serde(rename = "bindings")]
     pub bindings: Vec<EscalateRequestRunRayTracingKernelBinding>,

--- a/libs/streamlib-engine/src/apple/pixel_transfer.rs
+++ b/libs/streamlib-engine/src/apple/pixel_transfer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::apple::iosurface;
-use crate::core::rhi::{GpuDevice, RhiCommandQueue, RhiPixelBuffer, StreamTexture};
+use crate::core::rhi::{GpuDevice, RhiCommandQueue, RhiPixelBuffer, Texture};
 use crate::core::{Result, Error};
 use metal::foreign_types::ForeignTypeRef;
 use objc2_core_video::CVPixelBuffer;
@@ -100,7 +100,7 @@ impl PixelTransferSession {
     #[allow(dead_code)]
     pub fn convert_to_nv12(
         &self,
-        texture: &StreamTexture,
+        texture: &Texture,
         width: u32,
         height: u32,
     ) -> Result<*mut CVPixelBuffer> {
@@ -131,11 +131,11 @@ impl PixelTransferSession {
     #[allow(dead_code)]
     fn blit_to_rgba_pixel_buffer(
         &self,
-        texture: &StreamTexture,
+        texture: &Texture,
         width: u32,
         height: u32,
     ) -> Result<*mut CVPixelBuffer> {
-        // Get Metal texture directly from StreamTexture
+        // Get Metal texture directly from Texture
         let source_metal = texture.as_metal_texture();
 
         // Create destination CVPixelBuffer in BGRA format (32BGRA is standard for Metal/CoreVideo interop)

--- a/libs/streamlib-engine/src/apple/texture_pool_macos.rs
+++ b/libs/streamlib-engine/src/apple/texture_pool_macos.rs
@@ -12,7 +12,7 @@ use super::iosurface::{create_iosurface, create_metal_texture_from_iosurface, Pi
 use crate::core::context::texture_pool::{
     PoolSlot, TexturePoolDescriptor, TexturePoolInner, TexturePoolKey,
 };
-use crate::core::rhi::{StreamTexture, TextureFormat};
+use crate::core::rhi::{Texture, TextureFormat};
 use crate::core::{Result, Error};
 use crate::metal::rhi::MetalTexture;
 
@@ -71,8 +71,8 @@ pub fn allocate_iosurface_slot(
         desc.format,
     );
 
-    // Wrap in StreamTexture
-    let stream_texture = StreamTexture::from_metal(metal_texture);
+    // Wrap in Texture
+    let stream_texture = Texture::from_metal(metal_texture);
 
     let slot = PoolSlot {
         id: pool_inner.next_slot_id(),

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -685,7 +685,7 @@ fn assign_texture_handle_id(
 #[cfg(target_os = "linux")]
 fn assign_image_handle_id(
     full: &crate::core::context::GpuContextFullAccess,
-    texture: &crate::core::rhi::StreamTexture,
+    texture: &crate::core::rhi::Texture,
 ) -> crate::core::error::Result<String> {
     let handle_id = Uuid::new_v4().to_string();
     if let Some(store) = full.surface_store() {

--- a/libs/streamlib-engine/src/core/context/compute_kernel_bridge.rs
+++ b/libs/streamlib-engine/src/core/context/compute_kernel_bridge.rs
@@ -56,7 +56,7 @@ pub trait ComputeKernelBridge: Send + Sync {
     /// `surface_uuid` is the UUID string used for surface-share
     /// registration (`SurfaceStore::register_texture`); the bridge
     /// implementation maintains an application-provided UUID →
-    /// host-side `StreamTexture` map so it can look up the `VkImage`
+    /// host-side `Texture` map so it can look up the `VkImage`
     /// to bind. Bound as a `storage_image` at slot 0 (the
     /// single-output convention enforced for v1).
     ///

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -5,12 +5,12 @@ use crate::_generated_::VideoFrame;
 use crate::core::context::TextureRegistration;
 use crate::core::rhi::{
     CommandBuffer, GpuDevice, PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, RhiBlitter,
-    RhiCommandQueue, RhiPixelBuffer, RhiPixelBufferPool, StreamTexture, TextureDescriptor,
+    RhiCommandQueue, RhiPixelBuffer, RhiPixelBufferPool, Texture, TextureDescriptor,
     TextureFormat, TextureUsages,
 };
 use crate::core::{Result, Error};
 #[cfg(target_os = "linux")]
-use crate::host_rhi::HostStreamTextureExt;
+use crate::host_rhi::HostTextureExt;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
@@ -400,7 +400,7 @@ pub struct GpuContext {
     /// rotating-pool producers don't render stale contents — kept separate
     /// from `texture_cache` so a same-process cache hit can't shortcut the
     /// refresh.
-    buffer_texture_cache: Arc<Mutex<HashMap<String, StreamTexture>>>,
+    buffer_texture_cache: Arc<Mutex<HashMap<String, Texture>>>,
     /// Raw handle for the camera's timeline semaphore (same-process GPU-GPU sync).
     /// Stored as u64 for platform-agnostic GpuContext (0 = not set).
     camera_timeline_semaphore_handle: Arc<AtomicU64>,
@@ -629,7 +629,7 @@ impl GpuContext {
     /// [`Self::register_texture_with_layout`] instead so consumers
     /// reaching the texture via [`Self::resolve_video_frame_registration`]
     /// can issue correct layout transitions.
-    pub fn register_texture(&self, id: &str, texture: StreamTexture) {
+    pub fn register_texture(&self, id: &str, texture: Texture) {
         #[cfg(target_os = "linux")]
         let registration = TextureRegistration::new(texture, VulkanLayout::UNDEFINED);
         #[cfg(not(target_os = "linux"))]
@@ -651,7 +651,7 @@ impl GpuContext {
     pub fn register_texture_with_layout(
         &self,
         id: &str,
-        texture: StreamTexture,
+        texture: Texture,
         initial_layout: VulkanLayout,
     ) {
         let registration = TextureRegistration::new(texture, initial_layout);
@@ -780,7 +780,7 @@ impl GpuContext {
     /// Layout-aware consumers (display, future encoders) should call
     /// `resolve_video_frame_registration` directly so they can issue
     /// correct barriers.
-    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<StreamTexture> {
+    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<Texture> {
         Ok(self.resolve_video_frame_registration(frame)?.texture().clone())
     }
 
@@ -790,7 +790,7 @@ impl GpuContext {
         width: u32,
         height: u32,
         format: TextureFormat,
-    ) -> Result<(String, StreamTexture)> {
+    ) -> Result<(String, Texture)> {
         let desc = TextureDescriptor::new(width, height, format)
             .with_usage(TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST);
         let texture = self.device.create_texture(&desc)?;
@@ -811,7 +811,7 @@ impl GpuContext {
         pixel_buffer: &crate::core::rhi::RhiPixelBuffer,
         width: u32,
         height: u32,
-    ) -> Result<StreamTexture> {
+    ) -> Result<Texture> {
         use crate::core::rhi::{TextureDescriptor, TextureFormat, TextureUsages};
 
         // Get-or-create the cached texture for this surface_id.
@@ -964,7 +964,7 @@ impl GpuContext {
     ///
     /// The driver picks one of the EGL-advertised render-target modifiers
     /// from [`HostVulkanDevice::drm_modifier_table`]. The resulting
-    /// `StreamTexture` carries the chosen modifier on its inner
+    /// `Texture` carries the chosen modifier on its inner
     /// [`HostVulkanTexture`] (see [`HostVulkanTexture::chosen_drm_format_modifier`]),
     /// ready to be carried in a `SurfaceTransportHandle` when the host
     /// surface-share service registers the surface.
@@ -988,7 +988,7 @@ impl GpuContext {
         width: u32,
         height: u32,
         format: TextureFormat,
-    ) -> Result<StreamTexture> {
+    ) -> Result<Texture> {
         use crate::vulkan::rhi::drm_modifier_probe::fourcc;
 
         tracing::debug!(
@@ -1056,7 +1056,7 @@ impl GpuContext {
             &desc,
             &modifiers,
         )?;
-        Ok(StreamTexture::from_vulkan(texture))
+        Ok(Texture::from_vulkan(texture))
     }
 
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
@@ -1218,7 +1218,7 @@ impl GpuContext {
     #[cfg(target_os = "linux")]
     pub fn transition_storage_image_to_general(
         &self,
-        texture: &crate::core::rhi::StreamTexture,
+        texture: &crate::core::rhi::Texture,
     ) -> Result<()> {
         let vulkan_device = &self.device.inner;
         crate::vulkan::rhi::HostVulkanTexture::transition_to_general(
@@ -1741,7 +1741,7 @@ impl GpuContextLimitedAccess {
     }
 
     /// Register a texture in the same-process texture cache.
-    pub fn register_texture(&self, id: &str, texture: StreamTexture) {
+    pub fn register_texture(&self, id: &str, texture: Texture) {
         self.inner.register_texture(id, texture);
     }
 
@@ -1751,7 +1751,7 @@ impl GpuContextLimitedAccess {
     pub fn register_texture_with_layout(
         &self,
         id: &str,
-        texture: StreamTexture,
+        texture: Texture,
         initial_layout: VulkanLayout,
     ) {
         self.inner
@@ -1767,7 +1767,7 @@ impl GpuContextLimitedAccess {
     }
 
     /// Resolve a [`VideoFrame`]'s texture (Split: cache hit).
-    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<StreamTexture> {
+    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<Texture> {
         self.inner.resolve_video_frame_texture(frame)
     }
 
@@ -1868,7 +1868,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
         format: TextureFormat,
-    ) -> Result<StreamTexture> {
+    ) -> Result<Texture> {
         self.inner
             .acquire_render_target_dma_buf_image(width, height, format)
     }
@@ -1884,7 +1884,7 @@ impl GpuContextFullAccess {
     }
 
     /// Register a texture in the same-process texture cache.
-    pub fn register_texture(&self, id: &str, texture: StreamTexture) {
+    pub fn register_texture(&self, id: &str, texture: Texture) {
         self.inner.register_texture(id, texture);
     }
 
@@ -1894,7 +1894,7 @@ impl GpuContextFullAccess {
     pub fn register_texture_with_layout(
         &self,
         id: &str,
-        texture: StreamTexture,
+        texture: Texture,
         initial_layout: VulkanLayout,
     ) {
         self.inner
@@ -1910,7 +1910,7 @@ impl GpuContextFullAccess {
     }
 
     /// Resolve a [`VideoFrame`]'s texture.
-    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<StreamTexture> {
+    pub fn resolve_video_frame_texture(&self, frame: &VideoFrame) -> Result<Texture> {
         self.inner.resolve_video_frame_texture(frame)
     }
 
@@ -1920,7 +1920,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
         format: TextureFormat,
-    ) -> Result<(String, StreamTexture)> {
+    ) -> Result<(String, Texture)> {
         self.inner.acquire_output_texture(width, height, format)
     }
 

--- a/libs/streamlib-engine/src/core/context/ray_tracing_kernel_bridge.rs
+++ b/libs/streamlib-engine/src/core/context/ray_tracing_kernel_bridge.rs
@@ -164,7 +164,7 @@ pub struct TlasRegisterDecl {
 /// - [`RayTracingBindingKindWire::AccelerationStructure`]: an `as_id`
 ///   from a prior [`RayTracingKernelBridge::register_tlas`].
 /// - all other kinds: the surface-share UUID of a host-side
-///   `RhiPixelBuffer` / `StreamTexture` (same convention compute and
+///   `RhiPixelBuffer` / `Texture` (same convention compute and
 ///   graphics use).
 #[derive(Debug, Clone)]
 pub struct RayTracingBindingValue {
@@ -234,7 +234,7 @@ pub trait RayTracingKernelBridge: Send + Sync {
     /// Run one trace against a previously-registered kernel.
     ///
     /// Resolves binding `target_id`s through the application-provided
-    /// resolver (UUID → `RhiPixelBuffer` / `StreamTexture` for non-AS
+    /// resolver (UUID → `RhiPixelBuffer` / `Texture` for non-AS
     /// kinds; `as_id` → `Arc<VulkanAccelerationStructure>` for the AS
     /// kind), then submits + waits on the kernel's own command
     /// buffer + fence. Errors include unrecognized `kernel_id`,

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use crate::core::rhi::RhiPixelBuffer;
 use crate::core::{Result, Error};
 #[cfg(target_os = "linux")]
-use crate::host_rhi::HostStreamTextureExt;
+use crate::host_rhi::HostTextureExt;
 
 /// Maximum number of entries in the SurfaceCache before eviction.
 const MAX_SURFACE_CACHE_SIZE: usize = 512;
@@ -1089,7 +1089,7 @@ impl SurfaceStore {
     pub fn register_texture(
         &self,
         surface_id: &str,
-        texture: &crate::core::rhi::StreamTexture,
+        texture: &crate::core::rhi::Texture,
         timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
         current_image_layout: streamlib_consumer_rhi::VulkanLayout,
     ) -> Result<()> {
@@ -1458,7 +1458,7 @@ impl SurfaceStore {
     }
 
     /// Lookup a texture from the surface-share service via Unix socket.
-    /// Returns the imported [`StreamTexture`] paired with the
+    /// Returns the imported [`Texture`] paired with the
     /// producer's last-published `current_image_layout`. Cross-process
     /// consumers feed the layout into the source layout of their first
     /// QFOT acquire barrier (#633).
@@ -1466,7 +1466,7 @@ impl SurfaceStore {
     pub fn lookup_texture(
         &self,
         surface_id: &str,
-    ) -> Result<(crate::core::rhi::StreamTexture, streamlib_consumer_rhi::VulkanLayout)> {
+    ) -> Result<(crate::core::rhi::Texture, streamlib_consumer_rhi::VulkanLayout)> {
         let request = serde_json::json!({
             "op": "lookup",
             "surface_id": surface_id,
@@ -1578,7 +1578,7 @@ impl SurfaceStore {
             .unwrap_or(streamlib_consumer_rhi::VulkanLayout::UNDEFINED);
 
         Ok((
-            crate::core::rhi::StreamTexture::from_vulkan(vulkan_texture),
+            crate::core::rhi::Texture::from_vulkan(vulkan_texture),
             current_image_layout,
         ))
     }
@@ -1656,7 +1656,7 @@ impl SurfaceStore {
     pub fn register_texture(
         &self,
         _surface_id: &str,
-        _texture: &crate::core::rhi::StreamTexture,
+        _texture: &crate::core::rhi::Texture,
         _timeline: Option<&()>,
         _current_image_layout: i32,
     ) -> Result<()> {
@@ -1669,7 +1669,7 @@ impl SurfaceStore {
     pub fn lookup_texture(
         &self,
         _surface_id: &str,
-    ) -> Result<(crate::core::rhi::StreamTexture, i32)> {
+    ) -> Result<(crate::core::rhi::Texture, i32)> {
         Err(Error::NotSupported(
             "Texture lookup not supported on this platform".into(),
         ))

--- a/libs/streamlib-engine/src/core/context/texture_pool.rs
+++ b/libs/streamlib-engine/src/core/context/texture_pool.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use parking_lot::{Condvar, Mutex};
 
 use crate::core::rhi::{
-    GpuDevice, NativeTextureHandle, StreamTexture, TextureDescriptor, TextureFormat, TextureUsages,
+    GpuDevice, NativeTextureHandle, Texture, TextureDescriptor, TextureFormat, TextureUsages,
 };
 use crate::core::{Result, Error};
 
@@ -123,7 +123,7 @@ pub struct TexturePoolStats {
 /// A slot in the texture pool.
 pub(crate) struct PoolSlot {
     pub(crate) id: PoolSlotId,
-    pub(crate) texture: StreamTexture,
+    pub(crate) texture: Texture,
     pub(crate) key: TexturePoolKey,
     pub(crate) in_use: AtomicBool,
 }
@@ -218,7 +218,7 @@ impl TexturePoolInner {
 
 /// Handle to a pooled texture. Returns texture to pool on Drop.
 pub struct PooledTextureHandle {
-    texture: StreamTexture,
+    texture: Texture,
     pool_inner: Arc<TexturePoolInner>,
     slot_id: PoolSlotId,
     width: u32,
@@ -232,7 +232,7 @@ impl PooledTextureHandle {
     #[allow(dead_code)]
     #[cfg(not(target_os = "macos"))]
     pub(crate) fn new(
-        texture: StreamTexture,
+        texture: Texture,
         pool_inner: Arc<TexturePoolInner>,
         slot_id: PoolSlotId,
         width: u32,
@@ -250,12 +250,12 @@ impl PooledTextureHandle {
     }
 
     /// Get a reference to the underlying texture.
-    pub fn texture(&self) -> &StreamTexture {
+    pub fn texture(&self) -> &Texture {
         &self.texture
     }
 
     /// Get a cloneable reference to the underlying texture.
-    pub fn texture_clone(&self) -> StreamTexture {
+    pub fn texture_clone(&self) -> Texture {
         self.texture.clone()
     }
 

--- a/libs/streamlib-engine/src/core/context/texture_registration.rs
+++ b/libs/streamlib-engine/src/core/context/texture_registration.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use crate::core::rhi::StreamTexture;
+use crate::core::rhi::Texture;
 
 #[cfg(target_os = "linux")]
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -29,7 +29,7 @@ use streamlib_consumer_rhi::VulkanLayout;
 /// Per-surface registration record held by [`crate::core::context::GpuContext`]'s
 /// texture cache.
 pub struct TextureRegistration {
-    texture: StreamTexture,
+    texture: Texture,
     /// Last-known Vulkan image layout. Producers update after their
     /// final layout transition; consumers read before issuing their
     /// own barrier and update after.
@@ -46,7 +46,7 @@ pub struct TextureRegistration {
 impl TextureRegistration {
     /// Construct a registration with an initial layout.
     #[cfg(target_os = "linux")]
-    pub fn new(texture: StreamTexture, initial_layout: VulkanLayout) -> Arc<Self> {
+    pub fn new(texture: Texture, initial_layout: VulkanLayout) -> Arc<Self> {
         Arc::new(Self {
             texture,
             current_layout: AtomicI32::new(initial_layout.0),
@@ -55,12 +55,12 @@ impl TextureRegistration {
 
     /// Construct a registration on platforms without Vulkan layout tracking.
     #[cfg(not(target_os = "linux"))]
-    pub fn new(texture: StreamTexture) -> Arc<Self> {
+    pub fn new(texture: Texture) -> Arc<Self> {
         Arc::new(Self { texture })
     }
 
     /// Borrow the underlying texture.
-    pub fn texture(&self) -> &StreamTexture {
+    pub fn texture(&self) -> &Texture {
         &self.texture
     }
 
@@ -85,7 +85,7 @@ mod tests {
     use crate::core::context::GpuContext;
     use std::thread;
 
-    fn fresh_texture() -> Option<StreamTexture> {
+    fn fresh_texture() -> Option<Texture> {
         let gpu = GpuContext::init_for_platform().ok()?;
         let desc = TextureDescriptor::new(64, 64, TextureFormat::Rgba8Unorm)
             .with_usage(TextureUsages::TEXTURE_BINDING);

--- a/libs/streamlib-engine/src/core/rhi/command_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/command_buffer.rs
@@ -3,7 +3,7 @@
 
 //! RHI command buffer abstraction.
 
-use super::texture::StreamTexture;
+use super::texture::Texture;
 
 /// Platform-agnostic command buffer wrapper.
 ///
@@ -32,7 +32,7 @@ pub struct CommandBuffer {
 
 impl CommandBuffer {
     /// Copy one texture to another.
-    pub fn copy_texture(&mut self, src: &StreamTexture, dst: &StreamTexture) {
+    pub fn copy_texture(&mut self, src: &Texture, dst: &Texture) {
         // Metal backend
         #[cfg(all(
             not(feature = "backend-vulkan"),

--- a/libs/streamlib-engine/src/core/rhi/device.rs
+++ b/libs/streamlib-engine/src/core/rhi/device.rs
@@ -8,10 +8,10 @@ use crate::core::Result;
     feature = "backend-vulkan",
     all(target_os = "linux", not(feature = "backend-metal"))
 ))]
-use crate::host_rhi::HostStreamTextureExt;
+use crate::host_rhi::HostTextureExt;
 
 use super::command_queue::RhiCommandQueue;
-use super::texture::{StreamTexture, TextureDescriptor};
+use super::texture::{Texture, TextureDescriptor};
 
 /// Platform-agnostic GPU device wrapper.
 ///
@@ -145,7 +145,7 @@ impl GpuDevice {
     }
 
     /// Create a texture on this device.
-    pub fn create_texture(&self, desc: &TextureDescriptor) -> Result<StreamTexture> {
+    pub fn create_texture(&self, desc: &TextureDescriptor) -> Result<Texture> {
         // Metal backend
         #[cfg(all(
             not(feature = "backend-vulkan"),
@@ -153,7 +153,7 @@ impl GpuDevice {
         ))]
         {
             let metal_texture = self.inner.create_texture(desc)?;
-            Ok(StreamTexture::from_metal(metal_texture))
+            Ok(Texture::from_metal(metal_texture))
         }
 
         // Vulkan backend
@@ -163,13 +163,13 @@ impl GpuDevice {
         ))]
         {
             let vulkan_texture = self.inner.create_texture(desc)?;
-            Ok(StreamTexture::from_vulkan(vulkan_texture))
+            Ok(Texture::from_vulkan(vulkan_texture))
         }
 
         #[cfg(target_os = "windows")]
         {
             let dx12_texture = self.inner.create_texture(desc)?;
-            Ok(StreamTexture::from_dx12(dx12_texture))
+            Ok(Texture::from_dx12(dx12_texture))
         }
     }
 
@@ -179,9 +179,9 @@ impl GpuDevice {
     /// never cross process boundaries; reduces pressure on NVIDIA Linux's
     /// DMA-BUF allocation cap.
     #[cfg(target_os = "linux")]
-    pub fn create_texture_local(&self, desc: &TextureDescriptor) -> Result<StreamTexture> {
+    pub fn create_texture_local(&self, desc: &TextureDescriptor) -> Result<Texture> {
         let vulkan_texture = self.inner.create_texture_local(desc)?;
-        Ok(StreamTexture::from_vulkan(vulkan_texture))
+        Ok(Texture::from_vulkan(vulkan_texture))
     }
 
     /// Get the shared command queue.

--- a/libs/streamlib-engine/src/core/rhi/graphics_kernel.rs
+++ b/libs/streamlib-engine/src/core/rhi/graphics_kernel.rs
@@ -398,7 +398,7 @@ impl Default for ColorBlendState {
 /// Lives next to the graphics-kernel API (rather than in the public
 /// `TextureFormat` enum) because depth/stencil formats only show up at
 /// graphics-pipeline boundaries — `streamlib-consumer-rhi`'s
-/// `TextureFormat` covers color-only formats, and depth `StreamTexture`
+/// `TextureFormat` covers color-only formats, and depth `Texture`
 /// allocation is a separate concern tracked as a follow-up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DepthFormat {

--- a/libs/streamlib-engine/src/core/rhi/mod.rs
+++ b/libs/streamlib-engine/src/core/rhi/mod.rs
@@ -65,7 +65,7 @@ pub use pixel_buffer_ref::RhiPixelBufferRef;
 // coordination (#633). In-tree consumers reach it via this re-export
 // rather than depending on `streamlib-consumer-rhi` directly.
 pub use streamlib_consumer_rhi::{PixelFormat, TextureFormat, TextureUsages, VulkanLayout};
-pub use texture::{NativeTextureHandle, StreamTexture, TextureDescriptor};
+pub use texture::{NativeTextureHandle, Texture, TextureDescriptor};
 pub use texture_cache::{RhiTextureCache, RhiTextureView};
 pub use texture_readback::{
     ReadbackTicket, TextureReadbackDescriptor, TextureReadbackError, TextureSourceLayout,

--- a/libs/streamlib-engine/src/core/rhi/texture.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture.rs
@@ -76,7 +76,7 @@ impl<'a> TextureDescriptor<'a> {
 /// On macOS/iOS, Metal texture storage is always available for Apple platform
 /// interop (IOSurface, CVPixelBuffer) regardless of which GPU backend is selected.
 #[derive(Clone)]
-pub struct StreamTexture {
+pub struct Texture {
     // Metal backend: when vulkan NOT requested AND (explicit metal feature OR macOS/iOS)
     #[cfg(all(
         not(feature = "backend-vulkan"),
@@ -101,7 +101,7 @@ pub struct StreamTexture {
     pub(crate) metal_texture: Option<Arc<crate::metal::rhi::MetalTexture>>,
 }
 
-impl StreamTexture {
+impl Texture {
     /// Texture width in pixels.
     pub fn width(&self) -> u32 {
         // On macOS, prefer metal_texture if available (for IOSurface-backed textures)
@@ -227,14 +227,14 @@ impl StreamTexture {
 }
 
 // Privileged Host-flavor accessors (`from_vulkan`, `vulkan_inner`)
-// live on the [`crate::host_rhi::HostStreamTextureExt`] extension
+// live on the [`crate::host_rhi::HostTextureExt`] extension
 // trait — type-system-enforced boundary so the SDK's public inherent
 // impl stays Host-free. Engine RHI helpers and in-tree adapters
-// `use crate::host_rhi::HostStreamTextureExt;` to surface them.
+// `use crate::host_rhi::HostTextureExt;` to surface them.
 
-impl std::fmt::Debug for StreamTexture {
+impl std::fmt::Debug for Texture {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StreamTexture")
+        f.debug_struct("Texture")
             .field("width", &self.width())
             .field("height", &self.height())
             .field("format", &self.format())
@@ -242,6 +242,6 @@ impl std::fmt::Debug for StreamTexture {
     }
 }
 
-// Ensure StreamTexture is Send + Sync
-unsafe impl Send for StreamTexture {}
-unsafe impl Sync for StreamTexture {}
+// Ensure Texture is Send + Sync
+unsafe impl Send for Texture {}
+unsafe impl Sync for Texture {}

--- a/libs/streamlib-engine/src/core/texture.rs
+++ b/libs/streamlib-engine/src/core/texture.rs
@@ -3,8 +3,8 @@
 
 //! Re-exports RHI texture types for convenience.
 
-pub use super::rhi::{StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
+pub use super::rhi::{Texture, TextureDescriptor, TextureFormat, TextureUsages};
 
 pub mod prelude {
-    pub use super::super::rhi::{StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
+    pub use super::super::rhi::{Texture, TextureDescriptor, TextureFormat, TextureUsages};
 }

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -5,7 +5,7 @@
 //!
 //! In-tree surface adapters and engine-internal RHI code reach for
 //! raw Vulkan handles through this module. The SDK-bucket types
-//! ([`StreamTexture`], [`RhiPixelBufferRef`], [`GpuDevice`]) have no
+//! ([`Texture`], [`RhiPixelBufferRef`], [`GpuDevice`]) have no
 //! inherent `vulkan_*` accessors — the only way to the privileged
 //! surface is through the extension traits defined here. Importing
 //! one of these traits is an explicit acknowledgment that the caller
@@ -28,8 +28,8 @@
 //!
 //! ```compile_fail
 //! # #[cfg(target_os = "linux")]
-//! # fn _check(stream_texture: &streamlib::sdk::rhi::StreamTexture) {
-//! // Without `use streamlib::sdk::engine::HostStreamTextureExt;` the privileged
+//! # fn _check(stream_texture: &streamlib::sdk::rhi::Texture) {
+//! // Without `use streamlib::sdk::engine::HostTextureExt;` the privileged
 //! // `vulkan_inner` accessor is not visible — boundary held.
 //! let _ = stream_texture.vulkan_inner();
 //! # }
@@ -39,13 +39,13 @@
 //!
 //! ```no_run
 //! # #[cfg(target_os = "linux")]
-//! # fn _check(stream_texture: &streamlib::sdk::rhi::StreamTexture) {
-//! use streamlib::sdk::engine::HostStreamTextureExt;
+//! # fn _check(stream_texture: &streamlib::sdk::rhi::Texture) {
+//! use streamlib::sdk::engine::HostTextureExt;
 //! let _ = stream_texture.vulkan_inner();
 //! # }
 //! ```
 //!
-//! [`StreamTexture`]: crate::core::rhi::StreamTexture
+//! [`Texture`]: crate::core::rhi::Texture
 //! [`RhiPixelBufferRef`]: crate::core::rhi::RhiPixelBufferRef
 //! [`GpuDevice`]: crate::core::rhi::GpuDevice
 
@@ -61,20 +61,20 @@ pub use crate::vulkan::rhi::{
 
 pub use vulkanalia::vk::GeometryInstanceFlagsKHR;
 
-use crate::core::rhi::{GpuDevice, RhiPixelBufferRef, StreamTexture};
+use crate::core::rhi::{GpuDevice, RhiPixelBufferRef, Texture};
 
-/// Privileged engine-side accessors for [`StreamTexture`].
+/// Privileged engine-side accessors for [`Texture`].
 ///
 /// Engine RHI helpers and in-tree adapters import this trait to wrap a
-/// freshly-allocated [`HostVulkanTexture`] as a [`StreamTexture`] and
+/// freshly-allocated [`HostVulkanTexture`] as a [`Texture`] and
 /// to reach the underlying handle for raw `VkImage` access. Customer
-/// code never imports this trait — `streamlib::sdk::rhi::StreamTexture`
+/// code never imports this trait — `streamlib::sdk::rhi::Texture`
 /// is opaque on its public inherent impl.
 ///
 /// [`HostVulkanTexture`]: crate::vulkan::rhi::HostVulkanTexture
-pub trait HostStreamTextureExt {
+pub trait HostTextureExt {
     /// Wrap an already-allocated [`HostVulkanTexture`] as a
-    /// [`StreamTexture`].
+    /// [`Texture`].
     fn from_vulkan(texture: HostVulkanTexture) -> Self;
 
     /// Borrow the underlying [`HostVulkanTexture`] for raw `VkImage`
@@ -83,9 +83,9 @@ pub trait HostStreamTextureExt {
     fn vulkan_inner(&self) -> &Arc<HostVulkanTexture>;
 }
 
-impl HostStreamTextureExt for StreamTexture {
+impl HostTextureExt for Texture {
     fn from_vulkan(texture: HostVulkanTexture) -> Self {
-        StreamTexture {
+        Texture {
             inner: Arc::new(texture),
             #[cfg(any(target_os = "macos", target_os = "ios"))]
             metal_texture: None,

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -85,7 +85,7 @@ pub use core::{
     RuntimeContextFullAccess,
     RuntimeContextLimitedAccess,
     Error,
-    StreamTexture,
+    Texture,
     TextureDescriptor,
     TextureFormat,
     TexturePool,
@@ -160,7 +160,7 @@ pub mod host_rhi;
     feature = "backend-vulkan",
     all(target_os = "linux", not(feature = "backend-metal"))
 ))]
-pub use host_rhi::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostStreamTextureExt};
+pub use host_rhi::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt};
 
 // WebRTC streaming (cross-platform)
 pub use core::streaming::{WebRtcSession, WhepClient, WhepConfig, WhipClient, WhipConfig};
@@ -345,7 +345,7 @@ pub mod sdk {
     ))]
     pub mod engine {
         pub use crate::host_rhi;
-        pub use crate::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostStreamTextureExt};
+        pub use crate::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt};
         #[cfg(target_os = "linux")]
         pub use crate::linux_surface_share;
     }

--- a/libs/streamlib-engine/src/linux/processors/camera.rs
+++ b/libs/streamlib-engine/src/linux/processors/camera.rs
@@ -6,9 +6,9 @@ use vulkanalia::vk;
 use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
-use crate::core::rhi::{PixelFormat, StreamTexture, TextureDescriptor, TextureFormat, TextureUsages};
+use crate::core::rhi::{PixelFormat, Texture, TextureDescriptor, TextureFormat, TextureUsages};
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
-use crate::host_rhi::HostStreamTextureExt;
+use crate::host_rhi::HostTextureExt;
 use crate::iceoryx2::OutputWriter;
 use crate::vulkan::rhi::HostVulkanTexture;
 use streamlib_consumer_rhi::VulkanLayout;
@@ -780,7 +780,7 @@ fn capture_thread_loop(
                 | TextureUsages::COPY_SRC,
         );
 
-    let mut ring_textures: Vec<StreamTexture> = Vec::with_capacity(RING_TEXTURE_COUNT);
+    let mut ring_textures: Vec<Texture> = Vec::with_capacity(RING_TEXTURE_COUNT);
     let mut ring_texture_ids: Vec<String> = Vec::with_capacity(RING_TEXTURE_COUNT);
 
     for i in 0..RING_TEXTURE_COUNT {
@@ -837,7 +837,7 @@ fn capture_thread_loop(
         }
 
         let texture_id = uuid::Uuid::new_v4().to_string();
-        let stream_texture = StreamTexture::from_vulkan(vk_texture);
+        let stream_texture = Texture::from_vulkan(vk_texture);
 
         // Register with SurfaceStore for cross-process GPU-to-GPU sharing
         {
@@ -1780,7 +1780,7 @@ fn capture_thread_loop(
             }
         }
 
-        // Ring textures are owned by StreamTexture (Arc<HostVulkanTexture>) — they
+        // Ring textures are owned by Texture (Arc<HostVulkanTexture>) — they
         // clean up via Drop when ring_textures goes out of scope. Clear the
         // texture cache references so display doesn't try to use stale textures.
         gpu_context.set_camera_timeline_semaphore(0);

--- a/libs/streamlib-engine/src/linux/processors/display.rs
+++ b/libs/streamlib-engine/src/linux/processors/display.rs
@@ -1042,7 +1042,7 @@ impl DisplayEventLoopHandler {
     /// are skipped with a warning rather than rebuilding the handle.
     fn sample_texture_to_png(
         &mut self,
-        texture: &crate::core::rhi::StreamTexture,
+        texture: &crate::core::rhi::Texture,
         path: &std::path::Path,
         frame_idx: u64,
         input_frame_index: u64,

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -25,7 +25,7 @@ use vulkanalia::vk;
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
 use crate::core::rhi::{
-    ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer, StreamTexture,
+    ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer, Texture,
 };
 use crate::core::{Result, Error};
 
@@ -291,7 +291,7 @@ impl VulkanComputeKernel {
 
     /// Bind a sampled texture at `binding`, using the kernel's default
     /// linear-clamp sampler.
-    pub fn set_sampled_texture(&self, binding: u32, texture: &StreamTexture) -> Result<()> {
+    pub fn set_sampled_texture(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::SampledTexture)?;
         let view = vk_image_view_for(texture)?;
         let sampler = self.default_sampler()?;
@@ -304,7 +304,7 @@ impl VulkanComputeKernel {
 
     /// Bind a storage image at `binding`. Caller is responsible for ensuring
     /// the texture's `STORAGE_BINDING` usage was set when it was created.
-    pub fn set_storage_image(&self, binding: u32, texture: &StreamTexture) -> Result<()> {
+    pub fn set_storage_image(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::StorageImage)?;
         let view = vk_image_view_for(texture)?;
         self.pending
@@ -1089,7 +1089,7 @@ fn vk_buffer_for(buffer: &RhiPixelBuffer) -> Result<(vk::Buffer, vk::DeviceSize)
     Ok((inner.buffer(), inner.size()))
 }
 
-fn vk_image_view_for(texture: &StreamTexture) -> Result<vk::ImageView> {
+fn vk_image_view_for(texture: &Texture) -> Result<vk::ImageView> {
     texture.inner.image_view()
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -47,7 +47,7 @@ use crate::core::rhi::{
     DepthStencilState, DrawCall, DrawIndexedCall, FrontFace, GraphicsBindingKind,
     GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
     GraphicsShaderStage, GraphicsShaderStageFlags, GraphicsStage, IndexType, PolygonMode,
-    PrimitiveTopology, RhiPixelBuffer, ScissorRect, StreamTexture, TextureFormat,
+    PrimitiveTopology, RhiPixelBuffer, ScissorRect, Texture, TextureFormat,
     VertexAttributeFormat, VertexInputRate, VertexInputState, Viewport,
 };
 use crate::core::{Result, Error};
@@ -142,7 +142,7 @@ struct OffscreenScaffold {
 
 /// One color attachment for [`VulkanGraphicsKernel::offscreen_render`].
 pub struct OffscreenColorTarget<'a> {
-    pub texture: &'a StreamTexture,
+    pub texture: &'a Texture,
     /// `Some` clears the attachment to this RGBA value before drawing;
     /// `None` loads existing contents.
     pub clear_color: Option<[f32; 4]>,
@@ -348,7 +348,7 @@ impl VulkanGraphicsKernel {
         &self,
         frame_index: u32,
         binding: u32,
-        texture: &StreamTexture,
+        texture: &Texture,
     ) -> Result<()> {
         self.expect_kind(binding, GraphicsBindingKind::SampledTexture)?;
         let view = texture.inner.image_view()?;
@@ -403,7 +403,7 @@ impl VulkanGraphicsKernel {
         &self,
         frame_index: u32,
         binding: u32,
-        texture: &StreamTexture,
+        texture: &Texture,
     ) -> Result<()> {
         self.expect_kind(binding, GraphicsBindingKind::StorageImage)?;
         let view = texture.inner.image_view()?;
@@ -2043,7 +2043,7 @@ mod tests {
         VertexAttributeFormat, VertexInputAttribute, VertexInputBinding, VertexInputRate,
         VertexInputState, derive_bindings_from_spirv_multistage,
     };
-    use crate::host_rhi::HostStreamTextureExt;
+    use crate::host_rhi::HostTextureExt;
 
     fn try_vulkan_device() -> Option<Arc<HostVulkanDevice>> {
         match HostVulkanDevice::new() {
@@ -2330,7 +2330,7 @@ mod tests {
         // Some(...)` are set. This locks the *creation* path threading
         // `VkPipelineDepthStencilStateCreateInfo` through to the
         // pipeline builder — but does NOT lock depth-correctness
-        // rendering, because depth StreamTexture allocation depends on
+        // rendering, because depth Texture allocation depends on
         // `streamlib-consumer-rhi::TextureFormat` gaining depth
         // variants (tracked under the Graphics Kernel Buildout
         // milestone). A driver bug that silently ignored
@@ -2458,7 +2458,7 @@ mod tests {
         let texture =
             crate::vulkan::rhi::HostVulkanTexture::new_device_local(&device, &dummy_desc)
                 .expect("test texture allocation");
-        let stream_texture = crate::core::rhi::StreamTexture::from_vulkan(texture);
+        let stream_texture = crate::core::rhi::Texture::from_vulkan(texture);
 
         // Ring depth is 2; index 2 must fail.
         let err = kernel

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -32,7 +32,7 @@ use vma::Alloc as _;
 use crate::core::rhi::{
     validate_shader_groups, RayTracingBindingKind, RayTracingBindingSpec,
     RayTracingKernelDescriptor, RayTracingShaderGroup, RayTracingShaderStage,
-    RayTracingShaderStageFlags, RayTracingStage, RhiPixelBuffer, StreamTexture,
+    RayTracingShaderStageFlags, RayTracingStage, RhiPixelBuffer, Texture,
 };
 use crate::core::{Result, Error};
 
@@ -441,7 +441,7 @@ impl VulkanRayTracingKernel {
         Ok(())
     }
 
-    pub fn set_sampled_texture(&self, binding: u32, texture: &StreamTexture) -> Result<()> {
+    pub fn set_sampled_texture(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::SampledTexture)?;
         let view = texture.inner.image_view()?;
         let sampler = self.default_sampler()?;
@@ -452,7 +452,7 @@ impl VulkanRayTracingKernel {
         Ok(())
     }
 
-    pub fn set_storage_image(&self, binding: u32, texture: &StreamTexture) -> Result<()> {
+    pub fn set_storage_image(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::StorageImage)?;
         let view = texture.inner.image_view()?;
         self.pending
@@ -1605,11 +1605,11 @@ mod tests {
     use super::*;
     use crate::core::rhi::{
         RayTracingBindingSpec, RayTracingKernelDescriptor, RayTracingPushConstants,
-        RayTracingShaderGroup, RayTracingShaderStageFlags, RayTracingStage, StreamTexture,
+        RayTracingShaderGroup, RayTracingShaderStageFlags, RayTracingStage, Texture,
         TextureDescriptor, TextureFormat, TextureReadbackDescriptor, TextureSourceLayout,
         TextureUsages,
     };
-    use crate::host_rhi::HostStreamTextureExt;
+    use crate::host_rhi::HostTextureExt;
     use crate::vulkan::rhi::{
         HostVulkanDevice, HostVulkanTexture, TlasInstanceDesc, VulkanAccelerationStructure,
         VulkanTextureReadback,
@@ -1826,7 +1826,7 @@ mod tests {
             },
         )
         .expect("texture creation");
-        let stream_texture = StreamTexture::from_vulkan(texture);
+        let stream_texture = Texture::from_vulkan(texture);
         let image = stream_texture
             .vulkan_inner()
             .image()

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture_readback.rs
@@ -28,11 +28,11 @@ use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
 use crate::core::rhi::{
-    ReadbackTicket, StreamTexture, TextureFormat, TextureReadbackDescriptor, TextureReadbackError,
+    ReadbackTicket, Texture, TextureFormat, TextureReadbackDescriptor, TextureReadbackError,
     TextureSourceLayout,
 };
 use crate::core::{Result, Error};
-use crate::host_rhi::HostStreamTextureExt;
+use crate::host_rhi::HostTextureExt;
 
 use super::HostVulkanDevice;
 
@@ -257,7 +257,7 @@ impl VulkanTextureReadback {
     )]
     pub fn submit(
         &self,
-        texture: &StreamTexture,
+        texture: &Texture,
         source_layout: TextureSourceLayout,
     ) -> std::result::Result<ReadbackTicket, TextureReadbackError> {
         // ---- Validate descriptor match ----
@@ -720,7 +720,7 @@ mod tests {
         height: u32,
         format: TextureFormat,
         pattern: impl Fn(u32, u32) -> [u8; 4],
-    ) -> StreamTexture {
+    ) -> Texture {
         use crate::core::rhi::PixelFormat;
         use crate::vulkan::rhi::HostVulkanPixelBuffer;
 
@@ -759,7 +759,7 @@ mod tests {
             label: Some("readback-test-texture"),
         };
         let host_tex = crate::vulkan::rhi::HostVulkanTexture::new(device, &desc).expect("texture");
-        let texture = StreamTexture {
+        let texture = Texture {
             inner: Arc::new(host_tex),
         };
 

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -1431,13 +1431,13 @@ class EscalateRequestRunComputeKernel(EscalateRequest):
 
     surface_uuid: 'str'
     """
-    UUID string of a render-target surface previously registered with
-    the surface-share service via `register_texture`. The host bridge
-    holds an application-provided UUID→`StreamTexture` map (populated in
-    `install_setup_hook`) and binds the looked-up `VkImage` as a storage_image
-    at slot 0 (the single-output convention enforced for v1 — multi-binding
-    kernels are a future extension). UUID rather than u64 so the host can
-    resolve the surface without subprocess-side counter coordination.
+    UUID string of a render-target surface previously registered with the
+    surface-share service via `register_texture`. The host bridge holds an
+    application-provided UUID→`Texture` map (populated in `install_setup_hook`)
+    and binds the looked-up `VkImage` as a storage_image at slot 0 (the single-
+    output convention enforced for v1 — multi-binding kernels are a future
+    extension). UUID rather than u64 so the host can resolve the surface without
+    subprocess-side counter coordination.
     """
 
 
@@ -1754,7 +1754,7 @@ class EscalateRequestRunGraphicsDraw(EscalateRequest):
     """
     UUIDs of color attachment textures. v1 requires exactly one entry — multi-
     attachment is a future extension. Each UUID must resolve to a host-side
-    `StreamTexture` registered as a render target.
+    `Texture` registered as a render target.
     """
 
     draw: 'EscalateRequestRunGraphicsDrawDraw'
@@ -1921,7 +1921,7 @@ class EscalateRequestRunRayTracingKernel(EscalateRequest):
     `acceleration_structure`: `target_id` is an `as_id`
       from a prior `register_acceleration_structure_tlas`.
     - all other kinds: `target_id` is the surface-share UUID
-      of a host-side `RhiPixelBuffer` / `StreamTexture`
+      of a host-side `RhiPixelBuffer` / `Texture`
       (same convention compute and graphics use).
     """
 

--- a/libs/streamlib-python/python/streamlib/adapters/vulkan.py
+++ b/libs/streamlib-python/python/streamlib/adapters/vulkan.py
@@ -578,7 +578,7 @@ class VulkanContext:
             self._compute_kernel_ids[spv_id] = (spirv, kernel_id)
         # Send the surface-share UUID, not the cdylib's local u64
         # surface_id — the host bridge resolves UUID → host
-        # `StreamTexture` via an application-provided map.
+        # `Texture` via an application-provided map.
         ch.run_compute_kernel(
             kernel_id=kernel_id,
             surface_uuid=pool_id,
@@ -683,7 +683,7 @@ class VulkanContext:
 
         # Use `pool_id` (surface-share UUID) for the color target — same
         # convention as compute. Host bridge resolves UUID → host-side
-        # `StreamTexture`.
+        # `Texture`.
         ch.run_graphics_draw(
             kernel_id=kernel_id,
             frame_index=int(frame_index),

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -496,7 +496,7 @@ class EscalateChannel:
         "acceleration_structure"``, ``target_id`` is an ``as_id`` from
         a prior :meth:`register_acceleration_structure_tlas`; for all
         other kinds, ``target_id`` is the surface-share UUID of the
-        host-side ``RhiPixelBuffer`` / ``StreamTexture`` (same
+        host-side ``RhiPixelBuffer`` / ``Texture`` (same
         convention compute and graphics use).
 
         On failure raises :class:`EscalateError`.

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -15,7 +15,7 @@
 //! ```ignore
 //! use streamlib::sdk::runtime::Runner;
 //! use streamlib::sdk::processors::ProcessorSpec;
-//! use streamlib::sdk::rhi::StreamTexture;
+//! use streamlib::sdk::rhi::Texture;
 //! use streamlib::sdk::iceoryx2::OutputWriter;
 //! ```
 //!
@@ -208,9 +208,9 @@ pub mod sdk {
         /// Privileged extension traits surfacing raw `Host*` handles
         /// on SDK-bucket types. Importing one unlocks `vulkan_inner()`
         /// / `from_vulkan()` / `vulkan_device()` on
-        /// `StreamTexture` / `RhiPixelBufferRef` / `GpuDevice`.
+        /// `Texture` / `RhiPixelBufferRef` / `GpuDevice`.
         pub use streamlib_engine::{
-            HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostStreamTextureExt,
+            HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt,
         };
 
         /// Per-runtime surface-share service primitives. For adapter


### PR DESCRIPTION
## Summary

- Rename SDK-public `StreamTexture` struct to `Texture`; path becomes `streamlib::sdk::rhi::Texture`. Mirrors the post-#738 `StreamError → Error` pattern — the path namespace already conveys role, the `Stream` prefix was vestigial.
- Rename engine-side extension trait `HostStreamTextureExt` → `HostTextureExt`. The `Host` prefix stays as the boundary signal; `Stream` drops everywhere it appeared. (User-confirmed reading during pickup; the original AI-Agent-Note "keeps its name" was ambiguous.)
- Pure rename, no behavior change. 73 files touched (61 Rust + 12 non-Rust including Python/TS adapter modules, schema YAML descriptions, generated bindings, and architecture docs).

## Closes

Closes #739

## Exit criteria

- [x] `StreamTexture` struct renamed to `Texture` in `libs/streamlib-engine/src/core/rhi/texture.rs`.
- [x] `from_vulkan` / `vulkan_inner` extension trait methods updated; trait itself renamed to `HostTextureExt` (per pickup-time clarification).
- [x] All consumers updated — single mechanical sweep across 73 files.
- [x] All `cargo xtask check-*` lints pass: `check-boundaries` (3280 files, no violations), `check-schema-versions`, `check-no-streamlib-metadata`, `check-processor-spec-new`, `check-manifest-schema` (28 streamlib.yaml validated), `lint-logging` (475 files).
- [x] Workspace test gate green: 1418 passed, 0 failed, 126 ignored.
- [x] `camera-display` vivid E2E pass (see test plan below).

## Test plan

- [x] Workspace test gate per `docs/testing-baseline.md`:
      `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` → **passed=1418 failed=0 ignored=126**.
- [x] All xtask CI lints listed above → all pass.
- [x] `camera-display` against `/dev/video2` (vivid):
      `STREAMLIB_CAMERA_DEVICE=/dev/video2 STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=… STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 STREAMLIB_DISPLAY_FRAME_LIMIT=120 ./target/release/camera-display` → 121 frames captured, 4 PNG samples, zero `OUT_OF_DEVICE_MEMORY`/`DEVICE_LOST`/`process() failed`. PNG visually confirmed (1920×1080 vivid test pattern with `00:00:12:206 61` timecode overlay and metadata text).
- [x] Codegen idempotency: regenerated all three runtimes via `cargo xtask generate-schemas --project-dir libs/streamlib-engine --runtime {rust,python,typescript}` — only the 3 escalate_request artifacts changed (the ones whose YAML description prose touched `StreamTexture`).

## Notes

- The original AI-Agent-Notes claim that `libs/streamlib-macros/src/codegen.rs` emits `::streamlib::sdk::rhi::StreamTexture` turned out to be stale on pickup; the macro has no `StreamTexture` reference, so no macro update was needed. Issue body updated in place during pickup with strikethrough notes preserving the original guidance and reasoning.
- Pre-existing clippy errors in `libs/streamlib-adapter-abi/src/registry.rs` (let-bindings with unit value) confirmed unrelated by stash-and-rerun on main; not addressed here per CLAUDE.md "no auto-fixing on the side."

## Follow-ups

None — this is a complete in-tree rename. #740 (`RhiPixelBuffer*` → `PixelBuffer*`) tracks the parallel rename family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)