### PR TITLE
feat(pipeline): resolution propagation via first-frame inspection (#810)

### DIFF
--- a/examples/camera-display/src/main.rs
+++ b/examples/camera-display/src/main.rs
@@ -46,14 +46,30 @@ fn main() -> Result<()> {
 fn run_typed_mode() -> Result<()> {
     let runtime = Runner::new()?;
 
+    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
+    // honor each schema's `max_payload_bytes` instead of falling back to
+    // the 64 KiB default.
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+
     // =========================================================================
     // Add processors using typed API
     // =========================================================================
 
     println!("📷 Adding camera processor...");
     let device_id = std::env::var("STREAMLIB_CAMERA_DEVICE").ok();
+    // STREAMLIB_CAMERA_MAX_WIDTH / STREAMLIB_CAMERA_MAX_HEIGHT cap V4L2
+    // negotiation below the camera's advertised maximum. Useful for
+    // exercising non-1080p paths on devices that prefer 1080p.
+    let max_width = std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    let max_height = std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
+        .ok()
+        .and_then(|s| s.parse().ok());
     let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
         device_id,
+        max_width,
+        max_height,
         ..Default::default()
     }))?;
     println!("✓ Camera added: {}\n", camera);
@@ -97,6 +113,11 @@ fn run_typed_mode() -> Result<()> {
 /// String mode - simulates REST API with string-based processor names and JSON configs
 fn run_string_mode() -> Result<()> {
     let runtime = Runner::new()?;
+
+    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
+    // honor each schema's `max_payload_bytes` instead of falling back to
+    // the 64 KiB default.
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
 
     // =========================================================================
     // Add processors using string-based API (REST API style)

--- a/examples/camera-display/streamlib.yaml
+++ b/examples/camera-display/streamlib.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# camera-display example. Declares `@tatolab/core` so
+# `Runner::load_project(.)` registers the wire-vocabulary schemas with
+# the engine's runtime schema registry. Required so iceoryx2 publishers
+# size from the schema's declared `max_payload_bytes` instead of the
+# 64 KiB default.
+
+package:
+  org: tatolab
+  name: camera-display
+  version: "0.1.0"
+  description: "Minimal camera capture → display window"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/examples/moq-roundtrip/src/main.rs
+++ b/examples/moq-roundtrip/src/main.rs
@@ -42,6 +42,11 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
+    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
+    // honor each schema's `max_payload_bytes` instead of falling back to
+    // the 64 KiB default (which drops the encoder's first IDR).
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+
     // ---- PUBLISH SIDE ----
 
     let camera = runtime.add_processor(CameraProcessor::node(Default::default()))?;

--- a/examples/moq-roundtrip/streamlib.yaml
+++ b/examples/moq-roundtrip/streamlib.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# moq-roundtrip example. Declares `@tatolab/core` so
+# `Runner::load_project(.)` registers the wire-vocabulary schemas
+# (VideoFrame, EncodedVideoFrame, AudioFrame, EncodedAudioFrame) with
+# the engine's runtime schema registry. Required so iceoryx2 publishers
+# size from each schema's declared `max_payload_bytes` instead of the
+# 64 KiB default — without it the encoder's first IDR is rejected as
+# ExceedsMaxLoanSize and the decoder never sees SPS/PPS.
+
+package:
+  org: tatolab
+  name: moq-roundtrip
+  version: "0.1.0"
+  description: "MoQ publish/subscribe roundtrip with H.264 video, Opus audio, and sensor data tracks"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  AudioFrame:
+    package: "@tatolab/core"
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  EncodedAudioFrame:
+    package: "@tatolab/core"
+  EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/examples/vulkan-video-psnr/src/main.rs
+++ b/examples/vulkan-video-psnr/src/main.rs
@@ -38,6 +38,12 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
+    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
+    // honor each schema's `max_payload_bytes` instead of falling back to
+    // the 64 KiB default (which drops the encoder's first IDR with
+    // ExceedsMaxLoanSize and starves the decoder of SPS/PPS).
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+
     let source = runtime.add_processor(BgraFileSourceProcessor::node(
         BgraFileSourceProcessor::Config {
             file_path: bgra_path,

--- a/examples/vulkan-video-psnr/streamlib.yaml
+++ b/examples/vulkan-video-psnr/streamlib.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# vulkan-video-psnr example. Declares `@tatolab/core` so
+# `Runner::load_project(.)` registers the wire-vocabulary schemas
+# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
+# registry. Required so iceoryx2 publishers size from each schema's
+# declared `max_payload_bytes` instead of the 64 KiB default — without
+# it the encoder's first IDR is rejected as ExceedsMaxLoanSize and the
+# decoder never sees SPS/PPS.
+
+package:
+  org: tatolab
+  name: vulkan-video-psnr
+  version: "0.1.0"
+  description: "PSNR fixture rig — BgraFileSource → encoder → decoder → display, paired by input-frame index"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/examples/vulkan-video-roundtrip/src/main.rs
+++ b/examples/vulkan-video-roundtrip/src/main.rs
@@ -34,9 +34,26 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
+    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
+    // honor `EncodedVideoFrame.max_payload_bytes` instead of falling back
+    // to the 64 KiB default (which would drop the first IDR via
+    // ExceedsMaxLoanSize and starve the decoder of SPS/PPS).
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+
     // --- Camera ---
+    // STREAMLIB_CAMERA_MAX_WIDTH / STREAMLIB_CAMERA_MAX_HEIGHT cap V4L2
+    // negotiation below the camera's advertised maximum. Useful for
+    // exercising non-1080p paths on devices that prefer 1080p.
+    let max_width = std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    let max_height = std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
+        .ok()
+        .and_then(|s| s.parse().ok());
     let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
         device_id: Some(device.to_string()),
+        max_width,
+        max_height,
         ..Default::default()
     }))?;
     println!("+ Camera: {camera}");
@@ -48,11 +65,12 @@ fn main() -> Result<()> {
         .ok()
         .and_then(|s| s.parse().ok());
 
+    // Encoder dimensions come from the first VideoFrame the camera produces,
+    // so the example runs at whatever resolution V4L2 negotiates (capped by
+    // CameraConfig::max_width / max_height; default 1920×1080).
     let encoder = if is_h265 {
         runtime.add_processor(H265EncoderProcessor::node(
             H265EncoderProcessor::Config {
-                width: Some(1920),
-                height: Some(1080),
                 effort_level,
                 ..Default::default()
             },
@@ -60,8 +78,6 @@ fn main() -> Result<()> {
     } else {
         runtime.add_processor(H264EncoderProcessor::node(
             H264EncoderProcessor::Config {
-                width: Some(1920),
-                height: Some(1080),
                 effort_level,
                 ..Default::default()
             },

--- a/examples/vulkan-video-roundtrip/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip/streamlib.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# vulkan-video-roundtrip example. Declares `@tatolab/core` so
+# `Runner::load_project(.)` registers the wire-vocabulary schemas
+# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
+# registry. Without that, iceoryx2 publishers size to the 64 KiB default
+# from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's first
+# IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize, so the
+# decoder never sees the session parameters and decodes zero frames.
+
+package:
+  org: tatolab
+  name: vulkan-video-roundtrip
+  version: "0.1.0"
+  description: "Camera → encoder → decoder → display roundtrip exercising Vulkan Video hardware encode/decode"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/packages/camera/schemas/camera_config.yaml
+++ b/packages/camera/schemas/camera_config.yaml
@@ -20,3 +20,11 @@ optionalProperties:
     metadata:
       description: "Maximum frame rate. AVFoundation only; ignored on Linux. Defaults to the main display refresh rate."
     type: float64
+  max_width:
+    metadata:
+      description: "Upper bound on captured frame width in pixels. Caps V4L2 negotiation when the camera advertises a larger resolution (preserves real-time encoding guardrail). Default: 1920."
+    type: uint32
+  max_height:
+    metadata:
+      description: "Upper bound on captured frame height in pixels. Caps V4L2 negotiation when the camera advertises a larger resolution (preserves real-time encoding guardrail). Default: 1080."
+    type: uint32

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -228,11 +228,15 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxCameraProcessor::Proce
             negotiated.unwrap()
         };
 
-        // Cap capture resolution to 1920x1080 for real-time encoding performance.
-        let fmt = if fmt.width > 1920 || fmt.height > 1080 {
+        // Cap capture resolution at config.max_width / max_height (defaults
+        // 1920x1080 preserve the real-time-encoding guardrail; drone-racing
+        // and similar high-resolution use cases opt in by raising the cap).
+        let max_width = self.config.max_width.unwrap_or(1920);
+        let max_height = self.config.max_height.unwrap_or(1080);
+        let fmt = if fmt.width > max_width || fmt.height > max_height {
             let mut capped = fmt.clone();
-            capped.width = 1920;
-            capped.height = 1080;
+            capped.width = max_width;
+            capped.height = max_height;
             match dev.set_format(&capped) {
                 Ok(f) => {
                     tracing::info!(
@@ -247,8 +251,10 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxCameraProcessor::Proce
                 }
                 Err(e) => {
                     tracing::warn!(
-                        "Camera {}: failed to cap resolution to 1920x1080 ({}), using {}x{}",
+                        "Camera {}: failed to cap resolution to {}x{} ({}), using {}x{}",
                         self.camera_name,
+                        max_width,
+                        max_height,
                         e,
                         fmt.width,
                         fmt.height
@@ -1314,6 +1320,8 @@ mod tests {
             device_id: None,
             min_fps: None,
             max_fps: None,
+            max_width: None,
+            max_height: None,
         };
 
         let result = LinuxCameraProcessor::Processor::from_config(config);

--- a/packages/core/schemas/encoded_video_frame.yaml
+++ b/packages/core/schemas/encoded_video_frame.yaml
@@ -25,7 +25,15 @@ metadata:
   description: "Encoded video frame with H.264/H.265 NAL unit data"
   read_mode: read_next_in_order
   buffer_size: 16
-  max_payload_bytes: 524288
+  # 16 MiB per slot accommodates a 4K H.264/H.265 IDR with prepended SPS+PPS
+  # under default rate control (uncapped CQP IDR at 1920x1080 ≈ 2–3 MiB; 4K
+  # ≈ 8–12 MiB). iceoryx2 pre-allocates buffer_size * max_payload_bytes of
+  # shared memory per publisher, so this commits ~256 MiB per encoder; that
+  # cost is the price of supporting up to 4K real-time encode end-to-end
+  # without dropping the first IDR (which carries SPS/PPS and is the only
+  # entry point for the decoder). Lower bitrate-capped streams stay well
+  # under this cap; the schema-level limit just bounds the worst case.
+  max_payload_bytes: 16777216
 
 properties:
   data:

--- a/packages/h264/schemas/h264_encoder_config.yaml
+++ b/packages/h264/schemas/h264_encoder_config.yaml
@@ -10,11 +10,11 @@ metadata:
 optionalProperties:
   width:
     metadata:
-      description: "Video width in pixels (default: 1280)."
+      description: "Optional override / guardrail for video width in pixels. Unset = the encoder takes the width from the first VideoFrame it receives. Set values that disagree with the frame width log a warning and the frame still wins, matching the FPS pattern."
     type: uint32
   height:
     metadata:
-      description: "Video height in pixels (default: 720)."
+      description: "Optional override / guardrail for video height in pixels. Unset = the encoder takes the height from the first VideoFrame it receives. Set values that disagree with the frame height log a warning and the frame still wins, matching the FPS pattern."
     type: uint32
   bitrate_bps:
     metadata:

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -38,11 +38,15 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
     async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
+        // Decoder dimensions come from H.264 SPS — leaving `max_width` /
+        // `max_height` at zero tells `SimpleDecoder` to size the DPB and
+        // video session from the first parsed SPS rather than pre-allocating
+        // for a hard-coded resolution cap.
         let decoder_config = SimpleDecoderConfig {
             codec: Codec::H264,
             rgba_output: true,
-            max_width: 1920,
-            max_height: 1080,
+            max_width: 0,
+            max_height: 0,
             ..Default::default()
         };
 
@@ -57,7 +61,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
 
         let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
 
-        let mut decoder = SimpleDecoder::from_device(
+        let decoder = SimpleDecoder::from_device(
             decoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
@@ -72,19 +76,12 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
             Error::Runtime(format!("Failed to create H.264 decoder: {e}"))
         })?;
 
-        // Pre-create the video session BEFORE the display swapchain.
-        // NVIDIA limits video session creation after swapchain exists.
-        decoder.pre_initialize_session().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-initialize H.264 decoder session: {e}"))
-        })?;
-
-        // Eagerly allocate the NV12→RGBA converter. Decode-side resources
-        // are real allocations the decoder needs; the engine pre-warms the
-        // exportable VMA pools at `HostVulkanDevice` construction so this
-        // no longer races NVIDIA's post-swapchain exportable cap.
-        decoder.prepare_gpu_decode_resources().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-allocate H.264 decode resources: {e}"))
-        })?;
+        // Session creation, DPB allocation, and the NV12→RGBA converter are
+        // built lazily inside `SimpleDecoder::feed()` once the first SPS
+        // arrives — at that point the actual coded extent is known and
+        // sized to match. The processor-setup mutex inside `escalate` and
+        // the RHI queue submitter coordinate device-side ordering, so the
+        // historical pre-swapchain pre-init is no longer required.
 
         tracing::info!("[H264Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -7,6 +7,13 @@
 // HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
 // and queues — no separate device creation, no NVIDIA dual-device crash.
 //
+// The encoder is constructed lazily on the first VideoFrame so its session
+// dimensions track the upstream frame size. Config width/height become
+// guardrails (mismatch logs a warning, frame wins) mirroring how `frame.fps`
+// flows through `mp4_writer`. Privileged resource construction runs inside
+// `GpuContextLimitedAccess::escalate(|full| …)` so the processor-setup mutex
+// and `device_wait_idle` order it against the rest of the GPU work.
+//
 // The camera's GPU-resident textures are on the same device, so encode_image()
 // accepts them directly (zero-copy).
 
@@ -27,10 +34,11 @@ use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
 #[streamlib::sdk::processor("H264Encoder")]
 pub struct H264EncoderProcessor {
-    /// Vulkan Video hardware encoder (shares RHI device).
+    /// Vulkan Video hardware encoder (built lazily from the first frame).
     encoder: Option<SimpleEncoder>,
 
-    /// GPU context for resolving VideoFrame textures.
+    /// GPU context for resolving VideoFrame textures and escalating to
+    /// full access for the one-shot lazy encoder construction.
     gpu_context: Option<GpuContextLimitedAccess>,
 
     /// Frames encoded counter.
@@ -40,72 +48,9 @@ pub struct H264EncoderProcessor {
 impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Processor {
     async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
-
-        let width = self.config.width.unwrap_or(1920);
-        let height = self.config.height.unwrap_or(1080);
-        let fps = self.config.fps.unwrap_or(60);
-
-        let encoder_config = SimpleEncoderConfig {
-            width,
-            height,
-            fps,
-            codec: Codec::H264,
-            preset: Preset::Medium,
-            streaming: true,
-            idr_interval_secs: self.config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
-            bitrate_bps: self.config.bitrate_bps,
-            prepend_header_to_idr: Some(true),
-            effort_level: self.config.effort_level,
-            ..Default::default()
-        };
-
-        // Create the encoder in setup(). The engine pre-warms every
-        // export-capable VMA pool at `HostVulkanDevice` construction
-        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md), so
-        // encoder allocations no longer race the display's swapchain.
-        let vulkan_device = Arc::clone(ctx.gpu_full_access().device().vulkan_device());
-
-        let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
-            Error::Runtime("GPU does not support Vulkan Video encode".into())
-        })?;
-        let encode_queue_family = vulkan_device.video_encode_queue_family_index().ok_or_else(|| {
-            Error::Runtime("No video encode queue family".into())
-        })?;
-
-        let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
-
-        let mut encoder = SimpleEncoder::from_device(
-            encoder_config,
-            vulkan_device.instance().clone(),
-            vulkan_device.device().clone(),
-            vulkan_device.physical_device(),
-            vulkan_device.allocator().clone(),
-            submitter,
-            encode_queue,
-            encode_queue_family,
-            vulkan_device.transfer_queue(),
-            vulkan_device.transfer_queue_family_index(),
-            vulkan_device.compute_queue().unwrap_or_else(|| vulkan_device.queue()),
-            vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
-        ).map_err(|e| {
-            Error::Runtime(format!("Failed to create H.264 encoder: {e}"))
-        })?;
-
-        // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
-        // per-plane views + compute pipeline) eagerly in setup. These are
-        // real resources the encoder needs at first frame; engine pre-warm
-        // already materialized the underlying VMA blocks so this no longer
-        // races NVIDIA's post-swapchain export cap.
-        encoder.prepare_gpu_encode_resources().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}"))
-        })?;
-
         tracing::info!(
-            "[H264Encoder] Initialized ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
-            width, height, fps
+            "[H264Encoder] Setup complete (encoder construction deferred to first frame)"
         );
-
-        self.encoder = Some(encoder);
         Ok(())
     }
 
@@ -129,6 +74,11 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
             .gpu_context
             .as_ref()
             .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+
+        if self.encoder.is_none() {
+            let encoder = build_encoder_lazily(gpu_ctx, &self.config, &frame)?;
+            self.encoder = Some(encoder);
+        }
 
         let encoder = self
             .encoder
@@ -181,5 +131,143 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
         }
 
         Ok(())
+    }
+}
+
+/// Resolve the encoder's (width, height, fps) from the first frame, treating
+/// `config.width` / `config.height` / `config.fps` as guardrails. Frame wins on
+/// mismatch (mirrors `frame.fps.unwrap_or(self.config.fps)` in `mp4_writer`).
+fn select_encoder_dims(
+    config_width: Option<u32>,
+    config_height: Option<u32>,
+    config_fps: Option<u32>,
+    frame_width: u32,
+    frame_height: u32,
+    frame_fps: Option<u32>,
+) -> (u32, u32, u32) {
+    if let Some(cw) = config_width {
+        if cw != frame_width {
+            tracing::warn!(
+                config_width = cw,
+                frame_width,
+                "[H264Encoder] Config width does not match incoming frame width; using frame width"
+            );
+        }
+    }
+    if let Some(ch) = config_height {
+        if ch != frame_height {
+            tracing::warn!(
+                config_height = ch,
+                frame_height,
+                "[H264Encoder] Config height does not match incoming frame height; using frame height"
+            );
+        }
+    }
+    let fps = frame_fps.unwrap_or_else(|| config_fps.unwrap_or(60));
+    (frame_width, frame_height, fps)
+}
+
+fn build_encoder_lazily(
+    gpu_ctx: &GpuContextLimitedAccess,
+    config: &crate::_generated_::H264EncoderConfig,
+    frame: &VideoFrame,
+) -> Result<SimpleEncoder> {
+    let (width, height, fps) = select_encoder_dims(
+        config.width,
+        config.height,
+        config.fps,
+        frame.width,
+        frame.height,
+        frame.fps,
+    );
+
+    let encoder_config = SimpleEncoderConfig {
+        width,
+        height,
+        fps,
+        codec: Codec::H264,
+        preset: Preset::Medium,
+        streaming: true,
+        idr_interval_secs: config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
+        bitrate_bps: config.bitrate_bps,
+        prepend_header_to_idr: Some(true),
+        effort_level: config.effort_level,
+        ..Default::default()
+    };
+
+    let encoder = gpu_ctx.escalate(|full| {
+        let vulkan_device = Arc::clone(full.device().vulkan_device());
+
+        let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
+            Error::Runtime("GPU does not support Vulkan Video encode".into())
+        })?;
+        let encode_queue_family = vulkan_device
+            .video_encode_queue_family_index()
+            .ok_or_else(|| Error::Runtime("No video encode queue family".into()))?;
+
+        let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
+
+        let mut encoder = SimpleEncoder::from_device(
+            encoder_config,
+            vulkan_device.instance().clone(),
+            vulkan_device.device().clone(),
+            vulkan_device.physical_device(),
+            vulkan_device.allocator().clone(),
+            submitter,
+            encode_queue,
+            encode_queue_family,
+            vulkan_device.transfer_queue(),
+            vulkan_device.transfer_queue_family_index(),
+            vulkan_device
+                .compute_queue()
+                .unwrap_or_else(|| vulkan_device.queue()),
+            vulkan_device
+                .compute_queue_family_index()
+                .unwrap_or_else(|| vulkan_device.queue_family_index()),
+        )
+        .map_err(|e| Error::Runtime(format!("Failed to create H.264 encoder: {e}")))?;
+
+        encoder
+            .prepare_gpu_encode_resources()
+            .map_err(|e| Error::Runtime(format!("Failed to pre-allocate H.264 encode resources: {e}")))?;
+
+        Ok(encoder)
+    })?;
+
+    tracing::info!(
+        "[H264Encoder] Initialized lazily ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
+        width,
+        height,
+        fps
+    );
+
+    Ok(encoder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_encoder_dims;
+
+    #[test]
+    fn frame_dimensions_win_over_config() {
+        let (w, h, fps) =
+            select_encoder_dims(Some(1920), Some(1080), Some(60), 1280, 720, Some(30));
+        assert_eq!((w, h, fps), (1280, 720, 30));
+    }
+
+    #[test]
+    fn frame_fps_falls_back_to_config_then_default() {
+        let (_, _, fps_from_config) =
+            select_encoder_dims(None, None, Some(24), 1280, 720, None);
+        assert_eq!(fps_from_config, 24);
+
+        let (_, _, fps_default) = select_encoder_dims(None, None, None, 1280, 720, None);
+        assert_eq!(fps_default, 60);
+    }
+
+    #[test]
+    fn missing_config_dims_still_use_frame_dims() {
+        let (w, h, _) = select_encoder_dims(None, None, None, 3840, 2160, Some(30));
+        assert_eq!((w, h), (3840, 2160));
     }
 }

--- a/packages/h265/schemas/h265_encoder_config.yaml
+++ b/packages/h265/schemas/h265_encoder_config.yaml
@@ -10,11 +10,11 @@ metadata:
 optionalProperties:
   width:
     metadata:
-      description: "Video width in pixels (default: 1280)."
+      description: "Optional override / guardrail for video width in pixels. Unset = the encoder takes the width from the first VideoFrame it receives. Set values that disagree with the frame width log a warning and the frame still wins, matching the FPS pattern."
     type: uint32
   height:
     metadata:
-      description: "Video height in pixels (default: 720)."
+      description: "Optional override / guardrail for video height in pixels. Unset = the encoder takes the height from the first VideoFrame it receives. Set values that disagree with the frame height log a warning and the frame still wins, matching the FPS pattern."
     type: uint32
   bitrate_bps:
     metadata:

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -38,11 +38,15 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
     async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
+        // Decoder dimensions come from H.265 SPS — leaving `max_width` /
+        // `max_height` at zero tells `SimpleDecoder` to size the DPB and
+        // video session from the first parsed SPS rather than pre-allocating
+        // for a hard-coded resolution cap.
         let decoder_config = SimpleDecoderConfig {
             codec: Codec::H265,
             rgba_output: true,
-            max_width: 1920,
-            max_height: 1080,
+            max_width: 0,
+            max_height: 0,
             ..Default::default()
         };
 
@@ -57,7 +61,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
 
         let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
 
-        let mut decoder = SimpleDecoder::from_device(
+        let decoder = SimpleDecoder::from_device(
             decoder_config,
             vulkan_device.instance().clone(),
             vulkan_device.device().clone(),
@@ -72,19 +76,12 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
             Error::Runtime(format!("Failed to create H.265 decoder: {e}"))
         })?;
 
-        // Pre-create the video session BEFORE the display swapchain.
-        // NVIDIA limits video session creation after swapchain exists.
-        decoder.pre_initialize_session().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-initialize H.265 decoder session: {e}"))
-        })?;
-
-        // Eagerly allocate the NV12→RGBA converter. Decode-side resources
-        // are real allocations the decoder needs; the engine pre-warms the
-        // exportable VMA pools at `HostVulkanDevice` construction so this
-        // no longer races NVIDIA's post-swapchain exportable cap.
-        decoder.prepare_gpu_decode_resources().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-allocate H.265 decode resources: {e}"))
-        })?;
+        // Session creation, DPB allocation, and the NV12→RGBA converter are
+        // built lazily inside `SimpleDecoder::feed()` once the first SPS
+        // arrives — at that point the actual coded extent is known and
+        // sized to match. The processor-setup mutex inside `escalate` and
+        // the RHI queue submitter coordinate device-side ordering, so the
+        // historical pre-swapchain pre-init is no longer required.
 
         tracing::info!("[H265Decoder] Initialized (shared RHI device, Vulkan Video hardware)");
 

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -7,6 +7,13 @@
 // HostVulkanDevice. The encoder shares streamlib's Vulkan device, VMA allocator,
 // and queues — no separate device creation, no NVIDIA dual-device crash.
 //
