### PR TITLE
feat(surface-share): additive VkImageCreateInfo round-trip in wire format

### DIFF
--- a/libs/streamlib-engine/src/linux/surface_share/state.rs
+++ b/libs/streamlib-engine/src/linux/surface_share/state.rs
@@ -80,6 +80,39 @@ pub struct SurfaceMetadata {
     /// because producer-release and consumer-acquire can race; load with
     /// `Acquire`, store with `Release`.
     pub current_image_layout: AtomicI32,
+    /// `VkImageType` (raw `i32`): `_1D = 0`, `_2D = 1`, `_3D = 2`. Carries
+    /// the host's `VkImageCreateInfo::imageType` across the wire so the
+    /// consumer can reconstruct a matching `VkImage` for OPAQUE_FD import
+    /// — `cudaExternalMemoryGetMappedMipmappedArray` requires the
+    /// consumer-side `VkImageCreateInfo` to match the host's byte-for-byte.
+    /// Defaults to `1` (`_2D`) when absent — the only flavor every
+    /// in-tree allocator emits today.
+    pub vk_image_type: i32,
+    /// `VkImageCreateInfo::mipLevels`. Defaults to `1` when absent.
+    pub vk_image_mip_levels: u32,
+    /// `VkImageCreateInfo::arrayLayers`. Defaults to `1` when absent.
+    pub vk_image_array_layers: u32,
+    /// `VkSampleCountFlagBits` (raw `i32`): `_1 = 1`, `_2 = 2`, `_4 = 4`,
+    /// `_8 = 8`, etc. Defaults to `1` (`_1`) when absent.
+    pub vk_image_samples: i32,
+    /// `VkImageTiling` (raw `i32`): `OPTIMAL = 0`, `LINEAR = 1`,
+    /// `DRM_FORMAT_MODIFIER_EXT = 1000158000`. Defaults to `0` (`OPTIMAL`)
+    /// when absent — the OPAQUE_FD image flavor the new field set
+    /// primarily serves.
+    pub vk_image_tiling: i32,
+    /// `VkImageUsageFlags` (raw `u32` bitfield). Defaults to
+    /// `TRANSFER_SRC | TRANSFER_DST | SAMPLED | STORAGE = 0x0F` when
+    /// absent — the usage set [`crate::vulkan::rhi::HostVulkanTexture::new_opaque_fd_export`]
+    /// emits and the consumer side hardcodes today.
+    pub vk_image_usage: u32,
+    /// Host-side `VkMemoryRequirements::size` (i.e. `vmaGetAllocationInfo().size`)
+    /// of the imported VkImage's backing memory. Required for the
+    /// consumer's `vkAllocateMemory(VkImportMemoryFdInfoKHR)` size
+    /// argument; cross-device size mismatches reject the import.
+    /// Defaults to `0` ("unknown — consumer computes from width / height
+    /// / format") when absent — preserves the existing
+    /// pixel-buffer / DMA-BUF behavior where size is derived consumer-side.
+    pub vk_image_allocation_size: u64,
 }
 
 // The atomic field makes `SurfaceMetadata` not `Clone`-by-derive. Hand-roll
@@ -104,9 +137,31 @@ impl Clone for SurfaceMetadata {
             current_image_layout: AtomicI32::new(
                 self.current_image_layout.load(Ordering::Acquire),
             ),
+            vk_image_type: self.vk_image_type,
+            vk_image_mip_levels: self.vk_image_mip_levels,
+            vk_image_array_layers: self.vk_image_array_layers,
+            vk_image_samples: self.vk_image_samples,
+            vk_image_tiling: self.vk_image_tiling,
+            vk_image_usage: self.vk_image_usage,
+            vk_image_allocation_size: self.vk_image_allocation_size,
         }
     }
 }
