### PR TITLE
test(fixtures): reusable JPEG decode PSNR rig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "examples/raytracing-showcase",       # Example: VulkanRayTracingKernel rotating-cube showcase (#610)
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)
     "examples/vulkan-video-psnr",         # Example: fixture-driven encode/decode PSNR rig (#305)
+    "examples/jpeg-psnr",                 # Example: fixture-driven JPEG decode PSNR rig
     "tests/iceoryx2-cross-language",      # Test: Cross-language iceoryx2 validation (Rust ↔ Python)
     "libs/vulkan-video",                  # Vulkan Video encoder/decoder (H.264/H.265 via Vulkan Video extensions)
     "libs/vulkan-video/examples/h264-codec", # Example: H.264 encode/decode roundtrip

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,9 +200,44 @@ saturated single-color patterns are insensitive to range
 mis-interpretation. The main fixture rig's gradient references are
 where range-swap deterministically drops Y PSNR below FAIL.
 
+**JPEG decode rig** (`e2e_fixture_psnr_jpeg.sh`,
+[`libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh`](../libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh)).
+Sibling of the main rig for GPU JPEG decode (`@tatolab/jpeg::JpegDecoder`
+wrapping `vulkan-jpeg::SimpleJpegDecoder`). Same shape, decode-only:
+ffmpeg encodes each reference PNG to JPEG (the "encoder" half), then
+`JpegBytesSource → JpegDecoder → Display` decodes back to a PNG sample
+and ffmpeg computes Y/U/V PSNR vs reference. Same `swap-channels |
+bt601-bt709 | range-swap` bug-injection modes, same Y ≥ 35 dB pass bar.
+
+```bash
+# Clean pipeline — every reference should hit Y PSNR ≥ 35 dB.
+libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh /tmp/psnr-jpeg
+
+# Negative tests — each is expected to deterministically drop Y PSNR
+# below FAIL on the references that carry the affected channels:
+PSNR_INJECT_BUG=swap-channels \
+    libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh /tmp/psnr-jpeg-bug-swap
+PSNR_INJECT_BUG=bt601-bt709 \
+    libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh /tmp/psnr-jpeg-bug-matrix
+PSNR_INJECT_BUG=range-swap \
+    libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh /tmp/psnr-jpeg-bug-range
+```
+
+The default `JPEG_QUALITY=70` is load-bearing on the rig's payload-fit
+arithmetic: `rmp_serde` serializes `EncodedJpegFrame.data: Vec<u8>` as
+a msgpack array (per-byte tag overhead, ~1.5× wire expansion), and
+iceoryx2's per-slot default of 64 KiB applies when `@tatolab/jpeg`'s
+declared 16 MiB bound isn't registered with the runtime (the example's
+streamlib.yaml declares `@tatolab/core` only, matching how every
+in-tree example wires today). q=70 keeps even the worst-case
+`complex_pattern` fixture under that wire budget while still clearing
+the 35 dB Y PSNR pass bar. The `JPEG_QUALITY` env var overrides the
+default for ad-hoc experimentation; quality settings above ~70 will
+trip `ExceedsMaxLoanSize` on `complex_pattern` at 1920×1080.
+
 **Manual gate for color-management PRs.** Until the GPU CI runner
-milestone lands and CI can run the rigs automatically, treat both
-fixtures above as a mandatory manual gate on any PR that touches
+milestone lands and CI can run the rigs automatically, treat the
+fixture rigs above as a mandatory manual gate on any PR that touches
 the color path (RHI color converter, encoder/decoder VUI / colorimetry,
 display swapchain color space, tone mapper, any sampler-conversion
 key). The gate is:
@@ -211,7 +246,9 @@ key). The gate is:
    passes; same for `h265`.
 2. Vivid regression gate clean — `e2e_fixture_psnr_vivid.sh` passes
    against the checked-in baseline TSV.
-3. At least one negative test from the matrix above runs as part of
+3. JPEG fixture rig clean — `e2e_fixture_psnr_jpeg.sh /tmp/psnr-jpeg`
+   passes (when the change touches the JPEG path).
+4. At least one negative test from the matrix above runs as part of
    PR validation and is shown to deterministically FAIL — proves the
    gate is non-vacuous for this branch.
 

--- a/examples/jpeg-psnr/Cargo.toml
+++ b/examples/jpeg-psnr/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "jpeg-psnr"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
+streamlib-display = { path = "../../packages/display" }
+streamlib-jpeg = { path = "../../packages/jpeg" }
+anyhow = "1.0.100"

