### PR TITLE
feat(adapter-cuda): register_host_image_surface + CudaTextureView/CudaSurfaceView

### DIFF
--- a/libs/streamlib-adapter-cuda/src/adapter.rs
+++ b/libs/streamlib-adapter-cuda/src/adapter.rs
@@ -42,15 +42,20 @@ use streamlib_adapter_abi::{
     SurfaceRegistration, WriteGuard,
 };
 use streamlib_consumer_rhi::{
-    DevicePrivilege, VulkanLayout, VulkanRhiBuffer, VulkanRhiDevice, VulkanTextureLike,
-    VulkanTimelineSemaphoreLike,
+    DevicePrivilege, TextureFormat, VulkanLayout, VulkanRhiBuffer, VulkanRhiDevice,
+    VulkanTextureLike, VulkanTimelineSemaphoreLike,
 };
 #[cfg(target_os = "linux")]
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
-use crate::state::{HostSurfaceRegistration, SurfaceState};
-use crate::view::{CudaReadView, CudaWriteView};
+use crate::state::{
+    HostImageSurfaceRegistration, HostSurfaceRegistration, SurfaceResource, SurfaceState,
+};
+use crate::view::{
+    CudaReadView, CudaSurfaceGuard, CudaSurfaceView, CudaTextureGuard, CudaTextureView,
+    CudaWriteView,
+};
 
 /// Default per-acquire timeline-wait timeout. Long enough to cover any
 /// realistic GPU queue depth; short enough that a deadlock turns into
@@ -136,7 +141,9 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
             id,
             SurfaceState {
                 surface_id: id,
-                pixel_buffer: registration.pixel_buffer,
+                resource: SurfaceResource::Buffer {
+                    pixel_buffer: registration.pixel_buffer,
+                },
                 timeline: registration.timeline,
                 current_layout: registration.initial_layout,
                 read_holders: 0,
@@ -150,9 +157,63 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         Ok(())
     }
 
-    /// Drop a registered surface. Pending guards keep the underlying
-    /// `Arc<TimelineSemaphore>` and `Arc<PixelBuffer>` alive; the next
-    /// acquire returns [`AdapterError::SurfaceNotFound`].
+    /// Register an image-flavored surface for the CUDA texture / surface
+    /// object path.
+    ///
+    /// Validates that the texture's format is in the CUDA-mappable
+    /// subset (`Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`) at
+    /// registration time so the cdylib's later
+    /// `cudaExternalMemoryGetMappedMipmappedArray` call doesn't trip on
+    /// `CUDA_ERROR_INVALID_VALUE` for an unmappable format. The
+    /// host-side allocator (`HostVulkanTexture::new_opaque_fd_export`)
+    /// enforces the same check at construction; the adapter's check is
+    /// defense in depth and produces a typed
+    /// [`AdapterError::BackendRejected`] with a usage-correction hint
+    /// for the surface_id.
+    ///
+    /// Errors:
+    /// - [`AdapterError::SurfaceAlreadyRegistered`] — `id` is already
+    ///   registered (either flavor).
+    /// - [`AdapterError::BackendRejected`] — the texture's format isn't
+    ///   in the CUDA-mappable subset.
+    pub fn register_host_image_surface(
+        &self,
+        id: SurfaceId,
+        registration: HostImageSurfaceRegistration<D::Privilege>,
+    ) -> Result<(), AdapterError> {
+        let format = registration.texture.format();
+        if !is_cuda_mappable_format(format) {
+            return Err(AdapterError::BackendRejected {
+                reason: format!(
+                    "register_host_image_surface: surface_id={id}: format {format:?} is not \
+                     CUDA-mappable; allowed: Rgba8Unorm, Rgba16Float, Rgba32Float \
+                     (cudaExternalMemoryGetMappedMipmappedArray accepts only this subset)"
+                ),
+            });
+        }
+        let inserted = self.surfaces.register(
+            id,
+            SurfaceState {
+                surface_id: id,
+                resource: SurfaceResource::Image {
+                    texture: registration.texture,
+                },
+                timeline: registration.timeline,
+                current_layout: registration.initial_layout,
+                read_holders: 0,
+                write_held: false,
+                current_release_value: 0,
+            },
+        );
+        if !inserted {
+            return Err(AdapterError::SurfaceAlreadyRegistered { surface_id: id });
+        }
+        Ok(())
+    }
+
+    /// Drop a registered surface (either flavor). Pending guards keep
+    /// the underlying `Arc<TimelineSemaphore>` and resource `Arc` alive;
+    /// the next acquire returns [`AdapterError::SurfaceNotFound`].
     pub fn unregister_host_surface(&self, id: SurfaceId) -> bool {
         self.surfaces.unregister(id).is_some()
     }
@@ -164,21 +225,44 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
     }
 
     /// Power-user accessor: the registered pixel-buffer Arc for a
-    /// surface, if registered. Used by the carve-out test in
+    /// buffer-flavored surface. Used by the carve-out test in
     /// `streamlib-adapter-cuda-helpers` to call
     /// `export_opaque_fd_memory()` on the underlying buffer; future
     /// cdylib work will route this through the surface-share service
-    /// instead. Returns `None` when the surface isn't registered.
+    /// instead. Returns `None` when the surface isn't registered OR
+    /// when the surface was registered with an image-flavored
+    /// registration (use [`Self::surface_texture`] for those).
     pub fn surface_pixel_buffer(
         &self,
         id: SurfaceId,
     ) -> Option<Arc<<D::Privilege as DevicePrivilege>::Buffer>> {
         self.surfaces
-            .with(id, |state| Arc::clone(&state.pixel_buffer))
+            .with(id, |state| match &state.resource {
+                SurfaceResource::Buffer { pixel_buffer } => Some(Arc::clone(pixel_buffer)),
+                SurfaceResource::Image { .. } => None,
+            })
+            .flatten()
+    }
+
+    /// Power-user accessor: the registered texture Arc for an
+    /// image-flavored surface. Symmetric counterpart to
+    /// [`Self::surface_pixel_buffer`]. Returns `None` when the surface
+    /// isn't registered OR when the surface was registered with a
+    /// buffer-flavored registration.
+    pub fn surface_texture(
+        &self,
+        id: SurfaceId,
+    ) -> Option<Arc<<D::Privilege as DevicePrivilege>::Texture>> {
+        self.surfaces
+            .with(id, |state| match &state.resource {
+                SurfaceResource::Image { texture } => Some(Arc::clone(texture)),
+                SurfaceResource::Buffer { .. } => None,
+            })
+            .flatten()
     }
 
     /// Power-user accessor: the registered timeline-semaphore Arc for