+
+/// Documented defaults for the `vk_image_*` fields when the wire
+/// payload omits them. Match
+/// [`crate::vulkan::rhi::HostVulkanTexture::new_opaque_fd_export`]'s
+/// hardcoded shape so a daemon serving these defaults produces a
+/// `VkImageCreateInfo` byte-equal to what the existing consumer-side
+/// `from_opaque_fd` constructor already builds.
+pub const VK_IMAGE_TYPE_DEFAULT: i32 = 1; // VK_IMAGE_TYPE_2D
+pub const VK_IMAGE_MIP_LEVELS_DEFAULT: u32 = 1;
+pub const VK_IMAGE_ARRAY_LAYERS_DEFAULT: u32 = 1;
+pub const VK_IMAGE_SAMPLES_DEFAULT: i32 = 1; // VK_SAMPLE_COUNT_1_BIT
+pub const VK_IMAGE_TILING_DEFAULT: i32 = 0; // VK_IMAGE_TILING_OPTIMAL
+/// `TRANSFER_SRC (0x01) | TRANSFER_DST (0x02) | SAMPLED (0x04) | STORAGE (0x08)`.
+pub const VK_IMAGE_USAGE_DEFAULT: u32 = 0x0F;
+pub const VK_IMAGE_ALLOCATION_SIZE_DEFAULT: u64 = 0;
 
 /// Thread-safe surface table for the runtime-internal surface-share service.
 #[derive(Clone, Default)]
@@ -146,6 +201,21 @@ pub struct SurfacePlaneCheckout {
     /// (UNDEFINED) when no producer has declared a layout — the
     /// back-compat default for surfaces registered before issue #633.
     pub current_image_layout: i32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_type`] at lookup time.
+    pub vk_image_type: i32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_mip_levels`] at lookup time.
+    pub vk_image_mip_levels: u32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_array_layers`] at lookup time.
+    pub vk_image_array_layers: u32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_samples`] at lookup time.
+    pub vk_image_samples: i32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_tiling`] at lookup time.
+    pub vk_image_tiling: i32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_usage`] at lookup time.
+    pub vk_image_usage: u32,
+    /// Snapshot of [`SurfaceMetadata::vk_image_allocation_size`] at
+    /// lookup time.
+    pub vk_image_allocation_size: u64,
 }
 
 /// Arguments to [`SurfaceShareState::register_surface`]. Grouped so the
@@ -183,6 +253,30 @@ pub struct SurfaceRegistration<'a> {
     /// `oldLayout=UNDEFINED` (content-discard permitted) when no producer
     /// has declared a layout.
     pub current_image_layout: i32,
+    /// `VkImageCreateInfo::imageType` (raw `i32`). See
+    /// [`SurfaceMetadata::vk_image_type`]. Pass [`VK_IMAGE_TYPE_DEFAULT`]
+    /// when the surface isn't an OPAQUE_FD `VkImage` or when the consumer
+    /// can rely on the default `_2D` shape.
+    pub vk_image_type: i32,
+    /// `VkImageCreateInfo::mipLevels`. Pass [`VK_IMAGE_MIP_LEVELS_DEFAULT`]
+    /// (= 1) for the back-compat shape.
+    pub vk_image_mip_levels: u32,
+    /// `VkImageCreateInfo::arrayLayers`. Pass
+    /// [`VK_IMAGE_ARRAY_LAYERS_DEFAULT`] (= 1) for the back-compat shape.
+    pub vk_image_array_layers: u32,
+    /// `VkSampleCountFlagBits` (raw `i32`). Pass [`VK_IMAGE_SAMPLES_DEFAULT`]
+    /// (= 1) for the back-compat shape.
+    pub vk_image_samples: i32,
+    /// `VkImageTiling` (raw `i32`). Pass [`VK_IMAGE_TILING_DEFAULT`]
+    /// (= `OPTIMAL`) for OPAQUE_FD images.
+    pub vk_image_tiling: i32,
+    /// `VkImageUsageFlags` (raw `u32` bitfield). Pass
+    /// [`VK_IMAGE_USAGE_DEFAULT`] for the back-compat OPAQUE_FD usage set.
+    pub vk_image_usage: u32,
+    /// Host-side `VkMemoryRequirements::size`. Pass
+    /// [`VK_IMAGE_ALLOCATION_SIZE_DEFAULT`] (= 0) when the consumer
+    /// derives the size from `width * height * bytes_per_pixel`.
+    pub vk_image_allocation_size: u64,
 }
 
 impl SurfaceShareState {
@@ -227,6 +321,13 @@ impl SurfaceShareState {
                 sync_fd: reg.sync_fd,
                 checkout_count: 0,
                 current_image_layout: AtomicI32::new(reg.current_image_layout),
+                vk_image_type: reg.vk_image_type,
+                vk_image_mip_levels: reg.vk_image_mip_levels,
+                vk_image_array_layers: reg.vk_image_array_layers,
+                vk_image_samples: reg.vk_image_samples,
+                vk_image_tiling: reg.vk_image_tiling,
+                vk_image_usage: reg.vk_image_usage,
+                vk_image_allocation_size: reg.vk_image_allocation_size,
             },
         );
         Ok(())
