### PR TITLE
fix(engine): skip outer escalate wrap for subprocess host setup (#867)

### DIFF
--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -388,33 +388,28 @@ fn spawn_dedicated_thread(
 
 /// Run a processor's `__generated_setup` body under the right lock
 /// discipline for its `runtime`.
-///
-/// Rust processors wrap in `sandbox.escalate(|_| ...)` so concurrent
-/// video session / DPB / swapchain creation can't race on the device
-/// (#304); the setup mutex and the device-idle wait on exit are
-/// private implementation details of escalate.
-///
-/// Subprocess host processors (Python / TypeScript) skip the wrap
-/// deliberately. Their `__generated_setup` does no host-side GPU work
-/// — it spawns the child, constructs the bridge, sends a `setup`
-/// lifecycle, then blocks on the subprocess's `ready` reply. Holding
-/// `processor_setup_lock` across that IPC wait deadlocks every
-/// FullAccess escalate the subprocess tries to issue during its own
-/// init: the bridge-reader thread dispatches each `escalate_request`
-/// inline through `sandbox.escalate(|full| ...)`, which would try to
-/// acquire the same mutex the host setup thread already holds. Each
-/// bridge-handler escalate still acquires the lock + waits device
-/// idle on its own, so the GPU-resource serialization is preserved
-/// without the outer wrap (#867).
 fn run_setup_phase<F>(runtime: ProcessorRuntime, gpu: &GpuContext, setup_body: F) -> Result<()>
 where
     F: FnOnce() -> Result<()>,
 {
     match runtime {
+        // Rust setup may directly create video sessions / DPB images /
+        // swapchain; the wrap serializes that work via the setup mutex
+        // and waits device idle on exit (#304).
         ProcessorRuntime::Rust => {
             let sandbox = GpuContextLimitedAccess::new(gpu.clone());
             sandbox.escalate(|_full_gpu| setup_body())
         }
+        // Subprocess host setup does no host-side GPU work — it spawns
+        // the child, constructs the bridge, sends a `setup` lifecycle,
+        // then blocks on the subprocess's `ready` reply. Wrapping that
+        // IPC wait in escalate would hold `processor_setup_lock` against
+        // every FullAccess escalate the subprocess issues during its own
+        // init: the bridge-reader thread dispatches each
+        // `escalate_request` inline through `sandbox.escalate(|full|
+        // ...)` and deadlocks on the same mutex. Per-call bridge-handler
+        // escalates still acquire the lock + wait device idle on their
+        // own, so GPU-resource serialization is preserved (#867).
         ProcessorRuntime::Python | ProcessorRuntime::TypeScript => setup_body(),
     }
 }
@@ -513,6 +508,9 @@ mod tests {
     /// `sandbox.escalate`, so a concurrent escalate from another
     /// thread is correctly serialized against the outer wrap. Locks
     /// the asymmetry: the fix is targeted at subprocess hosts only.
+    /// Verifies both halves — the inner escalate is blocked while
+    /// the outer body is running, AND the inner escalate succeeds
+    /// once the outer body returns.
     #[test]
     fn rust_processor_setup_phase_holds_setup_lock_against_concurrent_escalate() {
         const TEST: &str = "rust_processor_setup_phase_holds_setup_lock_against_concurrent_escalate";
@@ -521,17 +519,20 @@ mod tests {
         };
 
         let gpu_handle = gpu.clone();
-        let result: Result<()> = run_setup_phase(ProcessorRuntime::Rust, &gpu, || {
+        let (done_tx, done_rx) = mpsc::channel();
+        let inner_thread = {
             let sandbox = GpuContextLimitedAccess::new(gpu_handle);
-            let (done_tx, done_rx) = mpsc::channel();
             thread::spawn(move || {
                 let inner = sandbox.escalate(|_full| Ok::<(), Error>(()));
                 let _ = done_tx.send(inner);
-            });
+            })
+        };
+
+        let outer_result: Result<()> = run_setup_phase(ProcessorRuntime::Rust, &gpu, || {
             // The Rust-branch wrap holds the setup lock here, so the
             // inner escalate from the spawned thread must NOT
             // complete until this body returns and the outer escalate
-            // releases. Wait briefly, then drop through.
+            // releases.
             match done_rx.recv_timeout(Duration::from_millis(500)) {
                 Err(mpsc::RecvTimeoutError::Timeout) => Ok(()),
                 Err(mpsc::RecvTimeoutError::Disconnected) => Err(Error::Runtime(
@@ -544,6 +545,21 @@ mod tests {
                 ))),
             }
         });
-        result.unwrap();
+        outer_result.unwrap();
+
+        // After the outer wrap releases, the spawned inner escalate
+        // must now succeed within bounded time — closes the asymmetry
+        // by proving the lock was held briefly, not permanently.
+        let inner_result = done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap_or_else(|_| {
+                panic!("{TEST}: inner escalate did not complete within 5s of outer release")
+            });
+        inner_result.unwrap_or_else(|e| {
+            panic!("{TEST}: inner escalate eventually failed: {e}")
+        });
+        inner_thread.join().unwrap_or_else(|_| {
+            panic!("{TEST}: spawned inner-escalate thread panicked")
+        });
     }
 }

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -9,7 +9,9 @@ use std::os::fd::OwnedFd;
 use parking_lot::{Mutex, RwLock};
 
 use crate::core::compiler::scheduling::{scheduling_strategy_for_processor, SchedulingStrategy};
-use crate::core::context::{GpuContextLimitedAccess, RuntimeContext, RuntimeContextFullAccess};
+use crate::core::context::{
+    GpuContext, GpuContextLimitedAccess, RuntimeContext, RuntimeContextFullAccess,
+};
 use crate::core::descriptors::ProcessorRuntime;
 use crate::core::error::{Result, Error};
 use crate::core::execution::run_processor_loop;
@@ -122,6 +124,7 @@ pub(crate) fn spawn_processor(
                 proc_id_clone,
                 priority,
                 barrier_component,
+                runtime,
             )?;
         }
     }
