### PR TITLE
feat(vulkan-jpeg): SimpleJpegDecoder API + internal texture ring (#842)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -525,6 +525,26 @@ impl GpuContext {
             .unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Wrap this `GpuContext` in a [`GpuContextLimitedAccess`] view.
+    ///
+    /// Intended for callers that already hold the raw `GpuContext` — setup
+    /// hooks ([`crate::core::runtime::Runner::install_setup_hook`]),
+    /// runtime orchestrators, and crate-external integration tests — and
+    /// need to invoke the typestate API surface (most notably
+    /// [`GpuContextLimitedAccess::escalate`] for serialized elevation to
+    /// [`GpuContextFullAccess`]).
+    ///
+    /// This does NOT weaken the capability moat: processor code never
+    /// holds a raw `GpuContext` (the field is `pub(crate)` on
+    /// `RuntimeContext`), so processors still reach the typestate
+    /// surface only through their `RuntimeContextLimitedAccess` /
+    /// `RuntimeContextFullAccess` borrows. The Limited view returned
+    /// here exposes a strict subset of `GpuContext`'s public API and is
+    /// safe to clone (it does not grant Full).
+    pub fn limited_access(&self) -> GpuContextLimitedAccess {
+        GpuContextLimitedAccess::new(self.clone())
+    }
+
     /// Wait for the GPU device to become idle. On Vulkan backends this calls
     /// `vkDeviceWaitIdle`; on other backends this is a no-op.
     pub fn wait_device_idle(&self) -> Result<()> {
@@ -2068,6 +2088,13 @@ impl GpuContextLimitedAccess {
             .register_texture_with_layout(id, texture, initial_layout);
     }
 
+    /// Update a registered texture's tracked layout after a transition.
+    /// See [`GpuContext::update_texture_registration_layout`].
+    #[cfg(target_os = "linux")]
+    pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
+        self.inner.update_texture_registration_layout(id, layout);
+    }
+
     /// Resolve a VideoFrame's full registration record (texture + layout).
     pub fn resolve_texture_registration_by_surface_id(
         &self,
@@ -2301,6 +2328,13 @@ impl GpuContextFullAccess {
     ) {
         self.inner
             .register_texture_with_layout(id, texture, initial_layout);
+    }
+
+    /// Update a registered texture's tracked layout after a transition.
+    /// See [`GpuContext::update_texture_registration_layout`].
+    #[cfg(target_os = "linux")]
+    pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
+        self.inner.update_texture_registration_layout(id, layout);
     }
 
     /// Resolve a VideoFrame's full registration record (texture + layout).

--- a/libs/vulkan-jpeg/src/kernel.rs
+++ b/libs/vulkan-jpeg/src/kernel.rs
@@ -101,18 +101,13 @@ impl JpegDecodeKernel {
     ///
     /// Allocates per-call HOST_VISIBLE storage buffers for the coefficient
     /// and quant-table uploads, copies the data in, binds, dispatches, and
-    /// waits on the kernel's fence before returning. Per-call allocation
-    /// is intentional for this issue's scope; a pooled `SimpleJpegDecoder`
-    /// wrapper is a follow-up.
+    /// waits on the kernel's fence before returning. This is the one-shot
+    /// convenience for callers without a pre-allocated buffer pool (e.g.
+    /// the kernel-level integration test); steady-state hot-path callers
+    /// should ride [`Self::dispatch_pooled`] through
+    /// [`crate::SimpleJpegDecoder`] instead.
     pub fn dispatch(&self, decoded: &DecodedJpeg, output_texture: &Texture) -> Result<()> {
         let layout = JpegBufferLayout::from_decoded(decoded)?;
-
-        // Pack i16 coefficients into i32 SSBO words. Sign-extension is
-        // implicit in `i32::from(i16)`. Quant tables go u16 -> u32 with
-        // zero extension. Packing on the host keeps the shader portable
-        // (no dependency on `VK_KHR_16bit_storage` / `shaderInt16`) at
-        // the cost of doubling the upload payload — for 640x360 4:2:0
-        // that's 690 KB, trivial against modern PCIe bandwidth.
         let coef_words = layout.pack_coefficients(decoded);
         let qt_words = layout.pack_quant_tables(decoded)?;
 
@@ -128,9 +123,75 @@ impl JpegDecodeKernel {
             qt_bytes.len() as u64,
         )?);
 
+        self.dispatch_with_buffers(decoded, &layout, output_texture, &coef_buf, &qt_buf)
+    }
+
+    /// Decode `decoded` into `output_texture` using caller-supplied
+    /// pre-allocated HOST_VISIBLE SSBOs. Steady-state hot-path entrypoint:
+    /// no `vkAllocateMemory`, no `vkCreateBuffer`, no `vkMapMemory`.
+    ///
+    /// `coef_buf` and `qt_buf` must be HOST_VISIBLE storage buffers (built
+    /// via [`HostVulkanBuffer::new_storage_buffer_host_visible`]) sized
+    /// to fit the largest decode the caller intends to run — typically the
+    /// worst-case 4:2:0 byte count for the decoder's `(max_width,
+    /// max_height)`. The kernel checks the sizes against `decoded` and
+    /// returns a typed error if too small, so undersized buffers can't
+    /// silently corrupt output.
+    ///
+    /// Same per-call texture contract as [`Self::dispatch`]: `output_texture`
+    /// must be an `Rgba8Unorm` storage image in `GENERAL` layout.
+    pub fn dispatch_pooled(
+        &self,
+        decoded: &DecodedJpeg,
+        output_texture: &Texture,
+        coef_buf: &Arc<HostVulkanBuffer>,
+        qt_buf: &Arc<HostVulkanBuffer>,
+    ) -> Result<()> {
+        let layout = JpegBufferLayout::from_decoded(decoded)?;
+        self.dispatch_with_buffers(decoded, &layout, output_texture, coef_buf, qt_buf)
+    }
+
+    /// Shared dispatch tail: pack coefficients + quant tables into the
+    /// supplied HOST_VISIBLE buffers, bind, set push constants, dispatch.
+    /// Validates that the supplied buffers are large enough so a too-small
+    /// pool surfaces as a typed error instead of an out-of-bounds memcpy.
+    fn dispatch_with_buffers(
+        &self,
+        decoded: &DecodedJpeg,
+        layout: &JpegBufferLayout,
+        output_texture: &Texture,
+        coef_buf: &Arc<HostVulkanBuffer>,
+        qt_buf: &Arc<HostVulkanBuffer>,
+    ) -> Result<()> {
+        // Pack i16 coefficients into i32 SSBO words. Sign-extension is
+        // implicit in `i32::from(i16)`. Quant tables go u16 -> u32 with
+        // zero extension. Packing on the host keeps the shader portable
+        // (no dependency on `VK_KHR_16bit_storage` / `shaderInt16`).
+        let coef_words = layout.pack_coefficients(decoded);
+        let qt_words = layout.pack_quant_tables(decoded)?;
+
+        let coef_bytes = bytemuck::cast_slice::<i32, u8>(&coef_words);
+        let qt_bytes = bytemuck::cast_slice::<u32, u8>(&qt_words);
+
+        if (coef_bytes.len() as u64) > coef_buf.size() {
+            return Err(Error::GpuError(format!(
+                "jpeg_decode: coefficient buffer too small — need {} bytes, pool sized for {} \
+                 (rebuild SimpleJpegDecoder with larger max_width/max_height)",
+                coef_bytes.len(),
+                coef_buf.size(),
+            )));
+        }
+        if (qt_bytes.len() as u64) > qt_buf.size() {
+            return Err(Error::GpuError(format!(
+                "jpeg_decode: quant-table buffer too small — need {} bytes, pool sized for {}",
+                qt_bytes.len(),
+                qt_buf.size(),
+            )));
+        }
+
         // Persistently mapped HOST_VISIBLE | HOST_COHERENT memory.
-        // SAFETY: `mapped_ptr()` returns a valid mapped pointer for the
-        // full allocation; sizes match by construction.
+        // SAFETY: size-checked above; `mapped_ptr()` returns a valid
+        // mapped pointer for the full allocation.
         unsafe {
             std::ptr::copy_nonoverlapping(
                 coef_bytes.as_ptr(),
@@ -144,8 +205,8 @@ impl JpegDecodeKernel {
             );
         }
 
-        let coef_storage = StorageBuffer::from_host_vulkan_buffer(coef_buf);
-        let qt_storage = StorageBuffer::from_host_vulkan_buffer(qt_buf);
+        let coef_storage = StorageBuffer::from_host_vulkan_buffer(Arc::clone(coef_buf));
+        let qt_storage = StorageBuffer::from_host_vulkan_buffer(Arc::clone(qt_buf));
 
         self.kernel.set_storage_buffer(0, &coef_storage)?;
         self.kernel.set_storage_buffer(1, &qt_storage)?;
@@ -169,6 +230,27 @@ impl JpegDecodeKernel {
         self.kernel.dispatch(dispatch_x, dispatch_y, 1)
     }
 }
+
+/// Worst-case byte size for the coefficient HOST_VISIBLE SSBO when
+/// decoding any 4:2:0 frame up to `(max_width, max_height)` pixels.
+///
+/// Dimensions are padded up to a 16-pixel MCU boundary (4:2:0's max
+/// sampling factor is 2×2, so the MCU is 16×16). Within each MCU the
+/// kernel packs `i16` coefficients into `i32` SSBO words: 4 Y blocks
+/// (256 coefficients) + 1 Cb block (64) + 1 Cr block (64), times 4
+/// bytes/coefficient → 1536 bytes per MCU.
+pub fn worst_case_coefficient_buffer_bytes_420(max_width: u32, max_height: u32) -> u64 {
+    const MCU_SIDE: u64 = 16;
+    const COEFFICIENTS_PER_MCU_420: u64 = 4 * 64 + 64 + 64; // Y(2×2) + Cb + Cr blocks
+    const BYTES_PER_COEFFICIENT: u64 = 4; // i32-packed
+    let padded_w = u64::from(max_width).div_ceil(MCU_SIDE);
+    let padded_h = u64::from(max_height).div_ceil(MCU_SIDE);
+    padded_w * padded_h * COEFFICIENTS_PER_MCU_420 * BYTES_PER_COEFFICIENT
+}
+
+/// Byte size for the quant-table HOST_VISIBLE SSBO. 128 entries (Y +
+/// shared chroma), each packed as `u32`.
+pub const QUANT_TABLE_BUFFER_BYTES: u64 = 128 * 4;
 
 /// Indices into `DecodedJpeg.components` for each YCbCr plane plus the
 /// per-plane geometry needed to lay out the SSBO uploads and push

--- a/libs/vulkan-jpeg/src/lib.rs
+++ b/libs/vulkan-jpeg/src/lib.rs
@@ -22,6 +22,8 @@ mod scan;
 
 #[cfg(target_os = "linux")]
 pub mod kernel;
+#[cfg(target_os = "linux")]
+pub mod simple_decoder;
 
 pub use error::{JpegError, JpegResult};
 pub use header::{
@@ -33,6 +35,8 @@ pub use marker::ZIGZAG;
 
 #[cfg(target_os = "linux")]
 pub use kernel::{JpegDecodeKernel, JPEG_DECODE_WORKGROUP_SIZE};
+#[cfg(target_os = "linux")]
+pub use simple_decoder::{JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
 
 /// Parse and entropy-decode a baseline-sequential JPEG bitstream.
 ///

--- a/libs/vulkan-jpeg/src/simple_decoder.rs
+++ b/libs/vulkan-jpeg/src/simple_decoder.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! High-level JPEG decoder API: parser + Huffman + fused compute kernel +
+//! pre-allocated HOST_VISIBLE SSBOs + pre-allocated [`TextureRing`] of
+//! `MAX_FRAMES_IN_FLIGHT = 2` output textures.
+//!
+//! Construction is privileged (allocates the kernel pipeline, the
+//! coefficient + quant-table HOST_VISIBLE SSBOs sized for the worst-case
+//! 4:2:0 frame at `(max_width, max_height)`, and a `TextureRing` of
+//! `Rgba8Unorm` STORAGE textures). Per-frame [`Self::decode`] rotates
+//! the ring and reuses the SSBOs — zero `vkAllocateMemory`, zero
+//! texture creation, zero command-pool / cb / fence creation in steady
+//! state.
+
+use std::sync::Arc;
+
+use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
+use streamlib::sdk::engine::host_rhi::{
+    HostVulkanBuffer, RhiCommandRecorder, VulkanAccess, VulkanStage,
+};
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{Texture, TextureFormat, TextureUsages, VulkanLayout};
+
+use crate::kernel::{
+    worst_case_coefficient_buffer_bytes_420, JpegDecodeKernel, QUANT_TABLE_BUFFER_BYTES,
+};
+
+/// Ring depth — one frame in flight on the GPU, one being recorded on
+/// the CPU. Matches every decoder in the engine.
+pub const MAX_FRAMES_IN_FLIGHT: usize = 2;
+
+/// Output produced by [`SimpleJpegDecoder::decode`]: the GPU texture the
+/// decode wrote into, its `surface_id` (registered in
+/// [`streamlib::sdk::context::GpuContext`]'s texture cache so downstream
+/// in-process consumers can resolve it), and the decoded frame's actual
+/// pixel dimensions.
+#[derive(Debug, Clone)]
+pub struct JpegDecodeOutput {
+    /// Output texture handle (`Arc<HostVulkanTexture>` under the hood —
+    /// cheap to clone, safe to ship across threads).
+    pub texture: Texture,
+    /// Same-process texture-cache id for this slot. Stable across
+    /// decodes against the same slot; rotates with the ring.
+    pub surface_id: String,
+    /// Decoded frame width, in pixels. Always ≤ `max_width`.
+    pub width: u32,
+    /// Decoded frame height, in pixels. Always ≤ `max_height`.
+    pub height: u32,
+}
+
+/// High-level fused-compute JPEG decoder with pre-allocated GPU
+/// resources. Drops in steady-state allocation on the per-frame hot
+/// path.
+pub struct SimpleJpegDecoder {
+    kernel: JpegDecodeKernel,
+    coef_buf: Arc<HostVulkanBuffer>,
+    qt_buf: Arc<HostVulkanBuffer>,
+    ring: Arc<TextureRing>,
+    max_width: u32,
+    max_height: u32,
+}
+
+impl std::fmt::Debug for SimpleJpegDecoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimpleJpegDecoder")
+            .field("max_width", &self.max_width)
+            .field("max_height", &self.max_height)
+            .field("ring_slots", &self.ring.len())
+            .finish()
+    }
+}
+
+impl SimpleJpegDecoder {
+    /// Construct a decoder ready to handle JPEGs up to
+    /// `(max_width, max_height)` pixels.
+    ///
+    /// Pre-allocates the fused compute kernel pipeline, a coefficient
+    /// SSBO sized for the worst-case 4:2:0 frame at the declared maxima,
+    /// a 128-entry quant-table SSBO, and a [`MAX_FRAMES_IN_FLIGHT`]-slot
+    /// [`TextureRing`] of `Rgba8Unorm` STORAGE textures. Each ring slot
+    /// is eagerly transitioned `UNDEFINED → GENERAL` and the slot's
+    /// registration layout updated to match — subsequent kernel
+    /// dispatches write directly without further transitions, and
+    /// downstream consumers that resolve the slot's `surface_id` see a
+    /// registration claim that matches reality.
+    ///
+    /// Must be called inside a [`streamlib::sdk::context::GpuContext::escalate`]
+    /// closure (the only way crate-external code obtains a
+    /// `&GpuContextFullAccess`). The processor-setup mutex is held for
+    /// the duration of `new`, serializing this work against any other
+    /// concurrent processor-setup-class allocation in the runtime.
+    pub fn new(
+        full_access: &GpuContextFullAccess,
+        max_width: u32,
+        max_height: u32,
+    ) -> Result<Self> {
+        if max_width == 0 || max_height == 0 {
+            return Err(Error::GpuError(format!(
+                "SimpleJpegDecoder::new: max dimensions must be non-zero, got {}x{}",
+                max_width, max_height,
+            )));
+        }
+
+        let device = full_access.device().vulkan_device();
+        let kernel = JpegDecodeKernel::new(device)?;
+
+        let coef_bytes = worst_case_coefficient_buffer_bytes_420(max_width, max_height);
+        let coef_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
+            device, coef_bytes,
+        )?);
+        let qt_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
+            device,
+            QUANT_TABLE_BUFFER_BYTES,
+        )?);
+
+        let ring = full_access.create_texture_ring(
+            max_width,
+            max_height,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::STORAGE_BINDING
+                | TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST
+                | TextureUsages::TEXTURE_BINDING,
+            MAX_FRAMES_IN_FLIGHT,
+        )?;
+
+        // Eagerly transition every slot UNDEFINED → GENERAL and refresh
+        // its TextureRegistration to match. The kernel writes via
+        // STORAGE_BINDING in GENERAL and never transitions back; this
+        // pre-warm means per-frame `decode()` records no transitions.
+        for slot_index in 0..ring.len() {
+            let slot = ring
+                .slot(slot_index)
+                .ok_or_else(|| Error::GpuError("ring slot index out of range".into()))?;
+            let mut recorder =
+                RhiCommandRecorder::new(device, "simple_jpeg_decoder_init_layout")?;
+            recorder.begin()?;
+            recorder.record_image_barrier(
+                &slot.texture,
+                VulkanLayout::UNDEFINED,
+                VulkanLayout::GENERAL,
+                VulkanStage::TOP_OF_PIPE,
+                VulkanStage::COMPUTE_SHADER,
+                VulkanAccess::NONE,
+                VulkanAccess::SHADER_WRITE,
+            )?;
+            recorder.submit_and_wait()?;
+            full_access
+                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
+        }
+
+        Ok(Self {
+            kernel,
+            coef_buf,
+            qt_buf,
+            ring,
+            max_width,
+            max_height,
+        })
+    }
+
+    /// Decode `jpeg_bytes` into the next ring slot's texture and return
+    /// a handle to it. Steady-state Limited-safe — no escalation, no
+    /// allocation. Single-threaded by `&mut self`; multi-decoder
+    /// parallelism is the caller's pattern.
+    ///
+    /// Rejects baseline-but-non-4:2:0 input ([`Error::NotSupported`]
+    /// from the kernel) and frames whose dimensions exceed the decoder's
+    /// declared maxima ([`Error::GpuError`] with "exceeds max"). Parser
+    /// / Huffman / kernel errors surface as their typed variants — no
+    /// panics, no leaked GPU resources.
+    pub fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
+        let decoded = crate::decode(jpeg_bytes)
+            .map_err(|e| Error::GpuError(format!("jpeg parse/huffman: {e}")))?;
+
+        let width = u32::from(decoded.frame.width);
+        let height = u32::from(decoded.frame.height);
+        if width > self.max_width || height > self.max_height {
+            return Err(Error::GpuError(format!(
+                "SimpleJpegDecoder::decode: frame {}x{} exceeds decoder maxima {}x{} \
+                 (rebuild SimpleJpegDecoder with larger max_width/max_height)",
+                width, height, self.max_width, self.max_height,
+            )));
+        }
+
+        let slot = self.ring.acquire_next();
+        self.kernel
+            .dispatch_pooled(&decoded, &slot.texture, &self.coef_buf, &self.qt_buf)?;
+
+        Ok(JpegDecodeOutput {
+            texture: slot.texture,
+            surface_id: slot.surface_id,
+            width,
+            height,
+        })
+    }
+
+    /// Borrow the underlying [`TextureRing`] — for tests and
+    /// introspection. Production callers consume slots via
+    /// [`Self::decode`].
+    #[doc(hidden)]
+    pub fn ring(&self) -> &Arc<TextureRing> {
+        &self.ring
+    }
+
+    /// Declared maximum width this decoder can handle, in pixels.
+    pub fn max_width(&self) -> u32 {
+        self.max_width
+    }
+
+    /// Declared maximum height this decoder can handle, in pixels.
+    pub fn max_height(&self) -> u32 {
+        self.max_height
+    }
+}

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -1,0 +1,408 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`SimpleJpegDecoder`] tests — slot rotation, allocation hygiene,
+//! typed-error surfaces, end-to-end PSNR round-trip.
+//!
+//! All GPU-bearing tests skip cleanly when no Vulkan-capable device is
+//! present, mirroring `tests/gpu_decode.rs`.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::needless_range_loop)]
+
+use std::sync::Arc;
+
+use jpeg_encoder::{ColorType, Encoder, SamplingFactor};
+use streamlib::sdk::context::GpuContext;
+use streamlib::sdk::engine::HostTextureExt;
+use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanTextureReadback};
+use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
+use vulkan_jpeg::{JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
+
+/// Acquire a `GpuContext` for tests, or skip cleanly when no GPU is
+/// available (the workstation has one; CI baseline runners may not).
+/// Probing `HostVulkanDevice::new` first means we skip on the host side
+/// before paying the cost of initializing the full GpuContext.
+fn fresh_gpu_context() -> Option<GpuContext> {
+    HostVulkanDevice::new().ok()?;
+    GpuContext::init_for_platform().ok()
+}
+
+fn synthesize_test_image(width: u16, height: u16) -> Vec<u8> {
+    let mut rgb = Vec::with_capacity(usize::from(width) * usize::from(height) * 3);
+    for y in 0..height {
+        for x in 0..width {
+            // Smoothly-varying gradients across R/G/B so Y, Cb, Cr all
+            // carry signal; matches the gpu_decode.rs fixture math.
+            let r = ((u32::from(x) * 4 + u32::from(y) * 3) & 0xFF) as u8;
+            let g = ((u32::from(x) * 5 + u32::from(y) * 7 + 32) & 0xFF) as u8;
+            let b = ((u32::from(x) * 3 + u32::from(y) * 11 + 96) & 0xFF) as u8;
+            rgb.extend_from_slice(&[r, g, b]);
+        }
+    }
+    rgb
+}
+
+fn encode_jpeg_rgb_420(width: u16, height: u16, rgb: &[u8], quality: u8) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, quality);
+    encoder.set_sampling_factor(SamplingFactor::R_4_2_0);
+    encoder
+        .encode(rgb, width, height, ColorType::Rgb)
+        .expect("jpeg encode");
+    bytes
+}
+
+fn readback_rgba(
+    device: &Arc<HostVulkanDevice>,
+    output: &JpegDecodeOutput,
+) -> Vec<u8> {
+    let readback = VulkanTextureReadback::new(
+        device,
+        &TextureReadbackDescriptor {
+            label: "simple_jpeg_test_readback",
+            format: TextureFormat::Rgba8Unorm,
+            width: output.width,
+            height: output.height,
+        },
+    )
+    .expect("readback handle");
+    let ticket = readback
+        .submit(&output.texture, TextureSourceLayout::General)
+        .expect("readback submit");
+    readback
+        .wait_and_read(ticket, u64::MAX)
+        .expect("readback wait")
+        .to_vec()
+}
+
+// -----------------------------------------------------------------------------
+// Construction + rotation
+// -----------------------------------------------------------------------------
+
+#[test]
+fn new_pre_allocates_ring_at_max_frames_in_flight_depth() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 128, 96))
+        .expect("decoder construction");
+
+    assert_eq!(
+        decoder.ring().len(),
+        MAX_FRAMES_IN_FLIGHT,
+        "decoder ring must have MAX_FRAMES_IN_FLIGHT slots"
+    );
+    assert_eq!(decoder.max_width(), 128);
+    assert_eq!(decoder.max_height(), 96);
+    assert_eq!(decoder.ring().width(), 128);
+    assert_eq!(decoder.ring().height(), 96);
+    assert_eq!(decoder.ring().format(), TextureFormat::Rgba8Unorm);
+}
+
+#[test]
+fn new_eagerly_transitions_ring_slots_to_general_and_updates_registration() {
+    use streamlib::sdk::rhi::VulkanLayout;
+
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    for slot_index in 0..decoder.ring().len() {
+        let slot = decoder.ring().slot(slot_index).expect("ring slot");
+        let reg = gpu
+            .resolve_texture_registration_by_surface_id(&slot.surface_id, None, 64, 64)
+            .expect("registration in cache");
+        assert_eq!(
+            reg.current_layout(),
+            VulkanLayout::GENERAL,
+            "slot {slot_index} layout must be GENERAL after SimpleJpegDecoder::new \
+             eager transition (anti-pattern #2: registration-vs-reality drift)"
+        );
+    }
+}
+
+#[test]
+fn decode_rotates_ring_and_reuses_pre_allocated_slot_textures() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    // Snapshot the underlying Arc<HostVulkanTexture> pointer for each
+    // ring slot before any decode runs. After multiple decodes, the
+    // ring must hand back the SAME Arcs — pointer drift would mean
+    // re-allocation, defeating the steady-state-no-alloc invariant.
+    let initial_arcs: Vec<_> = (0..decoder.ring().len())
+        .map(|i| {
+            Arc::as_ptr(decoder.ring().slot(i).expect("ring slot").texture.vulkan_inner())
+        })
+        .collect();
+
+    let rgb = synthesize_test_image(48, 48);
+    let jpeg = encode_jpeg_rgb_420(48, 48, &rgb, 85);
+
+    let mut surface_ids = Vec::new();
+    let mut texture_ptrs = Vec::new();
+    for _ in 0..(MAX_FRAMES_IN_FLIGHT * 2) {
+        let out = decoder.decode(&jpeg).expect("decode");
+        surface_ids.push(out.surface_id.clone());
+        texture_ptrs.push(Arc::as_ptr(out.texture.vulkan_inner()));
+    }
+
+    // Two passes through a 2-slot ring → surface_ids should match across
+    // pass 1 and pass 2.
+    assert_eq!(
+        surface_ids[0], surface_ids[MAX_FRAMES_IN_FLIGHT],
+        "second-pass slot 0 surface_id should match first-pass slot 0 — \
+         ring rotation order must be deterministic"
+    );
+    assert_eq!(
+        surface_ids[1],
+        surface_ids[MAX_FRAMES_IN_FLIGHT + 1],
+        "second-pass slot 1 surface_id should match first-pass slot 1"
+    );
+    assert_ne!(
+        surface_ids[0], surface_ids[1],
+        "consecutive decodes within a single pass must hand back distinct slots"
+    );
+
+    // Every observed texture ptr must match one of the pre-allocated
+    // ring Arcs — i.e. no decode re-allocated a slot texture.
+    for (i, ptr) in texture_ptrs.iter().enumerate() {
+        assert!(
+            initial_arcs.contains(ptr),
+            "decode #{i} returned a texture Arc that wasn't pre-allocated by the ring \
+             (initial arcs {initial_arcs:?}, got {ptr:?}) — steady-state allocation regression"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Error surfaces
+// -----------------------------------------------------------------------------
+
+#[test]
+fn new_rejects_zero_dimensions() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let err = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 0, 64))
+        .expect_err("zero max_width must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("max dimensions must be non-zero"),
+        "expected typed zero-dim error, got: {msg}"
+    );
+}
+
+#[test]
+fn decode_rejects_oversize_frame_with_typed_error() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 32, 32))
+        .expect("decoder construction");
+
+    // 64x64 source exceeds the 32x32 decoder maxima.
+    let rgb = synthesize_test_image(64, 64);
+    let jpeg = encode_jpeg_rgb_420(64, 64, &rgb, 85);
+    let err = decoder.decode(&jpeg).expect_err("oversize must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("exceeds decoder maxima"),
+        "expected oversize-typed error, got: {msg}"
+    );
+}
+
+#[test]
+fn decode_rejects_empty_input_with_typed_error() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    let err = decoder.decode(&[]).expect_err("empty input must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("jpeg parse/huffman"),
+        "expected wrapped parser error, got: {msg}"
+    );
+}
+
+#[test]
+fn decode_rejects_missing_soi_with_typed_error() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    let err = decoder
+        .decode(&[0u8, 1, 2, 3])
+        .expect_err("missing SOI must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("jpeg parse/huffman"),
+        "expected wrapped parser error, got: {msg}"
+    );
+}
+
+#[test]
+fn decode_rejects_progressive_sof_with_typed_error() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    // Encode a baseline JPEG, then patch SOF0 (0xFF 0xC0) → SOF2 (0xFF
+    // 0xC2) to make it progressive — the parser must reject it.
+    let rgb = synthesize_test_image(32, 32);
+    let mut jpeg = encode_jpeg_rgb_420(32, 32, &rgb, 85);
+    let pos = jpeg
+        .windows(2)
+        .position(|w| w == [0xFF, 0xC0])
+        .expect("SOF0 marker present in baseline JPEG");
+    jpeg[pos + 1] = 0xC2;
+
+    let err = decoder.decode(&jpeg).expect_err("progressive must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("jpeg parse/huffman"),
+        "expected wrapped parser error, got: {msg}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end round-trip + PSNR
+// -----------------------------------------------------------------------------
+
+const PSNR_FLOOR_DB_ROUND_TRIP: f64 = 35.0;
+
+/// Compute Y-channel PSNR between a source RGB image and the decoder's
+/// RGBA output, both in scanline order. BT.601 luma weights —
+/// independent of any production matrix code.
+fn y_channel_psnr_db(reference_rgb: &[u8], actual_rgba: &[u8]) -> f64 {
+    assert_eq!(reference_rgb.len() % 3, 0, "reference must be RGB-packed");
+    assert_eq!(actual_rgba.len() % 4, 0, "actual must be RGBA-packed");
+    let pixel_count = reference_rgb.len() / 3;
+    assert_eq!(actual_rgba.len() / 4, pixel_count, "pixel counts must match");
+
+    let mut sum_sq_err = 0.0f64;
+    for px in 0..pixel_count {
+        let r_ref = f64::from(reference_rgb[px * 3]);
+        let g_ref = f64::from(reference_rgb[px * 3 + 1]);
+        let b_ref = f64::from(reference_rgb[px * 3 + 2]);
+        let r_act = f64::from(actual_rgba[px * 4]);
+        let g_act = f64::from(actual_rgba[px * 4 + 1]);
+        let b_act = f64::from(actual_rgba[px * 4 + 2]);
+        let y_ref = 0.299 * r_ref + 0.587 * g_ref + 0.114 * b_ref;
+        let y_act = 0.299 * r_act + 0.587 * g_act + 0.114 * b_act;
+        let err = y_ref - y_act;
+        sum_sq_err += err * err;
+    }
+    if sum_sq_err == 0.0 {
+        return f64::INFINITY;
+    }
+    let mse = sum_sq_err / pixel_count as f64;
+    10.0 * (255.0f64 * 255.0 / mse).log10()
+}
+
+#[test]
+fn end_to_end_round_trip_y_psnr_at_least_35db() {
+    const W: u16 = 64;
+    const H: u16 = 64;
+    // Quality 95: high enough that the round-trip comfortably clears the
+    // 35 dB floor on the high-frequency synthetic fixture used here
+    // (which is designed to populate AC coefficients — stresses the
+    // pipeline more than typical natural content). Q85 sits ~33 dB on
+    // this fixture; the floor exists to gate end-to-end correctness, not
+    // to benchmark JPEG-quality vs. content type.
+    const QUALITY: u8 = 95;
+
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let host_device = HostVulkanDevice::new().ok().map(Arc::new).expect(
+        "GpuContext bootstrapped — HostVulkanDevice must be available",
+    );
+
+    let rgb = synthesize_test_image(W, H);
+    let jpeg = encode_jpeg_rgb_420(W, H, &rgb, QUALITY);
+
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, u32::from(W), u32::from(H)))
+        .expect("decoder construction");
+
+    let out = decoder.decode(&jpeg).expect("decode");
+    assert_eq!(out.width, u32::from(W));
+    assert_eq!(out.height, u32::from(H));
+
+    let rgba = readback_rgba(&host_device, &out);
+    let psnr = y_channel_psnr_db(&rgb, &rgba);
+    tracing::info!(psnr_db = psnr, floor_db = PSNR_FLOOR_DB_ROUND_TRIP, "Y PSNR");
+
+    // Sanity gate: output isn't all zeros. A fully-black readback would
+    // otherwise leak through with PSNR computed against the source —
+    // catches the failure mode where the kernel ran but didn't write
+    // (e.g. wrong layout, wrong binding, descriptor set unbound).
+    assert!(
+        rgba.chunks_exact(4).any(|p| p[0] != 0 || p[1] != 0 || p[2] != 0),
+        "readback was entirely zeros — kernel did not write the output texture"
+    );
+
+    assert!(
+        psnr >= PSNR_FLOOR_DB_ROUND_TRIP,
+        "round-trip Y PSNR {psnr:.2} dB below floor {PSNR_FLOOR_DB_ROUND_TRIP} dB \
+         — JPEG quality 85 should comfortably clear this"
+    );
+}
+
+#[test]
+fn decode_after_error_recovers_cleanly() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    // Bad input first — must error, must NOT leave the kernel in a
+    // half-bound state that breaks the next decode.
+    let _ = decoder.decode(&[]).expect_err("empty input rejection");
+    let _ = decoder
+        .decode(&[0u8, 1, 2])
+        .expect_err("garbage input rejection");
+
+    // Now a good decode must still work.
+    let rgb = synthesize_test_image(32, 32);
+    let jpeg = encode_jpeg_rgb_420(32, 32, &rgb, 85);
+    let out = decoder
+        .decode(&jpeg)
+        .expect("good decode after prior errors must succeed");
+    assert_eq!(out.width, 32);
+    assert_eq!(out.height, 32);
+}

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -33,10 +33,31 @@ fn synthesize_test_image(width: u16, height: u16) -> Vec<u8> {
     for y in 0..height {
         for x in 0..width {
             // Smoothly-varying gradients across R/G/B so Y, Cb, Cr all
-            // carry signal; matches the gpu_decode.rs fixture math.
+            // carry signal; matches the gpu_decode.rs fixture math —
+            // small high-frequency aliasing terms populate AC
+            // coefficients so the pipeline isn't tested only on DC.
             let r = ((u32::from(x) * 4 + u32::from(y) * 3) & 0xFF) as u8;
             let g = ((u32::from(x) * 5 + u32::from(y) * 7 + 32) & 0xFF) as u8;
             let b = ((u32::from(x) * 3 + u32::from(y) * 11 + 96) & 0xFF) as u8;
+            rgb.extend_from_slice(&[r, g, b]);
+        }
+    }
+    rgb
+}
+
+/// Smoother fixture for round-trip PSNR — clean per-channel gradients
+/// with no high-frequency aliasing. JPEG compresses this comfortably
+/// at baseline-quality settings (Q=85), unlike the stress fixture
+/// above which sits ~33 dB at Q=85 on Y PSNR vs source.
+fn synthesize_smooth_test_image(width: u16, height: u16) -> Vec<u8> {
+    let mut rgb = Vec::with_capacity(usize::from(width) * usize::from(height) * 3);
+    let w = u32::from(width.saturating_sub(1).max(1));
+    let h = u32::from(height.saturating_sub(1).max(1));
+    for y in 0..height {
+        for x in 0..width {
+            let r = (u32::from(x) * 255 / w) as u8;
+            let g = (u32::from(y) * 255 / h) as u8;
+            let b = ((u32::from(x) + u32::from(y)) * 255 / (w + h)) as u8;
             rgb.extend_from_slice(&[r, g, b]);
         }
     }
@@ -333,13 +354,13 @@ fn y_channel_psnr_db(reference_rgb: &[u8], actual_rgba: &[u8]) -> f64 {
 fn end_to_end_round_trip_y_psnr_at_least_35db() {
     const W: u16 = 64;
     const H: u16 = 64;
-    // Quality 95: high enough that the round-trip comfortably clears the
-    // 35 dB floor on the high-frequency synthetic fixture used here
-    // (which is designed to populate AC coefficients — stresses the
-    // pipeline more than typical natural content). Q85 sits ~33 dB on
-    // this fixture; the floor exists to gate end-to-end correctness, not
-    // to benchmark JPEG-quality vs. content type.
-    const QUALITY: u8 = 95;
+    // Baseline-quality JPEG per the issue body. The smooth fixture
+    // (`synthesize_smooth_test_image`) clears 35 dB comfortably here;
+    // the stress fixture used by the other tests in this file
+    // populates aggressive AC coefficients on purpose and would sit
+    // ~33 dB at this quality, so it's not the right pick for the
+    // round-trip gate.
+    const QUALITY: u8 = 85;
 
     let Some(gpu) = fresh_gpu_context() else {
         return;
@@ -348,7 +369,7 @@ fn end_to_end_round_trip_y_psnr_at_least_35db() {
         "GpuContext bootstrapped — HostVulkanDevice must be available",
     );
 
-    let rgb = synthesize_test_image(W, H);
+    let rgb = synthesize_smooth_test_image(W, H);
     let jpeg = encode_jpeg_rgb_420(W, H, &rgb, QUALITY);
 
     let mut decoder = gpu
@@ -380,8 +401,13 @@ fn end_to_end_round_trip_y_psnr_at_least_35db() {
     );
 }
 
+/// Locks the contract: parser/Huffman rejection (which aborts before
+/// any GPU work runs) must not leave `SimpleJpegDecoder` in a state
+/// that breaks subsequent decodes. Doesn't exercise mid-dispatch
+/// failure recovery — that's a harder scenario to construct
+/// deterministically from test-controllable inputs.
 #[test]
-fn decode_after_error_recovers_cleanly() {
+fn decode_after_parser_error_state_is_reusable() {
     let Some(gpu) = fresh_gpu_context() else {
         return;
     };
@@ -390,19 +416,19 @@ fn decode_after_error_recovers_cleanly() {
         .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
         .expect("decoder construction");
 
-    // Bad input first — must error, must NOT leave the kernel in a
-    // half-bound state that breaks the next decode.
     let _ = decoder.decode(&[]).expect_err("empty input rejection");
     let _ = decoder
         .decode(&[0u8, 1, 2])
         .expect_err("garbage input rejection");
 
-    // Now a good decode must still work.
+    // Good decode after the rejections must still work — verifies the
+    // parser-error path doesn't leave the decoder/kernel/ring in a
+    // half-baked state.
     let rgb = synthesize_test_image(32, 32);
     let jpeg = encode_jpeg_rgb_420(32, 32, &rgb, 85);
     let out = decoder
         .decode(&jpeg)
-        .expect("good decode after prior errors must succeed");
+        .expect("good decode after prior parser errors must succeed");
     assert_eq!(out.width, 32);
     assert_eq!(out.height, 32);
 }


### PR DESCRIPTION
## Summary

Ships the high-level `SimpleJpegDecoder` for `libs/vulkan-jpeg`, wrapping the already-landed CPU parser + Huffman entropy decoder (#852) + fused compute kernel (#841) + engine `TextureRing` helper (#845) into a steady-state-allocation-free decode primitive on the public RHI surface.

- `SimpleJpegDecoder::new(&GpuContextFullAccess, max_width, max_height)` pre-allocates the kernel pipeline, two HOST_VISIBLE SSBOs sized for the worst-case 4:2:0 frame at the declared maxima, and a `MAX_FRAMES_IN_FLIGHT = 2` `TextureRing` of `Rgba8Unorm` STORAGE textures eagerly transitioned UNDEFINED → GENERAL (with paired `TextureRegistration` layout updates so the in-process cache's claim matches GPU reality per [`texture-registration.md`](docs/architecture/texture-registration.md) anti-pattern #2).
- `decode(&mut self, &[u8]) -> Result<JpegDecodeOutput>` does CPU parse + Huffman, rotates the ring, runs the kernel against pre-allocated buffers. Steady-state: zero `vkAllocateMemory`, zero texture creation, zero command-pool/cb/fence creation, no escalation.

## Closes

Closes #842

## Engine API additions (separate commit `087a08d6`)

Three small public methods on the GpuContext capability surface to close a typestate gap that surfaced while wiring `SimpleJpegDecoder` from external test code:

- `GpuContext::limited_access(&self) -> GpuContextLimitedAccess` — tenant-card view of the raw context. Callers that legitimately hold a raw `GpuContext` (setup hooks via `install_setup_hook`, runtime orchestrators, external crate integration tests) can now reach the `escalate` ceremony. **The capability moat is preserved:** processors never hold a raw `GpuContext` (the field is `pub(crate)` on `RuntimeContext`), so they cannot call this method and still reach `Full` only through their existing `Limited::escalate(|full| ...)` path.
- `GpuContextLimitedAccess::update_texture_registration_layout(id, layout)` + same on `GpuContextFullAccess` — symmetric mirror of the already-public `register_texture_with_layout`. GPU-native producers using `TextureRing` (per [`texture-ring.md`](docs/architecture/texture-ring.md)'s "producers that leave the slot in a layout other than `SHADER_READ_ONLY_OPTIMAL` must update the registration") can now honor the `TextureRegistration` contract.

## Design choices worth flagging

- **`decode` returns `JpegDecodeOutput { texture: Texture, surface_id: String, width: u32, height: u32 }` by value** instead of the issue body's sketch `Result<&Texture>`. Same payload (the `Texture` is `Arc<HostVulkanTexture>`-backed under the hood and cheap to clone); the by-value return avoids tying downstream consumers to the decoder's `&mut self` borrow lifetime, and bundling the `surface_id` + dims prevents callers from accidentally desynchronizing them when emitting a `VideoFrame`.
- **`SimpleJpegDecoder::new` takes `&GpuContextFullAccess` (not `&GpuContextLimitedAccess`)** — matches the canonical pattern of `H264Decoder` / `H265Decoder` / `BgraFileSource` who call `gpu_ctx.escalate(|full| full.create_texture_ring(...))`. Escalation lives at the call site for visibility; the constructor takes `Full` and does no internal escalation, which keeps the function composition-safe (multiple `Full`-requiring constructors can share a single `escalate` scope without re-entering the non-reentrant setup mutex).
- **PSNR round-trip uses a smoother fixture** (`synthesize_smooth_test_image`) at the issue body's specified Q=85; the existing `synthesize_test_image` stress fixture is kept for the rotation / structural tests where AC-coefficient population matters.

## Exit criteria

- [x] Public `SimpleJpegDecoder::new(...)` constructor + `decode(&[u8])` API
- [x] Pre-allocated ring of 2 output textures via the engine `TextureRing` helper, rotated per decode
- [x] No per-frame `vkAllocateMemory` / texture creation in steady state (locked by Arc-pointer-stability assertion)
- [x] Coefficient buffer pool re-uses HOST_VISIBLE allocations across decodes
- [x] End-to-end PSNR ≥ 35 dB on Y channel for a baseline-quality JPEG round-trip

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p vulkan-jpeg --tests` — zero vulkan-jpeg warnings
- [x] `cargo test -p vulkan-jpeg --tests` — **39/39 pass**
  - 10 unit (parser + bit_reader + huffman)
  - 1 `gpu_decode` integration (CPU vs GPU PSNR ≥ 50 dB — unchanged)
  - 18 `integration` (parser end-to-end)
  - 10 `simple_decoder` (new): ring pre-allocation, eager GENERAL transition + registration update, slot rotation with Arc-pointer stability, oversize rejection, zero-dim rejection, empty/missing-SOI/progressive-SOF parser rejection, post-parser-error reusability, end-to-end Y PSNR ≥ 35 dB round-trip

## Follow-ups

- `packages/jpeg/` processor that wraps `SimpleJpegDecoder` (#830)
- nvJPEG runtime-selected backend (#843)
- VADR-vision depayloader (downstream UDP → JPEG → SimpleJpegDecoder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)