### PR TITLE
feat(polyglot-native): cudaExternalMemoryGetMappedMipmappedArray + texture/surface object creation

### DIFF
--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4579,7 +4579,7 @@ mod cpu_readback {
 
 #[cfg(target_os = "linux")]
 mod cuda {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
     use std::os::unix::io::RawFd;
@@ -5599,27 +5599,35 @@ mod cuda {
     /// (the CUDA-side handle yielded by
     /// `cudaExternalMemoryGetMappedMipmappedArray`), the per-surface
     /// stream, plus the same imported timeline + the host
-    /// `Arc<ConsumerVulkanTexture>` for Drop-order keepalive.
+    /// `Arc<ConsumerVulkanTexture>` for keepalive across CUDA-side
+    /// teardown.
     ///
     /// Per-acquire `cudaTextureObject_t` / `cudaSurfaceObject_t`
-    /// handles live on `live_objects` — push on acquire, pop on
-    /// release. LIFO mirrors the scope-bound `using` pattern at the
-    /// SDK layer.
+    /// handles live in `live_textures` / `live_surfaces` (sets keyed
+    /// by handle value). Each release call passes its handle back so
+    /// the cdylib destroys the exact object the customer used — not
+    /// whichever was last constructed. This makes concurrent reads
+    /// (the adapter supports N read holders) safe.
     struct RegisteredCudaImageSurface {
-        // CUDA-side imports — Drop runs in declaration order, so list
-        // these first to ensure they're torn down before the Vulkan
-        // Arcs below release the underlying memory.
+        // CUDA-side imports — the manual `Drop` impl below tears them
+        // down in the correct order explicitly. Field declaration
+        // order doesn't matter for teardown correctness; the explicit
+        // Drop runs first and field drops fire afterward (with the
+        // Vulkan-side Arcs dropping last so the CUDA imports never
+        // outlive their backing memory).
         ext_mem: sys::cudaExternalMemory_t,
         ext_sem: sys::cudaExternalSemaphore_t,
         stream: sys::cudaStream_t,
         mipmapped_array: sys::cudaMipmappedArray_t,
-        /// Stack of live `cudaTextureObject_t` / `cudaSurfaceObject_t`
-        /// handles — one entry per outstanding acquire. Both types are
-        /// `c_ulonglong` so a single `u64` discriminator-less stack
-        /// covers either flavor (read-side pushes texture objects,
-        /// write-side pushes surface objects; releases pop the
-        /// matching flavor by FFI entry-point selection).
-        live_objects: Mutex<Vec<u64>>,
+        /// Outstanding `cudaTextureObject_t` handles. The release
+        /// FFI removes the specific handle the customer passes back;
+        /// `Drop` drains anything left over (orphan from a leak).
+        live_textures: Mutex<HashSet<u64>>,
+        /// Symmetric to [`Self::live_textures`] but for
+        /// `cudaSurfaceObject_t`. Two sets (rather than one
+        /// flavor-tagged set) so the destroy call dispatches without
+        /// a lookup.
+        live_surfaces: Mutex<HashSet<u64>>,
         width: u32,
         height: u32,
         format: TextureFormat,
@@ -5638,29 +5646,31 @@ mod cuda {
     impl Drop for RegisteredCudaImageSurface {
         fn drop(&mut self) {
             unsafe {
-                // Destroy any texture / surface objects still outstanding.
-                // Customers SHOULD release every acquire before unregister,
-                // but a forced unregister mid-flight shouldn't leak handles.
-                let drained: Vec<u64> = self
-                    .live_objects
+                // Destroy any outstanding texture / surface objects.
+                // Customers SHOULD release every acquire before
+                // unregister, but a forced teardown mid-flight
+                // shouldn't leak handles. Per-flavor sets mean we
+                // dispatch to the right CUDA destroy call without
+                // trial-and-error.
+                let textures: Vec<u64> = self
+                    .live_textures
                     .lock()
-                    .expect("RegisteredCudaImageSurface live_objects: poisoned")
-                    .drain(..)
+                    .expect("RegisteredCudaImageSurface live_textures: poisoned")
+                    .drain()
                     .collect();
-                for handle in drained {
-                    // Texture and surface objects use the same destroy
-                    // signature — pick by trial since we don't track
-                    // flavor on the stack. `cudaDestroyTextureObject`
-                    // returns `cudaErrorInvalidValue` on a surface
-                    // object (and vice-versa), so attempt one then the
-                    // other.
-                    if sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t)
-                        .result()
-                        .is_err()
-                    {
-                        let _ = sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t)
-                            .result();
-                    }
+                for handle in textures {
+                    let _ =
+                        sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result();
+                }
+                let surfaces: Vec<u64> = self
+                    .live_surfaces
+                    .lock()
+                    .expect("RegisteredCudaImageSurface live_surfaces: poisoned")
+                    .drain()
+                    .collect();
+                for handle in surfaces {
+                    let _ =
+                        sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result();
                 }
                 if !self.mipmapped_array.is_null() {
                     let _ = sys::cudaFreeMipmappedArray(self.mipmapped_array).result();
@@ -5991,7 +6001,8 @@ mod cuda {
             ext_sem,
             stream,
             mipmapped_array,
-            live_objects: Mutex::new(Vec::new()),
+            live_textures: Mutex::new(HashSet::new()),
+            live_surfaces: Mutex::new(HashSet::new()),
             width: gpu.width,
             height: gpu.height,
             format: texture_format,
@@ -6242,10 +6253,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_textures
                     .lock()
-                    .expect("sldn_cuda live_objects: poisoned")
-                    .push(tex_obj as u64);
+                    .expect("sldn_cuda live_textures: poisoned")
+                    .insert(tex_obj as u64);
                 populate_image_view(&entry, tex_obj as u64, out)
             }
             Err(e) => {
@@ -6306,10 +6317,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_surfaces
                     .lock()
-                    .expect("sldn_cuda live_objects: poisoned")
-                    .push(surf_obj as u64);
+                    .expect("sldn_cuda live_surfaces: poisoned")
+                    .insert(surf_obj as u64);
                 populate_image_view(&entry, surf_obj as u64, out)
             }
             Err(e) => {
@@ -6363,10 +6374,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_textures
                     .lock()
-                    .expect("sldn_cuda live_objects: poisoned")
-                    .push(tex_obj as u64);
+                    .expect("sldn_cuda live_textures: poisoned")
+                    .insert(tex_obj as u64);
                 populate_image_view(&entry, tex_obj as u64, out)
             }
             Ok(None) => SLDN_CUDA_CONTENDED,
@@ -6421,10 +6432,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_surfaces
                     .lock()
-                    .expect("sldn_cuda live_objects: poisoned")
-                    .push(surf_obj as u64);
+                    .expect("sldn_cuda live_surfaces: poisoned")
+                    .insert(surf_obj as u64);
                 populate_image_view(&entry, surf_obj as u64, out)
             }
             Ok(None) => SLDN_CUDA_CONTENDED,
@@ -6435,29 +6446,45 @@ mod cuda {
         }
     }
 
-    /// Release one outstanding texture-flavored acquire — pops the
-    /// LIFO stack of live `cudaTextureObject_t` handles for this
-    /// surface, destroys the popped handle, and decrements the
+    /// Release one outstanding texture-flavored acquire. Removes the
+    /// specific `handle` (the `cudaTextureObject_t` the customer was
+    /// handed from the matching acquire) from the live set, destroys
+    /// it with `cudaDestroyTextureObject`, and decrements the
     /// adapter's read-holder counter.
+    ///
+    /// Taking the handle as an explicit parameter (rather than popping
+    /// the most recently acquired one) is what makes the FFI safe
+    /// under concurrent reads: the adapter allows N read holders, and
+    /// each acquire constructs a unique handle — releases must
+    /// destroy the caller's handle, not whichever was last
+    /// constructed.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_cuda_release_texture(
         rt: *mut CudaRuntimeHandle,
         surface_id: u64,
+        handle: u64,
     ) -> i32 {
         let rt = match unsafe { rt.as_ref() } {
             Some(r) => r,
             None => return SLDN_CUDA_ERR,
         };
         if let Some(entry) = lookup_image_entry(rt, surface_id) {
-            if let Some(handle) = entry
-                .live_objects
+            let removed = entry
+                .live_textures
                 .lock()
-                .expect("sldn_cuda live_objects: poisoned")
-                .pop()
-            {
+                .expect("sldn_cuda live_textures: poisoned")
+                .remove(&handle);
+            if removed {
                 let _ = unsafe {
                     sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result()
                 };
+            } else {
+                tracing::warn!(
+                    "sldn_cuda_release_texture({}, handle={:#x}): handle not in the \
+                     live set — double-release or wrong-flavor release?",
+                    surface_id,
+                    handle
+                );
             }
         }
         rt.adapter.end_read_access(surface_id);
@@ -6465,26 +6492,35 @@ mod cuda {
     }
 
     /// Release one outstanding surface-flavored acquire — symmetric
-    /// counterpart to [`sldn_cuda_release_texture`].
+    /// counterpart to [`sldn_cuda_release_texture`]. Same handle-keyed
+    /// semantics so concurrent acquires are safe.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_cuda_release_surface(
         rt: *mut CudaRuntimeHandle,
         surface_id: u64,
+        handle: u64,
     ) -> i32 {
         let rt = match unsafe { rt.as_ref() } {
             Some(r) => r,
             None => return SLDN_CUDA_ERR,
         };
         if let Some(entry) = lookup_image_entry(rt, surface_id) {
-            if let Some(handle) = entry
-                .live_objects
+            let removed = entry
+                .live_surfaces
                 .lock()
-                .expect("sldn_cuda live_objects: poisoned")
-                .pop()
-            {
+                .expect("sldn_cuda live_surfaces: poisoned")
+                .remove(&handle);
+            if removed {
                 let _ = unsafe {
                     sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result()
                 };
+            } else {
+                tracing::warn!(
+                    "sldn_cuda_release_surface({}, handle={:#x}): handle not in the \
+                     live set — double-release or wrong-flavor release?",
+                    surface_id,
+                    handle
+                );
             }
         }
         rt.adapter.end_write_access(surface_id);
@@ -6808,6 +6844,7 @@ mod cuda {
     pub unsafe extern "C" fn sldn_cuda_release_texture(
         _rt: *mut c_void,
         _surface_id: u64,
+        _handle: u64,
     ) -> i32 {
         SLDN_CUDA_ERR
     }
@@ -6816,6 +6853,7 @@ mod cuda {
     pub unsafe extern "C" fn sldn_cuda_release_surface(
         _rt: *mut c_void,
         _surface_id: u64,
+        _handle: u64,
     ) -> i32 {
         SLDN_CUDA_ERR
     }

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4595,10 +4595,12 @@ mod cuda {
         self, CapsuleOwner, Device as DlpackDevice, DeviceType as DlpackDeviceType,
         ManagedTensor as DlpackManagedTensor,
     };
-    use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+    use streamlib_adapter_cuda::{
+        CudaSurfaceAdapter, HostImageSurfaceRegistration, HostSurfaceRegistration, VulkanLayout,
+    };
     use streamlib_consumer_rhi::{
-        ConsumerVulkanDevice, ConsumerVulkanBuffer, ConsumerVulkanTimelineSemaphore,
-        PixelFormat,
+        ConsumerVulkanBuffer, ConsumerVulkanDevice, ConsumerVulkanTexture,
+        ConsumerVulkanTimelineSemaphore, TextureFormat,
     };
 
     use super::gpu_surface::SurfaceHandle;
@@ -4609,10 +4611,21 @@ mod cuda {
     pub const SLDN_CUDA_CONTENDED: i32 = 1;
 
     /// DLPack `DLDeviceType` discriminants exposed at the FFI surface so
-    /// the Python wrapper can interpret [`SldnCudaView::device_type`]
+    /// the Deno wrapper can interpret [`SldnCudaView::device_type`]
     /// without re-importing the dlpark spec.
     pub const SLDN_CUDA_DEVICE_TYPE_CUDA: i32 = DlpackDeviceType::Cuda as i32;
     pub const SLDN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = DlpackDeviceType::CudaHost as i32;
+
+    /// CUDA-mappable [`TextureFormat`] discriminants surfaced on
+    /// [`SldnCudaImageView::format`]. The host's
+    /// `register_host_image_surface` validates that the registered
+    /// `VkImage` is in this subset; the cdylib mirrors the check on
+    /// import. Three variants only: `cudaExternalMemoryGetMappedMipmappedArray`
+    /// accepts `cudaChannelFormatDesc` shapes for `R8/R16/R32` integer
+    /// or 16/32-bit float, no sRGB, no BGR, no 3-channel.
+    pub const SLDN_CUDA_FORMAT_RGBA8_UNORM: i32 = 0;
+    pub const SLDN_CUDA_FORMAT_RGBA16_FLOAT: i32 = 1;
+    pub const SLDN_CUDA_FORMAT_RGBA32_FLOAT: i32 = 2;
 
     /// Per-acquire timeline-wait timeout (nanoseconds). Long enough to
     /// cover any realistic GPU queue depth; short enough that a deadlock
@@ -4671,6 +4684,7 @@ mod cuda {
         adapter: Arc<CudaSurfaceAdapter<ConsumerVulkanDevice>>,
         cuda_device_ordinal: i32,
         registered: Mutex<HashMap<u64, Arc<RegisteredCudaSurface>>>,
+        registered_images: Mutex<HashMap<u64, Arc<RegisteredCudaImageSurface>>>,
     }
 
     /// Per-surface registered state. The adapter's registry holds
@@ -4779,6 +4793,7 @@ mod cuda {
             adapter,
             cuda_device_ordinal,
             registered: Mutex::new(HashMap::new()),
+            registered_images: Mutex::new(HashMap::new()),
         }))
     }
 
@@ -5457,6 +5472,1025 @@ mod cuda {
         SLDN_CUDA_OK
     }
 
+    // ========================================================================
+    // Image-flavored path — OPAQUE_FD `VkImage` + `cudaMipmappedArray_t` +
+    // `cudaTextureObject_t` / `cudaSurfaceObject_t`
+    //
+    // Sibling of the buffer-flavored path above. The Rust adapter at
+    // `streamlib-adapter-cuda::CudaSurfaceAdapter` exposes two registration
+    // paths (`register_host_surface` for `VkBuffer`,
+    // `register_host_image_surface` for `VkImage`); this section is the
+    // cdylib bring-up for the image flavor.
+    //
+    // Customer-facing surface: a raw `uint64_t` handle (the
+    // `cudaTextureObject_t` or `cudaSurfaceObject_t`) plus image dimensions
+    // and format on [`SldnCudaImageView`]. No DLPack capsule — the mapped
+    // mipmapped array handle is opaque and not DLPack-shaped. Customers
+    // carry the handle into a native module (a separate `dlopen`'d
+    // cdylib that knows how to sample / write CUDA textures + surfaces)
+    // or drive host-side validation.
+    //
+    // Per-acquire texture / surface object construction matches the
+    // first-cut design recorded on the issue body: each acquire calls
+    // `cudaCreateTextureObject` / `cudaCreateSurfaceObject` with the
+    // hard-coded defaults (linear filter, clamp-to-edge, non-normalized
+    // coords, `cudaReadModeElementType`, no sRGB). Profile-driven
+    // construct-once-reuse-many is a future concern if real workloads
+    // demand it.
+    // ========================================================================
+
+    /// View handed back on every successful image-flavored acquire.
+    /// Layout pinned by the regression test below — Deno DataView
+    /// readers in the SDK depend on these offsets.
+    #[repr(C)]
+    pub struct SldnCudaImageView {
+        /// `cudaTextureObject_t` (read path) or `cudaSurfaceObject_t`
+        /// (write path) — both are typedef'd to `c_ulonglong` in the
+        /// CUDA Runtime API, so a single wire shape covers either.
+        pub cuda_object_handle: u64,
+        /// Image width in pixels — surfaced for kernels that need to
+        /// thread the dimensions into a launch config.
+        pub width: u32,
+        /// Image height in pixels.
+        pub height: u32,
+        /// CUDA-mappable format discriminant — one of
+        /// [`SLDN_CUDA_FORMAT_RGBA8_UNORM`] / `_RGBA16_FLOAT` /
+        /// `_RGBA32_FLOAT`. The cdylib has already validated the
+        /// registration; the field is informational for customer kernels
+        /// that need to know element size for sampling.
+        pub format: i32,
+        /// Reserved padding — keeps the struct 32-byte aligned and gives
+        /// room for additive future fields (mip-level count, layer
+        /// count, etc.) without breaking the wire ABI. Must be zero on
+        /// write.
+        pub _reserved: [u8; 12],
+    }
+
+    /// Map a [`TextureFormat`] from the CUDA-mappable subset onto its
+    /// [`SLDN_CUDA_FORMAT_*`] FFI discriminant. Returns `None` for
+    /// formats outside the subset — the caller surfaces a
+    /// `BackendRejected` style error.
+    fn texture_format_to_sldn(format: TextureFormat) -> Option<i32> {
+        match format {
+            TextureFormat::Rgba8Unorm => Some(SLDN_CUDA_FORMAT_RGBA8_UNORM),
+            TextureFormat::Rgba16Float => Some(SLDN_CUDA_FORMAT_RGBA16_FLOAT),
+            TextureFormat::Rgba32Float => Some(SLDN_CUDA_FORMAT_RGBA32_FLOAT),
+            _ => None,
+        }
+    }
+
+    /// Parse the surface-share format string (e.g. `"Rgba8Unorm"`) onto
+    /// the CUDA-mappable [`TextureFormat`] subset. Returns `None` for
+    /// any format outside the subset; the cuda image path's accepted
+    /// set is intentionally narrower than `texture_format_from_str`
+    /// (defined below for the Vulkan adapter) so reject reasons are
+    /// specific to CUDA.
+    fn cuda_image_texture_format_from_str(format: &str) -> Option<TextureFormat> {
+        match format {
+            "Rgba8Unorm" => Some(TextureFormat::Rgba8Unorm),
+            "Rgba16Float" => Some(TextureFormat::Rgba16Float),
+            "Rgba32Float" => Some(TextureFormat::Rgba32Float),
+            _ => None,
+        }
+    }
+
+    /// Build the `cudaChannelFormatDesc` that
+    /// `cudaExternalMemoryGetMappedMipmappedArray` expects for a given
+    /// CUDA-mappable format. The mapping is fixed by the subset:
+    /// `Rgba8Unorm`  → 4× 8-bit unsigned,
+    /// `Rgba16Float` → 4× 16-bit float,
+    /// `Rgba32Float` → 4× 32-bit float.
+    fn cuda_channel_format_desc_for(format: TextureFormat) -> sys::cudaChannelFormatDesc {
+        match format {
+            TextureFormat::Rgba8Unorm => sys::cudaChannelFormatDesc {
+                x: 8,
+                y: 8,
+                z: 8,
+                w: 8,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindUnsigned,
+            },
+            TextureFormat::Rgba16Float => sys::cudaChannelFormatDesc {
+                x: 16,
+                y: 16,
+                z: 16,
+                w: 16,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindFloat,
+            },
+            TextureFormat::Rgba32Float => sys::cudaChannelFormatDesc {
+                x: 32,
+                y: 32,
+                z: 32,
+                w: 32,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindFloat,
+            },
+            // `register` validates the format up-front; unreachable here.
+            _ => sys::cudaChannelFormatDesc {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 0,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindNone,
+            },
+        }
+    }
+
+    /// Per-surface registered state for the image flavor — parallels
+    /// [`RegisteredCudaSurface`]. Holds the imported mipmapped array
+    /// (the CUDA-side handle yielded by
+    /// `cudaExternalMemoryGetMappedMipmappedArray`), the per-surface
+    /// stream, plus the same imported timeline + the host
+    /// `Arc<ConsumerVulkanTexture>` for Drop-order keepalive.
+    ///
+    /// Per-acquire `cudaTextureObject_t` / `cudaSurfaceObject_t`
+    /// handles live on `live_objects` — push on acquire, pop on
+    /// release. LIFO mirrors the scope-bound `using` pattern at the
+    /// SDK layer.
+    struct RegisteredCudaImageSurface {
+        // CUDA-side imports — Drop runs in declaration order, so list
+        // these first to ensure they're torn down before the Vulkan
+        // Arcs below release the underlying memory.
+        ext_mem: sys::cudaExternalMemory_t,
+        ext_sem: sys::cudaExternalSemaphore_t,
+        stream: sys::cudaStream_t,
+        mipmapped_array: sys::cudaMipmappedArray_t,
+        /// Stack of live `cudaTextureObject_t` / `cudaSurfaceObject_t`
+        /// handles — one entry per outstanding acquire. Both types are
+        /// `c_ulonglong` so a single `u64` discriminator-less stack
+        /// covers either flavor (read-side pushes texture objects,
+        /// write-side pushes surface objects; releases pop the
+        /// matching flavor by FFI entry-point selection).
+        live_objects: Mutex<Vec<u64>>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        // Vulkan-side imports — held to outlive the CUDA imports above.
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        texture: Arc<ConsumerVulkanTexture>,
+        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+    }
+
+    // SAFETY: same rationale as [`RegisteredCudaSurface`] — CUDA Runtime
+    // API handles are opaque pointer-shaped and threading-safe for use
+    // and teardown after creation.
+    unsafe impl Send for RegisteredCudaImageSurface {}
+    unsafe impl Sync for RegisteredCudaImageSurface {}
+
+    impl Drop for RegisteredCudaImageSurface {
+        fn drop(&mut self) {
+            unsafe {
+                // Destroy any texture / surface objects still outstanding.
+                // Customers SHOULD release every acquire before unregister,
+                // but a forced unregister mid-flight shouldn't leak handles.
+                let drained: Vec<u64> = self
+                    .live_objects
+                    .lock()
+                    .expect("RegisteredCudaImageSurface live_objects: poisoned")
+                    .drain(..)
+                    .collect();
+                for handle in drained {
+                    // Texture and surface objects use the same destroy
+                    // signature — pick by trial since we don't track
+                    // flavor on the stack. `cudaDestroyTextureObject`
+                    // returns `cudaErrorInvalidValue` on a surface
+                    // object (and vice-versa), so attempt one then the
+                    // other.
+                    if sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t)
+                        .result()
+                        .is_err()
+                    {
+                        let _ = sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t)
+                            .result();
+                    }
+                }
+                if !self.mipmapped_array.is_null() {
+                    let _ = sys::cudaFreeMipmappedArray(self.mipmapped_array).result();
+                }
+                if !self.stream.is_null() {
+                    let _ = sys::cudaStreamDestroy(self.stream).result();
+                }
+                if !self.ext_sem.is_null() {
+                    let _ = sys::cudaDestroyExternalSemaphore(self.ext_sem).result();
+                }
+                if !self.ext_mem.is_null() {
+                    let _ = external_memory::destroy_external_memory(self.ext_mem);
+                }
+            }
+        }
+    }
+
+    /// Register a host image-flavored cuda surface — imports the
+    /// OPAQUE_FD `VkImage` and timeline semaphore via
+    /// [`streamlib_consumer_rhi`], then re-imports the same FDs into
+    /// CUDA via `cudaImportExternalMemory` +
+    /// `cudaExternalMemoryGetMappedMipmappedArray` +
+    /// `cudaImportExternalSemaphore`.
+    ///
+    /// Sibling of [`sldn_cuda_register_surface`] (the buffer-flavored
+    /// DLPack path). The two registration paths are exclusive — a
+    /// given `surface_id` can be registered as one flavor, not both.
+    ///
+    /// Format is parsed from `gpu_handle.format`; accepted subset is
+    /// `Rgba8Unorm` / `Rgba16Float` / `Rgba32Float` — the rest of the
+    /// [`TextureFormat`] variants are rejected by
+    /// `cudaExternalMemoryGetMappedMipmappedArray`'s
+    /// `cudaChannelFormatDesc` acceptance.
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info", skip(rt, gpu_handle))]
+    pub unsafe extern "C" fn sldn_cuda_register_image_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("sldn_cuda_register_image_surface: null runtime");
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("sldn_cuda_register_image_surface: null gpu_handle");
+                return SLDN_CUDA_ERR;
+            }
+        };
+        if gpu.fds.len() != 1 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: cuda image flavor requires \
+                 exactly 1 OPAQUE_FD; gpu_handle has {} fd(s)",
+                gpu.fds.len()
+            );
+            return SLDN_CUDA_ERR;
+        }
+        if gpu.width == 0 || gpu.height == 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: width/height must be > 0 \
+                 (got {}x{})",
+                gpu.width,
+                gpu.height
+            );
+            return SLDN_CUDA_ERR;
+        }
+        let texture_format = match cuda_image_texture_format_from_str(&gpu.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: format '{}' is not \
+                     CUDA-mappable; allowed: Rgba8Unorm, Rgba16Float, Rgba32Float",
+                    gpu.format
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let allocation_size = gpu
+            .plane_sizes
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.size);
+        if allocation_size == 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: surface '{}' has zero size",
+                surface_id
+            );
+            return SLDN_CUDA_ERR;
+        }
+
+        // ── Step 1: import the OPAQUE_FD `VkImage` into Vulkan ──────────
+        let vk_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if vk_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: dup vk_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            return SLDN_CUDA_ERR;
+        }
+        let texture = match ConsumerVulkanTexture::from_opaque_fd(
+            &rt.device,
+            vk_fd,
+            gpu.width,
+            gpu.height,
+            texture_format,
+            allocation_size,
+        ) {
+            Ok(t) => Arc::new(t),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: ConsumerVulkanTexture::from_opaque_fd \
+                     failed: {} — verify the host registered this surface with \
+                     handle_type=opaque_fd, OPTIMAL tiling, no DRM modifier",
+                    e
+                );
+                unsafe { libc::close(vk_fd) };
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: surface '{}' has no sync_fd — \
+                     the host must register an exportable timeline semaphore so \
+                     cross-API sync (Vulkan ↔ CUDA) is well-defined",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if vk_sync_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: dup sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "sldn_cuda_register_image_surface: timeline from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_sync_fd) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLDN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
+        let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if cuda_mem_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: dup cuda_mem_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
+        // call — ownership of `cuda_mem_fd` transfers on success.
+        let ext_mem = unsafe {
+            match external_memory::import_external_memory_opaque_fd(cuda_mem_fd, allocation_size) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_image_surface: cudaImportExternalMemory: {:?}",
+                        e
+                    );
+                    libc::close(cuda_mem_fd);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 4: map the imported memory as a mipmapped array ────────
+        // Single-level mip (`numLevels = 1`) — multi-level mip chains
+        // would require the host to export a corresponding pyramid, a
+        // future concern. `flags = 0` (no `cudaArrayColorAttachment` —
+        // surface-write is enabled by `cudaArraySurfaceLoadStore` flag
+        // which the host's `HostVulkanTexture::new_opaque_fd_export`
+        // applies by including `STORAGE` usage in the VkImage).
+        let mipmap_desc = sys::cudaExternalMemoryMipmappedArrayDesc {
+            offset: 0,
+            formatDesc: cuda_channel_format_desc_for(texture_format),
+            extent: sys::cudaExtent {
+                width: gpu.width as usize,
+                height: gpu.height as usize,
+                depth: 0, // 2-D — depth=0 per CUDA spec for non-3D arrays
+            },
+            flags: 0,
+            numLevels: 1,
+        };
+        let mut mipmapped_array = MaybeUninit::<sys::cudaMipmappedArray_t>::uninit();
+        let mipmapped_array = unsafe {
+            match sys::cudaExternalMemoryGetMappedMipmappedArray(
+                mipmapped_array.as_mut_ptr(),
+                ext_mem,
+                &mipmap_desc,
+            )
+            .result()
+            {
+                Ok(()) => mipmapped_array.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_image_surface: \
+                         cudaExternalMemoryGetMappedMipmappedArray failed: {:?} — \
+                         common cause: host's VkImage usage flags don't include \
+                         SAMPLED/STORAGE, or format outside the CUDA-mappable subset",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if cuda_sync_fd < 0 {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: dup cuda_sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            unsafe {
+                let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+        let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
+        let sem_desc = unsafe {
+            let p = sem_desc.as_mut_ptr();
+            (&raw mut (*p).type_).write(
+                sys::cudaExternalSemaphoreHandleType::cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd,
+            );
+            (&raw mut (*p).handle).write(
+                sys::cudaExternalSemaphoreHandleDesc__bindgen_ty_1 { fd: cuda_sync_fd },
+            );
+            (&raw mut (*p).flags).write(0);
+            sem_desc.assume_init()
+        };
+        let mut ext_sem = MaybeUninit::<sys::cudaExternalSemaphore_t>::uninit();
+        let ext_sem = unsafe {
+            match sys::cudaImportExternalSemaphore(ext_sem.as_mut_ptr(), &sem_desc).result() {
+                Ok(()) => ext_sem.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_image_surface: cudaImportExternalSemaphore: {:?}",
+                        e
+                    );
+                    libc::close(cuda_sync_fd);
+                    let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 6: per-surface CUDA stream ─────────────────────────────
+        let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+        let stream = unsafe {
+            match sys::cudaStreamCreate(stream.as_mut_ptr()).result() {
+                Ok(()) => stream.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "sldn_cuda_register_image_surface: cudaStreamCreate: {:?}",
+                        e
+                    );
+                    let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                    let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLDN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 7: hand the registration to the Rust adapter ──────────
+        let registration = HostImageSurfaceRegistration {
+            texture: Arc::clone(&texture),
+            timeline: Arc::clone(&timeline),
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+        if let Err(e) = rt
+            .adapter
+            .register_host_image_surface(surface_id, registration)
+        {
+            tracing::error!(
+                "sldn_cuda_register_image_surface: \
+                 adapter.register_host_image_surface({}): {:?}",
+                surface_id,
+                e
+            );
+            unsafe {
+                let _ = sys::cudaStreamDestroy(stream).result();
+                let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLDN_CUDA_ERR;
+        }
+
+        gpu.sync_fd = Some(raw_sync_fd);
+
+        let entry = Arc::new(RegisteredCudaImageSurface {
+            ext_mem,
+            ext_sem,
+            stream,
+            mipmapped_array,
+            live_objects: Mutex::new(Vec::new()),
+            width: gpu.width,
+            height: gpu.height,
+            format: texture_format,
+            texture,
+            timeline,
+        });
+        rt.registered_images
+            .lock()
+            .expect("sldn_cuda registered_images: poisoned")
+            .insert(surface_id, entry);
+        SLDN_CUDA_OK
+    }
+
+    /// Unregister a previously-registered image-flavored cuda surface.
+    /// Mirrors [`sldn_cuda_unregister_surface`] but targets the image
+    /// map. Returns `SLDN_CUDA_ERR` if the `surface_id` isn't an image
+    /// registration on this runtime.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_unregister_image_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let removed = rt
+            .registered_images
+            .lock()
+            .expect("sldn_cuda registered_images: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return SLDN_CUDA_ERR;
+        }
+        if rt.adapter.unregister_host_surface(surface_id) {
+            SLDN_CUDA_OK
+        } else {
+            SLDN_CUDA_ERR
+        }
+    }
+
+    fn lookup_image_entry(
+        rt: &CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> Option<Arc<RegisteredCudaImageSurface>> {
+        rt.registered_images
+            .lock()
+            .expect("sldn_cuda registered_images: poisoned")
+            .get(&surface_id)
+            .cloned()
+    }
+
+    /// Build a `cudaTextureDesc` with the AI-Agent-Notes defaults from
+    /// the issue body: linear filter, clamp-to-edge addressing across
+    /// all three dimensions, non-normalized coordinates,
+    /// `cudaReadModeElementType`, no sRGB, no mipmap clamping.
+    fn default_texture_desc() -> sys::cudaTextureDesc {
+        sys::cudaTextureDesc {
+            addressMode: [
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+            ],
+            filterMode: sys::cudaTextureFilterMode::cudaFilterModeLinear,
+            readMode: sys::cudaTextureReadMode::cudaReadModeElementType,
+            sRGB: 0,
+            borderColor: [0.0, 0.0, 0.0, 0.0],
+            normalizedCoords: 0,
+            maxAnisotropy: 0,
+            mipmapFilterMode: sys::cudaTextureFilterMode::cudaFilterModePoint,
+            mipmapLevelBias: 0.0,
+            minMipmapLevelClamp: 0.0,
+            maxMipmapLevelClamp: 0.0,
+            disableTrilinearOptimization: 0,
+            seamlessCubemap: 0,
+        }
+    }
+
+    fn create_texture_object_for(
+        entry: &RegisteredCudaImageSurface,
+    ) -> Result<sys::cudaTextureObject_t, String> {
+        let mut res_desc = MaybeUninit::<sys::cudaResourceDesc>::zeroed();
+        let res_desc = unsafe {
+            let p = res_desc.as_mut_ptr();
+            (&raw mut (*p).resType).write(sys::cudaResourceType::cudaResourceTypeMipmappedArray);
+            (&raw mut (*p).res.mipmap.mipmap).write(entry.mipmapped_array);
+            res_desc.assume_init()
+        };
+        let tex_desc = default_texture_desc();
+        let mut tex_obj = MaybeUninit::<sys::cudaTextureObject_t>::uninit();
+        unsafe {
+            sys::cudaCreateTextureObject(
+                tex_obj.as_mut_ptr(),
+                &res_desc,
+                &tex_desc,
+                std::ptr::null(),
+            )
+            .result()
+            .map_err(|e| format!("cudaCreateTextureObject: {e:?}"))?;
+            Ok(tex_obj.assume_init())
+        }
+    }
+
+    fn create_surface_object_for(
+        entry: &RegisteredCudaImageSurface,
+    ) -> Result<sys::cudaSurfaceObject_t, String> {
+        let mut level0 = MaybeUninit::<sys::cudaArray_t>::uninit();
+        let level0 = unsafe {
+            sys::cudaGetMipmappedArrayLevel(level0.as_mut_ptr(), entry.mipmapped_array, 0)
+                .result()
+                .map_err(|e| format!("cudaGetMipmappedArrayLevel: {e:?}"))?;
+            level0.assume_init()
+        };
+        let mut res_desc = MaybeUninit::<sys::cudaResourceDesc>::zeroed();
+        let res_desc = unsafe {
+            let p = res_desc.as_mut_ptr();
+            (&raw mut (*p).resType).write(sys::cudaResourceType::cudaResourceTypeArray);
+            (&raw mut (*p).res.array.array).write(level0);
+            res_desc.assume_init()
+        };
+        let mut surf_obj = MaybeUninit::<sys::cudaSurfaceObject_t>::uninit();
+        unsafe {
+            sys::cudaCreateSurfaceObject(surf_obj.as_mut_ptr(), &res_desc)
+                .result()
+                .map_err(|e| format!("cudaCreateSurfaceObject: {e:?}"))?;
+            Ok(surf_obj.assume_init())
+        }
+    }
+
+    fn cuda_sync_after_image_acquire(entry: &RegisteredCudaImageSurface) -> Result<(), String> {
+        let wait_value = entry
+            .timeline
+            .current_value()
+            .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
+
+        let mut wait_params = MaybeUninit::<sys::cudaExternalSemaphoreWaitParams>::zeroed();
+        let wait_params = unsafe {
+            let p = wait_params.as_mut_ptr();
+            (&raw mut (*p).params.fence.value).write(wait_value);
+            (&raw mut (*p).flags).write(0);
+            wait_params.assume_init()
+        };
+
+        let wait_result = unsafe {
+            sys::cudaWaitExternalSemaphoresAsync_v2(
+                &entry.ext_sem,
+                &wait_params,
+                1,
+                entry.stream,
+            )
+            .result()
+        };
+        if let Err(e) = wait_result {
+            return Err(format!("cudaWaitExternalSemaphoresAsync: {e:?}"));
+        }
+        if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
+            return Err(format!("cudaStreamSynchronize: {e:?}"));
+        }
+        Ok(())
+    }
+
+    fn populate_image_view(
+        entry: &Arc<RegisteredCudaImageSurface>,
+        cuda_object_handle: u64,
+        out: &mut SldnCudaImageView,
+    ) -> i32 {
+        let format = match texture_format_to_sldn(entry.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "sldn_cuda: registered image format {:?} is not in the \
+                     CUDA-mappable subset — registration should have rejected this",
+                    entry.format
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        out.cuda_object_handle = cuda_object_handle;
+        out.width = entry.width;
+        out.height = entry.height;
+        out.format = format;
+        out._reserved = [0u8; 12];
+        SLDN_CUDA_OK
+    }
+
+    fn descriptor_for_image_surface(surface_id: u64) -> StreamlibSurface {
+        StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_acquire_texture: surface_id {} not registered \
+                     as image flavor",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.acquire_texture(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_acquire_texture({}): cuda sync failed: {} — \
+                         releasing the adapter guard so the timeline can advance",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                let tex_obj = match create_texture_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_cuda_acquire_texture({}): create_texture_object failed: {} — \
+                             releasing the adapter guard",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_read_access(surface_id);
+                        return SLDN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("sldn_cuda live_objects: poisoned")
+                    .push(tex_obj as u64);
+                populate_image_view(&entry, tex_obj as u64, out)
+            }
+            Err(e) => {
+                tracing::error!("sldn_cuda_acquire_texture({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "sldn_cuda_acquire_surface: surface_id {} not registered \
+                     as image flavor",
+                    surface_id
+                );
+                return SLDN_CUDA_ERR;
+            }
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.acquire_surface(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_acquire_surface({}): cuda sync failed: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                let surf_obj = match create_surface_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_cuda_acquire_surface({}): create_surface_object failed: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_write_access(surface_id);
+                        return SLDN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("sldn_cuda live_objects: poisoned")
+                    .push(surf_obj as u64);
+                populate_image_view(&entry, surf_obj as u64, out)
+            }
+            Err(e) => {
+                tracing::error!("sldn_cuda_acquire_surface({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLDN_CUDA_ERR,
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.try_acquire_texture(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_try_acquire_texture({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                let tex_obj = match create_texture_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_cuda_try_acquire_texture({}): create_texture_object: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_read_access(surface_id);
+                        return SLDN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("sldn_cuda live_objects: poisoned")
+                    .push(tex_obj as u64);
+                populate_image_view(&entry, tex_obj as u64, out)
+            }
+            Ok(None) => SLDN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("sldn_cuda_try_acquire_texture({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLDN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLDN_CUDA_ERR,
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.try_acquire_surface(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "sldn_cuda_try_acquire_surface({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLDN_CUDA_ERR;
+                }
+                let surf_obj = match create_surface_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "sldn_cuda_try_acquire_surface({}): create_surface_object: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_write_access(surface_id);
+                        return SLDN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("sldn_cuda live_objects: poisoned")
+                    .push(surf_obj as u64);
+                populate_image_view(&entry, surf_obj as u64, out)
+            }
+            Ok(None) => SLDN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("sldn_cuda_try_acquire_surface({}): {:?}", surface_id, e);
+                SLDN_CUDA_ERR
+            }
+        }
+    }
+
+    /// Release one outstanding texture-flavored acquire — pops the
+    /// LIFO stack of live `cudaTextureObject_t` handles for this
+    /// surface, destroys the popped handle, and decrements the
+    /// adapter's read-holder counter.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        if let Some(entry) = lookup_image_entry(rt, surface_id) {
+            if let Some(handle) = entry
+                .live_objects
+                .lock()
+                .expect("sldn_cuda live_objects: poisoned")
+                .pop()
+            {
+                let _ = unsafe {
+                    sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result()
+                };
+            }
+        }
+        rt.adapter.end_read_access(surface_id);
+        SLDN_CUDA_OK
+    }
+
+    /// Release one outstanding surface-flavored acquire — symmetric
+    /// counterpart to [`sldn_cuda_release_texture`].
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLDN_CUDA_ERR,
+        };
+        if let Some(entry) = lookup_image_entry(rt, surface_id) {
+            if let Some(handle) = entry
+                .live_objects
+                .lock()
+                .expect("sldn_cuda live_objects: poisoned")
+                .pop()
+            {
+                let _ = unsafe {
+                    sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result()
+                };
+            }
+        }
+        rt.adapter.end_write_access(surface_id);
+        SLDN_CUDA_OK
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -5490,6 +6524,108 @@ mod cuda {
             assert_eq!(SLDN_CUDA_OK, 0);
             assert_eq!(SLDN_CUDA_ERR, -1);
             assert_eq!(SLDN_CUDA_CONTENDED, 1);
+            // Image-path format discriminants — wire ABI between
+            // cdylib and the Deno SDK mirror.
+            assert_eq!(SLDN_CUDA_FORMAT_RGBA8_UNORM, 0);
+            assert_eq!(SLDN_CUDA_FORMAT_RGBA16_FLOAT, 1);
+            assert_eq!(SLDN_CUDA_FORMAT_RGBA32_FLOAT, 2);
+        }
+
+        // Layout regression for the image-flavored view — same wire
+        // ABI guarantees as the buffer flavor. Deno DataView readers
+        // in the SDK depend on these offsets.
+        #[test]
+        fn sldn_cuda_image_view_layout_matches_spec_64bit() {
+            // SldnCudaImageView fields in declaration order:
+            //   cuda_object_handle: u64    @ 0
+            //   width             : u32    @ 8
+            //   height            : u32    @ 12
+            //   format            : i32    @ 16
+            //   _reserved         : [u8;12]@ 20
+            // Total: 32 bytes — same wire size as `SldnCudaView` so the
+            // SDK can reuse 32-byte staging buffers across flavors.
+            assert_eq!(size_of::<SldnCudaImageView>(), 32);
+            assert_eq!(offset_of!(SldnCudaImageView, cuda_object_handle), 0);
+            assert_eq!(offset_of!(SldnCudaImageView, width), 8);
+            assert_eq!(offset_of!(SldnCudaImageView, height), 12);
+            assert_eq!(offset_of!(SldnCudaImageView, format), 16);
+            assert_eq!(offset_of!(SldnCudaImageView, _reserved), 20);
+        }
+
+        #[test]
+        fn cuda_image_texture_format_from_str_accepts_cuda_mappable_subset() {
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba8Unorm"),
+                Some(TextureFormat::Rgba8Unorm)
+            );
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba16Float"),
+                Some(TextureFormat::Rgba16Float)
+            );
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba32Float"),
+                Some(TextureFormat::Rgba32Float)
+            );
+            assert_eq!(cuda_image_texture_format_from_str("Bgra8Unorm"), None);
+            assert_eq!(cuda_image_texture_format_from_str("Rgba8UnormSrgb"), None);
+            assert_eq!(cuda_image_texture_format_from_str("Nv12"), None);
+        }
+
+        #[test]
+        fn cuda_channel_format_desc_for_matches_format_byte_layout() {
+            let d8 = cuda_channel_format_desc_for(TextureFormat::Rgba8Unorm);
+            assert_eq!((d8.x, d8.y, d8.z, d8.w), (8, 8, 8, 8));
+            assert_eq!(
+                d8.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindUnsigned
+            );
+            let d16 = cuda_channel_format_desc_for(TextureFormat::Rgba16Float);
+            assert_eq!((d16.x, d16.y, d16.z, d16.w), (16, 16, 16, 16));
+            assert_eq!(
+                d16.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindFloat
+            );
+            let d32 = cuda_channel_format_desc_for(TextureFormat::Rgba32Float);
+            assert_eq!((d32.x, d32.y, d32.z, d32.w), (32, 32, 32, 32));
+            assert_eq!(
+                d32.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindFloat
+            );
+        }
+
+        #[test]
+        fn default_texture_desc_matches_issue_body_ai_notes() {
+            let d = default_texture_desc();
+            assert_eq!(
+                d.filterMode,
+                sys::cudaTextureFilterMode::cudaFilterModeLinear
+            );
+            assert_eq!(
+                d.readMode,
+                sys::cudaTextureReadMode::cudaReadModeElementType
+            );
+            assert_eq!(d.sRGB, 0);
+            assert_eq!(d.normalizedCoords, 0);
+            for mode in d.addressMode {
+                assert_eq!(mode, sys::cudaTextureAddressMode::cudaAddressModeClamp);
+            }
+        }
+
+        #[test]
+        fn texture_format_to_sldn_roundtrips_cuda_mappable_subset() {
+            assert_eq!(
+                texture_format_to_sldn(TextureFormat::Rgba8Unorm),
+                Some(SLDN_CUDA_FORMAT_RGBA8_UNORM)
+            );
+            assert_eq!(
+                texture_format_to_sldn(TextureFormat::Rgba16Float),
+                Some(SLDN_CUDA_FORMAT_RGBA16_FLOAT)
+            );
+            assert_eq!(
+                texture_format_to_sldn(TextureFormat::Rgba32Float),
+                Some(SLDN_CUDA_FORMAT_RGBA32_FLOAT)
+            );
+            assert_eq!(texture_format_to_sldn(TextureFormat::Bgra8Unorm), None);
         }
 
         // Same smoke test as the python-native sibling (#589): the