@@ -136,6 +139,7 @@ fn spawn_dedicated_thread(
     processor_id: ProcessorUniqueId,
     priority: crate::core::execution::ThreadPriority,
     mut barrier: ProcessorReadyBarrierComponent,
+    runtime: ProcessorRuntime,
 ) -> Result<()> {
     // Clone Arcs for thread
     let graph_arc_clone = Arc::clone(&graph_arc);
@@ -316,32 +320,23 @@ fn spawn_dedicated_thread(
                 )
             }; // Lock released here
 
-            // === PHASE 4: Setup (serialized across processors) ===
+            // === PHASE 4: Setup ===
             // Create processor-specific context with both processor ID and pause gate
             let processor_context = runtime_ctx_clone
                 .with_processor_id(proc_id_clone.clone())
                 .with_pause_gate(pause_gate_inner.clone());
             {
                 let tokio_handle = runtime_ctx_clone.tokio_handle();
+                let full_ctx = RuntimeContextFullAccess::new(&processor_context);
+                let mut guard = processor_arc_clone.lock();
 
                 tracing::info!(
-                    "[{}] Calling setup (thread id={:?}) - escalating via setup mutex",
+                    "[{}] Calling setup (thread id={:?}, runtime={:?})",
                     proc_id_clone,
-                    thread_id
+                    thread_id,
+                    runtime,
                 );
-
-                // Serialize setup across processors and wait for device idle
-                // on exit via the escalate primitive. The setup mutex and the
-                // device-idle wait are private implementation details of
-                // escalate; concurrent video session / DPB / swapchain
-                // creation can't race on the device (#304).
-                let sandbox = GpuContextLimitedAccess::new(runtime_ctx_clone.gpu.clone());
-                let setup_result = sandbox.escalate(|_full_gpu| {
-                    // Build the privileged ctx view for setup. The borrow is
-                    // scoped to this closure, so `process()` inside the loop
-                    // below can never observe a full-access handle.
-                    let full_ctx = RuntimeContextFullAccess::new(&processor_context);
-                    let mut guard = processor_arc_clone.lock();
+                let setup_result = run_setup_phase(runtime, &runtime_ctx_clone.gpu, || {
                     tokio_handle.block_on(guard.__generated_setup(&full_ctx))
                 });
                 if let Err(e) = setup_result {
@@ -391,6 +386,39 @@ fn spawn_dedicated_thread(
     Ok(())
 }
 
+/// Run a processor's `__generated_setup` body under the right lock
+/// discipline for its `runtime`.
+///
+/// Rust processors wrap in `sandbox.escalate(|_| ...)` so concurrent
+/// video session / DPB / swapchain creation can't race on the device
+/// (#304); the setup mutex and the device-idle wait on exit are
+/// private implementation details of escalate.
+///
+/// Subprocess host processors (Python / TypeScript) skip the wrap
+/// deliberately. Their `__generated_setup` does no host-side GPU work
+/// — it spawns the child, constructs the bridge, sends a `setup`
+/// lifecycle, then blocks on the subprocess's `ready` reply. Holding
+/// `processor_setup_lock` across that IPC wait deadlocks every
+/// FullAccess escalate the subprocess tries to issue during its own
+/// init: the bridge-reader thread dispatches each `escalate_request`
+/// inline through `sandbox.escalate(|full| ...)`, which would try to
+/// acquire the same mutex the host setup thread already holds. Each
+/// bridge-handler escalate still acquires the lock + waits device
+/// idle on its own, so the GPU-resource serialization is preserved
+/// without the outer wrap (#867).
+fn run_setup_phase<F>(runtime: ProcessorRuntime, gpu: &GpuContext, setup_body: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    match runtime {
+        ProcessorRuntime::Rust => {
+            let sandbox = GpuContextLimitedAccess::new(gpu.clone());
+            sandbox.escalate(|_full_gpu| setup_body())
+        }
+        ProcessorRuntime::Python | ProcessorRuntime::TypeScript => setup_body(),
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn clone_shutdown_eventfd(
     channel: &ShutdownChannelComponent,
@@ -416,4 +444,106 @@ fn clone_shutdown_eventfd(
     _proc_id: &ProcessorUniqueId,
 ) -> Option<OwnedFd> {
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::context::GpuContext;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    fn gpu_or_skip(test_name: &str) -> Option<GpuContext> {
+        match GpuContext::init_for_platform_sync() {
+            Ok(gpu) => Some(gpu),
+            Err(e) => {
+                eprintln!("{test_name}: no GPU device ({e}) — skipping");
+                None
+            }
+        }
+    }
+
+    /// Regression for #867 — subprocess host setup must not hold
+    /// `processor_setup_lock` against a concurrent escalate from the
+    /// bridge-reader thread.
+    ///
+    /// Reproduces the deadlock the engine fix prevents: a setup body
+    /// (simulating a subprocess host's `__generated_setup` IPC wait)
+    /// blocks on another thread that's trying to acquire its own
+    /// `sandbox.escalate` (simulating a bridge-reader handler). With
+    /// the fix, `run_setup_phase` for `Python` / `TypeScript` skips
+    /// the outer wrap so the concurrent escalate proceeds and the
+    /// setup body completes. Mentally revert the runtime branch
+    /// (always wrap in `sandbox.escalate`) — this test hangs past
+    /// the 5-second timeout and fails.
+    #[test]
+    fn subprocess_host_setup_phase_does_not_block_concurrent_escalate() {
+        const TEST: &str = "subprocess_host_setup_phase_does_not_block_concurrent_escalate";
+        let Some(gpu) = gpu_or_skip(TEST) else {
+            return;
+        };
+
+        for runtime in [ProcessorRuntime::Python, ProcessorRuntime::TypeScript] {
+            let gpu_handle = gpu.clone();
+            let result = run_setup_phase(runtime.clone(), &gpu, || {
+                let sandbox = GpuContextLimitedAccess::new(gpu_handle);
+                let (done_tx, done_rx) = mpsc::channel();
+                thread::spawn(move || {
+                    let inner = sandbox.escalate(|_full| Ok::<(), Error>(()));
+                    let _ = done_tx.send(inner);
+                });
+                done_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .map_err(|_| {
+                        Error::Runtime(format!(
+                            "{TEST}: concurrent escalate did not complete within 5s \
+                             (runtime={runtime:?}) — outer setup-phase wrap is holding \
+                             processor_setup_lock against bridge-reader-thread escalate \
+                             dispatch (#867)"
+                        ))
+                    })?
+                    .map_err(|e| Error::Runtime(format!("{TEST}: inner escalate failed: {e}")))
+            });
+            result.unwrap_or_else(|e| panic!("{TEST} (runtime={runtime:?}): {e}"));
+        }
+    }
+
+    /// Positive control: Rust processors STILL wrap setup in
+    /// `sandbox.escalate`, so a concurrent escalate from another
+    /// thread is correctly serialized against the outer wrap. Locks
+    /// the asymmetry: the fix is targeted at subprocess hosts only.
+    #[test]
+    fn rust_processor_setup_phase_holds_setup_lock_against_concurrent_escalate() {
+        const TEST: &str = "rust_processor_setup_phase_holds_setup_lock_against_concurrent_escalate";
+        let Some(gpu) = gpu_or_skip(TEST) else {
+            return;
+        };
+
+        let gpu_handle = gpu.clone();
+        let result: Result<()> = run_setup_phase(ProcessorRuntime::Rust, &gpu, || {
+            let sandbox = GpuContextLimitedAccess::new(gpu_handle);
+            let (done_tx, done_rx) = mpsc::channel();
+            thread::spawn(move || {
+                let inner = sandbox.escalate(|_full| Ok::<(), Error>(()));
+                let _ = done_tx.send(inner);
+            });
+            // The Rust-branch wrap holds the setup lock here, so the
+            // inner escalate from the spawned thread must NOT
+            // complete until this body returns and the outer escalate
+            // releases. Wait briefly, then drop through.
+            match done_rx.recv_timeout(Duration::from_millis(500)) {
+                Err(mpsc::RecvTimeoutError::Timeout) => Ok(()),
+                Err(mpsc::RecvTimeoutError::Disconnected) => Err(Error::Runtime(
+                    format!("{TEST}: inner thread dropped without responding"),
+                )),
+                Ok(_) => Err(Error::Runtime(format!(
+                    "{TEST}: inner escalate completed while the outer Rust wrap was \
+                     supposed to be holding processor_setup_lock — Rust-branch wrap \
+                     regression"
+                ))),
+            }
+        });
+        result.unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

- Compiler's `spawn_processor_op::spawn_dedicated_thread` used to wrap every processor's `__generated_setup` in `sandbox.escalate(|_| block_on(setup))`, holding `processor_setup_lock` for the entire setup. For Python / TypeScript subprocess hosts that lock spans an IPC wait — the host sends a `setup` lifecycle frame and blocks on the subprocess's `ready` reply. Any FullAccess escalate the subprocess issues during its own init hits the bridge-reader thread, which dispatches each request inline through `sandbox.escalate(|full| ...)` and tries to acquire the same mutex the host setup thread already holds. Deadlock.
- Engine-layer fix: branch the setup-phase wrap on `runtime`. Rust processors keep the existing escalate wrap (their `setup()` may do host-side GPU work and needs the #304 GPU-resource serialization). Python / TypeScript subprocess hosts skip the wrap — their `__generated_setup` does no host-side GPU work, just spawn + IPC + wait. Each bridge-handler escalate still acquires the lock + waits device idle on its own, so GPU-resource serialization is preserved without the outer wrap.
- Setup-phase logic extracted into a private `run_setup_phase` helper for the test seam; regression test pair locks the asymmetry.

## Closes

Closes #867

## Exit criteria

- [x] Subprocess processors can trigger escalate ops during their `setup()` without deadlocking or failing-with-EOF
- [x] `polyglot_manual_source_python` and `polyglot_manual_source_deno` pass on `main` (verified already-passing; the original "fail on main" claim was stale, see issue-body strikethrough)
- [x] Regression test exercises the specific scenario (subprocess processor that escalates during setup) and would fail if the engine-layer fix is reverted

## Test plan

- [x] `cargo test -p streamlib-engine --lib core::compiler::compiler_ops::spawn_processor_op::tests` → 2 passed, 0 failed
- [x] `cargo test -p streamlib-engine --lib` → 421 passed / 0 failed / 109 ignored
- [x] `cargo test -p streamlib-engine --tests` → all integration tests green
- [x] `cargo test -p streamlib-engine --test polyglot_linux_execution_modes` → 4/4 passed across 3 consecutive runs (`polyglot_manual_source_python/_deno` + `polyglot_continuous_processor_python/_deno`)
- [x] Mental-revert check (twice, before and after the polish commit): replace `run_setup_phase`'s match with the buggy "always wrap" shape — `subprocess_host_setup_phase_does_not_block_concurrent_escalate` deadlocks past 5s and fails; restoring the fix makes it pass

## Polyglot coverage

- **Runtimes affected**: rust (engine-host only; no Python/Deno SDK code in this PR)
- **Schema regenerated**: n/a
- **Python and Deno both covered?** yes — the fix is in the engine's subprocess-host dispatch path, which applies uniformly to both `ProcessorRuntime::Python` and `ProcessorRuntime::TypeScript` (regression test exercises both arms)
- **E2E tests run**:
  - [x] Host-Rust: `spawn_processor_op::tests::subprocess_host_setup_phase_does_not_block_concurrent_escalate` + positive control — both pass; mental-revert catches the deadlock
  - [x] Python subprocess: `polyglot_manual_source_python` — green (3/3)
  - [x] Deno subprocess: `polyglot_manual_source_deno` — green (3/3)
- **FD-passing path**: n/a (no IPC schema or fd handling changes)

## Notes on the staleness of the original report

The issue body claimed `polyglot_manual_source_python/_deno` fail on `main` per PR #864 / #866 baselines. Verified on current `main` (`9dcdddb0`, post-#865): both tests pass in isolation (5/5 runs) and via `cargo test -p streamlib-engine --test polyglot_linux_execution_modes` (3/3 runs). Most likely cause: PR #865's `prctl(PR_SET_TIMERSLACK, 1)` tightened scheduler granularity enough that the race window closes too fast on this hardware, AND the in-tree manual-source example doesn't actually call a FullAccess escalate during its `setup()` (only fire-and-forget `streamlib.log.info`). The architectural bug class is real — any future subprocess processor that does a FullAccess escalate during init would hit the same deadlock — so the regression test for this PR explicitly constructs the scenario rather than relying on the existing polyglot E2E tests as the gate.

Issue body was updated in place with strikethrough + dated notes (2026-05-19) per CLAUDE.md's markdown editing rules.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)