### PR TITLE
feat(display): negotiate VkColorSpaceKHR from frame ColorInfo + wire vkSetHdrMetadataEXT (#817)

### DIFF
--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -74,6 +74,13 @@ pub use vulkan_present_target::{
     PresentFrame, VulkanPresentTarget, MAX_FRAMES_IN_FLIGHT,
 };
 
+#[cfg(target_os = "linux")]
+mod vulkan_swapchain_colorspace;
+#[cfg(target_os = "linux")]
+pub use vulkan_swapchain_colorspace::{
+    build_hdr_metadata, pick_swapchain_format, SwapchainColorPick,
+};
+
 mod vulkan_texture_cache;
 pub use vulkan_texture_cache::VulkanTextureCache;
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -55,6 +55,13 @@ pub struct HostVulkanDevice {
     /// available; this acquire-side extension is the only meaningful
     /// gate.
     has_acquire_unmodified: bool,
+    /// Whether `VK_EXT_hdr_metadata` was enabled at device creation.
+    /// Gates `vkSetHdrMetadataEXT`, the per-swapchain HDR static metadata
+    /// (mastering display + content light) attachment that drives the
+    /// driver's tone-mapping / color-volume signaling on transition into
+    /// a PQ/HLG colorspace. Useful only alongside `VK_KHR_swapchain` and
+    /// the instance-level `VK_EXT_swapchain_colorspace`.
+    has_hdr_metadata: bool,
     /// Whether the `VK_KHR_ray_tracing_pipeline` extension chain
     /// (acceleration_structure + ray_tracing_pipeline +
     /// deferred_host_operations + pipeline_library) was enabled at
@@ -371,6 +378,18 @@ impl HostVulkanDevice {
             if available_ext_names.contains(&headless_ext) {
                 instance_extensions.push(headless_ext.as_ptr());
                 tracing::info!("VK_EXT_headless_surface available");
+            }
+
+            // VK_EXT_swapchain_colorspace — exposes the wide-gamut + HDR
+            // VkColorSpaceKHR enumerants (HDR10_ST2084_EXT,
+            // EXTENDED_SRGB_LINEAR_EXT, DISPLAY_P3_*, BT709_*, etc.)
+            // through `vkGetPhysicalDeviceSurfaceFormatsKHR`. Without it,
+            // every WSI surface advertises only `SRGB_NONLINEAR_KHR` and
+            // the swapchain colorspace priority walk has nothing to walk.
+            let swapchain_colorspace_ext = c"VK_EXT_swapchain_colorspace";
+            if available_ext_names.contains(&swapchain_colorspace_ext) {
+                instance_extensions.push(swapchain_colorspace_ext.as_ptr());
+                tracing::info!("VK_EXT_swapchain_colorspace enabled");
             }
         }
 
@@ -765,7 +784,7 @@ impl HostVulkanDevice {
 
         // On Linux, enable VK_KHR_swapchain for windowed display rendering
         #[cfg(target_os = "linux")]
-        {
+        let has_hdr_metadata = {
             let swapchain_ext = c"VK_KHR_swapchain";
             if available_device_ext_names.contains(&swapchain_ext) {
                 device_extensions.push(swapchain_ext.as_ptr());
@@ -774,7 +793,22 @@ impl HostVulkanDevice {
 
             // VK_KHR_dynamic_rendering is core since Vulkan 1.3 — no extension string needed.
             // Feature struct (PhysicalDeviceDynamicRenderingFeatures) is still enabled below.
-        }
+
+            // VK_EXT_hdr_metadata — gates `vkSetHdrMetadataEXT`, which
+            // attaches `VkHdrMetadataEXT` (mastering display + content
+            // light) to a swapchain on transition into a PQ/HLG
+            // colorspace. Only useful alongside `VK_KHR_swapchain` and
+            // the instance-level `VK_EXT_swapchain_colorspace`.
+            let hdr_metadata_ext = c"VK_EXT_hdr_metadata";
+            let probe = available_device_ext_names.contains(&hdr_metadata_ext);
+            if probe {
+                device_extensions.push(hdr_metadata_ext.as_ptr());
+                tracing::info!("VK_EXT_hdr_metadata enabled");
+            }
+            probe
+        };
+        #[cfg(not(target_os = "linux"))]
+        let has_hdr_metadata = false;
 
         // On Linux, check for Vulkan Video encode extensions
         // VK_KHR_synchronization2 is core since Vulkan 1.3 — no extension string needed.
@@ -1186,13 +1220,14 @@ impl HostVulkanDevice {
         };
 
         tracing::info!(
-            "Vulkan device initialized: {} (queue family {}, {} memory types, external_memory={}, cross_device_dma_buf_probe={}, acquire_unmodified={}, ray_tracing={}, vma=enabled, dma_buf_pools={})",
+            "Vulkan device initialized: {} (queue family {}, {} memory types, external_memory={}, cross_device_dma_buf_probe={}, acquire_unmodified={}, hdr_metadata={}, ray_tracing={}, vma=enabled, dma_buf_pools={})",
             device_name,
             queue_family_index,
             memory_properties.memory_type_count,
             supports_external_memory,
             supports_cross_device_dma_buf_probe,
             has_acquire_unmodified,
+            has_hdr_metadata,
             has_ray_tracing_pipeline,
             {
                 #[cfg(target_os = "linux")]
@@ -1216,6 +1251,7 @@ impl HostVulkanDevice {
             supports_external_memory,
             supports_cross_device_dma_buf_probe,
             has_acquire_unmodified,
+            has_hdr_metadata,
             has_ray_tracing_pipeline,
             ray_tracing_properties,
             supports_video_encode,
@@ -2622,6 +2658,16 @@ impl HostVulkanDevice {
     /// list as of 2026-05-03); Mesa is the eventual landing point.
     pub fn supports_qfot_acquire_unmodified(&self) -> bool {
         self.has_acquire_unmodified
+    }
+
+    /// Whether `VK_EXT_hdr_metadata` was enabled at device construction.
+    /// Gates `vkSetHdrMetadataEXT` — the per-swapchain HDR static metadata
+    /// (mastering display + content light) attachment that signals
+    /// driver-side tone-mapping / color-volume on transition into a
+    /// PQ/HLG colorspace. Useful only alongside `VK_KHR_swapchain` and
+    /// the instance-level `VK_EXT_swapchain_colorspace`.
+    pub fn supports_hdr_metadata(&self) -> bool {
+        self.has_hdr_metadata
     }
 
     /// Whether the `VK_KHR_ray_tracing_pipeline` extension chain

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
@@ -8,14 +8,17 @@ use std::sync::Arc;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
+use vulkanalia::vk::ExtHdrMetadataExtensionDeviceCommands as _;
 use vulkanalia::vk::KhrSurfaceExtensionInstanceCommands as _;
 use vulkanalia::vk::KhrSwapchainExtensionDeviceCommands as _;
 
+use crate::_generated_::{ColorInfo, ContentLight, MasteringDisplay};
 use crate::core::rhi::TextureFormat;
 use crate::core::{Error, Result};
 
 use super::vulkan_command_recorder::RhiCommandRecorder;
 use super::vulkan_pipeline_flags::VulkanStage;
+use super::vulkan_swapchain_colorspace::{build_hdr_metadata, pick_swapchain_format, SwapchainColorPick};
 use super::vulkan_sync::HostVulkanTimelineSemaphore;
 use super::HostVulkanDevice;
 
@@ -41,6 +44,17 @@ pub struct VulkanPresentTarget {
     swapchain_format: vk::Format,
     swapchain_extent: vk::Extent2D,
     color_format: TextureFormat,
+    /// Negotiated `(format, color_space, is_hdr)` from the surface's
+    /// exposed format list and the most recent `ColorInfo` hint. Read
+    /// by [`Self::set_hdr_metadata`] to short-circuit when the current
+    /// colorspace is not HDR-signaling.
+    color_pick: SwapchainColorPick,
+    /// Cached most-recent `vk::HdrMetadataEXT` payload pushed to the
+    /// driver via `vkSetHdrMetadataEXT`. Carried so consecutive
+    /// identical metadata pushes (every-frame call sites) compress to
+    /// zero driver round-trips. `None` until the first successful
+    /// push.
+    last_hdr_metadata: Option<vk::HdrMetadataEXT>,
     vsync: bool,
 
     /// Per-swapchain-image binary semaphore signaled when rendering for
@@ -98,16 +112,19 @@ struct PresentFrameInner {
 
 impl VulkanPresentTarget {
     /// Build a present target bound to `window` at the requested initial
-    /// extent + vsync preference. The window handle must outlive the
-    /// present target; dropping the target destroys the surface +
-    /// swapchain + per-frame resources.
-    #[tracing::instrument(level = "trace", skip(device, window), fields(width, height, vsync))]
+    /// extent + vsync preference. `color_info` drives the
+    /// `VkColorSpaceKHR` priority walk; `None` keeps the legacy SDR
+    /// pick (`B8G8R8A8_UNORM` + `SRGB_NONLINEAR`). The window handle
+    /// must outlive the present target; dropping the target destroys
+    /// the surface + swapchain + per-frame resources.
+    #[tracing::instrument(level = "trace", skip(device, window, color_info), fields(width, height, vsync))]
     pub fn new(
         device: &Arc<HostVulkanDevice>,
         window: &(impl HasWindowHandle + HasDisplayHandle),
         width: u32,
         height: u32,
         vsync: bool,
+        color_info: Option<&ColorInfo>,
     ) -> Result<Self> {
         let instance = device.instance();
         let surface = unsafe { vulkanalia::window::create_surface(instance, window, window) }
@@ -136,8 +153,22 @@ impl VulkanPresentTarget {
             ));
         }
 
-        let (swapchain, swapchain_images, swapchain_image_views, swapchain_format, swapchain_extent) =
-            create_swapchain(device, surface, width, height, vsync, vk::SwapchainKHR::null())?;
+        let (
+            swapchain,
+            swapchain_images,
+            swapchain_image_views,
+            swapchain_format,
+            swapchain_extent,
+            color_pick,
+        ) = create_swapchain(
+            device,
+            surface,
+            width,
+            height,
+            vsync,
+            color_info,
+            vk::SwapchainKHR::null(),
+        )?;
 
         let color_format = vk_format_to_texture_format(swapchain_format).ok_or_else(|| {
             Error::GpuError(format!(
@@ -192,6 +223,8 @@ impl VulkanPresentTarget {
             swapchain_format,
             swapchain_extent,
             color_format,
+            color_pick,
+            last_hdr_metadata: None,
             vsync,
             render_finished_semaphores,
             image_available_semaphores,
@@ -204,9 +237,16 @@ impl VulkanPresentTarget {
 
     /// Recreate the swapchain for a new window extent (driven by the
     /// caller's resize handling or an `OUT_OF_DATE_KHR` return from
-    /// [`Self::render_frame`]).
-    #[tracing::instrument(level = "trace", skip(self), fields(width, height))]
-    pub fn recreate(&mut self, width: u32, height: u32) -> Result<()> {
+    /// [`Self::render_frame`]) or a new `ColorInfo` hint (driven by
+    /// first-frame inspection or mid-stream color change). Passing
+    /// `None` for `color_info` keeps the legacy SDR pick.
+    #[tracing::instrument(level = "trace", skip(self, color_info), fields(width, height))]
+    pub fn recreate(
+        &mut self,
+        width: u32,
+        height: u32,
+        color_info: Option<&ColorInfo>,
+    ) -> Result<()> {
         // Drain in-flight work before destroying the old swapchain.
         // `wait_idle()` takes the queue mutexes so it doesn't race with
         // an active submit on another thread.
@@ -217,14 +257,16 @@ impl VulkanPresentTarget {
         })?;
 
         let raw_device = self.device.device();
-        let (new_swapchain, new_images, new_views, new_format, new_extent) = create_swapchain(
-            &self.device,
-            self.surface,
-            width,
-            height,
-            self.vsync,
-            self.swapchain,
-        )?;
+        let (new_swapchain, new_images, new_views, new_format, new_extent, new_color_pick) =
+            create_swapchain(
+                &self.device,
+                self.surface,
+                width,
+                height,
+                self.vsync,
+                color_info,
+                self.swapchain,
+            )?;
 
         // Destroy old swapchain resources after successful recreate.
         unsafe {
@@ -261,6 +303,15 @@ impl VulkanPresentTarget {
         // overwrite anyway in case the surface caps changed.
         self.swapchain_format = new_format;
         self.swapchain_extent = new_extent;
+        // Update the cached colorspace pick. If the colorspace changed
+        // (SDR → HDR or vice versa, or one HDR variant → another),
+        // any previously-pushed `vkSetHdrMetadataEXT` payload is no
+        // longer valid for the new swapchain — clear the cache so the
+        // next `set_hdr_metadata` call re-pushes.
+        if new_color_pick != self.color_pick {
+            self.last_hdr_metadata = None;
+        }
+        self.color_pick = new_color_pick;
         // current_frame stays — slots are independent of swapchain count.
         Ok(())
     }
@@ -273,6 +324,49 @@ impl VulkanPresentTarget {
     /// Current swapchain extent (width, height).
     pub fn current_extent(&self) -> (u32, u32) {
         (self.swapchain_extent.width, self.swapchain_extent.height)
+    }
+
+    /// Last-negotiated `(format, colorspace, is_hdr)` triple. The
+    /// display processor uses this to decide whether to push HDR
+    /// metadata via [`Self::set_hdr_metadata`].
+    pub fn color_pick(&self) -> SwapchainColorPick {
+        self.color_pick
+    }
+
+    /// Push HDR static metadata to the driver via
+    /// `vkSetHdrMetadataEXT`. No-op when the current swapchain
+    /// colorspace is not one of the HDR signaling variants
+    /// (PQ / HLG), or when `VK_EXT_hdr_metadata` was not enabled at
+    /// device construction. Subsequent calls with byte-identical
+    /// metadata short-circuit to avoid redundant driver round-trips.
+    pub fn set_hdr_metadata(
+        &mut self,
+        mastering: &MasteringDisplay,
+        content_light: &ContentLight,
+    ) -> Result<()> {
+        if !self.color_pick.is_hdr {
+            return Ok(());
+        }
+        if !self.device.supports_hdr_metadata() {
+            tracing::debug!(
+                "VulkanPresentTarget::set_hdr_metadata: skipped — \
+                 VK_EXT_hdr_metadata not enabled at device construction"
+            );
+            return Ok(());
+        }
+        let metadata = build_hdr_metadata(mastering, content_light);
+        if hdr_metadata_eq(self.last_hdr_metadata.as_ref(), &metadata) {
+            return Ok(());
+        }
+        let swapchains = [self.swapchain];
+        let metadatas = [metadata];
+        // Safety: device is alive (we hold an Arc); swapchain is the
+        // currently-owned handle; metadata array is stack-allocated
+        // and lives across the call. The driver is required to read
+        // through the pointers before returning per spec.
+        unsafe { self.device.device().set_hdr_metadata_ext(&swapchains, &metadatas) };
+        self.last_hdr_metadata = Some(metadata);
+        Ok(())
     }
 
     /// Acquire the next swapchain image, run the caller's `render`
@@ -599,14 +693,17 @@ impl Drop for VulkanPresentTarget {
 unsafe impl Send for VulkanPresentTarget {}
 unsafe impl Sync for VulkanPresentTarget {}
 
-/// Engine-internal: surface + dimensions → swapchain handle chain.
-/// Returns `(swapchain, images, image_views, format, extent)`.
+/// Engine-internal: surface + dimensions + ColorInfo hint → swapchain
+/// handle chain. Returns `(swapchain, images, image_views, format,
+/// extent, color_pick)`. Colorspace negotiation is delegated to
+/// [`pick_swapchain_format`].
 fn create_swapchain(
     device: &Arc<HostVulkanDevice>,
     surface: vk::SurfaceKHR,
     width: u32,
     height: u32,
     vsync: bool,
+    color_info: Option<&ColorInfo>,
     old_swapchain: vk::SwapchainKHR,
 ) -> Result<(
     vk::SwapchainKHR,
@@ -614,6 +711,7 @@ fn create_swapchain(
     Vec<vk::ImageView>,
     vk::Format,
     vk::Extent2D,
+    SwapchainColorPick,
 )> {
     let instance = device.instance();
     let physical_device = device.physical_device();
@@ -646,14 +744,26 @@ fn create_swapchain(
         ))
     })?;
 
-    let chosen_format = surface_formats
-        .iter()
-        .find(|f| {
-            f.format == vk::Format::B8G8R8A8_UNORM
-                && f.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
-        })
-        .copied()
-        .unwrap_or(surface_formats[0]);
+    if surface_formats.is_empty() {
+        return Err(Error::GpuError(
+            "VulkanPresentTarget: surface advertised no formats — \
+             vkGetPhysicalDeviceSurfaceFormatsKHR returned an empty list"
+                .into(),
+        ));
+    }
+
+    let color_pick = pick_swapchain_format(&surface_formats, color_info);
+    let chosen_format = vk::SurfaceFormatKHR {
+        format: color_pick.format,
+        color_space: color_pick.color_space,
+    };
+    tracing::info!(
+        "VulkanPresentTarget: swapchain colorspace pick {:?} + {:?} (is_hdr={}, color_info={:?})",
+        chosen_format.format,
+        chosen_format.color_space,
+        color_pick.is_hdr,
+        color_info,
+    );
 
     let present_mode = if vsync {
         vk::PresentModeKHR::FIFO
@@ -744,7 +854,14 @@ fn create_swapchain(
         image_views.push(view);
     }
 
-    Ok((swapchain, images, image_views, chosen_format.format, extent))
+    Ok((
+        swapchain,
+        images,
+        image_views,
+        chosen_format.format,
+        extent,
+        color_pick,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -795,6 +912,27 @@ fn record_swapchain_barrier(
 /// duplicating an `Arc<HostVulkanDevice>` field on `PresentFrame`.
 fn recorder_device(recorder: &RhiCommandRecorder) -> &vulkanalia::Device {
     recorder.vulkan_device_ref().device()
+}
+
+/// Field-wise equality for `vk::HdrMetadataEXT`. The struct has no
+/// `PartialEq` impl in vulkanalia (it carries `*const c_void` for the
+/// `pNext` chain — never compared here since we always pass `null()`),
+/// so we compare the spec-significant fields directly. Used to
+/// short-circuit redundant `vkSetHdrMetadataEXT` round-trips.
+fn hdr_metadata_eq(a: Option<&vk::HdrMetadataEXT>, b: &vk::HdrMetadataEXT) -> bool {
+    let Some(a) = a else { return false };
+    a.display_primary_red.x == b.display_primary_red.x
+        && a.display_primary_red.y == b.display_primary_red.y
+        && a.display_primary_green.x == b.display_primary_green.x
+        && a.display_primary_green.y == b.display_primary_green.y
+        && a.display_primary_blue.x == b.display_primary_blue.x
+        && a.display_primary_blue.y == b.display_primary_blue.y
+        && a.white_point.x == b.white_point.x
+        && a.white_point.y == b.white_point.y
+        && a.max_luminance == b.max_luminance
+        && a.min_luminance == b.min_luminance
+        && a.max_content_light_level == b.max_content_light_level
+        && a.max_frame_average_light_level == b.max_frame_average_light_level
 }
 
 fn vk_format_to_texture_format(format: vk::Format) -> Option<TextureFormat> {

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
@@ -766,22 +766,7 @@ fn create_swapchain(
         ));
     }
 
-    // Filter the surface-exposed formats to those the engine's
-    // [`vk_format_to_texture_format`] table knows how to project to
-    // [`TextureFormat`]. Without this filter, the priority walk could
-    // pick a format the engine can't downstream — e.g. NVIDIA exposes
-    // `A2B10G10R10_UNORM_PACK32 + HDR10_ST2084_EXT` for HDR10 PQ, but
-    // the engine's `TextureFormat` enum doesn't yet have a 10-bit
-    // packed variant. An unrepresentable pick errors out at
-    // `vk_format_to_texture_format` below; pre-filtering keeps the
-    // picker honest and gracefully falls back to the next-best
-    // representable colorspace (HDR10 with `R16G16B16A16_SFLOAT` if
-    // exposed, then EXTENDED_SRGB_LINEAR, then SRGB_NONLINEAR).
-    let representable_formats: Vec<vk::SurfaceFormatKHR> = surface_formats
-        .iter()
-        .copied()
-        .filter(|sf| vk_format_to_texture_format(sf.format).is_some())
-        .collect();
+    let representable_formats = filter_representable_surface_formats(&surface_formats);
     if representable_formats.is_empty() {
         return Err(Error::GpuError(format!(
             "VulkanPresentTarget: surface advertised {} formats but none are \
@@ -953,6 +938,25 @@ fn recorder_device(recorder: &RhiCommandRecorder) -> &vulkanalia::Device {
     recorder.vulkan_device_ref().device()
 }
 
+/// Strip surface formats the engine's [`vk_format_to_texture_format`]
+/// table can't project to [`TextureFormat`]. Called by
+/// [`create_swapchain`] before the priority walk so the picker can
+/// never produce a `vk::Format` that fails downstream conversion —
+/// e.g. NVIDIA exposes `A2B10G10R10_UNORM_PACK32 + HDR10_ST2084_EXT`
+/// for HDR10 PQ, but the engine's `TextureFormat` enum doesn't yet
+/// carry a 10-bit packed variant. The filter degrades gracefully —
+/// the picker walks representable formats only, falling through to
+/// FP16 HDR or SDR.
+fn filter_representable_surface_formats(
+    surface_formats: &[vk::SurfaceFormatKHR],
+) -> Vec<vk::SurfaceFormatKHR> {
+    surface_formats
+        .iter()
+        .copied()
+        .filter(|sf| vk_format_to_texture_format(sf.format).is_some())
+        .collect()
+}
+
 /// Field-wise equality for `vk::HdrMetadataEXT`. The struct has no
 /// `PartialEq` impl in vulkanalia (it carries `*const c_void` for the
 /// `pNext` chain — never compared here since we always pass `null()`),
@@ -1113,12 +1117,11 @@ mod tests {
 
         // With the filter: picker walks representable formats only and
         // gracefully falls through to SDR (since FP16 isn't exposed
-        // here). No swapchain creation error.
-        let representable: Vec<_> = surface_formats
-            .iter()
-            .copied()
-            .filter(|sf| vk_format_to_texture_format(sf.format).is_some())
-            .collect();
+        // here). Call the same helper `create_swapchain` uses so a
+        // future regression that bypasses the filter at the production
+        // call site fails this test as soon as the helper's behavior
+        // diverges from inline filtering.
+        let representable = filter_representable_surface_formats(&surface_formats);
         let filtered_pick = pick_swapchain_format(&representable, Some(&pq_bt2020));
         assert_eq!(filtered_pick.format, vk::Format::B8G8R8A8_UNORM);
         assert_eq!(filtered_pick.color_space, vk::ColorSpaceKHR::SRGB_NONLINEAR);

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_present_target.rs
@@ -296,12 +296,26 @@ impl VulkanPresentTarget {
             }
         }
 
+        // Refresh the cached `TextureFormat` view alongside the raw
+        // `vk::Format` — a recreate that lands on a new format
+        // (e.g. SDR `BGRA8_UNORM` → HDR10 `R16G16B16A16_SFLOAT`)
+        // must update both fields, otherwise downstream code
+        // reading [`Self::color_format`] sees a stale value and
+        // [`build_display_kernel`] (called by display.rs after a
+        // colorspace transition) silently rebuilds against the old
+        // attachment format.
+        let new_color_format = vk_format_to_texture_format(new_format).ok_or_else(|| {
+            Error::GpuError(format!(
+                "VulkanPresentTarget::recreate: swapchain format {new_format:?} \
+                 not mapped to TextureFormat"
+            ))
+        })?;
+
         self.swapchain = new_swapchain;
         self.swapchain_images = new_images;
         self.swapchain_image_views = new_views;
-        // Spec: same swapchain recreated from old keeps the same format —
-        // overwrite anyway in case the surface caps changed.
         self.swapchain_format = new_format;
+        self.color_format = new_color_format;
         self.swapchain_extent = new_extent;
         // Update the cached colorspace pick. If the colorspace changed
         // (SDR → HDR or vice versa, or one HDR variant → another),
@@ -752,7 +766,32 @@ fn create_swapchain(
         ));
     }
 
-    let color_pick = pick_swapchain_format(&surface_formats, color_info);
+    // Filter the surface-exposed formats to those the engine's
+    // [`vk_format_to_texture_format`] table knows how to project to
+    // [`TextureFormat`]. Without this filter, the priority walk could
+    // pick a format the engine can't downstream — e.g. NVIDIA exposes
+    // `A2B10G10R10_UNORM_PACK32 + HDR10_ST2084_EXT` for HDR10 PQ, but
+    // the engine's `TextureFormat` enum doesn't yet have a 10-bit
+    // packed variant. An unrepresentable pick errors out at
+    // `vk_format_to_texture_format` below; pre-filtering keeps the
+    // picker honest and gracefully falls back to the next-best
+    // representable colorspace (HDR10 with `R16G16B16A16_SFLOAT` if
+    // exposed, then EXTENDED_SRGB_LINEAR, then SRGB_NONLINEAR).
+    let representable_formats: Vec<vk::SurfaceFormatKHR> = surface_formats
+        .iter()
+        .copied()
+        .filter(|sf| vk_format_to_texture_format(sf.format).is_some())
+        .collect();
+    if representable_formats.is_empty() {
+        return Err(Error::GpuError(format!(
+            "VulkanPresentTarget: surface advertised {} formats but none are \
+             representable as TextureFormat (extend `vk_format_to_texture_format` \
+             when adding new HDR / wide-gamut backends)",
+            surface_formats.len()
+        )));
+    }
+
+    let color_pick = pick_swapchain_format(&representable_formats, color_info);
     let chosen_format = vk::SurfaceFormatKHR {
         format: color_pick.format,
         color_space: color_pick.color_space,
@@ -941,6 +980,13 @@ fn vk_format_to_texture_format(format: vk::Format) -> Option<TextureFormat> {
         vk::Format::B8G8R8A8_SRGB => Some(TextureFormat::Bgra8UnormSrgb),
         vk::Format::R8G8B8A8_UNORM => Some(TextureFormat::Rgba8Unorm),
         vk::Format::R8G8B8A8_SRGB => Some(TextureFormat::Rgba8UnormSrgb),
+        // FP16 scanout — the representable path for both `HDR10_ST2084_EXT`
+        // and `EXTENDED_SRGB_LINEAR_EXT` colorspaces. The 10-bit packed
+        // formats `A2B10G10R10_UNORM_PACK32` / `A2R10G10B10_UNORM_PACK32`
+        // (the canonical HDR10 wire format) need a `Rgb10A2Unorm` variant
+        // on `TextureFormat` to map; not added here as it's a multi-
+        // backend / consumer-rhi change.
+        vk::Format::R16G16B16A16_SFLOAT => Some(TextureFormat::Rgba16Float),
         _ => None,
     }
 }
@@ -1006,10 +1052,78 @@ mod tests {
             Some(TextureFormat::Rgba8UnormSrgb)
         );
         assert_eq!(
+            vk_format_to_texture_format(vk::Format::R16G16B16A16_SFLOAT),
+            Some(TextureFormat::Rgba16Float),
+            "FP16 scanout drives both HDR10 (when 10-bit packed isn't \
+             representable) and EXTENDED_SRGB_LINEAR — must round-trip"
+        );
+        assert_eq!(
             vk_format_to_texture_format(vk::Format::D32_SFLOAT),
             None,
             "non-color-attachment format must not map"
         );
+    }
+
+    /// Locks the contract `create_swapchain` relies on: when a surface
+    /// exposes the picker-preferred HDR10 10-bit packed format that
+    /// `vk_format_to_texture_format` doesn't yet support, the
+    /// representability filter in `create_swapchain` strips it AND the
+    /// picker then walks the remaining (representable) formats. Without
+    /// the filter, an HDR10-capable surface that exposed only the
+    /// 10-bit packed pair would have been picked and then errored out
+    /// at the format-to-TextureFormat conversion step in
+    /// `create_swapchain`. The construction-time path is hardware-only
+    /// (needs a real surface), so this test simulates the
+    /// filter+pick contract directly.
+    #[test]
+    fn representability_filter_drops_unsupported_picker_targets() {
+        use crate::_generated_::tatolab__core::color_info::{Primaries, Transfer};
+        use crate::_generated_::ColorInfo;
+
+        let surface_formats = vec![
+            vk::SurfaceFormatKHR {
+                format: vk::Format::B8G8R8A8_UNORM,
+                color_space: vk::ColorSpaceKHR::SRGB_NONLINEAR,
+            },
+            // HDR10 with the canonical 10-bit packed format — picker
+            // would prefer this if unfiltered, but the engine has no
+            // `TextureFormat` variant for it today.
+            vk::SurfaceFormatKHR {
+                format: vk::Format::A2B10G10R10_UNORM_PACK32,
+                color_space: vk::ColorSpaceKHR::HDR10_ST2084_EXT,
+            },
+        ];
+        let pq_bt2020 = ColorInfo {
+            primaries: Some(Primaries::Bt2020),
+            transfer: Some(Transfer::Smpte2084),
+            matrix: None,
+            range: None,
+        };
+
+        // Without the filter: picker would pick A2B10G10R10_UNORM_PACK32
+        // and `create_swapchain` would error at format conversion.
+        let unfiltered_pick = pick_swapchain_format(&surface_formats, Some(&pq_bt2020));
+        assert_eq!(unfiltered_pick.format, vk::Format::A2B10G10R10_UNORM_PACK32);
+        assert!(
+            vk_format_to_texture_format(unfiltered_pick.format).is_none(),
+            "fixture assumption: picker-preferred HDR10 packed format must \
+             remain unrepresentable, otherwise this test no longer locks the \
+             filter contract"
+        );
+
+        // With the filter: picker walks representable formats only and
+        // gracefully falls through to SDR (since FP16 isn't exposed
+        // here). No swapchain creation error.
+        let representable: Vec<_> = surface_formats
+            .iter()
+            .copied()
+            .filter(|sf| vk_format_to_texture_format(sf.format).is_some())
+            .collect();
+        let filtered_pick = pick_swapchain_format(&representable, Some(&pq_bt2020));
+        assert_eq!(filtered_pick.format, vk::Format::B8G8R8A8_UNORM);
+        assert_eq!(filtered_pick.color_space, vk::ColorSpaceKHR::SRGB_NONLINEAR);
+        assert!(!filtered_pick.is_hdr);
+        assert!(vk_format_to_texture_format(filtered_pick.format).is_some());
     }
 
     /// `MAX_FRAMES_IN_FLIGHT = 2` is load-bearing across the engine

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_swapchain_colorspace.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_swapchain_colorspace.rs
@@ -1,0 +1,445 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Swapchain colorspace negotiation + HDR static metadata materialization.
+
+use vulkanalia::vk;
+use vulkanalia::vk::HasBuilder as _;
+
+use crate::_generated_::tatolab__core::color_info::{Primaries, Transfer};
+use crate::_generated_::{ColorInfo, ContentLight, MasteringDisplay};
+
+/// Result of [`pick_swapchain_format`] — the chosen `(format, color_space)`
+/// pair plus a flag indicating whether the chosen colorspace expects HDR
+/// signaling (PQ or HLG variants).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SwapchainColorPick {
+    pub format: vk::Format,
+    pub color_space: vk::ColorSpaceKHR,
+    /// True when the picked colorspace is one of the HDR signaling
+    /// variants. Drives whether [`build_hdr_metadata`] should be
+    /// materialized + attached via `vkSetHdrMetadataEXT`.
+    pub is_hdr: bool,
+}
+
+/// Walks the surface-exposed format list and picks the best
+/// `(VkFormat, VkColorSpaceKHR)` for the incoming frame's color
+/// description. SRGB_NONLINEAR + BGRA8_UNORM (then anything the
+/// surface offers) is the universal fallback.
+///
+/// Priority walk:
+/// 1. Frame says PQ + BT.2020 (HDR10) → walk for `HDR10_ST2084_EXT`,
+///    preferring `A2B10G10R10_UNORM_PACK32` then `R16G16B16A16_SFLOAT`.
+/// 2. Frame says HLG + BT.2020 → walk for `HDR10_HLG_EXT` with the
+///    same format preferences.
+/// 3. HDR signal but no matching HDR10 colorspace exposed → walk for
+///    `EXTENDED_SRGB_LINEAR_EXT` + `R16G16B16A16_SFLOAT` (scRGB-style
+///    float scanout — Mesa Wayland-only). Engine tone-maps to display.
+/// 4. SDR signal or fallthrough → `SRGB_NONLINEAR_KHR` with
+///    `B8G8R8A8_UNORM` if exposed, otherwise the first format the
+///    surface offered. Engine tone-maps + gamut-maps as needed.
+pub fn pick_swapchain_format(
+    surface_formats: &[vk::SurfaceFormatKHR],
+    color_info: Option<&ColorInfo>,
+) -> SwapchainColorPick {
+    debug_assert!(
+        !surface_formats.is_empty(),
+        "vkGetPhysicalDeviceSurfaceFormatsKHR returned an empty list — \
+         spec requires at least one entry on a supported surface"
+    );
+
+    let want_pq = matches!(color_info.and_then(|c| c.transfer.as_ref()), Some(Transfer::Smpte2084));
+    let want_hlg =
+        matches!(color_info.and_then(|c| c.transfer.as_ref()), Some(Transfer::AribStdB67));
+    let want_bt2020 =
+        matches!(color_info.and_then(|c| c.primaries.as_ref()), Some(Primaries::Bt2020));
+
+    if want_pq && want_bt2020 {
+        if let Some(pick) = walk_hdr10(surface_formats, vk::ColorSpaceKHR::HDR10_ST2084_EXT) {
+            return pick;
+        }
+    } else if want_hlg && want_bt2020 {
+        if let Some(pick) = walk_hdr10(surface_formats, vk::ColorSpaceKHR::HDR10_HLG_EXT) {
+            return pick;
+        }
+    }
+
+    // HDR signal present but no HDR10 colorspace exposed — try scRGB-style
+    // float scanout. Mesa exposes this on Wayland; NVIDIA does not. Engine
+    // is responsible for tone-mapping to the display luminance range.
+    if (want_pq || want_hlg)
+        && let Some(pick) = walk_extended_srgb_linear(surface_formats)
+    {
+        return pick;
+    }
+
+    // SDR / fallthrough: SRGB_NONLINEAR with BGRA8_UNORM, else BGRA8_SRGB,
+    // else the first format the surface advertised. Matches the legacy
+    // hardcoded pick so SDR-on-SDR behaves identically to today.
+    pick_srgb_fallback(surface_formats)
+}
+
+fn walk_hdr10(
+    surface_formats: &[vk::SurfaceFormatKHR],
+    target: vk::ColorSpaceKHR,
+) -> Option<SwapchainColorPick> {
+    // Prefer the 10-bit packed format — that's the canonical HDR10
+    // wire format. Fall back to FP16 if the driver only exposes
+    // float-scanout for the HDR10 colorspace (rare).
+    const HDR10_FORMATS: &[vk::Format] = &[
+        vk::Format::A2B10G10R10_UNORM_PACK32,
+        vk::Format::A2R10G10B10_UNORM_PACK32,
+        vk::Format::R16G16B16A16_SFLOAT,
+    ];
+    for &want_format in HDR10_FORMATS {
+        if let Some(sf) = surface_formats
+            .iter()
+            .find(|sf| sf.format == want_format && sf.color_space == target)
+        {
+            return Some(SwapchainColorPick {
+                format: sf.format,
+                color_space: sf.color_space,
+                is_hdr: true,
+            });
+        }
+    }
+    None
+}
+
+fn walk_extended_srgb_linear(
+    surface_formats: &[vk::SurfaceFormatKHR],
+) -> Option<SwapchainColorPick> {
+    // scRGB scanout requires float — half-float is the canonical
+    // choice. EXTENDED_SRGB_NONLINEAR pairs with 8-bit but is not
+    // wide-gamut in the same way; we only walk the linear variant
+    // here since we're explicitly looking for an HDR-capable scanout.
+    let target = vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT;
+    surface_formats
+        .iter()
+        .find(|sf| sf.format == vk::Format::R16G16B16A16_SFLOAT && sf.color_space == target)
+        .map(|sf| SwapchainColorPick {
+            format: sf.format,
+            color_space: sf.color_space,
+            // Float scanout signals HDR-capable but is not a PQ/HLG
+            // colorspace; vkSetHdrMetadataEXT is documented as
+            // applicable only to HDR10/HDR10_HLG, so leave is_hdr
+            // false here. The engine still does the tone-mapping.
+            is_hdr: false,
+        })
+}
+
+fn pick_srgb_fallback(surface_formats: &[vk::SurfaceFormatKHR]) -> SwapchainColorPick {
+    // Match the legacy pick first (BGRA8_UNORM + SRGB_NONLINEAR) so
+    // SDR-on-SDR is byte-identical to today's behavior. Then BGRA8_SRGB
+    // (some compositors only offer the sRGB-encoded variant). Last
+    // resort: surface_formats[0], whatever it is.
+    const SRGB_PRIORITIES: &[(vk::Format, vk::ColorSpaceKHR)] = &[
+        (vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+        (vk::Format::B8G8R8A8_SRGB, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+        (vk::Format::R8G8B8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+        (vk::Format::R8G8B8A8_SRGB, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+    ];
+    for &(want_format, want_color_space) in SRGB_PRIORITIES {
+        if let Some(sf) = surface_formats
+            .iter()
+            .find(|sf| sf.format == want_format && sf.color_space == want_color_space)
+        {
+            return SwapchainColorPick {
+                format: sf.format,
+                color_space: sf.color_space,
+                is_hdr: false,
+            };
+        }
+    }
+    let sf = surface_formats[0];
+    SwapchainColorPick {
+        format: sf.format,
+        color_space: sf.color_space,
+        is_hdr: false,
+    }
+}
+
+/// Materializes a `vk::HdrMetadataEXT` from the H.265 SEI / MP4 mdcv
+/// wire-format integers carried in the schemas. Schema units:
+///
+/// - chromaticity in 1/50000 increments (CIE 1931) → divided by 50000
+///   to land in `XYColorEXT`'s `[0.0, 1.0]` float range.
+/// - luminance in 0.0001 cd/m² increments → divided by 10000 to land
+///   in `HdrMetadataEXT`'s cd/m² float range.
+/// - `max_cll` / `max_fall` are integer cd/m² in the schema → cast to
+///   f32 directly (no scaling).
+pub fn build_hdr_metadata(
+    mastering: &MasteringDisplay,
+    content_light: &ContentLight,
+) -> vk::HdrMetadataEXT {
+    const CHROMA_SCALE: f32 = 1.0 / 50_000.0;
+    const LUM_SCALE: f32 = 1.0 / 10_000.0;
+
+    vk::HdrMetadataEXT::builder()
+        .display_primary_red(vk::XYColorEXT {
+            x: mastering.display_primaries_r_x as f32 * CHROMA_SCALE,
+            y: mastering.display_primaries_r_y as f32 * CHROMA_SCALE,
+        })
+        .display_primary_green(vk::XYColorEXT {
+            x: mastering.display_primaries_g_x as f32 * CHROMA_SCALE,
+            y: mastering.display_primaries_g_y as f32 * CHROMA_SCALE,
+        })
+        .display_primary_blue(vk::XYColorEXT {
+            x: mastering.display_primaries_b_x as f32 * CHROMA_SCALE,
+            y: mastering.display_primaries_b_y as f32 * CHROMA_SCALE,
+        })
+        .white_point(vk::XYColorEXT {
+            x: mastering.white_point_x as f32 * CHROMA_SCALE,
+            y: mastering.white_point_y as f32 * CHROMA_SCALE,
+        })
+        .max_luminance(mastering.max_luminance as f32 * LUM_SCALE)
+        .min_luminance(mastering.min_luminance as f32 * LUM_SCALE)
+        .max_content_light_level(content_light.max_cll as f32)
+        .max_frame_average_light_level(content_light.max_fall as f32)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fmt(format: vk::Format, color_space: vk::ColorSpaceKHR) -> vk::SurfaceFormatKHR {
+        vk::SurfaceFormatKHR { format, color_space }
+    }
+
+    fn pq_bt2020() -> ColorInfo {
+        ColorInfo {
+            primaries: Some(Primaries::Bt2020),
+            transfer: Some(Transfer::Smpte2084),
+            matrix: None,
+            range: None,
+        }
+    }
+
+    fn hlg_bt2020() -> ColorInfo {
+        ColorInfo {
+            primaries: Some(Primaries::Bt2020),
+            transfer: Some(Transfer::AribStdB67),
+            matrix: None,
+            range: None,
+        }
+    }
+
+    fn srgb_only() -> Vec<vk::SurfaceFormatKHR> {
+        vec![
+            fmt(vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(vk::Format::B8G8R8A8_SRGB, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+        ]
+    }
+
+    fn nvidia_hdr10() -> Vec<vk::SurfaceFormatKHR> {
+        vec![
+            fmt(vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(vk::Format::B8G8R8A8_SRGB, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(
+                vk::Format::A2B10G10R10_UNORM_PACK32,
+                vk::ColorSpaceKHR::HDR10_ST2084_EXT,
+            ),
+        ]
+    }
+
+    fn mesa_full_set() -> Vec<vk::SurfaceFormatKHR> {
+        vec![
+            fmt(vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(vk::Format::B8G8R8A8_SRGB, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(
+                vk::Format::A2B10G10R10_UNORM_PACK32,
+                vk::ColorSpaceKHR::HDR10_ST2084_EXT,
+            ),
+            fmt(
+                vk::Format::A2B10G10R10_UNORM_PACK32,
+                vk::ColorSpaceKHR::HDR10_HLG_EXT,
+            ),
+            fmt(
+                vk::Format::R16G16B16A16_SFLOAT,
+                vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT,
+            ),
+        ]
+    }
+
+    /// SDR-only surfaces (today's NVIDIA X11 reality) must always pick
+    /// the legacy `BGRA8_UNORM + SRGB_NONLINEAR` pair, regardless of
+    /// what the frame's `ColorInfo` requests. Mentally reverting the
+    /// `pick_srgb_fallback` priority order to "first format wins" would
+    /// regress to a non-deterministic pick; this test catches that.
+    #[test]
+    fn sdr_only_surface_always_picks_bgra8_srgb_nonlinear() {
+        let formats = srgb_only();
+        for color_info in [None, Some(pq_bt2020()), Some(hlg_bt2020())] {
+            let pick = pick_swapchain_format(&formats, color_info.as_ref());
+            assert_eq!(pick.format, vk::Format::B8G8R8A8_UNORM);
+            assert_eq!(pick.color_space, vk::ColorSpaceKHR::SRGB_NONLINEAR);
+            assert!(!pick.is_hdr);
+        }
+    }
+
+    /// PQ + BT.2020 frame against an HDR10-capable surface must pick
+    /// the 10-bit packed HDR10 pair and signal `is_hdr=true`. Mentally
+    /// reverting the `walk_hdr10` priority list to start at FP16 would
+    /// pick a needlessly-wide format; this asserts the canonical HDR10
+    /// 10-bit packed shape.
+    #[test]
+    fn pq_bt2020_picks_hdr10_st2084_with_a2b10g10r10() {
+        let pick = pick_swapchain_format(&nvidia_hdr10(), Some(&pq_bt2020()));
+        assert_eq!(pick.format, vk::Format::A2B10G10R10_UNORM_PACK32);
+        assert_eq!(pick.color_space, vk::ColorSpaceKHR::HDR10_ST2084_EXT);
+        assert!(pick.is_hdr);
+    }
+
+    /// HLG + BT.2020 frame against a Mesa-shaped full set must pick
+    /// HDR10_HLG_EXT, not HDR10_ST2084_EXT. Mentally reverting the
+    /// HLG arm to fall through to the PQ arm would mis-signal HLG
+    /// content as PQ.
+    #[test]
+    fn hlg_bt2020_picks_hdr10_hlg() {
+        let pick = pick_swapchain_format(&mesa_full_set(), Some(&hlg_bt2020()));
+        assert_eq!(pick.format, vk::Format::A2B10G10R10_UNORM_PACK32);
+        assert_eq!(pick.color_space, vk::ColorSpaceKHR::HDR10_HLG_EXT);
+        assert!(pick.is_hdr);
+    }
+
+    /// HDR-signaled frame against a surface that exposes only
+    /// scRGB-style float scanout (no HDR10 colorspace) must pick the
+    /// `EXTENDED_SRGB_LINEAR_EXT` + FP16 pair. Mentally reverting the
+    /// scRGB fallback would force this case down to SRGB_NONLINEAR
+    /// and lose the HDR-capable scanout the surface offered.
+    #[test]
+    fn hdr_signal_falls_through_to_extended_srgb_linear_when_no_hdr10() {
+        let formats = vec![
+            fmt(vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(
+                vk::Format::R16G16B16A16_SFLOAT,
+                vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT,
+            ),
+        ];
+        let pick = pick_swapchain_format(&formats, Some(&pq_bt2020()));
+        assert_eq!(pick.format, vk::Format::R16G16B16A16_SFLOAT);
+        assert_eq!(
+            pick.color_space,
+            vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT
+        );
+        // Float scanout doesn't take vkSetHdrMetadataEXT — the
+        // colorspace isn't PQ/HLG, the engine handles tone-mapping
+        // and the metadata would be a no-op signal.
+        assert!(!pick.is_hdr);
+    }
+
+    /// PQ frame against an HDR10 surface where only FP16 is exposed
+    /// for the HDR10 colorspace (some non-stock drivers) must still
+    /// pick HDR10_ST2084_EXT — the colorspace is what matters, not
+    /// the bit depth.
+    #[test]
+    fn hdr10_picks_fp16_when_packed_10_bit_unavailable() {
+        let formats = vec![
+            fmt(vk::Format::B8G8R8A8_UNORM, vk::ColorSpaceKHR::SRGB_NONLINEAR),
+            fmt(
+                vk::Format::R16G16B16A16_SFLOAT,
+                vk::ColorSpaceKHR::HDR10_ST2084_EXT,
+            ),
+        ];
+        let pick = pick_swapchain_format(&formats, Some(&pq_bt2020()));
+        assert_eq!(pick.format, vk::Format::R16G16B16A16_SFLOAT);
+        assert_eq!(pick.color_space, vk::ColorSpaceKHR::HDR10_ST2084_EXT);
+        assert!(pick.is_hdr);
+    }
+
+    /// `None` ColorInfo + HDR-capable surface must NOT promote the
+    /// pick to HDR10. Default-frame producers rely on the SRGB
+    /// fallback to stay byte-identical to today's behavior, and
+    /// promoting an absent ColorInfo to HDR would silently change
+    /// the engine's color-handling for every existing pipeline.
+    #[test]
+    fn absent_color_info_against_hdr_surface_stays_srgb() {
+        let pick = pick_swapchain_format(&mesa_full_set(), None);
+        assert_eq!(pick.format, vk::Format::B8G8R8A8_UNORM);
+        assert_eq!(pick.color_space, vk::ColorSpaceKHR::SRGB_NONLINEAR);
+        assert!(!pick.is_hdr);
+    }
+
+    /// `Smpte2084` (PQ) without `Bt2020` primaries is technically a
+    /// non-standard combination — HDR10 is defined as PQ + BT.2020.
+    /// Picking HDR10 anyway would mis-signal the scanout primaries.
+    /// Falling through to SRGB is correct: the engine tone-maps PQ
+    /// down to SDR, and the wrong-primaries case can't be fixed by
+    /// the colorspace pick.
+    #[test]
+    fn pq_without_bt2020_does_not_pick_hdr10() {
+        let color_info = ColorInfo {
+            primaries: Some(Primaries::Bt709),
+            transfer: Some(Transfer::Smpte2084),
+            matrix: None,
+            range: None,
+        };
+        let pick = pick_swapchain_format(&nvidia_hdr10(), Some(&color_info));
+        assert_eq!(pick.format, vk::Format::B8G8R8A8_UNORM);
+        assert_eq!(pick.color_space, vk::ColorSpaceKHR::SRGB_NONLINEAR);
+        assert!(!pick.is_hdr);
+    }
+
+    /// `build_hdr_metadata` must convert the schema's wire-format
+    /// integers to the `vk::HdrMetadataEXT` floating-point fields
+    /// using the right scale per axis: 1/50000 for chromaticity,
+    /// 1/10000 for mastering luminance, 1.0 for content light. A
+    /// silent bug here ships wrong HDR metadata to the driver — the
+    /// scanout will tone-map against the wrong volume.
+    ///
+    /// Reference values: BT.2020 primaries + D65 white point + a
+    /// canonical HDR10 mastering display (1000 cd/m² peak,
+    /// 0.0001 cd/m² floor).
+    #[test]
+    fn hdr_metadata_round_trip_uses_correct_unit_scaling() {
+        let mastering = MasteringDisplay {
+            // BT.2020 primaries:  R = (0.708, 0.292)  → 35400, 14600
+            //                     G = (0.170, 0.797)  →  8500, 39850
+            //                     B = (0.131, 0.046)  →  6550,  2300
+            display_primaries_r_x: 35_400,
+            display_primaries_r_y: 14_600,
+            display_primaries_g_x: 8_500,
+            display_primaries_g_y: 39_850,
+            display_primaries_b_x: 6_550,
+            display_primaries_b_y: 2_300,
+            // D65 white point: (0.3127, 0.3290) → 15635, 16450
+            white_point_x: 15_635,
+            white_point_y: 16_450,
+            // 1000 cd/m² peak → 10_000_000 in 0.0001 cd/m² units.
+            max_luminance: 10_000_000,
+            // 0.005 cd/m² floor → 50.
+            min_luminance: 50,
+        };
+        let content_light = ContentLight {
+            max_cll: 1000,
+            max_fall: 400,
+        };
+
+        let md = build_hdr_metadata(&mastering, &content_light);
+
+        let eps = 1e-4;
+        assert!((md.display_primary_red.x - 0.708).abs() < eps, "red.x={}", md.display_primary_red.x);
+        assert!((md.display_primary_red.y - 0.292).abs() < eps, "red.y={}", md.display_primary_red.y);
+        assert!((md.display_primary_green.x - 0.170).abs() < eps, "green.x={}", md.display_primary_green.x);
+        assert!((md.display_primary_green.y - 0.797).abs() < eps, "green.y={}", md.display_primary_green.y);
+        assert!((md.display_primary_blue.x - 0.131).abs() < eps, "blue.x={}", md.display_primary_blue.x);
+        assert!((md.display_primary_blue.y - 0.046).abs() < eps, "blue.y={}", md.display_primary_blue.y);
+        assert!((md.white_point.x - 0.3127).abs() < eps, "white.x={}", md.white_point.x);
+        assert!((md.white_point.y - 0.3290).abs() < eps, "white.y={}", md.white_point.y);
+        assert!((md.max_luminance - 1000.0).abs() < 1e-3, "max_lum={}", md.max_luminance);
+        assert!((md.min_luminance - 0.005).abs() < 1e-6, "min_lum={}", md.min_luminance);
+        assert!((md.max_content_light_level - 1000.0).abs() < 1e-3);
+        assert!((md.max_frame_average_light_level - 400.0).abs() < 1e-3);
+    }
+
+    /// Vulkan spec requires a non-empty surface format list. The
+    /// picker debug-asserts this and a release build would index past
+    /// the end of an empty slice — surface the requirement loudly so
+    /// regressions in surface-cap querying don't get past tests.
+    #[test]
+    #[should_panic(expected = "spec requires at least one entry")]
+    fn empty_surface_format_list_is_a_logic_bug() {
+        let _ = pick_swapchain_format(&[], None);
+    }
+}

--- a/packages/display/src/linux/display.rs
+++ b/packages/display/src/linux/display.rs
@@ -217,6 +217,7 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxDisplayProcessor::Proc
                     scaling_mode,
                     present_target: None,
                     graphics_kernel: None,
+                    current_frame_color_info: None,
                     frame_limit,
                     png_sample_dir,
                     png_sample_every,
@@ -323,6 +324,12 @@ struct DisplayEventLoopHandler {
     scaling_mode: ScalingMode,
     present_target: Option<VulkanPresentTarget>,
     graphics_kernel: Option<Arc<VulkanGraphicsKernel>>,
+    /// Last-applied frame `color_info` (package-local serialized form).
+    /// When a new frame arrives with a different value the swapchain is
+    /// recreated against the new `VkColorSpaceKHR` priority pick. `None`
+    /// covers both "no frame seen yet" and "every frame so far has had
+    /// `color_info: None`" — both stay on the legacy SDR pick.
+    current_frame_color_info: Option<crate::_generated_::ColorInfo>,
     frame_limit: Option<u64>,
     png_sample_dir: Option<std::path::PathBuf>,
     png_sample_every: u64,
@@ -358,12 +365,16 @@ impl ApplicationHandler for DisplayEventLoopHandler {
         };
 
         // Build the present target + graphics kernel for steady-state rendering.
+        // Initial colorspace pick is `None` — the legacy SDR pick. The first
+        // frame's `color_info`, if non-`None`, drives a recreate in
+        // `render_frame` once a frame actually arrives.
         let present_target = match VulkanPresentTarget::new(
             &self.vulkan_device,
             &window,
             self.width,
             self.height,
             self.vsync,
+            None,
         ) {
             Ok(pt) => pt,
             Err(e) => {
@@ -436,7 +447,14 @@ impl ApplicationHandler for DisplayEventLoopHandler {
                 self.height = new_size.height;
 
                 if let Some(pt) = self.present_target.as_mut() {
-                    if let Err(e) = pt.recreate(new_size.width, new_size.height) {
+                    // Resize-driven recreate keeps the current colorspace pick.
+                    let engine_color_info =
+                        package_color_info_to_engine(self.current_frame_color_info.as_ref());
+                    if let Err(e) = pt.recreate(
+                        new_size.width,
+                        new_size.height,
+                        engine_color_info.as_ref(),
+                    ) {
                         tracing::error!(
                             "Display {}: Failed to recreate present target: {}",
                             self.window_id,
@@ -503,6 +521,84 @@ impl DisplayEventLoopHandler {
                 return;
             }
         };
+
+        // Colorspace negotiation — recreate the swapchain if this frame's
+        // `color_info` differs from the last-applied value. First-frame
+        // inspection: when the very first frame arrives with non-`None`
+        // color_info, the present target was constructed in `resumed()`
+        // with `None` (legacy SDR pick) and is now upgraded to whatever
+        // the priority walk picks for the frame's color description.
+        // On NVIDIA + X11 (today's dev box) the surface only exposes
+        // SRGB_NONLINEAR so the pick stays SDR regardless — the recreate
+        // is a no-op-cost path that only fires when the WSI exposes
+        // wider colorspaces.
+        if ipc_frame.color_info != self.current_frame_color_info {
+            let new_engine_color_info =
+                package_color_info_to_engine(ipc_frame.color_info.as_ref());
+            let new_extent = present_target.current_extent();
+            let prior_color_format = present_target.color_format();
+            if let Err(e) = present_target.recreate(
+                new_extent.0,
+                new_extent.1,
+                new_engine_color_info.as_ref(),
+            ) {
+                tracing::warn!(
+                    "Display {}: ColorInfo recreate failed (keeping previous swapchain): {}",
+                    self.window_id, e
+                );
+            } else {
+                self.current_frame_color_info = ipc_frame.color_info.clone();
+                // If the recreate landed on a new color format (e.g.
+                // SDR BGRA8_UNORM → HDR10 A2B10G10R10_UNORM_PACK32),
+                // the cached graphics kernel was built against the
+                // prior attachment format and must be rebuilt before
+                // the next draw.
+                let new_color_format = present_target.color_format();
+                if new_color_format != prior_color_format {
+                    match build_display_kernel(&self.vulkan_device, new_color_format) {
+                        Ok(new_kernel) => {
+                            tracing::info!(
+                                "Display {}: rebuilt display blit kernel for new color format \
+                                 {:?} (was {:?})",
+                                self.window_id, new_color_format, prior_color_format
+                            );
+                            self.graphics_kernel = Some(Arc::new(new_kernel));
+                            // Skip this frame's draw — the cloned
+                            // `graphics_kernel` Arc above matches the
+                            // old format. The next frame uses the new
+                            // kernel.
+                            self.frame_counter.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Display {}: failed to rebuild display blit kernel: {}",
+                                self.window_id, e
+                            );
+                            self.frame_counter.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        // HDR static metadata push — fires only when the picked
+        // colorspace is one of the PQ/HLG variants (gated by
+        // `set_hdr_metadata` itself) and the frame carries the
+        // sidecar metadata. Subsequent frames with byte-identical
+        // payload short-circuit inside the present target.
+        if let (Some(md), Some(cl)) = (
+            package_mastering_display_to_engine(ipc_frame.mastering_display.as_ref()),
+            package_content_light_to_engine(ipc_frame.content_light.as_ref()),
+        ) {
+            if let Err(e) = present_target.set_hdr_metadata(&md, &cl) {
+                tracing::warn!(
+                    "Display {}: vkSetHdrMetadataEXT failed: {}",
+                    self.window_id, e
+                );
+            }
+        }
 
         // Resolve the texture + registration via the engine's blessed API.
         let registration = match self.gpu_context.resolve_texture_registration_by_surface_id(
@@ -798,6 +894,64 @@ impl DisplayEventLoopHandler {
             }
         }
     }
+}
+
+/// Convert a package-local `_generated_::ColorInfo` (or HDR sidecar) into
+/// the engine-facade equivalent. Both types are codegen-generated from
+/// the same JTD schema with identical serde rename names, so a one-shot
+/// JSON round-trip converts cleanly. Returns `None` on serde failure
+/// (logged, treated as no-color-info — keeps SDR behavior).
+///
+/// Same pattern + rationale as `LinuxCameraProcessor`'s
+/// `engine_cached_color_info` round-trip; see `packages/camera/src/linux/camera.rs`.
+fn package_color_info_to_engine(
+    pkg: Option<&crate::_generated_::ColorInfo>,
+) -> Option<streamlib::engine_internal::_generated_::ColorInfo> {
+    let pkg = pkg?;
+    match streamlib::sdk::serde_json::to_value(pkg)
+        .and_then(streamlib::sdk::serde_json::from_value)
+    {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(
+                "display: ColorInfo schema round-trip failed (treating as None): {}",
+                e
+            );
+            None
+        }
+    }
+}
+
+fn package_mastering_display_to_engine(
+    pkg: Option<&crate::_generated_::MasteringDisplay>,
+) -> Option<streamlib::engine_internal::_generated_::MasteringDisplay> {
+    let pkg = pkg?;
+    streamlib::sdk::serde_json::to_value(pkg)
+        .and_then(streamlib::sdk::serde_json::from_value)
+        .map_err(|e| {
+            tracing::warn!(
+                "display: MasteringDisplay schema round-trip failed (skipping HDR metadata): {}",
+                e
+            );
+            e
+        })
+        .ok()
+}
+
+fn package_content_light_to_engine(
+    pkg: Option<&crate::_generated_::ContentLight>,
+) -> Option<streamlib::engine_internal::_generated_::ContentLight> {
+    let pkg = pkg?;
+    streamlib::sdk::serde_json::to_value(pkg)
+        .and_then(streamlib::sdk::serde_json::from_value)
+        .map_err(|e| {
+            tracing::warn!(
+                "display: ContentLight schema round-trip failed (skipping HDR metadata): {}",
+                e
+            );
+            e
+        })
+        .ok()
 }
 
 fn build_display_kernel(


### PR DESCRIPTION
## Summary

- Engine swapchain now picks `VkColorSpaceKHR` + `vk::Format` via a priority walk over what `vkGetPhysicalDeviceSurfaceFormatsKHR` exposes, driven by the incoming frame's `ColorInfo` (PQ + BT.2020 → `HDR10_ST2084_EXT`; HLG + BT.2020 → `HDR10_HLG_EXT`; HDR fallback → `EXTENDED_SRGB_LINEAR_EXT` + FP16; SDR / fallthrough → `SRGB_NONLINEAR_KHR` + `BGRA8_UNORM`). Replaces the unconditional SDR pick at `vulkan_present_target.rs::create_swapchain`.
- `VK_EXT_swapchain_colorspace` (instance) and `VK_EXT_hdr_metadata` (device) probed + enabled when available; `HostVulkanDevice::supports_hdr_metadata()` exposes the gate.
- `VulkanPresentTarget` gains `set_hdr_metadata(&MasteringDisplay, &ContentLight)` — calls `vkSetHdrMetadataEXT` only when the picked colorspace is PQ/HLG and the extension is enabled, with byte-identical-payload short-circuit.
- Display processor inspects each frame's `color_info` and recreates the present target on change, rebuilding the graphics kernel when the attachment format also changes (SDR ↔ HDR transition).

## Closes

Closes #817

## Exit criteria

- [x] `VulkanPresentTarget::create_swapchain` takes a `ColorInfo` hint and picks `VkColorSpaceKHR` + format via the priority walk (HDR10-ST2084 → EXTENDED_SRGB_LINEAR → SRGB_NONLINEAR).
- [x] `vkSetHdrMetadataEXT` wired when (a) the picked colorspace is PQ/HLG, (b) the frame carries `MasteringDisplay` / `ContentLight`, (c) `VK_EXT_hdr_metadata` is enabled at device construction.
- [x] `SRGB_NONLINEAR` remains the default fallback; SDR content on SDR displays behaves identically to today.
- [ ] ~~Optional EDID-via-libdisplay-info probe behind a config flag, logging-only — not used to override WSI.~~ **Deferred** to a follow-up — pulls in a new C-binding crate dep (`libdisplay-info`) for logging-only behavior; not load-bearing for the colorspace pick (WSI is the authority).

## Test plan

### Unit (run via `cargo test -p streamlib-engine --lib vulkan_swapchain_colorspace` and `-- vulkan_present_target::tests`)

- [x] Priority walk picks the right format from synthetic surface-format lists — SDR-only (today's NVIDIA X11), Mesa full set with HDR10 + EXTENDED_SRGB_LINEAR, NVIDIA-shaped HDR10, FP16-only HDR10. Each test mentally-revertable: revert any picker arm and at least one test fails.
- [x] `VkHdrMetadataEXT` materialization round-trip — BT.2020 primaries + D65 white point + 1000 cd/m² peak with ε=1e-4 chromaticity tolerance and ε=1e-3 luminance. Reverting either unit-scale constant fails the assertion.
- [x] `vk_format_to_texture_format` covers the FP16 case (newly added for the HDR-fallback path).
- [x] `representability_filter_drops_unsupported_picker_targets` locks the contract that `create_swapchain` filters surface formats through `vk_format_to_texture_format` before handing to the picker — uses the same `filter_representable_surface_formats` helper as production, so a regression at either call site fails the test.

### E2E

#### E2E Test Report

- **Scenario**: camera+display-only
- **Example**: `camera-display`
- **Codec**: n/a
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=180`, ~25 s
- **Build profile**: release
- **Command**:
    ```
    STREAMLIB_CAMERA_DEVICE=/dev/video0 \
    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/colorspace-e2e/png_samples \
    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 \
    STREAMLIB_DISPLAY_FRAME_LIMIT=180 \
    timeout --kill-after=3 25 ./target/release/camera-display
    ```

##### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `swapchain colorspace pick`: `B8G8R8A8_UNORM + SRGB_NONLINEAR (is_hdr=false, color_info=None)` initially, then `... color_info=Some(ColorInfo { matrix: Some(Smpte170m), primaries: Some(Bt709), range: Some(Full), transfer: Some(Srgb) })` once the first vivid frame's `ColorInfo` arrives — recreate fires, picker walks the surface's exposed formats, lands back on SRGB (NVIDIA X11 only exposes `SRGB_NONLINEAR_KHR`), no kernel rebuild because the format didn't change.
- PNG samples saved: 5 across 180 displayed frames at every-30 interval.

##### PNG samples

- Directory: `/tmp/colorspace-e2e-2-1778889651/png_samples/`
- Sample count: 5
- PNGs read with Read tool: `display_001_frame_000060_input_000061.png`
- **What was in the image(s)**: vivid SMPTE-style color bars (gray, yellow, cyan, green, magenta, red, blue, black) at 1920×1080, with the embedded timecode overlay `00:00:12:006 60` and v4l2 control state in the upper-left. Matches the expected vivid test pattern exactly.
- Anomalies: none.

##### PSNR

- Reference frame: n/a — vivid color-bars source has no fixture-PNG ground truth in tree; visual Read-tool inspection is the gate per `docs/testing.md` for camera+display-only scenarios.
- Y / U / V PSNR: n/a

##### Outcome

- **Pass** (SDR fallback path).
- HDR runtime E2E: ⏭ skipped — empirically NVIDIA 595.58.03 + X11 + AW3423DW (HDR OLED on DP-1) only exposes `SRGB_NONLINEAR_KHR` on `vkGetPhysicalDeviceSurfaceFormatsKHR`, so the HDR write path can't be exercised end-to-end on this dev box. The picker logic and HDR metadata building are locked by unit tests in isolation.
- Caveats / follow-ups: see "Follow-ups" below.

## Follow-ups

- libdisplay-info EDID probe (criterion 4) — logging-only diagnostic; needs a new C-binding crate dep.
- HDR runtime E2E on Mesa Wayland (or future NVIDIA driver that exposes HDR10 on X11) — once an env exposes HDR10 colorspace through the WSI, run a PQ + BT.2020 fixture, sample PNGs, validate `vkSetHdrMetadataEXT` succeeds with validation layers clean.
- Add `Rgb10A2Unorm` variant to `TextureFormat` (multi-backend / consumer-rhi work) so the canonical HDR10 10-bit packed wire format becomes representable. Today the picker walks FP16 for HDR10 if exposed; 10-bit packed surfaces are filtered out before the priority walk and gracefully fall through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)