### PR TITLE
feat(runtime): prctl(PR_SET_TIMERSLACK, 1) at top of Runner::new()

### DIFF
--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -134,6 +134,21 @@ pub struct Runner {
 
 impl Runner {
     pub fn new() -> Result<Arc<Self>> {
+        // Cap per-thread timer slack at 1 ns on the calling thread before
+        // spawning any worker. Linux defaults to 50 µs grouping for
+        // `epoll_wait` / `nanosleep` / `futex` relative timeouts; new
+        // threads inherit the creator's slack at clone time, so setting it
+        // here propagates to the tokio worker pool, the logging drain
+        // worker, the iceoryx2 node, and every processor thread spawned
+        // later. SCHED_FIFO/RR threads (rtkit-promoted reactive processors)
+        // bypass slack entirely per kernel design — this only affects
+        // SCHED_OTHER waits. Same call QEMU has shipped in production
+        // since 2013. Cannot fail for self per `prctl(2)`.
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::prctl(libc::PR_SET_TIMERSLACK, 1u64, 0u64, 0u64, 0u64);
+        }
+
         // Auto-detect tokio context FIRST — telemetry exporters need a Tokio handle.
         // If inside tokio runtime: use current handle (external handle mode)
         // If outside tokio runtime: create owned runtime
@@ -1883,6 +1898,22 @@ mod tests {
     fn test_runtime_creation() {
         let _runtime = Runner::new();
         // Runtime creates successfully
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial]
+    fn runner_new_caps_timer_slack_to_one_nanosecond() {
+        // Linux default is 50_000 ns. `Runner::new` calls
+        // `prctl(PR_SET_TIMERSLACK, 1)` as its very first step;
+        // `prctl(PR_GET_TIMERSLACK)` on the same thread should report 1.
+        let _runtime = Runner::new().expect("Runner::new");
+        let slack = unsafe { libc::prctl(libc::PR_GET_TIMERSLACK) };
+        assert_eq!(
+            slack, 1,
+            "expected timer slack 1 ns after Runner::new (got {})",
+            slack
+        );
     }
 
     /// Path-style dep recursion: `runtime.load_project(A)` must walk into


### PR DESCRIPTION
## Summary

- `prctl(PR_SET_TIMERSLACK, 1)` at the top of `Runner::new()` (Linux only). Caps per-thread timer slack at 1 ns; default is ~50 µs grouping for `epoll_wait` / `nanosleep` / `futex` relative timeouts.
- Placement is load-bearing: the call runs **before** tokio runtime construction, logging init, and `Iceoryx2Node::new()` so the tokio worker pool, logging drain worker, iceoryx2 node, and every processor thread spawned later inherit the tightened slack at clone time.
- Same call QEMU has shipped in production since 2013. Cannot fail for self per `prctl(2)`. SCHED_FIFO/RR threads (rtkit-promoted reactive processors) bypass slack entirely per kernel design — this only affects `SCHED_OTHER` waits.

## Closes

Closes #839

## What this is NOT

#839's original body bundled four hygiene knobs. After heavy research (three max-effort Opus audits per knob) the issue was scoped down to just timer slack. The other three were intentionally dropped, with reasoning preserved in the issue body's strike-throughs and AI Agent Notes:

- ~~`mlockall(MCL_CURRENT | MCL_FUTURE)`~~ — would catastrophically break the engine. streamlib's HOST_VISIBLE Vulkan memory footprint (pixel buffer pools, camera staging, OPAQUE_FD CUDA interop, cpu-readback, texture-ring uploads) exceeds the typical 8 MiB systemd-logind `RLIMIT_MEMLOCK` default by orders of magnitude; `MCL_FUTURE` would return `VK_ERROR_MEMORY_MAP_FAILED` on every post-startup `vkMapMemory`. Right tool for a different engine.
- ~~`sched_setaffinity` per processor~~ — wrong layer. Production survey (PX4 / Aeron / PipeWire / DPDK / LMAX / Unreal / Bevy) found two shapes only: fixed-thread-pool with job-graph dispatch, or static pin against operator-supplied isolation (`taskset` / `isolcpus` / systemd `CPUAffinity=`). Nobody auto-pins under dynamic load. Per-processor `cpu_affinity: "4-7"` would bake machine assumptions into authored content, breaking portability across cloud VMs, containers, ARM SoCs. Defer until the broader thread-model question is settled.
- ~~`RealtimeHygieneConfig` opt-out struct~~ — unnecessary. Three converging audits (code-side / dependency-graph / kernel-semantics) confirmed no streamlib code path or third-party dep needs the off switch. Introducing a config struct future agents might "borrow and build on top of" adds API surface without value.

## Exit criteria

- [x] `Runner::new()` applies `prctl(PR_SET_TIMERSLACK, 1)` to the main thread by default
- [ ] ~~`Runner::new()` calls `mlockall(MCL_CURRENT | MCL_FUTURE)`~~ — dropped (see above)
- [ ] ~~Reactive-processor execution threads are pinned via `sched_setaffinity` to stable CPUs~~ — dropped (see above)
- [ ] ~~All three knobs can be disabled via a Runner builder option~~ — dropped (see above)

## Test plan

- [x] **Unit test** in `libs/streamlib-engine/src/core/runtime/runtime.rs`: `runner_new_caps_timer_slack_to_one_nanosecond` constructs a `Runner`, then reads back via `prctl(PR_GET_TIMERSLACK)` and asserts the value equals 1. Mentally revert the `prctl(PR_SET_TIMERSLACK, 1)` call in `Runner::new` → the libtest-spawned test thread inherits its parent's default 50_000 ns slack → assertion fails. Lock holds.

- [x] **Tier-1 workspace baseline** (`cargo test --workspace --no-fail-fast --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` per `docs/testing-baseline.md`): **1768 passed / 6 failed / 147 ignored**. All 6 failures match the pre-existing set documented in PR #864 (3 sentinel tests in jtd-codegen, 1 schema-payload-bytes test in streamlib-engine, 2 polyglot-manual-source tests in streamlib-engine). Pass count rose from 1762 → 1768 due to intervening commits + this PR's new test.

- [x] **UDP throughput bench** (mandatory perf gate per the pattern set in #859/#864, `packages/network/tests/udp_throughput_bench.rs`, full pipeline sweep, single sender per row):

  | payload | S | BASELINE Mpps | AFTER Mpps | Δ | BASELINE Gbps | AFTER Gbps | BASELINE rcv% | AFTER rcv% |
  |---|---|---|---|---|---|---|---|---|
  | 64 | 1 | 0.372 | 0.371 | -0.3% | 0.191 | 0.190 | 99.2 | 98.9 |
  | 64 | 2 | 0.395 | 0.395 | 0% | 0.202 | 0.202 | 53.2 | 52.6 |
  | 64 | 4 | 0.369 | 0.366 | -0.8% | 0.189 | 0.187 | 25.2 | 25.1 |
  | 64 | 8 | 0.344 | 0.341 | -0.9% | 0.176 | 0.175 | 12.1 | 11.8 |
  | 256 | 1 | 0.367 | 0.356 | -3.0% | 0.752 | 0.728 | 99.2 | 98.7 |
  | 256 | 2 | 0.390 | 0.385 | -1.3% | 0.799 | 0.789 | 51.2 | 52.4 |
  | 256 | 4 | 0.363 | 0.369 | +1.7% | 0.744 | 0.755 | 24.6 | 25.0 |
  | 256 | 8 | 0.354 | 0.353 | -0.3% | 0.725 | 0.723 | 12.3 | 12.3 |
  | 1472 | 1 | 0.357 | 0.353 | -1.1% | 4.203 | 4.156 | 99.6 | 99.1 |
  | 1472 | 2 | 0.360 | 0.358 | -0.6% | 4.240 | 4.219 | 50.0 | 50.4 |
  | 1472 | 4 | 0.344 | 0.336 | -2.3% | 4.056 | 3.953 | 24.1 | 24.1 |
  | 1472 | 8 | 0.327 | 0.329 | +0.6% | 3.855 | 3.880 | 11.9 | 11.9 |
  | 8192 | 1 | 0.178 | 0.175 | -1.7% | 11.653 | 11.484 | 65.4 | 65.3 |
  | 8192 | 2 | 0.266 | 0.261 | -1.9% | 17.464 | 17.073 | 48.2 | 47.4 |
  | 8192 | 4 | 0.243 | 0.252 | +3.7% | 15.896 | 16.512 | 22.4 | 22.7 |
  | 8192 | 8 | 0.231 | 0.227 | -1.7% | 15.153 | 14.852 | 10.8 | 10.7 |

  **Result: ±4% noise in random directions across all 16 cells, no measurable directional change.** This is the expected and correct outcome — the UDP throughput hot path is `recvmmsg` + epoll-readiness-driven, not timed-wait-driven. Timer slack improves precision for `nanosleep` / `futex` / `epoll_wait(timeout)` callers (audio clock fallback, crossbeam timed receives, future `tokio::time::sleep` consumers); UDP ingestion doesn't exercise those paths. The bench confirms the change is correctly scoped — neither hurts nor inflates the byte-bound throughput numbers from #863/#864.

  **Concrete domain translation** (per `feedback_perf_numbers_concrete_translation`): the win lands on **wakeup-latency-sensitive** code paths, not throughput. For the drone-racing perception → control reaction loop, when a downstream consumer waits with a relative timeout (e.g. `recv_timeout(50ms)` waiting for the next frame to arrive), the kernel now wakes that thread within ~hrtimer-resolution (single-digit µs floor) instead of with up to 50 µs of grouping delay. That's a per-call worst-case shave of ~45 µs on the timer-bound wakeups; the audio clock's `Missed N ticks, catching up` log line should fire less often; `tokio::time::sleep` lands closer to deadline. None of these surface in a `recvmmsg`-bound throughput bench by design.

## Three Opus research audits, condensed

1. **Code-side**: every streamlib `sleep` / `recv_timeout` / `condvar wait` / `epoll_wait(timeout)` / `nanosleep` site verified safe under slack=1. No test depends on slack-induced grouping. The `LinuxTimerFdAudioClock` uses `TFD_TIMER_ABSTIME` and is therefore unaffected (absolute timerfd bypasses per-task slack). `SoftwareAudioClock`'s `Missed N ticks, catching up` warning will fire less often (positive effect).
2. **Dependency-graph**: tokio (epoll-driven reactor, no slack contract), iceoryx2 (futex/eventfd, event-driven), winit (display-server-FD-driven), Vulkan presentation (GPU-clock-driven), zbus (epoll), PipeWire (designed to *expect* tight slack). No library in the dep graph contracts with the 50 µs default. QEMU's `qemu-timer.c` shipped this exact `prctl(..., 1, ...)` call in 2013 with explicit upstream sanction.
3. **Kernel semantics**: Cannot fail when called on self by an unprivileged process. Bypassed entirely by SCHED_FIFO/RR/DEADLINE (so rtkit-promoted reactive processors ignore slack regardless). Inherits via clone-time snapshot — `Runner::new`'s `prctl` call propagates to all later-spawned threads but does NOT retroactively affect threads spawned before it. Preserved across `fork(2)` and `execve(2)`, so subprocess cdylib processors inherit too.

## Out of scope (intentional)

- mlockall, sched_setaffinity, builder opt-out — see "What this is NOT" above. The issue body's AI Agent Notes section documents these rejections in detail so future pickers don't re-litigate.
- Any throughput-shaped perf win — by design, timer slack doesn't move the `recvmmsg`/epoll-readiness hot path. The bench is included as a regression check (confirming the change doesn't perturb byte-bound throughput), not as evidence of a throughput improvement.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