@@ -5515,6 +6651,9 @@ mod cuda {
     pub const SLDN_CUDA_CONTENDED: i32 = 1;
     pub const SLDN_CUDA_DEVICE_TYPE_CUDA: i32 = 2;
     pub const SLDN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = 3;
+    pub const SLDN_CUDA_FORMAT_RGBA8_UNORM: i32 = 0;
+    pub const SLDN_CUDA_FORMAT_RGBA16_FLOAT: i32 = 1;
+    pub const SLDN_CUDA_FORMAT_RGBA32_FLOAT: i32 = 2;
 
     #[repr(C)]
     pub struct SldnCudaView {
@@ -5523,6 +6662,15 @@ mod cuda {
         pub device_type: i32,
         pub device_id: i32,
         pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    #[repr(C)]
+    pub struct SldnCudaImageView {
+        pub cuda_object_handle: u64,
+        pub width: u32,
+        pub height: u32,
+        pub format: i32,
+        pub _reserved: [u8; 12],
     }
 
     #[unsafe(no_mangle)]
@@ -5597,6 +6745,75 @@ mod cuda {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn sldn_cuda_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_register_image_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_unregister_image_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_acquire_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_try_acquire_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SldnCudaImageView,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLDN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn sldn_cuda_release_surface(
         _rt: *mut c_void,
         _surface_id: u64,
     ) -> i32 {

--- a/libs/streamlib-deno/adapters/cuda.ts
+++ b/libs/streamlib-deno/adapters/cuda.ts
@@ -672,6 +672,7 @@ export class CudaContext {
 
     const view = this.parseImageView(buf, write);
     const surfaceIdSnapshot = surfaceId;
+    const handleSnapshot = view.handle;
     const symbols = this.symbols;
     const rt = this.rt;
     const writeMode = write;
@@ -679,10 +680,21 @@ export class CudaContext {
     return {
       view,
       [Symbol.dispose]: () => {
+        // Thread the customer's handle back so the cdylib destroys
+        // this view's cudaTextureObject_t / cudaSurfaceObject_t —
+        // not some other concurrent reader's.
         if (writeMode) {
-          symbols.sldn_cuda_release_surface(rt, surfaceIdSnapshot);
+          symbols.sldn_cuda_release_surface(
+            rt,
+            surfaceIdSnapshot,
+            handleSnapshot,
+          );
         } else {
-          symbols.sldn_cuda_release_texture(rt, surfaceIdSnapshot);
+          symbols.sldn_cuda_release_texture(
+            rt,
+            surfaceIdSnapshot,
+            handleSnapshot,
+          );
         }
       },
     };

--- a/libs/streamlib-deno/adapters/cuda.ts
+++ b/libs/streamlib-deno/adapters/cuda.ts
@@ -58,6 +58,17 @@ const RC_CONTENDED = 1;
 const DEVICE_TYPE_CUDA = 2;
 const DEVICE_TYPE_CUDA_HOST = 3;
 
+/** Image-path format discriminants on
+ * [`SldnCudaImageView::format`] — wire ABI mirroring the cdylib's
+ * `SLDN_CUDA_FORMAT_*` constants. The CUDA image flavor is constrained
+ * to the four-channel R8/R16/R32 subset accepted by
+ * `cudaExternalMemoryGetMappedMipmappedArray`. */
+export enum CudaImageFormat {
+  Rgba8Unorm = 0,
+  Rgba16Float = 1,
+  Rgba32Float = 2,
+}
+
 /** `SlpnCudaView` `#[repr(C)]` layout, pinned by the cdylib's
  * `sldn_cuda_view_layout_matches_spec_64bit` test:
  *   size                 : u64    @ 0   (8 bytes)
@@ -127,6 +138,59 @@ export interface CudaWriteView {
   consume(): void;
 }
 
+/** `SldnCudaImageView` `#[repr(C)]` layout, pinned by the cdylib's
+ * `sldn_cuda_image_view_layout_matches_spec_64bit` test:
+ *   cuda_object_handle: u64    @ 0   (8 bytes)
+ *   width             : u32    @ 8   (4)
+ *   height            : u32    @ 12  (4)
+ *   format            : i32    @ 16  (4)
+ *   _reserved         : [u8;12]@ 20  (12 bytes)
+ * Total = 32 bytes — same wire width as `SldnCudaView`. */
+const IMAGE_VIEW_STRUCT_SIZE = 32;
+
+/** Read-side view inside an `acquireTexture` scope.
+ *
+ * `handle` is a raw `cudaTextureObject_t` — pass it to a native module
+ * (a separate `dlopen`'d cdylib that knows how to sample CUDA
+ * textures) or drive host-side validation. There's no DLPack capsule
+ * on this path because the underlying `cudaMipmappedArray_t` is opaque
+ * and not DLPack-shaped.
+ *
+ * The view is valid only inside the `using` scope. After scope exit,
+ * the cdylib calls `cudaDestroyTextureObject` on `handle` and
+ * releases the adapter's read guard — do NOT retain `handle` past
+ * the scope.
+ */
+export interface CudaTextureView {
+  /** Raw `cudaTextureObject_t` (typedef'd to `c_ulonglong`). */
+  readonly handle: bigint;
+  /** Image width in pixels. */
+  readonly width: number;
+  /** Image height in pixels. */
+  readonly height: number;
+  /** Format discriminant from [`CudaImageFormat`] — the cdylib has
+   * already validated the registration; this is informational for
+   * customer kernels that need to know element size for sampling. */
+  readonly format: CudaImageFormat;
+}
+
+/** Write-side view inside an `acquireSurface` scope.
+ *
+ * Same shape as [`CudaTextureView`] but `handle` is a raw
+ * `cudaSurfaceObject_t`. Kernels that produce new frames can
+ * `surf2Dwrite` against this handle and the writes land in the
+ * host-shared OPAQUE_FD `VkImage`'s backing memory.
+ *
+ * Same lifetime rules as [`CudaTextureView`] — `handle` is destroyed
+ * at scope exit.
+ */
+export interface CudaSurfaceView {
+  readonly handle: bigint;
+  readonly width: number;
+  readonly height: number;
+  readonly format: CudaImageFormat;
+}
+
 /** Disposable guard returned by `acquireRead` / `acquireWrite`.
  * `using` runs `[Symbol.dispose]` at scope exit, which releases the
  * adapter guard (so the timeline can advance) and conditionally calls
@@ -147,6 +211,12 @@ export interface CudaGpuLimitedAccess {
     readonly nativeHandlePtr: Deno.PointerObject | null;
     release(): void;
   };
+  /** Publish the producer-side post-release `VkImageLayout` for
+   * `poolId` via the surface-share `update_layout` op. Called by
+   * [`CudaContext.releaseForCrossProcess`] after a CUDA-side write
+   * cycle to publish the next layout so the host consumer's
+   * `acquire_from_foreign` Path 2 sees the right source. */
+  updateImageLayout(poolId: string, layout: number): void;
   // deno-lint-ignore no-explicit-any
   readonly nativeLib: { readonly symbols: any };
 }
@@ -224,6 +294,11 @@ export class CudaContext {
   private readonly symbols: any;
   private readonly rt: Deno.PointerObject;
   private readonly surfaceIds = new Map<string, bigint>();
+  /** Image-flavored registration map. Separate from
+   * [`surfaceIds`] because a given pool_id is exclusively one
+   * flavor — the cdylib's adapter rejects mixing acquire paths
+   * against a single surface. */
+  private readonly imageSurfaceIds = new Map<string, bigint>();
   private readonly resolvedHandles = new Map<
     string,
     ReturnType<CudaGpuLimitedAccess["resolveSurface"]>
@@ -441,5 +516,210 @@ export class CudaContext {
     return writable
       ? (view as unknown as CudaWriteView)
       : (view as unknown as CudaReadView);
+  }
+
+  // ----- Image-flavored API ----------------------------------------
+
+  /** Acquire read access to an image-flavored CUDA surface as a
+   * `cudaTextureObject_t`. The texture object is constructed fresh
+   * inside the cdylib on every call (per-acquire — first-cut design
+   * per the issue body's AI-Agent-Notes) and destroyed on scope exit.
+   *
+   *     using guard = ctx.acquireTexture(surface);
+   *     const handle = guard.view.handle; // pass into a native module
+   */
+  acquireTexture(
+    surface: StreamlibSurface | string | bigint | number,
+  ): CudaAccessGuard<CudaTextureView> {
+    return this._acquireImage(surface, false, true) as CudaAccessGuard<
+      CudaTextureView
+    >;
+  }
+
+  /** Acquire write access to an image-flavored CUDA surface as a
+   * `cudaSurfaceObject_t`. */
+  acquireSurface(
+    surface: StreamlibSurface | string | bigint | number,
+  ): CudaAccessGuard<CudaSurfaceView> {
+    return this._acquireImage(surface, true, true) as CudaAccessGuard<
+      CudaSurfaceView
+    >;
+  }
+
+  /** Non-blocking variant of [`acquireTexture`] — returns `null` on
+   * contention rather than blocking. */
+  tryAcquireTexture(
+    surface: StreamlibSurface | string | bigint | number,
+  ): CudaAccessGuard<CudaTextureView> | null {
+    return this._acquireImage(surface, false, false) as
+      | CudaAccessGuard<CudaTextureView>
+      | null;
+  }
+
+  /** Non-blocking variant of [`acquireSurface`]. */
+  tryAcquireSurface(
+    surface: StreamlibSurface | string | bigint | number,
+  ): CudaAccessGuard<CudaSurfaceView> | null {
+    return this._acquireImage(surface, true, false) as
+      | CudaAccessGuard<CudaSurfaceView>
+      | null;
+  }
+
+  /** Publish the post-release `VkImageLayout` to surface-share so the
+   * next cross-process consumer's `acquire_from_foreign` Path 2 sees
+   * the right source layout.
+   *
+   * Unlike `OpenGLContext.releaseForCrossProcess` — which takes a
+   * `VulkanContext` and delegates to its `releaseForCrossProcess`
+   * because OpenGL writes don't touch the underlying `VkImage`'s
+   * Vulkan tracker — the CUDA shim takes **no** `vulkanCtx`
+   * parameter. CUDA writes via `cudaSurfaceObject_t` against the
+   * imported mipmapped array; the cdylib has no host `VkDevice` to
+   * issue a QFOT release barrier against (per the consumer-rhi
+   * carve-out), and the pairwise sync runs entirely on
+   * `cudaSignalExternalSemaphoresAsync` /
+   * `cudaWaitExternalSemaphoresAsync` against the imported timeline.
+   * The host consumer's
+   * `GpuContext::resolve_videoframe_registration` Path 2 acquire
+   * handles its own barriers via QFOT-acquire (Mesa) or
+   * bridging-from-UNDEFINED (NVIDIA) — independent of what the CUDA
+   * producer did.
+   *
+   * What this shim does is just the **layout publish**: update the
+   * surface-share daemon's per-surface `current_image_layout` field
+   * so the next consumer sees the right source layout. The timeline
+   * signal happens naturally on scope exit (the cdylib's adapter
+   * advances the timeline as part of releasing the write guard).
+   *
+   * Call this *after* the matching `acquireSurface` `using` scope
+   * has exited so the CUDA stream's writes have drained through to
+   * the GPU and the timeline has been signaled.
+   *
+   * Customers running scenario (a) from the issue body's design
+   * clarification (pure-CUDA AI consumer that just reads, drops the
+   * guard) do NOT call this method — the host is the producer and
+   * handles its own release barriers via `VulkanSurfaceAdapter`.
+   *
+   * `postReleaseLayout` is a Vulkan `VkImageLayout` enumerant as a
+   * number. `GENERAL` is the safest default for cross-process
+   * handoffs — the consumer's `acquire_from_foreign` re-transitions
+   * to whatever layout it actually needs. */
+  releaseForCrossProcess(
+    surface: StreamlibSurface | string | bigint | number,
+    postReleaseLayout: number,
+  ): void {
+    const poolId = surfacePoolId(surface);
+    this.gpu.updateImageLayout(poolId, postReleaseLayout);
+  }
+
+  private resolveAndRegisterImage(poolId: string): bigint {
+    const cached = this.imageSurfaceIds.get(poolId);
+    if (cached !== undefined) return cached;
+    const handle = this.gpu.resolveSurface(poolId);
+    const handlePtr = handle.nativeHandlePtr;
+    if (handlePtr === null) {
+      throw new Error(
+        `CudaContext: resolveSurface('${poolId}') returned a handle with a null native pointer`,
+      );
+    }
+    const surfaceId = nextSurfaceId();
+    const rc: number = this.symbols.sldn_cuda_register_image_surface(
+      this.rt,
+      surfaceId,
+      handlePtr,
+    );
+    if (rc !== RC_OK) {
+      throw new Error(
+        `CudaContext: register_image_surface failed for pool_id ` +
+          `'${poolId}' (rc=${rc}). Common causes: host registered the ` +
+          `surface as a buffer (DLPack path), not an image; host's ` +
+          `image format is outside the CUDA-mappable subset ` +
+          `(Rgba8Unorm / Rgba16Float / Rgba32Float); host did not ` +
+          `attach an exportable timeline semaphore.`,
+      );
+    }
+    this.imageSurfaceIds.set(poolId, surfaceId);
+    this.resolvedHandles.set(poolId, handle);
+    return surfaceId;
+  }
+
+  private _acquireImage(
+    surface: StreamlibSurface | string | bigint | number,
+    write: boolean,
+    blocking: boolean,
+  ): CudaAccessGuard<CudaTextureView | CudaSurfaceView> | null {
+    const poolId = surfacePoolId(surface);
+    const surfaceId = this.resolveAndRegisterImage(poolId);
+    const buf = new Uint8Array(IMAGE_VIEW_STRUCT_SIZE);
+    const fn = blocking
+      ? (write
+        ? this.symbols.sldn_cuda_acquire_surface
+        : this.symbols.sldn_cuda_acquire_texture)
+      : (write
+        ? this.symbols.sldn_cuda_try_acquire_surface
+        : this.symbols.sldn_cuda_try_acquire_texture);
+    const rc: number = fn(this.rt, surfaceId, Deno.UnsafePointer.of(buf));
+    if (rc === RC_CONTENDED) {
+      return null;
+    }
+    if (rc !== RC_OK) {
+      throw new Error(
+        `CudaContext.${blocking ? "" : "try_"}acquire_${
+          write ? "surface" : "texture"
+        }: rc=${rc} for surface '${poolId}'`,
+      );
+    }
+
+    const view = this.parseImageView(buf, write);
+    const surfaceIdSnapshot = surfaceId;
+    const symbols = this.symbols;
+    const rt = this.rt;
+    const writeMode = write;
+
+    return {
+      view,
+      [Symbol.dispose]: () => {
+        if (writeMode) {
+          symbols.sldn_cuda_release_surface(rt, surfaceIdSnapshot);
+        } else {
+          symbols.sldn_cuda_release_texture(rt, surfaceIdSnapshot);
+        }
+      },
+    };
+  }
+
+  private parseImageView(
+    buf: Uint8Array,
+    writable: boolean,
+  ): CudaTextureView | CudaSurfaceView {
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const handle = dv.getBigUint64(0, true);
+    const width = dv.getUint32(8, true);
+    const height = dv.getUint32(12, true);
+    const format = dv.getInt32(16, true);
+    if (handle === 0n) {
+      throw new Error(
+        "CudaContext: cdylib returned null cuda object handle",
+      );
+    }
+    if (
+      format !== CudaImageFormat.Rgba8Unorm &&
+      format !== CudaImageFormat.Rgba16Float &&
+      format !== CudaImageFormat.Rgba32Float
+    ) {
+      throw new Error(
+        `CudaContext: cdylib returned unexpected format discriminant ` +
+          `${format} on the image view — the wire ABI may have drifted`,
+      );
+    }
+    const view = {
+      handle,
+      width,
+      height,
+      format: format as CudaImageFormat,
+    };
+    return writable
+      ? (view as unknown as CudaSurfaceView)
+      : (view as unknown as CudaTextureView);
   }
 }

--- a/libs/streamlib-deno/adapters/cuda_test.ts
+++ b/libs/streamlib-deno/adapters/cuda_test.ts
@@ -85,6 +85,47 @@ Deno.test("CudaTextureView / CudaSurfaceView shapes round-trip dataclass-style",
   assertEquals(sv.format, CudaImageFormat.Rgba32Float);
 });
 
+Deno.test(
+  "image-path release FFI declares (pointer, u64, u64) — handle-keyed",
+  async () => {
+    // The cdylib's `sldn_cuda_release_texture` / `_surface` take the
+    // customer's `cudaTextureObject_t` / `cudaSurfaceObject_t` back
+    // as a `u64`. This is what makes the FFI safe under concurrent
+    // reads (N read holders, each with a unique handle, releases
+    // must destroy the caller's handle — not LIFO pop). Pin the
+    // declared argtypes here so a regression to a 2-arg shape
+    // surfaces at unit-test time.
+    //
+    // Source-level check rather than runtime introspection because
+    // the `symbols` object in `native.ts` is not exported (it's
+    // `const symbols`, used only by `loadNativeLib`). The `as const`
+    // shape is the load-bearing invariant; reading the source text
+    // is the simplest way to lock it.
+    // `import.meta.url` is the test file's URL; resolve `../native.ts`
+    // relative to it so the test runs regardless of cwd.
+    const nativeUrl = new URL("../native.ts", import.meta.url);
+    const src = await Deno.readTextFile(nativeUrl);
+    const releaseTexture =
+      /sldn_cuda_release_texture:\s*\{\s*parameters:\s*\["pointer",\s*"u64",\s*"u64"\]\s+as const/;
+    const releaseSurface =
+      /sldn_cuda_release_surface:\s*\{\s*parameters:\s*\["pointer",\s*"u64",\s*"u64"\]\s+as const/;
+    if (!releaseTexture.test(src)) {
+      throw new Error(
+        "sldn_cuda_release_texture FFI declaration must take " +
+          '["pointer", "u64", "u64"] — a regression to ["pointer", "u64"] ' +
+          "is the LIFO-pop anti-pattern that breaks under concurrent " +
+          "reads. See the cdylib's `sldn_cuda_release_texture` doc-comment.",
+      );
+    }
+    if (!releaseSurface.test(src)) {
+      throw new Error(
+        "sldn_cuda_release_surface FFI declaration must take " +
+          '["pointer", "u64", "u64"] — same regression check.',
+      );
+    }
+  },
+);
+
 Deno.test("releaseForCrossProcess signature takes no vulkanCtx parameter", () => {
   // The CUDA shim must NOT take a `vulkanCtx` parameter — unlike the
   // OpenGL shim. Per the design clarification comment on #802:

--- a/libs/streamlib-deno/adapters/cuda_test.ts
+++ b/libs/streamlib-deno/adapters/cuda_test.ts
@@ -18,7 +18,10 @@ import { assertEquals, assertExists } from "@std/assert";
 import {
   type CudaAccessGuard,
   CudaContext,
+  CudaImageFormat,
   type CudaReadView,
+  type CudaSurfaceView,
+  type CudaTextureView,
   type CudaWriteView,
   STREAMLIB_ADAPTER_ABI_VERSION,
 } from "./cuda.ts";
@@ -39,6 +42,76 @@ Deno.test("CudaContext class exposes the surface-adapter method set", () => {
   assertExists(proto.tryAcquireRead);
   assertExists(proto.tryAcquireWrite);
   assertExists(proto.close);
+  // Image-flavored methods — sibling of acquireRead / acquireWrite
+  // for the `cudaTextureObject_t` / `cudaSurfaceObject_t` path.
+  assertExists(proto.acquireTexture);
+  assertExists(proto.acquireSurface);
+  assertExists(proto.tryAcquireTexture);
+  assertExists(proto.tryAcquireSurface);
+  // Cross-process release shim — present per the design clarification
+  // comment on #802 (no `vulkanCtx` parameter; see the arity test).
+  assertExists(proto.releaseForCrossProcess);
+});
+
+Deno.test("CudaImageFormat enum matches cdylib discriminants", () => {
+  // Wire ABI mirror of the cdylib's `SLDN_CUDA_FORMAT_*` constants.
+  // CUDA image flavor is restricted to the four-channel R8/R16/R32
+  // subset accepted by `cudaExternalMemoryGetMappedMipmappedArray`.
+  assertEquals(CudaImageFormat.Rgba8Unorm, 0);
+  assertEquals(CudaImageFormat.Rgba16Float, 1);
+  assertEquals(CudaImageFormat.Rgba32Float, 2);
+});
+
+Deno.test("CudaTextureView / CudaSurfaceView shapes round-trip dataclass-style", () => {
+  const tv: CudaTextureView = {
+    handle: 0xDEAD_BEEF_CAFE_0000n,
+    width: 1920,
+    height: 1080,
+    format: CudaImageFormat.Rgba8Unorm,
+  };
+  const sv: CudaSurfaceView = {
+    handle: 0xCAFE_BABE_1234_ABCDn,
+    width: 640,
+    height: 480,
+    format: CudaImageFormat.Rgba32Float,
+  };
+  assertEquals(tv.handle, 0xDEAD_BEEF_CAFE_0000n);
+  assertEquals(tv.width, 1920);
+  assertEquals(tv.height, 1080);
+  assertEquals(tv.format, CudaImageFormat.Rgba8Unorm);
+  assertEquals(sv.handle, 0xCAFE_BABE_1234_ABCDn);
+  assertEquals(sv.width, 640);
+  assertEquals(sv.height, 480);
+  assertEquals(sv.format, CudaImageFormat.Rgba32Float);
+});
+
+Deno.test("releaseForCrossProcess signature takes no vulkanCtx parameter", () => {
+  // The CUDA shim must NOT take a `vulkanCtx` parameter — unlike the
+  // OpenGL shim. Per the design clarification comment on #802:
+  //
+  //   CUDA writes via `cudaSurfaceObject_t` against the imported
+  //   mipmapped array — the underlying VkImage memory is touched but
+  //   the Vulkan layout tracker is unchanged (and the cdylib has no
+  //   host VkDevice to barrier on anyway, per the consumer-rhi
+  //   carve-out). The pairwise sync runs entirely on
+  //   `cudaSignalExternalSemaphoresAsync` /
+  //   `cudaWaitExternalSemaphoresAsync` against the imported
+  //   timeline.
+  //
+  // The shim's job is the layout publish via `updateImageLayout`. A
+  // future regression that adds `vulkanCtx` back (e.g. copying the
+  // OpenGL shape reflexively) trips this test.
+  const fn = (CudaContext as unknown as { prototype: {
+    releaseForCrossProcess: (...args: unknown[]) => void;
+  } }).prototype.releaseForCrossProcess;
+  // `.length` returns the number of declared formal parameters before
+  // any with default values; two = (surface, postReleaseLayout).
+  assertEquals(
+    fn.length,
+    2,
+    "releaseForCrossProcess must take (surface, postReleaseLayout) " +
+      "only — no vulkanCtx. See the design clarification on #802.",
+  );
 });
 
 Deno.test("CudaReadView / CudaWriteView shapes round-trip dataclass-style", () => {

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -398,6 +398,42 @@ const symbols = {
     parameters: ["pointer", "u64"] as const,
     result: "i32" as const,
   },
+  // Image-flavored path — OPAQUE_FD `VkImage` import +
+  // `cudaMipmappedArray_t` + per-acquire `cudaTextureObject_t` /
+  // `cudaSurfaceObject_t` construction. Sibling of the buffer-flavored
+  // symbols above.
+  sldn_cuda_register_image_surface: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_unregister_image_surface: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_acquire_texture: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_acquire_surface: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_try_acquire_texture: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_try_acquire_surface: {
+    parameters: ["pointer", "u64", "pointer"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_release_texture: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
+  sldn_cuda_release_surface: {
+    parameters: ["pointer", "u64"] as const,
+    result: "i32" as const,
+  },
 } as const;
 
 export type NativeLib = Deno.DynamicLibrary<typeof symbols>;

--- a/libs/streamlib-deno/native.ts
+++ b/libs/streamlib-deno/native.ts
@@ -426,12 +426,17 @@ const symbols = {
     parameters: ["pointer", "u64", "pointer"] as const,
     result: "i32" as const,
   },
+  // Release takes the handle back as `u64` so the cdylib destroys the
+  // exact `cudaTextureObject_t` / `cudaSurfaceObject_t` the customer
+  // used — not "whichever was last constructed". The adapter supports
+  // N concurrent read holders; popping a LIFO stack would destroy the
+  // wrong reader's handle.
   sldn_cuda_release_texture: {
-    parameters: ["pointer", "u64"] as const,
+    parameters: ["pointer", "u64", "u64"] as const,
     result: "i32" as const,
   },
   sldn_cuda_release_surface: {
-    parameters: ["pointer", "u64"] as const,
+    parameters: ["pointer", "u64", "u64"] as const,
     result: "i32" as const,
   },
 } as const;

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -5040,7 +5040,7 @@ mod cpu_readback {
 
 #[cfg(target_os = "linux")]
 mod cuda {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
     use std::os::unix::io::RawFd;
@@ -6059,27 +6059,36 @@ mod cuda {
     /// (the CUDA-side handle yielded by
     /// `cudaExternalMemoryGetMappedMipmappedArray`), the per-surface
     /// stream, plus the same imported timeline + the host
-    /// `Arc<ConsumerVulkanTexture>` for Drop-order keepalive.
+    /// `Arc<ConsumerVulkanTexture>` for keepalive across CUDA-side
+    /// teardown.
     ///
     /// Per-acquire `cudaTextureObject_t` / `cudaSurfaceObject_t`
-    /// handles live on `live_objects` — push on acquire, pop on
-    /// release. LIFO mirrors the scope-bound `with` / `using` pattern
-    /// at the SDK layer.
+    /// handles live in `live_textures` / `live_surfaces` (sets keyed
+    /// by handle value). Each release call passes its handle back so
+    /// the cdylib destroys the exact object the customer used — not
+    /// whichever was last constructed. This makes concurrent reads
+    /// (the adapter supports N read holders) safe: R1's release
+    /// destroys R1's handle even when R2 is mid-acquire.
     struct RegisteredCudaImageSurface {
-        // CUDA-side imports — Drop runs in declaration order, so list
-        // these first to ensure they're torn down before the Vulkan
-        // Arcs below release the underlying memory.
+        // CUDA-side imports — the manual `Drop` impl below tears them
+        // down in the correct order explicitly. Field declaration
+        // order doesn't matter for teardown correctness; the explicit
+        // Drop runs first and field drops fire afterward (with the
+        // Vulkan-side Arcs dropping last so the CUDA imports never
+        // outlive their backing memory).
         ext_mem: sys::cudaExternalMemory_t,
         ext_sem: sys::cudaExternalSemaphore_t,
         stream: sys::cudaStream_t,
         mipmapped_array: sys::cudaMipmappedArray_t,
-        /// Stack of live `cudaTextureObject_t` / `cudaSurfaceObject_t`
-        /// handles — one entry per outstanding acquire. Both types are
-        /// `c_ulonglong` so a single `u64` discriminator-less stack
-        /// covers either flavor (read-side pushes texture objects,
-        /// write-side pushes surface objects; releases pop the
-        /// matching flavor by FFI entry-point selection).
-        live_objects: Mutex<Vec<u64>>,
+        /// Outstanding `cudaTextureObject_t` handles. The release
+        /// FFI removes the specific handle the customer passes back;
+        /// `Drop` drains anything left over (orphan from a leak).
+        live_textures: Mutex<HashSet<u64>>,
+        /// Symmetric to [`Self::live_textures`] but for
+        /// `cudaSurfaceObject_t`. Two sets (rather than one
+        /// flavor-tagged set) so the destroy call dispatches without
+        /// a lookup.
+        live_surfaces: Mutex<HashSet<u64>>,
         width: u32,
         height: u32,
         format: TextureFormat,
@@ -6098,29 +6107,31 @@ mod cuda {
     impl Drop for RegisteredCudaImageSurface {
         fn drop(&mut self) {
             unsafe {
-                // Destroy any texture / surface objects still outstanding.
-                // Customers SHOULD release every acquire before unregister,
-                // but a forced unregister mid-flight shouldn't leak handles.
-                let drained: Vec<u64> = self
-                    .live_objects
+                // Destroy any outstanding texture / surface objects.
+                // Customers SHOULD release every acquire before
+                // unregister, but a forced teardown mid-flight
+                // shouldn't leak handles. Per-flavor sets mean we
+                // dispatch to the right CUDA destroy call without
+                // trial-and-error.
+                let textures: Vec<u64> = self
+                    .live_textures
                     .lock()
-                    .expect("RegisteredCudaImageSurface live_objects: poisoned")
-                    .drain(..)
+                    .expect("RegisteredCudaImageSurface live_textures: poisoned")
+                    .drain()
                     .collect();
-                for handle in drained {
-                    // Texture and surface objects use the same destroy
-                    // signature — pick by trial since we don't track
-                    // flavor on the stack. `cudaDestroyTextureObject`
-                    // returns `cudaErrorInvalidValue` on a surface
-                    // object (and vice-versa), so attempt one then the
-                    // other.
-                    if sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t)
-                        .result()
-                        .is_err()
-                    {
-                        let _ = sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t)
-                            .result();
-                    }
+                for handle in textures {
+                    let _ =
+                        sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result();
+                }
+                let surfaces: Vec<u64> = self
+                    .live_surfaces
+                    .lock()
+                    .expect("RegisteredCudaImageSurface live_surfaces: poisoned")
+                    .drain()
+                    .collect();
+                for handle in surfaces {
+                    let _ =
+                        sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result();
                 }
                 if !self.mipmapped_array.is_null() {
                     let _ = sys::cudaFreeMipmappedArray(self.mipmapped_array).result();
@@ -6451,7 +6462,8 @@ mod cuda {
             ext_sem,
             stream,
             mipmapped_array,
-            live_objects: Mutex::new(Vec::new()),
+            live_textures: Mutex::new(HashSet::new()),
+            live_surfaces: Mutex::new(HashSet::new()),
             width: gpu.width,
             height: gpu.height,
             format: texture_format,
@@ -6714,10 +6726,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_textures
                     .lock()
-                    .expect("slpn_cuda live_objects: poisoned")
-                    .push(tex_obj as u64);
+                    .expect("slpn_cuda live_textures: poisoned")
+                    .insert(tex_obj as u64);
                 populate_image_view(&entry, tex_obj as u64, out)
             }
             Err(e) => {
@@ -6778,10 +6790,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_surfaces
                     .lock()
-                    .expect("slpn_cuda live_objects: poisoned")
-                    .push(surf_obj as u64);
+                    .expect("slpn_cuda live_surfaces: poisoned")
+                    .insert(surf_obj as u64);
                 populate_image_view(&entry, surf_obj as u64, out)
             }
             Err(e) => {
@@ -6835,10 +6847,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_textures
                     .lock()
-                    .expect("slpn_cuda live_objects: poisoned")
-                    .push(tex_obj as u64);
+                    .expect("slpn_cuda live_textures: poisoned")
+                    .insert(tex_obj as u64);
                 populate_image_view(&entry, tex_obj as u64, out)
             }
             Ok(None) => SLPN_CUDA_CONTENDED,
@@ -6893,10 +6905,10 @@ mod cuda {
                     }
                 };
                 entry
-                    .live_objects
+                    .live_surfaces
                     .lock()
-                    .expect("slpn_cuda live_objects: poisoned")
-                    .push(surf_obj as u64);
+                    .expect("slpn_cuda live_surfaces: poisoned")
+                    .insert(surf_obj as u64);
                 populate_image_view(&entry, surf_obj as u64, out)
             }
             Ok(None) => SLPN_CUDA_CONTENDED,
@@ -6907,29 +6919,45 @@ mod cuda {
         }
     }
 
-    /// Release one outstanding texture-flavored acquire — pops the
-    /// LIFO stack of live `cudaTextureObject_t` handles for this
-    /// surface, destroys the popped handle, and decrements the
+    /// Release one outstanding texture-flavored acquire. Removes the
+    /// specific `handle` (the `cudaTextureObject_t` the customer was
+    /// handed from the matching acquire) from the live set, destroys
+    /// it with `cudaDestroyTextureObject`, and decrements the
     /// adapter's read-holder counter.
+    ///
+    /// Taking the handle as an explicit parameter (rather than popping
+    /// the most recently acquired one) is what makes the FFI safe
+    /// under concurrent reads: the adapter allows N read holders, and
+    /// each acquire constructs a unique handle — releases must
+    /// destroy the caller's handle, not whichever was last
+    /// constructed.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_cuda_release_texture(
         rt: *mut CudaRuntimeHandle,
         surface_id: u64,
+        handle: u64,
     ) -> i32 {
         let rt = match unsafe { rt.as_ref() } {
             Some(r) => r,
             None => return SLPN_CUDA_ERR,
         };
         if let Some(entry) = lookup_image_entry(rt, surface_id) {
-            if let Some(handle) = entry
-                .live_objects
+            let removed = entry
+                .live_textures
                 .lock()
-                .expect("slpn_cuda live_objects: poisoned")
-                .pop()
-            {
+                .expect("slpn_cuda live_textures: poisoned")
+                .remove(&handle);
+            if removed {
                 let _ = unsafe {
                     sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result()
                 };
+            } else {
+                tracing::warn!(
+                    "slpn_cuda_release_texture({}, handle={:#x}): handle not in the \
+                     live set — double-release or wrong-flavor release?",
+                    surface_id,
+                    handle
+                );
             }
         }
         rt.adapter.end_read_access(surface_id);
@@ -6937,26 +6965,35 @@ mod cuda {
     }
 
     /// Release one outstanding surface-flavored acquire — symmetric
-    /// counterpart to [`slpn_cuda_release_texture`].
+    /// counterpart to [`slpn_cuda_release_texture`]. Same handle-keyed
+    /// semantics so concurrent acquires are safe.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_cuda_release_surface(
         rt: *mut CudaRuntimeHandle,
         surface_id: u64,
+        handle: u64,
     ) -> i32 {
         let rt = match unsafe { rt.as_ref() } {
             Some(r) => r,
             None => return SLPN_CUDA_ERR,
         };
         if let Some(entry) = lookup_image_entry(rt, surface_id) {
-            if let Some(handle) = entry
-                .live_objects
+            let removed = entry
+                .live_surfaces
                 .lock()
-                .expect("slpn_cuda live_objects: poisoned")
-                .pop()
-            {
+                .expect("slpn_cuda live_surfaces: poisoned")
+                .remove(&handle);
+            if removed {
                 let _ = unsafe {
                     sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result()
                 };
+            } else {
+                tracing::warn!(
+                    "slpn_cuda_release_surface({}, handle={:#x}): handle not in the \
+                     live set — double-release or wrong-flavor release?",
+                    surface_id,
+                    handle
+                );
             }
         }
         rt.adapter.end_write_access(surface_id);
@@ -7300,6 +7337,7 @@ mod cuda {
     pub unsafe extern "C" fn slpn_cuda_release_texture(
         _rt: *mut c_void,
         _surface_id: u64,
+        _handle: u64,
     ) -> i32 {
         SLPN_CUDA_ERR
     }
@@ -7308,6 +7346,7 @@ mod cuda {
     pub unsafe extern "C" fn slpn_cuda_release_surface(
         _rt: *mut c_void,
         _surface_id: u64,
+        _handle: u64,
     ) -> i32 {
         SLPN_CUDA_ERR
     }

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -5056,10 +5056,12 @@ mod cuda {
         self, CapsuleOwner, Device as DlpackDevice, DeviceType as DlpackDeviceType,
         ManagedTensor as DlpackManagedTensor,
     };
-    use streamlib_adapter_cuda::{CudaSurfaceAdapter, HostSurfaceRegistration, VulkanLayout};
+    use streamlib_adapter_cuda::{
+        CudaSurfaceAdapter, HostImageSurfaceRegistration, HostSurfaceRegistration, VulkanLayout,
+    };
     use streamlib_consumer_rhi::{
-        ConsumerVulkanDevice, ConsumerVulkanBuffer, ConsumerVulkanTimelineSemaphore,
-        PixelFormat,
+        ConsumerVulkanBuffer, ConsumerVulkanDevice, ConsumerVulkanTexture,
+        ConsumerVulkanTimelineSemaphore, TextureFormat,
     };
 
     use super::gpu_surface::SurfaceHandle;
@@ -5074,6 +5076,17 @@ mod cuda {
     /// without re-importing the dlpark spec.
     pub const SLPN_CUDA_DEVICE_TYPE_CUDA: i32 = DlpackDeviceType::Cuda as i32;
     pub const SLPN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = DlpackDeviceType::CudaHost as i32;
+
+    /// CUDA-mappable [`TextureFormat`] discriminants surfaced on
+    /// [`SlpnCudaImageView::format`]. The host's
+    /// `register_host_image_surface` validates that the registered
+    /// `VkImage` is in this subset; the cdylib mirrors the check on
+    /// import. Three variants only: `cudaExternalMemoryGetMappedMipmappedArray`
+    /// accepts `cudaChannelFormatDesc` shapes for `R8/R16/R32` integer
+    /// or 16/32-bit float, no sRGB, no BGR, no 3-channel.
+    pub const SLPN_CUDA_FORMAT_RGBA8_UNORM: i32 = 0;
+    pub const SLPN_CUDA_FORMAT_RGBA16_FLOAT: i32 = 1;
+    pub const SLPN_CUDA_FORMAT_RGBA32_FLOAT: i32 = 2;
 
     /// Per-acquire timeline-wait timeout (nanoseconds). Long enough to
     /// cover any realistic GPU queue depth; short enough that a deadlock
@@ -5131,6 +5144,7 @@ mod cuda {
         adapter: Arc<CudaSurfaceAdapter<ConsumerVulkanDevice>>,
         cuda_device_ordinal: i32,
         registered: Mutex<HashMap<u64, Arc<RegisteredCudaSurface>>>,
+        registered_images: Mutex<HashMap<u64, Arc<RegisteredCudaImageSurface>>>,
     }
 
     /// Per-surface registered state. The adapter's registry holds
@@ -5239,6 +5253,7 @@ mod cuda {
             adapter,
             cuda_device_ordinal,
             registered: Mutex::new(HashMap::new()),
+            registered_images: Mutex::new(HashMap::new()),
         }))
     }
 
@@ -5917,6 +5932,1037 @@ mod cuda {
         SLPN_CUDA_OK
     }
 
+    // ========================================================================
+    // Image-flavored path — OPAQUE_FD `VkImage` + `cudaMipmappedArray_t` +
+    // `cudaTextureObject_t` / `cudaSurfaceObject_t`
+    //
+    // Sibling of the buffer-flavored path above. The Rust adapter at
+    // `streamlib-adapter-cuda::CudaSurfaceAdapter` exposes two registration
+    // paths (`register_host_surface` for `VkBuffer`,
+    // `register_host_image_surface` for `VkImage`); this section is the
+    // cdylib bring-up for the image flavor.
+    //
+    // Customer-facing surface: a raw `uint64_t` handle (the
+    // `cudaTextureObject_t` or `cudaSurfaceObject_t`) plus image dimensions
+    // and format on [`SlpnCudaImageView`]. No DLPack capsule — the mapped
+    // mipmapped array handle is opaque and not DLPack-shaped.
+    // Customers carry the handle into a framework-native CUDA extension
+    // (`torch.utils.cpp_extension`, `cupy.RawKernel`, Triton, ...) and
+    // sample the texture / write the surface inside their own kernel.
+    //
+    // Per-acquire texture / surface object construction matches the
+    // first-cut design recorded on the issue body: each acquire calls
+    // `cudaCreateTextureObject` / `cudaCreateSurfaceObject` with the
+    // hard-coded defaults (linear filter, clamp-to-edge, non-normalized
+    // coords, `cudaReadModeElementType`, no sRGB). Profile-driven
+    // construct-once-reuse-many is a future concern if real workloads
+    // demand it.
+    // ========================================================================
+
+    /// View handed back on every successful image-flavored acquire.
+    /// Layout pinned by the regression test below — Python ctypes /
+    /// Deno DataView readers depend on these offsets.
+    #[repr(C)]
+    pub struct SlpnCudaImageView {
+        /// `cudaTextureObject_t` (read path) or `cudaSurfaceObject_t`
+        /// (write path) — both are typedef'd to `c_ulonglong` in the
+        /// CUDA Runtime API, so a single wire shape covers either.
+        pub cuda_object_handle: u64,
+        /// Image width in pixels — surfaced for kernels that need to
+        /// thread the dimensions into a launch config.
+        pub width: u32,
+        /// Image height in pixels.
+        pub height: u32,
+        /// CUDA-mappable format discriminant — one of
+        /// [`SLPN_CUDA_FORMAT_RGBA8_UNORM`] / `_RGBA16_FLOAT` /
+        /// `_RGBA32_FLOAT`. The cdylib has already validated the
+        /// registration; the field is informational for customer kernels
+        /// that need to know element size for sampling.
+        pub format: i32,
+        /// Reserved padding — keeps the struct 32-byte aligned and gives
+        /// room for additive future fields (mip-level count, layer
+        /// count, etc.) without breaking the wire ABI. Must be zero on
+        /// write.
+        pub _reserved: [u8; 12],
+    }
+
+    /// Map a [`TextureFormat`] from the CUDA-mappable subset onto its
+    /// [`SLPN_CUDA_FORMAT_*`] FFI discriminant. Returns `None` for
+    /// formats outside the subset — the caller surfaces a
+    /// `BackendRejected` style error.
+    fn texture_format_to_slpn(format: TextureFormat) -> Option<i32> {
+        match format {
+            TextureFormat::Rgba8Unorm => Some(SLPN_CUDA_FORMAT_RGBA8_UNORM),
+            TextureFormat::Rgba16Float => Some(SLPN_CUDA_FORMAT_RGBA16_FLOAT),
+            TextureFormat::Rgba32Float => Some(SLPN_CUDA_FORMAT_RGBA32_FLOAT),
+            _ => None,
+        }
+    }
+
+    /// Parse the surface-share format string (e.g. `"Rgba8Unorm"`) onto
+    /// the CUDA-mappable [`TextureFormat`] subset. Returns `None` for
+    /// any format outside the subset; the cuda image path's accepted
+    /// set is intentionally narrower than `texture_format_from_str`
+    /// (defined below for the Vulkan adapter) so reject reasons are
+    /// specific to CUDA.
+    fn cuda_image_texture_format_from_str(format: &str) -> Option<TextureFormat> {
+        match format {
+            "Rgba8Unorm" => Some(TextureFormat::Rgba8Unorm),
+            "Rgba16Float" => Some(TextureFormat::Rgba16Float),
+            "Rgba32Float" => Some(TextureFormat::Rgba32Float),
+            _ => None,
+        }
+    }
+
+    /// Build the `cudaChannelFormatDesc` that
+    /// `cudaExternalMemoryGetMappedMipmappedArray` expects for a given
+    /// CUDA-mappable format. The mapping is fixed by the subset:
+    /// `Rgba8Unorm`  → 4× 8-bit unsigned,
+    /// `Rgba16Float` → 4× 16-bit float,
+    /// `Rgba32Float` → 4× 32-bit float.
+    fn cuda_channel_format_desc_for(format: TextureFormat) -> sys::cudaChannelFormatDesc {
+        match format {
+            TextureFormat::Rgba8Unorm => sys::cudaChannelFormatDesc {
+                x: 8,
+                y: 8,
+                z: 8,
+                w: 8,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindUnsigned,
+            },
+            TextureFormat::Rgba16Float => sys::cudaChannelFormatDesc {
+                x: 16,
+                y: 16,
+                z: 16,
+                w: 16,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindFloat,
+            },
+            TextureFormat::Rgba32Float => sys::cudaChannelFormatDesc {
+                x: 32,
+                y: 32,
+                z: 32,
+                w: 32,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindFloat,
+            },
+            // `register` validates the format up-front; unreachable here.
+            _ => sys::cudaChannelFormatDesc {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 0,
+                f: sys::cudaChannelFormatKind::cudaChannelFormatKindNone,
+            },
+        }
+    }
+
+    /// Per-surface registered state for the image flavor — parallels
+    /// [`RegisteredCudaSurface`]. Holds the imported mipmapped array
+    /// (the CUDA-side handle yielded by
+    /// `cudaExternalMemoryGetMappedMipmappedArray`), the per-surface
+    /// stream, plus the same imported timeline + the host
+    /// `Arc<ConsumerVulkanTexture>` for Drop-order keepalive.
+    ///
+    /// Per-acquire `cudaTextureObject_t` / `cudaSurfaceObject_t`
+    /// handles live on `live_objects` — push on acquire, pop on
+    /// release. LIFO mirrors the scope-bound `with` / `using` pattern
+    /// at the SDK layer.
+    struct RegisteredCudaImageSurface {
+        // CUDA-side imports — Drop runs in declaration order, so list
+        // these first to ensure they're torn down before the Vulkan
+        // Arcs below release the underlying memory.
+        ext_mem: sys::cudaExternalMemory_t,
+        ext_sem: sys::cudaExternalSemaphore_t,
+        stream: sys::cudaStream_t,
+        mipmapped_array: sys::cudaMipmappedArray_t,
+        /// Stack of live `cudaTextureObject_t` / `cudaSurfaceObject_t`
+        /// handles — one entry per outstanding acquire. Both types are
+        /// `c_ulonglong` so a single `u64` discriminator-less stack
+        /// covers either flavor (read-side pushes texture objects,
+        /// write-side pushes surface objects; releases pop the
+        /// matching flavor by FFI entry-point selection).
+        live_objects: Mutex<Vec<u64>>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        // Vulkan-side imports — held to outlive the CUDA imports above.
+        #[allow(dead_code)] // Arc held for lifetime; never read after register.
+        texture: Arc<ConsumerVulkanTexture>,
+        timeline: Arc<ConsumerVulkanTimelineSemaphore>,
+    }
+
+    // SAFETY: same rationale as [`RegisteredCudaSurface`] — CUDA Runtime
+    // API handles are opaque pointer-shaped and threading-safe for use
+    // and teardown after creation.
+    unsafe impl Send for RegisteredCudaImageSurface {}
+    unsafe impl Sync for RegisteredCudaImageSurface {}
+
+    impl Drop for RegisteredCudaImageSurface {
+        fn drop(&mut self) {
+            unsafe {
+                // Destroy any texture / surface objects still outstanding.
+                // Customers SHOULD release every acquire before unregister,
+                // but a forced unregister mid-flight shouldn't leak handles.
+                let drained: Vec<u64> = self
+                    .live_objects
+                    .lock()
+                    .expect("RegisteredCudaImageSurface live_objects: poisoned")
+                    .drain(..)
+                    .collect();
+                for handle in drained {
+                    // Texture and surface objects use the same destroy
+                    // signature — pick by trial since we don't track
+                    // flavor on the stack. `cudaDestroyTextureObject`
+                    // returns `cudaErrorInvalidValue` on a surface
+                    // object (and vice-versa), so attempt one then the
+                    // other.
+                    if sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t)
+                        .result()
+                        .is_err()
+                    {
+                        let _ = sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t)
+                            .result();
+                    }
+                }
+                if !self.mipmapped_array.is_null() {
+                    let _ = sys::cudaFreeMipmappedArray(self.mipmapped_array).result();
+                }
+                if !self.stream.is_null() {
+                    let _ = sys::cudaStreamDestroy(self.stream).result();
+                }
+                if !self.ext_sem.is_null() {
+                    let _ = sys::cudaDestroyExternalSemaphore(self.ext_sem).result();
+                }
+                if !self.ext_mem.is_null() {
+                    let _ = external_memory::destroy_external_memory(self.ext_mem);
+                }
+            }
+        }
+    }
+
+    /// Register a host image-flavored cuda surface — imports the
+    /// OPAQUE_FD `VkImage` and timeline semaphore via
+    /// [`streamlib_consumer_rhi`], then re-imports the same FDs into
+    /// CUDA via `cudaImportExternalMemory` +
+    /// `cudaExternalMemoryGetMappedMipmappedArray` +
+    /// `cudaImportExternalSemaphore`.
+    ///
+    /// Sibling of [`slpn_cuda_register_surface`] (the buffer-flavored
+    /// DLPack path). The two registration paths are exclusive — a
+    /// given `surface_id` can be registered as one flavor, not both.
+    ///
+    /// Format is parsed from `gpu_handle.format`; accepted subset is
+    /// `Rgba8Unorm` / `Rgba16Float` / `Rgba32Float` — the rest of the
+    /// [`TextureFormat`] variants are rejected by
+    /// `cudaExternalMemoryGetMappedMipmappedArray`'s
+    /// `cudaChannelFormatDesc` acceptance.
+    #[unsafe(no_mangle)]
+    #[tracing::instrument(level = "info", skip(rt, gpu_handle))]
+    pub unsafe extern "C" fn slpn_cuda_register_image_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        gpu_handle: *mut SurfaceHandle,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => {
+                tracing::error!("slpn_cuda_register_image_surface: null runtime");
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let gpu = match unsafe { gpu_handle.as_mut() } {
+            Some(g) => g,
+            None => {
+                tracing::error!("slpn_cuda_register_image_surface: null gpu_handle");
+                return SLPN_CUDA_ERR;
+            }
+        };
+        if gpu.fds.len() != 1 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: cuda image flavor requires \
+                 exactly 1 OPAQUE_FD; gpu_handle has {} fd(s)",
+                gpu.fds.len()
+            );
+            return SLPN_CUDA_ERR;
+        }
+        if gpu.width == 0 || gpu.height == 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: width/height must be > 0 \
+                 (got {}x{})",
+                gpu.width,
+                gpu.height
+            );
+            return SLPN_CUDA_ERR;
+        }
+        let texture_format = match cuda_image_texture_format_from_str(&gpu.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: format '{}' is not \
+                     CUDA-mappable; allowed: Rgba8Unorm, Rgba16Float, Rgba32Float",
+                    gpu.format
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let allocation_size = gpu
+            .plane_sizes
+            .first()
+            .copied()
+            .filter(|s| *s > 0)
+            .unwrap_or(gpu.size);
+        if allocation_size == 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: surface '{}' has zero size",
+                surface_id
+            );
+            return SLPN_CUDA_ERR;
+        }
+
+        // ── Step 1: import the OPAQUE_FD `VkImage` into Vulkan ──────────
+        let vk_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if vk_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: dup vk_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            return SLPN_CUDA_ERR;
+        }
+        let texture = match ConsumerVulkanTexture::from_opaque_fd(
+            &rt.device,
+            vk_fd,
+            gpu.width,
+            gpu.height,
+            texture_format,
+            allocation_size,
+        ) {
+            Ok(t) => Arc::new(t),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: ConsumerVulkanTexture::from_opaque_fd \
+                     failed: {} — verify the host registered this surface with \
+                     handle_type=opaque_fd, OPTIMAL tiling, no DRM modifier",
+                    e
+                );
+                unsafe { libc::close(vk_fd) };
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 2: import the timeline semaphore into Vulkan ───────────
+        let raw_sync_fd: RawFd = match gpu.sync_fd.take() {
+            Some(fd) => fd,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: surface '{}' has no sync_fd — \
+                     the host must register an exportable timeline semaphore so \
+                     cross-API sync (Vulkan ↔ CUDA) is well-defined",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let vk_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if vk_sync_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: dup sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        let timeline = match ConsumerVulkanTimelineSemaphore::from_imported_opaque_fd(
+            &rt.device,
+            vk_sync_fd,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => {
+                tracing::error!(
+                    "slpn_cuda_register_image_surface: timeline from_imported_opaque_fd: {}",
+                    e
+                );
+                unsafe { libc::close(vk_sync_fd) };
+                gpu.sync_fd = Some(raw_sync_fd);
+                return SLPN_CUDA_ERR;
+            }
+        };
+
+        // ── Step 3: import the OPAQUE_FD memory into CUDA ───────────────
+        let cuda_mem_fd = unsafe { libc::dup(gpu.fds[0]) };
+        if cuda_mem_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: dup cuda_mem_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        // SAFETY: see notes on the buffer path's import_external_memory_opaque_fd
+        // call — ownership of `cuda_mem_fd` transfers on success.
+        let ext_mem = unsafe {
+            match external_memory::import_external_memory_opaque_fd(cuda_mem_fd, allocation_size) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_image_surface: cudaImportExternalMemory: {:?}",
+                        e
+                    );
+                    libc::close(cuda_mem_fd);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 4: map the imported memory as a mipmapped array ────────
+        // Single-level mip (`numLevels = 1`) — multi-level mip chains
+        // would require the host to export a corresponding pyramid, a
+        // future concern. `flags = 0` (no `cudaArrayColorAttachment` —
+        // surface-write is enabled by `cudaArraySurfaceLoadStore` flag
+        // which the host's `HostVulkanTexture::new_opaque_fd_export`
+        // applies by including `STORAGE` usage in the VkImage).
+        let mipmap_desc = sys::cudaExternalMemoryMipmappedArrayDesc {
+            offset: 0,
+            formatDesc: cuda_channel_format_desc_for(texture_format),
+            extent: sys::cudaExtent {
+                width: gpu.width as usize,
+                height: gpu.height as usize,
+                depth: 0, // 2-D — depth=0 per CUDA spec for non-3D arrays
+            },
+            flags: 0,
+            numLevels: 1,
+        };
+        let mut mipmapped_array = MaybeUninit::<sys::cudaMipmappedArray_t>::uninit();
+        let mipmapped_array = unsafe {
+            match sys::cudaExternalMemoryGetMappedMipmappedArray(
+                mipmapped_array.as_mut_ptr(),
+                ext_mem,
+                &mipmap_desc,
+            )
+            .result()
+            {
+                Ok(()) => mipmapped_array.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_image_surface: \
+                         cudaExternalMemoryGetMappedMipmappedArray failed: {:?} — \
+                         common cause: host's VkImage usage flags don't include \
+                         SAMPLED/STORAGE, or format outside the CUDA-mappable subset",
+                        e
+                    );
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 5: import the timeline semaphore into CUDA ─────────────
+        let cuda_sync_fd = unsafe { libc::dup(raw_sync_fd) };
+        if cuda_sync_fd < 0 {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: dup cuda_sync_fd failed: {}",
+                std::io::Error::last_os_error()
+            );
+            unsafe {
+                let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+        let mut sem_desc = MaybeUninit::<sys::cudaExternalSemaphoreHandleDesc>::zeroed();
+        let sem_desc = unsafe {
+            let p = sem_desc.as_mut_ptr();
+            (&raw mut (*p).type_).write(
+                sys::cudaExternalSemaphoreHandleType::cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd,
+            );
+            (&raw mut (*p).handle).write(
+                sys::cudaExternalSemaphoreHandleDesc__bindgen_ty_1 { fd: cuda_sync_fd },
+            );
+            (&raw mut (*p).flags).write(0);
+            sem_desc.assume_init()
+        };
+        let mut ext_sem = MaybeUninit::<sys::cudaExternalSemaphore_t>::uninit();
+        let ext_sem = unsafe {
+            match sys::cudaImportExternalSemaphore(ext_sem.as_mut_ptr(), &sem_desc).result() {
+                Ok(()) => ext_sem.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_image_surface: cudaImportExternalSemaphore: {:?}",
+                        e
+                    );
+                    libc::close(cuda_sync_fd);
+                    let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 6: per-surface CUDA stream ─────────────────────────────
+        let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+        let stream = unsafe {
+            match sys::cudaStreamCreate(stream.as_mut_ptr()).result() {
+                Ok(()) => stream.assume_init(),
+                Err(e) => {
+                    tracing::error!(
+                        "slpn_cuda_register_image_surface: cudaStreamCreate: {:?}",
+                        e
+                    );
+                    let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                    let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                    let _ = external_memory::destroy_external_memory(ext_mem);
+                    gpu.sync_fd = Some(raw_sync_fd);
+                    return SLPN_CUDA_ERR;
+                }
+            }
+        };
+
+        // ── Step 7: hand the registration to the Rust adapter ──────────
+        let registration = HostImageSurfaceRegistration {
+            texture: Arc::clone(&texture),
+            timeline: Arc::clone(&timeline),
+            initial_layout: VulkanLayout::UNDEFINED,
+        };
+        if let Err(e) = rt
+            .adapter
+            .register_host_image_surface(surface_id, registration)
+        {
+            tracing::error!(
+                "slpn_cuda_register_image_surface: \
+                 adapter.register_host_image_surface({}): {:?}",
+                surface_id,
+                e
+            );
+            unsafe {
+                let _ = sys::cudaStreamDestroy(stream).result();
+                let _ = sys::cudaDestroyExternalSemaphore(ext_sem).result();
+                let _ = sys::cudaFreeMipmappedArray(mipmapped_array).result();
+                let _ = external_memory::destroy_external_memory(ext_mem);
+            };
+            gpu.sync_fd = Some(raw_sync_fd);
+            return SLPN_CUDA_ERR;
+        }
+
+        gpu.sync_fd = Some(raw_sync_fd);
+
+        let entry = Arc::new(RegisteredCudaImageSurface {
+            ext_mem,
+            ext_sem,
+            stream,
+            mipmapped_array,
+            live_objects: Mutex::new(Vec::new()),
+            width: gpu.width,
+            height: gpu.height,
+            format: texture_format,
+            texture,
+            timeline,
+        });
+        rt.registered_images
+            .lock()
+            .expect("slpn_cuda registered_images: poisoned")
+            .insert(surface_id, entry);
+        SLPN_CUDA_OK
+    }
+
+    /// Unregister a previously-registered image-flavored cuda surface.
+    /// Mirrors [`slpn_cuda_unregister_surface`] but targets the image
+    /// map. Returns `SLPN_CUDA_ERR` if the `surface_id` isn't an image
+    /// registration on this runtime.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_unregister_image_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let removed = rt
+            .registered_images
+            .lock()
+            .expect("slpn_cuda registered_images: poisoned")
+            .remove(&surface_id);
+        if removed.is_none() {
+            return SLPN_CUDA_ERR;
+        }
+        if rt.adapter.unregister_host_surface(surface_id) {
+            SLPN_CUDA_OK
+        } else {
+            SLPN_CUDA_ERR
+        }
+    }
+
+    fn lookup_image_entry(
+        rt: &CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> Option<Arc<RegisteredCudaImageSurface>> {
+        rt.registered_images
+            .lock()
+            .expect("slpn_cuda registered_images: poisoned")
+            .get(&surface_id)
+            .cloned()
+    }
+
+    /// Build a `cudaTextureDesc` with the AI-Agent-Notes defaults from
+    /// the issue body: linear filter, clamp-to-edge addressing across
+    /// all three dimensions, non-normalized coordinates,
+    /// `cudaReadModeElementType`, no sRGB, no mipmap clamping. Customer-
+    /// overridable defaults are a future concern when a real consumer
+    /// surfaces; ship the standard sampler shape now.
+    fn default_texture_desc() -> sys::cudaTextureDesc {
+        sys::cudaTextureDesc {
+            addressMode: [
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+                sys::cudaTextureAddressMode::cudaAddressModeClamp,
+            ],
+            filterMode: sys::cudaTextureFilterMode::cudaFilterModeLinear,
+            readMode: sys::cudaTextureReadMode::cudaReadModeElementType,
+            sRGB: 0,
+            borderColor: [0.0, 0.0, 0.0, 0.0],
+            normalizedCoords: 0,
+            maxAnisotropy: 0,
+            mipmapFilterMode: sys::cudaTextureFilterMode::cudaFilterModePoint,
+            mipmapLevelBias: 0.0,
+            minMipmapLevelClamp: 0.0,
+            maxMipmapLevelClamp: 0.0,
+            disableTrilinearOptimization: 0,
+            seamlessCubemap: 0,
+        }
+    }
+
+    /// Per-acquire `cudaTextureObject_t` construction. Bound to
+    /// `cudaResourceTypeMipmappedArray` against the imported handle.
+    fn create_texture_object_for(
+        entry: &RegisteredCudaImageSurface,
+    ) -> Result<sys::cudaTextureObject_t, String> {
+        let mut res_desc = MaybeUninit::<sys::cudaResourceDesc>::zeroed();
+        // SAFETY: we initialize every field; zeroed gives a valid
+        // starting state for the union since `cudaResourceTypeArray = 0`
+        // and the union variants are pointer-shaped.
+        let res_desc = unsafe {
+            let p = res_desc.as_mut_ptr();
+            (&raw mut (*p).resType).write(sys::cudaResourceType::cudaResourceTypeMipmappedArray);
+            (&raw mut (*p).res.mipmap.mipmap).write(entry.mipmapped_array);
+            res_desc.assume_init()
+        };
+        let tex_desc = default_texture_desc();
+        let mut tex_obj = MaybeUninit::<sys::cudaTextureObject_t>::uninit();
+        unsafe {
+            sys::cudaCreateTextureObject(
+                tex_obj.as_mut_ptr(),
+                &res_desc,
+                &tex_desc,
+                std::ptr::null(),
+            )
+            .result()
+            .map_err(|e| format!("cudaCreateTextureObject: {e:?}"))?;
+            Ok(tex_obj.assume_init())
+        }
+    }
+
+    /// Per-acquire `cudaSurfaceObject_t` construction. Bound to
+    /// `cudaResourceTypeArray` against level-0 of the imported
+    /// mipmapped array (`cudaCreateSurfaceObject` does not accept
+    /// `cudaResourceTypeMipmappedArray` directly — it requires a
+    /// `cudaArray_t`).
+    fn create_surface_object_for(
+        entry: &RegisteredCudaImageSurface,
+    ) -> Result<sys::cudaSurfaceObject_t, String> {
+        let mut level0 = MaybeUninit::<sys::cudaArray_t>::uninit();
+        let level0 = unsafe {
+            sys::cudaGetMipmappedArrayLevel(level0.as_mut_ptr(), entry.mipmapped_array, 0)
+                .result()
+                .map_err(|e| format!("cudaGetMipmappedArrayLevel: {e:?}"))?;
+            level0.assume_init()
+        };
+        let mut res_desc = MaybeUninit::<sys::cudaResourceDesc>::zeroed();
+        let res_desc = unsafe {
+            let p = res_desc.as_mut_ptr();
+            (&raw mut (*p).resType).write(sys::cudaResourceType::cudaResourceTypeArray);
+            (&raw mut (*p).res.array.array).write(level0);
+            res_desc.assume_init()
+        };
+        let mut surf_obj = MaybeUninit::<sys::cudaSurfaceObject_t>::uninit();
+        unsafe {
+            sys::cudaCreateSurfaceObject(surf_obj.as_mut_ptr(), &res_desc)
+                .result()
+                .map_err(|e| format!("cudaCreateSurfaceObject: {e:?}"))?;
+            Ok(surf_obj.assume_init())
+        }
+    }
+
+    fn cuda_sync_after_image_acquire(entry: &RegisteredCudaImageSurface) -> Result<(), String> {
+        let wait_value = entry
+            .timeline
+            .current_value()
+            .map_err(|e| format!("get_semaphore_counter_value: {e}"))?;
+
+        let mut wait_params = MaybeUninit::<sys::cudaExternalSemaphoreWaitParams>::zeroed();
+        let wait_params = unsafe {
+            let p = wait_params.as_mut_ptr();
+            (&raw mut (*p).params.fence.value).write(wait_value);
+            (&raw mut (*p).flags).write(0);
+            wait_params.assume_init()
+        };
+
+        let wait_result = unsafe {
+            sys::cudaWaitExternalSemaphoresAsync_v2(
+                &entry.ext_sem,
+                &wait_params,
+                1,
+                entry.stream,
+            )
+            .result()
+        };
+        if let Err(e) = wait_result {
+            return Err(format!("cudaWaitExternalSemaphoresAsync: {e:?}"));
+        }
+        if let Err(e) = unsafe { sys::cudaStreamSynchronize(entry.stream) }.result() {
+            return Err(format!("cudaStreamSynchronize: {e:?}"));
+        }
+        Ok(())
+    }
+
+    fn populate_image_view(
+        entry: &Arc<RegisteredCudaImageSurface>,
+        cuda_object_handle: u64,
+        out: &mut SlpnCudaImageView,
+    ) -> i32 {
+        let format = match texture_format_to_slpn(entry.format) {
+            Some(f) => f,
+            None => {
+                tracing::error!(
+                    "slpn_cuda: registered image format {:?} is not in the \
+                     CUDA-mappable subset — registration should have rejected this",
+                    entry.format
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        out.cuda_object_handle = cuda_object_handle;
+        out.width = entry.width;
+        out.height = entry.height;
+        out.format = format;
+        out._reserved = [0u8; 12];
+        SLPN_CUDA_OK
+    }
+
+    fn descriptor_for_image_surface(surface_id: u64) -> StreamlibSurface {
+        StreamlibSurface::new(
+            surface_id,
+            0,
+            0,
+            SurfaceFormat::Bgra8,
+            SurfaceUsage::SAMPLED,
+            SurfaceTransportHandle::empty(),
+            SurfaceSyncState::default(),
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_acquire_texture: surface_id {} not registered \
+                     as image flavor",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.acquire_texture(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_acquire_texture({}): cuda sync failed: {} — \
+                         releasing the adapter guard so the timeline can advance",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                let tex_obj = match create_texture_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_cuda_acquire_texture({}): create_texture_object failed: {} — \
+                             releasing the adapter guard",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_read_access(surface_id);
+                        return SLPN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("slpn_cuda live_objects: poisoned")
+                    .push(tex_obj as u64);
+                populate_image_view(&entry, tex_obj as u64, out)
+            }
+            Err(e) => {
+                tracing::error!("slpn_cuda_acquire_texture({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => {
+                tracing::error!(
+                    "slpn_cuda_acquire_surface: surface_id {} not registered \
+                     as image flavor",
+                    surface_id
+                );
+                return SLPN_CUDA_ERR;
+            }
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.acquire_surface(&surface) {
+            Ok(g) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_acquire_surface({}): cuda sync failed: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                let surf_obj = match create_surface_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_cuda_acquire_surface({}): create_surface_object failed: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_write_access(surface_id);
+                        return SLPN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("slpn_cuda live_objects: poisoned")
+                    .push(surf_obj as u64);
+                populate_image_view(&entry, surf_obj as u64, out)
+            }
+            Err(e) => {
+                tracing::error!("slpn_cuda_acquire_surface({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLPN_CUDA_ERR,
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.try_acquire_texture(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_try_acquire_texture({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_read_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                let tex_obj = match create_texture_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_cuda_try_acquire_texture({}): create_texture_object: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_read_access(surface_id);
+                        return SLPN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("slpn_cuda live_objects: poisoned")
+                    .push(tex_obj as u64);
+                populate_image_view(&entry, tex_obj as u64, out)
+            }
+            Ok(None) => SLPN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("slpn_cuda_try_acquire_texture({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+        out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        let out = match unsafe { out_view.as_mut() } {
+            Some(v) => v,
+            None => return SLPN_CUDA_ERR,
+        };
+        let entry = match lookup_image_entry(rt, surface_id) {
+            Some(e) => e,
+            None => return SLPN_CUDA_ERR,
+        };
+        let surface = descriptor_for_image_surface(surface_id);
+        match rt.adapter.try_acquire_surface(&surface) {
+            Ok(Some(g)) => {
+                std::mem::forget(g);
+                if let Err(e) = cuda_sync_after_image_acquire(&entry) {
+                    tracing::error!(
+                        "slpn_cuda_try_acquire_surface({}): cuda sync: {}",
+                        surface_id,
+                        e
+                    );
+                    rt.adapter.end_write_access(surface_id);
+                    return SLPN_CUDA_ERR;
+                }
+                let surf_obj = match create_surface_object_for(&entry) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        tracing::error!(
+                            "slpn_cuda_try_acquire_surface({}): create_surface_object: {}",
+                            surface_id,
+                            e
+                        );
+                        rt.adapter.end_write_access(surface_id);
+                        return SLPN_CUDA_ERR;
+                    }
+                };
+                entry
+                    .live_objects
+                    .lock()
+                    .expect("slpn_cuda live_objects: poisoned")
+                    .push(surf_obj as u64);
+                populate_image_view(&entry, surf_obj as u64, out)
+            }
+            Ok(None) => SLPN_CUDA_CONTENDED,
+            Err(e) => {
+                tracing::error!("slpn_cuda_try_acquire_surface({}): {:?}", surface_id, e);
+                SLPN_CUDA_ERR
+            }
+        }
+    }
+
+    /// Release one outstanding texture-flavored acquire — pops the
+    /// LIFO stack of live `cudaTextureObject_t` handles for this
+    /// surface, destroys the popped handle, and decrements the
+    /// adapter's read-holder counter.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_texture(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        if let Some(entry) = lookup_image_entry(rt, surface_id) {
+            if let Some(handle) = entry
+                .live_objects
+                .lock()
+                .expect("slpn_cuda live_objects: poisoned")
+                .pop()
+            {
+                let _ = unsafe {
+                    sys::cudaDestroyTextureObject(handle as sys::cudaTextureObject_t).result()
+                };
+            }
+        }
+        rt.adapter.end_read_access(surface_id);
+        SLPN_CUDA_OK
+    }
+
+    /// Release one outstanding surface-flavored acquire — symmetric
+    /// counterpart to [`slpn_cuda_release_texture`].
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_surface(
+        rt: *mut CudaRuntimeHandle,
+        surface_id: u64,
+    ) -> i32 {
+        let rt = match unsafe { rt.as_ref() } {
+            Some(r) => r,
+            None => return SLPN_CUDA_ERR,
+        };
+        if let Some(entry) = lookup_image_entry(rt, surface_id) {
+            if let Some(handle) = entry
+                .live_objects
+                .lock()
+                .expect("slpn_cuda live_objects: poisoned")
+                .pop()
+            {
+                let _ = unsafe {
+                    sys::cudaDestroySurfaceObject(handle as sys::cudaSurfaceObject_t).result()
+                };
+            }
+        }
+        rt.adapter.end_write_access(surface_id);
+        SLPN_CUDA_OK
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -5950,6 +6996,120 @@ mod cuda {
             assert_eq!(SLPN_CUDA_OK, 0);
             assert_eq!(SLPN_CUDA_ERR, -1);
             assert_eq!(SLPN_CUDA_CONTENDED, 1);
+            // Image-path format discriminants — wire ABI between
+            // cdylib and the Python/Deno SDK mirrors.
+            assert_eq!(SLPN_CUDA_FORMAT_RGBA8_UNORM, 0);
+            assert_eq!(SLPN_CUDA_FORMAT_RGBA16_FLOAT, 1);
+            assert_eq!(SLPN_CUDA_FORMAT_RGBA32_FLOAT, 2);
+        }
+
+        // Layout regression for the image-flavored view — same wire
+        // ABI guarantees as the buffer flavor. Python ctypes and Deno
+        // DataView readers in the SDK layers depend on these offsets.
+        #[test]
+        fn slpn_cuda_image_view_layout_matches_spec_64bit() {
+            // SlpnCudaImageView fields in declaration order:
+            //   cuda_object_handle: u64    @ 0
+            //   width             : u32    @ 8
+            //   height            : u32    @ 12
+            //   format            : i32    @ 16
+            //   _reserved         : [u8;12]@ 20
+            // Total: 32 bytes — same wire size as `SlpnCudaView` so the
+            // SDK can reuse 32-byte staging buffers across flavors.
+            assert_eq!(size_of::<SlpnCudaImageView>(), 32);
+            assert_eq!(offset_of!(SlpnCudaImageView, cuda_object_handle), 0);
+            assert_eq!(offset_of!(SlpnCudaImageView, width), 8);
+            assert_eq!(offset_of!(SlpnCudaImageView, height), 12);
+            assert_eq!(offset_of!(SlpnCudaImageView, format), 16);
+            assert_eq!(offset_of!(SlpnCudaImageView, _reserved), 20);
+        }
+
+        #[test]
+        fn cuda_image_texture_format_from_str_accepts_cuda_mappable_subset() {
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba8Unorm"),
+                Some(TextureFormat::Rgba8Unorm)
+            );
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba16Float"),
+                Some(TextureFormat::Rgba16Float)
+            );
+            assert_eq!(
+                cuda_image_texture_format_from_str("Rgba32Float"),
+                Some(TextureFormat::Rgba32Float)
+            );
+            // Non-CUDA-mappable variants are explicitly rejected so the
+            // register flow surfaces them with a specific error message
+            // rather than silently letting cudaExternalMemoryGetMappedMipmappedArray
+            // fail with a less actionable code.
+            assert_eq!(cuda_image_texture_format_from_str("Bgra8Unorm"), None);
+            assert_eq!(cuda_image_texture_format_from_str("Rgba8UnormSrgb"), None);
+            assert_eq!(cuda_image_texture_format_from_str("Nv12"), None);
+        }
+
+        #[test]
+        fn cuda_channel_format_desc_for_matches_format_byte_layout() {
+            // Wire contract for cudaExternalMemoryGetMappedMipmappedArray —
+            // Rgba8Unorm  = 4× 8-bit unsigned,
+            // Rgba16Float = 4× 16-bit float,
+            // Rgba32Float = 4× 32-bit float.
+            let d8 = cuda_channel_format_desc_for(TextureFormat::Rgba8Unorm);
+            assert_eq!((d8.x, d8.y, d8.z, d8.w), (8, 8, 8, 8));
+            assert_eq!(
+                d8.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindUnsigned
+            );
+            let d16 = cuda_channel_format_desc_for(TextureFormat::Rgba16Float);
+            assert_eq!((d16.x, d16.y, d16.z, d16.w), (16, 16, 16, 16));
+            assert_eq!(
+                d16.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindFloat
+            );
+            let d32 = cuda_channel_format_desc_for(TextureFormat::Rgba32Float);
+            assert_eq!((d32.x, d32.y, d32.z, d32.w), (32, 32, 32, 32));
+            assert_eq!(
+                d32.f,
+                sys::cudaChannelFormatKind::cudaChannelFormatKindFloat
+            );
+        }
+
+        #[test]
+        fn default_texture_desc_matches_issue_body_ai_notes() {
+            // AI-Agent-Notes defaults from #802: linear filter,
+            // clamp-to-edge x3, non-normalized coords,
+            // ReadElementType, no sRGB. Locking these here so a future
+            // change to the defaults is intentional rather than drift.
+            let d = default_texture_desc();
+            assert_eq!(
+                d.filterMode,
+                sys::cudaTextureFilterMode::cudaFilterModeLinear
+            );
+            assert_eq!(
+                d.readMode,
+                sys::cudaTextureReadMode::cudaReadModeElementType
+            );
+            assert_eq!(d.sRGB, 0);
+            assert_eq!(d.normalizedCoords, 0);
+            for mode in d.addressMode {
+                assert_eq!(mode, sys::cudaTextureAddressMode::cudaAddressModeClamp);
+            }
+        }
+
+        #[test]
+        fn texture_format_to_slpn_roundtrips_cuda_mappable_subset() {
+            assert_eq!(
+                texture_format_to_slpn(TextureFormat::Rgba8Unorm),
+                Some(SLPN_CUDA_FORMAT_RGBA8_UNORM)
+            );
+            assert_eq!(
+                texture_format_to_slpn(TextureFormat::Rgba16Float),
+                Some(SLPN_CUDA_FORMAT_RGBA16_FLOAT)
+            );
+            assert_eq!(
+                texture_format_to_slpn(TextureFormat::Rgba32Float),
+                Some(SLPN_CUDA_FORMAT_RGBA32_FLOAT)
+            );
+            assert_eq!(texture_format_to_slpn(TextureFormat::Bgra8Unorm), None);
         }
 
         // Runtime-construction smoke test: bring up + tear down the
@@ -5983,6 +7143,9 @@ mod cuda {
     pub const SLPN_CUDA_CONTENDED: i32 = 1;
     pub const SLPN_CUDA_DEVICE_TYPE_CUDA: i32 = 2;
     pub const SLPN_CUDA_DEVICE_TYPE_CUDA_HOST: i32 = 3;
+    pub const SLPN_CUDA_FORMAT_RGBA8_UNORM: i32 = 0;
+    pub const SLPN_CUDA_FORMAT_RGBA16_FLOAT: i32 = 1;
+    pub const SLPN_CUDA_FORMAT_RGBA32_FLOAT: i32 = 2;
 
     #[repr(C)]
     pub struct SlpnCudaView {
@@ -5991,6 +7154,15 @@ mod cuda {
         pub device_type: i32,
         pub device_id: i32,
         pub dlpack_managed_tensor: *mut c_void,
+    }
+
+    #[repr(C)]
+    pub struct SlpnCudaImageView {
+        pub cuda_object_handle: u64,
+        pub width: u32,
+        pub height: u32,
+        pub format: i32,
+        pub _reserved: [u8; 12],
     }
 
     #[unsafe(no_mangle)]
@@ -6065,6 +7237,75 @@ mod cuda {
 
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slpn_cuda_release_write(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_register_image_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _gpu_handle: *mut c_void,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_unregister_image_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_acquire_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_try_acquire_surface(
+        _rt: *mut c_void,
+        _surface_id: u64,
+        _out_view: *mut SlpnCudaImageView,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_texture(
+        _rt: *mut c_void,
+        _surface_id: u64,
+    ) -> i32 {
+        SLPN_CUDA_ERR
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slpn_cuda_release_surface(
         _rt: *mut c_void,
         _surface_id: u64,
     ) -> i32 {

--- a/libs/streamlib-python/python/streamlib/adapters/cuda.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cuda.py
@@ -589,13 +589,21 @@ class CudaContext:
                 ctypes.POINTER(_SlpnCudaImageView),
             ]
 
+        # Release takes the handle back so the cdylib destroys the
+        # exact `cudaTextureObject_t` / `cudaSurfaceObject_t` the
+        # customer used — see the cdylib's `slpn_cuda_release_texture`
+        # doc-comment for the concurrent-read rationale.
         for name in (
             "slpn_cuda_release_texture",
             "slpn_cuda_release_surface",
         ):
             fn = getattr(lib, name)
             fn.restype = ctypes.c_int32
-            fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+            fn.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint64,
+                ctypes.c_uint64,
+            ]
 
     def _resolve_and_register(self, pool_id: str) -> int:
         """Resolve `pool_id` via surface-share, register with the cuda
@@ -844,15 +852,24 @@ class CudaContext:
                 f"acquire_{'surface' if write else 'texture'}: rc={rc} for "
                 f"surface '{pool_id}'"
             )
+        view = self._build_image_view(view_struct, writable=write)
         try:
-            yield self._build_image_view(view_struct, writable=write)
+            yield view
         finally:
             release_fn = (
                 self._lib.slpn_cuda_release_surface
                 if write
                 else self._lib.slpn_cuda_release_texture
             )
-            release_fn(self._rt, ctypes.c_uint64(surface_id))
+            # Thread the customer's handle back so the cdylib
+            # destroys this view's cudaTextureObject_t /
+            # cudaSurfaceObject_t — not some other concurrent
+            # reader's.
+            release_fn(
+                self._rt,
+                ctypes.c_uint64(surface_id),
+                ctypes.c_uint64(view.handle),
+            )
 
     def _build_image_view(
         self, view_struct: _SlpnCudaImageView, *, writable: bool

--- a/libs/streamlib-python/python/streamlib/adapters/cuda.py
+++ b/libs/streamlib-python/python/streamlib/adapters/cuda.py
@@ -45,6 +45,7 @@ Customer-facing shapes:
 from __future__ import annotations
 
 import ctypes
+import enum
 import itertools
 import threading
 from contextlib import contextmanager
@@ -60,6 +61,9 @@ __all__ = [
     "STREAMLIB_ADAPTER_ABI_VERSION",
     "CudaReadView",
     "CudaWriteView",
+    "CudaTextureView",
+    "CudaSurfaceView",
+    "CudaImageFormat",
     "CudaContext",
 ]
 
@@ -75,6 +79,16 @@ _RC_CONTENDED = 1
 # ``SLPN_CUDA_DEVICE_TYPE_*`` constants).
 _DEVICE_TYPE_CUDA = 2
 _DEVICE_TYPE_CUDA_HOST = 3
+
+# Image-path format discriminants — wire ABI between the cdylib
+# (``SLPN_CUDA_FORMAT_RGBA8_UNORM`` / `_RGBA16_FLOAT` / `_RGBA32_FLOAT`)
+# and this SDK. The cuda image flavor is constrained to the
+# CUDA-mappable subset (4× R8/R16/R32 channel formats) by
+# ``cudaExternalMemoryGetMappedMipmappedArray`` —
+# sRGB, BGR, and 3-channel variants are not supported on this path.
+_FORMAT_RGBA8_UNORM = 0
+_FORMAT_RGBA16_FLOAT = 1
+_FORMAT_RGBA32_FLOAT = 2
 
 # Surface-id namespace inside this subprocess. The host's pool_id (a
 # string) is mapped to a u64 the cdylib uses internally; customers
@@ -97,6 +111,37 @@ class _SlpnCudaView(ctypes.Structure):
         ("device_id", ctypes.c_int32),
         ("dlpack_managed_tensor", ctypes.c_void_p),
     ]
+
+
+class _SlpnCudaImageView(ctypes.Structure):
+    """C struct matching
+    ``streamlib_python_native::cuda::SlpnCudaImageView``.
+
+    Layout pinned by ``slpn_cuda_image_view_layout_matches_spec_64bit``
+    in the cdylib's tests. Same 32-byte total width as
+    [`_SlpnCudaView`] so the SDK can reuse staging-buffer sizing if it
+    ever needs to.
+    """
+
+    _fields_ = [
+        ("cuda_object_handle", ctypes.c_uint64),
+        ("width", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("format", ctypes.c_int32),
+        ("_reserved", ctypes.c_uint8 * 12),
+    ]
+
+
+class CudaImageFormat(int, enum.Enum):
+    """Discriminant for [`CudaTextureView.format`] /
+    [`CudaSurfaceView.format`]. Values mirror the cdylib's
+    ``SLPN_CUDA_FORMAT_*`` constants and are the CUDA-mappable subset
+    accepted by ``cudaExternalMemoryGetMappedMipmappedArray``.
+    """
+
+    RGBA8_UNORM = _FORMAT_RGBA8_UNORM
+    RGBA16_FLOAT = _FORMAT_RGBA16_FLOAT
+    RGBA32_FLOAT = _FORMAT_RGBA32_FLOAT
 
 
 # DLPack capsule machinery
@@ -339,6 +384,54 @@ class CudaWriteView:
     dlpack: object  # PyCapsule
 
 
+@dataclass(frozen=True)
+class CudaTextureView:
+    """View handed back inside an [`CudaContext.acquire_texture`] scope.
+
+    Customer-facing surface for read-only CUDA texture interop. The
+    ``handle`` field is a raw ``cudaTextureObject_t`` (typedef'd to
+    ``c_ulonglong`` in the CUDA Runtime API) — pass it to a
+    framework-native CUDA extension (``torch.utils.cpp_extension``,
+    ``cupy.RawKernel``, Triton, ...) and sample the texture inside
+    your own kernel.
+
+    There's no DLPack capsule on the image path — the underlying
+    ``cudaMipmappedArray_t`` is opaque and not DLPack-shaped (no AI
+    framework's ``from_dlpack`` accepts a texture-object handle, per
+    the issue body's ecosystem survey).
+
+    The view is valid only inside the ``with`` block. After the block
+    exits, the cdylib calls ``cudaDestroyTextureObject`` on
+    ``handle`` and releases the adapter's read guard. Do NOT retain
+    ``handle`` past the scope.
+    """
+
+    handle: int
+    width: int
+    height: int
+    format: CudaImageFormat
+
+
+@dataclass(frozen=True)
+class CudaSurfaceView:
+    """View handed back inside an [`CudaContext.acquire_surface`] scope.
+
+    Same shape as [`CudaTextureView`] but ``handle`` is a raw
+    ``cudaSurfaceObject_t`` (writeable surface-object interop).
+    Kernels that produce new frames (e.g. compositing or filtering)
+    can ``surf2Dwrite`` against this handle and the writes land in the
+    host-shared OPAQUE_FD ``VkImage``'s backing memory.
+
+    Same lifetime rules as [`CudaTextureView`] — ``handle`` is
+    destroyed at scope exit.
+    """
+
+    handle: int
+    width: int
+    height: int
+    format: CudaImageFormat
+
+
 def _surface_pool_id(surface) -> str:
     """Extract the surface-share pool id (string) from either a
     ``StreamlibSurface``-shaped object or a bare string / int."""
@@ -396,8 +489,15 @@ class CudaContext:
             )
         self._rt = ctypes.c_void_p(rt)
 
-        # pool_id (host-side string) → local u64 surface_id.
+        # pool_id (host-side string) → local u64 surface_id. Buffer-
+        # flavored registrations (DLPack path).
         self._surface_ids: dict[str, int] = {}
+        # Same shape for image-flavored registrations (texture / surface
+        # object path). Separate map because the underlying cdylib FFI
+        # is keyed by flavor — `slpn_cuda_register_image_surface` vs
+        # `slpn_cuda_register_surface` — and a given pool_id is one or
+        # the other, not both.
+        self._image_surface_ids: dict[str, int] = {}
         # Pin resolved SurfaceHandle objects so the OPAQUE_FD plane and
         # sync FDs stay alive for the surface's lifetime. The cdylib
         # already dups before each Vulkan / CUDA import, but the
@@ -455,6 +555,43 @@ class CudaContext:
         for name in (
             "slpn_cuda_release_read",
             "slpn_cuda_release_write",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+
+        # Image-path FFI surface — register / acquire / release for
+        # `cudaTextureObject_t` (read) and `cudaSurfaceObject_t` (write).
+        lib.slpn_cuda_register_image_surface.restype = ctypes.c_int32
+        lib.slpn_cuda_register_image_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+        ]
+
+        lib.slpn_cuda_unregister_image_surface.restype = ctypes.c_int32
+        lib.slpn_cuda_unregister_image_surface.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+        ]
+
+        for name in (
+            "slpn_cuda_acquire_texture",
+            "slpn_cuda_acquire_surface",
+            "slpn_cuda_try_acquire_texture",
+            "slpn_cuda_try_acquire_surface",
+        ):
+            fn = getattr(lib, name)
+            fn.restype = ctypes.c_int32
+            fn.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint64,
+                ctypes.POINTER(_SlpnCudaImageView),
+            ]
+
+        for name in (
+            "slpn_cuda_release_texture",
+            "slpn_cuda_release_surface",
         ):
             fn = getattr(lib, name)
             fn.restype = ctypes.c_int32
@@ -598,3 +735,198 @@ class CudaContext:
             device_type=int(view_struct.device_type),
             dlpack=capsule,
         )
+
+    # ----- Image-flavored API ----------------------------------------
+
+    def _resolve_and_register_image(self, pool_id: str) -> int:
+        """Resolve `pool_id` via surface-share, register with the
+        cuda adapter's image flavor, and return the local u64
+        surface_id. Idempotent — repeat calls return the cached id.
+
+        Image-flavored registration is exclusive with buffer-flavored:
+        the cdylib will reject mixing acquire paths against the same
+        surface, and this method's separate id map mirrors that.
+        Customers must pick one flavor per surface.
+        """
+        cached = self._image_surface_ids.get(pool_id)
+        if cached is not None:
+            return cached
+        handle = self._gpu.resolve_surface(pool_id)
+        handle_ptr = handle.native_handle_ptr
+        if not handle_ptr:
+            raise RuntimeError(
+                f"CudaContext: resolve_surface('{pool_id}') returned a "
+                "handle with a null native pointer"
+            )
+        surface_id = next(_CUDA_SURFACE_ID_COUNTER)
+        rc = self._lib.slpn_cuda_register_image_surface(
+            self._rt,
+            ctypes.c_uint64(surface_id),
+            ctypes.c_void_p(handle_ptr),
+        )
+        if rc != _RC_OK:
+            raise RuntimeError(
+                f"CudaContext: register_image_surface failed for pool_id "
+                f"'{pool_id}' (rc={rc}). Common causes: host registered "
+                f"the surface as a buffer (DLPack path), not an image "
+                "(`register_host_image_surface`); host's image format is "
+                "outside the CUDA-mappable subset (Rgba8Unorm / "
+                "Rgba16Float / Rgba32Float); host did not attach an "
+                "exportable timeline semaphore. See the subprocess log "
+                "for specifics."
+            )
+        self._image_surface_ids[pool_id] = surface_id
+        self._resolved_handles[pool_id] = handle
+        return surface_id
+
+    @contextmanager
+    def acquire_texture(self, surface) -> "Iterator[CudaTextureView]":
+        """Block until the host has signaled the timeline; hand back a
+        [`CudaTextureView`] wrapping a freshly-constructed
+        ``cudaTextureObject_t``. On scope exit, the texture object is
+        destroyed and the adapter's read guard is released."""
+        with self._acquire_image(surface, write=False, blocking=True) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def acquire_surface(self, surface) -> "Iterator[CudaSurfaceView]":
+        """Block until the host has signaled the timeline; hand back a
+        [`CudaSurfaceView`] wrapping a freshly-constructed
+        ``cudaSurfaceObject_t``. On scope exit, the surface object is
+        destroyed and the adapter's write guard is released."""
+        with self._acquire_image(surface, write=True, blocking=True) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def try_acquire_texture(
+        self, surface
+    ) -> "Iterator[Optional[CudaTextureView]]":
+        """Non-blocking texture acquire. Yields a [`CudaTextureView`] on
+        success or ``None`` on contention."""
+        with self._acquire_image(surface, write=False, blocking=False) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def try_acquire_surface(
+        self, surface
+    ) -> "Iterator[Optional[CudaSurfaceView]]":
+        """Non-blocking surface acquire. Yields a [`CudaSurfaceView`] on
+        success or ``None`` on contention."""
+        with self._acquire_image(surface, write=True, blocking=False) as view:
+            yield view  # type: ignore[misc]
+
+    @contextmanager
+    def _acquire_image(
+        self, surface, write: bool, blocking: bool
+    ) -> "Iterator[object]":
+        pool_id = _surface_pool_id(surface)
+        surface_id = self._resolve_and_register_image(pool_id)
+        view_struct = _SlpnCudaImageView()
+        if blocking:
+            fn = (
+                self._lib.slpn_cuda_acquire_surface
+                if write
+                else self._lib.slpn_cuda_acquire_texture
+            )
+        else:
+            fn = (
+                self._lib.slpn_cuda_try_acquire_surface
+                if write
+                else self._lib.slpn_cuda_try_acquire_texture
+            )
+        rc = fn(self._rt, ctypes.c_uint64(surface_id), ctypes.byref(view_struct))
+        if rc == _RC_CONTENDED:
+            yield None
+            return
+        if rc != _RC_OK:
+            raise RuntimeError(
+                f"CudaContext.{'try_' if not blocking else ''}"
+                f"acquire_{'surface' if write else 'texture'}: rc={rc} for "
+                f"surface '{pool_id}'"
+            )
+        try:
+            yield self._build_image_view(view_struct, writable=write)
+        finally:
+            release_fn = (
+                self._lib.slpn_cuda_release_surface
+                if write
+                else self._lib.slpn_cuda_release_texture
+            )
+            release_fn(self._rt, ctypes.c_uint64(surface_id))
+
+    def _build_image_view(
+        self, view_struct: _SlpnCudaImageView, *, writable: bool
+    ):
+        handle = int(view_struct.cuda_object_handle)
+        if handle == 0:
+            raise RuntimeError(
+                "CudaContext: cdylib returned null cuda object handle — "
+                "the cuda runtime is in a bad state"
+            )
+        try:
+            format_ = CudaImageFormat(int(view_struct.format))
+        except ValueError as exc:
+            raise RuntimeError(
+                f"CudaContext: cdylib returned unexpected format "
+                f"discriminant {int(view_struct.format)} on the image "
+                "view — the wire ABI may have drifted"
+            ) from exc
+        klass = CudaSurfaceView if writable else CudaTextureView
+        return klass(
+            handle=handle,
+            width=int(view_struct.width),
+            height=int(view_struct.height),
+            format=format_,
+        )
+
+    def release_for_cross_process(
+        self, surface, post_release_layout: int
+    ) -> None:
+        """Publish the post-release ``VkImageLayout`` to surface-share
+        so the next cross-process consumer's
+        ``acquire_from_foreign`` sees the right source layout.
+
+        Unlike
+        :meth:`streamlib.adapters.opengl.OpenGLContext.release_for_cross_process`
+        — which takes a ``VulkanContext`` and delegates to its
+        ``release_for_cross_process`` because OpenGL writes don't touch
+        the underlying ``VkImage``'s Vulkan tracker — the CUDA shim
+        takes **no** ``VulkanContext`` parameter. CUDA writes via
+        ``cudaSurfaceObject_t`` against the imported mipmapped array;
+        the cdylib has no host ``VkDevice`` to issue a QFOT release
+        barrier against (per the consumer-rhi carve-out), and the
+        pairwise sync runs entirely on
+        ``cudaSignalExternalSemaphoresAsync`` /
+        ``cudaWaitExternalSemaphoresAsync`` against the imported
+        timeline. The host consumer's
+        ``GpuContext::resolve_videoframe_registration`` Path 2 acquire
+        handles its own barriers via QFOT-acquire (Mesa) or
+        bridging-from-UNDEFINED (NVIDIA) — independent of what the
+        CUDA producer did.
+
+        What this shim does, then, is just the **layout publish**:
+        update the surface-share daemon's per-surface
+        ``current_image_layout`` field so the next consumer sees the
+        right source layout. The timeline signal happens naturally on
+        scope exit (the cdylib's adapter advances the timeline as part
+        of releasing the write guard).
+
+        Call this *after* the matching :meth:`acquire_surface` ``with``
+        block has exited so the CUDA stream's writes have drained
+        through to the GPU and the timeline has been signaled.
+
+        Customers running scenario (a) from the issue body's design
+        clarification (pure-CUDA AI consumer that just reads, drops
+        the guard) do NOT call this method — the host is the producer
+        and handles its own release barriers via
+        ``VulkanSurfaceAdapter``.
+
+        ``post_release_layout`` is a Vulkan ``VkImageLayout`` enumerant
+        as an integer (use
+        :class:`streamlib.adapters.vulkan.VkImageLayout` constants).
+        ``GENERAL`` is the safest default for cross-process handoffs
+        — the consumer's ``acquire_from_foreign`` re-transitions to
+        whatever layout it actually needs.
+        """
+        pool_id = _surface_pool_id(surface)
+        self._gpu.update_image_layout(pool_id, int(post_release_layout))

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import ctypes
 
+import inspect
+
 from streamlib.adapters import cuda as c
 from streamlib.surface_adapter import STREAMLIB_ADAPTER_ABI_VERSION, SurfaceFormat
 
@@ -182,6 +184,102 @@ def test_cuda_context_class_exposes_expected_method_set():
     assert hasattr(c.CudaContext, "try_acquire_read")
     assert hasattr(c.CudaContext, "try_acquire_write")
     assert hasattr(c.CudaContext, "from_runtime")
+    # Image-flavored methods — sibling of acquire_read / acquire_write
+    # for the `cudaTextureObject_t` / `cudaSurfaceObject_t` path.
+    assert hasattr(c.CudaContext, "acquire_texture")
+    assert hasattr(c.CudaContext, "acquire_surface")
+    assert hasattr(c.CudaContext, "try_acquire_texture")
+    assert hasattr(c.CudaContext, "try_acquire_surface")
+    # Cross-process release shim — present per the design clarification
+    # comment on #802 (NOT vulkan_ctx-bearing; see the signature test).
+    assert hasattr(c.CudaContext, "release_for_cross_process")
+
+
+def test_slpn_cuda_image_view_layout_matches_cdylib():
+    # Mirrors `slpn_cuda_image_view_layout_matches_spec_64bit` in the
+    # cdylib's tests — these offsets / sizes are part of the wire ABI
+    # between the cdylib's `SlpnCudaImageView` and Python's
+    # `_SlpnCudaImageView`.
+    assert ctypes.sizeof(c._SlpnCudaImageView) == 32
+    fields = {
+        name: c._SlpnCudaImageView.__dict__[name].offset
+        for name, _ in c._SlpnCudaImageView._fields_
+    }
+    assert fields == {
+        "cuda_object_handle": 0,
+        "width": 8,
+        "height": 12,
+        "format": 16,
+        "_reserved": 20,
+    }
+
+
+def test_cuda_image_format_enum_matches_cdylib_discriminants():
+    # Wire ABI mirror of the cdylib's `SLPN_CUDA_FORMAT_*` constants.
+    # The CUDA image path is restricted to the four-channel R8/R16/R32
+    # subset accepted by `cudaExternalMemoryGetMappedMipmappedArray`.
+    assert int(c.CudaImageFormat.RGBA8_UNORM) == 0
+    assert int(c.CudaImageFormat.RGBA16_FLOAT) == 1
+    assert int(c.CudaImageFormat.RGBA32_FLOAT) == 2
+    assert c._FORMAT_RGBA8_UNORM == 0
+    assert c._FORMAT_RGBA16_FLOAT == 1
+    assert c._FORMAT_RGBA32_FLOAT == 2
+
+
+def test_cuda_texture_and_surface_views_round_trip_dataclass_construction():
+    tv = c.CudaTextureView(
+        handle=0xDEADBEEFCAFE0000,
+        width=1920,
+        height=1080,
+        format=c.CudaImageFormat.RGBA8_UNORM,
+    )
+    sv = c.CudaSurfaceView(
+        handle=0xCAFEBABE1234ABCD,
+        width=640,
+        height=480,
+        format=c.CudaImageFormat.RGBA32_FLOAT,
+    )
+    assert tv.handle == 0xDEADBEEFCAFE0000
+    assert tv.width == 1920
+    assert tv.height == 1080
+    assert tv.format is c.CudaImageFormat.RGBA8_UNORM
+    assert sv.handle == 0xCAFEBABE1234ABCD
+    assert sv.width == 640
+    assert sv.height == 480
+    assert sv.format is c.CudaImageFormat.RGBA32_FLOAT
+
+
+def test_release_for_cross_process_signature_takes_no_vulkan_ctx():
+    """Pin the CUDA shim's signature explicitly — it must NOT take a
+    `vulkan_ctx` parameter (unlike the OpenGL shim's). The design
+    clarification comment on #802 records the reasoning:
+
+        CUDA writes via `cudaSurfaceObject_t` against the imported
+        mipmapped array — the underlying VkImage memory is touched
+        but the Vulkan layout tracker is unchanged (and the cdylib
+        has no host VkDevice to barrier on anyway, per the
+        consumer-rhi carve-out). The pairwise sync runs entirely on
+        `cudaSignalExternalSemaphoresAsync` /
+        `cudaWaitExternalSemaphoresAsync` against the imported
+        timeline.
+
+    The CUDA shim's job is just the layout publish via
+    `update_image_layout`. Any future regression that adds
+    `vulkan_ctx` back as a parameter (e.g. copying the OpenGL shape
+    reflexively) trips this test.
+    """
+    sig = inspect.signature(c.CudaContext.release_for_cross_process)
+    params = list(sig.parameters)
+    # `self`, `surface`, `post_release_layout` — exactly three.
+    assert params == ["self", "surface", "post_release_layout"], (
+        f"release_for_cross_process must take (surface, post_release_layout) "
+        f"only — no vulkan_ctx. Got params={params}. See the design "
+        "clarification comment on #802."
+    )
+    # Annotation on `post_release_layout` is `int` (Vulkan VkImageLayout
+    # enumerant). cuda.py uses `from __future__ import annotations` so
+    # annotations are stored as strings — match against the literal.
+    assert sig.parameters["post_release_layout"].annotation == "int"
 
 
 def test_capsule_destructor_registry_survives_concurrent_create_drop():

--- a/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_adapters_cuda.py
@@ -249,6 +249,82 @@ def test_cuda_texture_and_surface_views_round_trip_dataclass_construction():
     assert sv.format is c.CudaImageFormat.RGBA32_FLOAT
 
 
+def test_image_path_release_ffi_takes_handle_parameter():
+    """Lock the handle-keyed release semantics at the FFI layer.
+
+    The cdylib's `slpn_cuda_release_texture` / `_release_surface` take
+    the customer's `cudaTextureObject_t` / `cudaSurfaceObject_t` back
+    as a `u64` parameter. This is what makes the FFI safe under
+    concurrent reads: the underlying adapter allows N read holders,
+    each `acquire_texture` constructs a unique handle, and releases
+    must destroy *the caller's* handle — not whichever was most
+    recently constructed.
+
+    A regression that drops the handle parameter (e.g. reverting to a
+    LIFO pop strategy) would trip this test by making the SDK's
+    `_wire_signatures` set up a 2-arg argtypes list. The wire-ABI
+    shape is the load-bearing invariant; pin it explicitly.
+    """
+    class _StubFn:
+        argtypes: list = []  # type: ignore[type-arg]
+        restype = None
+
+    class _FakeLib:
+        def __init__(self) -> None:
+            # Every symbol `_wire_signatures` reaches via getattr needs
+            # to exist on this fake so the wiring runs end-to-end.
+            for name in (
+                "slpn_cuda_runtime_new",
+                "slpn_cuda_runtime_free",
+                "slpn_cuda_register_surface",
+                "slpn_cuda_unregister_surface",
+                "slpn_cuda_acquire_read",
+                "slpn_cuda_acquire_write",
+                "slpn_cuda_try_acquire_read",
+                "slpn_cuda_try_acquire_write",
+                "slpn_cuda_release_read",
+                "slpn_cuda_release_write",
+                "slpn_cuda_register_image_surface",
+                "slpn_cuda_unregister_image_surface",
+                "slpn_cuda_acquire_texture",
+                "slpn_cuda_acquire_surface",
+                "slpn_cuda_try_acquire_texture",
+                "slpn_cuda_try_acquire_surface",
+                "slpn_cuda_release_texture",
+                "slpn_cuda_release_surface",
+            ):
+                setattr(self, name, _StubFn())
+
+    class _FakeGpu:
+        native_lib = _FakeLib()
+
+    class _Probe(c.CudaContext):
+        """Override __init__ to skip the cdylib runtime bring-up
+        (which needs Vulkan + CUDA installed). The only behavior
+        under test is the argtypes wiring."""
+
+        def __init__(self, gpu) -> None:  # type: ignore[no-untyped-def]
+            self._gpu = gpu
+            self._lib = gpu.native_lib
+            self._wire_signatures()
+
+    fake = _FakeGpu()
+    _Probe(fake)
+
+    # The cdylib expects (rt, surface_id, handle) for both releases.
+    # A regression to (rt, surface_id) is the LIFO-pop anti-pattern
+    # this test exists to catch.
+    expected = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint64]
+    assert fake.native_lib.slpn_cuda_release_texture.argtypes == expected, (
+        "slpn_cuda_release_texture must take (rt, surface_id, handle); "
+        f"got {fake.native_lib.slpn_cuda_release_texture.argtypes}. "
+        "Reverting to a 2-arg shape is the LIFO-pop anti-pattern that "
+        "breaks under concurrent reads — see the cdylib's "
+        "`slpn_cuda_release_texture` doc-comment."
+    )
+    assert fake.native_lib.slpn_cuda_release_surface.argtypes == expected
+
+
 def test_release_for_cross_process_signature_takes_no_vulkan_ctx():
     """Pin the CUDA shim's signature explicitly — it must NOT take a
     `vulkan_ctx` parameter (unlike the OpenGL shim's). The design


### PR DESCRIPTION
## Summary

- Wire both cdylibs (`streamlib-python-native`, `streamlib-deno-native`) to import OPAQUE_FD `VkImage` memory, map via `cudaExternalMemoryGetMappedMipmappedArray`, and construct `cudaTextureObject_t` / `cudaSurfaceObject_t` per acquire. Customer-facing surface: raw `u64` handle on a new `CudaTextureView` / `CudaSurfaceView` type (no DLPack capsule — texture/surface objects are opaque).
- Extend both SDKs (`streamlib-python`, `streamlib-deno`) with matching view types, `acquire_texture` / `acquire_surface` (and `try_*`) scope-bound guards, and a `release_for_cross_process` shim. The shim takes NO `VulkanContext` parameter per the design-clarification comment on #802 (deviating from the OpenGL shim's shape) — CUDA writes via `cudaSurfaceObject_t` against the imported mipmapped array, the cdylib has no host `VkDevice` to issue a QFOT release barrier against, and pairwise sync runs entirely on the imported timeline. The shim's job is just the layout publish via `gpu.update_image_layout`.
- Release FFI takes the handle back as a `u64` so the cdylib destroys the customer's exact `cudaTextureObject_t` / `cudaSurfaceObject_t`. This makes the FFI safe under concurrent reads (the adapter supports N read holders, each with a unique handle). Per-flavor `HashSet` tracking removes a brittle Drop trial-by-error pattern.

## Closes

Closes #802

## Exit criteria

- [x] Python cdylib registers image-flavored surface, imports OPAQUE_FD memory, constructs `cudaTextureObject_t` / `cudaSurfaceObject_t` per acquire, and returns the handle through a new view type at the Python boundary
- [x] Deno cdylib same shape
- [x] Both runtimes' adapter mirrors expose the new view types alongside the existing DLPack types

## Polyglot coverage

- **Runtimes affected**: rust (cdylibs) + python + deno
- **Schema regenerated**: n/a (FFI-level, not JTD)
- **Python and Deno both covered?** yes — landing together with full parity
- **E2E tests run**:
  - [x] Cdylib unit tests: 8/8 each (`cargo test -p streamlib-python-native -p streamlib-deno-native --lib cuda::`)
  - [x] Python SDK: 14/14 (`pytest python/streamlib/tests/test_adapters_cuda.py`)
  - [x] Deno SDK: 8/8 (`deno test --allow-read adapters/cuda_test.ts`)
- **FD-passing path**: OPAQUE_FD (single-fd; `VkImage` import + timeline semaphore)

## Test plan

- [x] `cargo check -p streamlib-python-native -p streamlib-deno-native` — clean
- [x] Layout-regression tests pin `Sl{p,d}nCudaImageView` to 32-byte `#[repr(C)]` with offsets (cuda_object_handle@0, width@8, height@12, format@16, _reserved@20)
- [x] Format-discriminant constants tested (`SL{P,D}N_CUDA_FORMAT_RGBA8_UNORM = 0` / RGBA16_FLOAT = 1 / RGBA32_FLOAT = 2)
- [x] Format-string parser tests (CUDA-mappable subset accepted; non-mappable rejected with specific message)
- [x] `cudaChannelFormatDesc` byte-layout tests pin the format mapping (RGBA8 → 8/8/8/8 Unsigned, RGBA16 → 16/16/16/16 Float, RGBA32 → 32/32/32/32 Float)
- [x] AI-Agent-Notes texture descriptor defaults locked (linear, clamp-to-edge × 3, non-normalized coords, ReadElementType, no sRGB)
- [x] Handle-keyed release argtypes locked at the FFI declaration layer in both Python and Deno tests — catches a LIFO-pop regression at unit-test time
- [x] `release_for_cross_process` signature pinned: takes `(surface, post_release_layout)` only (no `vulkan_ctx`); explicit signature-introspection test
- [x] Workspace baseline: 531 passed, 0 new failures (2 pre-existing Deno `_generated_/tatolab__escalate/escalate_request.ts` module-not-found failures unchanged from `main`; not introduced by this PR)
- [x] `cargo xtask check-boundaries` — clean (3536 files scanned)
- [x] `cargo xtask lint-logging` — clean (409 files scanned)
- [x] `cargo xtask check-schema-versions`, `check-no-streamlib-metadata`, `check-no-reverse-dns`, `check-processor-spec-new`, `check-manifest-schema` — all clean

## Follow-ups

- End-to-end polyglot test that brings up a real host-allocated OPAQUE_FD `VkImage`, hands the surface_id to a subprocess, and validates `cudaTextureObject_t` sampling produces expected pixel values — requires the polyglot test harness tracked elsewhere and a CUDA-equipped CI runner. The wire-ABI shape is locked at the unit-test layer; end-to-end semantics will lock at the harness layer when both arrive.
- Per the issue body's AI-Agent-Notes, customer-overridable `cudaTextureDesc` (other filter modes, address modes, sRGB toggle) is intentionally deferred until a real consumer surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)