-    /// a surface. Used by the carve-out test to call
+    /// a surface (either flavor). Used by the carve-out test to call
     /// `export_opaque_fd()` on the underlying timeline; cdylib work
     /// will route this through the surface-share service.
     pub fn surface_timeline(
@@ -259,7 +343,19 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         let session: HostCopySession<D::Privilege> = self
             .surfaces
             .try_begin_write(id, |state| {
-                let buffer_size = state.pixel_buffer.size();
+                let pixel_buffer = match &state.resource {
+                    SurfaceResource::Buffer { pixel_buffer } => pixel_buffer,
+                    SurfaceResource::Image { .. } => {
+                        return Err(AdapterError::BackendRejected {
+                            reason: format!(
+                                "submit_host_copy_image_to_buffer: surface_id={id} was \
+                                 registered as an image-flavored surface; this host-pipeline \
+                                 copy targets a buffer-flavored surface only"
+                            ),
+                        });
+                    }
+                };
+                let buffer_size = pixel_buffer.size();
                 if buffer_size < required_bytes {
                     return Err(AdapterError::BackendRejected {
                         reason: format!(
@@ -276,7 +372,7 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
                 let signal_value = state.next_release_value();
                 Ok(HostCopySession {
                     timeline: Arc::clone(&state.timeline),
-                    buffer: state.pixel_buffer.buffer(),
+                    buffer: pixel_buffer.buffer(),
                     signal_value,
                 })
             })?
@@ -326,17 +422,19 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface: &StreamlibSurface,
     ) -> Result<Option<ReadAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
-        self.surfaces.try_begin_read(id, |state| {
-            let timeline = Arc::clone(&state.timeline);
-            let wait_value = state.current_release_value;
-            let buffer = state.pixel_buffer.buffer();
-            let size = state.pixel_buffer.size();
-            Ok(ReadAcquired {
-                timeline,
-                wait_value,
-                buffer,
-                size,
-            })
+        self.surfaces.try_begin_read(id, |state| match &state.resource {
+            SurfaceResource::Buffer { pixel_buffer } => Ok(ReadAcquired {
+                timeline: Arc::clone(&state.timeline),
+                wait_value: state.current_release_value,
+                buffer: pixel_buffer.buffer(),
+                size: pixel_buffer.size(),
+            }),
+            SurfaceResource::Image { .. } => Err(AdapterError::BackendRejected {
+                reason: format!(
+                    "acquire_read: surface_id={id} was registered as an image-flavored \
+                     surface; use acquire_texture (for cudaTextureObject_t) instead"
+                ),
+            }),
         })
     }
 
@@ -345,18 +443,213 @@ impl<D: VulkanRhiDevice> CudaSurfaceAdapter<D> {
         surface: &StreamlibSurface,
     ) -> Result<Option<WriteAcquired<D::Privilege>>, AdapterError> {
         let id = surface.id;
-        self.surfaces.try_begin_write(id, |state| {
-            let timeline = Arc::clone(&state.timeline);
-            let wait_value = state.current_release_value;
-            let buffer = state.pixel_buffer.buffer();
-            let size = state.pixel_buffer.size();
-            Ok(WriteAcquired {
-                timeline,
-                wait_value,
-                buffer,
-                size,
-            })
+        self.surfaces.try_begin_write(id, |state| match &state.resource {
+            SurfaceResource::Buffer { pixel_buffer } => Ok(WriteAcquired {
+                timeline: Arc::clone(&state.timeline),
+                wait_value: state.current_release_value,
+                buffer: pixel_buffer.buffer(),
+                size: pixel_buffer.size(),
+            }),
+            SurfaceResource::Image { .. } => Err(AdapterError::BackendRejected {
+                reason: format!(
+                    "acquire_write: surface_id={id} was registered as an image-flavored \
+                     surface; use acquire_surface (for cudaSurfaceObject_t) instead"
+                ),
+            }),
         })
+    }
+
+    fn try_begin_image_read(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ImageReadAcquired<D::Privilege>>, AdapterError> {
+        let id = surface.id;
+        self.surfaces.try_begin_read(id, |state| match &state.resource {
+            SurfaceResource::Image { texture } => {
+                let image = texture.image().ok_or_else(|| AdapterError::BackendRejected {
+                    reason: format!(
+                        "acquire_texture: surface_id={id} texture has no VkImage (placeholder?)"
+                    ),
+                })?;
+                Ok(ImageReadAcquired {
+                    timeline: Arc::clone(&state.timeline),
+                    wait_value: state.current_release_value,
+                    image,
+                    width: texture.width(),
+                    height: texture.height(),
+                    format: texture.format(),
+                })
+            }
+            SurfaceResource::Buffer { .. } => Err(AdapterError::BackendRejected {
+                reason: format!(
+                    "acquire_texture: surface_id={id} was registered as a buffer-flavored \
+                     surface; use acquire_read (for DLPack capsules) instead"
+                ),
+            }),
+        })
+    }
+
+    fn try_begin_image_write(
+        &self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<ImageWriteAcquired<D::Privilege>>, AdapterError> {
+        let id = surface.id;
+        self.surfaces.try_begin_write(id, |state| match &state.resource {
+            SurfaceResource::Image { texture } => {
+                let image = texture.image().ok_or_else(|| AdapterError::BackendRejected {
+                    reason: format!(
+                        "acquire_surface: surface_id={id} texture has no VkImage (placeholder?)"
+                    ),
+                })?;
+                Ok(ImageWriteAcquired {
+                    timeline: Arc::clone(&state.timeline),
+                    wait_value: state.current_release_value,
+                    image,
+                    width: texture.width(),
+                    height: texture.height(),
+                    format: texture.format(),
+                })
+            }
+            SurfaceResource::Buffer { .. } => Err(AdapterError::BackendRejected {
+                reason: format!(
+                    "acquire_surface: surface_id={id} was registered as a buffer-flavored \
+                     surface; use acquire_write (for DLPack capsules) instead"
+                ),
+            }),
+        })
+    }
+
+    fn finalize_image_read(
+        &self,
+        surface_id: SurfaceId,
+        acquired: ImageReadAcquired<D::Privilege>,
+    ) -> Result<CudaTextureView<'_>, AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            self.surfaces.rollback_read(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+        Ok(CudaTextureView {
+            image: acquired.image,
+            width: acquired.width,
+            height: acquired.height,
+            format: acquired.format,
+            _marker: PhantomData,
+        })
+    }
+
+    fn finalize_image_write(
+        &self,
+        surface_id: SurfaceId,
+        acquired: ImageWriteAcquired<D::Privilege>,
+    ) -> Result<CudaSurfaceView<'_>, AdapterError> {
+        if acquired
+            .timeline
+            .wait(acquired.wait_value, self.acquire_timeout.as_nanos() as u64)
+            .is_err()
+        {
+            self.surfaces.rollback_write(surface_id);
+            return Err(AdapterError::SyncTimeout {
+                duration: self.acquire_timeout,
+            });
+        }
+        Ok(CudaSurfaceView {
+            image: acquired.image,
+            width: acquired.width,
+            height: acquired.height,
+            format: acquired.format,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Blocking acquire of read-only image access — the
+    /// `cudaTextureObject_t` side of CUDA's texture interop.
+    /// Returns a [`CudaTextureGuard`] scoped to the acquire window;
+    /// drop releases the read holder and signals the timeline.
+    pub fn acquire_texture<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<CudaTextureGuard<'g, D>, AdapterError> {
+        let acquired = match self.try_begin_image_read(surface)? {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder: "writer".to_string(),
+                });
+            }
+        };
+        let view = self.finalize_image_read(surface.id, acquired)?;
+        Ok(CudaTextureGuard {
+            adapter: self,
+            surface_id: surface.id,
+            view,
+        })
+    }
+
+    /// Non-blocking variant of [`Self::acquire_texture`]. Returns
+    /// `Ok(None)` on contention rather than blocking.
+    pub fn try_acquire_texture<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<CudaTextureGuard<'g, D>>, AdapterError> {
+        let acquired = match self.try_begin_image_read(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let view = self.finalize_image_read(surface.id, acquired)?;
+        Ok(Some(CudaTextureGuard {
+            adapter: self,
+            surface_id: surface.id,
+            view,
+        }))
+    }
+
+    /// Blocking acquire of read-write image access — the
+    /// `cudaSurfaceObject_t` side of CUDA's texture interop. Returns
+    /// a [`CudaSurfaceGuard`] scoped to the acquire window; drop
+    /// releases the write hold and signals the timeline.
+    pub fn acquire_surface<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<CudaSurfaceGuard<'g, D>, AdapterError> {
+        let acquired = match self.try_begin_image_write(surface)? {
+            Some(a) => a,
+            None => {
+                return Err(AdapterError::WriteContended {
+                    surface_id: surface.id,
+                    holder: self.surfaces.describe_contention(surface.id),
+                });
+            }
+        };
+        let view = self.finalize_image_write(surface.id, acquired)?;
+        Ok(CudaSurfaceGuard {
+            adapter: self,
+            surface_id: surface.id,
+            view,
+        })
+    }
+
+    /// Non-blocking variant of [`Self::acquire_surface`].
+    pub fn try_acquire_surface<'g>(
+        &'g self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<CudaSurfaceGuard<'g, D>>, AdapterError> {
+        let acquired = match self.try_begin_image_write(surface)? {
+            Some(a) => a,
+            None => return Ok(None),
+        };
+        let view = self.finalize_image_write(surface.id, acquired)?;
+        Ok(Some(CudaSurfaceGuard {
+            adapter: self,
+            surface_id: surface.id,
+            view,
+        }))
     }
 
     fn finalize_read(
@@ -689,6 +982,46 @@ struct WriteAcquired<P: DevicePrivilege> {
     size: vk::DeviceSize,
 }
 
+/// Image-flavored read snapshot — sibling of [`ReadAcquired`] for the
+/// `acquire_texture` path. Carries the `vk::Image` handle + the
+/// dimensions / format the cdylib needs to build a
+/// `cudaTextureObject_t`.
+struct ImageReadAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
+    wait_value: u64,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+}
+
+/// Image-flavored write snapshot — sibling of [`WriteAcquired`] for
+/// the `acquire_surface` path.
+struct ImageWriteAcquired<P: DevicePrivilege> {
+    timeline: Arc<P::TimelineSemaphore>,
+    wait_value: u64,
+    image: vk::Image,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+}
+
+/// Format gate enforced at [`CudaSurfaceAdapter::register_host_image_surface`]
+/// time. The CUDA-mappable subset is fixed by
+/// `cudaExternalMemoryGetMappedMipmappedArray`'s accepted
+/// `cudaChannelFormatDesc`: 1/2/4-channel `R8/R16/R32` integer or
+/// 16/32-bit float, no sRGB, no `BGR*`, no three-channel formats.
+/// Mapped to `TextureFormat` variants the streamlib RHI exposes today:
+/// `Rgba8Unorm`, `Rgba16Float`, `Rgba32Float`. Other variants
+/// (`Rgba8UnormSrgb`, `Bgra8Unorm`, `Bgra8UnormSrgb`, `Nv12`) are
+/// rejected.
+fn is_cuda_mappable_format(format: TextureFormat) -> bool {
+    matches!(
+        format,
+        TextureFormat::Rgba8Unorm | TextureFormat::Rgba16Float | TextureFormat::Rgba32Float
+    )
+}
+
 impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
     type ReadView<'g> = CudaReadView<'g>;
     type WriteView<'g> = CudaWriteView<'g>;
@@ -836,5 +1169,28 @@ impl<D: VulkanRhiDevice + 'static> SurfaceAdapter for CudaSurfaceAdapter<D> {
         if let Err(e) = timeline.signal_host(value) {
             tracing::error!(?surface_id, %value, %e, "timeline signal failed on write release");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks the CUDA-mappable format gate. Mentally revert
+    /// `is_cuda_mappable_format` to `|_| true` (or remove the
+    /// `matches!` arm) and the second assertion fires.
+    #[test]
+    fn cuda_mappable_format_accepts_supported_subset() {
+        assert!(is_cuda_mappable_format(TextureFormat::Rgba8Unorm));
+        assert!(is_cuda_mappable_format(TextureFormat::Rgba16Float));
+        assert!(is_cuda_mappable_format(TextureFormat::Rgba32Float));
+    }
+
+    #[test]
+    fn cuda_mappable_format_rejects_other_variants() {
+        assert!(!is_cuda_mappable_format(TextureFormat::Rgba8UnormSrgb));
+        assert!(!is_cuda_mappable_format(TextureFormat::Bgra8Unorm));
+        assert!(!is_cuda_mappable_format(TextureFormat::Bgra8UnormSrgb));
+        assert!(!is_cuda_mappable_format(TextureFormat::Nv12));
     }
 }

--- a/libs/streamlib-adapter-cuda/src/context.rs
+++ b/libs/streamlib-adapter-cuda/src/context.rs
@@ -28,6 +28,7 @@ use streamlib_adapter_abi::{
 use streamlib_consumer_rhi::VulkanRhiDevice;
 
 use crate::adapter::CudaSurfaceAdapter;
+use crate::view::{CudaSurfaceGuard, CudaTextureGuard};
 
 /// Customer-facing handle bound to a single runtime, generic over the
 /// device flavor. Holds a shared reference to a [`CudaSurfaceAdapter`]
@@ -83,5 +84,41 @@ impl<D: VulkanRhiDevice + 'static> CudaContext<D> {
         surface: &StreamlibSurface,
     ) -> Result<Option<WriteGuard<'a, CudaSurfaceAdapter<D>>>, AdapterError> {
         self.adapter.try_acquire_write(surface)
+    }
+
+    /// Blocking acquire of read-only image access — produces a
+    /// [`CudaTextureGuard`] whose view carries the `vk::Image` the
+    /// cdylib uses to construct a `cudaTextureObject_t`.
+    pub fn acquire_texture<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<CudaTextureGuard<'a, D>, AdapterError> {
+        self.adapter.acquire_texture(surface)
+    }
+
+    /// Non-blocking variant of [`Self::acquire_texture`].
+    pub fn try_acquire_texture<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<CudaTextureGuard<'a, D>>, AdapterError> {
+        self.adapter.try_acquire_texture(surface)
+    }
+
+    /// Blocking acquire of read-write image access — produces a
+    /// [`CudaSurfaceGuard`] whose view carries the `vk::Image` the
+    /// cdylib uses to construct a `cudaSurfaceObject_t`.
+    pub fn acquire_surface<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<CudaSurfaceGuard<'a, D>, AdapterError> {
+        self.adapter.acquire_surface(surface)
+    }
+
+    /// Non-blocking variant of [`Self::acquire_surface`].
+    pub fn try_acquire_surface<'a>(
+        &'a self,
+        surface: &StreamlibSurface,
+    ) -> Result<Option<CudaSurfaceGuard<'a, D>>, AdapterError> {
+        self.adapter.try_acquire_surface(surface)
     }
 }

