### PR TITLE
feat(core): ColorInfo + HDR sidecar metadata on VideoFrame / EncodedVideoFrame (#811)

### DIFF
--- a/examples/camera-audio-recorder/streamlib.yaml
+++ b/examples/camera-audio-recorder/streamlib.yaml
@@ -24,6 +24,12 @@ patch:
 schemas:
   AudioFrame:
     package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   AudioCaptureConfig:

--- a/examples/camera-deno-subprocess/deno/streamlib.yaml
+++ b/examples/camera-deno-subprocess/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/camera-python-display/python/streamlib.yaml
+++ b/examples/camera-python-display/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -40,7 +40,8 @@ use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
 use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::iceoryx2::{InputMailboxes, OutputWriter};
-use crate::_generated_::VideoFrame;
+use crate::_generated_::tatolab__core::color_info::{Matrix, Primaries, Range, Transfer};
+use crate::_generated_::{ColorInfo, VideoFrame};
 
 // Sandboxed kernel wrapper — see `blending_compositor_kernel.rs` for
 // the transitional rationale (this kernel previously lived in the
@@ -566,9 +567,18 @@ fn compose_one_frame(
         // `current_image_layout` published via surface-share / Path 1
         // is the default.
         texture_layout: None,
-        // Compositor doesn't synthesize color metadata; downstream
-        // consumers default-as-they-do today.
-        color_info: None,
+        // The compositor's RGBA8 output is sRGB-encoded by convention
+        // (the input layers are sampled as-is and blended in the
+        // shader's working space). Stamp the canonical sRGB color
+        // description so downstream consumers see the correct
+        // characteristics. Identity matrix because the output is
+        // RGB, not YCbCr.
+        color_info: Some(ColorInfo {
+            primaries: Some(Primaries::Bt709),
+            transfer: Some(Transfer::Srgb),
+            matrix: Some(Matrix::Identity),
+            range: Some(Range::Full),
+        }),
         mastering_display: None,
         content_light: None,
     };

--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -562,10 +562,15 @@ fn compose_one_frame(
         timestamp_ns: timestamp_ns.to_string(),
         frame_index: count.to_string(),
         fps: None,
-        // Per-frame override is opt-in (#633); the per-surface
+        // Per-frame override is opt-in; the per-surface
         // `current_image_layout` published via surface-share / Path 1
         // is the default.
         texture_layout: None,
+        // Compositor doesn't synthesize color metadata; downstream
+        // consumers default-as-they-do today.
+        color_info: None,
+        mastering_display: None,
+        content_light: None,
     };
     outputs.write("video_out", &output_frame)?;
 
@@ -631,6 +636,9 @@ fn slot_videoframe(surface_id: &str, width: u32, height: u32) -> VideoFrame {
         frame_index: "0".into(),
         fps: None,
         texture_layout: None,
+        color_info: None,
+        mastering_display: None,
+        content_light: None,
     }
 }
 

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -220,10 +220,15 @@ impl streamlib::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Pr
             timestamp_ns: frame.timestamp_ns.clone(),
             frame_index: frame.frame_index.clone(),
             fps: frame.fps,
-            // Per-frame override is opt-in (#633); the per-surface
+            // Per-frame override is opt-in; the per-surface
             // `current_image_layout` published via surface-share is
             // the default.
             texture_layout: None,
+            // Pass through input color metadata — the CRT effect
+            // doesn't change the source's primaries/transfer/matrix.
+            color_info: frame.color_info.clone(),
+            mastering_display: frame.mastering_display.clone(),
+            content_light: frame.content_light.clone(),
         };
         self.outputs.write("video_out", &output_frame)?;
         self.frame_count.fetch_add(1, Ordering::Relaxed);
@@ -334,6 +339,9 @@ fn synth_slot_videoframe(surface_id: &str, width: u32, height: u32) -> VideoFram
         frame_index: "0".into(),
         fps: None,
         texture_layout: None,
+        color_info: None,
+        mastering_display: None,
+        content_light: None,
     }
 }
 

--- a/examples/camera-python-display/streamlib.yaml
+++ b/examples/camera-python-display/streamlib.yaml
@@ -14,7 +14,13 @@ patch:
     path: ../../packages/core
 
 schemas:
-  # Wire types imported from @tatolab/core (#767).
+  # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/camera-python-subprocess/python/streamlib.yaml
+++ b/examples/camera-python-subprocess/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/camera-rust-plugin/plugin/streamlib.yaml
+++ b/examples/camera-rust-plugin/plugin/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/cuda-fisheye-detection/python/streamlib.yaml
+++ b/examples/cuda-fisheye-detection/python/streamlib.yaml
@@ -13,6 +13,12 @@ patch:
     path: ../../../packages/core
 
 schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/cuda-fisheye-detection/runner/streamlib.yaml
+++ b/examples/cuda-fisheye-detection/runner/streamlib.yaml
@@ -25,5 +25,11 @@ patch:
     path: ../python
 
 schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
