### PR TITLE
feat(packages): emit export_plugin! from every Rust-impl package's lib.rs

### DIFF
--- a/libs/streamlib-cli/src/commands/pack.rs
+++ b/libs/streamlib-cli/src/commands/pack.rs
@@ -183,8 +183,10 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
             }
         } else if no_build {
             let cargo_hint = read_cargo_package_name(package_dir)
-                .map(|name| format!("cargo build --release -p {}", name))
-                .unwrap_or_else(|_| "cargo build --release -p <name>".to_string());
+                .map(|name| format!("cargo build --release -p {n} --features {n}/plugin", n = name))
+                .unwrap_or_else(|_| {
+                    "cargo build --release -p <name> --features <name>/plugin".to_string()
+                });
             anyhow::bail!(
                 "Package at {} declares Rust runtime processors but {} contains no \
                  host-OS dylib (`*.{}`) for triple `{}` and `--no-build` was specified. \
@@ -340,21 +342,34 @@ fn run_cargo_build_release(
     cargo_name: &str,
     dylib_ext: &str,
 ) -> Result<PathBuf> {
-    println!("Building {} (cargo build --release -p {})", cargo_name, cargo_name);
+    // `--features <name>/plugin` enables the `export_plugin!` invocation
+    // in the package's `lib.rs`. The feature is default-off so force-link
+    // rlib consumers don't pull in the unmangled `STREAMLIB_PLUGIN`
+    // symbol (multiple rlibs with the same static collide at link time);
+    // pack flips it on so the produced cdylib carries the symbol the
+    // runtime dlopens.
+    let features_flag = format!("{}/plugin", cargo_name);
+    println!(
+        "Building {} (cargo build --release -p {} --features {})",
+        cargo_name, cargo_name, features_flag
+    );
     let output = Command::new("cargo")
         .arg("build")
         .arg("--release")
         .arg("--message-format=json")
         .arg("-p")
         .arg(cargo_name)
+        .arg("--features")
+        .arg(&features_flag)
         .current_dir(package_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .output()
         .with_context(|| {
             format!(
-                "Failed to invoke `cargo build --release -p {}` in {}",
+                "Failed to invoke `cargo build --release -p {} --features {}` in {}",
                 cargo_name,
+                features_flag,
                 package_dir.display()
             )
         })?;

--- a/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Jonathan Fontanez
+// Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Smoke test for the dynamic Rust-plugin load path: build a real

--- a/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Smoke test for the dynamic Rust-plugin load path: build a real
+//! `packages/test-fixtures` cdylib, stage it next to its manifest in a
+//! tempdir, call `runtime.load_project(...)`, and assert
+//! `TestConfiguredProcessor` registered via the `STREAMLIB_PLUGIN`
+//! callback. Mentally revert the `export_plugin!` invocation in
+//! `packages/test-fixtures/src/lib.rs` and this test fails — the
+//! dlopen path validates the processor was registered by the dylib
+//! and surfaces a `Configuration` error when it wasn't.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::processors::PROCESSOR_REGISTRY;
+use streamlib::sdk::runtime::Runner;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn load_project_real_dylib_registers_processor_via_export_plugin() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // Build test-fixtures with the `plugin` feature so the cdylib carries
+    // the `STREAMLIB_PLUGIN` symbol. Default-off — see the feature note
+    // in `packages/test-fixtures/Cargo.toml`. Idempotent: cargo's
+    // incremental machinery skips the rebuild on a warm tree.
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    // Stage test-fixtures + its `@tatolab/core` dep in a tempdir so the
+    // `patch: path: ../core` entry in test-fixtures' streamlib.yaml
+    // resolves naturally without any yaml rewriting.
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    // Stage the cdylib under `lib/<host-triple>/` — the layout
+    // `load_project` expects for `runtime: rust` processor entries.
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed against a real test-fixtures cdylib");
+
+    let registered = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .any(|desc| desc.name.r#type.as_str() == "TestConfiguredProcessor");
+    assert!(
+        registered,
+        "TestConfiguredProcessor must be registered after load_project — \
+         STREAMLIB_PLUGIN callback should have fired"
+    );
+}

--- a/packages/api-server/Cargo.toml
+++ b/packages/api-server/Cargo.toml
@@ -19,6 +19,11 @@ path = "src/bin/generate_openapi.rs"
 
 [features]
 default = []
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+plugin = []
 moq = ["dep:streamlib-moq"]
 
 [build-dependencies]
@@ -27,6 +32,7 @@ streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 streamlib-moq = { path = "../moq", optional = true }
 
 axum.workspace = true

--- a/packages/api-server/src/lib.rs
+++ b/packages/api-server/src/lib.rs
@@ -12,3 +12,6 @@ mod state;
 
 pub use _generated_::ApiServerConfig;
 pub use processor::ApiServerProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(crate::ApiServerProcessor::Processor);

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -11,7 +11,15 @@ categories = ["multimedia::audio", "multimedia"]
 
 [lib]
 name = "streamlib_audio"
-crate-type = ["rlib"]
+crate-type = ["rlib", "cdylib"]
+
+[features]
+# Default off so force-link rlib consumers don't see the `STREAMLIB_PLUGIN`
+# symbol (multiple Rust-impl rlibs with the same unmangled static collide
+# at link time). `streamlib pack` invokes `cargo build --features plugin`
+# when packing the cdylib for dlopen-based loading.
+default = []
+plugin = []
 
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Cross-platform deps used by every audio processor.
 parking_lot = "0.12"

--- a/packages/audio/src/lib.rs
+++ b/packages/audio/src/lib.rs
@@ -50,3 +50,17 @@ pub use chord_generator::ChordGeneratorProcessor;
 pub use processor_audio_converter::{
     ProcessorAudioConverter, ProcessorAudioConverterStatus, ProcessorAudioConverterTargetFormat,
 };
+
+#[cfg(all(
+    feature = "plugin",
+    any(target_os = "linux", target_os = "macos", target_os = "ios")
+))]
+streamlib_plugin_abi::export_plugin!(
+    crate::AudioChannelConverterProcessor::Processor,
+    crate::AudioMixerProcessor::Processor,
+    crate::AudioResamplerProcessor::Processor,
+    crate::BufferRechunkerProcessor::Processor,
+    crate::ChordGeneratorProcessor::Processor,
+    crate::AudioCaptureProcessor::Processor,
+    crate::AudioOutputProcessor::Processor,
+);

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_camera"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Cross-platform deps used by the camera processor.
 parking_lot = "0.12"