--- a/libs/streamlib-adapter-cuda/src/lib.rs
+++ b/libs/streamlib-adapter-cuda/src/lib.rs
@@ -56,6 +56,9 @@ mod view;
 
 pub use adapter::CudaSurfaceAdapter;
 pub use context::CudaContext;
-pub use state::HostSurfaceRegistration;
+pub use state::{HostImageSurfaceRegistration, HostSurfaceRegistration};
 pub use streamlib_consumer_rhi::VulkanLayout;
-pub use view::{CudaReadView, CudaWriteView};
+pub use view::{
+    CudaReadView, CudaSurfaceGuard, CudaSurfaceView, CudaTextureGuard, CudaTextureView,
+    CudaWriteView,
+};

--- a/libs/streamlib-adapter-cuda/src/state.rs
+++ b/libs/streamlib-adapter-cuda/src/state.rs
@@ -3,26 +3,34 @@
 
 //! Per-surface adapter state.
 //!
-//! `CudaSurfaceAdapter<D>` is generic over the device flavor (`HostMarker`
-//! today; future cdylib work will add a consumer flavor). The structs in
-//! this module carry the privilege parameter through so the pixel-buffer
-//! and timeline-semaphore types resolve to the matching flavor (`Host*`
-//! or, eventually, `Consumer*`) at instantiation.
+//! `CudaSurfaceAdapter<D>` is generic over the device flavor and
+//! registers two resource flavors at the same scope:
 //!