+++ b/examples/polyglot-cpu-readback-blur/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-cuda-inference/deno/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-cuda-inference/python/streamlib.yaml
+++ b/examples/polyglot-cuda-inference/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
+++ b/examples/polyglot-dma-buf-consumer/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-manual-source/deno/streamlib.yaml
+++ b/examples/polyglot-manual-source/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-manual-source/plugin/streamlib.yaml
+++ b/examples/polyglot-manual-source/plugin/streamlib.yaml
@@ -18,6 +18,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-manual-source/python/streamlib.yaml
+++ b/examples/polyglot-manual-source/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
+++ b/examples/polyglot-opengl-fragment-shader/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-skia-canvas/python/streamlib.yaml
+++ b/examples/polyglot-skia-canvas/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-compute/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-compute/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-compute/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-graphics/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-graphics/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/deno/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
+++ b/examples/polyglot-vulkan-ray-tracing/python/streamlib.yaml
@@ -15,6 +15,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core (#767).
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
 

--- a/examples/webrtc-cloudflare-stream/streamlib.yaml
+++ b/examples/webrtc-cloudflare-stream/streamlib.yaml
@@ -30,6 +30,12 @@ patch:
 schemas:
   AudioFrame:
     package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   AudioCaptureConfig:

--- a/libs/streamlib-deno/color_info_round_trip_test.ts
+++ b/libs/streamlib-deno/color_info_round_trip_test.ts
@@ -83,6 +83,17 @@ Deno.test("ContentLight round-trips with cd/m^2 values", () => {
   assertEquals(parsed, cll);
 });
 
+Deno.test("ColorInfo with no axes set serializes as empty object", () => {
+  // Locks the foot-gun fix: every axis is optional in the schema, so
+  // a ColorInfo with no axes set serializes to `{}` (no axis fields
+  // on the wire). Mirrors Rust `ColorInfo::default()` and the Python
+  // empty-dict invariant. Mentally revert `optionalProperties:` in
+  // the schema and the JSON gains four `null` axis fields.
+  const info: ColorInfo = {};
+  const json = JSON.parse(JSON.stringify(info));
+  assertEquals(json, {}, "ColorInfo with no axes must round-trip as empty object");
+});
+
 Deno.test("VideoFrame with all color metadata round-trips", () => {
   const frame: VideoFrame = {
     surface_id: "s",

--- a/libs/streamlib-deno/color_info_round_trip_test.ts
+++ b/libs/streamlib-deno/color_info_round_trip_test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Wire round-trip for VideoFrame's color metadata fields (#811).
+ *
+ * Locks the JSON shape Deno sees for ColorInfo / MasteringDisplay /
+ * ContentLight after jtd-codegen regenerates from
+ * `packages/core/schemas/`. Mirrors the Rust round-trip in
+ * `libs/streamlib-engine/src/core/context/gpu_context.rs::videoframe_color_metadata_round_trip`
+ * and the Python equivalent — schema changes have to update all three.
+ *
+ * TypeScript codegen emits `interface` types — there's no runtime
+ * `from_json_data` step like Python's; round-trip is plain
+ * JSON.stringify / JSON.parse with the type cast preserved.
+ */
+
+import { assertEquals } from "@std/assert";
+
+import {
+  type ColorInfo,
+  ColorInfoMatrix,
+  ColorInfoPrimaries,
+  ColorInfoRange,
+  ColorInfoTransfer,
+} from "./_generated_/tatolab__core/color_info.ts";
+import { type ContentLight } from "./_generated_/tatolab__core/content_light.ts";
+import { type MasteringDisplay } from "./_generated_/tatolab__core/mastering_display.ts";
+import { type VideoFrame } from "./_generated_/tatolab__core/video_frame.ts";
+
+function bt2020PqColorInfo(): ColorInfo {
+  return {
+    primaries: ColorInfoPrimaries.Bt2020,
+    transfer: ColorInfoTransfer.Smpte2084,
+    matrix: ColorInfoMatrix.Bt2020Ncl,
+    range: ColorInfoRange.Limited,
+  };
+}
+
+function bt2020MasteringDisplay(): MasteringDisplay {
+  return {
+    display_primaries_r_x: 35400,
+    display_primaries_r_y: 14600,
+    display_primaries_g_x: 8500,
+    display_primaries_g_y: 39850,
+    display_primaries_b_x: 6550,
+    display_primaries_b_y: 2300,
+    white_point_x: 15635,
+    white_point_y: 16450,
+    min_luminance: 1, // 0.0001 cd/m^2
+    max_luminance: 10_000_000, // 1000 cd/m^2
+  };
+}
+
+Deno.test("ColorInfo serializes as snake_case discriminants (H.273 alignment)", () => {
+  const info = bt2020PqColorInfo();
+  const json = JSON.parse(JSON.stringify(info));
+  assertEquals(json, {
+    primaries: "bt2020",
+    transfer: "smpte2084",
+    matrix: "bt2020_ncl",
+    range: "limited",
+  });
+  // Round-trip back to typed.
+  const parsed = JSON.parse(JSON.stringify(info)) as ColorInfo;
+  assertEquals(parsed.primaries, ColorInfoPrimaries.Bt2020);
+  assertEquals(parsed.transfer, ColorInfoTransfer.Smpte2084);
+  assertEquals(parsed.matrix, ColorInfoMatrix.Bt2020Ncl);
+  assertEquals(parsed.range, ColorInfoRange.Limited);
+});
+
+Deno.test("MasteringDisplay round-trips with ST.2086 native units", () => {
+  const mdcv = bt2020MasteringDisplay();
+  const parsed = JSON.parse(JSON.stringify(mdcv)) as MasteringDisplay;
+  assertEquals(parsed.display_primaries_r_x, 35400);
+  assertEquals(parsed.max_luminance, 10_000_000);
+  assertEquals(parsed.min_luminance, 1);
+});
+
+Deno.test("ContentLight round-trips with cd/m^2 values", () => {
+  const cll: ContentLight = { max_cll: 1000, max_fall: 400 };
+  const parsed = JSON.parse(JSON.stringify(cll)) as ContentLight;
+  assertEquals(parsed, cll);
+});
+
+Deno.test("VideoFrame with all color metadata round-trips", () => {
+  const frame: VideoFrame = {
+    surface_id: "s",
+    width: 1920,
+    height: 1080,
+    timestamp_ns: "0",
+    frame_index: "0",
+    color_info: bt2020PqColorInfo(),
+    mastering_display: bt2020MasteringDisplay(),
+    content_light: { max_cll: 1000, max_fall: 400 },
+  };
+  const json = JSON.parse(JSON.stringify(frame));
+  assertEquals(json.color_info.transfer, "smpte2084");
+  assertEquals(json.mastering_display.max_luminance, 10_000_000);
+  assertEquals(json.content_light.max_cll, 1000);
+
+  const parsed = JSON.parse(JSON.stringify(frame)) as VideoFrame;
+  assertEquals(parsed.color_info, frame.color_info);
+  assertEquals(parsed.mastering_display, frame.mastering_display);
+  assertEquals(parsed.content_light, frame.content_light);
+});
+
+Deno.test("VideoFrame without color metadata omits fields on wire", () => {
+  // Optional fields not set — the JSON wire form does not carry them
+  // (mirrors Rust's `skip_serializing_if = "Option::is_none"` and
+  // Python's absent-on-None contract). Older consumers rely on this:
+  // a `null` value is structurally distinct from absence.
+  const frame: VideoFrame = {
+    surface_id: "s",
+    width: 1920,
+    height: 1080,
+    timestamp_ns: "0",
+    frame_index: "0",
+  };
+  const json = JSON.parse(JSON.stringify(frame));
+  assertEquals(json.color_info, undefined);
+  assertEquals(json.mastering_display, undefined);
+  assertEquals(json.content_light, undefined);
+});

--- a/libs/streamlib-deno/streamlib.lock
+++ b/libs/streamlib-deno/streamlib.lock
@@ -14,7 +14,7 @@ packages:
     source:
       kind: path
       path: ../../packages/core
-    content_hash: sha256:66793bc49db3792713f9d6c06be36733a93fea700a20e1e9543a939da0615de4
+    content_hash: sha256:d5543c6dd759164d65702ab058612b6f779dd3a14ed7b55e2e9651b6e55cb502
   '@tatolab/escalate':
     version: 1.0.0
     source:

--- a/libs/streamlib-deno/streamlib.lock
+++ b/libs/streamlib-deno/streamlib.lock
@@ -14,7 +14,7 @@ packages:
     source:
       kind: path
       path: ../../packages/core
-    content_hash: sha256:42929566e77db3311b1bcf576124ee36d5505f1cd1a2e70ccca50ffcba431ec5
+    content_hash: sha256:66793bc49db3792713f9d6c06be36733a93fea700a20e1e9543a939da0615de4
   '@tatolab/escalate':
     version: 1.0.0
     source:

--- a/libs/streamlib-deno/streamlib.yaml
+++ b/libs/streamlib-deno/streamlib.yaml
@@ -18,9 +18,15 @@ patch:
 schemas:
   AudioFrame:
     package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedAudioFrame:
     package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -2456,6 +2456,9 @@ mod tests {
             frame_index: "1".to_string(),
             fps: None,
             texture_layout: None,
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
 
         let resolved = gpu
@@ -2500,6 +2503,9 @@ mod tests {
             frame_index: "1".to_string(),
             fps: None,
             texture_layout: None,
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
 
         let registration = gpu
@@ -2564,6 +2570,9 @@ mod tests {
             fps: None,
             // SHADER_READ_ONLY_OPTIMAL = 5 per Vulkan spec.
             texture_layout: Some(5),
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
         let json = serde_json::to_value(&with_layout).expect("serialize");
         assert_eq!(
@@ -2580,6 +2589,9 @@ mod tests {
             frame_index: "1".to_string(),
             fps: None,
             texture_layout: None,
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
         let json_absent = serde_json::to_value(&absent).expect("serialize");
         assert!(
@@ -2596,6 +2608,101 @@ mod tests {
         let parsed_absent: crate::_generated_::VideoFrame =
             serde_json::from_str(&serialized_absent).unwrap();
         assert_eq!(parsed_absent.texture_layout, None);
+    }
+
+    /// Issue #811 — `VideoFrame.{color_info, mastering_display,
+    /// content_light}` are optional sidecar fields that producers
+    /// populate from V4L2 / VUI / EDID / HDR metadata. Lock the
+    /// serialization shape: present when set (with all sub-fields
+    /// round-tripping), absent when None. Mentally revert the
+    /// `skip_serializing_if = "Option::is_none"` on either field
+    /// in the generated `_generated_/tatolab__core/video_frame.rs` and
+    /// the absent assertions start failing.
+    #[test]
+    fn videoframe_color_metadata_round_trip() {
+        use crate::_generated_::tatolab__core::color_info::{Matrix, Primaries, Range, Transfer};
+        use crate::_generated_::{ColorInfo, ContentLight, MasteringDisplay, VideoFrame};
+
+        let with_color = VideoFrame {
+            surface_id: "s".to_string(),
+            width: 1920,
+            height: 1080,
+            timestamp_ns: "0".to_string(),
+            frame_index: "0".to_string(),
+            fps: None,
+            texture_layout: None,
+            color_info: Some(ColorInfo {
+                primaries: Primaries::Bt2020,
+                transfer: Transfer::Smpte2084,
+                matrix: Matrix::Bt2020Ncl,
+                range: Range::Limited,
+            }),
+            mastering_display: Some(MasteringDisplay {
+                // BT.2020 primaries in 1/50000 increments — round-trip
+                // proof, not a real mastering display.
+                display_primaries_r_x: 35400,
+                display_primaries_r_y: 14600,
+                display_primaries_g_x: 8500,
+                display_primaries_g_y: 39850,
+                display_primaries_b_x: 6550,
+                display_primaries_b_y: 2300,
+                white_point_x: 15635,
+                white_point_y: 16450,
+                min_luminance: 1, // 0.0001 cd/m^2
+                max_luminance: 10_000_000, // 1000 cd/m^2
+            }),
+            content_light: Some(ContentLight {
+                max_cll: 1000,
+                max_fall: 400,
+            }),
+        };
+        let json = serde_json::to_value(&with_color).expect("serialize");
+        assert!(json.get("color_info").is_some());
+        assert!(json.get("mastering_display").is_some());
+        assert!(json.get("content_light").is_some());
+        // Enums round-trip as snake_case strings (H.273 alignment).
+        assert_eq!(
+            json.pointer("/color_info/transfer").and_then(|v| v.as_str()),
+            Some("smpte2084"),
+            "transfer enum serializes as the snake_case discriminant"
+        );
+
+        let serialized = serde_json::to_string(&with_color).unwrap();
+        let parsed: VideoFrame = serde_json::from_str(&serialized).unwrap();
+        let parsed_color = parsed.color_info.expect("color_info round-trips");
+        assert_eq!(parsed_color.primaries, Primaries::Bt2020);
+        assert_eq!(parsed_color.transfer, Transfer::Smpte2084);
+        assert_eq!(parsed_color.matrix, Matrix::Bt2020Ncl);
+        assert_eq!(parsed_color.range, Range::Limited);
+        let parsed_mdcv = parsed.mastering_display.expect("mastering_display round-trips");
+        assert_eq!(parsed_mdcv.display_primaries_r_x, 35400);
+        assert_eq!(parsed_mdcv.max_luminance, 10_000_000);
+        let parsed_cll = parsed.content_light.expect("content_light round-trips");
+        assert_eq!(parsed_cll.max_cll, 1000);
+        assert_eq!(parsed_cll.max_fall, 400);
+
+        // Absent on the wire when None — the optional-field plumbing
+        // pattern (mirrors `texture_layout`'s shape).
+        let absent = VideoFrame {
+            surface_id: "s".to_string(),
+            width: 1920,
+            height: 1080,
+            timestamp_ns: "0".to_string(),
+            frame_index: "0".to_string(),
+            fps: None,
+            texture_layout: None,
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
+        };
+        let json_absent = serde_json::to_value(&absent).unwrap();
+        assert!(json_absent.get("color_info").is_none());
+        assert!(json_absent.get("mastering_display").is_none());
+        assert!(json_absent.get("content_light").is_none());
+        let parsed_absent: VideoFrame = serde_json::from_str(&serde_json::to_string(&absent).unwrap()).unwrap();
+        assert!(parsed_absent.color_info.is_none());
+        assert!(parsed_absent.mastering_display.is_none());
+        assert!(parsed_absent.content_light.is_none());
     }
 
     #[test]
@@ -2617,6 +2724,9 @@ mod tests {
             frame_index: "1".to_string(),
             fps: None,
             texture_layout: None,
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
         assert!(gpu
             .resolve_texture_by_surface_id(&frame.surface_id, frame.texture_layout, frame.width, frame.height)

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -2632,10 +2632,10 @@ mod tests {
             fps: None,
             texture_layout: None,
             color_info: Some(ColorInfo {
-                primaries: Primaries::Bt2020,
-                transfer: Transfer::Smpte2084,
-                matrix: Matrix::Bt2020Ncl,
-                range: Range::Limited,
+                primaries: Some(Primaries::Bt2020),
+                transfer: Some(Transfer::Smpte2084),
+                matrix: Some(Matrix::Bt2020Ncl),
+                range: Some(Range::Limited),
             }),
             mastering_display: Some(MasteringDisplay {
                 // BT.2020 primaries in 1/50000 increments — round-trip
@@ -2670,10 +2670,26 @@ mod tests {
         let serialized = serde_json::to_string(&with_color).unwrap();
         let parsed: VideoFrame = serde_json::from_str(&serialized).unwrap();
         let parsed_color = parsed.color_info.expect("color_info round-trips");
-        assert_eq!(parsed_color.primaries, Primaries::Bt2020);
-        assert_eq!(parsed_color.transfer, Transfer::Smpte2084);
-        assert_eq!(parsed_color.matrix, Matrix::Bt2020Ncl);
-        assert_eq!(parsed_color.range, Range::Limited);
+        assert_eq!(parsed_color.primaries, Some(Primaries::Bt2020));
+        assert_eq!(parsed_color.transfer, Some(Transfer::Smpte2084));
+        assert_eq!(parsed_color.matrix, Some(Matrix::Bt2020Ncl));
+        assert_eq!(parsed_color.range, Some(Range::Limited));
+
+        // ColorInfo with all axes None — wire-format-correct
+        // representation of "I have a ColorInfo record but every
+        // axis is unspecified." Lock the per-axis skip-on-None
+        // behavior; mentally revert `optionalProperties` in the
+        // schema and the JSON gains four `null` axis fields.
+        let info_all_none = ColorInfo::default();
+        let json_info_none = serde_json::to_value(&info_all_none).expect("serialize");
+        assert_eq!(
+            json_info_none,
+            serde_json::json!({}),
+            "ColorInfo::default() serializes as empty object — every axis is None and skipped",
+        );
+        let parsed_info_none: ColorInfo =
+            serde_json::from_value(json_info_none).expect("deserialize empty");
+        assert_eq!(parsed_info_none, ColorInfo::default());
         let parsed_mdcv = parsed.mastering_display.expect("mastering_display round-trips");
         assert_eq!(parsed_mdcv.display_primaries_r_x, 35400);
         assert_eq!(parsed_mdcv.max_luminance, 10_000_000);

--- a/libs/streamlib-engine/streamlib.yaml
+++ b/libs/streamlib-engine/streamlib.yaml
@@ -31,9 +31,15 @@ schemas:
   # Wire types imported from @tatolab/core.
   AudioFrame:
     package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedAudioFrame:
     package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/libs/streamlib-jtd-codegen/src/sentinel.rs
+++ b/libs/streamlib-jtd-codegen/src/sentinel.rs
@@ -171,11 +171,16 @@ fn rewrite_refs(value: &mut Value, alias_to_sentinel: &BTreeMap<String, String>)
     }
 }
 
-/// Sentinel name for a [`SchemaIdent`]. Format: `__STREAMLIB_REF_<hex16>__`.
+/// Sentinel name for a [`SchemaIdent`]. Format: `__STREAMLIB_REF_h<hex16>__`.
 ///
 /// `<hex16>` is the first 16 hex chars of `sha256(@org/package/Type@version)`.
-/// Truncating yields a stable, deterministic identifier that fits comfortably
-/// in Rust/Python/TS identifier rules (`[A-Za-z_][A-Za-z0-9_]*`).
+/// The `h` prefix ensures the digest segment never starts with a digit —
+/// `jtd-codegen` strips leading digits when mangling identifiers into Rust /
+/// Python class names (Rust identifiers can't start with a digit), and a
+/// leading-digit hash slips past the post-pass strip / replace because the
+/// name in the generated output no longer matches the sentinel string.
+/// `h` is opaque, lowercase, and survives all three backends' PascalCase
+/// pass.
 pub fn sentinel_name(ident: &SchemaIdent) -> String {
     let canonical = format!(
         "@{}/{}/{}@{}",
@@ -185,7 +190,48 @@ pub fn sentinel_name(ident: &SchemaIdent) -> String {
         ident.version
     );
     let digest = sha256_hex(&canonical);
-    format!("__STREAMLIB_REF_{}__", &digest[..16])
+    format!("__STREAMLIB_REF_h{}__", &digest[..16])
+}
+
+/// PascalCase → snake_case (e.g. `ColorInfo` → `color_info`,
+/// `MasteringDisplay` → `mastering_display`). Insert an underscore before
+/// every uppercase letter that's not the first character, then lowercase
+/// the whole thing. Mirrors the same transform the codegen emits for
+/// per-type Python module file names.
+fn pascal_to_snake_simple(pascal: &str) -> String {
+    let mut out = String::with_capacity(pascal.len() + pascal.len() / 4);
+    for (i, c) in pascal.chars().enumerate() {
+        if i > 0 && c.is_ascii_uppercase() {
+            out.push('_');
+        }
+        out.push(c.to_ascii_lowercase());
+    }
+    out
+}
+
+/// PascalCase form a sentinel takes after `jtd-codegen` mangles it into a
+/// type identifier (e.g. `__STREAMLIB_REF_b6261594f80ea4d8__` →
+/// `StreamlibRefB6261594f80ea4d8`). Used by the language-specific
+/// post-passes — `jtd-codegen` rewrites the sentinel into PascalCase
+/// when it lands in a struct / class / interface name OR a field type
+/// reference, so the strip + replace passes have to look for the
+/// PascalCase form, not the original underscore-decorated sentinel.
+fn mangle_sentinel_pascal(sentinel: &str) -> String {
+    sentinel
+        .trim_matches('_')
+        .split('_')
+        .filter(|seg| !seg.is_empty())
+        .map(|seg| {
+            let mut chars = seg.chars();
+            match chars.next() {
+                Some(first) => first
+                    .to_uppercase()
+                    .chain(chars.flat_map(|c| c.to_lowercase()))
+                    .collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect()
 }
 
 fn sha256_hex(input: &str) -> String {
@@ -201,7 +247,15 @@ pub fn restore_rust(code: &str, table: &SentinelTable) -> String {
         return code.to_string();
     }
 
-    let stripped = strip_placeholder_decls_rust(code, &table.map.keys().cloned().collect());
+    // jtd-codegen writes the sentinel into Rust output PascalCase'd
+    // (`__STREAMLIB_REF_xxx__` → `StreamlibRefXxx`). The strip and
+    // replace passes have to search for the mangled form.
+    let mangled_sentinels: BTreeSet<String> = table
+        .map
+        .keys()
+        .map(|s| mangle_sentinel_pascal(s))
+        .collect();
+    let stripped = strip_placeholder_decls_rust(code, &mangled_sentinels);
 
     let mut imports_by_module: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut sentinel_replacements: Vec<(String, String)> = Vec::new();
@@ -216,7 +270,7 @@ pub fn restore_rust(code: &str, table: &SentinelTable) -> String {
             .entry(module_path)
             .or_default()
             .insert(type_name.clone());
-        sentinel_replacements.push((sentinel.clone(), type_name));
+        sentinel_replacements.push((mangle_sentinel_pascal(sentinel), type_name));
     }
 
     let mut substituted = stripped;
@@ -247,23 +301,38 @@ pub fn restore_python(code: &str, table: &SentinelTable) -> String {
         return code.to_string();
     }
 
-    let sentinels: BTreeSet<String> = table.map.keys().cloned().collect();
-    let stripped = strip_placeholder_decls_python(code, &sentinels);
+    // Same shape as Rust — `jtd-codegen` PascalCase's the sentinel
+    // for Python class names, so search for the mangled form.
+    let mangled_sentinels: BTreeSet<String> = table
+        .map
+        .keys()
+        .map(|s| mangle_sentinel_pascal(s))
+        .collect();
+    let stripped = strip_placeholder_decls_python(code, &mangled_sentinels);
 
     let mut imports_by_module: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut replacements: Vec<(String, String)> = Vec::new();
     for (sentinel, ident) in &table.map {
+        // Python: relative import directly from the per-type module
+        // (`from ..tatolab__core.color_info import ColorInfo`) so the
+        // codegen output is host-package-name agnostic AND avoids
+        // re-entering the per-package `__init__.py` — same-package
+        // imports otherwise loop through the package's own init while
+        // its own names are still being bound, causing a partial-module
+        // circular-import failure.
+        let snake_type = pascal_to_snake_simple(ident.r#type.as_str());
         let module_path = format!(
-            "_generated_.{}__{}",
+            "..{}__{}.{}",
             ident.org.as_str(),
-            ident.package.as_str().replace('-', "_")
+            ident.package.as_str().replace('-', "_"),
+            snake_type
         );
         let type_name = ident.r#type.as_str().to_string();
         imports_by_module
             .entry(module_path)
             .or_default()
             .insert(type_name.clone());
-        replacements.push((sentinel.clone(), type_name));
+        replacements.push((mangle_sentinel_pascal(sentinel), type_name));
     }
 
     let mut substituted = stripped;
@@ -290,8 +359,14 @@ pub fn restore_typescript(code: &str, table: &SentinelTable) -> String {
         return code.to_string();
     }
 
-    let sentinels: BTreeSet<String> = table.map.keys().cloned().collect();
-    let stripped = strip_placeholder_decls_typescript(code, &sentinels);
+    // Same shape as Rust / Python — `jtd-codegen` PascalCase's the
+    // sentinel for TypeScript interface / type names.
+    let mangled_sentinels: BTreeSet<String> = table
+        .map
+        .keys()
+        .map(|s| mangle_sentinel_pascal(s))
+        .collect();
+    let stripped = strip_placeholder_decls_typescript(code, &mangled_sentinels);
 
     let mut imports_by_module: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut replacements: Vec<(String, String)> = Vec::new();
@@ -306,7 +381,7 @@ pub fn restore_typescript(code: &str, table: &SentinelTable) -> String {
             .entry(module_path)
             .or_default()
             .insert(type_name.clone());
-        replacements.push((sentinel.clone(), type_name));
+        replacements.push((mangle_sentinel_pascal(sentinel), type_name));
     }
 
     let mut substituted = stripped;

--- a/libs/streamlib-python/python/streamlib/tests/test_color_info_round_trip.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_color_info_round_trip.py
@@ -39,7 +39,8 @@ def _bt2020_pq_color_info() -> ColorInfo:
     """Reference HDR10 stream tag — BT.2020 primaries + PQ transfer +
     BT.2020 NCL matrix + limited range. Matches the Rust + Deno
     fixtures so a wire-format drift on any axis surfaces in all three
-    suites."""
+    suites. Each axis is `Optional[Enum]`; the None case is exercised
+    by `test_color_info_all_none_serializes_as_empty_object`."""
     return ColorInfo(
         primaries=ColorInfoPrimaries.BT2020,
         transfer=ColorInfoTransfer.SMPTE2084,
@@ -94,6 +95,22 @@ def test_content_light_round_trip():
     assert payload == {"max_cll": 1000, "max_fall": 400}
     parsed = ContentLight.from_json_data(payload)
     assert parsed == cll
+
+
+def test_color_info_all_none_serializes_as_empty_object():
+    """Locks the foot-gun fix: a `ColorInfo` with every axis None
+    serializes as `{}` (no axis fields on the wire), matching Rust
+    `ColorInfo::default()` and Deno `{}`. Mentally revert the
+    `optionalProperties:` shape in the schema and the JSON gains
+    four `null` axis fields."""
+    info = ColorInfo(primaries=None, transfer=None, matrix=None, range=None)
+    payload = info.to_json_data()
+    assert payload == {}, (
+        f"ColorInfo with all-None axes must serialize to empty object, "
+        f"not {payload!r} — every axis is in optionalProperties and absence is unspecified"
+    )
+    parsed = ColorInfo.from_json_data(payload)
+    assert parsed == info
 
 
 def test_video_frame_with_full_color_metadata_round_trips():

--- a/libs/streamlib-python/python/streamlib/tests/test_color_info_round_trip.py
+++ b/libs/streamlib-python/python/streamlib/tests/test_color_info_round_trip.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Wire round-trip for VideoFrame's color metadata fields (#811).
+
+Locks the JSON shape Python sees for ColorInfo / MasteringDisplay /
+ContentLight after jtd-codegen regenerates from `packages/core/schemas/`.
+Mirrors the Rust round-trip in
+`libs/streamlib-engine/src/core/context/gpu_context.rs::videoframe_color_metadata_round_trip`
+and the Deno equivalent — schema changes have to update all three.
+
+Skip-when-None semantics: the Python jtd-codegen emits dataclasses where
+optional fields default to a sentinel and round-trip as JSON only when
+populated. We assert on the *parsed-back* value, not on the wire JSON,
+because that's what application code observes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# pyright: reportMissingImports=false
+_color_info_mod = pytest.importorskip("streamlib._generated_.tatolab__core.color_info")
+_content_light_mod = pytest.importorskip("streamlib._generated_.tatolab__core.content_light")
+_mastering_display_mod = pytest.importorskip("streamlib._generated_.tatolab__core.mastering_display")
+_video_frame_mod = pytest.importorskip("streamlib._generated_.tatolab__core.video_frame")
+
+ColorInfo = _color_info_mod.ColorInfo
+ColorInfoMatrix = _color_info_mod.ColorInfoMatrix
+ColorInfoPrimaries = _color_info_mod.ColorInfoPrimaries
+ColorInfoRange = _color_info_mod.ColorInfoRange
+ColorInfoTransfer = _color_info_mod.ColorInfoTransfer
+ContentLight = _content_light_mod.ContentLight
+MasteringDisplay = _mastering_display_mod.MasteringDisplay
+VideoFrame = _video_frame_mod.VideoFrame
+
+
+def _bt2020_pq_color_info() -> ColorInfo:
+    """Reference HDR10 stream tag — BT.2020 primaries + PQ transfer +
+    BT.2020 NCL matrix + limited range. Matches the Rust + Deno
+    fixtures so a wire-format drift on any axis surfaces in all three
+    suites."""
+    return ColorInfo(
+        primaries=ColorInfoPrimaries.BT2020,
+        transfer=ColorInfoTransfer.SMPTE2084,
+        matrix=ColorInfoMatrix.BT2020_NCL,
+        range=ColorInfoRange.LIMITED,
+    )
+
+
+def _bt2020_mastering_display() -> MasteringDisplay:
+    """Reference ST.2086 mastering display in 1/50000 chromaticity +
+    0.0001 cd/m^2 luminance increments — the wire format the H.265
+    SEI / MP4 mdcv box carries verbatim."""
+    return MasteringDisplay(
+        display_primaries_r_x=35400,
+        display_primaries_r_y=14600,
+        display_primaries_g_x=8500,
+        display_primaries_g_y=39850,
+        display_primaries_b_x=6550,
+        display_primaries_b_y=2300,
+        white_point_x=15635,
+        white_point_y=16450,
+        min_luminance=1,         # 0.0001 cd/m^2
+        max_luminance=10_000_000,  # 1000 cd/m^2
+    )
+
+
+def test_color_info_round_trip():
+    info = _bt2020_pq_color_info()
+    payload = info.to_json_data()
+    assert payload == {
+        "primaries": "bt2020",
+        "transfer": "smpte2084",
+        "matrix": "bt2020_ncl",
+        "range": "limited",
+    }
+    parsed = ColorInfo.from_json_data(payload)
+    assert parsed == info
+
+
+def test_mastering_display_round_trip():
+    mdcv = _bt2020_mastering_display()
+    payload = mdcv.to_json_data()
+    assert payload["display_primaries_r_x"] == 35400
+    assert payload["max_luminance"] == 10_000_000
+    parsed = MasteringDisplay.from_json_data(payload)
+    assert parsed == mdcv
+
+
+def test_content_light_round_trip():
+    cll = ContentLight(max_cll=1000, max_fall=400)
+    payload = cll.to_json_data()
+    assert payload == {"max_cll": 1000, "max_fall": 400}
+    parsed = ContentLight.from_json_data(payload)
+    assert parsed == cll
+
+
+def test_video_frame_with_full_color_metadata_round_trips():
+    frame = VideoFrame(
+        surface_id="s",
+        width=1920,
+        height=1080,
+        timestamp_ns="0",
+        frame_index="0",
+        fps=None,
+        texture_layout=None,
+        color_info=_bt2020_pq_color_info(),
+        mastering_display=_bt2020_mastering_display(),
+        content_light=ContentLight(max_cll=1000, max_fall=400),
+    )
+    payload = frame.to_json_data()
+    # Optional fields present on the wire when populated.
+    assert payload["color_info"]["transfer"] == "smpte2084"
+    assert payload["mastering_display"]["max_luminance"] == 10_000_000
+    assert payload["content_light"]["max_cll"] == 1000
+    parsed = VideoFrame.from_json_data(payload)
+    assert parsed.color_info == frame.color_info
+    assert parsed.mastering_display == frame.mastering_display
+    assert parsed.content_light == frame.content_light
+
+
+def test_video_frame_without_color_metadata_omits_fields_on_wire():
+    """Absent color metadata must not serialize as `null` — older
+    Python / Deno consumers (pre-#811) reject unknown fields, and a
+    `null` value is structurally distinct from absence."""
+    frame = VideoFrame(
+        surface_id="s",
+        width=1920,
+        height=1080,
+        timestamp_ns="0",
+        frame_index="0",
+        fps=None,
+        texture_layout=None,
+        color_info=None,
+        mastering_display=None,
+        content_light=None,
+    )
+    payload = frame.to_json_data()
+    assert "color_info" not in payload
+    assert "mastering_display" not in payload
+    assert "content_light" not in payload
+    parsed = VideoFrame.from_json_data(payload)
+    assert parsed.color_info is None
+    assert parsed.mastering_display is None
+    assert parsed.content_light is None

--- a/libs/streamlib-python/streamlib.lock
+++ b/libs/streamlib-python/streamlib.lock
@@ -14,7 +14,7 @@ packages:
     source:
       kind: path
       path: ../../packages/core
-    content_hash: sha256:66793bc49db3792713f9d6c06be36733a93fea700a20e1e9543a939da0615de4
+    content_hash: sha256:d5543c6dd759164d65702ab058612b6f779dd3a14ed7b55e2e9651b6e55cb502
   '@tatolab/escalate':
     version: 1.0.0
     source:

--- a/libs/streamlib-python/streamlib.lock
+++ b/libs/streamlib-python/streamlib.lock
@@ -14,7 +14,7 @@ packages:
     source:
       kind: path
       path: ../../packages/core
-    content_hash: sha256:42929566e77db3311b1bcf576124ee36d5505f1cd1a2e70ccca50ffcba431ec5
+    content_hash: sha256:66793bc49db3792713f9d6c06be36733a93fea700a20e1e9543a939da0615de4
   '@tatolab/escalate':
     version: 1.0.0
     source:

--- a/libs/streamlib-python/streamlib.yaml
+++ b/libs/streamlib-python/streamlib.yaml
@@ -18,9 +18,15 @@ patch:
 schemas:
   AudioFrame:
     package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedAudioFrame:
     package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -467,6 +467,45 @@ fn capture_thread_loop(
         }
     };
 
+    // Query V4L2 colorspace once at processor start. V4L2 contract is
+    // that colorspace doesn't change during streaming, so we cache the
+    // resolved ColorInfo and clone it into every emitted frame. Vivid
+    // reports SMPTE170M (BT.601 525); UVC webcams typically report
+    // SRGB (BT.709 primaries + sRGB transfer + BT.601 matrix + full
+    // range — V4L2 convention). See `v4l2_color::v4l2_color_to_color_info`.
+    let cached_color_info: Option<crate::_generated_::ColorInfo> = unsafe {
+        let mut v4l2_fmt: v4l::v4l_sys::v4l2_format = std::mem::zeroed();
+        v4l2_fmt.type_ = v4l::buffer::Type::VideoCapture as u32;
+        if libc::ioctl(
+            device_fd,
+            v4l::v4l2::vidioc::VIDIOC_G_FMT as libc::c_ulong,
+            &mut v4l2_fmt,
+        ) == 0
+        {
+            Some(crate::linux::v4l2_color::v4l2_color_to_color_info(
+                v4l2_fmt.fmt.pix.colorspace,
+                v4l2_fmt.fmt.pix.xfer_func,
+                // ycbcr_enc shares an anonymous union with hsv_enc;
+                // use the YCbCr field since this code path is YUV-only
+                // (NV12 / YUYV — guarded by the SPV match above).
+                v4l2_fmt.fmt.pix.__bindgen_anon_1.ycbcr_enc,
+                v4l2_fmt.fmt.pix.quantization,
+            ))
+        } else {
+            None
+        }
+    };
+    if let Some(ref ci) = cached_color_info {
+        tracing::info!(
+            camera = camera_name,
+            primaries = ?ci.primaries,
+            transfer = ?ci.transfer,
+            matrix = ?ci.matrix,
+            range = ?ci.range,
+            "V4L2 colorspace detected",
+        );
+    }
+
     const KERNEL_BINDINGS: &[ComputeBindingSpec] = &[
         ComputeBindingSpec::storage_buffer(0),
         ComputeBindingSpec::storage_image(1),
@@ -1112,9 +1151,14 @@ fn capture_thread_loop(
             timestamp_ns: timestamp_ns.to_string(),
             frame_index: timeline_signal_value.to_string(),
             fps: capture_fps,
-            // Per-frame override is opt-in (#633); per-surface
+            // Per-frame override is opt-in; per-surface
             // `current_image_layout` from surface-share is the default.
             texture_layout: None,
+            color_info: cached_color_info.clone(),
+            // HDR static metadata: V4L2 doesn't surface ST.2086 / CLLI;
+            // populated by HDR-aware sources only.
+            mastering_display: None,
+            content_light: None,
         };
 
         if let Err(e) = outputs.write("video", &ipc_frame) {

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -473,7 +473,7 @@ fn capture_thread_loop(
     // reports SMPTE170M (BT.601 525); UVC webcams typically report
     // SRGB (BT.709 primaries + sRGB transfer + BT.601 matrix + full
     // range — V4L2 convention). See `v4l2_color::v4l2_color_to_color_info`.
-    let cached_color_info: Option<crate::_generated_::ColorInfo> = unsafe {
+    let cached_color_info: crate::_generated_::ColorInfo = unsafe {
         let mut v4l2_fmt: v4l::v4l_sys::v4l2_format = std::mem::zeroed();
         v4l2_fmt.type_ = v4l::buffer::Type::VideoCapture as u32;
         if libc::ioctl(
@@ -482,26 +482,45 @@ fn capture_thread_loop(
             &mut v4l2_fmt,
         ) == 0
         {
-            Some(crate::linux::v4l2_color::v4l2_color_to_color_info(
+            crate::linux::v4l2_color::v4l2_color_to_color_info(
                 v4l2_fmt.fmt.pix.colorspace,
                 v4l2_fmt.fmt.pix.xfer_func,
                 // ycbcr_enc shares an anonymous union with hsv_enc;
                 // use the YCbCr field since this code path is YUV-only
                 // (NV12 / YUYV — guarded by the SPV match above).
+                //
+                // `__bindgen_anon_1` is the bindgen-generated name for
+                // the inner `union { ycbcr_enc; hsv_enc }`. Stable on
+                // v4l2-sys-mit 0.3.x as long as the C struct keeps a
+                // single anonymous union at this position; an upstream
+                // bump that adds a second anonymous union to the parent
+                // struct would shift the suffix to `_2` and this access
+                // would stop compiling — caught at build time, not
+                // runtime.
                 v4l2_fmt.fmt.pix.__bindgen_anon_1.ycbcr_enc,
                 v4l2_fmt.fmt.pix.quantization,
-            ))
+            )
         } else {
-            None
+            // ioctl failed — emit "all unknown" rather than guessing.
+            // `ColorInfo::default()` is structurally `{ primaries: None,
+            // transfer: None, matrix: None, range: None }` per the
+            // schema's `optionalProperties` shape.
+            crate::_generated_::ColorInfo::default()
         }
     };
-    if let Some(ref ci) = cached_color_info {
+    {
+        // Render unspecified axes as the literal string "unspecified"
+        // rather than `None` so the structured log reads cleanly for
+        // operators (and matches the H.273 wire-level term).
+        fn axis<T: std::fmt::Debug>(v: &Option<T>) -> String {
+            v.as_ref().map(|v| format!("{:?}", v)).unwrap_or_else(|| "unspecified".to_string())
+        }
         tracing::info!(
             camera = camera_name,
-            primaries = ?ci.primaries,
-            transfer = ?ci.transfer,
-            matrix = ?ci.matrix,
-            range = ?ci.range,
+            primaries = %axis(&cached_color_info.primaries),
+            transfer = %axis(&cached_color_info.transfer),
+            matrix = %axis(&cached_color_info.matrix),
+            range = %axis(&cached_color_info.range),
             "V4L2 colorspace detected",
         );
     }
@@ -1154,7 +1173,7 @@ fn capture_thread_loop(
             // Per-frame override is opt-in; per-surface
             // `current_image_layout` from surface-share is the default.
             texture_layout: None,
-            color_info: cached_color_info.clone(),
+            color_info: Some(cached_color_info.clone()),
             // HDR static metadata: V4L2 doesn't surface ST.2086 / CLLI;
             // populated by HDR-aware sources only.
             mastering_display: None,

--- a/packages/camera/src/linux/mod.rs
+++ b/packages/camera/src/linux/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 pub mod camera;
+pub mod v4l2_color;
 
 pub use camera::{LinuxCameraDevice, LinuxCameraProcessor};

--- a/packages/camera/src/linux/v4l2_color.rs
+++ b/packages/camera/src/linux/v4l2_color.rs
@@ -10,6 +10,11 @@
 //! `quantization`. When any sub-field is `*_DEFAULT` (= 0), V4L2's
 //! `V4L2_MAP_*_DEFAULT` macros derive the value from `colorspace`.
 //! We do the same here.
+//!
+//! Each axis returns `Option<T>` — `None` is the canonical "unknown"
+//! representation per `ColorInfo`'s `optionalProperties` shape.
+//! `V4L2_COLORSPACE_DEFAULT` and any unrecognized enumerant
+//! propagate as `None`.
 
 use crate::_generated_::tatolab__core::color_info::{Matrix, Primaries, Range, Transfer};
 use crate::_generated_::ColorInfo;
@@ -55,39 +60,42 @@ const V4L2_QUANTIZATION_LIM_RANGE: u32 = 2;
 /// Translate a V4L2 colorspace report to a `ColorInfo`. Sub-fields
 /// reported as `*_DEFAULT` are resolved from the `colorspace` field
 /// per the V4L2 mapping macros. `V4L2_COLORSPACE_DEFAULT` propagates
-/// as `unspecified` across the board.
+/// as `None` across the board.
 pub fn v4l2_color_to_color_info(
     colorspace: u32,
     xfer_func: u32,
     ycbcr_enc: u32,
     quantization: u32,
 ) -> ColorInfo {
-    let primaries = primaries_from_v4l2(colorspace);
-    let transfer = transfer_from_v4l2(xfer_func, colorspace);
-    let matrix = matrix_from_v4l2(ycbcr_enc, colorspace);
-    let range = range_from_v4l2(quantization, colorspace);
-    ColorInfo { primaries, transfer, matrix, range }
-}
-
-fn primaries_from_v4l2(colorspace: u32) -> Primaries {
-    match colorspace {
-        V4L2_COLORSPACE_DEFAULT => Primaries::Unspecified,
-        V4L2_COLORSPACE_SMPTE170M | V4L2_COLORSPACE_BT878 => Primaries::Smpte170m,
-        V4L2_COLORSPACE_SMPTE240M => Primaries::Smpte240m,
-        V4L2_COLORSPACE_REC709 => Primaries::Bt709,
-        V4L2_COLORSPACE_470_SYSTEM_M => Primaries::Bt470M,
-        V4L2_COLORSPACE_470_SYSTEM_BG => Primaries::Bt470Bg,
-        // V4L2_COLORSPACE_JPEG is "shorthand for SRGB primaries +
-        // BT.601 matrix + full range" per kernel comment.
-        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => Primaries::Bt709,
-        V4L2_COLORSPACE_BT2020 => Primaries::Bt2020,
-        V4L2_COLORSPACE_DCI_P3 => Primaries::Smpte431,
-        // RAW, anything unrecognized: don't guess.
-        _ => Primaries::Unspecified,
+    ColorInfo {
+        primaries: primaries_from_v4l2(colorspace),
+        transfer: transfer_from_v4l2(xfer_func, colorspace),
+        matrix: matrix_from_v4l2(ycbcr_enc, colorspace),
+        range: range_from_v4l2(quantization, colorspace),
     }
 }
 
-fn transfer_from_v4l2(xfer_func: u32, colorspace: u32) -> Transfer {
+fn primaries_from_v4l2(colorspace: u32) -> Option<Primaries> {
+    match colorspace {
+        V4L2_COLORSPACE_DEFAULT => None,
+        V4L2_COLORSPACE_SMPTE170M | V4L2_COLORSPACE_BT878 => Some(Primaries::Smpte170m),
+        V4L2_COLORSPACE_SMPTE240M => Some(Primaries::Smpte240m),
+        V4L2_COLORSPACE_REC709 => Some(Primaries::Bt709),
+        V4L2_COLORSPACE_470_SYSTEM_M => Some(Primaries::Bt470M),
+        V4L2_COLORSPACE_470_SYSTEM_BG => Some(Primaries::Bt470Bg),
+        // V4L2_COLORSPACE_JPEG is "shorthand for SRGB primaries +
+        // BT.601 matrix + full range" per kernel comment.
+        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
+            Some(Primaries::Bt709)
+        }
+        V4L2_COLORSPACE_BT2020 => Some(Primaries::Bt2020),
+        V4L2_COLORSPACE_DCI_P3 => Some(Primaries::Smpte431),
+        // RAW, anything unrecognized: don't guess.
+        _ => None,
+    }
+}
+
+fn transfer_from_v4l2(xfer_func: u32, colorspace: u32) -> Option<Transfer> {
     let resolved = if xfer_func == V4L2_XFER_FUNC_DEFAULT {
         // V4L2_MAP_XFER_FUNC_DEFAULT: derive from colorspace.
         match colorspace {
@@ -96,49 +104,49 @@ fn transfer_from_v4l2(xfer_func: u32, colorspace: u32) -> Transfer {
             V4L2_COLORSPACE_DCI_P3 => V4L2_XFER_FUNC_DCI_P3,
             V4L2_COLORSPACE_RAW => V4L2_XFER_FUNC_NONE,
             V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_JPEG => V4L2_XFER_FUNC_SRGB,
-            V4L2_COLORSPACE_DEFAULT => return Transfer::Unspecified,
+            V4L2_COLORSPACE_DEFAULT => return None,
             _ => V4L2_XFER_FUNC_709,
         }
     } else {
         xfer_func
     };
     match resolved {
-        V4L2_XFER_FUNC_709 => Transfer::Bt709,
-        V4L2_XFER_FUNC_SRGB => Transfer::Srgb,
-        // OPRGB / DCI_P3 have no direct H.273 mapping; report
-        // unspecified rather than misrepresent.
-        V4L2_XFER_FUNC_OPRGB | V4L2_XFER_FUNC_DCI_P3 => Transfer::Unspecified,
-        V4L2_XFER_FUNC_SMPTE240M => Transfer::Smpte240m,
-        V4L2_XFER_FUNC_NONE => Transfer::Linear,
-        V4L2_XFER_FUNC_SMPTE2084 => Transfer::Smpte2084,
-        _ => Transfer::Unspecified,
+        V4L2_XFER_FUNC_709 => Some(Transfer::Bt709),
+        V4L2_XFER_FUNC_SRGB => Some(Transfer::Srgb),
+        // OPRGB / DCI_P3 have no direct H.273 mapping; report None
+        // rather than misrepresent.
+        V4L2_XFER_FUNC_OPRGB | V4L2_XFER_FUNC_DCI_P3 => None,
+        V4L2_XFER_FUNC_SMPTE240M => Some(Transfer::Smpte240m),
+        V4L2_XFER_FUNC_NONE => Some(Transfer::Linear),
+        V4L2_XFER_FUNC_SMPTE2084 => Some(Transfer::Smpte2084),
+        _ => None,
     }
 }
 
-fn matrix_from_v4l2(ycbcr_enc: u32, colorspace: u32) -> Matrix {
+fn matrix_from_v4l2(ycbcr_enc: u32, colorspace: u32) -> Option<Matrix> {
     let resolved = if ycbcr_enc == V4L2_YCBCR_ENC_DEFAULT {
         // V4L2_MAP_YCBCR_ENC_DEFAULT: derive from colorspace.
         match colorspace {
             V4L2_COLORSPACE_REC709 | V4L2_COLORSPACE_DCI_P3 => V4L2_YCBCR_ENC_709,
             V4L2_COLORSPACE_BT2020 => V4L2_YCBCR_ENC_BT2020,
             V4L2_COLORSPACE_SMPTE240M => V4L2_YCBCR_ENC_SMPTE240M,
-            V4L2_COLORSPACE_DEFAULT => return Matrix::Unspecified,
+            V4L2_COLORSPACE_DEFAULT => return None,
             _ => V4L2_YCBCR_ENC_601,
         }
     } else {
         ycbcr_enc
     };
     match resolved {
-        V4L2_YCBCR_ENC_601 | V4L2_YCBCR_ENC_XV601 | V4L2_YCBCR_ENC_SYCC => Matrix::Smpte170m,
-        V4L2_YCBCR_ENC_709 | V4L2_YCBCR_ENC_XV709 => Matrix::Bt709,
-        V4L2_YCBCR_ENC_BT2020 => Matrix::Bt2020Ncl,
-        V4L2_YCBCR_ENC_BT2020_CONST_LUM => Matrix::Bt2020Cl,
-        V4L2_YCBCR_ENC_SMPTE240M => Matrix::Smpte240m,
-        _ => Matrix::Unspecified,
+        V4L2_YCBCR_ENC_601 | V4L2_YCBCR_ENC_XV601 | V4L2_YCBCR_ENC_SYCC => Some(Matrix::Smpte170m),
+        V4L2_YCBCR_ENC_709 | V4L2_YCBCR_ENC_XV709 => Some(Matrix::Bt709),
+        V4L2_YCBCR_ENC_BT2020 => Some(Matrix::Bt2020Ncl),
+        V4L2_YCBCR_ENC_BT2020_CONST_LUM => Some(Matrix::Bt2020Cl),
+        V4L2_YCBCR_ENC_SMPTE240M => Some(Matrix::Smpte240m),
+        _ => None,
     }
 }
 
-fn range_from_v4l2(quantization: u32, colorspace: u32) -> Range {
+fn range_from_v4l2(quantization: u32, colorspace: u32) -> Option<Range> {
     let resolved = if quantization == V4L2_QUANTIZATION_DEFAULT {
         // V4L2_MAP_QUANTIZATION_DEFAULT: full for JPEG / SRGB / OPRGB,
         // limited for everything else.
@@ -146,16 +154,16 @@ fn range_from_v4l2(quantization: u32, colorspace: u32) -> Range {
             V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
                 V4L2_QUANTIZATION_FULL_RANGE
             }
-            V4L2_COLORSPACE_DEFAULT => return Range::Unspecified,
+            V4L2_COLORSPACE_DEFAULT => return None,
             _ => V4L2_QUANTIZATION_LIM_RANGE,
         }
     } else {
         quantization
     };
     match resolved {
-        V4L2_QUANTIZATION_FULL_RANGE => Range::Full,
-        V4L2_QUANTIZATION_LIM_RANGE => Range::Limited,
-        _ => Range::Unspecified,
+        V4L2_QUANTIZATION_FULL_RANGE => Some(Range::Full),
+        V4L2_QUANTIZATION_LIM_RANGE => Some(Range::Limited),
+        _ => None,
     }
 }
 
@@ -171,10 +179,10 @@ mod tests {
             V4L2_YCBCR_ENC_709,
             V4L2_QUANTIZATION_LIM_RANGE,
         );
-        assert_eq!(info.primaries, Primaries::Bt709);
-        assert_eq!(info.transfer, Transfer::Bt709);
-        assert_eq!(info.matrix, Matrix::Bt709);
-        assert_eq!(info.range, Range::Limited);
+        assert_eq!(info.primaries, Some(Primaries::Bt709));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Bt709));
+        assert_eq!(info.range, Some(Range::Limited));
     }
 
     #[test]
@@ -187,10 +195,10 @@ mod tests {
             V4L2_YCBCR_ENC_DEFAULT,
             V4L2_QUANTIZATION_DEFAULT,
         );
-        assert_eq!(info.primaries, Primaries::Smpte170m);
-        assert_eq!(info.transfer, Transfer::Bt709);
-        assert_eq!(info.matrix, Matrix::Smpte170m);
-        assert_eq!(info.range, Range::Limited);
+        assert_eq!(info.primaries, Some(Primaries::Smpte170m));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Smpte170m));
+        assert_eq!(info.range, Some(Range::Limited));
     }
 
     #[test]
@@ -204,10 +212,10 @@ mod tests {
             V4L2_YCBCR_ENC_DEFAULT,
             V4L2_QUANTIZATION_DEFAULT,
         );
-        assert_eq!(info.primaries, Primaries::Bt709);
-        assert_eq!(info.transfer, Transfer::Srgb);
-        assert_eq!(info.matrix, Matrix::Smpte170m);
-        assert_eq!(info.range, Range::Full);
+        assert_eq!(info.primaries, Some(Primaries::Bt709));
+        assert_eq!(info.transfer, Some(Transfer::Srgb));
+        assert_eq!(info.matrix, Some(Matrix::Smpte170m));
+        assert_eq!(info.range, Some(Range::Full));
     }
 
     #[test]
@@ -218,24 +226,24 @@ mod tests {
             V4L2_YCBCR_ENC_DEFAULT,
             V4L2_QUANTIZATION_DEFAULT,
         );
-        assert_eq!(info.primaries, Primaries::Bt2020);
-        assert_eq!(info.transfer, Transfer::Bt709);
-        assert_eq!(info.matrix, Matrix::Bt2020Ncl);
-        assert_eq!(info.range, Range::Limited);
+        assert_eq!(info.primaries, Some(Primaries::Bt2020));
+        assert_eq!(info.transfer, Some(Transfer::Bt709));
+        assert_eq!(info.matrix, Some(Matrix::Bt2020Ncl));
+        assert_eq!(info.range, Some(Range::Limited));
     }
 
     #[test]
-    fn colorspace_default_propagates_unspecified() {
+    fn colorspace_default_propagates_none_on_every_axis() {
         let info = v4l2_color_to_color_info(
             V4L2_COLORSPACE_DEFAULT,
             V4L2_XFER_FUNC_DEFAULT,
             V4L2_YCBCR_ENC_DEFAULT,
             V4L2_QUANTIZATION_DEFAULT,
         );
-        assert_eq!(info.primaries, Primaries::Unspecified);
-        assert_eq!(info.transfer, Transfer::Unspecified);
-        assert_eq!(info.matrix, Matrix::Unspecified);
-        assert_eq!(info.range, Range::Unspecified);
+        assert_eq!(info.primaries, None);
+        assert_eq!(info.transfer, None);
+        assert_eq!(info.matrix, None);
+        assert_eq!(info.range, None);
     }
 
     #[test]
@@ -248,9 +256,21 @@ mod tests {
             V4L2_YCBCR_ENC_BT2020,
             V4L2_QUANTIZATION_LIM_RANGE,
         );
-        assert_eq!(info.primaries, Primaries::Bt2020);
-        assert_eq!(info.transfer, Transfer::Smpte2084);
-        assert_eq!(info.matrix, Matrix::Bt2020Ncl);
-        assert_eq!(info.range, Range::Limited);
+        assert_eq!(info.primaries, Some(Primaries::Bt2020));
+        assert_eq!(info.transfer, Some(Transfer::Smpte2084));
+        assert_eq!(info.matrix, Some(Matrix::Bt2020Ncl));
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+
+    #[test]
+    fn default_color_info_is_all_none() {
+        // Locks the foot-gun fix: ColorInfo::default() must be the
+        // semantic "unknown" state, not whatever the codegen puts on
+        // an alphabetically-first variant.
+        let info = ColorInfo::default();
+        assert_eq!(info.primaries, None);
+        assert_eq!(info.transfer, None);
+        assert_eq!(info.matrix, None);
+        assert_eq!(info.range, None);
     }
 }

--- a/packages/camera/src/linux/v4l2_color.rs
+++ b/packages/camera/src/linux/v4l2_color.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! V4L2 colorspace → `ColorInfo` translation.
+//!
+//! Mirrors FFmpeg's `libavcodec/v4l2_buffers.c` mapping plus the
+//! V4L2 `*_DEFAULT` resolution rules from
+//! `<linux/videodev2.h>`. V4L2 reports four orthogonal fields on
+//! `v4l2_pix_format`: `colorspace`, `xfer_func`, `ycbcr_enc`,
+//! `quantization`. When any sub-field is `*_DEFAULT` (= 0), V4L2's
+//! `V4L2_MAP_*_DEFAULT` macros derive the value from `colorspace`.
+//! We do the same here.
+
+use crate::_generated_::tatolab__core::color_info::{Matrix, Primaries, Range, Transfer};
+use crate::_generated_::ColorInfo;
+
+// V4L2 `colorspace` enumerants (from `<linux/videodev2.h>`).
+const V4L2_COLORSPACE_DEFAULT: u32 = 0;
+const V4L2_COLORSPACE_SMPTE170M: u32 = 1;
+const V4L2_COLORSPACE_SMPTE240M: u32 = 2;
+const V4L2_COLORSPACE_REC709: u32 = 3;
+const V4L2_COLORSPACE_BT878: u32 = 4;
+const V4L2_COLORSPACE_470_SYSTEM_M: u32 = 5;
+const V4L2_COLORSPACE_470_SYSTEM_BG: u32 = 6;
+const V4L2_COLORSPACE_JPEG: u32 = 7;
+const V4L2_COLORSPACE_SRGB: u32 = 8;
+const V4L2_COLORSPACE_OPRGB: u32 = 9;
+const V4L2_COLORSPACE_BT2020: u32 = 10;
+const V4L2_COLORSPACE_RAW: u32 = 11;
+const V4L2_COLORSPACE_DCI_P3: u32 = 12;
+
+const V4L2_XFER_FUNC_DEFAULT: u32 = 0;
+const V4L2_XFER_FUNC_709: u32 = 1;
+const V4L2_XFER_FUNC_SRGB: u32 = 2;
+const V4L2_XFER_FUNC_OPRGB: u32 = 3;
+const V4L2_XFER_FUNC_SMPTE240M: u32 = 4;
+const V4L2_XFER_FUNC_NONE: u32 = 5;
+const V4L2_XFER_FUNC_DCI_P3: u32 = 6;
+const V4L2_XFER_FUNC_SMPTE2084: u32 = 7;
+
+const V4L2_YCBCR_ENC_DEFAULT: u32 = 0;
+const V4L2_YCBCR_ENC_601: u32 = 1;
+const V4L2_YCBCR_ENC_709: u32 = 2;
+const V4L2_YCBCR_ENC_XV601: u32 = 3;
+const V4L2_YCBCR_ENC_XV709: u32 = 4;
+const V4L2_YCBCR_ENC_SYCC: u32 = 5;
+const V4L2_YCBCR_ENC_BT2020: u32 = 6;
+const V4L2_YCBCR_ENC_BT2020_CONST_LUM: u32 = 7;
+const V4L2_YCBCR_ENC_SMPTE240M: u32 = 8;
+
+const V4L2_QUANTIZATION_DEFAULT: u32 = 0;
+const V4L2_QUANTIZATION_FULL_RANGE: u32 = 1;
+const V4L2_QUANTIZATION_LIM_RANGE: u32 = 2;
+
+/// Translate a V4L2 colorspace report to a `ColorInfo`. Sub-fields
+/// reported as `*_DEFAULT` are resolved from the `colorspace` field
+/// per the V4L2 mapping macros. `V4L2_COLORSPACE_DEFAULT` propagates
+/// as `unspecified` across the board.
+pub fn v4l2_color_to_color_info(
+    colorspace: u32,
+    xfer_func: u32,
+    ycbcr_enc: u32,
+    quantization: u32,
+) -> ColorInfo {
+    let primaries = primaries_from_v4l2(colorspace);
+    let transfer = transfer_from_v4l2(xfer_func, colorspace);
+    let matrix = matrix_from_v4l2(ycbcr_enc, colorspace);
+    let range = range_from_v4l2(quantization, colorspace);
+    ColorInfo { primaries, transfer, matrix, range }
+}
+
+fn primaries_from_v4l2(colorspace: u32) -> Primaries {
+    match colorspace {
+        V4L2_COLORSPACE_DEFAULT => Primaries::Unspecified,
+        V4L2_COLORSPACE_SMPTE170M | V4L2_COLORSPACE_BT878 => Primaries::Smpte170m,
+        V4L2_COLORSPACE_SMPTE240M => Primaries::Smpte240m,
+        V4L2_COLORSPACE_REC709 => Primaries::Bt709,
+        V4L2_COLORSPACE_470_SYSTEM_M => Primaries::Bt470M,
+        V4L2_COLORSPACE_470_SYSTEM_BG => Primaries::Bt470Bg,
+        // V4L2_COLORSPACE_JPEG is "shorthand for SRGB primaries +
+        // BT.601 matrix + full range" per kernel comment.
+        V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => Primaries::Bt709,
+        V4L2_COLORSPACE_BT2020 => Primaries::Bt2020,
+        V4L2_COLORSPACE_DCI_P3 => Primaries::Smpte431,
+        // RAW, anything unrecognized: don't guess.
+        _ => Primaries::Unspecified,
+    }
+}
+
+fn transfer_from_v4l2(xfer_func: u32, colorspace: u32) -> Transfer {
+    let resolved = if xfer_func == V4L2_XFER_FUNC_DEFAULT {
+        // V4L2_MAP_XFER_FUNC_DEFAULT: derive from colorspace.
+        match colorspace {
+            V4L2_COLORSPACE_OPRGB => V4L2_XFER_FUNC_OPRGB,
+            V4L2_COLORSPACE_SMPTE240M => V4L2_XFER_FUNC_SMPTE240M,
+            V4L2_COLORSPACE_DCI_P3 => V4L2_XFER_FUNC_DCI_P3,
+            V4L2_COLORSPACE_RAW => V4L2_XFER_FUNC_NONE,
+            V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_JPEG => V4L2_XFER_FUNC_SRGB,
+            V4L2_COLORSPACE_DEFAULT => return Transfer::Unspecified,
+            _ => V4L2_XFER_FUNC_709,
+        }
+    } else {
+        xfer_func
+    };
+    match resolved {
+        V4L2_XFER_FUNC_709 => Transfer::Bt709,
+        V4L2_XFER_FUNC_SRGB => Transfer::Srgb,
+        // OPRGB / DCI_P3 have no direct H.273 mapping; report
+        // unspecified rather than misrepresent.
+        V4L2_XFER_FUNC_OPRGB | V4L2_XFER_FUNC_DCI_P3 => Transfer::Unspecified,
+        V4L2_XFER_FUNC_SMPTE240M => Transfer::Smpte240m,
+        V4L2_XFER_FUNC_NONE => Transfer::Linear,
+        V4L2_XFER_FUNC_SMPTE2084 => Transfer::Smpte2084,
+        _ => Transfer::Unspecified,
+    }
+}
+
+fn matrix_from_v4l2(ycbcr_enc: u32, colorspace: u32) -> Matrix {
+    let resolved = if ycbcr_enc == V4L2_YCBCR_ENC_DEFAULT {
+        // V4L2_MAP_YCBCR_ENC_DEFAULT: derive from colorspace.
+        match colorspace {
+            V4L2_COLORSPACE_REC709 | V4L2_COLORSPACE_DCI_P3 => V4L2_YCBCR_ENC_709,
+            V4L2_COLORSPACE_BT2020 => V4L2_YCBCR_ENC_BT2020,
+            V4L2_COLORSPACE_SMPTE240M => V4L2_YCBCR_ENC_SMPTE240M,
+            V4L2_COLORSPACE_DEFAULT => return Matrix::Unspecified,
+            _ => V4L2_YCBCR_ENC_601,
+        }
+    } else {
+        ycbcr_enc
+    };
+    match resolved {
+        V4L2_YCBCR_ENC_601 | V4L2_YCBCR_ENC_XV601 | V4L2_YCBCR_ENC_SYCC => Matrix::Smpte170m,
+        V4L2_YCBCR_ENC_709 | V4L2_YCBCR_ENC_XV709 => Matrix::Bt709,
+        V4L2_YCBCR_ENC_BT2020 => Matrix::Bt2020Ncl,
+        V4L2_YCBCR_ENC_BT2020_CONST_LUM => Matrix::Bt2020Cl,
+        V4L2_YCBCR_ENC_SMPTE240M => Matrix::Smpte240m,
+        _ => Matrix::Unspecified,
+    }
+}
+
+fn range_from_v4l2(quantization: u32, colorspace: u32) -> Range {
+    let resolved = if quantization == V4L2_QUANTIZATION_DEFAULT {
+        // V4L2_MAP_QUANTIZATION_DEFAULT: full for JPEG / SRGB / OPRGB,
+        // limited for everything else.
+        match colorspace {
+            V4L2_COLORSPACE_JPEG | V4L2_COLORSPACE_SRGB | V4L2_COLORSPACE_OPRGB => {
+                V4L2_QUANTIZATION_FULL_RANGE
+            }
+            V4L2_COLORSPACE_DEFAULT => return Range::Unspecified,
+            _ => V4L2_QUANTIZATION_LIM_RANGE,
+        }
+    } else {
+        quantization
+    };
+    match resolved {
+        V4L2_QUANTIZATION_FULL_RANGE => Range::Full,
+        V4L2_QUANTIZATION_LIM_RANGE => Range::Limited,
+        _ => Range::Unspecified,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rec709_explicit_maps_to_bt709() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_REC709,
+            V4L2_XFER_FUNC_709,
+            V4L2_YCBCR_ENC_709,
+            V4L2_QUANTIZATION_LIM_RANGE,
+        );
+        assert_eq!(info.primaries, Primaries::Bt709);
+        assert_eq!(info.transfer, Transfer::Bt709);
+        assert_eq!(info.matrix, Matrix::Bt709);
+        assert_eq!(info.range, Range::Limited);
+    }
+
+    #[test]
+    fn vivid_smpte170m_with_defaults_resolves_to_bt601_525() {
+        // Vivid reports V4L2_COLORSPACE_SMPTE170M with everything else
+        // default. SMPTE 170M is BT.601 525-line.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_SMPTE170M,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Primaries::Smpte170m);
+        assert_eq!(info.transfer, Transfer::Bt709);
+        assert_eq!(info.matrix, Matrix::Smpte170m);
+        assert_eq!(info.range, Range::Limited);
+    }
+
+    #[test]
+    fn webcam_srgb_with_defaults_resolves_to_bt601_matrix_full_range() {
+        // The standard UVC webcam combo per V4L2 convention: SRGB
+        // colorspace means SRGB primaries + sRGB transfer + BT.601
+        // matrix + FULL range. Surprising but documented.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_SRGB,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Primaries::Bt709);
+        assert_eq!(info.transfer, Transfer::Srgb);
+        assert_eq!(info.matrix, Matrix::Smpte170m);
+        assert_eq!(info.range, Range::Full);
+    }
+
+    #[test]
+    fn bt2020_with_defaults_resolves_to_bt2020_ncl() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_BT2020,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Primaries::Bt2020);
+        assert_eq!(info.transfer, Transfer::Bt709);
+        assert_eq!(info.matrix, Matrix::Bt2020Ncl);
+        assert_eq!(info.range, Range::Limited);
+    }
+
+    #[test]
+    fn colorspace_default_propagates_unspecified() {
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_DEFAULT,
+            V4L2_XFER_FUNC_DEFAULT,
+            V4L2_YCBCR_ENC_DEFAULT,
+            V4L2_QUANTIZATION_DEFAULT,
+        );
+        assert_eq!(info.primaries, Primaries::Unspecified);
+        assert_eq!(info.transfer, Transfer::Unspecified);
+        assert_eq!(info.matrix, Matrix::Unspecified);
+        assert_eq!(info.range, Range::Unspecified);
+    }
+
+    #[test]
+    fn bt2020_with_pq_transfer_resolves_to_smpte2084() {
+        // HDR10 source: BT.2020 primaries + PQ transfer + BT.2020 NCL
+        // matrix + limited range.
+        let info = v4l2_color_to_color_info(
+            V4L2_COLORSPACE_BT2020,
+            V4L2_XFER_FUNC_SMPTE2084,
+            V4L2_YCBCR_ENC_BT2020,
+            V4L2_QUANTIZATION_LIM_RANGE,
+        );
+        assert_eq!(info.primaries, Primaries::Bt2020);
+        assert_eq!(info.transfer, Transfer::Smpte2084);
+        assert_eq!(info.matrix, Matrix::Bt2020Ncl);
+        assert_eq!(info.range, Range::Limited);
+    }
+}

--- a/packages/camera/streamlib.yaml
+++ b/packages/camera/streamlib.yaml
@@ -21,7 +21,13 @@ patch:
     path: ../core
 
 schemas:
-  # Wire types imported from @tatolab/core (#767).
+  # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   # Local config schemas this package owns.

--- a/packages/core/schemas/color_info.yaml
+++ b/packages/core/schemas/color_info.yaml
@@ -10,21 +10,34 @@
 # MediaFoundation): primaries, transfer, matrix, range. Values align
 # with ITU-T H.273 / ISO/IEC 23091-2 enum identifiers so encoder /
 # decoder / muxer code hands them through verbatim — no translation
-# tables. Numeric H.273 values are mapped from / to these string
-# discriminants by helpers in `packages/core/src/color_info_ext.rs`.
+# tables.
+#
+# Each axis is an `optionalProperties` field — **absence on the wire
+# IS the unknown state.** The H.273 "Unspecified" enumerant (value 2
+# on every axis) maps to `None` here, matching what every consumer
+# already does in practice (V4L2 detect collapses unknown values into
+# absence; FFmpeg's encoder treats `AVCOL_PRI_UNSPECIFIED` as "skip
+# the colour_description block"). This shape mirrors the W3C
+# WebCodecs `VideoColorSpace` interface, which uses nullable enum
+# fields with no explicit "unspecified" variant for the same reason —
+# JSON-spec peers in this problem space converge on Option-wrapping
+# rather than sentinel enum values, because the wrapper makes
+# `ColorInfo::default()` semantically correct (all axes absent =
+# unknown) without relying on a per-variant default attribute the
+# generator cannot reorder.
 
 metadata:
   type: ColorInfo
   description: "Per-frame color description (H.273 / ITU-T VUI 4-tuple)"
 
-properties:
+optionalProperties:
   primaries:
     metadata:
       description: >
         Color primaries (chromaticities). Maps to H.273
-        `ColourPrimaries` enumerant.
+        `ColourPrimaries` enumerant. Absent = unspecified
+        (H.273 value 2).
     enum:
-      - unspecified           # H.273 value 2
       - bt709                 # H.273 value 1 — Rec.709, sRGB primaries
       - bt470_m               # H.273 value 4 — System M, NTSC 1953
       - bt470_bg              # H.273 value 5 — System B/G, EBU
@@ -40,9 +53,9 @@ properties:
     metadata:
       description: >
         Transfer characteristic (EOTF / OETF). Maps to H.273
-        `TransferCharacteristics` enumerant.
+        `TransferCharacteristics` enumerant. Absent = unspecified
+        (H.273 value 2).
     enum:
-      - unspecified           # H.273 value 2
       - bt709                 # H.273 value 1 — Rec.709 OETF
       - gamma22               # H.273 value 4
       - gamma28               # H.273 value 5
@@ -63,9 +76,9 @@ properties:
     metadata:
       description: >
         YCbCr matrix coefficients. Maps to H.273
-        `MatrixCoefficients` enumerant.
+        `MatrixCoefficients` enumerant. Absent = unspecified
+        (H.273 value 2).
     enum:
-      - unspecified           # H.273 value 2
       - identity              # H.273 value 0 — RGB / GBR (no matrix)
       - bt709                 # H.273 value 1
       - fcc                   # H.273 value 4 — FCC 73.682
@@ -84,7 +97,7 @@ properties:
       description: >
         Quantization range. Maps to H.264/H.265 VUI
         `video_full_range_flag` (`limited` = 0, `full` = 1).
+        Absent = unspecified.
     enum:
-      - unspecified
       - limited
       - full

--- a/packages/core/schemas/color_info.yaml
+++ b/packages/core/schemas/color_info.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for video color information.
+#
+# Models the four-axis color description used by every modern codec
+# bitstream (H.264/H.265 VUI, AV1 OBU color_config), every container
+# (MP4 nclx, WebM Colour, AVIF, PNG cICP), and every production media
+# framework (FFmpeg, WebRTC, Chromium gfx::ColorSpace, NVENC,
+# MediaFoundation): primaries, transfer, matrix, range. Values align
+# with ITU-T H.273 / ISO/IEC 23091-2 enum identifiers so encoder /
+# decoder / muxer code hands them through verbatim — no translation
+# tables. Numeric H.273 values are mapped from / to these string
+# discriminants by helpers in `packages/core/src/color_info_ext.rs`.
+
+metadata:
+  type: ColorInfo
+  description: "Per-frame color description (H.273 / ITU-T VUI 4-tuple)"
+
+properties:
+  primaries:
+    metadata:
+      description: >
+        Color primaries (chromaticities). Maps to H.273
+        `ColourPrimaries` enumerant.
+    enum:
+      - unspecified           # H.273 value 2
+      - bt709                 # H.273 value 1 — Rec.709, sRGB primaries
+      - bt470_m               # H.273 value 4 — System M, NTSC 1953
+      - bt470_bg              # H.273 value 5 — System B/G, EBU
+      - smpte170m             # H.273 value 6 — SMPTE-C, BT.601 525-line
+      - smpte240m             # H.273 value 7
+      - film                  # H.273 value 8 — generic film
+      - bt2020                # H.273 value 9 — Rec.2020 / Rec.2100
+      - smpte428              # H.273 value 10 — XYZ
+      - smpte431              # H.273 value 11 — DCI-P3 (theatrical)
+      - smpte432              # H.273 value 12 — Display-P3 (D65)
+      - ebu3213               # H.273 value 22
+  transfer:
+    metadata:
+      description: >
+        Transfer characteristic (EOTF / OETF). Maps to H.273
+        `TransferCharacteristics` enumerant.
+    enum:
+      - unspecified           # H.273 value 2
+      - bt709                 # H.273 value 1 — Rec.709 OETF
+      - gamma22               # H.273 value 4
+      - gamma28               # H.273 value 5
+      - smpte170m             # H.273 value 6 — BT.601 OETF
+      - smpte240m             # H.273 value 7
+      - linear                # H.273 value 8
+      - log100                # H.273 value 9
+      - log100_sqrt10         # H.273 value 10
+      - xvycc                 # H.273 value 11 — IEC 61966-2-4 (extended xvYCC)
+      - bt1361                # H.273 value 12
+      - srgb                  # H.273 value 13 — IEC 61966-2-1 (sRGB / Display-P3)
+      - bt2020_ten_bit        # H.273 value 14 — Rec.2020 10-bit
+      - bt2020_twelve_bit     # H.273 value 15 — Rec.2020 12-bit
+      - smpte2084             # H.273 value 16 — PQ (HDR10)
+      - smpte428              # H.273 value 17 — XYZ
+      - arib_std_b67          # H.273 value 18 — HLG
+  matrix:
+    metadata:
+      description: >
+        YCbCr matrix coefficients. Maps to H.273
+        `MatrixCoefficients` enumerant.
+    enum:
+      - unspecified           # H.273 value 2
+      - identity              # H.273 value 0 — RGB / GBR (no matrix)
+      - bt709                 # H.273 value 1
+      - fcc                   # H.273 value 4 — FCC 73.682
+      - bt470_bg              # H.273 value 5 — BT.601 625-line
+      - smpte170m             # H.273 value 6 — BT.601 525-line
+      - smpte240m             # H.273 value 7
+      - ycgco                 # H.273 value 8
+      - bt2020_ncl            # H.273 value 9 — non-constant luminance
+      - bt2020_cl             # H.273 value 10 — constant luminance
+      - smpte2085             # H.273 value 11 — Y'D'zD'x
+      - chroma_ncl            # H.273 value 12 — chromaticity-derived NCL
+      - chroma_cl             # H.273 value 13 — chromaticity-derived CL
+      - ictcp                 # H.273 value 14 — Rec.2100 ICtCp
+  range:
+    metadata:
+      description: >
+        Quantization range. Maps to H.264/H.265 VUI
+        `video_full_range_flag` (`limited` = 0, `full` = 1).
+    enum:
+      - unspecified
+      - limited
+      - full

--- a/packages/core/schemas/content_light.yaml
+++ b/packages/core/schemas/content_light.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for HDR10 content light level
+# information (CTA-861.3 / CEA-861.3). Carried in H.265 / H.266 SEI
+# `content_light_level_info` messages, MP4 `clli` boxes, AV1 OBU
+# `metadata_hdr_cll`. Reports the maximum light levels actually
+# present in the content (as opposed to the display capability
+# captured by `MasteringDisplay`).
+#
+# Units are cd/m^2 as integers (1 = 1 cd/m^2). Matches the wire
+# format byte-for-byte.
+
+metadata:
+  type: ContentLight
+  description: "HDR10 content light level info (MaxCLL / MaxFALL)"
+
+properties:
+  max_cll:
+    metadata: { description: "Maximum content light level in cd/m^2 (peak single-pixel light level)" }
+    type: uint32
+  max_fall:
+    metadata: { description: "Maximum frame-average light level in cd/m^2" }
+    type: uint32

--- a/packages/core/schemas/encoded_video_frame.yaml
+++ b/packages/core/schemas/encoded_video_frame.yaml
@@ -3,6 +3,23 @@
 #
 # JSON Type Definition (RFC 8927) schema for encoded video frames.
 
+imports:
+  ColorInfo:
+    org: tatolab
+    package: core
+    type: ColorInfo
+    version: "1.0.0"
+  MasteringDisplay:
+    org: tatolab
+    package: core
+    type: MasteringDisplay
+    version: "1.0.0"
+  ContentLight:
+    org: tatolab
+    package: core
+    type: ContentLight
+    version: "1.0.0"
+
 metadata:
   type: EncodedVideoFrame
   description: "Encoded video frame with H.264/H.265 NAL unit data"
@@ -34,3 +51,15 @@ optionalProperties:
     metadata:
       description: "Source frame rate in frames per second (pass-through from capture device)"
     type: uint32
+  color_info:
+    metadata:
+      description: "H.273 / ITU-T VUI four-tuple describing this frame's color. Encoder writes this so muxers / downstream consumers can populate VUI / colr boxes without re-deriving from the bitstream."
+    ref: ColorInfo
+  mastering_display:
+    metadata:
+      description: "SMPTE ST.2086 mastering display color volume (HDR10 static metadata). Absent for SDR streams."
+    ref: MasteringDisplay
+  content_light:
+    metadata:
+      description: "HDR10 content light level info (MaxCLL / MaxFALL). Absent for SDR streams or when not measured."
+    ref: ContentLight

--- a/packages/core/schemas/mastering_display.yaml
+++ b/packages/core/schemas/mastering_display.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for SMPTE ST.2086 Mastering
+# Display Color Volume — the static HDR metadata describing the
+# display the content was mastered on. Carried in H.265 / H.266 SEI
+# messages (`mastering_display_colour_volume`), MP4 `mdcv` boxes, AV1
+# OBU metadata (`metadata_hdr_mdcv`), and WebM `MasteringMetadata`
+# elements.
+#
+# Field units match the wire format byte-for-byte so encoders /
+# decoders / muxers hand the values through verbatim:
+#
+# - Chromaticity values (`display_primaries_*`, `white_point_*`) are
+#   in increments of 0.00002 (1/50000), so 0.708 = 35400. Range
+#   [0, 50000].
+# - Luminance values (`min_luminance`, `max_luminance`) are in
+#   increments of 0.0001 cd/m², so 1000 cd/m² = 10000000.
+#
+# Primaries are listed in R, G, B order (matching SMPTE ST.2086 and
+# the H.265 / H.266 SEI ordering).
+
+metadata:
+  type: MasteringDisplay
+  description: "SMPTE ST.2086 mastering display color volume (HDR10 static metadata)"
+
+properties:
+  display_primaries_r_x:
+    metadata: { description: "Red primary x chromaticity in 1/50000 increments" }
+    type: uint32
+  display_primaries_r_y:
+    metadata: { description: "Red primary y chromaticity in 1/50000 increments" }
+    type: uint32
+  display_primaries_g_x:
+    metadata: { description: "Green primary x chromaticity in 1/50000 increments" }
+    type: uint32
+  display_primaries_g_y:
+    metadata: { description: "Green primary y chromaticity in 1/50000 increments" }
+    type: uint32
+  display_primaries_b_x:
+    metadata: { description: "Blue primary x chromaticity in 1/50000 increments" }
+    type: uint32
+  display_primaries_b_y:
+    metadata: { description: "Blue primary y chromaticity in 1/50000 increments" }
+    type: uint32
+  white_point_x:
+    metadata: { description: "White point x chromaticity in 1/50000 increments" }
+    type: uint32
+  white_point_y:
+    metadata: { description: "White point y chromaticity in 1/50000 increments" }
+    type: uint32
+  min_luminance:
+    metadata: { description: "Minimum mastering display luminance in 0.0001 cd/m^2 increments" }
+    type: uint32
+  max_luminance:
+    metadata: { description: "Maximum mastering display luminance in 0.0001 cd/m^2 increments" }
+    type: uint32

--- a/packages/core/schemas/video_frame.yaml
+++ b/packages/core/schemas/video_frame.yaml
@@ -3,6 +3,23 @@
 #
 # JSON Type Definition (RFC 8927) schema for video frames.
 
+imports:
+  ColorInfo:
+    org: tatolab
+    package: core
+    type: ColorInfo
+    version: "1.0.0"
+  MasteringDisplay:
+    org: tatolab
+    package: core
+    type: MasteringDisplay
+    version: "1.0.0"
+  ContentLight:
+    org: tatolab
+    package: core
+    type: ContentLight
+    version: "1.0.0"
+
 metadata:
   type: VideoFrame
   description: "Video frame for IPC - references GPU surface by ID"
@@ -39,5 +56,17 @@ optionalProperties:
     type: uint32
   texture_layout:
     metadata:
-      description: "Producer's published VkImageLayout for this frame's texture (#633). Per-frame override of the per-surface current_image_layout published via surface-share register/update_layout. Encoded as the raw int32 VkImageLayout enumerant. Absent when the producer relies on the per-surface default."
+      description: "Producer's published VkImageLayout for this frame's texture. Per-frame override of the per-surface current_image_layout published via surface-share register/update_layout. Encoded as the raw int32 VkImageLayout enumerant. Absent when the producer relies on the per-surface default."
     type: int32
+  color_info:
+    metadata:
+      description: "H.273 / ITU-T VUI four-tuple describing this frame's color. Absent means unknown — every consumer treats absent the same as all-`unspecified`. Producers fill from V4L2 (camera), VUI (decoder), application config, or leave absent."
+    ref: ColorInfo
+  mastering_display:
+    metadata:
+      description: "SMPTE ST.2086 mastering display color volume (HDR10 static metadata). Absent for SDR streams."
+    ref: MasteringDisplay
+  content_light:
+    metadata:
+      description: "HDR10 content light level info (MaxCLL / MaxFALL). Absent for SDR streams or when not measured."
+    ref: ContentLight

--- a/packages/core/streamlib.yaml
+++ b/packages/core/streamlib.yaml
@@ -17,9 +17,15 @@ package:
 schemas:
   AudioFrame:
     file: schemas/audio_frame.yaml
+  ColorInfo:
+    file: schemas/color_info.yaml
+  ContentLight:
+    file: schemas/content_light.yaml
   EncodedAudioFrame:
     file: schemas/encoded_audio_frame.yaml
   EncodedVideoFrame:
     file: schemas/encoded_video_frame.yaml
+  MasteringDisplay:
+    file: schemas/mastering_display.yaml
   VideoFrame:
     file: schemas/video_frame.yaml

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -182,9 +182,15 @@ fn source_thread_loop(
             timestamp_ns: timestamp_ns.to_string(),
             frame_index: frame_idx.to_string(),
             fps: Some(fps),
-            // Per-frame override is opt-in (#633); per-surface
+            // Per-frame override is opt-in; per-surface
             // `current_image_layout` from surface-share is the default.
             texture_layout: None,
+            // Fixture frames are RGB sRGB by construction; leaving
+            // `color_info` absent (== unknown) is the conservative
+            // choice — downstream consumers default-as-they-do today.
+            color_info: None,
+            mastering_display: None,
+            content_light: None,
         };
 
         if let Err(e) = outputs.write("video", &video_frame) {

--- a/packages/debug-utilities/streamlib.yaml
+++ b/packages/debug-utilities/streamlib.yaml
@@ -23,6 +23,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   # Local config schemas this package owns.

--- a/packages/display/streamlib.yaml
+++ b/packages/display/streamlib.yaml
@@ -21,7 +21,13 @@ patch:
     path: ../core
 
 schemas:
-  # Wire types imported from @tatolab/core (#767).
+  # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   # Local config schemas this package owns.

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -161,9 +161,16 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
                 timestamp_ns,
                 frame_index: encoded.frame_number.clone(),
                 fps: encoded.fps,
-                // Per-frame override is opt-in (#633); per-surface
+                // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
+                // Pass color metadata through encoded → decoded so
+                // downstream consumers see what the producer attested.
+                // VUI parsing for codec-attested color lands in a
+                // follow-up.
+                color_info: encoded.color_info.clone(),
+                mastering_display: encoded.mastering_display.clone(),
+                content_light: encoded.content_light.clone(),
             };
 
             self.outputs.write("video_out", &video_frame)?;

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -147,6 +147,13 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
+        // Pass color metadata through input → encoded so the muxer /
+        // downstream consumer can populate VUI / colr without re-
+        // deriving from the bitstream. VUI write-back from encoder
+        // config lands in a follow-up.
+        let frame_color_info = frame.color_info.clone();
+        let frame_mastering_display = frame.mastering_display.clone();
+        let frame_content_light = frame.content_light.clone();
 
         let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
             Error::Runtime(format!("H.264 encode failed: {e}"))
@@ -159,6 +166,9 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
                 is_keyframe: packet.is_keyframe,
                 timestamp_ns: packet.timestamp_ns.unwrap_or(0).to_string(),
                 frame_number: self.frames_encoded.to_string(),
+                color_info: frame_color_info.clone(),
+                mastering_display: frame_mastering_display.clone(),
+                content_light: frame_content_light.clone(),
             };
             self.outputs.write("encoded_video_out", &encoded)?;
         }

--- a/packages/h264/streamlib.yaml
+++ b/packages/h264/streamlib.yaml
@@ -21,8 +21,14 @@ patch:
     path: ../core
 
 schemas:
-  # Wire types imported from @tatolab/core (#767).
+  # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -161,9 +161,16 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
                 timestamp_ns,
                 frame_index: encoded.frame_number.clone(),
                 fps: encoded.fps,
-                // Per-frame override is opt-in (#633); per-surface
+                // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
+                // Pass color metadata through encoded → decoded so
+                // downstream consumers see what the producer attested.
+                // VUI parsing for codec-attested color lands in a
+                // follow-up.
+                color_info: encoded.color_info.clone(),
+                mastering_display: encoded.mastering_display.clone(),
+                content_light: encoded.content_light.clone(),
             };
 
             self.outputs.write("video_out", &video_frame)?;

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -147,6 +147,13 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
 
         let timestamp_ns: Option<i64> = frame.timestamp_ns.parse().ok();
         let frame_fps = frame.fps;
+        // Pass color metadata through input → encoded so the muxer /
+        // downstream consumer can populate VUI / colr without re-
+        // deriving from the bitstream. VUI write-back from encoder
+        // config lands in a follow-up.
+        let frame_color_info = frame.color_info.clone();
+        let frame_mastering_display = frame.mastering_display.clone();
+        let frame_content_light = frame.content_light.clone();
 
         let packets = encoder.encode_image(image_view, timestamp_ns).map_err(|e| {
             Error::Runtime(format!("H.265 encode failed: {e}"))
@@ -159,6 +166,9 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
                 is_keyframe: packet.is_keyframe,
                 timestamp_ns: packet.timestamp_ns.unwrap_or(0).to_string(),
                 frame_number: self.frames_encoded.to_string(),
+                color_info: frame_color_info.clone(),
+                mastering_display: frame_mastering_display.clone(),
+                content_light: frame_content_light.clone(),
             };
             self.outputs.write("encoded_video_out", &encoded)?;
         }

--- a/packages/h265/streamlib.yaml
+++ b/packages/h265/streamlib.yaml
@@ -21,7 +21,13 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"

--- a/packages/moq/streamlib.yaml
+++ b/packages/moq/streamlib.yaml
@@ -18,7 +18,13 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   # Local config schemas this package owns.
   MoqPublishTrackConfig:

--- a/packages/mp4/streamlib.yaml
+++ b/packages/mp4/streamlib.yaml
@@ -17,6 +17,12 @@ patch:
     path: ../core
 
 schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   LinuxMp4WriterConfig:

--- a/packages/screen-capture/streamlib.yaml
+++ b/packages/screen-capture/streamlib.yaml
@@ -21,6 +21,12 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
   VideoFrame:
     package: "@tatolab/core"
   # Local config schemas this package owns.

--- a/packages/webrtc/src/webrtc_whep.rs
+++ b/packages/webrtc/src/webrtc_whep.rs
@@ -191,6 +191,13 @@ async fn run_whep_receive_loop(
                             timestamp_ns: timestamp_ns.to_string(),
                             is_keyframe,
                             frame_number: video_frame_count.to_string(),
+                            // WHEP receives RTP without container-level
+                            // color metadata; populating ColorInfo
+                            // requires VUI parsing from the bitstream
+                            // (a follow-up).
+                            color_info: None,
+                            mastering_display: None,
+                            content_light: None,
                         };
 
                         if let Err(e) = outputs.write("encoded_video_out", &encoded) {

--- a/packages/webrtc/streamlib.yaml
+++ b/packages/webrtc/streamlib.yaml
@@ -18,9 +18,15 @@ patch:
 
 schemas:
   # Wire types imported from @tatolab/core.
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
   EncodedAudioFrame:
     package: "@tatolab/core"
   EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
     package: "@tatolab/core"
   # Local config schemas this package owns.
   WebrtcWhepConfig:


### PR DESCRIPTION
## Summary

- Adds H.273-aligned `ColorInfo` + ST.2086 `MasteringDisplay` + HDR10 `ContentLight` as optional sidecar fields on `VideoFrame` + `EncodedVideoFrame`. Camera populates `ColorInfo` from V4L2 (`colorspace` / `xfer_func` / `ycbcr_enc` / `quantization`); encoders + decoders pass through. **No consumer-side fix yet** — green-vivid lands in #812-spawned 312.3.
- Schema uses `optionalProperties` with no `unspecified` enum variant per axis — absence on the wire IS the unknown state. `ColorInfo::default()` is structurally `{ all None }`; foot-gun is type-system-enforced unrepresentable, not just doc-warned. Mirrors W3C WebCodecs `VideoColorSpace` exactly.
- Engine-level codegen fix in `libs/streamlib-jtd-codegen/src/sentinel.rs` — first-time use of the `imports:` mechanism surfaced two real bugs (PascalCase mangling + leading-digit hash collision) and one Python-specific bug (relative-import circular dep), all fixed for every future user of cross-package schema imports.

## Closes

Closes #811

## Exit criteria (from issue body, plus user-approved scope expansions)

- [x] `ColorInfo` added to `packages/core/schemas/` as a top-level shared schema, referenced from `VideoFrame` + `EncodedVideoFrame` via the `imports:` + `ref:` sentinel mechanism.
- [x] H.273-aligned enum values for primaries / transfer / matrix / range — zero translation cost across every codec / container / Vulkan Video boundary.
- [x] HDR static metadata (`MasteringDisplay` + `ContentLight`) included — user-approved scope expansion: "I do also want to land hdr as well since I will have devices that use it." Dynamic HDR (HDR10+ / Dolby Vision RPU) deferred until a real consumer arrives.
- [x] Generated Rust / Python / Deno bindings regenerate cleanly. Rust via `cargo build` (camera, engine, h264, h265, etc.); Python via `cargo run -p streamlib-cli -- generate --runtime python ...`; Deno via the same with `--runtime typescript`.
- [x] Camera populates `ColorInfo` end-to-end as the smoke test — V4L2 detect at processor start, cached, stamped on every emitted `VideoFrame`. Verified on vivid (`SMPTE170M / BT.601 525-line`).
- [x] No visual regression on existing 1080p vivid roundtrips with default `None` axes.

## Architectural decisions made during planning

- **H.273 numeric-aligned enum values** (vs. abstract names the issue body originally proposed) — every modern bitstream / container / production media stack converges on H.273; FFmpeg / WebRTC / NVENC / Media Foundation / Chromium all do this. GStreamer's invented enum is the cautionary tale.
- **Single shared schema types via `imports:` + `ref:`** (vs. inline-duplicated definitions in each frame schema) — `ColorInfo` is one canonical Rust / Python / Deno type referenced from both `VideoFrame` and `EncodedVideoFrame`, no parallel types to keep in sync.
- **`optionalProperties` per axis, no `unspecified` variant** (vs. enum with `Unspecified` + `Option`-wrapped at field level) — informed by 3 parallel Opus research agents on the JTD spec, jtd-codegen Rust backend internals, and schema-shape alternatives. WebCodecs `VideoColorSpace` (the only JSON-spec peer) converged on the same shape; `ColorInfo::default()` becomes semantically correct by construction.
- **Camera reads V4L2 colorspace + translates to `ColorInfo`** (vs. hardcoded BT.709-limited stamp) — small extra scope (~30 LOC + a small lookup table) that produces correct truth for vivid + UVC out of the gate, mirroring FFmpeg's `libavcodec/v4l2_buffers.c`.

## Engine-level codegen fixes (sentinel post-pass)

The `imports:` cross-schema reference mechanism was infrastructure that shipped earlier but was never consumed in tree. This PR became the first user and surfaced three real bugs:

1. **PascalCase mangling.** Post-pass searched for the original `__STREAMLIB_REF_xxx__` sentinel in jtd-codegen output, but jtd-codegen mangles identifiers into PascalCase (`StreamlibRefXxx`) for struct / class / interface names AND field type references. Strip + replace updated for all three backends to look for the mangled form.
2. **Leading-digit hash collision.** SHA-256 hashes that start with a digit (e.g. `MasteringDisplay` → `70dcb...`) — jtd-codegen strips leading digits when mangling identifiers, so the mangled name dropped the digits and no longer matched the search pattern. Fixed by prefixing the hash with `h`.
3. **Python relative-import circular dep.** Same-package imports via `from ..tatolab__core import X` re-entered the package's own `__init__.py` while names were still being bound. Fixed by importing directly from the per-type module file (`from ..tatolab__core.color_info import ColorInfo`).

## Test plan

- [x] **Rust unit (`cargo test -p streamlib-camera --lib v4l2_color`)** — 7 tests: REC709, vivid SMPTE170M, webcam SRGB, BT.2020, COLORSPACE_DEFAULT (all axes None), HDR PQ, default-is-all-None lock.
- [x] **Rust round-trip (`cargo test -p streamlib-engine --lib videoframe_color_metadata_round_trip`)** — full ColorInfo + MasteringDisplay + ContentLight serialize / deserialize, absent-on-None invariant, `ColorInfo::default() == {}` invariant.
- [x] **Python round-trip (`pytest libs/streamlib-python/python/streamlib/tests/test_color_info_round_trip.py`)** — 6 tests, including `test_color_info_all_none_serializes_as_empty_object` lock.
- [x] **Deno round-trip (`deno test libs/streamlib-deno/color_info_round_trip_test.ts`)** — 6 tests, including the matching empty-object lock.
- [x] **Workspace `cargo test` baseline** (per `docs/testing-baseline.md` exclusion list) — passes; the same two pre-existing Deno polyglot test failures (`polyglot_continuous_processor_deno`, `polyglot_manual_source_deno`) reproduce on `main` independently of this PR.
- [x] **E2E vivid camera-display** — 127 frames captured, V4L2 colorspace logged as `matrix="Smpte170m" primaries="Bt709" range="Full" transfer="Srgb"` (the V4L2 SRGB convention vivid actually reports), 6 PNG samples visually identical to current main. Pipeline log clean (zero OOM / DEVICE_LOST / process() failed). Same green-vivid frame as today (the bug isn't this PR's to fix).

## Polyglot coverage

- **Runtimes affected**: rust, python, deno (all)
- **Schema regenerated**: yes (Python via `streamlib-cli --runtime python`, Deno via `streamlib-cli --runtime typescript`, Rust auto via build.rs)
- **Python AND Deno both covered?** yes — round-trip tests in both runtimes, both pass.
- **E2E tests run**:
  - [x] Host-Rust: `videoframe_color_metadata_round_trip` (engine), `v4l2_color::tests::*` (camera) — pass
  - [x] Python subprocess: `test_color_info_round_trip.py` 6/6 — pass
  - [x] Deno subprocess: `color_info_round_trip_test.ts` 6/6 — pass
- **FD-passing path**: n/a (schema-only addition, no new FD plumbing)

## Follow-ups

- **#812-spawned 312.3** — consumer-side YUV→RGB matrix selection (the actual green-vivid fix). ColorInfo plumbing is in place; the shader still hardcodes BT.601.
- **Codegen Rust enum naming inconsistency** — Rust emits `Matrix` / `Primaries` / `Range` / `Transfer` while Python emits `ColorInfoMatrix` / etc. Worth filing a codegen-shape follow-up to align Rust with Python's `<ParentType><EnumName>` convention. Larger blast radius than this PR's scope (would rename existing in-tree types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)