### PR TITLE
feat(codec): H.264/H.265 VUI — encoder writes from ColorInfo, decoder parses into frame.color_info

### DIFF
--- a/libs/vulkan-video/src/decode/mod.rs
+++ b/libs/vulkan-video/src/decode/mod.rs
@@ -667,6 +667,55 @@ impl SimpleDecoder {
         (self.sps_width, self.sps_height)
     }
 
+    /// Return the H.273 color VUI parsed from the active SPS, or `None` if
+    /// no SPS has been parsed yet or the SPS didn't carry a VUI.
+    ///
+    /// Each axis is `Some(byte)` only if the bitstream actually carried it
+    /// AND it isn't the H.273 "Unspecified" enumerant (value `2`); axes
+    /// that the bitstream omitted or marked Unspecified come back as
+    /// `None`. Callers translate these byte values to their domain
+    /// `ColorInfo` at the codec-processor seam.
+    pub fn current_color_vui(&self) -> Option<crate::H273ColorVui> {
+        match self.config.codec {
+            crate::encode::Codec::H264 => {
+                let parser = self.h264_parser.as_ref()?;
+                let sps = parser.sps.as_ref()?;
+                if !sps.flags.vui_parameters_present_flag {
+                    return None;
+                }
+                let vui = &sps.vui;
+                let primaries = decoded_byte_to_option(vui.colour_primaries as i32);
+                let transfer = decoded_byte_to_option(vui.transfer_characteristics as i32);
+                let matrix = decoded_byte_to_option(vui.matrix_coefficients as i32);
+                let full_range = if vui.video_signal_type_present_flag {
+                    Some(vui.video_full_range_flag)
+                } else {
+                    None
+                };
+                build_color_vui(primaries, transfer, matrix, full_range)
+            }
+            crate::encode::Codec::H265 => {
+                let parser = self.h265_parser.as_ref()?;
+                // Find the first populated SPS slot — streamlib's encoder
+                // only emits sps_id=0, and decoders typically only see one.
+                let sps = parser.spss.iter().filter_map(|s| s.as_ref()).next()?;
+                if !sps.flags.vui_parameters_present_flag {
+                    return None;
+                }
+                let vui = &sps.vui;
+                let primaries = decoded_byte_to_option(vui.colour_primaries as i32);
+                let transfer = decoded_byte_to_option(vui.transfer_characteristics as i32);
+                let matrix = decoded_byte_to_option(vui.matrix_coeffs as i32);
+                let full_range = if vui.flags.video_signal_type_present_flag {
+                    Some(vui.flags.video_full_range_flag)
+                } else {
+                    None
+                };
+                build_color_vui(primaries, transfer, matrix, full_range)
+            }
+        }
+    }
+
     // ------------------------------------------------------------------
     // Private: NAL unit splitting
     // ------------------------------------------------------------------
@@ -1002,6 +1051,98 @@ impl SimpleDecoder {
         }
         // All slots in use — evict slot 0 (simplistic sliding window)
         0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — H.273 byte → Option<u8>
+// ---------------------------------------------------------------------------
+
+/// Map an H.273 byte parsed from the bitstream to `Some(byte)` if it is a
+/// real value, or `None` if it is the H.273 "Unspecified" enumerant
+/// (value `2`) or out-of-range. Returning `None` for `Unspecified` means
+/// `current_color_vui()` axes match the on-wire ColorInfo semantics ("absent
+/// IS unknown").
+fn decoded_byte_to_option(value: i32) -> Option<u8> {
+    if value <= 0 || value > 255 {
+        return None;
+    }
+    let byte = value as u8;
+    if byte == crate::encode::color_vui::H273_UNSPECIFIED {
+        return None;
+    }
+    Some(byte)
+}
+
+/// Build an [`H273ColorVui`] from per-axis options, returning `None` when
+/// every axis is `None` (so callers can disambiguate "no VUI" from "VUI
+/// present but every axis was Unspecified").
+fn build_color_vui(
+    primaries: Option<u8>,
+    transfer: Option<u8>,
+    matrix: Option<u8>,
+    full_range: Option<bool>,
+) -> Option<crate::H273ColorVui> {
+    if primaries.is_none() && transfer.is_none() && matrix.is_none() && full_range.is_none() {
+        return None;
+    }
+    Some(crate::H273ColorVui {
+        primaries,
+        transfer,
+        matrix,
+        full_range,
+    })
+}
+
+#[cfg(test)]
+mod color_vui_helper_tests {
+    use super::*;
+    use crate::encode::color_vui;
+
+    #[test]
+    fn unspecified_byte_becomes_none() {
+        assert_eq!(decoded_byte_to_option(2), None);
+    }
+
+    #[test]
+    fn zero_or_negative_byte_becomes_none() {
+        assert_eq!(decoded_byte_to_option(0), None);
+        assert_eq!(decoded_byte_to_option(-1), None);
+    }
+
+    #[test]
+    fn real_byte_becomes_some() {
+        assert_eq!(decoded_byte_to_option(1), Some(1)); // BT.709
+        assert_eq!(decoded_byte_to_option(13), Some(13)); // sRGB
+        assert_eq!(decoded_byte_to_option(16), Some(16)); // PQ
+    }
+
+    #[test]
+    fn all_axes_none_returns_none_vui() {
+        assert!(build_color_vui(None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn full_range_alone_returns_some_vui() {
+        let vui = build_color_vui(None, None, None, Some(true))
+            .expect("non-empty axis yields Some");
+        assert_eq!(vui.full_range, Some(true));
+        assert!(vui.primaries.is_none());
+    }
+
+    #[test]
+    fn hdr10_axes_round_trip_to_h273_bytes() {
+        let vui = build_color_vui(
+            Some(color_vui::primaries::BT2020),
+            Some(color_vui::transfer::SMPTE2084),
+            Some(color_vui::matrix::BT2020_NCL),
+            Some(true),
+        )
+        .expect("non-empty axes yield Some");
+        assert_eq!(vui.primaries, Some(9));
+        assert_eq!(vui.transfer, Some(16));
+        assert_eq!(vui.matrix, Some(9));
+        assert_eq!(vui.full_range, Some(true));
     }
 }
 

--- a/libs/vulkan-video/src/encode/color_vui.rs
+++ b/libs/vulkan-video/src/encode/color_vui.rs
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! H.273 / VUI color metadata in its native bitstream byte representation.
+//!
+//! The vulkan-video crate is leaf-level — it does not depend on
+//! `@tatolab/core` schemas, the streamlib SDK, or the engine's `ColorInfo`
+//! type. The encoder and decoder work in raw H.273 enumerant bytes (the
+//! representation that appears verbatim in the H.264 / H.265 / AV1
+//! bitstream). Callers in `packages/h26{4,5}/` translate
+//! `ColorInfo` ↔ [`H273ColorVui`] at the codec-processor seam.
+
+/// H.273 color VUI carried by the H.264 / H.265 SPS.
+///
+/// Each axis is optional: `None` means "the codec processor did not specify
+/// this axis." When the SPS VUI is emitted, an axis that is `None` while a
+/// peer axis is `Some` is written as H.273 value `2` (Unspecified) per
+/// ISO/IEC 23091-2.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct H273ColorVui {
+    /// ColourPrimaries — ITU-T H.273 §8.1. `bt709 == 1`, `smpte170m == 6`,
+    /// `bt2020 == 9`, etc.
+    pub primaries: Option<u8>,
+    /// TransferCharacteristics — ITU-T H.273 §8.2. `bt709 == 1`,
+    /// `srgb == 13`, `smpte2084 == 16`, etc.
+    pub transfer: Option<u8>,
+    /// MatrixCoefficients — ITU-T H.273 §8.3. `identity == 0`, `bt709 == 1`,
+    /// `smpte170m == 6`, `bt2020_ncl == 9`, etc.
+    pub matrix: Option<u8>,
+    /// `true` = full range (PC), `false` = limited range (TV). Maps to the
+    /// H.264 / H.265 `video_full_range_flag`.
+    pub full_range: Option<bool>,
+}
+
+/// H.273 value 2 — "Unspecified" placeholder for axes that are `None` but
+/// must be written because a peer axis in the same description block is
+/// `Some`.
+pub const H273_UNSPECIFIED: u8 = 2;
+
+impl H273ColorVui {
+    /// `true` when at least one axis is set; signals that the SPS should
+    /// emit `video_signal_type_present_flag = 1`.
+    pub fn is_video_signal_type_block_needed(&self) -> bool {
+        self.primaries.is_some()
+            || self.transfer.is_some()
+            || self.matrix.is_some()
+            || self.full_range.is_some()
+    }
+
+    /// `true` when at least one of primaries / transfer / matrix is set;
+    /// signals that the SPS should emit `colour_description_present_flag = 1`
+    /// inside the video signal type block.
+    pub fn is_colour_description_block_needed(&self) -> bool {
+        self.primaries.is_some() || self.transfer.is_some() || self.matrix.is_some()
+    }
+
+    /// Returns the byte that should be written to the SPS for `colour_primaries`.
+    /// Substitutes [`H273_UNSPECIFIED`] for `None`.
+    pub fn primaries_byte(&self) -> u8 {
+        self.primaries.unwrap_or(H273_UNSPECIFIED)
+    }
+
+    /// Returns the byte that should be written for `transfer_characteristics`.
+    pub fn transfer_byte(&self) -> u8 {
+        self.transfer.unwrap_or(H273_UNSPECIFIED)
+    }
+
+    /// Returns the byte that should be written for `matrix_coefficients`
+    /// (H.264) / `matrix_coeffs` (H.265).
+    pub fn matrix_byte(&self) -> u8 {
+        self.matrix.unwrap_or(H273_UNSPECIFIED)
+    }
+
+    /// Returns the bit (`0` or `1`) that should be written for
+    /// `video_full_range_flag`. Defaults to `0` (limited range) when unset
+    /// — H.264 / H.265 spec requires writing the flag whenever
+    /// `video_signal_type_present_flag = 1`.
+    pub fn full_range_bit(&self) -> u32 {
+        u32::from(self.full_range.unwrap_or(false))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// H.273 enumerant constants (ITU-T H.273 / ISO/IEC 23091-2)
+// ---------------------------------------------------------------------------
+//
+// These let translator callers reference values by name rather than by
+// magic byte. The set is the subset streamlib's `ColorInfo` schema
+// declares — full H.273 tables are larger.
+
+/// ColourPrimaries values — H.273 §8.1.
+pub mod primaries {
+    pub const BT709: u8 = 1;
+    pub const UNSPECIFIED: u8 = 2;
+    pub const BT470_M: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const FILM: u8 = 8;
+    pub const BT2020: u8 = 9;
+    pub const SMPTE428: u8 = 10;
+    pub const SMPTE431: u8 = 11;
+    pub const SMPTE432: u8 = 12;
+    pub const EBU3213: u8 = 22;
+}
+
+/// TransferCharacteristics values — H.273 §8.2.
+pub mod transfer {
+    pub const BT709: u8 = 1;
+    pub const UNSPECIFIED: u8 = 2;
+    pub const GAMMA22: u8 = 4;
+    pub const GAMMA28: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const LINEAR: u8 = 8;
+    pub const LOG100: u8 = 9;
+    pub const LOG100_SQRT10: u8 = 10;
+    pub const XVYCC: u8 = 11;
+    pub const BT1361: u8 = 12;
+    pub const SRGB: u8 = 13;
+    pub const BT2020_TEN_BIT: u8 = 14;
+    pub const BT2020_TWELVE_BIT: u8 = 15;
+    pub const SMPTE2084: u8 = 16;
+    pub const SMPTE428: u8 = 17;
+    pub const ARIB_STD_B67: u8 = 18;
+}
+
+/// MatrixCoefficients values — H.273 §8.3.
+pub mod matrix {
+    pub const IDENTITY: u8 = 0;
+    pub const BT709: u8 = 1;
+    pub const UNSPECIFIED: u8 = 2;
+    pub const FCC: u8 = 4;
+    pub const BT470_BG: u8 = 5;
+    pub const SMPTE170M: u8 = 6;
+    pub const SMPTE240M: u8 = 7;
+    pub const YCGCO: u8 = 8;
+    pub const BT2020_NCL: u8 = 9;
+    pub const BT2020_CL: u8 = 10;
+    pub const SMPTE2085: u8 = 11;
+    pub const CHROMA_NCL: u8 = 12;
+    pub const CHROMA_CL: u8 = 13;
+    pub const ICTCP: u8 = 14;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_all_none() {
+        let v = H273ColorVui::default();
+        assert!(!v.is_video_signal_type_block_needed());
+        assert!(!v.is_colour_description_block_needed());
+    }
+
+    #[test]
+    fn full_range_alone_triggers_video_signal_type_block_but_not_colour_description() {
+        let v = H273ColorVui {
+            full_range: Some(true),
+            ..Default::default()
+        };
+        assert!(v.is_video_signal_type_block_needed());
+        assert!(!v.is_colour_description_block_needed());
+        assert_eq!(v.full_range_bit(), 1);
+    }
+
+    #[test]
+    fn any_color_axis_triggers_both_blocks() {
+        let v = H273ColorVui {
+            primaries: Some(primaries::BT709),
+            ..Default::default()
+        };
+        assert!(v.is_video_signal_type_block_needed());
+        assert!(v.is_colour_description_block_needed());
+    }
+
+    #[test]
+    fn unspecified_substitutes_for_none() {
+        let v = H273ColorVui {
+            primaries: Some(primaries::BT709),
+            transfer: None,
+            matrix: Some(matrix::SMPTE170M),
+            full_range: Some(false),
+        };
+        assert_eq!(v.primaries_byte(), 1);
+        assert_eq!(v.transfer_byte(), H273_UNSPECIFIED);
+        assert_eq!(v.matrix_byte(), 6);
+        assert_eq!(v.full_range_bit(), 0);
+    }
+
+    #[test]
+    fn h273_enumerant_constants_match_spec() {
+        // Spot-check the values streamlib's color_info.yaml claims map to
+        // H.273. If any of these change the YAML is wrong.
+        assert_eq!(primaries::BT709, 1);
+        assert_eq!(primaries::SMPTE170M, 6);
+        assert_eq!(primaries::BT2020, 9);
+        assert_eq!(transfer::BT709, 1);
+        assert_eq!(transfer::SRGB, 13);
+        assert_eq!(transfer::SMPTE2084, 16);
+        assert_eq!(transfer::ARIB_STD_B67, 18);
+        assert_eq!(matrix::IDENTITY, 0);
+        assert_eq!(matrix::BT709, 1);
+        assert_eq!(matrix::SMPTE170M, 6);
+        assert_eq!(matrix::BT2020_NCL, 9);
+    }
+}

--- a/libs/vulkan-video/src/encode/config.rs
+++ b/libs/vulkan-video/src/encode/config.rs
@@ -9,6 +9,7 @@
 use vulkanalia::vk;
 use vulkanalia::vk::Handle;
 
+use super::color_vui::H273ColorVui;
 use crate::video_context::{VideoError, VideoResult};
 use crate::vk_video_encoder::vk_video_encoder_def::{align_size, H264_MB_SIZE_ALIGNMENT};
 use crate::vk_video_encoder::vk_video_gop_structure::{
@@ -141,6 +142,11 @@ pub(crate) struct EncodeConfig {
     pub(crate) max_dpb_slots: u32,
     /// Bitstream output buffer size in bytes (0 = use default 2 MiB).
     pub(crate) bitstream_buffer_size: usize,
+    /// H.273 color VUI metadata to chain into the SPS. `None` skips the
+    /// colour_description block; an `H273ColorVui` whose every axis is
+    /// `None` is equivalent. Range alone (no primaries/transfer/matrix)
+    /// emits only the video_signal_type block.
+    pub(crate) color_vui: Option<H273ColorVui>,
 }
 
 impl Default for EncodeConfig {
@@ -166,6 +172,7 @@ impl Default for EncodeConfig {
             num_b_frames: 0,
             max_dpb_slots: 16,
             bitstream_buffer_size: 0,
+            color_vui: None,
         }
     }
 }
@@ -370,6 +377,11 @@ pub struct SimpleEncoderConfig {
     /// See `docs/research/h265-encoder-quality-knobs.md` for why this knob
     /// does not move PSNR at fixed CQP.
     pub effort_level: Option<u32>,
+    /// H.273 color VUI metadata baked into the SPS at session-parameter
+    /// creation time. `None` (or `Some(H273ColorVui::default())`) emits no
+    /// colour_description block. Callers translate their domain `ColorInfo`
+    /// → [`H273ColorVui`] at the processor seam.
+    pub color_vui: Option<H273ColorVui>,
 }
 
 /// Default Vulkan encoder-effort index per codec.
@@ -405,6 +417,7 @@ impl Default for SimpleEncoderConfig {
             idr_interval_secs: 2,
             prepend_header_to_idr: None,
             effort_level: None,
+            color_vui: None,
         }
     }
 }
@@ -504,6 +517,7 @@ impl SimpleEncoderConfig {
             idr_period,
             num_b_frames: num_b,
             max_dpb_slots: if num_b > 0 { 6 } else { 4 },
+            color_vui: self.color_vui,
             ..Default::default()
         }
     }

--- a/libs/vulkan-video/src/encode/mod.rs
+++ b/libs/vulkan-video/src/encode/mod.rs
@@ -17,6 +17,7 @@
 //! interface that stitches together VkVideoEncoder, VkEncoderConfig, the DPB
 //! modules, and Vulkan Video encode commands into a usable library API.
 
+pub mod color_vui;
 pub mod config;
 mod session;
 mod submit;
@@ -27,6 +28,7 @@ mod vui_patch;
 #[cfg(test)]
 mod tests;
 
+pub use color_vui::H273ColorVui;
 pub use config::*;
 
 use vulkanalia::prelude::v1_4::*;

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -560,9 +560,15 @@ impl SimpleEncoder {
                     }
                 }
             }