-//! The CUDA adapter mirrors the *crate split* of
-//! `streamlib-adapter-cpu-readback` (adapter crate + helpers crate) and
-//! the *struct shape* of `streamlib-adapter-vulkan` (no per-acquire
-//! trigger or bridge — the host registers the OPAQUE_FD-exportable
-//! resource and the carve-out test imports it into CUDA directly,
-//! because GPU-resident inference dispatches inside the CUDA context
-//! without needing per-acquire host work).
+//! - **Buffer** ([`HostSurfaceRegistration`]) — OPAQUE_FD-exportable
+//!   `VkBuffer` for the DLPack flat-tensor path
+//!   (`cudaExternalMemoryGetMappedBuffer` → flat `void*` consumed by
+//!   `from_dlpack`-compatible AI frameworks).
+//! - **Image** ([`HostImageSurfaceRegistration`]) — OPAQUE_FD-exportable
+//!   `VkImage` for the texture / surface-object path
+//!   (`cudaExternalMemoryGetMappedMipmappedArray` → tiled mipmapped
+//!   array consumed by `cudaCreateTextureObject` /
+//!   `cudaCreateSurfaceObject` for hardware-bilinear sampling and
+//!   surface-write writes from CUDA kernels).
+//!
+//! Both flavors share the same per-surface bookkeeping (timeline,
+//! holder counters, release value, layout); the [`SurfaceResource`]
+//! enum is the discriminator. The OpenGL adapter uses the same shape
+//! at a different scope — one `SurfaceState` with a `target: u32`
+//! discriminator covers both `GL_TEXTURE_2D` and
+//! `GL_TEXTURE_EXTERNAL_OES`.
 
 use std::sync::Arc;
 
 use streamlib_adapter_abi::{SurfaceId, SurfaceRegistration};
 use streamlib_consumer_rhi::{DevicePrivilege, VulkanLayout};
 
-/// Inputs handed to [`crate::CudaSurfaceAdapter::register_host_surface`].
+/// Buffer-flavored registration — handed to
+/// [`crate::CudaSurfaceAdapter::register_host_surface`].
 ///
 /// On the host side `pixel_buffer` is a fresh `Arc<HostVulkanBuffer>`
 /// allocated via either `HostVulkanBuffer::new_opaque_fd_export`
@@ -45,12 +53,59 @@ pub struct HostSurfaceRegistration<P: DevicePrivilege> {
     /// [`streamlib_consumer_rhi::VulkanTimelineSemaphoreLike`] so the
     /// adapter's wait + signal calls work uniformly.
     pub timeline: Arc<P::TimelineSemaphore>,
-    /// Initial layout the resource is in at registration time. For
-    /// pixel buffers this is unused (buffers don't have layouts), but
-    /// the field is kept for shape parity with `streamlib-adapter-vulkan`
-    /// so the future #589/#590 work can add VkImage support without
-    /// breaking the registration shape. Pass [`VulkanLayout::UNDEFINED`].
+    /// Unused on the buffer path (buffers have no `VkImageLayout`); kept
+    /// for shape parity with [`HostImageSurfaceRegistration`]. Pass
+    /// [`VulkanLayout::UNDEFINED`].
     pub initial_layout: VulkanLayout,
+}
+
+/// Image-flavored registration — handed to
+/// [`crate::CudaSurfaceAdapter::register_host_image_surface`].
+///
+/// `texture` is a fresh `Arc<HostVulkanTexture>` allocated via
+/// `HostVulkanTexture::new_opaque_fd_export` — DEVICE_LOCAL,
+/// `VK_IMAGE_TILING_OPTIMAL`, no DRM modifier, format restricted to the
+/// CUDA-mappable subset (`Rgba8Unorm`, `Rgba16Float`, `Rgba32Float`).
+/// The CUDA cdylib imports this image via `cudaImportExternalMemory`
+/// + `cudaExternalMemoryGetMappedMipmappedArray` and constructs
+/// `cudaTextureObject_t` / `cudaSurfaceObject_t` handles per acquire.
+pub struct HostImageSurfaceRegistration<P: DevicePrivilege> {
+    /// OPAQUE_FD-exportable image — the resource CUDA imports as a
+    /// tiled mipmapped array. Host- or consumer-flavored per `P`.
+    pub texture: Arc<P::Texture>,
+    /// Timeline semaphore — same role and constraints as
+    /// [`HostSurfaceRegistration::timeline`].
+    pub timeline: Arc<P::TimelineSemaphore>,
+    /// Vulkan image layout the image is in at registration time. The
+    /// cross-process release path (a `CudaContext.release_for_cross_process`
+    /// SDK shim that delegates to `VulkanSurfaceAdapter::release_to_foreign`,
+    /// per `docs/architecture/adapter-authoring.md` → "Cross-process
+    /// producer composition") reads this when running the producer-side
+    /// QFOT release barrier. The cuda adapter itself does NOT issue any
+    /// Vulkan-side barriers on the imported image — CUDA's sync runs
+    /// pairwise via `cudaWaitExternalSemaphoresAsync` /
+    /// `cudaSignalExternalSemaphoresAsync` on the timeline.
+    pub initial_layout: VulkanLayout,
+}
+
+/// Resource discriminator stored on every [`SurfaceState`].
+///
+/// The cuda adapter holds both `Buffer` and `Image` registrations in
+/// the same [`streamlib_adapter_abi::Registry`]; the variant identifies
+/// which acquire path (`acquire_read`/`acquire_write` for buffers,
+/// `acquire_texture`/`acquire_surface` for images) is valid for a
+/// given surface_id. Mixing paths (e.g. calling `acquire_read` on an
+/// image surface) returns
+/// [`streamlib_adapter_abi::AdapterError::BackendRejected`] with a
+/// usage-correction hint, the same shape the OpenGL adapter uses for
+/// its EXTERNAL_OES read-only restriction.
+pub(crate) enum SurfaceResource<P: DevicePrivilege> {
+    Buffer {
+        pixel_buffer: Arc<P::Buffer>,
+    },
+    Image {
+        texture: Arc<P::Texture>,
+    },
 }
 
 /// Per-surface state held inside the adapter's `Registry<...>`.
