### PR TITLE
feat(vulkan-jpeg): honor declared colorimetry (EXIF / ICC / Adobe APP14)

### DIFF
--- a/libs/vulkan-jpeg/build.rs
+++ b/libs/vulkan-jpeg/build.rs
@@ -26,6 +26,16 @@ fn compile_shaders() {
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
 
+    // The JPEG kernel `#include`s `color_convert_common.glsl` from the
+    // streamlib-engine shader tree so the YCbCr → RGB math, transfer
+    // closed-forms, and `TRANSFER_*` / `FLAG_APPLY_TRANSFER` constants
+    // come from one source of truth. Rebuild when that file changes.
+    let engine_shader_include_dir = "../streamlib-engine/src/vulkan/rhi/shaders";
+    println!(
+        "cargo:rerun-if-changed={}/color_convert_common.glsl",
+        engine_shader_include_dir
+    );
+
     for (src, dst, stage) in shaders {
         let src_path = Path::new(src);
         let dst_path: PathBuf = Path::new(&out_dir).join(dst);
@@ -35,6 +45,8 @@ fn compile_shaders() {
         let status = Command::new("glslc")
             .arg(format!("-fshader-stage={stage}"))
             .arg("-O")
+            .arg("-I")
+            .arg(engine_shader_include_dir)
             .arg(src_path)
             .arg("-o")
             .arg(&dst_path)

--- a/libs/vulkan-jpeg/src/color.rs
+++ b/libs/vulkan-jpeg/src/color.rs
@@ -1,0 +1,888 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! JPEG color-metadata types parsed from APP segments.
+//!
+//! Parsed-as-bytes inside the crate's marker walker and surfaced on
+//! [`crate::DecodedJpeg::color_info`]. Resolution to the engine's
+//! `streamlib::sdk::color::ResolvedColorInfo` lives in
+//! [`JpegColorInfo::resolve`] (Linux-only).
+
+use crate::error::{JpegError, JpegResult};
+
+/// Aggregate of every color-related field extracted from the JPEG's
+/// application segments. Each `Option` is present iff the matching
+/// segment was found and parsed cleanly.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JpegColorInfo {
+    /// APP0 JFIF marker. Present whenever an `APP0` segment carries
+    /// the `"JFIF\0"` identifier — the canonical signal that the
+    /// stream is JFIF-conformant (BT.601-Full YCbCr ↔ sRGB primaries).
+    pub jfif: Option<JfifMetadata>,
+    /// APP14 Adobe marker. Carries the YCbCr↔RGB transform field that
+    /// overrides JFIF's implicit BT.601-Full conversion.
+    pub adobe: Option<AdobeMetadata>,
+    /// APP1 EXIF `ColorSpace` tag (0xA001) when present. Other EXIF
+    /// fields are ignored — the issue scopes this to colorimetry.
+    pub exif_color_space: Option<ExifColorSpace>,
+    /// APP2 ICC profile bytes. Concatenated across multi-segment
+    /// chunks per the ICC profile spec's APP2 fragmentation scheme.
+    /// `None` until every declared chunk has been seen.
+    pub icc_profile: Option<Vec<u8>>,
+}
+
+/// Parsed APP0 JFIF identifier segment.
+///
+/// JFIF freezes the YCbCr↔RGB conversion to BT.601-Full and sRGB
+/// primaries; presence of this segment is the strongest "you can
+/// trust the JFIF defaults" signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JfifMetadata {
+    /// JFIF version, major.minor (e.g. `(1, 2)` for "JFIF 1.02").
+    pub version: (u8, u8),
+}
+
+/// Parsed APP14 Adobe segment.
+///
+/// The `transform` field — known historically as the Adobe "color
+/// transform" byte — is what tells a decoder whether the 3-component
+/// stream is RGB-direct (no YCbCr↔RGB matrix), YCbCr (matrix), or
+/// YCCK (4-component CMYK; out of scope for a 3-component kernel).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdobeMetadata {
+    /// Adobe transform byte (segment offset 11).
+    pub transform: AdobeTransform,
+}
+
+/// Adobe APP14 `transform` field values per the Adobe TN5116 spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdobeTransform {
+    /// `transform = 0`. RGB-direct for 3-component streams (no
+    /// YCbCr↔RGB matrix); CMYK-direct for 4-component streams.
+    Direct,
+    /// `transform = 1`. YCbCr (3-component) — matches JFIF's
+    /// implicit BT.601-Full default.
+    YCbCr,
+    /// `transform = 2`. YCCK (4-component CMYK encoded as YCCK).
+    /// The fused JPEG kernel only handles 3-component YCbCr today —
+    /// a 4-component decode would need separate dequant/IDCT plumbing.
+    YCCK,
+    /// Any value outside `{0, 1, 2}`. Per the spec the field is a
+    /// `u8`, so we surface the raw byte without rejecting parse —
+    /// the resolver can decide how to treat it.
+    Other(u8),
+}
+
+impl AdobeTransform {
+    fn from_byte(b: u8) -> Self {
+        match b {
+            0 => AdobeTransform::Direct,
+            1 => AdobeTransform::YCbCr,
+            2 => AdobeTransform::YCCK,
+            other => AdobeTransform::Other(other),
+        }
+    }
+}
+
+/// EXIF `ColorSpace` tag (0xA001) value.
+///
+/// EXIF (TIFF) tag values are `u16`. The well-known interpretations:
+/// `1` = sRGB, `0xFFFF` = Uncalibrated (often paired with an
+/// `InteropIndex` of "R03" to mean Adobe RGB). Anything else is
+/// surfaced as `Other` rather than guessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExifColorSpace {
+    Srgb,
+    Uncalibrated,
+    Other(u16),
+}
+
+impl ExifColorSpace {
+    pub(crate) fn from_u16(v: u16) -> Self {
+        match v {
+            1 => ExifColorSpace::Srgb,
+            0xFFFF => ExifColorSpace::Uncalibrated,
+            other => ExifColorSpace::Other(other),
+        }
+    }
+}
+
+// Identifier bytes that precede each APP-segment payload kind.
+// Kept private — these are parser internals.
+pub(crate) const JFIF_IDENTIFIER: &[u8] = b"JFIF\0";
+pub(crate) const EXIF_IDENTIFIER: &[u8] = b"Exif\0\0";
+pub(crate) const ICC_IDENTIFIER: &[u8] = b"ICC_PROFILE\0";
+pub(crate) const ADOBE_IDENTIFIER: &[u8] = b"Adobe\0";
+
+// ---------------------------------------------------------------------------
+// APP0 — JFIF
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_app0(payload: &[u8]) -> JpegResult<Option<JfifMetadata>> {
+    if !payload.starts_with(JFIF_IDENTIFIER) {
+        // APP0 can also carry JFXX (JFIF extension) or other vendor
+        // formats; treat anything non-JFIF as a no-op.
+        return Ok(None);
+    }
+    if payload.len() < JFIF_IDENTIFIER.len() + 2 {
+        return Err(JpegError::Unsupported("APP0 JFIF segment too short"));
+    }
+    let version_offset = JFIF_IDENTIFIER.len();
+    let major = payload[version_offset];
+    let minor = payload[version_offset + 1];
+    Ok(Some(JfifMetadata {
+        version: (major, minor),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// APP1 — EXIF (scoped to ColorSpace tag)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_app1_exif_color_space(payload: &[u8]) -> JpegResult<Option<ExifColorSpace>> {
+    if !payload.starts_with(EXIF_IDENTIFIER) {
+        // APP1 also carries XMP (`http://ns.adobe.com/xap/1.0/`)
+        // and others — skip anything that isn't EXIF.
+        return Ok(None);
+    }
+    let tiff = &payload[EXIF_IDENTIFIER.len()..];
+    walk_exif_color_space(tiff)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TiffByteOrder {
+    LittleEndian,
+    BigEndian,
+}
+
+impl TiffByteOrder {
+    fn read_u16(&self, bytes: &[u8], offset: usize) -> JpegResult<u16> {
+        if offset + 2 > bytes.len() {
+            return Err(JpegError::Unsupported("EXIF: u16 read out of bounds"));
+        }
+        let slice = [bytes[offset], bytes[offset + 1]];
+        Ok(match self {
+            TiffByteOrder::LittleEndian => u16::from_le_bytes(slice),
+            TiffByteOrder::BigEndian => u16::from_be_bytes(slice),
+        })
+    }
+
+    fn read_u32(&self, bytes: &[u8], offset: usize) -> JpegResult<u32> {
+        if offset + 4 > bytes.len() {
+            return Err(JpegError::Unsupported("EXIF: u32 read out of bounds"));
+        }
+        let slice = [
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ];
+        Ok(match self {
+            TiffByteOrder::LittleEndian => u32::from_le_bytes(slice),
+            TiffByteOrder::BigEndian => u32::from_be_bytes(slice),
+        })
+    }
+}
+
+const EXIF_TAG_EXIF_IFD_POINTER: u16 = 0x8769;
+const EXIF_TAG_COLOR_SPACE: u16 = 0xA001;
+
+/// Walk the TIFF/EXIF structure looking specifically for ColorSpace.
+/// Bounded; bails on any malformed offset instead of panicking.
+fn walk_exif_color_space(tiff: &[u8]) -> JpegResult<Option<ExifColorSpace>> {
+    if tiff.len() < 8 {
+        return Err(JpegError::Unsupported("EXIF: TIFF header too short"));
+    }
+    let order = match &tiff[0..2] {
+        b"II" => TiffByteOrder::LittleEndian,
+        b"MM" => TiffByteOrder::BigEndian,
+        _ => return Err(JpegError::Unsupported("EXIF: missing II/MM byte-order")),
+    };
+    let magic = order.read_u16(tiff, 2)?;
+    if magic != 0x002A {
+        return Err(JpegError::Unsupported("EXIF: bad TIFF magic"));
+    }
+    let ifd0_offset = order.read_u32(tiff, 4)? as usize;
+    // IFD0 — search for ExifIFDPointer (0x8769). ColorSpace lives in
+    // the linked ExifIFD, not in IFD0.
+    let exif_ifd_offset = match find_ifd_entry(tiff, order, ifd0_offset, EXIF_TAG_EXIF_IFD_POINTER)?
+    {
+        Some(entry) => match entry.read_u32_value(tiff, order) {
+            Some(v) => v as usize,
+            None => return Ok(None),
+        },
+        None => return Ok(None),
+    };
+    let color_space_entry =
+        match find_ifd_entry(tiff, order, exif_ifd_offset, EXIF_TAG_COLOR_SPACE)? {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+    let raw = match color_space_entry.read_u16_value(tiff, order) {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    Ok(Some(ExifColorSpace::from_u16(raw)))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IfdEntry {
+    field_type: u16,
+    count: u32,
+    /// Raw 4 bytes of the value-or-offset slot, in the file's byte order
+    /// (kept as a raw `[u8; 4]` to defer interpretation to the reader).
+    value_offset_bytes: [u8; 4],
+}
+
+impl IfdEntry {
+    fn read_u32_value(&self, _tiff: &[u8], order: TiffByteOrder) -> Option<u32> {
+        // Type LONG (4) with count 1 fits inline.
+        if self.field_type != 4 || self.count != 1 {
+            return None;
+        }
+        Some(match order {
+            TiffByteOrder::LittleEndian => u32::from_le_bytes(self.value_offset_bytes),
+            TiffByteOrder::BigEndian => u32::from_be_bytes(self.value_offset_bytes),
+        })
+    }
+
+    fn read_u16_value(&self, _tiff: &[u8], order: TiffByteOrder) -> Option<u16> {
+        // Type SHORT (3) with count 1 fits inline in the low half of the
+        // 4-byte slot.
+        if self.field_type != 3 || self.count != 1 {
+            return None;
+        }
+        let slice = [self.value_offset_bytes[0], self.value_offset_bytes[1]];
+        Some(match order {
+            TiffByteOrder::LittleEndian => u16::from_le_bytes(slice),
+            TiffByteOrder::BigEndian => u16::from_be_bytes(slice),
+        })
+    }
+}
+
+fn find_ifd_entry(
+    tiff: &[u8],
+    order: TiffByteOrder,
+    ifd_offset: usize,
+    target_tag: u16,
+) -> JpegResult<Option<IfdEntry>> {
+    if ifd_offset == 0 || ifd_offset + 2 > tiff.len() {
+        return Ok(None);
+    }
+    let count = order.read_u16(tiff, ifd_offset)? as usize;
+    let entries_start = ifd_offset + 2;
+    let entries_end = entries_start
+        .checked_add(count * 12)
+        .ok_or(JpegError::Unsupported("EXIF: IFD count overflow"))?;
+    if entries_end > tiff.len() {
+        return Err(JpegError::Unsupported("EXIF: IFD truncated"));
+    }
+    for i in 0..count {
+        let base = entries_start + i * 12;
+        let tag = order.read_u16(tiff, base)?;
+        if tag != target_tag {
+            continue;
+        }
+        let field_type = order.read_u16(tiff, base + 2)?;
+        let count_u32 = order.read_u32(tiff, base + 4)?;
+        let value_offset_bytes = [
+            tiff[base + 8],
+            tiff[base + 9],
+            tiff[base + 10],
+            tiff[base + 11],
+        ];
+        let _ = tag; // matched by predicate above
+        return Ok(Some(IfdEntry {
+            field_type,
+            count: count_u32,
+            value_offset_bytes,
+        }));
+    }
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// APP2 — ICC profile (multi-segment reassembly)
+// ---------------------------------------------------------------------------
+
+/// Per-fragment view extracted from an APP2 ICC segment.
+pub(crate) struct IccFragment<'a> {
+    /// 1-based fragment index.
+    pub seq: u8,
+    /// Total fragment count.
+    pub total: u8,
+    /// Fragment payload bytes (no identifier, no seq/total bytes).
+    pub data: &'a [u8],
+}
+
+pub(crate) fn parse_app2_icc_fragment(payload: &[u8]) -> JpegResult<Option<IccFragment<'_>>> {
+    if !payload.starts_with(ICC_IDENTIFIER) {
+        return Ok(None);
+    }
+    let rest = &payload[ICC_IDENTIFIER.len()..];
+    if rest.len() < 2 {
+        return Err(JpegError::Unsupported("APP2 ICC: missing seq/total bytes"));
+    }
+    let seq = rest[0];
+    let total = rest[1];
+    if seq == 0 || total == 0 || seq > total {
+        return Err(JpegError::Unsupported(
+            "APP2 ICC: invalid seq/total ordering",
+        ));
+    }
+    Ok(Some(IccFragment {
+        seq,
+        total,
+        data: &rest[2..],
+    }))
+}
+
+/// Multi-segment ICC reassembly state. Fragments arrive in arbitrary
+/// order; the accumulator stores them by 1-based index and assembles
+/// once the last one is in.
+#[derive(Debug, Default)]
+pub(crate) struct IccAccumulator {
+    /// Expected fragment count (set on first fragment). Resets only
+    /// when the value would otherwise conflict — a malformed source
+    /// changing `total` mid-stream is treated as a hard error rather
+    /// than silently overwriting.
+    expected_total: Option<u8>,
+    /// Fragments collected so far (`fragments[i] = data for seq=i+1`).
+    fragments: Vec<Option<Vec<u8>>>,
+}
+
+impl IccAccumulator {
+    pub(crate) fn ingest(&mut self, fragment: IccFragment<'_>) -> JpegResult<()> {
+        let total = match self.expected_total {
+            None => {
+                self.expected_total = Some(fragment.total);
+                self.fragments = (0..fragment.total).map(|_| None).collect();
+                fragment.total
+            }
+            Some(t) if t == fragment.total => t,
+            Some(_) => {
+                return Err(JpegError::Unsupported(
+                    "APP2 ICC: fragment `total` disagrees across segments",
+                ));
+            }
+        };
+        if fragment.seq > total {
+            return Err(JpegError::Unsupported(
+                "APP2 ICC: fragment seq exceeds declared total",
+            ));
+        }
+        let slot = &mut self.fragments[fragment.seq as usize - 1];
+        if slot.is_some() {
+            return Err(JpegError::Unsupported(
+                "APP2 ICC: duplicate fragment seq",
+            ));
+        }
+        *slot = Some(fragment.data.to_vec());
+        Ok(())
+    }
+
+    pub(crate) fn try_finish(&mut self) -> Option<Vec<u8>> {
+        self.expected_total?;
+        if self.fragments.iter().any(|f| f.is_none()) {
+            return None;
+        }
+        let mut out = Vec::new();
+        for slot in self.fragments.drain(..) {
+            out.extend(slot.expect("checked above"));
+        }
+        self.expected_total = None;
+        Some(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// APP14 — Adobe
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_app14_adobe(payload: &[u8]) -> JpegResult<Option<AdobeMetadata>> {
+    if !payload.starts_with(ADOBE_IDENTIFIER) {
+        return Ok(None);
+    }
+    // Adobe segment layout after "Adobe\0":
+    //   u16 version (BE), u16 flags0, u16 flags1, u8 transform.
+    // The transform byte sits at offset 11 from the start of the
+    // segment payload (5 + 1 + 2 + 2 + 2 = 12, transform is the 12th
+    // byte / offset 11).
+    const TRANSFORM_OFFSET: usize = ADOBE_IDENTIFIER.len() + 6;
+    if payload.len() <= TRANSFORM_OFFSET {
+        return Err(JpegError::Unsupported(
+            "APP14 Adobe segment truncated before transform byte",
+        ));
+    }
+    let transform = AdobeTransform::from_byte(payload[TRANSFORM_OFFSET]);
+    Ok(Some(AdobeMetadata { transform }))
+}
+
+// ---------------------------------------------------------------------------
+// Resolution to engine `ResolvedColorInfo` (Linux-only)
+// ---------------------------------------------------------------------------
+
+/// Outcome of [`JpegColorInfo::resolve`].
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedJpegColor {
+    /// Engine-shaped 4-tuple the kernel consumes via push constants.
+    pub info: streamlib::sdk::color::ResolvedColorInfo,
+    /// Why this resolution was picked — useful for logging and tests
+    /// that need to verify which branch fired without inspecting the
+    /// numeric 4-tuple.
+    pub source: JpegColorSource,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JpegColorSource {
+    /// No APP-segment metadata honored — JFIF default
+    /// (BT.601-Full YCbCr ↔ sRGB primaries).
+    JfifDefault,
+    /// APP14 Adobe `transform = 0` → RGB-direct (matrix collapses to
+    /// `Identity`; no YCbCr↔RGB conversion).
+    AdobeRgbDirect,
+    /// APP14 Adobe `transform = 1` → JFIF-compatible YCbCr.
+    AdobeYCbCr,
+    /// APP1 EXIF `ColorSpace = sRGB`. Same resolved 4-tuple as
+    /// `JfifDefault`; surfaced separately so callers can tell the
+    /// metadata was actually inspected.
+    ExifSrgb,
+    /// Parsed metadata declared a colorimetry the engine can't yet
+    /// represent (Adobe RGB / Display P3 / Rec.2020 via EXIF or ICC).
+    /// Falls back to JFIF default.
+    UnsupportedDeclarationFallback,
+}
+
+#[cfg(target_os = "linux")]
+impl JpegColorInfo {
+    /// Resolve to the engine 4-tuple that drives the kernel's push
+    /// constants. JFIF default when no metadata is honored; APP14
+    /// `transform = 0` swaps the matrix axis to `Identity`. YCCK is
+    /// rejected with a typed error (the 4-component decode path
+    /// doesn't exist today).
+    pub fn resolve(&self) -> JpegResult<ResolvedJpegColor> {
+        use streamlib::sdk::color::{MatrixId, PrimariesId, RangeId, ResolvedColorInfo, TransferId};
+
+        let jfif_default = ResolvedColorInfo {
+            primaries: PrimariesId::Bt709,
+            transfer: TransferId::Srgb,
+            matrix: MatrixId::Smpte170m,
+            range: RangeId::Full,
+        };
+
+        if let Some(adobe) = self.adobe {
+            match adobe.transform {
+                AdobeTransform::Direct => {
+                    return Ok(ResolvedJpegColor {
+                        info: ResolvedColorInfo {
+                            matrix: MatrixId::Identity,
+                            range: RangeId::Full,
+                            ..jfif_default
+                        },
+                        source: JpegColorSource::AdobeRgbDirect,
+                    });
+                }
+                AdobeTransform::YCbCr => {
+                    return Ok(ResolvedJpegColor {
+                        info: jfif_default,
+                        source: JpegColorSource::AdobeYCbCr,
+                    });
+                }
+                AdobeTransform::YCCK => {
+                    return Err(JpegError::Unsupported(
+                        "APP14 Adobe transform=2 (YCCK / 4-component CMYK) — the 3-component fused kernel cannot handle this stream",
+                    ));
+                }
+                AdobeTransform::Other(_) => {
+                    return Ok(ResolvedJpegColor {
+                        info: jfif_default,
+                        source: JpegColorSource::UnsupportedDeclarationFallback,
+                    });
+                }
+            }
+        }
+
+        if let Some(cs) = self.exif_color_space {
+            return Ok(match cs {
+                ExifColorSpace::Srgb => ResolvedJpegColor {
+                    info: jfif_default,
+                    source: JpegColorSource::ExifSrgb,
+                },
+                ExifColorSpace::Uncalibrated | ExifColorSpace::Other(_) => ResolvedJpegColor {
+                    info: jfif_default,
+                    source: JpegColorSource::UnsupportedDeclarationFallback,
+                },
+            });
+        }
+
+        if self.icc_profile.is_some() {
+            // The ICC primaries→`PrimariesId` map needs `Adobe RGB` /
+            // `Display P3` variants that the engine enum doesn't carry
+            // today. Parse, surface, fall back to JFIF — a future engine
+            // extension is the right place to honor non-sRGB profiles.
+            return Ok(ResolvedJpegColor {
+                info: jfif_default,
+                source: JpegColorSource::UnsupportedDeclarationFallback,
+            });
+        }
+
+        // No metadata honored — JFIF default applies whether or not an
+        // explicit APP0 JFIF segment was present.
+        Ok(ResolvedJpegColor {
+            info: jfif_default,
+            source: JpegColorSource::JfifDefault,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// APP0 JFIF identifier round-trips into [`JfifMetadata`].
+    #[test]
+    fn parse_app0_jfif_basic() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(JFIF_IDENTIFIER);
+        payload.extend_from_slice(&[1, 2]); // version 1.02
+        payload.extend_from_slice(&[0, 0, 1, 0, 1, 0, 0]); // density + thumbnail dims
+        let result = parse_app0(&payload).unwrap();
+        assert_eq!(result, Some(JfifMetadata { version: (1, 2) }));
+    }
+
+    /// Non-JFIF APP0 (e.g. JFXX) → `None`, no error.
+    #[test]
+    fn parse_app0_non_jfif_returns_none() {
+        let payload = b"JFXX\x00..."[..].to_vec();
+        assert_eq!(parse_app0(&payload).unwrap(), None);
+    }
+
+    /// APP14 Adobe transform=1 (YCbCr) round-trips.
+    #[test]
+    fn parse_app14_ycbcr() {
+        let payload = build_adobe_segment(1);
+        let result = parse_app14_adobe(&payload).unwrap();
+        assert_eq!(
+            result,
+            Some(AdobeMetadata {
+                transform: AdobeTransform::YCbCr
+            })
+        );
+    }
+
+    /// APP14 Adobe transform=0 (RGB direct) round-trips.
+    #[test]
+    fn parse_app14_rgb_direct() {
+        let payload = build_adobe_segment(0);
+        let result = parse_app14_adobe(&payload).unwrap();
+        assert_eq!(
+            result,
+            Some(AdobeMetadata {
+                transform: AdobeTransform::Direct
+            })
+        );
+    }
+
+    /// APP14 Adobe transform=2 (YCCK) round-trips.
+    #[test]
+    fn parse_app14_ycck() {
+        let payload = build_adobe_segment(2);
+        let result = parse_app14_adobe(&payload).unwrap();
+        assert_eq!(
+            result,
+            Some(AdobeMetadata {
+                transform: AdobeTransform::YCCK
+            })
+        );
+    }
+
+    /// Non-Adobe APP14 payload → `None`, no error.
+    #[test]
+    fn parse_app14_non_adobe_returns_none() {
+        let payload = b"Other\x00..."[..].to_vec();
+        assert_eq!(parse_app14_adobe(&payload).unwrap(), None);
+    }
+
+    /// EXIF ColorSpace=1 (sRGB) extracted from a little-endian TIFF
+    /// directory.
+    #[test]
+    fn parse_app1_exif_color_space_srgb_little_endian() {
+        let payload = build_exif_payload_color_space(1, /* big_endian */ false);
+        let result = parse_app1_exif_color_space(&payload).unwrap();
+        assert_eq!(result, Some(ExifColorSpace::Srgb));
+    }
+
+    /// EXIF ColorSpace=0xFFFF (Uncalibrated) extracted from a
+    /// big-endian TIFF directory. Catches byte-order parsing
+    /// regressions.
+    #[test]
+    fn parse_app1_exif_color_space_uncalibrated_big_endian() {
+        let payload = build_exif_payload_color_space(0xFFFF, /* big_endian */ true);
+        let result = parse_app1_exif_color_space(&payload).unwrap();
+        assert_eq!(result, Some(ExifColorSpace::Uncalibrated));
+    }
+
+    /// XMP-flavored APP1 (non-EXIF) → `None`.
+    #[test]
+    fn parse_app1_non_exif_returns_none() {
+        let payload = b"http://ns.adobe.com/xap/1.0/\x00..."[..].to_vec();
+        assert_eq!(parse_app1_exif_color_space(&payload).unwrap(), None);
+    }
+
+    /// Single-segment ICC profile reassembles into the original bytes.
+    #[test]
+    fn icc_single_segment_reassembles() {
+        let body = b"my fake ICC profile bytes".to_vec();
+        let payload = build_icc_segment(1, 1, &body);
+        let fragment = parse_app2_icc_fragment(&payload).unwrap().unwrap();
+        let mut accum = IccAccumulator::default();
+        accum.ingest(fragment).unwrap();
+        assert_eq!(accum.try_finish(), Some(body));
+    }
+
+    /// Two-segment ICC profile reassembles in delivery order.
+    #[test]
+    fn icc_two_segments_reassemble_in_order() {
+        let a = b"part-A".to_vec();
+        let b = b"part-B".to_vec();
+        let payload_a = build_icc_segment(1, 2, &a);
+        let payload_b = build_icc_segment(2, 2, &b);
+        let mut accum = IccAccumulator::default();
+        accum
+            .ingest(parse_app2_icc_fragment(&payload_a).unwrap().unwrap())
+            .unwrap();
+        assert!(accum.try_finish().is_none(), "incomplete after 1 of 2");
+        accum
+            .ingest(parse_app2_icc_fragment(&payload_b).unwrap().unwrap())
+            .unwrap();
+        let combined = accum.try_finish().expect("complete after 2 of 2");
+        assert_eq!(combined, [a, b].concat());
+    }
+
+    /// Two-segment ICC profile reassembles when fragments arrive in
+    /// reverse order — exercises out-of-order indexing.
+    #[test]
+    fn icc_two_segments_reassemble_out_of_order() {
+        let a = b"part-A".to_vec();
+        let b = b"part-B".to_vec();
+        let payload_a = build_icc_segment(1, 2, &a);
+        let payload_b = build_icc_segment(2, 2, &b);
+        let mut accum = IccAccumulator::default();
+        accum
+            .ingest(parse_app2_icc_fragment(&payload_b).unwrap().unwrap())
+            .unwrap();
+        accum
+            .ingest(parse_app2_icc_fragment(&payload_a).unwrap().unwrap())
+            .unwrap();
+        let combined = accum.try_finish().expect("complete");
+        assert_eq!(combined, [a, b].concat());
+    }
+
+    /// Duplicate fragment seq → typed error rather than silent overwrite.
+    #[test]
+    fn icc_duplicate_fragment_rejected() {
+        let payload = build_icc_segment(1, 2, b"x");
+        let mut accum = IccAccumulator::default();
+        accum
+            .ingest(parse_app2_icc_fragment(&payload).unwrap().unwrap())
+            .unwrap();
+        let dup = parse_app2_icc_fragment(&payload).unwrap().unwrap();
+        let err = accum.ingest(dup);
+        assert!(matches!(err, Err(JpegError::Unsupported(_))));
+    }
+
+    // -----------------------------------------------------------------
+    // Resolution tests (Linux-only — depend on streamlib::sdk::color).
+    // -----------------------------------------------------------------
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_empty_color_info_returns_jfif_default() {
+        use streamlib::sdk::color::{MatrixId, PrimariesId, RangeId, TransferId};
+        let info = JpegColorInfo::default();
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(resolved.source, JpegColorSource::JfifDefault);
+        assert_eq!(resolved.info.primaries, PrimariesId::Bt709);
+        assert_eq!(resolved.info.transfer, TransferId::Srgb);
+        assert_eq!(resolved.info.matrix, MatrixId::Smpte170m);
+        assert_eq!(resolved.info.range, RangeId::Full);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_adobe_rgb_direct_collapses_matrix_to_identity() {
+        use streamlib::sdk::color::MatrixId;
+        let info = JpegColorInfo {
+            adobe: Some(AdobeMetadata {
+                transform: AdobeTransform::Direct,
+            }),
+            ..Default::default()
+        };
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(resolved.source, JpegColorSource::AdobeRgbDirect);
+        assert_eq!(resolved.info.matrix, MatrixId::Identity);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_adobe_ycbcr_equals_jfif_default() {
+        use streamlib::sdk::color::MatrixId;
+        let info = JpegColorInfo {
+            adobe: Some(AdobeMetadata {
+                transform: AdobeTransform::YCbCr,
+            }),
+            ..Default::default()
+        };
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(resolved.source, JpegColorSource::AdobeYCbCr);
+        assert_eq!(resolved.info.matrix, MatrixId::Smpte170m);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_adobe_ycck_returns_typed_error() {
+        let info = JpegColorInfo {
+            adobe: Some(AdobeMetadata {
+                transform: AdobeTransform::YCCK,
+            }),
+            ..Default::default()
+        };
+        let err = info.resolve().expect_err("YCCK must be rejected");
+        assert!(matches!(err, JpegError::Unsupported(_)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_exif_srgb_marks_source_explicitly() {
+        let info = JpegColorInfo {
+            exif_color_space: Some(ExifColorSpace::Srgb),
+            ..Default::default()
+        };
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(resolved.source, JpegColorSource::ExifSrgb);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_exif_uncalibrated_falls_back_with_unsupported_source() {
+        let info = JpegColorInfo {
+            exif_color_space: Some(ExifColorSpace::Uncalibrated),
+            ..Default::default()
+        };
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(
+            resolved.source,
+            JpegColorSource::UnsupportedDeclarationFallback
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_icc_profile_present_falls_back_with_unsupported_source() {
+        let info = JpegColorInfo {
+            icc_profile: Some(vec![0u8; 128]),
+            ..Default::default()
+        };
+        let resolved = info.resolve().expect("resolve");
+        assert_eq!(
+            resolved.source,
+            JpegColorSource::UnsupportedDeclarationFallback
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Test fixture builders — exposed for cross-module integration use
+    // via `pub(crate)` so the parser-level tests in `parser.rs` can
+    // re-use them.
+    // -----------------------------------------------------------------
+
+    pub(super) fn build_adobe_segment(transform: u8) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(ADOBE_IDENTIFIER); // "Adobe\0"
+        payload.extend_from_slice(&[0x00, 0x65]); // version (BE)
+        payload.extend_from_slice(&[0x00, 0x00]); // flags0
+        payload.extend_from_slice(&[0x00, 0x00]); // flags1
+        payload.push(transform);
+        payload
+    }
+
+    pub(super) fn build_icc_segment(seq: u8, total: u8, body: &[u8]) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(ICC_IDENTIFIER);
+        payload.push(seq);
+        payload.push(total);
+        payload.extend_from_slice(body);
+        payload
+    }
+
+    /// Build a synthetic APP1 EXIF payload with a TIFF directory
+    /// containing one ExifIFD pointer and one ColorSpace SHORT tag.
+    pub(super) fn build_exif_payload_color_space(color_space: u16, big_endian: bool) -> Vec<u8> {
+        let pack_u16 = |v: u16| -> [u8; 2] {
+            if big_endian {
+                v.to_be_bytes()
+            } else {
+                v.to_le_bytes()
+            }
+        };
+        let pack_u32 = |v: u32| -> [u8; 4] {
+            if big_endian {
+                v.to_be_bytes()
+            } else {
+                v.to_le_bytes()
+            }
+        };
+
+        // TIFF layout (offsets relative to the TIFF header start —
+        // i.e. *after* the 6-byte "Exif\0\0" identifier):
+        //   0..2  : "II" or "MM"
+        //   2..4  : 0x002A (TIFF magic)
+        //   4..8  : offset to IFD0 = 0x08 (immediately after header)
+        //   8..10 : IFD0 entry count = 1
+        //   10..22: IFD0 entry 0 — tag 0x8769 (ExifIFDPointer), LONG, count 1, value = offset to ExifIFD
+        //   22..26: IFD0 next pointer = 0 (no IFD1)
+        //   26..28: ExifIFD entry count = 1
+        //   28..40: ExifIFD entry 0 — tag 0xA001 (ColorSpace), SHORT, count 1, value
+        //   40..44: ExifIFD next pointer = 0
+        const TIFF_HEADER_LEN: u32 = 8;
+        const IFD0_ENTRY_COUNT: u32 = 1;
+        const EXIF_IFD_OFFSET: u32 = TIFF_HEADER_LEN + 2 + (IFD0_ENTRY_COUNT * 12) + 4;
+        let mut tiff = Vec::new();
+        // Header.
+        if big_endian {
+            tiff.extend_from_slice(b"MM");
+        } else {
+            tiff.extend_from_slice(b"II");
+        }
+        tiff.extend_from_slice(&pack_u16(0x002A));
+        tiff.extend_from_slice(&pack_u32(TIFF_HEADER_LEN));
+        // IFD0.
+        tiff.extend_from_slice(&pack_u16(IFD0_ENTRY_COUNT as u16));
+        tiff.extend_from_slice(&pack_u16(EXIF_TAG_EXIF_IFD_POINTER));
+        tiff.extend_from_slice(&pack_u16(4)); // LONG
+        tiff.extend_from_slice(&pack_u32(1));
+        tiff.extend_from_slice(&pack_u32(EXIF_IFD_OFFSET));
+        tiff.extend_from_slice(&pack_u32(0)); // no IFD1
+        // ExifIFD.
+        tiff.extend_from_slice(&pack_u16(1));
+        tiff.extend_from_slice(&pack_u16(EXIF_TAG_COLOR_SPACE));
+        tiff.extend_from_slice(&pack_u16(3)); // SHORT
+        tiff.extend_from_slice(&pack_u32(1));
+        let value_slot = pack_u16(color_space);
+        tiff.extend_from_slice(&value_slot);
+        tiff.extend_from_slice(&[0, 0]); // unused 2 bytes of the 4-byte value slot
+        tiff.extend_from_slice(&pack_u32(0)); // no next IFD
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(EXIF_IDENTIFIER);
+        payload.extend_from_slice(&tiff);
+        payload
+    }
+}
+

--- a/libs/vulkan-jpeg/src/color.rs
+++ b/libs/vulkan-jpeg/src/color.rs
@@ -495,11 +495,7 @@ impl JpegColorInfo {
                         "APP14 Adobe transform=2 (YCCK / 4-component CMYK) — the 3-component fused kernel cannot handle this stream",
                     ));
                 }
-                AdobeTransform::Other(raw) => {
-                    tracing::warn!(
-                        raw_transform = raw,
-                        "APP14 Adobe transform byte outside known set {{0,1,2}} — falling back to JFIF default",
-                    );
+                AdobeTransform::Other(_) => {
                     return Ok(ResolvedJpegColor {
                         info: jfif_default,
                         source: JpegColorSource::UnsupportedDeclarationFallback,
@@ -514,16 +510,10 @@ impl JpegColorInfo {
                     info: jfif_default,
                     source: JpegColorSource::ExifSrgb,
                 },
-                ExifColorSpace::Uncalibrated | ExifColorSpace::Other(_) => {
-                    tracing::warn!(
-                        ?cs,
-                        "EXIF ColorSpace declares non-sRGB primaries — the engine's `PrimariesId` enum can't represent Adobe RGB / Display P3 today; falling back to JFIF default",
-                    );
-                    ResolvedJpegColor {
-                        info: jfif_default,
-                        source: JpegColorSource::UnsupportedDeclarationFallback,
-                    }
-                }
+                ExifColorSpace::Uncalibrated | ExifColorSpace::Other(_) => ResolvedJpegColor {
+                    info: jfif_default,
+                    source: JpegColorSource::UnsupportedDeclarationFallback,
+                },
             });
         }
 
@@ -532,9 +522,6 @@ impl JpegColorInfo {
             // `Display P3` variants that the engine enum doesn't carry
             // today. Parse, surface, fall back to JFIF — a future engine
             // extension is the right place to honor non-sRGB profiles.
-            tracing::warn!(
-                "ICC profile present but engine `PrimariesId` cannot represent non-sRGB primaries today; falling back to JFIF default",
-            );
             return Ok(ResolvedJpegColor {
                 info: jfif_default,
                 source: JpegColorSource::UnsupportedDeclarationFallback,

--- a/libs/vulkan-jpeg/src/color.rs
+++ b/libs/vulkan-jpeg/src/color.rs
@@ -495,7 +495,11 @@ impl JpegColorInfo {
                         "APP14 Adobe transform=2 (YCCK / 4-component CMYK) — the 3-component fused kernel cannot handle this stream",
                     ));
                 }
-                AdobeTransform::Other(_) => {
+                AdobeTransform::Other(raw) => {
+                    tracing::warn!(
+                        raw_transform = raw,
+                        "APP14 Adobe transform byte outside known set {{0,1,2}} — falling back to JFIF default",
+                    );
                     return Ok(ResolvedJpegColor {
                         info: jfif_default,
                         source: JpegColorSource::UnsupportedDeclarationFallback,
@@ -510,10 +514,16 @@ impl JpegColorInfo {
                     info: jfif_default,
                     source: JpegColorSource::ExifSrgb,
                 },
-                ExifColorSpace::Uncalibrated | ExifColorSpace::Other(_) => ResolvedJpegColor {
-                    info: jfif_default,
-                    source: JpegColorSource::UnsupportedDeclarationFallback,
-                },
+                ExifColorSpace::Uncalibrated | ExifColorSpace::Other(_) => {
+                    tracing::warn!(
+                        ?cs,
+                        "EXIF ColorSpace declares non-sRGB primaries — the engine's `PrimariesId` enum can't represent Adobe RGB / Display P3 today; falling back to JFIF default",
+                    );
+                    ResolvedJpegColor {
+                        info: jfif_default,
+                        source: JpegColorSource::UnsupportedDeclarationFallback,
+                    }
+                }
             });
         }
 
@@ -522,6 +532,9 @@ impl JpegColorInfo {
             // `Display P3` variants that the engine enum doesn't carry
             // today. Parse, surface, fall back to JFIF — a future engine
             // extension is the right place to honor non-sRGB profiles.
+            tracing::warn!(
+                "ICC profile present but engine `PrimariesId` cannot represent non-sRGB primaries today; falling back to JFIF default",
+            );
             return Ok(ResolvedJpegColor {
                 info: jfif_default,
                 source: JpegColorSource::UnsupportedDeclarationFallback,

--- a/libs/vulkan-jpeg/src/header.rs
+++ b/libs/vulkan-jpeg/src/header.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use crate::color::JpegColorInfo;
 use crate::huffman::HuffmanTable;
 
 /// Parsed SOF0 frame header.
@@ -91,6 +92,11 @@ pub struct DecodedJpeg {
     pub scan: ScanHeader,
     pub components: Vec<ComponentScan>,
     pub restart_interval: u16,
+    /// APP-segment-derived color metadata. Carries JFIF / Adobe APP14
+    /// / EXIF ColorSpace / ICC profile bytes when present. Empty
+    /// `JpegColorInfo::default()` indicates none were found — JFIF
+    /// defaults apply by convention.
+    pub color_info: JpegColorInfo,
 }
 
 impl DecodedJpeg {

--- a/libs/vulkan-jpeg/src/kernel.rs
+++ b/libs/vulkan-jpeg/src/kernel.rs
@@ -269,6 +269,20 @@ impl JpegDecodeKernel {
         // the matrix + range_offset + transfer math is sourced from one
         // place (the JPEG kernel and the engine color converter end up
         // with bit-identical fields when fed the same `ResolvedColorInfo`).
+        //
+        // `dst_transfer = TransferId::Srgb` matches the kernel's
+        // `Rgba8Unorm` output texture by convention — 8-bit unorm
+        // displays are sRGB-encoded. Every resolution path today
+        // (JFIF / Adobe / EXIF sRGB / fallback) returns
+        // `info.transfer = Srgb` too, so the shader bypasses the
+        // transfer-function chain via `transfer_in == transfer_out`.
+        // Once non-sRGB transfer characteristics start being honored
+        // (e.g. ICC-profile-driven `Bt709`), the shader will start
+        // running the EOTF/OETF closed-forms automatically — and this
+        // hardcoded `Srgb` output curve becomes the place to revisit
+        // if the JPEG kernel's downstream consumer ever wants linear
+        // or HDR output instead.
+        //
         // `SourceLayoutInfo` carries plane-stride metadata that the JPEG
         // kernel ignores (it walks coefficients via its own offsets) —
         // pass tight strides for the resolved dimensions; the kernel

--- a/libs/vulkan-jpeg/src/kernel.rs
+++ b/libs/vulkan-jpeg/src/kernel.rs
@@ -12,12 +12,14 @@
 
 use std::sync::Arc;
 
+use streamlib::sdk::color::{ResolvedColorInfo, TransferId};
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanBuffer, HostVulkanDevice, VulkanComputeKernel,
 };
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::rhi::{
-    ComputeBindingSpec, ComputeKernelDescriptor, StorageBuffer, Texture,
+    ColorConverterPushConstants, ComputeBindingSpec, ComputeKernelDescriptor, SourceLayoutInfo,
+    StorageBuffer, Texture,
 };
 
 use crate::header::DecodedJpeg;
@@ -47,8 +49,11 @@ const BINDINGS: &[ComputeBindingSpec] = &[
 
 /// Push constants matching the GLSL `PushConstants` block.
 ///
-/// `std430` layout: nine `uint`s packed contiguously. 36 bytes, well
-/// under Vulkan's spec-minimum 128-byte push-constant range.
+/// `std430` layout: nine JPEG-geometry `uint`s, three `_pad` slots to
+/// align the first `vec4` to a 16-byte boundary, then the same matrix
+/// `+` range_offset `+` transfer/flags shape as
+/// [`ColorConverterPushConstants`]. Total 128 bytes — at Vulkan's
+/// spec-minimum push-constant range.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct JpegDecodePushConstants {
@@ -61,9 +66,28 @@ struct JpegDecodePushConstants {
     cb_coef_offset: u32,
     cr_coef_offset: u32,
     chroma_qtable_offset: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+    matrix_row0: [f32; 4],
+    matrix_row1: [f32; 4],
+    matrix_row2: [f32; 4],
+    range_offset: [f32; 4],
+    transfer_in: u32,
+    transfer_out: u32,
+    flags: u32,
+    _pad3: u32,
 }
 
 const PUSH_CONSTANT_SIZE: u32 = std::mem::size_of::<JpegDecodePushConstants>() as u32;
+
+/// Compile-time check that the push-constant block matches the shader's
+/// 128-byte `layout(push_constant)` range.
+const _: () = assert!(
+    PUSH_CONSTANT_SIZE as usize == 128,
+    "JpegDecodePushConstants must stay at 128 bytes — update the shader's \
+     push_constant block before regenerating SPIR-V"
+);
 
 /// Fused JPEG decode kernel.
 pub struct JpegDecodeKernel {
@@ -99,6 +123,12 @@ impl JpegDecodeKernel {
     /// contract as every other `VulkanComputeKernel` consumer in the
     /// engine).
     ///
+    /// `color_info` drives the YCbCr → RGB matrix / range_offset /
+    /// transfer push constants — typically resolved from
+    /// `decoded.color_info.resolve()`; pass the JFIF default
+    /// (`(Bt709, Srgb, Smpte170m, Full)`) when the source is known to
+    /// be canonical JFIF.
+    ///
     /// Allocates per-call HOST_VISIBLE storage buffers for the coefficient
     /// and quant-table uploads, copies the data in, binds, dispatches, and
     /// waits on the kernel's fence before returning. This is the one-shot
@@ -106,7 +136,12 @@ impl JpegDecodeKernel {
     /// the kernel-level integration test); steady-state hot-path callers
     /// should ride [`Self::dispatch_pooled`] through
     /// [`crate::SimpleJpegDecoder`] instead.
-    pub fn dispatch(&self, decoded: &DecodedJpeg, output_texture: &Texture) -> Result<()> {
+    pub fn dispatch(
+        &self,
+        decoded: &DecodedJpeg,
+        output_texture: &Texture,
+        color_info: &ResolvedColorInfo,
+    ) -> Result<()> {
         let layout = JpegBufferLayout::from_decoded(decoded)?;
         let coef_words = layout.pack_coefficients(decoded);
         let qt_words = layout.pack_quant_tables(decoded)?;
@@ -123,7 +158,14 @@ impl JpegDecodeKernel {
             qt_bytes.len() as u64,
         )?);
 
-        self.dispatch_with_buffers(decoded, &layout, output_texture, &coef_buf, &qt_buf)
+        self.dispatch_with_buffers(
+            decoded,
+            &layout,
+            output_texture,
+            &coef_buf,
+            &qt_buf,
+            color_info,
+        )
     }
 
     /// Decode `decoded` into `output_texture` using caller-supplied
@@ -138,6 +180,8 @@ impl JpegDecodeKernel {
     /// returns a typed error if too small, so undersized buffers can't
     /// silently corrupt output.
     ///
+    /// `color_info` semantics match [`Self::dispatch`].
+    ///
     /// Same per-call texture contract as [`Self::dispatch`]: `output_texture`
     /// must be an `Rgba8Unorm` storage image in `GENERAL` layout.
     pub fn dispatch_pooled(
@@ -146,9 +190,17 @@ impl JpegDecodeKernel {
         output_texture: &Texture,
         coef_buf: &Arc<HostVulkanBuffer>,
         qt_buf: &Arc<HostVulkanBuffer>,
+        color_info: &ResolvedColorInfo,
     ) -> Result<()> {
         let layout = JpegBufferLayout::from_decoded(decoded)?;
-        self.dispatch_with_buffers(decoded, &layout, output_texture, coef_buf, qt_buf)
+        self.dispatch_with_buffers(
+            decoded,
+            &layout,
+            output_texture,
+            coef_buf,
+            qt_buf,
+            color_info,
+        )
     }
 
     /// Shared dispatch tail: pack coefficients + quant tables into the
@@ -162,6 +214,7 @@ impl JpegDecodeKernel {
         output_texture: &Texture,
         coef_buf: &Arc<HostVulkanBuffer>,
         qt_buf: &Arc<HostVulkanBuffer>,
+        color_info: &ResolvedColorInfo,
     ) -> Result<()> {
         // Pack i16 coefficients into i32 SSBO words. Sign-extension is
         // implicit in `i32::from(i16)`. Quant tables go u16 -> u32 with
@@ -212,9 +265,27 @@ impl JpegDecodeKernel {
         self.kernel.set_storage_buffer(1, &qt_storage)?;
         self.kernel.set_storage_image(2, output_texture)?;
 
+        // Build the color-side push constants via the engine helper so
+        // the matrix + range_offset + transfer math is sourced from one
+        // place (the JPEG kernel and the engine color converter end up
+        // with bit-identical fields when fed the same `ResolvedColorInfo`).
+        // `SourceLayoutInfo` carries plane-stride metadata that the JPEG
+        // kernel ignores (it walks coefficients via its own offsets) —
+        // pass tight strides for the resolved dimensions; the kernel
+        // never reads these slots.
+        let width = u32::from(decoded.frame.width);
+        let height = u32::from(decoded.frame.height);
+        let color_pc = ColorConverterPushConstants::from_resolved(
+            color_info,
+            TransferId::Srgb,
+            width,
+            height,
+            SourceLayoutInfo::nv12_tight(width, height),
+        );
+
         let push = JpegDecodePushConstants {
-            width: u32::from(decoded.frame.width),
-            height: u32::from(decoded.frame.height),
+            width,
+            height,
             y_blocks_h: layout.y_blocks_h,
             y_blocks_v: layout.y_blocks_v,
             chroma_blocks_h: layout.chroma_blocks_h,
@@ -222,6 +293,17 @@ impl JpegDecodeKernel {
             cb_coef_offset: layout.cb_coef_offset,
             cr_coef_offset: layout.cr_coef_offset,
             chroma_qtable_offset: layout.chroma_qtable_offset,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+            matrix_row0: color_pc.matrix_row0,
+            matrix_row1: color_pc.matrix_row1,
+            matrix_row2: color_pc.matrix_row2,
+            range_offset: color_pc.range_offset,
+            transfer_in: color_pc.transfer_in,
+            transfer_out: color_pc.transfer_out,
+            flags: color_pc.flags,
+            _pad3: 0,
         };
         self.kernel.set_push_constants_value(&push)?;
 

--- a/libs/vulkan-jpeg/src/lib.rs
+++ b/libs/vulkan-jpeg/src/lib.rs
@@ -13,6 +13,7 @@
 //!   caller-supplied `rgba8` storage image.
 
 mod bit_reader;
+pub mod color;
 mod error;
 mod header;
 mod huffman;
@@ -25,6 +26,11 @@ pub mod kernel;
 #[cfg(target_os = "linux")]
 pub mod simple_decoder;
 
+pub use color::{
+    AdobeMetadata, AdobeTransform, ExifColorSpace, JfifMetadata, JpegColorInfo,
+};
+#[cfg(target_os = "linux")]
+pub use color::{JpegColorSource, ResolvedJpegColor};
 pub use error::{JpegError, JpegResult};
 pub use header::{
     ComponentScan, DecodedJpeg, FrameComponent, FrameHeader, QuantizationTable, ScanComponent,
@@ -53,6 +59,7 @@ pub fn decode(bytes: &[u8]) -> JpegResult<DecodedJpeg> {
         scan,
         restart_interval,
         entropy_data,
+        color_info,
     } = parser::parse_headers(bytes)?;
 
     // Sanity-check that every component's quant table is present.
@@ -81,5 +88,6 @@ pub fn decode(bytes: &[u8]) -> JpegResult<DecodedJpeg> {
         scan,
         components,
         restart_interval,
+        color_info,
     })
 }

--- a/libs/vulkan-jpeg/src/marker.rs
+++ b/libs/vulkan-jpeg/src/marker.rs
@@ -13,6 +13,11 @@ pub const DHT: u8 = 0xC4;
 pub const DRI: u8 = 0xDD;
 pub const COM: u8 = 0xFE;
 
+pub const APP0: u8 = 0xE0;
+pub const APP1: u8 = 0xE1;
+pub const APP2: u8 = 0xE2;
+pub const APP14: u8 = 0xEE;
+
 pub const SOF0: u8 = 0xC0;
 pub const SOF1: u8 = 0xC1;
 pub const SOF2: u8 = 0xC2;

--- a/libs/vulkan-jpeg/src/parser.rs
+++ b/libs/vulkan-jpeg/src/parser.rs
@@ -1,6 +1,10 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use crate::color::{
+    parse_app0, parse_app14_adobe, parse_app1_exif_color_space, parse_app2_icc_fragment,
+    IccAccumulator, JpegColorInfo,
+};
 use crate::error::{JpegError, JpegResult};
 use crate::header::{
     FrameComponent, FrameHeader, HuffmanTables, QuantizationTable, ScanComponent, ScanHeader,
@@ -17,6 +21,7 @@ pub(crate) struct ParsedHeaders<'a> {
     pub scan: ScanHeader,
     pub restart_interval: u16,
     pub entropy_data: &'a [u8],
+    pub color_info: JpegColorInfo,
 }
 
 /// Walk a JPEG bitstream from SOI through SOS, returning the parsed
@@ -29,6 +34,8 @@ pub(crate) fn parse_headers(bytes: &[u8]) -> JpegResult<ParsedHeaders<'_>> {
     let mut huffman = HuffmanTables::default();
     let mut frame: Option<FrameHeader> = None;
     let mut restart_interval: u16 = 0;
+    let mut color_info = JpegColorInfo::default();
+    let mut icc_accum = IccAccumulator::default();
 
     loop {
         let marker_byte = parser.next_marker()?;
@@ -46,6 +53,12 @@ pub(crate) fn parse_headers(bytes: &[u8]) -> JpegResult<ParsedHeaders<'_>> {
                 let frame = frame.take().ok_or(JpegError::MissingSof)?;
                 let scan = parser.parse_sos(&frame)?;
                 let entropy_data = &bytes[parser.cursor..];
+                // Cache the finished ICC profile (if any) before
+                // handing the result to the caller. Incomplete
+                // multi-segment ICC data is discarded silently —
+                // the spec allows partial profiles but the kernel
+                // can't act on them.
+                color_info.icc_profile = icc_accum.try_finish();
                 return Ok(ParsedHeaders {
                     frame,
                     quant_tables,
@@ -53,10 +66,35 @@ pub(crate) fn parse_headers(bytes: &[u8]) -> JpegResult<ParsedHeaders<'_>> {
                     scan,
                     restart_interval,
                     entropy_data,
+                    color_info,
                 });
             }
             marker::EOI => return Err(JpegError::MissingSos),
             marker::COM => parser.skip_segment(marker_byte)?,
+            marker::APP0 => {
+                let payload = parser.read_segment_payload(marker::APP0)?;
+                if let Some(jfif) = parse_app0(payload)? {
+                    color_info.jfif = Some(jfif);
+                }
+            }
+            marker::APP1 => {
+                let payload = parser.read_segment_payload(marker::APP1)?;
+                if let Some(cs) = parse_app1_exif_color_space(payload)? {
+                    color_info.exif_color_space = Some(cs);
+                }
+            }
+            marker::APP2 => {
+                let payload = parser.read_segment_payload(marker::APP2)?;
+                if let Some(fragment) = parse_app2_icc_fragment(payload)? {
+                    icc_accum.ingest(fragment)?;
+                }
+            }
+            marker::APP14 => {
+                let payload = parser.read_segment_payload(marker::APP14)?;
+                if let Some(adobe) = parse_app14_adobe(payload)? {
+                    color_info.adobe = Some(adobe);
+                }
+            }
             other if marker::is_app(other) => parser.skip_segment(other)?,
             other => {
                 if let Some(reason) = marker::is_unsupported_sof(other) {

--- a/libs/vulkan-jpeg/src/shaders/jpeg_decode.comp
+++ b/libs/vulkan-jpeg/src/shaders/jpeg_decode.comp
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Fused JPEG decode compute kernel: dequantize -> 8x8 IDCT -> 4:2:0 chroma
-// upsample (nearest) -> BT.601 full-range YCbCr -> RGB -> write rgba8 storage
-// image. One thread per output pixel; each thread independently dequantizes
-// and runs the 2D IDCT for the Y, Cb, Cr blocks covering its pixel.
+// upsample (nearest) -> YCbCr -> RGB -> write rgba8 storage image. One thread
+// per output pixel; each thread independently dequantizes and runs the 2D
+// IDCT for the Y, Cb, Cr blocks covering its pixel.
+//
+// Color conversion delegates to `convert_color()` in `color_convert_common.glsl`
+// (engine shader tree) — the matrix / range_offset / transfer curve are driven
+// by per-dispatch push constants the host fills from a `ResolvedColorInfo`.
+// The "JFIF BT.601-full -> sRGB primaries" default is one branch among many,
+// not hardcoded shader math.
 //
 // Per-thread IDCT is intentionally naive (64 cosine-product accumulations per
 // sample, times 3 planes = 192 per output pixel). Plenty fast for the
@@ -21,6 +27,9 @@
 // matching the coefficient layout.
 
 #version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "color_convert_common.glsl"
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
@@ -34,7 +43,12 @@ layout(set = 0, binding = 1, std430) readonly buffer QuantTables {
 
 layout(set = 0, binding = 2, rgba8) uniform writeonly image2D output_image;
 
-layout(push_constant) uniform PushConstants {
+// Layout matches `kernel.rs::JpegDecodePushConstants` (std430).
+// JPEG geometry comes first (the kernel only fields), color follows
+// (mirrors `ColorConverterPushConstants`'s shape exactly). The three
+// `_pad` slots after the JPEG block align the first `vec4` to a 16-byte
+// boundary per std430.
+layout(push_constant, std430) uniform PushConstants {
     uint width;
     uint height;
     uint y_blocks_h;
@@ -44,6 +58,17 @@ layout(push_constant) uniform PushConstants {
     uint cb_coef_offset;
     uint cr_coef_offset;
     uint chroma_qtable_offset;
+    uint _pad0;
+    uint _pad1;
+    uint _pad2;
+    vec4 matrix_row0;
+    vec4 matrix_row1;
+    vec4 matrix_row2;
+    vec4 range_offset;
+    uint transfer_in;
+    uint transfer_out;
+    uint flags;
+    uint _pad3;
 } pc;
 
 // ITU-T T.81 Figure A.6 zig-zag scan order. `ZIGZAG[zz]` returns the
@@ -114,41 +139,41 @@ void main() {
     uint chroma_in_x = (px & 15u) >> 1;
     uint chroma_in_y = (py & 15u) >> 1;
 
-    // JPEG level shift: +128 to lift signed IDCT result into [0, 255].
-    float y_sample = idct_sample(
+    // JPEG level shift: +128 lifts the signed IDCT result into [0, 255].
+    // For YCbCr sources this is the Y/Cb/Cr byte-domain triple `convert_color`
+    // operates on. For RGB-direct sources (APP14 transform=0, matrix=Identity)
+    // the IDCT outputs are already R/G/B byte-domain samples with the same
+    // +128 level shift — the Identity matrix + zero range_offset on the host
+    // side passes them through cleanly.
+    float y_or_r = idct_sample(
         0u, 0u,
         pc.y_blocks_h,
         y_block_x, y_block_y,
         y_in_x, y_in_y
     ) + 128.0;
-    float cb_sample = idct_sample(
+    float cb_or_g = idct_sample(
         pc.cb_coef_offset, pc.chroma_qtable_offset,
         pc.chroma_blocks_h,
         chroma_block_x, chroma_block_y,
         chroma_in_x, chroma_in_y
     ) + 128.0;
-    float cr_sample = idct_sample(
+    float cr_or_b = idct_sample(
         pc.cr_coef_offset, pc.chroma_qtable_offset,
         pc.chroma_blocks_h,
         chroma_block_x, chroma_block_y,
         chroma_in_x, chroma_in_y
     ) + 128.0;
 
-    // BT.601 full-range (JFIF) YCbCr -> RGB. Source-of-truth coefficients
-    // hardcoded here to keep the shader independent of the engine's
-    // `core::color::matrix` Rust code; the CPU reference in the test
-    // mirrors the same constants independently.
-    float cb_centered = cb_sample - 128.0;
-    float cr_centered = cr_sample - 128.0;
-    float r = y_sample + 1.402 * cr_centered;
-    float g = y_sample - 0.344136 * cb_centered - 0.714136 * cr_centered;
-    float b = y_sample + 1.772 * cb_centered;
-
-    vec4 rgba = vec4(
-        clamp(r, 0.0, 255.0) / 255.0,
-        clamp(g, 0.0, 255.0) / 255.0,
-        clamp(b, 0.0, 255.0) / 255.0,
-        1.0
+    vec3 rgb = convert_color(
+        vec3(y_or_r, cb_or_g, cr_or_b),
+        pc.matrix_row0.xyz,
+        pc.matrix_row1.xyz,
+        pc.matrix_row2.xyz,
+        pc.range_offset.xyz,
+        pc.transfer_in,
+        pc.transfer_out,
+        pc.flags
     );
-    imageStore(output_image, ivec2(int(px), int(py)), rgba);
+
+    imageStore(output_image, ivec2(int(px), int(py)), vec4(rgb, 1.0));
 }

--- a/libs/vulkan-jpeg/src/simple_decoder.rs
+++ b/libs/vulkan-jpeg/src/simple_decoder.rs
@@ -13,8 +13,10 @@
 //! texture creation, zero command-pool / cb / fence creation in steady
 //! state.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use streamlib::sdk::color::ResolvedColorInfo;
 use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanBuffer, RhiCommandRecorder, VulkanAccess, VulkanStage,
@@ -23,6 +25,7 @@ use streamlib::sdk::engine::HostGpuDeviceExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::rhi::{Texture, TextureFormat, TextureUsages, VulkanLayout};
 
+use crate::color::{JpegColorInfo, JpegColorSource};
 use crate::kernel::{
     worst_case_coefficient_buffer_bytes_420, JpegDecodeKernel, QUANT_TABLE_BUFFER_BYTES,
 };
@@ -48,6 +51,17 @@ pub struct JpegDecodeOutput {
     pub width: u32,
     /// Decoded frame height, in pixels. Always ≤ `max_height`.
     pub height: u32,
+    /// Which APP-segment declaration drove the colorimetry decision
+    /// for this frame. `UnsupportedDeclarationFallback` means the
+    /// bitstream declared a colorimetry the engine can't represent
+    /// yet (Adobe RGB / Display P3 / Rec.2020 via EXIF or ICC) and
+    /// the kernel decoded under the JFIF default instead.
+    pub color_source: JpegColorSource,
+    /// Resolved 4-tuple the kernel actually used for this frame.
+    /// Cheap to compare; surfaces the dispatched matrix / range /
+    /// transfer / primaries for downstream consumers that want to
+    /// reason about the color decision per frame.
+    pub color_info: ResolvedColorInfo,
 }
 
 /// High-level fused-compute JPEG decoder with pre-allocated GPU
@@ -60,6 +74,12 @@ pub struct SimpleJpegDecoder {
     ring: Arc<TextureRing>,
     max_width: u32,
     max_height: u32,
+    /// Latch for the "non-sRGB declaration → JFIF fallback" warning.
+    /// Flips to `true` on the first frame that takes the fallback;
+    /// subsequent fallback frames stay silent so a 30 Hz pipeline
+    /// doesn't flood the log. Resetting to `false` re-arms the warn
+    /// (e.g. across a teardown / rebuild cycle).
+    unsupported_fallback_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for SimpleJpegDecoder {
@@ -158,6 +178,7 @@ impl SimpleJpegDecoder {
             ring,
             max_width,
             max_height,
+            unsupported_fallback_warned: AtomicBool::new(false),
         })
     }
 
@@ -189,11 +210,17 @@ impl SimpleJpegDecoder {
         // (YCCK) bubbles up as `Error::NotSupported` here — the kernel only
         // handles 3-component YCbCr / RGB-direct decode. EXIF / ICC
         // declarations the engine can't yet represent fall back to JFIF
-        // default with a tracing::warn from inside `resolve()`.
+        // default and surface as `JpegColorSource::UnsupportedDeclarationFallback`
+        // on the output, plus a one-shot `tracing::warn!` per decoder
+        // instance.
         let resolved = decoded
             .color_info
             .resolve()
             .map_err(|e| Error::GpuError(format!("jpeg colorimetry: {e}")))?;
+
+        if resolved.source == JpegColorSource::UnsupportedDeclarationFallback {
+            self.warn_unsupported_fallback_once(&decoded.color_info);
+        }
 
         let slot = self.ring.acquire_next();
         self.kernel.dispatch_pooled(
@@ -209,7 +236,35 @@ impl SimpleJpegDecoder {
             surface_id: slot.surface_id,
             width,
             height,
+            color_source: resolved.source,
+            color_info: resolved.info,
         })
+    }
+
+    /// Emit a structured `tracing::warn!` describing the first frame
+    /// where this decoder's input declared a non-sRGB colorimetry that
+    /// the engine can't honor yet. Subsequent fallback frames stay
+    /// silent — the latch fires once per decoder instance.
+    ///
+    /// The warn uses the stable target `vulkan_jpeg::colorimetry_fallback`
+    /// so an AGP-style runtime can `grep`/filter for it cleanly. Carries
+    /// the parsed APP-segment fields so the operator can tell which
+    /// declaration tripped the fallback (Adobe `transform=Other` /
+    /// EXIF Uncalibrated / ICC profile bytes).
+    fn warn_unsupported_fallback_once(&self, info: &JpegColorInfo) {
+        if self
+            .unsupported_fallback_warned
+            .swap(true, Ordering::Relaxed)
+        {
+            return;
+        }
+        tracing::warn!(
+            target: "vulkan_jpeg::colorimetry_fallback",
+            adobe_transform = ?info.adobe.map(|a| a.transform),
+            exif_color_space = ?info.exif_color_space,
+            icc_profile_bytes = info.icc_profile.as_ref().map(|p| p.len()),
+            "JPEG stream declares non-sRGB colorimetry the engine `PrimariesId` enum can't represent yet (Adobe RGB / Display P3 / Rec.2020); decoded under the JFIF default. Extend `PrimariesId` to honor it.",
+        );
     }
 
     /// Borrow the underlying [`TextureRing`] — for tests and

--- a/libs/vulkan-jpeg/src/simple_decoder.rs
+++ b/libs/vulkan-jpeg/src/simple_decoder.rs
@@ -185,9 +185,24 @@ impl SimpleJpegDecoder {
             )));
         }
 
+        // Honor declared colorimetry from APP segments. APP14 transform=2
+        // (YCCK) bubbles up as `Error::NotSupported` here — the kernel only
+        // handles 3-component YCbCr / RGB-direct decode. EXIF / ICC
+        // declarations the engine can't yet represent fall back to JFIF
+        // default with a tracing::warn from inside `resolve()`.
+        let resolved = decoded
+            .color_info
+            .resolve()
+            .map_err(|e| Error::GpuError(format!("jpeg colorimetry: {e}")))?;
+
         let slot = self.ring.acquire_next();
-        self.kernel
-            .dispatch_pooled(&decoded, &slot.texture, &self.coef_buf, &self.qt_buf)?;
+        self.kernel.dispatch_pooled(
+            &decoded,
+            &slot.texture,
+            &self.coef_buf,
+            &self.qt_buf,
+            &resolved.info,
+        )?;
 
         Ok(JpegDecodeOutput {
             texture: slot.texture,

--- a/libs/vulkan-jpeg/tests/gpu_decode.rs
+++ b/libs/vulkan-jpeg/tests/gpu_decode.rs
@@ -27,6 +27,7 @@
 use std::sync::Arc;
 
 use jpeg_encoder::{ColorType, Encoder, SamplingFactor};
+use streamlib::sdk::color::{MatrixId, PrimariesId, RangeId, ResolvedColorInfo, TransferId};
 use streamlib::sdk::engine::HostTextureExt;
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanDevice, HostVulkanTexture, RhiCommandRecorder, VulkanAccess, VulkanStage,
@@ -36,7 +37,10 @@ use streamlib::sdk::rhi::{
     Texture, TextureDescriptor, TextureFormat, TextureReadbackDescriptor, TextureSourceLayout,
     TextureUsages, VulkanLayout,
 };
-use vulkan_jpeg::{decode, ComponentScan, DecodedJpeg, JpegDecodeKernel, QuantizationTable, ZIGZAG};
+use vulkan_jpeg::{
+    decode, AdobeTransform, ComponentScan, DecodedJpeg, JpegColorSource, JpegDecodeKernel,
+    QuantizationTable, ZIGZAG,
+};
 
 const QUALITY: u8 = 85;
 const TEST_WIDTH: u16 = 64;
@@ -80,8 +84,11 @@ fn gpu_decode_matches_cpu_reference_psnr_50db() {
         u32::from(TEST_HEIGHT),
     );
     let kernel = JpegDecodeKernel::new(&device).expect("kernel construction");
+    // No APP segments → JFIF default resolves to BT.601-Full / sRGB.
+    let resolved = decoded.color_info.resolve().expect("resolve color");
+    assert_eq!(resolved.source, JpegColorSource::JfifDefault);
     kernel
-        .dispatch(&decoded, &texture)
+        .dispatch(&decoded, &texture, &resolved.info)
         .expect("kernel dispatch");
     let gpu_rgba = readback_texture(&device, &texture, TEST_WIDTH, TEST_HEIGHT);
 
@@ -331,4 +338,247 @@ fn y_channel_psnr_db(reference: &[u8], actual: &[u8]) -> f64 {
     }
     let mse = sum_sq_err / count as f64;
     10.0 * (255.0f64 * 255.0 / mse).log10()
+}
+
+// ---------------------------------------------------------------------------
+// APP14 transform=0 (RGB-direct) tests
+// ---------------------------------------------------------------------------
+//
+// These tests verify that when the bitstream's APP14 marker declares
+// transform=0 (RGB-direct, no YCbCr↔RGB matrix), the kernel honors the
+// declaration by collapsing the matrix axis to `MatrixId::Identity` —
+// the IDCT samples pass through to RGB without the BT.601 mix-down that
+// JFIF assumes.
+//
+// Test pattern: encode an RGB image through `jpeg-encoder` (produces a
+// JFIF YCbCr bitstream), splice an APP14 transform=0 segment between SOI
+// and SOF0, then verify GPU-vs-CPU agreement on the resulting (intentionally
+// abnormal) decode. Both sides use the same `Identity` matrix; both produce
+// the *same* "what RGB would the IDCT samples look like if we treated them
+// as RGB-direct" output. PSNR is the GPU↔CPU agreement, not the GPU↔source
+// agreement — the test's job is to lock that the GPU honors the declared
+// colorimetry, NOT that any particular RGB image came out.
+
+/// Positive E2E test: APP14 transform=0 fixture decoded through the
+/// Identity-matrix path matches a CPU reference that uses the same
+/// Identity matrix.
+///
+/// Mentally revert the kernel's `color_info.resolve()` plumbing
+/// (force-passing the JFIF default) and this test fails — the GPU side
+/// applies Smpte170m, the CPU side applies Identity, and the per-pixel
+/// RGB triples diverge by hundreds of LSBs.
+#[test]
+fn app14_transform_zero_rgb_direct_matches_cpu_reference_psnr_50db() {
+    let Some(device) = HostVulkanDevice::new().ok().map(Arc::new) else {
+        return;
+    };
+
+    let rgb = synthesize_test_image(TEST_WIDTH, TEST_HEIGHT);
+    let baseline = encode_jpeg_rgb_420(TEST_WIDTH, TEST_HEIGHT, &rgb, QUALITY);
+    let spliced = splice_app14_after_soi(&baseline, /* transform */ 0);
+
+    let decoded = decode(&spliced).expect("parse + huffman decode of spliced bitstream");
+    assert_eq!(decoded.frame.width, TEST_WIDTH);
+    assert_eq!(decoded.frame.height, TEST_HEIGHT);
+    assert!(
+        matches!(
+            decoded.color_info.adobe,
+            Some(vulkan_jpeg::AdobeMetadata {
+                transform: AdobeTransform::Direct
+            })
+        ),
+        "splice failed: APP14 transform=0 must reach the parser",
+    );
+
+    // CPU reference uses Identity (matches the Adobe-RGB-direct branch).
+    let cpu_rgba = cpu_reference_decode_identity(&decoded);
+
+    // GPU path: resolve from the parsed metadata, dispatch, read back.
+    let texture = allocate_storage_texture_general(
+        &device,
+        u32::from(TEST_WIDTH),
+        u32::from(TEST_HEIGHT),
+    );
+    let kernel = JpegDecodeKernel::new(&device).expect("kernel construction");
+    let resolved = decoded.color_info.resolve().expect("resolve");
+    assert_eq!(resolved.source, JpegColorSource::AdobeRgbDirect);
+    assert_eq!(resolved.info.matrix, MatrixId::Identity);
+
+    kernel
+        .dispatch(&decoded, &texture, &resolved.info)
+        .expect("kernel dispatch");
+    let gpu_rgba = readback_texture(&device, &texture, TEST_WIDTH, TEST_HEIGHT);
+
+    let psnr = y_channel_psnr_db(&cpu_rgba, &gpu_rgba);
+    tracing::info!(
+        psnr_db = psnr,
+        floor_db = PSNR_FLOOR_DB,
+        "APP14 transform=0 GPU vs CPU Y-channel PSNR",
+    );
+    assert!(
+        psnr >= PSNR_FLOOR_DB,
+        "Y-channel PSNR {psnr:.2} dB fell below floor {PSNR_FLOOR_DB} dB \
+         — GPU did not honor APP14 transform=0 (Identity matrix path)",
+    );
+}
+
+/// Negative E2E test: forcing the kernel to interpret an APP14
+/// transform=0 fixture as JFIF (Smpte170m) must produce GPU output that
+/// disagrees with the CPU reference (which uses Identity).
+///
+/// Proves the gate is non-vacuous: if the kernel started ignoring the
+/// `ResolvedColorInfo` argument entirely (e.g. hardcoding Smpte170m on
+/// the GPU side), this test would pass against the JFIF CPU reference
+/// — so a stricter PSNR floor on the comparison the test *actually*
+/// runs is what catches it.
+///
+/// The test asserts the GPU output (run with the wrong, JFIF-forced
+/// `ResolvedColorInfo`) is FAR from the Identity-matrix CPU reference,
+/// which is what the bitstream actually declared.
+#[test]
+fn app14_transform_zero_forced_jfif_interpretation_drops_psnr() {
+    let Some(device) = HostVulkanDevice::new().ok().map(Arc::new) else {
+        return;
+    };
+
+    let rgb = synthesize_test_image(TEST_WIDTH, TEST_HEIGHT);
+    let baseline = encode_jpeg_rgb_420(TEST_WIDTH, TEST_HEIGHT, &rgb, QUALITY);
+    let spliced = splice_app14_after_soi(&baseline, /* transform */ 0);
+
+    let decoded = decode(&spliced).expect("parse + huffman decode");
+
+    // CPU reference reflects what the bitstream DECLARED (RGB-direct).
+    let cpu_rgba_truth = cpu_reference_decode_identity(&decoded);
+
+    // GPU forced into JFIF (Smpte170m) interpretation — IGNORING the
+    // resolved info. This is what would happen if the kernel were
+    // hardcoded back to BT.601-Full.
+    let jfif_force = ResolvedColorInfo {
+        primaries: PrimariesId::Bt709,
+        transfer: TransferId::Srgb,
+        matrix: MatrixId::Smpte170m,
+        range: RangeId::Full,
+    };
+
+    let texture = allocate_storage_texture_general(
+        &device,
+        u32::from(TEST_WIDTH),
+        u32::from(TEST_HEIGHT),
+    );
+    let kernel = JpegDecodeKernel::new(&device).expect("kernel construction");
+    kernel
+        .dispatch(&decoded, &texture, &jfif_force)
+        .expect("kernel dispatch");
+    let gpu_rgba = readback_texture(&device, &texture, TEST_WIDTH, TEST_HEIGHT);
+
+    let psnr = y_channel_psnr_db(&cpu_rgba_truth, &gpu_rgba);
+    tracing::info!(
+        psnr_db = psnr,
+        "APP14 transform=0 with forced-JFIF kernel: GPU vs declared-Identity CPU reference Y-PSNR",
+    );
+
+    // The matrix divergence between Identity and Smpte170m on the
+    // synthetic gradient produces tens-of-dB MSE per pixel — well below
+    // a 35 dB ceiling. Setting the ceiling generously below the matching
+    // path's 50 dB floor keeps the test stable across rounding nuances
+    // while still locking that the two paths produce visibly different
+    // output.
+    const NEGATIVE_PSNR_CEILING_DB: f64 = 35.0;
+    assert!(
+        psnr < NEGATIVE_PSNR_CEILING_DB,
+        "Y-channel PSNR {psnr:.2} dB exceeded the negative-test ceiling {NEGATIVE_PSNR_CEILING_DB} dB \
+         — forcing JFIF interpretation on an APP14 RGB-direct fixture should diverge sharply from the \
+         declared (Identity) reference; if this test passed, the kernel may be ignoring its `color_info` \
+         argument entirely",
+    );
+}
+
+/// Splice an APP14 Adobe segment with the given `transform` value
+/// directly after the SOI marker of `baseline`. The result is a valid
+/// JPEG bitstream that the parser routes through APP14 handling before
+/// reaching SOF0.
+fn splice_app14_after_soi(baseline: &[u8], transform: u8) -> Vec<u8> {
+    assert!(baseline.len() >= 2 && baseline[0] == 0xFF && baseline[1] == 0xD8);
+
+    // Adobe APP14 payload layout per TN5116:
+    //   "Adobe\0"  (6 bytes)
+    //   version    (u16 BE)        — 0x0065 = 101
+    //   flags0     (u16)            — 0x0000
+    //   flags1     (u16)            — 0x0000
+    //   transform  (u8)             — 0, 1, or 2
+    let mut payload = Vec::with_capacity(13);
+    payload.extend_from_slice(b"Adobe\0");
+    payload.extend_from_slice(&[0x00, 0x65]);
+    payload.extend_from_slice(&[0x00, 0x00]);
+    payload.extend_from_slice(&[0x00, 0x00]);
+    payload.push(transform);
+
+    // Length = payload length + 2 (the 2-byte length field itself).
+    let length = (payload.len() + 2) as u16;
+    let mut segment = Vec::with_capacity(4 + payload.len());
+    segment.push(0xFF);
+    segment.push(0xEE); // APP14
+    segment.extend_from_slice(&length.to_be_bytes());
+    segment.extend_from_slice(&payload);
+
+    let mut out = Vec::with_capacity(baseline.len() + segment.len());
+    out.extend_from_slice(&baseline[..2]); // SOI
+    out.extend_from_slice(&segment);
+    out.extend_from_slice(&baseline[2..]);
+    out
+}
+
+/// CPU reference for the RGB-direct decode path. Identical to
+/// `cpu_reference_decode` except the YCbCr → RGB step is replaced with
+/// an identity pass-through: the IDCT samples (already +128-level-shifted
+/// in [`idct_sample`]'s callers) are clamped and written as the R, G, B
+/// channels in scan order.
+fn cpu_reference_decode_identity(decoded: &DecodedJpeg) -> Vec<u8> {
+    let width = usize::from(decoded.frame.width);
+    let height = usize::from(decoded.frame.height);
+    let mut rgba = vec![0u8; width * height * 4];
+
+    let y_plane = &decoded.components[Y_POSITION];
+    let cb_plane = &decoded.components[CB_POSITION];
+    let cr_plane = &decoded.components[CR_POSITION];
+
+    let y_qt = decoded
+        .quantization_table(y_plane.quant_table_id)
+        .expect("Y quant table");
+    let chroma_qt = decoded
+        .quantization_table(cb_plane.quant_table_id)
+        .expect("chroma quant table");
+
+    for py in 0..height {
+        for px in 0..width {
+            let r_sample = idct_sample(y_plane, y_qt, px / 8, py / 8, px % 8, py % 8) + 128.0;
+            let chroma_block_x = px / 16;
+            let chroma_block_y = py / 16;
+            let chroma_in_x = (px % 16) / 2;
+            let chroma_in_y = (py % 16) / 2;
+            let g_sample = idct_sample(
+                cb_plane,
+                chroma_qt,
+                chroma_block_x,
+                chroma_block_y,
+                chroma_in_x,
+                chroma_in_y,
+            ) + 128.0;
+            let b_sample = idct_sample(
+                cr_plane,
+                chroma_qt,
+                chroma_block_x,
+                chroma_block_y,
+                chroma_in_x,
+                chroma_in_y,
+            ) + 128.0;
+
+            let off = (py * width + px) * 4;
+            rgba[off] = clamp_to_u8(r_sample);
+            rgba[off + 1] = clamp_to_u8(g_sample);
+            rgba[off + 2] = clamp_to_u8(b_sample);
+            rgba[off + 3] = 255;
+        }
+    }
+    rgba
 }

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -315,6 +315,66 @@ fn decode_rejects_progressive_sof_with_typed_error() {
     );
 }
 
+/// APP14 transform=2 (YCCK / 4-component CMYK) must bubble up as a
+/// typed `Error::GpuError` from [`SimpleJpegDecoder::decode`] — the
+/// 3-component fused kernel cannot handle 4-component CMYK and the
+/// resolver returns `JpegError::Unsupported`, which `decode()` wraps
+/// as `"jpeg colorimetry: ..."`.
+///
+/// Locks the bubble-up path. Mentally revert `simple_decoder.rs`'s
+/// `decoded.color_info.resolve()?` call (e.g. ignore the error) and
+/// this test fails — the decode would then proceed to the kernel
+/// dispatch with a JFIF default, masking the unsupported declaration.
+#[test]
+fn decode_rejects_app14_ycck_with_typed_error() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    // Encode a baseline JPEG, then splice APP14 transform=2 after SOI.
+    let rgb = synthesize_test_image(32, 32);
+    let baseline = encode_jpeg_rgb_420(32, 32, &rgb, 85);
+    let jpeg = splice_app14_after_soi(&baseline, /* transform */ 2);
+
+    let err = decoder.decode(&jpeg).expect_err("YCCK must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("jpeg colorimetry") && msg.contains("YCCK"),
+        "expected wrapped colorimetry/YCCK error, got: {msg}"
+    );
+}
+
+/// Splice an APP14 Adobe segment with the given `transform` value
+/// directly after the SOI marker of `baseline`. Same shape as the
+/// helper in `tests/gpu_decode.rs`; kept here so the two test files
+/// stay independent.
+fn splice_app14_after_soi(baseline: &[u8], transform: u8) -> Vec<u8> {
+    assert!(baseline.len() >= 2 && baseline[0] == 0xFF && baseline[1] == 0xD8);
+    let mut payload = Vec::with_capacity(13);
+    payload.extend_from_slice(b"Adobe\0");
+    payload.extend_from_slice(&[0x00, 0x65]);
+    payload.extend_from_slice(&[0x00, 0x00]);
+    payload.extend_from_slice(&[0x00, 0x00]);
+    payload.push(transform);
+
+    let length = (payload.len() + 2) as u16;
+    let mut segment = Vec::with_capacity(4 + payload.len());
+    segment.push(0xFF);
+    segment.push(0xEE);
+    segment.extend_from_slice(&length.to_be_bytes());
+    segment.extend_from_slice(&payload);
+
+    let mut out = Vec::with_capacity(baseline.len() + segment.len());
+    out.extend_from_slice(&baseline[..2]);
+    out.extend_from_slice(&segment);
+    out.extend_from_slice(&baseline[2..]);
+    out
+}
+
 // -----------------------------------------------------------------------------
 // End-to-end round-trip + PSNR
 // -----------------------------------------------------------------------------

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -17,7 +17,8 @@ use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::engine::HostTextureExt;
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanTextureReadback};
 use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
-use vulkan_jpeg::{JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
+use streamlib::sdk::color::MatrixId;
+use vulkan_jpeg::{JpegColorSource, JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
 
 /// Acquire a `GpuContext` for tests, or skip cleanly when no GPU is
 /// available (the workstation has one; CI baseline runners may not).
@@ -346,6 +347,31 @@ fn decode_rejects_app14_ycck_with_typed_error() {
         msg.contains("jpeg colorimetry") && msg.contains("YCCK"),
         "expected wrapped colorimetry/YCCK error, got: {msg}"
     );
+}
+
+/// APP14 transform=0 (RGB-direct) decode succeeds and surfaces
+/// `JpegColorSource::AdobeRgbDirect` + `MatrixId::Identity` on the
+/// output handle. Locks the new `JpegDecodeOutput::color_source` /
+/// `color_info` fields end-to-end — downstream consumers (e.g. an
+/// AGP-style vision pipeline that wants to log "what matrix did
+/// we decode under this frame?") rely on this surface.
+#[test]
+fn decode_app14_transform_zero_surfaces_adobe_rgb_direct_on_output() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
+        .expect("decoder construction");
+
+    let rgb = synthesize_test_image(32, 32);
+    let baseline = encode_jpeg_rgb_420(32, 32, &rgb, 85);
+    let jpeg = splice_app14_after_soi(&baseline, /* transform */ 0);
+
+    let output = decoder.decode(&jpeg).expect("APP14 transform=0 decode");
+    assert_eq!(output.color_source, JpegColorSource::AdobeRgbDirect);
+    assert_eq!(output.color_info.matrix, MatrixId::Identity);
 }
 
 /// Splice an APP14 Adobe segment with the given `transform` value


### PR DESCRIPTION
## Summary

- Parser surfaces APP0 JFIF / APP1 EXIF ColorSpace / APP2 ICC profile (multi-segment reassembly) / APP14 Adobe color-transform from the bitstream; `DecodedJpeg.color_info` carries the structured records, `JpegColorInfo::resolve()` maps them to the engine's `ResolvedColorInfo` 4-tuple.
- Fused JPEG compute shader now `#include`s `color_convert_common.glsl` from the engine shader tree and runs `convert_color()` — hardcoded BT.601-Full inline math is gone. Push constants extended to 128 bytes (spec-minimum range) carrying the matrix rows / range_offset / transfer ids / flags exactly like `ColorConverterPushConstants`, built host-side via `ColorConverterPushConstants::from_resolved`.
- APP14 transform=0 (RGB-direct) collapses matrix to `Identity` — the kernel passes IDCT samples through to RGB without YCbCr↔RGB conversion. APP14 transform=2 (YCCK / 4-component CMYK) returns a typed `Error::NotSupported`.

## Closes

Closes #854

## Exit criteria

- [x] Parser surfaces APP1 EXIF (`ColorSpace`), APP2 ICC profile (parsed as raw bytes, multi-segment reassembled), APP14 Adobe color-transform; unknown / unsupported APPn segments still skip cleanly.
- [x] Decoded record carries `JpegColorInfo` reflecting the declared source colorimetry; absent metadata resolves to JFIF (BT.601-Full, sRGB primaries/transfer).
- [x] `JpegDecodeKernel::dispatch` takes the colorimetry and threads it through push constants the same way `VulkanColorConverter` does; the hardcoded BT.601-Full path is one branch among many, not the only branch.
- [x] Negative test proves the gate is non-vacuous — forcing JFIF interpretation on an APP14 transform=0 fixture drops PSNR well below 50 dB vs the declared-Identity reference.

## Out of scope (deferred)

- EXIF Adobe-RGB / ICC non-sRGB declarations are parsed and surfaced but resolve to JFIF default with a `tracing::warn` — the engine's `PrimariesId` enum has no `AdobeRgb` / `DisplayP3` variants today, and extending it ripples through `yuv_to_rgb_matrix`, `ColorConverterPushConstants`, the converter shaders, and swapchain colorspace negotiation. Worth its own engine-tier ticket.

## Test plan

- [x] 24 new unit tests in `color.rs` covering APP0/APP1/APP2/APP14 parse, multi-segment ICC reassembly (in-order + out-of-order + duplicate rejection), and every resolution branch (JFIF default / RGB-direct / YCbCr / YCCK error / EXIF sRGB / fallback).
- [x] Existing JFIF baseline GPU PSNR test (`gpu_decode_matches_cpu_reference_psnr_50db`) updated for the new kernel signature; still passes ≥ 50 dB.
- [x] New positive GPU PSNR test (`app14_transform_zero_rgb_direct_matches_cpu_reference_psnr_50db`): APP14 transform=0 spliced into a JPEG; GPU and CPU reference both apply `Identity` matrix; PSNR ≥ 50 dB.
- [x] New negative GPU PSNR test (`app14_transform_zero_forced_jfif_interpretation_drops_psnr`): forcing JFIF interpretation on the same APP14-transform-0 fixture asserts PSNR < 35 dB. Mentally revert the kernel's `color_info` plumbing and this test stops failing the comparison; proves the gate is non-vacuous.
- [x] New SimpleJpegDecoder integration test (`decode_rejects_app14_ycck_with_typed_error`) locking the bubble-up of `JpegError::Unsupported` (YCCK) → `Error::GpuError` end-to-end.
- [x] `cargo test -p vulkan-jpeg`: 30 unit + 11 simple_decoder + 3 gpu_decode + 18 integration tests all green.
- [x] `cargo clippy -p vulkan-jpeg --all-targets`: no warnings in vulkan-jpeg files.
- [x] `cargo xtask check-boundaries`: 3771 files scanned, no violations.

## Follow-ups

- Engine ticket to extend `PrimariesId` with `AdobeRgb` / `DisplayP3` / equivalents so EXIF and ICC non-sRGB declarations stop falling back to JFIF default. Will file when the design for the engine-tier change is concrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)