### PR TITLE
feat(plugin-abi): HostServices v2 bridges process-wide statics across dlopen

### DIFF
--- a/libs/streamlib-engine/Cargo.toml
+++ b/libs/streamlib-engine/Cargo.toml
@@ -40,6 +40,13 @@ streamlib-idents = { path = "../streamlib-idents" }
 # Procedural macros
 streamlib-macros = { path = "../streamlib-macros" }
 
+# Plugin ABI wire-protocol header. Dep direction reversed in #877:
+# streamlib-plugin-abi no longer depends on streamlib (the SDK), so the
+# cyclic dep this dep used to dodge (engine → plugin-abi → sdk → engine)
+# is gone. The engine's dlopen loader uses `PluginDeclaration` and
+# `STREAMLIB_ABI_VERSION` from this crate directly.
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
+
 # Shared iceoryx2 payload types (for cross-process IPC)
 streamlib-ipc-types = { path = "../streamlib-ipc-types" }
 
@@ -62,6 +69,7 @@ inventory = "0.3"
 parking_lot = "0.12"  # Fast mutexes for all synchronization
 crossbeam-queue = "0.3"  # Lock-free MPMC queue for thread-safe mailboxes
 iceoryx2 = "0.8.1"  # Zero-copy IPC pub/sub for cross-process communication
+iceoryx2-log = "0.8.1"  # Bridge iceoryx2's internal log records into streamlib tracing
 rmp-serde = "1.3"  # MessagePack serialization for frame payloads
 signal-hook = "0.3"  # Native signal handling (SIGTERM, SIGINT) for event bus
 ctrlc = "3.4"  # Cross-platform Ctrl+C handler (works with GUI apps)

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -20,23 +20,55 @@
 
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 #[cfg(test)]
 mod integration_tests;
 
-/// Runtime schema registry. Populated by [`register_schema`] (called
-/// from `Runner::load_project` for each loaded package's `schemas:`
-/// entries). Empty until something registers.
-static SCHEMA_REGISTRY: LazyLock<RwLock<HashMap<String, Arc<str>>>> =
+/// Canonical-id → YAML-body store backing the runtime schema registry.
+pub type SchemaRegistryStorage = RwLock<HashMap<String, Arc<str>>>;
+
+/// Per-DSO schema registry. Each linked copy of streamlib-engine
+/// (host binary + every dlopen'd cdylib plugin) gets its own
+/// `LOCAL_SCHEMA_REGISTRY` because Rust mangled statics are not in the
+/// dynsym table. The host bridges every DSO to a single instance via
+/// [`ACTIVE_SCHEMA_REGISTRY`].
+static LOCAL_SCHEMA_REGISTRY: LazyLock<SchemaRegistryStorage> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Active schema registry for this DSO. First read lazy-binds to
+/// [`LOCAL_SCHEMA_REGISTRY`]; plugin cdylibs override via
+/// [`install_host_schema_registry`] from their `STREAMLIB_PLUGIN`
+/// register callback so `register_schema` + `get_embedded_schema_definition`
+/// in cdylib code reach the host's instance.
+static ACTIVE_SCHEMA_REGISTRY: OnceLock<&'static SchemaRegistryStorage> = OnceLock::new();
+
+fn active_schema_registry() -> &'static SchemaRegistryStorage {
+    *ACTIVE_SCHEMA_REGISTRY.get_or_init(|| &LOCAL_SCHEMA_REGISTRY)
+}
+
+/// Install a host-owned schema-registry reference into this DSO's
+/// [`ACTIVE_SCHEMA_REGISTRY`] slot. Called by
+/// `streamlib::sdk::plugin::install_host_services` from a plugin
+/// cdylib's register callback. Idempotent at the type-system level
+/// (OnceLock); a later call is a no-op so emit once at register time
+/// before any schema-registry touch.
+pub fn install_host_schema_registry(host: &'static SchemaRegistryStorage) {
+    let _ = ACTIVE_SCHEMA_REGISTRY.set(host);
+}
+
+/// This DSO's local schema-registry instance. The host hands the
+/// pointer to plugin cdylibs through `HostServices.schema_registry`.
+pub fn local_schema_registry() -> &'static SchemaRegistryStorage {
+    &LOCAL_SCHEMA_REGISTRY
+}
 
 /// Register a schema's YAML body under its canonical identifier. Last
 /// write wins. Idempotent for identical bodies.
 pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>>) {
     let canonical = canonical_id.into();
     let body = body.into();
-    let mut guard = SCHEMA_REGISTRY.write();
+    let mut guard = active_schema_registry().write();
     guard.insert(canonical, body);
 }
 
@@ -47,7 +79,7 @@ pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>
 /// stripped before lookup.
 pub fn get_embedded_schema_definition(name: &str) -> Option<Arc<str>> {
     let canonical = strip_semver_suffix(name);
-    SCHEMA_REGISTRY.read().get(canonical).cloned()
+    active_schema_registry().read().get(canonical).cloned()
 }
 
 /// Resolve `max_payload_bytes` from a structured port-schema spec.
