### PR TITLE
feat(network): @tatolab/network — generic UDP source/sink processors

### DIFF
--- a/.amosrc.toml
+++ b/.amosrc.toml
@@ -1,1 +1,1 @@
-focus = "Pipeline Color & Resolution"
+focus = "Network + JPEG + MAVLink Packages"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "packages/screen-capture",   # @tatolab/screen-capture — screen capture processor (Apple-only today; Linux follows in #374)
     "packages/test-fixtures",    # @tatolab/test-fixtures — attribute-macro test fixtures (TestConfiguredProcessor)
     "packages/debug-utilities",  # @tatolab/debug-utilities — utility processors for development, demos, and rigorous-input testing (BgraFileSource, SimplePassthrough)
+    "packages/network",          # @tatolab/network — generic UDP source/sink processors (byte-level transport)
     # Disabled examples blocked on Apple codec/display impls parked in `_apple_impl_pending_/`:
     #   - camera-audio-recorder, screen-recorder, runtime-graph-json-demo (Apple Mp4WriterProcessor)
     #   - whep-player (Apple VideoToolbox + DisplayProcessor)

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "streamlib-network"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+description = "Generic UDP source/sink processors for streamlib — byte-level transport. Framing/protocol concerns belong in consumer packages (MAVLink, RTP, etc.)."
+keywords = ["udp", "network", "transport", "streamlib"]
+categories = ["network-programming", "multimedia"]
+
+[lib]
+name = "streamlib_network"
+crate-type = ["rlib", "cdylib"]
+
+[build-dependencies]
+streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
+
+[dependencies]
+# Engine substrate — runtime context, processor traits, generated config
+# types under `crate::_generated_::*`.
+streamlib = { path = "../../libs/streamlib-sdk" }
+
+# Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
+# crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
+streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Serialization (config dataclasses ship as serde-derived).
+serde.workspace = true
+
+# Async UDP via tokio::net::UdpSocket; the engine already exposes a shared
+# tokio runtime via RuntimeContext::tokio_handle().
+tokio = { workspace = true }
+
+# Pre-bind sockopt configuration (SO_RCVBUF / SO_SNDBUF). tokio::net::UdpSocket
+# doesn't expose these; socket2 is the idiomatic shim.
+socket2 = "0.5"
+
+# Logging.
+tracing.workspace = true
+
+[dev-dependencies]
+# Integration tests spin up a Runner and exercise the processors end-to-end.
+streamlib = { path = "../../libs/streamlib-sdk" }
+tokio = { workspace = true }
+serde_json.workspace = true
+serial_test = "3.1"
+
+[lints]
+workspace = true

--- a/packages/network/build.rs
+++ b/packages/network/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+fn main() {
+    streamlib_jtd_codegen::build_rs::run_for_rust_crate();
+}

--- a/packages/network/schemas/network_packet.yaml
+++ b/packages/network/schemas/network_packet.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for a single UDP datagram on
+# the wire. Used by both UdpSource (inbound) and UdpSink (outbound) so
+# a source can be wired directly to a sink for echo-style pipelines.
+
+metadata:
+  type: NetworkPacket
+  description: "One UDP datagram — raw payload bytes plus peer address and recv timestamp"
+  read_mode: read_next_in_order
+  buffer_size: 64
+  # 65,536 covers the theoretical UDP datagram maximum (65,507 payload +
+  # IP/UDP headers margin). Real-world datagrams ride 1500-MTU links and
+  # are 1–1472 B; the cap just bounds the worst-case buffer slot.
+  max_payload_bytes: 65536
+
+properties:
+  payload:
+    metadata:
+      description: "Raw UDP datagram bytes (payload only — no IP or UDP headers)"
+    elements:
+      type: uint8
+  peer_addr:
+    metadata:
+      description: |
+        Remote peer address as host:port. On inbound packets this is the
+        sender's address; on outbound packets it targets the destination
+        (overriding UdpSinkConfig.default_destination). Empty string means
+        "use the sink's default_destination". Parses as
+        std::net::SocketAddr — IPv4 ("1.2.3.4:5") or IPv6 ("[::1]:5").
+    type: string
+  timestamp_ns:
+    metadata:
+      description: "Monotonic recv timestamp in nanoseconds at recv_from time (int64 as string). Populated by UdpSource; ignored by UdpSink."
+    type: string

--- a/packages/network/schemas/udp_sink_config.yaml
+++ b/packages/network/schemas/udp_sink_config.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for UdpSink config.
+
+metadata:
+  type: UdpSinkConfig
+  description: "Configuration for a UDP sink processor — open an outbound socket and send NetworkPackets"
+
+optionalProperties:
+  bind_addr:
+    metadata:
+      description: |
+        Local bind address as host:port. Defaults to "0.0.0.0:0" (ephemeral
+        port on all interfaces) which is correct for most outbound use.
+        Set explicitly if you need a fixed source port (e.g. paired with a
+        UdpSource sharing SO_REUSEADDR).
+    type: string
+  default_destination:
+    metadata:
+      description: |
+        Default destination as host:port for outbound packets when
+        NetworkPacket.peer_addr is empty. Set this for fixed-peer client
+        modes (e.g. always send to a known autopilot). Leave unset and
+        rely on per-packet peer_addr for echo / reply-style servers. If
+        both are unset for a given packet, the sink logs and drops.
+    type: string
+  send_buffer_bytes:
+    metadata:
+      description: "SO_SNDBUF size hint in bytes. Linux defaults are ~200 KB; raise for sustained high-rate streams."
+    type: uint32

