### PR TITLE
test(rhi): GPU-output bit-exact regression tests for VulkanColorConverter

### DIFF
--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
@@ -188,6 +188,19 @@ fn validate_format_pair(src: PixelFormat, dst: PixelFormat) -> Result<()> {
 mod tests {
     use super::*;
 
+    use vulkanalia::prelude::v1_4::*;
+    use vulkanalia::vk;
+
+    use crate::core::color::{
+        from_linear, to_linear, yuv_to_rgb_matrix, MatrixId, PrimariesId, RangeId,
+    };
+    use crate::core::rhi::{
+        PixelBuffer, TextureDescriptor, TextureFormat, TextureReadbackDescriptor,
+        TextureSourceLayout, TextureUsages,
+    };
+    use crate::host_rhi::HostTextureExt;
+    use crate::vulkan::rhi::{HostVulkanBuffer, HostVulkanTexture, VulkanTextureReadback};
+
     fn try_device() -> Option<Arc<HostVulkanDevice>> {
         HostVulkanDevice::new().ok()
     }
@@ -219,5 +232,391 @@ mod tests {
             .err()
             .expect("must reject Bgra32 dest today");
         assert!(matches!(err, Error::NotSupported(_)));
+    }
+
+    // ---- GPU-output bit-exact regression coverage ----
+    //
+    // The reference is computed in-code from the same `core::color`
+    // helpers the converter's push-constant builder uses
+    // (`yuv_to_rgb_matrix`, `to_linear` / `from_linear`). Choosing an
+    // in-code reference over a committed PNG fixture is deliberate:
+    // the new converter is parameterized on `(matrix, range,
+    // transfer_in, transfer_out)` per dispatch, so a PNG snapshot
+    // would lock the test to one tuple while leaving the rest of the
+    // matrix uncovered. The in-code reference covers any
+    // `ResolvedColorInfo` shape with the same ~10 lines of math.
+    //
+    // The math chain mirrors `convert_color` in
+    // `vulkan/rhi/shaders/color_convert_common.glsl`:
+    //   1. `c = ycbcr_byte - range_offset`
+    //   2. `rgb_byte = M * c` (3×3 row-major matrix)
+    //   3. `rgb = clamp(rgb_byte / 255, 0, 1)`
+    //   4. if `transfer_in != transfer_out`:
+    //         `rgb = from_linear(out, to_linear(in, rgb))`  per channel
+    // Mentally revert any step in `vulkan_color_converter.rs` or
+    // `core::rhi::color_converter::ColorConverterPushConstants::from_resolved`
+    // and these tests should fail.
+
+    /// CPU reference: one NV12 source pixel → one RGBA8 output pixel.
+    ///
+    /// Mirrors `convert_color()` in `color_convert_common.glsl` exactly.
+    fn cpu_reference_rgba(
+        y_byte: u8,
+        u_byte: u8,
+        v_byte: u8,
+        info: &ResolvedColorInfo,
+        dst_transfer: TransferId,
+    ) -> [u8; 4] {
+        let decomp = yuv_to_rgb_matrix(info.matrix, info.range);
+        let m = decomp.matrix_row_major;
+        let off = decomp.offset;
+        let c = [
+            y_byte as f32 - off[0],
+            u_byte as f32 - off[1],
+            v_byte as f32 - off[2],
+        ];
+        let mut rgb = [
+            (m[0] * c[0] + m[1] * c[1] + m[2] * c[2]) / 255.0,
+            (m[3] * c[0] + m[4] * c[1] + m[5] * c[2]) / 255.0,
+            (m[6] * c[0] + m[7] * c[1] + m[8] * c[2]) / 255.0,
+        ];
+        for ch in &mut rgb {
+            *ch = ch.clamp(0.0, 1.0);
+        }
+        if info.transfer != dst_transfer {
+            for ch in &mut rgb {
+                *ch = from_linear(dst_transfer, to_linear(info.transfer, *ch));
+            }
+        }
+        [
+            (rgb[0] * 255.0).round() as u8,
+            (rgb[1] * 255.0).round() as u8,
+            (rgb[2] * 255.0).round() as u8,
+            255,
+        ]
+    }
+
+    /// Synthesize a tight-packed NV12 byte buffer of size
+    /// `width * height * 3 / 2`. Picks Y / U / V patterns that vary
+    /// across the frame so chroma actually contributes (plane swaps
+    /// surface as wrong color) and stays away from byte saturation
+    /// (full bytes go through the matrix-expand path without
+    /// clamping dominating the signal).
+    fn build_deterministic_nv12(width: u32, height: u32) -> Vec<u8> {
+        assert!(width % 2 == 0 && height % 2 == 0, "NV12 needs even dims");
+        let y_plane_size = (width * height) as usize;
+        let uv_plane_size = (width * height / 2) as usize;
+        let mut buf = vec![0u8; y_plane_size + uv_plane_size];
+        for y in 0..height {
+            for x in 0..width {
+                buf[(y * width + x) as usize] =
+                    (28u32 + (x.wrapping_mul(5).wrapping_add(y.wrapping_mul(7))) % 200) as u8;
+            }
+        }
+        let uv_base = y_plane_size;
+        let half_h = height / 2;
+        let half_w = width / 2;
+        for cy in 0..half_h {
+            for cx in 0..half_w {
+                let off = uv_base + (cy * width + cx * 2) as usize;
+                buf[off] =
+                    (48u32 + (cx.wrapping_mul(13).wrapping_add(cy.wrapping_mul(11))) % 160) as u8;
+                buf[off + 1] =
+                    (48u32 + (cx.wrapping_mul(7).wrapping_add(cy.wrapping_mul(17)).wrapping_add(32)) % 160)
+                        as u8;
+            }
+        }
+        buf
+    }
+
+    /// Allocate an `Rgba8Unorm` storage texture with `STORAGE | COPY_SRC
+    /// | COPY_DST` usage, transition it from `UNDEFINED` to `GENERAL` so
+    /// the converter's `imageStore` is spec-legal, and return it.
+    ///
+    /// Mirrors the `make_filled_texture` UNDEFINED→GENERAL one-shot in
+    /// `vulkan_texture_readback.rs::tests`; this variant skips the fill
+    /// step because the converter dispatch will write every pixel.
+    fn allocate_storage_target_in_general(
+        device: &Arc<HostVulkanDevice>,
+        width: u32,
+        height: u32,
+    ) -> Texture {
+        let desc = TextureDescriptor {
+            width,
+            height,
+            format: TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST
+                | TextureUsages::STORAGE_BINDING,
+            label: Some("color-converter-test-output"),
+        };
+        let host_tex = HostVulkanTexture::new(device, &desc).expect("host texture");
+        let texture = Texture {
+            inner: Arc::new(host_tex),
+        };
+
+        let dev = device.device();
+        let queue = device.queue();
+        let qf = device.queue_family_index();
+        unsafe {
+            let pool = dev
+                .create_command_pool(
+                    &vk::CommandPoolCreateInfo::builder()
+                        .queue_family_index(qf)
+                        .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+                        .build(),
+                    None,
+                )
+                .expect("command pool");
+            let cmd = dev
+                .allocate_command_buffers(
+                    &vk::CommandBufferAllocateInfo::builder()
+                        .command_pool(pool)
+                        .level(vk::CommandBufferLevel::PRIMARY)
+                        .command_buffer_count(1)
+                        .build(),
+                )
+                .expect("command buffer")[0];
+            dev.begin_command_buffer(
+                cmd,
+                &vk::CommandBufferBeginInfo::builder()
+                    .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                    .build(),
+            )
+            .expect("begin");
+
+            let to_general = vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .src_access_mask(vk::AccessFlags2::empty())
+                .dst_stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)
+                .dst_access_mask(vk::AccessFlags2::MEMORY_READ | vk::AccessFlags2::MEMORY_WRITE)
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::GENERAL)
+                .src_queue_family_index(qf)
+                .dst_queue_family_index(qf)
+                .image(texture.vulkan_inner().image().expect("vk image"))
+                .subresource_range(
+                    vk::ImageSubresourceRange::builder()
+                        .aspect_mask(vk::ImageAspectFlags::COLOR)
+                        .level_count(1)
+                        .layer_count(1)
+                        .build(),
+                )
+                .build();
+            let bs = [to_general];
+            let dep = vk::DependencyInfo::builder().image_memory_barriers(&bs).build();
+            dev.cmd_pipeline_barrier2(cmd, &dep);
+            dev.end_command_buffer(cmd).expect("end");
+
+            let cmd_infos = [vk::CommandBufferSubmitInfo::builder().command_buffer(cmd).build()];
+            let submits = [vk::SubmitInfo2::builder().command_buffer_infos(&cmd_infos).build()];
+            device
+                .submit_to_queue(queue, &submits, vk::Fence::null())
+                .expect("submit transition");
+            dev.queue_wait_idle(queue).expect("wait idle");
+            dev.destroy_command_pool(pool, None);
+        }
+
+        texture
+    }
+
+    /// Wrap a raw NV12 byte buffer in a HOST_VISIBLE `HostVulkanBuffer`
+    /// + `PixelBuffer` so the converter sees it as a storage-buffer
+    /// source.
+    fn upload_nv12_pixel_buffer(
+        device: &Arc<HostVulkanDevice>,
+        nv12_bytes: &[u8],
+        width: u32,
+        height: u32,
+        pixel_format: PixelFormat,
+    ) -> PixelBuffer {
+        let host_buf =
+            HostVulkanBuffer::new(device, nv12_bytes.len() as u64).expect("host buffer");
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                nv12_bytes.as_ptr(),
+                host_buf.mapped_ptr(),
+                nv12_bytes.len(),
+            );
+        }
+        // `bytes_per_pixel` is descriptive metadata only — the shader
+        // walks the buffer via `SourceLayoutInfo` push constants.
+        PixelBuffer::from_host_vulkan_buffer(Arc::new(host_buf), width, height, 1, pixel_format)
+    }
+
+    /// End-to-end driver: dispatch the converter on a deterministic
+    /// NV12 input under the given `(matrix, range, transfer)` info,
+    /// read the resulting RGBA storage texture back to a CPU buffer,
+    /// and assert every output pixel matches the in-code CPU
+    /// reference within `±1` per channel.
+    fn run_nv12_to_rgba_pixel_check(
+        device: &Arc<HostVulkanDevice>,
+        src_pixel_format: PixelFormat,
+        info: &ResolvedColorInfo,
+        dst_transfer: TransferId,
+        width: u32,
+        height: u32,
+        label: &str,
+    ) {
+        let nv12_bytes = build_deterministic_nv12(width, height);
+        let pixel_buf = upload_nv12_pixel_buffer(device, &nv12_bytes, width, height, src_pixel_format);
+        let output_texture = allocate_storage_target_in_general(device, width, height);
+
+        let converter = VulkanColorConverter::new(device, src_pixel_format, PixelFormat::Rgba32)
+            .expect("converter construction");
+
+        let src_layout = SourceLayoutInfo::nv12_tight(width, height);
+        let kernel = converter
+            .prepare_buffer_to_image(&pixel_buf, src_layout, &output_texture, info, dst_transfer)
+            .expect("prepare");
+        let dispatch_x = width.div_ceil(COLOR_CONVERTER_WORKGROUP_SIZE);
+        let dispatch_y = height.div_ceil(COLOR_CONVERTER_WORKGROUP_SIZE);
+        kernel.dispatch(dispatch_x, dispatch_y, 1).expect("dispatch");
+
+        let readback = VulkanTextureReadback::new(
+            device,
+            &TextureReadbackDescriptor {
+                label: "color-converter-test-readback",
+                format: TextureFormat::Rgba8Unorm,
+                width,
+                height,
+            },
+        )
+        .expect("readback handle");
+        let ticket = readback
+            .submit(&output_texture, TextureSourceLayout::General)
+            .expect("readback submit");
+        let gpu = readback.wait_and_read(ticket, u64::MAX).expect("readback wait");
+
+        let y_plane_size = (width * height) as usize;
+        let mut mismatches = 0u32;
+        let mut first_mismatch_msg = String::new();
+        for y in 0..height {
+            for x in 0..width {
+                let y_byte = nv12_bytes[(y * width + x) as usize];
+                // Interleaved (U, V) at half spatial resolution, even-x.
+                let uv_offset =
+                    y_plane_size + ((y >> 1) * width + (x & !1)) as usize;
+                let u_byte = nv12_bytes[uv_offset];
+                let v_byte = nv12_bytes[uv_offset + 1];
+
+                let expected = cpu_reference_rgba(y_byte, u_byte, v_byte, info, dst_transfer);
+
+                let off = ((y * width + x) * 4) as usize;
+                let actual = [gpu[off], gpu[off + 1], gpu[off + 2], gpu[off + 3]];
+
+                for ch in 0..4 {
+                    let diff = (actual[ch] as i32 - expected[ch] as i32).abs();
+                    if diff > 1 {
+                        if mismatches == 0 {
+                            first_mismatch_msg = format!(
+                                "[{label}] pixel ({x},{y}) ch {ch}: gpu={actual:?} expected={expected:?} (Y={y_byte},U={u_byte},V={v_byte})"
+                            );
+                        }
+                        mismatches += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            mismatches, 0,
+            "{} pixel(s) failed ±1 tolerance. First: {}",
+            mismatches, first_mismatch_msg
+        );
+    }
+
+    /// BT.601 full-range NV12 (the canonical webcam path) → Rgba8Unorm
+    /// must match the CPU reference within ±1 per channel.
+    ///
+    /// Exercises:
+    /// - Matrix decomposition (`MatrixId::Smpte170m, RangeId::Full`)
+    ///   → row 0 = `(1.0, 0.0, 1.402)`, offset = `(0, 128, 128)`.
+    /// - Transfer-bypass path (`Srgb` source = `Srgb` dest →
+    ///   `FLAG_APPLY_TRANSFER` cleared, no `pow()` per channel).
+    /// - `SourceLayoutInfo::nv12_tight` strides flow through push
+    ///   constants and the shader walks them correctly.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn nv12_full_range_bt601_matches_cpu_reference() {
+        let Some(device) = try_device() else { return };
+        let info = ResolvedColorInfo {
+            primaries: PrimariesId::Bt709,
+            transfer: TransferId::Srgb,
+            matrix: MatrixId::Smpte170m,
+            range: RangeId::Full,
+        };
+        run_nv12_to_rgba_pixel_check(
+            &device,
+            PixelFormat::Nv12FullRange,
+            &info,
+            TransferId::Srgb,
+            64,
+            32,
+            "bt601-full",
+        );
+    }
+
+    /// BT.709 limited-range NV12 (the codec-output path) → Rgba8Unorm
+    /// must match the CPU reference within ±1 per channel.
+    ///
+    /// Exercises:
+    /// - Matrix decomposition (`MatrixId::Bt709, RangeId::Limited`)
+    ///   → row 0 Y-scale = `255/219 ≈ 1.164`, offset =
+    ///   `(16, 128, 128)`. Reverting the `255/219` in
+    ///   `core::color::matrix::range_scaling` drops the scale to 1.0
+    ///   and this test fails for every non-saturated Y byte.
+    /// - Transfer-bypass path (`Bt709` source = `Bt709` dest).
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn nv12_video_range_bt709_matches_cpu_reference() {
+        let Some(device) = try_device() else { return };
+        let info = ResolvedColorInfo {
+            primaries: PrimariesId::Bt709,
+            transfer: TransferId::Bt709,
+            matrix: MatrixId::Bt709,
+            range: RangeId::Limited,
+        };
+        run_nv12_to_rgba_pixel_check(
+            &device,
+            PixelFormat::Nv12VideoRange,
+            &info,
+            TransferId::Bt709,
+            64,
+            32,
+            "bt709-limited",
+        );
+    }
+
+    /// BT.709 limited-range NV12 with mismatched dest transfer
+    /// (`Bt709` source → `Srgb` dest) → Rgba8Unorm must match the CPU
+    /// reference within ±1 per channel.
+    ///
+    /// Exercises:
+    /// - `FLAG_APPLY_TRANSFER` path (`transfer_in != transfer_out` →
+    ///   shader runs `from_linear(srgb, to_linear(bt709, x))` per
+    ///   channel). Bypass tests above don't catch shader-vs-CPU drift
+    ///   in the transfer math; this test does.
+    /// - Mid-stream transfer change costs only push constants — no
+    ///   pipeline rebuild — which the test verifies by reusing the
+    ///   same `(src, dst)` PixelFormat pair as the prior test.
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn nv12_bt709_to_srgb_transfer_path_matches_cpu_reference() {
+        let Some(device) = try_device() else { return };
+        let info = ResolvedColorInfo {
+            primaries: PrimariesId::Bt709,
+            transfer: TransferId::Bt709,
+            matrix: MatrixId::Bt709,
+            range: RangeId::Limited,
+        };
+        run_nv12_to_rgba_pixel_check(
+            &device,
+            PixelFormat::Nv12VideoRange,
+            &info,
+            TransferId::Srgb,
+            64,
+            32,
+            "bt709→srgb",
+        );
     }
 }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
@@ -191,9 +191,7 @@ mod tests {
     use vulkanalia::prelude::v1_4::*;
     use vulkanalia::vk;
 
-    use crate::core::color::{
-        from_linear, to_linear, yuv_to_rgb_matrix, MatrixId, PrimariesId, RangeId,
-    };
+    use crate::core::color::{from_linear, to_linear, MatrixId, PrimariesId, RangeId};
     use crate::core::rhi::{
         PixelBuffer, TextureDescriptor, TextureFormat, TextureReadbackDescriptor,
         TextureSourceLayout, TextureUsages,
@@ -236,11 +234,24 @@ mod tests {
 
     // ---- GPU-output bit-exact regression coverage ----
     //
-    // The reference is computed in-code from `core::color` helpers
-    // (`yuv_to_rgb_matrix`, `to_linear` / `from_linear`) so any
-    // `(matrix, range, transfer_in, transfer_out)` tuple is one new
-    // test, not one new fixture. Committed-PNG would lock the test
-    // to a single tuple.
+    // Restores the regression coverage deleted with
+    // `VulkanFormatConverter::tests::nv12_full_range_to_bgra_matches_cpu_reference`
+    // in #823. The deleted test's CPU reference used hardcoded
+    // BT.601-Full coefficients (1.402 / 0.344136 / 0.714136 / 1.772),
+    // which made it independent of any production matrix code — a
+    // bug in the production matrix would fail the test. This file
+    // preserves that property: each test passes its hardcoded
+    // matrix + offset into [`cpu_reference_rgba`] as plain `[f32; 9]`
+    // + `[f32; 3]`, NOT through `yuv_to_rgb_matrix`. The shader-side
+    // values come from `yuv_to_rgb_matrix` via push constants, so a
+    // regression in the Rust matrix shifts only the GPU side and the
+    // test fails.
+    //
+    // Transfer functions stay routed through `core::color::transfer`
+    // because the GLSL has independent closed-form implementations
+    // in `color_convert_common.glsl` — Rust-vs-GLSL drift is the
+    // failure mode the transfer-path test below catches, and that
+    // requires both implementations to be independently authored.
     //
     // The math chain mirrors `convert_color` in
     // `vulkan/rhi/shaders/color_convert_common.glsl`:
@@ -252,54 +263,81 @@ mod tests {
     //
     // What these tests catch:
     //   - `ColorConverterPushConstants` std430 field ORDER / SIZE
-    //     drift — the GPU pulls the matrix + offset out of push
-    //     constants laid out in a specific slot order, so swapping
-    //     `matrix_row0` and `range_offset` (or anything analogous)
-    //     in `from_resolved` makes the shader multiply with the
-    //     wrong values. Confirmed by negative-test (#822 PR): zeroing
-    //     the Y component of `range_offset` in `from_resolved` fails
-    //     the BT.709-limited and BT.709→sRGB tests with thousands of
-    //     pixel mismatches.
+    //     drift. Confirmed by negative-test: zeroing the Y component
+    //     of `range_offset` in `from_resolved` fails the BT.709-limited
+    //     and BT.709→sRGB tests with thousands of pixel mismatches.
+    //   - `yuv_to_rgb_matrix` / `range_scaling` coefficient
+    //     regressions — CPU reference is hardcoded, GPU pulls
+    //     through the production path, any divergence is caught.
     //   - Shader's NV12 stride math (`read_byte` packed-uint
     //     extraction + `plane0_stride_bytes` / `plane1_stride_bytes`
     //     / `plane1_offset_bytes` walks).
-    //   - GLSL ↔ Rust drift in the transfer functions — these are
-    //     independently implemented in `color_convert_common.glsl`
-    //     and `core::color::transfer`, so the `bt709→srgb` test is
-    //     the gate that the two stay in sync.
-    //   - `imageStore` correctness on `rgba8` storage image (writes
-    //     ending up in the right pixel, with UNORM rounding within
-    //     ±1 of the CPU reference).
+    //   - GLSL ↔ Rust drift in the transfer functions
+    //     (`color_convert_common.glsl` vs `core::color::transfer`).
+    //   - `imageStore` correctness on `rgba8` storage image (UNORM
+    //     rounding within ±1 of the CPU reference).
     //   - The `UNDEFINED → GENERAL` layout transition on the output
     //     texture (without it the dispatch is spec-illegal).
     //
-    // What they don't catch (locked elsewhere by design):
-    //   - `yuv_to_rgb_matrix` returning wrong matrix coefficients —
-    //     the same Rust function feeds both push constants and the
-    //     CPU reference here, so a coefficient bug shifts both sides
-    //     in lockstep. Locked by `core::color::matrix::tests` with
-    //     hardcoded canonical coefficients (BT.601/709/2020 ×
-    //     Full/Limited).
-    //   - `to_linear` / `from_linear` math errors in Rust — locked by
-    //     `core::color::transfer::tests` (round-trip + known points).
-    //     Note that the `bt709→srgb` test below DOES catch
-    //     Rust-vs-GLSL drift in the transfer functions; what it
-    //     can't catch is Rust-side errors that haven't drifted from
-    //     GLSL yet.
+    // Out of scope (locked by their own unit-test layers):
+    //   - `core::color::matrix::tests` independently locks matrix
+    //     coefficients with hardcoded golden values per
+    //     (matrix, range) tuple — the source of truth this file's
+    //     hardcoded matrices were taken from.
+    //   - `core::color::transfer::tests` locks Rust-side transfer
+    //     math via round-trip + known-points.
+
+    /// Hardcoded matrix + offset for a `(MatrixId, RangeId)` tuple.
+    /// Source: H.273 / ITU-T canonical coefficients (same numbers
+    /// `core::color::matrix::tests` independently locks).
+    ///
+    /// Authored independently of the production
+    /// `core::color::yuv_to_rgb_matrix` so a regression there shifts
+    /// only the GPU side of the pipeline and the test fails.
+    struct CpuReferenceMatrix {
+        row_major: [f32; 9],
+        offset: [f32; 3],
+    }
+
+    /// BT.601 (SMPTE 170M) full-range, the canonical webcam path.
+    const BT601_FULL: CpuReferenceMatrix = CpuReferenceMatrix {
+        row_major: [
+            1.0, 0.0, 1.402,
+            1.0, -0.344136, -0.714136,
+            1.0, 1.772, 0.0,
+        ],
+        offset: [0.0, 128.0, 128.0],
+    };
+
+    /// BT.709 limited-range, the codec-output path. Coefficients
+    /// from `255/219 * Y` scale + chroma `255/224 * 1.5748` etc.
+    const BT709_LIMITED: CpuReferenceMatrix = CpuReferenceMatrix {
+        row_major: [
+            1.164384, 0.0, 1.792741,
+            1.164384, -0.213249, -0.532909,
+            1.164384, 2.112402, 0.0,
+        ],
+        offset: [16.0, 128.0, 128.0],
+    };
 
     /// CPU reference: one NV12 source pixel → one RGBA8 output pixel.
     ///
-    /// Mirrors `convert_color()` in `color_convert_common.glsl` exactly.
+    /// Mirrors `convert_color()` in `color_convert_common.glsl`.
+    /// `matrix` and `offset` are passed in explicitly (hardcoded by
+    /// the caller) so the reference stays independent of the
+    /// production `yuv_to_rgb_matrix`. Transfer math uses
+    /// `core::color::transfer` since the GLSL closed-form is
+    /// independently authored.
     fn cpu_reference_rgba(
         y_byte: u8,
         u_byte: u8,
         v_byte: u8,
-        info: &ResolvedColorInfo,
-        dst_transfer: TransferId,
+        matrix: &CpuReferenceMatrix,
+        transfer_in: TransferId,
+        transfer_out: TransferId,
     ) -> [u8; 4] {
-        let decomp = yuv_to_rgb_matrix(info.matrix, info.range);
-        let m = decomp.matrix_row_major;
-        let off = decomp.offset;
+        let m = matrix.row_major;
+        let off = matrix.offset;
         let c = [
             y_byte as f32 - off[0],
             u_byte as f32 - off[1],
@@ -313,9 +351,9 @@ mod tests {
         for ch in &mut rgb {
             *ch = ch.clamp(0.0, 1.0);
         }
-        if info.transfer != dst_transfer {
+        if transfer_in != transfer_out {
             for ch in &mut rgb {
-                *ch = from_linear(dst_transfer, to_linear(info.transfer, *ch));
+                *ch = from_linear(transfer_out, to_linear(transfer_in, *ch));
             }
         }
         [
@@ -475,15 +513,19 @@ mod tests {
     }
 
     /// End-to-end driver: dispatch the converter on a deterministic
-    /// NV12 input under the given `(matrix, range, transfer)` info,
-    /// read the resulting RGBA storage texture back to a CPU buffer,
-    /// and assert every output pixel matches the in-code CPU
-    /// reference within `±1` per channel.
+    /// NV12 input under `info` (drives the production push-constant
+    /// builder), read the resulting RGBA storage texture back to a
+    /// CPU buffer, and assert every output pixel matches the
+    /// independently-hardcoded `cpu_matrix` + transfer round-trip
+    /// within ±1 per channel. `info.matrix` / `info.range` must
+    /// describe the same tuple `cpu_matrix` was authored for —
+    /// the test catches regressions where the two diverge.
     fn run_nv12_to_rgba_pixel_check(
         device: &Arc<HostVulkanDevice>,
         src_pixel_format: PixelFormat,
         info: &ResolvedColorInfo,
         dst_transfer: TransferId,
+        cpu_matrix: &CpuReferenceMatrix,
         width: u32,
         height: u32,
         label: &str,
@@ -530,7 +572,14 @@ mod tests {
                 let u_byte = nv12_bytes[uv_offset];
                 let v_byte = nv12_bytes[uv_offset + 1];
 
-                let expected = cpu_reference_rgba(y_byte, u_byte, v_byte, info, dst_transfer);
+                let expected = cpu_reference_rgba(
+                    y_byte,
+                    u_byte,
+                    v_byte,
+                    cpu_matrix,
+                    info.transfer,
+                    dst_transfer,
+                );
 
                 let off = ((y * width + x) * 4) as usize;
                 let actual = [gpu[off], gpu[off + 1], gpu[off + 2], gpu[off + 3]];
@@ -580,6 +629,7 @@ mod tests {
             PixelFormat::Nv12FullRange,
             &info,
             TransferId::Srgb,
+            &BT601_FULL,
             64,
             32,
             "bt601-full",
@@ -594,8 +644,13 @@ mod tests {
     ///   shader's `c = ycbcr_byte - range_offset` step — confirmed
     ///   by negative-test: zeroing the Y component of `range_offset`
     ///   in `from_resolved` fails this test with thousands of
-    ///   mismatches (full-range stays green because its Y-offset is
-    ///   already 0).
+    ///   mismatches.
+    /// - `yuv_to_rgb_matrix` / `range_scaling` regressions on the
+    ///   production side — confirmed by negative-test: reverting
+    ///   the `255/219` Y-scale in `core::color::matrix::range_scaling`
+    ///   fails this test (the CPU reference's `BT709_LIMITED` matrix
+    ///   is hardcoded, so a regression in the Rust matrix shifts only
+    ///   the GPU side and the test catches it).
     /// - Transfer-bypass path (`Bt709` source = `Bt709` dest).
     #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
@@ -612,6 +667,7 @@ mod tests {
             PixelFormat::Nv12VideoRange,
             &info,
             TransferId::Bt709,
+            &BT709_LIMITED,
             64,
             32,
             "bt709-limited",
@@ -649,6 +705,7 @@ mod tests {
             PixelFormat::Nv12VideoRange,
             &info,
             TransferId::Srgb,
+            &BT709_LIMITED,
             64,
             32,
             "bt709→srgb",

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_color_converter.rs
@@ -236,15 +236,11 @@ mod tests {
 
     // ---- GPU-output bit-exact regression coverage ----
     //
-    // The reference is computed in-code from the same `core::color`
-    // helpers the converter's push-constant builder uses
-    // (`yuv_to_rgb_matrix`, `to_linear` / `from_linear`). Choosing an
-    // in-code reference over a committed PNG fixture is deliberate:
-    // the new converter is parameterized on `(matrix, range,
-    // transfer_in, transfer_out)` per dispatch, so a PNG snapshot
-    // would lock the test to one tuple while leaving the rest of the
-    // matrix uncovered. The in-code reference covers any
-    // `ResolvedColorInfo` shape with the same ~10 lines of math.
+    // The reference is computed in-code from `core::color` helpers
+    // (`yuv_to_rgb_matrix`, `to_linear` / `from_linear`) so any
+    // `(matrix, range, transfer_in, transfer_out)` tuple is one new
+    // test, not one new fixture. Committed-PNG would lock the test
+    // to a single tuple.
     //
     // The math chain mirrors `convert_color` in
     // `vulkan/rhi/shaders/color_convert_common.glsl`:
@@ -253,9 +249,43 @@ mod tests {
     //   3. `rgb = clamp(rgb_byte / 255, 0, 1)`
     //   4. if `transfer_in != transfer_out`:
     //         `rgb = from_linear(out, to_linear(in, rgb))`  per channel
-    // Mentally revert any step in `vulkan_color_converter.rs` or
-    // `core::rhi::color_converter::ColorConverterPushConstants::from_resolved`
-    // and these tests should fail.
+    //
+    // What these tests catch:
+    //   - `ColorConverterPushConstants` std430 field ORDER / SIZE
+    //     drift — the GPU pulls the matrix + offset out of push
+    //     constants laid out in a specific slot order, so swapping
+    //     `matrix_row0` and `range_offset` (or anything analogous)
+    //     in `from_resolved` makes the shader multiply with the
+    //     wrong values. Confirmed by negative-test (#822 PR): zeroing
+    //     the Y component of `range_offset` in `from_resolved` fails
+    //     the BT.709-limited and BT.709→sRGB tests with thousands of
+    //     pixel mismatches.
+    //   - Shader's NV12 stride math (`read_byte` packed-uint
+    //     extraction + `plane0_stride_bytes` / `plane1_stride_bytes`
+    //     / `plane1_offset_bytes` walks).
+    //   - GLSL ↔ Rust drift in the transfer functions — these are
+    //     independently implemented in `color_convert_common.glsl`
+    //     and `core::color::transfer`, so the `bt709→srgb` test is
+    //     the gate that the two stay in sync.
+    //   - `imageStore` correctness on `rgba8` storage image (writes
+    //     ending up in the right pixel, with UNORM rounding within
+    //     ±1 of the CPU reference).
+    //   - The `UNDEFINED → GENERAL` layout transition on the output
+    //     texture (without it the dispatch is spec-illegal).
+    //
+    // What they don't catch (locked elsewhere by design):
+    //   - `yuv_to_rgb_matrix` returning wrong matrix coefficients —
+    //     the same Rust function feeds both push constants and the
+    //     CPU reference here, so a coefficient bug shifts both sides
+    //     in lockstep. Locked by `core::color::matrix::tests` with
+    //     hardcoded canonical coefficients (BT.601/709/2020 ×
+    //     Full/Limited).
+    //   - `to_linear` / `from_linear` math errors in Rust — locked by
+    //     `core::color::transfer::tests` (round-trip + known points).
+    //     Note that the `bt709→srgb` test below DOES catch
+    //     Rust-vs-GLSL drift in the transfer functions; what it
+    //     can't catch is Rust-side errors that haven't drifted from
+    //     GLSL yet.
 
     /// CPU reference: one NV12 source pixel → one RGBA8 output pixel.
     ///
@@ -528,13 +558,13 @@ mod tests {
     /// BT.601 full-range NV12 (the canonical webcam path) → Rgba8Unorm
     /// must match the CPU reference within ±1 per channel.
     ///
-    /// Exercises:
-    /// - Matrix decomposition (`MatrixId::Smpte170m, RangeId::Full`)
-    ///   → row 0 = `(1.0, 0.0, 1.402)`, offset = `(0, 128, 128)`.
-    /// - Transfer-bypass path (`Srgb` source = `Srgb` dest →
-    ///   `FLAG_APPLY_TRANSFER` cleared, no `pow()` per channel).
-    /// - `SourceLayoutInfo::nv12_tight` strides flow through push
-    ///   constants and the shader walks them correctly.
+    /// Locks (see module header for the full taxonomy):
+    /// - Push-constant struct field-order — the shader pulls the
+    ///   matrix + offset out of fixed std430 slots.
+    /// - Transfer-bypass path (`Srgb` source = `Srgb` dest → shader
+    ///   skips `pow()` per channel).
+    /// - `SourceLayoutInfo::nv12_tight` strides flowing through push
+    ///   constants and the shader's `read_byte` walk.
     #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
     fn nv12_full_range_bt601_matches_cpu_reference() {
@@ -559,12 +589,13 @@ mod tests {
     /// BT.709 limited-range NV12 (the codec-output path) → Rgba8Unorm
     /// must match the CPU reference within ±1 per channel.
     ///
-    /// Exercises:
-    /// - Matrix decomposition (`MatrixId::Bt709, RangeId::Limited`)
-    ///   → row 0 Y-scale = `255/219 ≈ 1.164`, offset =
-    ///   `(16, 128, 128)`. Reverting the `255/219` in
-    ///   `core::color::matrix::range_scaling` drops the scale to 1.0
-    ///   and this test fails for every non-saturated Y byte.
+    /// Locks (see module header for the full taxonomy):
+    /// - Push-constant `range_offset` slot is wired through to the
+    ///   shader's `c = ycbcr_byte - range_offset` step — confirmed
+    ///   by negative-test: zeroing the Y component of `range_offset`
+    ///   in `from_resolved` fails this test with thousands of
+    ///   mismatches (full-range stays green because its Y-offset is
+    ///   already 0).
     /// - Transfer-bypass path (`Bt709` source = `Bt709` dest).
     #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
     #[test]
@@ -591,11 +622,15 @@ mod tests {
     /// (`Bt709` source → `Srgb` dest) → Rgba8Unorm must match the CPU
     /// reference within ±1 per channel.
     ///
-    /// Exercises:
-    /// - `FLAG_APPLY_TRANSFER` path (`transfer_in != transfer_out` →
-    ///   shader runs `from_linear(srgb, to_linear(bt709, x))` per
-    ///   channel). Bypass tests above don't catch shader-vs-CPU drift
-    ///   in the transfer math; this test does.
+    /// Locks (see module header for the full taxonomy):
+    /// - `FLAG_APPLY_TRANSFER` path active (`transfer_in !=
+    ///   transfer_out` → shader runs `from_linear(srgb,
+    ///   to_linear(bt709, x))` per channel).
+    /// - GLSL ↔ Rust transfer-function drift. The transfer-bypass
+    ///   tests above can't catch this; here the GLSL closed-forms
+    ///   in `color_convert_common.glsl` and the Rust closed-forms in
+    ///   `core::color::transfer` are independent implementations,
+    ///   and the test fails the moment they disagree.
     /// - Mid-stream transfer change costs only push constants — no
     ///   pipeline rebuild — which the test verifies by reusing the
     ///   same `(src, dst)` PixelFormat pair as the prior test.


### PR DESCRIPTION
## Summary

- Adds three hardware-tier tests in `vulkan_color_converter::tests` that dispatch deterministic NV12 input through `VulkanColorConverter` and assert each output pixel matches an in-code CPU reference within ±1 per channel.
- Restores the regression coverage deleted with `VulkanFormatConverter` in #823, adapted to the new converter's storage-image output by reusing `VulkanTextureReadback` for GPU→host copy.
- CPU reference matrices (`BT601_FULL`, `BT709_LIMITED`) are **hardcoded canonical coefficients** (H.273 / ITU-T) rather than calling `core::color::yuv_to_rgb_matrix`, preserving the deleted predecessor test's independence property. A regression in the production matrix code shifts only the GPU side and the test fails.
- Transfer functions stay routed through `core::color::transfer` because the GLSL closed-forms in `color_convert_common.glsl` are independent implementations — the `bt709→srgb` test catches GLSL ↔ Rust drift.

## Closes

Closes #822

## Exit criteria

- [x] Hardware-tier test exercises the converter on a deterministic NV12 input, reads back the RGBA output, and asserts pixel-bit-exactness within ±1 per channel for at least one `(matrix, range)` tuple. (Three tests; BT.601-Full + BT.709-Limited × transfer-bypass + BT.709-Limited→sRGB transfer-active.)
- [x] In-code CPU reference (not a PNG fixture). Choice documented in the test module header — `(matrix, range, transfer_in, transfer_out)` is parametric, so one tuple per test instead of one fixture per tuple.

## Test plan

| Command | Result |
|---|---|
| `cargo check -p streamlib-engine` | ✅ |
| `cargo test -p streamlib-engine --lib -- vulkan_color_converter` (tier-1) | ✅ 2 passed, 3 ignored (new tests correctly gated behind `hardware-tests` feature) |
| `cargo test -p streamlib-engine --features streamlib-engine/hardware-tests --lib -- --test-threads=1 vulkan_color_converter` (tier-2) | ✅ 5 passed |

### Negative tests (proving the gate is non-vacuous)

Two independent regressions deliberately introduced and verified to fail the tests, then reverted:

1. **Push-constant layout regression.** Zeroed the Y component of `range_offset` in `ColorConverterPushConstants::from_resolved` (in `libs/streamlib-engine/src/core/rhi/color_converter.rs`). Result: `nv12_video_range_bt709_matches_cpu_reference` failed with **5109 pixel mismatches**, `nv12_bt709_to_srgb_transfer_path_matches_cpu_reference` failed with **5115 mismatches**, `nv12_full_range_bt601_matches_cpu_reference` stayed green (correctly — its canonical Y-offset is 0, so the break is a no-op there).
2. **Matrix decomposition regression.** Reverted `255/219` to `1.0` for the limited-range branch in `core::color::matrix::range_scaling`. Result: `nv12_video_range_bt709_matches_cpu_reference` failed with **5266 mismatches**, `nv12_bt709_to_srgb_transfer_path_matches_cpu_reference` failed with **5275 mismatches**, `nv12_full_range_bt601_matches_cpu_reference` stayed green (correctly — Full uses Y-scale = 1.0 by spec).

Both regression classes are caught. The BT.601-Full test stays green by design under both because the broken paths don't apply to it; the full taxonomy of what each test locks is documented in the module header.

## Implementation notes

- The test calls `prepare_buffer_to_image` + `kernel.dispatch` rather than the public `convert_buffer_to_image` end-to-end helper. Reason: the latter hardcodes `dst_transfer = TransferId::Srgb`, which is insufficient for the BT.709 transfer-bypass test (needs `Bt709 → Bt709`) and the transfer-path test (needs `Bt709 → Srgb`). The prepare+dispatch sequence is exactly what `convert_buffer_to_image` does internally, so the same code path is exercised.
- Texture allocation, `UNDEFINED → GENERAL` transition, and `HostVulkanBuffer` + `PixelBuffer` upload all follow the existing pattern from `vulkan_texture_readback.rs::tests::make_filled_texture` for consistency with the surrounding test idiom in `vulkan/rhi/`.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)