@@ -61,9 +116,13 @@ pub struct HostSurfaceRegistration<P: DevicePrivilege> {
 pub(crate) struct SurfaceState<P: DevicePrivilege> {
     #[allow(dead_code)] // kept for tracing / debug output, not read in hot paths
     pub(crate) surface_id: SurfaceId,
-    pub(crate) pixel_buffer: Arc<P::Buffer>,
+    pub(crate) resource: SurfaceResource<P>,
     pub(crate) timeline: Arc<P::TimelineSemaphore>,
-    #[allow(dead_code)] // shape-parity with the Vulkan adapter; read by future image support
+    /// Vulkan image layout the resource is in. Load-bearing for image
+    /// surfaces (consumed by the cross-process release shim that
+    /// composes `VulkanSurfaceAdapter::release_to_foreign`); ignored on
+    /// the buffer path.
+    #[allow(dead_code)] // consumed by the cross-process release shim (see HostImageSurfaceRegistration::initial_layout)
     pub(crate) current_layout: VulkanLayout,
     pub(crate) read_holders: u64,
     pub(crate) write_held: bool,

--- a/libs/streamlib-adapter-cuda/src/view.rs
+++ b/libs/streamlib-adapter-cuda/src/view.rs
@@ -4,28 +4,47 @@
 //! Read and write views handed back to consumers inside an acquire
 //! scope.
 //!
-//! Each view exposes the underlying `vk::Buffer` handle, the buffer
-//! size, and a [`dlpack_managed_tensor`](CudaReadView::dlpack_managed_tensor)
-//! constructor that wraps a caller-supplied CUDA device pointer in a
-//! DLPack-spec [`crate::dlpack::ManagedTensor`]. The cdylib subprocess
-//! runtimes (`streamlib-python-native` / `streamlib-deno-native` in
-//! #589/#590) obtain the device pointer via
-//! `cudaExternalMemoryGetMappedBuffer` against the
-//! [`vk_buffer`](CudaReadView::vk_buffer) FD and feed it into the
-//! constructor; this crate stays free of `cudarc` so non-CUDA customers
-//! don't pay for unused dependencies.
+//! Two flavors, one per resource kind:
+//!
+//! - **Buffer flavor** ([`CudaReadView`] / [`CudaWriteView`]) — exposes
+//!   `vk::Buffer` + size + a DLPack-spec
+//!   [`crate::dlpack::ManagedTensor`] constructor over a caller-supplied
+//!   CUDA device pointer. The cdylib subprocess runtimes obtain the
+//!   device pointer via `cudaExternalMemoryGetMappedBuffer` against the
+//!   imported OPAQUE_FD `VkBuffer` and feed it into the constructor.
+//! - **Image flavor** ([`CudaTextureView`] / [`CudaSurfaceView`]) —
+//!   exposes `vk::Image` + dimensions + format. The cdylib imports the
+//!   image via `cudaImportExternalMemory` +
+//!   `cudaExternalMemoryGetMappedMipmappedArray`, then constructs a
+//!   `cudaTextureObject_t` (read-only sampling, [`CudaTextureView`]) or
+//!   a `cudaSurfaceObject_t` (read-write surface ops, [`CudaSurfaceView`])
+//!   at the cdylib's own FFI surface. The Rust view stays
+//!   `cudarc`-free so non-CUDA customers don't pay for unused
+//!   dependencies.
+//!
+//! Image-flavored guards ([`CudaTextureGuard`], [`CudaSurfaceGuard`])
+//! live alongside the views because the `SurfaceAdapter` trait fixes a
+//! single `ReadView` / `WriteView` associated type per adapter (the
+//! buffer flavor); the image flavor's acquire methods are
+//! adapter-specific and use their own guard types. Drop on both guard
+//! types calls into the same `end_read_access` / `end_write_access`
+//! machinery the trait guards use — the underlying registry
+//! bookkeeping is resource-agnostic.
 
 use std::marker::PhantomData;
 
+use streamlib_adapter_abi::{SurfaceAdapter, SurfaceId};
+use streamlib_consumer_rhi::{TextureFormat, VulkanRhiDevice};
 use vulkanalia::vk;
 
+use crate::adapter::CudaSurfaceAdapter;
 use crate::dlpack::{
     self, CapsuleOwner, Device as DlpackDevice, ManagedTensor as DlpackManagedTensor,
 };
 
-/// Read view of an acquired surface — exposes the host's `vk::Buffer`
-/// handle, its size in bytes, and a DLPack capsule constructor over a
-/// caller-supplied CUDA device pointer.
+/// Read view of an acquired buffer-flavored surface — exposes the
+/// host's `vk::Buffer` handle, its size in bytes, and a DLPack capsule
+/// constructor over a caller-supplied CUDA device pointer.
 pub struct CudaReadView<'g> {
     pub(crate) buffer: vk::Buffer,
     pub(crate) size: vk::DeviceSize,
@@ -60,8 +79,8 @@ impl<'g> CudaReadView<'g> {
     }
 }
 
-/// Write view of an acquired surface — symmetric counterpart to
-/// [`CudaReadView`].
+/// Write view of an acquired buffer-flavored surface — symmetric
+/// counterpart to [`CudaReadView`].
 pub struct CudaWriteView<'g> {
     pub(crate) buffer: vk::Buffer,
     pub(crate) size: vk::DeviceSize,
@@ -85,5 +104,143 @@ impl<'g> CudaWriteView<'g> {
         owner: CapsuleOwner,
     ) -> *mut DlpackManagedTensor {
         dlpack::build_byte_buffer_managed_tensor(device_ptr, self.size, device, owner)
+    }
+}
+
+/// Read-only view of an acquired image-flavored surface — exposes the
+/// underlying `vk::Image` handle and the image's dimensions + format.
+///
+/// The CUDA cdylib uses these fields to construct a
+/// `cudaTextureObject_t` for the surface's pre-imported mipmapped
+/// array (one-time `cudaImportExternalMemory` +
+/// `cudaExternalMemoryGetMappedMipmappedArray` at registration) and
+/// returns the raw `uint64_t` handle to the customer at the cdylib's
+/// FFI surface. The construction step itself lives in the cdylib
+/// because `cudarc` isn't a dep of this crate.
+pub struct CudaTextureView<'g> {
+    pub(crate) image: vk::Image,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) format: TextureFormat,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl<'g> CudaTextureView<'g> {
+    /// Underlying Vulkan image handle.
+    pub fn vk_image(&self) -> vk::Image {
+        self.image
+    }
+    /// Image width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+    /// Image height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+    /// Image format — guaranteed to be in the CUDA-mappable subset
+    /// (`Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`) by the adapter's
+    /// registration-time check.
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+}
+
+/// Read-write view of an acquired image-flavored surface — same
+/// Vulkan-side shape as [`CudaTextureView`], but the cdylib constructs
+/// a `cudaSurfaceObject_t` (the writeable side of CUDA texture
+/// interop) for kernels that need surface-write semantics.
+pub struct CudaSurfaceView<'g> {
+    pub(crate) image: vk::Image,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) format: TextureFormat,
+    pub(crate) _marker: PhantomData<&'g ()>,
+}
+
+impl<'g> CudaSurfaceView<'g> {
+    /// Underlying Vulkan image handle.
+    pub fn vk_image(&self) -> vk::Image {
+        self.image
+    }
+    /// Image width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+    /// Image height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+    /// Image format — see [`CudaTextureView::format`].
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+}
+
+/// RAII guard for [`CudaSurfaceAdapter::acquire_texture`] /
+/// [`CudaSurfaceAdapter::try_acquire_texture`]. Scoped to the
+/// image-flavored read path; drop releases the read holder and signals
+/// the timeline.
+pub struct CudaTextureGuard<'g, D: VulkanRhiDevice + 'static> {
+    pub(crate) adapter: &'g CudaSurfaceAdapter<D>,
+    pub(crate) surface_id: SurfaceId,
+    pub(crate) view: CudaTextureView<'g>,
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> CudaTextureGuard<'g, D> {
+    pub fn view(&self) -> &CudaTextureView<'g> {
+        &self.view
+    }
+    pub fn surface_id(&self) -> SurfaceId {
+        self.surface_id
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> Drop for CudaTextureGuard<'_, D> {
+    fn drop(&mut self) {
+        self.adapter.end_read_access(self.surface_id);
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> std::fmt::Debug for CudaTextureGuard<'_, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CudaTextureGuard")
+            .field("surface_id", &self.surface_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// RAII guard for [`CudaSurfaceAdapter::acquire_surface`] /
+/// [`CudaSurfaceAdapter::try_acquire_surface`]. Symmetric to
+/// [`CudaTextureGuard`] for the writeable image path.
+pub struct CudaSurfaceGuard<'g, D: VulkanRhiDevice + 'static> {
+    pub(crate) adapter: &'g CudaSurfaceAdapter<D>,
+    pub(crate) surface_id: SurfaceId,
+    pub(crate) view: CudaSurfaceView<'g>,
+}
+
+impl<'g, D: VulkanRhiDevice + 'static> CudaSurfaceGuard<'g, D> {
+    pub fn view(&self) -> &CudaSurfaceView<'g> {
+        &self.view
+    }
+    pub fn view_mut(&mut self) -> &mut CudaSurfaceView<'g> {
+        &mut self.view
+    }
+    pub fn surface_id(&self) -> SurfaceId {
+        self.surface_id
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> Drop for CudaSurfaceGuard<'_, D> {
+    fn drop(&mut self) {
+        self.adapter.end_write_access(self.surface_id);
+    }
+}
+
+impl<D: VulkanRhiDevice + 'static> std::fmt::Debug for CudaSurfaceGuard<'_, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CudaSurfaceGuard")
+            .field("surface_id", &self.surface_id)
+            .finish_non_exhaustive()
     }
 }