+            // Decoders skip these fields entirely when
+            // `colour_description_present_flag = 0`, but emit H.273
+            // "Unspecified" (2) rather than "Reserved" (0) for
+            // spec-symmetry — the fields are part of the same byte
+            // budget the per-axis `_byte()` accessors already honor.
+            let unspec = crate::encode::color_vui::H273_UNSPECIFIED;
             let (vui_primaries, vui_transfer, vui_matrix) = color_vui
                 .map(|cv| (cv.primaries_byte(), cv.transfer_byte(), cv.matrix_byte()))
-                .unwrap_or((0, 0, 0));
+                .unwrap_or((unspec, unspec, unspec));
 
             h264_sps_vui = vk::video::StdVideoH264SequenceParameterSetVui {
                 flags: vui_flags,

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -509,6 +509,7 @@ impl SimpleEncoder {
         // H.264: add SPS + PPS parameter sets
         let h264_sps;
         let h264_pps;
+        let h264_sps_vui;
         let h264_add_info;
         let mut h264_params;
 
@@ -518,6 +519,7 @@ impl SimpleEncoder {
         let h265_vps;
         let h265_sps;
         let h265_pps;
+        let h265_sps_vui: Option<vk::video::StdVideoH265SequenceParameterSetVui>;
         let h265_add_info;
         let mut h265_params;
         let h265_dec_pic_buf_mgr;
@@ -538,10 +540,54 @@ impl SimpleEncoder {
                 enc.log2_max_pic_order_cnt_lsb_minus4,
             );
 
+            // Build the SPS VUI: always emit timing (replaces the post-write
+            // patch in vui_patch.rs) and conditionally include the
+            // colour_description block when the caller provided color info.
+            // Time scale convention matches the legacy patcher:
+            // num_units_in_tick = framerate_denominator,
+            // time_scale = framerate_numerator * 2 (field-based, 2 ticks
+            // per frame).
+            let mut vui_flags: vk::video::StdVideoH264SpsVuiFlags = std::mem::zeroed();
+            vui_flags.set_timing_info_present_flag(1);
+            vui_flags.set_fixed_frame_rate_flag(1);
+            let color_vui = config.color_vui;
+            if let Some(cv) = color_vui {
+                if cv.is_video_signal_type_block_needed() {
+                    vui_flags.set_video_signal_type_present_flag(1);
+                    vui_flags.set_video_full_range_flag(cv.full_range_bit());
+                    if cv.is_colour_description_block_needed() {
+                        vui_flags.set_color_description_present_flag(1);
+                    }
+                }
+            }
+            let (vui_primaries, vui_transfer, vui_matrix) = color_vui
+                .map(|cv| (cv.primaries_byte(), cv.transfer_byte(), cv.matrix_byte()))
+                .unwrap_or((0, 0, 0));
+
+            h264_sps_vui = vk::video::StdVideoH264SequenceParameterSetVui {
+                flags: vui_flags,
+                aspect_ratio_idc: vk::video::StdVideoH264AspectRatioIdc(0),
+                sar_width: 0,
+                sar_height: 0,
+                video_format: 5, // "Unspecified" per H.264 Annex E
+                colour_primaries: vui_primaries,
+                transfer_characteristics: vui_transfer,
+                matrix_coefficients: vui_matrix,
+                num_units_in_tick: config.framerate_denominator,
+                time_scale: config.framerate_numerator.saturating_mul(2),
+                max_num_reorder_frames: 0,
+                max_dec_frame_buffering: 0,
+                chroma_sample_loc_type_top_field: 0,
+                chroma_sample_loc_type_bottom_field: 0,
+                reserved1: 0,
+                pHrdParameters: ptr::null(),
+            };
+
             let mut sps_flags: vk::video::StdVideoH264SpsFlags = std::mem::zeroed();
             sps_flags.set_direct_8x8_inference_flag(if state.sps_info.direct_8x8_inference_flag { 1 } else { 0 });
             sps_flags.set_frame_mbs_only_flag(if state.sps_info.frame_mbs_only_flag { 1 } else { 0 });
             sps_flags.set_frame_cropping_flag(if state.sps_info.frame_cropping_flag { 1 } else { 0 });
+            sps_flags.set_vui_parameters_present_flag(1);
 
             h264_sps = vk::video::StdVideoH264SequenceParameterSet {
                 flags: sps_flags,
@@ -570,7 +616,7 @@ impl SimpleEncoder {
                 reserved2: 0,
                 pOffsetForRefFrame: ptr::null(),
                 pScalingLists: ptr::null(),
-                pSequenceParameterSetVui: ptr::null(),
+                pSequenceParameterSetVui: &h264_sps_vui,
             };
 
             let mut pps_flags: vk::video::StdVideoH264PpsFlags = std::mem::zeroed();
@@ -660,6 +706,53 @@ impl SimpleEncoder {
                 pProfileTierLevel: &h265_profile_tier_level,
             };
 
+            // --- SPS VUI (color-only) ---
+            // H.265 timing rides in the VPS (patched separately in
+            // vui_patch.rs because NVIDIA's driver emits broken VPS
+            // timing). The SPS VUI therefore carries color metadata
+            // only — skipped entirely when the caller provided no
+            // color info, since fabricating defaults defeats the
+            // purpose of typed color metadata.
+            h265_sps_vui = match config.color_vui {
+                Some(cv) if cv.is_video_signal_type_block_needed() => {
+                    let mut flags: vk::video::StdVideoH265SpsVuiFlags = std::mem::zeroed();
+                    flags.set_video_signal_type_present_flag(1);
+                    flags.set_video_full_range_flag(cv.full_range_bit());
+                    if cv.is_colour_description_block_needed() {
+                        flags.set_colour_description_present_flag(1);
+                    }
+                    Some(vk::video::StdVideoH265SequenceParameterSetVui {
+                        flags,
+                        aspect_ratio_idc: vk::video::StdVideoH265AspectRatioIdc(0),
+                        sar_width: 0,
+                        sar_height: 0,
+                        video_format: 5, // "Unspecified" per H.265 Annex E
+                        colour_primaries: cv.primaries_byte(),
+                        transfer_characteristics: cv.transfer_byte(),
+                        matrix_coeffs: cv.matrix_byte(),
+                        chroma_sample_loc_type_top_field: 0,
+                        chroma_sample_loc_type_bottom_field: 0,
+                        reserved1: 0,
+                        reserved2: 0,
+                        def_disp_win_left_offset: 0,
+                        def_disp_win_right_offset: 0,
+                        def_disp_win_top_offset: 0,
+                        def_disp_win_bottom_offset: 0,
+                        vui_num_units_in_tick: 0,
+                        vui_time_scale: 0,
+                        vui_num_ticks_poc_diff_one_minus1: 0,
+                        min_spatial_segmentation_idc: 0,
+                        reserved3: 0,
+                        max_bytes_per_pic_denom: 0,
+                        max_bits_per_min_cu_denom: 0,
+                        log2_max_mv_length_horizontal: 0,
+                        log2_max_mv_length_vertical: 0,
+                        pHrdParameters: ptr::null(),
+                    })
+                }
+                _ => None,
+            };
+
             // --- SPS flags (C++ lines 661-689) ---
             let mut sps_flags: vk::video::StdVideoH265SpsFlags = std::mem::zeroed();
             sps_flags.set_sps_temporal_id_nesting_flag(1);            // C++ line 661
@@ -675,6 +768,9 @@ impl SimpleEncoder {
             sps_flags.set_sample_adaptive_offset_enabled_flag(1);      // C++ line 667
             // strong_intra_smoothing_enabled_flag = 0 (C++ line 672) — already 0
             // sps_temporal_mvp_enabled_flag = 0 (C++ line 671) — already 0
+            if h265_sps_vui.is_some() {
+                sps_flags.set_vui_parameters_present_flag(1);
+            }
 
             // --- SPS (C++ lines 691-757) ---
             h265_sps = vk::video::StdVideoH265SequenceParameterSet {
@@ -716,7 +812,10 @@ impl SimpleEncoder {
                 pScalingLists: ptr::null(),
                 pShortTermRefPicSet: ptr::null(),
                 pLongTermRefPicsSps: ptr::null(),
-                pSequenceParameterSetVui: ptr::null(),
+                pSequenceParameterSetVui: h265_sps_vui
+                    .as_ref()
+                    .map(|v| v as *const _)
+                    .unwrap_or(ptr::null()),
                 pPredictorPaletteEntries: ptr::null(),
             };
 

--- a/libs/vulkan-video/src/encode/vui_patch.rs
+++ b/libs/vulkan-video/src/encode/vui_patch.rs
@@ -1,17 +1,19 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Patch VUI/timing fields in driver-generated SPS/VPS NAL units.
+//! Patch VPS timing fields in driver-generated H.265 VPS NAL units.
 //!
-//! The NVIDIA Vulkan Video encoder emits SPS/VPS NAL units with broken timing
-//! info (time_scale=0 for H.264, wrong r_frame_rate for H.265). This module
-//! parses the cached header bytes, locates the VUI/timing section, and rewrites
-//! it with correct values derived from the encoder config's framerate.
+//! The NVIDIA Vulkan Video encoder emits an H.265 VPS NAL with broken timing
+//! (`vps_time_scale = 0` / wrong `vps_num_units_in_tick`). The VPS is a
+//! separate NAL from the SPS, so its timing block cannot be set through the
+//! standard `pSequenceParameterSetVui` chain — this module parses the cached
+//! VPS bytes, locates the timing section, and rewrites it with correct
+//! values derived from the encoder config's framerate.
 //!
-//! Approach: parse the driver-generated NAL to the VUI/timing bit offset, copy
-//! all preceding bits verbatim, then write a corrected VUI/timing section
-//! followed by RBSP trailing bits. This avoids re-serializing the entire
-//! parameter set.
+//! H.264 timing rides in the SPS VUI, which the session-parameter creation
+//! path now chains directly via `pSequenceParameterSetVui` (see
+//! `session.rs::create_session_parameters`). No post-write H.264 patching
+//! is required.
 
 use vulkanalia::vk;
 
@@ -71,18 +73,6 @@ impl<'a> BitReader<'a> {
         (1u32 << lz) - 1 + suffix
     }
 
-    fn se(&mut self) -> i32 {
-        let code = self.ue();
-        if code == 0 {
-            return 0;
-        }
-        let val = ((code + 1) / 2) as i32;
-        if code % 2 == 0 {
-            -val
-        } else {
-            val
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -276,103 +266,6 @@ fn reassemble_nals(nals: &[(usize, Vec<u8>)]) -> Vec<u8> {
 }
 
 // ---------------------------------------------------------------------------
-// H.264: find vui_parameters_present_flag bit offset in SPS RBSP
-// ---------------------------------------------------------------------------
-
-/// Advance the reader past an H.264 scaling list of the given size.
-/// Reads `scaling_list_present_flag` and, if set, up to `size` delta values.
-fn skip_h264_scaling_list(r: &mut BitReader, size: usize) {
-    if r.flag() {
-        let mut last_scale: i32 = 8;
-        let mut next_scale: i32 = 8;
-        for _j in 0..size {
-            if next_scale != 0 {
-                let delta = r.se();
-                next_scale = (last_scale + delta) & 0xff;
-            }
-            let scale = if next_scale == 0 {
-                last_scale
-            } else {
-                next_scale
-            };
-            last_scale = scale;
-        }
-    }
-}
-
-/// Parse H.264 SPS RBSP (after NAL header byte) to find the bit offset of
-/// `vui_parameters_present_flag`. Returns `None` if parsing fails (data too
-/// short or unexpected structure).
-fn find_h264_sps_vui_bit_offset(rbsp: &[u8]) -> Option<usize> {
-    let mut r = BitReader::new(rbsp);
-    if r.remaining() < 24 {
-        return None;
-    }
-
-    let profile_idc = r.u(8) as u8;
-    r.u(8); // constraint_set_flags
-    r.u(8); // level_idc
-    r.ue(); // seq_parameter_set_id
-
-    // High profile extensions
-    if matches!(
-        profile_idc,
-        100 | 110 | 122 | 244 | 44 | 83 | 86 | 118 | 128 | 138 | 139 | 134 | 135
-    ) {
-        let chroma_format_idc = r.ue();
-        if chroma_format_idc == 3 {
-            r.flag(); // separate_colour_plane_flag
-        }
-        r.ue(); // bit_depth_luma_minus8
-        r.ue(); // bit_depth_chroma_minus8
-        r.flag(); // qpprime_y_zero_transform_bypass_flag
-        if r.flag() {
-            // seq_scaling_matrix_present_flag
-            for i in 0..8u32 {
-                let size = if i < 6 { 16 } else { 64 };
-                skip_h264_scaling_list(&mut r, size);
-            }
-        }
-    }
-
-    r.ue(); // log2_max_frame_num_minus4
-    let poc_type = r.ue();
-    if poc_type == 0 {
-        r.ue(); // log2_max_pic_order_cnt_lsb_minus4
-    } else if poc_type == 1 {
-        r.flag(); // delta_pic_order_always_zero_flag
-        r.se(); // offset_for_non_ref_pic
-        r.se(); // offset_for_top_to_bottom_field
-        let n = r.ue();
-        for _ in 0..n {
-            r.se(); // offset_for_ref_frame[i]
-        }
-    }
-
-    r.ue(); // max_num_ref_frames
-    r.flag(); // gaps_in_frame_num_value_allowed_flag
-    r.ue(); // pic_width_in_mbs_minus1
-    r.ue(); // pic_height_in_map_units_minus1
-    let frame_mbs_only = r.flag();
-    if !frame_mbs_only {
-        r.flag(); // mb_adaptive_frame_field_flag
-    }
-    r.flag(); // direct_8x8_inference_flag
-    if r.flag() {
-        // frame_cropping_flag
-        r.ue(); // crop_left
-        r.ue(); // crop_right
-        r.ue(); // crop_top
-        r.ue(); // crop_bottom
-    }
-
-    if r.remaining() < 1 {
-        return None;
-    }
-    Some(r.pos())
-}
-
-// ---------------------------------------------------------------------------
 // H.265: find timing_info_present_flag bit offset in VPS RBSP
 // ---------------------------------------------------------------------------
 
@@ -456,70 +349,6 @@ fn find_h265_vps_timing_bit_offset(rbsp: &[u8]) -> Option<usize> {
 }
 
 // ---------------------------------------------------------------------------
-// H.264 SPS NAL patching
-// ---------------------------------------------------------------------------
-
-/// Patch an H.264 SPS NAL unit to include correct VUI timing.
-/// `nal_bytes` includes the 1-byte NAL header.
-fn patch_h264_sps_nal(nal_bytes: &[u8], fps_num: u32, fps_den: u32) -> Vec<u8> {
-    if nal_bytes.len() < 2 {
-        return nal_bytes.to_vec();
-    }
-
-    let nal_header = nal_bytes[0];
-    let rbsp_with_epb = &nal_bytes[1..];
-    let rbsp = remove_epb(rbsp_with_epb);
-
-    let vui_offset = match find_h264_sps_vui_bit_offset(&rbsp) {
-        Some(off) => off,
-        None => {
-            tracing::warn!("Failed to find VUI offset in H.264 SPS, skipping timing patch");
-            return nal_bytes.to_vec();
-        }
-    };
-
-    let mut w = BitWriter::new();
-
-    // Copy all bits before vui_parameters_present_flag
-    copy_bits(&rbsp, &mut w, vui_offset);
-
-    // Write vui_parameters_present_flag = 1
-    w.put_bit(1);
-
-    // Write minimal VUI with correct timing info.
-    // All flags before timing are set to 0 (no aspect ratio, overscan,
-    // video signal type, or chroma loc info).
-    w.put_bit(0); // aspect_ratio_info_present_flag
-    w.put_bit(0); // overscan_info_present_flag
-    w.put_bit(0); // video_signal_type_present_flag
-    w.put_bit(0); // chroma_loc_info_present_flag
-
-    // Timing info
-    w.put_bit(1); // timing_info_present_flag
-    w.put_bits(fps_den, 32); // num_units_in_tick
-    w.put_bits(fps_num * 2, 32); // time_scale (field-based: 2 ticks per frame)
-    w.put_bit(1); // fixed_frame_rate_flag
-
-    // HRD and remaining VUI flags
-    w.put_bit(0); // nal_hrd_parameters_present_flag
-    w.put_bit(0); // vcl_hrd_parameters_present_flag
-    // (no low_delay_hrd_flag since neither HRD present)
-    w.put_bit(0); // pic_struct_present_flag
-    w.put_bit(0); // bitstream_restriction_flag
-
-    // RBSP trailing bits
-    w.trailing_bits();
-
-    // Re-add EPBs and prepend NAL header
-    let patched_rbsp = w.into_bytes();
-    let with_epb = add_epb(&patched_rbsp);
-    let mut result = Vec::with_capacity(1 + with_epb.len());
-    result.push(nal_header);
-    result.extend_from_slice(&with_epb);
-    result
-}
-
-// ---------------------------------------------------------------------------
 // H.265 VPS NAL patching
 // ---------------------------------------------------------------------------
 
@@ -573,15 +402,15 @@ fn patch_h265_vps_nal(nal_bytes: &[u8], fps_num: u32, fps_den: u32) -> Vec<u8> {
 // Top-level: patch entire cached header
 // ---------------------------------------------------------------------------
 
-/// Patch the timing info in the cached SPS/VPS header bytes.
+/// Patch the timing info in the cached H.265 VPS header bytes.
 ///
-/// For H.264: rewrites the SPS VUI to include correct `num_units_in_tick` and
-/// `time_scale` derived from `fps_num` / `fps_den`.
+/// Only the H.265 VPS is rewritten — `vps_num_units_in_tick` /
+/// `vps_time_scale`. H.264 SPS VUI timing is now produced directly by the
+/// session-parameter creation path (`session.rs::create_session_parameters`
+/// chains `pSequenceParameterSetVui`), so calls with
+/// `codec_flag = ENCODE_H264` are a no-op and return the input unchanged.
 ///
-/// For H.265: rewrites the VPS to include correct `vps_num_units_in_tick` and
-/// `vps_time_scale`.
-///
-/// PPS NAL units are passed through unchanged.
+/// All other NAL units (SPS, PPS, slice data) are passed through unchanged.
 pub(crate) fn patch_header_timing(
     header: &[u8],
     codec_flag: vk::VideoCodecOperationFlagsKHR,
@@ -589,6 +418,10 @@ pub(crate) fn patch_header_timing(
     fps_den: u32,
 ) -> Vec<u8> {
     if header.is_empty() || fps_num == 0 || fps_den == 0 {
+        return header.to_vec();
+    }
+    if codec_flag != vk::VideoCodecOperationFlagsKHR::ENCODE_H265 {
+        // H.264 timing now rides in the SPS VUI chain; nothing to patch.
         return header.to_vec();
     }
 
@@ -604,36 +437,17 @@ pub(crate) fn patch_header_timing(
             patched.push((*sc_len, nal_data.clone()));
             continue;
         }
-
-        if codec_flag == vk::VideoCodecOperationFlagsKHR::ENCODE_H264 {
-            let nal_type = nal_data[0] & 0x1F;
-            if nal_type == 7 {
-                // SPS
-                tracing::debug!(
-                    original_len = nal_data.len(),
-                    fps_num,
-                    fps_den,
-                    "Patching H.264 SPS VUI timing"
-                );
-                patched.push((*sc_len, patch_h264_sps_nal(nal_data, fps_num, fps_den)));
-            } else {
-                patched.push((*sc_len, nal_data.clone()));
-            }
-        } else if codec_flag == vk::VideoCodecOperationFlagsKHR::ENCODE_H265 {
-            // H.265 NAL type is bits [1:6] of the first byte
-            let nal_type = (nal_data[0] >> 1) & 0x3F;
-            if nal_type == 32 {
-                // VPS
-                tracing::debug!(
-                    original_len = nal_data.len(),
-                    fps_num,
-                    fps_den,
-                    "Patching H.265 VPS timing"
-                );
-                patched.push((*sc_len, patch_h265_vps_nal(nal_data, fps_num, fps_den)));
-            } else {
-                patched.push((*sc_len, nal_data.clone()));
-            }
+        // H.265 NAL type is bits [1:6] of the first byte
+        let nal_type = (nal_data[0] >> 1) & 0x3F;
+        if nal_type == 32 {
+            // VPS
+            tracing::debug!(
+                original_len = nal_data.len(),
+                fps_num,
+                fps_den,
+                "Patching H.265 VPS timing"
+            );
+            patched.push((*sc_len, patch_h265_vps_nal(nal_data, fps_num, fps_den)));
         } else {
             patched.push((*sc_len, nal_data.clone()));
         }
@@ -781,131 +595,19 @@ mod tests {
     }
 
     #[test]
-    fn test_h264_sps_vui_offset_basic() {
-        // Build a minimal Baseline profile SPS RBSP (after NAL header byte):
-        // profile_idc=66 (Baseline, NOT high profile), constraint=0, level=30
-        // sps_id=0, log2_max_frame_num=0, poc_type=0, log2_max_poc_lsb=0,
-        // max_ref=1, gaps=0, width=7 (128px), height=5 (96px),
-        // frame_mbs_only=1, direct_8x8=1, no cropping
-        let mut w = BitWriter::new();
-        w.put_bits(66, 8); // profile_idc = Baseline
-        w.put_bits(0, 8); // constraint_set_flags
-        w.put_bits(30, 8); // level_idc
-        w.put_ue(0); // sps_id
-        // (no high profile extension)
-        w.put_ue(0); // log2_max_frame_num_minus4
-        w.put_ue(0); // pic_order_cnt_type = 0
-        w.put_ue(0); // log2_max_pic_order_cnt_lsb_minus4
-        w.put_ue(1); // max_num_ref_frames
-        w.put_bit(0); // gaps_in_frame_num
-        w.put_ue(7); // pic_width_in_mbs_minus1
-        w.put_ue(5); // pic_height_in_map_units_minus1
-        w.put_bit(1); // frame_mbs_only_flag
-        w.put_bit(1); // direct_8x8_inference_flag
-        w.put_bit(0); // frame_cropping_flag
-        // NEXT BIT: vui_parameters_present_flag
-        let expected_offset = w.bit_pos;
-        w.put_bit(0); // vui_parameters_present_flag = 0
-        w.trailing_bits();
-
-        let rbsp = w.into_bytes();
-        let offset = find_h264_sps_vui_bit_offset(&rbsp).unwrap();
-        assert_eq!(offset, expected_offset);
-    }
-
-    #[test]
-    fn test_patch_h264_sps_roundtrip() {
-        // Build a minimal SPS NAL and patch it
-        let mut w = BitWriter::new();
-        w.put_bits(66, 8); // profile_idc
-        w.put_bits(0, 8); // constraint
-        w.put_bits(30, 8); // level
-        w.put_ue(0); // sps_id
-        w.put_ue(0); // log2_max_frame_num
-        w.put_ue(0); // poc_type
-        w.put_ue(0); // log2_max_poc_lsb
-        w.put_ue(1); // max_ref
-        w.put_bit(0); // gaps
-        w.put_ue(7); // width
-        w.put_ue(5); // height
-        w.put_bit(1); // frame_mbs_only
-        w.put_bit(1); // direct_8x8
-        w.put_bit(0); // cropping
-        w.put_bit(0); // vui_present=0
-        w.trailing_bits();
-        let rbsp = w.into_bytes();
-
-        // Add NAL header (SPS, nal_ref_idc=3)
-        let mut nal = vec![0x67]; // 0110 0111 = ref_idc=3, type=7
-        nal.extend_from_slice(&add_epb(&rbsp));
-
-        let patched = patch_h264_sps_nal(&nal, 30, 1);
-
-        // Parse the patched NAL to verify VUI timing
-        let patched_rbsp = remove_epb(&patched[1..]);
-        let vui_offset = find_h264_sps_vui_bit_offset(&patched_rbsp).unwrap();
-        let mut r = BitReader::new(&patched_rbsp);
-        r.u(vui_offset as u32); // skip to VUI flag
-        assert!(r.flag()); // vui_parameters_present_flag = 1
-        assert!(!r.flag()); // aspect_ratio_info_present_flag = 0
-        assert!(!r.flag()); // overscan_info_present_flag = 0
-        assert!(!r.flag()); // video_signal_type_present_flag = 0
-        assert!(!r.flag()); // chroma_loc_info_present_flag = 0
-        assert!(r.flag()); // timing_info_present_flag = 1
-        let num_units = r.u(32);
-        let time_scale = r.u(32);
-        let fixed = r.flag();
-        assert_eq!(num_units, 1); // fps_den
-        assert_eq!(time_scale, 60); // fps_num * 2
-        assert!(fixed); // fixed_frame_rate_flag
-    }
-
-    #[test]
-    fn test_patch_header_h264() {
-        // Build a complete Annex-B header with SPS + PPS
-        let mut sps_w = BitWriter::new();
-        sps_w.put_bits(66, 8);
-        sps_w.put_bits(0, 8);
-        sps_w.put_bits(30, 8);
-        sps_w.put_ue(0);
-        sps_w.put_ue(0);
-        sps_w.put_ue(0);
-        sps_w.put_ue(0);
-        sps_w.put_ue(1);
-        sps_w.put_bit(0);
-        sps_w.put_ue(7);
-        sps_w.put_ue(5);
-        sps_w.put_bit(1);
-        sps_w.put_bit(1);
-        sps_w.put_bit(0);
-        sps_w.put_bit(0); // no VUI
-        sps_w.trailing_bits();
-        let sps_rbsp = sps_w.into_bytes();
-
-        let mut header = Vec::new();
-        // SPS with 4-byte start code
-        header.extend_from_slice(&[0, 0, 0, 1, 0x67]);
-        header.extend_from_slice(&add_epb(&sps_rbsp));
-        // PPS with 4-byte start code
-        header.extend_from_slice(&[0, 0, 0, 1, 0x68, 0xCE, 0x38, 0x80]);
-
+    fn h264_patch_header_timing_is_no_op() {
+        // H.264 timing rides in the SPS VUI chain now; patch_header_timing
+        // should pass the bytes through unchanged for H.264.
+        let header = vec![
+            0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1E, // SPS NAL (Baseline)
+            0, 0, 0, 1, 0x68, 0xCE, 0x38, 0x80, // PPS NAL
+        ];
         let patched = patch_header_timing(
             &header,
             vk::VideoCodecOperationFlagsKHR::ENCODE_H264,
             30,
             1,
         );
-
-        // The patched header should still have 2 NALs
-        let nals = split_nals(&patched);
-        assert_eq!(nals.len(), 2);
-        // SPS should be patched (different from original)
-        assert_ne!(nals[0].1, {
-            let mut v = vec![0x67];
-            v.extend_from_slice(&add_epb(&sps_rbsp));
-            v
-        });
-        // PPS should be unchanged
-        assert_eq!(nals[1].1, vec![0x68, 0xCE, 0x38, 0x80]);
+        assert_eq!(patched, header);
     }
 }

--- a/libs/vulkan-video/src/lib.rs
+++ b/libs/vulkan-video/src/lib.rs
@@ -32,6 +32,7 @@ pub use video_context::{
 pub use decode::{DecodedFrame, SimpleDecoder, SimpleDecoderConfig, SimpleDecodedFrame};
 pub use encode::{EncodedOutput, FrameType};
 pub use encode::{SimpleEncoder, SimpleEncoderConfig, EncodePacket, Codec, Preset};
+pub use encode::{color_vui, H273ColorVui};
 pub use rgb_to_nv12::RgbToNv12Converter;
 pub use nv12_to_rgb::Nv12ToRgbConverter;
 pub use rhi::{RhiQueueSubmitter, RawQueueSubmitter};

--- a/libs/vulkan-video/src/nv_video_parser/vulkan_h265_decoder.rs
+++ b/libs/vulkan-video/src/nv_video_parser/vulkan_h265_decoder.rs
@@ -2558,9 +2558,44 @@ impl VulkanH265Decoder {
         sps.flags.sps_temporal_mvp_enabled_flag = reader.u(1)? != 0;
         sps.flags.strong_intra_smoothing_enabled_flag = reader.u(1)? != 0;
 
-        // VUI parameters — skip for now (not needed for decode correctness)
+        // VUI parameters — parse only the color-relevant subset
+        // (aspect-ratio + video_signal_type → colour_description).
+        // The rest of the VUI is left unparsed; full H.265 VUI parsing
+        // is huge and not needed for decode correctness. Color fields
+        // are surfaced via `SimpleDecoder::current_color_vui()`.
         sps.flags.vui_parameters_present_flag = reader.u(1)? != 0;
-        // VUI parsing omitted; only needed for display timing, not decode
+        if sps.flags.vui_parameters_present_flag {
+            // aspect_ratio_info_present_flag
+            let aspect_ratio_info_present = reader.u(1)? != 0;
+            if aspect_ratio_info_present {
+                let aspect_ratio_idc = reader.u(8)?;
+                if aspect_ratio_idc == 255 {
+                    // EXTENDED_SAR
+                    reader.u(16)?; // sar_width
+                    reader.u(16)?; // sar_height
+                }
+            }
+            // overscan_info_present_flag
+            let overscan_info_present = reader.u(1)? != 0;
+            if overscan_info_present {
+                reader.u(1)?; // overscan_appropriate_flag
+            }
+            // video_signal_type_present_flag
+            sps.vui.flags.video_signal_type_present_flag = reader.u(1)? != 0;
+            if sps.vui.flags.video_signal_type_present_flag {
+                sps.vui.video_format = reader.u(3)? as u8;
+                sps.vui.flags.video_full_range_flag = reader.u(1)? != 0;
+                sps.vui.flags.colour_description_present_flag = reader.u(1)? != 0;
+                if sps.vui.flags.colour_description_present_flag {
+                    sps.vui.colour_primaries = reader.u(8)? as u8;
+                    sps.vui.transfer_characteristics = reader.u(8)? as u8;
+                    sps.vui.matrix_coeffs = reader.u(8)? as u8;
+                }
+            }
+            // Stop here — remaining VUI fields (chroma_loc_info, neutral_chroma,
+            // field_seq, frame_field_info, default_display_window, timing, HRD,
+            // bitstream_restriction) are not consumed by streamlib today.
+        }
 
         // SPS extensions — skip
         // (not needed for basic decode correctness)

--- a/packages/h264/src/linux/color_vui_translate.rs
+++ b/packages/h264/src/linux/color_vui_translate.rs
@@ -1,0 +1,236 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Translation between the engine-side `ColorInfo` domain enums (from
+//! `@tatolab/core`'s JTD codegen) and `vulkan_video::H273ColorVui`, the
+//! codec-native byte representation that crosses into the leaf
+//! `libs/vulkan-video` crate.
+//!
+//! The vulkan-video crate does not depend on `@tatolab/core` or the
+//! streamlib SDK; this seam is what keeps that boundary clean. Both H.264
+//! and H.265 packages carry an identical translator because each has its
+//! own codegen module (`crate::_generated_::*`); the duplication is ~70
+//! lines per codec and disappears if vulkan-video later adopts the SDK.
+
+use crate::_generated_::tatolab__core::color_info::{
+    ColorInfo, Matrix, Primaries, Range, Transfer,
+};
+use vulkan_video::{color_vui, H273ColorVui};
+
+/// Translate `ColorInfo` → `H273ColorVui` for the encoder's SPS chain.
+///
+/// Returns `None` when every axis is `None` — the caller treats that as
+/// "no codec-side color VUI requested" and leaves `SimpleEncoderConfig::
+/// color_vui = None`, which skips the colour_description block in the
+/// SPS entirely (timing is still emitted because the H.264 SPS always
+/// chains a VUI for it).
+pub fn color_info_to_h273(info: &ColorInfo) -> Option<H273ColorVui> {
+    let v = H273ColorVui {
+        primaries: info.primaries.as_ref().map(primaries_to_byte),
+        transfer: info.transfer.as_ref().map(transfer_to_byte),
+        matrix: info.matrix.as_ref().map(matrix_to_byte),
+        full_range: info.range.as_ref().map(|r| matches!(r, Range::Full)),
+    };
+    if !v.is_video_signal_type_block_needed() {
+        return None;
+    }
+    Some(v)
+}
+
+/// Translate `H273ColorVui` → `ColorInfo` for surfacing decoded VUI
+/// metadata on `VideoFrame.color_info`. Per-axis `None` (Unspecified on
+/// the wire) stays `None` in the result.
+pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
+    ColorInfo {
+        primaries: vui.primaries.and_then(primaries_from_byte),
+        transfer: vui.transfer.and_then(transfer_from_byte),
+        matrix: vui.matrix.and_then(matrix_from_byte),
+        range: vui.full_range.map(|f| if f { Range::Full } else { Range::Limited }),
+    }
+}
+
+fn primaries_to_byte(p: &Primaries) -> u8 {
+    match p {
+        Primaries::Bt709 => color_vui::primaries::BT709,
+        Primaries::Bt470M => color_vui::primaries::BT470_M,
+        Primaries::Bt470Bg => color_vui::primaries::BT470_BG,
+        Primaries::Smpte170m => color_vui::primaries::SMPTE170M,
+        Primaries::Smpte240m => color_vui::primaries::SMPTE240M,
+        Primaries::Film => color_vui::primaries::FILM,
+        Primaries::Bt2020 => color_vui::primaries::BT2020,
+        Primaries::Smpte428 => color_vui::primaries::SMPTE428,
+        Primaries::Smpte431 => color_vui::primaries::SMPTE431,
+        Primaries::Smpte432 => color_vui::primaries::SMPTE432,
+        Primaries::Ebu3213 => color_vui::primaries::EBU3213,
+    }
+}
+
+fn primaries_from_byte(b: u8) -> Option<Primaries> {
+    Some(match b {
+        x if x == color_vui::primaries::BT709 => Primaries::Bt709,
+        x if x == color_vui::primaries::BT470_M => Primaries::Bt470M,
+        x if x == color_vui::primaries::BT470_BG => Primaries::Bt470Bg,
+        x if x == color_vui::primaries::SMPTE170M => Primaries::Smpte170m,
+        x if x == color_vui::primaries::SMPTE240M => Primaries::Smpte240m,
+        x if x == color_vui::primaries::FILM => Primaries::Film,
+        x if x == color_vui::primaries::BT2020 => Primaries::Bt2020,
+        x if x == color_vui::primaries::SMPTE428 => Primaries::Smpte428,
+        x if x == color_vui::primaries::SMPTE431 => Primaries::Smpte431,
+        x if x == color_vui::primaries::SMPTE432 => Primaries::Smpte432,
+        x if x == color_vui::primaries::EBU3213 => Primaries::Ebu3213,
+        _ => return None,
+    })
+}
+
+fn transfer_to_byte(t: &Transfer) -> u8 {
+    match t {
+        Transfer::Bt709 => color_vui::transfer::BT709,
+        Transfer::Gamma22 => color_vui::transfer::GAMMA22,
+        Transfer::Gamma28 => color_vui::transfer::GAMMA28,
+        Transfer::Smpte170m => color_vui::transfer::SMPTE170M,
+        Transfer::Smpte240m => color_vui::transfer::SMPTE240M,
+        Transfer::Linear => color_vui::transfer::LINEAR,
+        Transfer::Log100 => color_vui::transfer::LOG100,
+        Transfer::Log100Sqrt10 => color_vui::transfer::LOG100_SQRT10,
+        Transfer::Xvycc => color_vui::transfer::XVYCC,
+        Transfer::Bt1361 => color_vui::transfer::BT1361,
+        Transfer::Srgb => color_vui::transfer::SRGB,
+        Transfer::Bt2020TenBit => color_vui::transfer::BT2020_TEN_BIT,
+        Transfer::Bt2020TwelveBit => color_vui::transfer::BT2020_TWELVE_BIT,
+        Transfer::Smpte2084 => color_vui::transfer::SMPTE2084,
+        Transfer::Smpte428 => color_vui::transfer::SMPTE428,
+        Transfer::AribStdB67 => color_vui::transfer::ARIB_STD_B67,
+    }
+}
+
+fn transfer_from_byte(b: u8) -> Option<Transfer> {
+    Some(match b {
+        x if x == color_vui::transfer::BT709 => Transfer::Bt709,
+        x if x == color_vui::transfer::GAMMA22 => Transfer::Gamma22,
+        x if x == color_vui::transfer::GAMMA28 => Transfer::Gamma28,
+        x if x == color_vui::transfer::SMPTE170M => Transfer::Smpte170m,
+        x if x == color_vui::transfer::SMPTE240M => Transfer::Smpte240m,
+        x if x == color_vui::transfer::LINEAR => Transfer::Linear,
+        x if x == color_vui::transfer::LOG100 => Transfer::Log100,
+        x if x == color_vui::transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
+        x if x == color_vui::transfer::XVYCC => Transfer::Xvycc,
+        x if x == color_vui::transfer::BT1361 => Transfer::Bt1361,
+        x if x == color_vui::transfer::SRGB => Transfer::Srgb,
+        x if x == color_vui::transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
+        x if x == color_vui::transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
+        x if x == color_vui::transfer::SMPTE2084 => Transfer::Smpte2084,
+        x if x == color_vui::transfer::SMPTE428 => Transfer::Smpte428,
+        x if x == color_vui::transfer::ARIB_STD_B67 => Transfer::AribStdB67,
+        _ => return None,
+    })
+}
+
+fn matrix_to_byte(m: &Matrix) -> u8 {
+    match m {
+        Matrix::Identity => color_vui::matrix::IDENTITY,
+        Matrix::Bt709 => color_vui::matrix::BT709,
+        Matrix::Fcc => color_vui::matrix::FCC,
+        Matrix::Bt470Bg => color_vui::matrix::BT470_BG,
+        Matrix::Smpte170m => color_vui::matrix::SMPTE170M,
+        Matrix::Smpte240m => color_vui::matrix::SMPTE240M,
+        Matrix::Ycgco => color_vui::matrix::YCGCO,
+        Matrix::Bt2020Ncl => color_vui::matrix::BT2020_NCL,
+        Matrix::Bt2020Cl => color_vui::matrix::BT2020_CL,
+        Matrix::Smpte2085 => color_vui::matrix::SMPTE2085,
+        Matrix::ChromaNcl => color_vui::matrix::CHROMA_NCL,
+        Matrix::ChromaCl => color_vui::matrix::CHROMA_CL,
+        Matrix::Ictcp => color_vui::matrix::ICTCP,
+    }
+}
+
+fn matrix_from_byte(b: u8) -> Option<Matrix> {
+    Some(match b {
+        x if x == color_vui::matrix::IDENTITY => Matrix::Identity,
+        x if x == color_vui::matrix::BT709 => Matrix::Bt709,
+        x if x == color_vui::matrix::FCC => Matrix::Fcc,
+        x if x == color_vui::matrix::BT470_BG => Matrix::Bt470Bg,
+        x if x == color_vui::matrix::SMPTE170M => Matrix::Smpte170m,
+        x if x == color_vui::matrix::SMPTE240M => Matrix::Smpte240m,
+        x if x == color_vui::matrix::YCGCO => Matrix::Ycgco,
+        x if x == color_vui::matrix::BT2020_NCL => Matrix::Bt2020Ncl,
+        x if x == color_vui::matrix::BT2020_CL => Matrix::Bt2020Cl,
+        x if x == color_vui::matrix::SMPTE2085 => Matrix::Smpte2085,
+        x if x == color_vui::matrix::CHROMA_NCL => Matrix::ChromaNcl,
+        x if x == color_vui::matrix::CHROMA_CL => Matrix::ChromaCl,
+        x if x == color_vui::matrix::ICTCP => Matrix::Ictcp,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_color_info_round_trip() {
+        let info = ColorInfo {
+            primaries: Some(Primaries::Bt709),
+            transfer: Some(Transfer::Srgb),
+            matrix: Some(Matrix::Smpte170m),
+            range: Some(Range::Full),
+        };
+        let vui = color_info_to_h273(&info).expect("non-empty input yields Some");
+        assert_eq!(vui.primaries, Some(1));
+        assert_eq!(vui.transfer, Some(13));
+        assert_eq!(vui.matrix, Some(6));
+        assert_eq!(vui.full_range, Some(true));
+        let back = h273_to_color_info(&vui);
+        assert_eq!(back, info);
+    }
+
+    #[test]
+    fn all_none_yields_no_vui() {
+        let info = ColorInfo::default();
+        assert!(color_info_to_h273(&info).is_none());
+    }
+
+    #[test]
+    fn range_alone_still_yields_vui() {
+        let info = ColorInfo {
+            range: Some(Range::Limited),
+            ..Default::default()
+        };
+        let vui = color_info_to_h273(&info).expect("range alone is enough");
+        assert_eq!(vui.full_range, Some(false));
+        assert!(vui.primaries.is_none());
+    }
+
+    #[test]
+    fn hdr10_round_trip() {
+        // The canonical HDR10 four-tuple: BT.2020 / PQ / BT.2020-NCL / Full.
+        let info = ColorInfo {
+            primaries: Some(Primaries::Bt2020),
+            transfer: Some(Transfer::Smpte2084),
+            matrix: Some(Matrix::Bt2020Ncl),
+            range: Some(Range::Full),
+        };
+        let vui = color_info_to_h273(&info).unwrap();
+        assert_eq!(vui.primaries, Some(9));
+        assert_eq!(vui.transfer, Some(16));
+        assert_eq!(vui.matrix, Some(9));
+        assert_eq!(vui.full_range, Some(true));
+        assert_eq!(h273_to_color_info(&vui), info);
+    }
+
+    #[test]
+    fn unknown_byte_decodes_to_none() {
+        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g.
+        // 99) should drop them silently rather than fabricate variants.
+        let vui = H273ColorVui {
+            primaries: Some(99),
+            transfer: Some(13),
+            matrix: Some(99),
+            full_range: Some(false),
+        };
+        let info = h273_to_color_info(&vui);
+        assert!(info.primaries.is_none());
+        assert_eq!(info.transfer, Some(Transfer::Srgb));
+        assert!(info.matrix.is_none());
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+}

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
+use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
@@ -148,6 +149,20 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 
+            // Color info: prefer the parsed bitstream VUI (self-describing,
+            // survives muxer round-trips that re-encode `EncodedVideoFrame.
+            // color_info`) over the producer's attestation. Falls back to the
+            // passthrough when the bitstream didn't carry a VUI.
+            let parsed_vui = decoder.current_color_vui();
+            let color_info_source = if parsed_vui.is_some() {
+                "bitstream"
+            } else {
+                "encoded_passthrough"
+            };
+            let color_info = parsed_vui
+                .map(|vui| h273_to_color_info(&vui))
+                .or_else(|| encoded.color_info.clone());
+
             // Carry the encoder's input-frame index (`frame_number`) through to the
             // decoded output so downstream consumers (PSNR rig, display PNG sampler)
             // can pair each decoded frame with the reference input.
@@ -161,22 +176,24 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
                 // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
-                // Pass color metadata through encoded → decoded so
-                // downstream consumers see what the producer attested.
-                // VUI parsing for codec-attested color lands in a
-                // follow-up.
-                color_info: encoded.color_info.clone(),
+                color_info,
                 mastering_display: encoded.mastering_display.clone(),
                 content_light: encoded.content_light.clone(),
             };
 
+            let log_color = self.frames_decoded == 0;
             self.outputs.write("video_out", &video_frame)?;
             self.frames_decoded += 1;
+            if log_color {
+                tracing::info!(
+                    color_info = ?video_frame.color_info,
+                    source = color_info_source,
+                    "[H264Decoder] First frame decoded — surfaced color_info"
+                );
+            }
         }
 
-        if self.frames_decoded == 1 {
-            tracing::info!("[H264Decoder] First frame decoded");
-        } else if self.frames_decoded % 300 == 0 {
+        if self.frames_decoded % 300 == 0 && self.frames_decoded > 0 {
             tracing::info!(frames = self.frames_decoded, "[H264Decoder] Decode progress");
         }
 

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
+use crate::linux::color_vui_translate::color_info_to_h273;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
@@ -181,6 +182,14 @@ fn build_encoder_lazily(
         frame.fps,
     );
 
+    // First-frame color info drives the session-level SPS VUI. Mid-stream
+    // ColorInfo changes are not honored — switching colorimetry requires a
+    // new SPS, which the encoder doesn't re-emit per frame.
+    let color_vui = frame
+        .color_info
+        .as_ref()
+        .and_then(color_info_to_h273);
+
     let encoder_config = SimpleEncoderConfig {
         width,
         height,
@@ -192,6 +201,7 @@ fn build_encoder_lazily(
         bitrate_bps: config.bitrate_bps,
         prepend_header_to_idr: Some(true),
         effort_level: config.effort_level,
+        color_vui,
         ..Default::default()
     };
 
@@ -240,8 +250,31 @@ fn build_encoder_lazily(
         height,
         fps
     );
+    tracing::info!(
+        color_vui = ?color_vui,
+        "[H264Encoder] SPS VUI color metadata chained from first-frame color_info"
+    );
+    // Debug: emit the cached SPS+PPS bytes as hex once at construction so
+    // E2E flows can `ffprobe` the SPS VUI without saving a full MP4. This
+    // is a one-shot trace; encoded packets at frame rate are not logged.
+    tracing::debug!(
+        header_hex = %hex_encode(encoder.header()),
+        header_len = encoder.header().len(),
+        "[H264Encoder] Cached SPS+PPS header"
+    );
 
     Ok(encoder)
+}
+
+/// Lowercase hex encoder for the one-shot SPS+PPS debug log. Returns an
+/// empty string on empty input.
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 #[cfg(test)]

--- a/packages/h264/src/linux/mod.rs
+++ b/packages/h264/src/linux/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+pub mod color_vui_translate;
 pub mod decoder;
 pub mod encoder;
 

--- a/packages/h265/src/linux/color_vui_translate.rs
+++ b/packages/h265/src/linux/color_vui_translate.rs
@@ -1,0 +1,236 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Translation between the engine-side `ColorInfo` domain enums (from
+//! `@tatolab/core`'s JTD codegen) and `vulkan_video::H273ColorVui`, the
+//! codec-native byte representation that crosses into the leaf
+//! `libs/vulkan-video` crate.
+//!
+//! The vulkan-video crate does not depend on `@tatolab/core` or the
+//! streamlib SDK; this seam is what keeps that boundary clean. Both H.264
+//! and H.265 packages carry an identical translator because each has its
+//! own codegen module (`crate::_generated_::*`); the duplication is ~70
+//! lines per codec and disappears if vulkan-video later adopts the SDK.
+
+use crate::_generated_::tatolab__core::color_info::{
+    ColorInfo, Matrix, Primaries, Range, Transfer,
+};
+use vulkan_video::{color_vui, H273ColorVui};
+
+/// Translate `ColorInfo` → `H273ColorVui` for the encoder's SPS chain.
+///
+/// Returns `None` when every axis is `None` — the caller treats that as
+/// "no codec-side color VUI requested" and leaves `SimpleEncoderConfig::
+/// color_vui = None`, which skips the colour_description block in the
+/// SPS entirely (timing is still emitted because the H.264 SPS always
+/// chains a VUI for it).
+pub fn color_info_to_h273(info: &ColorInfo) -> Option<H273ColorVui> {
+    let v = H273ColorVui {
+        primaries: info.primaries.as_ref().map(primaries_to_byte),
+        transfer: info.transfer.as_ref().map(transfer_to_byte),
+        matrix: info.matrix.as_ref().map(matrix_to_byte),
+        full_range: info.range.as_ref().map(|r| matches!(r, Range::Full)),
+    };
+    if !v.is_video_signal_type_block_needed() {
+        return None;
+    }
+    Some(v)
+}
+
+/// Translate `H273ColorVui` → `ColorInfo` for surfacing decoded VUI
+/// metadata on `VideoFrame.color_info`. Per-axis `None` (Unspecified on
+/// the wire) stays `None` in the result.
+pub fn h273_to_color_info(vui: &H273ColorVui) -> ColorInfo {
+    ColorInfo {
+        primaries: vui.primaries.and_then(primaries_from_byte),
+        transfer: vui.transfer.and_then(transfer_from_byte),
+        matrix: vui.matrix.and_then(matrix_from_byte),
+        range: vui.full_range.map(|f| if f { Range::Full } else { Range::Limited }),
+    }
+}
+
+fn primaries_to_byte(p: &Primaries) -> u8 {
+    match p {
+        Primaries::Bt709 => color_vui::primaries::BT709,
+        Primaries::Bt470M => color_vui::primaries::BT470_M,
+        Primaries::Bt470Bg => color_vui::primaries::BT470_BG,
+        Primaries::Smpte170m => color_vui::primaries::SMPTE170M,
+        Primaries::Smpte240m => color_vui::primaries::SMPTE240M,
+        Primaries::Film => color_vui::primaries::FILM,
+        Primaries::Bt2020 => color_vui::primaries::BT2020,
+        Primaries::Smpte428 => color_vui::primaries::SMPTE428,
+        Primaries::Smpte431 => color_vui::primaries::SMPTE431,
+        Primaries::Smpte432 => color_vui::primaries::SMPTE432,
+        Primaries::Ebu3213 => color_vui::primaries::EBU3213,
+    }
+}
+
+fn primaries_from_byte(b: u8) -> Option<Primaries> {
+    Some(match b {
+        x if x == color_vui::primaries::BT709 => Primaries::Bt709,
+        x if x == color_vui::primaries::BT470_M => Primaries::Bt470M,
+        x if x == color_vui::primaries::BT470_BG => Primaries::Bt470Bg,
+        x if x == color_vui::primaries::SMPTE170M => Primaries::Smpte170m,
+        x if x == color_vui::primaries::SMPTE240M => Primaries::Smpte240m,
+        x if x == color_vui::primaries::FILM => Primaries::Film,
+        x if x == color_vui::primaries::BT2020 => Primaries::Bt2020,
+        x if x == color_vui::primaries::SMPTE428 => Primaries::Smpte428,
+        x if x == color_vui::primaries::SMPTE431 => Primaries::Smpte431,
+        x if x == color_vui::primaries::SMPTE432 => Primaries::Smpte432,
+        x if x == color_vui::primaries::EBU3213 => Primaries::Ebu3213,
+        _ => return None,
+    })
+}
+
+fn transfer_to_byte(t: &Transfer) -> u8 {
+    match t {
+        Transfer::Bt709 => color_vui::transfer::BT709,
+        Transfer::Gamma22 => color_vui::transfer::GAMMA22,
+        Transfer::Gamma28 => color_vui::transfer::GAMMA28,
+        Transfer::Smpte170m => color_vui::transfer::SMPTE170M,
+        Transfer::Smpte240m => color_vui::transfer::SMPTE240M,
+        Transfer::Linear => color_vui::transfer::LINEAR,
+        Transfer::Log100 => color_vui::transfer::LOG100,
+        Transfer::Log100Sqrt10 => color_vui::transfer::LOG100_SQRT10,
+        Transfer::Xvycc => color_vui::transfer::XVYCC,
+        Transfer::Bt1361 => color_vui::transfer::BT1361,
+        Transfer::Srgb => color_vui::transfer::SRGB,
+        Transfer::Bt2020TenBit => color_vui::transfer::BT2020_TEN_BIT,
+        Transfer::Bt2020TwelveBit => color_vui::transfer::BT2020_TWELVE_BIT,
+        Transfer::Smpte2084 => color_vui::transfer::SMPTE2084,
+        Transfer::Smpte428 => color_vui::transfer::SMPTE428,
+        Transfer::AribStdB67 => color_vui::transfer::ARIB_STD_B67,
+    }
+}
+
+fn transfer_from_byte(b: u8) -> Option<Transfer> {
+    Some(match b {
+        x if x == color_vui::transfer::BT709 => Transfer::Bt709,
+        x if x == color_vui::transfer::GAMMA22 => Transfer::Gamma22,
+        x if x == color_vui::transfer::GAMMA28 => Transfer::Gamma28,
+        x if x == color_vui::transfer::SMPTE170M => Transfer::Smpte170m,
+        x if x == color_vui::transfer::SMPTE240M => Transfer::Smpte240m,
+        x if x == color_vui::transfer::LINEAR => Transfer::Linear,
+        x if x == color_vui::transfer::LOG100 => Transfer::Log100,
+        x if x == color_vui::transfer::LOG100_SQRT10 => Transfer::Log100Sqrt10,
+        x if x == color_vui::transfer::XVYCC => Transfer::Xvycc,
+        x if x == color_vui::transfer::BT1361 => Transfer::Bt1361,
+        x if x == color_vui::transfer::SRGB => Transfer::Srgb,
+        x if x == color_vui::transfer::BT2020_TEN_BIT => Transfer::Bt2020TenBit,
+        x if x == color_vui::transfer::BT2020_TWELVE_BIT => Transfer::Bt2020TwelveBit,
+        x if x == color_vui::transfer::SMPTE2084 => Transfer::Smpte2084,
+        x if x == color_vui::transfer::SMPTE428 => Transfer::Smpte428,
+        x if x == color_vui::transfer::ARIB_STD_B67 => Transfer::AribStdB67,
+        _ => return None,
+    })
+}
+
+fn matrix_to_byte(m: &Matrix) -> u8 {
+    match m {
+        Matrix::Identity => color_vui::matrix::IDENTITY,
+        Matrix::Bt709 => color_vui::matrix::BT709,
+        Matrix::Fcc => color_vui::matrix::FCC,
+        Matrix::Bt470Bg => color_vui::matrix::BT470_BG,
+        Matrix::Smpte170m => color_vui::matrix::SMPTE170M,
+        Matrix::Smpte240m => color_vui::matrix::SMPTE240M,
+        Matrix::Ycgco => color_vui::matrix::YCGCO,
+        Matrix::Bt2020Ncl => color_vui::matrix::BT2020_NCL,
+        Matrix::Bt2020Cl => color_vui::matrix::BT2020_CL,
+        Matrix::Smpte2085 => color_vui::matrix::SMPTE2085,
+        Matrix::ChromaNcl => color_vui::matrix::CHROMA_NCL,
+        Matrix::ChromaCl => color_vui::matrix::CHROMA_CL,
+        Matrix::Ictcp => color_vui::matrix::ICTCP,
+    }
+}
+
+fn matrix_from_byte(b: u8) -> Option<Matrix> {
+    Some(match b {
+        x if x == color_vui::matrix::IDENTITY => Matrix::Identity,
+        x if x == color_vui::matrix::BT709 => Matrix::Bt709,
+        x if x == color_vui::matrix::FCC => Matrix::Fcc,
+        x if x == color_vui::matrix::BT470_BG => Matrix::Bt470Bg,
+        x if x == color_vui::matrix::SMPTE170M => Matrix::Smpte170m,
+        x if x == color_vui::matrix::SMPTE240M => Matrix::Smpte240m,
+        x if x == color_vui::matrix::YCGCO => Matrix::Ycgco,
+        x if x == color_vui::matrix::BT2020_NCL => Matrix::Bt2020Ncl,
+        x if x == color_vui::matrix::BT2020_CL => Matrix::Bt2020Cl,
+        x if x == color_vui::matrix::SMPTE2085 => Matrix::Smpte2085,
+        x if x == color_vui::matrix::CHROMA_NCL => Matrix::ChromaNcl,
+        x if x == color_vui::matrix::CHROMA_CL => Matrix::ChromaCl,
+        x if x == color_vui::matrix::ICTCP => Matrix::Ictcp,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_color_info_round_trip() {
+        let info = ColorInfo {
+            primaries: Some(Primaries::Bt709),
+            transfer: Some(Transfer::Srgb),
+            matrix: Some(Matrix::Smpte170m),
+            range: Some(Range::Full),
+        };
+        let vui = color_info_to_h273(&info).expect("non-empty input yields Some");
+        assert_eq!(vui.primaries, Some(1));
+        assert_eq!(vui.transfer, Some(13));
+        assert_eq!(vui.matrix, Some(6));
+        assert_eq!(vui.full_range, Some(true));
+        let back = h273_to_color_info(&vui);
+        assert_eq!(back, info);
+    }
+
+    #[test]
+    fn all_none_yields_no_vui() {
+        let info = ColorInfo::default();
+        assert!(color_info_to_h273(&info).is_none());
+    }
+
+    #[test]
+    fn range_alone_still_yields_vui() {
+        let info = ColorInfo {
+            range: Some(Range::Limited),
+            ..Default::default()
+        };
+        let vui = color_info_to_h273(&info).expect("range alone is enough");
+        assert_eq!(vui.full_range, Some(false));
+        assert!(vui.primaries.is_none());
+    }
+
+    #[test]
+    fn hdr10_round_trip() {
+        // The canonical HDR10 four-tuple: BT.2020 / PQ / BT.2020-NCL / Full.
+        let info = ColorInfo {
+            primaries: Some(Primaries::Bt2020),
+            transfer: Some(Transfer::Smpte2084),
+            matrix: Some(Matrix::Bt2020Ncl),
+            range: Some(Range::Full),
+        };
+        let vui = color_info_to_h273(&info).unwrap();
+        assert_eq!(vui.primaries, Some(9));
+        assert_eq!(vui.transfer, Some(16));
+        assert_eq!(vui.matrix, Some(9));
+        assert_eq!(vui.full_range, Some(true));
+        assert_eq!(h273_to_color_info(&vui), info);
+    }
+
+    #[test]
+    fn unknown_byte_decodes_to_none() {
+        // A decoder seeing H.273 enumerants streamlib doesn't model (e.g.
+        // 99) should drop them silently rather than fabricate variants.
+        let vui = H273ColorVui {
+            primaries: Some(99),
+            transfer: Some(13),
+            matrix: Some(99),
+            full_range: Some(false),
+        };
+        let info = h273_to_color_info(&vui);
+        assert!(info.primaries.is_none());
+        assert_eq!(info.transfer, Some(Transfer::Srgb));
+        assert!(info.matrix.is_none());
+        assert_eq!(info.range, Some(Range::Limited));
+    }
+}

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
+use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
@@ -148,6 +149,20 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 
+            // Color info: prefer the parsed bitstream VUI (self-describing,
+            // survives muxer round-trips that re-encode `EncodedVideoFrame.
+            // color_info`) over the producer's attestation. Falls back to the
+            // passthrough when the bitstream didn't carry a VUI.
+            let parsed_vui = decoder.current_color_vui();
+            let color_info_source = if parsed_vui.is_some() {
+                "bitstream"
+            } else {
+                "encoded_passthrough"
+            };
+            let color_info = parsed_vui
+                .map(|vui| h273_to_color_info(&vui))
+                .or_else(|| encoded.color_info.clone());
+
             // Carry the encoder's input-frame index (`frame_number`) through to the
             // decoded output so downstream consumers (PSNR rig, display PNG sampler)
             // can pair each decoded frame with the reference input.
@@ -161,22 +176,24 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
                 // Per-frame override is opt-in; per-surface
                 // `current_image_layout` from surface-share is the default.
                 texture_layout: None,
-                // Pass color metadata through encoded → decoded so
-                // downstream consumers see what the producer attested.
-                // VUI parsing for codec-attested color lands in a
-                // follow-up.
-                color_info: encoded.color_info.clone(),
+                color_info,
                 mastering_display: encoded.mastering_display.clone(),
                 content_light: encoded.content_light.clone(),
             };
 
+            let log_color = self.frames_decoded == 0;
             self.outputs.write("video_out", &video_frame)?;
             self.frames_decoded += 1;
+            if log_color {
+                tracing::info!(
+                    color_info = ?video_frame.color_info,
+                    source = color_info_source,
+                    "[H265Decoder] First frame decoded — surfaced color_info"
+                );
+            }
         }
 
-        if self.frames_decoded == 1 {
-            tracing::info!("[H265Decoder] First frame decoded");
-        } else if self.frames_decoded % 300 == 0 {
+        if self.frames_decoded % 300 == 0 && self.frames_decoded > 0 {
             tracing::info!(frames = self.frames_decoded, "[H265Decoder] Decode progress");
         }
 

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -254,8 +254,27 @@ fn build_encoder_lazily(
         color_vui = ?color_vui,
         "[H265Encoder] SPS VUI color metadata chained from first-frame color_info"
     );
+    // Debug: emit the cached VPS+SPS+PPS bytes as hex once at construction
+    // so E2E flows can `ffprobe` the parameter sets without saving a full
+    // MP4. One-shot trace; encoded packets at frame rate are not logged.
+    tracing::debug!(
+        header_hex = %hex_encode(encoder.header()),
+        header_len = encoder.header().len(),
+        "[H265Encoder] Cached VPS+SPS+PPS header"
+    );
 
     Ok(encoder)
+}
+
+/// Lowercase hex encoder for the one-shot VPS+SPS+PPS debug log. Returns an
+/// empty string on empty input.
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 #[cfg(test)]

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
+use crate::linux::color_vui_translate::color_info_to_h273;
 use streamlib::sdk::context::{
     GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
 };
@@ -181,6 +182,14 @@ fn build_encoder_lazily(
         frame.fps,
     );
 
+    // First-frame color info drives the session-level SPS VUI. Mid-stream
+    // ColorInfo changes are not honored — switching colorimetry requires a
+    // new SPS, which the encoder doesn't re-emit per frame.
+    let color_vui = frame
+        .color_info
+        .as_ref()
+        .and_then(color_info_to_h273);
+
     let encoder_config = SimpleEncoderConfig {
         width,
         height,
@@ -192,6 +201,7 @@ fn build_encoder_lazily(
         bitrate_bps: config.bitrate_bps,
         prepend_header_to_idr: Some(true),
         effort_level: config.effort_level,
+        color_vui,
         ..Default::default()
     };
 
@@ -239,6 +249,10 @@ fn build_encoder_lazily(
         width,
         height,
         fps
+    );
+    tracing::info!(
+        color_vui = ?color_vui,
+        "[H265Encoder] SPS VUI color metadata chained from first-frame color_info"
     );
 
     Ok(encoder)

--- a/packages/h265/src/linux/mod.rs
+++ b/packages/h265/src/linux/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+pub mod color_vui_translate;
 pub mod decoder;
 pub mod encoder;
 


### PR DESCRIPTION
## Summary

- Wires H.273 color VUI between the H.264/H.265 encoder and decoder in both directions: encoder builds `StdVideoH26{4,5}SequenceParameterSetVui` from configured color metadata and chains via `pSequenceParameterSetVui`; decoder parses the bitstream VUI and surfaces it on `frame.color_info`, preferring the bitstream over the producer's encoded passthrough.
- Replaces the H.264 portion of `libs/vulkan-video/src/encode/vui_patch.rs` (the post-write timing patcher); timing now rides in the proper SPS VUI chain. H.265 VPS timing patch retained (VPS is a separate NAL, independently broken in the NVIDIA driver).
- Keeps `libs/vulkan-video/` a leaf crate (no `streamlib` / `@tatolab/core` dep): the codec layer works in raw H.273 bytes via `H273ColorVui`; `ColorInfo` ↔ H.273 translation lives at the codec-processor seam in `packages/h26{4,5}/src/linux/color_vui_translate.rs`.

## Closes

Closes #816

## Exit criteria

- [x] `SimpleEncoderConfig` accepts optional `H273ColorVui` (codec-native byte representation); H.264 + H.265 encoders chain `StdVideoH26{4,5}SequenceParameterSetVui` when present.
- [x] `SimpleDecoder::current_color_vui() -> Option<H273ColorVui>` returns the four-axis byte tuple parsed from the active SPS VUI (or per-axis `None` when the SPS omitted the block / used H.273 Unspecified).
- [x] H.264/H.265 codec processors set `frame.color_info = decoder.current_color_vui().map(h273_to_color_info).or_else(|| encoded.color_info.clone())`.
- [x] `vui_patch.rs` H.264 timing path removed (timing now rides in the always-emitted H.264 SPS VUI chain); H.265 VPS timing patch retained.

## Test plan

### E2E Test Report — H.264

- **Scenario**: encoder/decoder roundtrip
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=150`, 10s
- **Build profile**: release
- **Command**:
    \`\`\`
    RUST_LOG="info,streamlib_h264=debug" STREAMLIB_DISPLAY_PNG_SAMPLE_DIR=/tmp/e2e-h264-final-…/png_samples \
        STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY=30 STREAMLIB_DISPLAY_FRAME_LIMIT=150 \
        timeout --kill-after=3 25 cargo run --release -q -p vulkan-video-roundtrip -- h264 /dev/video0 10
    \`\`\`

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `Validation Error`: not enabled
- `First frame encoded` / decoded / surfaced color: all fired (timestamps ~50ms apart at start)
- Decoder log shows `source="bitstream"` — parsed VUI is the surfaced color, not the passthrough fallback.

#### Bitstream VUI verification (ffprobe-equivalent manual decode)

Cached SPS hex captured via the new `tracing::debug!` hook:
\`0000000167640028acca501e0089f966e021a0c800000300080000030054200000000168ee3cb0\`

Manual SPS bit-decode confirms on-wire bytes:
- \`vui_parameters_present_flag = 1\`
- \`video_signal_type_present_flag = 1\`
- \`video_full_range_flag = 1\`
- \`colour_description_present_flag = 1\`
- \`colour_primaries = 1\` (BT.709)
- \`transfer_characteristics = 13\` (sRGB)
- \`matrix_coefficients = 6\` (Smpte170m)

Exactly the H.273 bytes the issue body required.

#### PNG samples

- Directory: `/tmp/e2e-h264-final-…/png_samples/`
- Sample count: 2 (frames 0 and 30 of 50 displayed)
- PNGs read with Read tool: `display_001_frame_000030_input_000030.png`
- What was in the image: vivid's vertical color bars (gray / yellow-green / cyan / green / magenta / red / blue / black) with timecode overlay `00:00:06:002`, frame counter `30`, and the vivid debug overlay (brightness 128, contrast 128, saturation 128, gain 80). Colors are clean — no green/magenta tint, no banding.
- Anomalies: none.

#### PSNR

- Reference frame: N/A — vivid live source; PSNR validation done via fixture rig below.

#### Outcome

- **Pass**

### E2E Test Report — H.265

Same shape as H.264. Decoder also logged `source="bitstream"` — H.265 VUI parser walks the color subset correctly. PNG inspection at frame 30 shows the same clean vivid color bars with timecode `00:00:06:008`. Zero OOM / DEVICE_LOST / process() failed.

### Fixture PSNR rig

\`libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr.sh /tmp/psnr-816-h264 h264\` → PASS:
- complex_pattern: Y 43.16 / U 37.05 / V 33.37 dB
- gradients + solids: Y inf / mid–high U/V
- All 9 fixtures verdict PASS

\`libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr.sh /tmp/psnr-816-h265 h265\` → PASS:
- complex_pattern: Y 43.07 / U 36.82 / V 33.20 dB
- All 9 fixtures verdict PASS

### Vivid color regression gate

\`libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_vivid.sh /tmp/vivid-psnr-816 h264\` → PASS:
- R drift 0.0001, G drift 0.0000, B drift 0.0000 (tolerance 0.05)

### Workspace tests

\`cargo test --workspace --exclude api-server-demo … -- --test-threads=1\` — touched packages: 642 passed, 0 failed, 5 ignored. The 3 sentinel test failures (`streamlib-jtd-codegen`) and 1 schema-payload-bytes failure (`streamlib-engine`) are pre-existing on \`main\` and unrelated to this branch — verified by re-running on a clean tree.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)