### PR TITLE
refactor(sdk): rename RhiPixelBuffer* to PixelBuffer* (#740)

### DIFF
--- a/docs/architecture/compute-kernel.md
+++ b/docs/architecture/compute-kernel.md
@@ -36,7 +36,7 @@ Given a SPIR-V blob and a small typed declaration, the kernel:
 3. **Stages bindings as data** through `set_storage_buffer`,
    `set_uniform_buffer`, `set_sampled_texture`, `set_storage_image`,
    and `set_push_constants`. Each setter takes RHI-level types
-   (`RhiPixelBuffer`, `Texture`, `&[u8]`).
+   (`PixelBuffer`, `Texture`, `&[u8]`).
 4. **Flushes + dispatches + waits** in `dispatch(x, y, z)`. The fence is
    pre-signaled so the first dispatch doesn't block, and consecutive
    dispatches against the same kernel are serial (one in flight at a time).

--- a/docs/architecture/graphics-kernel.md
+++ b/docs/architecture/graphics-kernel.md
@@ -39,7 +39,7 @@ declaration, the kernel:
 3. **Stages bindings as data** through `set_sampled_texture`,
    `set_storage_buffer`, `set_uniform_buffer`, `set_storage_image`,
    `set_push_constants`, `set_vertex_buffer`, `set_index_buffer`. Each
-   setter takes RHI-level types (`Texture`, `RhiPixelBuffer`,
+   setter takes RHI-level types (`Texture`, `PixelBuffer`,
    `&[u8]`).
 
 4. **Records bind + push + draw into the caller's command buffer.**

--- a/docs/architecture/ray-tracing-kernel.md
+++ b/docs/architecture/ray-tracing-kernel.md
@@ -58,7 +58,7 @@ binding declaration, the kernel:
 3. **Stages bindings as data** through `set_storage_buffer`,
    `set_uniform_buffer`, `set_sampled_texture`, `set_storage_image`,
    `set_acceleration_structure`, `set_push_constants`. Each setter
-   takes RHI-level types (`RhiPixelBuffer`, `Texture`,
+   takes RHI-level types (`PixelBuffer`, `Texture`,
    `Arc<VulkanAccelerationStructure>`, `&[u8]`).
 
 4. **Records bind + push + trace + waits** in `trace_rays(width,

--- a/docs/architecture/texture-readback.md
+++ b/docs/architecture/texture-readback.md
@@ -102,7 +102,7 @@ handles.
   multi-plane host-side readback callsite arrives.
 - **Caller-supplied staging buffers.** The handle owns its staging
   buffer. If a future caller has reason to read into someone else's
-  buffer (e.g. into a pre-mapped `RhiPixelBuffer`), extend the
+  buffer (e.g. into a pre-mapped `PixelBuffer`), extend the
   abstraction with an `into_buffer` variant.
 - **Asynchronous-with-callback API** (`submit(then: impl FnOnce)`).
   The current `try_read` / `wait_and_read` shape is sufficient for

--- a/docs/research/blit-copy-classification.md
+++ b/docs/research/blit-copy-classification.md
@@ -39,11 +39,11 @@ below for the shape callers take.
 ```rust
 // libs/streamlib-engine/src/core/rhi/blitter.rs
 pub trait RhiBlitter: Send + Sync {
-    fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()>;
+    fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()>;
     unsafe fn blit_copy_iosurface_raw(
         &self,
         src: *const std::ffi::c_void,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()>;
@@ -169,7 +169,7 @@ capture, videotoolbox decoder) pre-warm in `setup()` by:
    `acquire_pixel_buffer` growth path).
 2. Running a zero-cost warming blit per slot (e.g., blit from a
    throwaway source IOSurface of matching size — or, simpler, a
-   dedicated Metal `fn warm_blitter_cache(&self, dest: &RhiPixelBuffer)`
+   dedicated Metal `fn warm_blitter_cache(&self, dest: &PixelBuffer)`
    helper on `MetalBlitter` that runs `get_or_create_texture(dest)`
    without issuing the actual blit).
 

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -25,7 +25,7 @@ use streamlib::sdk::_generated_::VideoFrame;
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 #[cfg(target_os = "linux")]
-use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer};
+use streamlib::sdk::rhi::{PixelFormat, PixelBuffer};
 #[cfg(target_os = "linux")]
 use streamlib::sdk::context::GpuContextLimitedAccess;
 #[cfg(target_os = "linux")]
@@ -166,7 +166,7 @@ impl CameraToCudaCopyProcessor::Processor {
         })?;
         let pixel_buffer_arc = Arc::new(pixel_buffer);
         let pixel_buffer_rhi =
-            RhiPixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&pixel_buffer_arc));
+            PixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&pixel_buffer_arc));
 
         // 2. Exportable timeline. The cdylib imports it as a CUDA
         //    timeline external semaphore so `acquire_read` blocks

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -50,7 +50,7 @@ use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
 
 use streamlib::sdk::context::{CpuReadbackBridge, CpuReadbackCopyDirection, GpuContext};
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
-use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat};
+use streamlib::sdk::rhi::{PixelFormat, PixelBuffer, TextureFormat};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
@@ -367,7 +367,7 @@ fn register_host_surface(
     .map_err(|e| format!("HostVulkanPixelBuffer::new: {e}"))?;
     let staging_arc = Arc::new(staging);
     let staging_rhi =
-        RhiPixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&staging_arc));
+        PixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&staging_arc));
 
     // 3. Allocate the exportable timeline semaphore.
     let timeline = Arc::new(

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -52,7 +52,7 @@ use streamlib::sdk::engine::HostGpuDeviceExt;
 
 use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::descriptors::{Org, Package, SchemaIdent, SemVer, TypeName};
-use streamlib::sdk::rhi::{PixelFormat, RhiPixelBuffer};
+use streamlib::sdk::rhi::{PixelFormat, PixelBuffer};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{
@@ -309,7 +309,7 @@ fn register_host_surface(
     .map_err(|e| format!("HostVulkanPixelBuffer::new_opaque_fd_export: {e}"))?;
     let pixel_buffer_arc = Arc::new(pixel_buffer);
     let pixel_buffer_rhi =
-        RhiPixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&pixel_buffer_arc));
+        PixelBuffer::from_host_vulkan_pixel_buffer(Arc::clone(&pixel_buffer_arc));
 
     // 2. Allocate the exportable timeline semaphore (initial value 0).
     //    First subprocess `acquire_*` will wait on 0 → satisfied

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -1015,8 +1015,8 @@ export enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
 
 /**
  * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
- * `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
- * into it.
+ * `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset into
+ * it.
  */
 export interface EscalateRequestRunGraphicsDrawIndexBuffer {
   index_type: EscalateRequestRunGraphicsDrawIndexBufferIndexType;
@@ -1126,7 +1126,7 @@ export interface EscalateRequestRunGraphicsDraw {
 
   /**
    * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-   * `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+   * `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset
    * into it.
    */
   index_buffer?: EscalateRequestRunGraphicsDrawIndexBuffer;

--- a/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
+++ b/libs/streamlib-deno/_generated_/com_streamlib_escalate_request.ts
@@ -1015,7 +1015,7 @@ export enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
 
 /**
  * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
- * `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+ * `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
  * into it.
  */
 export interface EscalateRequestRunGraphicsDrawIndexBuffer {
@@ -1112,9 +1112,9 @@ export interface EscalateRequestRunGraphicsDraw {
 
   /**
    * Per-draw vertex buffer bindings. Each entry's `surface_uuid` must resolve
-   * to a host-side `RhiPixelBuffer`. `offset` is the byte offset into the
-   * buffer where vertex data starts (decimal-encoded u64 — JTD has no native
-   * u64). Empty for vertex-fabricating shaders (`gl_VertexIndex` patterns).
+   * to a host-side `PixelBuffer`. `offset` is the byte offset into the buffer
+   * where vertex data starts (decimal-encoded u64 — JTD has no native u64).
+   * Empty for vertex-fabricating shaders (`gl_VertexIndex` patterns).
    */
   vertex_buffers: EscalateRequestRunGraphicsDrawVertexBuffer[];
 
@@ -1126,7 +1126,7 @@ export interface EscalateRequestRunGraphicsDraw {
 
   /**
    * Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-   * `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+   * `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
    * into it.
    */
   index_buffer?: EscalateRequestRunGraphicsDrawIndexBuffer;
@@ -1167,7 +1167,7 @@ export interface EscalateRequestRunRayTracingKernel {
    * `acceleration_structure`: `target_id` is an `as_id`
    *   from a prior `register_acceleration_structure_tlas`.
    * - all other kinds: `target_id` is the surface-share UUID
-   *   of a host-side `RhiPixelBuffer` / `Texture`
+   *   of a host-side `PixelBuffer` / `Texture`
    *   (same convention compute and graphics use).
    */
   bindings: EscalateRequestRunRayTracingKernelBinding[];

--- a/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -559,7 +559,7 @@ mapping:
           description: >
             Per-draw vertex buffer bindings. Each entry's
             `surface_uuid` must resolve to a host-side
-            `RhiPixelBuffer`. `offset` is the byte offset into the
+            `PixelBuffer`. `offset` is the byte offset into the
             buffer where vertex data starts (decimal-encoded u64 —
             JTD has no native u64). Empty for vertex-fabricating
             shaders (`gl_VertexIndex` patterns).
@@ -630,7 +630,7 @@ mapping:
           description: >
             Required when `draw.kind == "draw_indexed"`, must be
             absent otherwise. `surface_uuid` resolves to an
-            `RhiPixelBuffer`; `offset` is the byte offset into it.
+            `PixelBuffer`; `offset` is the byte offset into it.
         properties:
           surface_uuid:
             type: string
@@ -949,7 +949,7 @@ mapping:
             - `acceleration_structure`: `target_id` is an `as_id`
               from a prior `register_acceleration_structure_tlas`.
             - all other kinds: `target_id` is the surface-share UUID
-              of a host-side `RhiPixelBuffer` / `Texture`
+              of a host-side `PixelBuffer` / `Texture`
               (same convention compute and graphics use).
         elements:
           properties:

--- a/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
+++ b/libs/streamlib-engine/schemas/com.streamlib.escalate_request@1.0.0.yaml
@@ -629,7 +629,7 @@ mapping:
         metadata:
           description: >
             Required when `draw.kind == "draw_indexed"`, must be
-            absent otherwise. `surface_uuid` resolves to an
+            absent otherwise. `surface_uuid` resolves to a
             `PixelBuffer`; `offset` is the byte offset into it.
         properties:
           surface_uuid:

--- a/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
@@ -1365,7 +1365,7 @@ pub enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
 }
 
 /// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-/// `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+/// `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset
 /// into it.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1491,7 +1491,7 @@ pub struct EscalateRequestRunGraphicsDraw {
     pub depth_target_uuid: Option<String>,
 
     /// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    /// `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+    /// `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset
     /// into it.
     #[serde(rename = "index_buffer")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
+++ b/libs/streamlib-engine/src/_generated_/com_streamlib_escalate_request.rs
@@ -1365,7 +1365,7 @@ pub enum EscalateRequestRunGraphicsDrawIndexBufferIndexType {
 }
 
 /// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-/// `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+/// `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
 /// into it.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1477,9 +1477,9 @@ pub struct EscalateRequestRunGraphicsDraw {
     pub request_id: String,
 
     /// Per-draw vertex buffer bindings. Each entry's `surface_uuid` must
-    /// resolve to a host-side `RhiPixelBuffer`. `offset` is the byte offset
-    /// into the buffer where vertex data starts (decimal-encoded u64 — JTD has
-    /// no native u64). Empty for vertex-fabricating shaders (`gl_VertexIndex`
+    /// resolve to a host-side `PixelBuffer`. `offset` is the byte offset into
+    /// the buffer where vertex data starts (decimal-encoded u64 — JTD has no
+    /// native u64). Empty for vertex-fabricating shaders (`gl_VertexIndex`
     /// patterns).
     #[serde(rename = "vertex_buffers")]
     pub vertex_buffers: Vec<EscalateRequestRunGraphicsDrawVertexBuffer>,
@@ -1491,8 +1491,8 @@ pub struct EscalateRequestRunGraphicsDraw {
     pub depth_target_uuid: Option<String>,
 
     /// Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    /// `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte
-    /// offset into it.
+    /// `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+    /// into it.
     #[serde(rename = "index_buffer")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_buffer: Option<EscalateRequestRunGraphicsDrawIndexBuffer>,
@@ -1550,7 +1550,7 @@ pub struct EscalateRequestRunRayTracingKernel {
     /// `acceleration_structure`: `target_id` is an `as_id`
     ///   from a prior `register_acceleration_structure_tlas`.
     /// - all other kinds: `target_id` is the surface-share UUID
-    ///   of a host-side `RhiPixelBuffer` / `Texture`
+    ///   of a host-side `PixelBuffer` / `Texture`
     ///   (same convention compute and graphics use).
     #[serde(rename = "bindings")]
     pub bindings: Vec<EscalateRequestRunRayTracingKernelBinding>,

--- a/libs/streamlib-engine/src/apple/pixel_transfer.rs
+++ b/libs/streamlib-engine/src/apple/pixel_transfer.rs
@@ -118,7 +118,7 @@ impl PixelTransferSession {
         Ok(dest_nv12_buffer)
     }
 
-    /// Converts an PixelBuffer (containing CVPixelBuffer) to NV12 CVPixelBuffer.
+    /// Converts a PixelBuffer (containing CVPixelBuffer) to NV12 CVPixelBuffer.
     ///
     /// This is the buffer-centric path for VideoFrame encoding. The source buffer
     /// is typically BGRA from camera capture or BGRA from video decoder.

--- a/libs/streamlib-engine/src/apple/pixel_transfer.rs
+++ b/libs/streamlib-engine/src/apple/pixel_transfer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use crate::apple::iosurface;
-use crate::core::rhi::{GpuDevice, RhiCommandQueue, RhiPixelBuffer, Texture};
+use crate::core::rhi::{GpuDevice, RhiCommandQueue, PixelBuffer, Texture};
 use crate::core::{Result, Error};
 use metal::foreign_types::ForeignTypeRef;
 use objc2_core_video::CVPixelBuffer;
@@ -118,11 +118,11 @@ impl PixelTransferSession {
         Ok(dest_nv12_buffer)
     }
 
-    /// Converts an RhiPixelBuffer (containing CVPixelBuffer) to NV12 CVPixelBuffer.
+    /// Converts an PixelBuffer (containing CVPixelBuffer) to NV12 CVPixelBuffer.
     ///
     /// This is the buffer-centric path for VideoFrame encoding. The source buffer
     /// is typically BGRA from camera capture or BGRA from video decoder.
-    pub fn convert_buffer_to_nv12(&self, buffer: &RhiPixelBuffer) -> Result<*mut CVPixelBuffer> {
+    pub fn convert_buffer_to_nv12(&self, buffer: &PixelBuffer) -> Result<*mut CVPixelBuffer> {
         let source_ptr = buffer.ref_.as_ptr() as *mut CVPixelBuffer;
         self.transfer_rgba_to_nv12(source_ptr, buffer.width, buffer.height)
     }

--- a/libs/streamlib-engine/src/apple/processors/camera.rs
+++ b/libs/streamlib-engine/src/apple/processors/camera.rs
@@ -4,7 +4,7 @@
 use crate::apple::corevideo_ffi::{
     CVPixelBufferGetHeight, CVPixelBufferGetIOSurface, CVPixelBufferGetWidth, IOSurfaceGetID,
 };
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
+use crate::core::rhi::{PixelFormat, PixelBuffer, PixelBufferRef};
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use objc2::rc::Retained;
@@ -293,7 +293,7 @@ impl CameraDelegate {
 unsafe fn blit_iosurface_to_pooled_buffer(
     ctx: &CameraCallbackContext,
     camera_iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
-    pooled_buffer: &RhiPixelBuffer,
+    pooled_buffer: &PixelBuffer,
     width: u32,
     height: u32,
 ) -> crate::core::Result<()> {
@@ -308,9 +308,9 @@ unsafe fn forward_camera_iosurface_directly(
     ctx: &CameraCallbackContext,
     camera_iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
 ) -> String {
-    match RhiPixelBufferRef::from_iosurface_ref(camera_iosurface) {
+    match PixelBufferRef::from_iosurface_ref(camera_iosurface) {
         Ok(pixel_buffer_ref) => {
-            let pixel_buffer = RhiPixelBuffer::new(pixel_buffer_ref);
+            let pixel_buffer = PixelBuffer::new(pixel_buffer_ref);
             match ctx.gpu_context.check_in_surface(&pixel_buffer) {
                 Ok(id) => id,
                 Err(_) => {

--- a/libs/streamlib-engine/src/apple/processors/screen_capture.rs
+++ b/libs/streamlib-engine/src/apple/processors/screen_capture.rs
@@ -4,7 +4,7 @@
 use crate::apple::corevideo_ffi::{
     CVPixelBufferGetHeight, CVPixelBufferGetIOSurface, CVPixelBufferGetWidth, IOSurfaceGetID,
 };
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
+use crate::core::rhi::{PixelFormat, PixelBuffer, PixelBufferRef};
 use crate::core::{GpuContextLimitedAccess, Result, RuntimeContextFullAccess, Error};
 use crate::iceoryx2::OutputWriter;
 use block2::RcBlock;
@@ -237,7 +237,7 @@ impl ScreenCaptureDelegate {
 unsafe fn blit_iosurface_to_pooled_buffer(
     ctx: &ScreenCaptureCallbackContext,
     source_iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
-    pooled_buffer: &RhiPixelBuffer,
+    pooled_buffer: &PixelBuffer,
     width: u32,
     height: u32,
 ) -> crate::core::Result<()> {
@@ -250,9 +250,9 @@ unsafe fn forward_iosurface_directly(
     ctx: &ScreenCaptureCallbackContext,
     source_iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
 ) -> String {
-    match RhiPixelBufferRef::from_iosurface_ref(source_iosurface) {
+    match PixelBufferRef::from_iosurface_ref(source_iosurface) {
         Ok(pixel_buffer_ref) => {
-            let pixel_buffer = RhiPixelBuffer::new(pixel_buffer_ref);
+            let pixel_buffer = PixelBuffer::new(pixel_buffer_ref);
             match ctx.gpu_context.check_in_surface(&pixel_buffer) {
                 Ok(id) => id,
                 Err(_) => IOSurfaceGetID(source_iosurface).to_string(),

--- a/libs/streamlib-engine/src/apple/videotoolbox/decoder.rs
+++ b/libs/streamlib-engine/src/apple/videotoolbox/decoder.rs
@@ -17,7 +17,7 @@
 
 use super::{ffi, format};
 use crate::_generated_::VideoFrame;
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
+use crate::core::rhi::{PixelFormat, PixelBuffer, PixelBufferRef};
 use crate::core::{GpuContext, Result, RuntimeContext, Error, VideoDecoderConfig};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -379,17 +379,17 @@ impl VideoToolboxDecoder {
         decoded_frame: DecodedFrame,
         gpu: &GpuContext,
     ) -> Result<VideoFrame> {
-        // Wrap CVPixelBuffer in RhiPixelBufferRef.
+        // Wrap CVPixelBuffer in PixelBufferRef.
         // Use no_retain since the callback already retained the buffer.
-        // When RhiPixelBufferRef is dropped, it will release the CVPixelBuffer.
+        // When PixelBufferRef is dropped, it will release the CVPixelBuffer.
         let buffer_ref = unsafe {
-            RhiPixelBufferRef::from_cv_pixel_buffer_no_retain(
+            PixelBufferRef::from_cv_pixel_buffer_no_retain(
                 decoded_frame.pixel_buffer as ffi::CVPixelBufferRef,
             )
         }
         .ok_or_else(|| Error::GpuError("Decoded frame has null pixel buffer".into()))?;
 
-        let source_buffer = RhiPixelBuffer::new(buffer_ref);
+        let source_buffer = PixelBuffer::new(buffer_ref);
 
         // Log resolution discovery on first frame or if resolution changes
         if source_buffer.width != self.config.width || source_buffer.height != self.config.height {

--- a/libs/streamlib-engine/src/apple/videotoolbox/encoder.rs
+++ b/libs/streamlib-engine/src/apple/videotoolbox/encoder.rs
@@ -8,7 +8,7 @@
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::apple::PixelTransferSession;
-use crate::core::rhi::{PixelBufferPoolId, RhiPixelBuffer};
+use crate::core::rhi::{PixelBufferPoolId, PixelBuffer};
 use crate::core::{GpuContext, Result, RuntimeContext, Error, VideoEncoderConfig};
 use objc2_core_video::CVPixelBuffer;
 use std::collections::VecDeque;
@@ -228,10 +228,10 @@ impl VideoToolboxEncoder {
         Ok(())
     }
 
-    /// Convert RhiPixelBuffer to NV12 CVPixelBuffer using GPU-accelerated VTPixelTransferSession
+    /// Convert PixelBuffer to NV12 CVPixelBuffer using GPU-accelerated VTPixelTransferSession
     fn convert_buffer_to_pixel_buffer(
         &self,
-        buffer: &RhiPixelBuffer,
+        buffer: &PixelBuffer,
     ) -> Result<*mut CVPixelBuffer> {
         // GPU-accelerated conversion using VTPixelTransferSession
         let pixel_transfer = self.pixel_transfer.as_ref().ok_or_else(|| {

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -75,7 +75,7 @@ use crate::core::context::{
     RAY_TRACING_STAGE_INDEX_NONE,
 };
 use crate::core::logging::{push_polyglot_record, LogLevel, LogRecord, Source};
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer, TextureFormat, TextureUsages};
+use crate::core::rhi::{PixelFormat, PixelBuffer, TextureFormat, TextureUsages};
 
 #[cfg(test)]
 use crate::core::error::{Result, Error};
@@ -123,7 +123,7 @@ fn request_id(op: &EscalateRequest) -> Option<&str> {
 /// `run_cpu_readback_copy` trigger that returns a timeline value.
 pub(crate) enum RegisteredHandle {
     #[allow(dead_code)]
-    PixelBuffer(RhiPixelBuffer),
+    PixelBuffer(PixelBuffer),
     #[allow(dead_code)]
     Texture(PooledTextureHandle),
 }
@@ -133,7 +133,7 @@ pub(crate) enum RegisteredHandle {
 /// alive for the duration of the host pool; this map simply prevents the
 /// resource from being immediately recycled while the subprocess still
 /// references it by ID. Dropping a [`PooledTextureHandle`] releases the pool
-/// slot; dropping an [`RhiPixelBuffer`] releases its refcount.
+/// slot; dropping an [`PixelBuffer`] releases its refcount.
 #[derive(Default)]
 pub(crate) struct EscalateHandleRegistry {
     handles: Mutex<HashMap<String, RegisteredHandle>>,
@@ -144,7 +144,7 @@ impl EscalateHandleRegistry {
         Arc::new(Self::default())
     }
 
-    pub(crate) fn insert_buffer(&self, handle_id: String, buffer: RhiPixelBuffer) {
+    pub(crate) fn insert_buffer(&self, handle_id: String, buffer: PixelBuffer) {
         let mut map = self.handles.lock().expect("poisoned");
         map.insert(handle_id, RegisteredHandle::PixelBuffer(buffer));
     }
@@ -631,7 +631,7 @@ fn now_ns() -> u64 {
 fn assign_buffer_handle_id(
     full: &crate::core::context::GpuContextFullAccess,
     pool_id: &crate::core::rhi::PixelBufferPoolId,
-    buffer: &RhiPixelBuffer,
+    buffer: &PixelBuffer,
 ) -> crate::core::error::Result<String> {
     #[cfg(target_os = "linux")]
     {

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -5,7 +5,7 @@ use crate::_generated_::VideoFrame;
 use crate::core::context::TextureRegistration;
 use crate::core::rhi::{
     CommandBuffer, GpuDevice, PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, RhiBlitter,
-    RhiCommandQueue, RhiPixelBuffer, RhiPixelBufferPool, Texture, TextureDescriptor,
+    RhiCommandQueue, PixelBuffer, RhiPixelBufferPool, Texture, TextureDescriptor,
     TextureFormat, TextureUsages,
 };
 use crate::core::{Result, Error};
@@ -32,7 +32,7 @@ struct NoOpBlitter;
 
 #[cfg(not(target_os = "macos"))]
 impl RhiBlitter for NoOpBlitter {
-    fn blit_copy(&self, _src: &RhiPixelBuffer, _dest: &RhiPixelBuffer) -> Result<()> {
+    fn blit_copy(&self, _src: &PixelBuffer, _dest: &PixelBuffer) -> Result<()> {
         Err(Error::NotSupported(
             "Blitter not supported on this platform".into(),
         ))
@@ -41,7 +41,7 @@ impl RhiBlitter for NoOpBlitter {
     unsafe fn blit_copy_iosurface_raw(
         &self,
         _src: *const std::ffi::c_void,
-        _dest: &RhiPixelBuffer,
+        _dest: &PixelBuffer,
         _width: u32,
         _height: u32,
     ) -> Result<()> {
@@ -77,7 +77,7 @@ struct PixelBufferPoolKey {
 /// A single entry in the ring pool.
 struct PixelBufferRingEntry {
     pool_id: PixelBufferPoolId,
-    buffer: RhiPixelBuffer,
+    buffer: PixelBuffer,
 }
 
 /// Ring pool of permanently held pixel buffers for a given (width, height, format).
@@ -102,9 +102,9 @@ struct PixelBufferRingPool {
 /// Buffers are held permanently for the runtime's lifetime.
 struct PixelBufferPoolManager {
     pools: Mutex<HashMap<PixelBufferPoolKey, PixelBufferRingPool>>,
-    /// Global cache for UUID -> RhiPixelBuffer lookups (includes buffers from all pools).
+    /// Global cache for UUID -> PixelBuffer lookups (includes buffers from all pools).
     /// Used by consumers (e.g., display processor) to resolve UUIDs received via IPC.
-    buffer_cache: Mutex<HashMap<String, RhiPixelBuffer>>,
+    buffer_cache: Mutex<HashMap<String, PixelBuffer>>,
     /// GPU device reference for creating platform pixel buffer pools.
     #[allow(dead_code)]
     device: Arc<GpuDevice>,
@@ -130,7 +130,7 @@ impl PixelBufferPoolManager {
         height: u32,
         format: PixelFormat,
         surface_store: Option<&SurfaceStore>,
-    ) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         let key = PixelBufferPoolKey {
             width,
             height,
@@ -265,7 +265,7 @@ impl PixelBufferPoolManager {
             let entry = &ring_pool.buffers[idx];
 
             // Check if buffer is available (only our permanent references exist)
-            // RhiPixelBuffer wraps Arc<RhiPixelBufferRef>, so strong_count > 2 means in use
+            // PixelBuffer wraps Arc<PixelBufferRef>, so strong_count > 2 means in use
             // (2 = one in ring pool buffers Vec + one in buffer_cache HashMap)
             if Arc::strong_count(&entry.buffer.ref_) <= 2 {
                 tracing::trace!(
@@ -358,12 +358,12 @@ impl PixelBufferPoolManager {
     }
 
     /// Get a buffer by its UUID from local cache.
-    fn get_from_cache(&self, pool_id: &str) -> Option<RhiPixelBuffer> {
+    fn get_from_cache(&self, pool_id: &str) -> Option<PixelBuffer> {
         self.buffer_cache.lock().unwrap().get(pool_id).cloned()
     }
 
     /// Add a buffer to the local cache.
-    fn cache_buffer(&self, pool_id: &str, buffer: RhiPixelBuffer) {
+    fn cache_buffer(&self, pool_id: &str, buffer: PixelBuffer) {
         let mut cache = self.buffer_cache.lock().unwrap();
         cache.insert(pool_id.to_string(), buffer);
         if cache.len() > MAX_BUFFER_CACHE_SIZE {
@@ -565,7 +565,7 @@ impl GpuContext {
         width: u32,
         height: u32,
         format: PixelFormat,
-    ) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         tracing::debug!(
             rhi_op = "acquire_pixel_buffer",
             width,
@@ -582,7 +582,7 @@ impl GpuContext {
     ///
     /// First checks local cache, then falls back to surface-share service lookup for cross-process sharing.
     /// Returns the buffer if found, or an error if not found anywhere.
-    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<RhiPixelBuffer> {
+    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
         // Check local cache first
         if let Some(buffer) = self
             .pixel_buffer_pool_manager
@@ -615,7 +615,7 @@ impl GpuContext {
     }
 
     /// Resolve a VideoFrame's buffer from its surface_id.
-    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<RhiPixelBuffer> {
+    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<PixelBuffer> {
         let pool_id = PixelBufferPoolId::from_str(&frame.surface_id);
         self.get_pixel_buffer(&pool_id)
     }
@@ -808,7 +808,7 @@ impl GpuContext {
     fn refresh_pixel_buffer_texture(
         &self,
         surface_id: &str,
-        pixel_buffer: &crate::core::rhi::RhiPixelBuffer,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<Texture> {
@@ -868,7 +868,7 @@ impl GpuContext {
     pub fn upload_pixel_buffer_as_texture(
         &self,
         surface_id: &str,
-        pixel_buffer: &crate::core::rhi::RhiPixelBuffer,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {
@@ -1320,7 +1320,7 @@ impl GpuContext {
     /// Copy pixels between same-format, same-size buffers.
     ///
     /// Uses GPU blit with texture caching for efficient repeated copies.
-    pub fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         self.blitter.blit_copy(src, dest)
     }
 
@@ -1333,7 +1333,7 @@ impl GpuContext {
     pub unsafe fn blit_copy_iosurface(
         &self,
         src: crate::apple::corevideo_ffi::IOSurfaceRef,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {
@@ -1457,7 +1457,7 @@ impl GpuContext {
     ///
     /// If this pixel buffer was already checked in, returns the existing ID.
     #[cfg(target_os = "macos")]
-    pub fn check_in_surface(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in_surface(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
         let store = self.surface_store.lock().unwrap();
         let store = store.as_ref().ok_or_else(|| {
             crate::core::Error::Configuration(
@@ -1473,7 +1473,7 @@ impl GpuContext {
     /// The first checkout for a given ID incurs XPC overhead (~100-200µs),
     /// subsequent checkouts are cache hits (~10-50ns).
     #[cfg(target_os = "macos")]
-    pub fn check_out_surface(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
         let store = self.surface_store.lock().unwrap();
         let store = store.as_ref().ok_or_else(|| {
             crate::core::Error::Configuration(
@@ -1485,7 +1485,7 @@ impl GpuContext {
 
     /// Check in a pixel buffer (non-macOS stub).
     #[cfg(not(target_os = "macos"))]
-    pub fn check_in_surface(&self, _pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in_surface(&self, _pixel_buffer: &PixelBuffer) -> Result<String> {
         Err(crate::core::Error::NotSupported(
             "Surface store is only supported on macOS".into(),
         ))
@@ -1493,7 +1493,7 @@ impl GpuContext {
 
     /// Check out a surface (non-macOS stub).
     #[cfg(not(target_os = "macos"))]
-    pub fn check_out_surface(&self, _surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out_surface(&self, _surface_id: &str) -> Result<PixelBuffer> {
         Err(crate::core::Error::NotSupported(
             "Surface store is only supported on macOS".into(),
         ))
@@ -1726,17 +1726,17 @@ impl GpuContextLimitedAccess {
         width: u32,
         height: u32,
         format: PixelFormat,
-    ) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         self.inner.acquire_pixel_buffer(width, height, format)
     }
 
     /// Get a pixel buffer by its pool id (Split: local cache).
-    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<RhiPixelBuffer> {
+    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
         self.inner.get_pixel_buffer(pool_id)
     }
 
     /// Resolve a [`VideoFrame`]'s buffer from its surface_id.
-    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<RhiPixelBuffer> {
+    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<PixelBuffer> {
         self.inner.resolve_video_frame_buffer(frame)
     }
 
@@ -1807,7 +1807,7 @@ impl GpuContextLimitedAccess {
     }
 
     /// Copy pixels between same-format, same-size buffers (Split: cache hit).
-    pub fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         self.inner.blit_copy(src, dest)
     }
 
@@ -1820,7 +1820,7 @@ impl GpuContextLimitedAccess {
     pub unsafe fn blit_copy_iosurface(
         &self,
         src: crate::apple::corevideo_ffi::IOSurfaceRef,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {
@@ -1833,7 +1833,7 @@ impl GpuContextLimitedAccess {
     }
 
     /// Check out a surface by ID (Split: cache hit).
-    pub fn check_out_surface(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
         self.inner.check_out_surface(surface_id)
     }
 }
@@ -1855,7 +1855,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
         format: PixelFormat,
-    ) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         self.inner.acquire_pixel_buffer(width, height, format)
     }
 
@@ -1874,12 +1874,12 @@ impl GpuContextFullAccess {
     }
 
     /// Get a pixel buffer by its pool id.
-    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<RhiPixelBuffer> {
+    pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
         self.inner.get_pixel_buffer(pool_id)
     }
 
     /// Resolve a [`VideoFrame`]'s buffer from its surface_id.
-    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<RhiPixelBuffer> {
+    pub fn resolve_video_frame_buffer(&self, frame: &VideoFrame) -> Result<PixelBuffer> {
         self.inner.resolve_video_frame_buffer(frame)
     }
 
@@ -1929,7 +1929,7 @@ impl GpuContextFullAccess {
     pub fn upload_pixel_buffer_as_texture(
         &self,
         surface_id: &str,
-        pixel_buffer: &RhiPixelBuffer,
+        pixel_buffer: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {
@@ -2046,7 +2046,7 @@ impl GpuContextFullAccess {
     }
 
     /// Copy pixels between same-format, same-size buffers.
-    pub fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         self.inner.blit_copy(src, dest)
     }
 
@@ -2059,7 +2059,7 @@ impl GpuContextFullAccess {
     pub unsafe fn blit_copy_iosurface(
         &self,
         src: crate::apple::corevideo_ffi::IOSurfaceRef,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {
@@ -2077,12 +2077,12 @@ impl GpuContextFullAccess {
     }
 
     /// Check in a pixel buffer to the surface-share service.
-    pub fn check_in_surface(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in_surface(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
         self.inner.check_in_surface(pixel_buffer)
     }
 
     /// Check out a surface by ID.
-    pub fn check_out_surface(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
         self.inner.check_out_surface(surface_id)
     }
 

--- a/libs/streamlib-engine/src/core/context/ray_tracing_kernel_bridge.rs
+++ b/libs/streamlib-engine/src/core/context/ray_tracing_kernel_bridge.rs
@@ -164,7 +164,7 @@ pub struct TlasRegisterDecl {
 /// - [`RayTracingBindingKindWire::AccelerationStructure`]: an `as_id`
 ///   from a prior [`RayTracingKernelBridge::register_tlas`].
 /// - all other kinds: the surface-share UUID of a host-side
-///   `RhiPixelBuffer` / `Texture` (same convention compute and
+///   `PixelBuffer` / `Texture` (same convention compute and
 ///   graphics use).
 #[derive(Debug, Clone)]
 pub struct RayTracingBindingValue {
@@ -234,7 +234,7 @@ pub trait RayTracingKernelBridge: Send + Sync {
     /// Run one trace against a previously-registered kernel.
     ///
     /// Resolves binding `target_id`s through the application-provided
-    /// resolver (UUID → `RhiPixelBuffer` / `Texture` for non-AS
+    /// resolver (UUID → `PixelBuffer` / `Texture` for non-AS
     /// kinds; `as_id` → `Arc<VulkanAccelerationStructure>` for the AS
     /// kind), then submits + waits on the kernel's own command
     /// buffer + fence. Errors include unrecognized `kernel_id`,

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -16,7 +16,7 @@ use std::ffi::c_void;
 
 use parking_lot::Mutex;
 
-use crate::core::rhi::RhiPixelBuffer;
+use crate::core::rhi::PixelBuffer;
 use crate::core::{Result, Error};
 #[cfg(target_os = "linux")]
 use crate::host_rhi::HostTextureExt;
@@ -39,7 +39,7 @@ use crate::apple::xpc_ffi::{
 #[derive(Debug, Clone)]
 pub struct CachedSurface {
     /// The resolved pixel buffer.
-    pub pixel_buffer: RhiPixelBuffer,
+    pub pixel_buffer: PixelBuffer,
     /// Number of times this surface has been checked out.
     pub checkout_count: u64,
 }
@@ -57,7 +57,7 @@ impl SurfaceCache {
         }
     }
 
-    fn insert(&mut self, surface_id: String, pixel_buffer: RhiPixelBuffer) {
+    fn insert(&mut self, surface_id: String, pixel_buffer: PixelBuffer) {
         self.surfaces.insert(
             surface_id,
             CachedSurface {
@@ -235,7 +235,7 @@ impl SurfaceStore {
     /// If this pixel buffer was already checked in, returns the existing ID.
     /// Otherwise, sends the mach port to the surface-share service and receives a new ID.
     #[cfg(target_os = "macos")]
-    pub fn check_in(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
         use crate::apple::corevideo_ffi::{mach_port_deallocate, mach_task_self, IOSurfaceGetID};
 
         // Get the IOSurface ID for deduplication
@@ -304,7 +304,7 @@ impl SurfaceStore {
     ///
     /// Returns from cache if available, otherwise fetches from the surface-share service.
     #[cfg(target_os = "macos")]
-    pub fn check_out(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out(&self, surface_id: &str) -> Result<PixelBuffer> {
         // Check cache first
         {
             let mut cache = self.inner.cache.lock();
@@ -328,15 +328,15 @@ impl SurfaceStore {
 
         // Import the pixel buffer from mach port
         use crate::core::rhi::{
-            PixelFormat, RhiExternalHandle, RhiPixelBufferImport, RhiPixelBufferRef,
+            PixelFormat, RhiExternalHandle, RhiPixelBufferImport, PixelBufferRef,
         };
 
         let handle = RhiExternalHandle::IOSurfaceMachPort { port: mach_port };
         // Width/height/format are extracted from the IOSurface itself after import
         // We pass dummy values as the import will query the actual values from the IOSurface
         let pixel_buffer_ref =
-            RhiPixelBufferRef::from_external_handle(handle, 0, 0, PixelFormat::default())?;
-        let pixel_buffer = RhiPixelBuffer::new(pixel_buffer_ref);
+            PixelBufferRef::from_external_handle(handle, 0, 0, PixelFormat::default())?;
+        let pixel_buffer = PixelBuffer::new(pixel_buffer_ref);
 
         // Cache for future use
         self.inner
@@ -509,7 +509,7 @@ impl SurfaceStore {
     /// The client provides the UUID (PixelBufferPoolId) and the buffer.
     /// This is used for pre-registering pooled buffers.
     #[cfg(target_os = "macos")]
-    pub fn register_buffer(&self, pool_id: &str, pixel_buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn register_buffer(&self, pool_id: &str, pixel_buffer: &PixelBuffer) -> Result<()> {
         use crate::apple::corevideo_ffi::{mach_port_deallocate, mach_task_self};
 
         // Export mach port from the pixel buffer
@@ -628,18 +628,18 @@ impl SurfaceStore {
     ///
     /// Returns the mach port for the given UUID.
     #[cfg(target_os = "macos")]
-    pub fn lookup_buffer(&self, pool_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn lookup_buffer(&self, pool_id: &str) -> Result<PixelBuffer> {
         let mach_port = self.lookup_from_surface_share(pool_id)?;
 
         // Import the pixel buffer from mach port
         use crate::core::rhi::{
-            PixelFormat, RhiExternalHandle, RhiPixelBufferImport, RhiPixelBufferRef,
+            PixelFormat, RhiExternalHandle, RhiPixelBufferImport, PixelBufferRef,
         };
 
         let handle = RhiExternalHandle::IOSurfaceMachPort { port: mach_port };
         let pixel_buffer_ref =
-            RhiPixelBufferRef::from_external_handle(handle, 0, 0, PixelFormat::default())?;
-        Ok(RhiPixelBuffer::new(pixel_buffer_ref))
+            PixelBufferRef::from_external_handle(handle, 0, 0, PixelFormat::default())?;
+        Ok(PixelBuffer::new(pixel_buffer_ref))
     }
 
     /// Send lookup request to surface-share service via XPC (new protocol).
@@ -854,7 +854,7 @@ impl SurfaceStore {
 
     /// Check in a pixel buffer via Unix socket, returning a surface ID.
     #[cfg(target_os = "linux")]
-    pub fn check_in(&self, pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
         use crate::core::rhi::RhiPixelBufferExport;
 
         // Export every plane's fd. Single-plane pixel buffers return a
@@ -935,7 +935,7 @@ impl SurfaceStore {
 
     /// Check out a surface by ID via Unix socket.
     #[cfg(target_os = "linux")]
-    pub fn check_out(&self, surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out(&self, surface_id: &str) -> Result<PixelBuffer> {
         // Check cache first
         {
             let mut cache = self.inner.cache.lock();
@@ -1013,7 +1013,7 @@ impl SurfaceStore {
             })
             .collect();
         let pixel_buffer =
-            RhiPixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())?;
+            PixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())?;
 
         // Cache for future use
         self.inner
@@ -1026,7 +1026,7 @@ impl SurfaceStore {
 
     /// Register a buffer with the surface-share service via Unix socket.
     #[cfg(target_os = "linux")]
-    pub fn register_buffer(&self, pool_id: &str, pixel_buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn register_buffer(&self, pool_id: &str, pixel_buffer: &PixelBuffer) -> Result<()> {
         use crate::core::rhi::RhiPixelBufferExport;
 
         // Export the buffer's natural handle — DMA-BUF or OPAQUE_FD per
@@ -1204,7 +1204,7 @@ impl SurfaceStore {
     pub fn register_pixel_buffer_with_timeline(
         &self,
         surface_id: &str,
-        pixel_buffer: &RhiPixelBuffer,
+        pixel_buffer: &PixelBuffer,
         timeline: Option<&crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) -> Result<()> {
         use crate::core::rhi::RhiPixelBufferExport;
@@ -1312,7 +1312,7 @@ impl SurfaceStore {
     /// buffer in the same process (e.g. the escalate-on-behalf flow) skip the
     /// per-frame unix-socket round-trip and DMA-BUF re-import.
     #[cfg(target_os = "linux")]
-    pub fn lookup_buffer(&self, pool_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn lookup_buffer(&self, pool_id: &str) -> Result<PixelBuffer> {
         {
             let cache = self.inner.cache.lock();
             if let Some(cached) = cache.surfaces.get(pool_id) {
@@ -1357,7 +1357,7 @@ impl SurfaceStore {
         }
 
         // Dispatch on the wire-level handle type. OPAQUE_FD lookups can't
-        // construct a host-side `RhiPixelBuffer` (that import path is
+        // construct a host-side `PixelBuffer` (that import path is
         // DMA-BUF-only — see `RhiPixelBufferImport::from_external_plane_handles`).
         // Subprocess consumers go through `streamlib-surface-client` directly
         // and import via `streamlib_consumer_rhi::ConsumerVulkanPixelBuffer::from_opaque_fd`.
@@ -1372,7 +1372,7 @@ impl SurfaceStore {
             }
             return Err(Error::NotSupported(
                 "SurfaceStore::lookup_buffer: surface registered with \
-                 handle_type=\"opaque_fd\"; the host-side RhiPixelBuffer \
+                 handle_type=\"opaque_fd\"; the host-side PixelBuffer \
                  import path is DMA-BUF-only. Subprocess consumers should \
                  use streamlib-surface-client directly + \
                  ConsumerVulkanPixelBuffer::from_opaque_fd."
@@ -1397,7 +1397,7 @@ impl SurfaceStore {
                 size: *size as usize,
             })
             .collect();
-        RhiPixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())
+        PixelBuffer::from_external_plane_handles(&handles, 0, 0, PixelFormat::default())
     }
 
     /// Publish a producer's post-release `VkImageLayout` for the given
@@ -1619,28 +1619,28 @@ impl SurfaceStore {
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    pub fn check_in(&self, _pixel_buffer: &RhiPixelBuffer) -> Result<String> {
+    pub fn check_in(&self, _pixel_buffer: &PixelBuffer) -> Result<String> {
         Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    pub fn check_out(&self, _surface_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn check_out(&self, _surface_id: &str) -> Result<PixelBuffer> {
         Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    pub fn register_buffer(&self, _pool_id: &str, _pixel_buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn register_buffer(&self, _pool_id: &str, _pixel_buffer: &PixelBuffer) -> Result<()> {
         Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    pub fn lookup_buffer(&self, _pool_id: &str) -> Result<RhiPixelBuffer> {
+    pub fn lookup_buffer(&self, _pool_id: &str) -> Result<PixelBuffer> {
         Err(Error::NotSupported(
             "SurfaceStore is only supported on macOS and Linux".into(),
         ))

--- a/libs/streamlib-engine/src/core/rhi/blitter.rs
+++ b/libs/streamlib-engine/src/core/rhi/blitter.rs
@@ -3,13 +3,13 @@
 
 //! GPU blit operations with texture caching.
 
-use super::RhiPixelBuffer;
+use super::PixelBuffer;
 use crate::core::Result;
 
 /// Trait for GPU blit operations with texture caching.
 pub trait RhiBlitter: Send + Sync {
     /// Copy pixels between same-format, same-size buffers.
-    fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()>;
+    fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()>;
 
     /// Copy from raw IOSurface (platform-specific, unsafe).
     ///
@@ -19,7 +19,7 @@ pub trait RhiBlitter: Send + Sync {
     unsafe fn blit_copy_iosurface_raw(
         &self,
         src: *const std::ffi::c_void,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()>;

--- a/libs/streamlib-engine/src/core/rhi/external_handle.rs
+++ b/libs/streamlib-engine/src/core/rhi/external_handle.rs
@@ -71,7 +71,7 @@ impl RhiExternalHandle {
     }
 }
 
-/// Extension trait for exporting RhiPixelBuffer to external handle.
+/// Extension trait for exporting PixelBuffer to external handle.
 pub trait RhiPixelBufferExport {
     /// Export the GPU buffer for sharing with another process.
     fn export_handle(&self) -> Result<RhiExternalHandle>;
@@ -87,7 +87,7 @@ pub trait RhiPixelBufferExport {
     }
 }
 
-/// Extension trait for importing RhiPixelBuffer from external handle.
+/// Extension trait for importing PixelBuffer from external handle.
 pub trait RhiPixelBufferImport {
     /// Import a GPU buffer from a single external handle.
     fn from_external_handle(
@@ -128,7 +128,7 @@ pub trait RhiPixelBufferImport {
 }
 
 #[cfg(target_os = "linux")]
-impl RhiPixelBufferExport for super::RhiPixelBuffer {
+impl RhiPixelBufferExport for super::PixelBuffer {
     /// Returns the natural handle type for the underlying allocation —
     /// `RhiExternalHandle::OpaqueFd` for OPAQUE_FD-flavored buffers
     /// (see [`crate::vulkan::rhi::HostVulkanPixelBuffer::new_opaque_fd_export`]),
@@ -140,7 +140,7 @@ impl RhiPixelBufferExport for super::RhiPixelBuffer {
 }
 
 #[cfg(target_os = "linux")]
-impl RhiPixelBufferImport for super::RhiPixelBuffer {
+impl RhiPixelBufferImport for super::PixelBuffer {
     fn from_external_handle(
         handle: RhiExternalHandle,
         width: u32,
@@ -235,11 +235,11 @@ impl RhiPixelBufferImport for super::RhiPixelBuffer {
                 format,
             )?;
 
-        let pixel_buffer_ref = super::RhiPixelBufferRef {
+        let pixel_buffer_ref = super::PixelBufferRef {
             inner: std::sync::Arc::new(vulkan_pixel_buffer),
         };
 
-        Ok(super::RhiPixelBuffer::new(pixel_buffer_ref))
+        Ok(super::PixelBuffer::new(pixel_buffer_ref))
     }
 }
 
@@ -276,7 +276,7 @@ mod tests {
         // silently miscoercing through the DMA-BUF code path.
         let opaque = RhiExternalHandle::OpaqueFd { fd: -1, size: 0 };
         let result =
-            <super::super::RhiPixelBuffer as RhiPixelBufferImport>::from_external_plane_handles(
+            <super::super::PixelBuffer as RhiPixelBufferImport>::from_external_plane_handles(
                 &[opaque],
                 1,
                 1,

--- a/libs/streamlib-engine/src/core/rhi/format_converter.rs
+++ b/libs/streamlib-engine/src/core/rhi/format_converter.rs
@@ -10,7 +10,7 @@
 //! The converter is thread-safe and can be used concurrently from multiple
 //! processors without any locking.
 
-use super::{PixelFormat, RhiPixelBuffer};
+use super::{PixelFormat, PixelBuffer};
 use crate::core::Result;
 
 /// Stateless format converter - a "recipe" for pixel format conversion.
@@ -100,7 +100,7 @@ impl RhiFormatConverter {
     ///
     /// This is thread-safe and can be called concurrently from multiple
     /// processors - no internal locking is performed.
-    pub fn convert(&self, source: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn convert(&self, source: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         #[cfg(target_os = "macos")]
         {
             self.inner.convert(source, dest)

--- a/libs/streamlib-engine/src/core/rhi/gl_interop.rs
+++ b/libs/streamlib-engine/src/core/rhi/gl_interop.rs
@@ -11,7 +11,7 @@
 //! - Linux: DMA-BUF → GL texture via `EGL_EXT_image_dma_buf_import` (future)
 //! - Windows: DXGI → GL texture via `WGL_NV_DX_interop` (future)
 
-use crate::core::rhi::RhiPixelBuffer;
+use crate::core::rhi::PixelBuffer;
 use crate::core::{Result, Error};
 use std::ffi::c_void;
 
@@ -142,7 +142,7 @@ impl GlTextureBinding {
     /// # Requirements
     /// - GL context must be current
     /// - Pixel buffer must have GPU-compatible backing
-    pub fn update(&mut self, gl_ctx: &GlContext, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn update(&mut self, gl_ctx: &GlContext, buffer: &PixelBuffer) -> Result<()> {
         #[cfg(target_os = "macos")]
         {
             self.inner.update(&gl_ctx.inner, buffer)

--- a/libs/streamlib-engine/src/core/rhi/mod.rs
+++ b/libs/streamlib-engine/src/core/rhi/mod.rs
@@ -50,11 +50,11 @@ pub use ray_tracing_kernel::{
 pub use format_converter::RhiFormatConverter;
 pub use format_converter_cache::RhiFormatConverterCache;
 pub use gl_interop::{gl_constants, GlContext, GlTextureBinding};
-pub use pixel_buffer::RhiPixelBuffer;
+pub use pixel_buffer::PixelBuffer;
 pub use pixel_buffer_pool::{PixelBufferDescriptor, PixelBufferPoolId};
 // Note: RhiPixelBufferPool is intentionally not exported - use GpuContext::acquire_pixel_buffer()
 pub(crate) use pixel_buffer_pool::RhiPixelBufferPool;
-pub use pixel_buffer_ref::RhiPixelBufferRef;
+pub use pixel_buffer_ref::PixelBufferRef;
 // PixelFormat / TextureFormat / TextureUsages / VulkanLayout are
 // defined in the `streamlib-consumer-rhi` crate so subprocess-shape dep
 // graphs can reach them without pulling streamlib. Re-exported here for

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
@@ -5,11 +5,11 @@
 
 use std::sync::Arc;
 
-use super::{PixelFormat, RhiPixelBufferRef};
+use super::{PixelFormat, PixelBufferRef};
 
 /// Pixel buffer with cached dimensions.
 ///
-/// Wraps [`RhiPixelBufferRef`] in an Arc for cheap cloning. Clone only increments
+/// Wraps [`PixelBufferRef`] in an Arc for cheap cloning. Clone only increments
 /// the Arc refcount - it does NOT increment the platform buffer refcount (e.g.,
 /// CVPixelBufferRetain on macOS). This is critical for avoiding memory leaks
 /// when sharing buffers between Rust and Python.
@@ -17,22 +17,22 @@ use super::{PixelFormat, RhiPixelBufferRef};
 /// The platform buffer is retained exactly once (when created) and released
 /// exactly once (when the last Arc reference is dropped).
 #[derive(Clone)]
-pub struct RhiPixelBuffer {
+pub struct PixelBuffer {
     /// The underlying platform buffer reference, shared via Arc.
     /// Clone increments Arc refcount, NOT platform refcount.
-    pub(crate) ref_: Arc<RhiPixelBufferRef>,
+    pub(crate) ref_: Arc<PixelBufferRef>,
     /// Cached width (queried once at construction).
     pub width: u32,
     /// Cached height (queried once at construction).
     pub height: u32,
 }
 
-impl RhiPixelBuffer {
+impl PixelBuffer {
     /// Create from a platform buffer reference.
     ///
     /// Queries width and height from the platform once and caches them.
-    /// The RhiPixelBufferRef is wrapped in Arc for cheap cloning.
-    pub fn new(ref_: RhiPixelBufferRef) -> Self {
+    /// The PixelBufferRef is wrapped in Arc for cheap cloning.
+    pub fn new(ref_: PixelBufferRef) -> Self {
         let width = ref_.width();
         let height = ref_.height();
         Self {
@@ -43,7 +43,7 @@ impl RhiPixelBuffer {
     }
 
     /// Wrap an externally-allocated `Arc<HostVulkanPixelBuffer>` so it can
-    /// be passed to host-side APIs that take `&RhiPixelBuffer` (e.g.
+    /// be passed to host-side APIs that take `&PixelBuffer` (e.g.
     /// [`crate::core::context::SurfaceStore::register_pixel_buffer_with_timeline`])
     /// without going through the [`crate::core::context::PixelBufferPoolManager`].
     /// Used by application setup code that wants to allocate a staging
@@ -56,7 +56,7 @@ impl RhiPixelBuffer {
         let width = buffer.width();
         let height = buffer.height();
         Self {
-            ref_: Arc::new(RhiPixelBufferRef { inner: buffer }),
+            ref_: Arc::new(PixelBufferRef { inner: buffer }),
             width,
             height,
         }
@@ -68,7 +68,7 @@ impl RhiPixelBuffer {
     }
 
     /// Get the underlying buffer reference.
-    pub fn buffer_ref(&self) -> &RhiPixelBufferRef {
+    pub fn buffer_ref(&self) -> &PixelBufferRef {
         &self.ref_
     }
 
@@ -80,7 +80,7 @@ impl RhiPixelBuffer {
 
     /// Mapped base address for the given plane, or null if out of range.
     /// Plane 0 on a VMA-allocated or single-plane-imported buffer points
-    /// at the same bytes as [`mapped_ptr`](RhiPixelBufferRef::plane_base_address)
+    /// at the same bytes as [`mapped_ptr`](PixelBufferRef::plane_base_address)
     /// with index 0.
     pub fn plane_base_address(&self, plane_index: u32) -> *mut u8 {
         self.ref_.plane_base_address(plane_index)
@@ -98,9 +98,9 @@ impl RhiPixelBuffer {
     }
 }
 
-impl std::fmt::Debug for RhiPixelBuffer {
+impl std::fmt::Debug for PixelBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RhiPixelBuffer")
+        f.debug_struct("PixelBuffer")
             .field("width", &self.width)
             .field("height", &self.height)
             .field("format", &self.format())
@@ -108,4 +108,4 @@ impl std::fmt::Debug for RhiPixelBuffer {
     }
 }
 
-// Send + Sync inherited from Arc<RhiPixelBufferRef>
+// Send + Sync inherited from Arc<PixelBufferRef>

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer_pool.rs
@@ -3,7 +3,7 @@
 
 //! Pixel buffer pool for efficient buffer allocation.
 
-use super::{PixelFormat, RhiPixelBuffer};
+use super::{PixelFormat, PixelBuffer};
 use crate::core::Result;
 
 /// Platform-agnostic identifier for a pooled pixel buffer.
@@ -89,7 +89,7 @@ impl RhiPixelBufferPool {
     ///
     /// Returns (id, buffer) where id is the platform-agnostic identifier.
     /// Returns a recycled buffer if available, or allocates a new one.
-    pub fn acquire(&self) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    pub fn acquire(&self) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         #[cfg(target_os = "macos")]
         {
             self.inner.acquire()

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer_ref.rs
@@ -14,7 +14,7 @@ use super::PixelFormat;
 ///
 /// Clone increments the appropriate refcount, Drop decrements it.
 /// No image data is ever copied.
-pub struct RhiPixelBufferRef {
+pub struct PixelBufferRef {
     #[cfg(target_os = "macos")]
     pub(crate) inner: std::ptr::NonNull<std::ffi::c_void>,
 
@@ -25,7 +25,7 @@ pub struct RhiPixelBufferRef {
     pub(crate) _marker: std::marker::PhantomData<()>,
 }
 
-impl RhiPixelBufferRef {
+impl PixelBufferRef {
     /// Query the pixel format from the platform.
     pub fn format(&self) -> PixelFormat {
         #[cfg(target_os = "macos")]
@@ -126,7 +126,7 @@ impl RhiPixelBufferRef {
         self.inner.as_ptr()
     }
 
-    /// Create an RhiPixelBufferRef from a raw IOSurfaceRef (macOS only).
+    /// Create an PixelBufferRef from a raw IOSurfaceRef (macOS only).
     ///
     /// This is useful for cross-process frame sharing where the IOSurfaceRef
     /// is received from another process.
@@ -141,7 +141,7 @@ impl RhiPixelBufferRef {
     }
 }
 
-impl Clone for RhiPixelBufferRef {
+impl Clone for PixelBufferRef {
     fn clone(&self) -> Self {
         #[cfg(target_os = "macos")]
         {
@@ -162,7 +162,7 @@ impl Clone for RhiPixelBufferRef {
     }
 }
 
-impl Drop for RhiPixelBufferRef {
+impl Drop for PixelBufferRef {
     fn drop(&mut self) {
         #[cfg(target_os = "macos")]
         {
@@ -174,12 +174,12 @@ impl Drop for RhiPixelBufferRef {
 }
 
 // Safety: CVPixelBufferRef is thread-safe (reference counted with atomic ops)
-unsafe impl Send for RhiPixelBufferRef {}
-unsafe impl Sync for RhiPixelBufferRef {}
+unsafe impl Send for PixelBufferRef {}
+unsafe impl Sync for PixelBufferRef {}
 
-impl std::fmt::Debug for RhiPixelBufferRef {
+impl std::fmt::Debug for PixelBufferRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RhiPixelBufferRef")
+        f.debug_struct("PixelBufferRef")
             .field("format", &self.format())
             .field("width", &self.width())
             .field("height", &self.height())

--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer_ref.rs
@@ -126,7 +126,7 @@ impl PixelBufferRef {
         self.inner.as_ptr()
     }
 
-    /// Create an PixelBufferRef from a raw IOSurfaceRef (macOS only).
+    /// Create a PixelBufferRef from a raw IOSurfaceRef (macOS only).
     ///
     /// This is useful for cross-process frame sharing where the IOSurfaceRef
     /// is received from another process.

--- a/libs/streamlib-engine/src/core/rhi/texture_cache.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture_cache.rs
@@ -3,7 +3,7 @@
 
 //! Texture cache for creating texture views from pixel buffers.
 
-use super::{PixelFormat, RhiPixelBuffer};
+use super::{PixelFormat, PixelBuffer};
 use crate::core::Result;
 
 /// Creates texture views from pixel buffers.
@@ -27,7 +27,7 @@ impl RhiTextureCache {
     ///
     /// The view is ephemeral - create it each frame and let it drop after use.
     /// The platform manages GPU synchronization internally.
-    pub fn create_view(&self, buffer: &RhiPixelBuffer) -> Result<RhiTextureView> {
+    pub fn create_view(&self, buffer: &PixelBuffer) -> Result<RhiTextureView> {
         #[cfg(target_os = "macos")]
         {
             self.inner.create_view(buffer)
@@ -35,7 +35,7 @@ impl RhiTextureCache {
         #[cfg(target_os = "linux")]
         {
             // VulkanTextureCache needs a VkImage to create a view from,
-            // but RhiPixelBuffer on Linux wraps a VkBuffer (not VkImage).
+            // but PixelBuffer on Linux wraps a VkBuffer (not VkImage).
             // For now, return NotSupported until pixel buffer -> texture path is wired.
             let _ = buffer;
             Err(crate::core::Error::NotSupported(
@@ -88,7 +88,7 @@ pub struct RhiTextureView {
 
     /// Keep the source buffer alive while this view exists.
     #[allow(dead_code)]
-    pub(crate) source_buffer: RhiPixelBuffer,
+    pub(crate) source_buffer: PixelBuffer,
 }
 
 impl RhiTextureView {

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -5,7 +5,7 @@
 //!
 //! In-tree surface adapters and engine-internal RHI code reach for
 //! raw Vulkan handles through this module. The SDK-bucket types
-//! ([`Texture`], [`RhiPixelBufferRef`], [`GpuDevice`]) have no
+//! ([`Texture`], [`PixelBufferRef`], [`GpuDevice`]) have no
 //! inherent `vulkan_*` accessors — the only way to the privileged
 //! surface is through the extension traits defined here. Importing
 //! one of these traits is an explicit acknowledgment that the caller
@@ -46,7 +46,7 @@
 //! ```
 //!
 //! [`Texture`]: crate::core::rhi::Texture
-//! [`RhiPixelBufferRef`]: crate::core::rhi::RhiPixelBufferRef
+//! [`PixelBufferRef`]: crate::core::rhi::PixelBufferRef
 //! [`GpuDevice`]: crate::core::rhi::GpuDevice
 
 use std::sync::Arc;
@@ -61,7 +61,7 @@ pub use crate::vulkan::rhi::{
 
 pub use vulkanalia::vk::GeometryInstanceFlagsKHR;
 
-use crate::core::rhi::{GpuDevice, RhiPixelBufferRef, Texture};
+use crate::core::rhi::{GpuDevice, PixelBufferRef, Texture};
 
 /// Privileged engine-side accessors for [`Texture`].
 ///
@@ -97,19 +97,19 @@ impl HostTextureExt for Texture {
     }
 }
 
-/// Privileged engine-side accessor for [`RhiPixelBufferRef`].
+/// Privileged engine-side accessor for [`PixelBufferRef`].
 ///
 /// In-tree adapters that issue `vkCmdCopyImageToBuffer` or
 /// `vkCmdCopyBufferToImage` against a HOST_VISIBLE staging buffer
 /// reach the underlying [`HostVulkanPixelBuffer`] through this trait.
 ///
 /// [`HostVulkanPixelBuffer`]: crate::vulkan::rhi::HostVulkanPixelBuffer
-pub trait HostRhiPixelBufferRefExt {
+pub trait HostPixelBufferRefExt {
     /// Borrow the underlying [`HostVulkanPixelBuffer`].
     fn vulkan_inner(&self) -> &Arc<HostVulkanPixelBuffer>;
 }
 
-impl HostRhiPixelBufferRefExt for RhiPixelBufferRef {
+impl HostPixelBufferRefExt for PixelBufferRef {
     fn vulkan_inner(&self) -> &Arc<HostVulkanPixelBuffer> {
         &self.inner
     }

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -160,7 +160,7 @@ pub mod host_rhi;
     feature = "backend-vulkan",
     all(target_os = "linux", not(feature = "backend-metal"))
 ))]
-pub use host_rhi::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt};
+pub use host_rhi::{HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt};
 
 // WebRTC streaming (cross-platform)
 pub use core::streaming::{WebRtcSession, WhepClient, WhepConfig, WhipClient, WhipConfig};
@@ -345,7 +345,7 @@ pub mod sdk {
     ))]
     pub mod engine {
         pub use crate::host_rhi;
-        pub use crate::{HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt};
+        pub use crate::{HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt};
         #[cfg(target_os = "linux")]
         pub use crate::linux_surface_share;
     }

--- a/libs/streamlib-engine/src/metal/rhi/blitter.rs
+++ b/libs/streamlib-engine/src/metal/rhi/blitter.rs
@@ -6,7 +6,7 @@
 use crate::apple::iosurface::create_metal_texture_from_iosurface;
 use crate::apple::texture_pool_macos::get_iosurface_id;
 use crate::core::rhi::blitter::RhiBlitter;
-use crate::core::rhi::{RhiCommandQueue, RhiPixelBuffer};
+use crate::core::rhi::{RhiCommandQueue, PixelBuffer};
 use crate::core::{Result, Error};
 use metal::foreign_types::ForeignTypeRef;
 use objc2::rc::Retained;
@@ -75,7 +75,7 @@ impl MetalBlitter {
 }
 
 impl RhiBlitter for MetalBlitter {
-    fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         // Get IOSurfaces from both buffers
         let src_iosurface = src
             .buffer_ref()
@@ -144,7 +144,7 @@ impl RhiBlitter for MetalBlitter {
     unsafe fn blit_copy_iosurface_raw(
         &self,
         src: *const std::ffi::c_void,
-        dest: &RhiPixelBuffer,
+        dest: &PixelBuffer,
         width: u32,
         height: u32,
     ) -> Result<()> {

--- a/libs/streamlib-engine/src/metal/rhi/format_converter.rs
+++ b/libs/streamlib-engine/src/metal/rhi/format_converter.rs
@@ -11,7 +11,7 @@ use crate::apple::vimage_ffi::{
     vimage_error_description, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
     CVPixelBufferLockBaseAddress, CVPixelBufferUnlockBaseAddress,
 };
-use crate::core::rhi::{PixelFormat, RhiPixelBuffer};
+use crate::core::rhi::{PixelFormat, PixelBuffer};
 use crate::core::{Result, Error};
 use std::ptr;
 
@@ -111,7 +111,7 @@ impl FormatConverterMacOS {
     ///
     /// Thread-safe: vImageConvert_AnyToAny is safe for concurrent use with
     /// the same converter as long as source/dest buffers are distinct.
-    pub fn convert(&self, source: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn convert(&self, source: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         // Verify dimensions match
         if source.width != dest.width || source.height != dest.height {
             return Err(Error::Configuration(format!(

--- a/libs/streamlib-engine/src/metal/rhi/gl_interop.rs
+++ b/libs/streamlib-engine/src/metal/rhi/gl_interop.rs
@@ -13,7 +13,7 @@
 //! - Texture IDs are STABLE - safe to cache in Skia objects
 
 use crate::apple::corevideo_ffi::CVPixelBufferRef;
-use crate::core::rhi::RhiPixelBuffer;
+use crate::core::rhi::PixelBuffer;
 use crate::core::{Result, Error};
 use std::ffi::c_void;
 
@@ -400,7 +400,7 @@ impl GlTextureBinding {
     /// # Requirements
     /// - GL context must be current
     /// - Pixel buffer must have IOSurface backing (created with proper attributes)
-    pub fn update(&mut self, gl_ctx: &MacOsGlContext, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn update(&mut self, gl_ctx: &MacOsGlContext, buffer: &PixelBuffer) -> Result<()> {
         unsafe {
             let cv_buffer: CVPixelBufferRef = buffer.as_ptr();
 

--- a/libs/streamlib-engine/src/metal/rhi/pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/metal/rhi/pixel_buffer_pool.rs
@@ -25,8 +25,8 @@ use crate::apple::corevideo_ffi::{
     kCVReturnSuccess, CVPixelBufferGetIOSurface, CVPixelBufferRef, IOSurfaceGetID,
 };
 use crate::core::rhi::{
-    PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, RhiPixelBuffer, RhiPixelBufferPool,
-    RhiPixelBufferRef,
+    PixelBufferDescriptor, PixelBufferPoolId, PixelFormat, PixelBuffer, RhiPixelBufferPool,
+    PixelBufferRef,
 };
 use crate::core::{Result, Error};
 
@@ -81,7 +81,7 @@ impl PixelBufferPoolMacOS {
     ///
     /// Returns (id, buffer) where id is a stable UUID for this physical buffer.
     /// If CVPixelBufferPool returns a recycled buffer, the same UUID is returned.
-    pub fn acquire(&self) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    pub fn acquire(&self) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         tracing::trace!("PixelBufferPoolMacOS::acquire: requesting buffer");
         let mut pixel_buffer: CVPixelBufferRef = std::ptr::null_mut();
 
@@ -109,7 +109,7 @@ impl PixelBufferPoolMacOS {
 
         // The pool gives us a retained buffer, so use no_retain
         let buffer_ref = unsafe {
-            RhiPixelBufferRef::from_cv_pixel_buffer_no_retain(pixel_buffer)
+            PixelBufferRef::from_cv_pixel_buffer_no_retain(pixel_buffer)
                 .ok_or_else(|| Error::GpuError("Null pixel buffer from pool".into()))?
         };
 
@@ -155,7 +155,7 @@ impl PixelBufferPoolMacOS {
             new_id
         };
 
-        Ok((pool_id, RhiPixelBuffer::new(buffer_ref)))
+        Ok((pool_id, PixelBuffer::new(buffer_ref)))
     }
 }
 

--- a/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
@@ -386,7 +386,7 @@ fn create_cv_buffer_from_iosurface(
         .ok_or_else(|| Error::Configuration("Failed to wrap CVPixelBuffer".into()))
 }
 
-/// Create an PixelBufferRef from a raw IOSurfaceRef.
+/// Create a PixelBufferRef from a raw IOSurfaceRef.
 ///
 /// This is the implementation called from core/rhi/pixel_buffer_ref.rs.
 ///

--- a/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
+++ b/libs/streamlib-engine/src/metal/rhi/pixel_buffer_ref.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! macOS RhiPixelBufferRef implementation.
+//! macOS PixelBufferRef implementation.
 
 use std::ptr::NonNull;
 
@@ -9,9 +9,9 @@ use crate::apple::corevideo_ffi::{
     CVPixelBufferGetHeight, CVPixelBufferGetPixelFormatType, CVPixelBufferGetWidth,
     CVPixelBufferRef, CVPixelBufferRelease, CVPixelBufferRetain,
 };
-use crate::core::rhi::{PixelFormat, RhiPixelBufferRef};
+use crate::core::rhi::{PixelFormat, PixelBufferRef};
 
-impl RhiPixelBufferRef {
+impl PixelBufferRef {
     /// Create from a raw CVPixelBufferRef.
     ///
     /// # Safety
@@ -64,33 +64,33 @@ impl RhiPixelBufferRef {
 }
 
 /// Query pixel format from CVPixelBuffer.
-pub(crate) fn format_impl(buffer_ref: &RhiPixelBufferRef) -> PixelFormat {
+pub(crate) fn format_impl(buffer_ref: &PixelBufferRef) -> PixelFormat {
     let cv_format = unsafe { CVPixelBufferGetPixelFormatType(buffer_ref.inner.as_ptr()) };
     PixelFormat::from_cv_pixel_format_type(cv_format)
 }
 
 /// Query width from CVPixelBuffer.
-pub(crate) fn width_impl(buffer_ref: &RhiPixelBufferRef) -> u32 {
+pub(crate) fn width_impl(buffer_ref: &PixelBufferRef) -> u32 {
     unsafe { CVPixelBufferGetWidth(buffer_ref.inner.as_ptr()) as u32 }
 }
 
 /// Query height from CVPixelBuffer.
-pub(crate) fn height_impl(buffer_ref: &RhiPixelBufferRef) -> u32 {
+pub(crate) fn height_impl(buffer_ref: &PixelBufferRef) -> u32 {
     unsafe { CVPixelBufferGetHeight(buffer_ref.inner.as_ptr()) as u32 }
 }
 
 /// Clone implementation - retains the CVPixelBuffer.
-pub(crate) fn clone_impl(buffer_ref: &RhiPixelBufferRef) -> RhiPixelBufferRef {
+pub(crate) fn clone_impl(buffer_ref: &PixelBufferRef) -> PixelBufferRef {
     unsafe {
         CVPixelBufferRetain(buffer_ref.inner.as_ptr());
-        RhiPixelBufferRef {
+        PixelBufferRef {
             inner: buffer_ref.inner,
         }
     }
 }
 
 /// Drop implementation - releases the CVPixelBuffer.
-pub(crate) fn drop_impl(buffer_ref: &mut RhiPixelBufferRef) {
+pub(crate) fn drop_impl(buffer_ref: &mut PixelBufferRef) {
     unsafe {
         CVPixelBufferRelease(buffer_ref.inner.as_ptr());
     }
@@ -108,7 +108,7 @@ use crate::apple::corevideo_ffi::{
 use crate::core::rhi::{RhiExternalHandle, RhiPixelBufferExport, RhiPixelBufferImport};
 use crate::core::{Result, Error};
 
-impl RhiPixelBufferExport for RhiPixelBufferRef {
+impl RhiPixelBufferExport for PixelBufferRef {
     /// Export the CVPixelBuffer's IOSurface for cross-process sharing.
     ///
     /// Uses IOSurface ID for sharing. Requires kIOSurfaceIsGlobal to be set
@@ -162,7 +162,7 @@ impl RhiPixelBufferExport for RhiPixelBufferRef {
     }
 }
 
-impl RhiPixelBufferRef {
+impl PixelBufferRef {
     /// Export the CVPixelBuffer's IOSurface as a mach port for cross-process sharing.
     ///
     /// This is the recommended method for cross-process IOSurface sharing on macOS.
@@ -227,7 +227,7 @@ impl RhiPixelBufferRef {
     }
 }
 
-impl RhiPixelBufferImport for RhiPixelBufferRef {
+impl RhiPixelBufferImport for PixelBufferRef {
     /// Import a CVPixelBuffer from an external handle.
     ///
     /// Supports:
@@ -340,7 +340,7 @@ impl RhiPixelBufferImport for RhiPixelBufferRef {
 /// Helper to create CVPixelBuffer from IOSurface.
 fn create_cv_buffer_from_iosurface(
     iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
-) -> Result<RhiPixelBufferRef> {
+) -> Result<PixelBufferRef> {
     let mut cv_buffer: crate::apple::corevideo_ffi::CVPixelBufferRef = std::ptr::null_mut();
 
     let result = unsafe {
@@ -382,11 +382,11 @@ fn create_cv_buffer_from_iosurface(
 
     // The CVPixelBuffer is already retained by CreateWithIOSurface,
     // so use from_cv_pixel_buffer_no_retain
-    unsafe { RhiPixelBufferRef::from_cv_pixel_buffer_no_retain(cv_buffer) }
+    unsafe { PixelBufferRef::from_cv_pixel_buffer_no_retain(cv_buffer) }
         .ok_or_else(|| Error::Configuration("Failed to wrap CVPixelBuffer".into()))
 }
 
-/// Create an RhiPixelBufferRef from a raw IOSurfaceRef.
+/// Create an PixelBufferRef from a raw IOSurfaceRef.
 ///
 /// This is the implementation called from core/rhi/pixel_buffer_ref.rs.
 ///
@@ -394,7 +394,7 @@ fn create_cv_buffer_from_iosurface(
 /// The caller must ensure the IOSurfaceRef is valid.
 pub unsafe fn from_iosurface_ref_impl(
     iosurface: crate::apple::corevideo_ffi::IOSurfaceRef,
-) -> Result<RhiPixelBufferRef> {
+) -> Result<PixelBufferRef> {
     if iosurface.is_null() {
         return Err(Error::Configuration("IOSurfaceRef is null".into()));
     }

--- a/libs/streamlib-engine/src/metal/rhi/texture_cache.rs
+++ b/libs/streamlib-engine/src/metal/rhi/texture_cache.rs
@@ -23,7 +23,7 @@ use crate::apple::corevideo_ffi::{
     CVMetalTextureCacheCreateTextureFromImage, CVMetalTextureCacheFlush, CVMetalTextureCacheRef,
     CVMetalTextureGetTexture, CVMetalTextureRef,
 };
-use crate::core::rhi::{RhiPixelBuffer, RhiTextureCache, RhiTextureView};
+use crate::core::rhi::{PixelBuffer, RhiTextureCache, RhiTextureView};
 use crate::core::{Result, Error};
 
 /// macOS texture cache wrapping CVMetalTextureCache.
@@ -66,7 +66,7 @@ impl TextureCacheMacOS {
     /// Create a texture view from a pixel buffer.
     ///
     /// Automatically flushes stale cache entries every [`AUTO_FLUSH_INTERVAL`] calls.
-    pub fn create_view(&self, buffer: &RhiPixelBuffer) -> Result<RhiTextureView> {
+    pub fn create_view(&self, buffer: &PixelBuffer) -> Result<RhiTextureView> {
         // Auto-flush disabled temporarily - causes video skip
         // TODO: Investigate why flush causes frame discontinuity
         // let count = self.view_count.fetch_add(1, Ordering::Relaxed);

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_blitter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_blitter.rs
@@ -7,7 +7,7 @@ use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
 use crate::core::rhi::blitter::RhiBlitter;
-use crate::core::rhi::RhiPixelBuffer;
+use crate::core::rhi::PixelBuffer;
 use crate::core::{Result, Error};
 
 use super::HostVulkanDevice;
@@ -47,7 +47,7 @@ impl VulkanBlitter {
 }
 
 impl RhiBlitter for VulkanBlitter {
-    fn blit_copy(&self, src: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         let src_buffer = src.buffer_ref().inner.buffer();
         let dest_buffer = dest.buffer_ref().inner.buffer();
         let src_size = src.buffer_ref().inner.size();
@@ -160,7 +160,7 @@ impl RhiBlitter for VulkanBlitter {
     unsafe fn blit_copy_iosurface_raw(
         &self,
         _src: *const std::ffi::c_void,
-        _dest: &RhiPixelBuffer,
+        _dest: &PixelBuffer,
         _width: u32,
         _height: u32,
     ) -> Result<()> {
@@ -186,7 +186,7 @@ unsafe impl Sync for VulkanBlitter {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::rhi::{PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
+    use crate::core::rhi::{PixelFormat, PixelBuffer, PixelBufferRef};
     use crate::vulkan::rhi::{HostVulkanDevice, HostVulkanPixelBuffer};
     use std::sync::Arc;
 
@@ -194,10 +194,10 @@ mod tests {
         device: &Arc<HostVulkanDevice>,
         width: u32,
         height: u32,
-    ) -> RhiPixelBuffer {
+    ) -> PixelBuffer {
         let buf = HostVulkanPixelBuffer::new(device, width, height, 4, PixelFormat::Bgra32)
             .expect("pixel buffer allocation failed");
-        RhiPixelBuffer::new(RhiPixelBufferRef {
+        PixelBuffer::new(PixelBufferRef {
             inner: Arc::new(buf),
         })
     }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -25,7 +25,7 @@ use vulkanalia::vk;
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
 use crate::core::rhi::{
-    ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, RhiPixelBuffer, Texture,
+    ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, PixelBuffer, Texture,
 };
 use crate::core::{Result, Error};
 
@@ -261,7 +261,7 @@ impl VulkanComputeKernel {
 
     /// Bind a storage buffer at `binding`. The slot must be declared as
     /// [`ComputeBindingKind::StorageBuffer`] in the descriptor.
-    pub fn set_storage_buffer(&self, binding: u32, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn set_storage_buffer(&self, binding: u32, buffer: &PixelBuffer) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::StorageBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer)?;
         self.pending.lock().bindings.insert(
@@ -276,7 +276,7 @@ impl VulkanComputeKernel {
 
     /// Bind a uniform buffer at `binding`. The slot must be declared as
     /// [`ComputeBindingKind::UniformBuffer`] in the descriptor.
-    pub fn set_uniform_buffer(&self, binding: u32, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn set_uniform_buffer(&self, binding: u32, buffer: &PixelBuffer) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::UniformBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer)?;
         self.pending.lock().bindings.insert(
@@ -1084,7 +1084,7 @@ fn allocate_command_buffer(
     Ok(buffers[0])
 }
 
-fn vk_buffer_for(buffer: &RhiPixelBuffer) -> Result<(vk::Buffer, vk::DeviceSize)> {
+fn vk_buffer_for(buffer: &PixelBuffer) -> Result<(vk::Buffer, vk::DeviceSize)> {
     let inner = &buffer.buffer_ref().inner;
     Ok((inner.buffer(), inner.size()))
 }
@@ -1114,23 +1114,23 @@ mod tests {
     fn make_storage_buffer(
         device: &Arc<HostVulkanDevice>,
         element_count: u32,
-    ) -> RhiPixelBuffer {
+    ) -> PixelBuffer {
         let vk_buf = HostVulkanPixelBuffer::new(device, element_count, 1, 4, PixelFormat::Bgra32)
             .expect("Failed to create storage buffer");
-        let ref_ = crate::core::rhi::RhiPixelBufferRef {
+        let ref_ = crate::core::rhi::PixelBufferRef {
             inner: Arc::new(vk_buf),
         };
-        RhiPixelBuffer::new(ref_)
+        PixelBuffer::new(ref_)
     }
 
-    fn write_buffer_u32(buf: &RhiPixelBuffer, values: &[u32]) {
+    fn write_buffer_u32(buf: &PixelBuffer, values: &[u32]) {
         let ptr = buf.buffer_ref().inner.mapped_ptr() as *mut u32;
         unsafe {
             std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
         }
     }
 
-    fn read_buffer_u32(buf: &RhiPixelBuffer, len: usize) -> Vec<u32> {
+    fn read_buffer_u32(buf: &PixelBuffer, len: usize) -> Vec<u32> {
         let ptr = buf.buffer_ref().inner.mapped_ptr() as *const u32;
         let mut out = vec![0u32; len];
         unsafe {
@@ -1162,7 +1162,7 @@ mod tests {
         device: &Arc<HostVulkanDevice>,
         input_count: u32,
         element_count: u32,
-    ) -> (Vec<RhiPixelBuffer>, RhiPixelBuffer) {
+    ) -> (Vec<PixelBuffer>, PixelBuffer) {
         let bindings = blend_descriptor(input_count);
         let kernel = VulkanComputeKernel::new(
             device,
@@ -1175,7 +1175,7 @@ mod tests {
         )
         .expect("kernel creation");
 
-        let inputs: Vec<RhiPixelBuffer> = (0..input_count)
+        let inputs: Vec<PixelBuffer> = (0..input_count)
             .map(|i| {
                 let buf = make_storage_buffer(device, element_count);
                 let pattern: Vec<u32> = (0..element_count)
@@ -1207,7 +1207,7 @@ mod tests {
         (inputs, output)
     }
 
-    fn expected_blend(inputs: &[RhiPixelBuffer], element_count: u32) -> Vec<u32> {
+    fn expected_blend(inputs: &[PixelBuffer], element_count: u32) -> Vec<u32> {
         let active: Vec<Vec<u32>> = inputs
             .iter()
             .map(|b| read_buffer_u32(b, element_count as usize))

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_format_converter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_format_converter.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use crate::core::rhi::{
-    ComputeBindingSpec, ComputeKernelDescriptor, PixelFormat, RhiPixelBuffer,
+    ComputeBindingSpec, ComputeKernelDescriptor, PixelFormat, PixelBuffer,
 };
 use crate::core::{Result, Error};
 
@@ -61,7 +61,7 @@ impl VulkanFormatConverter {
 
     /// Convert NV12 → RGBA/BGRA. Source and destination must have the same
     /// dimensions; destination format determines the BGRA-vs-RGBA flag.
-    pub fn convert(&self, source: &RhiPixelBuffer, dest: &RhiPixelBuffer) -> Result<()> {
+    pub fn convert(&self, source: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
         let width = source.width;
         let height = source.height;
         if width != dest.width || height != dest.height {
@@ -111,7 +111,7 @@ impl VulkanFormatConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::rhi::RhiPixelBufferRef;
+    use crate::core::rhi::PixelBufferRef;
     use crate::core::Error;
     use crate::vulkan::rhi::HostVulkanPixelBuffer;
 
@@ -131,13 +131,13 @@ mod tests {
         height: u32,
         bytes_per_pixel: u32,
         format: PixelFormat,
-    ) -> RhiPixelBuffer {
+    ) -> PixelBuffer {
         let vk_buf = HostVulkanPixelBuffer::new(device, width, height, bytes_per_pixel, format)
             .expect("Failed to create pixel buffer");
-        let ref_ = RhiPixelBufferRef {
+        let ref_ = PixelBufferRef {
             inner: Arc::new(vk_buf),
         };
-        RhiPixelBuffer::new(ref_)
+        PixelBuffer::new(ref_)
     }
 
     /// CPU reference for the GLSL `nv12_to_bgra.comp` shader, full-range path.

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -47,7 +47,7 @@ use crate::core::rhi::{
     DepthStencilState, DrawCall, DrawIndexedCall, FrontFace, GraphicsBindingKind,
     GraphicsBindingSpec, GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState,
     GraphicsShaderStage, GraphicsShaderStageFlags, GraphicsStage, IndexType, PolygonMode,
-    PrimitiveTopology, RhiPixelBuffer, ScissorRect, Texture, TextureFormat,
+    PrimitiveTopology, PixelBuffer, ScissorRect, Texture, TextureFormat,
     VertexAttributeFormat, VertexInputRate, VertexInputState, Viewport,
 };
 use crate::core::{Result, Error};
@@ -367,7 +367,7 @@ impl VulkanGraphicsKernel {
         &self,
         frame_index: u32,
         binding: u32,
-        buffer: &RhiPixelBuffer,
+        buffer: &PixelBuffer,
     ) -> Result<()> {
         self.expect_kind(binding, GraphicsBindingKind::StorageBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer);
@@ -385,7 +385,7 @@ impl VulkanGraphicsKernel {
         &self,
         frame_index: u32,
         binding: u32,
-        buffer: &RhiPixelBuffer,
+        buffer: &PixelBuffer,
     ) -> Result<()> {
         self.expect_kind(binding, GraphicsBindingKind::UniformBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer);
@@ -451,7 +451,7 @@ impl VulkanGraphicsKernel {
         &self,
         frame_index: u32,
         binding: u32,
-        buffer: &RhiPixelBuffer,
+        buffer: &PixelBuffer,
         offset: u64,
     ) -> Result<()> {
         match &self.pipeline_state.vertex_input {
@@ -487,7 +487,7 @@ impl VulkanGraphicsKernel {
     pub fn set_index_buffer(
         &self,
         frame_index: u32,
-        buffer: &RhiPixelBuffer,
+        buffer: &PixelBuffer,
         offset: u64,
         index_type: IndexType,
     ) -> Result<()> {
@@ -1664,7 +1664,7 @@ fn allocate_command_buffer(
     Ok(buffers[0])
 }
 
-fn vk_buffer_for(buffer: &RhiPixelBuffer) -> (vk::Buffer, vk::DeviceSize) {
+fn vk_buffer_for(buffer: &PixelBuffer) -> (vk::Buffer, vk::DeviceSize) {
     let inner = &buffer.buffer_ref().inner;
     (inner.buffer(), inner.size())
 }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_pixel_buffer_pool.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::core::rhi::{PixelBufferPoolId, PixelFormat, RhiPixelBuffer, RhiPixelBufferRef};
+use crate::core::rhi::{PixelBufferPoolId, PixelFormat, PixelBuffer, PixelBufferRef};
 use crate::core::{Result, Error};
 
 use super::{HostVulkanDevice, HostVulkanPixelBuffer};
@@ -100,7 +100,7 @@ impl VulkanPixelBufferPool {
     ///
     /// Skips buffers still held externally (Arc::strong_count > 1).
     /// Returns error if all buffers are in use.
-    pub fn acquire(&self) -> Result<(PixelBufferPoolId, RhiPixelBuffer)> {
+    pub fn acquire(&self) -> Result<(PixelBufferPoolId, PixelBuffer)> {
         let len = self.buffers.len();
         if len == 0 {
             return Err(Error::BufferError(
@@ -123,11 +123,11 @@ impl VulkanPixelBufferPool {
                         .unwrap_or_else(PixelBufferPoolId::new)
                 };
 
-                let pixel_buffer_ref = RhiPixelBufferRef {
+                let pixel_buffer_ref = PixelBufferRef {
                     inner: Arc::clone(buffer),
                 };
 
-                let rhi_pixel_buffer = RhiPixelBuffer::new(pixel_buffer_ref);
+                let rhi_pixel_buffer = PixelBuffer::new(pixel_buffer_ref);
 
                 return Ok((pool_id, rhi_pixel_buffer));
             }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -32,7 +32,7 @@ use vma::Alloc as _;
 use crate::core::rhi::{
     validate_shader_groups, RayTracingBindingKind, RayTracingBindingSpec,
     RayTracingKernelDescriptor, RayTracingShaderGroup, RayTracingShaderStage,
-    RayTracingShaderStageFlags, RayTracingStage, RhiPixelBuffer, Texture,
+    RayTracingShaderStageFlags, RayTracingStage, PixelBuffer, Texture,
 };
 use crate::core::{Result, Error};
 
@@ -415,7 +415,7 @@ impl VulkanRayTracingKernel {
         Ok(())
     }
 
-    pub fn set_storage_buffer(&self, binding: u32, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn set_storage_buffer(&self, binding: u32, buffer: &PixelBuffer) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::StorageBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer);
         self.pending.lock().bindings.insert(
@@ -428,7 +428,7 @@ impl VulkanRayTracingKernel {
         Ok(())
     }
 
-    pub fn set_uniform_buffer(&self, binding: u32, buffer: &RhiPixelBuffer) -> Result<()> {
+    pub fn set_uniform_buffer(&self, binding: u32, buffer: &PixelBuffer) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::UniformBuffer)?;
         let (vk_buf, size) = vk_buffer_for(buffer);
         self.pending.lock().bindings.insert(
@@ -1595,7 +1595,7 @@ fn drop_sbt(sbt: &Sbt, vulkan_device: &Arc<HostVulkanDevice>) {
     }
 }
 
-fn vk_buffer_for(buffer: &RhiPixelBuffer) -> (vk::Buffer, vk::DeviceSize) {
+fn vk_buffer_for(buffer: &PixelBuffer) -> (vk::Buffer, vk::DeviceSize) {
     let inner = &buffer.buffer_ref().inner;
     (inner.buffer(), inner.size())
 }

--- a/libs/streamlib-engine/tests/polyglot_linux_resolve_surface_multi_plane.rs
+++ b/libs/streamlib-engine/tests/polyglot_linux_resolve_surface_multi_plane.rs
@@ -287,7 +287,7 @@ mod polyglot_dma_buf_producer;
 /// Rust analogue of the Python / Deno shim tests: the host check_ins a
 /// 2-plane surface backed by real Vulkan-exported DMA-BUFs, then the
 /// Rust consumer calls `SurfaceStore::check_out` and confirms the
-/// returned `RhiPixelBuffer` carries two mapped planes whose bytes match
+/// returned `PixelBuffer` carries two mapped planes whose bytes match
 /// the source patterns. This is the symmetry gate — if the Rust
 /// importer silently dropped a plane, this test fails.
 #[test]

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -1654,7 +1654,7 @@ class EscalateRequestRunGraphicsDrawIndexBufferIndexType(Enum):
 class EscalateRequestRunGraphicsDrawIndexBuffer:
     """
     Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+    `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset
     into it.
     """
 
@@ -1819,7 +1819,7 @@ class EscalateRequestRunGraphicsDraw(EscalateRequest):
     index_buffer: 'Optional[EscalateRequestRunGraphicsDrawIndexBuffer]'
     """
     Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
+    `surface_uuid` resolves to a `PixelBuffer`; `offset` is the byte offset
     into it.
     """
 

--- a/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
+++ b/libs/streamlib-python/python/streamlib/_generated_/com_streamlib_escalate_request.py
@@ -1654,7 +1654,7 @@ class EscalateRequestRunGraphicsDrawIndexBufferIndexType(Enum):
 class EscalateRequestRunGraphicsDrawIndexBuffer:
     """
     Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+    `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
     into it.
     """
 
@@ -1804,10 +1804,10 @@ class EscalateRequestRunGraphicsDraw(EscalateRequest):
 
     vertex_buffers: 'List[EscalateRequestRunGraphicsDrawVertexBuffer]'
     """
-    Per-draw vertex buffer bindings. Each entry's `surface_uuid` must resolve
-    to a host-side `RhiPixelBuffer`. `offset` is the byte offset into the buffer
-    where vertex data starts (decimal-encoded u64 — JTD has no native u64).
-    Empty for vertex-fabricating shaders (`gl_VertexIndex` patterns).
+    Per-draw vertex buffer bindings. Each entry's `surface_uuid` must resolve to
+    a host-side `PixelBuffer`. `offset` is the byte offset into the buffer where
+    vertex data starts (decimal-encoded u64 — JTD has no native u64). Empty for
+    vertex-fabricating shaders (`gl_VertexIndex` patterns).
     """
 
     depth_target_uuid: 'Optional[str]'
@@ -1819,7 +1819,7 @@ class EscalateRequestRunGraphicsDraw(EscalateRequest):
     index_buffer: 'Optional[EscalateRequestRunGraphicsDrawIndexBuffer]'
     """
     Required when `draw.kind == "draw_indexed"`, must be absent otherwise.
-    `surface_uuid` resolves to an `RhiPixelBuffer`; `offset` is the byte offset
+    `surface_uuid` resolves to an `PixelBuffer`; `offset` is the byte offset
     into it.
     """
 
@@ -1921,7 +1921,7 @@ class EscalateRequestRunRayTracingKernel(EscalateRequest):
     `acceleration_structure`: `target_id` is an `as_id`
       from a prior `register_acceleration_structure_tlas`.
     - all other kinds: `target_id` is the surface-share UUID
-      of a host-side `RhiPixelBuffer` / `Texture`
+      of a host-side `PixelBuffer` / `Texture`
       (same convention compute and graphics use).
     """
 

--- a/libs/streamlib-python/python/streamlib/escalate.py
+++ b/libs/streamlib-python/python/streamlib/escalate.py
@@ -496,7 +496,7 @@ class EscalateChannel:
         "acceleration_structure"``, ``target_id`` is an ``as_id`` from
         a prior :meth:`register_acceleration_structure_tlas`; for all
         other kinds, ``target_id`` is the surface-share UUID of the
-        host-side ``RhiPixelBuffer`` / ``Texture`` (same
+        host-side ``PixelBuffer`` / ``Texture`` (same
         convention compute and graphics use).
 
         On failure raises :class:`EscalateError`.

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -208,9 +208,9 @@ pub mod sdk {
         /// Privileged extension traits surfacing raw `Host*` handles
         /// on SDK-bucket types. Importing one unlocks `vulkan_inner()`
         /// / `from_vulkan()` / `vulkan_device()` on
-        /// `Texture` / `RhiPixelBufferRef` / `GpuDevice`.
+        /// `Texture` / `PixelBufferRef` / `GpuDevice`.
         pub use streamlib_engine::{
-            HostGpuDeviceExt, HostRhiPixelBufferRefExt, HostTextureExt,
+            HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt,
         };
 
         /// Per-runtime surface-share service primitives. For adapter


### PR DESCRIPTION
## Summary

- Drops the redundant `Rhi` prefix from the SDK-bucket pixel-buffer types — `RhiPixelBuffer` → `PixelBuffer`, `RhiPixelBufferRef` → `PixelBufferRef`, `HostRhiPixelBufferRefExt` → `HostPixelBufferRefExt`. The path `streamlib::sdk::rhi::*` already conveys the role post-#731.
- `RhiPixelBufferPool` (pub(crate)) and `RhiPixelBufferExport` / `RhiPixelBufferImport` (external-handle ABI traits) keep the `Rhi` prefix — out of scope.
- Same shape as the recently-merged #738 (`StreamError → Error`) and #739 (`StreamTexture → Texture`).

## Closes

Closes #740

## Exit criteria

- [x] `RhiPixelBuffer` renamed to `PixelBuffer` in `libs/streamlib-engine/src/core/rhi/pixel_buffer.rs`.
- [x] `RhiPixelBufferRef` renamed to `PixelBufferRef` in `libs/streamlib-engine/src/core/rhi/pixel_buffer_ref.rs`.
- [x] `HostRhiPixelBufferRefExt` extension trait → `HostPixelBufferRefExt` (no collision with `HostVulkanPixelBuffer`).
- [x] All consumers updated — engine, examples, integration test, schema YAML doc-comments, regenerated codegen (Rust/Python/TypeScript), 5 architecture docs, Python `escalate.py`.
- [x] All `cargo xtask check-*` lints pass.
- [x] Workspace test gate green.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean.
- [x] `cargo doc -p streamlib --no-deps` — no unresolved doc-link warnings.
- [x] `cargo test --workspace` per `docs/testing-baseline.md` exclusion list — **1418 passed, 0 failed, 126 ignored**.
- [x] `cargo xtask check-boundaries` — 3280 files scanned, no violations.
- [x] `cargo xtask check-schema-versions` — clean.
- [x] `cargo xtask check-no-streamlib-metadata` — clean.
- [x] `cargo xtask check-processor-spec-new` — clean.
- [x] `cargo xtask check-manifest-schema` — 28 manifests validated.
- [x] `cargo xtask lint-logging` — 475 files scanned, clean.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)