+// The encoder is constructed lazily on the first VideoFrame so its session
+// dimensions track the upstream frame size. Config width/height become
+// guardrails (mismatch logs a warning, frame wins) mirroring how `frame.fps`
+// flows through `mp4_writer`. Privileged resource construction runs inside
+// `GpuContextLimitedAccess::escalate(|full| …)` so the processor-setup mutex
+// and `device_wait_idle` order it against the rest of the GPU work.
+//
 // The camera's GPU-resident textures are on the same device, so encode_image()
 // accepts them directly (zero-copy).
 
@@ -27,10 +34,11 @@ use vulkan_video::{Codec, Preset, SimpleEncoder, SimpleEncoderConfig};
 
 #[streamlib::sdk::processor("H265Encoder")]
 pub struct H265EncoderProcessor {
-    /// Vulkan Video hardware encoder (shares RHI device).
+    /// Vulkan Video hardware encoder (built lazily from the first frame).
     encoder: Option<SimpleEncoder>,
 
-    /// GPU context for resolving VideoFrame textures.
+    /// GPU context for resolving VideoFrame textures and escalating to
+    /// full access for the one-shot lazy encoder construction.
     gpu_context: Option<GpuContextLimitedAccess>,
 
     /// Frames encoded counter.
@@ -40,72 +48,9 @@ pub struct H265EncoderProcessor {
 impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Processor {
     async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
-
-        let width = self.config.width.unwrap_or(1920);
-        let height = self.config.height.unwrap_or(1080);
-        let fps = self.config.fps.unwrap_or(60);
-
-        let encoder_config = SimpleEncoderConfig {
-            width,
-            height,
-            fps,
-            codec: Codec::H265,
-            preset: Preset::Medium,
-            streaming: true,
-            idr_interval_secs: self.config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
-            bitrate_bps: self.config.bitrate_bps,
-            prepend_header_to_idr: Some(true),
-            effort_level: self.config.effort_level,
-            ..Default::default()
-        };
-
-        // Create the encoder in setup(). The engine pre-warms every
-        // export-capable VMA pool at `HostVulkanDevice` construction
-        // (see docs/learnings/nvidia-dma-buf-after-swapchain.md), so
-        // encoder allocations no longer race the display's swapchain.
-        let vulkan_device = Arc::clone(ctx.gpu_full_access().device().vulkan_device());
-
-        let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
-            Error::Runtime("GPU does not support Vulkan Video encode".into())
-        })?;
-        let encode_queue_family = vulkan_device.video_encode_queue_family_index().ok_or_else(|| {
-            Error::Runtime("No video encode queue family".into())
-        })?;
-
-        let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
-
-        let mut encoder = SimpleEncoder::from_device(
-            encoder_config,
-            vulkan_device.instance().clone(),
-            vulkan_device.device().clone(),
-            vulkan_device.physical_device(),
-            vulkan_device.allocator().clone(),
-            submitter,
-            encode_queue,
-            encode_queue_family,
-            vulkan_device.transfer_queue(),
-            vulkan_device.transfer_queue_family_index(),
-            vulkan_device.compute_queue().unwrap_or_else(|| vulkan_device.queue()),
-            vulkan_device.compute_queue_family_index().unwrap_or_else(|| vulkan_device.queue_family_index()),
-        ).map_err(|e| {
-            Error::Runtime(format!("Failed to create H.265 encoder: {e}"))
-        })?;
-
-        // Allocate the RGB→NV12 converter (NV12 DEVICE_LOCAL VkImage +
-        // per-plane views + compute pipeline) eagerly in setup. These are
-        // real resources the encoder needs at first frame; engine pre-warm
-        // already materialized the underlying VMA blocks so this no longer
-        // races NVIDIA's post-swapchain export cap.
-        encoder.prepare_gpu_encode_resources().map_err(|e| {
-            Error::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}"))
-        })?;
-
         tracing::info!(
-            "[H265Encoder] Initialized ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
-            width, height, fps
+            "[H265Encoder] Setup complete (encoder construction deferred to first frame)"
         );