--- a/packages/network/schemas/udp_source_config.yaml
+++ b/packages/network/schemas/udp_source_config.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# JSON Type Definition (RFC 8927) schema for UdpSource config.
+
+metadata:
+  type: UdpSourceConfig
+  description: "Configuration for a UDP source processor — bind a local socket and emit inbound datagrams"
+
+properties:
+  bind_addr:
+    metadata:
+      description: |
+        Local bind address as host:port (e.g. "0.0.0.0:14540" for MAVLink
+        on all interfaces, "[::]:5600" for IPv6 dual-stack, "127.0.0.1:9001"
+        for a loopback-only listener). Parses as std::net::SocketAddr.
+    type: string
+
+optionalProperties:
+  recv_buffer_bytes:
+    metadata:
+      description: |
+        SO_RCVBUF size hint in bytes. Linux defaults to ~200 KB which can
+        drop packets at burst rates (e.g. AGP vision stream at 30Hz × N
+        chunks per JPEG frame). Set to 4–8 MiB for high-rate consumers.
+        The kernel typically clamps to net.core.rmem_max; values above
+        that are silently truncated.
+    type: uint32

--- a/packages/network/src/lib.rs
+++ b/packages/network/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `@tatolab/network` — generic UDP source/sink processors. Byte-level
+//! transport only. Framing, reassembly, and protocol-specific concerns
+//! belong in consumer packages.
+
+#[allow(non_snake_case, unused_imports, clippy::all)]
+pub mod _generated_ {
+    include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
+}
+
+pub mod udp_sink;
+pub mod udp_source;
+
+pub use udp_sink::UdpSinkProcessor;
+pub use udp_source::UdpSourceProcessor;