@@ -274,6 +375,13 @@ impl SurfaceShareState {
                 current_image_layout: metadata
                     .current_image_layout
                     .load(Ordering::Acquire),
+                vk_image_type: metadata.vk_image_type,
+                vk_image_mip_levels: metadata.vk_image_mip_levels,
+                vk_image_array_layers: metadata.vk_image_array_layers,
+                vk_image_samples: metadata.vk_image_samples,
+                vk_image_tiling: metadata.vk_image_tiling,
+                vk_image_usage: metadata.vk_image_usage,
+                vk_image_allocation_size: metadata.vk_image_allocation_size,
             }
         })
     }
@@ -332,6 +440,13 @@ mod tests {
             drm_format_modifier: 0,
             sync_fd: None,
             current_image_layout: 0,
+            vk_image_type: VK_IMAGE_TYPE_DEFAULT,
+            vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,
+            vk_image_array_layers: VK_IMAGE_ARRAY_LAYERS_DEFAULT,
+            vk_image_samples: VK_IMAGE_SAMPLES_DEFAULT,
+            vk_image_tiling: VK_IMAGE_TILING_DEFAULT,
+            vk_image_usage: VK_IMAGE_USAGE_DEFAULT,
+            vk_image_allocation_size: VK_IMAGE_ALLOCATION_SIZE_DEFAULT,
         }
     }
 
@@ -443,6 +558,59 @@ mod tests {
         assert!(!state.update_image_layout("missing", 0));
     }
 
+    /// The seven `vk_image_*` fields round-trip through register → lookup:
+    /// the producer's declared `VkImageCreateInfo` shape (#800) must
+    /// survive verbatim so an OPAQUE_FD `VkImage` consumer can rebuild a
+    /// matching `VkImage` whose `cudaExternalMemoryMipmappedArrayDesc`
+    /// equals the host's byte-for-byte. Mentally revert the
+    /// `register_surface` body (drop the seven assignments) and this test
+    /// fails on the first field — locking the contract end-to-end through
+    /// the typed `SurfaceShareState` API.
+    #[test]
+    fn vk_image_create_info_fields_round_trip_through_register_lookup() {
+        let state = SurfaceShareState::new();
+        // Pick a deliberately non-default value for every field — so a
+        // regression that silently zeroes one is visible against the
+        // assert. Values are spec-realistic (mipmapped 3D image with
+        // multisample + multi-layer + custom usage).
+        state
+            .register_surface(SurfaceRegistration {
+                surface_id: "vk-image-rt",
+                runtime_id: "rt",
+                dma_buf_fds: vec![-1],
+                plane_sizes: vec![0],
+                plane_offsets: vec![0],
+                plane_strides: vec![0],
+                width: 256,
+                height: 256,
+                format: "Rgba16Float",
+                resource_type: "texture",
+                handle_type: "opaque_fd",
+                drm_format_modifier: 0,
+                sync_fd: None,
+                current_image_layout: 0,
+                vk_image_type: 2,        // VK_IMAGE_TYPE_3D
+                vk_image_mip_levels: 9,  // 256 = 2^8, plus base = 9 levels
+                vk_image_array_layers: 6,
+                vk_image_samples: 4,                // _4
+                vk_image_tiling: 1000158000,        // DRM_FORMAT_MODIFIER_EXT
+                vk_image_usage: 0x4F,               // 0x0F | COLOR_ATTACHMENT (0x40)
+                vk_image_allocation_size: 16_777_216,
+            })
+            .expect("register vk-image-rt");
+
+        let checkout = state
+            .get_surface_planes("vk-image-rt")
+            .expect("lookup after register");
+        assert_eq!(checkout.vk_image_type, 2);
+        assert_eq!(checkout.vk_image_mip_levels, 9);
+        assert_eq!(checkout.vk_image_array_layers, 6);
+        assert_eq!(checkout.vk_image_samples, 4);
+        assert_eq!(checkout.vk_image_tiling, 1000158000);
+        assert_eq!(checkout.vk_image_usage, 0x4F);
+        assert_eq!(checkout.vk_image_allocation_size, 16_777_216);
+    }
+
     /// Releasing a surface registered with multiple plane fds must close
     /// every fd — the state is the last owner of the table's fd dups and
     /// leaking any plane would leak the whole DMA-BUF. Verified via pipes:
