### PR TITLE
feat(vulkan-jpeg): scaffold libs/vulkan-jpeg with baseline parser + Huffman entropy decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "libs/vulkan-video",                  # Vulkan Video encoder/decoder (H.264/H.265 via Vulkan Video extensions)
     "libs/vulkan-video/examples/h264-codec", # Example: H.264 encode/decode roundtrip
     "libs/vulkan-video/examples/h265-codec", # Example: H.265 encode/decode roundtrip
+    "libs/vulkan-jpeg",                   # JPEG decoder: CPU parser + Huffman entropy decode + GPU compute kernel (compute kernel ships in a follow-up issue)
 ]
 
 [workspace.package]

--- a/libs/vulkan-jpeg/Cargo.toml
+++ b/libs/vulkan-jpeg/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vulkan-jpeg"
+version.workspace = true
+edition = "2024"
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+description = "JPEG decode for streamlib — CPU parser + Huffman entropy decode; GPU compute kernel (dequant + IDCT + chroma upsample + YCbCr->RGB) ships in a follow-up issue"
+
+[dependencies]
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+jpeg-encoder = "0.6"
+zune-jpeg = "0.4"
+
+[lints]
+workspace = true

--- a/libs/vulkan-jpeg/src/bit_reader.rs
+++ b/libs/vulkan-jpeg/src/bit_reader.rs
@@ -1,0 +1,254 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use crate::error::{JpegError, JpegResult};
+use crate::marker;
+
+/// MSB-first bit reader over a JPEG entropy-coded segment.
+///
+/// Handles the `0xFF 0x00` byte-stuffing escape (the literal data byte
+/// is `0xFF`) and surfaces any other `0xFF xx` sequence as a marker via
+/// [`BitReader::pending_marker`]. The bit-by-bit decode loop never crosses
+/// a marker boundary; the entropy decoder is expected to inspect the
+/// pending marker (typically a restart `RSTm` or terminating `EOI`) and
+/// either consume it via [`BitReader::consume_marker`] or stop.
+pub struct BitReader<'a> {
+    bytes: &'a [u8],
+    /// Byte offset into `bytes` of the *next* byte to fetch into `buffer`.
+    cursor: usize,
+    /// Bit buffer, MSB-first; `bits_in_buffer` is how many valid bits remain.
+    buffer: u64,
+    bits_in_buffer: u32,
+    /// Marker byte (the byte after `0xFF`) encountered during refill, if any.
+    pending_marker: Option<u8>,
+    /// Byte offset where the pending marker was found.
+    pending_marker_offset: Option<usize>,
+}
+
+impl<'a> BitReader<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            cursor: 0,
+            buffer: 0,
+            bits_in_buffer: 0,
+            pending_marker: None,
+            pending_marker_offset: None,
+        }
+    }
+
+    /// Byte offset of the next byte the reader would fetch (after the
+    /// current bit buffer). Used for error messages and marker offset.
+    pub fn byte_offset(&self) -> usize {
+        self.cursor
+    }
+
+    #[cfg(test)]
+    pub fn pending_marker(&self) -> Option<u8> {
+        self.pending_marker
+    }
+
+    /// Discard any partial-byte bits and clear the bit buffer. Called by
+    /// the entropy decoder before consuming a restart marker so the next
+    /// read starts on a byte boundary.
+    pub fn reset_to_byte_boundary(&mut self) {
+        self.buffer = 0;
+        self.bits_in_buffer = 0;
+    }
+
+    /// Read the next marker byte (the byte after `0xFF`) from the
+    /// underlying stream, advancing past both bytes. Honors a previously-
+    /// surfaced pending marker if present. Fill `0xFF` bytes are skipped.
+    pub fn read_marker(&mut self) -> JpegResult<u8> {
+        if let Some(marker_byte) = self.pending_marker {
+            let offset = self
+                .pending_marker_offset
+                .unwrap_or(self.cursor);
+            self.cursor = offset + 2;
+            self.pending_marker = None;
+            self.pending_marker_offset = None;
+            return Ok(marker_byte);
+        }
+        // No pending marker — read raw from the source. Skip any run of
+        // 0xFF fill bytes preceding the actual marker.
+        while self.cursor + 1 < self.bytes.len()
+            && self.bytes[self.cursor] == marker::PREFIX
+            && self.bytes[self.cursor + 1] == marker::PREFIX
+        {
+            self.cursor += 1;
+        }
+        if self.cursor + 1 >= self.bytes.len() {
+            return Err(JpegError::UnexpectedEof {
+                offset: self.cursor,
+            });
+        }
+        if self.bytes[self.cursor] != marker::PREFIX {
+            return Err(JpegError::UnexpectedMarker {
+                marker: self.bytes[self.cursor],
+                offset: self.cursor,
+            });
+        }
+        let marker_byte = self.bytes[self.cursor + 1];
+        self.cursor += 2;
+        Ok(marker_byte)
+    }
+
+    /// Read a single bit. Returns the bit as 0 or 1.
+    pub fn read_bit(&mut self) -> JpegResult<u8> {
+        if self.bits_in_buffer == 0 {
+            self.refill()?;
+            if self.bits_in_buffer == 0 {
+                // Refill stalled on a marker or EOF.
+                return Err(self.eof_or_marker_error());
+            }
+        }
+        self.bits_in_buffer -= 1;
+        Ok(((self.buffer >> self.bits_in_buffer) & 1) as u8)
+    }
+
+    /// Read `n` bits (1..=16) as an MSB-first unsigned integer.
+    pub fn read_bits(&mut self, n: u32) -> JpegResult<u32> {
+        debug_assert!(n <= 16);
+        while self.bits_in_buffer < n {
+            let before = self.bits_in_buffer;
+            self.refill()?;
+            if self.bits_in_buffer == before {
+                return Err(self.eof_or_marker_error());
+            }
+        }
+        self.bits_in_buffer -= n;
+        let mask = if n == 32 { u32::MAX } else { (1u32 << n) - 1 };
+        Ok(((self.buffer >> self.bits_in_buffer) as u32) & mask)
+    }
+
+    /// JPEG F.2.1.3.1: extend an `n`-bit value read from the stream into a
+    /// signed coefficient. Values with the MSB set are positive as-is;
+    /// values with the MSB clear are negated relative to `(1 << n) - 1`.
+    pub fn extend(value: u32, n: u32) -> i32 {
+        if n == 0 {
+            return 0;
+        }
+        let vt = 1i32 << (n - 1);
+        let v = value as i32;
+        if v < vt { v + (-1i32 << n) + 1 } else { v }
+    }
+
+    fn refill(&mut self) -> JpegResult<()> {
+        // Pull bytes one at a time so we can honor stuffed-byte escapes and
+        // surface markers immediately. The buffer is 64 bits wide so we
+        // can keep going until we hit a marker or run out of room.
+        while self.bits_in_buffer <= 56 && self.pending_marker.is_none() {
+            if self.cursor >= self.bytes.len() {
+                return Ok(());
+            }
+            let byte = self.bytes[self.cursor];
+            if byte == marker::PREFIX {
+                // Need at least one more byte to disambiguate stuff vs. marker.
+                if self.cursor + 1 >= self.bytes.len() {
+                    // Hanging 0xFF at end of input — treat as EOF.
+                    return Ok(());
+                }
+                let next = self.bytes[self.cursor + 1];
+                if next == 0x00 {
+                    // Byte stuff: consume both, push a single 0xFF data byte.
+                    self.cursor += 2;
+                    self.buffer = (self.buffer << 8) | (marker::PREFIX as u64);
+                    self.bits_in_buffer += 8;
+                } else {
+                    // Real marker. Surface to caller. Do NOT advance past it;
+                    // the entropy decoder will consume it via consume_marker
+                    // and then jump the parser cursor accordingly.
+                    self.pending_marker = Some(next);
+                    self.pending_marker_offset = Some(self.cursor);
+                    return Ok(());
+                }
+            } else {
+                self.cursor += 1;
+                self.buffer = (self.buffer << 8) | (byte as u64);
+                self.bits_in_buffer += 8;
+            }
+        }
+        Ok(())
+    }
+
+    fn eof_or_marker_error(&self) -> JpegError {
+        if let Some(marker_byte) = self.pending_marker {
+            JpegError::UnexpectedMarker {
+                marker: marker_byte,
+                offset: self.pending_marker_offset.unwrap_or(self.cursor),
+            }
+        } else {
+            JpegError::UnexpectedEof {
+                offset: self.cursor,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_msb_first() {
+        // 0b1010_1100 0b0011_0101
+        let bytes = [0xAC, 0x35];
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(4).unwrap(), 0b1010);
+        assert_eq!(br.read_bits(4).unwrap(), 0b1100);
+        assert_eq!(br.read_bits(8).unwrap(), 0x35);
+    }
+
+    #[test]
+    fn unstuffs_ff_00() {
+        // Stuffed 0xFF data byte: in stream as `0xFF 0x00`.
+        let bytes = [0xFF, 0x00, 0x55];
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(8).unwrap(), 0xFF);
+        assert_eq!(br.read_bits(8).unwrap(), 0x55);
+        assert!(br.pending_marker().is_none());
+    }
+
+    #[test]
+    fn surfaces_marker_without_consuming() {
+        // 0xFF D0 = RST0 marker. Bits before it are valid, then refill stops.
+        let bytes = [0xAB, 0xFF, 0xD0, 0x99];
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(8).unwrap(), 0xAB);
+        // Next read must fail because the marker isn't data.
+        let err = br.read_bits(8).unwrap_err();
+        assert!(matches!(err, JpegError::UnexpectedMarker { marker: 0xD0, .. }));
+        assert_eq!(br.pending_marker(), Some(0xD0));
+    }
+
+    #[test]
+    fn read_marker_after_pending() {
+        let bytes = [0xAB, 0xFF, 0xD0, 0x99];
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(8).unwrap(), 0xAB);
+        // Force a refill to surface the marker.
+        let _ = br.read_bits(8);
+        br.reset_to_byte_boundary();
+        assert_eq!(br.read_marker().unwrap(), 0xD0);
+        // After consuming the marker the next byte is data again.
+        assert_eq!(br.byte_offset(), 3);
+    }
+
+    #[test]
+    fn read_marker_from_raw_stream() {
+        let bytes = [0xFF, 0xD9];
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_marker().unwrap(), 0xD9);
+    }
+
+    #[test]
+    fn extend_matches_jpeg_spec() {
+        // Per F.2.1.3.1: a category-3 value of 0b000 means -7, 0b111 means +7.
+        assert_eq!(BitReader::extend(0b000, 3), -7);
+        assert_eq!(BitReader::extend(0b001, 3), -6);
+        assert_eq!(BitReader::extend(0b011, 3), -4);
+        assert_eq!(BitReader::extend(0b100, 3), 4);
+        assert_eq!(BitReader::extend(0b111, 3), 7);
+        assert_eq!(BitReader::extend(0, 0), 0);
+    }
+}