--- a/packages/network/src/udp_sink.rs
+++ b/packages/network/src/udp_sink.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! UDP sink processor — consumes `NetworkPacket` and writes the payload
+//! to a UDP socket. `process()` is non-blocking: it pushes work onto a
+//! bounded mpsc that a background tokio task drains via `send_to`. On
+//! mpsc overflow the packet is dropped and a counter increments — back-
+//! pressure into the pipeline is deliberately avoided so a slow network
+//! can't stall upstream processors.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ReactiveProcessor;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+
+use crate::_generated_::NetworkPacket;
+
+const OUTBOUND_MPSC_CAPACITY: usize = 256;
+
+struct OutboundDatagram {
+    peer: SocketAddr,
+    payload: Vec<u8>,
+}
+
+#[streamlib::sdk::processor("UdpSink")]
+pub struct UdpSinkProcessor {
+    tokio_handle: Option<tokio::runtime::Handle>,
+    /// Resolved at setup time so we don't re-parse on every send.
+    default_destination: Option<SocketAddr>,
+    /// Outbound queue; producer (`process()`) is non-blocking via
+    /// `try_send`; consumer is the background send task.
+    outbound_tx: Option<mpsc::Sender<OutboundDatagram>>,
+    send_task_handle: Option<tokio::task::JoinHandle<()>>,
+    packets_sent: Arc<AtomicU64>,
+    packets_dropped_queue_full: Arc<AtomicU64>,
+    packets_dropped_no_destination: Arc<AtomicU64>,
+}
+
+impl ReactiveProcessor for UdpSinkProcessor::Processor {
+    fn setup(
+        &mut self,
+        ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        let tokio_handle = ctx.tokio_handle().clone();
+        self.tokio_handle = Some(tokio_handle.clone());
+
+        let bind_str = self
+            .config
+            .bind_addr
+            .clone()
+            .unwrap_or_else(|| "0.0.0.0:0".to_string());
+
+        // Parse default_destination eagerly so a misconfig surfaces at
+        // setup rather than on first packet.
+        let default_destination_result = self
+            .config
+            .default_destination
+            .as_deref()
+            .map(|s| {
+                s.parse::<SocketAddr>().map_err(|e| {
+                    Error::Configuration(format!(
+                        "UdpSink: invalid default_destination {s:?}: {e}"
+                    ))
+                })
+            })
+            .transpose();
+
+        let send_buffer_bytes = self.config.send_buffer_bytes;
+        let packets_sent = Arc::clone(&self.packets_sent);
+        let outbound_tx_slot = &mut self.outbound_tx;
+        let send_task_slot = &mut self.send_task_handle;
+        let default_destination_slot = &mut self.default_destination;
+
+        std::future::ready((|| -> Result<()> {
+            let default_destination = default_destination_result?;
+            *default_destination_slot = default_destination;
+
+            let bind_addr: SocketAddr = bind_str.parse().map_err(|e| {
+                Error::Configuration(format!("UdpSink: invalid bind_addr {bind_str:?}: {e}"))
+            })?;
+
+            let socket = build_udp_socket(bind_addr, send_buffer_bytes, &tokio_handle)?;
+
+            let (tx, rx) = mpsc::channel::<OutboundDatagram>(OUTBOUND_MPSC_CAPACITY);
+            *outbound_tx_slot = Some(tx);
+
+            let handle = tokio_handle.spawn(async move {
+                send_loop(socket, rx, packets_sent).await;
+            });
+            *send_task_slot = Some(handle);
+
+            tracing::info!(
+                bind_addr = %bind_addr,
+                default_destination = ?default_destination_slot.as_ref().map(|d| d.to_string()),
+                send_buffer_bytes = ?send_buffer_bytes,
+                "UdpSink: bound + send task spawned",
+            );
+            Ok(())
+        })())
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        if !self.inputs.has_data("packets") {
+            return Ok(());
+        }
+        let packet: NetworkPacket = self.inputs.read("packets")?;
+
+        let peer = resolve_destination(&packet.peer_addr, self.default_destination);
+        let Some(peer) = peer else {
+            let n = self
+                .packets_dropped_no_destination
+                .fetch_add(1, Ordering::Relaxed)
+                + 1;
+            if n == 1 || n.is_power_of_two() {
+                tracing::warn!(
+                    dropped_total = n,
+                    "UdpSink: dropping packet — empty peer_addr and no default_destination",
+                );
+            }
+            return Ok(());
+        };
+
+        let Some(tx) = self.outbound_tx.as_ref() else {
+            return Err(Error::Configuration(
+                "UdpSink: send task not initialized — setup() did not run".into(),
+            ));
+        };
+
+        match tx.try_send(OutboundDatagram {
+            peer,
+            payload: packet.payload,
+        }) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                let n = self
+                    .packets_dropped_queue_full
+                    .fetch_add(1, Ordering::Relaxed)
+                    + 1;
+                if n == 1 || n.is_power_of_two() {
+                    tracing::warn!(
+                        dropped_total = n,
+                        capacity = OUTBOUND_MPSC_CAPACITY,
+                        "UdpSink: outbound queue full — dropping packet",
+                    );
+                }
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(Error::Runtime(
+                "UdpSink: outbound channel closed — send task died".into(),
+            )),
+        }
+    }
+
+    fn teardown(
+        &mut self,
+        _ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        // Drop the sender so the send loop sees `Closed` and exits.
+        self.outbound_tx.take();
+        if let Some(handle) = self.send_task_handle.take() {
+            handle.abort();
+        }
+        let sent = self.packets_sent.load(Ordering::Relaxed);
+        let dropped_full = self.packets_dropped_queue_full.load(Ordering::Relaxed);
+        let dropped_nodst = self.packets_dropped_no_destination.load(Ordering::Relaxed);
+        tracing::info!(
+            packets_sent = sent,
+            packets_dropped_queue_full = dropped_full,
+            packets_dropped_no_destination = dropped_nodst,
+            "UdpSink: teardown",
+        );
+        std::future::ready(Ok(()))
+    }
+}
+
+fn resolve_destination(packet_peer: &str, default: Option<SocketAddr>) -> Option<SocketAddr> {
+    if packet_peer.is_empty() {
+        return default;
+    }
+    match packet_peer.parse::<SocketAddr>() {
+        Ok(addr) => Some(addr),
+        Err(_) => {
+            // Malformed addresses arrive from network input; we don't want
+            // a bad upstream to kill the sink, so log+fall-back to default
+            // (which may also be None, in which case the caller drops).
+            tracing::warn!(peer_addr = packet_peer, "UdpSink: malformed peer_addr — falling back to default_destination");
+            default
+        }
+    }
+}
+
+fn build_udp_socket(
+    addr: SocketAddr,
+    send_buffer_bytes: Option<u32>,
+    tokio_handle: &tokio::runtime::Handle,
+) -> Result<UdpSocket> {
+    let domain = match addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))
+        .map_err(|e| Error::Configuration(format!("UdpSink: socket() failed: {e}")))?;
+    socket
+        .set_reuse_address(true)
+        .map_err(|e| Error::Configuration(format!("UdpSink: SO_REUSEADDR failed: {e}")))?;
+    socket
+        .set_nonblocking(true)
+        .map_err(|e| Error::Configuration(format!("UdpSink: set_nonblocking failed: {e}")))?;
+    if let Some(bytes) = send_buffer_bytes {
+        socket.set_send_buffer_size(bytes as usize).map_err(|e| {
+            Error::Configuration(format!("UdpSink: SO_SNDBUF={bytes} failed: {e}"))
+        })?;
+    }
+    socket
+        .bind(&addr.into())
+        .map_err(|e| Error::Configuration(format!("UdpSink: bind {addr} failed: {e}")))?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    let _guard = tokio_handle.enter();
+    UdpSocket::from_std(std_socket)
+        .map_err(|e| Error::Configuration(format!("UdpSink: from_std failed: {e}")))
+}
+
+async fn send_loop(
+    socket: UdpSocket,
+    mut rx: mpsc::Receiver<OutboundDatagram>,
+    packets_sent: Arc<AtomicU64>,
+) {
+    while let Some(datagram) = rx.recv().await {
+        match socket.send_to(&datagram.payload, datagram.peer).await {
+            Ok(_) => {
+                let n = packets_sent.fetch_add(1, Ordering::Relaxed) + 1;
+                if n == 1 {
+                    tracing::info!(peer = %datagram.peer, bytes = datagram.payload.len(), "UdpSink: first packet sent");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, peer = %datagram.peer, "UdpSink: send_to failed");
+            }
+        }
+    }
+    tracing::debug!(
+        packets_sent = packets_sent.load(Ordering::Relaxed),
+        "UdpSink: send loop exiting (channel closed)",
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn resolve_uses_packet_peer_when_set() {
+        let default: Option<SocketAddr> = Some("1.2.3.4:1000".parse().unwrap());
+        let resolved = resolve_destination("5.6.7.8:2000", default);
+        assert_eq!(resolved, Some("5.6.7.8:2000".parse().unwrap()));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_when_packet_empty() {
+        let default: Option<SocketAddr> = Some("1.2.3.4:1000".parse().unwrap());
+        let resolved = resolve_destination("", default);
+        assert_eq!(resolved, default);
+    }
+
+    #[test]
+    fn resolve_returns_none_when_packet_empty_and_no_default() {
+        let resolved = resolve_destination("", None);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_on_malformed_peer() {
+        let default: Option<SocketAddr> = Some("1.2.3.4:1000".parse().unwrap());
+        let resolved = resolve_destination("not-an-addr", default);
+        assert_eq!(resolved, default);
+    }
+}

--- a/packages/network/src/udp_source.rs
+++ b/packages/network/src/udp_source.rs
@@ -6,8 +6,8 @@
 //! `NetworkPacket` on its output port.
 
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
 use streamlib::sdk::context::RuntimeContextFullAccess;
@@ -15,6 +15,7 @@ use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::iceoryx2::OutputWriter;
 use streamlib::sdk::processors::ManualProcessor;
 use tokio::net::UdpSocket;
+use tokio::sync::Notify;
 
 use crate::_generated_::NetworkPacket;
 
@@ -23,10 +24,21 @@ use crate::_generated_::NetworkPacket;
 /// alignment; the extra bytes are unused.
 const MAX_DATAGRAM_BYTES: usize = 65_536;
 
+/// Process-wide monotonic anchor for `NetworkPacket.timestamp_ns`.
+/// Initialized on first use; all `UdpSource` instances in the same
+/// process resolve against this anchor so consumers can compare
+/// timestamps across sources (e.g. correlating a MAVLink heartbeat
+/// recv on one socket with a vision-stream chunk recv on another).
+static MONOTONIC_EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+fn monotonic_ns() -> i64 {
+    MONOTONIC_EPOCH.elapsed().as_nanos() as i64
+}
+
 #[streamlib::sdk::processor("UdpSource")]
 pub struct UdpSourceProcessor {
     tokio_handle: Option<tokio::runtime::Handle>,
-    is_running: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
     packets_received: Arc<AtomicU64>,
     recv_task_handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -37,6 +49,9 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
         ctx: &RuntimeContextFullAccess<'_>,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
         self.tokio_handle = Some(ctx.tokio_handle().clone());
+        // Touch the lazy anchor so the first packet's timestamp is
+        // genuinely relative to setup-time, not to first-recv-time.
+        let _ = monotonic_ns();
         tracing::info!(
             bind_addr = %self.config.bind_addr,
             recv_buffer_bytes = ?self.config.recv_buffer_bytes,
@@ -60,13 +75,12 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
 
         let socket = build_udp_socket(bind_addr, self.config.recv_buffer_bytes, &tokio_handle)?;
 
-        self.is_running.store(true, Ordering::Release);
-        let is_running = Arc::clone(&self.is_running);
+        let shutdown = Arc::clone(&self.shutdown);
         let packets_received = Arc::clone(&self.packets_received);
         let outputs: Arc<OutputWriter> = self.outputs.clone();
 
         let handle = tokio_handle.spawn(async move {
-            recv_loop(socket, is_running, packets_received, outputs).await;
+            recv_loop(socket, shutdown, packets_received, outputs).await;
         });
         self.recv_task_handle = Some(handle);
 
@@ -75,11 +89,14 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
     }
 
     fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        self.is_running.store(false, Ordering::Release);
-        let n = self.packets_received.load(Ordering::Relaxed);
+        // Notify-first: the recv loop selects on (recv_from, notified)
+        // and exits its `loop` body cleanly when notified. The abort
+        // below is defense-in-depth in case the task is wedged.
+        self.shutdown.notify_waiters();
         if let Some(handle) = self.recv_task_handle.take() {
             handle.abort();
         }
+        let n = self.packets_received.load(Ordering::Relaxed);
         tracing::info!(packets_received = n, "UdpSource: stopped");
         Ok(())
     }
@@ -91,7 +108,7 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
 /// underlying `socket2::Socket::bind` is sync and equivalent for UDP.
 /// `UdpSocket::from_std` requires being inside a tokio runtime context;
 /// the `handle.enter()` guard provides it for the duration of the call.
-fn build_udp_socket(
+pub(crate) fn build_udp_socket(
     addr: SocketAddr,
     recv_buffer_bytes: Option<u32>,
     tokio_handle: &tokio::runtime::Handle,
@@ -128,46 +145,48 @@ fn build_udp_socket(
 
 async fn recv_loop(
     socket: UdpSocket,
-    is_running: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
     packets_received: Arc<AtomicU64>,
     outputs: Arc<OutputWriter>,
 ) {
-    // Monotonic clock anchor — `Instant::elapsed` is the right monotonic
-    // primitive (per the `monotonic_clocks_for_timing` rule); we publish
-    // absolute nanos since processor start so consumers can compare
-    // across packets without needing a shared epoch.
-    let clock_start = Instant::now();
     let mut buf = vec![0u8; MAX_DATAGRAM_BYTES];
 
     loop {
-        if !is_running.load(Ordering::Acquire) {
-            break;
-        }
+        tokio::select! {
+            biased;
+            // Shutdown branch first — `biased` makes the select check
+            // it before polling the long-running recv, so a notify
+            // delivered while we were already mid-recv still gets
+            // observed on the next loop iteration without latency.
+            _ = shutdown.notified() => break,
 
-        let (n, peer) = match socket.recv_from(&mut buf).await {
-            Ok(pair) => pair,
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-            Err(e) => {
-                tracing::error!(error = %e, "UdpSource: recv_from failed");
-                continue;
+            recv = socket.recv_from(&mut buf) => {
+                let (n, peer) = match recv {
+                    Ok(pair) => pair,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) => {
+                        tracing::error!(error = %e, "UdpSource: recv_from failed");
+                        continue;
+                    }
+                };
+
+                let timestamp_ns = monotonic_ns();
+                let packet = NetworkPacket {
+                    payload: buf[..n].to_vec(),
+                    peer_addr: peer.to_string(),
+                    timestamp_ns: timestamp_ns.to_string(),
+                };
+
+                if let Err(e) = outputs.write("packets", &packet) {
+                    tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
+                    continue;
+                }
+
+                let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
+                if count == 1 {
+                    tracing::info!(peer = %peer, bytes = n, "UdpSource: first packet received");
+                }
             }
-        };
-
-        let timestamp_ns = clock_start.elapsed().as_nanos() as i64;
-        let packet = NetworkPacket {
-            payload: buf[..n].to_vec(),
-            peer_addr: peer.to_string(),
-            timestamp_ns: timestamp_ns.to_string(),
-        };
-
-        if let Err(e) = outputs.write("packets", &packet) {
-            tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
-            continue;
-        }
-
-        let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
-        if count == 1 {
-            tracing::info!(peer = %peer, bytes = n, "UdpSource: first packet received");
         }
     }
 
@@ -175,4 +194,69 @@ async fn recv_loop(
         packets_received = packets_received.load(Ordering::Relaxed),
         "UdpSource: recv loop exiting",
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lifecycle: bind ephemeral port, capture it, drop the socket,
+    /// rebind on the same port. SO_REUSEADDR lets the rebind succeed
+    /// even if the previous socket is still in TIME_WAIT-equivalent
+    /// kernel state.
+    #[tokio::test]
+    async fn build_socket_lifecycle_bind_drop_rebind() {
+        let handle = tokio::runtime::Handle::current();
+        let ephemeral: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        let socket_a = build_udp_socket(ephemeral, None, &handle).expect("bind 1");
+        let bound_addr = socket_a.local_addr().expect("local_addr");
+        assert_eq!(bound_addr.ip().to_string(), "127.0.0.1");
+        assert_ne!(bound_addr.port(), 0, "kernel assigned a real port");
+        drop(socket_a);
+
+        // Rebind on the same address — the SO_REUSEADDR flag is the
+        // load-bearing knob; without it this rebind would fail with
+        // EADDRINUSE on systems that delay port reuse.
+        let socket_b = build_udp_socket(bound_addr, None, &handle).expect("rebind");
+        assert_eq!(socket_b.local_addr().unwrap(), bound_addr);
+    }
+
+    /// Bind error: try to bind to a non-local IPv4 address. The kernel
+    /// returns EADDRNOTAVAIL, which surfaces as `Error::Configuration`
+    /// — NOT a panic. Locks in the "bind failure surfaces a clean
+    /// typed error" exit criterion from #829.
+    #[tokio::test]
+    async fn build_socket_bind_failure_returns_typed_error() {
+        let handle = tokio::runtime::Handle::current();
+        // 192.0.2.0/24 is RFC 5737 TEST-NET-1 — guaranteed not to be a
+        // local interface address anywhere. bind() against it returns
+        // EADDRNOTAVAIL on every Linux kernel.
+        let unreachable: SocketAddr = "192.0.2.1:9999".parse().unwrap();
+
+        match build_udp_socket(unreachable, None, &handle) {
+            Err(Error::Configuration(msg)) => {
+                assert!(
+                    msg.contains("bind"),
+                    "bind failure message should mention bind, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected Error::Configuration, got {other:?}"),
+            Ok(_) => panic!("expected bind failure on non-local 192.0.2.1"),
+        }
+    }
+
+    /// Sockopt error: SO_RCVBUF accepts any value the kernel can clamp,
+    /// so a positive request always succeeds. Test the happy path —
+    /// the kernel reports back the (possibly clamped) value via
+    /// SO_RCVBUF read, which would diverge from request — but the
+    /// build itself completes.
+    #[tokio::test]
+    async fn build_socket_with_recv_buffer_hint_succeeds() {
+        let handle = tokio::runtime::Handle::current();
+        let ephemeral: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let socket = build_udp_socket(ephemeral, Some(1 << 20), &handle)
+            .expect("bind with 1 MiB SO_RCVBUF hint");
+        assert!(socket.local_addr().is_ok());
+    }
 }

--- a/packages/network/src/udp_source.rs
+++ b/packages/network/src/udp_source.rs
@@ -89,9 +89,14 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
     }
 
     fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        // Notify-first: the recv loop selects on (recv_from, notified)
-        // and exits its `loop` body cleanly when notified. The abort
-        // below is defense-in-depth in case the task is wedged.
+        // The actual shutdown contract is `handle.abort()` — the
+        // tokio runtime guarantees the spawned task is cancelled.
+        // `notify_waiters` is a best-effort graceful signal so a loop
+        // mid-await-on-recv can break the `select!` cleanly before
+        // the abort lands; if the task hasn't yet registered the
+        // `notified()` future (race: stop fires between spawn and
+        // first poll), notify_waiters is a no-op but abort still
+        // does the job.
         self.shutdown.notify_waiters();
         if let Some(handle) = self.recv_task_handle.take() {
             handle.abort();
@@ -200,12 +205,16 @@ async fn recv_loop(
 mod tests {
     use super::*;
 
-    /// Lifecycle: bind ephemeral port, capture it, drop the socket,
-    /// rebind on the same port. SO_REUSEADDR lets the rebind succeed
-    /// even if the previous socket is still in TIME_WAIT-equivalent
-    /// kernel state.
+    /// Locks the bind → drop → rebind path through `build_udp_socket`.
+    /// Linux UDP has no TIME_WAIT (TCP-only), so the rebind succeeds
+    /// regardless of `SO_REUSEADDR` — this test does NOT verify the
+    /// REUSEADDR knob (that would require overlapping wildcard /
+    /// specific binds, out of scope for the v1 surface). What it
+    /// does lock is that the function itself doesn't leak a kernel-
+    /// side socket descriptor: a refactor that forgot to close the
+    /// fd would make the rebind fail with EADDRINUSE.
     #[tokio::test]
-    async fn build_socket_lifecycle_bind_drop_rebind() {
+    async fn build_socket_binds_drops_and_rebinds_cleanly() {
         let handle = tokio::runtime::Handle::current();
         let ephemeral: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -215,9 +224,6 @@ mod tests {
         assert_ne!(bound_addr.port(), 0, "kernel assigned a real port");
         drop(socket_a);
 
-        // Rebind on the same address — the SO_REUSEADDR flag is the
-        // load-bearing knob; without it this rebind would fail with
-        // EADDRINUSE on systems that delay port reuse.
         let socket_b = build_udp_socket(bound_addr, None, &handle).expect("rebind");
         assert_eq!(socket_b.local_addr().unwrap(), bound_addr);
     }
@@ -246,13 +252,15 @@ mod tests {
         }
     }
 
-    /// Sockopt error: SO_RCVBUF accepts any value the kernel can clamp,
-    /// so a positive request always succeeds. Test the happy path —
-    /// the kernel reports back the (possibly clamped) value via
-    /// SO_RCVBUF read, which would diverge from request — but the
-    /// build itself completes.
+    /// Smoke test that passing a `recv_buffer_bytes` hint does not
+    /// break the build path. The kernel may silently clamp the value
+    /// to `net.core.rmem_max`, and `socket2` does NOT surface a clamp
+    /// as an error — so this only locks "the optional code path
+    /// doesn't error", not "the hint is honored by the kernel".
+    /// Verifying the actual SO_RCVBUF value would require reading it
+    /// back via `socket2` getsockopt; that's overkill for v1.
     #[tokio::test]
-    async fn build_socket_with_recv_buffer_hint_succeeds() {
+    async fn build_socket_accepts_recv_buffer_hint() {
         let handle = tokio::runtime::Handle::current();
         let ephemeral: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let socket = build_udp_socket(ephemeral, Some(1 << 20), &handle)

--- a/packages/network/src/udp_source.rs
+++ b/packages/network/src/udp_source.rs
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! UDP source processor — binds a socket, spawns a tokio recv loop on
+//! the engine's shared runtime, and emits each inbound datagram as a
+//! `NetworkPacket` on its output port.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use streamlib::sdk::context::RuntimeContextFullAccess;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::iceoryx2::OutputWriter;
+use streamlib::sdk::processors::ManualProcessor;
+use tokio::net::UdpSocket;
+
+use crate::_generated_::NetworkPacket;
+
+/// Worst-case UDP datagram payload (RFC 768 / RFC 791): 65,535 − 8 (UDP
+/// header) − 20 (IPv4 header) = 65,507. Round up to 65,536 for a clean
+/// alignment; the extra bytes are unused.
+const MAX_DATAGRAM_BYTES: usize = 65_536;
+
+#[streamlib::sdk::processor("UdpSource")]
+pub struct UdpSourceProcessor {
+    tokio_handle: Option<tokio::runtime::Handle>,
+    is_running: Arc<AtomicBool>,
+    packets_received: Arc<AtomicU64>,
+    recv_task_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ManualProcessor for UdpSourceProcessor::Processor {
+    fn setup(
+        &mut self,
+        ctx: &RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        self.tokio_handle = Some(ctx.tokio_handle().clone());
+        tracing::info!(
+            bind_addr = %self.config.bind_addr,
+            recv_buffer_bytes = ?self.config.recv_buffer_bytes,
+            "UdpSource: setup",
+        );
+        std::future::ready(Ok(()))
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let tokio_handle = self
+            .tokio_handle
+            .clone()
+            .ok_or_else(|| Error::Configuration("tokio handle not stashed in setup()".into()))?;
+
+        let bind_addr: SocketAddr = self.config.bind_addr.parse().map_err(|e| {
+            Error::Configuration(format!(
+                "UdpSource: invalid bind_addr {:?}: {e}",
+                self.config.bind_addr
+            ))
+        })?;
+
+        let socket = build_udp_socket(bind_addr, self.config.recv_buffer_bytes, &tokio_handle)?;
+
+        self.is_running.store(true, Ordering::Release);
+        let is_running = Arc::clone(&self.is_running);
+        let packets_received = Arc::clone(&self.packets_received);
+        let outputs: Arc<OutputWriter> = self.outputs.clone();
+
+        let handle = tokio_handle.spawn(async move {
+            recv_loop(socket, is_running, packets_received, outputs).await;
+        });
+        self.recv_task_handle = Some(handle);
+
+        tracing::info!(bind_addr = %bind_addr, "UdpSource: bound + recv loop started");
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.is_running.store(false, Ordering::Release);
+        let n = self.packets_received.load(Ordering::Relaxed);
+        if let Some(handle) = self.recv_task_handle.take() {
+            handle.abort();
+        }
+        tracing::info!(packets_received = n, "UdpSource: stopped");
+        Ok(())
+    }
+}
+
+/// Build a tokio `UdpSocket`, applying pre-bind sockopts (SO_RCVBUF when
+/// requested) via socket2 then converting to a tokio handle. Bind runs
+/// synchronously — `tokio::net::UdpSocket::bind` is async, but the
+/// underlying `socket2::Socket::bind` is sync and equivalent for UDP.
+/// `UdpSocket::from_std` requires being inside a tokio runtime context;
+/// the `handle.enter()` guard provides it for the duration of the call.
+fn build_udp_socket(
+    addr: SocketAddr,
+    recv_buffer_bytes: Option<u32>,
+    tokio_handle: &tokio::runtime::Handle,
+) -> Result<UdpSocket> {
+    let domain = match addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))
+        .map_err(|e| Error::Configuration(format!("UdpSource: socket() failed: {e}")))?;
+    socket.set_reuse_address(true).map_err(|e| {
+        Error::Configuration(format!("UdpSource: SO_REUSEADDR failed: {e}"))
+    })?;
+    socket.set_nonblocking(true).map_err(|e| {
+        Error::Configuration(format!("UdpSource: set_nonblocking failed: {e}"))
+    })?;
+    if let Some(bytes) = recv_buffer_bytes {
+        // The kernel may clamp to net.core.rmem_max; that's an OK silent
+        // truncation — we report what we asked for, the kernel logs the
+        // ceiling separately.
+        socket.set_recv_buffer_size(bytes as usize).map_err(|e| {
+            Error::Configuration(format!("UdpSource: SO_RCVBUF={bytes} failed: {e}"))
+        })?;
+    }
+    socket
+        .bind(&addr.into())
+        .map_err(|e| Error::Configuration(format!("UdpSource: bind {addr} failed: {e}")))?;
+
+    let std_socket: std::net::UdpSocket = socket.into();
+    let _guard = tokio_handle.enter();
+    UdpSocket::from_std(std_socket)
+        .map_err(|e| Error::Configuration(format!("UdpSource: from_std failed: {e}")))
+}
+
+async fn recv_loop(
+    socket: UdpSocket,
+    is_running: Arc<AtomicBool>,
+    packets_received: Arc<AtomicU64>,
+    outputs: Arc<OutputWriter>,
+) {
+    // Monotonic clock anchor — `Instant::elapsed` is the right monotonic
+    // primitive (per the `monotonic_clocks_for_timing` rule); we publish
+    // absolute nanos since processor start so consumers can compare
+    // across packets without needing a shared epoch.
+    let clock_start = Instant::now();
+    let mut buf = vec![0u8; MAX_DATAGRAM_BYTES];
+
+    loop {
+        if !is_running.load(Ordering::Acquire) {
+            break;
+        }
+
+        let (n, peer) = match socket.recv_from(&mut buf).await {
+            Ok(pair) => pair,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(e) => {
+                tracing::error!(error = %e, "UdpSource: recv_from failed");
+                continue;
+            }
+        };
+
+        let timestamp_ns = clock_start.elapsed().as_nanos() as i64;
+        let packet = NetworkPacket {
+            payload: buf[..n].to_vec(),
+            peer_addr: peer.to_string(),
+            timestamp_ns: timestamp_ns.to_string(),
+        };
+
+        if let Err(e) = outputs.write("packets", &packet) {
+            tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
+            continue;
+        }
+
+        let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
+        if count == 1 {
+            tracing::info!(peer = %peer, bytes = n, "UdpSource: first packet received");
+        }
+    }
+
+    tracing::debug!(
+        packets_received = packets_received.load(Ordering::Relaxed),
+        "UdpSource: recv loop exiting",
+    );
+}

--- a/packages/network/streamlib.yaml
+++ b/packages/network/streamlib.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+# @tatolab/network — generic UDP source/sink processors. Byte-level
+# transport only; framing, reassembly, and protocol concerns belong in
+# consumer packages (streamlib-mavlink for MAVLink2 framing, the
+# VADR-vision depayloader for the AGP chunked-JPEG header, etc.).
+package:
+  org: tatolab
+  name: network
+  version: 1.0.0
+  description: "Generic UDP source/sink processors — byte-level transport for protocol packages"
+
+schemas:
+  # Local schemas this package owns.
+  NetworkPacket:
+    file: schemas/network_packet.yaml
+  UdpSourceConfig:
+    file: schemas/udp_source_config.yaml
+  UdpSinkConfig:
+    file: schemas/udp_sink_config.yaml
+
+processors:
+  - name: UdpSource
+    version: 1.0.0
+    description: "Binds a UDP socket and emits inbound datagrams as NetworkPacket with sender address + recv timestamp"
+    execution: manual
+    scheduling:
+      priority: high
+    runtime:
+      language: rust
+    config:
+      name: config
+      schema: UdpSourceConfig
+    outputs:
+      - name: packets
+        schema: NetworkPacket
+        description: Inbound UDP datagrams, one NetworkPacket per recv
+
+  - name: UdpSink
+    version: 1.0.0
+    description: "Writes NetworkPacket payloads to a UDP socket. Per-packet peer_addr overrides default_destination."
+    execution: reactive
+    scheduling:
+      priority: high
+    runtime:
+      language: rust
+    config:
+      name: config
+      schema: UdpSinkConfig
+    inputs:
+      - name: packets
+        schema: NetworkPacket
+        description: Outbound UDP datagrams; peer_addr targets the destination, falling back to default_destination
+        read_mode: read_next_in_order
+        buffer_size: 64

--- a/packages/network/tests/udp_loopback.rs
+++ b/packages/network/tests/udp_loopback.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Loopback round-trip integration test for `streamlib-network`.
+//!
+//! Wires `UdpSource` → `UdpSink` in a real `Runner`, then drives traffic
+//! across `127.0.0.1`: a test-side socket sends a datagram to the
+//! source's bind port; the source emits a `NetworkPacket` with
+//! `peer_addr = <test socket>` onto the link; the sink picks it up and
+//! `send_to`s the payload back to that exact peer_addr. The test socket
+//! then receives its own bytes echoed back. This exercises:
+//!
+//! 1. UdpSource binds, recv loop publishes one NetworkPacket per
+//!    datagram.
+//! 2. iceoryx2 byte-shape mailbox round-trips a NetworkPacket between
+//!    two in-process processors.
+//! 3. UdpSink reads NetworkPacket from its input port and writes the
+//!    payload back to the kernel via send_to.
+//! 4. `peer_addr` propagates end-to-end without any router processor
+//!    in the middle — the echo-server shape #831 needs is implicit.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use serial_test::serial;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+
+// Force-link the package's lib crate so its `inventory::submit!` factory
+// registrations (one per `#[streamlib::sdk::processor("...")]`) are
+// pulled into the test binary. Without an explicit reference rustc's
+// dead-code elimination would drop the lib entirely from the link line.
+#[allow(unused_imports)]
+use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
+
+/// Bind an ephemeral UDP port, capture its address, drop the socket so
+/// the port is free for the processor to bind. The brief window
+/// between drop and rebind is racy in principle but in practice
+/// nothing else binds the port in the test process inside a few
+/// milliseconds; SO_REUSEADDR makes the rebind tolerate TIME_WAIT.
+fn pick_free_udp_port() -> SocketAddr {
+    let probe = std::net::UdpSocket::bind("127.0.0.1:0").expect("probe bind");
+    let addr = probe.local_addr().expect("probe local_addr");
+    drop(probe);
+    addr
+}
+
+#[test]
+#[serial]
+fn loopback_round_trip_propagates_peer_addr() {
+    // Pre-bind the test socket so the sink has somewhere to send to
+    // *before* the source has a chance to relay the first packet.
+    let test_socket =
+        std::net::UdpSocket::bind("127.0.0.1:0").expect("bind test socket");
+    test_socket
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .expect("set test socket read timeout");
+    let test_addr = test_socket.local_addr().expect("test socket local_addr");
+
+    let source_bind = pick_free_udp_port();
+
+    let runtime = Runner::new().expect("Runner::new");
+
+    let source_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSource", "1.0.0"),
+            serde_json::json!({
+                "bind_addr": source_bind.to_string(),
+            }),
+        ))
+        .expect("add UdpSource");
+
+    let sink_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSink", "1.0.0"),
+            serde_json::json!({}),
+        ))
+        .expect("add UdpSink");
+
+    runtime
+        .connect(
+            OutputLinkPortRef::new(source_id.as_str(), "packets"),
+            InputLinkPortRef::new(sink_id.as_str(), "packets"),
+        )
+        .expect("connect UdpSource → UdpSink");
+
+    runtime.start().expect("runtime.start");
+
+    // Give the recv loop a moment to bind + iceoryx2 subscribers to warm
+    // up. Without this the first send can race the bind and the kernel
+    // drops the datagram silently. 250ms is the documented PUBSUB
+    // warm-up ballpark in docs/learnings/pubsub-lazy-init-silent-noop.md
+    // and is comfortably above iceoryx2 service-open latency.
+    std::thread::sleep(Duration::from_millis(250));
+
+    let payload: &[u8] = b"hello-udp-loopback";
+    test_socket
+        .send_to(payload, source_bind)
+        .expect("test socket send_to source");
+
+    let mut buf = [0u8; 64];
+    let (n, recv_from) = test_socket
+        .recv_from(&mut buf)
+        .expect("test socket recv_from echo");
+
+    assert_eq!(&buf[..n], payload, "payload bytes round-tripped intact");
+
+    // The sink's source-port on its outbound socket is ephemeral and
+    // not the source's bind_addr — what matters is the peer_addr was
+    // honored (data arrived back at test_socket at all). Just confirm
+    // the recv came from 127.0.0.1 to lock in the loopback path.
+    assert_eq!(
+        recv_from.ip().to_string(),
+        "127.0.0.1",
+        "echo arrived on loopback, not some other interface",
+    );
+    assert_ne!(
+        recv_from.port(),
+        0,
+        "echo sender used a real port",
+    );
+    // The destination of the echo was our test_addr (the kernel
+    // routed it via 127.0.0.1, which we just confirmed).
+    let _ = test_addr;
+
+    runtime.stop().expect("runtime.stop");
+}

--- a/packages/network/tests/udp_loopback.rs
+++ b/packages/network/tests/udp_loopback.rs
@@ -57,7 +57,6 @@ fn loopback_round_trip_propagates_peer_addr() {
     test_socket
         .set_read_timeout(Some(Duration::from_secs(3)))
         .expect("set test socket read timeout");
-    let test_addr = test_socket.local_addr().expect("test socket local_addr");
 
     let source_bind = pick_free_udp_port();
 
@@ -109,8 +108,13 @@ fn loopback_round_trip_propagates_peer_addr() {
 
     // The sink's source-port on its outbound socket is ephemeral and
     // not the source's bind_addr — what matters is the peer_addr was
-    // honored (data arrived back at test_socket at all). Just confirm
-    // the recv came from 127.0.0.1 to lock in the loopback path.
+    // honored end-to-end. The recv succeeding at all proves the sink
+    // sent to our exact test_socket's bound port (kernel routes by
+    // dst-port match); the recv from 127.0.0.1 proves the loopback
+    // path; together they lock peer_addr propagation through the
+    // source's emit → iceoryx2 link → sink's send_to chain. If
+    // peer_addr were dropped or misrouted, recv_from would have
+    // timed out (3-second deadline above).
     assert_eq!(
         recv_from.ip().to_string(),
         "127.0.0.1",
@@ -121,9 +125,6 @@ fn loopback_round_trip_propagates_peer_addr() {
         0,
         "echo sender used a real port",
     );
-    // The destination of the echo was our test_addr (the kernel
-    // routed it via 127.0.0.1, which we just confirmed).
-    let _ = test_addr;
 
     runtime.stop().expect("runtime.stop");
 }


### PR DESCRIPTION
## Summary

- New BUSL package `packages/network` providing two byte-level transport processors: `UdpSource` (Manual, self-driven tokio recv loop) and `UdpSink` (Reactive, background tokio send task + bounded mpsc, non-blocking `process()`).
- Single `NetworkPacket { payload, peer_addr, timestamp_ns }` schema for both source output and sink input — per-packet `peer_addr` overrides `UdpSinkConfig.default_destination` so echo-style reply-to-last-sender flows work without a router processor.
- Process-wide `LazyLock<Instant>` anchors `timestamp_ns` so cross-source comparison is well-defined (matters for AGP's parallel MAVLink + vision-stream flows).
- Foundation for #831 (`streamlib-mavlink`, wraps `rust-mavlink`'s codec only — its UDP layer is single-peer auto-reply, disqualifying as a transport adapter) and #834 (VADR-vision depayloader for the AGP 24-byte chunked-JPEG protocol).

## Closes

Closes #829

## Anchor: AI Grand Prix VADR-TS-002

Implementation anchored on the Anduril AI Grand Prix technical spec — two parallel UDP flows (MAVLink2 control/telemetry + custom JPEG vision stream on port 5600). Both flows ride this transport unchanged. Framing/protocol concerns deliberately live in consumer packages.

## Exit criteria

- [x] `streamlib-network` package exists with `streamlib.yaml` manifest + Cargo crate following the existing package shape
- [x] UDP source processor configurable with bind address + port + buffer size (`bind_addr`, `recv_buffer_bytes`)
- [x] UDP sink processor configurable with destination + port (`default_destination`, `send_buffer_bytes`)
- [x] Inbound packets carry source address metadata (`NetworkPacket.peer_addr`)
- [x] Integration test exercises round-trip via loopback

## Test plan

- [x] Unit tests for socket lifecycle (bind → drop → rebind, no fd leak)
- [x] Unit test for bind failure → typed `Error::Configuration` (RFC 5737 TEST-NET-1 → EADDRNOTAVAIL)
- [x] Unit tests for `peer_addr` / `default_destination` resolution logic (4 cases)
- [x] Integration test: source ↔ sink loopback over 127.0.0.1, byte-exact round-trip, peer_addr propagates end-to-end
- [ ] Stress test (iperf-shaped) — deferred. Spec rates (~50 Hz MAVLink, ~1 kHz vision-stream chunks) are ~3 orders below where tokio + iceoryx2 byte-shape mailbox bottlenecks; will file follow-up only if a real consumer hits a ceiling.

8/8 tests pass locally. `cargo clippy -p streamlib-network --all-targets` clean. `cargo xtask check-boundaries` + `cargo xtask lint-logging` clean.

## Review-gate notes

Pre-PR review ran 3 iterations. Iterations 1 + 2 surfaced real issues (tests gap, dead `is_running: AtomicBool` flag, per-source `timestamp_ns` base, misleading SO_REUSEADDR test claim) — all addressed across two follow-up commits. Iteration 3 verdict: PASS.

## Deliberate scope-cuts (called out so they're not surprises)

- `peer_addr` is required `string` with empty-string sentinel rather than `optionalProperties` — mirrors `EncodedVideoFrame.timestamp_ns` convention. Source always populates; sink consumers write `""` to fall back to `default_destination`.
- `OUTBOUND_MPSC_CAPACITY = 256` hardcoded — promoting to config is purely additive when a real consumer needs tuning.
- No multicast / DSCP / `IP_PKTINFO` / IPv6-only / `SO_REUSEPORT` / GSO / `connect()` — none in VADR-TS-002, all additive via `optionalProperties` later.

## Follow-ups filed (this session)

- #834 — VADR-vision depayloader (blocked-by #829 + #830, no milestone)

Also closed #4 / #5 / #6 / #8 as superseded — pre-package-shape early-architecture network issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)