@@ -102,7 +134,7 @@ pub fn max_queued_messages_for_port_spec(
 /// Sorted alphabetically so consumers (api-server) get diff-stable
 /// output across processes.
 pub fn list_embedded_schema_names() -> Vec<String> {
-    let mut names: Vec<String> = SCHEMA_REGISTRY.read().keys().cloned().collect();
+    let mut names: Vec<String> = active_schema_registry().read().keys().cloned().collect();
     names.sort();
     names
 }

--- a/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
+++ b/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Bridge iceoryx2-log records into the streamlib tracing pipeline.
+//!
+//! `iceoryx2` exposes its own logging trait via `iceoryx2-log`'s
+//! [`Log`] interface plus a one-shot global `set_logger` that takes a
+//! `&'static dyn Log`. Without a bridge, iceoryx2's internal log
+//! records go to its default stderr logger and bypass the streamlib
+//! JSONL pipeline entirely. With this bridge:
+//!
+//! - Host-side: `Runner::new` calls `install_iceoryx2_log_bridge()`
+//!   once on first construction, installing [`HOST_BRIDGE`] as
+//!   `iceoryx2`'s process-wide logger.
+//! - Plugin cdylib-side: the cdylib's `STREAMLIB_PLUGIN` register
+//!   callback receives the host's `&'static dyn Log` pointer via
+//!   [`crate::core::plugin::HostServices::iceoryx2_logger`] and
+//!   installs it in the cdylib's `iceoryx2-log` static. Each DSO has
+//!   its own `iceoryx2-log` static; both end up pointing at the same
+//!   bridge value living in host memory.
+//!
+//! Cross-DSO safety: both DSOs link the same `iceoryx2-log-types`
+//! version (workspace pin), so the `&'static dyn Log` fat pointer's
+//! vtable is layout-compatible on both sides. Logging through the
+//! pointer dispatches through the host's vtable, which calls back
+//! into the host's tracing pipeline.
+
+use iceoryx2_log::Log;
+use iceoryx2_log::LogLevel;
+
+/// Zero-sized bridge implementing iceoryx2's [`Log`] trait by
+/// forwarding records into the streamlib tracing pipeline.
+pub struct IceoryxLogBridge;
+
+impl Log for IceoryxLogBridge {
+    fn log(
+        &self,
+        log_level: LogLevel,
+        origin: core::fmt::Arguments,
+        formatted_message: core::fmt::Arguments,
+    ) {
+        // `tracing::*!` macros take compile-time log levels; dispatch
+        // through a match so iceoryx2's runtime LogLevel maps to the
+        // matching tracing level. `Fatal` collapses to `Error` —
+        // tracing has no separate fatal level and iceoryx2 emits
+        // `Fatal` for genuinely-process-ending conditions that
+        // iceoryx2 itself will abort on shortly after.
+        match log_level {
+            LogLevel::Trace => {
+                tracing::trace!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Debug => {
+                tracing::debug!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Info => {
+                tracing::info!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Warn => {
+                tracing::warn!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Error | LogLevel::Fatal => {
+                tracing::error!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+        }
+    }
+}
+
+/// Process-wide bridge value. Lives in `.rodata` (zero-sized) per
+/// DSO; the host's copy is the one shared with plugin cdylibs via
+/// [`crate::core::plugin::HostServices::iceoryx2_logger`]. Both
+/// host's and cdylib's copies impl `Log` against the same workspace-
+/// pinned `iceoryx2-log-types::Log` vtable.
+pub static HOST_BRIDGE: IceoryxLogBridge = IceoryxLogBridge;
+
+/// Install [`HOST_BRIDGE`] as this DSO's iceoryx2 process-wide
+/// logger. Idempotent — `iceoryx2_log::set_logger` is `Once`-guarded
+/// and returns false on subsequent calls, which we treat as success.
+pub fn install_iceoryx2_log_bridge_for_self() {
+    let _ = iceoryx2_log::set_logger(&HOST_BRIDGE);
+}
+
+/// Install a foreign `&'static dyn Log` into this DSO's iceoryx2
+/// process-wide logger. Used by plugin cdylibs receiving the host's
+/// bridge pointer through `HostServices`.
+///
+/// # Safety
+///
+/// `logger` must remain valid for the lifetime of this DSO. The
+/// host's [`HOST_BRIDGE`] is `'static` by construction, so passing
+/// `&HOST_BRIDGE` from the host satisfies this.
+pub unsafe fn install_foreign_iceoryx2_logger(logger: &'static dyn Log) {
+    let _ = iceoryx2_log::set_logger(logger);
+}

--- a/libs/streamlib-engine/src/core/logging/mod.rs
+++ b/libs/streamlib-engine/src/core/logging/mod.rs
@@ -17,6 +17,7 @@ pub use worker::format_event_pretty;
 
 mod config;
 mod event;
+pub(crate) mod iceoryx2_log_bridge;
 mod init;
 mod layer;
 mod paths;

--- a/libs/streamlib-engine/src/core/mod.rs
+++ b/libs/streamlib-engine/src/core/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod config;
 pub(crate) mod embedded_schemas;
 pub(crate) mod logging;
 pub(crate) mod observability;
+pub mod plugin;
 pub(crate) mod runtime_hooks;
 pub(crate) mod signals;
 pub(crate) mod streamlib_home;

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-services payload carried by the `STREAMLIB_PLUGIN` register
+//! callback.
+//!
+//! When the host's `Runner::load_project` (or `streamlib-runtime`'s
+//! standalone plugin loader) `dlopen`s a Rust plugin cdylib and
+//! invokes its `STREAMLIB_PLUGIN.register(host_services)` callback,
+//! `host_services` points at a [`HostServices`] payload owned by the
+//! host. The cdylib's macro expansion forwards the pointer into
+//! [`install_host_services`], which:
+//!
+//! 1. Validates the wire layout (`abi_layout_version`) before any
+//!    other field is touched. On mismatch the helper logs and returns
+//!    `None` — the host's post-call "processor not registered" check
+//!    then surfaces an actionable error.
+//! 2. Bridges every process-wide static the cdylib statically embeds
+//!    a per-DSO copy of (tracing dispatch, [`PUBSUB`], schema
+//!    registry, iceoryx2-log logger) into the host's instances.
+//! 3. Returns the host's `&'static ProcessorInstanceFactory` so the
+//!    macro can register the plugin's processor types into it.
+//!
+//! ## Why this lives in streamlib-engine, not streamlib-plugin-abi
+//!
+//! `streamlib-plugin-abi` is the bare wire-protocol header
+//! (`PluginDeclaration`, `STREAMLIB_ABI_VERSION`, the macro). It
+//! intentionally carries no streamlib deps so it doesn't pull the
+//! whole engine into every dependent crate's graph (and so the
+//! pre-#877 cyclic `engine → plugin-abi → sdk → engine` workaround
+//! is gone). The typed host-services payload lives here because all
+//! its field types (`ProcessorInstanceFactory`, `PubSub`,
+//! `Iceoryx2Node`, `tracing::Dispatch`, etc.) are engine types.
+//!
+//! The cdylib reaches this module via
+//! `streamlib::sdk::plugin::install_host_services` — the SDK
+//! re-exports it under that path. Plugin-abi's macro hard-codes that
+//! path in its expansion.
+//!
+//! ## Cross-DSO safety
+//!
+//! Every field of [`HostServices`] is a raw pointer or a value type
+//! whose layout the dynamic linker does not dedupe across DSOs. The
+//! safety contract for casting a `*const c_void` back to a typed
+//! reference is that **both the host and cdylib link the same
+//! version of every relevant crate** (workspace dep pins). The
+//! milestone-level commitment is "rustc-version coupling stays";
+//! this module rides that commitment for `streamlib-engine`,
+//! `iceoryx2`, and `iceoryx2-log-types`.
+//!
+//! ## Known gap — tracing dispatch passthrough
+//!
+//! `set_global_default` succeeds in the cdylib and installs the
+//! host's `Dispatch` as the cdylib's global. Empirically, events
+//! emitted from cdylib code via `tracing::*!()` still do not reach
+//! the host's `Subscriber::event` impl — they are absorbed
+//! somewhere between the cdylib's `Dispatch::event` and the host's
+//! `Layered<EnvFilter, ...>` Subscriber even with both DSOs on the
+//! same workspace-pinned `tracing-core 0.1.36`. Cross-DSO Callsite
+//! identity, vtable layout, or Registry span-stack semantics are
+//! the prime suspects.
+//!
+//! Cross-DSO tracing-dispatch passthrough is a known-not-viable
+//! pattern in the broader Rust ecosystem. The canonical fix is a
+//! callback-table shape — host exports `extern "C"` callbacks for
+//! `emit` / `enabled` / `enter` / `exit`, cdylib installs a thin
+//! local Subscriber that forwards through them. `tracing-ext-ffi-subscriber`
+//! is the reference implementation cited in #877's issue body.
+//!
+//! This module ships the partial bridge today (PUBSUB + schema
+//! registry + iceoryx2-log work end-to-end; tracing dispatch
+//! installs but events don't flow). The callback-table tracing
+//! bridge is a follow-up. Until it lands, cdylib code that wants
+//! observability should rely on PUBSUB events for its host-visible
+//! signals.
+
+use std::ffi::c_void;
+
+use tracing::Dispatch;
+
+use crate::core::embedded_schemas::SchemaRegistryStorage;
+use crate::core::logging::iceoryx2_log_bridge;
+use crate::core::processors::ProcessorInstanceFactory;
+use crate::core::pubsub::PubSub;
+
+/// Wire layout version. Bump on any change to [`HostServices`]'s
+/// field ordering or contents (including non-`#[repr(C)]` value-type
+/// fields whose Rust layout may shift across compiler versions —
+/// `tracing::Dispatch` is the canonical example).
+///
+/// Read first by [`install_host_services`] before any other field
+/// is touched. On mismatch the helper bails out without dereferencing
+/// the rest of the struct, so it's safe even if the cdylib was built
+/// against an older `HostServices` layout.
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 1;
+
+/// Payload the host passes through the `STREAMLIB_PLUGIN` register
+/// callback. The cdylib's macro expansion casts the `*const c_void`
+/// parameter to `*const HostServices` and reads the fields below.
+///
+/// Field ordering is **stable** within a layout-version bucket — the
+/// first two fields (`abi_layout_version`, `fatal_log`) are pinned
+/// at offset 0 forever so [`install_host_services`] can read them
+/// even when the rest of the struct's layout has drifted. New
+/// fields go at the end and bump [`HOST_SERVICES_LAYOUT_VERSION`].
+///
+/// Field semantics:
+///
+/// * `abi_layout_version` — must equal [`HOST_SERVICES_LAYOUT_VERSION`].
+/// * `processor_registry` — host's `&'static ProcessorInstanceFactory`
+///   (`PROCESSOR_REGISTRY`). The cdylib registers into this rather
+///   than its own per-DSO `LazyLock<ProcessorInstanceFactory>`.
+/// * `pubsub` — host's `&'static PubSub`
+///   (`crate::core::pubsub::bus::local_pubsub()` value). The cdylib's
+///   `crate::core::pubsub::bus::install_host_pubsub` installs it so
+///   `PUBSUB.publish(...)` in cdylib code reaches the host's bus.
+/// * `schema_registry` — host's `&'static
+///   SchemaRegistryStorage`. Same shape as PUBSUB bridging:
+///   `crate::core::embedded_schemas::install_host_schema_registry`
+///   wires the cdylib's `register_schema` /
+///   `get_embedded_schema_definition` through to the host's storage.
+/// * `tracing_dispatch_ptr` — pointer to a `Dispatch` value the host
+///   keeps alive (`Box::leak`-ed at first plugin load — see
+///   [`runtime_facing::host_dispatch_for_self`]). The cdylib clones
+///   it via `(&*ptr).clone()` and calls
+///   `tracing::dispatcher::set_global_default(...)` against its own
+///   `tracing-core` static. After this, `tracing::info!` in cdylib
+///   code flows into the host's subscriber.
+/// * `iceoryx2_logger_ptr` — pointer to a `&'static dyn Log`
+///   trait-object value living in host memory (specifically a
+///   reference to [`HOST_BRIDGE`], boxed-and-leaked once). The
+///   cdylib installs it via
+///   `crate::core::logging::iceoryx2_log_bridge::install_foreign_iceoryx2_logger`
+///   so iceoryx2's internal log records in cdylib code reach the
+///   host's tracing pipeline. May be null if the host hasn't wired
+///   one (today: never null — `Runner::new` always installs the
+///   bridge before any plugin load).
+/// * `iceoryx2_node_ptr` — pointer to the host's `Iceoryx2Node`.
+///   Reserved for future cdylib code that needs to create iceoryx2
+///   services in its own DSO using the host's node identity; today
+///   no cdylib code uses this, but it's the right shape and rounds
+///   out the FFI surface so future consumers don't redo this design.
+#[repr(C)]
+pub struct HostServices {
+    /// Wire layout version. See [`HOST_SERVICES_LAYOUT_VERSION`].
+    pub abi_layout_version: u32,
+
+    /// Padding to keep the following pointer fields naturally
+    /// aligned across 32/64-bit hosts (not relevant on streamlib's
+    /// 64-bit targets today; explicit for clarity).
+    pub _reserved_padding: u32,
+
+    /// Host's process-instance factory (`PROCESSOR_REGISTRY`).
+    pub processor_registry: *const c_void,
+
+    /// Host's `&'static PubSub` (`local_pubsub` value).
+    pub pubsub: *const c_void,
+
+    /// Host's `&'static SchemaRegistryStorage` (`local_schema_registry`
+    /// value).
+    pub schema_registry: *const c_void,
+
+    /// Pointer to a `Dispatch` value the host keeps alive on the
+    /// heap (see [`runtime_facing::host_dispatch_for_self`]).
+    pub tracing_dispatch_ptr: *const c_void,
+
+    /// Pointer to a `&'static dyn iceoryx2_log::Log` value the host
+    /// keeps alive (see [`runtime_facing::host_iceoryx2_logger_for_self`]).
+    /// May be null.
+    pub iceoryx2_logger_ptr: *const c_void,
+
+    /// Pointer to the host's `Iceoryx2Node` value, kept alive on the
+    /// heap (see [`runtime_facing::host_iceoryx2_node_for_self`]).
+    /// Reserved for future cdylib consumers; safe to ignore.
+    pub iceoryx2_node_ptr: *const c_void,
+}
+
+// Safety: every field is a raw pointer or a primitive. The host
+// guarantees the pointed-at values outlive the cdylib's process
+// lifetime via the `LOADED_PLUGIN_LIBRARIES` pinning shape.
+unsafe impl Send for HostServices {}
+unsafe impl Sync for HostServices {}
+
+/// Bridge every process-wide static this DSO embeds a per-DSO copy
+/// of to the host's instances. Called from a plugin cdylib's
+/// `STREAMLIB_PLUGIN` register callback via the
+/// [`streamlib_plugin_abi::export_plugin`] macro expansion.
+///
+/// # Returns
+///
+/// `Some(&'static ProcessorInstanceFactory)` on success — the host's
+/// registry the cdylib registers into. `None` on layout-version
+/// mismatch (the cdylib was built against a stale `HostServices`
+/// layout). The macro short-circuits processor registration on
+/// `None`, and the host's post-call "processor not registered"
+/// check surfaces a `Configuration` error.
+///
+/// # Safety
+///
+/// `host_services_ptr` must point at a [`HostServices`] value
+/// initialized by the host. The host's loader guarantees this.
+pub unsafe fn install_host_services(
+    host_services_ptr: *const c_void,
+) -> Option<&'static ProcessorInstanceFactory> {
+    if host_services_ptr.is_null() {
+        return None;
+    }
+
+    // SAFETY: per the caller's promise. Read `abi_layout_version`
+    // before touching any other field — if the layout doesn't match,
+    // the rest of the struct may have a different shape on the wire.
+    let services = unsafe { &*(host_services_ptr as *const HostServices) };
+
+    if services.abi_layout_version != HOST_SERVICES_LAYOUT_VERSION {
+        // Logging may not be wired yet — emit through tracing
+        // (which is silent if this DSO's dispatch hasn't been
+        // installed) AND via the host's stderr as a backstop. The
+        // host's loader will surface the failure via the post-call
+        // "processor not registered" check.
+        //
+        // We deliberately do NOT write to stderr directly here
+        // (banned by streamlib's logging discipline). The host can
+        // tell something went wrong because no processors registered.
+        tracing::error!(
+            target: "streamlib::plugin",
+            host_layout = HOST_SERVICES_LAYOUT_VERSION,
+            cdylib_layout = services.abi_layout_version,
+            "Plugin HostServices layout mismatch; aborting register"
+        );
+        return None;
+    }
+
+    // SAFETY: pointers were constructed by the host from `&'static`
+    // references to its own statics. Both DSOs link the same
+    // streamlib-engine version per the milestone-level rustc-version
+    // coupling commitment, so the layouts match.
+    let processor_registry =
+        unsafe { &*(services.processor_registry as *const ProcessorInstanceFactory) };
+    let pubsub = unsafe { &*(services.pubsub as *const PubSub) };
+    let schema_registry =
+        unsafe { &*(services.schema_registry as *const SchemaRegistryStorage) };
+
+    // Best-effort tracing-dispatch bridge.
+    //
+    // `set_global_default` here transitions the cdylib's per-DSO
+    // `tracing-core::GLOBAL_INIT` to `INITIALIZED` with a Dispatch
+    // whose `Kind::Global` subscriber pointer is the host's. The
+    // call returns `Ok` in production. Empirically, however, events
+    // emitted from cdylib code via `tracing::*!()` do NOT reach the
+    // host's `Subscriber::event` impl through this path — events
+    // are silently absorbed somewhere between the cdylib's
+    // `Dispatch::event` and the host's `Layered<EnvFilter, ...>`
+    // Subscriber, even though both DSOs link the same workspace-
+    // pinned `tracing-core 0.1.36` version. The exact cause is
+    // unclear; cross-DSO Callsite identity, vtable, or Registry
+    // span-stack semantics are the prime suspects.
+    //
+    // Cross-DSO tracing-dispatch passthrough is a known-not-viable
+    // pattern in the broader Rust ecosystem — the canonical fix is
+    // a callback-table shape (see `tracing-ext-ffi-subscriber`,
+    // cited in #877's issue body) where the host exports
+    // `extern "C"` callbacks for emit/enabled/enter/exit and the
+    // cdylib installs a thin local Subscriber that forwards through
+    // them. That work is tracked as a follow-up to #877; see the
+    // gap section in this module's docs.
+    //
+    // We still call `set_global_default` here so the cdylib's
+    // `GLOBAL_DISPATCH` isn't the no-op default — that lets
+    // `tracing::*!()` macros short-circuit fast and avoids any
+    // tracing-subscriber lazy-init costs on the cdylib's hot path.
+    if !services.tracing_dispatch_ptr.is_null() {
+        let host_dispatch = unsafe { &*(services.tracing_dispatch_ptr as *const Dispatch) };
+        let _ = tracing::dispatcher::set_global_default(host_dispatch.clone());
+    }
+
+    // Bridge PUBSUB + schema registry. Order doesn't matter — both
+    // are `OnceLock<&'static T>` writes.
+    crate::core::pubsub::install_host_pubsub(pubsub);
+    crate::core::embedded_schemas::install_host_schema_registry(schema_registry);
+
+    // Bridge iceoryx2-log if the host installed one. The host
+    // currently always installs `HOST_BRIDGE` at `Runner::new`, so
+    // the null branch is unreachable in production — kept for
+    // forward-compat with embedded contexts that may not.
+    if !services.iceoryx2_logger_ptr.is_null() {
+        // The host stores `&'static dyn Log` (a fat pointer) at the
+        // heap location pointed to by `iceoryx2_logger_ptr`. Read
+        // and forward to this DSO's `iceoryx2-log`.
+        let logger_ref =
+            unsafe { *(services.iceoryx2_logger_ptr as *const &'static dyn iceoryx2_log::Log) };
+        unsafe { iceoryx2_log_bridge::install_foreign_iceoryx2_logger(logger_ref) };
+    }
+
+    // `iceoryx2_node_ptr` is reserved — no in-tree consumer reads
+    // it yet. The cdylib leaves it as null-or-set; future code that
+    // wants the host's Iceoryx2Node can clone via
+    // `Arc<Mutex<Node>>` semantics (Iceoryx2Node is `Clone`).
+
+    Some(processor_registry)
+}
+
+// =============================================================================
+// Host-facing helpers for building a HostServices payload.
+// =============================================================================
+
+/// Host-facing helpers — used by `Runner::load_project` and
+/// `streamlib-runtime`'s plugin loader to build a [`HostServices`]
+/// payload from the host's own statics.
+pub mod runtime_facing {
+    use super::{HostServices, HOST_SERVICES_LAYOUT_VERSION};
+    use std::ffi::c_void;
+    use std::sync::OnceLock;
+
+    use tracing::Dispatch;
+
+    /// Heap-allocated `Dispatch` clone the host keeps alive so the
+    /// pointer handed to plugin cdylibs stays valid. Lazy-built on
+    /// first call; subsequent calls reuse the same boxed value.
+    ///
+    /// Uses `Box::leak` — the leak lasts the process lifetime, which
+    /// matches `LOADED_PLUGIN_LIBRARIES`'s pinning lifetime for
+    /// loaded cdylibs.
+    static HOST_TRACING_DISPATCH: OnceLock<&'static Dispatch> = OnceLock::new();
+
+    /// Heap-allocated `&'static dyn Log` trait-object pointer the
+    /// host hands to plugin cdylibs. Boxed-and-leaked once for the
+    /// same lifetime reason.
+    type StaticLogRef = &'static dyn iceoryx2_log::Log;
+    static HOST_ICEORYX2_LOGGER: OnceLock<&'static StaticLogRef> = OnceLock::new();
+
+    /// Heap-allocated `Iceoryx2Node` clone the host keeps alive for
+    /// the same reason. Boxed once and reused.
+    static HOST_ICEORYX2_NODE: OnceLock<&'static crate::iceoryx2::Iceoryx2Node> = OnceLock::new();
+
+    /// Return a `&'static Dispatch` pointing at a clone of
+    /// tracing-core's current `GLOBAL_DISPATCH`. Captured on first
+    /// call so plugins loaded later still see the dispatch active
+    /// at the time `Runner::new` wired tracing.
+    fn host_dispatch_for_self() -> &'static Dispatch {
+        HOST_TRACING_DISPATCH.get_or_init(|| {
+            // Capture the current global dispatcher by cloning the
+            // value passed through `tracing::dispatcher::get_default`.
+            let dispatch = tracing::dispatcher::get_default(|d| d.clone());
+            Box::leak(Box::new(dispatch))
+        })
+    }
+
+    /// Return a `&'static StaticLogRef` pointing at the host's
+    /// iceoryx2 logger bridge.
+    fn host_iceoryx2_logger_for_self() -> &'static StaticLogRef {
+        HOST_ICEORYX2_LOGGER.get_or_init(|| {
+            let logger: StaticLogRef = &crate::core::logging::iceoryx2_log_bridge::HOST_BRIDGE;
+            Box::leak(Box::new(logger))
+        })
+    }
+
+    /// Return a `&'static Iceoryx2Node` pointing at a clone of the
+    /// caller's node. Captured on first call.
+    fn host_iceoryx2_node_for_self(
+        node: &crate::iceoryx2::Iceoryx2Node,
+    ) -> &'static crate::iceoryx2::Iceoryx2Node {
+        HOST_ICEORYX2_NODE.get_or_init(|| Box::leak(Box::new(node.clone())))
+    }
+
+    /// Build a [`HostServices`] payload from the host's own statics.
+    /// Heap-leaks the underlying `Dispatch`, `&dyn Log`, and
+    /// `Iceoryx2Node` values on first call; pointers are stable for
+    /// the process lifetime, which matches `LOADED_PLUGIN_LIBRARIES`'s
+    /// pinning lifetime for loaded cdylibs.
+    ///
+    /// Returns by value; the caller binds it to a local and passes
+    /// `&services as *const HostServices as *const c_void` into the
+    /// cdylib's register callback. For multi-plugin loaders that
+    /// retain the payload past one call site, prefer
+    /// [`leaked_host_services_for_self`].
+    pub fn host_services_for_self(node: &crate::iceoryx2::Iceoryx2Node) -> HostServices {
+        let dispatch_ptr = host_dispatch_for_self() as *const Dispatch as *const c_void;
+        let logger_ptr = host_iceoryx2_logger_for_self() as *const StaticLogRef as *const c_void;
+        let node_ptr = host_iceoryx2_node_for_self(node) as *const crate::iceoryx2::Iceoryx2Node
+            as *const c_void;
+
+        HostServices {
+            abi_layout_version: HOST_SERVICES_LAYOUT_VERSION,
+            _reserved_padding: 0,
+            processor_registry: &*crate::core::processors::PROCESSOR_REGISTRY
+                as *const crate::core::processors::ProcessorInstanceFactory
+                as *const c_void,
+            pubsub: crate::core::pubsub::local_pubsub() as *const _ as *const c_void,
+            schema_registry: crate::core::embedded_schemas::local_schema_registry()
+                as *const _ as *const c_void,
+            tracing_dispatch_ptr: dispatch_ptr,
+            iceoryx2_logger_ptr: logger_ptr,
+            iceoryx2_node_ptr: node_ptr,
+        }
+    }
+
+    /// Same as [`host_services_for_self`] but returns a
+    /// `&'static HostServices` keyed off the host's iceoryx2 node —
+    /// constructed once per process and reused across every dlopen
+    /// from this host.
+    pub fn leaked_host_services_for_self(
+        node: &crate::iceoryx2::Iceoryx2Node,
+    ) -> &'static HostServices {
+        static LEAKED: OnceLock<&'static HostServices> = OnceLock::new();
+        LEAKED.get_or_init(|| Box::leak(Box::new(host_services_for_self(node))))
+    }
+}

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -336,10 +336,21 @@ pub mod runtime_facing {
     /// tracing-core's current `GLOBAL_DISPATCH`. Captured on first
     /// call so plugins loaded later still see the dispatch active
     /// at the time `Runner::new` wired tracing.
+    ///
+    /// Must not be called before `Runner::new` returns — if no
+    /// `set_global_default` has fired yet, `get_default` returns
+    /// the no-op dispatch and the capture freezes that for the
+    /// process lifetime, silently dropping every plugin emit. The
+    /// debug-build `assert` below makes the ordering violation
+    /// loud; release builds rely on the documented invariant.
     fn host_dispatch_for_self() -> &'static Dispatch {
         HOST_TRACING_DISPATCH.get_or_init(|| {
-            // Capture the current global dispatcher by cloning the
-            // value passed through `tracing::dispatcher::get_default`.
+            debug_assert!(
+                tracing::dispatcher::has_been_set(),
+                "host_dispatch_for_self called before any global tracing dispatch \
+                 was installed — Runner::new must run before plugin loading so \
+                 HostServices captures a configured Dispatch rather than the noop default"
+            );
             let dispatch = tracing::dispatcher::get_default(|d| d.clone());
             Box::leak(Box::new(dispatch))
         })

--- a/libs/streamlib-engine/src/core/plugin/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO plugin bridging.
+//!
+//! Rust plugin cdylibs loaded via `Runner::load_project` /
+//! `Runner::load_package` (or the standalone `streamlib-runtime`
+//! binary's `--plugin` flag) statically embed their entire transitive
+//! dep tree. Without bridging, every process-wide static the engine
+//! relies on (tracing dispatch, [`PUBSUB`], the schema registry,
+//! iceoryx2's logger) exists as a per-DSO copy with no
+//! dynamic-linker dedup — Rust mangled statics aren't in the dynsym
+//! table.
+//!
+//! This module owns the typed [`HostServices`] payload the host
+//! hands to plugin cdylibs through `STREAMLIB_PLUGIN.register`, and
+//! the cdylib-side [`install_host_services`] helper that bridges
+//! every static to the host's instances.
+//!
+//! [`PUBSUB`]: crate::core::pubsub::PUBSUB
+
+pub mod host_services;
+
+pub use host_services::{install_host_services, HostServices, HOST_SERVICES_LAYOUT_VERSION};

--- a/libs/streamlib-engine/src/core/pubsub/bus.rs
+++ b/libs/streamlib-engine/src/core/pubsub/bus.rs
@@ -4,6 +4,7 @@
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 
 use super::events::{topics, Event, EventListener};
@@ -23,12 +24,65 @@ thread_local! {
         RefCell::new(HashMap::new());
 }
 
-/// Global pub/sub instance for runtime events.
+/// Per-DSO `PubSub` instance.
 ///
-/// Created as an empty shell via LazyLock. Must be initialized via `init()`
-/// during `Runner::new()` before iceoryx2 services are available.
-/// Before init, publish is a no-op and subscribe is buffered.
-pub static PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
+/// Each linked copy of streamlib-engine (host binary, every dlopen'd
+/// cdylib plugin) gets its own `LOCAL_PUBSUB` — Rust mangled statics
+/// aren't in the dynsym table and the dynamic linker doesn't dedupe
+/// them. The host's loader bridges them through [`ACTIVE_PUBSUB`] so
+/// every DSO converges on a single canonical instance.
+static LOCAL_PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
+
+/// Active `PubSub` reference. Set once per DSO:
+/// - on the host, by `Runner::new` → `wire_host_pubsub_for_self()` (points at this DSO's `LOCAL_PUBSUB`).
+/// - in a cdylib, by `streamlib::sdk::plugin::install_host_services` (points at the host's `LOCAL_PUBSUB`).
+///
+/// `OnceLock` semantics: the first writer wins. Calling
+/// [`install_host_pubsub`] after the proxy has already lazy-initialised
+/// to the local instance is a no-op — emit before any `PUBSUB.foo()`
+/// touch.
+static ACTIVE_PUBSUB: OnceLock<&'static PubSub> = OnceLock::new();
+
+/// Proxy that derefs to the active `PubSub`. Lets every call site keep
+/// the `PUBSUB.publish(...)` / `PUBSUB.subscribe(...)` syntax while
+/// the underlying instance can be host-injected at plugin-load time.
+pub struct PubSubProxy {
+    _private: (),
+}
+
+impl Deref for PubSubProxy {
+    type Target = PubSub;
+
+    fn deref(&self) -> &'static PubSub {
+        *ACTIVE_PUBSUB.get_or_init(|| &LOCAL_PUBSUB)
+    }
+}
+
+/// Process-wide pub/sub handle. Reads through [`PubSubProxy`] so a
+/// dlopen'd cdylib plugin gets the host's `PubSub` instance after
+/// `STREAMLIB_PLUGIN`'s register callback wires it via
+/// [`install_host_pubsub`].
+pub static PUBSUB: PubSubProxy = PubSubProxy { _private: () };
+
+/// Install a host-owned `PubSub` reference into this DSO's
+/// [`ACTIVE_PUBSUB`] slot. Called by `streamlib::sdk::plugin::install_host_services`
+/// from a plugin cdylib's register callback to share the host's
+/// `PubSub` instance instead of the cdylib's per-DSO `LOCAL_PUBSUB`.
+///
+/// Idempotent at the type-system level (OnceLock semantics) but a
+/// later call is a no-op — call once at register time before any
+/// `PUBSUB.*` touch.
+pub fn install_host_pubsub(host: &'static PubSub) {
+    let _ = ACTIVE_PUBSUB.set(host);
+}
+
+/// Return this DSO's local `PubSub` instance. Used by the host's
+/// loader to obtain the pointer it hands to plugin cdylibs through
+/// `HostServices.pubsub`, and by `Runner::new()` to wire the host's
+/// own DSO through the same indirection layer plugins ride.
+pub fn local_pubsub() -> &'static PubSub {
+    &LOCAL_PUBSUB
+}
 
 /// iceoryx2-backed pub/sub for runtime events.
 pub struct PubSub {

--- a/libs/streamlib-engine/src/core/pubsub/mod.rs
+++ b/libs/streamlib-engine/src/core/pubsub/mod.rs
@@ -7,5 +7,5 @@ mod events;
 #[cfg(test)]
 mod integration_tests;
 
-pub use bus::PUBSUB;
+pub use bus::{install_host_pubsub, local_pubsub, PubSub, PubSubProxy, PUBSUB};
 pub use events::{topics, Event, EventListener, ProcessorEvent, RuntimeEvent};

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -35,21 +35,6 @@ use crate::iceoryx2::Iceoryx2Node;
 static LOADED_PLUGIN_LIBRARIES: std::sync::LazyLock<parking_lot::Mutex<Vec<libloading::Library>>> =
     std::sync::LazyLock::new(|| parking_lot::Mutex::new(Vec::new()));
 
-/// ABI version for plugin compatibility checks.
-///
-/// Must match `streamlib_plugin_abi::STREAMLIB_ABI_VERSION`. Duplicated here to
-/// avoid a cyclic dependency (streamlib-plugin-abi depends on streamlib).
-const PLUGIN_ABI_VERSION: u32 = 1;
-
-/// Plugin declaration exported by dynamic libraries.
-///
-/// Must match the layout of `streamlib_plugin_abi::PluginDeclaration`.
-#[repr(C)]
-struct PluginDeclaration {
-    abi_version: u32,
-    register: extern "C" fn(&'static crate::core::processors::ProcessorInstanceFactory),
-}
-
 /// Storage variant for tokio runtime in Runner.
 ///
 /// Enables Runner to work both standalone (owning its runtime) and
@@ -200,6 +185,15 @@ impl Runner {
         let result = crate::core::processors::PROCESSOR_REGISTRY.register_all_processors();
         tracing::debug!("Registered {} processors from inventory", result.count);
 
+        // Bridge iceoryx2's internal log records into streamlib tracing
+        // before creating the iceoryx2 Node so any iceoryx2 emit at
+        // construction time lands in the unified JSONL pipeline. The
+        // host's bridge value is the same `&'static dyn Log` that
+        // [`crate::core::plugin::host_services`] hands to plugin cdylibs
+        // via `HostServices.iceoryx2_logger_ptr` so every DSO converges
+        // on a single logger.
+        crate::core::logging::iceoryx2_log_bridge::install_iceoryx2_log_bridge_for_self();
+
         // Create iceoryx2 Node early so PUBSUB can initialize before start().
         // The node is cloned into RuntimeContext during start().
         tracing::info!("[new] Creating iceoryx2 Node...");
@@ -284,6 +278,16 @@ impl Runner {
     /// Unique identifier for this runtime instance.
     pub fn runtime_id(&self) -> &RuntimeUniqueId {
         &self.runtime_id
+    }
+
+    /// This runtime's iceoryx2 node. Exposed so external loaders
+    /// (`streamlib-runtime`'s `--plugin` flag, embedding apps that
+    /// `dlopen` a cdylib outside `load_project`) can hand it to
+    /// [`crate::core::plugin::host_services::runtime_facing::host_services_for_self`]
+    /// when assembling the `HostServices` payload for a plugin
+    /// register callback.
+    pub fn iceoryx2_node(&self) -> &Iceoryx2Node {
+        &self.iceoryx2_node
     }
 
     /// Path of the JSONL log file this runtime is writing to, if any.
@@ -579,9 +583,11 @@ impl Runner {
                             })?
                         };
 
-                        let decl: &PluginDeclaration = unsafe {
+                        let decl: &streamlib_plugin_abi::PluginDeclaration = unsafe {
                             let symbol = lib
-                                .get::<*const PluginDeclaration>(b"STREAMLIB_PLUGIN\0")
+                                .get::<*const streamlib_plugin_abi::PluginDeclaration>(
+                                    b"STREAMLIB_PLUGIN\0",
+                                )
                                 .map_err(|e| {
                                     Error::Configuration(format!(
                                         "Plugin '{}' missing STREAMLIB_PLUGIN symbol. \
@@ -593,18 +599,37 @@ impl Runner {
                             &**symbol
                         };
 
-                        if decl.abi_version != PLUGIN_ABI_VERSION {
+                        if decl.abi_version != streamlib_plugin_abi::STREAMLIB_ABI_VERSION {
                             return Err(Error::Configuration(format!(
                                 "ABI version mismatch for '{}': plugin has v{}, \
                                  runtime expects v{}. Rebuild the plugin with a \
                                  compatible streamlib-plugin-abi version.",
                                 dylib_path.display(),
                                 decl.abi_version,
-                                PLUGIN_ABI_VERSION
+                                streamlib_plugin_abi::STREAMLIB_ABI_VERSION,
                             )));
                         }
 
-                        (decl.register)(&crate::core::processors::PROCESSOR_REGISTRY);
+                        // Build the HostServices payload from the host's
+                        // process-wide statics + this runtime's iceoryx2
+                        // node, hand it to the cdylib's register callback.
+                        // The cdylib's macro-emitted prologue calls
+                        // `install_host_services` which bridges every
+                        // per-DSO static (tracing dispatch, PUBSUB,
+                        // schema registry, iceoryx2 logger) into the
+                        // host's instances before processor registration.
+                        let host_services =
+                            crate::core::plugin::host_services::runtime_facing::host_services_for_self(
+                                &self.iceoryx2_node,
+                            );
+                        // SAFETY: `host_services` outlives the call;
+                        // the cdylib's callback returns before this
+                        // function frame is dropped.
+                        unsafe {
+                            (decl.register)(
+                                &host_services as *const _ as *const ::std::ffi::c_void,
+                            );
+                        }
 
                         // Keep the library alive for the process lifetime
                         LOADED_PLUGIN_LIBRARIES.lock().push(lib);

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -218,6 +218,7 @@ pub mod sdk {
     pub use crate::core::graph_file;
     pub use crate::core::json_schema;
     pub use crate::core::media_clock;
+    pub use crate::core::plugin;
     pub use crate::core::prelude;
     pub use crate::core::rhi;
     pub use crate::core::runtime;

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `STREAMLIB_PLUGIN` ABI v2 — PUBSUB bridge end-to-end.
+//!
+//! A listener subscribed in the host before `load_project` receives
+//! the `RuntimeDidRegisterProcessorType` event that cdylib code
+//! publishes when it invokes `host_registry.register::<P>()`.
+//! Mentally revert `install_host_pubsub` in
+//! `libs/streamlib-engine/src/core/plugin/host_services.rs` and
+//! this test fails: the cdylib's per-DSO `PUBSUB` instance never
+//! converges on the host's bus, so the publish lands in a
+//! subscriber-less iceoryx2 service.
+//!
+//! Runs in its own test binary so `PROCESSOR_REGISTRY` and the
+//! one-shot tracing/logging globals are fresh — the sibling
+//! `load_project_dylib_tracing_bridge.rs` needs the same fresh
+//! state, and registry duplicates from a sibling-test register call
+//! would early-return the `register::<P>()` path without firing
+//! either bridge.
+
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serial_test::serial;
+use streamlib::sdk::pubsub::{topics, Event, EventListener, RuntimeEvent, PUBSUB};
+use streamlib::sdk::runtime::Runner;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+fn build_and_stage_test_fixtures_dylib() -> (tempfile::TempDir, std::path::PathBuf) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    (tmp, fixtures_dst)
+}
+
+struct CountingListener {
+    matched: Arc<AtomicUsize>,
+}
+
+impl EventListener for CountingListener {
+    fn on_event(&mut self, event: &Event) -> streamlib::sdk::error::Result<()> {
+        if let Event::RuntimeGlobal(RuntimeEvent::RuntimeDidRegisterProcessorType {
+            processor_type,
+        }) = event
+        {
+            if processor_type.r#type.as_str() == "TestConfiguredProcessor" {
+                self.matched.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+#[serial]
+fn plugin_register_pubsub_event_reaches_host_subscriber() {
+    let (_tmp, fixtures_dst) = build_and_stage_test_fixtures_dylib();
+
+    let runtime = Runner::new().unwrap();
+
+    // Subscribe BEFORE load_project so the cdylib's register-time
+    // publish has somewhere to land. Sleep ~200 ms so the subscriber
+    // thread opens its iceoryx2 service before the publish (per the
+    // pubsub-lazy-init-silent-noop learning's setup-time recipe).
+    let matched = Arc::new(AtomicUsize::new(0));
+    let listener_arc: Arc<Mutex<dyn EventListener>> =
+        Arc::new(Mutex::new(CountingListener {
+            matched: Arc::clone(&matched),
+        }));
+    PUBSUB.subscribe(topics::RUNTIME_GLOBAL, Arc::clone(&listener_arc));
+    std::thread::sleep(Duration::from_millis(200));
+
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while matched.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        matched.load(Ordering::SeqCst) >= 1,
+        "host subscriber should have received a RuntimeDidRegisterProcessorType \
+         event for TestConfiguredProcessor — the cdylib's PUBSUB.publish call \
+         from inside ProcessorInstanceFactory::register did not reach the \
+         host's bus. Check `install_host_pubsub` in \
+         libs/streamlib-engine/src/core/plugin/host_services.rs."
+    );
+
+    drop(listener_arc);
+}

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -13,11 +13,11 @@
 //! subscriber-less iceoryx2 service.
 //!
 //! Runs in its own test binary so `PROCESSOR_REGISTRY` and the
-//! one-shot tracing/logging globals are fresh — the sibling
-//! `load_project_dylib_tracing_bridge.rs` needs the same fresh
-//! state, and registry duplicates from a sibling-test register call
-//! would early-return the `register::<P>()` path without firing
-//! either bridge.
+//! one-shot tracing/logging globals are fresh. The same-binary
+//! `#[serial]`-guarded shape leaves `PROCESSOR_REGISTRY` populated
+//! between tests, and `register::<P>()` early-returns on a
+//! duplicate type-name — silently skipping the PUBSUB publish this
+//! test asserts.
 
 use std::path::Path;
 use std::sync::{

--- a/libs/streamlib-plugin-abi/Cargo.toml
+++ b/libs/streamlib-plugin-abi/Cargo.toml
@@ -9,9 +9,15 @@ license = "BUSL-1.1"
 description = "Plugin interface for StreamLib dynamic processor loading"
 repository.workspace = true
 
-# Depends on streamlib for ProcessorInstanceFactory type in the registration function signature
+# The plugin-abi crate is the wire-protocol header for the
+# `STREAMLIB_PLUGIN` symbol. It carries no streamlib dependencies —
+# the macro expansion calls into `streamlib::sdk::plugin::*` (defined
+# in streamlib-engine) at the cdylib's call site, where the streamlib
+# dep already lives. Keeping plugin-abi dep-free resolves the cyclic
+# `streamlib-engine → streamlib-plugin-abi → streamlib-sdk →
+# streamlib-engine` cycle the engine used to dodge by redeclaring
+# `PluginDeclaration` locally.
 [dependencies]
-streamlib = { path = "../streamlib-sdk" }
 
 [lints]
 workspace = true

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -3,11 +3,14 @@
 
 //! ABI-stable plugin interface for StreamLib dynamic processor loading.
 //!
-//! This crate provides the minimal interface for plugins to register their
-//! processors with the StreamLib runtime. Plugins use the same `#[streamlib::sdk::processor]`
-//! macro as built-in processors - the only difference is how they're registered.
+//! This crate is the wire-protocol header for the `STREAMLIB_PLUGIN`
+//! symbol: it defines [`PluginDeclaration`], [`STREAMLIB_ABI_VERSION`],
+//! and the [`export_plugin!`] macro. **It does not depend on the
+//! streamlib SDK** — the register callback takes an opaque pointer that
+//! the macro hands to a helper inside the SDK, which is the layer that
+//! knows the typed shape of the host services.
 //!
-//! # Example Plugin
+//! # Example plugin
 //!
 //! ```ignore
 //! use streamlib::prelude::*;
@@ -25,15 +28,13 @@
 //! impl ContinuousProcessor for MyProcessor::Processor {
 //!     fn process(&mut self) -> Result<()> {
 //!         if let Some(frame) = self.video_in.read() {
-//!             // Process frame...
 //!             self.video_out.write(frame);
 //!         }
 //!         Ok(())
 //!     }
 //! }
 //!
-//! // Export for dynamic loading
-//! export_plugin!(MyProcessor);
+//! export_plugin!(MyProcessor::Processor);
 //! ```
 //!
 //! # Plugin Cargo.toml
@@ -47,74 +48,106 @@
 //! streamlib-plugin-abi = "0.2"
 //! ```
 
-use streamlib::sdk::processors::ProcessorInstanceFactory;
+/// Current ABI version. Plugins must match this exactly. Bumped when
+/// the wire shape of [`PluginDeclaration`] or the register callback's
+/// signature changes incompatibly. The shape of the *host-services
+/// payload* passed through the opaque pointer is versioned separately
+/// inside the SDK (see `streamlib::sdk::plugin::HostServices::LAYOUT_VERSION`).
+pub const STREAMLIB_ABI_VERSION: u32 = 2;
 
-/// Current ABI version. Plugins must match this exactly.
+/// Plugin register function signature.
 ///
-/// Increment when making breaking changes to the plugin interface.
-pub const STREAMLIB_ABI_VERSION: u32 = 1;
-
-/// Function signature for plugin registration.
+/// The host passes a pointer to its `HostServices` payload (defined in
+/// streamlib-engine). The cdylib's macro expansion forwards the pointer
+/// into `streamlib::sdk::plugin::install_host_services` which validates
+/// the layout, bridges every process-wide static (tracing dispatch,
+/// PUBSUB, schema registry, iceoryx2 logger), and returns the host's
+/// processor registry the cdylib registers into.
 ///
-/// The host passes its `ProcessorInstanceFactory` reference to ensure processors
-/// register with the host's registry, not a duplicate in the plugin's address space.
-pub type PluginRegisterFn = extern "C" fn(&'static ProcessorInstanceFactory);
+/// # Safety
+///
+/// `host_services` must point at a valid `HostServices` payload owned
+/// by the host. The host guarantees the pointer outlives the cdylib's
+/// process lifetime (today: the cdylib's `Library` handle is pinned by
+/// the host's `LOADED_PLUGIN_LIBRARIES` static).
+pub type PluginRegisterFn = unsafe extern "C" fn(host_services: *const core::ffi::c_void);
 
 /// Plugin declaration exported by dynamic libraries.
 ///
-/// Plugins must export a static symbol named `STREAMLIB_PLUGIN` of this type.
-/// Use the [`export_plugin!`] macro to generate this correctly.
+/// Plugins export a static named `STREAMLIB_PLUGIN` of this type via
+/// [`export_plugin!`]. The host's loader looks up the symbol, validates
+/// `abi_version`, and invokes `register`.
 #[repr(C)]
 pub struct PluginDeclaration {
-    /// ABI version - must match [`STREAMLIB_ABI_VERSION`].
+    /// Wire ABI version — must equal [`STREAMLIB_ABI_VERSION`] at load
+    /// time. Bumped when [`PluginDeclaration`] or [`PluginRegisterFn`]
+    /// changes incompatibly.
     pub abi_version: u32,
 
-    /// Registration function called by the CLI to register processors.
-    ///
-    /// The host passes its [`ProcessorInstanceFactory`] reference to ensure
-    /// processors register with the host's registry, not a duplicate static
-    /// in the plugin's address space.
+    /// Register callback. Receives the host-services pointer; the
+    /// cdylib's macro expansion uses it to bridge process-wide statics
+    /// before registering processors with the host's registry.
     pub register: PluginRegisterFn,
 }
 
-// Safety: PluginDeclaration contains only a version number and function pointer,
-// both of which are Send + Sync.
+// Safety: contains only a u32 and a function pointer.
 unsafe impl Send for PluginDeclaration {}
 unsafe impl Sync for PluginDeclaration {}
 
 /// Export processors for dynamic loading.
 ///
-/// This macro generates the `STREAMLIB_PLUGIN` symbol that the CLI looks for
-/// when loading plugin libraries. It creates a registration function that
-/// registers each processor with the host's `ProcessorInstanceFactory`.
+/// Emits the `STREAMLIB_PLUGIN` static the host's loader looks for, and
+/// generates the register callback that:
+///
+/// 1. Bridges process-wide statics from the host (tracing dispatch,
+///    `PUBSUB`, schema registry, iceoryx2 logger) into the cdylib's
+///    own per-DSO copies via
+///    `streamlib::sdk::plugin::install_host_services`.
+/// 2. Registers each declared processor type with the host's
+///    `ProcessorInstanceFactory`.
+///
+/// Step 1 has to happen before step 2 — the registry's
+/// `register::<P>()` path publishes a `RuntimeDidRegisterProcessorType`
+/// event via `PUBSUB`, which only flows back to the host once `PUBSUB`
+/// points at the host's instance.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use streamlib_plugin_abi::export_plugin;
-///
-/// // Export a single processor
-/// export_plugin!(MyProcessor);
-///
-/// // Export multiple processors
-/// export_plugin!(ProcessorA, ProcessorB, ProcessorC);
+/// export_plugin!(MyProcessor::Processor);
+/// export_plugin!(ProcessorA::Processor, ProcessorB::Processor);
 /// ```
-///
-/// # Requirements
-///
-/// - Each processor must be defined using `#[streamlib::sdk::processor]`
-/// - The processor's `Processor` type must implement the appropriate trait
-///   (`ContinuousProcessor`, `ReactiveProcessor`, or `ManualProcessor`)
 #[macro_export]
 macro_rules! export_plugin {
     ($($processor:ty),* $(,)?) => {
+        /// Generated by `streamlib_plugin_abi::export_plugin!`.
+        ///
+        /// # Safety
+        ///
+        /// `host_services` must point at a layout-compatible
+        /// `HostServices` payload, per the [`PluginRegisterFn`] contract.
         #[allow(non_snake_case)]
-        extern "C" fn __streamlib_plugin_register(
-            registry: &'static ::streamlib::sdk::processors::ProcessorInstanceFactory
+        unsafe extern "C" fn __streamlib_plugin_register(
+            host_services: *const ::core::ffi::c_void,
         ) {
-            $(
-                registry.register::<$processor>();
-            )*
+            // Panic across an `extern "C"` boundary is UB. `catch_unwind`
+            // contains any unwinding within the cdylib; a panic in
+            // `install_host_services` or `registry.register::<_>()` is
+            // converted to silent return on the host side, where the
+            // post-call "processor not registered" check surfaces an
+            // actionable error.
+            let _ = ::std::panic::catch_unwind(|| {
+                // SAFETY: forwarded per the [`PluginRegisterFn`] contract.
+                let registry = unsafe {
+                    ::streamlib::sdk::plugin::install_host_services(host_services)
+                };
+                let Some(registry) = registry else {
+                    return;
+                };
+                $(
+                    registry.register::<$processor>();
+                )*
+            });
         }
 
         #[unsafe(no_mangle)]

--- a/libs/streamlib-runtime/src/main.rs
+++ b/libs/streamlib-runtime/src/main.rs
@@ -6,11 +6,13 @@
 //! Standalone process that hosts a StreamLib runtime with API server.
 //! Spawned by the `streamlib run` CLI command (kubectl model).
 
+use std::ffi::c_void;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use libloading::Library;
+use streamlib::sdk::plugin::host_services::runtime_facing;
 use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 use streamlib::sdk::runtime::Runner;
 use streamlib_api_server::{ApiServerConfig, ApiServerProcessor};
@@ -170,7 +172,17 @@ impl PluginLoader {
         }
     }
 
-    fn load_plugin(&mut self, path: &Path) -> Result<usize> {
+    /// Load a Rust plugin cdylib and invoke its `STREAMLIB_PLUGIN`
+    /// register callback. `runtime` provides the host's iceoryx2 node
+    /// used to build the cdylib-facing `HostServices` payload — every
+    /// process-wide static the plugin's per-DSO copy of streamlib
+    /// would otherwise see in isolation (tracing dispatch, PUBSUB,
+    /// schema registry, iceoryx2 logger) is bridged to the host's
+    /// instance before the cdylib's `register::<P>()` calls run.
+    ///
+    /// Must be called AFTER `Runner::new()` — the iceoryx2 node and
+    /// tracing-subscriber pipeline only exist post-construction.
+    fn load_plugin(&mut self, path: &Path, runtime: &Runner) -> Result<usize> {
         let lib = unsafe {
             Library::new(path)
                 .with_context(|| format!("Failed to load plugin library: {}", path.display()))?
@@ -200,7 +212,11 @@ impl PluginLoader {
         }
 
         let before_count = PROCESSOR_REGISTRY.list_registered().len();
-        (decl.register)(&PROCESSOR_REGISTRY);
+        let host_services = runtime_facing::host_services_for_self(runtime.iceoryx2_node());
+        // SAFETY: `host_services` outlives the call.
+        unsafe {
+            (decl.register)(&host_services as *const _ as *const c_void);
+        }
         let after_count = PROCESSOR_REGISTRY.list_registered().len();
         let registered_count = after_count - before_count;
 
@@ -209,7 +225,7 @@ impl PluginLoader {
         Ok(registered_count)
     }
 
-    fn load_plugin_dir(&mut self, dir: &Path) -> Result<usize> {
+    fn load_plugin_dir(&mut self, dir: &Path, runtime: &Runner) -> Result<usize> {
         let mut total_registered = 0;
 
         let entries = std::fs::read_dir(dir)
@@ -220,7 +236,7 @@ impl PluginLoader {
             let path = entry.path();
 
             if is_plugin_library(&path) {
-                match self.load_plugin(&path) {
+                match self.load_plugin(&path, runtime) {
                     Ok(count) => {
                         tracing::info!(
                             "Loaded plugin '{}': {} processor(s) registered",
@@ -298,22 +314,28 @@ async fn run(args: Args) -> Result<()> {
 
     tracing::info!("Starting runtime: {} ({})", runtime_name, runtime_id);
 
-    // Load plugins BEFORE creating runtime (registers processors in global registry)
+    // Construct the runtime FIRST so HostServices is constructable:
+    // tracing dispatch, PUBSUB, schema registry, and the iceoryx2
+    // node only exist post-`Runner::new()`. Plugins loaded below
+    // bridge their per-DSO statics through HostServices and so must
+    // see the host's wired instances.
+    let runtime = Runner::new()?;
+
+    // Load plugins (registers processors with the host's registry,
+    // bridges every per-DSO static into the host's instance).
     let mut loader = PluginLoader::new();
 
     for plugin_path in &args.plugins {
         println!("Loading plugin: {}", plugin_path.display());
-        let count = loader.load_plugin(plugin_path)?;
+        let count = loader.load_plugin(plugin_path, &runtime)?;
         println!("  Registered {} processor(s)", count);
     }
 
     if let Some(ref dir) = args.plugin_dir {
         println!("Loading plugins from: {}", dir.display());
-        let count = loader.load_plugin_dir(dir)?;
+        let count = loader.load_plugin_dir(dir, &runtime)?;
         println!("  Registered {} processor(s) total", count);
     }
-
-    let runtime = Runner::new()?;
 
     let log_path = runtime
         .jsonl_log_path()

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -86,6 +86,10 @@ pub mod sdk {
     pub use streamlib_engine::core::graph_file;
     pub use streamlib_engine::core::json_schema;
     pub use streamlib_engine::core::media_clock;
+    /// Plugin-loading host-services payload + cdylib install helper
+    /// — referenced from `streamlib_plugin_abi::export_plugin!`
+    /// macro expansion.
+    pub use streamlib_engine::core::plugin;
     pub use streamlib_engine::core::prelude;
     pub use streamlib_engine::core::pubsub;
     pub use streamlib_engine::core::rhi;


### PR DESCRIPTION
## Summary

Engine-tier fix for the cross-DSO static-state isolation defect that
broke observability and iceoryx2 data flow when a processor ran inside
a dlopen'd Rust cdylib loaded via `Runner::load_project` /
`Runner::load_package` / `streamlib-runtime --plugin`.

- Bumps `STREAMLIB_ABI_VERSION` 1 → 2 and reshapes the
  `STREAMLIB_PLUGIN.register` callback to take a `HostServices`
  payload (opaque-ptr-on-the-wire + typed struct in
  `streamlib::sdk::plugin::host_services`). Macro stays
  source-compatible at every `export_plugin!(MyProcessor::Processor)`
  invocation site — none of the 18 in-tree package `lib.rs` files
  or 2 example plugin `lib.rs` files needed edits.
- Bridges PUBSUB, schema registry, and iceoryx2-log to the host's
  instances at register time. PUBSUB cross-DSO is locked by a new
  integration test (cdylib `register::<P>()` publishes
  `RuntimeDidRegisterProcessorType`, host subscriber sees it).
- Drops `streamlib-plugin-abi`'s dep on `streamlib`, resolving the
  cyclic dep the engine used to dodge by redeclaring
  `PluginDeclaration` locally in `runtime.rs:38-51` — the
  redeclaration is gone.

## Closes

Closes #877

## Exit criteria

- [x] Plugin ABI v2: `PluginDeclaration` carries a `HostServices`
      shape with host references for tracing dispatch, PUBSUB,
      SCHEMA_REGISTRY, polyglot sink, iceoryx2 `Node` + statics.
- [x] Cdylib-side init wires the cdylib's duplicated globals to host
      instances at register time.
- [ ] One representative in-tree example migrates to `load_project`
      and drops its processor-package Cargo deps as the end-to-end
      proof point — **deferred to #881** (mechanical follow-up,
      separable from engine-tier bridging).
- [x] Workspace tests stay green; new test
      `load_project_dylib_pubsub_bridge.rs` exercises a dlopen'd
      processor's PUBSUB publish flowing back to a host subscriber
      end-to-end.

## Test plan

- [x] `cargo test --workspace --lib` — 626 passed, 0 failed in the
      streamlib-engine lib gate; full workspace green.
- [x] `cargo test -p streamlib-engine --test load_project_dylib_smoke`
      — pre-existing smoke test still green after the ABI bump.
- [x] `cargo test -p streamlib-engine --test load_project_dylib_pubsub_bridge`
      — new integration test asserts cdylib-emitted
      `RuntimeDidRegisterProcessorType` reaches a host PUBSUB
      subscriber.
- [ ] Tracing observability cross-DSO — **deferred to #880**.
      Empirically discovered during pickup that
      dispatch-passthrough doesn't flow events across DSO even
      with workspace-pinned `tracing-core`; canonical fix is the
      `tracing-ext-ffi-subscriber` callback-table shape (~150-300
      lines), out of scope here. The cdylib's `set_global_default`
      install is best-effort kept for future-compat; gap is
      documented in `host_services.rs` under "Known gap — tracing
      dispatch passthrough".

## Architectural notes

**`HostServices` layout discipline.** First two fields
(`abi_layout_version`, `_reserved_padding`) are pinned at offset 0
forever. `install_host_services` reads `abi_layout_version` before
dereferencing any other field, so the cdylib can refuse to load
cleanly when a host bumps the layout. Add new fields at the end and
bump `HOST_SERVICES_LAYOUT_VERSION`.

**Bridging shape.** Engine statics (`PUBSUB`, `SCHEMA_REGISTRY`)
now ride an `OnceLock<&'static T>` indirection layer:
- Host's DSO lazy-binds to its own `LOCAL_*` instance on first
  access.
- Plugin cdylibs call `install_host_*` from
  `install_host_services` to override the slot with the host's
  pointer.
- All read sites unchanged (still `PUBSUB.publish(...)`,
  `register_schema(...)`).

**iceoryx2-log.** New `IceoryxLogBridge` impls
`iceoryx2-log-types::Log` and forwards into `tracing::*!`. Host
installs at `Runner::new`; cdylib re-installs the same `&'static dyn
Log` pointer via `HostServices.iceoryx2_logger_ptr`.

**Ordering invariant.** `streamlib-runtime/main.rs` had to swap its
order — `Runner::new` now runs before `load_plugin` so
`HostServices` is constructable. A `debug_assert!` on
`tracing::dispatcher::has_been_set()` inside
`host_dispatch_for_self` surfaces the ordering violation loudly in
debug builds for any future loader that accidentally inverts it.

## Follow-ups filed

- #879 — chore(iceoryx2): patch `UniqueSystemId::COUNTER` to a
  process-shared counter for cross-DSO uniqueness (residual
  collision risk acknowledged in #877 AI Agent Notes).
- #880 — feat(plugin-abi): callback-table tracing-dispatch bridge
  for cross-DSO observability (the empirically-discovered tracing
  gap).
- #881 — feat(examples): migrate one example to `load_project` +
  drop processor-package Cargo deps (exit criterion 3
  proof-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)