### PR TITLE
refactor(plugins): explicit register::<P>() replaces inventory force-link for in-tree tests + engine mocks

### DIFF
--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -854,12 +854,14 @@ mod tests {
 
     /// Look up a registered mock processor's structured ident by its
     /// PascalCase short name. The mock processors live in
-    /// `graph::graph_tests` and self-register via the `#[processor]`
-    /// macro at link time; their full ident is composed from
-    /// `libs/streamlib/streamlib.yaml`'s `package:` block — so reading
-    /// the version off the registry rather than hardcoding it keeps
-    /// these tests robust to package-version bumps.
+    /// [`crate::core::test_support`] and are registered explicitly via
+    /// `ensure_test_mocks_registered()` (no `inventory::submit!`
+    /// auto-discovery); their full ident is composed from the engine
+    /// `streamlib.yaml`'s `package:` block, so reading the version off
+    /// the registry rather than hardcoding it keeps these tests robust
+    /// to package-version bumps.
     fn lookup_registered_ident(short: &str) -> SchemaIdent {
+        crate::core::test_support::ensure_test_mocks_registered();
         PROCESSOR_REGISTRY
             .list_registered()
             .into_iter()

--- a/libs/streamlib-engine/src/core/graph/graph_tests.rs
+++ b/libs/streamlib-engine/src/core/graph/graph_tests.rs
@@ -4,7 +4,7 @@
 //! Graph data structure tests using only the traversal API.
 //!
 //! Tests verify Graph operates as a standalone data structure.
-//! MockProcessor implements the Processor trait to work with add_v.
+//! Engine-shared TestMock processors live in [`crate::core::test_support`].
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -13,85 +13,18 @@ use serde_json::{json, Value as JsonValue};
 
 use crate::core::graph::{Graph, GraphEdgeWithComponents, GraphNodeWithComponents};
 use crate::core::processors::ProcessorState;
+use crate::core::test_support::{
+    ensure_test_mocks_registered, MockInputOnlyProcessor, MockOutputOnlyProcessor, MockProcessor,
+};
 use crate::core::JsonSerializableComponent;
 
-// =============================================================================
-// Mock Processor and Config
-// =============================================================================
-
-/// Mock processor for testing graph operations.
-#[crate::processor("TestMockProcessor")]
-struct MockProcessor;
-
-impl crate::core::ManualProcessor for MockProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn teardown(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn start(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> crate::core::error::Result<()> {
-        Ok(())
-    }
-}
-
-/// Processor with only output ports.
-#[crate::processor("TestMockOutputOnlyProcessor")]
-struct MockOutputOnlyProcessor;
-
-impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn teardown(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn start(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> crate::core::error::Result<()> {
-        Ok(())
-    }
-}
-
-/// Processor with only input ports.
-#[crate::processor("TestMockInputOnlyProcessor")]
-struct MockInputOnlyProcessor;
-
-impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn teardown(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
-        std::future::ready(Ok(()))
-    }
-    fn start(
-        &mut self,
-        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
-    ) -> crate::core::error::Result<()> {
-        Ok(())
-    }
+/// Construct a fresh `Graph` with the engine-internal test mock
+/// processors registered in `PROCESSOR_REGISTRY`. Tests use this in
+/// place of `test_graph()` so `add_v` can resolve mock port info and
+/// `add_e` can validate port presence on those nodes.
+fn test_graph() -> Graph {
+    ensure_test_mocks_registered();
+    Graph::new()
 }
 
 // =============================================================================
@@ -213,7 +146,7 @@ mod query_ops {
 
     #[test]
     fn test_v_all_returns_all_processors() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         graph
             .traversal_mut()
@@ -231,7 +164,7 @@ mod query_ops {
 
     #[test]
     fn test_v_by_id_returns_specific_processor() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let id = graph
             .traversal_mut()
@@ -254,7 +187,7 @@ mod query_ops {
 
     #[test]
     fn test_v_nonexistent_returns_empty() {
-        let graph = Graph::new();
+        let graph = test_graph();
 
         let found = graph.traversal().v("nonexistent").first();
         assert!(found.is_none());
@@ -262,7 +195,7 @@ mod query_ops {
 
     #[test]
     fn test_exists_true_when_found() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -276,14 +209,14 @@ mod query_ops {
 
     #[test]
     fn test_exists_false_when_not_found() {
-        let graph = Graph::new();
+        let graph = test_graph();
 
         assert!(!graph.traversal().v("nonexistent").exists());
     }
 
     #[test]
     fn test_ids_returns_all_processor_ids() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let id1 = graph
             .traversal_mut()
@@ -308,7 +241,7 @@ mod query_ops {
 
     #[test]
     fn test_first_returns_some_processor() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()));
@@ -319,14 +252,14 @@ mod query_ops {
 
     #[test]
     fn test_first_on_empty_returns_none() {
-        let graph = Graph::new();
+        let graph = test_graph();
 
         assert!(graph.traversal().v(()).first().is_none());
     }
 
     #[test]
     fn test_iter_yields_all_processors() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         graph
             .traversal_mut()
@@ -362,7 +295,7 @@ mod edge_query_ops {
 
     #[test]
     fn test_e_all_returns_all_links() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -401,7 +334,7 @@ mod edge_query_ops {
 
     #[test]
     fn test_e_by_id_returns_specific_link() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -435,7 +368,7 @@ mod edge_query_ops {
 
     #[test]
     fn test_link_from_port_and_to_port() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -482,7 +415,7 @@ mod filter_ops {
 
     #[test]
     fn test_filter_by_processor_type() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         graph
             .traversal_mut()
@@ -505,7 +438,7 @@ mod filter_ops {
 
     #[test]
     fn test_has_component_filters_correctly() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let id1 = graph
             .traversal_mut()
@@ -533,7 +466,7 @@ mod filter_ops {
 
     #[test]
     fn test_filter_links_by_destination() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -586,7 +519,7 @@ mod component_ops {
 
     #[test]
     fn test_insert_and_get_component() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -615,7 +548,7 @@ mod component_ops {
 
     #[test]
     fn test_has_component() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -648,7 +581,7 @@ mod component_ops {
 
     #[test]
     fn test_remove_component() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -683,7 +616,7 @@ mod component_ops {
 
     #[test]
     fn test_multiple_components_on_same_node() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -708,7 +641,7 @@ mod component_ops {
 
     #[test]
     fn test_link_components() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -764,7 +697,7 @@ mod mutation_persistence {
 
     #[test]
     fn test_component_mutation_persists() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -800,7 +733,7 @@ mod mutation_persistence {
 
     #[test]
     fn test_arc_shared_component_modification() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -834,7 +767,7 @@ mod mutation_persistence {
 
     #[test]
     fn test_drop_removes_processor() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -852,7 +785,7 @@ mod mutation_persistence {
 
     #[test]
     fn test_drop_removes_link() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -897,7 +830,7 @@ mod real_world_scenarios {
 
     #[test]
     fn test_compiler_create_phase_pattern() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
         let id = graph
             .traversal_mut()
             .add_v(MockProcessor::Processor::node(Default::default()))
@@ -921,7 +854,7 @@ mod real_world_scenarios {
 
     #[test]
     fn test_compiler_wire_phase_pattern() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -963,7 +896,7 @@ mod real_world_scenarios {
 
     #[test]
     fn test_runtime_pause_all_pattern() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let id1 = graph
             .traversal_mut()
@@ -1018,7 +951,7 @@ mod real_world_scenarios {
 
     #[test]
     fn test_runtime_status_pattern() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let id1 = graph
             .traversal_mut()
@@ -1072,7 +1005,7 @@ mod real_world_scenarios {
 
     #[test]
     fn test_pipeline_topology() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -1120,7 +1053,7 @@ mod edge_navigation {
 
     #[test]
     fn test_out_e_returns_outgoing_links() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -1159,7 +1092,7 @@ mod edge_navigation {
 
     #[test]
     fn test_in_e_returns_incoming_links() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream1_id = graph
             .traversal_mut()
@@ -1198,7 +1131,7 @@ mod edge_navigation {
 
     #[test]
     fn test_out_v_returns_upstream_processor() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()
@@ -1233,7 +1166,7 @@ mod edge_navigation {
 
     #[test]
     fn test_in_v_returns_downstream_processor() {
-        let mut graph = Graph::new();
+        let mut graph = test_graph();
 
         let upstream_id = graph
             .traversal_mut()

--- a/libs/streamlib-engine/src/core/mod.rs
+++ b/libs/streamlib-engine/src/core/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod observability;
 pub(crate) mod runtime_hooks;
 pub(crate) mod signals;
 pub(crate) mod streamlib_home;
+#[cfg(test)]
+pub(crate) mod test_support;
 // Apple-flavored codec wrappers + VideoToolbox + AppleMp4Muxer live in
 // their domain packages' `_apple_impl_pending_/` directories (#786):
 // h264 (videotoolbox + video_codec/encoder/decoder + their configs),

--- a/libs/streamlib-engine/src/core/test_support.rs
+++ b/libs/streamlib-engine/src/core/test_support.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Engine-internal test fixtures shared across `#[cfg(test)]` modules.
+//!
+//! The TestMock processor types live here so engine tests can drive
+//! graph + compiler code without depending on any external package's
+//! processors. They are declared with `no_inventory` so registration
+//! is explicit (via [`ensure_test_mocks_registered`]) rather than
+//! happening at link-time via the macro's `inventory::submit!`.
+
+use std::sync::Once;
+
+use crate::core::processors::PROCESSOR_REGISTRY;
+
+/// Mock processor with two input ports + two output ports.
+#[crate::processor("TestMockProcessor", no_inventory)]
+pub(crate) struct MockProcessor;
+
+impl crate::core::ManualProcessor for MockProcessor::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+/// Mock processor with only output ports.
+#[crate::processor("TestMockOutputOnlyProcessor", no_inventory)]
+pub(crate) struct MockOutputOnlyProcessor;
+
+impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+/// Mock processor with only input ports.
+#[crate::processor("TestMockInputOnlyProcessor", no_inventory)]
+pub(crate) struct MockInputOnlyProcessor;
+
+impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {
+    fn setup(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn teardown(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> impl std::future::Future<Output = crate::core::error::Result<()>> + Send {
+        std::future::ready(Ok(()))
+    }
+    fn start(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextFullAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
+/// Register all engine-internal test mock processors with the global
+/// `PROCESSOR_REGISTRY`. Idempotent — safe to call from every test
+/// fixture that builds a graph against `lookup_registered_ident` or
+/// drives the compiler against a `ProcessorSpec`.
+pub(crate) fn ensure_test_mocks_registered() {
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| {
+        PROCESSOR_REGISTRY.register::<MockProcessor::Processor>();
+        PROCESSOR_REGISTRY.register::<MockOutputOnlyProcessor::Processor>();
+        PROCESSOR_REGISTRY.register::<MockInputOnlyProcessor::Processor>();
+    });
+}

--- a/libs/streamlib-engine/tests/attribute_macro_test.rs
+++ b/libs/streamlib-engine/tests/attribute_macro_test.rs
@@ -9,8 +9,11 @@
 use streamlib_engine::core::GeneratedProcessor;
 use streamlib_engine::core::{EmptyConfig, Result, RuntimeContextFullAccess};
 
-// Define a simple processor using YAML schema
-#[streamlib::sdk::processor("TestProcessor")]
+// Define a simple processor using YAML schema. `no_inventory` opts out
+// of the macro's `inventory::submit!` emission — this test only exercises
+// the macro's typed-API surface (descriptor + ident + port markers) and
+// doesn't need the processor in the global `PROCESSOR_REGISTRY`.
+#[streamlib::sdk::processor("TestProcessor", no_inventory)]
 pub struct TestProcessor;
 
 // User implements the Processor trait on the generated Processor struct

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -80,6 +80,7 @@ pub fn generate_from_processor_schema(
     schema: &ProcessorSchema,
     schema_ident: &SchemaIdent,
     config_schema_id: Option<&str>,
+    no_inventory: bool,
 ) -> TokenStream {
     let module_name = &item.ident;
 
@@ -147,11 +148,20 @@ pub fn generate_from_processor_schema(
         quote! {}
     };
 
-    // Auto-registration via inventory crate
-    let inventory_submit = quote! {
-        ::streamlib::sdk::inventory::submit! {
-            ::streamlib::sdk::processors::macro_codegen::FactoryRegistration {
-                register_fn: |factory| factory.register::<Processor>(),
+    // Auto-registration via inventory crate. Suppressed when the
+    // processor attribute carries `no_inventory` — used by test-only
+    // mocks and any future processor that wants the consumer to
+    // register explicitly (via load_project / load_package or a direct
+    // PROCESSOR_REGISTRY.register::<P>() call) rather than relying on
+    // link-time auto-discovery.
+    let inventory_submit = if no_inventory {
+        quote! {}
+    } else {
+        quote! {
+            ::streamlib::sdk::inventory::submit! {
+                ::streamlib::sdk::processors::macro_codegen::FactoryRegistration {
+                    register_fn: |factory| factory.register::<Processor>(),
+                }
             }
         }
     };

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -49,17 +49,23 @@ use syn::{
 /// `SchemaIdent { org: tatolab, package: streamlib, type: Camera,
 /// version: <package.version> }` when used inside a manifest declaring
 /// `package: { org: tatolab, name: streamlib, ... }`.
+///
+/// An optional `no_inventory` flag suppresses the
+/// `inventory::submit!` emission so consumers can opt out of link-time
+/// auto-registration: `#[streamlib::processor("Foo", no_inventory)]`.
+/// The generated `Processor` type is unchanged; callers register it
+/// explicitly via `PROCESSOR_REGISTRY.register::<Foo::Processor>()`.
 #[proc_macro_attribute]
 pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item_struct = parse_macro_input!(item as ItemStruct);
 
-    let short_name = match parse_processor_short_name(attr) {
-        Ok(name) => name,
+    let parsed = match parse_processor_attr(attr) {
+        Ok(parsed) => parsed,
         Err(err) => return err.to_compile_error().into(),
     };
 
     let (schema, schema_ident, config_schema_id) =
-        match load_processor_schema(&short_name, &item_struct) {
+        match load_processor_schema(&parsed.short_name, &item_struct) {
             Ok(triple) => triple,
             Err(err) => return err.to_compile_error().into(),
         };
@@ -69,15 +75,50 @@ pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
         &schema,
         &schema_ident,
         config_schema_id.as_deref(),
+        parsed.no_inventory,
     );
 
     TokenStream::from(generated)
 }
 
-/// Parse the processor short name from the attribute argument.
-fn parse_processor_short_name(attr: TokenStream) -> syn::Result<String> {
-    let lit: LitStr = syn::parse(attr)?;
-    Ok(lit.value())
+/// Parsed `#[processor(...)]` attribute arguments.
+struct ProcessorAttr {
+    short_name: String,
+    no_inventory: bool,
+}
+
+/// Parse the processor short name plus optional flags.
+fn parse_processor_attr(attr: TokenStream) -> syn::Result<ProcessorAttr> {
+    use syn::parse::Parser;
+
+    let parser = |input: syn::parse::ParseStream<'_>| -> syn::Result<ProcessorAttr> {
+        let name: LitStr = input.parse()?;
+        let mut no_inventory = false;
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let flag: syn::Ident = input.parse()?;
+            match flag.to_string().as_str() {
+                "no_inventory" => no_inventory = true,
+                other => {
+                    return Err(syn::Error::new(
+                        flag.span(),
+                        format!(
+                            "unknown processor attribute flag `{}` (expected `no_inventory`)",
+                            other
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(ProcessorAttr {
+            short_name: name.value(),
+            no_inventory,
+        })
+    };
+    parser.parse(attr.into())
 }
 
 /// Locate `CARGO_MANIFEST_DIR/streamlib.yaml`, resolve the package metadata

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -14,10 +14,10 @@ name = "streamlib_audio"
 crate-type = ["rlib", "cdylib"]
 
 [features]
-# Default off so force-link rlib consumers don't see the `STREAMLIB_PLUGIN`
-# symbol (multiple Rust-impl rlibs with the same unmangled static collide
-# at link time). `streamlib pack` invokes `cargo build --features plugin`
-# when packing the cdylib for dlopen-based loading.
+# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
+# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
+# the same unmangled static collide at link time). `streamlib pack`
+# invokes `cargo build --features plugin` when packing.
 default = []
 plugin = []
 

--- a/packages/jpeg/tests/jpeg_smoke.rs
+++ b/packages/jpeg/tests/jpeg_smoke.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 use streamlib_debug_utilities::_generated_::tatolab__core::color_info::{
@@ -45,16 +45,18 @@ use streamlib_debug_utilities::video_frame_counter::{
     FIRST_FRAME, FIRST_HEIGHT, FIRST_SURFACE_ID_LEN, FIRST_WIDTH, FRAMES_OBSERVED,
 };
 
-// Force-link the package lib crates so their `inventory::submit!`
-// factory registrations are pulled into the test binary's link line.
-// Without this rustc's dead-code elimination drops the libs entirely
-// and `add_processor` errors with `UnknownProcessorType`.
-#[allow(unused_imports)]
-use streamlib_debug_utilities::{
-    JpegBytesSourceProcessor as _, VideoFrameCounterProcessor as _,
-};
-#[allow(unused_imports)]
-use streamlib_jpeg::JpegDecoderProcessor as _;
+/// Explicit typed registration for the package processors this test
+/// drives. Replaces the legacy `use foo::Bar as _;` inventory
+/// force-link pattern — the typed `register::<P>()` calls pull each
+/// package's rlib into the link line (without which rustc's dead-code
+/// elimination would drop it) and make registration intent explicit.
+fn register_test_processors() {
+    PROCESSOR_REGISTRY
+        .register::<streamlib_debug_utilities::JpegBytesSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY
+        .register::<streamlib_debug_utilities::VideoFrameCounterProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_jpeg::JpegDecoderProcessor::Processor>();
+}
 
 const FIXTURE_WIDTH: u32 = 320;
 const FIXTURE_HEIGHT: u32 = 180;
@@ -73,6 +75,7 @@ fn valid_jpeg_runs_through_pipeline_cleanly() {
     streamlib_debug_utilities::video_frame_counter::reset();
 
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(
@@ -212,6 +215,7 @@ fn invalid_max_dimensions_do_not_crash_runtime() {
     streamlib_debug_utilities::video_frame_counter::reset();
 
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(
@@ -279,6 +283,7 @@ fn malformed_jpeg_bytes_do_not_crash_runtime() {
     streamlib_debug_utilities::video_frame_counter::reset();
 
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(

--- a/packages/mavlink/tests/mavlink_over_udp.rs
+++ b/packages/mavlink/tests/mavlink_over_udp.rs
@@ -23,16 +23,19 @@ use std::time::Duration;
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 
-// Force-link the package lib crates so their `inventory::submit!`
-// factory registrations are present in the test binary's link line.
-#[allow(unused_imports)]
-use streamlib_mavlink::{MavlinkDecoderProcessor as _, MavlinkEncoderProcessor as _};
-#[allow(unused_imports)]
-use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
+/// Explicit typed registration for the package processors this test
+/// drives. Replaces the legacy `use foo::Bar as _;` inventory
+/// force-link pattern.
+fn register_test_processors() {
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSinkProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_mavlink::MavlinkDecoderProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_mavlink::MavlinkEncoderProcessor::Processor>();
+}
 
 use mavlink::MavHeader;
 use mavlink::dialects::common::{
@@ -204,6 +207,7 @@ fn udp_source_decoder_then_encoder_udp_sink_loopback_all_six_variants() {
     let source_bind = pick_free_udp_port();
 
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(

--- a/packages/network/tests/udp_burst_stress.rs
+++ b/packages/network/tests/udp_burst_stress.rs
@@ -31,12 +31,9 @@ use std::time::{Duration, Instant};
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
-
-#[allow(unused_imports)]
-use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
 
 const SENDER_COUNT: usize = 6;
 const PACKETS_PER_SENDER: usize = 300;
@@ -57,6 +54,14 @@ fn burst_six_streams_at_200hz_round_trips_without_loss() {
     let source_bind = pick_free_udp_port();
 
     let runtime = Runner::new().expect("Runner::new");
+
+    // Explicit typed registration replaces the legacy
+    // `use foo::Bar as _;` inventory force-link. The typed
+    // reference pulls the rlib into the link line; the
+    // `register::<P>()` call makes registration intent explicit
+    // (idempotent — dedup'd against the rlib's inventory submission).
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSinkProcessor::Processor>();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(

--- a/packages/network/tests/udp_loopback.rs
+++ b/packages/network/tests/udp_loopback.rs
@@ -26,14 +26,8 @@ use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 use streamlib::sdk::schema_ident;
-
-// Force-link the package's lib crate so its `inventory::submit!` factory
-// registrations (one per `#[streamlib::sdk::processor("...")]`) are
-// pulled into the test binary. Without an explicit reference rustc's
-// dead-code elimination would drop the lib entirely from the link line.
-#[allow(unused_imports)]
-use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
 
 /// Bind an ephemeral UDP port, capture its address, drop the socket so
 /// the port is free for the processor to bind. The brief window
@@ -61,6 +55,16 @@ fn loopback_round_trip_propagates_peer_addr() {
     let source_bind = pick_free_udp_port();
 
     let runtime = Runner::new().expect("Runner::new");
+
+    // Replace the legacy `use foo::Bar as _;` inventory force-link
+    // pattern with explicit, typed `register::<P>()` calls. The
+    // package macros opt out of `inventory::submit!` via
+    // `no_inventory` so the registry sees these registrations only.
+    // Cross-DSO `load_project + dlopen` is the production path but
+    // is not exercised here — see issue #873 + the follow-up engine
+    // ticket on `HostServices` plugin-ABI v2 for the dlopen story.
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSinkProcessor::Processor>();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(

--- a/packages/network/tests/udp_loopback.rs
+++ b/packages/network/tests/udp_loopback.rs
@@ -24,9 +24,8 @@ use std::time::Duration;
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 use streamlib::sdk::schema_ident;
 
 /// Bind an ephemeral UDP port, capture its address, drop the socket so
@@ -56,13 +55,12 @@ fn loopback_round_trip_propagates_peer_addr() {
 
     let runtime = Runner::new().expect("Runner::new");
 
-    // Replace the legacy `use foo::Bar as _;` inventory force-link
-    // pattern with explicit, typed `register::<P>()` calls. The
-    // package macros opt out of `inventory::submit!` via
-    // `no_inventory` so the registry sees these registrations only.
-    // Cross-DSO `load_project + dlopen` is the production path but
-    // is not exercised here — see issue #873 + the follow-up engine
-    // ticket on `HostServices` plugin-ABI v2 for the dlopen story.
+    // Explicit typed registration replaces the legacy
+    // `use foo::Bar as _;` inventory force-link pattern. The typed
+    // reference pulls the rlib into the link line (without which
+    // rustc's dead-code elimination would drop it); the
+    // `register::<P>()` call makes registration intent explicit
+    // (idempotent — dedup'd against the rlib's inventory submission).
     PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
     PROCESSOR_REGISTRY.register::<streamlib_network::UdpSinkProcessor::Processor>();
 

--- a/packages/network/tests/udp_throughput_bench.rs
+++ b/packages/network/tests/udp_throughput_bench.rs
@@ -34,15 +34,12 @@ use std::time::{Duration, Instant};
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 use tokio::io::Interest;
 use tokio::net::UdpSocket as TokioUdpSocket;
 use tracing_subscriber::fmt::MakeWriter;
-
-#[allow(unused_imports)]
-use streamlib_network::{UdpSinkProcessor as _, UdpSourceProcessor as _};
 
 // --------------------------------------------------------------------
 // Captured-tracing harness for #2.
@@ -370,6 +367,11 @@ fn pipeline_scenario(
 
     let source_bind = pick_free_udp_port();
     let runtime = Runner::new().expect("Runner::new");
+
+    // Explicit typed registration replaces the legacy
+    // `use foo::Bar as _;` inventory force-link.
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSinkProcessor::Processor>();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(

--- a/packages/vadr-vision/Cargo.toml
+++ b/packages/vadr-vision/Cargo.toml
@@ -51,9 +51,10 @@ tracing.workspace = true
 [dev-dependencies]
 # Integration tests spin up a Runner and exercise the full vision
 # pipeline: UdpSource → VadrVisionDepayloader → JpegDecoder →
-# VideoFrameCounter. force-link the upstream / downstream crates so
-# their `inventory::submit!` factory registrations are present in
-# the test binary.
+# VideoFrameCounter. Tests reference each upstream / downstream
+# crate's typed `Processor` types via explicit
+# `PROCESSOR_REGISTRY.register::<P>()` calls in setup, which both
+# pulls the rlib into the link line and makes registration explicit.
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-network = { path = "../network" }
 streamlib-jpeg = { path = "../jpeg" }

--- a/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
+++ b/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 
 use serial_test::serial;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 use streamlib_debug_utilities::video_frame_counter::{
@@ -36,18 +36,17 @@ use streamlib_debug_utilities::video_frame_counter::{
 };
 use streamlib_vadr_vision::header::{ChunkHeader, encode};
 
-// Force-link the package lib crates so their `inventory::submit!`
-// factory registrations are pulled into the test binary's link line.
-// Without this rustc's dead-code elimination drops the libs entirely
-// and `add_processor` errors with `UnknownProcessorType`.
-#[allow(unused_imports)]
-use streamlib_debug_utilities::VideoFrameCounterProcessor as _;
-#[allow(unused_imports)]
-use streamlib_jpeg::JpegDecoderProcessor as _;
-#[allow(unused_imports)]
-use streamlib_network::UdpSourceProcessor as _;
-#[allow(unused_imports)]
-use streamlib_vadr_vision::VadrVisionDepayloaderProcessor as _;
+/// Explicit typed registration for the package processors this test
+/// drives. Replaces the legacy `use foo::Bar as _;` inventory
+/// force-link pattern.
+fn register_test_processors() {
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY
+        .register::<streamlib_vadr_vision::VadrVisionDepayloaderProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_jpeg::JpegDecoderProcessor::Processor>();
+    PROCESSOR_REGISTRY
+        .register::<streamlib_debug_utilities::VideoFrameCounterProcessor::Processor>();
+}
 
 const FIXTURE_WIDTH: u32 = 320;
 const FIXTURE_HEIGHT: u32 = 180;
@@ -105,6 +104,7 @@ fn chunked_datagrams(frame_id: u32, sim_time_ns: u64, jpeg: &[u8]) -> Vec<Vec<u8
 /// the counter atomics afterward.
 fn run_pipeline(bind_addr: SocketAddr, jpeg: &[u8], frames: u32) {
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(
@@ -297,6 +297,7 @@ fn malformed_vadr_datagrams_do_not_crash_runtime() {
 
     let bind_addr = pick_free_udp_port();
     let runtime = Runner::new().expect("Runner::new");
+    register_test_processors();
 
     let source_id = runtime
         .add_processor(ProcessorSpec::new(


### PR DESCRIPTION
## Summary

- Replace the legacy `use foo::Bar as _;` link-time auto-discovery pattern with explicit, typed `PROCESSOR_REGISTRY.register::<P>()` calls in test setup. Six in-tree integration tests + four engine test mocks migrated.
- Add an opt-in `no_inventory` flag to the `#[streamlib::sdk::processor]` macro so engine test mocks register without emitting `inventory::submit!` at all.
- Defer cluster 3 (examples drop processor-package Cargo deps and use `load_project`) to a separate engine fix — the dlopen path is empirically broken end-to-end on Linux due to cross-DSO static-state isolation. Issue #873's body has been updated in place to reflect this strategic shift (see strike-throughs + AI Agent Notes).

## Closes

Closes #873

## Strategic framing

The milestone's full vision (issue #875: examples drop Cargo deps; `load_project` is the only registration path) requires an engine-layer fix that is out of scope here. The dlopen'd cdylib statically embeds its own copies of every transitive Rust dep — including `streamlib_engine`'s LazyLock statics (PUBSUB, SCHEMA_REGISTRY, polyglot_sink), `tracing-core::GLOBAL_DISPATCH`, and the iceoryx2 internal statics (`UniqueSystemId::COUNTER`, `iceoryx2_log::LOGGER`, `SignalHandler::HANDLE`). Only `PROCESSOR_REGISTRY` is bridged today (via `export_plugin!`'s explicit `&'static ProcessorInstanceFactory` reference). The rest silently misroute when a processor runs in dlopen'd cdylib code — empirically observed via `nm`/`objdump`, then confirmed by an empirical probe that ruled out the tokio-worker-panic hypothesis.

Sweeping examples to explicit-register now would be throwaway work: examples will eventually drop their Cargo deps entirely (the milestone's vision) and skip the explicit-register intermediate. So they stay on the legacy implicit-inventory path **deliberately** until the engine HostServices ABI v2 ships; then a single follow-up migrates them straight to `load_project`, and that PR also retires the macro's `inventory::submit!` emission (no remaining consumer).

## Architectural addition: `no_inventory` macro flag

This PR adds an opt-in attribute flag to `#[streamlib::sdk::processor]`:

```rust
#[streamlib::sdk::processor("TestMockProcessor", no_inventory)]
struct MockProcessor;
```

It suppresses the macro's `inventory::submit!` emission. The generated `Processor` type, `Config` alias, `node()` builder, and trait impls are unchanged; callers register the type explicitly via `PROCESSOR_REGISTRY.register::<Foo::Processor>()`. Documented at `libs/streamlib-macros/src/lib.rs:53-57`.

The issue body suggested two other shapes: a `register_dynamic`-based test helper, and a fixture project loaded via `load_project`. Neither worked: the first re-implements ~150-200 LOC of what the macro already emits (the `DynGeneratedProcessor` trait carries an explicit "DO NOT IMPLEMENT DIRECTLY" doc); the second routes through the broken dlopen path. The macro flag is the smallest change that satisfies "register without `inventory::submit!`" for test-only types — opt-in, backward-compatible, ~30 LOC including docs.

Survives the engine fix: legitimate cfg(test) types that want the typed Processor codegen but not global registration are a real, durable concept.

## Exit criteria (per #873)

- [x] Engine-internal test mocks register without `inventory::submit!` — `no_inventory` flag + `ensure_test_mocks_registered()` helper in `libs/streamlib-engine/src/core/test_support.rs`.
- [x] Every `packages/*/tests/*.rs` force-link test moves to explicit `PROCESSOR_REGISTRY.register::<P>()` setup (superseded body criterion: load_project setup; strategic shift documented in #873 body).
- [ ] ~~Every example pipeline drops processor-package Cargo deps and loads via `streamlib.yaml`.~~ — Deferred to the engine HostServices ABI v2 follow-up; rationale in #873 body's AI Agent Notes.
- [x] Workspace tests stay green throughout the migration.

## Test plan

- [x] `cargo test --workspace --lib` — 1421 passed, 0 failed
- [x] `cargo test --workspace --tests` — 1753 passed, 0 failed
- [x] `cargo test -p streamlib-network --test udp_loopback` — passes with full tracing output visible
- [x] `cargo test -p streamlib-network --test udp_burst_stress` — passes
- [x] `cargo check -p streamlib-network --test udp_throughput_bench` (which is `#[ignore]`-d) — compiles
- [x] `cargo test -p streamlib-mavlink --test mavlink_over_udp` — passes
- [x] `cargo test -p streamlib-jpeg --test jpeg_smoke` — 3 passed
- [x] `cargo test -p streamlib-vadr-vision --test udp_vadr_jpeg_e2e` — 2 passed
- [x] `cargo test -p streamlib-engine --lib graph_tests` — 33 passed (tests now driven via `ensure_test_mocks_registered()` instead of inventory)
- [x] `cargo test -p streamlib-engine --lib open_iceoryx2` — 2 passed (compiler-op tests now register via the shared test_support helper)
- [x] `cargo test -p streamlib-engine --test attribute_macro_test` — 7 passed (`TestProcessor` now uses `no_inventory`)
- [x] `cargo test -p streamlib-engine --test load_project_dylib_smoke` — 1 passed (unaffected; registers via `STREAMLIB_PLUGIN` callback)
- [x] Empirical diagnostic probe: `STREAMLIB_DANGEROUSLY_DEFER_LOGGING_TO_HOST=1 RUST_BACKTRACE=full RUST_LOG=iceoryx2=trace cargo test -p streamlib-network --test udp_loopback` against an in-place migration to `load_project` — confirmed no background-thread panic; ruled out the tokio-worker-panic hypothesis; data flow genuinely broken in iceoryx2 cross-DSO.

## Follow-up (separate engine issue to file)

Engine HostServices ABI v2: extend `PluginDeclaration` (`libs/streamlib-plugin-abi/src/lib.rs:67-78`) so the host hands the loaded cdylib references to `tracing::Dispatch`, `PUBSUB`, `SCHEMA_REGISTRY`, polyglot sink, and the iceoryx2 globals at load time. The cdylib calls `tracing::dispatcher::set_global_default(host_dispatch)` etc. against its own cdylib-side `tracing-core::GLOBAL_DISPATCH` so events from cdylib code reach the host's subscriber; ditto for the other singletons. Precedent: `tracing-ext-ffi-subscriber` (the canonical ecosystem pattern for this exact problem). Blocks issue #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)