--- a/libs/streamlib-adapter-cuda/tests/image_registration.rs
+++ b/libs/streamlib-adapter-cuda/tests/image_registration.rs
@@ -1,0 +1,498 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `streamlib_adapter_cuda::tests::image_registration` — exercises the
+//! image-flavored registration path (`register_host_image_surface` +
+//! `CudaTextureView` / `CudaSurfaceView` + `acquire_texture` /
+//! `acquire_surface`) end-to-end through the host RHI's
+//! `HostVulkanTexture::new_opaque_fd_export` primitive.
+//!
+//! The cdylib's CUDA-side mapping (`cudaImportExternalMemory` →
+//! `cudaExternalMemoryGetMappedMipmappedArray` →
+//! `cudaCreateTextureObject` / `cudaCreateSurfaceObject`) is **out of
+//! scope** here — that's the cdylib bring-up work in the polyglot CUDA
+//! cdylib image-path issue. This test asserts the adapter's
+//! registration shape, the view types' Vulkan-side accessors, the
+//! release-on-drop release semantics, and the path-restriction error
+//! messages when callers mix buffer and image acquire paths.
+//!
+//! Test gating:
+//! - `target_os = "linux"` — OPAQUE_FD `VkImage` is Linux-only by
+//!   construction.
+//! - Skips when Vulkan is unavailable OR when
+//!   `HostVulkanDevice::opaque_fd_image_pool()` returns `None` (NVIDIA
+//!   driver without external-memory; CI Mesa hosts).
+
+#![cfg(target_os = "linux")]
+
+use std::sync::Arc;
+
+use streamlib::sdk::context::GpuContext;
+use streamlib::sdk::engine::host_rhi::{
+    HostVulkanBuffer, HostVulkanDevice, HostVulkanTexture, HostVulkanTimelineSemaphore,
+};
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::rhi::{TextureDescriptor, TextureFormat as RhiTextureFormat};
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceFormat, SurfaceId, SurfaceSyncState,
+    SurfaceTransportHandle, SurfaceUsage,
+};
+use streamlib_adapter_cuda::{
+    CudaSurfaceAdapter, HostImageSurfaceRegistration, HostSurfaceRegistration, VulkanLayout,
+};
+use streamlib_consumer_rhi::TextureFormat as ConsumerTextureFormat;
+
+const W: u32 = 32;
+const H: u32 = 32;
+
+fn try_init_gpu() -> Option<Arc<GpuContext>> {
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter("streamlib_adapter_cuda=debug,streamlib=warn")
+        .try_init();
+    GpuContext::init_for_platform_sync().ok().map(Arc::new)
+}
+
+/// Acquire a host device, skip the test if the OPAQUE_FD image pool
+/// is missing on this driver.
+fn host_device_or_skip(test_name: &str) -> Option<Arc<HostVulkanDevice>> {
+    let gpu = try_init_gpu()?;
+    let host_device = Arc::clone(gpu.device().vulkan_device());
+    if host_device.opaque_fd_image_pool().is_none() {
+        println!(
+            "{test_name}: skipping — OPAQUE_FD image pool unavailable on this driver"
+        );
+        return None;
+    }
+    Some(host_device)
+}
+
+fn make_image(
+    host_device: &Arc<HostVulkanDevice>,
+    format: RhiTextureFormat,
+) -> Result<Arc<HostVulkanTexture>, String> {
+    let desc = TextureDescriptor::new(W, H, format);
+    HostVulkanTexture::new_opaque_fd_export(host_device, &desc)
+        .map(Arc::new)
+        .map_err(|e| format!("HostVulkanTexture::new_opaque_fd_export({format:?}): {e}"))
+}
+
+fn make_timeline(
+    host_device: &Arc<HostVulkanDevice>,
+) -> Result<Arc<HostVulkanTimelineSemaphore>, String> {
+    HostVulkanTimelineSemaphore::new_exportable(host_device.device(), 0)
+        .map(Arc::new)
+        .map_err(|e| format!("HostVulkanTimelineSemaphore::new_exportable: {e}"))
+}
+
+fn make_buffer(host_device: &Arc<HostVulkanDevice>) -> Result<Arc<HostVulkanBuffer>, String> {
+    HostVulkanBuffer::new_opaque_fd_export(host_device, (W as u64) * (H as u64) * 4)
+        .map(Arc::new)
+        .map_err(|e| format!("HostVulkanBuffer::new_opaque_fd_export: {e}"))
+}
+
+fn make_surface(id: SurfaceId) -> StreamlibSurface {
+    StreamlibSurface::new(
+        id,
+        W,
+        H,
+        SurfaceFormat::Bgra8,
+        SurfaceUsage::SAMPLED,
+        SurfaceTransportHandle::empty(),
+        SurfaceSyncState::default(),
+    )
+}
+
+/// Register an image surface and confirm the registry exposes the
+/// texture (not a buffer). Mentally revert `register_host_image_surface`
+/// to store in `SurfaceResource::Buffer` and the `surface_texture`
+/// lookup fails (returns `None`).
+#[test]
+fn image_registration_round_trips_through_surface_texture_accessor() {
+    let Some(host_device) = host_device_or_skip(
+        "image_registration_round_trips_through_surface_texture_accessor",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x4001;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm)
+        .expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture: Arc::clone(&texture),
+                timeline: Arc::clone(&timeline),
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    assert_eq!(adapter.registered_count(), 1);
+    let stored = adapter.surface_texture(id).expect("surface_texture Some");
+    assert!(Arc::ptr_eq(&stored, &texture), "texture Arc round-trip");
+    let stored_tl = adapter.surface_timeline(id).expect("surface_timeline Some");
+    assert!(Arc::ptr_eq(&stored_tl, &timeline), "timeline Arc round-trip");
+    // Buffer accessor must return None for image-flavored registrations.
+    assert!(
+        adapter.surface_pixel_buffer(id).is_none(),
+        "surface_pixel_buffer should be None for image surfaces"
+    );
+    assert!(adapter.unregister_host_surface(id));
+    assert_eq!(adapter.registered_count(), 0);
+}
+
+/// Validates each CUDA-mappable format registers cleanly. The host RHI
+/// also enforces the same gate at construction; this test asserts the
+/// adapter accepts every variant the host can build.
+#[test]
+fn image_registration_accepts_each_cuda_mappable_format() {
+    let Some(host_device) = host_device_or_skip(
+        "image_registration_accepts_each_cuda_mappable_format",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    for (i, fmt) in [
+        RhiTextureFormat::Rgba8Unorm,
+        RhiTextureFormat::Rgba16Float,
+        RhiTextureFormat::Rgba32Float,
+    ]
+    .iter()
+    .enumerate()
+    {
+        let id = 0x5000 + i as SurfaceId;
+        let texture = match make_image(&host_device, *fmt) {
+            Ok(t) => t,
+            Err(e) => {
+                println!(
+                    "image_registration_accepts_each_cuda_mappable_format: skipping {fmt:?}: {e}"
+                );
+                continue;
+            }
+        };
+        let timeline = make_timeline(&host_device).expect("timeline");
+        adapter
+            .register_host_image_surface(
+                id,
+                HostImageSurfaceRegistration {
+                    texture,
+                    timeline,
+                    initial_layout: VulkanLayout::UNDEFINED,
+                },
+            )
+            .unwrap_or_else(|e| panic!("register {fmt:?}: {e:?}"));
+    }
+}
+
+/// Buffer and image registrations on the same `SurfaceId` collide —
+/// the registry is one keyspace regardless of flavor.
+#[test]
+fn buffer_then_image_registration_returns_surface_already_registered() {
+    let Some(host_device) = host_device_or_skip(
+        "buffer_then_image_registration_returns_surface_already_registered",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x6001;
+    let buffer = make_buffer(&host_device).expect("buffer");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_surface(
+            id,
+            HostSurfaceRegistration {
+                pixel_buffer: buffer,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register buffer");
+    let image = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("image");
+    let timeline2 = make_timeline(&host_device).expect("timeline2");
+    let result = adapter.register_host_image_surface(
+        id,
+        HostImageSurfaceRegistration {
+            texture: image,
+            timeline: timeline2,
+            initial_layout: VulkanLayout::GENERAL,
+        },
+    );
+    match result {
+        Err(AdapterError::SurfaceAlreadyRegistered { surface_id }) => {
+            assert_eq!(surface_id, id);
+        }
+        other => panic!("expected SurfaceAlreadyRegistered, got {other:?}"),
+    }
+}
+
+/// `acquire_texture` on a registered image surface returns a guard
+/// whose view exposes the correct `vk::Image`, dimensions, and format.
+/// Drop releases the read holder so a subsequent acquire succeeds —
+/// mentally revert `Drop for CudaTextureGuard` (skip the
+/// `end_read_access` call) and the second acquire fails with a stale
+/// holder lingering.
+#[test]
+fn acquire_texture_returns_view_with_correct_handles_and_releases_on_drop() {
+    let Some(host_device) = host_device_or_skip(
+        "acquire_texture_returns_view_with_correct_handles_and_releases_on_drop",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x7001;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba16Float).expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture: Arc::clone(&texture),
+                timeline,
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    {
+        let guard = adapter.acquire_texture(&surface).expect("acquire_texture");
+        let view = guard.view();
+        let expected_image = streamlib_consumer_rhi::VulkanTextureLike::image(&*texture)
+            .expect("texture has VkImage");
+        assert_eq!(view.vk_image(), expected_image);
+        assert_eq!(view.width(), W);
+        assert_eq!(view.height(), H);
+        assert_eq!(view.format(), ConsumerTextureFormat::Rgba16Float);
+        assert_eq!(guard.surface_id(), id);
+    }
+    // Guard dropped — the next acquire must succeed because the read
+    // holder was released by Drop.
+    let _again = adapter.acquire_texture(&surface).expect("re-acquire_texture");
+}
+
+/// `acquire_surface` mirrors `acquire_texture` on the writeable side.
+#[test]
+fn acquire_surface_returns_view_with_correct_handles_and_releases_on_drop() {
+    let Some(host_device) = host_device_or_skip(
+        "acquire_surface_returns_view_with_correct_handles_and_releases_on_drop",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x7002;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba32Float).expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture: Arc::clone(&texture),
+                timeline,
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    {
+        let guard = adapter.acquire_surface(&surface).expect("acquire_surface");
+        let view = guard.view();
+        let expected_image = streamlib_consumer_rhi::VulkanTextureLike::image(&*texture)
+            .expect("texture has VkImage");
+        assert_eq!(view.vk_image(), expected_image);
+        assert_eq!(view.width(), W);
+        assert_eq!(view.height(), H);
+        assert_eq!(view.format(), ConsumerTextureFormat::Rgba32Float);
+        assert_eq!(guard.surface_id(), id);
+    }
+    let _again = adapter.acquire_surface(&surface).expect("re-acquire_surface");
+}
+
+/// Path-restriction: an image-flavored surface rejects `acquire_read`
+/// / `acquire_write` (the buffer-path methods) with a typed
+/// `BackendRejected` carrying a usage-correction hint. Symmetric to
+/// the OpenGL adapter's EXTERNAL_OES-rejects-write hint.
+#[test]
+fn buffer_path_rejects_image_surface_with_usage_correction_hint() {
+    let Some(host_device) = host_device_or_skip(
+        "buffer_path_rejects_image_surface_with_usage_correction_hint",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x8001;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    use streamlib_adapter_abi::SurfaceAdapter;
+    match adapter.acquire_read(&surface) {
+        Err(AdapterError::BackendRejected { reason }) => {
+            assert!(
+                reason.contains("acquire_texture"),
+                "error should suggest acquire_texture; got: {reason}"
+            );
+        }
+        other => panic!("expected BackendRejected, got {other:?}"),
+    }
+    // `WriteGuard` doesn't impl `Debug`, so we can't `{:?}` the Ok arm;
+    // pattern-match explicitly to keep the failure mode informative.
+    let write_result = adapter.acquire_write(&surface);
+    match write_result {
+        Err(AdapterError::BackendRejected { reason }) => {
+            assert!(
+                reason.contains("acquire_surface"),
+                "error should suggest acquire_surface; got: {reason}"
+            );
+        }
+        Err(e) => panic!("expected BackendRejected, got Err({e:?})"),
+        Ok(_) => panic!("expected BackendRejected on image surface, got Ok(WriteGuard)"),
+    }
+}
+
+/// Path-restriction: a buffer-flavored surface rejects
+/// `acquire_texture` / `acquire_surface` (the image-path methods)
+/// with a typed `BackendRejected` carrying the inverse usage hint.
+#[test]
+fn image_path_rejects_buffer_surface_with_usage_correction_hint() {
+    let Some(host_device) = host_device_or_skip(
+        "image_path_rejects_buffer_surface_with_usage_correction_hint",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x8101;
+    let buffer = make_buffer(&host_device).expect("buffer");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_surface(
+            id,
+            HostSurfaceRegistration {
+                pixel_buffer: buffer,
+                timeline,
+                initial_layout: VulkanLayout::UNDEFINED,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    match adapter.acquire_texture(&surface) {
+        Err(AdapterError::BackendRejected { reason }) => {
+            assert!(
+                reason.contains("acquire_read"),
+                "error should suggest acquire_read; got: {reason}"
+            );
+        }
+        other => panic!("expected BackendRejected, got {other:?}"),
+    }
+    match adapter.acquire_surface(&surface) {
+        Err(AdapterError::BackendRejected { reason }) => {
+            assert!(
+                reason.contains("acquire_write"),
+                "error should suggest acquire_write; got: {reason}"
+            );
+        }
+        other => panic!("expected BackendRejected, got {other:?}"),
+    }
+}
+
+/// `try_acquire_surface` returns `Ok(None)` (rather than blocking) when
+/// the surface is already held for read. Mirrors the buffer-path
+/// `try_acquire_write` contention behavior.
+#[test]
+fn try_acquire_surface_returns_none_on_reader_contention() {
+    let Some(host_device) = host_device_or_skip(
+        "try_acquire_surface_returns_none_on_reader_contention",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x9001;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    let _reader = adapter.acquire_texture(&surface).expect("acquire_texture");
+    let result = adapter.try_acquire_surface(&surface);
+    match result {
+        Ok(None) => {}
+        Ok(Some(_)) => panic!("expected Ok(None) on reader contention, got Ok(Some(_))"),
+        Err(e) => panic!("expected Ok(None) on reader contention, got Err({e:?})"),
+    }
+}
+
+/// `try_acquire_texture` returns `Ok(None)` when the surface is held
+/// for write.
+#[test]
+fn try_acquire_texture_returns_none_on_writer_contention() {
+    let Some(host_device) = host_device_or_skip(
+        "try_acquire_texture_returns_none_on_writer_contention",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::new(Arc::clone(&host_device));
+    let id: SurfaceId = 0x9002;
+    let texture = make_image(&host_device, RhiTextureFormat::Rgba8Unorm).expect("texture");
+    let timeline = make_timeline(&host_device).expect("timeline");
+    adapter
+        .register_host_image_surface(
+            id,
+            HostImageSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout::GENERAL,
+            },
+        )
+        .expect("register");
+    let surface = make_surface(id);
+    let _writer = adapter.acquire_surface(&surface).expect("acquire_surface");
+    match adapter.try_acquire_texture(&surface) {
+        Ok(None) => {}
+        other => panic!("expected Ok(None) on writer contention, got {other:?}"),
+    }
+}
+
+/// Acquire methods on an unregistered surface return
+/// `AdapterError::SurfaceNotFound`. Symmetric to the buffer path's
+/// `SurfaceNotFound` behavior; locks that the image-acquire methods
+/// surface the same error variant rather than falling into a generic
+/// rejection.
+#[test]
+fn image_acquire_on_unregistered_surface_returns_surface_not_found() {
+    let Some(_host_device) = host_device_or_skip(
+        "image_acquire_on_unregistered_surface_returns_surface_not_found",
+    ) else {
+        return;
+    };
+    let adapter = CudaSurfaceAdapter::<HostVulkanDevice>::new(_host_device);
+    let surface = make_surface(0xdead_b001);
+    match adapter.acquire_texture(&surface) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_b001);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+    match adapter.acquire_surface(&surface) {
+        Err(AdapterError::SurfaceNotFound { surface_id }) => {
+            assert_eq!(surface_id, 0xdead_b001);
+        }
+        other => panic!("expected SurfaceNotFound, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a parallel image-flavored registration path on `CudaSurfaceAdapter` alongside the existing buffer-flavored DLPack path. `register_host_image_surface(id, HostImageSurfaceRegistration<P>)` accepts an OPAQUE_FD-exportable `Arc<P::Texture>` (from #799) + timeline + initial_layout, validates the CUDA-mappable format subset (`Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`), and stashes it alongside buffer surfaces in one keyspace.
- New `CudaTextureView<'g>` (`cudaTextureObject_t` side — read-only sampling) and `CudaSurfaceView<'g>` (`cudaSurfaceObject_t` side — read-write surface ops), plus `CudaTextureGuard` / `CudaSurfaceGuard` RAII guards and `acquire_texture` / `try_acquire_texture` / `acquire_surface` / `try_acquire_surface` on `CudaSurfaceAdapter` + `CudaContext`. The views carry the Vulkan-side identity (`vk::Image` + dims + format); the cdylib constructs the CUDA u64 handles at its own FFI surface (deferred to #802).
- `SurfaceState<P>` refactored to carry a `SurfaceResource { Buffer | Image }` discriminator. Mixing acquire paths (e.g. `acquire_read` on an image surface) returns `AdapterError::BackendRejected` with a usage-correction hint pointing at the right method — same shape as the OpenGL adapter's `GL_TEXTURE_2D` ↔ `GL_TEXTURE_EXTERNAL_OES` precedent.

## Closes

Closes #801

## Out of scope, deferred to #802

- Python/Deno cdylib FFI bring-up: `slpn_cuda_register_image_surface`, `slpn_cuda_acquire_texture`, `slpn_cuda_acquire_surface`, etc. — and Deno equivalents.
- Python/Deno SDK `CudaContext.release_for_cross_process` shim (mirrors `OpenGLContext.release_for_cross_process` — a one-line delegate to `VulkanContext.release_for_cross_process`).
- CUDA-side mapping: `cudaImportExternalMemory(OPAQUE_FD)` → `cudaExternalMemoryGetMappedMipmappedArray` → `cudaCreateTextureObject` / `cudaCreateSurfaceObject`.
- Integration test for the dual-registration release path (the shim is at the SDK layer, so its test goes with the shim).

## Not needed (deferred indefinitely)

- Image-flavored `AdapterPersistentSubmitContext` sibling: the existing `{ pool, cmd, fence }` struct is resource-agnostic. The cuda image path does NOT need host-side submit machinery in `streamlib-adapter-cuda` — producers (in-process Vulkan-based) write the registered `VkImage` directly, and CUDA's sync runs pairwise via `cudaWaitExternalSemaphoresAsync` / `cudaSignalExternalSemaphoresAsync` on the timeline (zero Vulkan-side barriers on the imported VkImage from the cuda adapter). The existing triplication for the buffer-path `submit_host_copy_image_to_buffer` is untouched.

## Test plan

- [x] `cargo check -p streamlib-adapter-cuda --tests` — clean
- [x] `cargo check -p streamlib-python-native -p streamlib-deno-native` — cdylibs compile (the additive API didn't break existing callers)
- [x] `cargo test -p streamlib-adapter-cuda -p streamlib-adapter-cuda-helpers` — all green:
  - 12 unit tests (src/state, src/dlpack, src/adapter format gate)
  - 3 conformance tests (existing buffer path — unchanged)
  - **10 new image-registration tests** (`tests/image_registration.rs`):
    - registration round-trip through `surface_texture` accessor
    - each CUDA-mappable format accepted
    - buffer + image registration on same `SurfaceId` collides with `SurfaceAlreadyRegistered`
    - `acquire_texture` / `acquire_surface` return views with correct `vk::Image` + dims + format
    - Drop on `CudaTextureGuard` / `CudaSurfaceGuard` releases holders (next acquire works)
    - buffer path rejects image surface with `acquire_texture` / `acquire_surface` hint
    - image path rejects buffer surface with `acquire_read` / `acquire_write` hint
    - `try_acquire_*` returns `Ok(None)` on contention
    - acquire on unregistered surface returns `SurfaceNotFound`
  - 1 persistent command pool test (existing — unchanged)
  - 2 helpers carve-out tests (engine-level OPAQUE_FD VkBuffer + VkImage round-trips — unchanged)
- [x] `cargo xtask lint-logging` — 409 files scanned, no violations
- [x] `cargo xtask check-boundaries` — 3536 files scanned, no violations

## Reviewer notes

`pr-review-gate` returned **PASS** with one DISCUSS-level note: the adapter-side format-rejection path (`BackendRejected` from `register_host_image_surface` when given a non-CUDA-mappable format) has no integration test, because both `HostVulkanTexture::new_opaque_fd_export` and `ConsumerVulkanTexture::from_opaque_fd` gate the same format subset at construction — there's no constructible input that exercises the adapter-level gate today. The `is_cuda_mappable_format` helper is unit-tested (positive and negative cases lock the format list); mental-reverting the helper to `|_| true` fires the negative-case assertion. The adapter-level integration test would require a mock `VulkanRhiDevice` + `VulkanTextureLike` that lies about its format; small follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)