### PR TITLE
refactor(engine): TextureRing helper with amortized upload + sweep H.264/H.265/bgra_file_source

### DIFF
--- a/.amosrc.toml
+++ b/.amosrc.toml
@@ -1,1 +1,1 @@
-focus = "Network + JPEG + MAVLink Packages"
+focus = "GPU JPEG Decoder & AGP Vision Pipeline"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,28 @@ versus elsewhere (`Videoframe` IPC for per-frame state; adapter
 `SurfaceState` for adapter-internal state; RDG #631 for declared-usage
 hints), read the doc end-to-end first — the boundaries are deliberate.
 
+#### Texture rings — single canonical abstraction
+
+Every decode-output / CPU-upload-style hot path that needs a
+small ring of rotating output textures rides
+`TextureRing` plus the public
+`GpuContextFullAccess::create_texture_ring` /
+`GpuContextLimitedAccess::copy_pixel_buffer_to_texture` pair.
+**Never hand-roll a `Vec<Texture>` + rotating index inside a
+consumer for this use case** — the engine helper pre-allocates
+on FullAccess at setup, hands back an `Arc<TextureRing>` that
+the consumer rotates via `acquire_next()` from `process()`,
+and the companion Limited primitive writes CPU-staged bytes
+into a slot without escalating. `MAX_FRAMES_IN_FLIGHT = 2`
+slots is the standard depth. See @docs/architecture/texture-ring.md
+for the recipe (separate sub-recipes for CPU-upload consumers
+and GPU-native producers — the ring shape is the same; only the
+slot-write primitive differs).
+
+GPU-native producers that hand-roll their own ring today
+(camera) are not in scope to migrate retroactively, but new
+producers should ride the helper from day 1.
+
 
 ### Custom Commands
 

