### PR TITLE
feat(network): recvmmsg batching + 4 MiB default SO_RCVBUF in UdpSource

### DIFF
--- a/libs/streamlib-engine/src/core/logging/init.rs
+++ b/libs/streamlib-engine/src/core/logging/init.rs
@@ -89,12 +89,64 @@ impl Drop for StreamlibLoggingGuard {
 
 static GLOBAL_INSTALLED: AtomicBool = AtomicBool::new(false);
 
+/// Env-var escape hatch. When set to `1` / `true`, streamlib skips
+/// **all** logging initialization (worker, JSONL writer, stdio
+/// interceptor, polyglot sink, panic hook) and defers ownership of
+/// the global `tracing` subscriber to whatever the host process has
+/// already installed.
+///
+/// Use cases:
+///
+/// - **Throughput benchmarks** that need to install their own
+///   subscriber to capture per-processor counter events.
+/// - **Host applications** that own their own tracing setup
+///   end-to-end and don't want streamlib's defaults.
+///
+/// **Demotions when set** — these features rely on the streamlib
+/// worker existing, so opting in disables them:
+///
+/// - JSONL forensics (`~/.local/state/streamlib/runtime-<id>/...`)
+/// - Stdio interception that converges python/deno cdylib subprocess
+///   stderr onto the same tracing dispatch as Rust events.
+/// - The streamlib panic hook that funnels Rust panics through the
+///   tracing worker.
+///
+/// The `DANGEROUSLY_` prefix is there to make the trade-off
+/// unmistakable to anyone reading a runbook or `env | grep`.
+pub const DEFER_LOGGING_TO_HOST_ENV: &str = "STREAMLIB_DANGEROUSLY_DEFER_LOGGING_TO_HOST";
+
+fn host_owns_logging() -> bool {
+    matches!(
+        std::env::var(DEFER_LOGGING_TO_HOST_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
 /// Install the logging pathway as the **global** tracing subscriber.
 /// First-caller wins: subsequent calls return a no-op guard and the
 /// original subscriber stays live. Used by production entrypoints
 /// (`Runner::new`, `streamlib-cli`, `streamlib-runtime`).
+///
+/// When [`DEFER_LOGGING_TO_HOST_ENV`] is set, this function skips
+/// initialization entirely and returns a noop guard so the host
+/// process keeps full control of the global subscriber. See the
+/// constant's docs for the precise behavioral demotions.
 pub fn init(config: StreamlibLoggingConfig) -> Result<StreamlibLoggingGuard> {
     if GLOBAL_INSTALLED.swap(true, Ordering::SeqCst) {
+        return Ok(StreamlibLoggingGuard::noop());
+    }
+
+    if host_owns_logging() {
+        // Emit a one-line marker via raw stderr (tracing isn't ours
+        // to use here) so the demotion is visible in logs.
+        #[allow(clippy::disallowed_macros)]
+        {
+            eprintln!(
+                "streamlib::logging: {}=1 — deferring all logging initialization to the host \
+                 process (JSONL forensics, stdio interception, and panic hook are disabled)",
+                DEFER_LOGGING_TO_HOST_ENV,
+            );
+        }
         return Ok(StreamlibLoggingGuard::noop());
     }
 

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -50,6 +50,7 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 tokio = { workspace = true }
 serde_json.workspace = true
 serial_test = "3.1"
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -36,6 +36,11 @@ tokio = { workspace = true }
 # doesn't expose these; socket2 is the idiomatic shim.
 socket2 = "0.5"
 
+# Raw libc::recvmmsg for the Linux batched-recv path. Bound to Linux
+# at the use site via cfg; on macOS / non-Linux the per-datagram
+# recv_from fallback path doesn't reach libc.
+libc.workspace = true
+
 # Logging.
 tracing.workspace = true
 

--- a/packages/network/schemas/udp_source_config.yaml
+++ b/packages/network/schemas/udp_source_config.yaml
@@ -22,7 +22,18 @@ optionalProperties:
       description: |
         SO_RCVBUF size hint in bytes. Linux defaults to ~200 KB which can
         drop packets at burst rates (e.g. AGP vision stream at 30Hz × N
-        chunks per JPEG frame). Set to 4–8 MiB for high-rate consumers.
-        The kernel typically clamps to net.core.rmem_max; values above
-        that are silently truncated.
+        chunks per JPEG frame). When unset, UdpSource asks the kernel for
+        4 MiB — the kernel typically clamps to net.core.rmem_max, so on
+        stock Linux you get ~208 KiB and on tuned hosts you get the full
+        4 MiB. Override to raise or lower this hint.
+    type: uint32
+  batch_size:
+    metadata:
+      description: |
+        Max datagrams drained per wakeup. On Linux the recv loop uses
+        recvmmsg(2) to pull up to batch_size datagrams in one syscall;
+        on other platforms the value caps a drain loop around recv_from.
+        Defaults to 64 — matches the Quinn (QUIC) shape and is enough
+        to amortize syscall cost on bursty sources without latching
+        long stalls into the loop.
     type: uint32

--- a/packages/network/src/udp_source.rs
+++ b/packages/network/src/udp_source.rs
@@ -4,6 +4,11 @@
 //! UDP source processor — binds a socket, spawns a tokio recv loop on
 //! the engine's shared runtime, and emits each inbound datagram as a
 //! `NetworkPacket` on its output port.
+//!
+//! On Linux the recv loop drains up to `batch_size` datagrams per
+//! wakeup via `recvmmsg(2)` (one syscall per batch). Off Linux the
+//! per-datagram `recv_from` path runs unchanged, capped by the same
+//! `batch_size` so the loop never starves the shutdown branch.
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -23,6 +28,18 @@ use crate::_generated_::NetworkPacket;
 /// header) − 20 (IPv4 header) = 65,507. Round up to 65,536 for a clean
 /// alignment; the extra bytes are unused.
 const MAX_DATAGRAM_BYTES: usize = 65_536;
+
+/// Default `recvmmsg` batch / fallback drain cap. Matches Quinn's UDP
+/// recv shape — large enough to amortize syscall cost on bursty
+/// sources, small enough that a full drain doesn't latch a long stall
+/// into the loop before re-checking shutdown.
+const DEFAULT_BATCH_SIZE: u32 = 64;
+
+/// Default SO_RCVBUF hint when the consumer doesn't override. The
+/// kernel typically clamps to `net.core.rmem_max` (~208 KiB on stock
+/// Linux, often 8–16 MiB on tuned hosts); asking for more than the
+/// ceiling is silently truncated.
+const DEFAULT_RECV_BUFFER_BYTES: u32 = 4 * 1024 * 1024;
 
 /// Process-wide monotonic anchor for `NetworkPacket.timestamp_ns`.
 /// Initialized on first use; all `UdpSource` instances in the same
@@ -55,6 +72,7 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
         tracing::info!(
             bind_addr = %self.config.bind_addr,
             recv_buffer_bytes = ?self.config.recv_buffer_bytes,
+            batch_size = ?self.config.batch_size,
             "UdpSource: setup",
         );
         std::future::ready(Ok(()))
@@ -78,13 +96,18 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
         let shutdown = Arc::clone(&self.shutdown);
         let packets_received = Arc::clone(&self.packets_received);
         let outputs: Arc<OutputWriter> = self.outputs.clone();
+        let batch_size = resolve_batch_size(self.config.batch_size);
 
         let handle = tokio_handle.spawn(async move {
-            recv_loop(socket, shutdown, packets_received, outputs).await;
+            recv_loop(socket, shutdown, packets_received, outputs, batch_size).await;
         });
         self.recv_task_handle = Some(handle);
 
-        tracing::info!(bind_addr = %bind_addr, "UdpSource: bound + recv loop started");
+        tracing::info!(
+            bind_addr = %bind_addr,
+            batch_size = batch_size,
+            "UdpSource: bound + recv loop started",
+        );
         Ok(())
     }
 
@@ -107,10 +130,21 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
     }
 }
 
+/// Resolve the configured batch size against the default. Clamped at
+/// 1 so a misconfigured 0 doesn't deadlock the loop, and at
+/// `u16::MAX` to keep the per-batch buffer allocation below ~4 GiB
+/// even at 64 KiB per slot (real callers stay well below this).
+fn resolve_batch_size(configured: Option<u32>) -> usize {
+    configured
+        .unwrap_or(DEFAULT_BATCH_SIZE)
+        .clamp(1, u16::MAX as u32) as usize
+}
+
 /// Build a tokio `UdpSocket`, applying pre-bind sockopts (SO_RCVBUF when
-/// requested) via socket2 then converting to a tokio handle. Bind runs
-/// synchronously — `tokio::net::UdpSocket::bind` is async, but the
-/// underlying `socket2::Socket::bind` is sync and equivalent for UDP.
+/// requested, defaulting to `DEFAULT_RECV_BUFFER_BYTES` otherwise) via
+/// socket2 then converting to a tokio handle. Bind runs synchronously —
+/// `tokio::net::UdpSocket::bind` is async, but the underlying
+/// `socket2::Socket::bind` is sync and equivalent for UDP.
 /// `UdpSocket::from_std` requires being inside a tokio runtime context;
 /// the `handle.enter()` guard provides it for the duration of the call.
 pub(crate) fn build_udp_socket(
@@ -130,14 +164,15 @@ pub(crate) fn build_udp_socket(
     socket.set_nonblocking(true).map_err(|e| {
         Error::Configuration(format!("UdpSource: set_nonblocking failed: {e}"))
     })?;
-    if let Some(bytes) = recv_buffer_bytes {
-        // The kernel may clamp to net.core.rmem_max; that's an OK silent
-        // truncation — we report what we asked for, the kernel logs the
-        // ceiling separately.
-        socket.set_recv_buffer_size(bytes as usize).map_err(|e| {
-            Error::Configuration(format!("UdpSource: SO_RCVBUF={bytes} failed: {e}"))
+    let requested_bytes = recv_buffer_bytes.unwrap_or(DEFAULT_RECV_BUFFER_BYTES);
+    // The kernel may clamp to net.core.rmem_max; that's an OK silent
+    // truncation — we report what we asked for, the kernel logs the
+    // ceiling separately.
+    socket
+        .set_recv_buffer_size(requested_bytes as usize)
+        .map_err(|e| {
+            Error::Configuration(format!("UdpSource: SO_RCVBUF={requested_bytes} failed: {e}"))
         })?;
-    }
     socket
         .bind(&addr.into())
         .map_err(|e| Error::Configuration(format!("UdpSource: bind {addr} failed: {e}")))?;
@@ -153,8 +188,31 @@ async fn recv_loop(
     shutdown: Arc<Notify>,
     packets_received: Arc<AtomicU64>,
     outputs: Arc<OutputWriter>,
+    batch_size: usize,
 ) {
-    let mut buf = vec![0u8; MAX_DATAGRAM_BYTES];
+    #[cfg(target_os = "linux")]
+    {
+        recv_loop_linux(socket, shutdown, packets_received, outputs, batch_size).await;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        recv_loop_fallback(socket, shutdown, packets_received, outputs, batch_size).await;
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn recv_loop_linux(
+    socket: UdpSocket,
+    shutdown: Arc<Notify>,
+    packets_received: Arc<AtomicU64>,
+    outputs: Arc<OutputWriter>,
+    batch_size: usize,
+) {
+    use std::os::fd::AsRawFd;
+    use tokio::io::Interest;
+
+    let mut batch = recvmmsg_linux::RecvBatch::new(batch_size);
+    let fd = socket.as_raw_fd();
 
     loop {
         tokio::select! {
@@ -163,6 +221,63 @@ async fn recv_loop(
             // it before polling the long-running recv, so a notify
             // delivered while we were already mid-recv still gets
             // observed on the next loop iteration without latency.
+            _ = shutdown.notified() => break,
+
+            // SAFETY: drain captures `&mut batch` which lives only as
+            // long as the async_io future (dropped at end of arm).
+            drained = socket.async_io(Interest::READABLE, || batch.drain(fd)) => {
+                let n = match drained {
+                    Ok(n) => n,
+                    Err(e) => {
+                        tracing::error!(error = %e, "UdpSource: recvmmsg failed");
+                        continue;
+                    }
+                };
+                let timestamp_ns = monotonic_ns();
+                let timestamp_str = timestamp_ns.to_string();
+                for i in 0..n {
+                    let Some((payload, peer)) = batch.slot(i) else {
+                        // Malformed peer addr from kernel (shouldn't
+                        // happen for AF_INET/AF_INET6 dgrams); skip.
+                        continue;
+                    };
+                    let packet = NetworkPacket {
+                        payload: payload.to_vec(),
+                        peer_addr: peer.to_string(),
+                        timestamp_ns: timestamp_str.clone(),
+                    };
+                    if let Err(e) = outputs.write("packets", &packet) {
+                        tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
+                        continue;
+                    }
+                    let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
+                    if count == 1 {
+                        tracing::info!(peer = %peer, bytes = payload.len(), "UdpSource: first packet received");
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!(
+        packets_received = packets_received.load(Ordering::Relaxed),
+        "UdpSource: recv loop exiting",
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn recv_loop_fallback(
+    socket: UdpSocket,
+    shutdown: Arc<Notify>,
+    packets_received: Arc<AtomicU64>,
+    outputs: Arc<OutputWriter>,
+    batch_size: usize,
+) {
+    let mut buf = vec![0u8; MAX_DATAGRAM_BYTES];
+
+    loop {
+        tokio::select! {
+            biased;
             _ = shutdown.notified() => break,
 
             recv = socket.recv_from(&mut buf) => {
@@ -174,22 +289,22 @@ async fn recv_loop(
                         continue;
                     }
                 };
+                publish_one(&buf[..n], peer, &packets_received, &outputs);
 
-                let timestamp_ns = monotonic_ns();
-                let packet = NetworkPacket {
-                    payload: buf[..n].to_vec(),
-                    peer_addr: peer.to_string(),
-                    timestamp_ns: timestamp_ns.to_string(),
-                };
-
-                if let Err(e) = outputs.write("packets", &packet) {
-                    tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
-                    continue;
-                }
-
-                let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
-                if count == 1 {
-                    tracing::info!(peer = %peer, bytes = n, "UdpSource: first packet received");
+                // Opportunistically drain up to batch_size-1 more
+                // datagrams that may already be sitting in the
+                // socket buffer; per-packet recv_from cost on these
+                // platforms is the baseline, batching here is a
+                // syscall-amortization courtesy.
+                for _ in 1..batch_size {
+                    match socket.try_recv_from(&mut buf) {
+                        Ok((n, peer)) => publish_one(&buf[..n], peer, &packets_received, &outputs),
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                        Err(e) => {
+                            tracing::error!(error = %e, "UdpSource: try_recv_from failed");
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -199,6 +314,179 @@ async fn recv_loop(
         packets_received = packets_received.load(Ordering::Relaxed),
         "UdpSource: recv loop exiting",
     );
+}
+
+#[cfg(not(target_os = "linux"))]
+fn publish_one(
+    payload: &[u8],
+    peer: SocketAddr,
+    packets_received: &Arc<AtomicU64>,
+    outputs: &Arc<OutputWriter>,
+) {
+    let packet = NetworkPacket {
+        payload: payload.to_vec(),
+        peer_addr: peer.to_string(),
+        timestamp_ns: monotonic_ns().to_string(),
+    };
+    if let Err(e) = outputs.write("packets", &packet) {
+        tracing::error!(error = %e, peer = %peer, "UdpSource: output write failed");
+        return;
+    }
+    let count = packets_received.fetch_add(1, Ordering::Relaxed) + 1;
+    if count == 1 {
+        tracing::info!(peer = %peer, bytes = payload.len(), "UdpSource: first packet received");
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod recvmmsg_linux {
+    //! Linux-specific batched recv via `recvmmsg(2)`. Pre-allocates a
+    //! fixed array of (buffer, sockaddr_storage, iovec, mmsghdr) slots
+    //! at construction and reuses them per syscall — zero allocation
+    //! on the hot path.
+
+    use std::io;
+    use std::net::SocketAddr;
+    use std::os::fd::RawFd;
+
+    use super::MAX_DATAGRAM_BYTES;
+
+    /// Per-slot storage: one datagram buffer, one peer-addr storage,
+    /// one iovec pointing into the buffer. Boxed so the address is
+    /// stable independent of the enclosing Vec's reallocation.
+    struct Slot {
+        buffer: Box<[u8; MAX_DATAGRAM_BYTES]>,
+        peer_storage: libc::sockaddr_storage,
+        iovec: libc::iovec,
+    }
+
+    pub(super) struct RecvBatch {
+        slots: Box<[Slot]>,
+        /// Parallel array of `mmsghdr`s whose `msg_hdr` fields point
+        /// into the matching `slots[i]`. Stable as long as `slots` is
+        /// not resized; we never resize it.
+        mmsghdrs: Box<[libc::mmsghdr]>,
+    }
+
+    // SAFETY: `mmsghdr` contains raw `*mut` pointers that point into
+    // the same `RecvBatch`'s `slots` (heap-allocated; addresses
+    // stable across moves of `RecvBatch` itself). The pointers never
+    // escape the `RecvBatch`, so no other thread can observe them
+    // unless the whole batch moves with them. The recv task that
+    // owns the batch is the only reader and writer.
+    unsafe impl Send for RecvBatch {}
+
+    impl RecvBatch {
+        pub(super) fn new(batch_size: usize) -> Self {
+            let mut slots: Vec<Slot> = (0..batch_size)
+                .map(|_| Slot {
+                    buffer: Box::new([0u8; MAX_DATAGRAM_BYTES]),
+                    peer_storage: unsafe { std::mem::zeroed() },
+                    iovec: libc::iovec {
+                        iov_base: std::ptr::null_mut(),
+                        iov_len: 0,
+                    },
+                })
+                .collect();
+
+            // Wire iovec.iov_base into each buffer. Do this BEFORE
+            // building mmsghdrs so the iovec pointers are stable.
+            for slot in slots.iter_mut() {
+                slot.iovec.iov_base = slot.buffer.as_mut_ptr() as *mut libc::c_void;
+                slot.iovec.iov_len = MAX_DATAGRAM_BYTES;
+            }
+            let slots = slots.into_boxed_slice();
+
+            let mut mmsghdrs: Vec<libc::mmsghdr> = Vec::with_capacity(batch_size);
+            for slot in slots.iter() {
+                let hdr = libc::msghdr {
+                    msg_name: &slot.peer_storage as *const _ as *mut libc::c_void,
+                    msg_namelen: std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t,
+                    msg_iov: &slot.iovec as *const _ as *mut libc::iovec,
+                    msg_iovlen: 1,
+                    msg_control: std::ptr::null_mut(),
+                    msg_controllen: 0,
+                    msg_flags: 0,
+                };
+                mmsghdrs.push(libc::mmsghdr {
+                    msg_hdr: hdr,
+                    msg_len: 0,
+                });
+            }
+            let mmsghdrs = mmsghdrs.into_boxed_slice();
+
+            Self { slots, mmsghdrs }
+        }
+
+        /// Drain up to `batch_size` datagrams via one `recvmmsg`
+        /// syscall. Returns the count on success or `WouldBlock` when
+        /// no datagrams are ready — `async_io` treats `WouldBlock` as
+        /// "re-await readiness," which matches kernel semantics for a
+        /// spurious wake.
+        pub(super) fn drain(&mut self, fd: RawFd) -> io::Result<usize> {
+            // Reset per-call mutable fields. msg_namelen is rewritten
+            // by the kernel to the actual peer-addr length, and
+            // msg_len reports the datagram length per slot.
+            let slot_count = self.slots.len();
+            for i in 0..slot_count {
+                self.mmsghdrs[i].msg_hdr.msg_namelen =
+                    std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                self.mmsghdrs[i].msg_len = 0;
+            }
+
+            // SAFETY: `self.mmsghdrs` is a boxed slice whose backing
+            // memory is owned by &mut self. Each mmsghdr.msg_hdr
+            // points into the matching `self.slots[i]` (peer_storage,
+            // iovec), also owned by &mut self for the duration of the
+            // call. `recvmmsg` writes into `msg_len`, into
+            // `peer_storage` (length capped by msg_namelen), and into
+            // the iovec target buffers. MSG_DONTWAIT ensures the
+            // syscall returns -EAGAIN instead of blocking when no
+            // data is ready.
+            let n = unsafe {
+                libc::recvmmsg(
+                    fd,
+                    self.mmsghdrs.as_mut_ptr(),
+                    slot_count as libc::c_uint,
+                    libc::MSG_DONTWAIT,
+                    std::ptr::null_mut(),
+                )
+            };
+            if n < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(n as usize)
+        }
+
+        /// Return `(payload, peer)` for slot `idx` after a successful
+        /// `drain(n)`. Caller must respect `idx < n`; indexing beyond
+        /// that yields stale data from a prior call.
+        pub(super) fn slot(&self, idx: usize) -> Option<(&[u8], SocketAddr)> {
+            let mh = self.mmsghdrs.get(idx)?;
+            let len = (mh.msg_len as usize).min(MAX_DATAGRAM_BYTES);
+            let slot = &self.slots[idx];
+            let payload = &slot.buffer[..len];
+            let peer = sockaddr_storage_to_socket(&slot.peer_storage, mh.msg_hdr.msg_namelen)?;
+            Some((payload, peer))
+        }
+    }
+
+    fn sockaddr_storage_to_socket(
+        storage: &libc::sockaddr_storage,
+        len: libc::socklen_t,
+    ) -> Option<SocketAddr> {
+        // SAFETY: `socket2::SockAddr::new` requires `storage` to be
+        // initialized as a valid sockaddr_storage value of the
+        // indicated length. The kernel writes the peer address into
+        // `slot.peer_storage` and reports the actual length in
+        // `msg_namelen` for AF_INET / AF_INET6 sockets, which is what
+        // a UDP socket bound to an IP address produces. socket2 then
+        // narrows to `Option<SocketAddr>`, returning `None` for any
+        // address family it can't classify (AF_UNIX, AF_NETLINK,
+        // etc.) — which never appears here.
+        let sock_addr = unsafe { socket2::SockAddr::new(*storage, len) };
+        sock_addr.as_socket()
+    }
 }
 
 #[cfg(test)]
@@ -266,5 +554,89 @@ mod tests {
         let socket = build_udp_socket(ephemeral, Some(1 << 20), &handle)
             .expect("bind with 1 MiB SO_RCVBUF hint");
         assert!(socket.local_addr().is_ok());
+    }
+
+    /// `resolve_batch_size` clamps a zero override to 1 so a misconfig
+    /// can't deadlock the recv loop (a 0-element `recvmmsg` returns 0
+    /// without consuming readiness, which would spin). `None` resolves
+    /// to the documented default.
+    #[test]
+    fn batch_size_defaults_and_clamp_invariants() {
+        assert_eq!(resolve_batch_size(None), DEFAULT_BATCH_SIZE as usize);
+        assert_eq!(resolve_batch_size(Some(0)), 1);
+        assert_eq!(resolve_batch_size(Some(32)), 32);
+        assert_eq!(resolve_batch_size(Some(64)), 64);
+        // Above the clamp ceiling, capped instead of overflowed.
+        assert_eq!(resolve_batch_size(Some(1_000_000)), u16::MAX as usize);
+    }
+
+    /// Linux-only: send N datagrams into a paired socket, drive one
+    /// `recvmmsg` syscall, and assert all N come back in one drain
+    /// with the correct peer address and payload bytes. This is the
+    /// per-syscall amortization invariant — the whole point of the
+    /// batching change. A regression that fell back to per-datagram
+    /// recv would still pass this (it would just take N syscalls);
+    /// what locks the batching behavior specifically is the count
+    /// returned by `drain()` (≥ 2 means more than one msg landed in
+    /// one syscall).
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn recvmmsg_drains_multiple_datagrams_in_one_syscall() {
+        use std::os::fd::AsRawFd;
+
+        let handle = tokio::runtime::Handle::current();
+        let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let recv_socket = build_udp_socket(bind, None, &handle).expect("bind recv");
+        let recv_addr = recv_socket.local_addr().expect("local_addr");
+
+        let send_socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind sender");
+        let send_addr = send_socket.local_addr().expect("send local_addr");
+
+        // Burst N datagrams synchronously — the kernel queues them in
+        // the recv socket's buffer; the subsequent recvmmsg picks all
+        // up in one syscall.
+        const N: usize = 8;
+        for i in 0..N {
+            let payload = [i as u8; 16];
+            send_socket
+                .send_to(&payload, recv_addr)
+                .expect("send datagram");
+        }
+
+        // Yield to let the kernel deliver the datagrams. On loopback
+        // delivery is immediate, but the recv readiness needs to
+        // propagate to tokio's mio reactor.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut batch = recvmmsg_linux::RecvBatch::new(N);
+        let fd = recv_socket.as_raw_fd();
+
+        // Drive readiness through tokio so the socket is registered
+        // with the reactor; otherwise `recvmmsg` could race the
+        // kernel's queue settling.
+        recv_socket
+            .readable()
+            .await
+            .expect("readable after burst");
+
+        let n = batch.drain(fd).expect("recvmmsg drains");
+        assert!(
+            n >= 2,
+            "expected ≥2 datagrams in one syscall (batching invariant), got {n}",
+        );
+
+        for i in 0..n {
+            let (payload, peer) = batch.slot(i).expect("slot decoded");
+            assert_eq!(peer, send_addr, "peer addr decoded from sockaddr_storage");
+            assert_eq!(payload.len(), 16, "16-byte datagram");
+            // Bytes inside a slot are the bytes the kernel wrote for
+            // that datagram; recvmmsg orders slots in arrival order,
+            // and loopback preserves send order, so slot[i] carries
+            // the i-th datagram's payload.
+            assert!(
+                payload.iter().all(|&b| b == i as u8),
+                "slot {i} payload bytes mismatch",
+            );
+        }
     }
 }

--- a/packages/network/tests/udp_burst_stress.rs
+++ b/packages/network/tests/udp_burst_stress.rs
@@ -198,18 +198,20 @@ fn burst_six_streams_at_200hz_round_trips_without_loss() {
 
     assert_eq!(sent, expected, "every sender completed its full burst");
 
-    // Zero loss is the goal. A small loss tolerance accommodates
-    // loopback scheduling noise — recvmmsg amortizes the syscall
-    // cost, but if the test host is heavily loaded the sink's mpsc
-    // (capacity 256) can momentarily back-pressure the source's
-    // iceoryx2 publish chain. The lower bound here is far above
-    // what a regression to per-datagram recv_from would survive
-    // (that path drops a meaningful fraction on this burst shape
-    // under the kernel's default rmem clamp).
-    let min_received = expected * 95 / 100;
-    assert!(
-        received >= min_received,
-        "expected at least {min_received}/{expected} round-trips with recvmmsg + 4 MiB SO_RCVBUF; \
-         got {received}. send took {send_elapsed:?}, total {total_elapsed:?}.",
+    // Zero loss is the exit criterion from #838. recvmmsg + the
+    // 4 MiB SO_RCVBUF default + iceoryx2's 64-entry NetworkPacket
+    // ring + UdpSink's 256-entry mpsc all stack up such that 1800
+    // datagrams over ~1.5 s on loopback round-trip cleanly. A
+    // regression to per-datagram recv_from or to the old ~208 KiB
+    // SO_RCVBUF default would drop a meaningful fraction on this
+    // burst shape, which the strict equality assertion catches.
+    // If this ever flakes on a contended CI box the failure
+    // message includes the wall times so the loss can be
+    // re-characterized — but the goal is the exit criterion, not
+    // an arbitrary tolerance.
+    assert_eq!(
+        received, expected,
+        "expected zero loss round-trip with recvmmsg + 4 MiB SO_RCVBUF default; \
+         got {received}/{expected}. send took {send_elapsed:?}, total {total_elapsed:?}.",
     );
 }

--- a/packages/network/tests/udp_burst_stress.rs
+++ b/packages/network/tests/udp_burst_stress.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Burst-stress for `UdpSource` → `UdpSink` end-to-end. Wires a real
+//! `Runner` with the echo-server shape (source publishes
+//! `NetworkPacket`s to the sink; sink writes the payload back to
+//! `peer_addr`), then fires 6 sender streams at ~200 Hz each for
+//! ~1.5 s and asserts every datagram round-trips.
+//!
+//! What this locks:
+//!
+//! 1. The Linux `recvmmsg` path in `UdpSource` drains kernel-queued
+//!    bursts without dropping when the source's per-call wakeups are
+//!    paced by tokio.
+//! 2. The default 4 MiB SO_RCVBUF hint (silently clamped to
+//!    `net.core.rmem_max` on stock Linux) is large enough to absorb
+//!    the burst between wakeups.
+//! 3. iceoryx2's per-schema ring depth (the `max_queued_messages:
+//!    64` on `NetworkPacket` from #837) doesn't bottleneck the
+//!    source→sink mailbox at this rate.
+//!
+//! Numbers are deliberately conservative for a CI-grade test:
+//! 200 Hz × 6 × 1.5 s ≈ 1800 datagrams, well under any single
+//! bottleneck on loopback. The stress is the *burst shape*, not
+//! the absolute throughput.
+
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+
+#[allow(unused_imports)]
+use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
+
+const SENDER_COUNT: usize = 6;
+const PACKETS_PER_SENDER: usize = 300;
+const SEND_INTERVAL: Duration = Duration::from_micros(5_000); // 200 Hz per sender
+const PAYLOAD_LEN: usize = 64;
+const ECHO_DRAIN_AFTER_SEND: Duration = Duration::from_secs(3);
+
+fn pick_free_udp_port() -> SocketAddr {
+    let probe = UdpSocket::bind("127.0.0.1:0").expect("probe bind");
+    let addr = probe.local_addr().expect("probe local_addr");
+    drop(probe);
+    addr
+}
+
+#[test]
+#[serial]
+fn burst_six_streams_at_200hz_round_trips_without_loss() {
+    let source_bind = pick_free_udp_port();
+
+    let runtime = Runner::new().expect("Runner::new");
+
+    let source_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSource", "1.0.0"),
+            serde_json::json!({
+                "bind_addr": source_bind.to_string(),
+                // batch_size left at default (64) — the whole point of
+                // this test is the default shape, not a tuned override.
+            }),
+        ))
+        .expect("add UdpSource");
+
+    let sink_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSink", "1.0.0"),
+            serde_json::json!({}),
+        ))
+        .expect("add UdpSink");
+
+    runtime
+        .connect(
+            OutputLinkPortRef::new(source_id.as_str(), "packets"),
+            InputLinkPortRef::new(sink_id.as_str(), "packets"),
+        )
+        .expect("connect UdpSource → UdpSink");
+
+    runtime.start().expect("runtime.start");
+
+    // Warm-up so the recv loop is bound and the iceoryx2 subscriber
+    // is open before the first burst lands (per
+    // docs/learnings/pubsub-lazy-init-silent-noop.md, iceoryx2
+    // service open is best-effort and a publish before subscribe is
+    // observed disappears silently).
+    std::thread::sleep(Duration::from_millis(250));
+
+    // Per-sender shape: one sender thread paces 200 Hz for
+    // PACKETS_PER_SENDER datagrams, one receiver thread drains
+    // echoes on the same socket with a deadline. Pairing the
+    // receiver into a separate thread keeps the sender's pacing
+    // free of recv latency.
+    let total_sent = Arc::new(AtomicUsize::new(0));
+    let total_received = Arc::new(AtomicUsize::new(0));
+
+    let burst_start = Instant::now();
+    let mut sender_handles = Vec::with_capacity(SENDER_COUNT);
+    let mut receiver_handles = Vec::with_capacity(SENDER_COUNT);
+
+    for sender_idx in 0..SENDER_COUNT {
+        // Each sender owns its socket — sink echoes back to peer_addr,
+        // and peer_addr is this socket's bound port.
+        let sock = Arc::new(UdpSocket::bind("127.0.0.1:0").expect("sender bind"));
+        // 50ms read timeout on the receiver thread; long enough that
+        // the loop doesn't spin tightly, short enough that the
+        // deadline check fires within a few iterations.
+        sock.set_read_timeout(Some(Duration::from_millis(50)))
+            .expect("set read timeout");
+
+        let sender_sock = Arc::clone(&sock);
+        let recv_sock = Arc::clone(&sock);
+        let sent_counter = Arc::clone(&total_sent);
+        let recv_counter = Arc::clone(&total_received);
+
+        let send_handle = std::thread::Builder::new()
+            .name(format!("udp-burst-sender-{sender_idx}"))
+            .spawn(move || {
+                let mut clock = Instant::now();
+                for packet_idx in 0..PACKETS_PER_SENDER {
+                    let mut payload = [0u8; PAYLOAD_LEN];
+                    payload[0] = sender_idx as u8;
+                    payload[1..5].copy_from_slice(&(packet_idx as u32).to_le_bytes());
+                    sender_sock
+                        .send_to(&payload, source_bind)
+                        .expect("send_to");
+                    sent_counter.fetch_add(1, Ordering::Relaxed);
+
+                    clock += SEND_INTERVAL;
+                    let now = Instant::now();
+                    if clock > now {
+                        std::thread::sleep(clock - now);
+                    } else {
+                        clock = now;
+                    }
+                }
+            })
+            .expect("spawn sender");
+        sender_handles.push(send_handle);
+
+        let recv_handle = std::thread::Builder::new()
+            .name(format!("udp-burst-receiver-{sender_idx}"))
+            .spawn(move || {
+                // Generous deadline: send takes ~1.5s + echo tail.
+                let deadline = Instant::now()
+                    + Duration::from_secs(2)
+                    + ECHO_DRAIN_AFTER_SEND;
+                let mut local_received = 0usize;
+                let mut buf = [0u8; PAYLOAD_LEN];
+                while Instant::now() < deadline && local_received < PACKETS_PER_SENDER {
+                    match recv_sock.recv_from(&mut buf) {
+                        Ok((n, _peer)) if n == PAYLOAD_LEN => {
+                            local_received += 1;
+                        }
+                        Ok(_) => {} // unexpected short read
+                        Err(e)
+                            if e.kind() == std::io::ErrorKind::WouldBlock
+                                || e.kind() == std::io::ErrorKind::TimedOut => {}
+                        Err(e) => panic!("recv_from failed: {e}"),
+                    }
+                }
+                recv_counter.fetch_add(local_received, Ordering::Relaxed);
+            })
+            .expect("spawn receiver");
+        receiver_handles.push(recv_handle);
+    }
+
+    for handle in sender_handles {
+        handle.join().expect("sender thread");
+    }
+    let send_elapsed = burst_start.elapsed();
+
+    for handle in receiver_handles {
+        handle.join().expect("receiver thread");
+    }
+    let total_elapsed = burst_start.elapsed();
+
+    runtime.stop().expect("runtime.stop");
+
+    let sent = total_sent.load(Ordering::Relaxed);
+    let received = total_received.load(Ordering::Relaxed);
+    let expected = SENDER_COUNT * PACKETS_PER_SENDER;
+
+    tracing::info!(
+        sent,
+        expected,
+        received,
+        ?send_elapsed,
+        ?total_elapsed,
+        "burst-stress completed",
+    );
+
+    assert_eq!(sent, expected, "every sender completed its full burst");
+
+    // Zero loss is the goal. A small loss tolerance accommodates
+    // loopback scheduling noise — recvmmsg amortizes the syscall
+    // cost, but if the test host is heavily loaded the sink's mpsc
+    // (capacity 256) can momentarily back-pressure the source's
+    // iceoryx2 publish chain. The lower bound here is far above
+    // what a regression to per-datagram recv_from would survive
+    // (that path drops a meaningful fraction on this burst shape
+    // under the kernel's default rmem clamp).
+    let min_received = expected * 95 / 100;
+    assert!(
+        received >= min_received,
+        "expected at least {min_received}/{expected} round-trips with recvmmsg + 4 MiB SO_RCVBUF; \
+         got {received}. send took {send_elapsed:?}, total {total_elapsed:?}.",
+    );
+}

--- a/packages/network/tests/udp_throughput_bench.rs
+++ b/packages/network/tests/udp_throughput_bench.rs
@@ -1,0 +1,462 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Ad-hoc throughput bench — NOT part of the regular test suite.
+// Marked `#[ignore]` so `cargo test` skips it. Run explicitly:
+//
+//   cargo test -p streamlib-network --test udp_throughput_bench \
+//     --release -- --ignored --nocapture --test-threads=1
+//
+// Two measurements:
+//
+//   1. Pure `recvmmsg(2)` drain rate — how fast a single tokio recv
+//      loop can pull datagrams off a non-blocking UDP socket using
+//      the same recvmmsg+async_io shape the real `UdpSourceProcessor`
+//      uses. Upper bound on what streamlib can ever achieve on this
+//      hardware.
+//
+//   2. Full UdpSource → iceoryx2 → UdpSink pipeline — the real
+//      streamlib path. Delta vs (1) is the per-packet engine
+//      overhead.
+//
+// The Runner-wrapped measurement (#2) installs the bench's tracing
+// subscriber FIRST so streamlib's `init()` gracefully no-ops the
+// dispatcher install and routes its events through our buffer.
+// The bench then greps the buffer for the source's teardown line
+// to read `packets_received`.
+
+use std::io::Write;
+use std::net::{SocketAddr, UdpSocket};
+use std::os::fd::AsRawFd;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use tokio::io::Interest;
+use tokio::net::UdpSocket as TokioUdpSocket;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[allow(unused_imports)]
+use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
+
+// --------------------------------------------------------------------
+// Captured-tracing harness for #2.
+// --------------------------------------------------------------------
+
+static GLOBAL_LOG_BUF: OnceLock<Arc<Mutex<Vec<u8>>>> = OnceLock::new();
+
+#[derive(Clone)]
+struct CapturedLog(Arc<Mutex<Vec<u8>>>);
+
+impl Write for CapturedLog {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturedLog {
+    type Writer = CapturedLog;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn ensure_global_subscriber() -> Arc<Mutex<Vec<u8>>> {
+    GLOBAL_LOG_BUF
+        .get_or_init(|| {
+            // Tell streamlib to skip its own logging init so this
+            // bench can own the global subscriber and capture
+            // streamlib events for counter-grepping. The constant
+            // name lives in the engine crate; we set it by literal
+            // string here to avoid a deeper internal import. See
+            // `streamlib_engine::core::logging::init`'s
+            // DEFER_LOGGING_TO_HOST_ENV constant for what this
+            // env var disables.
+            // SAFETY: this is set before any Runner::new call, so
+            // no streamlib thread has read it yet. No concurrent
+            // env mutation in this test binary.
+            unsafe {
+                std::env::set_var("STREAMLIB_DANGEROUSLY_DEFER_LOGGING_TO_HOST", "1");
+            }
+            let buf = Arc::new(Mutex::new(Vec::with_capacity(256 * 1024)));
+            let writer = CapturedLog(Arc::clone(&buf));
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(writer)
+                .with_target(false)
+                .without_time()
+                .with_ansi(false)
+                .with_max_level(tracing::Level::INFO)
+                .finish();
+            let _ = tracing::subscriber::set_global_default(subscriber);
+            buf
+        })
+        .clone()
+}
+
+/// Pull the most recent `packets_received=N` value off any
+/// `UdpSource: stopped` line emitted since `log_start_offset`.
+fn parse_packets_received(log: &str) -> u64 {
+    log.lines()
+        .filter(|line| line.contains("UdpSource: stopped"))
+        .filter_map(|line| {
+            line.split_whitespace()
+                .find_map(|tok| tok.strip_prefix("packets_received="))
+                .and_then(|n| n.parse::<u64>().ok())
+        })
+        .next_back()
+        .unwrap_or(0)
+}
+
+// --------------------------------------------------------------------
+// Shared helpers
+// --------------------------------------------------------------------
+
+/// Tiny inline reimplementation of `RecvBatch` for the pure-syscall
+/// bench — same shape as `udp_source.rs::recvmmsg_linux::RecvBatch`
+/// but reachable from the test crate.
+struct BenchRecvBatch {
+    slots: Box<[BenchSlot]>,
+    mmsghdrs: Box<[libc::mmsghdr]>,
+}
+struct BenchSlot {
+    buffer: Box<[u8; 65_536]>,
+    peer_storage: libc::sockaddr_storage,
+    iovec: libc::iovec,
+}
+unsafe impl Send for BenchRecvBatch {}
+
+impl BenchRecvBatch {
+    fn new(batch_size: usize) -> Self {
+        let mut slots: Vec<BenchSlot> = (0..batch_size)
+            .map(|_| BenchSlot {
+                buffer: Box::new([0u8; 65_536]),
+                peer_storage: unsafe { std::mem::zeroed() },
+                iovec: libc::iovec {
+                    iov_base: std::ptr::null_mut(),
+                    iov_len: 0,
+                },
+            })
+            .collect();
+        for slot in slots.iter_mut() {
+            slot.iovec.iov_base = slot.buffer.as_mut_ptr() as *mut libc::c_void;
+            slot.iovec.iov_len = 65_536;
+        }
+        let slots = slots.into_boxed_slice();
+
+        let mut mmsghdrs: Vec<libc::mmsghdr> = Vec::with_capacity(batch_size);
+        for slot in slots.iter() {
+            let hdr = libc::msghdr {
+                msg_name: &slot.peer_storage as *const _ as *mut libc::c_void,
+                msg_namelen: std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t,
+                msg_iov: &slot.iovec as *const _ as *mut libc::iovec,
+                msg_iovlen: 1,
+                msg_control: std::ptr::null_mut(),
+                msg_controllen: 0,
+                msg_flags: 0,
+            };
+            mmsghdrs.push(libc::mmsghdr {
+                msg_hdr: hdr,
+                msg_len: 0,
+            });
+        }
+        Self {
+            slots,
+            mmsghdrs: mmsghdrs.into_boxed_slice(),
+        }
+    }
+
+    fn drain(&mut self, fd: std::os::fd::RawFd) -> std::io::Result<usize> {
+        for i in 0..self.slots.len() {
+            self.mmsghdrs[i].msg_hdr.msg_namelen =
+                std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+            self.mmsghdrs[i].msg_len = 0;
+        }
+        let n = unsafe {
+            libc::recvmmsg(
+                fd,
+                self.mmsghdrs.as_mut_ptr(),
+                self.slots.len() as libc::c_uint,
+                libc::MSG_DONTWAIT,
+                std::ptr::null_mut(),
+            )
+        };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(n as usize)
+        }
+    }
+}
+
+fn pick_free_udp_port() -> SocketAddr {
+    let probe = UdpSocket::bind("127.0.0.1:0").expect("probe bind");
+    let addr = probe.local_addr().expect("probe local_addr");
+    drop(probe);
+    addr
+}
+
+fn build_recv_socket(
+    addr: SocketAddr,
+    recv_buffer_bytes: u32,
+    handle: &tokio::runtime::Handle,
+) -> TokioUdpSocket {
+    let sock = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )
+    .expect("socket()");
+    sock.set_reuse_address(true).unwrap();
+    sock.set_nonblocking(true).unwrap();
+    sock.set_recv_buffer_size(recv_buffer_bytes as usize).unwrap();
+    sock.bind(&addr.into()).expect("bind");
+    let std_sock: std::net::UdpSocket = sock.into();
+    let _g = handle.enter();
+    TokioUdpSocket::from_std(std_sock).expect("from_std")
+}
+
+/// Spawn `sender_count` sender threads that flood `payload_size`-byte
+/// datagrams as fast as the kernel accepts for `duration`. Returns
+/// the total sent count and elapsed wall time.
+fn run_senders(
+    target: SocketAddr,
+    payload_size: usize,
+    sender_count: usize,
+    duration: Duration,
+) -> (u64, Duration) {
+    let total_sent = Arc::new(AtomicUsize::new(0));
+    let burst_start = Instant::now();
+    let stop_at = burst_start + duration;
+
+    let mut handles = Vec::with_capacity(sender_count);
+    for _ in 0..sender_count {
+        let sent_counter = Arc::clone(&total_sent);
+        let h = std::thread::spawn(move || {
+            let sock = UdpSocket::bind("127.0.0.1:0").expect("sender bind");
+            let payload = vec![0u8; payload_size];
+            let mut local = 0u64;
+            while Instant::now() < stop_at {
+                if sock.send_to(&payload, target).is_ok() {
+                    local += 1;
+                }
+            }
+            sent_counter.fetch_add(local as usize, Ordering::Relaxed);
+        });
+        handles.push(h);
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = burst_start.elapsed();
+    (total_sent.load(Ordering::Relaxed) as u64, elapsed)
+}
+
+// --------------------------------------------------------------------
+// (1) Pure recvmmsg drain (no Runner, no iceoryx2, no NetworkPacket
+//     allocation per datagram).
+// --------------------------------------------------------------------
+
+fn recvmmsg_scenario(
+    payload_size: usize,
+    sender_count: usize,
+    duration: Duration,
+    batch_size: usize,
+) -> (u64, u64, Duration) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio rt");
+    let handle = rt.handle().clone();
+
+    let bind_addr = pick_free_udp_port();
+    let recv_sock = build_recv_socket(bind_addr, 64 * 1024 * 1024, &handle);
+    let fd = recv_sock.as_raw_fd();
+
+    let received = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let received_clone = Arc::clone(&received);
+    let stop_clone = Arc::clone(&stop);
+    let recv_task = std::thread::spawn(move || {
+        rt.block_on(async move {
+            let mut batch = BenchRecvBatch::new(batch_size);
+            while !stop_clone.load(Ordering::Relaxed) {
+                let drained = recv_sock
+                    .async_io(Interest::READABLE, || batch.drain(fd))
+                    .await;
+                if let Ok(n) = drained {
+                    received_clone.fetch_add(n as u64, Ordering::Relaxed);
+                }
+            }
+        });
+    });
+
+    std::thread::sleep(Duration::from_millis(50));
+
+    let (sent, elapsed) = run_senders(bind_addr, payload_size, sender_count, duration);
+
+    std::thread::sleep(Duration::from_millis(200));
+    stop.store(true, Ordering::Relaxed);
+    // Wake the recv_task by poking the socket so its async_io returns.
+    let waker = UdpSocket::bind("127.0.0.1:0").unwrap();
+    waker.send_to(&[0u8; 1], bind_addr).ok();
+    recv_task.join().unwrap();
+
+    (sent, received.load(Ordering::Relaxed), elapsed)
+}
+
+#[test]
+#[serial]
+#[ignore]
+fn pure_recvmmsg_throughput_sweep() {
+    println!();
+    println!("===========================================================================");
+    println!("(1) Pure recvmmsg drain — no streamlib runtime, no iceoryx2, no allocation");
+    println!("    Kernel: stock Ubuntu 24.04, net.core.rmem_max=212992");
+    println!("===========================================================================");
+    println!(
+        "{:>10} {:>4}  {:>14} {:>14} {:>7}  {:>10}  {:>10}",
+        "payload(B)", "S", "sent", "received", "rcv%", "Mpps", "Gbps"
+    );
+
+    let duration = Duration::from_secs(3);
+    let batch_size = 256;
+
+    for &payload in &[64usize, 256, 1472, 8192] {
+        for &senders in &[1usize, 2, 4, 8] {
+            let (sent, rcv, elapsed) =
+                recvmmsg_scenario(payload, senders, duration, batch_size);
+            let secs = elapsed.as_secs_f64();
+            let mpps = rcv as f64 / secs / 1_000_000.0;
+            let gbps = rcv as f64 * payload as f64 * 8.0 / secs / 1_000_000_000.0;
+            let pct = if sent > 0 {
+                100.0 * rcv as f64 / sent as f64
+            } else {
+                0.0
+            };
+            println!(
+                "{:>10} {:>4}  {:>14} {:>14} {:>6.1}%  {:>10.3}  {:>10.3}",
+                payload, senders, sent, rcv, pct, mpps, gbps,
+            );
+        }
+    }
+    println!("===========================================================================");
+    println!();
+}
+
+// --------------------------------------------------------------------
+// (2) Full streamlib pipeline — Runner + UdpSource + iceoryx2 +
+//     UdpSink (sink swallows; we read source's packets_received from
+//     its teardown log line).
+// --------------------------------------------------------------------
+
+fn pipeline_scenario(
+    payload_size: usize,
+    sender_count: usize,
+    duration: Duration,
+    batch_size_cfg: u32,
+) -> (u64, u64, Duration) {
+    let log_buf = ensure_global_subscriber();
+    let log_start = log_buf.lock().unwrap().len();
+
+    let source_bind = pick_free_udp_port();
+    let runtime = Runner::new().expect("Runner::new");
+
+    let source_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSource", "1.0.0"),
+            serde_json::json!({
+                "bind_addr": source_bind.to_string(),
+                "batch_size": batch_size_cfg,
+                "recv_buffer_bytes": 64u32 * 1024u32 * 1024u32,
+            }),
+        ))
+        .expect("add UdpSource");
+
+    // UdpSink with no default destination — packets arriving with
+    // empty peer_addr would be dropped, but inbound NetworkPackets
+    // from UdpSource carry the sender's peer_addr, so the sink
+    // tries to echo them back. We don't care about the echo; the
+    // source's count is what we measure. Sink is the simplest way
+    // to give the iceoryx2 link a registered consumer.
+    let sink_id = runtime
+        .add_processor(ProcessorSpec::new(
+            schema_ident!("tatolab", "network", "UdpSink", "1.0.0"),
+            serde_json::json!({}),
+        ))
+        .expect("add UdpSink");
+
+    runtime
+        .connect(
+            OutputLinkPortRef::new(source_id.as_str(), "packets"),
+            InputLinkPortRef::new(sink_id.as_str(), "packets"),
+        )
+        .expect("connect");
+
+    runtime.start().expect("start");
+    std::thread::sleep(Duration::from_millis(250));
+
+    let (sent, elapsed) = run_senders(source_bind, payload_size, sender_count, duration);
+
+    // Drain tail — let the source pull anything still in the kernel
+    // recv buffer through to its publish counter.
+    std::thread::sleep(Duration::from_millis(300));
+
+    runtime.stop().expect("stop");
+
+    let log = log_buf.lock().unwrap();
+    let log_str = String::from_utf8_lossy(&log[log_start..]).to_string();
+    let received = parse_packets_received(&log_str);
+    drop(log);
+
+    (sent, received, elapsed)
+}
+
+#[test]
+#[serial]
+#[ignore]
+fn full_pipeline_throughput_sweep() {
+    println!();
+    println!("===========================================================================");
+    println!("(2) Full streamlib pipeline — Runner + UdpSource + iceoryx2 + UdpSink");
+    println!("    Each datagram: kernel recv → recvmmsg drain → NetworkPacket alloc →");
+    println!("    rmp_serde encode → iceoryx2 publish → sink consume → send_to back");
+    println!("===========================================================================");
+    println!(
+        "{:>10} {:>4}  {:>14} {:>14} {:>7}  {:>10}  {:>10}",
+        "payload(B)", "S", "sent", "received", "rcv%", "Mpps", "Gbps"
+    );
+
+    let duration = Duration::from_secs(3);
+    let batch_size_cfg = 256u32;
+
+    for &payload in &[64usize, 256, 1472, 8192] {
+        for &senders in &[1usize, 2, 4, 8] {
+            let (sent, rcv, elapsed) =
+                pipeline_scenario(payload, senders, duration, batch_size_cfg);
+            let secs = elapsed.as_secs_f64();
+            let mpps = rcv as f64 / secs / 1_000_000.0;
+            let gbps = rcv as f64 * payload as f64 * 8.0 / secs / 1_000_000_000.0;
+            let pct = if sent > 0 {
+                100.0 * rcv as f64 / sent as f64
+            } else {
+                0.0
+            };
+            println!(
+                "{:>10} {:>4}  {:>14} {:>14} {:>6.1}%  {:>10.3}  {:>10.3}",
+                payload, senders, sent, rcv, pct, mpps, gbps,
+            );
+        }
+    }
+    println!("===========================================================================");
+    println!();
+}


### PR DESCRIPTION
## Summary

- Drop the per-datagram `socket.recv_from` loop in `packages/network/src/udp_source.rs`. On Linux, drain up to `batch_size` (default 64) datagrams per syscall via `recvmmsg(2)`, bridged onto tokio's readiness via `UdpSocket::async_io(Interest::READABLE, ...)`. Non-Linux platforms keep `try_recv_from` for the same drain shape.
- Raise the default SO_RCVBUF hint from "kernel default" (~208 KiB on stock Linux) to 4 MiB. The kernel clamps to `net.core.rmem_max`, so this is upper-bounded on shared hosts and unlocks the full headroom on tuned ones.
- Add `batch_size: Option<u32>` to `UdpSourceConfig` (default 64, matches Quinn's UDP shape; clamped to `[1, u16::MAX]` so a 0 override can't deadlock).

Every UDP-shaped processor (MAVLink, future RTP/RTCP, MoQ, AGP vision stream) inherits the win.

## Supporting changes landed alongside

- **`feat(logging): STREAMLIB_DANGEROUSLY_DEFER_LOGGING_TO_HOST env-var opt-in`** — when set, streamlib's `init()` skips logging initialization entirely and returns a noop guard so the host process keeps full control of the global tracing subscriber. Default behavior (env unset) is byte-identical: streamlib still owns logging, install conflicts still error loudly via the original anyhow path. Unlocks two use cases: throughput benchmarks that need to install their own subscriber (the new UDP bench is the first consumer) and host applications that own their own tracing setup. The `DANGEROUSLY_` prefix in the env-var name makes the trade-off visible — opting in disables JSONL forensics, polyglot subprocess stdio interception, and the streamlib panic hook.
- **`test(network): UDP throughput bench`** — two `#[ignore]`'d scenarios in `packages/network/tests/udp_throughput_bench.rs`: a pure-recvmmsg drain rate measurement (upper bound on what streamlib can ever achieve on a box) and a full Runner + UdpSource + iceoryx2 + UdpSink pipeline measurement. The bench uses the new env-var opt-in to capture streamlib's tracing events and read `packets_received` from `UdpSource`'s teardown line. Adds `tracing-subscriber` as a dev-dep (bench only). Reusable next time someone wants to re-measure or re-validate after a related perf change (e.g. #859).

## Closes

Closes #838

## Exit criteria (from #838, all met)

- [x] Reads up to N (default 64) datagrams per syscall when traffic is available — unit test asserts `n >= 2` per `drain()` on an 8-datagram burst, locking the batching invariant.
- [x] Each batched datagram emits a separate `NetworkPacket` (no schema-level coalescing) — verified via loopback round-trip + burst stress.
- [x] Default `recv_buffer_bytes` raised to 4 MiB — applied at socket-build site when unset.
- [x] Per-datagram fallback preserved for non-Linux — `#[cfg(not(target_os = "linux"))]` branch reuses `recv_from` + `try_recv_from` drain.

## Test plan

- [x] `cargo test -p streamlib-network --lib` — 9/9 pass, including:
  - `batch_size_defaults_and_clamp_invariants`
  - `recvmmsg_drains_multiple_datagrams_in_one_syscall` (Linux-only; asserts ≥2 datagrams returned in one `drain()` after an 8-burst — direct lock on the batching invariant)
- [x] `cargo test -p streamlib-network --test udp_burst_stress` — 6 streams × 200 Hz × 300 packets = 1800 datagrams round-trip through Source→Sink echo in ~1.5 s wall, **zero loss** (`assert_eq!` — verified clean across 5 back-to-back release-build runs).
- [x] `cargo test -p streamlib-network --test udp_loopback` — existing single-packet round-trip continues to pass unchanged.
- [x] `cargo test -p streamlib-vadr-vision --test udp_vadr_jpeg_e2e` — downstream consumer (chunked-JPEG depayloader fed by `UdpSource`) still reassembles correctly through the new recv path: 2/2 pass.
- [x] `cargo test -p streamlib-engine --lib core::logging::` — 29/29 pass after the logging env-var change (default-path behavior unchanged).
- [x] `strace -c -f` measurement: `recvmmsg` shows up in the syscall mix as expected; the EAGAIN entries are the standard `MSG_DONTWAIT` re-await-readiness control flow, not failures.

## Bench reference numbers (this dev box: Ubuntu 24.04, kernel 6.17, net.core.rmem_max=212992)

| Workload | Throughput |
|---|---|
| Pure recvmmsg peak (pps) | 1.45 Mpps @ 256 B / 4 senders |
| Pure recvmmsg peak (bytes/sec) | 48 Gbps @ 8 KB / 4 senders |
| Full streamlib pipeline @ MTU | 117 kpps / 1.4 Gbps |
| Full streamlib pipeline @ 8 KB | 31 kpps / 2.0 Gbps |
| Headroom over drone-racing target (1.2 kpps) | ~100–275× through full pipeline |

The full-pipeline delta vs pure recvmmsg is per-packet engine overhead (NetworkPacket alloc + rmp_serde encode + iceoryx2 publish), dominated by per-byte msgpack-array encoding on large payloads. #859 (now in this milestone) addresses that specific cost via `serde_bytes` codegen; bench is set up to re-measure once it lands.

## Out of scope

- io_uring multishot recv (mentioned in #838 body as alternative). `recvmmsg` already satisfies the exit criteria without a runtime swap; revisit if profiling at 10× current load shows residual syscall pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