--- a/examples/jpeg-psnr/src/main.rs
+++ b/examples/jpeg-psnr/src/main.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Fixture-driven JPEG decode PSNR rig (issue #844).
+//!
+//! Feeds a single JPEG file through `JpegBytesSource → JpegDecoder →
+//! Display` so the decoded PNG sampler can capture the decoded frame
+//! for external PSNR comparison against the reference PNG that
+//! produced the JPEG.
+//!
+//! Usage:
+//!   jpeg-psnr <jpeg-path> <width> <height> <fps> <frame-count>
+
+use streamlib::sdk::error::Result;
+use streamlib::sdk::processors::{input, output};
+use streamlib::sdk::runtime::Runner;
+use streamlib_debug_utilities::JpegBytesSourceProcessor;
+use streamlib_display::DisplayProcessor;
+use streamlib_jpeg::JpegDecoderProcessor;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let jpeg_path = args
+        .get(1)
+        .cloned()
+        .expect("missing <jpeg-path>: usage jpeg-psnr <jpeg-path> <w> <h> <fps> <frames>");
+    let width: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1920);
+    let height: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1080);
+    let fps: u32 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(10);
+    let frame_count: u32 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(15);
+
+    println!("=== JPEG decode PSNR rig ===");
+    println!("Fixture: {jpeg_path}");
+    println!("Format:  {width}x{height} @ {fps}fps, {frame_count} frames\n");
+
+    let runtime = Runner::new()?;
+
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+
+    let source = runtime.add_processor(JpegBytesSourceProcessor::node(
+        JpegBytesSourceProcessor::Config {
+            file_path: jpeg_path,
+            fps: Some(fps),
+            frame_count: Some(frame_count),
+        },
+    ))?;
+    println!("+ JpegBytesSource: {source}");
+
+    let decoder = runtime.add_processor(JpegDecoderProcessor::node(
+        JpegDecoderProcessor::Config {
+            max_width: Some(width.max(1)),
+            max_height: Some(height.max(1)),
+        },
+    ))?;
+    println!("+ JpegDecoder: {decoder}");
+
+    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
+        width,
+        height,
+        title: Some("streamlib JPEG PSNR rig".to_string()),
+        ..Default::default()
+    }))?;
+    println!("+ Display: {display}");
+
+    runtime.connect(
+        output::<JpegBytesSourceProcessor::OutputLink::encoded_jpeg>(&source),
+        input::<JpegDecoderProcessor::InputLink::encoded_jpeg_in>(&decoder),
+    )?;
+    runtime.connect(
+        output::<JpegDecoderProcessor::OutputLink::video_out>(&decoder),
+        input::<DisplayProcessor::InputLink::video>(&display),
+    )?;
+    println!("\nPipeline: jpeg_bytes_source -> jpeg_decoder -> display\n");
+
+    // Source emits `frame_count` JPEGs at `fps` then stops (its
+    // background thread exits). Sleep covers the source's emit window
+    // plus a small tail for decoder GPU dispatch + display draws.
+    let seconds = frame_count / fps.max(1) + 3;
+    println!("Starting pipeline for ~{seconds}s...\n");
+    runtime.start()?;
+    std::thread::sleep(std::time::Duration::from_secs(seconds as u64));
+    println!("\nStopping pipeline...");
+    runtime.stop()?;
+
+    Ok(())
+}