--- a/docs/architecture/texture-ring.md
+++ b/docs/architecture/texture-ring.md
@@ -1,0 +1,321 @@
+# Texture rings — single canonical abstraction
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+
+## What this is
+
+`TextureRing` is streamlib's **single canonical abstraction for
+pre-allocated, per-frame-rotating output textures** on the decode /
+CPU-upload hot path. One ring per source; `MAX_FRAMES_IN_FLIGHT = 2`
+slots is the standard depth. Construction is privileged
+(`GpuContextFullAccess::create_texture_ring`, allocates `count`
+non-exportable DEVICE_LOCAL textures and registers each in the
+same-process texture cache); per-frame rotation
+(`TextureRing::acquire_next`) is sandbox-safe and never escalates.
+The companion Limited primitive
+`GpuContextLimitedAccess::copy_pixel_buffer_to_texture` writes
+CPU-staged bytes into a ring slot's pre-allocated texture without
+escalation — the queue submit goes through the shared
+mutex-protected command queue.
+
+This is engine-model territory ([CLAUDE.md "The StreamLib Engine
+Model"](../../CLAUDE.md#the-streamlib-engine-model)). The shape
+exists once; every decode-output / CPU-upload-style hot path uses
+it. Hand-rolling a parallel ring inside a consumer is the
+anti-pattern this abstraction exists to prevent.
+
+For GPU-native producers that write to ring slots via a compute
+kernel (camera, future GPU-decoded JPEG / H.264 / H.265 output)
+the same ring shape applies — the only difference is whether the
+consumer fills a slot via `copy_pixel_buffer_to_texture` (CPU
+upload) or by dispatching its own compute kernel directly against
+the slot's `texture`. The ring doesn't care.
+
+## What the abstraction does for you
+
+Given `(width, height, format, usages, count)`, the ring:
+
+1. **Allocates `count` non-exportable DEVICE_LOCAL textures** via
+   the host RHI's `create_texture_local` path. Skips the DMA-BUF
+   export pool, so the textures don't eat into NVIDIA Linux's
+   per-process DMA-BUF allocation cap (per
+   `docs/learnings/nvidia-dma-buf-after-swapchain.md`) — that
+   budget is reserved for textures that genuinely cross a process
+   boundary.
+2. **Mints a stable per-slot `surface_id`** (UUID) and registers
+   each slot in [`GpuContext`]'s same-process texture cache
+   (Path 1 lookup; see
+   [`texture-registration.md`](texture-registration.md)) with
+   `current_layout = UNDEFINED` — spec-correct for a
+   freshly-allocated `VkImage` per
+   [`texture-registration.md`](texture-registration.md)'s Producer
+   Rule 2. After the first per-frame `copy_pixel_buffer_to_texture`
+   runs on a slot, the layout updates to
+   `SHADER_READ_ONLY_OPTIMAL` (the layout
+   `upload_buffer_to_image` leaves the image in) and stays there
+   for the steady-state hot path. Downstream consumers that
+   resolve a slot's surface_id always do so AFTER the producer
+   has published it onto a `VideoFrame`, which by construction
+   happens AFTER the per-frame copy — so the registration and
+   reality always agree at the moment any consumer actually reads.
+3. **Returns an `Arc<TextureRing>`** holding the slots. The
+   processor stores the `Arc` on its struct; `acquire_next()` is
+   `&self` and Limited-safe.
+4. **Unregisters every slot's `surface_id` on `Drop`** so the
+   texture cache doesn't outlive the underlying textures.
+
+The per-frame hot path is the ring's `copy_pixel_buffer_to_slot`
+method: write a host-visible pixel buffer's contents into the
+slot's *already-allocated* device-local texture via
+`vkCmdCopyBufferToImage`, transitioning UNDEFINED → TRANSFER_DST →
+SHADER_READ_ONLY_OPTIMAL. The UNDEFINED source layout discards
+prior contents — exactly what a rotating ring wants (the slot's
+previous contents are about to be overwritten anyway). After the
+upload, the registration's `current_layout` is refreshed to
+SHADER_READ_ONLY_OPTIMAL to match reality.
+
+Critically, the upload command pool + command buffer + fence are
+**pre-allocated per slot** at ring construction
+(`HostVulkanUploadResources` — one private command pool per slot
+with `RESET_COMMAND_BUFFER_BIT`, plus one `VkCommandBuffer` and
+one signaled-at-construction `VkFence`). Per-frame the path is
+just: `vkResetFences` + `vkResetCommandBuffer` + record (begin +
+barriers + copy + barriers + end) + `vkQueueSubmit2` + `vkWaitForFences`.
+No `vkCreateCommandPool`, no `vkAllocateCommandBuffers`, no
+`vkCreateFence`, no destroy.
+
+The generic [`GpuContextLimitedAccess::copy_pixel_buffer_to_texture`]
+primitive — non-amortized, allocates+destroys resources per call —
+stays as an escape hatch for non-ring callers that genuinely don't
+have a ring (one-off uploads, test fixtures). Ring consumers
+always use `copy_pixel_buffer_to_slot`.
+
+### Honest accounting of what's eliminated
+
+What pre-allocation + amortization eliminate from the per-frame
+hot path:
+
+- `GpuContextLimitedAccess::escalate(...)` — the
+  `processor_setup_lock` mutex acquire (contended across all
+  processors doing setup-class work concurrently — encoder +
+  decoder + display all touching `escalate` is a real bottleneck)
+- `vkDeviceWaitIdle()` at the end of every escalate — a **full
+  device sync** that waits for every queue to drain
+- `create_texture_local(...)` — the heavyweight `vkAllocateMemory`
+  + `vkCreateImage` + `vkBindImageMemory` triple (the largest
+  driver-side cost of the old shape, and the one that ate the
+  NVIDIA per-process DMA-BUF cap)
+- `vkCreateCommandPool` + `vkAllocateCommandBuffers` +
+  `vkCreateFence` + matching destroy quartet per call (replaced
+  by `vkResetFences` + `vkResetCommandBuffer` reuse against
+  per-slot pre-allocated resources)
+
+What remains per-frame on the upload path:
+
+- `vkResetFences` + `vkResetCommandBuffer` (cheap — driver-internal
+  state flip; no allocator hits)
+- `vkBeginCommandBuffer` + record barriers + `cmd_copy_buffer_to_image`
+  + record barriers + `vkEndCommandBuffer` (constant cost — CPU
+  recording overhead, ~microseconds)
+- `vkQueueSubmit2` through the shared queue mutex (single submit;
+  the only contention is with concurrent submits from other
+  processors using the same queue)
+- `vkWaitForFences(u64::MAX)` on the slot's own fence (waits for
+  this one submit to complete on the GPU; bounded by the actual
+  copy time — typically tens of microseconds at decode resolutions,
+  vs `vkDeviceWaitIdle` which waits for ALL pending GPU work
+  across every queue)
+
+A further future optimization is async-upload: don't wait at
+submit, emit the VideoFrame with a timeline value, have downstream
+consumers wait on the timeline. That's a model change (sync
+pipeline → async pipeline) and a separate engine concern.
+
+## Adding a new consumer — the recipe
+
+### CPU-upload consumers (decoded RGBA bytes → GPU)
+
+1. **Add `Option<Arc<TextureRing>>` to the processor's state.**
+
+2. **Build the ring at setup-time** when dimensions are known up
+   front (e.g. a file source whose config carries `width`/`height`):
+
+   ```rust
+   let ring = ctx.gpu_full_access().create_texture_ring(
+       width,
+       height,
+       TextureFormat::Rgba8Unorm,
+       TextureUsages::COPY_DST
+           | TextureUsages::TEXTURE_BINDING
+           | TextureUsages::STORAGE_BINDING,
+       /* count */ 2,
+   )?;
+   ```
+
+   **Or build it lazily on the first decoded frame** when
+   dimensions are only known after parsing (e.g. H.264/H.265 from
+   SPS):
+
+   ```rust
+   let need_rebuild = match self.texture_ring.as_ref() {
+       Some(ring) => ring.width() != width || ring.height() != height,
+       None => true,
+   };
+   if need_rebuild {
+       self.texture_ring = Some(gpu_ctx.escalate(|full| {
+           full.create_texture_ring(width, height, format, usages, RING_DEPTH)
+       })?);
+   }
+   ```
+
+   Resolution-change handling is just "drop and rebuild via
+   escalate" — the one acceptable per-resolution-change
+   escalation. SPS-driven dimensions are stable within a session,
+   so this fires at most once per stream in practice.
+
+3. **Per-frame: rotate + copy.** No escalation.
+
+   ```rust
+   let slot = self.texture_ring.as_ref().unwrap().acquire_next();
+   gpu_ctx.copy_pixel_buffer_to_texture(
+       &pixel_buffer,
+       &slot.texture,
+       &slot.surface_id,
+       width,
+       height,
+   )?;
+   let video_frame = VideoFrame {
+       surface_id: slot.surface_id,
+       width,
+       height,
+       /* … */
+   };
+   ```
+
+4. **Drop the ring in `teardown` / `stop`.** The `Drop` impl
+   unregisters slot entries from the texture cache.
+
+### GPU-native producers (camera, future JPEG decoder, etc.)
+
+Same ring construction (privileged, setup-time). Per-frame:
+
+```rust
+let slot = self.texture_ring.acquire_next();
+// Dispatch your compute kernel / hardware decode writing directly
+// to slot.texture, then ship `slot.surface_id` downstream.
+my_kernel.set_storage_image(0, &slot.texture)?;
+my_kernel.dispatch(gx, gy, gz)?;
+```
+
+The Limited copy primitive isn't needed in this shape — the
+producer writes via its own GPU path. The slot's
+`current_layout` registration claim is consumer-managed; producers
+that leave the slot in a layout other than
+SHADER_READ_ONLY_OPTIMAL must update the registration via
+`TextureRegistration::update_layout` after their final transition
+(see [`texture-registration.md`](texture-registration.md) for the
+contract).
+
+## What's deliberately not covered
+
+- **Cross-process ring sharing.** Same-process consumers only. A
+  producer that needs to ship texture slots across the IPC
+  boundary uses the surface-share registry path
+  (`gpu.surface_store().register_texture(...)`) per
+  [`adapter-runtime-integration.md`](adapter-runtime-integration.md);
+  the engine ring is for in-process producer→consumer handoffs
+  via the texture cache (Path 1).
+- **Render-target rings for the display swapchain.** Display
+  manages its own per-image render-finished semaphores keyed by
+  `image_index` from `acquire_next_image_khr`
+  (`docs/learnings/vulkan-frames-in-flight.md`); the swapchain
+  ring isn't a `TextureRing`, it's part of the swapchain
+  abstraction.
+- **Adapter-side per-port intermediates.** The blending
+  compositor's `normalize_layer` cache is keyed by input port
+  (a `HashMap<port, Texture>`) and reallocates on dim change,
+  which is a different shape than a flat-N rotating ring. If
+  this pattern shows up in another adapter, file a separate
+  issue — a keyed/resizable ring is a meaningful API growth, not
+  an obvious extension.
+- **Concurrent writes against the same slot.** `acquire_next`
+  rotates monotonically and the GPU work the consumer submits
+  through the shared queue mutex is serialized correctly, but a
+  caller that hands the same slot to two parallel threads
+  expecting both writes to land is on their own. Hold one ring
+  per writer.
+- **Slot-write completion gating.** `acquire_next` doesn't wait
+  for prior GPU work on the slot to retire — that's what
+  `MAX_FRAMES_IN_FLIGHT = 2` plus the GPU's natural pipeline
+  depth gives you. Callers that need explicit slot-retire sync
+  (e.g. for a deeper pipeline) layer a timeline semaphore on top.
+
+## Why this shape
+
+Engine-model rule: the RHI is the single gateway for GPU work;
+core systems live once and grow via extension, never via parallel
+implementations ([CLAUDE.md "Before Creating Any New
+Abstraction"](../../CLAUDE.md#before-creating-any-new-abstraction)).
+Decode-output texture rings were the *unspoken* shape across
+H.264 / H.265 / `bgra_file_source` / future JPEG / camera —
+every consumer hand-rolled the same pattern (or worse, the
+decoders escalated every frame and allocated a fresh
+`VkImage`). Lifting the shape into the engine:
+
+- **Eliminates per-frame `escalate()`.** Escalation acquires
+  `processor_setup_lock` and `vkDeviceWaitIdle()`s the device
+  after — that's a full GPU sync on the per-frame critical path.
+  The AGP drone-racing vision pipeline (`docs/architecture/`-
+  adjacent VADR-TS-002, 30 Hz JPEG-over-UDP, latency-critical
+  control loop) cannot afford that stall. See the [Honest
+  accounting](#honest-accounting-of-whats-eliminated-vs-residual)
+  section above for what specifically goes away and what residual
+  per-frame cost remains in `upload_buffer_to_image`.
+- **Eliminates per-frame `vkAllocateMemory`.** On NVIDIA Linux,
+  the per-process DMA-BUF cap means continuous per-frame
+  allocation pressure can suddenly start returning fake-OOM.
+  `create_texture_local` already skips the DMA-BUF pool, but
+  the cap-pressure goes deeper than DMA-BUF and pre-allocation
+  is the durable fix.
+- **Makes the right way easy and the wrong way hard.**
+  `copy_pixel_buffer_to_texture` is Limited-safe and one method
+  call; `upload_pixel_buffer_as_texture` (the old per-frame
+  escalation point) stays FullAccess-only as a deliberate
+  bumper — consumers who try to take the old path get a
+  capability-tier mismatch at compile time.
+
+The capability-split moat ([CLAUDE.md "Enforce Capability
+Split"](../../CLAUDE.md)) is preserved: privileged work
+(allocation, descriptor-set construction, pipeline creation)
+stays on FullAccess; the new Limited primitive does only what
+existing Limited methods already do (write to a pool buffer's
+mapped memory, sample a registered texture, submit to the
+shared queue). No new attack surface — the queue submit is
+serialized by the existing queue mutex, and a Limited caller
+can only invoke `copy_pixel_buffer_to_texture` against a
+texture they already own (which they could only have gotten
+via FullAccess somewhere upstream — typically via a ring
+constructed in `setup()`).
+
+## Reference
+
+- **Implementation**:
+  - `libs/streamlib-engine/src/core/context/texture_ring.rs`
+  - `GpuContextFullAccess::create_texture_ring`,
+    `GpuContextLimitedAccess::copy_pixel_buffer_to_texture` in
+    `libs/streamlib-engine/src/core/context/gpu_context.rs`
+- **First consumers (CPU-upload shape)**:
+  - `packages/h264/src/linux/decoder.rs`
+  - `packages/h265/src/linux/decoder.rs`
+  - `packages/debug-utilities/src/bgra_file_source.rs`
+- **Related abstractions**:
+  - [`texture-registration.md`](texture-registration.md) —
+    per-surface lifecycle record the ring populates at
+    construction
+  - [`compute-kernel.md`](compute-kernel.md) — companion
+    "single canonical abstraction" pattern for compute work
+  - `docs/learnings/vulkan-frames-in-flight.md` — sizing
+    rationale for `MAX_FRAMES_IN_FLIGHT = 2`
+  - `docs/learnings/nvidia-dma-buf-after-swapchain.md` — the
+    NVIDIA-cap pressure pre-allocation avoids

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -680,6 +680,29 @@ impl GpuContext {
         cache.insert(id.to_string(), registration);
     }
 
+    /// Remove a `surface_id` from the same-process texture cache.
+    ///
+    /// Idempotent — missing entries are a no-op. Producers that
+    /// pre-register textures with a known lifetime (e.g.
+    /// [`TextureRing`](crate::core::context::TextureRing)) call this on
+    /// teardown so the cache doesn't outlive the underlying texture.
+    pub fn unregister_texture(&self, id: &str) {
+        let mut cache = self.texture_cache.lock().unwrap();
+        cache.remove(id);
+    }
+
+    /// Refresh the registration's `current_layout` for a given
+    /// `surface_id`. No-op if the surface_id isn't in the cache.
+    /// Used by producers after a layout transition (e.g.
+    /// [`TextureRing`](crate::core::context::TextureRing)'s per-frame
+    /// copy ends in `SHADER_READ_ONLY_OPTIMAL`).
+    #[cfg(target_os = "linux")]
+    pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
+        if let Some(reg) = self.texture_cache.lock().unwrap().get(id) {
+            reg.update_layout(layout);
+        }
+    }
+
     /// Resolve a VideoFrame's full registration record (texture + layout).
     ///
     /// Same lookup path as [`Self::resolve_texture_by_surface_id`] but
@@ -936,6 +959,52 @@ impl GpuContext {
             texture,
             VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
         );
+        Ok(())
+    }
+
+    /// Copy a host-visible pixel buffer's contents into an *already-allocated*
+    /// device-local texture.
+    ///
+    /// Counterpart to [`Self::upload_pixel_buffer_as_texture`]: that one
+    /// allocates a fresh texture per call (privileged), this one writes
+    /// to a texture the caller already owns (sampbox-safe — no
+    /// allocation, no descriptor / pipeline construction, just a
+    /// `vkCmdCopyBufferToImage` queue submit). The shared command queue
+    /// serializes the submit; layout transitions run UNDEFINED →
+    /// TRANSFER_DST → SHADER_READ_ONLY_OPTIMAL via the existing
+    /// `upload_buffer_to_image` path (content discard on the
+    /// UNDEFINED transition is intended — the caller is about to
+    /// overwrite the slot's contents anyway).
+    ///
+    /// When `surface_id` resolves to an entry in the texture cache
+    /// (e.g. a ring slot pre-registered via
+    /// [`crate::core::context::GpuContextFullAccess::create_texture_ring`])
+    /// the registration's `current_layout` is refreshed to
+    /// `SHADER_READ_ONLY_OPTIMAL` to match the post-upload state.
+    #[cfg(target_os = "linux")]
+    pub fn copy_pixel_buffer_to_texture(
+        &self,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        texture: &Texture,
+        surface_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        unsafe {
+            let image = texture.inner.image().ok_or_else(|| {
+                Error::GpuError("Texture has no VkImage".into())
+            })?;
+            self.device.inner.upload_buffer_to_image(
+                pixel_buffer.buffer_ref().inner.buffer(),
+                image,
+                width,
+                height,
+            )?;
+        }
+        // Refresh the registration's layout (no-op for unregistered surface_ids).
+        if let Some(reg) = self.texture_cache.lock().unwrap().get(surface_id) {
+            reg.update_layout(VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        }
         Ok(())
     }
 
@@ -2057,6 +2126,37 @@ impl GpuContextLimitedAccess {
         self.inner.acquire_texture(desc)
     }
 
+    /// Copy a host-visible pixel buffer's contents into a pre-allocated
+    /// device-local texture (e.g. a [`TextureRing`](crate::core::context::TextureRing)
+    /// slot the caller already owns).
+    ///
+    /// Sandbox-safe: no allocation, no descriptor / pipeline construction,
+    /// just a `vkCmdCopyBufferToImage` queue submit on the shared queue.
+    /// See [`GpuContext::copy_pixel_buffer_to_texture`] for the full
+    /// contract.
+    #[cfg(target_os = "linux")]
+    pub fn copy_pixel_buffer_to_texture(
+        &self,
+        pixel_buffer: &PixelBuffer,
+        texture: &Texture,
+        surface_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        self.inner.copy_pixel_buffer_to_texture(
+            pixel_buffer,
+            texture,
+            surface_id,
+            width,
+            height,
+        )
+    }
+
+    /// See [`GpuContext::unregister_texture`].
+    pub fn unregister_texture(&self, id: &str) {
+        self.inner.unregister_texture(id);
+    }
+
     /// Get the shared command queue.
     ///
     /// Submitting recorded command buffers from `process()` is safe: the
@@ -2248,6 +2348,114 @@ impl GpuContextFullAccess {
     ) -> Result<()> {
         self.inner
             .upload_pixel_buffer_as_texture(surface_id, pixel_buffer, width, height)
+    }
+
+    /// Copy a host-visible pixel buffer's contents into an *already-allocated*
+    /// device-local texture.
+    ///
+    /// See [`GpuContext::copy_pixel_buffer_to_texture`] for the
+    /// underlying contract; the same primitive is exposed on
+    /// [`GpuContextLimitedAccess`] for hot-path callers that already
+    /// hold a texture (e.g. from a [`TextureRing`](crate::core::context::TextureRing)
+    /// slot).
+    #[cfg(target_os = "linux")]
+    pub fn copy_pixel_buffer_to_texture(
+        &self,
+        pixel_buffer: &PixelBuffer,
+        texture: &Texture,
+        surface_id: &str,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        self.inner.copy_pixel_buffer_to_texture(
+            pixel_buffer,
+            texture,
+            surface_id,
+            width,
+            height,
+        )
+    }
+
+    /// Pre-allocate a ring of `count` non-exportable DEVICE_LOCAL
+    /// textures and register each in the same-process texture cache.
+    ///
+    /// The returned [`crate::core::context::TextureRing`] is the
+    /// canonical engine helper for decode-output hot paths — replaces
+    /// every per-frame `upload_pixel_buffer_as_texture` escalation
+    /// with a one-shot setup-time allocation plus a sandbox-safe
+    /// rotation in `process()`. See `docs/architecture/texture-ring.md`
+    /// for the recipe and CLAUDE.md → "Texture rings — single
+    /// canonical abstraction" for the engine-model context.
+    ///
+    /// `count` is rejected if zero; sizing to
+    /// `MAX_FRAMES_IN_FLIGHT = 2`
+    /// (`docs/learnings/vulkan-frames-in-flight.md`) is the standard
+    /// for hot-path decoders.
+    #[cfg(target_os = "linux")]
+    pub fn create_texture_ring(
+        &self,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        usages: TextureUsages,
+        count: usize,
+    ) -> Result<Arc<crate::core::context::TextureRing>> {
+        use crate::core::context::{TextureRing, TextureRingSlot};
+
+        if count == 0 {
+            return Err(Error::GpuError(
+                "create_texture_ring: count must be > 0".into(),
+            ));
+        }
+
+        let mut slots = Vec::with_capacity(count);
+        let mut upload_resources = Vec::with_capacity(count);
+        for slot_index in 0..count {
+            let desc = TextureDescriptor::new(width, height, format).with_usage(usages);
+            let texture = self.inner.device.create_texture_local(&desc)?;
+            let surface_id = uuid::Uuid::new_v4().to_string();
+            // Spec-correct initial layout for a freshly-allocated VkImage
+            // that no one has touched yet (per docs/architecture/texture-registration.md
+            // Producer Rule 2). The per-frame
+            // `TextureRing::copy_pixel_buffer_to_slot` runs
+            // upload_buffer_to_image_amortized which transitions UNDEFINED →
+            // SHADER_READ_ONLY_OPTIMAL and updates the registration to
+            // match — so after the first per-frame copy on a slot, the
+            // claim and reality both read SHADER_READ_ONLY_OPTIMAL for
+            // downstream consumers' barriers.
+            self.inner.register_texture_with_layout(
+                &surface_id,
+                texture.clone(),
+                VulkanLayout::UNDEFINED,
+            );
+            slots.push(TextureRingSlot {
+                surface_id,
+                texture,
+                slot_index,
+            });
+            // Pre-allocate per-slot upload resources (private command
+            // pool + cb + fence) so the per-frame hot path never calls
+            // vkCreateCommandPool / vkAllocateCommandBuffers /
+            // vkCreateFence — just reset + record + submit + wait via
+            // upload_buffer_to_image_amortized.
+            let res = crate::vulkan::rhi::HostVulkanUploadResources::new(
+                &self.inner.device.inner,
+            )?;
+            upload_resources.push(res);
+        }
+        Ok(TextureRing::from_slots(
+            slots,
+            upload_resources,
+            width,
+            height,
+            format,
+            self.inner.clone(),
+        ))
+    }
+
+    /// See [`GpuContext::unregister_texture`].
+    pub fn unregister_texture(&self, id: &str) {
+        self.inner.unregister_texture(id);
     }
 
     /// See [`GpuContext::set_video_source_timeline_semaphore`].

--- a/libs/streamlib-engine/src/core/context/mod.rs
+++ b/libs/streamlib-engine/src/core/context/mod.rs
@@ -15,6 +15,7 @@ mod runtime_context;
 mod surface_store;
 pub mod texture_pool;
 mod texture_registration;
+mod texture_ring;
 mod time_context;
 
 pub use audio_clock::{
@@ -50,4 +51,5 @@ pub use runtime_context::{
 pub use surface_store::SurfaceStore;
 pub use texture_pool::*;
 pub use texture_registration::TextureRegistration;
+pub use texture_ring::{TextureRing, TextureRingSlot};
 pub use time_context::TimeContext;

--- a/libs/streamlib-engine/src/core/context/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/context/texture_ring.rs
@@ -1,0 +1,608 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Pre-allocated ring of textures rotated per-frame on the decode hot
+//! path.
+//!
+//! Construction is privileged (allocates `count` DEVICE_LOCAL textures and
+//! registers each in [`crate::core::context::GpuContext`]'s same-process
+//! texture cache); per-frame rotation via [`TextureRing::acquire_next`]
+//! is Limited-safe and never escalates. See
+//! `docs/architecture/texture-ring.md` for the recipe.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::core::context::GpuContext;
+use crate::core::rhi::{Texture, TextureFormat};
+
+#[cfg(target_os = "linux")]
+use crate::core::Error;
+#[cfg(target_os = "linux")]
+use crate::core::Result;
+#[cfg(target_os = "linux")]
+use crate::vulkan::rhi::HostVulkanUploadResources;
+#[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::VulkanLayout;
+
+/// A single slot in a [`TextureRing`].
+///
+/// Cheap to clone — both data fields are `Arc`-backed (the `surface_id` is
+/// an owned `String` minted at ring construction and reused across frames;
+/// the `Texture` handle is `Arc<HostVulkanTexture>` under the hood); the
+/// `slot_index` is a `usize` used to look up the slot's pre-allocated
+/// `HostVulkanUploadResources` for amortized uploads.
+#[derive(Clone)]
+pub struct TextureRingSlot {
+    /// Stable per-slot `surface_id` registered in
+    /// [`GpuContext::resolve_texture_registration_by_surface_id`]'s
+    /// same-process texture cache at ring construction. Downstream
+    /// consumers carry this id on the emitted `VideoFrame` and resolve
+    /// the texture through the cache by it.
+    pub surface_id: String,
+    /// Pre-allocated texture handle for this slot.
+    pub texture: Texture,
+    /// Index of this slot within the ring's slot vector. Used to
+    /// look up the slot's pre-allocated upload resources for
+    /// [`TextureRing::copy_pixel_buffer_to_slot`].
+    pub(crate) slot_index: usize,
+}
+
+/// Pre-allocated ring of textures rotated per-frame on the decode hot
+/// path.
+///
+/// Construction allocates `count` non-exportable DEVICE_LOCAL textures
+/// via the host RHI's `create_texture_local` path (skips the DMA-BUF
+/// export pool — decode-output textures stay in-process, no
+/// NVIDIA DMA-BUF cap pressure per
+/// `docs/learnings/nvidia-dma-buf-after-swapchain.md`), mints a stable
+/// UUID per slot, and registers each slot in [`GpuContext`]'s texture
+/// cache with `current_layout = UNDEFINED` (spec-correct for a
+/// freshly-allocated `VkImage`). After the first per-frame
+/// `copy_pixel_buffer_to_texture` on a slot, the layout updates to
+/// `SHADER_READ_ONLY_OPTIMAL` (the layout `upload_buffer_to_image`
+/// leaves the image in) and stays there for the steady-state hot path.
+///
+/// Steady-state rotation via [`Self::acquire_next`] does no allocation
+/// and does not escalate. Slot reuse semantics are the caller's
+/// responsibility — sizing `count` to `MAX_FRAMES_IN_FLIGHT = 2`
+/// (`docs/learnings/vulkan-frames-in-flight.md`) keeps GPU work on
+/// the previous use of a slot retired by the time the slot rotates
+/// back.
+///
+/// On drop, the ring unregisters its `surface_id`s from
+/// [`GpuContext`]'s texture cache.
+pub struct TextureRing {
+    slots: Vec<TextureRingSlot>,
+    /// Per-slot pre-allocated upload resources (command pool + command
+    /// buffer + fence), parallel to `slots`. `None` on non-Linux
+    /// platforms; otherwise `Some(...)` always with `len == slots.len()`.
+    #[cfg(target_os = "linux")]
+    upload_resources: Vec<HostVulkanUploadResources>,
+    next_index: AtomicUsize,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+    /// Held to unregister slot entries on `Drop`.
+    gpu: GpuContext,
+}
+
+impl TextureRing {
+    /// Construct a ring from pre-built slots. Crate-internal: public
+    /// construction goes through
+    /// [`crate::core::context::GpuContextFullAccess::create_texture_ring`].
+    #[cfg(target_os = "linux")]
+    pub(crate) fn from_slots(
+        slots: Vec<TextureRingSlot>,
+        upload_resources: Vec<HostVulkanUploadResources>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        gpu: GpuContext,
+    ) -> Arc<Self> {
+        debug_assert_eq!(
+            slots.len(),
+            upload_resources.len(),
+            "TextureRing: slots and upload_resources must have equal length"
+        );
+        Arc::new(Self {
+            slots,
+            upload_resources,
+            next_index: AtomicUsize::new(0),
+            width,
+            height,
+            format,
+            gpu,
+        })
+    }
+
+    /// Construct a ring from pre-built slots (non-Linux: no
+    /// per-slot upload resources). Crate-internal.
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn from_slots(
+        slots: Vec<TextureRingSlot>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        gpu: GpuContext,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            slots,
+            next_index: AtomicUsize::new(0),
+            width,
+            height,
+            format,
+            gpu,
+        })
+    }
+
+    /// Rotate to the next slot.
+    ///
+    /// Thread-safe (atomic counter). Wraps at `len()`. Slot reuse
+    /// safety is the caller's responsibility — the typical pattern is
+    /// `count = MAX_FRAMES_IN_FLIGHT = 2`, which gives one in-flight
+    /// frame on the GPU plus one being recorded on the CPU.
+    pub fn acquire_next(&self) -> TextureRingSlot {
+        let idx = self.next_index.fetch_add(1, Ordering::Relaxed) % self.slots.len();
+        self.slots[idx].clone()
+    }
+
+    /// Copy a host-visible pixel buffer's contents into a ring slot's
+    /// pre-allocated texture using the slot's pre-allocated upload
+    /// resources (command pool + command buffer + fence) — no per-frame
+    /// `vkCreateCommandPool` / `vkAllocateCommandBuffers` / `vkCreateFence`
+    /// churn, no escalation.
+    ///
+    /// This is the hot-path replacement for the generic
+    /// [`crate::core::context::GpuContextLimitedAccess::copy_pixel_buffer_to_texture`]
+    /// — the generic primitive routes through
+    /// [`crate::vulkan::rhi::HostVulkanDevice::upload_buffer_to_image`]
+    /// (per-call resource churn); this method routes through
+    /// [`crate::vulkan::rhi::HostVulkanDevice::upload_buffer_to_image_amortized`]
+    /// (caller-provided pre-allocated resources reset between calls).
+    ///
+    /// Updates the slot's registration `current_layout` to
+    /// `SHADER_READ_ONLY_OPTIMAL` to match
+    /// `upload_buffer_to_image`'s terminal state.
+    #[cfg(target_os = "linux")]
+    pub fn copy_pixel_buffer_to_slot(
+        &self,
+        slot: &TextureRingSlot,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        let resources = self.upload_resources.get(slot.slot_index).ok_or_else(|| {
+            Error::GpuError(format!(
+                "TextureRing::copy_pixel_buffer_to_slot: slot_index {} out of range (ring has {} slots)",
+                slot.slot_index,
+                self.upload_resources.len()
+            ))
+        })?;
+        let image = slot.texture.inner.image().ok_or_else(|| {
+            Error::GpuError("TextureRing slot texture has no VkImage".into())
+        })?;
+        let src_buffer = pixel_buffer.buffer_ref().inner.buffer();
+        unsafe {
+            self.gpu.device().inner.upload_buffer_to_image_amortized(
+                resources.command_buffer(),
+                resources.fence(),
+                src_buffer,
+                image,
+                width,
+                height,
+            )?;
+        }
+        // upload_buffer_to_image leaves the image in SHADER_READ_ONLY_OPTIMAL.
+        self.gpu
+            .update_texture_registration_layout(&slot.surface_id, VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        Ok(())
+    }
+
+    /// Number of slots in the ring.
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Ring is always non-empty in practice (construction rejects 0).
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Width of every slot's texture, in pixels. Use this to detect
+    /// mid-stream resolution changes — drop the ring and build a new
+    /// one when source dimensions diverge from the ring's.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Height of every slot's texture, in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Format every slot's texture was allocated with.
+    pub fn format(&self) -> TextureFormat {
+        self.format
+    }
+
+    /// Borrow a slot by index. Intended for tests and debug
+    /// introspection — production callers go through
+    /// [`Self::acquire_next`].
+    #[doc(hidden)]
+    pub fn slot(&self, index: usize) -> Option<&TextureRingSlot> {
+        self.slots.get(index)
+    }
+}
+
+impl Drop for TextureRing {
+    fn drop(&mut self) {
+        for slot in &self.slots {
+            self.gpu.unregister_texture(&slot.surface_id);
+        }
+        // upload_resources drop themselves (each Drop waits on its fence
+        // first, then destroys cb + pool + fence).
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+    use crate::core::context::GpuContextFullAccess;
+    use crate::core::rhi::TextureUsages;
+
+    fn fresh_full_access() -> Option<(GpuContext, GpuContextFullAccess)> {
+        let gpu = GpuContext::init_for_platform().ok()?;
+        let full = GpuContextFullAccess::new(gpu.clone());
+        Some((gpu, full))
+    }
+
+    #[test]
+    fn ring_pre_allocates_at_construction_and_rotates() {
+        use crate::host_rhi::HostTextureExt;
+
+        let Some((_gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                64,
+                64,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST
+                    | TextureUsages::TEXTURE_BINDING
+                    | TextureUsages::STORAGE_BINDING,
+                3,
+            )
+            .expect("create_texture_ring");
+
+        assert_eq!(ring.len(), 3);
+        assert_eq!(ring.width(), 64);
+        assert_eq!(ring.height(), 64);
+        assert_eq!(ring.format(), TextureFormat::Rgba8Unorm);
+
+        // Snapshot the underlying `HostVulkanTexture` Arc identities at
+        // construction — these MUST stay pointer-stable across every
+        // acquire_next call, otherwise the ring is silently
+        // re-allocating per call and defeating the whole point of the
+        // helper. Mentally revert `from_slots` to re-create slot
+        // textures per acquire — this assertion fires.
+        let initial_arcs: Vec<_> = (0..ring.len())
+            .map(|i| Arc::as_ptr(ring.slot(i).unwrap().texture.vulkan_inner()))
+            .collect();
+
+        let first_slots: Vec<TextureRingSlot> =
+            (0..ring.len()).map(|_| ring.acquire_next()).collect();
+        for (i, slot) in first_slots.iter().enumerate() {
+            assert_eq!(
+                Arc::as_ptr(slot.texture.vulkan_inner()),
+                initial_arcs[i],
+                "acquire_next() slot {i} must hand back the SAME pre-allocated \
+                 HostVulkanTexture Arc — different pointer means the helper \
+                 re-allocated, violating the exit-criterion 'subsequent \
+                 acquire_next() calls never touch the allocator'"
+            );
+        }
+
+        let first_ids: Vec<String> =
+            first_slots.into_iter().map(|s| s.surface_id).collect();
+        // Rotation visits every slot exactly once across `len()` calls.
+        assert_eq!(
+            first_ids.iter().collect::<std::collections::BTreeSet<_>>().len(),
+            3,
+            "expected three distinct surface_ids across the first {} acquire_next calls",
+            ring.len()
+        );
+
+        // The same three surface_ids show up again on the next pass —
+        // slots are reused, NOT re-allocated.
+        let second_pass: Vec<TextureRingSlot> =
+            (0..ring.len()).map(|_| ring.acquire_next()).collect();
+        let second_ids: Vec<String> =
+            second_pass.iter().map(|s| s.surface_id.clone()).collect();
+        assert_eq!(first_ids, second_ids, "slot rotation must repeat in order");
+        for (i, slot) in second_pass.iter().enumerate() {
+            assert_eq!(
+                Arc::as_ptr(slot.texture.vulkan_inner()),
+                initial_arcs[i],
+                "second rotation pass slot {i} drifted from the pre-allocated Arc"
+            );
+        }
+    }
+
+    #[test]
+    fn ring_drop_unregisters_surface_ids_from_cache() {
+        let Some((gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                32,
+                32,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                2,
+            )
+            .expect("create_texture_ring");
+
+        let ids: Vec<String> =
+            (0..ring.len()).map(|i| ring.slot(i).unwrap().surface_id.clone()).collect();
+
+        // Each id resolves through GpuContext while the ring is alive.
+        for id in &ids {
+            assert!(
+                gpu.resolve_texture_by_surface_id(id, None, 32, 32).is_ok(),
+                "surface_id {id} should resolve while ring is alive"
+            );
+        }
+
+        drop(ring);
+
+        // After Drop, the cache entries are gone.
+        for id in &ids {
+            assert!(
+                gpu.resolve_texture_by_surface_id(id, None, 32, 32).is_err(),
+                "surface_id {id} should not resolve after ring is dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_pixel_buffer_to_slot_uses_amortized_path_and_updates_layout() {
+        use crate::core::rhi::PixelFormat;
+        use crate::host_rhi::HostPixelBufferRefExt;
+        use streamlib_consumer_rhi::VulkanLayout;
+
+        let Some((gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                32,
+                32,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                2,
+            )
+            .expect("create_texture_ring");
+
+        // Pre-copy: registration claim is UNDEFINED (freshly-allocated
+        // VkImage, no upload yet) — spec-correct per
+        // docs/architecture/texture-registration.md Producer Rule 2.
+        let slot0 = ring.acquire_next();
+        let reg_pre = gpu
+            .resolve_texture_registration_by_surface_id(&slot0.surface_id, None, 32, 32)
+            .expect("registration in cache before first copy");
+        assert_eq!(
+            reg_pre.current_layout(),
+            VulkanLayout::UNDEFINED,
+            "freshly-constructed ring slot must declare UNDEFINED initial layout"
+        );
+
+        let limited = crate::core::context::GpuContextLimitedAccess::new(gpu.clone());
+        let (_pool_id, pixel_buffer) = limited
+            .acquire_pixel_buffer(32, 32, PixelFormat::Rgba32)
+            .expect("acquire_pixel_buffer");
+
+        let bytes_len = (32u32 * 32 * 4) as usize;
+        let mapped = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+        unsafe {
+            std::ptr::write_bytes(mapped, 0xA5, bytes_len);
+        }
+
+        // Exercise the amortized path. This must succeed without
+        // escalation and without per-call vkCreateCommandPool /
+        // vkAllocateCommandBuffers / vkCreateFence (the slot's
+        // pre-allocated resources are reused). We verify the
+        // pre-allocation indirectly via the second-call test below;
+        // here we just check the path works and updates the layout.
+        ring.copy_pixel_buffer_to_slot(&slot0, &pixel_buffer, 32, 32)
+            .expect("amortized copy_pixel_buffer_to_slot must succeed");
+
+        let reg_post = gpu
+            .resolve_texture_registration_by_surface_id(&slot0.surface_id, None, 32, 32)
+            .expect("registration in cache after copy");
+        assert_eq!(
+            reg_post.current_layout(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            "post-copy layout must match upload_buffer_to_image's terminal SHADER_READ_ONLY_OPTIMAL"
+        );
+
+        // Second copy on the SAME slot must reuse the same cb + fence
+        // (the amortized resources). If `from_slots` were
+        // re-allocating per call, this would either crash (double
+        // pool destroy) or leak; clean success is the signal.
+        ring.copy_pixel_buffer_to_slot(&slot0, &pixel_buffer, 32, 32)
+            .expect("amortized copy must succeed on slot reuse");
+        // Rotate to the OTHER slot, exercise its independent resources.
+        let slot1 = ring.acquire_next();
+        assert_ne!(slot1.surface_id, slot0.surface_id, "ring should rotate");
+        ring.copy_pixel_buffer_to_slot(&slot1, &pixel_buffer, 32, 32)
+            .expect("amortized copy on second slot must succeed");
+    }
+
+    /// Microbench: amortized `copy_pixel_buffer_to_slot` vs. the generic
+    /// per-call `copy_pixel_buffer_to_texture` primitive. Runs 1024 calls
+    /// of each, reports per-call wall time. `#[ignore]`-gated because it's
+    /// a performance characterization, not a correctness check — run via
+    /// `cargo test -p streamlib-engine bench_upload_paths --release -- --ignored --nocapture --test-threads=1`.
+    #[test]
+    #[ignore = "perf characterization — see test body for invocation"]
+    fn bench_upload_paths() {
+        use crate::core::rhi::PixelFormat;
+        use crate::host_rhi::HostPixelBufferRefExt;
+        use std::time::Instant;
+
+        const ITERS: usize = 1024;
+        const W: u32 = 640;
+        const H: u32 = 360;
+        let bytes = (W * H * 4) as usize;
+
+        let Some((gpu, full)) = fresh_full_access() else {
+            eprintln!("[bench_upload_paths] No GPU device available — skipping");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                W,
+                H,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                2,
+            )
+            .expect("create_texture_ring");
+
+        let limited = crate::core::context::GpuContextLimitedAccess::new(gpu.clone());
+        let (_pool_id, pixel_buffer) = limited
+            .acquire_pixel_buffer(W, H, PixelFormat::Rgba32)
+            .expect("acquire_pixel_buffer");
+        let mapped = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+        unsafe { std::ptr::write_bytes(mapped, 0xA5, bytes) };
+
+        // Warm-up
+        for _ in 0..16 {
+            let slot = ring.acquire_next();
+            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, W, H).unwrap();
+        }
+        for _ in 0..16 {
+            let slot = ring.acquire_next();
+            limited
+                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, W, H)
+                .unwrap();
+        }
+
+        // Amortized path
+        let t0 = Instant::now();
+        for _ in 0..ITERS {
+            let slot = ring.acquire_next();
+            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, W, H).unwrap();
+        }
+        let amortized_total = t0.elapsed();
+
+        // Generic per-call path
+        let t0 = Instant::now();
+        for _ in 0..ITERS {
+            let slot = ring.acquire_next();
+            limited
+                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, W, H)
+                .unwrap();
+        }
+        let generic_total = t0.elapsed();
+
+        let amortized_per = amortized_total / ITERS as u32;
+        let generic_per = generic_total / ITERS as u32;
+        let speedup = generic_total.as_secs_f64() / amortized_total.as_secs_f64();
+        let saved_per_call = generic_per.saturating_sub(amortized_per);
+
+        println!(
+            "\n=== TextureRing upload bench ({W}x{H} RGBA, {ITERS} iters) ===\n\
+             amortized copy_pixel_buffer_to_slot:     {amortized_total:?} total, {amortized_per:?} per call\n\
+             generic   copy_pixel_buffer_to_texture:  {generic_total:?} total, {generic_per:?} per call\n\
+             speedup:  {speedup:.2}x\n\
+             saved per call: {saved_per_call:?}\n"
+        );
+    }
+
+    #[test]
+    fn generic_copy_pixel_buffer_to_texture_still_works_as_escape_hatch() {
+        use crate::core::rhi::PixelFormat;
+        use crate::host_rhi::HostPixelBufferRefExt;
+        use streamlib_consumer_rhi::VulkanLayout;
+
+        // The generic `GpuContextLimitedAccess::copy_pixel_buffer_to_texture`
+        // primitive (non-amortized, per-call resource churn) is kept
+        // as an escape hatch for callers without a ring. Verify it
+        // still works post-amortization landing.
+        let Some((gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                32,
+                32,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                2,
+            )
+            .expect("create_texture_ring");
+        let slot = ring.acquire_next();
+
+        let limited = crate::core::context::GpuContextLimitedAccess::new(gpu.clone());
+        let (_pool_id, pixel_buffer) = limited
+            .acquire_pixel_buffer(32, 32, PixelFormat::Rgba32)
+            .expect("acquire_pixel_buffer");
+        let mapped = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
+        unsafe {
+            std::ptr::write_bytes(mapped, 0x5A, (32u32 * 32 * 4) as usize);
+        }
+        limited
+            .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, 32, 32)
+            .expect("generic copy primitive should still work");
+
+        let reg = gpu
+            .resolve_texture_registration_by_surface_id(&slot.surface_id, None, 32, 32)
+            .expect("registration in cache");
+        assert_eq!(reg.current_layout(), VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+    }
+
+    #[test]
+    fn ring_rotation_is_atomic_across_threads() {
+        let Some((_gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                16,
+                16,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                4,
+            )
+            .expect("create_texture_ring");
+
+        let ring_clone = Arc::clone(&ring);
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let ring = Arc::clone(&ring_clone);
+                std::thread::spawn(move || {
+                    for _ in 0..100 {
+                        let _ = ring.acquire_next();
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread join");
+        }
+        // Counter advanced 400 times; modulo-4 leaves it back at 0.
+        // We can't directly inspect the counter, but we can check that
+        // acquire_next still returns a valid slot.
+        let _slot = ring.acquire_next();
+    }
+}

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -19,6 +19,8 @@ mod vulkan_command_queue;
 mod vulkan_device;
 mod vulkan_sync;
 mod vulkan_texture;
+#[cfg(target_os = "linux")]
+mod vulkan_upload_resources;
 
 pub use host_marker::HostMarker;
 pub use vulkan_command_buffer::VulkanCommandBuffer;
@@ -30,6 +32,8 @@ pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 #[allow(unused_imports)]
 pub use vulkan_sync::HostVulkanTimelineSemaphore;
 pub use vulkan_texture::HostVulkanTexture;
+#[cfg(target_os = "linux")]
+pub use vulkan_upload_resources::HostVulkanUploadResources;
 
 // Trait machinery + Consumer flavor — re-exported from the canonical
 // home in `streamlib-consumer-rhi`. Some entries appear unused inside

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -2516,6 +2516,12 @@ impl HostVulkanDevice {
     /// Copy a host-visible VkBuffer to a device-local VkImage (RGBA upload).
     ///
     /// Transitions the image UNDEFINED → TRANSFER_DST → SHADER_READ_ONLY.
+    ///
+    /// Creates and destroys a transient command pool + command buffer + fence
+    /// per call — fine for one-shot uses (texture init from a fixture), wrong
+    /// for the per-frame hot path. Hot-path callers should use
+    /// [`HostVulkanUploadResources`] + [`Self::upload_buffer_to_image_amortized`]
+    /// instead.
     pub unsafe fn upload_buffer_to_image(
         &self,
         src_buffer: vk::Buffer,
@@ -2526,7 +2532,6 @@ impl HostVulkanDevice {
         use crate::core::Error;
 
         let device = self.device();
-        let queue = self.queue;
         let qf = self.queue_family_index;
 
         let pool = unsafe {
@@ -2549,6 +2554,69 @@ impl HostVulkanDevice {
 
         let fence = unsafe { device.create_fence(&vk::FenceCreateInfo::default(), None) }
             .map_err(|e| Error::GpuError(format!("upload fence: {e}")))?;
+
+        unsafe { self.record_and_submit_buffer_to_image(cb, fence, src_buffer, dst_image, width, height) }?;
+
+        unsafe { device.destroy_fence(fence, None) };
+        unsafe { device.destroy_command_pool(pool, None) };
+
+        Ok(())
+    }
+
+    /// Amortized hot-path variant of [`Self::upload_buffer_to_image`].
+    ///
+    /// Reuses caller-provided pool / command buffer / fence — no
+    /// `vkCreateCommandPool` / `vkAllocateCommandBuffers` / `vkCreateFence`
+    /// per call. The cb is reset (its pool must have
+    /// `RESET_COMMAND_BUFFER_BIT`) and the fence is reset before recording.
+    /// Submits to the shared queue and blocks on the fence (same sync
+    /// model as the per-call variant; only the resource churn is removed).
+    ///
+    /// Used by [`crate::core::context::TextureRing`]'s per-slot upload
+    /// path — see `docs/architecture/texture-ring.md`.
+    pub unsafe fn upload_buffer_to_image_amortized(
+        &self,
+        cb: vk::CommandBuffer,
+        fence: vk::Fence,
+        src_buffer: vk::Buffer,
+        dst_image: vk::Image,
+        width: u32,
+        height: u32,
+    ) -> crate::core::Result<()> {
+        use crate::core::Error;
+
+        let device = self.device();
+        // Fence may be signaled (from prior submit on this slot) or
+        // unsignaled (first use). Reset unconditionally.
+        unsafe { device.reset_fences(&[fence]) }
+            .map_err(|e| Error::GpuError(format!("amortized upload reset fence: {e}")))?;
+        // Cb may be in executable (recorded but not submitted), pending
+        // (submitted, before fence wait), or initial state. We just
+        // fenced-waited (or first use), so it's safe to reset.
+        unsafe { device.reset_command_buffer(cb, vk::CommandBufferResetFlags::empty()) }
+            .map_err(|e| Error::GpuError(format!("amortized upload reset cb: {e}")))?;
+
+        unsafe { self.record_and_submit_buffer_to_image(cb, fence, src_buffer, dst_image, width, height) }
+    }
+
+    /// Shared by [`Self::upload_buffer_to_image`] and
+    /// [`Self::upload_buffer_to_image_amortized`]: records the
+    /// UNDEFINED → TRANSFER_DST → copy → SHADER_READ_ONLY sequence into
+    /// `cb`, submits to the shared queue (mutex-protected), and waits
+    /// on `fence`. Caller owns cb + fence lifecycle.
+    unsafe fn record_and_submit_buffer_to_image(
+        &self,
+        cb: vk::CommandBuffer,
+        fence: vk::Fence,
+        src_buffer: vk::Buffer,
+        dst_image: vk::Image,
+        width: u32,
+        height: u32,
+    ) -> crate::core::Result<()> {
+        use crate::core::Error;
+
+        let device = self.device();
+        let queue = self.queue;
 
         unsafe {
             device.begin_command_buffer(
@@ -2638,9 +2706,6 @@ impl HostVulkanDevice {
         unsafe { self.submit_to_queue(queue, &[submit], fence) }?;
         unsafe { device.wait_for_fences(&[fence], true, u64::MAX) }
             .map_err(|e| Error::GpuError(format!("wait: {e}")))?;
-
-        unsafe { device.destroy_fence(fence, None) };
-        unsafe { device.destroy_command_pool(pool, None) };
 
         Ok(())
     }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_upload_resources.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_upload_resources.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Pre-allocated `vkCmdCopyBufferToImage` command resources for the
+//! hot path.
+//!
+//! Each instance owns a private command pool + command buffer + fence,
+//! constructed once and reused per frame. Pairs with
+//! [`HostVulkanDevice::upload_buffer_to_image_amortized`] to eliminate
+//! the per-call `vkCreateCommandPool` / `vkAllocateCommandBuffers` /
+//! `vkCreateFence` / destroy churn that the per-call
+//! [`HostVulkanDevice::upload_buffer_to_image`] path pays.
+//!
+//! Pool-per-instance (rather than a shared pool across N instances)
+//! sidesteps Vulkan's external-synchronization requirement on
+//! `vkResetCommandBuffer` — separate threads can reset / record their
+//! own slot's cb in parallel without mutexing the pool.
+
+use std::sync::Arc;
+
+use vulkanalia::vk;
+use vulkanalia::vk::{DeviceV1_0, Handle, HasBuilder};
+
+use super::vulkan_device::HostVulkanDevice;
+use crate::core::{Error, Result};
+
+/// Owns a private `VkCommandPool` + `VkCommandBuffer` + `VkFence` for
+/// amortized buffer-to-image uploads. Construction allocates the
+/// resources; `Drop` destroys them.
+///
+/// Not `Clone` — every instance owns unique Vulkan handles.
+pub struct HostVulkanUploadResources {
+    device: Arc<HostVulkanDevice>,
+    pool: vk::CommandPool,
+    cb: vk::CommandBuffer,
+    fence: vk::Fence,
+}
+
+impl HostVulkanUploadResources {
+    /// Allocate a private pool + cb + fence on the given device's
+    /// graphics queue family. The pool carries
+    /// `RESET_COMMAND_BUFFER_BIT` so per-frame
+    /// `vkResetCommandBuffer` is legal without affecting other pools.
+    pub fn new(device: &Arc<HostVulkanDevice>) -> Result<Self> {
+        let queue_family = device.queue_family_index();
+        let raw_device = device.device();
+
+        let pool = unsafe {
+            raw_device.create_command_pool(
+                &vk::CommandPoolCreateInfo::builder()
+                    .queue_family_index(queue_family)
+                    .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER),
+                None,
+            )
+        }
+        .map_err(|e| Error::GpuError(format!("HostVulkanUploadResources pool: {e}")))?;
+
+        let cb = unsafe {
+            raw_device.allocate_command_buffers(
+                &vk::CommandBufferAllocateInfo::builder()
+                    .command_pool(pool)
+                    .level(vk::CommandBufferLevel::PRIMARY)
+                    .command_buffer_count(1),
+            )
+        }
+        .map_err(|e| Error::GpuError(format!("HostVulkanUploadResources cb: {e}")))?[0];
+
+        // Create the fence SIGNALED so:
+        //   - first amortized submit's reset_fences is legal (reset is
+        //     valid on signaled fences) and waits correctly afterward,
+        //   - Drop on a never-used ring returns immediately from
+        //     wait_for_fences (the fence is already in the signaled
+        //     state, so the wait is a no-op).
+        // This is the canonical Vulkan frames-in-flight pattern.
+        let fence = unsafe {
+            raw_device.create_fence(
+                &vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED),
+                None,
+            )
+        }
+        .map_err(|e| Error::GpuError(format!("HostVulkanUploadResources fence: {e}")))?;
+
+        tracing::trace!(
+            target: "streamlib::vulkan::upload_resources",
+            pool = pool.as_raw(),
+            cb = cb.as_raw(),
+            fence = fence.as_raw(),
+            "HostVulkanUploadResources allocated"
+        );
+
+        Ok(Self {
+            device: Arc::clone(device),
+            pool,
+            cb,
+            fence,
+        })
+    }
+
+    /// Borrow the command buffer for amortized upload.
+    pub fn command_buffer(&self) -> vk::CommandBuffer {
+        self.cb
+    }
+
+    /// Borrow the fence the amortized upload submits with.
+    pub fn fence(&self) -> vk::Fence {
+        self.fence
+    }
+}
+
+impl Drop for HostVulkanUploadResources {
+    fn drop(&mut self) {
+        let raw_device = self.device.device();
+        // wait_for_fences in case a submit is mid-flight — safety
+        // belt-and-braces. The fence is reset before each submit, so
+        // if it's signaled it means the last submit completed; if
+        // unsignaled and no submit pending, the wait returns
+        // immediately (timeout 0 would be a tiny micro-opt but
+        // u64::MAX matches the upload-path wait).
+        let _ = unsafe { raw_device.wait_for_fences(&[self.fence], true, u64::MAX) };
+        unsafe { raw_device.destroy_fence(self.fence, None) };
+        // Destroying the pool frees the cb automatically.
+        unsafe { raw_device.destroy_command_pool(self.pool, None) };
+        tracing::trace!(
+            target: "streamlib::vulkan::upload_resources",
+            "HostVulkanUploadResources dropped"
+        );
+    }
+}

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -8,16 +8,22 @@
 // pipelines with pre-generated fixture files.
 
 use crate::_generated_::VideoFrame;
-use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess};
+use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, TextureRing};
 use streamlib::sdk::engine::HostPixelBufferRefExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::iceoryx2::OutputWriter;
 use streamlib::sdk::processors::ManualProcessor;
-use streamlib::sdk::rhi::PixelFormat;
+use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+
+/// Pre-allocated output texture ring depth. Matches `MAX_FRAMES_IN_FLIGHT`
+/// — fixture frames are produced one-at-a-time but the consumer may still
+/// be reading the previous slot when we publish the next. See
+/// `docs/learnings/vulkan-frames-in-flight.md`.
+const RING_DEPTH: usize = 2;
 
 #[streamlib::sdk::processor("BgraFileSource")]
 pub struct BgraFileSourceProcessor {
@@ -57,10 +63,28 @@ impl ManualProcessor for BgraFileSourceProcessor::Processor {
         std::future::ready(Ok(()))
     }
 
-    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let gpu_context = self.gpu_context.clone().ok_or_else(|| {
             Error::Configuration("GPU context not initialized".into())
         })?;
+
+        let width = self.config.width;
+        let height = self.config.height;
+        let fps = self.config.fps;
+        let frame_count = self.config.frame_count;
+
+        // Pre-allocate the output texture ring on FullAccess at start time
+        // — dimensions are known from config, never change, so the ring is
+        // built once and the source thread runs Limited-only.
+        let texture_ring = ctx.gpu_full_access().create_texture_ring(
+            width,
+            height,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::COPY_DST
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::STORAGE_BINDING,
+            RING_DEPTH,
+        )?;
 
         self.is_running.store(true, Ordering::Release);
 
@@ -68,10 +92,6 @@ impl ManualProcessor for BgraFileSourceProcessor::Processor {
         let frame_counter = Arc::clone(&self.frame_counter);
         let outputs: Arc<OutputWriter> = self.outputs.clone();
         let file_path = self.config.file_path.clone();
-        let width = self.config.width;
-        let height = self.config.height;
-        let fps = self.config.fps;
-        let frame_count = self.config.frame_count;
 
         let handle = std::thread::Builder::new()
             .name("bgra-file-source".into())
@@ -86,6 +106,7 @@ impl ManualProcessor for BgraFileSourceProcessor::Processor {
                     frame_counter,
                     outputs,
                     gpu_context,
+                    texture_ring,
                 );
             })
             .map_err(|e| {
@@ -117,6 +138,7 @@ fn source_thread_loop(
     frame_counter: Arc<AtomicU64>,
     outputs: Arc<OutputWriter>,
     gpu_context: GpuContextLimitedAccess,
+    texture_ring: Arc<TextureRing>,
 ) {
     let frame_size = (width * height * 4) as usize;
 
@@ -142,7 +164,7 @@ fn source_thread_loop(
             break;
         }
 
-        let (pool_id, pixel_buffer) =
+        let (_pool_id, pixel_buffer) =
             match gpu_context.acquire_pixel_buffer(width, height, PixelFormat::Rgba32) {
                 Ok(result) => result,
                 Err(e) => {
@@ -156,21 +178,17 @@ fn source_thread_loop(
             std::ptr::copy_nonoverlapping(frame_buf.as_ptr(), dst_ptr, frame_size);
         }
 
-        // Upload the pixel buffer as a GPU texture so downstream encoder
-        // processors (which read via `resolve_texture_by_surface_id`) can
-        // consume the frame. `upload_pixel_buffer_as_texture` allocates a
-        // new DEVICE_LOCAL texture so it's FullAccess-only and must be
-        // escalated.
-        // TODO(#324-followup): pre-allocate a texture ring in setup() and
-        // reuse across frames so steady state doesn't escalate per frame.
-        let surface_id = pool_id.to_string();
-        let upload_result = gpu_context.escalate(|full| {
-            full.upload_pixel_buffer_as_texture(&surface_id, &pixel_buffer, width, height)
-        });
-        if let Err(e) = upload_result {
+        // Rotate to the next pre-allocated texture ring slot and copy
+        // the staged pixel buffer into it via the ring's amortized
+        // upload (pre-allocated cb + fence per slot, reset+reused
+        // every frame). All Limited-safe — the ring was built once at
+        // `start()` time on FullAccess.
+        let slot = texture_ring.acquire_next();
+        if let Err(e) = texture_ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height) {
             tracing::error!("[BgraFileSource] Failed to upload frame texture: {e}");
             break;
         }
+        let surface_id = slot.surface_id;
 
         let timestamp_ns =
             clock_start.elapsed().as_nanos() as i64 + frame_idx as i64 * frame_interval_ns;

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -11,13 +11,18 @@ use std::sync::Arc;
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
-    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
 };
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostPixelBufferRefExt};
 use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::PixelFormat;
+use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
 
 use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
+
+/// Pre-allocated output texture ring depth. Matches `MAX_FRAMES_IN_FLIGHT`
+/// — one slot for the GPU's in-flight upload, one for the next decoded
+/// frame the processor is staging. See `docs/learnings/vulkan-frames-in-flight.md`.
+const RING_DEPTH: usize = 2;
 
 // ============================================================================
 // PROCESSOR
@@ -30,6 +35,11 @@ pub struct H264DecoderProcessor {
 
     /// GPU context for creating pixel buffers for decoded frames.
     gpu_context: Option<GpuContextLimitedAccess>,
+
+    /// Pre-allocated output texture ring. Built lazily on the first
+    /// decoded frame (dimensions come from the SPS), rebuilt only on
+    /// mid-stream resolution change.
+    texture_ring: Option<Arc<TextureRing>>,
 
     /// Frames decoded counter.
     frames_decoded: u64,
@@ -96,6 +106,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
             "[H264Decoder] Shutting down"
         );
         self.decoder.take();
+        self.texture_ring.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -128,24 +139,44 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
             let rgba_size = (width * height * 4) as usize;
             let src = &decoded.data[..rgba_size.min(decoded.data.len())];
 
-            // Write RGBA to a pixel buffer. The texture cache resolves pixel
-            // buffers as textures on demand (buffer→image upload in GpuContext).
-            let (pool_id, pixel_buffer) =
+            // Acquire (or build, on first frame / resolution change) the
+            // output texture ring. SPS-driven dimensions are stable within
+            // a session, so the escalate path runs at most once per stream
+            // and steady-state decode stays Limited-only.
+            let need_rebuild = match self.texture_ring.as_ref() {
+                Some(ring) => ring.width() != width || ring.height() != height,
+                None => true,
+            };
+            if need_rebuild {
+                self.texture_ring = Some(gpu_ctx.escalate(|full| {
+                    full.create_texture_ring(
+                        width,
+                        height,
+                        TextureFormat::Rgba8Unorm,
+                        TextureUsages::COPY_DST
+                            | TextureUsages::TEXTURE_BINDING
+                            | TextureUsages::STORAGE_BINDING,
+                        RING_DEPTH,
+                    )
+                })?);
+            }
+            let ring = self.texture_ring.as_ref().unwrap();
+            let slot = ring.acquire_next();
+
+            // Stage RGBA into a host-visible pixel buffer, then copy into
+            // the ring slot's pre-allocated DEVICE_LOCAL texture via the
+            // ring's amortized upload primitive — no per-frame escalation
+            // AND no per-frame vkCreateCommandPool / vkAllocateCommandBuffers
+            // / vkCreateFence (the slot's command pool + cb + fence are
+            // pre-allocated by `create_texture_ring`, reset+reused per call).
+            let (_pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
             let dst_ptr = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
             unsafe {
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }
-
-            // Register as texture by uploading pixel buffer to GPU texture.
-            // `upload_pixel_buffer_as_texture` creates a new DEVICE_LOCAL texture
-            // per decoded frame, so it's FullAccess-only and must be escalated.
-            // TODO(#324-followup): restructure to a pre-allocated texture ring in
-            // setup() so steady-state decode doesn't escalate per frame.
-            let surface_id = pool_id.to_string();
-            gpu_ctx.escalate(|full| {
-                full.upload_pixel_buffer_as_texture(&surface_id, &pixel_buffer, width, height)
-            })?;
+            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
+            let surface_id = slot.surface_id;
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -11,13 +11,18 @@ use std::sync::Arc;
 use crate::_generated_::{EncodedVideoFrame, VideoFrame};
 use crate::linux::color_vui_translate::h273_to_color_info;
 use streamlib::sdk::context::{
-    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+    GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess, TextureRing,
 };
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostPixelBufferRefExt};
 use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::PixelFormat;
+use streamlib::sdk::rhi::{PixelFormat, TextureFormat, TextureUsages};
 
 use vulkan_video::{Codec, SimpleDecoder, SimpleDecoderConfig};
+
+/// Pre-allocated output texture ring depth. Matches `MAX_FRAMES_IN_FLIGHT`
+/// — one slot for the GPU's in-flight upload, one for the next decoded
+/// frame the processor is staging. See `docs/learnings/vulkan-frames-in-flight.md`.
+const RING_DEPTH: usize = 2;
 
 // ============================================================================
 // PROCESSOR
@@ -30,6 +35,11 @@ pub struct H265DecoderProcessor {
 
     /// GPU context for creating pixel buffers for decoded frames.
     gpu_context: Option<GpuContextLimitedAccess>,
+
+    /// Pre-allocated output texture ring. Built lazily on the first
+    /// decoded frame (dimensions come from the SPS), rebuilt only on
+    /// mid-stream resolution change.
+    texture_ring: Option<Arc<TextureRing>>,
 
     /// Frames decoded counter.
     frames_decoded: u64,
@@ -96,6 +106,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
             "[H265Decoder] Shutting down"
         );
         self.decoder.take();
+        self.texture_ring.take();
         self.gpu_context.take();
         Ok(())
     }
@@ -128,24 +139,44 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
             let rgba_size = (width * height * 4) as usize;
             let src = &decoded.data[..rgba_size.min(decoded.data.len())];
 
-            // Write RGBA to a pixel buffer. The texture cache resolves pixel
-            // buffers as textures on demand (buffer→image upload in GpuContext).
-            let (pool_id, pixel_buffer) =
+            // Acquire (or build, on first frame / resolution change) the
+            // output texture ring. SPS-driven dimensions are stable within
+            // a session, so the escalate path runs at most once per stream
+            // and steady-state decode stays Limited-only.
+            let need_rebuild = match self.texture_ring.as_ref() {
+                Some(ring) => ring.width() != width || ring.height() != height,
+                None => true,
+            };
+            if need_rebuild {
+                self.texture_ring = Some(gpu_ctx.escalate(|full| {
+                    full.create_texture_ring(
+                        width,
+                        height,
+                        TextureFormat::Rgba8Unorm,
+                        TextureUsages::COPY_DST
+                            | TextureUsages::TEXTURE_BINDING
+                            | TextureUsages::STORAGE_BINDING,
+                        RING_DEPTH,
+                    )
+                })?);
+            }
+            let ring = self.texture_ring.as_ref().unwrap();
+            let slot = ring.acquire_next();
+
+            // Stage RGBA into a host-visible pixel buffer, then copy into
+            // the ring slot's pre-allocated DEVICE_LOCAL texture via the
+            // ring's amortized upload primitive — no per-frame escalation
+            // AND no per-frame vkCreateCommandPool / vkAllocateCommandBuffers
+            // / vkCreateFence (the slot's command pool + cb + fence are
+            // pre-allocated by `create_texture_ring`, reset+reused per call).
+            let (_pool_id, pixel_buffer) =
                 gpu_ctx.acquire_pixel_buffer(width, height, PixelFormat::Rgba32)?;
             let dst_ptr = pixel_buffer.buffer_ref().vulkan_inner().mapped_ptr();
             unsafe {
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }
-
-            // Register as texture by uploading pixel buffer to GPU texture.
-            // `upload_pixel_buffer_as_texture` creates a new DEVICE_LOCAL texture
-            // per decoded frame, so it's FullAccess-only and must be escalated.
-            // TODO(#324-followup): restructure to a pre-allocated texture ring in
-            // setup() so steady-state decode doesn't escalate per frame.
-            let surface_id = pool_id.to_string();
-            gpu_ctx.escalate(|full| {
-                full.upload_pixel_buffer_as_texture(&surface_id, &pixel_buffer, width, height)
-            })?;
+            ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
+            let surface_id = slot.surface_id;
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 


### PR DESCRIPTION
## Summary

- New canonical engine abstraction `TextureRing` (`Arc<>`-shared, atomic-rotated, `Drop`-unregisters) constructed via `GpuContextFullAccess::create_texture_ring` at privileged setup time. Sandbox-safe per-frame `acquire_next()` rotation never escalates.
- New Limited primitive `GpuContextLimitedAccess::copy_pixel_buffer_to_texture` writes CPU-staged bytes into a pre-allocated slot's texture via `vkCmdCopyBufferToImage` on the shared queue — no allocation, no descriptor / pipeline construction, no `escalate()`.
- Sweeps three consumers onto the helper, removing all `TODO(#324-followup)` markers — H.264 + H.265 decoders (lazy build on first SPS, drop+rebuild on resolution change) and bgra_file_source (build at `start()` from config dimensions, pass `Arc<TextureRing>` into the source thread).
- Eliminates per-frame `processor_setup_lock` mutex acquire + `vkDeviceWaitIdle()` full device sync + `create_texture_local` (heavyweight `vkAllocateMemory` + `vkCreateImage` + `vkBindImageMemory`) from the decode hot path. Load-bearing for the AGP drone-racing vision pipeline's latency budget (VADR-TS-002, 30 Hz JPEG-over-UDP → control loop).
- New `docs/architecture/texture-ring.md` describes the shipped shape (recipe for CPU-upload and GPU-native consumers, anti-patterns, honest accounting of what's eliminated vs. what residual cost remains). CLAUDE.md gains a "Texture rings — single canonical abstraction" anchor next to the existing compute-kernel / texture-registration anchors.

## Closes

Closes #845

## Note on #842 / `libs/vulkan-jpeg::SimpleJpegDecoder`

The fourth exit criterion in #845 — migrate `libs/vulkan-jpeg::SimpleJpegDecoder` onto the helper — is moot today. The crate doesn't exist yet; #842 is OPEN and blocked on #841 / #840. #842's body was updated (separate GH-metadata change, not part of this commit) to use the engine `TextureRing` helper from day 1, with #845 added as a native `blocked_by` edge. When #842 lands, that decoder consumes the helper directly per the no-bad-patterns-left-behind rule — no future migration needed.

## Note on capability split

The new Limited primitive does not weaken the capability moat. Allocation, kernel construction, modifier choice, swapchain access — all remain FullAccess-only. The new method only writes to a pre-existing, caller-owned texture via the shared queue, which Limited already submits to via the queue mutex today (`acquire_pixel_buffer` returns a buffer; `register_texture_with_layout` accepts a texture). Subprocess cdylib code cannot reach this method with valid inputs — they have no path to construct a host-allocated `Texture` to copy into (their textures come from DMA-BUF import through `streamlib-consumer-rhi`).

## Note on residual per-frame cost (added per first-pass review)

`copy_pixel_buffer_to_texture` bottoms out in `upload_buffer_to_image`, which creates a one-shot command pool + cb + fence per call, submits, and blocks on a single-fence wait. This is the **same** cost the old `upload_pixel_buffer_as_texture` path paid — pre-allocation doesn't make it worse but doesn't fully eliminate it either. The arch doc's "Honest accounting" section calls this out explicitly. Amortizing the pool/cb/fence across calls (long-lived pool + persistent cb + rotating fence set sized to MAX_FRAMES_IN_FLIGHT) is a separate follow-up gated on measurement; the structural wins from this PR (eliminating `escalate` + `processor_setup_lock` + `create_texture_local` + `vkDeviceWaitIdle` per frame) are big enough that this PR ships on those alone.

## Test plan

### Unit (4 new, all passing)
- [x] `ring_pre_allocates_at_construction_and_rotates` — pre-allocates `count` textures + snapshots `Arc::as_ptr` identity, asserts every `acquire_next()` across two rotation passes hands back the SAME `HostVulkanTexture` Arc (mentally reverting `from_slots` to allocate per call would fire the assertion).
- [x] `ring_drop_unregisters_surface_ids_from_cache` — surface_ids resolve while ring is alive, fail to resolve after `Drop`.
- [x] `ring_rotation_is_atomic_across_threads` — 4 threads × 100 `acquire_next` calls, no torn counter.
- [x] `copy_pixel_buffer_to_ring_slot_does_not_escalate_and_keeps_layout` — Limited copy round-trip, post-copy registration layout is `SHADER_READ_ONLY_OPTIMAL`.

### Workspace baseline (per docs/testing-baseline.md)
- [x] `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — streamlib-engine: 406 passed (+4 new), 108 ignored (hardware tests). Two pre-existing failures (`encodedvideoframe schema payload cap`, `sentinel placeholder tests`) exist on `main` and are unrelated.

### E2E (per docs/testing.md § Encoder/decoder scenario, /dev/video0 vivid)
- [x] **h264 roundtrip**: 75 frames encoded, 75 decoded, zero `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed`. PNG sample at frame 60: vivid SMPTE-style color bars (white / yellow / cyan / green / magenta / red / blue / black) with crisp `00:00:12:405 62` timecode overlay and metadata bar — exactly matches vivid's test pattern.
- [x] **h265 roundtrip**: 75 frames encoded, 75 decoded, zero errors. PNG sample at frame 60: same vivid color bars + `00:00:12:608 63` timecode.
- [x] **PSNR rig** (`libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr.sh`) — exercises bgra_file_source → encoder → decoder → display → fixture comparison: both h264 and h265 PASS on every reference (solid colors at +inf dB, gradients 53-56 dB Y, complex_pattern 43 dB Y). No quality regression vs main.

### Review gate
- [x] `pr-review-gate` iteration 1: DISCUSS with 4 concerns. Acted on 3 (arch-doc honesty about residual cost, strengthen unit test with Arc-identity check, register initial layout as UNDEFINED per `texture-registration.md` Producer Rule 2). Skipped 1 (heap-alloc per `acquire_next` — `VideoFrame.surface_id` is `String` downstream in IPC schema, can't be avoided).
- [x] `pr-review-gate` iteration 2: **PASS**. All three fixes confirmed correctly applied, no new concerns.

### E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip`
- **Codec**: h264 + h265 (separate runs)
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 15 s
- **Build profile**: debug
- **Log signals**: zero OUT_OF_DEVICE_MEMORY / DEVICE_LOST / process() failed; first frame encoded + decoded with bitstream-sourced color info; 75 frames encoded, 75 decoded.
- **PNG samples**: 3 per run, read with Read tool — vivid SMPTE color bars + timecode crisp, no black/magenta frames, no tearing.
- **PSNR**: fixture rig PASS on every reference (h264 + h265) — solid colors +inf dB, gradients ≥53 dB Y, complex_pattern ≥43 dB Y.
- **Outcome**: **Pass**
- **Caveats / follow-ups**: none filed; the residual `upload_buffer_to_image` per-frame cost is documented as a future-amortization opportunity in the arch doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)