-
-        self.encoder = Some(encoder);
         Ok(())
     }
 
@@ -129,6 +74,11 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
             .gpu_context
             .as_ref()
             .ok_or_else(|| Error::Runtime("GPU context not initialized".into()))?;
+
+        if self.encoder.is_none() {
+            let encoder = build_encoder_lazily(gpu_ctx, &self.config, &frame)?;
+            self.encoder = Some(encoder);
+        }
 
         let encoder = self
             .encoder
@@ -181,5 +131,143 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
         }
 
         Ok(())
+    }
+}
+
+/// Resolve the encoder's (width, height, fps) from the first frame, treating
+/// `config.width` / `config.height` / `config.fps` as guardrails. Frame wins on
+/// mismatch (mirrors `frame.fps.unwrap_or(self.config.fps)` in `mp4_writer`).
+fn select_encoder_dims(
+    config_width: Option<u32>,
+    config_height: Option<u32>,
+    config_fps: Option<u32>,
+    frame_width: u32,
+    frame_height: u32,
+    frame_fps: Option<u32>,
+) -> (u32, u32, u32) {
+    if let Some(cw) = config_width {
+        if cw != frame_width {
+            tracing::warn!(
+                config_width = cw,
+                frame_width,
+                "[H265Encoder] Config width does not match incoming frame width; using frame width"
+            );
+        }
+    }
+    if let Some(ch) = config_height {
+        if ch != frame_height {
+            tracing::warn!(
+                config_height = ch,
+                frame_height,
+                "[H265Encoder] Config height does not match incoming frame height; using frame height"
+            );
+        }
+    }
+    let fps = frame_fps.unwrap_or_else(|| config_fps.unwrap_or(60));
+    (frame_width, frame_height, fps)
+}
+
+fn build_encoder_lazily(
+    gpu_ctx: &GpuContextLimitedAccess,
+    config: &crate::_generated_::H265EncoderConfig,
+    frame: &VideoFrame,
+) -> Result<SimpleEncoder> {
+    let (width, height, fps) = select_encoder_dims(
+        config.width,
+        config.height,
+        config.fps,
+        frame.width,
+        frame.height,
+        frame.fps,
+    );
+
+    let encoder_config = SimpleEncoderConfig {
+        width,
+        height,
+        fps,
+        codec: Codec::H265,
+        preset: Preset::Medium,
+        streaming: true,
+        idr_interval_secs: config.keyframe_interval_seconds.unwrap_or(2.0) as u32,
+        bitrate_bps: config.bitrate_bps,
+        prepend_header_to_idr: Some(true),
+        effort_level: config.effort_level,
+        ..Default::default()
+    };
+
+    let encoder = gpu_ctx.escalate(|full| {
+        let vulkan_device = Arc::clone(full.device().vulkan_device());
+
+        let encode_queue = vulkan_device.video_encode_queue().ok_or_else(|| {
+            Error::Runtime("GPU does not support Vulkan Video encode".into())
+        })?;
+        let encode_queue_family = vulkan_device
+            .video_encode_queue_family_index()
+            .ok_or_else(|| Error::Runtime("No video encode queue family".into()))?;
+
+        let submitter: Arc<dyn vulkan_video::RhiQueueSubmitter> = vulkan_device.clone();
+
+        let mut encoder = SimpleEncoder::from_device(
+            encoder_config,
+            vulkan_device.instance().clone(),
+            vulkan_device.device().clone(),
+            vulkan_device.physical_device(),
+            vulkan_device.allocator().clone(),
+            submitter,
+            encode_queue,
+            encode_queue_family,
+            vulkan_device.transfer_queue(),
+            vulkan_device.transfer_queue_family_index(),
+            vulkan_device
+                .compute_queue()
+                .unwrap_or_else(|| vulkan_device.queue()),
+            vulkan_device
+                .compute_queue_family_index()
+                .unwrap_or_else(|| vulkan_device.queue_family_index()),
+        )
+        .map_err(|e| Error::Runtime(format!("Failed to create H.265 encoder: {e}")))?;
+
+        encoder
+            .prepare_gpu_encode_resources()
+            .map_err(|e| Error::Runtime(format!("Failed to pre-allocate H.265 encode resources: {e}")))?;
+
+        Ok(encoder)
+    })?;
+
+    tracing::info!(
+        "[H265Encoder] Initialized lazily ({}x{}, {}fps, shared RHI device, Vulkan Video hardware)",
+        width,
+        height,
+        fps
+    );
+
+    Ok(encoder)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_encoder_dims;
+
+    #[test]
+    fn frame_dimensions_win_over_config() {
+        let (w, h, fps) =
+            select_encoder_dims(Some(1920), Some(1080), Some(60), 1280, 720, Some(30));
+        assert_eq!((w, h, fps), (1280, 720, 30));
+    }
+
+    #[test]
+    fn frame_fps_falls_back_to_config_then_default() {
+        let (_, _, fps_from_config) =
+            select_encoder_dims(None, None, Some(24), 1280, 720, None);
+        assert_eq!(fps_from_config, 24);
+
+        let (_, _, fps_default) = select_encoder_dims(None, None, None, 1280, 720, None);
+        assert_eq!(fps_default, 60);
+    }
+
+    #[test]
+    fn missing_config_dims_still_use_frame_dims() {
+        let (w, h, _) = select_encoder_dims(None, None, None, 3840, 2160, Some(30));
+        assert_eq!((w, h), (3840, 2160));
     }
 }


