### PR TITLE
feat(vulkan-jpeg): nvJPEG backend + ThirdPartyGpuCapabilities + arch doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,5 +672,21 @@ make sense if the surrounding files were renamed or restructured.
   `texture_cache` — extend `TextureRegistration`. Adapter-internal
   `SurfaceState<P>` lives at a different scope and is not the failure
   mode this rule prevents.
+- @docs/architecture/third-party-gpu-backends.md — Canonical shape for
+  integrating a third-party GPU library (NVIDIA nvJPEG, NVDEC, OptiX
+  denoiser, AMD AMF, Intel MFX) as a backend behind a streamlib
+  decoder/encoder/post-processor: engine-allocates an OPAQUE_FD
+  staging surface via `HostVulkanBuffer::new_opaque_fd_export*`,
+  vendor library imports the FD via its own SDK
+  (`cudaImportExternalMemory` for CUDA), Vulkan timeline semaphore
+  carries the cross-API signal, host-side `vkCmdCopyBufferToImage`
+  lands the result in a normal `TextureRing` slot consumers see via
+  `surface_id`. Direction is **engine-allocates / vendor-imports**
+  universally — the inverse (CUDA-allocates / Vulkan-imports) cannot
+  bind a tiled `VkImage` and is the anti-pattern this doc rules out.
+  Read before adding a second backend-using library — the doc names
+  the trigger ("`ThirdPartyGpuCapabilities` grew a second `bool`
+  field") for lifting the JPEG-shaped backend trait to an engine-tier
+  `ThirdPartyGpuBackend` primitive.
 
 Index: @docs/learnings/README.md

--- a/docs/architecture/third-party-gpu-backends.md
+++ b/docs/architecture/third-party-gpu-backends.md
@@ -1,0 +1,306 @@
+# Third-party GPU library backends — the engine-allocates / vendor-imports pattern
+
+> **Living document.** Validate, update, and critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+> Verify against current code before generalizing.
+
+## What this is
+
+This doc records the canonical shape for "a third-party GPU compute
+library produces output that needs to enter streamlib's RHI as a
+sampleable resource downstream consumers can read through the normal
+`surface_id` contract." The library is typically vendor-specific
+(NVIDIA nvJPEG, NVIDIA NVDEC, NVIDIA OptiX denoiser, AMD AMF, Intel
+MFX), runs on its own GPU API surface (CUDA, vendor SDK), and has no
+direct understanding of Vulkan tiling, layouts, or queue semantics.
+
+The pattern lifts cleanly to any such library; the trade-offs are the
+same; the shape is the same. **Don't re-derive it per library —
+follow this doc.**
+
+## The shape
+
+```
+                              streamlib RHI
+                                   │
+            host-side              │           vendor library
+                                   │
+   ┌─────────────────────────┐     │     ┌──────────────────────┐
+   │  HostVulkanBuffer       │     │     │  e.g. CUDA context  │
+   │  ::new_opaque_fd_export │ ◄───┼──── │  cudaImportExternal │
+   │  (Vulkan-allocated,     │ FD  │     │      Memory(...)    │
+   │  OPAQUE_FD, DEVICE_LOCAL│     │     │  cudaExternalMemory │
+   │  or HOST_VISIBLE)       │     │     │      GetMappedBuffer│
+   └─────────────────────────┘     │     └──────────────────────┘
+              │                    │                │
+              │  ┌─ vendor lib writes into the imported pointer ─┐
+              │  │                                               │
+              ▼  ▼                                               │
+   ┌─────────────────────────┐     │                             │
+   │  Vulkan timeline        │     │     ┌──────────────────────┐│
+   │  semaphore (exportable) │ ◄───┼──── │  cudaImportExternal  ││
+   │  signaled by vendor lib │  FD │     │      Semaphore(...)  ││
+   └─────────────────────────┘     │     └──────────────────────┘│
+              │                    │                              │
+              ▼                    │                              │
+   ┌─────────────────────────┐     │                              │
+   │  vkCmdCopyBufferToImage │     │                              │
+   │  → render-target        │     │                              │
+   │  HostVulkanTexture in   │     │                              │
+   │  TextureRing slot       │     │                              │
+   │  (normal pipeline       │     │                              │
+   │  Vulkan resource)       │     │                              │
+   └─────────────────────────┘     │                              │
+              │                    │                              │
+              ▼                    │                              │
+   downstream consumers read       │
+   via surface_id (no awareness    │
+   that vendor lib was involved)   │
+```
+
+Direction is **engine-allocates / vendor-imports** universally.
+streamlib's RHI is the single gateway for GPU allocation; vendor
+libraries import the FD the engine produces. This matches Granite's
+`ExternalHandle` pattern, Unreal's NGX/OptiX integrations, and
+Khronos's reference cross-API samples.
+
+## Two flavors
+
+### Buffer-flavored (vendor writes flat memory)
+
+Use when the vendor library accepts a flat `void* / CUdeviceptr` and
+writes pixels in row-major or planar order without internal tiling.
+nvJPEG is the canonical example — every output format
+(`NVJPEG_OUTPUT_RGBI`, `NVJPEG_OUTPUT_YUV`, etc.) writes into a
+caller-supplied `unsigned char *`.
+
+Engine resources:
+- [`HostVulkanBuffer::new_opaque_fd_export_device_local`] for the
+  staging surface (DEVICE_LOCAL VRAM, exported as OPAQUE_FD). The
+  HOST_VISIBLE sibling [`HostVulkanBuffer::new_opaque_fd_export`]
+  exists for vendors that need pinned-host access.
+- [`HostVulkanTimelineSemaphore::new_exportable`] for cross-API
+  sync. The vendor library signals the timeline after its writes
+  complete; the Vulkan side `vkCmdCopyBufferToImage` waits on it.
+- A normal `TextureRing` of render-target textures (the existing
+  [`GpuContextFullAccess::create_texture_ring`] primitive). Output
+  slots are non-exportable DEVICE_LOCAL; the OPAQUE_FD staging
+  buffer is internal to the backend.
+
+Per-frame steady state: vendor lib decodes into the imported
+buffer → signals timeline → Vulkan-side `vkCmdCopyBufferToImage`
+into the next ring slot → return the slot's `surface_id` downstream.
+One Vulkan-side GPU copy per frame, no `vkAllocateMemory` on the
+hot path.
+
+### Image / mipmapped-array-flavored (vendor writes into cudaArrays)
+
+Use when the vendor library writes into a CUDA `cudaArray_t` /
+`cudaMipmappedArray_t` or its API equivalent (sampler-textured
+write surface). Some image-processing libs (NPP image kernels,
+OptiX texture writes, cuFFT 2D) prefer this shape because the
+vendor's kernels are written against `surf2Dwrite` /
+`cudaTextureObject_t` rather than flat pointers.
+
+Engine resources:
+- [`HostVulkanTexture::new_opaque_fd_export`] (`VK_IMAGE_TILING_OPTIMAL`,
+  no DRM modifier, format restricted to the CUDA-mappable subset —
+  `Rgba8Unorm` / `Rgba16Float` / `Rgba32Float`).
+- Same timeline-semaphore primitive.
+- The vendor library imports via `cudaImportExternalMemory(OPAQUE_FD)` +
+  `cudaExternalMemoryGetMappedMipmappedArray` and writes via surface
+  objects.
+
+Per-frame steady state: vendor lib writes directly into the
+imported mipmapped array → signals timeline → no Vulkan-side blit
+needed (the image is the consumer-visible resource). Trade-off:
+no intermediate copy, but the vendor must natively support the
+mipmapped-array sink and the format gate must hold.
+
+### Hybrid (vendor writes flat, consumer wants mipmapped)
+
+The streamlib NVIDIA reference flow (the `vulkanImageCUDA` sample)
+combines both: vendor writes flat → CUDA-side
+`cudaMemcpy2DToArrayAsync` into a Vulkan-imported mipmapped array.
+Adds a CUDA copy per frame; not the recommended starting point.
+Use only when buffer-flavored can't satisfy a tight texture-sampling
+requirement.
+
+## Capability tier
+
+The engine primitives ([`HostVulkanBuffer::new_opaque_fd_export*`],
+[`HostVulkanTexture::new_opaque_fd_export`],
+[`HostVulkanTimelineSemaphore::new_exportable`]) are all
+**FullAccess-only**. Backend construction (vendor SDK init, OPAQUE_FD
+buffer allocation, timeline creation) happens at host-side
+processor-setup time inside an `escalate(|full| ...)` closure. The
+backend's steady-state per-frame work
+(`vkCmdCopyBufferToImage`, timeline wait, ring rotation) runs on
+LimitedAccess and never escalates.
+
+Subprocess (Python / Deno cdylib) consumers reach the result via the
+normal `surface_id` contract — they import the **ring slot's
+render-target VkImage** (via surface-share, per
+[`adapter-runtime-integration.md`](adapter-runtime-integration.md)),
+not the internal OPAQUE_FD staging buffer. The vendor-library /
+CUDA-side machinery stays inside the host-side backend; subprocess
+customers consume the Vulkan output identically regardless of which
+backend produced it.
+
+If a subprocess customer needs to *invoke* a third-party GPU library
+directly (Python-side `nvjpeg.decode(bytes)` returning a
+subprocess-side handle), that's escalate-IPC shape — the subprocess
+sends the request, the host runs the backend, the response carries
+a `surface_id` the subprocess imports via the existing carve-out.
+This is the same pattern every other escalate op already uses
+(per [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md)) and
+doesn't require new engine surface.
+
+## Probe + selection
+
+Capability is exposed on [`HostVulkanDevice`] via a typed struct
+([`ThirdPartyGpuCapabilities`]) probed once at device construction.
+Each field is a `bool` named after the library
+(`nvjpeg`, `optix_denoiser`, etc.); future siblings extend the
+struct, not the device's method surface.
+
+Selection inside a backend-using library (e.g. `SimpleJpegDecoder`)
+is **runtime**: the library auto-selects the highest-tier backend
+whose capability is `true`, with an optional caller override for
+forcing a specific backend.
+
+Build gating is **dynamic loading via `libloading`**, not a Cargo
+feature. Backends that need a vendor `.so` (libnvjpeg, etc.) `dlopen`
+it at probe time; build hosts without the library still compile
+the backend code, and the probe simply returns `false` at runtime.
+This matches the `cudarc` `fallback-dynamic-loading` shape already
+used in the workspace and removes the "I forgot to enable the
+Cargo feature" foot-gun.
+
+## When to lift to engine-tier
+
+**Today there is one shipped backend-using library** —
+[`vulkan-jpeg`]'s `SimpleJpegDecoder`, which carries its own
+`JpegDecodeBackend` trait with `VulkanComputeBackend` and
+`NvJpegBackend` implementations. The shape is JPEG-specific by
+design at this stage — a single consumer doesn't justify lifting
+the trait to an engine-tier primitive yet.
+
+**When a second backend-using library lands** (NVDEC-flavored
+H.264/H.265 decoder, OptiX-denoiser post-processor, AMF encoder
+backend swap), **do not copy the JPEG-specific trait shape**. The
+trigger is to lift a generic `ThirdPartyGpuBackend` trait to the
+engine layer, codifying:
+
+- Backend identity + capability dependence (which
+  `ThirdPartyGpuCapabilities` field gates it)
+- The engine-allocated OPAQUE_FD staging surface contract
+  (buffer-flavored or image-flavored)
+- The timeline-semaphore signaling contract
+- The Vulkan-side post-write step (`vkCmdCopyBufferToImage` for
+  buffer-flavored; no-op for image-flavored)
+- Runtime selection / override
+
+The new trait lives next to [`ThirdPartyGpuCapabilities`] in the
+engine's RHI module. Both the JPEG library and the second
+backend-using library migrate to it in the same PR per CLAUDE.md
+"No bad patterns left behind on engine changes." That migration
+is the moment the engine-model lift happens — not before.
+
+**The signal that you've hit the trigger** is that
+[`ThirdPartyGpuCapabilities`] grew a second `bool` field. The struct
+definition is the canonical place readers will look to understand
+what backends exist; adding a field next to `nvjpeg` is the natural
+prompt to read this doc and consider the lift.
+
+## Anti-patterns
+
+These are the failure modes the pattern exists to prevent. Each
+matches a real foot-gun I've seen or one a future agent would
+plausibly attempt without this doc.
+
+1. **CUDA-allocates / Vulkan-imports.** Allocating via `cudaMalloc`
+   + `cuMemExportToShareableHandle` and importing via
+   `vkImportMemoryFdKHR` works for buffers but cannot bind to a
+   tiled `VK_IMAGE_TILING_OPTIMAL` `VkImage` (the tile layout is
+   opaque to CUDA's VMM allocator). It's also the inverse of every
+   production pattern surveyed (Granite, Unreal NGX, Khronos
+   OpenCL interop sample, NVIDIA `vulkanImageCUDA`). Stick with
+   engine-allocates / vendor-imports.
+
+2. **Subprocess-side vendor SDK init.** Linking a vendor SDK
+   (libnvjpeg, libavcodec-CUDA, etc.) into the cdylib breaks the
+   FullAccess vs LimitedAccess split — privileged allocation paths
+   would re-emerge on the subprocess side. Vendor-SDK init stays
+   on the host; subprocess customers reach the output via
+   surface-share or escalate IPC.
+
+3. **Parallel `JpegDecodeBackend`-shaped trait per library.** When
+   the second backend-using library arrives, lift to engine-tier
+   immediately (see "When to lift" above). Three hand-rolled
+   JPEG/H.264/AMF backend traits is the failure mode this doc
+   exists to prevent.
+
+4. **Per-frame `vkAllocateMemory` on the OPAQUE_FD staging surface.**
+   The staging buffer is allocated once at backend construction
+   and reused across every frame — pre-warming the OPAQUE_FD pool
+   (per [`docs/learnings/nvidia-opaque-fd-after-swapchain.md`](../learnings/nvidia-opaque-fd-after-swapchain.md))
+   keeps the NVIDIA post-swapchain cap from biting. Allocating a
+   fresh staging buffer per decode re-introduces the cap pressure
+   the pre-warm machinery exists to avoid.
+
+5. **Cargo-feature gating of the vendor SDK.** A Cargo feature
+   means the build host has to remember to enable it. The cdylibs'
+   `cudarc = { features = ["fallback-dynamic-loading"] }` is the
+   reference shape — link nothing at build time, `dlopen` at
+   runtime, fall back gracefully when the SDK isn't present.
+   "I forgot to enable the feature flag for the drone-racer
+   release" is the failure mode this rule prevents.
+
+## Reference
+
+- **Backend-using library**:
+  [`libs/vulkan-jpeg/src/backend.rs`](../../libs/vulkan-jpeg/src/backend.rs)
+  (`JpegDecodeBackend` trait),
+  [`libs/vulkan-jpeg/src/nvjpeg_backend.rs`](../../libs/vulkan-jpeg/src/nvjpeg_backend.rs)
+  (`NvJpegBackend` implementation).
+- **Engine primitives**:
+  - [`HostVulkanBuffer::new_opaque_fd_export`] (HOST_VISIBLE) and
+    [`HostVulkanBuffer::new_opaque_fd_export_device_local`]
+    (DEVICE_LOCAL) in
+    `libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs`.
+  - [`HostVulkanTexture::new_opaque_fd_export`] in
+    `libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs`.
+  - [`HostVulkanTimelineSemaphore::new_exportable`] in
+    `libs/streamlib-engine/src/vulkan/rhi/vulkan_sync.rs`.
+  - [`ThirdPartyGpuCapabilities`] on [`HostVulkanDevice`] in
+    `libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs`.
+- **Companion docs**:
+  - [`subprocess-rhi-parity.md`](subprocess-rhi-parity.md) —
+    subprocess-side carve-out machinery (cdylib import shape).
+  - [`adapter-runtime-integration.md`](adapter-runtime-integration.md) —
+    how a subprocess obtains a surface adapter context.
+  - [`texture-ring.md`](texture-ring.md) — ring shape backend
+    libraries reuse for their render-target output slots.
+  - [`compute-kernel.md`](compute-kernel.md) — the streamlib-
+    native Vulkan-compute backend pattern (the alternative to
+    routing through a vendor SDK).
+- **Hard-won learnings**:
+  - [`docs/learnings/nvidia-opaque-fd-after-swapchain.md`](../learnings/nvidia-opaque-fd-after-swapchain.md) —
+    pre-warm sentinels keep post-swapchain OPAQUE_FD allocations
+    from failing on NVIDIA Linux.
+  - [`docs/learnings/cross-process-vkimage-layout.md`](../learnings/cross-process-vkimage-layout.md) —
+    layout coordination for cross-process flows (relevant when a
+    subprocess consumer reads the backend's output via
+    surface-share).
+- **External references**:
+  - [NVIDIA cuda-samples `vulkanImageCUDA`](https://github.com/NVIDIA/cuda-samples/tree/master/cpp/5_Domain_Specific/vulkanImageCUDA)
+    — canonical CUDA → Vulkan tiled-image interop.
+  - [NVIDIA cuda-samples `simpleVulkanMMAP`](https://github.com/NVIDIA/cuda-samples/tree/master/cpp/5_Domain_Specific/simpleVulkanMMAP)
+    — CUDA-side `cuMemExportToShareableHandle` plumbing (the
+    inverse direction, anti-pattern #1 above).
+  - [Granite `ExternalHandle`](https://github.com/Themaister/Granite/blob/master/vulkan/image.hpp) —
+    closest precedent for a single-constructor engine-allocates /
+    vendor-imports shape.
+  - [`VK_KHR_external_memory_fd`](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_external_memory_fd.html)
+    — the Vulkan-side spec the host's OPAQUE_FD export rides.

--- a/libs/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
+++ b/libs/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
@@ -78,6 +78,14 @@ pub struct ConsumerVulkanDevice {
     /// available; only this acquire-side extension is the meaningful
     /// gate.
     has_acquire_unmodified: bool,
+    /// `VkPhysicalDeviceIDProperties::deviceUUID` — 16-byte unique
+    /// identifier the driver assigns to the physical device. Mirrors
+    /// the same field on the host-side device. CUDA / OpenCL interop
+    /// matches this against `cudaDeviceProp::uuid` to pick the
+    /// matching CUDA device on multi-GPU rigs; without the match
+    /// CUDA's default device may differ from the Vulkan-selected
+    /// physical device and OPAQUE_FD imports land on the wrong GPU.
+    physical_device_uuid: [u8; 16],
     /// Live count of memory allocations made via [`Self::import_dma_buf_memory`]
     /// (raw `vkAllocateMemory`). Mirrors the host counterpart; surfaces leaks
     /// on drop via the warning emitted in [`Drop`].
@@ -143,6 +151,16 @@ impl ConsumerVulkanDevice {
         let device_props = unsafe { instance.get_physical_device_properties(physical_device) };
         let device_name =
             unsafe { CStr::from_ptr(device_props.device_name.as_ptr()) }.to_string_lossy().into_owned();
+
+        // Extract VkPhysicalDeviceIDProperties::deviceUUID via
+        // vkGetPhysicalDeviceProperties2. Used by CUDA / OpenCL interop
+        // to pick the matching foreign-API device on multi-GPU rigs.
+        let mut id_props = vk::PhysicalDeviceIDProperties::default();
+        let mut props2 = vk::PhysicalDeviceProperties2::builder()
+            .push_next(&mut id_props)
+            .build();
+        unsafe { instance.get_physical_device_properties2(physical_device, &mut props2) };
+        let physical_device_uuid: [u8; 16] = id_props.device_uuid.into();
 
         // Pick any GRAPHICS-capable queue family (graphics implies transfer +
         // compute on every conformant Vulkan implementation, which covers
@@ -263,9 +281,18 @@ impl ConsumerVulkanDevice {
             queue_family_index,
             device_name,
             has_acquire_unmodified,
+            physical_device_uuid,
             live_allocation_count: AtomicUsize::new(0),
             queue_mutex: Mutex::new(()),
         })
+    }
+
+    /// `VkPhysicalDeviceIDProperties::deviceUUID` for the selected
+    /// physical device. CUDA / OpenCL interop matches against
+    /// `cudaDeviceProp::uuid` to pick the foreign-API device that
+    /// shares this Vulkan device's PCI identity.
+    pub fn physical_device_uuid(&self) -> [u8; 16] {
+        self.physical_device_uuid
     }
 
     /// Device label from `VkPhysicalDeviceProperties::deviceName`.

--- a/libs/streamlib-deno-native/src/lib.rs
+++ b/libs/streamlib-deno-native/src/lib.rs
@@ -4687,6 +4687,48 @@ mod cuda {
         registered_images: Mutex<HashMap<u64, Arc<RegisteredCudaImageSurface>>>,
     }
 
+    /// Match `vulkan_uuid` (`VkPhysicalDeviceIDProperties::deviceUUID`)
+    /// against every CUDA device's `cudaDeviceProp::uuid` and return the
+    /// matching ordinal, or `None` when no CUDA device shares the UUID
+    /// (or CUDA isn't available).
+    ///
+    /// Multi-GPU defensive helper: CUDA's default device may not be the
+    /// same physical device Vulkan selected, in which case
+    /// `cudaImportExternalMemory(OPAQUE_FD)` lands on the wrong GPU.
+    /// Callers pair this with `cudaSetDevice(matched_ordinal)` before
+    /// any other CUDA work; on `None`, fall back to ordinal 0 with a
+    /// warn log (single-GPU behavior preserved).
+    ///
+    /// Duplicated in `streamlib-python-native::cuda` and
+    /// `vulkan-jpeg::nvjpeg_backend::resources` — keep the three in
+    /// sync. A future refactor lifts this to a shared utility crate.
+    fn match_cuda_device_to_vulkan_uuid(vulkan_uuid: &[u8; 16]) -> Option<i32> {
+        let mut count: i32 = 0;
+        if unsafe { sys::cudaGetDeviceCount(&mut count) }
+            .result()
+            .is_err()
+        {
+            return None;
+        }
+        for ordinal in 0..count {
+            let mut props = MaybeUninit::<sys::cudaDeviceProp>::uninit();
+            // SAFETY: `cudaGetDeviceProperties_v2` fully initializes the
+            // out-pointer on success. On error we skip the ordinal.
+            let ok = unsafe { sys::cudaGetDeviceProperties_v2(props.as_mut_ptr(), ordinal) }
+                .result();
+            if ok.is_err() {
+                continue;
+            }
+            let props = unsafe { props.assume_init() };
+            let cuda_uuid_bytes: [u8; 16] =
+                unsafe { std::mem::transmute::<sys::cudaUUID_t, [u8; 16]>(props.uuid) };
+            if cuda_uuid_bytes == *vulkan_uuid {
+                return Some(ordinal);
+            }
+        }
+        None
+    }
+
     /// Per-surface registered state. The adapter's registry holds
     /// references to the same Vulkan-side `Arc`s; this struct adds the
     /// CUDA-side handles + the per-surface stream the cdylib uses for
@@ -4777,7 +4819,26 @@ mod cuda {
             return std::ptr::null_mut();
         }
 
-        let cuda_device_ordinal: i32 = 0;
+        // Bind CUDA to the physical device Vulkan selected. Single-GPU
+        // hosts resolve to ordinal 0 either way; multi-GPU rigs need
+        // the UUID match or CUDA's default device may differ from
+        // Vulkan's selected `physicalDevice` and every OPAQUE_FD import
+        // below lands on the wrong GPU. Falls back to ordinal 0 with a
+        // warn log when no CUDA device matches the Vulkan UUID
+        // (defensive — keeps single-GPU behavior even if the probe
+        // fails).
+        let vulkan_uuid = device.physical_device_uuid();
+        let cuda_device_ordinal =
+            match_cuda_device_to_vulkan_uuid(&vulkan_uuid).unwrap_or_else(|| {
+                tracing::warn!(
+                    target: "sldn_cuda::device_match",
+                    vulkan_uuid = ?vulkan_uuid,
+                    "no CUDA device matches Vulkan device UUID; falling back to CUDA \
+                     ordinal 0 (single-GPU hosts unaffected; multi-GPU may run on the \
+                     wrong device)",
+                );
+                0
+            });
         if let Err(e) = unsafe { sys::cudaSetDevice(cuda_device_ordinal) }.result() {
             tracing::error!(
                 "sldn_cuda_runtime_new: cudaSetDevice({}) failed: {:?}",

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -55,10 +55,10 @@ pub use crate::vulkan::rhi::{
     drm_modifier_probe, AccelerationStructureKind, HostMarker, HostVulkanDevice,
     HostVulkanBuffer, HostVulkanTexture, HostVulkanTimelineSemaphore, ImageCopyRegion,
     OffscreenColorTarget, OffscreenDraw, RayTracingPipelineProperties, RhiCommandRecorder,
-    TlasInstanceDesc, VulkanAccelerationStructure, VulkanAccess, VulkanBufferLike,
-    VulkanComputeKernel, VulkanGraphicsKernel, VulkanIndexBindable, VulkanRayTracingKernel,
-    VulkanStage, VulkanStorageBindable, VulkanTextureReadback, VulkanUniformBindable,
-    VulkanVertexBindable, IDENTITY_TRANSFORM,
+    ThirdPartyGpuCapabilities, TlasInstanceDesc, VulkanAccelerationStructure, VulkanAccess,
+    VulkanBufferLike, VulkanComputeKernel, VulkanGraphicsKernel, VulkanIndexBindable,
+    VulkanRayTracingKernel, VulkanStage, VulkanStorageBindable, VulkanTextureReadback,
+    VulkanUniformBindable, VulkanVertexBindable, IDENTITY_TRANSFORM,
 };
 
 #[cfg(target_os = "linux")]

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -25,7 +25,7 @@ mod vulkan_upload_resources;
 pub use host_marker::HostMarker;
 pub use vulkan_command_buffer::VulkanCommandBuffer;
 pub use vulkan_command_queue::VulkanCommandQueue;
-pub use vulkan_device::{HostVulkanDevice, RayTracingPipelineProperties};
+pub use vulkan_device::{HostVulkanDevice, RayTracingPipelineProperties, ThirdPartyGpuCapabilities};
 #[allow(unused_imports)]
 pub use vulkan_sync::{VulkanFence, VulkanSemaphore};
 #[cfg(target_os = "linux")]

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Engine-internal trait that lets command-buffer recording methods on
-//! [`RhiCommandRecorder`](super::RhiCommandRecorder) accept any of the
-//! five typed buffer wrappers
-//! ([`PixelBuffer`], [`StorageBuffer`], [`UniformBuffer`],
-//! [`VertexBuffer`], [`IndexBuffer`]) uniformly.
+//! [`RhiCommandRecorder`](super::RhiCommandRecorder) accept any of
+//! streamlib's typed buffer wrappers ([`PixelBuffer`],
+//! [`StorageBuffer`], [`UniformBuffer`], [`VertexBuffer`],
+//! [`IndexBuffer`]) or a raw [`HostVulkanBuffer`] uniformly. The raw
+//! variant is needed because some allocation flavors — notably
+//! OPAQUE_FD-exportable buffers used in CUDA / OpenCL interop — have
+//! no typed wrapper above [`HostVulkanBuffer`] but still participate
+//! in transfer + barrier recording.
 //!
 //! Distinct from the binding-site traits in
 //! [`vulkan_storage_binding`](super::vulkan_storage_binding) (which gate
@@ -18,6 +22,7 @@
 //! [`UniformBuffer`]: crate::core::rhi::UniformBuffer
 //! [`VertexBuffer`]: crate::core::rhi::VertexBuffer
 //! [`IndexBuffer`]: crate::core::rhi::IndexBuffer
+//! [`HostVulkanBuffer`]: super::HostVulkanBuffer
 
 use vulkanalia::vk;
 
@@ -93,5 +98,15 @@ impl VulkanBufferLike for IndexBuffer {
     }
     fn vk_buffer_size(&self) -> vk::DeviceSize {
         self.inner.size()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl VulkanBufferLike for crate::vulkan::rhi::HostVulkanBuffer {
+    fn vk_buffer(&self) -> vk::Buffer {
+        self.buffer()
+    }
+    fn vk_buffer_size(&self) -> vk::DeviceSize {
+        self.size()
     }
 }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -20,6 +20,98 @@ use crate::core::{Result, Error};
 use super::drm_modifier_probe::{self, DrmModifierTable};
 use super::{HostMarker, VulkanCommandQueue, VulkanRhiDevice, HostVulkanTexture};
 
+/// Best-effort hint about which third-party GPU compute libraries are
+/// **available to integrate against this device**. Probed once at
+/// device construction; each field is `true` when the matching vendor
+/// SDK can plausibly run on this physical device + host environment.
+///
+/// "Available" is a build-host hint, not a runtime guarantee: the
+/// actual `Backend::new` step may still fail (CUDA context init
+/// fails, driver mismatch, GPU lacks the right compute capability,
+/// etc.). Backend-using libraries (e.g. `vulkan-jpeg`'s
+/// `SimpleJpegDecoder`) treat the field as "try this backend first,
+/// fall back if construction fails."
+///
+/// **When you add a second field to this struct**, read
+/// `docs/architecture/third-party-gpu-backends.md` first. The single-
+/// consumer JPEG-specific backend trait in `vulkan-jpeg` is the right
+/// shape for one consumer — the second consumer is the trigger to
+/// lift the trait to an engine-tier `ThirdPartyGpuBackend` primitive
+/// next to this struct. Don't copy the JPEG-specific shape.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ThirdPartyGpuCapabilities {
+    /// NVIDIA `libnvjpeg` (CUDA-based JPEG decode). True when this
+    /// physical device's PCI vendor matches NVIDIA and
+    /// `libnvjpeg.so.12` is loadable via `dlopen`. The actual nvJPEG
+    /// init (`nvjpegCreateSimple` + CUDA context creation) happens at
+    /// backend construction time and may still fail for reasons not
+    /// covered by this probe (e.g. CUDA driver missing, GPU lacks
+    /// the required compute capability).
+    pub nvjpeg: bool,
+}
+
+impl ThirdPartyGpuCapabilities {
+    /// PCI vendor ID assigned by the Khronos Vulkan registry to NVIDIA.
+    const PCI_VENDOR_NVIDIA: u32 = 0x10DE;
+
+    /// Probe the host environment for available third-party GPU
+    /// libraries. Cheap — `dlopen` + `dlclose` per probed lib, no
+    /// vendor SDK init, no CUDA context creation. Safe to call from
+    /// `HostVulkanDevice::new` before any consumer code runs.
+    pub(crate) fn probe(vendor_id: u32) -> Self {
+        Self {
+            nvjpeg: vendor_id == Self::PCI_VENDOR_NVIDIA && probe_nvjpeg_loadable(),
+        }
+    }
+}
+
+/// Try to `dlopen` `libnvjpeg.so.12` and close it immediately. Returns
+/// `true` when the dynamic linker can find the library by any of:
+///
+/// 1. The bare SONAME `libnvjpeg.so.12` — works when the toolkit's
+///    `/etc/ld.so.conf.d/*cuda*.conf` entries have been picked up by a
+///    recent `ldconfig` run.
+/// 2. The canonical CUDA Toolkit install paths (12.x versioned
+///    `/usr/local/cuda-12.{9,8,7,6,5,4,3,2,1,0}/targets/x86_64-linux/lib/`
+///    and the unversioned `/usr/local/cuda/...` symlink). A fresh
+///    `libnvjpeg-dev-12-*` apt install often leaves the ldconfig cache
+///    stale until the next `ldconfig` run; falling back to explicit
+///    paths means our capability probe doesn't depend on root-only
+///    cache state.
+/// 3. The Debian multiarch path `/usr/lib/x86_64-linux-gnu/` —
+///    distro-packaged installs land here.
+///
+/// Probing the actual `nvjpegCreateSimple` symbol would require a CUDA
+/// context (CUDA initializes lazily on first call), so the minimal probe
+/// stops at the library-loadable level. Backend construction validates
+/// the rest.
+fn probe_nvjpeg_loadable() -> bool {
+    // SAFETY: `libloading::Library::new` is safe to call against any
+    // path — failure to find the lib returns `Err`, not undefined
+    // behavior. The library is dropped immediately, calling `dlclose`.
+    let candidates: &[&str] = &[
+        "libnvjpeg.so.12",
+        "/usr/local/cuda/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.9/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.8/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.7/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.6/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.5/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.4/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.3/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.1/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/lib/x86_64-linux-gnu/libnvjpeg.so.12",
+    ];
+    for candidate in candidates {
+        if unsafe { libloading::Library::new(candidate) }.is_ok() {
+            return true;
+        }
+    }
+    false
+}
+
 /// Vulkan GPU device.
 ///
 /// Wraps the Vulkan instance, physical device, and logical device.
@@ -38,6 +130,10 @@ pub struct HostVulkanDevice {
     #[allow(dead_code)]
     device_name: String,
     supports_external_memory: bool,
+    /// Best-effort hint about which third-party GPU compute libraries
+    /// (nvJPEG, etc.) are available to integrate against this device.
+    /// Probed at construction; see [`ThirdPartyGpuCapabilities`].
+    third_party_gpu_capabilities: ThirdPartyGpuCapabilities,
     /// Whether the driver tolerates a failed cross-device DMA-BUF import
     /// (raw `vkAllocateMemory` chained with `VkImportMemoryFdInfoKHR`)
     /// without perturbing per-handle-type accounting for other export
@@ -480,6 +576,15 @@ impl HostVulkanDevice {
         // this, the blocklist is a one-line update.
         const PCI_VENDOR_NVIDIA: u32 = 0x10DE;
         let supports_cross_device_dma_buf_probe = device_props.vendor_id != PCI_VENDOR_NVIDIA;
+
+        // Probe third-party GPU library availability (nvJPEG, future
+        // siblings like AMD AMF / Intel MFX / OptiX denoiser). Cheap
+        // dlopen-based hint; backend construction validates the rest.
+        // See `docs/architecture/third-party-gpu-backends.md` and the
+        // `ThirdPartyGpuCapabilities` struct doc for the "when to lift
+        // to engine-tier" trigger as siblings arrive.
+        let third_party_gpu_capabilities =
+            ThirdPartyGpuCapabilities::probe(device_props.vendor_id);
 
         // 5b. Query VkPhysicalDeviceIDProperties::deviceUUID via
         //     vkGetPhysicalDeviceProperties2. CUDA-Vulkan interop matches
@@ -1249,6 +1354,7 @@ impl HostVulkanDevice {
             transfer_queue,
             device_name: device_name.into_owned(),
             supports_external_memory,
+            third_party_gpu_capabilities,
             supports_cross_device_dma_buf_probe,
             has_acquire_unmodified,
             has_hdr_metadata,
@@ -2304,6 +2410,26 @@ impl HostVulkanDevice {
         self.supports_cross_device_dma_buf_probe
     }
 
+    /// Best-effort hint about which third-party GPU compute libraries
+    /// (nvJPEG today; future siblings as the workspace grows) are
+    /// available to integrate against this device. Probed once at
+    /// construction; cheap to clone.
+    ///
+    /// Backend-using libraries (e.g. `vulkan-jpeg`'s `SimpleJpegDecoder`)
+    /// consult this to decide which backend to attempt first. A `true`
+    /// field is a *hint*, not a guarantee — the matching backend's
+    /// `new()` may still fail for reasons not covered by the probe
+    /// (CUDA context init, GPU compute-capability mismatch, etc.).
+    /// Callers handle that by falling back to a lower-tier backend.
+    ///
+    /// See [`ThirdPartyGpuCapabilities`] and
+    /// `docs/architecture/third-party-gpu-backends.md` for the
+    /// integration shape and the trigger that lifts the JPEG-specific
+    /// backend trait to an engine-tier primitive as siblings arrive.
+    pub fn third_party_gpu_capabilities(&self) -> ThirdPartyGpuCapabilities {
+        self.third_party_gpu_capabilities
+    }
+
     /// Whether Vulkan Video encode extensions are available.
     #[allow(dead_code)]
     pub fn supports_video_encode(&self) -> bool {
@@ -3228,6 +3354,58 @@ mod tests {
                 "expected supports_cross_device_dma_buf_probe()=true on non-NVIDIA ({name}), got false"
             );
         }
+    }
+
+    /// Non-NVIDIA vendor IDs must report `nvjpeg = false` regardless
+    /// of whether `libnvjpeg.so.12` happens to be on the host. Locks
+    /// the vendor-id gate inside [`ThirdPartyGpuCapabilities::probe`]
+    /// — mentally revert that gate (`vendor_id == PCI_VENDOR_NVIDIA &&`
+    /// → `true &&`) and this test fails on any host where libnvjpeg
+    /// IS present (true on this development host). Cheap, no Vulkan
+    /// device required.
+    #[test]
+    fn third_party_gpu_capabilities_non_nvidia_vendor_disables_nvjpeg() {
+        // PCI vendor IDs from the Khronos Vulkan registry. Intel, AMD,
+        // ARM Mali, Qualcomm Adreno — none are NVIDIA.
+        for non_nvidia_vendor in [0x8086_u32, 0x1002, 0x13B5, 0x5143] {
+            let caps = ThirdPartyGpuCapabilities::probe(non_nvidia_vendor);
+            assert!(
+                !caps.nvjpeg,
+                "non-NVIDIA vendor 0x{:04X} must report nvjpeg=false; \
+                 got nvjpeg=true (vendor-id gate broken)",
+                non_nvidia_vendor,
+            );
+        }
+    }
+
+    /// On NVIDIA-vendor hosts, `nvjpeg` reflects whether `libnvjpeg.so.12`
+    /// is dlopen-able — runtime-detection shape, not a build-time
+    /// feature gate. The probe is deterministic for a given host, so
+    /// the field's value must equal the independent dlopen check.
+    /// Cheap, no Vulkan device required.
+    #[test]
+    fn third_party_gpu_capabilities_nvidia_nvjpeg_tracks_library_loadability() {
+        const PCI_VENDOR_NVIDIA: u32 = 0x10DE;
+        let caps = ThirdPartyGpuCapabilities::probe(PCI_VENDOR_NVIDIA);
+        let independent_check = probe_nvjpeg_loadable();
+        assert_eq!(
+            caps.nvjpeg, independent_check,
+            "ThirdPartyGpuCapabilities::probe must report nvjpeg=true \
+             iff libnvjpeg.so.12 is dlopen-able; got caps.nvjpeg={} \
+             but independent dlopen returns {}",
+            caps.nvjpeg, independent_check,
+        );
+    }
+
+    /// `Default` must produce an all-`false` capabilities struct.
+    /// Lets callers spell "no third-party libs available" without
+    /// touching every field — important for future siblings that
+    /// extend the struct (the `Default` derive auto-tracks new
+    /// fields). Cheap, no Vulkan device required.
+    #[test]
+    fn third_party_gpu_capabilities_default_is_all_false() {
+        let caps = ThirdPartyGpuCapabilities::default();
+        assert!(!caps.nvjpeg, "Default::nvjpeg must be false");
     }
 
     /// Issue #633 — `supports_qfot_acquire_unmodified` must equal the

--- a/libs/streamlib-python-native/src/lib.rs
+++ b/libs/streamlib-python-native/src/lib.rs
@@ -5147,6 +5147,48 @@ mod cuda {
         registered_images: Mutex<HashMap<u64, Arc<RegisteredCudaImageSurface>>>,
     }
 
+    /// Match `vulkan_uuid` (`VkPhysicalDeviceIDProperties::deviceUUID`)
+    /// against every CUDA device's `cudaDeviceProp::uuid` and return the
+    /// matching ordinal, or `None` when no CUDA device shares the UUID
+    /// (or CUDA isn't available).
+    ///
+    /// Multi-GPU defensive helper: CUDA's default device may not be the
+    /// same physical device Vulkan selected, in which case
+    /// `cudaImportExternalMemory(OPAQUE_FD)` lands on the wrong GPU.
+    /// Callers pair this with `cudaSetDevice(matched_ordinal)` before
+    /// any other CUDA work; on `None`, fall back to ordinal 0 with a
+    /// warn log (single-GPU behavior preserved).
+    ///
+    /// Duplicated in `streamlib-deno-native::cuda` and
+    /// `vulkan-jpeg::nvjpeg_backend::resources` — keep the three in
+    /// sync. A future refactor lifts this to a shared utility crate.
+    fn match_cuda_device_to_vulkan_uuid(vulkan_uuid: &[u8; 16]) -> Option<i32> {
+        let mut count: i32 = 0;
+        if unsafe { sys::cudaGetDeviceCount(&mut count) }
+            .result()
+            .is_err()
+        {
+            return None;
+        }
+        for ordinal in 0..count {
+            let mut props = MaybeUninit::<sys::cudaDeviceProp>::uninit();
+            // SAFETY: `cudaGetDeviceProperties_v2` fully initializes the
+            // out-pointer on success. On error we skip the ordinal.
+            let ok = unsafe { sys::cudaGetDeviceProperties_v2(props.as_mut_ptr(), ordinal) }
+                .result();
+            if ok.is_err() {
+                continue;
+            }
+            let props = unsafe { props.assume_init() };
+            let cuda_uuid_bytes: [u8; 16] =
+                unsafe { std::mem::transmute::<sys::cudaUUID_t, [u8; 16]>(props.uuid) };
+            if cuda_uuid_bytes == *vulkan_uuid {
+                return Some(ordinal);
+            }
+        }
+        None
+    }
+
     /// Per-surface registered state. The adapter's registry holds
     /// references to the same Vulkan-side `Arc`s; this struct adds the
     /// CUDA-side handles + the per-surface stream the cdylib uses for
@@ -5237,7 +5279,26 @@ mod cuda {
             return std::ptr::null_mut();
         }
 
-        let cuda_device_ordinal: i32 = 0;
+        // Bind CUDA to the physical device Vulkan selected. Single-GPU
+        // hosts resolve to ordinal 0 either way; multi-GPU rigs need
+        // the UUID match or CUDA's default device may differ from
+        // Vulkan's selected `physicalDevice` and every OPAQUE_FD import
+        // below lands on the wrong GPU. Falls back to ordinal 0 with a
+        // warn log when no CUDA device matches the Vulkan UUID
+        // (defensive — keeps single-GPU behavior even if the probe
+        // fails).
+        let vulkan_uuid = device.physical_device_uuid();
+        let cuda_device_ordinal =
+            match_cuda_device_to_vulkan_uuid(&vulkan_uuid).unwrap_or_else(|| {
+                tracing::warn!(
+                    target: "slpn_cuda::device_match",
+                    vulkan_uuid = ?vulkan_uuid,
+                    "no CUDA device matches Vulkan device UUID; falling back to CUDA \
+                     ordinal 0 (single-GPU hosts unaffected; multi-GPU may run on the \
+                     wrong device)",
+                );
+                0
+            });
         if let Err(e) = unsafe { sys::cudaSetDevice(cuda_device_ordinal) }.result() {
             tracing::error!(
                 "slpn_cuda_runtime_new: cudaSetDevice({}) failed: {:?}",

--- a/libs/vulkan-jpeg/Cargo.toml
+++ b/libs/vulkan-jpeg/Cargo.toml
@@ -14,6 +14,20 @@ bytemuck = { version = "1.16", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 streamlib = { path = "../streamlib-sdk" }
+# Dynamic loading for libnvjpeg.so.12. nvJPEG is NVIDIA-only and not
+# always installed; resolving at runtime keeps the workspace building
+# cleanly on hosts without the CUDA Toolkit. See
+# `docs/architecture/third-party-gpu-backends.md` for the rationale
+# (anti-pattern #5: Cargo-feature gating of vendor SDKs).
+libloading = "0.8"
+# CUDA bindings — `fallback-dynamic-loading` mirrors the dlopen shape
+# above for the cudart side. Workspace pin keeps `cuda-12090` aligned
+# with the cdylibs.
+cudarc = { workspace = true }
+# `libc::close` for closing the dup'd OPAQUE_FD on the error path of
+# `cudaImportExternalMemory` — ownership stays with us when the import
+# fails, so we must `close(fd)`.
+libc = "0.2"
 
 [dev-dependencies]
 jpeg-encoder = "0.6"

--- a/libs/vulkan-jpeg/src/backend.rs
+++ b/libs/vulkan-jpeg/src/backend.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Backend dispatch for [`SimpleJpegDecoder`].
+//!
+//! Two implementations ship today:
+//!
+//! - [`VulkanComputeBackend`] — cross-vendor Vulkan compute kernel, host CPU
+//!   parser + Huffman entropy decode → fused dequant + IDCT + chroma upsample
+//!   + YCbCr→RGB compute kernel. Always available on any Vulkan device.
+//! - [`NvJpegBackend`] — NVIDIA `libnvjpeg` (CUDA-based JPEG decode). Used
+//!   automatically when [`HostVulkanDevice::third_party_gpu_capabilities`]
+//!   reports `nvjpeg = true` and the backend's own initialization succeeds.
+//!
+//! **If you're integrating a non-JPEG GPU library that follows the same
+//! engine-allocates / vendor-imports shape (NVDEC for H.264/H.265, AMD AMF,
+//! Intel MFX, OptiX denoiser): do not copy this trait shape per-library.**
+//! See `docs/architecture/third-party-gpu-backends.md` — the second
+//! backend-using library is the trigger to lift this JPEG-specific trait
+//! to an engine-tier `ThirdPartyGpuBackend` primitive.
+//!
+//! [`HostVulkanDevice::third_party_gpu_capabilities`]:
+//!   streamlib::sdk::engine::host_rhi::HostVulkanDevice::third_party_gpu_capabilities
+//! [`VulkanComputeBackend`]: crate::vulkan_compute_backend::VulkanComputeBackend
+//! [`NvJpegBackend`]: crate::nvjpeg_backend::NvJpegBackend
+
+use streamlib::sdk::error::Result;
+
+use crate::simple_decoder::JpegDecodeOutput;
+
+/// Stable identifier for a JPEG-decode backend implementation. Used by
+/// callers that want to force a specific backend via
+/// [`crate::simple_decoder::JpegBackendPreference::Force`], by tracing
+/// instrumentation that wants to label which backend produced a frame,
+/// and by callers preflighting available backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JpegBackendKind {
+    /// Cross-vendor Vulkan compute kernel — host CPU parser + Huffman
+    /// entropy decode → fused dequant + IDCT + chroma upsample +
+    /// YCbCr→RGB compute kernel. Always available on any Vulkan device.
+    VulkanCompute,
+    /// NVIDIA `libnvjpeg` (CUDA-based JPEG decode). Available on NVIDIA
+    /// hardware when `libnvjpeg.so.12` is loadable and the backend's
+    /// own initialization succeeds.
+    NvJpeg,
+}
+
+impl JpegBackendKind {
+    /// Human-readable label, used in tracing and error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            JpegBackendKind::VulkanCompute => "vulkan-compute",
+            JpegBackendKind::NvJpeg => "nvjpeg",
+        }
+    }
+}
+
+/// JPEG-decode backend contract — `&[u8] → JpegDecodeOutput`. The trait
+/// sits above the host CPU parser + Huffman stage because nvJPEG does its
+/// own entropy decode on the GPU and bypasses the
+/// host-parser-then-dispatch-compute shape of the Vulkan-compute backend.
+///
+/// Implementations own all backend-specific pre-allocated state
+/// (compute pipeline + SSBOs for Vulkan-compute; CUDA context + OPAQUE_FD
+/// staging buffer + nvJPEG handle for nvJPEG) and a [`TextureRing`] of
+/// output texture slots that `decode` rotates through. Per-call work is
+/// Limited-safe — no `vkAllocateMemory`, no `cudaMalloc`, no pipeline /
+/// fence creation in steady state.
+///
+/// [`TextureRing`]: streamlib::sdk::context::TextureRing
+pub trait JpegDecodeBackend: Send + std::fmt::Debug {
+    /// Decode `jpeg_bytes` into the backend's next output slot. Returns
+    /// the slot's [`JpegDecodeOutput`] (texture + surface_id + dimensions
+    /// + resolved colorimetry) so downstream consumers can pick it up
+    /// through the normal `surface_id` contract.
+    ///
+    /// Errors:
+    /// - [`streamlib::sdk::error::Error::GpuError`] for parser / Huffman
+    ///   failures, dimension overflows past the backend's declared maxima,
+    ///   colorimetry-resolution failures, and backend-specific GPU /
+    ///   vendor-SDK failures.
+    /// - [`streamlib::sdk::error::Error::NotSupported`] for inputs the
+    ///   backend cannot handle (e.g. non-4:2:0 sampling on the
+    ///   Vulkan-compute backend; progressive JPEGs on nvJPEG when the
+    ///   subsystem isn't enabled).
+    fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput>;
+
+    /// Backend identity. Stable across the backend's lifetime; used by
+    /// tracing and callers that want to confirm which backend
+    /// [`crate::simple_decoder::SimpleJpegDecoder`] selected.
+    fn kind(&self) -> JpegBackendKind;
+}

--- a/libs/vulkan-jpeg/src/lib.rs
+++ b/libs/vulkan-jpeg/src/lib.rs
@@ -22,9 +22,15 @@ mod parser;
 mod scan;
 
 #[cfg(target_os = "linux")]
+pub mod backend;
+#[cfg(target_os = "linux")]
 pub mod kernel;
 #[cfg(target_os = "linux")]
+pub mod nvjpeg_backend;
+#[cfg(target_os = "linux")]
 pub mod simple_decoder;
+#[cfg(target_os = "linux")]
+pub mod vulkan_compute_backend;
 
 pub use color::{
     AdobeMetadata, AdobeTransform, ExifColorSpace, JfifMetadata, JpegColorInfo,
@@ -40,9 +46,17 @@ pub use huffman::HuffmanClass;
 pub use marker::ZIGZAG;
 
 #[cfg(target_os = "linux")]
+pub use backend::{JpegBackendKind, JpegDecodeBackend};
+#[cfg(target_os = "linux")]
 pub use kernel::{JpegDecodeKernel, JPEG_DECODE_WORKGROUP_SIZE};
 #[cfg(target_os = "linux")]
-pub use simple_decoder::{JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
+pub use nvjpeg_backend::NvJpegBackend;
+#[cfg(target_os = "linux")]
+pub use simple_decoder::{
+    JpegBackendPreference, JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT,
+};
+#[cfg(target_os = "linux")]
+pub use vulkan_compute_backend::VulkanComputeBackend;
 
 /// Parse and entropy-decode a baseline-sequential JPEG bitstream.
 ///

--- a/libs/vulkan-jpeg/src/nvjpeg_backend.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend.rs
@@ -2,15 +2,39 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! NVIDIA `libnvjpeg` (CUDA-based JPEG decode) [`JpegDecodeBackend`]
-//! implementation — placeholder. The dispatcher in
-//! [`crate::simple_decoder::SimpleJpegDecoder`] references this type so
-//! [`crate::backend::JpegBackendKind::NvJpeg`] has a typed
-//! implementation to dispatch to; the actual decode flow (CUDA context
-//! init, OPAQUE_FD interop, `nvjpegDecode` + cudaMemcpy2DAsync +
-//! vkCmdCopyBufferToImage) lands in a follow-up commit. Until then,
-//! `NvJpegBackend::new` returns [`Error::NotSupported`] and the
-//! dispatcher's `Auto` path falls back to
-//! [`crate::vulkan_compute_backend::VulkanComputeBackend`].
+//! implementation.
+//!
+//! Engine-allocates / vendor-imports per
+//! `docs/architecture/third-party-gpu-backends.md`:
+//!
+//! 1. Host allocates a DEVICE_LOCAL OPAQUE_FD-exportable `VkBuffer` sized
+//!    for `max_width * max_height * 4` (worst-case RGBA8 output) via
+//!    [`HostVulkanBuffer::new_opaque_fd_export_device_local`] — one per
+//!    [`MAX_FRAMES_IN_FLIGHT`] ring slot.
+//! 2. Host exports the FD via `vkGetMemoryFdKHR` and imports it into
+//!    CUDA via `cudaImportExternalMemory(OPAQUE_FD)` →
+//!    `cudaExternalMemoryGetMappedBuffer`, yielding a `CUdeviceptr`
+//!    aliased to the same physical memory the Vulkan side sees.
+//! 3. Host allocates an OPAQUE_FD-exportable Vulkan timeline semaphore
+//!    via [`HostVulkanTimelineSemaphore::new_exportable`] and imports
+//!    it into CUDA via `cudaImportExternalSemaphore(TimelineSemaphoreFd)`.
+//! 4. Per-frame: `nvjpegDecode` decodes into the imported CUDA pointer
+//!    (output format `NVJPEG_OUTPUT_RGBI` packed to a 4-channel layout
+//!    matching `Rgba8Unorm`); CUDA signals the timeline; the Vulkan
+//!    side waits on the same timeline (cross-API sync) and records
+//!    `vkCmdCopyBufferToImage` into the next ring slot's render-target
+//!    [`Texture`].
+//! 5. The ring slot's `surface_id` is returned through
+//!    [`JpegDecodeOutput`] — downstream consumers consume the texture
+//!    identically regardless of which backend produced it.
+//!
+//! The `nvjpeg.h` symbols are resolved via [`libloading`] at construction
+//! time; the workspace builds cleanly on hosts without libnvjpeg
+//! installed, and the dlopen-failure path surfaces as
+//! [`Error::NotSupported`]. See [`crate::backend::JpegDecodeBackend`] for
+//! the trait contract and
+//! `docs/architecture/third-party-gpu-backends.md` for the architecture
+//! framing and "when to lift to engine-tier" trigger.
 
 use streamlib::sdk::context::GpuContextFullAccess;
 use streamlib::sdk::error::{Error, Result};
@@ -18,35 +42,74 @@ use streamlib::sdk::error::{Error, Result};
 use crate::backend::{JpegBackendKind, JpegDecodeBackend};
 use crate::simple_decoder::JpegDecodeOutput;
 
-pub struct NvJpegBackend;
+mod ffi;
+mod resources;
+
+use resources::NvJpegResources;
+
+/// NVIDIA `libnvjpeg` backend for [`crate::simple_decoder::SimpleJpegDecoder`].
+///
+/// Allocates one OPAQUE_FD-exportable `VkBuffer` per ring slot (sized for
+/// worst-case RGBA8 output at `max_width * max_height`) plus an exportable
+/// Vulkan timeline semaphore — all imported into a CUDA context that
+/// `libnvjpeg` decodes into. Per-frame decode runs on CUDA, signals the
+/// timeline, and the host-side `vkCmdCopyBufferToImage` lands the result
+/// in a normal render-target [`crate::simple_decoder::JpegDecodeOutput::texture`].
+pub struct NvJpegBackend {
+    resources: NvJpegResources,
+    max_width: u32,
+    max_height: u32,
+}
 
 impl std::fmt::Debug for NvJpegBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NvJpegBackend").finish_non_exhaustive()
+        f.debug_struct("NvJpegBackend")
+            .field("max_width", &self.max_width)
+            .field("max_height", &self.max_height)
+            .finish()
     }
 }
 
 impl NvJpegBackend {
+    /// Build an nvJPEG backend ready to handle JPEGs up to
+    /// `(max_width, max_height)` pixels.
+    ///
+    /// Returns [`Error::NotSupported`] when:
+    /// - `libnvjpeg.so.12` cannot be `dlopen`ed (caller can fall back to
+    ///   the Vulkan-compute backend; this is the gating check
+    ///   [`crate::simple_decoder::SimpleJpegDecoder::new_with_preference`]
+    ///   uses to choose `Auto`).
+    /// - `libcudart.so.12` cannot be loaded.
+    /// - CUDA context initialization fails (no CUDA-capable device, driver
+    ///   mismatch, etc.).
+    /// - `nvjpegCreateSimple` returns a non-success status.
+    ///
+    /// All other errors (OPAQUE_FD pool unavailable, FD export failure,
+    /// timeline-semaphore export failure, CUDA memory-import failure)
+    /// surface as [`Error::GpuError`].
     pub fn new(
-        _full_access: &GpuContextFullAccess,
-        _max_width: u32,
-        _max_height: u32,
+        full_access: &GpuContextFullAccess,
+        max_width: u32,
+        max_height: u32,
     ) -> Result<Self> {
-        Err(Error::NotSupported(
-            "nvJPEG backend implementation pending — only the dispatcher \
-             wiring + capability probe land in this commit"
-                .into(),
-        ))
+        if max_width == 0 || max_height == 0 {
+            return Err(Error::GpuError(format!(
+                "NvJpegBackend::new: max dimensions must be non-zero, got {}x{}",
+                max_width, max_height,
+            )));
+        }
+        let resources = NvJpegResources::new(full_access, max_width, max_height)?;
+        Ok(Self {
+            resources,
+            max_width,
+            max_height,
+        })
     }
 }
 
 impl JpegDecodeBackend for NvJpegBackend {
-    fn decode(&mut self, _jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
-        // Unreachable: `Self::new` always errors at this commit's tree
-        // state, so no caller holds a constructed `NvJpegBackend`.
-        Err(Error::NotSupported(
-            "nvJPEG backend implementation pending".into(),
-        ))
+    fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
+        self.resources.decode(jpeg_bytes, self.max_width, self.max_height)
     }
 
     fn kind(&self) -> JpegBackendKind {

--- a/libs/vulkan-jpeg/src/nvjpeg_backend.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! NVIDIA `libnvjpeg` (CUDA-based JPEG decode) [`JpegDecodeBackend`]
+//! implementation — placeholder. The dispatcher in
+//! [`crate::simple_decoder::SimpleJpegDecoder`] references this type so
+//! [`crate::backend::JpegBackendKind::NvJpeg`] has a typed
+//! implementation to dispatch to; the actual decode flow (CUDA context
+//! init, OPAQUE_FD interop, `nvjpegDecode` + cudaMemcpy2DAsync +
+//! vkCmdCopyBufferToImage) lands in a follow-up commit. Until then,
+//! `NvJpegBackend::new` returns [`Error::NotSupported`] and the
+//! dispatcher's `Auto` path falls back to
+//! [`crate::vulkan_compute_backend::VulkanComputeBackend`].
+
+use streamlib::sdk::context::GpuContextFullAccess;
+use streamlib::sdk::error::{Error, Result};
+
+use crate::backend::{JpegBackendKind, JpegDecodeBackend};
+use crate::simple_decoder::JpegDecodeOutput;
+
+pub struct NvJpegBackend;
+
+impl std::fmt::Debug for NvJpegBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NvJpegBackend").finish_non_exhaustive()
+    }
+}
+
+impl NvJpegBackend {
+    pub fn new(
+        _full_access: &GpuContextFullAccess,
+        _max_width: u32,
+        _max_height: u32,
+    ) -> Result<Self> {
+        Err(Error::NotSupported(
+            "nvJPEG backend implementation pending — only the dispatcher \
+             wiring + capability probe land in this commit"
+                .into(),
+        ))
+    }
+}
+
+impl JpegDecodeBackend for NvJpegBackend {
+    fn decode(&mut self, _jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
+        // Unreachable: `Self::new` always errors at this commit's tree
+        // state, so no caller holds a constructed `NvJpegBackend`.
+        Err(Error::NotSupported(
+            "nvJPEG backend implementation pending".into(),
+        ))
+    }
+
+    fn kind(&self) -> JpegBackendKind {
+        JpegBackendKind::NvJpeg
+    }
+}

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/ffi.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/ffi.rs
@@ -1,0 +1,295 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Hand-written FFI declarations for the subset of `libnvjpeg.so.12` the
+//! backend uses. Resolved via [`libloading`] at runtime — the workspace
+//! builds cleanly on hosts without nvJPEG installed; failure to `dlopen`
+//! surfaces as [`Error::NotSupported`] from
+//! [`crate::nvjpeg_backend::NvJpegBackend::new`].
+//!
+//! Symbols mirror NVIDIA's `nvjpeg.h` from the CUDA Toolkit 12.x line. The
+//! C API is stable across the 12.x major: signatures match the header
+//! verbatim, and we resolve a small subset (handle init/destroy, state
+//! init/destroy, image-info query, decode).
+//!
+//! [`Error::NotSupported`]: streamlib::sdk::error::Error::NotSupported
+
+#![allow(non_camel_case_types, non_upper_case_globals, dead_code)]
+
+use std::ffi::{c_int, c_uint, c_void};
+use std::sync::Arc;
+
+use libloading::{Library, Symbol};
+use streamlib::sdk::error::{Error, Result};
+
+/// Opaque handle type — `struct nvjpegHandle*`.
+pub type nvjpegHandle_t = *mut c_void;
+/// Opaque per-decoder state — `struct nvjpegJpegState*`.
+pub type nvjpegJpegState_t = *mut c_void;
+/// CUDA stream handle — `cudaStream_t` is `void*` in CUDA runtime.
+pub type cudaStream_t = *mut c_void;
+
+/// `nvjpegStatus_t` — full enum from `nvjpeg.h`. We only special-case
+/// `NVJPEG_STATUS_SUCCESS`; other variants map to a descriptive error
+/// string.
+pub const NVJPEG_STATUS_SUCCESS: c_int = 0;
+
+/// `NVJPEG_MAX_COMPONENT` from the header — fixed at 4 for the 12.x
+/// API. Matches `nvjpegImage_t::channel[]` / `pitch[]` array sizing.
+pub const NVJPEG_MAX_COMPONENT: usize = 4;
+
+/// `nvjpegOutputFormat_t` — we only use `NVJPEG_OUTPUT_RGBI`
+/// (interleaved RGB, 3 bytes per pixel in `channel[0]`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum nvjpegOutputFormat_t {
+    Unchanged = 0,
+    Yuv = 1,
+    Y = 2,
+    Rgb = 3,
+    Bgr = 4,
+    Rgbi = 5,
+    Bgri = 6,
+}
+
+/// `nvjpegChromaSubsampling_t` from the header. Returned by
+/// `nvjpegGetImageInfo`; we forward it to the caller for tracing but
+/// don't gate on it (nvJPEG accepts any subsampling on the decode path).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum nvjpegChromaSubsampling_t {
+    Css444 = 0,
+    Css422 = 1,
+    Css420 = 2,
+    Css440 = 3,
+    Css411 = 4,
+    Css410 = 5,
+    CssGray = 6,
+    Css410v = 7,
+    CssUnknown = -1,
+}
+
+/// `nvjpegImage_t` — caller-supplied output descriptor passed to
+/// `nvjpegDecode`. For `NVJPEG_OUTPUT_RGBI` only `channel[0]` /
+/// `pitch[0]` are used.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct nvjpegImage_t {
+    pub channel: [*mut u8; NVJPEG_MAX_COMPONENT],
+    pub pitch: [usize; NVJPEG_MAX_COMPONENT],
+}
+
+impl Default for nvjpegImage_t {
+    fn default() -> Self {
+        Self {
+            channel: [std::ptr::null_mut(); NVJPEG_MAX_COMPONENT],
+            pitch: [0; NVJPEG_MAX_COMPONENT],
+        }
+    }
+}
+
+// ---- FFI signatures ----
+//
+// All return `nvjpegStatus_t` (i.e. `c_int`). Status codes are
+// translated via `status_to_error` below.
+
+type nvjpegCreateSimpleFn = unsafe extern "C" fn(handle: *mut nvjpegHandle_t) -> c_int;
+type nvjpegDestroyFn = unsafe extern "C" fn(handle: nvjpegHandle_t) -> c_int;
+type nvjpegJpegStateCreateFn =
+    unsafe extern "C" fn(handle: nvjpegHandle_t, state: *mut nvjpegJpegState_t) -> c_int;
+type nvjpegJpegStateDestroyFn = unsafe extern "C" fn(state: nvjpegJpegState_t) -> c_int;
+type nvjpegGetImageInfoFn = unsafe extern "C" fn(
+    handle: nvjpegHandle_t,
+    data: *const u8,
+    length: usize,
+    n_components: *mut c_int,
+    subsampling: *mut nvjpegChromaSubsampling_t,
+    widths: *mut c_int,
+    heights: *mut c_int,
+) -> c_int;
+type nvjpegDecodeFn = unsafe extern "C" fn(
+    handle: nvjpegHandle_t,
+    state: nvjpegJpegState_t,
+    data: *const u8,
+    length: usize,
+    output_format: nvjpegOutputFormat_t,
+    destination: *mut nvjpegImage_t,
+    stream: cudaStream_t,
+) -> c_int;
+
+/// Loaded `libnvjpeg.so.12` + every symbol we use, resolved once at
+/// construction. Cheap to clone (`Arc<Library>` underneath, raw fn
+/// pointers).
+#[derive(Clone)]
+pub struct NvJpegLib {
+    // Keeping `_library` alive in the struct ensures the resolved
+    // function pointers stay valid; dropping the lib would `dlclose`
+    // and invalidate them.
+    _library: Arc<Library>,
+    pub create_simple: nvjpegCreateSimpleFn,
+    pub destroy: nvjpegDestroyFn,
+    pub state_create: nvjpegJpegStateCreateFn,
+    pub state_destroy: nvjpegJpegStateDestroyFn,
+    pub get_image_info: nvjpegGetImageInfoFn,
+    pub decode: nvjpegDecodeFn,
+}
+
+impl std::fmt::Debug for NvJpegLib {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NvJpegLib").finish_non_exhaustive()
+    }
+}
+
+impl NvJpegLib {
+    /// Resolve `libnvjpeg.so.12` and every symbol we use. Returns
+    /// [`Error::NotSupported`] when the dynamic linker can't find the
+    /// library — that's the canonical "no nvJPEG on this host" signal
+    /// the auto-selection path checks. Tries the bare SONAME first
+    /// (works when `ldconfig` has refreshed since the CUDA Toolkit
+    /// install) then falls back to canonical CUDA Toolkit install
+    /// paths — see [`probe_nvjpeg_loadable_paths`] for the list.
+    pub fn load() -> Result<Self> {
+        // SAFETY: `libloading::Library::new` is safe per its contract —
+        // failure returns `Err`, not undefined behavior. The library is
+        // held in `Arc<Library>` to keep `_library` (and thus the
+        // resolved symbol addresses) alive for the struct's lifetime.
+        let mut last_err: Option<libloading::Error> = None;
+        let mut loaded: Option<Library> = None;
+        for candidate in probe_nvjpeg_loadable_paths() {
+            match unsafe { Library::new(candidate) } {
+                Ok(lib) => {
+                    loaded = Some(lib);
+                    break;
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+        let library = loaded.ok_or_else(|| {
+            let err_msg = last_err.map_or_else(
+                || "no candidate paths".to_string(),
+                |e| format!("{e}"),
+            );
+            Error::NotSupported(format!(
+                "libnvjpeg.so.12 not loadable: {err_msg} (install libnvjpeg-dev-12-* \
+                 from the NVIDIA CUDA apt repository, or `sudo ldconfig` if just installed)"
+            ))
+        })?;
+        let library = Arc::new(library);
+
+        // SAFETY: each symbol lookup either succeeds with a non-null
+        // function pointer whose signature matches the C ABI per
+        // `nvjpeg.h`, or returns `Err`. Resolved fn pointers are copied
+        // out before the `Symbol` borrow ends; calling them through
+        // their FFI types stays sound for as long as `_library` keeps
+        // the underlying `Library` alive.
+        let (create_simple, destroy, state_create, state_destroy, get_image_info, decode) = unsafe {
+            let create_simple: Symbol<nvjpegCreateSimpleFn> = library
+                .get(b"nvjpegCreateSimple\0")
+                .map_err(|e| symbol_err("nvjpegCreateSimple", e))?;
+            let destroy: Symbol<nvjpegDestroyFn> = library
+                .get(b"nvjpegDestroy\0")
+                .map_err(|e| symbol_err("nvjpegDestroy", e))?;
+            let state_create: Symbol<nvjpegJpegStateCreateFn> = library
+                .get(b"nvjpegJpegStateCreate\0")
+                .map_err(|e| symbol_err("nvjpegJpegStateCreate", e))?;
+            let state_destroy: Symbol<nvjpegJpegStateDestroyFn> = library
+                .get(b"nvjpegJpegStateDestroy\0")
+                .map_err(|e| symbol_err("nvjpegJpegStateDestroy", e))?;
+            let get_image_info: Symbol<nvjpegGetImageInfoFn> = library
+                .get(b"nvjpegGetImageInfo\0")
+                .map_err(|e| symbol_err("nvjpegGetImageInfo", e))?;
+            let decode: Symbol<nvjpegDecodeFn> = library
+                .get(b"nvjpegDecode\0")
+                .map_err(|e| symbol_err("nvjpegDecode", e))?;
+            (
+                *create_simple,
+                *destroy,
+                *state_create,
+                *state_destroy,
+                *get_image_info,
+                *decode,
+            )
+        };
+
+        Ok(Self {
+            _library: library,
+            create_simple,
+            destroy,
+            state_create,
+            state_destroy,
+            get_image_info,
+            decode,
+        })
+    }
+}
+
+/// Candidate paths the dynamic linker tries for `libnvjpeg.so.12`,
+/// in priority order. Matches the engine's
+/// `probe_nvjpeg_loadable` fallback list — keep the two in sync. A
+/// fresh `libnvjpeg-dev-12-*` apt install often leaves the ldconfig
+/// cache stale until the next `ldconfig` run; falling back to
+/// explicit paths means runtime backend selection doesn't depend on
+/// root-only cache state.
+pub(crate) fn probe_nvjpeg_loadable_paths() -> &'static [&'static str] {
+    &[
+        "libnvjpeg.so.12",
+        "/usr/local/cuda/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.9/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.8/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.7/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.6/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.5/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.4/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.3/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.2/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.1/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvjpeg.so.12",
+        "/usr/lib/x86_64-linux-gnu/libnvjpeg.so.12",
+    ]
+}
+
+fn symbol_err(symbol: &str, e: libloading::Error) -> Error {
+    Error::GpuError(format!(
+        "libnvjpeg.so.12 found but symbol {symbol} unresolvable: {e} \
+         (ABI mismatch — nvJPEG header may be older than the loaded library)"
+    ))
+}
+
+/// Translate a non-success `nvjpegStatus_t` into a `streamlib::Error`.
+pub fn status_to_error(context: &str, status: c_int) -> Error {
+    if status == NVJPEG_STATUS_SUCCESS {
+        // Defensive — callers should only reach this with a non-success
+        // status, but a guard makes misuse obvious.
+        return Error::GpuError(format!(
+            "{context}: unexpected status_to_error call with SUCCESS (0)"
+        ));
+    }
+    Error::GpuError(format!(
+        "{context}: nvjpegStatus_t = {status} ({})",
+        nvjpeg_status_label(status),
+    ))
+}
+
+/// Best-effort human-readable label for a `nvjpegStatus_t`. The exact
+/// enum identifiers come from `nvjpeg.h`.
+fn nvjpeg_status_label(status: c_int) -> &'static str {
+    match status {
+        0 => "NVJPEG_STATUS_SUCCESS",
+        1 => "NVJPEG_STATUS_NOT_INITIALIZED",
+        2 => "NVJPEG_STATUS_INVALID_PARAMETER",
+        3 => "NVJPEG_STATUS_BAD_JPEG",
+        4 => "NVJPEG_STATUS_JPEG_NOT_SUPPORTED",
+        5 => "NVJPEG_STATUS_ALLOCATOR_FAILURE",
+        6 => "NVJPEG_STATUS_EXECUTION_FAILED",
+        7 => "NVJPEG_STATUS_ARCH_MISMATCH",
+        8 => "NVJPEG_STATUS_INTERNAL_ERROR",
+        9 => "NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED",
+        10 => "NVJPEG_STATUS_INCOMPLETE_BITSTREAM",
+        _ => "unknown",
+    }
+}
+
+// Keep the linker happy: rustc complains if `c_uint` and `c_void` are
+// imported but unused after refactors. Bind them to a dummy `_` so the
+// imports stay live in case future symbols need them.
+const _: c_uint = 0;

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
@@ -630,3 +630,62 @@ fn match_cuda_device_to_vulkan_uuid(vulkan_uuid: &[u8; 16]) -> Option<i32> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On a non-NVIDIA / no-CUDA host (and on no-match-found CUDA hosts),
+    /// the helper returns `None` rather than panicking — that's the
+    /// fallback case the caller's `.unwrap_or_else(|| 0)` relies on.
+    /// Bogus all-zero UUID exercises the no-match branch even on
+    /// CUDA-capable hosts.
+    #[test]
+    fn match_cuda_device_to_vulkan_uuid_bogus_uuid_returns_none() {
+        let bogus = [0u8; 16];
+        let result = match_cuda_device_to_vulkan_uuid(&bogus);
+        assert!(
+            result.is_none(),
+            "all-zero Vulkan UUID must not match any real CUDA device; got {result:?}"
+        );
+    }
+
+    /// When a Vulkan device is available on this host, the helper must
+    /// return `Some(ordinal)` for that device's UUID — locks the
+    /// "successful UUID match on a single-GPU NVIDIA host" path that
+    /// the production `NvJpegResources::new` relies on. Skips cleanly
+    /// when no Vulkan device or no CUDA runtime is available.
+    #[test]
+    fn match_cuda_device_to_vulkan_uuid_matches_local_vulkan_device() {
+        use streamlib::sdk::engine::host_rhi::HostVulkanDevice;
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!("Skipping — no Vulkan device available");
+                return;
+            }
+        };
+        if !device.third_party_gpu_capabilities().nvjpeg {
+            eprintln!(
+                "Skipping — capability probe says nvjpeg=false; \
+                 host probably has no NVIDIA + libnvjpeg combination"
+            );
+            return;
+        }
+        let vulkan_uuid = device.physical_device_uuid();
+        let ordinal = match_cuda_device_to_vulkan_uuid(&vulkan_uuid);
+        // Defensive: even if the UUID match somehow fails on this NVIDIA
+        // host, the caller's `unwrap_or_else(|| 0)` keeps single-GPU
+        // behavior alive. The assertion locks the GREEN path — UUID
+        // matching DOES work against real hardware when capability is
+        // true. Mentally revert the `unsafe { std::mem::transmute }`
+        // call to e.g. `[0u8; 16]` and this test fails on every
+        // NVIDIA host.
+        assert!(
+            ordinal.is_some(),
+            "nvjpeg capability is true but the UUID match returned None — \
+             Vulkan device UUID {vulkan_uuid:?} did not match any CUDA \
+             device. This is a multi-GPU mismatch or a UUID transmute regression."
+        );
+    }
+}

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
@@ -155,6 +155,32 @@ impl NvJpegResources {
         let lib = NvJpegLib::load()?;
         let device = Arc::clone(full_access.device().vulkan_device());
 
+        // ── Bind CUDA to the matching physical device ──────────────────
+        // Match the Vulkan-selected device's `VkPhysicalDeviceIDProperties::deviceUUID`
+        // against each CUDA device's `cudaDeviceProp::uuid` and call
+        // `cudaSetDevice` with the matching ordinal. On a single-GPU host
+        // this resolves to ordinal 0 either way; on multi-GPU rigs without
+        // the match, CUDA's default device may differ from the Vulkan-
+        // selected one and the OPAQUE_FD import below would land on the
+        // wrong GPU. Falls back to ordinal 0 with a warn log when no CUDA
+        // device's UUID matches (defensive — keeps single-GPU behavior
+        // even if the probe fails).
+        let vulkan_uuid = device.physical_device_uuid();
+        let cuda_ordinal = match_cuda_device_to_vulkan_uuid(&vulkan_uuid).unwrap_or_else(|| {
+            tracing::warn!(
+                target: "vulkan_jpeg::cuda_device_match",
+                vulkan_uuid = ?vulkan_uuid,
+                "no CUDA device matches Vulkan device UUID; falling back to CUDA ordinal 0 \
+                 (single-GPU hosts unaffected; multi-GPU may decode on the wrong device)",
+            );
+            0
+        });
+        unsafe {
+            sys::cudaSetDevice(cuda_ordinal).result().map_err(|e| {
+                Error::GpuError(format!("cudaSetDevice({cuda_ordinal}): {e:?}"))
+            })?;
+        }
+
         // ── CUDA stream ────────────────────────────────────────────────
         let stream = unsafe {
             let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
@@ -555,4 +581,52 @@ fn build_slot(
         cuda_shared_dev_ptr,
         cuda_rgbi_ptr,
     })
+}
+
+/// Match `vulkan_uuid` (`VkPhysicalDeviceIDProperties::deviceUUID`)
+/// against every CUDA device's `cudaDeviceProp::uuid` and return the
+/// matching ordinal, or `None` when no CUDA device shares the UUID
+/// (or CUDA isn't available).
+///
+/// Defensive helper for the multi-GPU case: CUDA's default device may
+/// not be the same physical device Vulkan selected, in which case
+/// every `cudaImportExternalMemory(OPAQUE_FD)` call lands on the
+/// wrong device and decode silently writes to the wrong GPU. Callers
+/// pair this with `cudaSetDevice(matched_ordinal)` before any other
+/// CUDA work. Returns `None` when CUDA can't be queried — caller
+/// falls back to ordinal 0 (single-GPU behavior) with a warn log.
+///
+/// Duplicated in `streamlib-python-native::cuda` and
+/// `streamlib-deno-native::cuda` — keep the three in sync. A future
+/// refactor lifts this to a shared utility crate; today's
+/// duplication is cheap enough that the engine/library/cdylib dep
+/// graph doesn't need to grow yet.
+fn match_cuda_device_to_vulkan_uuid(vulkan_uuid: &[u8; 16]) -> Option<i32> {
+    let mut count: i32 = 0;
+    if unsafe { sys::cudaGetDeviceCount(&mut count) }
+        .result()
+        .is_err()
+    {
+        return None;
+    }
+    for ordinal in 0..count {
+        let mut props = MaybeUninit::<sys::cudaDeviceProp>::uninit();
+        // SAFETY: `cudaGetDeviceProperties_v2` fully initializes the
+        // out-pointer on success. On error we skip the ordinal.
+        let ok = unsafe { sys::cudaGetDeviceProperties_v2(props.as_mut_ptr(), ordinal) }
+            .result();
+        if ok.is_err() {
+            continue;
+        }
+        let props = unsafe { props.assume_init() };
+        // `cudaDeviceProp::uuid` is `cudaUUID_t` which is
+        // `#[repr(C)] struct { bytes: [c_char; 16] }`. Transmute to a
+        // plain `[u8; 16]` for comparison against Vulkan's UUID bytes.
+        let cuda_uuid_bytes: [u8; 16] =
+            unsafe { std::mem::transmute::<sys::cudaUUID_t, [u8; 16]>(props.uuid) };
+        if cuda_uuid_bytes == *vulkan_uuid {
+            return Some(ordinal);
+        }
+    }
+    None
 }

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
@@ -1,0 +1,558 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! All the pre-allocated state the nvJPEG backend owns:
+//!
+//! - `libnvjpeg` handle + per-decoder state (resolved via `libloading`).
+//! - One CUDA stream the decode + cudaMemcpy2DAsync work runs on.
+//! - One [`TextureRing`] of `Rgba8Unorm` output textures (the consumer-
+//!   visible result; matches the Vulkan-compute backend exactly).
+//! - Per ring slot, two CUDA-side resources:
+//!   - A CUDA-private `cudaMalloc` buffer sized `max_width * max_height *
+//!     3` — the linear RGBI region nvJPEG writes into directly.
+//!   - An OPAQUE_FD-exported DEVICE_LOCAL `VkBuffer` sized
+//!     `max_width * max_height * 4` — pre-filled with `0xFF` (alpha=255
+//!     in every pixel) and imported into CUDA via
+//!     [`external_memory::import_external_memory_opaque_fd`] +
+//!     [`external_memory::get_mapped_buffer`]. The shared region acts as
+//!     the cross-API staging between CUDA's `cudaMemcpy2DAsync` and the
+//!     host-side `vkCmdCopyBufferToImage`.
+//!
+//! Per-frame decode does no allocation: nvjpegDecode → cudaMemcpy2DAsync
+//! (3bpp → 4bpp with stride trick, leaving the pre-filled alpha
+//! byte at `0xFF`) → cudaStreamSynchronize → vkCmdCopyBufferToImage →
+//! `submit_and_wait`. The CPU-side sync after cudaStreamSynchronize is
+//! sufficient cross-API ordering for same-process / same-device CUDA-
+//! Vulkan interop — no timeline semaphore is needed; the Vulkan-side
+//! `submit_and_wait` mirrors the synchronous shape the Vulkan-compute
+//! backend already uses.
+
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+use std::os::unix::io::RawFd;
+use std::sync::Arc;
+
+use cudarc::runtime::result::external_memory;
+use cudarc::runtime::sys;
+
+use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
+use streamlib::sdk::engine::host_rhi::{
+    HostVulkanBuffer, HostVulkanDevice, ImageCopyRegion, RhiCommandRecorder, VulkanAccess,
+    VulkanStage,
+};
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{Texture, TextureFormat, TextureUsages, VulkanLayout};
+
+use crate::simple_decoder::{JpegDecodeOutput, MAX_FRAMES_IN_FLIGHT};
+
+use super::ffi::{
+    self, nvjpegHandle_t, nvjpegImage_t, nvjpegJpegState_t, nvjpegOutputFormat_t, NvJpegLib,
+    NVJPEG_STATUS_SUCCESS,
+};
+
+/// Per ring slot's CUDA + Vulkan staging state.
+struct NvJpegSlot {
+    /// Consumer-visible output texture.
+    texture: Texture,
+    /// Same-process texture-cache id for the slot.
+    surface_id: String,
+
+    /// OPAQUE_FD-exported DEVICE_LOCAL `VkBuffer`, sized
+    /// `max_width * max_height * 4`. Pre-filled with `0xFF` at
+    /// construction so cudaMemcpy2DAsync's stride trick (writing 3 bytes
+    /// per pixel) leaves the alpha byte at 255.
+    shared_buffer: Arc<HostVulkanBuffer>,
+
+    /// CUDA-side import handle. Lifetime: lives until [`Self::destroy`]
+    /// drops it before the Vulkan-side `shared_buffer` Arc drops. The
+    /// drop order matters — CUDA must release its hold on the kernel FD
+    /// before Vulkan frees the underlying VkDeviceMemory.
+    cuda_ext_mem: sys::cudaExternalMemory_t,
+    /// Mapped CUDA device pointer aliasing the same kernel memory as
+    /// `shared_buffer`. Stable for the slot's lifetime.
+    cuda_shared_dev_ptr: u64,
+
+    /// CUDA-private RGBI staging buffer (`cudaMalloc`-allocated). nvJPEG
+    /// writes interleaved-RGB pixels here at pitch `width * 3`; the
+    /// subsequent `cudaMemcpy2DAsync` repitches the rows into
+    /// `shared_buffer`. Sized `max_width * max_height * 3` at
+    /// construction; freed via `cudaFree` in [`Self::destroy`].
+    cuda_rgbi_ptr: u64,
+}
+
+/// SAFETY: `cudaExternalMemory_t` is an opaque pointer-shaped handle.
+/// The CUDA Runtime API's threading contract permits creation + use +
+/// teardown from any thread, with the application responsible for not
+/// concurrently using and destroying the same handle. Our enclosing
+/// `NvJpegResources` is `&mut self` on every per-frame call, so no
+/// concurrent use is possible.
+unsafe impl Send for NvJpegSlot {}
+
+impl NvJpegSlot {
+    /// Tear down the slot's CUDA-side resources in the correct order:
+    /// `cudaExternalMemory` (releases the OPAQUE_FD kernel hold) and
+    /// the cudaMalloc'd RGBI buffer. Vulkan-side `shared_buffer`'s
+    /// `Arc<HostVulkanBuffer>` drops at the end (Rust drop order),
+    /// returning the underlying VkDeviceMemory to VMA's pool.
+    fn destroy(&mut self) {
+        unsafe {
+            if self.cuda_rgbi_ptr != 0 {
+                let _ = sys::cudaFree(self.cuda_rgbi_ptr as *mut c_void).result();
+                self.cuda_rgbi_ptr = 0;
+            }
+            if !self.cuda_ext_mem.is_null() {
+                let _ = external_memory::destroy_external_memory(self.cuda_ext_mem);
+                self.cuda_ext_mem = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
+impl Drop for NvJpegSlot {
+    fn drop(&mut self) {
+        self.destroy();
+    }
+}
+
+/// Backend-internal state owning the nvJPEG handle, CUDA stream, and
+/// per-slot CUDA + Vulkan staging.
+pub(super) struct NvJpegResources {
+    lib: NvJpegLib,
+    nvjpeg_handle: nvjpegHandle_t,
+    nvjpeg_state: nvjpegJpegState_t,
+    stream: sys::cudaStream_t,
+
+    /// Held to back the slots' `texture` references and to drop after
+    /// every per-slot CUDA handle is torn down. Unused after construction.
+    _ring: Arc<TextureRing>,
+
+    slots: Vec<NvJpegSlot>,
+    current_slot: usize,
+
+    /// Device handle for per-frame `RhiCommandRecorder` construction.
+    device: Arc<HostVulkanDevice>,
+}
+
+/// SAFETY: every field's threading contract is documented above.
+/// `Arc<HostVulkanDevice>` is `Send + Sync` already. The CUDA-side
+/// handles (`nvjpegHandle_t`, `nvjpegJpegState_t`, `cudaStream_t`) are
+/// pointer-shaped — CUDA permits use from any thread once created.
+/// We never share a `NvJpegResources` across threads concurrently; the
+/// backend is owned by a single `SimpleJpegDecoder` and every per-frame
+/// call goes through `&mut self`.
+unsafe impl Send for NvJpegResources {}
+
+impl NvJpegResources {
+    /// Bring up the nvJPEG handle + per-slot CUDA + Vulkan resources.
+    /// See module doc for the allocation shape. Construction is
+    /// privileged (FullAccess); steady-state per-frame work is not.
+    pub(super) fn new(
+        full_access: &GpuContextFullAccess,
+        max_width: u32,
+        max_height: u32,
+    ) -> Result<Self> {
+        let lib = NvJpegLib::load()?;
+        let device = Arc::clone(full_access.device().vulkan_device());
+
+        // ── CUDA stream ────────────────────────────────────────────────
+        let stream = unsafe {
+            let mut stream = MaybeUninit::<sys::cudaStream_t>::uninit();
+            sys::cudaStreamCreate(stream.as_mut_ptr())
+                .result()
+                .map_err(|e| Error::GpuError(format!("cudaStreamCreate: {e:?}")))?;
+            stream.assume_init()
+        };
+
+        // ── nvJPEG handle + state ──────────────────────────────────────
+        let mut nvjpeg_handle: nvjpegHandle_t = std::ptr::null_mut();
+        let status = unsafe { (lib.create_simple)(&mut nvjpeg_handle) };
+        if status != NVJPEG_STATUS_SUCCESS {
+            unsafe {
+                let _ = sys::cudaStreamDestroy(stream).result();
+            }
+            return Err(ffi::status_to_error("nvjpegCreateSimple", status));
+        }
+
+        let mut nvjpeg_state: nvjpegJpegState_t = std::ptr::null_mut();
+        let status = unsafe { (lib.state_create)(nvjpeg_handle, &mut nvjpeg_state) };
+        if status != NVJPEG_STATUS_SUCCESS {
+            unsafe {
+                let _ = (lib.destroy)(nvjpeg_handle);
+                let _ = sys::cudaStreamDestroy(stream).result();
+            }
+            return Err(ffi::status_to_error("nvjpegJpegStateCreate", status));
+        }
+
+        // ── Output texture ring (consumer-visible Rgba8Unorm) ──────────
+        // GENERAL layout — same shape as VulkanComputeBackend's ring,
+        // because `vkCmdCopyBufferToImage` accepts GENERAL as the dst
+        // layout (suboptimal vs TRANSFER_DST_OPTIMAL but allows zero
+        // per-frame barriers).
+        let ring = full_access.create_texture_ring(
+            max_width,
+            max_height,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_SRC,
+            MAX_FRAMES_IN_FLIGHT,
+        )?;
+
+        for slot_index in 0..ring.len() {
+            let slot = ring
+                .slot(slot_index)
+                .ok_or_else(|| Error::GpuError("ring slot index out of range".into()))?;
+            let mut recorder =
+                RhiCommandRecorder::new(&device, "nvjpeg_backend_init_layout")?;
+            recorder.begin()?;
+            recorder.record_image_barrier(
+                &slot.texture,
+                VulkanLayout::UNDEFINED,
+                VulkanLayout::GENERAL,
+                VulkanStage::TOP_OF_PIPE,
+                VulkanStage::ALL_TRANSFER,
+                VulkanAccess::NONE,
+                VulkanAccess::TRANSFER_WRITE,
+            )?;
+            recorder.submit_and_wait()?;
+            full_access
+                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
+        }
+
+        // ── Per-slot OPAQUE_FD staging + CUDA imports ──────────────────
+        let shared_size_bytes: usize = (max_width as usize)
+            .checked_mul(max_height as usize)
+            .and_then(|v| v.checked_mul(4))
+            .ok_or_else(|| {
+                Error::GpuError(format!(
+                    "NvJpegBackend: shared buffer size overflow at {}x{}",
+                    max_width, max_height,
+                ))
+            })?;
+        let rgbi_size_bytes: usize = (max_width as usize)
+            .checked_mul(max_height as usize)
+            .and_then(|v| v.checked_mul(3))
+            .ok_or_else(|| {
+                Error::GpuError(format!(
+                    "NvJpegBackend: RGBI buffer size overflow at {}x{}",
+                    max_width, max_height,
+                ))
+            })?;
+
+        let mut slots: Vec<NvJpegSlot> = Vec::with_capacity(ring.len());
+        let mut construction_err: Option<Error> = None;
+
+        for slot_index in 0..ring.len() {
+            let ring_slot = match ring.slot(slot_index) {
+                Some(s) => s,
+                None => {
+                    construction_err =
+                        Some(Error::GpuError("ring slot index out of range".into()));
+                    break;
+                }
+            };
+
+            let result = build_slot(
+                &device,
+                &ring_slot.texture,
+                &ring_slot.surface_id,
+                shared_size_bytes,
+                rgbi_size_bytes,
+                stream,
+            );
+            match result {
+                Ok(slot) => slots.push(slot),
+                Err(e) => {
+                    construction_err = Some(e);
+                    break;
+                }
+            }
+        }
+
+        if let Some(e) = construction_err {
+            // Tear down whatever we got far enough on. `slots`'s
+            // `Drop` runs CUDA teardown; we still need to drop nvJPEG
+            // + stream.
+            drop(slots);
+            unsafe {
+                let _ = (lib.state_destroy)(nvjpeg_state);
+                let _ = (lib.destroy)(nvjpeg_handle);
+                let _ = sys::cudaStreamDestroy(stream).result();
+            }
+            return Err(e);
+        }
+
+        Ok(Self {
+            lib,
+            nvjpeg_handle,
+            nvjpeg_state,
+            stream,
+            _ring: ring,
+            slots,
+            current_slot: 0,
+            device,
+        })
+    }
+
+    /// Per-frame decode. Steady-state Limited-safe (no allocation, no
+    /// pipeline / fence creation; one cudaMemcpy2DAsync + one short
+    /// Vulkan submit per frame).
+    pub(super) fn decode(
+        &mut self,
+        jpeg_bytes: &[u8],
+        max_width: u32,
+        max_height: u32,
+    ) -> Result<JpegDecodeOutput> {
+        // Parse the JPEG headers on the CPU to extract dimensions + color
+        // metadata; nvJPEG re-parses internally on the GPU side. The CPU
+        // parser also runs Huffman entropy decode whose result is unused
+        // on this path — wasted ~1-3 ms per frame on a modern CPU, worth
+        // it for color-info reporting parity with the Vulkan-compute
+        // backend. A future optimization can extract a parser-only path.
+        let decoded = crate::decode(jpeg_bytes)
+            .map_err(|e| Error::GpuError(format!("jpeg parse/huffman: {e}")))?;
+
+        let width = u32::from(decoded.frame.width);
+        let height = u32::from(decoded.frame.height);
+        if width > max_width || height > max_height {
+            return Err(Error::GpuError(format!(
+                "NvJpegBackend::decode: frame {}x{} exceeds decoder maxima {}x{} \
+                 (rebuild SimpleJpegDecoder with larger max_width/max_height)",
+                width, height, max_width, max_height,
+            )));
+        }
+
+        let resolved = decoded
+            .color_info
+            .resolve()
+            .map_err(|e| Error::GpuError(format!("jpeg colorimetry: {e}")))?;
+
+        // Rotate ring slot.
+        let slot_idx = self.current_slot;
+        self.current_slot = (self.current_slot + 1) % self.slots.len();
+        let slot = &self.slots[slot_idx];
+
+        // ── nvJPEG decode into the slot's CUDA-private RGBI buffer ──────
+        let mut nvjpeg_image = nvjpegImage_t::default();
+        nvjpeg_image.channel[0] = slot.cuda_rgbi_ptr as *mut u8;
+        nvjpeg_image.pitch[0] = (width as usize) * 3;
+        let status = unsafe {
+            (self.lib.decode)(
+                self.nvjpeg_handle,
+                self.nvjpeg_state,
+                jpeg_bytes.as_ptr(),
+                jpeg_bytes.len(),
+                nvjpegOutputFormat_t::Rgbi,
+                &mut nvjpeg_image,
+                self.stream as *mut c_void,
+            )
+        };
+        if status != NVJPEG_STATUS_SUCCESS {
+            return Err(ffi::status_to_error("nvjpegDecode", status));
+        }
+
+        // ── cudaMemcpy2DAsync RGBI → shared OPAQUE_FD with alpha-padding ─
+        //
+        // The stride trick: cudaMemcpy2D treats each pixel as a "row":
+        //   - `width = 3` bytes per row (the 3 RGB bytes of one pixel)
+        //   - `height = width * height` rows (one per pixel)
+        //   - `spitch = 3` (advance source by 3 bytes after each pixel)
+        //   - `dpitch = 4` (advance destination by 4 bytes after each
+        //     pixel, leaving the 4th byte at the pre-fill 0xFF)
+        // This expands 3-channel RGBI into 4-channel `Rgba8Unorm` layout
+        // in-place — every output pixel reads `[R, G, B, 0xFF]`. The
+        // destination is laid out tightly at `actual_width * actual_height
+        // * 4` bytes; the Vulkan copy-buffer-to-image below uses
+        // `buffer_row_length = width` to match.
+        let total_pixels = (width as usize)
+            .checked_mul(height as usize)
+            .ok_or_else(|| {
+                Error::GpuError(format!(
+                    "NvJpegBackend::decode: pixel count overflow at {}x{}",
+                    width, height
+                ))
+            })?;
+        unsafe {
+            sys::cudaMemcpy2DAsync(
+                slot.cuda_shared_dev_ptr as *mut c_void,
+                4,
+                slot.cuda_rgbi_ptr as *const c_void,
+                3,
+                3,
+                total_pixels,
+                sys::cudaMemcpyKind::cudaMemcpyDeviceToDevice,
+                self.stream,
+            )
+            .result()
+            .map_err(|e| {
+                Error::GpuError(format!("cudaMemcpy2DAsync RGBI → shared: {e:?}"))
+            })?;
+        }
+
+        // ── CPU-side sync. After this returns, all CUDA writes are
+        // committed and visible to the subsequent Vulkan submit on the
+        // same physical device. Same-process / same-device CUDA-Vulkan
+        // interop doesn't require an external semaphore; the CPU-
+        // mediated ordering (`cudaStreamSynchronize` returns →
+        // `vkQueueSubmit` issues) is sufficient per CUDA and Vulkan
+        // specs. ─────────────────────────────────────────────────────────
+        unsafe {
+            sys::cudaStreamSynchronize(self.stream).result().map_err(|e| {
+                Error::GpuError(format!("cudaStreamSynchronize: {e:?}"))
+            })?;
+        }
+
+        // ── Vulkan vkCmdCopyBufferToImage shared buffer → ring slot ─────
+        let mut recorder = RhiCommandRecorder::new(&self.device, "nvjpeg_copy_to_image")?;
+        recorder.begin()?;
+        recorder.record_buffer_barrier(
+            slot.shared_buffer.as_ref(),
+            VulkanStage::ALL_COMMANDS,
+            VulkanStage::ALL_TRANSFER,
+            VulkanAccess::MEMORY_WRITE,
+            VulkanAccess::TRANSFER_READ,
+        )?;
+        recorder.record_copy_buffer_to_image(
+            slot.shared_buffer.as_ref(),
+            &slot.texture,
+            VulkanLayout::GENERAL,
+            ImageCopyRegion {
+                width,
+                height,
+                buffer_offset: 0,
+                buffer_row_length: width,
+                buffer_image_height: height,
+                mip_level: 0,
+                array_layer: 0,
+            },
+        )?;
+        recorder.submit_and_wait()?;
+
+        Ok(JpegDecodeOutput {
+            texture: slot.texture.clone(),
+            surface_id: slot.surface_id.clone(),
+            width,
+            height,
+            color_source: resolved.source,
+            color_info: resolved.info,
+        })
+    }
+}
+
+impl Drop for NvJpegResources {
+    fn drop(&mut self) {
+        // Order matters:
+        // 1. Drop slots first → CUDA imports release their OPAQUE_FD
+        //    kernel holds.
+        // 2. Drop nvJPEG state + handle next.
+        // 3. Destroy CUDA stream.
+        // 4. `_ring` drops with `self` → Vulkan teardown.
+        self.slots.clear();
+        unsafe {
+            if !self.nvjpeg_state.is_null() {
+                let _ = (self.lib.state_destroy)(self.nvjpeg_state);
+                self.nvjpeg_state = std::ptr::null_mut();
+            }
+            if !self.nvjpeg_handle.is_null() {
+                let _ = (self.lib.destroy)(self.nvjpeg_handle);
+                self.nvjpeg_handle = std::ptr::null_mut();
+            }
+            if !self.stream.is_null() {
+                let _ = sys::cudaStreamDestroy(self.stream).result();
+                self.stream = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
+/// Build one ring slot's CUDA-side staging: OPAQUE_FD export from the
+/// engine's pool, FD ownership transfer to CUDA via
+/// `cudaImportExternalMemory`, pointer mapping, RGBI cudaMalloc, and
+/// alpha pre-fill on the shared buffer.
+///
+/// FD ownership: `vkGetMemoryFdKHR` returns a fresh kernel FD; on
+/// success in `import_external_memory_opaque_fd` ownership transfers
+/// to CUDA. The error path closes the FD ourselves.
+fn build_slot(
+    device: &Arc<HostVulkanDevice>,
+    texture: &Texture,
+    surface_id: &str,
+    shared_size_bytes: usize,
+    rgbi_size_bytes: usize,
+    stream: sys::cudaStream_t,
+) -> Result<NvJpegSlot> {
+    // Vulkan-side OPAQUE_FD buffer.
+    let shared_buffer = Arc::new(HostVulkanBuffer::new_opaque_fd_export_device_local(
+        device,
+        shared_size_bytes as u64,
+    )?);
+
+    // Export FD → ownership transfers to CUDA on success.
+    let fd: RawFd = shared_buffer.export_opaque_fd_memory()?;
+    let cuda_ext_mem = unsafe {
+        match external_memory::import_external_memory_opaque_fd(fd, shared_size_bytes as u64)
+        {
+            Ok(m) => m,
+            Err(e) => {
+                // FD ownership stays with us on error — close it.
+                libc::close(fd);
+                return Err(Error::GpuError(format!(
+                    "cudaImportExternalMemory(OPAQUE_FD): {e:?}"
+                )));
+            }
+        }
+    };
+    let cuda_shared_dev_ptr = unsafe {
+        match external_memory::get_mapped_buffer(cuda_ext_mem, 0, shared_size_bytes as u64) {
+            Ok(p) => p as u64,
+            Err(e) => {
+                let _ = external_memory::destroy_external_memory(cuda_ext_mem);
+                return Err(Error::GpuError(format!(
+                    "cudaExternalMemoryGetMappedBuffer: {e:?}"
+                )));
+            }
+        }
+    };
+
+    // CUDA-private RGBI buffer.
+    let mut cuda_rgbi_raw: *mut c_void = std::ptr::null_mut();
+    unsafe {
+        sys::cudaMalloc(&mut cuda_rgbi_raw, rgbi_size_bytes).result().map_err(|e| {
+            // Clean up the shared mapping before bailing.
+            let _ = external_memory::destroy_external_memory(cuda_ext_mem);
+            Error::GpuError(format!("cudaMalloc RGBI ({rgbi_size_bytes} bytes): {e:?}"))
+        })?;
+    }
+    let cuda_rgbi_ptr = cuda_rgbi_raw as u64;
+
+    // Pre-fill the shared buffer with 0xFF (alpha=255). Issued on the
+    // shared stream so it serializes with subsequent decode work.
+    unsafe {
+        sys::cudaMemsetAsync(
+            cuda_shared_dev_ptr as *mut c_void,
+            0xFF,
+            shared_size_bytes,
+            stream,
+        )
+        .result()
+        .map_err(|e| {
+            let _ = sys::cudaFree(cuda_rgbi_raw).result();
+            let _ = external_memory::destroy_external_memory(cuda_ext_mem);
+            Error::GpuError(format!("cudaMemsetAsync alpha pre-fill: {e:?}"))
+        })?;
+        // Block until the pre-fill commits so no decode races it.
+        sys::cudaStreamSynchronize(stream).result().map_err(|e| {
+            let _ = sys::cudaFree(cuda_rgbi_raw).result();
+            let _ = external_memory::destroy_external_memory(cuda_ext_mem);
+            Error::GpuError(format!("cudaStreamSynchronize (pre-fill): {e:?}"))
+        })?;
+    }
+
+    Ok(NvJpegSlot {
+        texture: texture.clone(),
+        surface_id: surface_id.to_string(),
+        shared_buffer,
+        cuda_ext_mem,
+        cuda_shared_dev_ptr,
+        cuda_rgbi_ptr,
+    })
+}

--- a/libs/vulkan-jpeg/src/simple_decoder.rs
+++ b/libs/vulkan-jpeg/src/simple_decoder.rs
@@ -1,34 +1,36 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! High-level JPEG decoder API: parser + Huffman + fused compute kernel +
-//! pre-allocated HOST_VISIBLE SSBOs + pre-allocated [`TextureRing`] of
-//! `MAX_FRAMES_IN_FLIGHT = 2` output textures.
+//! High-level JPEG decoder API. Wraps a [`JpegDecodeBackend`] and
+//! selects between [`VulkanComputeBackend`] (cross-vendor, default) and
+//! [`NvJpegBackend`] (NVIDIA fast path) at construction time based on
+//! [`HostVulkanDevice::third_party_gpu_capabilities`] and an optional
+//! caller-supplied [`JpegBackendPreference`].
 //!
-//! Construction is privileged (allocates the kernel pipeline, the
-//! coefficient + quant-table HOST_VISIBLE SSBOs sized for the worst-case
-//! 4:2:0 frame at `(max_width, max_height)`, and a `TextureRing` of
-//! `Rgba8Unorm` STORAGE textures). Per-frame [`Self::decode`] rotates
-//! the ring and reuses the SSBOs — zero `vkAllocateMemory`, zero
-//! texture creation, zero command-pool / cb / fence creation in steady
-//! state.
-
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+//! Runtime selection rule: nvJPEG is preferred when (a) the device's
+//! `ThirdPartyGpuCapabilities::nvjpeg` is `true` and (b)
+//! [`NvJpegBackend::new`] succeeds. Construction falls back to
+//! [`VulkanComputeBackend`] otherwise. Callers can force a specific
+//! backend via [`JpegBackendPreference::Force`] — useful for testing,
+//! benchmarking, and consumers who want determinism across hosts.
+//!
+//! [`VulkanComputeBackend`]: crate::vulkan_compute_backend::VulkanComputeBackend
+//! [`NvJpegBackend`]: crate::nvjpeg_backend::NvJpegBackend
+//! [`HostVulkanDevice::third_party_gpu_capabilities`]:
+//!   streamlib::sdk::engine::host_rhi::HostVulkanDevice::third_party_gpu_capabilities
 
 use streamlib::sdk::color::ResolvedColorInfo;
-use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
-use streamlib::sdk::engine::host_rhi::{
-    HostVulkanBuffer, RhiCommandRecorder, VulkanAccess, VulkanStage,
-};
+use streamlib::sdk::context::GpuContextFullAccess;
 use streamlib::sdk::engine::HostGpuDeviceExt;
 use streamlib::sdk::error::{Error, Result};
-use streamlib::sdk::rhi::{Texture, TextureFormat, TextureUsages, VulkanLayout};
+use streamlib::sdk::rhi::Texture;
 
-use crate::color::{JpegColorInfo, JpegColorSource};
-use crate::kernel::{
-    worst_case_coefficient_buffer_bytes_420, JpegDecodeKernel, QUANT_TABLE_BUFFER_BYTES,
-};
+use crate::backend::{JpegBackendKind, JpegDecodeBackend};
+use crate::color::JpegColorSource;
+use crate::vulkan_compute_backend::VulkanComputeBackend;
+
+#[cfg(target_os = "linux")]
+use crate::nvjpeg_backend::NvJpegBackend;
 
 /// Ring depth — one frame in flight on the GPU, one being recorded on
 /// the CPU. Matches every decoder in the engine.
@@ -55,56 +57,72 @@ pub struct JpegDecodeOutput {
     /// for this frame. `UnsupportedDeclarationFallback` means the
     /// bitstream declared a colorimetry the engine can't represent
     /// yet (Adobe RGB / Display P3 / Rec.2020 via EXIF or ICC) and
-    /// the kernel decoded under the JFIF default instead.
+    /// the backend decoded under the JFIF default instead.
     pub color_source: JpegColorSource,
-    /// Resolved 4-tuple the kernel actually used for this frame.
+    /// Resolved 4-tuple the backend actually used for this frame.
     /// Cheap to compare; surfaces the dispatched matrix / range /
     /// transfer / primaries for downstream consumers that want to
     /// reason about the color decision per frame.
     pub color_info: ResolvedColorInfo,
 }
 
-/// High-level fused-compute JPEG decoder with pre-allocated GPU
-/// resources. Drops in steady-state allocation on the per-frame hot
-/// path.
+/// Backend-selection preference passed to [`SimpleJpegDecoder::new`]
+/// alongside the device.
+///
+/// [`Auto`](Self::Auto) is the recommended default: nvJPEG when
+/// available, Vulkan-compute otherwise. The escape hatches are for
+/// testing, benchmarking, and consumers that need determinism across
+/// hosts.
+#[derive(Debug, Clone, Copy)]
+pub enum JpegBackendPreference {
+    /// Use nvJPEG when the device's
+    /// [`ThirdPartyGpuCapabilities::nvjpeg`] is `true` and
+    /// [`NvJpegBackend::new`] succeeds. Fall back to the
+    /// cross-vendor Vulkan-compute backend otherwise.
+    ///
+    /// [`ThirdPartyGpuCapabilities::nvjpeg`]:
+    ///   streamlib::sdk::engine::host_rhi::ThirdPartyGpuCapabilities::nvjpeg
+    /// [`NvJpegBackend::new`]: crate::nvjpeg_backend::NvJpegBackend::new
+    Auto,
+    /// Force a specific backend. `new` returns
+    /// [`Error::NotSupported`] when the forced backend isn't
+    /// available (e.g. `Force(NvJpeg)` on a non-NVIDIA host or one
+    /// without `libnvjpeg.so.12`).
+    Force(JpegBackendKind),
+}
+
+impl Default for JpegBackendPreference {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+/// High-level fused-compute JPEG decoder.
+///
+/// Wraps a single [`JpegDecodeBackend`] chosen at construction time per
+/// [`JpegBackendPreference`]. Per-frame [`Self::decode`] forwards to the
+/// backend — no decision overhead, no hot-path allocation.
 pub struct SimpleJpegDecoder {
-    kernel: JpegDecodeKernel,
-    coef_buf: Arc<HostVulkanBuffer>,
-    qt_buf: Arc<HostVulkanBuffer>,
-    ring: Arc<TextureRing>,
+    backend: Box<dyn JpegDecodeBackend>,
     max_width: u32,
     max_height: u32,
-    /// Latch for the "non-sRGB declaration → JFIF fallback" warning.
-    /// Flips to `true` on the first frame that takes the fallback;
-    /// subsequent fallback frames stay silent so a 30 Hz pipeline
-    /// doesn't flood the log. Resetting to `false` re-arms the warn
-    /// (e.g. across a teardown / rebuild cycle).
-    unsupported_fallback_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for SimpleJpegDecoder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SimpleJpegDecoder")
+            .field("backend", &self.backend.kind().as_str())
             .field("max_width", &self.max_width)
             .field("max_height", &self.max_height)
-            .field("ring_slots", &self.ring.len())
             .finish()
     }
 }
 
 impl SimpleJpegDecoder {
     /// Construct a decoder ready to handle JPEGs up to
-    /// `(max_width, max_height)` pixels.
-    ///
-    /// Pre-allocates the fused compute kernel pipeline, a coefficient
-    /// SSBO sized for the worst-case 4:2:0 frame at the declared maxima,
-    /// a 128-entry quant-table SSBO, and a [`MAX_FRAMES_IN_FLIGHT`]-slot
-    /// [`TextureRing`] of `Rgba8Unorm` STORAGE textures. Each ring slot
-    /// is eagerly transitioned `UNDEFINED → GENERAL` and the slot's
-    /// registration layout updated to match — subsequent kernel
-    /// dispatches write directly without further transitions, and
-    /// downstream consumers that resolve the slot's `surface_id` see a
-    /// registration claim that matches reality.
+    /// `(max_width, max_height)` pixels, with auto-selected backend.
+    /// Equivalent to [`Self::new_with_preference`] with
+    /// [`JpegBackendPreference::Auto`].
     ///
     /// Must be called inside a [`streamlib::sdk::context::GpuContext::escalate`]
     /// closure (the only way crate-external code obtains a
@@ -116,163 +134,61 @@ impl SimpleJpegDecoder {
         max_width: u32,
         max_height: u32,
     ) -> Result<Self> {
-        if max_width == 0 || max_height == 0 {
-            return Err(Error::GpuError(format!(
-                "SimpleJpegDecoder::new: max dimensions must be non-zero, got {}x{}",
-                max_width, max_height,
-            )));
-        }
-
-        let device = full_access.device().vulkan_device();
-        let kernel = JpegDecodeKernel::new(device)?;
-
-        let coef_bytes = worst_case_coefficient_buffer_bytes_420(max_width, max_height);
-        let coef_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
-            device, coef_bytes,
-        )?);
-        let qt_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
-            device,
-            QUANT_TABLE_BUFFER_BYTES,
-        )?);
-
-        let ring = full_access.create_texture_ring(
+        Self::new_with_preference(
+            full_access,
             max_width,
             max_height,
-            TextureFormat::Rgba8Unorm,
-            TextureUsages::STORAGE_BINDING
-                | TextureUsages::COPY_SRC
-                | TextureUsages::COPY_DST
-                | TextureUsages::TEXTURE_BINDING,
-            MAX_FRAMES_IN_FLIGHT,
-        )?;
+            JpegBackendPreference::Auto,
+        )
+    }
 
-        // Eagerly transition every slot UNDEFINED → GENERAL and refresh
-        // its TextureRegistration to match. The kernel writes via
-        // STORAGE_BINDING in GENERAL and never transitions back; this
-        // pre-warm means per-frame `decode()` records no transitions.
-        for slot_index in 0..ring.len() {
-            let slot = ring
-                .slot(slot_index)
-                .ok_or_else(|| Error::GpuError("ring slot index out of range".into()))?;
-            let mut recorder =
-                RhiCommandRecorder::new(device, "simple_jpeg_decoder_init_layout")?;
-            recorder.begin()?;
-            recorder.record_image_barrier(
-                &slot.texture,
-                VulkanLayout::UNDEFINED,
-                VulkanLayout::GENERAL,
-                VulkanStage::TOP_OF_PIPE,
-                VulkanStage::COMPUTE_SHADER,
-                VulkanAccess::NONE,
-                VulkanAccess::SHADER_WRITE,
-            )?;
-            recorder.submit_and_wait()?;
-            full_access
-                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
-        }
-
+    /// Construct a decoder with explicit backend preference.
+    ///
+    /// - [`JpegBackendPreference::Auto`] picks nvJPEG when the device's
+    ///   [`ThirdPartyGpuCapabilities::nvjpeg`] reports `true` and
+    ///   nvJPEG construction succeeds; falls back to Vulkan-compute
+    ///   otherwise. A failed nvJPEG construction logs at
+    ///   `tracing::warn!` level and the decoder transparently uses
+    ///   Vulkan-compute.
+    /// - [`JpegBackendPreference::Force`] requires the specified backend
+    ///   to construct successfully. Returns
+    ///   [`Error::NotSupported`] otherwise. Useful for testing,
+    ///   benchmarking, and consumers that need determinism across
+    ///   hosts.
+    ///
+    /// [`ThirdPartyGpuCapabilities::nvjpeg`]:
+    ///   streamlib::sdk::engine::host_rhi::ThirdPartyGpuCapabilities::nvjpeg
+    pub fn new_with_preference(
+        full_access: &GpuContextFullAccess,
+        max_width: u32,
+        max_height: u32,
+        preference: JpegBackendPreference,
+    ) -> Result<Self> {
+        let backend = build_backend(full_access, max_width, max_height, preference)?;
+        tracing::debug!(
+            target: "vulkan_jpeg::backend_selection",
+            backend = backend.kind().as_str(),
+            max_width,
+            max_height,
+            "SimpleJpegDecoder constructed",
+        );
         Ok(Self {
-            kernel,
-            coef_buf,
-            qt_buf,
-            ring,
+            backend,
             max_width,
             max_height,
-            unsupported_fallback_warned: AtomicBool::new(false),
         })
     }
 
     /// Decode `jpeg_bytes` into the next ring slot's texture and return
-    /// a handle to it. Steady-state Limited-safe — no escalation, no
-    /// allocation. Single-threaded by `&mut self`; multi-decoder
-    /// parallelism is the caller's pattern.
-    ///
-    /// Rejects baseline-but-non-4:2:0 input ([`Error::NotSupported`]
-    /// from the kernel) and frames whose dimensions exceed the decoder's
-    /// declared maxima ([`Error::GpuError`] with "exceeds max"). Parser
-    /// / Huffman / kernel errors surface as their typed variants — no
-    /// panics, no leaked GPU resources.
+    /// a handle to it. Forwards to the selected backend — see the
+    /// backend's documentation for backend-specific behavior.
     pub fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
-        let decoded = crate::decode(jpeg_bytes)
-            .map_err(|e| Error::GpuError(format!("jpeg parse/huffman: {e}")))?;
-
-        let width = u32::from(decoded.frame.width);
-        let height = u32::from(decoded.frame.height);
-        if width > self.max_width || height > self.max_height {
-            return Err(Error::GpuError(format!(
-                "SimpleJpegDecoder::decode: frame {}x{} exceeds decoder maxima {}x{} \
-                 (rebuild SimpleJpegDecoder with larger max_width/max_height)",
-                width, height, self.max_width, self.max_height,
-            )));
-        }
-
-        // Honor declared colorimetry from APP segments. APP14 transform=2
-        // (YCCK) bubbles up as `Error::NotSupported` here — the kernel only
-        // handles 3-component YCbCr / RGB-direct decode. EXIF / ICC
-        // declarations the engine can't yet represent fall back to JFIF
-        // default and surface as `JpegColorSource::UnsupportedDeclarationFallback`
-        // on the output, plus a one-shot `tracing::warn!` per decoder
-        // instance.
-        let resolved = decoded
-            .color_info
-            .resolve()
-            .map_err(|e| Error::GpuError(format!("jpeg colorimetry: {e}")))?;
-
-        if resolved.source == JpegColorSource::UnsupportedDeclarationFallback {
-            self.warn_unsupported_fallback_once(&decoded.color_info);
-        }
-
-        let slot = self.ring.acquire_next();
-        self.kernel.dispatch_pooled(
-            &decoded,
-            &slot.texture,
-            &self.coef_buf,
-            &self.qt_buf,
-            &resolved.info,
-        )?;
-
-        Ok(JpegDecodeOutput {
-            texture: slot.texture,
-            surface_id: slot.surface_id,
-            width,
-            height,
-            color_source: resolved.source,
-            color_info: resolved.info,
-        })
+        self.backend.decode(jpeg_bytes)
     }
 
-    /// Emit a structured `tracing::warn!` describing the first frame
-    /// where this decoder's input declared a non-sRGB colorimetry that
-    /// the engine can't honor yet. Subsequent fallback frames stay
-    /// silent — the latch fires once per decoder instance.
-    ///
-    /// The warn uses the stable target `vulkan_jpeg::colorimetry_fallback`
-    /// so an AGP-style runtime can `grep`/filter for it cleanly. Carries
-    /// the parsed APP-segment fields so the operator can tell which
-    /// declaration tripped the fallback (Adobe `transform=Other` /
-    /// EXIF Uncalibrated / ICC profile bytes).
-    fn warn_unsupported_fallback_once(&self, info: &JpegColorInfo) {
-        if self
-            .unsupported_fallback_warned
-            .swap(true, Ordering::Relaxed)
-        {
-            return;
-        }
-        tracing::warn!(
-            target: "vulkan_jpeg::colorimetry_fallback",
-            adobe_transform = ?info.adobe.map(|a| a.transform),
-            exif_color_space = ?info.exif_color_space,
-            icc_profile_bytes = info.icc_profile.as_ref().map(|p| p.len()),
-            "JPEG stream declares non-sRGB colorimetry the engine `PrimariesId` enum can't represent yet (Adobe RGB / Display P3 / Rec.2020); decoded under the JFIF default. Extend `PrimariesId` to honor it.",
-        );
-    }
-
-    /// Borrow the underlying [`TextureRing`] — for tests and
-    /// introspection. Production callers consume slots via
-    /// [`Self::decode`].
-    #[doc(hidden)]
-    pub fn ring(&self) -> &Arc<TextureRing> {
-        &self.ring
+    /// The backend this decoder selected at construction.
+    pub fn backend_kind(&self) -> JpegBackendKind {
+        self.backend.kind()
     }
 
     /// Declared maximum width this decoder can handle, in pixels.
@@ -283,5 +199,70 @@ impl SimpleJpegDecoder {
     /// Declared maximum height this decoder can handle, in pixels.
     pub fn max_height(&self) -> u32 {
         self.max_height
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn build_backend(
+    full_access: &GpuContextFullAccess,
+    max_width: u32,
+    max_height: u32,
+    preference: JpegBackendPreference,
+) -> Result<Box<dyn JpegDecodeBackend>> {
+    let caps = full_access
+        .device()
+        .vulkan_device()
+        .third_party_gpu_capabilities();
+
+    match preference {
+        JpegBackendPreference::Force(JpegBackendKind::VulkanCompute) => {
+            VulkanComputeBackend::new(full_access, max_width, max_height)
+                .map(|b| Box::new(b) as Box<dyn JpegDecodeBackend>)
+        }
+        JpegBackendPreference::Force(JpegBackendKind::NvJpeg) => {
+            if !caps.nvjpeg {
+                return Err(Error::NotSupported(
+                    "JpegBackendPreference::Force(NvJpeg): nvJPEG not available on this device \
+                     (ThirdPartyGpuCapabilities::nvjpeg = false)"
+                        .into(),
+                ));
+            }
+            NvJpegBackend::new(full_access, max_width, max_height)
+                .map(|b| Box::new(b) as Box<dyn JpegDecodeBackend>)
+        }
+        JpegBackendPreference::Auto => {
+            if caps.nvjpeg {
+                match NvJpegBackend::new(full_access, max_width, max_height) {
+                    Ok(b) => return Ok(Box::new(b)),
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "vulkan_jpeg::backend_selection",
+                            error = %e,
+                            "nvJPEG construction failed; falling back to Vulkan-compute backend",
+                        );
+                    }
+                }
+            }
+            VulkanComputeBackend::new(full_access, max_width, max_height)
+                .map(|b| Box::new(b) as Box<dyn JpegDecodeBackend>)
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn build_backend(
+    full_access: &GpuContextFullAccess,
+    max_width: u32,
+    max_height: u32,
+    preference: JpegBackendPreference,
+) -> Result<Box<dyn JpegDecodeBackend>> {
+    // nvJPEG ships only for Linux; on other platforms the only available
+    // backend is Vulkan-compute.
+    match preference {
+        JpegBackendPreference::Force(JpegBackendKind::NvJpeg) => Err(Error::NotSupported(
+            "JpegBackendPreference::Force(NvJpeg): nvJPEG backend is Linux-only".into(),
+        )),
+        _ => VulkanComputeBackend::new(full_access, max_width, max_height)
+            .map(|b| Box::new(b) as Box<dyn JpegDecodeBackend>),
     }
 }

--- a/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
+++ b/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-vendor [`JpegDecodeBackend`] implementation: host CPU parser +
+//! Huffman entropy decode → fused Vulkan compute kernel (dequant + IDCT +
+//! chroma upsample + YCbCr→RGB), writing directly into a non-exportable
+//! DEVICE_LOCAL [`TextureRing`] of `Rgba8Unorm` STORAGE textures.
+//!
+//! Construction is privileged (allocates the kernel pipeline, the
+//! coefficient + quant-table HOST_VISIBLE SSBOs sized for the worst-case
+//! 4:2:0 frame at the declared maxima, and the ring). Per-frame
+//! [`JpegDecodeBackend::decode`] rotates the ring and reuses the SSBOs —
+//! zero `vkAllocateMemory`, zero texture creation, zero command-pool /
+//! cb / fence creation in steady state.
+//!
+//! Default backend selected by [`crate::simple_decoder::SimpleJpegDecoder`]
+//! when nvJPEG isn't available or isn't preferred.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
+use streamlib::sdk::engine::host_rhi::{
+    HostVulkanBuffer, RhiCommandRecorder, VulkanAccess, VulkanStage,
+};
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{TextureFormat, TextureUsages, VulkanLayout};
+
+use crate::backend::{JpegBackendKind, JpegDecodeBackend};
+use crate::color::JpegColorInfo;
+use crate::kernel::{
+    worst_case_coefficient_buffer_bytes_420, JpegDecodeKernel, QUANT_TABLE_BUFFER_BYTES,
+};
+use crate::simple_decoder::{JpegDecodeOutput, MAX_FRAMES_IN_FLIGHT};
+use crate::JpegColorSource;
+
+/// Cross-vendor Vulkan-compute JPEG decode backend.
+pub struct VulkanComputeBackend {
+    kernel: JpegDecodeKernel,
+    coef_buf: Arc<HostVulkanBuffer>,
+    qt_buf: Arc<HostVulkanBuffer>,
+    ring: Arc<TextureRing>,
+    max_width: u32,
+    max_height: u32,
+    /// Latch for the "non-sRGB declaration → JFIF fallback" warning.
+    /// Flips to `true` on the first frame that takes the fallback;
+    /// subsequent fallback frames stay silent so a 30 Hz pipeline
+    /// doesn't flood the log. Resetting to `false` re-arms the warn
+    /// (e.g. across a teardown / rebuild cycle).
+    unsupported_fallback_warned: AtomicBool,
+}
+
+impl std::fmt::Debug for VulkanComputeBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanComputeBackend")
+            .field("max_width", &self.max_width)
+            .field("max_height", &self.max_height)
+            .field("ring_slots", &self.ring.len())
+            .finish()
+    }
+}
+
+impl VulkanComputeBackend {
+    /// Build a Vulkan-compute backend ready to handle JPEGs up to
+    /// `(max_width, max_height)` pixels.
+    ///
+    /// Pre-allocates the fused compute kernel pipeline, a coefficient
+    /// SSBO sized for the worst-case 4:2:0 frame at the declared maxima,
+    /// a 128-entry quant-table SSBO, and a [`MAX_FRAMES_IN_FLIGHT`]-slot
+    /// [`TextureRing`] of `Rgba8Unorm` STORAGE textures. Each ring slot
+    /// is eagerly transitioned `UNDEFINED → GENERAL` and the slot's
+    /// registration layout updated to match — subsequent kernel dispatches
+    /// write directly without further transitions, and downstream
+    /// consumers that resolve the slot's `surface_id` see a registration
+    /// claim that matches reality.
+    pub fn new(
+        full_access: &GpuContextFullAccess,
+        max_width: u32,
+        max_height: u32,
+    ) -> Result<Self> {
+        if max_width == 0 || max_height == 0 {
+            return Err(Error::GpuError(format!(
+                "VulkanComputeBackend::new: max dimensions must be non-zero, got {}x{}",
+                max_width, max_height,
+            )));
+        }
+
+        let device = full_access.device().vulkan_device();
+        let kernel = JpegDecodeKernel::new(device)?;
+
+        let coef_bytes = worst_case_coefficient_buffer_bytes_420(max_width, max_height);
+        let coef_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
+            device, coef_bytes,
+        )?);
+        let qt_buf = Arc::new(HostVulkanBuffer::new_storage_buffer_host_visible(
+            device,
+            QUANT_TABLE_BUFFER_BYTES,
+        )?);
+
+        let ring = full_access.create_texture_ring(
+            max_width,
+            max_height,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::STORAGE_BINDING
+                | TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST
+                | TextureUsages::TEXTURE_BINDING,
+            MAX_FRAMES_IN_FLIGHT,
+        )?;
+
+        // Eagerly transition every slot UNDEFINED → GENERAL and refresh
+        // its TextureRegistration to match. The kernel writes via
+        // STORAGE_BINDING in GENERAL and never transitions back; this
+        // pre-warm means per-frame `decode()` records no transitions.
+        for slot_index in 0..ring.len() {
+            let slot = ring
+                .slot(slot_index)
+                .ok_or_else(|| Error::GpuError("ring slot index out of range".into()))?;
+            let mut recorder =
+                RhiCommandRecorder::new(device, "vulkan_compute_backend_init_layout")?;
+            recorder.begin()?;
+            recorder.record_image_barrier(
+                &slot.texture,
+                VulkanLayout::UNDEFINED,
+                VulkanLayout::GENERAL,
+                VulkanStage::TOP_OF_PIPE,
+                VulkanStage::COMPUTE_SHADER,
+                VulkanAccess::NONE,
+                VulkanAccess::SHADER_WRITE,
+            )?;
+            recorder.submit_and_wait()?;
+            full_access
+                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
+        }
+
+        Ok(Self {
+            kernel,
+            coef_buf,
+            qt_buf,
+            ring,
+            max_width,
+            max_height,
+            unsupported_fallback_warned: AtomicBool::new(false),
+        })
+    }
+
+    /// Borrow the underlying [`TextureRing`] — for tests and
+    /// introspection.
+    #[doc(hidden)]
+    pub fn ring(&self) -> &Arc<TextureRing> {
+        &self.ring
+    }
+
+    /// Emit a structured `tracing::warn!` describing the first frame
+    /// where this backend's input declared a non-sRGB colorimetry that
+    /// the engine can't honor yet. Subsequent fallback frames stay
+    /// silent — the latch fires once per backend instance.
+    ///
+    /// The warn uses the stable target `vulkan_jpeg::colorimetry_fallback`
+    /// so an AGP-style runtime can `grep`/filter for it cleanly. Carries
+    /// the parsed APP-segment fields so the operator can tell which
+    /// declaration tripped the fallback.
+    fn warn_unsupported_fallback_once(&self, info: &JpegColorInfo) {
+        if self
+            .unsupported_fallback_warned
+            .swap(true, Ordering::Relaxed)
+        {
+            return;
+        }
+        tracing::warn!(
+            target: "vulkan_jpeg::colorimetry_fallback",
+            adobe_transform = ?info.adobe.map(|a| a.transform),
+            exif_color_space = ?info.exif_color_space,
+            icc_profile_bytes = info.icc_profile.as_ref().map(|p| p.len()),
+            "JPEG stream declares non-sRGB colorimetry the engine `PrimariesId` enum can't represent yet (Adobe RGB / Display P3 / Rec.2020); decoded under the JFIF default. Extend `PrimariesId` to honor it.",
+        );
+    }
+}
+
+impl JpegDecodeBackend for VulkanComputeBackend {
+    fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput> {
+        let decoded = crate::decode(jpeg_bytes)
+            .map_err(|e| Error::GpuError(format!("jpeg parse/huffman: {e}")))?;
+
+        let width = u32::from(decoded.frame.width);
+        let height = u32::from(decoded.frame.height);
+        if width > self.max_width || height > self.max_height {
+            return Err(Error::GpuError(format!(
+                "VulkanComputeBackend::decode: frame {}x{} exceeds decoder maxima {}x{} \
+                 (rebuild SimpleJpegDecoder with larger max_width/max_height)",
+                width, height, self.max_width, self.max_height,
+            )));
+        }
+
+        // Honor declared colorimetry from APP segments. APP14 transform=2
+        // (YCCK) bubbles up as `Error::NotSupported` here — the kernel only
+        // handles 3-component YCbCr / RGB-direct decode. EXIF / ICC
+        // declarations the engine can't yet represent fall back to JFIF
+        // default and surface as `JpegColorSource::UnsupportedDeclarationFallback`
+        // on the output, plus a one-shot `tracing::warn!` per backend
+        // instance.
+        let resolved = decoded
+            .color_info
+            .resolve()
+            .map_err(|e| Error::GpuError(format!("jpeg colorimetry: {e}")))?;
+
+        if resolved.source == JpegColorSource::UnsupportedDeclarationFallback {
+            self.warn_unsupported_fallback_once(&decoded.color_info);
+        }
+
+        let slot = self.ring.acquire_next();
+        self.kernel.dispatch_pooled(
+            &decoded,
+            &slot.texture,
+            &self.coef_buf,
+            &self.qt_buf,
+            &resolved.info,
+        )?;
+
+        Ok(JpegDecodeOutput {
+            texture: slot.texture,
+            surface_id: slot.surface_id,
+            width,
+            height,
+            color_source: resolved.source,
+            color_info: resolved.info,
+        })
+    }
+
+    fn kind(&self) -> JpegBackendKind {
+        JpegBackendKind::VulkanCompute
+    }
+}

--- a/libs/vulkan-jpeg/tests/nvjpeg_backend.rs
+++ b/libs/vulkan-jpeg/tests/nvjpeg_backend.rs
@@ -1,0 +1,275 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! [`NvJpegBackend`] integration tests — exercises the engine-allocates /
+//! vendor-imports OPAQUE_FD interop path end-to-end on hosts where the
+//! nvJPEG library + NVIDIA CUDA hardware are present. Skips cleanly on
+//! every other host (Mesa / non-NVIDIA / no libnvjpeg) so the same
+//! test file passes in CI without nvJPEG installed.
+//!
+//! The Vulkan-compute backend has its own broader regression coverage in
+//! `tests/simple_decoder.rs`; this file specifically locks the nvJPEG
+//! path so regressions in the CUDA + libnvjpeg integration surface
+//! immediately rather than silently re-routing through the fallback.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::needless_range_loop)]
+
+use std::sync::Arc;
+
+use jpeg_encoder::{ColorType, Encoder, SamplingFactor};
+use streamlib::sdk::context::GpuContext;
+use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanTextureReadback};
+use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
+use vulkan_jpeg::{
+    JpegBackendKind, JpegBackendPreference, JpegDecodeOutput, SimpleJpegDecoder,
+};
+
+/// Acquire a `GpuContext` for tests, or skip cleanly when no GPU is
+/// available or nvJPEG isn't wired on this host.
+fn fresh_nvjpeg_gpu_context() -> Option<GpuContext> {
+    // Vulkan device must come up first — gates GpuContext init.
+    let device = HostVulkanDevice::new().ok()?;
+    if !device.third_party_gpu_capabilities().nvjpeg {
+        eprintln!(
+            "Skipping nvJPEG test — ThirdPartyGpuCapabilities::nvjpeg=false \
+             (non-NVIDIA host or libnvjpeg.so.12 not installed)"
+        );
+        return None;
+    }
+    GpuContext::init_for_platform().ok()
+}
+
+fn synthesize_smooth_test_image(width: u16, height: u16) -> Vec<u8> {
+    let mut rgb = Vec::with_capacity(usize::from(width) * usize::from(height) * 3);
+    let w = u32::from(width.saturating_sub(1).max(1));
+    let h = u32::from(height.saturating_sub(1).max(1));
+    for y in 0..height {
+        for x in 0..width {
+            let r = (u32::from(x) * 255 / w) as u8;
+            let g = (u32::from(y) * 255 / h) as u8;
+            let b = ((u32::from(x) + u32::from(y)) * 255 / (w + h)) as u8;
+            rgb.extend_from_slice(&[r, g, b]);
+        }
+    }
+    rgb
+}
+
+fn encode_jpeg_rgb_420(width: u16, height: u16, rgb: &[u8], quality: u8) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, quality);
+    encoder.set_sampling_factor(SamplingFactor::R_4_2_0);
+    encoder
+        .encode(rgb, width, height, ColorType::Rgb)
+        .expect("jpeg encode");
+    bytes
+}
+
+fn readback_rgba(device: &Arc<HostVulkanDevice>, output: &JpegDecodeOutput) -> Vec<u8> {
+    use streamlib::sdk::engine::HostTextureExt;
+    let readback = VulkanTextureReadback::new(
+        device,
+        &TextureReadbackDescriptor {
+            label: "nvjpeg_test_readback",
+            format: TextureFormat::Rgba8Unorm,
+            width: output.width,
+            height: output.height,
+        },
+    )
+    .expect("readback handle");
+    let _ = output.texture.vulkan_inner();
+    let ticket = readback
+        .submit(&output.texture, TextureSourceLayout::General)
+        .expect("readback submit");
+    readback
+        .wait_and_read(ticket, u64::MAX)
+        .expect("readback wait")
+        .to_vec()
+}
+
+/// Y-channel PSNR against the source RGB image. BT.601 luma weights —
+/// independent of any production matrix code; mirrors the helper in
+/// `tests/simple_decoder.rs::y_channel_psnr_db`.
+fn y_channel_psnr_db(reference_rgb: &[u8], actual_rgba: &[u8]) -> f64 {
+    assert_eq!(reference_rgb.len() % 3, 0);
+    assert_eq!(actual_rgba.len() % 4, 0);
+    let pixel_count = reference_rgb.len() / 3;
+    assert_eq!(actual_rgba.len() / 4, pixel_count);
+    let mut sum_sq_err = 0.0f64;
+    for px in 0..pixel_count {
+        let r_ref = f64::from(reference_rgb[px * 3]);
+        let g_ref = f64::from(reference_rgb[px * 3 + 1]);
+        let b_ref = f64::from(reference_rgb[px * 3 + 2]);
+        let r_act = f64::from(actual_rgba[px * 4]);
+        let g_act = f64::from(actual_rgba[px * 4 + 1]);
+        let b_act = f64::from(actual_rgba[px * 4 + 2]);
+        let y_ref = 0.299 * r_ref + 0.587 * g_ref + 0.114 * b_ref;
+        let y_act = 0.299 * r_act + 0.587 * g_act + 0.114 * b_act;
+        let err = y_ref - y_act;
+        sum_sq_err += err * err;
+    }
+    let mse = sum_sq_err / pixel_count as f64;
+    if mse == 0.0 {
+        f64::INFINITY
+    } else {
+        10.0 * (255.0_f64.powi(2) / mse).log10()
+    }
+}
+
+const PSNR_FLOOR_DB: f64 = 35.0;
+
+/// Decode-and-readback round-trip with the nvJPEG backend explicitly
+/// selected via [`JpegBackendPreference::Force`]. Locks the OPAQUE_FD
+/// staging path end-to-end: `nvjpegDecode` writes RGBI into the CUDA-
+/// private buffer, `cudaMemcpy2DAsync` repitches into the shared
+/// OPAQUE_FD buffer (with alpha pre-fill leaving the 4th byte at 0xFF),
+/// the Vulkan-side `vkCmdCopyBufferToImage` lands it in the ring slot,
+/// and the readback returns an Rgba8Unorm scanline.
+///
+/// Y-channel PSNR vs the source RGB must clear the 35 dB floor —
+/// matches the cross-vendor backend's PSNR test, so the two backends
+/// are quality-comparable on baseline 4:2:0 input.
+#[test]
+fn nvjpeg_backend_round_trip_y_psnr_at_least_35db() {
+    let Some(gpu) = fresh_nvjpeg_gpu_context() else {
+        return;
+    };
+    let device = gpu.device().vulkan_device().clone();
+
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| {
+            SimpleJpegDecoder::new_with_preference(
+                full,
+                64,
+                64,
+                JpegBackendPreference::Force(JpegBackendKind::NvJpeg),
+            )
+        })
+        .expect("nvJPEG decoder construction");
+    assert_eq!(
+        decoder.backend_kind(),
+        JpegBackendKind::NvJpeg,
+        "Force(NvJpeg) must select the nvJPEG backend"
+    );
+
+    let rgb = synthesize_smooth_test_image(64, 64);
+    let jpeg = encode_jpeg_rgb_420(64, 64, &rgb, 92);
+    let output = decoder.decode(&jpeg).expect("nvJPEG decode");
+    assert_eq!(output.width, 64);
+    assert_eq!(output.height, 64);
+
+    let readback = readback_rgba(&device, &output);
+
+    // Alpha channel: every pixel must be 0xFF (the cudaMemset pre-fill,
+    // preserved across cudaMemcpy2DAsync's stride trick). A regression
+    // in the alpha-padding path would surface as alpha != 255 here.
+    for px in 0..(64 * 64) {
+        assert_eq!(
+            readback[px * 4 + 3],
+            0xFF,
+            "pixel {px} alpha must be 0xFF (alpha pre-fill regression)"
+        );
+    }
+
+    let psnr = y_channel_psnr_db(&rgb, &readback);
+    assert!(
+        psnr >= PSNR_FLOOR_DB,
+        "nvJPEG Y-channel PSNR {psnr:.2} dB < {PSNR_FLOOR_DB} dB floor — \
+         color-correctness regression in the nvJPEG → OPAQUE_FD → Vulkan path"
+    );
+}
+
+/// Two consecutive decodes through the 2-slot ring must hand back
+/// distinct `surface_id`s, then re-use them on the third + fourth
+/// decodes. Locks the ring rotation through the nvJPEG path — separate
+/// from the Vulkan-compute backend's equivalent test in
+/// `tests/simple_decoder.rs`.
+#[test]
+fn nvjpeg_backend_decode_rotates_ring_deterministically() {
+    let Some(gpu) = fresh_nvjpeg_gpu_context() else {
+        return;
+    };
+    let mut decoder = gpu
+        .limited_access()
+        .escalate(|full| {
+            SimpleJpegDecoder::new_with_preference(
+                full,
+                64,
+                64,
+                JpegBackendPreference::Force(JpegBackendKind::NvJpeg),
+            )
+        })
+        .expect("nvJPEG decoder construction");
+
+    let rgb = synthesize_smooth_test_image(48, 48);
+    let jpeg = encode_jpeg_rgb_420(48, 48, &rgb, 85);
+
+    let mut surface_ids = Vec::new();
+    for _ in 0..4 {
+        let out = decoder.decode(&jpeg).expect("decode");
+        surface_ids.push(out.surface_id.clone());
+    }
+
+    assert_ne!(
+        surface_ids[0], surface_ids[1],
+        "consecutive decodes must hand back distinct ring slots"
+    );
+    assert_eq!(
+        surface_ids[0], surface_ids[2],
+        "third decode must reuse the first slot (2-slot ring)"
+    );
+    assert_eq!(
+        surface_ids[1], surface_ids[3],
+        "fourth decode must reuse the second slot (2-slot ring)"
+    );
+}
+
+/// [`JpegBackendPreference::Force(NvJpeg)`] on a non-NVIDIA host (or one
+/// without libnvjpeg) must surface as a typed
+/// [`streamlib::sdk::error::Error::NotSupported`] from `new_with_preference`
+/// rather than panicking, transparently falling back, or silently
+/// using Vulkan-compute. This is the only "negative" capability test
+/// that runs on every host — the rest skip when nvjpeg is available.
+///
+/// The shape of the test: query the capability struct, then try to
+/// force nvJPEG. If the capability says `false`, the construction must
+/// return `NotSupported`. Locks the gating logic in
+/// `simple_decoder::build_backend`.
+#[test]
+fn force_nvjpeg_returns_not_supported_when_capability_false() {
+    let Some(device) = HostVulkanDevice::new().ok() else {
+        eprintln!("Skipping — no Vulkan device available");
+        return;
+    };
+    if device.third_party_gpu_capabilities().nvjpeg {
+        eprintln!(
+            "Skipping — nvJPEG IS available on this host; the negative path \
+             can't fire here. Run on a Mesa or no-CUDA host to exercise it."
+        );
+        return;
+    }
+    let Some(gpu) = GpuContext::init_for_platform().ok() else {
+        eprintln!("Skipping — GpuContext init failed");
+        return;
+    };
+
+    let err = gpu
+        .limited_access()
+        .escalate(|full| {
+            SimpleJpegDecoder::new_with_preference(
+                full,
+                64,
+                64,
+                JpegBackendPreference::Force(JpegBackendKind::NvJpeg),
+            )
+        })
+        .expect_err("Force(NvJpeg) on a host without nvJPEG must error");
+
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("nvJPEG not available"),
+        "expected typed 'nvJPEG not available' error, got: {msg}"
+    );
+}

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -18,7 +18,10 @@ use streamlib::sdk::engine::HostTextureExt;
 use streamlib::sdk::engine::host_rhi::{HostVulkanDevice, VulkanTextureReadback};
 use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};
 use streamlib::sdk::color::MatrixId;
-use vulkan_jpeg::{JpegColorSource, JpegDecodeOutput, SimpleJpegDecoder, MAX_FRAMES_IN_FLIGHT};
+use vulkan_jpeg::{
+    JpegBackendKind, JpegBackendPreference, JpegColorSource, JpegDecodeOutput, SimpleJpegDecoder,
+    VulkanComputeBackend, MAX_FRAMES_IN_FLIGHT,
+};
 
 /// Acquire a `GpuContext` for tests, or skip cleanly when no GPU is
 /// available (the workstation has one; CI baseline runners may not).
@@ -102,71 +105,77 @@ fn readback_rgba(
 // Construction + rotation
 // -----------------------------------------------------------------------------
 
+// Ring-internal tests exercise the [`VulkanComputeBackend`]'s
+// pre-allocation contract — eager ring sizing, eager layout transition,
+// slot Arc reuse across decodes. They construct the backend directly so
+// they stay deterministic on hosts where [`SimpleJpegDecoder::new`]
+// auto-selects a different backend (e.g. nvJPEG on NVIDIA + libnvjpeg).
+
 #[test]
-fn new_pre_allocates_ring_at_max_frames_in_flight_depth() {
+fn vulkan_compute_backend_pre_allocates_ring_at_max_frames_in_flight_depth() {
     let Some(gpu) = fresh_gpu_context() else {
         return;
     };
-    let decoder = gpu
+    let backend = gpu
         .limited_access()
-        .escalate(|full| SimpleJpegDecoder::new(full, 128, 96))
-        .expect("decoder construction");
+        .escalate(|full| VulkanComputeBackend::new(full, 128, 96))
+        .expect("backend construction");
 
     assert_eq!(
-        decoder.ring().len(),
+        backend.ring().len(),
         MAX_FRAMES_IN_FLIGHT,
-        "decoder ring must have MAX_FRAMES_IN_FLIGHT slots"
+        "backend ring must have MAX_FRAMES_IN_FLIGHT slots"
     );
-    assert_eq!(decoder.max_width(), 128);
-    assert_eq!(decoder.max_height(), 96);
-    assert_eq!(decoder.ring().width(), 128);
-    assert_eq!(decoder.ring().height(), 96);
-    assert_eq!(decoder.ring().format(), TextureFormat::Rgba8Unorm);
+    assert_eq!(backend.ring().width(), 128);
+    assert_eq!(backend.ring().height(), 96);
+    assert_eq!(backend.ring().format(), TextureFormat::Rgba8Unorm);
 }
 
 #[test]
-fn new_eagerly_transitions_ring_slots_to_general_and_updates_registration() {
+fn vulkan_compute_backend_eagerly_transitions_ring_slots_to_general_and_updates_registration() {
     use streamlib::sdk::rhi::VulkanLayout;
 
     let Some(gpu) = fresh_gpu_context() else {
         return;
     };
-    let decoder = gpu
+    let backend = gpu
         .limited_access()
-        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
-        .expect("decoder construction");
+        .escalate(|full| VulkanComputeBackend::new(full, 64, 64))
+        .expect("backend construction");
 
-    for slot_index in 0..decoder.ring().len() {
-        let slot = decoder.ring().slot(slot_index).expect("ring slot");
+    for slot_index in 0..backend.ring().len() {
+        let slot = backend.ring().slot(slot_index).expect("ring slot");
         let reg = gpu
             .resolve_texture_registration_by_surface_id(&slot.surface_id, None, 64, 64)
             .expect("registration in cache");
         assert_eq!(
             reg.current_layout(),
             VulkanLayout::GENERAL,
-            "slot {slot_index} layout must be GENERAL after SimpleJpegDecoder::new \
+            "slot {slot_index} layout must be GENERAL after VulkanComputeBackend::new \
              eager transition (anti-pattern #2: registration-vs-reality drift)"
         );
     }
 }
 
 #[test]
-fn decode_rotates_ring_and_reuses_pre_allocated_slot_textures() {
+fn vulkan_compute_backend_decode_rotates_ring_and_reuses_pre_allocated_slot_textures() {
+    use vulkan_jpeg::JpegDecodeBackend;
+
     let Some(gpu) = fresh_gpu_context() else {
         return;
     };
-    let mut decoder = gpu
+    let mut backend = gpu
         .limited_access()
-        .escalate(|full| SimpleJpegDecoder::new(full, 64, 64))
-        .expect("decoder construction");
+        .escalate(|full| VulkanComputeBackend::new(full, 64, 64))
+        .expect("backend construction");
 
     // Snapshot the underlying Arc<HostVulkanTexture> pointer for each
     // ring slot before any decode runs. After multiple decodes, the
     // ring must hand back the SAME Arcs — pointer drift would mean
     // re-allocation, defeating the steady-state-no-alloc invariant.
-    let initial_arcs: Vec<_> = (0..decoder.ring().len())
+    let initial_arcs: Vec<_> = (0..backend.ring().len())
         .map(|i| {
-            Arc::as_ptr(decoder.ring().slot(i).expect("ring slot").texture.vulkan_inner())
+            Arc::as_ptr(backend.ring().slot(i).expect("ring slot").texture.vulkan_inner())
         })
         .collect();
 
@@ -176,7 +185,7 @@ fn decode_rotates_ring_and_reuses_pre_allocated_slot_textures() {
     let mut surface_ids = Vec::new();
     let mut texture_ptrs = Vec::new();
     for _ in 0..(MAX_FRAMES_IN_FLIGHT * 2) {
-        let out = decoder.decode(&jpeg).expect("decode");
+        let out = backend.decode(&jpeg).expect("decode");
         surface_ids.push(out.surface_id.clone());
         texture_ptrs.push(Arc::as_ptr(out.texture.vulkan_inner()));
     }
@@ -207,6 +216,28 @@ fn decode_rotates_ring_and_reuses_pre_allocated_slot_textures() {
              (initial arcs {initial_arcs:?}, got {ptr:?}) — steady-state allocation regression"
         );
     }
+}
+
+#[test]
+fn simple_decoder_forwards_max_dimensions_through_dispatcher() {
+    let Some(gpu) = fresh_gpu_context() else {
+        return;
+    };
+    let decoder = gpu
+        .limited_access()
+        .escalate(|full| {
+            SimpleJpegDecoder::new_with_preference(
+                full,
+                128,
+                96,
+                JpegBackendPreference::Force(JpegBackendKind::VulkanCompute),
+            )
+        })
+        .expect("decoder construction");
+
+    assert_eq!(decoder.max_width(), 128);
+    assert_eq!(decoder.max_height(), 96);
+    assert_eq!(decoder.backend_kind(), JpegBackendKind::VulkanCompute);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds **`NvJpegBackend`** behind the existing `SimpleJpegDecoder` API as a runtime-selected NVIDIA fast path. Cross-vendor `VulkanComputeBackend` (extracted from the existing implementation) stays the default.
- Introduces the engine-side **`ThirdPartyGpuCapabilities`** struct + dlopen-based runtime probe on `HostVulkanDevice` — no Cargo feature gating; the backend is automatically picked when the hardware + libnvjpeg are present.
- Ships **`docs/architecture/third-party-gpu-backends.md`** codifying the engine-allocates / vendor-imports pattern, the buffer- vs image-flavored interop split, and the "lift to engine-tier when the second backend lands" trigger.
- Sweeps the multi-GPU `cudaSetDevice` UUID match into every CUDA-using consumer (vulkan-jpeg, python-native cdylib, deno-native cdylib) instead of the previous hardcoded `cuda_device_ordinal = 0`.

## Closes

Closes #843

## Layered architecture

### Trait shape
`JpegDecodeBackend` (`libs/vulkan-jpeg/src/backend.rs`) sits at the `&[u8] → JpegDecodeOutput` level, above the host CPU parser stage. `VulkanComputeBackend` (cross-vendor) and `NvJpegBackend` (NVIDIA) implement it; `SimpleJpegDecoder` becomes a thin dispatcher with `JpegBackendPreference::{Auto, Force}`. Auto picks nvJPEG when capability is `true` and `NvJpegBackend::new` succeeds, falling back to Vulkan-compute on construction failure.

### nvJPEG interop (buffer-flavored, per the arch doc)
Per ring slot:
- Host-allocated DEVICE_LOCAL OPAQUE_FD `VkBuffer` sized `max_w * max_h * 4`, pre-filled with `0xFF` (alpha pre-fill).
- CUDA imports the OPAQUE_FD via `cudaImportExternalMemory(OPAQUE_FD)` + `cudaExternalMemoryGetMappedBuffer` → aliased `CUdeviceptr`.
- CUDA-private `cudaMalloc` buffer for nvJPEG's `NVJPEG_OUTPUT_RGBI` output (3 bpp).

Per frame:
1. `nvjpegDecode` → CUDA-private RGBI buffer
2. `cudaMemcpy2DAsync` with per-pixel stride trick (`width=3, height=pixels, spitch=3, dpitch=4`) → shared OPAQUE_FD buffer; writes RGB into bytes 0..2 of every 4-byte group, alpha stays at the pre-fill `0xFF`
3. `cudaStreamSynchronize` (CPU-mediated cross-API order; sufficient for same-process / same-device interop per CUDA + Vulkan specs)
4. `vkCmdCopyBufferToImage` → render-target `Rgba8Unorm` texture in the ring slot

### Multi-GPU `cudaSetDevice` UUID match
Every CUDA-using consumer now calls `cudaSetDevice(matched_ordinal)` before any other CUDA work, where the ordinal is resolved by matching the Vulkan-selected device's `VkPhysicalDeviceIDProperties::deviceUUID` against each CUDA device's `cudaDeviceProp::uuid`. Falls back to ordinal 0 with a `tracing::warn!` when no CUDA device matches — defensive shape preserving single-GPU behavior if the probe fails. The same helper is duplicated across `vulkan-jpeg`, `streamlib-python-native`, and `streamlib-deno-native` (consumer-rhi can't pull cudarc by design); cross-referencing comments keep the three in sync until a future refactor lifts to a shared utility crate.

### Runtime probe + dynamic loading
nvJPEG symbols resolved via hand-written `libloading` declarations (no `bindgen`, no link-time dep). The workspace builds cleanly on hosts without libnvjpeg installed. The probe tries the bare SONAME `libnvjpeg.so.12` first, then falls back to the canonical CUDA Toolkit install paths — a fresh `libnvjpeg-dev-12-*` apt install leaves the ldconfig cache stale until the next `ldconfig` run, so the fallback prevents capability-mismatch flakes. cudarc 0.19's `fallback-dynamic-loading` feature handles cudart loading the same way.

## Exit criteria

- [x] Output is a `VkImage` (DEVICE_LOCAL) via CUDA OPAQUE_FD interop; same API surface as the Vulkan-compute backend
- [x] Capability query on the device exposes nvJPEG availability (`HostVulkanDevice::third_party_gpu_capabilities().nvjpeg`)
- [x] Runtime-detected (no Cargo feature) — nvJPEG is auto-selected on NVIDIA hosts when the library is loadable

## Test plan

- [x] **Unit**: `cargo test -p streamlib-engine --lib third_party_gpu` — 3/3 pass. `ThirdPartyGpuCapabilities` probe returns sensible results on non-NVIDIA vendors (Intel / AMD / ARM / Qualcomm), tracks `libnvjpeg.so.12` loadability on NVIDIA, and `Default` produces an all-`false` struct.
- [x] **Integration (nvJPEG, NVIDIA-only)**: `cargo test -p vulkan-jpeg --test nvjpeg_backend` — 3/3 pass on this NVIDIA + libnvjpeg dev host. The PSNR test asserts Y PSNR ≥ 35 dB AND every pixel's alpha byte is `0xFF` (locks the alpha-pre-fill / stride-trick contract). Skips cleanly when capability is `false`.
- [x] **Cross-vendor regression**: `cargo test -p vulkan-jpeg --test simple_decoder` — 13/13 pass. Ring-internal tests construct `VulkanComputeBackend` directly so they stay deterministic regardless of which backend Auto selects on the host.
- [x] **Workspace**: `cargo check --workspace --all-targets` clean.
- [x] **RHI boundary**: `cargo xtask check-boundaries` — 3801 files scanned, no violations.
- [x] **CUDA adapter helpers**: `cargo test -p streamlib-adapter-cuda-helpers --features cuda` — pass.

## Pre-PR review gate

Returned **PASS** with 5 DISCUSS items; the multi-GPU `cudaSetDevice` concern was the biggest of them and is now absorbed into the PR (see commit 4 below). The other DISCUSS items: module-doc drift on `vulkan_buffer_binding.rs` (fixed in commit 1); the cudaMemcpy2DAsync stride-trick refactoring concern (dismissed — inline comment carries the load); candidate-paths list duplication between engine probe and FFI loader (dismissed — engine can't depend on vulkan-jpeg by direction; cross-referencing comments document the dependency); alpha=`0xFF` assertion test analysis (no action — reviewer's own analysis confirmed mental-revert robustness).

## Commit map

- `feat(rhi): ThirdPartyGpuCapabilities probe + third-party GPU backends arch doc` — engine additions, no consumer dependencies
- `refactor(vulkan-jpeg): extract JpegDecodeBackend trait + dispatcher` — trait + Vulkan-compute backend extraction + dispatcher; `NvJpegBackend` is a stub returning `NotSupported` so the tree compiles and existing tests pass
- `feat(vulkan-jpeg): NvJpegBackend — CUDA decode + OPAQUE_FD interop` — replaces the stub with the real CUDA-side implementation + integration tests
- `fix(cuda): match Vulkan deviceUUID to CUDA ordinal in every consumer` — closes the multi-GPU `cudaSetDevice` gap from the review gate; adds `ConsumerVulkanDevice::physical_device_uuid()` + sweeps every CUDA-using consumer (nvjpeg_backend, python-native cdylib, deno-native cdylib) to UUID-match instead of hardcoding ordinal 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