--- a/packages/camera/src/lib.rs
+++ b/packages/camera/src/lib.rs
@@ -18,3 +18,9 @@ pub mod linux;
 pub mod apple;
 
 pub use camera::{CameraDevice, CameraProcessor};
+
+#[cfg(all(
+    feature = "plugin",
+    any(target_os = "linux", target_os = "macos", target_os = "ios")
+))]
+streamlib_plugin_abi::export_plugin!(crate::CameraProcessor::Processor);

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::audio", "multimedia"]
 name = "streamlib_clap"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -29,6 +37,10 @@ streamlib-audio = { path = "../audio" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/clap/src/lib.rs
+++ b/packages/clap/src/lib.rs
@@ -37,3 +37,6 @@ pub use plugin_info::{ParameterInfo, PluginInfo};
 pub use scanner::{ClapPluginInfo, ClapScanner};
 
 pub use _generated_::ClapEffectConfig;
+
+#[cfg(all(feature = "plugin", any(target_os = "macos", target_os = "ios")))]
+streamlib_plugin_abi::export_plugin!(crate::ClapEffectProcessor::Processor);

--- a/packages/debug-utilities/Cargo.toml
+++ b/packages/debug-utilities/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["development-tools"]
 name = "streamlib_debug_utilities"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/debug-utilities/src/lib.rs
+++ b/packages/debug-utilities/src/lib.rs
@@ -26,3 +26,17 @@ pub use bgra_file_source::BgraFileSourceProcessor;
 
 #[cfg(target_os = "linux")]
 pub use jpeg_bytes_source::JpegBytesSourceProcessor;
+
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(
+    crate::SimplePassthroughProcessor::Processor,
+    crate::VideoFrameCounterProcessor::Processor,
+    crate::BgraFileSourceProcessor::Processor,
+    crate::JpegBytesSourceProcessor::Processor,
+);
+
+#[cfg(all(feature = "plugin", not(target_os = "linux")))]
+streamlib_plugin_abi::export_plugin!(
+    crate::SimplePassthroughProcessor::Processor,
+    crate::VideoFrameCounterProcessor::Processor,
+);

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_display"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -27,6 +35,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 tracing.workspace = true
 serde.workspace = true

--- a/packages/display/src/lib.rs
+++ b/packages/display/src/lib.rs
@@ -22,3 +22,6 @@ pub mod linux;
 // wrong contract for this carve-out.
 
 pub use display::{DisplayConfig, DisplayProcessor};
+
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(crate::DisplayProcessor::Processor);

--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_h264"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/h264/src/lib.rs
+++ b/packages/h264/src/lib.rs
@@ -19,6 +19,12 @@ pub use linux::{H264DecoderProcessor, H264EncoderProcessor};
 
 pub use _generated_::{H264DecoderConfig, H264EncoderConfig};
 
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(
+    crate::H264DecoderProcessor::Processor,
+    crate::H264EncoderProcessor::Processor,
+);
+
 // `_apple_impl_pending_` holds the VideoToolbox encoder/decoder + the
 // cross-platform Apple-flavored codec wrappers parked out of the engine
 // in #786. Gated so it never compiles; re-enable + rewire imports to

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_h265"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/h265/src/lib.rs
+++ b/packages/h265/src/lib.rs
@@ -17,3 +17,9 @@ pub mod linux;
 pub use linux::{H265DecoderProcessor, H265EncoderProcessor};
 
 pub use _generated_::{H265DecoderConfig, H265EncoderConfig};
+
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(
+    crate::H265DecoderProcessor::Processor,
+    crate::H265EncoderProcessor::Processor,
+);

--- a/packages/jpeg/Cargo.toml
+++ b/packages/jpeg/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::images", "multimedia"]
 name = "streamlib_jpeg"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/jpeg/src/lib.rs
+++ b/packages/jpeg/src/lib.rs
@@ -20,3 +20,6 @@ pub mod linux;
 pub use linux::JpegDecoderProcessor;
 
 pub use _generated_::{EncodedJpegFrame, JpegDecoderConfig};
+
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(crate::JpegDecoderProcessor::Processor);

--- a/packages/mavlink/Cargo.toml
+++ b/packages/mavlink/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["aerospace::drones", "encoding", "multimedia"]
 name = "streamlib_mavlink"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/mavlink/src/lib.rs
+++ b/packages/mavlink/src/lib.rs
@@ -15,3 +15,9 @@ pub mod mavlink_encoder;
 
 pub use mavlink_decoder::MavlinkDecoderProcessor;
 pub use mavlink_encoder::MavlinkEncoderProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(
+    crate::MavlinkDecoderProcessor::Processor,
+    crate::MavlinkEncoderProcessor::Processor,
+);

--- a/packages/moq/Cargo.toml
+++ b/packages/moq/Cargo.toml
@@ -13,12 +13,21 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_moq"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 serde.workspace = true
 # Generated `EncodedVideoFrame.data` rides msgpack `bin` instead of array.

--- a/packages/moq/src/lib.rs
+++ b/packages/moq/src/lib.rs
@@ -25,3 +25,9 @@ pub use moq_session::{
     DEFAULT_MOQ_RELAY_URL,
 };
 pub use moq_subscribe_track::MoqSubscribeTrackProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(
+    crate::MoqPublishTrackProcessor::Processor,
+    crate::MoqSubscribeTrackProcessor::Processor,
+);

--- a/packages/mp4/Cargo.toml
+++ b/packages/mp4/Cargo.toml
@@ -13,12 +13,21 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_mp4"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 serde.workspace = true
 tracing.workspace = true

--- a/packages/mp4/src/lib.rs
+++ b/packages/mp4/src/lib.rs
@@ -22,3 +22,6 @@ pub use linux::mp4_writer::LinuxMp4WriterProcessor;
 mod _apple_impl_pending_;
 
 pub use _generated_::LinuxMp4WriterConfig;
+
+#[cfg(all(feature = "plugin", target_os = "linux"))]
+streamlib_plugin_abi::export_plugin!(crate::LinuxMp4WriterProcessor::Processor);

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["network-programming", "multimedia"]
 name = "streamlib_network"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -24,6 +32,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/network/src/lib.rs
+++ b/packages/network/src/lib.rs
@@ -15,3 +15,9 @@ pub mod udp_source;
 
 pub use udp_sink::UdpSinkProcessor;
 pub use udp_source::UdpSourceProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(
+    crate::UdpSinkProcessor::Processor,
+    crate::UdpSourceProcessor::Processor,
+);

--- a/packages/opus/Cargo.toml
+++ b/packages/opus/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::audio", "multimedia"]
 name = "streamlib_opus"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -25,6 +33,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/opus/src/lib.rs
+++ b/packages/opus/src/lib.rs
@@ -26,3 +26,12 @@ pub use opus_encoder::{
 };
 
 pub use _generated_::{OpusDecoderConfig, OpusEncoderConfig};
+
+#[cfg(all(
+    feature = "plugin",
+    any(target_os = "macos", target_os = "ios", target_os = "linux")
+))]
+streamlib_plugin_abi::export_plugin!(
+    crate::OpusDecoderProcessor::Processor,
+    crate::OpusEncoderProcessor::Processor,
+);