@@ -483,6 +651,13 @@ mod tests {
                 drm_format_modifier: 0,
                 sync_fd: None,
                 current_image_layout: 0,
+                vk_image_type: VK_IMAGE_TYPE_DEFAULT,
+                vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,
+                vk_image_array_layers: VK_IMAGE_ARRAY_LAYERS_DEFAULT,
+                vk_image_samples: VK_IMAGE_SAMPLES_DEFAULT,
+                vk_image_tiling: VK_IMAGE_TILING_DEFAULT,
+                vk_image_usage: VK_IMAGE_USAGE_DEFAULT,
+                vk_image_allocation_size: VK_IMAGE_ALLOCATION_SIZE_DEFAULT,
             })
             .expect("register multi-plane");
 

--- a/libs/streamlib-engine/src/linux/surface_share/unix_socket_service.rs
+++ b/libs/streamlib-engine/src/linux/surface_share/unix_socket_service.rs
@@ -21,7 +21,11 @@ use streamlib_surface_client::{
     recv_message_with_fds, send_message_with_fds, MAX_DMA_BUF_PLANES, MAX_SCM_RIGHTS_FDS,
 };
 
-use super::state::{SurfaceShareState, SurfaceRegistration};
+use super::state::{
+    SurfaceRegistration, SurfaceShareState, VK_IMAGE_ALLOCATION_SIZE_DEFAULT,
+    VK_IMAGE_ARRAY_LAYERS_DEFAULT, VK_IMAGE_MIP_LEVELS_DEFAULT, VK_IMAGE_SAMPLES_DEFAULT,
+    VK_IMAGE_TILING_DEFAULT, VK_IMAGE_TYPE_DEFAULT, VK_IMAGE_USAGE_DEFAULT,
+};
 
 pub struct UnixSocketSurfaceService {
     state: SurfaceShareState,
@@ -248,6 +252,59 @@ fn handle_client_connection(
     }
 }
 
+/// Parsed view of the seven optional `vk_image_*` fields a producer of an
+/// OPAQUE_FD `VkImage` ships across the wire so the consumer can rebuild a
+/// matching `VkImageCreateInfo` (required for
+/// `cudaExternalMemoryGetMappedMipmappedArray` byte-for-byte parity, and
+/// for the consumer-side `vkAllocateMemory(VkImportMemoryFdInfoKHR)` size
+/// argument).
+///
+/// Each field is absent-defaultable to the documented constants in
+/// [`super::state`], so a register payload that omits the section behaves
+/// exactly like the pre-#800 wire — the existing DMA-BUF and OPAQUE_FD
+/// VkBuffer callers ride the defaults transparently.
+struct VkImageCreateInfoFields {
+    vk_image_type: i32,
+    vk_image_mip_levels: u32,
+    vk_image_array_layers: u32,
+    vk_image_samples: i32,
+    vk_image_tiling: i32,
+    vk_image_usage: u32,
+    vk_image_allocation_size: u64,
+}
+
+fn parse_vk_image_create_info_fields(request: &serde_json::Value) -> VkImageCreateInfoFields {
+    let as_i32 = |key: &str, default: i32| -> i32 {
+        request
+            .get(key)
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32)
+            .unwrap_or(default)
+    };
+    let as_u32 = |key: &str, default: u32| -> u32 {
+        request
+            .get(key)
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32)
+            .unwrap_or(default)
+    };
+    let as_u64 = |key: &str, default: u64| -> u64 {
+        request.get(key).and_then(|v| v.as_u64()).unwrap_or(default)
+    };
+    VkImageCreateInfoFields {
+        vk_image_type: as_i32("vk_image_type", VK_IMAGE_TYPE_DEFAULT),
+        vk_image_mip_levels: as_u32("vk_image_mip_levels", VK_IMAGE_MIP_LEVELS_DEFAULT),
+        vk_image_array_layers: as_u32("vk_image_array_layers", VK_IMAGE_ARRAY_LAYERS_DEFAULT),
+        vk_image_samples: as_i32("vk_image_samples", VK_IMAGE_SAMPLES_DEFAULT),
+        vk_image_tiling: as_i32("vk_image_tiling", VK_IMAGE_TILING_DEFAULT),
+        vk_image_usage: as_u32("vk_image_usage", VK_IMAGE_USAGE_DEFAULT),
+        vk_image_allocation_size: as_u64(
+            "vk_image_allocation_size",
+            VK_IMAGE_ALLOCATION_SIZE_DEFAULT,
+        ),
+    }
+}
+
 /// Extract `plane_sizes`, `plane_offsets`, and `plane_strides` from a JSON
 /// request body. Returns vecs whose length matches `expected_plane_count`,
 /// falling back to `[0]` for single-plane registrations that omit the arrays.