### PR DESCRIPTION
## Summary
- Encoder lazy first-frame init via `escalate(|full| …)`, `select_encoder_dims` resolves frame-wins-over-config + warning on mismatch (h264 + h265 + 3 unit tests each); decoder DPB switched to SPS-driven (`max_width: 0`, `max_height: 0`, no `pre_initialize_session`); `CameraConfig::max_width` / `max_height` replace the hardcoded V4L2 cap.
- `EncodedVideoFrame.max_payload_bytes` 512 KiB → 16 MiB so the encoder's first IDR (with prepended SPS+PPS) survives the iceoryx2 publisher; required to ship #810 end-to-end (the IDR-drop is what was masking the decoder's correctness in #272's era).
- Examples sweep: `vulkan-video-roundtrip`, `camera-display`, `moq-roundtrip`, `vulkan-video-psnr` each gain a `streamlib.yaml` declaring `@tatolab/core` + a `runtime.load_project(...)` call. Without it the post-#727 schema-registry refactor makes any consumer of `Runner::new()` size publishers from the 64 KiB default and drop IDRs.

## Closes
Closes #810

## Exit criteria
- [x] Encoders (h264, h265) read dimensions from the first `VideoFrame`, lazily configuring the Vulkan video session + GPU resources. Config dims become an override / guardrail.
- [x] `CameraConfig::max_width` / `max_height` field exists with default 1920×1080; the camera cap reads from it.
- [x] `examples/vulkan-video-roundtrip` and `examples/camera-display` run end-to-end at a non-1080p resolution without hand-editing processor Configs (env-var override on the camera cap; encoder Configs no longer carry literals).
- [x] Schema/code default drift in encoder Config resolved (1280×720 docstring literals removed; the schema now describes width/height as override/guardrail).