--- a/packages/screen-capture/Cargo.toml
+++ b/packages/screen-capture/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_screen_capture"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -24,6 +32,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/screen-capture/src/lib.rs
+++ b/packages/screen-capture/src/lib.rs
@@ -19,3 +19,6 @@ pub use apple::AppleScreenCaptureProcessor;
 
 pub use _generated_::ScreenCaptureConfig;
 pub use _generated_::tatolab__screen_capture::screen_capture_config::TargetType;
+
+#[cfg(all(feature = "plugin", any(target_os = "macos", target_os = "ios")))]
+streamlib_plugin_abi::export_plugin!(crate::AppleScreenCaptureProcessor::Processor);

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["development-tools::testing"]
 name = "streamlib_test_fixtures"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -24,6 +32,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclass ships as serde-derived).
 serde.workspace = true

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -11,3 +11,6 @@ pub mod _generated_ {
 pub mod test_configured_processor;
 
 pub use test_configured_processor::ConfiguredProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(crate::ConfiguredProcessor::Processor);

--- a/packages/vadr-vision/Cargo.toml
+++ b/packages/vadr-vision/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["aerospace::drones", "encoding", "multimedia"]
 name = "streamlib_vadr_vision"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
@@ -26,6 +34,10 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+
+# Plugin ABI — `export_plugin!` emits the `STREAMLIB_PLUGIN` symbol the
+# runtime dlopens at load time.
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 # Serialization (config dataclasses ship as serde-derived).
 serde.workspace = true

--- a/packages/vadr-vision/src/lib.rs
+++ b/packages/vadr-vision/src/lib.rs
@@ -17,3 +17,6 @@ pub mod header;
 pub mod reassembly;
 
 pub use depayloader::VadrVisionDepayloaderProcessor;
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(crate::VadrVisionDepayloaderProcessor::Processor);

--- a/packages/webrtc/Cargo.toml
+++ b/packages/webrtc/Cargo.toml
@@ -13,12 +13,21 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_webrtc"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
+default = []
+plugin = []
+
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-macros = { path = "../../libs/streamlib-macros" }
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 
 serde.workspace = true
 # Generated `EncodedVideoFrame.data` / `EncodedAudioFrame.data` ride msgpack

--- a/packages/webrtc/src/lib.rs
+++ b/packages/webrtc/src/lib.rs
@@ -15,3 +15,9 @@ pub use webrtc_whep::WebRtcWhepProcessor;
 pub use webrtc_whip::WebRtcWhipProcessor;
 
 pub use _generated_::{WebrtcWhepConfig, WebrtcWhipConfig};
+
+#[cfg(feature = "plugin")]
+streamlib_plugin_abi::export_plugin!(
+    crate::WebRtcWhepProcessor::Processor,
+    crate::WebRtcWhipProcessor::Processor,
+);


### PR DESCRIPTION
## Summary
- Every Rust-impl `packages/*` crate now declares the `STREAMLIB_PLUGIN` symbol via `streamlib_plugin_abi::export_plugin!`, so the runtime can dlopen the cdylib and call the symbol callback at `load_project` time. Dual-registration with the existing `#[processor]` macro inventory submit is intentional and idempotent — both paths flow through `ProcessorInstanceFactory::register::<P>()` which logs and skips on duplicate.
- The `export_plugin!` invocation is gated behind a default-off `plugin` Cargo feature on every package. Without that gate, the unmangled `STREAMLIB_PLUGIN` static leaks into rlib outputs too, and every example that force-links 2+ Rust-impl packages (vulkan-video-roundtrip, jpeg-psnr, moq-roundtrip, camera-display, …) collides at link time. `streamlib pack` now passes `--features <name>/plugin` to its cargo build invocation so the produced cdylib carries the symbol while in-tree force-link consumers keep building cleanly. Once the migration issue (#873) removes the Cargo deps on packages, the gate can be lifted in a follow-up.
- `packages/audio` was rlib-only; flipped to `["rlib", "cdylib"]` to fit the "every Rust-impl package emits export_plugin!" goal.

## Closes
Closes #791

## Exit criteria
- [x] Every Rust-impl `packages/*` crate emits `export_plugin!(...)` from `lib.rs` (18 packages: api-server, audio, camera, clap, debug-utilities, display, h264, h265, jpeg, mavlink, moq, mp4, network, opus, screen-capture, test-fixtures, vadr-vision, webrtc).
- [x] Dual-registration with `#[processor]` inventory works without duplicate-key errors (`register::<P>` is idempotent at `processor_instance_factory.rs:171-179`).
- [x] Runtime registers schemas + processors via `STREAMLIB_PLUGIN` at dlopen time when loading the package as a slpkg (verified by the new integration smoke test).

## Test plan
- [x] `cargo check --workspace` — clean (warnings are pre-existing, not introduced by this PR).
- [x] `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — **216 `test result: ok`, 0 failed**.
- [x] New integration test `libs/streamlib-engine/tests/load_project_dylib_smoke.rs` — builds `streamlib-test-fixtures` with `--features streamlib-test-fixtures/plugin`, stages a synthetic project against the real cdylib, calls `load_project`, asserts `TestConfiguredProcessor` registered via the `STREAMLIB_PLUGIN` callback. Non-vacuous: mentally reverting the `export_plugin!` invocation OR the `register::<P>` call inside the macro fails the assertion.

## Follow-ups
The issue body referenced `load_package(slpkg_path)` for the integration test; this PR substitutes `load_project` against a staged dir (functionally equivalent — `load_package` extracts the slpkg then calls `load_project`). When `streamlib pack` smoke coverage lands separately the slpkg path gets exercised end-to-end. No other follow-ups; this is Step A of the three-step path (#791 → #873 migration → #790 inventory retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)