@@ -384,6 +441,11 @@ fn handle_register(
         .and_then(|v| v.as_i64())
         .map(|v| v as i32)
         .unwrap_or(0);
+    // OPAQUE_FD VkImage carries the full VkImageCreateInfo shape so a
+    // CUDA-importable consumer can rebuild a matching VkImage; every
+    // field absent-defaults to the OPAQUE_FD constructor's hardcoded
+    // shape so legacy callers see no behavior change.
+    let vk_image = parse_vk_image_create_info_fields(request);
 
     let mut dup_plane_fds: Vec<RawFd> = Vec::with_capacity(plane_fds.len());
     for fd in plane_fds {
@@ -432,6 +494,13 @@ fn handle_register(
         drm_format_modifier,
         sync_fd: dup_sync_fd,
         current_image_layout,
+        vk_image_type: vk_image.vk_image_type,
+        vk_image_mip_levels: vk_image.vk_image_mip_levels,
+        vk_image_array_layers: vk_image.vk_image_array_layers,
+        vk_image_samples: vk_image.vk_image_samples,
+        vk_image_tiling: vk_image.vk_image_tiling,
+        vk_image_usage: vk_image.vk_image_usage,
+        vk_image_allocation_size: vk_image.vk_image_allocation_size,
     }) {
         Ok(()) => {
             tracing::debug!(
@@ -530,6 +599,16 @@ fn handle_lookup(
             "drm_format_modifier": checkout.drm_format_modifier,
             "has_sync_fd": has_sync_fd,
             "current_image_layout": checkout.current_image_layout,
+            // VkImageCreateInfo round-trip for OPAQUE_FD VkImage
+            // consumers. Always echoed; absent producers see the
+            // documented defaults from `super::state`.
+            "vk_image_type": checkout.vk_image_type,
+            "vk_image_mip_levels": checkout.vk_image_mip_levels,
+            "vk_image_array_layers": checkout.vk_image_array_layers,
+            "vk_image_samples": checkout.vk_image_samples,
+            "vk_image_tiling": checkout.vk_image_tiling,
+            "vk_image_usage": checkout.vk_image_usage,
+            "vk_image_allocation_size": checkout.vk_image_allocation_size,
         }),
         dup_fds,
     )
@@ -638,6 +717,12 @@ fn handle_check_in(
         .get("handle_type")
         .and_then(|v| v.as_str())
         .unwrap_or("dma_buf");
+    // Parse the optional VkImageCreateInfo block. `check_in` is the
+    // subprocess-registers-pixel-buffer path that legacy DMA-BUF /
+    // OPAQUE_FD buffer consumers ride; every field absent-defaults to
+    // the OPAQUE_FD constructor's hardcoded shape so legacy callers
+    // see no behavior change.
+    let vk_image = parse_vk_image_create_info_fields(request);
 
     let surface_id = uuid::Uuid::new_v4().to_string();
 
@@ -678,6 +763,13 @@ fn handle_check_in(
         // image layout. Seed UNDEFINED; the field is unused for buffer
         // surfaces but must be populated for the wire format.
         current_image_layout: 0,
+        vk_image_type: vk_image.vk_image_type,
+        vk_image_mip_levels: vk_image.vk_image_mip_levels,
+        vk_image_array_layers: vk_image.vk_image_array_layers,
+        vk_image_samples: vk_image.vk_image_samples,
+        vk_image_tiling: vk_image.vk_image_tiling,
+        vk_image_usage: vk_image.vk_image_usage,
+        vk_image_allocation_size: vk_image.vk_image_allocation_size,
     }) {
         for fd in &leftover_planes {
             unsafe { libc::close(*fd) };
@@ -1254,6 +1346,13 @@ mod tests {
                     drm_format_modifier: 0,
                     sync_fd: None,
                     current_image_layout: 0,
+                    vk_image_type: VK_IMAGE_TYPE_DEFAULT,
+                    vk_image_mip_levels: VK_IMAGE_MIP_LEVELS_DEFAULT,
+                    vk_image_array_layers: VK_IMAGE_ARRAY_LAYERS_DEFAULT,
+                    vk_image_samples: VK_IMAGE_SAMPLES_DEFAULT,
+                    vk_image_tiling: VK_IMAGE_TILING_DEFAULT,
+                    vk_image_usage: VK_IMAGE_USAGE_DEFAULT,
+                    vk_image_allocation_size: VK_IMAGE_ALLOCATION_SIZE_DEFAULT,
                 })
                 .expect("register");
         }
@@ -1399,6 +1498,226 @@ mod tests {
             unsafe { libc::close(*fd) };
         }
 
+        drop(stream);
+        service.stop();
+    }
+
+    /// Full `VkImageCreateInfo` round-trip through the wire (#800): a
+    /// producer ships every `vk_image_*` field on register; the consumer
+    /// reads them off lookup. Locks the OPAQUE_FD VkImage consumer's
+    /// ability to rebuild a matching `VkImage` whose
+    /// `cudaExternalMemoryMipmappedArrayDesc` equals the host's
+    /// byte-for-byte. Mentally revert any of the seven echo writes in
+    /// `handle_lookup` and this test fails — the seven assertions are
+    /// independent and field-specific.
+    #[test]
+    fn vk_image_create_info_round_trip_through_register_lookup() {
+        let state = SurfaceShareState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+
+        let send_fd = make_memfd_with(b"opaque-fd-vkimage-fixture");
+        // Non-default values for every field so a regression that zeroes
+        // one is caught against a deliberate non-zero assert.
+        let register_req = serde_json::json!({
+            "op": "register",
+            "surface_id": "vk-image-wire-rt",
+            "runtime_id": "test-runtime",
+            "width": 256,
+            "height": 256,
+            "format": "Rgba16Float",
+            "resource_type": "texture",
+            "handle_type": "opaque_fd",
+            "vk_image_type": 2,               // VK_IMAGE_TYPE_3D
+            "vk_image_mip_levels": 9,
+            "vk_image_array_layers": 6,
+            "vk_image_samples": 4,            // _4
+            "vk_image_tiling": 1000158000,    // DRM_FORMAT_MODIFIER_EXT
+            "vk_image_usage": 0x4Fu32,
+            "vk_image_allocation_size": 16_777_216u64,
+        });
+        let (register_resp, _) = send_request_with_fds(&stream, &register_req, &[send_fd], 0)
+            .expect("register request");
+        unsafe { libc::close(send_fd) };
+        assert_eq!(
+            register_resp.get("success").and_then(|v| v.as_bool()),
+            Some(true),
+            "register must succeed: {:?}",
+            register_resp
+        );
+
+        let lookup_req = serde_json::json!({
+            "op": "lookup",
+            "surface_id": "vk-image-wire-rt",
+        });
+        let (lookup_resp, lookup_fds) =
+            send_request_with_fds(&stream, &lookup_req, &[], MAX_DMA_BUF_PLANES)
+                .expect("lookup request");
+        for fd in &lookup_fds {
+            unsafe { libc::close(*fd) };
+        }
+
+        assert_eq!(
+            lookup_resp.get("vk_image_type").and_then(|v| v.as_i64()),
+            Some(2),
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_mip_levels")
+                .and_then(|v| v.as_u64()),
+            Some(9),
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_array_layers")
+                .and_then(|v| v.as_u64()),
+            Some(6),
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_samples").and_then(|v| v.as_i64()),
+            Some(4),
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_tiling").and_then(|v| v.as_i64()),
+            Some(1000158000),
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_usage").and_then(|v| v.as_u64()),
+            Some(0x4F),
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_allocation_size")
+                .and_then(|v| v.as_u64()),
+            Some(16_777_216),
+        );
+
+        let _ = send_request_with_fds(
+            &stream,
+            &serde_json::json!({
+                "op": "release",
+                "surface_id": "vk-image-wire-rt",
+                "runtime_id": "test-runtime",
+            }),
+            &[],
+            0,
+        );
+        drop(stream);
+        service.stop();
+    }
+
+    /// Back-compat sibling of [`vk_image_create_info_round_trip_through_register_lookup`]:
+    /// a register payload that omits the seven `vk_image_*` fields must
+    /// surface the documented defaults on lookup. This is the contract
+    /// every legacy producer (DMA-BUF VkImage, OPAQUE_FD VkBuffer)
+    /// relies on — without the defaults, a daemon serving an old client
+    /// would echo zero / unknown values and break the consumer's
+    /// VkImageCreateInfo reconstruction. Mentally revert one of the
+    /// `unwrap_or(...)` defaults in `parse_vk_image_create_info_fields`
+    /// and this test fails on the corresponding assertion.
+    ///
+    /// Default constants live in `super::state::VK_IMAGE_*_DEFAULT` —
+    /// the test mirrors their literal values so a default change
+    /// surfaces here too.
+    #[test]
+    fn vk_image_create_info_absent_fields_surface_documented_defaults() {
+        let state = SurfaceShareState::new();
+        let socket_path = tmp_socket_path();
+        let mut service = UnixSocketSurfaceService::new(state, socket_path.clone());
+        service.start().expect("service start");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let stream = connect_to_surface_share_socket(&socket_path).expect("connect");
+
+        let send_fd = make_memfd_with(b"legacy-no-vk-image-fields");
+        let register_req = serde_json::json!({
+            "op": "register",
+            "surface_id": "legacy-defaults",
+            "runtime_id": "test-runtime",
+            "width": 64,
+            "height": 64,
+            "format": "Rgba8Unorm",
+            "resource_type": "texture",
+            // No vk_image_* fields — exercise the defaults path.
+        });
+        let (register_resp, _) = send_request_with_fds(&stream, &register_req, &[send_fd], 0)
+            .expect("register request");
+        unsafe { libc::close(send_fd) };
+        assert_eq!(
+            register_resp.get("success").and_then(|v| v.as_bool()),
+            Some(true),
+            "legacy register must succeed: {:?}",
+            register_resp
+        );
+
+        let lookup_req = serde_json::json!({
+            "op": "lookup",
+            "surface_id": "legacy-defaults",
+        });
+        let (lookup_resp, lookup_fds) =
+            send_request_with_fds(&stream, &lookup_req, &[], MAX_DMA_BUF_PLANES)
+                .expect("lookup request");
+        for fd in &lookup_fds {
+            unsafe { libc::close(*fd) };
+        }
+
+        // VK_IMAGE_TYPE_2D = 1, mip = 1, layers = 1, samples = 1,
+        // tiling = OPTIMAL = 0,
+        // usage = TRANSFER_SRC | TRANSFER_DST | SAMPLED | STORAGE = 0x0F,
+        // allocation_size = 0 (consumer derives from width * height * bpp).
+        assert_eq!(
+            lookup_resp.get("vk_image_type").and_then(|v| v.as_i64()),
+            Some(1),
+            "absent vk_image_type defaults to VK_IMAGE_TYPE_2D",
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_mip_levels")
+                .and_then(|v| v.as_u64()),
+            Some(1),
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_array_layers")
+                .and_then(|v| v.as_u64()),
+            Some(1),
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_samples").and_then(|v| v.as_i64()),
+            Some(1),
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_tiling").and_then(|v| v.as_i64()),
+            Some(0),
+            "absent vk_image_tiling defaults to VK_IMAGE_TILING_OPTIMAL",
+        );
+        assert_eq!(
+            lookup_resp.get("vk_image_usage").and_then(|v| v.as_u64()),
+            Some(0x0F),
+            "absent vk_image_usage defaults to TRANSFER_SRC|TRANSFER_DST|SAMPLED|STORAGE",
+        );
+        assert_eq!(
+            lookup_resp
+                .get("vk_image_allocation_size")
+                .and_then(|v| v.as_u64()),
+            Some(0),
+            "absent vk_image_allocation_size defaults to 0 (consumer-derived)",
+        );
+
+        let _ = send_request_with_fds(
+            &stream,
+            &serde_json::json!({
+                "op": "release",
+                "surface_id": "legacy-defaults",
+                "runtime_id": "test-runtime",
+            }),
+            &[],
+            0,
+        );
         drop(stream);
         service.stop();
     }


### PR DESCRIPTION
## Summary

- Extend the surface-share daemon's register/lookup wire with seven optional `vk_image_*` fields (`image_type`, `mip_levels`, `array_layers`, `samples`, `tiling`, `usage`, `allocation_size`) so an OPAQUE_FD `VkImage` consumer can rebuild a matching `VkImageCreateInfo` byte-for-byte — required for `cudaExternalMemoryGetMappedMipmappedArray` and for the consumer's `vkAllocateMemory` size argument.
- Every field absent-defaults to `ConsumerVulkanTexture::from_opaque_fd`'s hardcoded shape (mip=1, layers=1, samples=1, type=2D, tiling=OPTIMAL, usage=`TRANSFER_SRC|TRANSFER_DST|SAMPLED|STORAGE`=0x0F, alloc_size=0 ⇒ consumer derives), so every legacy producer (DLPack buffer path, DMA-BUF render-target path, every `check_in` pixel-buffer caller) sees no behavior change.
- No cdylib code change in this PR — the wire is hand-rolled `serde_json::Value` parsing, and Python/Deno native crates consume only the fields they already read. The CUDA adapter image-path (#801) will populate the new fields when it lands.

## Closes

Closes #800

## What changed vs. the original issue body

- Struck the "Schema regenerated for Rust + Python + Deno via `cargo xtask generate-schemas`" exit criterion in plan-out (with dated supersession). Verified: surface-share is hand-rolled `serde_json::Value` on both daemon and subprocess sides — `cargo xtask generate-schemas` only regenerates processor configs from yaml schemas under `packages/*/schemas/`. No codegen step applies.
- The polyglot rule's "schema-only / language-specific by construction" carve-out applies: additive JSON-field extension where Python/Deno cdylibs read raw JSON and currently consume only existing fields.

## Exit criteria (refined in plan-out)

- [x] `SurfaceMetadata` / `SurfaceRegistration` / `SurfacePlaneCheckout` carry the seven new `vk_image_*` fields
- [x] `handle_register` and `handle_check_in` parse the new optional JSON fields with documented defaults; `handle_lookup` echoes them in the response payload
- [x] Workspace builds green; Python + Deno cdylibs run unchanged (no consumption of new fields today)

## Test plan

- [x] Unit test: `state::tests::vk_image_create_info_fields_round_trip_through_register_lookup` exercises non-default values through the typed `SurfaceShareState` API
- [x] Wire test: `unix_socket_service::tests::vk_image_create_info_round_trip_through_register_lookup` exercises full JSON register→lookup round-trip
- [x] Back-compat test: `unix_socket_service::tests::vk_image_create_info_absent_fields_surface_documented_defaults` exercises absent-fields path and asserts the documented defaults surface verbatim
- [x] All three tests mentally-revert-fail per the lock-in rule (each assertion ties to a specific impl line)
- [x] All 18 `linux::surface_share::*` tests pass
- [x] Workspace baseline: `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` runs to `347 passed; 2 failed; 109 ignored`. The two failures (`deno_log_surfaces_in_host_jsonl`, `deno_log_burst_preserves_order`) **pre-exist on `main`** and are unrelated to this change — they fail because `libs/streamlib-deno/_generated_/tatolab__escalate/escalate_request.ts` is missing from the working tree (Deno codegen artifact). Verified by checking out `main` and reproducing.
- [x] `cargo clippy -p streamlib-engine --lib --no-deps` surfaces no new warnings from the surface-share changes
- [x] pr-review-gate verdict: PASS, no concerns

## Polyglot coverage

- **Runtimes affected**: rust (wire-format only)
- **Schema regenerated**: n/a — surface-share wire is hand-rolled `serde_json::Value`, no codegen
- **Python and Deno both covered?** schema-only / language-specific by construction — both cdylibs parse raw JSON via `serde_json::Value` and currently consume only the existing fields (`width`, `height`, `format`, `plane_sizes`, etc.). The new `vk_image_*` fields are read by future CUDA-adapter code in #801; no cdylib code change is required in this PR. Existing tests confirm Python/Deno cdylibs run unchanged.
- **E2E tests run**:
  - [x] Host-Rust: 18 surface-share lib tests pass; workspace baseline above
  - [x] Python subprocess: no Python-side change to test — cdylib reads existing fields only
  - [x] Deno subprocess: no Deno-side change to test — cdylib reads existing fields only
- **FD-passing path**: n/a — no new FD plumbing in this PR; wire-format additive only

## Follow-ups

- #801 (blocked-by-this): adds the CUDA adapter image-path registration that populates the new wire fields and exposes `CudaTextureView` / `CudaSurfaceView` to subprocess customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)