--- a/libs/vulkan-jpeg/src/error.rs
+++ b/libs/vulkan-jpeg/src/error.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use thiserror::Error;
+
+/// Errors surfaced by the JPEG parser + Huffman entropy decoder.
+#[derive(Debug, Error)]
+pub enum JpegError {
+    #[error("unexpected end of input at byte {offset}")]
+    UnexpectedEof { offset: usize },
+
+    #[error("missing SOI marker — first two bytes were {first:#04x} {second:#04x}")]
+    MissingSoi { first: u8, second: u8 },
+
+    #[error("missing SOS marker before end of stream")]
+    MissingSos,
+
+    #[error("missing SOF marker before SOS")]
+    MissingSof,
+
+    #[error("missing quantization table id {id}")]
+    MissingQuantizationTable { id: u8 },
+
+    #[error("missing Huffman table (class {class}, id {id})")]
+    MissingHuffmanTable { class: u8, id: u8 },
+
+    #[error("unexpected marker {marker:#04x} at byte {offset}")]
+    UnexpectedMarker { marker: u8, offset: usize },
+
+    #[error("unsupported SOF marker {marker:#04x}: {reason}")]
+    UnsupportedSof { marker: u8, reason: &'static str },
+
+    #[error("invalid segment length {length} for marker {marker:#04x}")]
+    InvalidSegmentLength { marker: u8, length: usize },
+
+    #[error("malformed quantization table: {0}")]
+    MalformedQuantizationTable(&'static str),
+
+    #[error("malformed Huffman table: {0}")]
+    MalformedHuffmanTable(&'static str),
+
+    #[error("invalid Huffman code in entropy stream at byte {offset}")]
+    InvalidHuffmanCode { offset: usize },
+
+    #[error("invalid scan: {0}")]
+    InvalidScan(&'static str),
+
+    #[error("expected restart marker RST{expected} at byte {offset}, got {marker:#04x}")]
+    UnexpectedRestartMarker { expected: u8, marker: u8, offset: usize },
+
+    #[error("unsupported feature: {0}")]
+    Unsupported(&'static str),
+}
+
+pub type JpegResult<T> = Result<T, JpegError>;

--- a/libs/vulkan-jpeg/src/header.rs
+++ b/libs/vulkan-jpeg/src/header.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use crate::huffman::HuffmanTable;
+
+/// Parsed SOF0 frame header.
+#[derive(Debug, Clone)]
+pub struct FrameHeader {
+    /// Sample precision in bits (baseline JPEG: 8).
+    pub precision: u8,
+    pub height: u16,
+    pub width: u16,
+    pub components: Vec<FrameComponent>,
+    pub max_h_sampling: u8,
+    pub max_v_sampling: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct FrameComponent {
+    pub id: u8,
+    pub h_sampling: u8,
+    pub v_sampling: u8,
+    pub quant_table_id: u8,
+}
+
+/// One quantization table parsed from a DQT segment.
+#[derive(Debug, Clone)]
+pub struct QuantizationTable {
+    pub id: u8,
+    /// 0 = 8-bit precision, 1 = 16-bit precision.
+    pub precision: u8,
+    /// 64 values in zig-zag scan order, exactly as stored in the JPEG
+    /// bitstream. The GPU kernel applies these during dequantization.
+    pub values: [u16; 64],
+}
+
+/// One scan-component entry parsed from the SOS segment.
+#[derive(Debug, Clone)]
+pub struct ScanComponent {
+    pub component_id: u8,
+    pub dc_table_id: u8,
+    pub ac_table_id: u8,
+}
+
+/// Parsed SOS header. Baseline JPEG: `spectral_start = 0`,
+/// `spectral_end = 63`, `successive_high = 0`, `successive_low = 0`.
+#[derive(Debug, Clone)]
+pub struct ScanHeader {
+    pub components: Vec<ScanComponent>,
+    pub spectral_start: u8,
+    pub spectral_end: u8,
+    pub successive_high: u8,
+    pub successive_low: u8,
+}
+
+/// Per-component decoded coefficient plane.
+#[derive(Debug, Clone)]
+pub struct ComponentScan {
+    pub component_id: u8,
+    pub h_sampling: u8,
+    pub v_sampling: u8,
+    pub quant_table_id: u8,
+    /// Number of 8x8 blocks horizontally (already widened to cover the
+    /// MCU grid: `mcus_horizontal * h_sampling`).
+    pub blocks_horizontal: usize,
+    /// Number of 8x8 blocks vertically (already widened to cover the
+    /// MCU grid: `mcus_vertical * v_sampling`).
+    pub blocks_vertical: usize,
+    /// Length = `blocks_horizontal * blocks_vertical * 64`. Indexed as
+    /// `[(y * blocks_horizontal + x) * 64 + zz]`, where `zz` is the
+    /// zig-zag-ordered coefficient index (0..64). Values are post-Huffman,
+    /// pre-dequant signed coefficients.
+    pub coefficients: Vec<i16>,
+}
+
+impl ComponentScan {
+    /// Returns the 64-element zig-zag-ordered coefficient slice for the
+    /// block at `(block_x, block_y)`.
+    pub fn block(&self, block_x: usize, block_y: usize) -> &[i16] {
+        let start = (block_y * self.blocks_horizontal + block_x) * 64;
+        &self.coefficients[start..start + 64]
+    }
+}
+
+/// Top-level decoded JPEG — parsed headers plus the per-component
+/// coefficient buffers ready for a GPU kernel to consume.
+#[derive(Debug, Clone)]
+pub struct DecodedJpeg {
+    pub frame: FrameHeader,
+    pub quant_tables: Vec<QuantizationTable>,
+    pub scan: ScanHeader,
+    pub components: Vec<ComponentScan>,
+    pub restart_interval: u16,
+}
+
+impl DecodedJpeg {
+    /// Look up the quantization table by id.
+    pub fn quantization_table(&self, id: u8) -> Option<&QuantizationTable> {
+        self.quant_tables.iter().find(|t| t.id == id)
+    }
+}
+
+/// Internal bag of Huffman tables indexed by class + id.
+#[derive(Default)]
+pub(crate) struct HuffmanTables {
+    pub dc: [Option<HuffmanTable>; 4],
+    pub ac: [Option<HuffmanTable>; 4],
+}

--- a/libs/vulkan-jpeg/src/huffman.rs
+++ b/libs/vulkan-jpeg/src/huffman.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use crate::bit_reader::BitReader;
+use crate::error::{JpegError, JpegResult};
+
+/// Huffman table class — DC tables encode coefficient categories for the
+/// 0th coefficient (delta-coded); AC tables encode `(zero-run, category)`
+/// pairs for the 1st..63rd coefficients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HuffmanClass {
+    Dc,
+    Ac,
+}
+
+impl HuffmanClass {
+    pub fn from_class_byte(value: u8) -> JpegResult<Self> {
+        match value {
+            0 => Ok(HuffmanClass::Dc),
+            1 => Ok(HuffmanClass::Ac),
+            _ => Err(JpegError::MalformedHuffmanTable("class must be 0 (DC) or 1 (AC)")),
+        }
+    }
+}
+
+/// Canonical Huffman decode table built per ITU-T T.81 Annex C.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // `class` / `id` retained for diagnostics
+pub struct HuffmanTable {
+    pub class: HuffmanClass,
+    pub id: u8,
+    /// `min_code[n]` is the smallest n+1-bit code, or `i32::MAX` if no
+    /// codes exist at that length.
+    min_code: [i32; 16],
+    /// `max_code[n]` is the largest n+1-bit code, or `-1` if no codes
+    /// exist at that length.
+    max_code: [i32; 16],
+    /// `val_offset[n]` is the index into `huffval` for the first symbol
+    /// of length n+1.
+    val_offset: [usize; 16],
+    /// Symbols (HUFFVAL) in canonical order.
+    huffval: Vec<u8>,
+}
+
+impl HuffmanTable {
+    /// Build a canonical Huffman table from BITS (16 entries, count of
+    /// codes of each length 1..=16) and HUFFVAL (the symbol stream).
+    ///
+    /// Implements the recipe from T.81 Figure C.1 / C.2.
+    pub fn build(class: HuffmanClass, id: u8, bits: &[u8; 16], huffval: &[u8]) -> JpegResult<Self> {
+        let total: usize = bits.iter().map(|&b| b as usize).sum();
+        if total > 256 {
+            return Err(JpegError::MalformedHuffmanTable("BITS sum exceeds 256"));
+        }
+        if total != huffval.len() {
+            return Err(JpegError::MalformedHuffmanTable(
+                "BITS sum disagrees with HUFFVAL length",
+            ));
+        }
+
+        let mut min_code = [i32::MAX; 16];
+        let mut max_code = [-1i32; 16];
+        let mut val_offset = [0usize; 16];
+
+        let mut code: i32 = 0;
+        let mut offset = 0usize;
+        for n in 0..16 {
+            let count = bits[n] as i32;
+            if count == 0 {
+                code <<= 1;
+                continue;
+            }
+            // Codes of this length run [code, code + count - 1].
+            if code + count > (1i32 << (n + 1)) {
+                return Err(JpegError::MalformedHuffmanTable(
+                    "BITS overflows the Huffman code space",
+                ));
+            }
+            min_code[n] = code;
+            max_code[n] = code + count - 1;
+            val_offset[n] = offset;
+            offset += count as usize;
+            code = (code + count) << 1;
+        }
+
+        Ok(Self {
+            class,
+            id,
+            min_code,
+            max_code,
+            val_offset,
+            huffval: huffval.to_vec(),
+        })
+    }
+
+    /// Decode one Huffman code from `reader` and return the symbol.
+    pub fn decode_symbol(&self, reader: &mut BitReader<'_>) -> JpegResult<u8> {
+        let mut code: i32 = 0;
+        for n in 0..16 {
+            code = (code << 1) | (reader.read_bit()? as i32);
+            if code <= self.max_code[n] {
+                let idx = self.val_offset[n] + (code - self.min_code[n]) as usize;
+                if idx >= self.huffval.len() {
+                    return Err(JpegError::InvalidHuffmanCode {
+                        offset: reader.byte_offset(),
+                    });
+                }
+                return Ok(self.huffval[idx]);
+            }
+        }
+        Err(JpegError::InvalidHuffmanCode {
+            offset: reader.byte_offset(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Standard JPEG luminance DC Huffman table from Annex K Table K.3.
+    /// Used by every libjpeg-style encoder including jpeg-encoder.
+    pub(crate) fn k3_luminance_dc() -> HuffmanTable {
+        let bits = [0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+        let huffval = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        HuffmanTable::build(HuffmanClass::Dc, 0, &bits, &huffval).unwrap()
+    }
+
+    #[test]
+    fn builds_canonical_table() {
+        let table = k3_luminance_dc();
+        // The shortest code is two bits (one entry); the longest is nine
+        // bits (one entry). Spot-check both ends.
+        assert_eq!(table.max_code[1], 0b00); // first 2-bit code is 0b00
+        assert_eq!(table.max_code[8] - table.min_code[8], 0); // single 9-bit code
+    }
+
+    #[test]
+    fn round_trip_decode() {
+        // T.81 Figure C.2 says symbol 0 corresponds to the 2-bit code 0b00.
+        // Encode + decode that exact bit pattern.
+        let bytes: [u8; 1] = [0b00_00_00_00];
+        let mut reader = BitReader::new(&bytes);
+        let table = k3_luminance_dc();
+        let sym = table.decode_symbol(&mut reader).unwrap();
+        assert_eq!(sym, 0);
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        // BITS sum > HUFFVAL length.
+        let bits = [0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let huffval = [0u8; 1];
+        let err = HuffmanTable::build(HuffmanClass::Dc, 0, &bits, &huffval).unwrap_err();
+        assert!(matches!(err, JpegError::MalformedHuffmanTable(_)));
+    }
+
+    #[test]
+    fn rejects_code_space_overflow() {
+        // 3 codes of length 1 — only 2 possible 1-bit codes (0 and 1).
+        let bits = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let huffval = [0u8, 1, 2];
+        let err = HuffmanTable::build(HuffmanClass::Dc, 0, &bits, &huffval).unwrap_err();
+        assert!(matches!(err, JpegError::MalformedHuffmanTable(_)));
+    }
+}

--- a/libs/vulkan-jpeg/src/lib.rs
+++ b/libs/vulkan-jpeg/src/lib.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! JPEG decode for streamlib.
+//!
+//! This crate ships the CPU half of a JPEG decoder:
+//!
+//! - Baseline-sequential JPEG marker parser (SOI/DQT/DHT/SOF0/SOS/DRI/EOI,
+//!   skips APPn/COM).
+//! - Huffman entropy decoder that produces zig-zag-ordered DCT coefficient
+//!   buffers, one per component, ready for a GPU compute kernel to
+//!   dequantize + IDCT + chroma-upsample + colorspace-convert.
+//!
+//! A companion GPU kernel built on the streamlib RHI public surface
+//! (`HostVulkanDevice`, `VulkanComputeKernel`) lands in a follow-up
+//! issue under the same milestone.
+
+mod bit_reader;
+mod error;
+mod header;
+mod huffman;
+mod marker;
+mod parser;
+mod scan;
+
+pub use error::{JpegError, JpegResult};
+pub use header::{
+    ComponentScan, DecodedJpeg, FrameComponent, FrameHeader, QuantizationTable, ScanComponent,
+    ScanHeader,
+};
+pub use huffman::HuffmanClass;
+pub use marker::ZIGZAG;
+
+/// Parse and entropy-decode a baseline-sequential JPEG bitstream.
+///
+/// Returns a [`DecodedJpeg`] carrying the parsed headers and one
+/// [`ComponentScan`] per component with the post-Huffman, pre-dequant
+/// coefficient buffer in zig-zag order. Progressive, lossless, and
+/// arithmetic-coded JPEGs are rejected with [`JpegError::UnsupportedSof`]
+/// or [`JpegError::Unsupported`].
+pub fn decode(bytes: &[u8]) -> JpegResult<DecodedJpeg> {
+    let parser::ParsedHeaders {
+        frame,
+        quant_tables,
+        huffman,
+        scan,
+        restart_interval,
+        entropy_data,
+    } = parser::parse_headers(bytes)?;
+
+    // Sanity-check that every component's quant table is present.
+    for component in &frame.components {
+        if !quant_tables
+            .iter()
+            .any(|t| t.id == component.quant_table_id)
+        {
+            return Err(JpegError::MissingQuantizationTable {
+                id: component.quant_table_id,
+            });
+        }
+    }
+
+    let components = scan::decode_entropy(
+        &frame,
+        &scan,
+        &huffman,
+        restart_interval,
+        entropy_data,
+    )?;
+
+    Ok(DecodedJpeg {
+        frame,
+        quant_tables,
+        scan,
+        components,
+        restart_interval,
+    })
+}

--- a/libs/vulkan-jpeg/src/marker.rs
+++ b/libs/vulkan-jpeg/src/marker.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! JPEG marker constants per ITU-T T.81 / ISO/IEC 10918-1 Table B.1.
+
+pub const PREFIX: u8 = 0xFF;
+
+pub const SOI: u8 = 0xD8;
+pub const EOI: u8 = 0xD9;
+pub const SOS: u8 = 0xDA;
+pub const DQT: u8 = 0xDB;
+pub const DHT: u8 = 0xC4;
+pub const DRI: u8 = 0xDD;
+pub const COM: u8 = 0xFE;
+
+pub const SOF0: u8 = 0xC0;
+pub const SOF1: u8 = 0xC1;
+pub const SOF2: u8 = 0xC2;
+pub const SOF3: u8 = 0xC3;
+pub const SOF5: u8 = 0xC5;
+pub const SOF6: u8 = 0xC6;
+pub const SOF7: u8 = 0xC7;
+pub const SOF9: u8 = 0xC9;
+pub const SOF10: u8 = 0xCA;
+pub const SOF11: u8 = 0xCB;
+pub const SOF13: u8 = 0xCD;
+pub const SOF14: u8 = 0xCE;
+pub const SOF15: u8 = 0xCF;
+
+pub const RST0: u8 = 0xD0;
+pub const RST7: u8 = 0xD7;
+
+pub fn is_app(marker: u8) -> bool {
+    (0xE0..=0xEF).contains(&marker)
+}
+
+pub fn is_restart(marker: u8) -> bool {
+    (RST0..=RST7).contains(&marker)
+}
+
+pub fn is_standalone(marker: u8) -> bool {
+    matches!(marker, SOI | EOI) || is_restart(marker)
+}
+
+pub fn is_unsupported_sof(marker: u8) -> Option<&'static str> {
+    match marker {
+        SOF1 => Some("extended sequential DCT (SOF1)"),
+        SOF2 => Some("progressive DCT (SOF2)"),
+        SOF3 => Some("lossless sequential (SOF3)"),
+        SOF5 => Some("differential sequential DCT (SOF5)"),
+        SOF6 => Some("differential progressive DCT (SOF6)"),
+        SOF7 => Some("differential lossless (SOF7)"),
+        SOF9 => Some("arithmetic-coded extended sequential (SOF9)"),
+        SOF10 => Some("arithmetic-coded progressive (SOF10)"),
+        SOF11 => Some("arithmetic-coded lossless (SOF11)"),
+        SOF13 => Some("differential arithmetic sequential (SOF13)"),
+        SOF14 => Some("differential arithmetic progressive (SOF14)"),
+        SOF15 => Some("differential arithmetic lossless (SOF15)"),
+        _ => None,
+    }
+}
+
+/// Zig-zag scan order from natural 8x8 row-major to JPEG sequential order
+/// (ITU-T T.81 Figure A.6). Maps natural index -> zig-zag index.
+pub const ZIGZAG: [usize; 64] = [
+    0, 1, 8, 16, 9, 2, 3, 10,
+    17, 24, 32, 25, 18, 11, 4, 5,
+    12, 19, 26, 33, 40, 48, 41, 34,
+    27, 20, 13, 6, 7, 14, 21, 28,
+    35, 42, 49, 56, 57, 50, 43, 36,
+    29, 22, 15, 23, 30, 37, 44, 51,
+    58, 59, 52, 45, 38, 31, 39, 46,
+    53, 60, 61, 54, 47, 55, 62, 63,
+];

--- a/libs/vulkan-jpeg/src/parser.rs
+++ b/libs/vulkan-jpeg/src/parser.rs
@@ -1,0 +1,399 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use crate::error::{JpegError, JpegResult};
+use crate::header::{
+    FrameComponent, FrameHeader, HuffmanTables, QuantizationTable, ScanComponent, ScanHeader,
+};
+use crate::huffman::{HuffmanClass, HuffmanTable};
+use crate::marker;
+
+/// Header-section result: everything parsed up to and including the SOS
+/// segment, plus the byte offset where the entropy-coded data starts.
+pub(crate) struct ParsedHeaders<'a> {
+    pub frame: FrameHeader,
+    pub quant_tables: Vec<QuantizationTable>,
+    pub huffman: HuffmanTables,
+    pub scan: ScanHeader,
+    pub restart_interval: u16,
+    pub entropy_data: &'a [u8],
+}
+
+/// Walk a JPEG bitstream from SOI through SOS, returning the parsed
+/// headers and a slice over the entropy-coded segment.
+pub(crate) fn parse_headers(bytes: &[u8]) -> JpegResult<ParsedHeaders<'_>> {
+    let mut parser = Parser::new(bytes);
+    parser.expect_soi()?;
+
+    let mut quant_tables: Vec<QuantizationTable> = Vec::new();
+    let mut huffman = HuffmanTables::default();
+    let mut frame: Option<FrameHeader> = None;
+    let mut restart_interval: u16 = 0;
+
+    loop {
+        let marker_byte = parser.next_marker()?;
+        match marker_byte {
+            marker::DQT => parser.parse_dqt(&mut quant_tables)?,
+            marker::DHT => parser.parse_dht(&mut huffman)?,
+            marker::SOF0 => {
+                if frame.is_some() {
+                    return Err(JpegError::InvalidScan("duplicate SOF segment"));
+                }
+                frame = Some(parser.parse_sof0()?);
+            }
+            marker::DRI => restart_interval = parser.parse_dri()?,
+            marker::SOS => {
+                let frame = frame.take().ok_or(JpegError::MissingSof)?;
+                let scan = parser.parse_sos(&frame)?;
+                let entropy_data = &bytes[parser.cursor..];
+                return Ok(ParsedHeaders {
+                    frame,
+                    quant_tables,
+                    huffman,
+                    scan,
+                    restart_interval,
+                    entropy_data,
+                });
+            }
+            marker::EOI => return Err(JpegError::MissingSos),
+            marker::COM => parser.skip_segment(marker_byte)?,
+            other if marker::is_app(other) => parser.skip_segment(other)?,
+            other => {
+                if let Some(reason) = marker::is_unsupported_sof(other) {
+                    return Err(JpegError::UnsupportedSof {
+                        marker: other,
+                        reason,
+                    });
+                }
+                if marker::is_standalone(other) {
+                    return Err(JpegError::UnexpectedMarker {
+                        marker: other,
+                        offset: parser.cursor,
+                    });
+                }
+                // Unknown but length-prefixed — skip it defensively.
+                parser.skip_segment(other)?;
+            }
+        }
+    }
+}
+
+struct Parser<'a> {
+    bytes: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, cursor: 0 }
+    }
+
+    fn expect_soi(&mut self) -> JpegResult<()> {
+        if self.bytes.len() < 2 {
+            return Err(JpegError::UnexpectedEof { offset: 0 });
+        }
+        if self.bytes[0] != marker::PREFIX || self.bytes[1] != marker::SOI {
+            return Err(JpegError::MissingSoi {
+                first: self.bytes[0],
+                second: self.bytes[1],
+            });
+        }
+        self.cursor = 2;
+        Ok(())
+    }
+
+    /// Read the next marker byte (the byte after `0xFF`). JPEG allows
+    /// fill `0xFF` bytes before a marker; we consume them.
+    fn next_marker(&mut self) -> JpegResult<u8> {
+        loop {
+            let b = self.read_byte()?;
+            if b != marker::PREFIX {
+                return Err(JpegError::UnexpectedMarker {
+                    marker: b,
+                    offset: self.cursor - 1,
+                });
+            }
+            let m = self.read_byte()?;
+            if m == marker::PREFIX {
+                // Fill byte (0xFF followed by 0xFF) — keep scanning.
+                continue;
+            }
+            if m == 0 {
+                return Err(JpegError::UnexpectedMarker {
+                    marker: 0,
+                    offset: self.cursor - 1,
+                });
+            }
+            return Ok(m);
+        }
+    }
+
+    fn read_byte(&mut self) -> JpegResult<u8> {
+        if self.cursor >= self.bytes.len() {
+            return Err(JpegError::UnexpectedEof {
+                offset: self.cursor,
+            });
+        }
+        let b = self.bytes[self.cursor];
+        self.cursor += 1;
+        Ok(b)
+    }
+
+    fn read_u16(&mut self) -> JpegResult<u16> {
+        let high = self.read_byte()?;
+        let low = self.read_byte()?;
+        Ok(((high as u16) << 8) | (low as u16))
+    }
+
+    fn read_segment_payload(&mut self, marker_byte: u8) -> JpegResult<&'a [u8]> {
+        let length = self.read_u16()? as usize;
+        if length < 2 {
+            return Err(JpegError::InvalidSegmentLength {
+                marker: marker_byte,
+                length,
+            });
+        }
+        let payload_len = length - 2;
+        let start = self.cursor;
+        let end = start
+            .checked_add(payload_len)
+            .ok_or(JpegError::UnexpectedEof { offset: start })?;
+        if end > self.bytes.len() {
+            return Err(JpegError::UnexpectedEof { offset: start });
+        }
+        self.cursor = end;
+        Ok(&self.bytes[start..end])
+    }
+
+    fn skip_segment(&mut self, marker_byte: u8) -> JpegResult<()> {
+        self.read_segment_payload(marker_byte)?;
+        Ok(())
+    }
+
+    fn parse_dqt(&mut self, out: &mut Vec<QuantizationTable>) -> JpegResult<()> {
+        let payload = self.read_segment_payload(marker::DQT)?;
+        let mut cursor = 0;
+        while cursor < payload.len() {
+            if cursor + 1 > payload.len() {
+                return Err(JpegError::MalformedQuantizationTable(
+                    "missing precision/id byte",
+                ));
+            }
+            let pq_tq = payload[cursor];
+            cursor += 1;
+            let precision = pq_tq >> 4;
+            let id = pq_tq & 0x0F;
+            if precision > 1 {
+                return Err(JpegError::MalformedQuantizationTable(
+                    "precision must be 0 (8-bit) or 1 (16-bit)",
+                ));
+            }
+            if id > 3 {
+                return Err(JpegError::MalformedQuantizationTable("id must be 0..=3"));
+            }
+            let bytes_per_value = if precision == 0 { 1 } else { 2 };
+            let needed = 64 * bytes_per_value;
+            if cursor + needed > payload.len() {
+                return Err(JpegError::MalformedQuantizationTable(
+                    "segment too short for 64 values",
+                ));
+            }
+            let mut values = [0u16; 64];
+            for value in values.iter_mut() {
+                if precision == 0 {
+                    *value = payload[cursor] as u16;
+                    cursor += 1;
+                } else {
+                    *value = ((payload[cursor] as u16) << 8) | (payload[cursor + 1] as u16);
+                    cursor += 2;
+                }
+            }
+            if let Some(existing) = out.iter_mut().find(|t| t.id == id) {
+                *existing = QuantizationTable {
+                    id,
+                    precision,
+                    values,
+                };
+            } else {
+                out.push(QuantizationTable {
+                    id,
+                    precision,
+                    values,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_dht(&mut self, out: &mut HuffmanTables) -> JpegResult<()> {
+        let payload = self.read_segment_payload(marker::DHT)?;
+        let mut cursor = 0;
+        while cursor < payload.len() {
+            if cursor + 17 > payload.len() {
+                return Err(JpegError::MalformedHuffmanTable(
+                    "DHT segment too short for class/id + BITS",
+                ));
+            }
+            let tc_th = payload[cursor];
+            cursor += 1;
+            let class = HuffmanClass::from_class_byte(tc_th >> 4)?;
+            let id = tc_th & 0x0F;
+            if id > 3 {
+                return Err(JpegError::MalformedHuffmanTable("id must be 0..=3"));
+            }
+            let mut bits = [0u8; 16];
+            bits.copy_from_slice(&payload[cursor..cursor + 16]);
+            cursor += 16;
+            let total: usize = bits.iter().map(|&b| b as usize).sum();
+            if cursor + total > payload.len() {
+                return Err(JpegError::MalformedHuffmanTable(
+                    "DHT segment too short for HUFFVAL",
+                ));
+            }
+            let huffval = &payload[cursor..cursor + total];
+            cursor += total;
+            let table = HuffmanTable::build(class, id, &bits, huffval)?;
+            let slot = match class {
+                HuffmanClass::Dc => &mut out.dc[id as usize],
+                HuffmanClass::Ac => &mut out.ac[id as usize],
+            };
+            *slot = Some(table);
+        }
+        Ok(())
+    }
+
+    fn parse_sof0(&mut self) -> JpegResult<FrameHeader> {
+        let payload = self.read_segment_payload(marker::SOF0)?;
+        if payload.len() < 6 {
+            return Err(JpegError::InvalidScan("SOF0 payload too short"));
+        }
+        let precision = payload[0];
+        if precision != 8 {
+            return Err(JpegError::UnsupportedSof {
+                marker: marker::SOF0,
+                reason: "baseline JPEG requires 8-bit sample precision",
+            });
+        }
+        let height = ((payload[1] as u16) << 8) | (payload[2] as u16);
+        let width = ((payload[3] as u16) << 8) | (payload[4] as u16);
+        let num_components = payload[5] as usize;
+        if num_components == 0 || num_components > 4 {
+            return Err(JpegError::InvalidScan("SOF0 component count out of range"));
+        }
+        if width == 0 || height == 0 {
+            return Err(JpegError::InvalidScan("SOF0 width/height is zero"));
+        }
+        if payload.len() < 6 + 3 * num_components {
+            return Err(JpegError::InvalidScan(
+                "SOF0 payload too short for component descriptors",
+            ));
+        }
+        let mut components = Vec::with_capacity(num_components);
+        let mut max_h_sampling = 0u8;
+        let mut max_v_sampling = 0u8;
+        for i in 0..num_components {
+            let base = 6 + i * 3;
+            let id = payload[base];
+            let sampling = payload[base + 1];
+            let h_sampling = sampling >> 4;
+            let v_sampling = sampling & 0x0F;
+            let quant_table_id = payload[base + 2];
+            if !(1..=4).contains(&h_sampling) || !(1..=4).contains(&v_sampling) {
+                return Err(JpegError::InvalidScan(
+                    "SOF0 sampling factor out of range (must be 1..=4)",
+                ));
+            }
+            if quant_table_id > 3 {
+                return Err(JpegError::InvalidScan(
+                    "SOF0 quantization table id out of range",
+                ));
+            }
+            if components.iter().any(|c: &FrameComponent| c.id == id) {
+                return Err(JpegError::InvalidScan("SOF0 duplicate component id"));
+            }
+            max_h_sampling = max_h_sampling.max(h_sampling);
+            max_v_sampling = max_v_sampling.max(v_sampling);
+            components.push(FrameComponent {
+                id,
+                h_sampling,
+                v_sampling,
+                quant_table_id,
+            });
+        }
+        Ok(FrameHeader {
+            precision,
+            height,
+            width,
+            components,
+            max_h_sampling,
+            max_v_sampling,
+        })
+    }
+
+    fn parse_dri(&mut self) -> JpegResult<u16> {
+        let payload = self.read_segment_payload(marker::DRI)?;
+        if payload.len() != 2 {
+            return Err(JpegError::InvalidSegmentLength {
+                marker: marker::DRI,
+                length: payload.len() + 2,
+            });
+        }
+        Ok(((payload[0] as u16) << 8) | (payload[1] as u16))
+    }
+
+    fn parse_sos(&mut self, frame: &FrameHeader) -> JpegResult<ScanHeader> {
+        let payload = self.read_segment_payload(marker::SOS)?;
+        if payload.is_empty() {
+            return Err(JpegError::InvalidScan("SOS payload empty"));
+        }
+        let ns = payload[0] as usize;
+        if ns == 0 || ns > frame.components.len() {
+            return Err(JpegError::InvalidScan(
+                "SOS component count outside frame components",
+            ));
+        }
+        if payload.len() < 1 + 2 * ns + 3 {
+            return Err(JpegError::InvalidScan("SOS payload too short"));
+        }
+        let mut components = Vec::with_capacity(ns);
+        for i in 0..ns {
+            let base = 1 + i * 2;
+            let component_id = payload[base];
+            let tdta = payload[base + 1];
+            let dc_table_id = tdta >> 4;
+            let ac_table_id = tdta & 0x0F;
+            if dc_table_id > 3 || ac_table_id > 3 {
+                return Err(JpegError::InvalidScan("SOS table id out of range"));
+            }
+            if !frame.components.iter().any(|c| c.id == component_id) {
+                return Err(JpegError::InvalidScan(
+                    "SOS references component not in SOF",
+                ));
+            }
+            components.push(ScanComponent {
+                component_id,
+                dc_table_id,
+                ac_table_id,
+            });
+        }
+        let trailer = &payload[1 + 2 * ns..];
+        let spectral_start = trailer[0];
+        let spectral_end = trailer[1];
+        let succ = trailer[2];
+        let successive_high = succ >> 4;
+        let successive_low = succ & 0x0F;
+        if spectral_start != 0 || spectral_end != 63 || successive_high != 0 || successive_low != 0
+        {
+            return Err(JpegError::Unsupported(
+                "progressive / spectral-selection / successive-approximation scans",
+            ));
+        }
+        Ok(ScanHeader {
+            components,
+            spectral_start,
+            spectral_end,
+            successive_high,
+            successive_low,
+        })
+    }
+}

--- a/libs/vulkan-jpeg/src/scan.rs
+++ b/libs/vulkan-jpeg/src/scan.rs
@@ -1,0 +1,204 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+use crate::bit_reader::BitReader;
+use crate::error::{JpegError, JpegResult};
+use crate::header::{ComponentScan, FrameHeader, HuffmanTables, ScanHeader};
+use crate::huffman::HuffmanTable;
+use crate::marker;
+
+/// Run the entropy-decode loop, producing one [`ComponentScan`] per
+/// component declared in the scan header, in scan order.
+pub(crate) fn decode_entropy(
+    frame: &FrameHeader,
+    scan: &ScanHeader,
+    huffman: &HuffmanTables,
+    restart_interval: u16,
+    entropy_data: &[u8],
+) -> JpegResult<Vec<ComponentScan>> {
+    let mcus_h = (frame.width as usize).div_ceil(8 * frame.max_h_sampling as usize);
+    let mcus_v = (frame.height as usize).div_ceil(8 * frame.max_v_sampling as usize);
+
+    // For each scanned component, capture the matching frame component +
+    // pre-built Huffman tables, and allocate the output coefficient buffer.
+    let mut planes: Vec<ComponentPlane<'_>> = Vec::with_capacity(scan.components.len());
+    for scan_comp in &scan.components {
+        let frame_comp = frame
+            .components
+            .iter()
+            .find(|c| c.id == scan_comp.component_id)
+            .ok_or(JpegError::InvalidScan(
+                "SOS component id missing from SOF",
+            ))?;
+        let dc_table = huffman.dc[scan_comp.dc_table_id as usize]
+            .as_ref()
+            .ok_or(JpegError::MissingHuffmanTable {
+                class: 0,
+                id: scan_comp.dc_table_id,
+            })?;
+        let ac_table = huffman.ac[scan_comp.ac_table_id as usize]
+            .as_ref()
+            .ok_or(JpegError::MissingHuffmanTable {
+                class: 1,
+                id: scan_comp.ac_table_id,
+            })?;
+        let blocks_h = mcus_h * frame_comp.h_sampling as usize;
+        let blocks_v = mcus_v * frame_comp.v_sampling as usize;
+        planes.push(ComponentPlane {
+            component_id: frame_comp.id,
+            h_sampling: frame_comp.h_sampling,
+            v_sampling: frame_comp.v_sampling,
+            quant_table_id: frame_comp.quant_table_id,
+            blocks_h,
+            blocks_v,
+            coefficients: vec![0i16; blocks_h * blocks_v * 64],
+            dc_predictor: 0,
+            dc_table,
+            ac_table,
+        });
+    }
+
+    let mut reader = BitReader::new(entropy_data);
+    let mut mcus_since_restart: u32 = 0;
+    let mut expected_restart: u8 = 0;
+
+    for mcu_y in 0..mcus_v {
+        for mcu_x in 0..mcus_h {
+            if restart_interval > 0 && mcus_since_restart == restart_interval as u32 {
+                handle_restart(&mut reader, &mut planes, &mut expected_restart)?;
+                mcus_since_restart = 0;
+            }
+            for plane in planes.iter_mut() {
+                let h_sampling = plane.h_sampling as usize;
+                let v_sampling = plane.v_sampling as usize;
+                for vy in 0..v_sampling {
+                    for vx in 0..h_sampling {
+                        let block_x = mcu_x * h_sampling + vx;
+                        let block_y = mcu_y * v_sampling + vy;
+                        decode_block(&mut reader, plane, block_x, block_y)?;
+                    }
+                }
+            }
+            mcus_since_restart += 1;
+        }
+    }
+
+    Ok(planes
+        .into_iter()
+        .map(|p| ComponentScan {
+            component_id: p.component_id,
+            h_sampling: p.h_sampling,
+            v_sampling: p.v_sampling,
+            quant_table_id: p.quant_table_id,
+            blocks_horizontal: p.blocks_h,
+            blocks_vertical: p.blocks_v,
+            coefficients: p.coefficients,
+        })
+        .collect())
+}
+
+struct ComponentPlane<'tables> {
+    component_id: u8,
+    h_sampling: u8,
+    v_sampling: u8,
+    quant_table_id: u8,
+    blocks_h: usize,
+    blocks_v: usize,
+    coefficients: Vec<i16>,
+    dc_predictor: i32,
+    dc_table: &'tables HuffmanTable,
+    ac_table: &'tables HuffmanTable,
+}
+
+fn decode_block(
+    reader: &mut BitReader<'_>,
+    plane: &mut ComponentPlane<'_>,
+    block_x: usize,
+    block_y: usize,
+) -> JpegResult<()> {
+    let block_offset = (block_y * plane.blocks_h + block_x) * 64;
+    let block = &mut plane.coefficients[block_offset..block_offset + 64];
+
+    // DC coefficient: read category, then `category` bits, then extend.
+    let dc_category = plane.dc_table.decode_symbol(reader)?;
+    if dc_category > 11 {
+        return Err(JpegError::InvalidScan(
+            "DC category exceeds baseline JPEG limit of 11",
+        ));
+    }
+    let dc_diff = if dc_category == 0 {
+        0
+    } else {
+        let raw = reader.read_bits(dc_category as u32)?;
+        BitReader::extend(raw, dc_category as u32)
+    };
+    let dc = plane.dc_predictor + dc_diff;
+    plane.dc_predictor = dc;
+    block[0] = clamp_i16(dc)?;
+
+    // AC coefficients 1..=63.
+    let mut k = 1usize;
+    while k < 64 {
+        let rs = plane.ac_table.decode_symbol(reader)?;
+        let run = (rs >> 4) as usize;
+        let category = (rs & 0x0F) as u32;
+        if category == 0 {
+            if run == 15 {
+                // ZRL: 16 zeros, no value.
+                k += 16;
+                if k > 64 {
+                    return Err(JpegError::InvalidScan(
+                        "ZRL would overrun 8x8 block",
+                    ));
+                }
+                continue;
+            }
+            // EOB: remaining coefficients are zero (already initialized).
+            break;
+        }
+        if category > 10 {
+            return Err(JpegError::InvalidScan(
+                "AC category exceeds baseline JPEG limit of 10",
+            ));
+        }
+        k += run;
+        if k >= 64 {
+            return Err(JpegError::InvalidScan(
+                "AC run+category overruns 8x8 block",
+            ));
+        }
+        let raw = reader.read_bits(category)?;
+        let value = BitReader::extend(raw, category);
+        block[k] = clamp_i16(value)?;
+        k += 1;
+    }
+    Ok(())
+}
+
+fn clamp_i16(value: i32) -> JpegResult<i16> {
+    i16::try_from(value).map_err(|_| {
+        JpegError::InvalidScan("coefficient outside i16 range (corrupt entropy stream)")
+    })
+}
+
+fn handle_restart(
+    reader: &mut BitReader<'_>,
+    planes: &mut [ComponentPlane<'_>],
+    expected_restart: &mut u8,
+) -> JpegResult<()> {
+    reader.reset_to_byte_boundary();
+    let marker_byte = reader.read_marker()?;
+    let expected = marker::RST0 + *expected_restart;
+    if marker_byte != expected {
+        return Err(JpegError::UnexpectedRestartMarker {
+            expected: *expected_restart,
+            marker: marker_byte,
+            offset: reader.byte_offset(),
+        });
+    }
+    *expected_restart = (*expected_restart + 1) & 0x07;
+    for plane in planes.iter_mut() {
+        plane.dc_predictor = 0;
+    }
+    Ok(())
+}

--- a/libs/vulkan-jpeg/tests/integration.rs
+++ b/libs/vulkan-jpeg/tests/integration.rs
@@ -1,0 +1,514 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+#![allow(clippy::needless_range_loop)] // natural reading for 8x8 IDCT + per-block pixel iteration
+
+use jpeg_encoder::{ColorType, Encoder, SamplingFactor};
+use vulkan_jpeg::{DecodedJpeg, JpegError, decode};
+
+const QUALITY: u8 = 90;
+
+/// Encode `pixels` as a JPEG with the requested color type and chroma
+/// subsampling, returning the bitstream bytes.
+fn encode_jpeg(
+    width: u16,
+    height: u16,
+    pixels: &[u8],
+    color_type: ColorType,
+    sampling: SamplingFactor,
+) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, QUALITY);
+    encoder.set_sampling_factor(sampling);
+    encoder.encode(pixels, width, height, color_type).unwrap();
+    bytes
+}
+
+fn solid_grayscale(width: u16, height: u16, luma: u8) -> Vec<u8> {
+    let pixels = vec![luma; (width as usize) * (height as usize)];
+    encode_jpeg(
+        width,
+        height,
+        &pixels,
+        ColorType::Luma,
+        SamplingFactor::F_1_1,
+    )
+}
+
+fn solid_rgb(width: u16, height: u16, r: u8, g: u8, b: u8) -> Vec<u8> {
+    let mut pixels = Vec::with_capacity((width as usize) * (height as usize) * 3);
+    for _ in 0..(width as usize) * (height as usize) {
+        pixels.extend_from_slice(&[r, g, b]);
+    }
+    encode_jpeg(
+        width,
+        height,
+        &pixels,
+        ColorType::Rgb,
+        SamplingFactor::R_4_2_0,
+    )
+}
+
+fn gradient_grayscale(width: u16, height: u16) -> Vec<u8> {
+    let w = width as usize;
+    let h = height as usize;
+    let mut pixels = Vec::with_capacity(w * h);
+    for y in 0..h {
+        for x in 0..w {
+            // Horizontal+vertical gradient: avoids any single-component
+            // degenerate case while keeping DC predictable.
+            let v = ((x + y) as f32 / (w + h) as f32 * 255.0) as u8;
+            pixels.push(v);
+        }
+    }
+    encode_jpeg(
+        width,
+        height,
+        &pixels,
+        ColorType::Luma,
+        SamplingFactor::F_1_1,
+    )
+}
+
+fn complex_rgb(width: u16, height: u16) -> Vec<u8> {
+    let w = width as usize;
+    let h = height as usize;
+    let mut pixels = Vec::with_capacity(w * h * 3);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 7) % 256) as u8;
+            let g = ((y * 11) % 256) as u8;
+            let b = (((x + y) * 13) % 256) as u8;
+            pixels.extend_from_slice(&[r, g, b]);
+        }
+    }
+    encode_jpeg(
+        width,
+        height,
+        &pixels,
+        ColorType::Rgb,
+        SamplingFactor::R_4_2_0,
+    )
+}
+
+fn assert_well_formed(decoded: &DecodedJpeg, width: u16, height: u16, components: usize) {
+    assert_eq!(decoded.frame.width, width);
+    assert_eq!(decoded.frame.height, height);
+    assert_eq!(decoded.frame.components.len(), components);
+    assert_eq!(decoded.components.len(), components);
+
+    for component in &decoded.components {
+        let expected_len = component.blocks_horizontal * component.blocks_vertical * 64;
+        assert_eq!(component.coefficients.len(), expected_len);
+    }
+}
+
+#[test]
+fn parses_solid_grayscale() {
+    let bytes = solid_grayscale(16, 16, 128);
+    let decoded = decode(&bytes).expect("decode solid grayscale");
+
+    assert_well_formed(&decoded, 16, 16, 1);
+    assert_eq!(decoded.scan.spectral_start, 0);
+    assert_eq!(decoded.scan.spectral_end, 63);
+    assert_eq!(decoded.scan.successive_high, 0);
+    assert_eq!(decoded.scan.successive_low, 0);
+
+    // 1 component, 1x1 sampling, 16x16 image → 2x2 = 4 blocks.
+    let luma = &decoded.components[0];
+    assert_eq!(luma.h_sampling, 1);
+    assert_eq!(luma.v_sampling, 1);
+    assert_eq!(luma.blocks_horizontal, 2);
+    assert_eq!(luma.blocks_vertical, 2);
+
+    // Solid color: every AC coefficient in every block is zero.
+    for by in 0..luma.blocks_vertical {
+        for bx in 0..luma.blocks_horizontal {
+            let block = luma.block(bx, by);
+            for &ac in &block[1..64] {
+                assert_eq!(
+                    ac, 0,
+                    "AC coefficient at block ({bx},{by}) should be zero for solid color"
+                );
+            }
+        }
+    }
+
+    // Solid color → every block has the same (predictor-resolved) absolute
+    // DC. The library stores absolute DCs in coefficient[0], so the buffer
+    // values themselves should be identical across blocks.
+    let first_dc = luma.block(0, 0)[0];
+    for by in 0..luma.blocks_vertical {
+        for bx in 0..luma.blocks_horizontal {
+            assert_eq!(
+                luma.block(bx, by)[0],
+                first_dc,
+                "DC at block ({bx},{by}) should equal the first block's DC for solid color"
+            );
+        }
+    }
+}
+
+#[test]
+fn parses_solid_rgb_4_2_0() {
+    let bytes = solid_rgb(32, 32, 200, 50, 50);
+    let decoded = decode(&bytes).expect("decode solid RGB");
+
+    assert_well_formed(&decoded, 32, 32, 3);
+
+    // 4:2:0: Y has 2x2 sampling, Cb/Cr have 1x1.
+    let y = &decoded.components[0];
+    let cb = &decoded.components[1];
+    let cr = &decoded.components[2];
+
+    assert_eq!(y.h_sampling, 2);
+    assert_eq!(y.v_sampling, 2);
+    assert_eq!(cb.h_sampling, 1);
+    assert_eq!(cb.v_sampling, 1);
+    assert_eq!(cr.h_sampling, 1);
+    assert_eq!(cr.v_sampling, 1);
+
+    // 32x32 with max-sampling 2x2: MCU = 16x16 → 2x2 MCUs.
+    // Y: 2x2 MCUs × 2x2 per-MCU blocks = 4x4 blocks.
+    // Cb/Cr: 2x2 MCUs × 1x1 per-MCU blocks = 2x2 blocks.
+    assert_eq!(y.blocks_horizontal, 4);
+    assert_eq!(y.blocks_vertical, 4);
+    assert_eq!(cb.blocks_horizontal, 2);
+    assert_eq!(cb.blocks_vertical, 2);
+
+    // Every AC coefficient in every component should be zero for a solid color.
+    for component in &decoded.components {
+        for by in 0..component.blocks_vertical {
+            for bx in 0..component.blocks_horizontal {
+                let block = component.block(bx, by);
+                for (i, &ac) in block.iter().enumerate().skip(1) {
+                    assert_eq!(
+                        ac, 0,
+                        "AC[{i}] at component {} block ({bx},{by}) should be zero",
+                        component.component_id
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn parses_gradient_grayscale_dc_increases() {
+    let bytes = gradient_grayscale(32, 32);
+    let decoded = decode(&bytes).expect("decode gradient");
+    assert_well_formed(&decoded, 32, 32, 1);
+
+    let luma = &decoded.components[0];
+    assert_eq!(luma.blocks_horizontal, 4);
+    assert_eq!(luma.blocks_vertical, 4);
+
+    // Gradient → each block's mean pixel value differs, so absolute DCs
+    // should span a range. Coefficient[0] is the predictor-resolved
+    // absolute DC, so we can read directly.
+    let mut abs_dcs = Vec::new();
+    for by in 0..luma.blocks_vertical {
+        for bx in 0..luma.blocks_horizontal {
+            abs_dcs.push(luma.block(bx, by)[0]);
+        }
+    }
+    assert!(
+        abs_dcs.iter().min().unwrap() != abs_dcs.iter().max().unwrap(),
+        "gradient DC range should span more than one value, got {abs_dcs:?}"
+    );
+}
+
+#[test]
+fn parses_complex_rgb_4_2_0() {
+    // Complex pattern: just confirm the parser doesn't reject it and the
+    // coefficient buffers are well-shaped. Anything more specific would
+    // require a reference IDCT, which is the next issue's GPU kernel.
+    let bytes = complex_rgb(48, 32);
+    let decoded = decode(&bytes).expect("decode complex RGB");
+    assert_well_formed(&decoded, 48, 32, 3);
+
+    // Cross-check: zune-jpeg accepts the same bitstream. If we accept it
+    // and zune doesn't (or vice versa), one of us is wrong.
+    let mut zune = zune_jpeg::JpegDecoder::new(&bytes);
+    let pixels = zune.decode().expect("zune-jpeg should accept this bitstream");
+    assert!(!pixels.is_empty());
+}
+
+#[test]
+fn parses_dimensions_with_padding() {
+    // 17x17 with 4:2:0 sampling: MCU = 16x16 → 2x2 MCUs (the bottom-right
+    // MCU is padding-only). The parser shouldn't reject it; coefficient
+    // buffers should be sized to cover the padded MCU grid.
+    let pixels = vec![64u8; 17 * 17 * 3];
+    let bytes = encode_jpeg(17, 17, &pixels, ColorType::Rgb, SamplingFactor::R_4_2_0);
+    let decoded = decode(&bytes).expect("decode 17x17 with padding");
+    assert_well_formed(&decoded, 17, 17, 3);
+
+    // Y has 2x2 sampling, image is 17x17 → 2 MCUs in each direction.
+    let y = &decoded.components[0];
+    assert_eq!(y.blocks_horizontal, 4);
+    assert_eq!(y.blocks_vertical, 4);
+}
+
+#[test]
+fn empty_input_rejected() {
+    let err = decode(&[]).unwrap_err();
+    assert!(matches!(err, JpegError::UnexpectedEof { .. }));
+}
+
+#[test]
+fn missing_soi_rejected() {
+    // Bytes that aren't a JPEG.
+    let bytes = [0u8, 1, 2, 3];
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::MissingSoi { .. }));
+}
+
+#[test]
+fn truncated_after_soi_rejected() {
+    let bytes = [0xFFu8, 0xD8];
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::UnexpectedEof { .. }));
+}
+
+#[test]
+fn truncated_in_segment_rejected() {
+    // SOI + DQT marker + truncated length.
+    let bytes = [0xFFu8, 0xD8, 0xFF, 0xDB];
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::UnexpectedEof { .. }));
+}
+
+#[test]
+fn progressive_sof_rejected() {
+    // Encode a valid baseline JPEG, then rewrite SOF0 (0xFF 0xC0) to SOF2.
+    let mut bytes = solid_grayscale(16, 16, 100);
+    let pos = bytes
+        .windows(2)
+        .position(|w| w == [0xFF, 0xC0])
+        .expect("solid_grayscale should contain SOF0");
+    bytes[pos + 1] = 0xC2;
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::UnsupportedSof { marker: 0xC2, .. }));
+}
+
+#[test]
+fn invalid_huffman_table_rejected() {
+    // Encode a valid JPEG, then corrupt the BITS region of the first DHT
+    // segment so the code space overflows.
+    let mut bytes = solid_grayscale(16, 16, 100);
+    let dht_pos = bytes
+        .windows(2)
+        .position(|w| w == [0xFF, 0xC4])
+        .expect("expected DHT in encoded JPEG");
+    // dht_pos points at FF; payload starts at +4 (FF C4 LH LL Tc/Th BITS[16] ...)
+    // First BITS entry is at dht_pos+5. Force more codes than possible.
+    bytes[dht_pos + 5] = 5; // 5 codes of length 1 — only 2 are possible.
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::MalformedHuffmanTable(_)));
+}
+
+#[test]
+fn missing_huffman_table_rejected() {
+    // Construct a tiny minimal stream: SOI + SOF0 (8-bit, 8x8, 1 component
+    // with quant table id 0) + DQT (id 0, all 16s) + SOS (component 0,
+    // dc=0, ac=0, baseline) + a single 0x00 byte for entropy + EOI.
+    // No DHT — should fail with MissingHuffmanTable.
+    #[rustfmt::skip]
+    let bytes = vec![
+        0xFF, 0xD8, // SOI
+        0xFF, 0xDB, 0x00, 0x43, // DQT, length 67
+        0x00, // Pq=0, Tq=0
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        16, 16, 16, 16, 16, 16, 16, 16,
+        0xFF, 0xC0, 0x00, 0x0B, // SOF0, length 11
+        8, // precision
+        0x00, 0x08, // height = 8
+        0x00, 0x08, // width = 8
+        0x01, // 1 component
+        0x01, 0x11, 0x00, // component 1, sampling 1x1, quant id 0
+        0xFF, 0xDA, 0x00, 0x08, // SOS, length 8
+        0x01, // 1 component
+        0x01, 0x00, // component 1, dc=0, ac=0
+        0x00, 0x3F, 0x00, // Ss=0, Se=63, Ah=0, Al=0
+        0x00, // entropy stub
+        0xFF, 0xD9, // EOI
+    ];
+    let err = decode(&bytes).unwrap_err();
+    assert!(
+        matches!(err, JpegError::MissingHuffmanTable { .. }),
+        "expected MissingHuffmanTable, got {err:?}"
+    );
+}
+
+#[test]
+fn missing_sos_rejected() {
+    // SOI followed directly by EOI — no scan.
+    let bytes = [0xFFu8, 0xD8, 0xFF, 0xD9];
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, JpegError::MissingSos));
+}
+
+#[test]
+fn round_trip_via_zune_jpeg_sanity() {
+    // For every fixture we encode, zune-jpeg should also decode it without
+    // errors. This guards against accidentally generating bitstreams that
+    // are only well-formed in our parser's reading.
+    let bytes = complex_rgb(64, 64);
+    let mut zune = zune_jpeg::JpegDecoder::new(&bytes);
+    zune.decode().expect("zune-jpeg sanity check");
+    // And our parser accepts it too.
+    decode(&bytes).expect("our parser accepts the same bitstream");
+}
+
+#[test]
+fn parses_with_restart_intervals() {
+    // Force jpeg-encoder to emit DRI + RST markers so the entropy
+    // decoder's restart resync path runs end-to-end. 32x32 4:2:0 → 4 MCUs;
+    // restart_interval=2 yields two restart groups → RST0 fires after MCU 1.
+    let width: u16 = 32;
+    let height: u16 = 32;
+    let pixels: Vec<u8> = (0..(width as usize) * (height as usize) * 3)
+        .map(|i| (i & 0xFF) as u8)
+        .collect();
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, QUALITY);
+    encoder.set_sampling_factor(SamplingFactor::R_4_2_0);
+    encoder.set_restart_interval(2);
+    encoder.encode(&pixels, width, height, ColorType::Rgb).unwrap();
+
+    // Confirm the encoder actually emitted DRI; otherwise the test is vacuous.
+    assert!(
+        bytes.windows(2).any(|w| w == [0xFF, 0xDD]),
+        "expected DRI marker in the encoded bitstream"
+    );
+
+    let decoded = decode(&bytes).expect("decode JPEG with restart markers");
+    assert_well_formed(&decoded, width, height, 3);
+    assert_eq!(decoded.restart_interval, 2);
+
+    // Cross-validate against zune-jpeg to make sure restart handling
+    // didn't desynchronize the entropy stream.
+    let mut zune = zune_jpeg::JpegDecoder::new(&bytes);
+    zune.decode().expect("zune-jpeg accepts restart-bearing JPEG");
+}
+
+#[test]
+fn parses_rgb_4_2_2() {
+    let pixels = vec![100u8; 32 * 16 * 3];
+    let bytes = encode_jpeg(32, 16, &pixels, ColorType::Rgb, SamplingFactor::R_4_2_2);
+    let decoded = decode(&bytes).expect("decode RGB 4:2:2");
+    assert_well_formed(&decoded, 32, 16, 3);
+    let y = &decoded.components[0];
+    let cb = &decoded.components[1];
+    // 4:2:2 → Y has 2x1 sampling, chroma 1x1.
+    assert_eq!(y.h_sampling, 2);
+    assert_eq!(y.v_sampling, 1);
+    assert_eq!(cb.h_sampling, 1);
+    assert_eq!(cb.v_sampling, 1);
+}
+
+#[test]
+fn parses_rgb_4_4_4() {
+    let pixels = vec![100u8; 16 * 16 * 3];
+    let bytes = encode_jpeg(16, 16, &pixels, ColorType::Rgb, SamplingFactor::R_4_4_4);
+    let decoded = decode(&bytes).expect("decode RGB 4:4:4");
+    assert_well_formed(&decoded, 16, 16, 3);
+    // All three components have 1x1 sampling.
+    for component in &decoded.components {
+        assert_eq!(component.h_sampling, 1);
+        assert_eq!(component.v_sampling, 1);
+    }
+}
+
+/// Minimal CPU dequant + IDCT + level-shift on a single 8x8 block of
+/// zig-zag-ordered coefficients. Lives in the test crate so the library
+/// itself stays pure parser + Huffman. Used only to cross-check our
+/// Huffman output against `zune-jpeg`'s decoded pixels.
+fn idct_block_to_pixels(zigzag_coeffs: &[i16; 64], quant: &[u16; 64]) -> [[u8; 8]; 8] {
+    use std::f64::consts::PI;
+
+    // 1. Dequantize while undoing zig-zag back to natural row-major order.
+    let mut natural = [0f64; 64];
+    for (zz_idx, &nat_idx) in vulkan_jpeg::ZIGZAG.iter().enumerate() {
+        natural[nat_idx] = (zigzag_coeffs[zz_idx] as i32 * quant[zz_idx] as i32) as f64;
+    }
+
+    // 2. Reference 2D IDCT (ITU-T T.81 A.3.3).
+    let mut out = [[0u8; 8]; 8];
+    for y in 0..8 {
+        for x in 0..8 {
+            let mut sum = 0f64;
+            for v in 0..8 {
+                for u in 0..8 {
+                    let cu = if u == 0 { 1.0 / 2f64.sqrt() } else { 1.0 };
+                    let cv = if v == 0 { 1.0 / 2f64.sqrt() } else { 1.0 };
+                    let coef = natural[v * 8 + u];
+                    sum += cu
+                        * cv
+                        * coef
+                        * ((2.0 * x as f64 + 1.0) * u as f64 * PI / 16.0).cos()
+                        * ((2.0 * y as f64 + 1.0) * v as f64 * PI / 16.0).cos();
+                }
+            }
+            sum /= 4.0;
+            sum += 128.0; // level shift
+            out[y][x] = sum.round().clamp(0.0, 255.0) as u8;
+        }
+    }
+    out
+}
+
+#[test]
+fn huffman_output_idct_matches_zune_jpeg_grayscale() {
+    // Numeric cross-check: our Huffman + a textbook CPU IDCT should
+    // produce pixel values within rounding of zune-jpeg's decoded pixels
+    // for a grayscale fixture with non-trivial AC content.
+    let bytes = gradient_grayscale(16, 16);
+    let decoded = decode(&bytes).expect("our parser");
+    let mut zune = zune_jpeg::JpegDecoder::new(&bytes);
+    let zune_pixels = zune.decode().expect("zune-jpeg");
+    let info = zune.info().expect("zune info");
+    assert_eq!(info.width, 16);
+    assert_eq!(info.height, 16);
+    let stride = info.width as usize;
+
+    let luma = &decoded.components[0];
+    assert_eq!(luma.blocks_horizontal, 2);
+    assert_eq!(luma.blocks_vertical, 2);
+
+    let quant_id = luma.quant_table_id;
+    let quant = decoded
+        .quantization_table(quant_id)
+        .expect("luma quant table");
+
+    // Coefficient[0] is the predictor-resolved absolute DC; the test just
+    // needs to copy the block as-is, dequantize via the JPEG-stored quant
+    // table, and run the reference IDCT.
+    for by in 0..luma.blocks_vertical {
+        for bx in 0..luma.blocks_horizontal {
+            let mut block_coeffs = [0i16; 64];
+            block_coeffs.copy_from_slice(luma.block(bx, by));
+            let pixels = idct_block_to_pixels(&block_coeffs, &quant.values);
+            for py in 0..8 {
+                for px in 0..8 {
+                    let global_x = bx * 8 + px;
+                    let global_y = by * 8 + py;
+                    let zune_pixel = zune_pixels[global_y * stride + global_x];
+                    let our_pixel = pixels[py][px];
+                    let diff = (zune_pixel as i32 - our_pixel as i32).abs();
+                    assert!(
+                        diff <= 1,
+                        "pixel mismatch at ({global_x},{global_y}): ours {our_pixel}, zune {zune_pixel}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffolds the new `libs/vulkan-jpeg/` workspace crate that owns the CPU half of streamlib's JPEG decoder: baseline-sequential marker parser (SOI / DQT / DHT / SOF0 / SOS / DRI / EOI; skips APPn / COM) plus a canonical-Huffman entropy decoder that emits per-component zig-zag-ordered DCT coefficient buffers.
- Public API is the minimal `vulkan_jpeg::decode(bytes) -> JpegResult<DecodedJpeg>` carrying parsed frame / scan headers, the quantization tables exactly as stored, and one `ComponentScan` per component sized to the padded MCU grid (`mcus * sampling_factor` blocks per axis). Coefficient[0] is the predictor-resolved absolute DC so the follow-up GPU compute kernel (dequant + IDCT + chroma upsample + YCbCr→RGB) can dispatch one work-group per (channel, block_y, block_x) tuple without inter-block dependencies.
- Pure CPU; no Vulkan in this PR, per the issue's scope. The follow-up GPU kernel ships under the same milestone (`GPU JPEG Decoder & AGP Vision Pipeline`) and rides the public RHI surface (`HostVulkanDevice`, `VulkanComputeKernel`).

## Closes
Closes #840

## Notes on shape
Issue body asks for "a packed coefficient buffer indexed by `(block_y, block_x, channel, coefficient)`". Implemented as `Vec<ComponentScan>` with a flat per-channel buffer indexed `[(y * blocks_horizontal + x) * 64 + zz]`. Caller does `decoded.components[ch].block(bx, by)[zz]`. A single rank-4 buffer would need to either pad chroma blocks up to luma's count (wasteful for 4:2:0) or use jagged storage; per-component flat buffers are the natural shape and what the GPU kernel will iterate over. Documented on `DecodedJpeg` / `ComponentScan`.

Restart-interval support (DRI marker + `RST0..RST7` resync) is implemented even though the body's marker list doesn't call them out: every real-world JPEG that sets a restart interval needs them honored to entropy-decode at all, and the test against `jpeg-encoder`'s `set_restart_interval(2)` would fail without it.

## Exit criteria
- [x] `libs/vulkan-jpeg/` crate exists in the workspace, builds clean
- [x] Parser handles SOI/DQT/DHT/SOF0/SOS/EOI, skips APPn segments (plus DRI/RST/COM defensively)
- [x] CPU Huffman entropy decode produces a packed coefficient buffer indexed by `(block_y, block_x, channel, coefficient)`
- [x] Public API surface exposes the parsed headers + coefficient buffer for the GPU kernel issue to consume

## Test plan
- [x] `cargo test -p vulkan-jpeg` — 28 passed (10 unit + 18 integration)
  - Parser correctness: solid grayscale, solid RGB 4:2:0, gradient grayscale (DC range check), complex RGB 4:2:0, 4:2:2 / 4:4:4 sampling, 17×17 padded-MCU
  - Restart intervals: DRI + `RST0..RST7` resync exercised end-to-end against `jpeg-encoder`'s `set_restart_interval(2)`
  - Numeric Huffman cross-check: our coefficients → CPU dequant + reference IDCT pixel-matches `zune-jpeg` within ±1 LSB on a grayscale gradient
  - Malformed inputs: empty, missing SOI, truncated after SOI, truncated mid-segment, progressive SOF rejected, malformed Huffman table (code-space overflow), missing Huffman table, missing SOS
- [x] `cargo clippy -p vulkan-jpeg --all-targets -- -D warnings` clean
- [x] `cargo doc -p vulkan-jpeg --no-deps` clean
- [x] `cargo check --workspace` clean (only pre-existing warnings in unrelated crates)

No binary blobs in the repo — fixtures come from `jpeg-encoder` (dev-dep) at test time and are cross-validated against `zune-jpeg` (dev-dep).

## Follow-ups
- #841 (GPU compute kernel: dequant + IDCT + chroma upsample + YCbCr→RGB) blocks on this; the kernel will consume the coefficient buffers via `decoded.components[ch].block(bx, by)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)