## Architecture notes — what changed vs. the issue body

The issue body's "encoders defer `from_device` … satisfied vs the pre-swapchain allocation rule because export pools are pre-warmed" framing was research-locked before sandboxing landed. Re-derived during pickup: the real coordination that makes lazy encoder init safe today is the capability split (`GpuContextLimitedAccess::escalate` acquires the processor-setup mutex and runs `device_wait_idle` after the closure) plus the RHI queue submitter. Commit `37724009` (the historical lazy-init revert) cited "NVIDIA limits DMA-BUF exportable allocations after swapchain creation" but predated #624 (export-pool pre-warm) and the sandboxing milestone. The lazy path is now the right shape — kept the same `from_device` API, just wrapped in `escalate(|full| …)`.

The decoder's `pre_initialize_session` was added in #272 for the same NVIDIA video-session-post-swapchain race. With the queue mutex serializing video session creation, it's no longer required — `configure_session()` runs lazily from the first parsed SPS at the actual coded extent.

`EncodedVideoFrame.max_payload_bytes: 16777216` (16 MiB) is sized for a 4K H.264/H.265 IDR with prepended SPS+PPS under default rate control (1080p IDR ≈ 2–3 MiB; 4K ≈ 8–12 MiB). The 256 MiB-per-publisher shm cost (16 slots × 16 MiB) is the price of supporting up-to-4K real-time encode end-to-end without dropping the first IDR. Production-grade headroom rather than just-enough-for-720p — matches the drone-racing 4K future use case and avoids re-bumping when that lands.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] Unit tests (`streamlib-h264`, `streamlib-h265`, `streamlib-camera`, `vulkan-video`) — 632 passed (5 ignored)
- [x] E2E `vulkan-video-roundtrip` h264 @ 1280×720 vivid — 50 encoded / 50 decoded, 0 `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed`
- [x] E2E `vulkan-video-roundtrip` h264 @ 1920×1080 vivid regression — 40 / 40, 0 errors
- [x] E2E `vulkan-video-roundtrip` h265 @ 1280×720 vivid — 50 / 50, 0 errors
- [x] E2E `vulkan-video-roundtrip` h265 @ 1920×1080 vivid regression — 40 / 40, 0 errors
- [x] E2E `camera-display` @ 1280×720 vivid (post-sweep) — 60 frames, 0 errors
- [ ] Cam Link 4K @ 1080p — hardware not connected during this run
- [ ] v4l2loopback motion + fixture PSNR rig — deferred until #815 lands (visual content depends on the same NV12↔RGBA shaders that #815 replaces, so any PSNR run today would measure the bug, not the fix)

## Known visual artifact — covered by #815
PNG samples at every resolution show the "green vivid" tint (predominantly green vs. expected rainbow color bars). This is the exact "green vivid symptom" called out verbatim in #815's body — the three hand-rolled YUV→RGB shaders (`packages/camera/.../nv12_to_rgba.comp`, `libs/streamlib-engine/.../nv12_to_bgra.comp`, `libs/vulkan-video/src/nv12_to_rgb.rs`) read raw V4L2 quantization bytes instead of consuming `frame.color_info.range`. #815 replaces all three with the engine-owned `VulkanColorConverter` driven by `ColorInfo` push constants. The mechanical pipeline this PR delivers is independent and correct; the chroma shaders ride a separate engine-tier deliverable.

## Follow-ups
- [`select_encoder_dims`] No test asserts the `tracing::warn!` fires on a config/frame mismatch. Frame-wins behavior is locked; warn-fired behavior is feel-good only. Marginal value vs. tracing-test wiring cost — left as-is. If it matters, a small `tracing_test::traced_test`-based test would slot in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)