--- a/examples/jpeg-psnr/src/main.rs
+++ b/examples/jpeg-psnr/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Fixture-driven JPEG decode PSNR rig (issue #844).
+//! Fixture-driven JPEG decode PSNR rig.
 //!
 //! Feeds a single JPEG file through `JpegBytesSource → JpegDecoder →
 //! Display` so the decoded PNG sampler can capture the decoded frame

--- a/examples/jpeg-psnr/streamlib.yaml
+++ b/examples/jpeg-psnr/streamlib.yaml
@@ -3,12 +3,21 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # jpeg-psnr example. Declares `@tatolab/core` so `Runner::load_project(.)`
-# registers the wire-vocabulary schemas (VideoFrame, …) with the engine's
-# runtime schema registry. `EncodedJpegFrame` (owned by @tatolab/jpeg) is
-# NOT registered here — the rig's 1920×1080 reference JPEGs encode to
-# well under iceoryx2's 64 KiB per-slot default (~57 KiB worst case for
-# `complex_pattern` at quality=95), so the schema's declared 16 MiB
-# upper bound isn't load-bearing for this binary.
+# registers the wire-vocabulary schemas (VideoFrame, …) with the
+# engine's runtime schema registry. `EncodedJpegFrame` (owned by
+# `@tatolab/jpeg`) is NOT registered here — the in-tree pattern
+# statically links the `@tatolab/jpeg` Cargo crate for inventory-based
+# processor registration and avoids triggering `load_project`'s
+# packed-dylib lookup against `packages/jpeg/lib/`. The unregistered
+# schema means iceoryx2 sizes `EncodedJpegFrame` slots to its 64 KiB
+# per-slot default rather than the schema's declared 16 MiB. That
+# budget IS load-bearing for the rig: `rmp_serde` serializes
+# `EncodedJpegFrame.data: Vec<u8>` as a msgpack array (~1.5× wire
+# expansion), so the harness caps `JPEG_QUALITY` at 70 to keep the
+# worst-case `complex_pattern` fixture's wire-encoded payload under
+# 64 KiB. See the harness header in
+# `libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh` for
+# the full arithmetic.
 
 package:
   org: tatolab

--- a/examples/jpeg-psnr/streamlib.yaml
+++ b/examples/jpeg-psnr/streamlib.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# jpeg-psnr example. Declares `@tatolab/core` so `Runner::load_project(.)`
+# registers the wire-vocabulary schemas (VideoFrame, …) with the engine's
+# runtime schema registry. `EncodedJpegFrame` (owned by @tatolab/jpeg) is
+# NOT registered here — the rig's 1920×1080 reference JPEGs encode to
+# well under iceoryx2's 64 KiB per-slot default (~57 KiB worst case for
+# `complex_pattern` at quality=95), so the schema's declared 16 MiB
+# upper bound isn't load-bearing for this binary.
+
+package:
+  org: tatolab
+  name: jpeg-psnr
+  version: "0.1.0"
+  description: "PSNR fixture rig — JpegBytesSource → JpegDecoder → Display, decoded PNG sampling for comparison vs reference"
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh
+++ b/libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh
@@ -8,9 +8,15 @@
 # reviewer can read both rigs with the same mental model. Differences
 # (per the JPEG pipeline's shape):
 #
-#   - JPEG is self-contained per-frame and `JpegBytesSource` republishes
-#     a single file. The rig therefore loops references one at a time
-#     rather than concatenating raw BGRA across references.
+#   - JPEG is self-contained per-frame and `JpegBytesSource` reads a
+#     single file at setup (its schema's `file_path` is a required
+#     scalar string, not an array). The rig therefore invokes the
+#     `jpeg-psnr` binary once per reference rather than running a
+#     single binary across a concatenated BGRA stream and pairing
+#     decoded PNGs to references by `frame_index`. Per-invocation
+#     overhead is small (~3s per reference at the configured FPS),
+#     and the per-reference output subdirs match the rig's
+#     middle-sample selection cleanly.
 #   - ffmpeg performs the PNG → JPEG encode step (the "encoder" half of
 #     the PSNR comparison); the streamlib pipeline owns the decode half.
 #
@@ -218,11 +224,19 @@ if [ -n "$PSNR_INJECT_BUG" ]; then
             ;;
     esac
 
-    for f in $(find "$PNG_DIR" -name "display_*_frame_*.png" 2>/dev/null); do
-        ffmpeg -y -hide_banner -loglevel error -i "$f" \
-            -vf "$inject_filter" \
-            "${f}.injected.png"
-        mv "${f}.injected.png" "$f"
+    # Iterate per-reference subdir and glob each — matches the sibling
+    # rig's whitespace-safe glob idiom (rather than the path-splitting
+    # `for f in $(find ...)` form).
+    for i in "${!REF_PNGS[@]}"; do
+        name="$(basename "${REF_PNGS[$i]}" .png)"
+        idx="$(printf "%02d" "$i")"
+        for f in "$PNG_DIR/${idx}_${name}"/display_*_frame_*.png; do
+            [ -f "$f" ] || continue
+            ffmpeg -y -hide_banner -loglevel error -i "$f" \
+                -vf "$inject_filter" \
+                "${f}.injected.png"
+            mv "${f}.injected.png" "$f"
+        done
     done
 fi
 

--- a/libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh
+++ b/libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Fixture-driven JPEG decode PSNR harness.
+#
+# Mirrors libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr.sh so a
+# reviewer can read both rigs with the same mental model. Differences
+# (per the JPEG pipeline's shape):
+#
+#   - JPEG is self-contained per-frame and `JpegBytesSource` republishes
+#     a single file. The rig therefore loops references one at a time
+#     rather than concatenating raw BGRA across references.
+#   - ffmpeg performs the PNG → JPEG encode step (the "encoder" half of
+#     the PSNR comparison); the streamlib pipeline owns the decode half.
+#
+# 1. For each reference PNG in libs/streamlib-engine/tests/fixtures/psnr/:
+#    a. Convert PNG → JPEG (rgba → yuvj420p, configurable quality).
+#    b. Run the `jpeg-psnr` example (JpegBytesSource → JpegDecoder →
+#       Display with PNG sampling).
+# 2. Pick a middle-of-run decoded PNG and compute PSNR vs the reference.
+# 3. Classify per docs/testing.md: Y ≥ 35 dB pass, 30–35 dB warn,
+#    < 30 dB fail.
+#
+# Usage:
+#   libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh [output_dir]
+#
+# Arguments:
+#   output_dir — defaults to /tmp/streamlib-fixture-psnr-jpeg-<timestamp>
+#
+# Environment overrides:
+#   JPEG_QUALITY       — encode quality 1–100 (default 70). The cap is
+#                        load-bearing: rmp_serde serializes
+#                        `EncodedJpegFrame.data: Vec<u8>` as a msgpack
+#                        array (one tag-byte per source byte for u8
+#                        values ≥ 128, half the bytes in a JPEG entropy
+#                        stream), inflating the payload ~1.5× on the
+#                        wire. With iceoryx2's per-slot default of
+#                        64 KiB (no schema-declared bound registered
+#                        for `EncodedJpegFrame` when the package isn't
+#                        loaded — see the "Why q=70 as default" comment
+#                        in the QSCALE block below), `complex_pattern`
+#                        only fits at q ≤ 70. At q=70 every reference
+#                        still clears the Y PSNR ≥ 35 dB pass bar on a
+#                        clean pipeline.
+#   FIXTURE_REPS       — frames per reference (default 10)
+#   PNG_SAMPLE_EVERY   — displayed-frame sampling interval (default 2)
+#   WIDTH / HEIGHT     — frame dimensions (default 1920x1080, must
+#                        match the checked-in fixture PNGs)
+#   FPS                — JpegBytesSource republish rate (default 10)
+#   PSNR_INJECT_BUG    — post-decode bug injection; verifies the FAIL
+#                        threshold trips for color-management regressions.
+#                        One of:
+#                          swap-channels  — R↔B channel swap (catches
+#                                           plane-order regressions)
+#                          bt601-bt709    — encode→YUV as bt601, decode→
+#                                           RGB as bt709 (real matrix
+#                                           mis-interpretation)
+#                          range-swap     — encode→YUV as PC range, decode
+#                                           as TV range (range expansion
+#                                           mis-interpretation)
+#                        Unknown values exit non-zero (no silent no-op).
+#
+# Exit codes: 0 = pass (all refs ≥ warn threshold), 1 = fail, 77 = skip.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/psnr"
+
+OUTPUT_DIR="${1:-/tmp/streamlib-fixture-psnr-jpeg-$(date +%s)}"
+
+JPEG_QUALITY="${JPEG_QUALITY:-70}"
+FIXTURE_REPS="${FIXTURE_REPS:-10}"
+PNG_SAMPLE_EVERY="${PNG_SAMPLE_EVERY:-2}"
+WIDTH="${WIDTH:-1920}"
+HEIGHT="${HEIGHT:-1080}"
+FPS="${FPS:-10}"
+PSNR_INJECT_BUG="${PSNR_INJECT_BUG:-}"
+
+# Thresholds (dB, Y channel).
+PSNR_PASS_DB=35
+PSNR_WARN_DB=30
+
+# ── Prerequisites ────────────────────────────────────────────────────
+need() { command -v "$1" >/dev/null || { echo "[psnr-jpeg] missing: $1" >&2; exit 77; }; }
+need cargo
+need ffmpeg
+need awk
+
+if [ ! -d "$FIXTURES_DIR" ]; then
+    echo "[psnr-jpeg] SKIP: fixtures dir not found at $FIXTURES_DIR" >&2
+    exit 77
+fi
+
+mapfile -t REF_PNGS < <(ls "$FIXTURES_DIR"/*.png 2>/dev/null | sort)
+if [ "${#REF_PNGS[@]}" -eq 0 ]; then
+    echo "[psnr-jpeg] SKIP: no fixture PNGs in $FIXTURES_DIR" >&2
+    exit 77
+fi
+
+mkdir -p "$OUTPUT_DIR"
+JPEG_DIR="$OUTPUT_DIR/encoded_jpegs"
+PNG_DIR="$OUTPUT_DIR/png_samples"
+REF_DIR="$OUTPUT_DIR/refs"
+LOG_DIR="$OUTPUT_DIR/logs"
+mkdir -p "$JPEG_DIR" "$PNG_DIR" "$REF_DIR" "$LOG_DIR"
+
+echo "[psnr-jpeg] Output dir:    $OUTPUT_DIR"
+echo "[psnr-jpeg] Fixtures:      ${#REF_PNGS[@]} references at ${WIDTH}x${HEIGHT} @ ${FPS}fps × ${FIXTURE_REPS} reps"
+echo "[psnr-jpeg] JPEG quality:  $JPEG_QUALITY"
+[ -n "$PSNR_INJECT_BUG" ] && echo "[psnr-jpeg] Bug injection: $PSNR_INJECT_BUG"
+
+# Why q=70 as default
+# -------------------
+# `EncodedJpegFrame.data` is a `Vec<u8>` (per JTD `elements: uint8`)
+# and `rmp_serde` serializes it as a msgpack array — every source byte
+# with value ≥ 128 takes 2 wire bytes (1 tag + 1 value). JPEG entropy
+# streams are statistically ~uniform across [0, 255], so roughly half
+# the bytes pay the per-byte tax — net wire expansion ~1.5×. With
+# iceoryx2's per-slot default of 64 KiB (no schema-declared bound
+# registered for `EncodedJpegFrame` at this rig's load_project shape),
+# the largest fixture (`complex_pattern`, the synthetic high-entropy
+# test pattern) only fits at q ≤ 70 (~38 KiB raw → ~57 KiB on the
+# wire). q=70 still clears Y PSNR ≥ 35 dB on every reference in a
+# clean pipeline (`complex_pattern` measured at Y=39 dB on initial
+# rig validation).
+#
+# ffmpeg's -q:v scale for libmjpeg is ~2..31 (lower = higher quality).
+# The mapping below sends q=70 → -q:v 13, q=85 → -q:v 9, q=95 → -q:v 7.
+QSCALE="$(awk -v q="$JPEG_QUALITY" 'BEGIN{
+    if (q < 1) q = 1;
+    if (q > 100) q = 100;
+    v = 31 - int(q * 0.26);
+    if (v < 2) v = 2;
+    if (v > 31) v = 31;
+    print v
+}')"
+
+# ── Build ────────────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+echo "[psnr-jpeg] Building jpeg-psnr..."
+if ! cargo build -p jpeg-psnr 2>"$LOG_DIR/build.log"; then
+    echo "[psnr-jpeg] FAIL: build failed"
+    tail -40 "$LOG_DIR/build.log"
+    exit 1
+fi
+BINARY="$REPO_ROOT/target/debug/jpeg-psnr"
+
+cleanup() { pkill -9 -f "$BINARY" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ── Per-reference: encode JPEG, run pipeline, capture PNG ─────────────
+# Total samples per reference at FPS=10, REPS=10, every=2: ~5 samples.
+# Run window per reference is `(REPS / FPS) + 3` seconds — matches the
+# example binary's internal sleep envelope.
+RUN_SECS=$(( FIXTURE_REPS / FPS + 3 ))
+
+for i in "${!REF_PNGS[@]}"; do
+    src_png="${REF_PNGS[$i]}"
+    name="$(basename "$src_png" .png)"
+    idx="$(printf "%02d" "$i")"
+
+    # Reference at working dimensions / pixel format. Same shape as the
+    # sibling rig — forces rgba so monochrome-encoded source PNGs don't
+    # skew the YUV conversion vs the decoded RGBA-sourced samples.
+    ref_png="$REF_DIR/${idx}_${name}.png"
+    ffmpeg -y -hide_banner -loglevel error \
+        -i "$src_png" -vf "scale=${WIDTH}:${HEIGHT},format=rgba" "$ref_png"
+
+    # PNG → JPEG via ffmpeg's libmjpeg encoder. yuvj420p is the JFIF
+    # baseline (full-range YCbCr 4:2:0) the decoder is built around;
+    # using yuvj420p (rather than yuv420p) keeps the encoder honest
+    # about JFIF's full-range convention.
+    jpeg_path="$JPEG_DIR/${idx}_${name}.jpg"
+    ffmpeg -y -hide_banner -loglevel error \
+        -i "$ref_png" -vf "format=yuvj420p" -q:v "$QSCALE" "$jpeg_path"
+
+    ref_png_dir="$PNG_DIR/${idx}_${name}"
+    mkdir -p "$ref_png_dir"
+
+    log_file="$LOG_DIR/${idx}_${name}.log"
+    STREAMLIB_DISPLAY_PNG_SAMPLE_DIR="$ref_png_dir" \
+    STREAMLIB_DISPLAY_PNG_SAMPLE_EVERY="$PNG_SAMPLE_EVERY" \
+    STREAMLIB_DISPLAY_FRAME_LIMIT="$FIXTURE_REPS" \
+    DISPLAY="${DISPLAY:-:0}" \
+    RUST_LOG=warn,streamlib=info \
+    timeout --kill-after=3 "$RUN_SECS" "$BINARY" \
+        "$jpeg_path" "$WIDTH" "$HEIGHT" "$FPS" "$FIXTURE_REPS" \
+        > "$log_file" 2>&1 || true
+done
+
+# ── Optional bug injection ───────────────────────────────────────────
+# Post-process every decoded sample with a specific color-management
+# regression class before PSNR comparison. Each variant is expected to
+# drop Y PSNR below the FAIL threshold on the references that carry
+# the affected channels — proving the rig flags real quality
+# regressions, not just smoke-test runs.
+if [ -n "$PSNR_INJECT_BUG" ]; then
+    case "$PSNR_INJECT_BUG" in
+        swap-channels)
+            echo "[psnr-jpeg] INJECTING BUG: swapping R↔B on decoded samples"
+            inject_filter="colorchannelmixer=rr=0:rb=1:bb=0:br=1:gg=1"
+            ;;
+        bt601-bt709)
+            echo "[psnr-jpeg] INJECTING BUG: BT.601→BT.709 matrix mis-interpretation"
+            inject_filter="scale=out_color_matrix=bt601:flags=accurate_rnd,format=yuv420p,scale=in_color_matrix=bt709:flags=accurate_rnd,format=rgba"
+            ;;
+        range-swap)
+            echo "[psnr-jpeg] INJECTING BUG: PC→TV range mis-interpretation"
+            inject_filter="scale=out_range=pc:flags=accurate_rnd,format=yuv420p,scale=in_range=tv:flags=accurate_rnd,format=rgba"
+            ;;
+        *)
+            echo "[psnr-jpeg] ERROR: unknown PSNR_INJECT_BUG=$PSNR_INJECT_BUG" >&2
+            echo "[psnr-jpeg] valid: swap-channels | bt601-bt709 | range-swap" >&2
+            exit 1
+            ;;
+    esac
+
+    for f in $(find "$PNG_DIR" -name "display_*_frame_*.png" 2>/dev/null); do
+        ffmpeg -y -hide_banner -loglevel error -i "$f" \
+            -vf "$inject_filter" \
+            "${f}.injected.png"
+        mv "${f}.injected.png" "$f"
+    done
+fi
+
+# ── PSNR per reference ───────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════════════════"
+echo "  Fixture PSNR results (jpeg)"
+echo "══════════════════════════════════════════════════════════════"
+printf "  %-28s  %8s  %8s  %8s   %s\n" "reference" "Y(dB)" "U(dB)" "V(dB)" "verdict"
+echo "  ───────────────────────────────────────────────────────────"
+
+OVERALL_PASS=true
+REPORT_TSV="$OUTPUT_DIR/psnr_report.tsv"
+echo -e "reference\tinput_frame\ty_db\tu_db\tv_db\tverdict" > "$REPORT_TSV"
+
+for i in "${!REF_PNGS[@]}"; do
+    src_png="${REF_PNGS[$i]}"
+    name="$(basename "$src_png" .png)"
+    idx="$(printf "%02d" "$i")"
+    ref_png="$REF_DIR/${idx}_${name}.png"
+    ref_png_dir="$PNG_DIR/${idx}_${name}"
+
+    # Pick a middle-of-run sample. Trim first and last to avoid display
+    # mailbox boundary effects (the input-frame number embedded in the
+    # filename rises as the source emits, so middle = stable steady
+    # state).
+    mapfile -t samples < <(ls "$ref_png_dir"/display_*_frame_*.png 2>/dev/null | sort)
+    if [ "${#samples[@]}" -eq 0 ]; then
+        printf "  %-28s  %8s  %8s  %8s   %s\n" "$name" "n/a" "n/a" "n/a" "NO-SAMPLE"
+        echo -e "$name\t-\tn/a\tn/a\tn/a\tNO-SAMPLE" >> "$REPORT_TSV"
+        OVERALL_PASS=false
+        continue
+    fi
+
+    # Pick the middle sample, trimming endpoints when we have enough.
+    if [ "${#samples[@]}" -ge 3 ]; then
+        mid_index=$(( ${#samples[@]} / 2 ))
+        decoded_png="${samples[$mid_index]}"
+    else
+        decoded_png="${samples[0]}"
+    fi
+    decoded_idx="$(basename "$decoded_png" .png | sed -E 's/.*_input_([0-9]+)$/\1/' | awk '{print int($0)}')"
+
+    psnr_log="$OUTPUT_DIR/psnr_${name}.log"
+    # Convert both sides to yuv420p (same matrix + range) before PSNR
+    # so we report y/u/v values comparable across runs. `setparams`
+    # pins color_range=pc so ffmpeg doesn't guess different defaults
+    # per input. No `crop` step is needed for JPEG (no CTU padding).
+    ffmpeg -y -hide_banner \
+        -i "$decoded_png" -i "$ref_png" \
+        -lavfi "[0:v]format=rgba,setparams=range=pc,format=yuv420p[a];[1:v]format=rgba,setparams=range=pc,format=yuv420p[b];[a][b]psnr=stats_file=$OUTPUT_DIR/psnr_${name}_stats.log" \
+        -f null - > "$psnr_log" 2>&1 || true
+
+    line="$(grep -oE 'PSNR y:[0-9.inf]+ u:[0-9.inf]+ v:[0-9.inf]+' "$psnr_log" | tail -1 || true)"
+    y_db="$(echo "$line" | sed -nE 's/.*y:([0-9.]+|inf).*/\1/p')"
+    u_db="$(echo "$line" | sed -nE 's/.*u:([0-9.]+|inf).*/\1/p')"
+    v_db="$(echo "$line" | sed -nE 's/.*v:([0-9.]+|inf).*/\1/p')"
+    [ -z "$y_db" ] && y_db="nan"
+    [ -z "$u_db" ] && u_db="nan"
+    [ -z "$v_db" ] && v_db="nan"
+
+    verdict="FAIL"
+    if [ "$y_db" = "inf" ]; then
+        verdict="PASS"
+    elif [ "$y_db" != "nan" ]; then
+        ge_pass="$(awk -v a="$y_db" -v b="$PSNR_PASS_DB" 'BEGIN{print (a+0 >= b+0) ? 1 : 0}')"
+        ge_warn="$(awk -v a="$y_db" -v b="$PSNR_WARN_DB" 'BEGIN{print (a+0 >= b+0) ? 1 : 0}')"
+        if [ "$ge_pass" = "1" ]; then
+            verdict="PASS"
+        elif [ "$ge_warn" = "1" ]; then
+            verdict="WARN"
+        else
+            verdict="FAIL"
+        fi
+    fi
+    if [ "$verdict" = "FAIL" ] || [ "$verdict" = "NO-SAMPLE" ]; then
+        OVERALL_PASS=false
+    fi
+
+    printf "  %-28s  %8s  %8s  %8s   %s\n" "$name" "$y_db" "$u_db" "$v_db" "$verdict"
+    echo -e "$name\t$decoded_idx\t$y_db\t$u_db\t$v_db\t$verdict" >> "$REPORT_TSV"
+done
+
+echo "══════════════════════════════════════════════════════════════"
+echo "  Output dir:        $OUTPUT_DIR"
+echo "  Report TSV:        $REPORT_TSV"
+echo "  Pipeline logs:     $LOG_DIR/"
+echo "══════════════════════════════════════════════════════════════"
+
+if [ "$OVERALL_PASS" = true ]; then
+    echo "[psnr-jpeg] RESULT: PASS"
+    exit 0
+else
+    echo "[psnr-jpeg] RESULT: FAIL"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- New `libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh` — sibling of the H.264/H.265 PSNR rig for GPU JPEG decode. Same reference PNGs, same Y PSNR ≥ 35 dB pass bar, same `swap-channels | bt601-bt709 | range-swap` bug-injection matrix.
- New `examples/jpeg-psnr/` — thin `JpegBytesSource → JpegDecoder → Display` binary the rig drives.
- `docs/testing.md` gains a JPEG section in the color-management manual gate.

Default `JPEG_QUALITY=70` is load-bearing: `rmp_serde` serializes `EncodedJpegFrame.data: Vec<u8>` as a msgpack array (~1.5× wire expansion), and iceoryx2's 64 KiB per-slot default applies because `@tatolab/jpeg`'s 16 MiB bound isn't registered when the example statically links the package (the in-tree pattern). Codegen-side fix tracked at #859.

## Closes

Closes #844

## Exit criteria

- [x] `libs/streamlib-engine/tests/fixtures/e2e_fixture_psnr_jpeg.sh` shell harness under the same env-var contract as `e2e_fixture_psnr.sh`
- [x] Output TSV report at `<output>/psnr_report.tsv` with Y/U/V PSNR per reference frame, classification (PASS / WARN / FAIL / NO-SAMPLE)
- [x] Negative-test modes prove the gate fails when the pipeline is broken (e.g. `PSNR_INJECT_BUG=swap-channels`)
- [x] Pass bar: Y PSNR ≥ 35 dB (matches existing rig)
- [x] `docs/testing.md` updated to point at the new rig in the color-management gate section

## Test plan

Clean pipeline (no injection):

```
complex_pattern               39.342856  39.677843  37.539331   PASS
gradient_horizontal           51.313368  48.187469  48.154998   PASS
gradient_vertical             53.820518  48.201445  48.107343   PASS
solid_black                   48.130804  75.454741  75.454741   PASS
solid_blue                         inf  48.146918       inf   PASS
solid_gray                         inf  48.146918  48.106743   PASS
solid_green                        inf       inf       inf   PASS
solid_red                          inf  48.154998  48.146918   PASS
solid_white                   48.130804  75.454741  48.154998   PASS
[psnr-jpeg] RESULT: PASS
```

`PSNR_INJECT_BUG=swap-channels` — trips FAIL on color references (the gate is non-vacuous):

```
complex_pattern               16.567808  5.387070  6.608600   FAIL
solid_blue                    14.688846  3.521825  4.784237   FAIL
solid_red                     14.688846  3.521919  4.725569   FAIL
(8 other references PASS — single-channel content is insensitive to R↔B swap)
[psnr-jpeg] RESULT: FAIL
```

`PSNR_INJECT_BUG=bt601-bt709` — trips FAIL on chroma-bearing references:

```
complex_pattern               23.474457  28.394180  26.387454   FAIL
solid_green                   20.526579  25.850652  24.048404   FAIL
solid_red                     25.208243  31.221463  28.130804   FAIL
solid_blue                    30.069004  34.163000  32.567779   WARN
```

`PSNR_INJECT_BUG=range-swap` — trips FAIL on gradients:

```
gradient_horizontal           27.822896  42.825487  39.412481   FAIL
gradient_vertical             27.837135  42.785411  39.366763   FAIL
```

Workspace gates green: `cargo check --workspace --all-targets`, `cargo xtask check-boundaries` (3852 files, 0 violations), `cargo xtask lint-logging` (436 files, 0 violations).

## Follow-ups

- #859 (codegen `serde_bytes` for `elements: uint8`) lifts the `JPEG_QUALITY=70` cap by removing the ~1.5× msgpack-Vec<u8> wire overhead.


## Visual evidence

![PSNR rig verdicts — clean baseline vs. each bug-injection mode](https://gh-artifact.tatolab.com/pr-860/psnr_rig_verdicts.jpg)

*Top row (`complex_pattern`): reference → clean q=70 PASS (Y=39.3 dB) → swap-channels FAIL (Y=16.6 dB, R↔B obviously inverted) → bt601-bt709 FAIL (Y=23.5 dB, subtle matrix shift).*
*Bottom row (`gradient_horizontal`): reference → clean q=70 PASS (Y=51.3 dB) → range-swap FAIL (Y=27.8 dB, tone curve clipped). The range-swap mode is the variant that catches PC↔TV range mis-interpretation; swap-channels and bt601-bt709 don't trip on single-channel gradients.*

### TSV reports

Each TSV is the `<output>/psnr_report.tsv` from the corresponding harness run (reference name, input-frame index, Y/U/V PSNR in dB, verdict).

- [Clean baseline — no injection (458 B, 10 rows)](https://gh-artifact.tatolab.com/pr-860/01_clean_baseline.tsv)
- [Inject `swap-channels` — R↔B (470 B, 10 rows)](https://gh-artifact.tatolab.com/pr-860/02_inject_swap_channels.tsv)
- [Inject `bt601-bt709` — matrix mis-interpretation (482 B, 10 rows)](https://gh-artifact.tatolab.com/pr-860/03_inject_bt601_bt709.tsv)
- [Inject `range-swap` — PC↔TV range mis-interpretation (410 B, 10 rows)](https://gh-artifact.tatolab.com/pr-860/04_inject_range_swap.tsv)

### Representative pipeline log

- [`complex_pattern` clean-run pipeline log (23 KB)](https://gh-artifact.tatolab.com/pr-860/sample_pipeline_log_complex_pattern.log) — full streamlib runtime log from the worst-case fixture's pipeline run: processor spawn, iceoryx2 service open, JpegDecoder backend selection (`nvjpeg` on this host), and graceful teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
