### PR TITLE
feat(plugin-abi): pure callback-table ABI for cross-DSO bridges

### DIFF
--- a/libs/streamlib-engine/Cargo.toml
+++ b/libs/streamlib-engine/Cargo.toml
@@ -40,6 +40,13 @@ streamlib-idents = { path = "../streamlib-idents" }
 # Procedural macros
 streamlib-macros = { path = "../streamlib-macros" }
 
+# Plugin ABI wire-protocol header. Dep direction reversed in #877:
+# streamlib-plugin-abi no longer depends on streamlib (the SDK), so the
+# cyclic dep this dep used to dodge (engine → plugin-abi → sdk → engine)
+# is gone. The engine's dlopen loader uses `PluginDeclaration` and
+# `STREAMLIB_ABI_VERSION` from this crate directly.
+streamlib-plugin-abi = { path = "../streamlib-plugin-abi" }
+
 # Shared iceoryx2 payload types (for cross-process IPC)
 streamlib-ipc-types = { path = "../streamlib-ipc-types" }
 
@@ -62,6 +69,7 @@ inventory = "0.3"
 parking_lot = "0.12"  # Fast mutexes for all synchronization
 crossbeam-queue = "0.3"  # Lock-free MPMC queue for thread-safe mailboxes
 iceoryx2 = "0.8.1"  # Zero-copy IPC pub/sub for cross-process communication
+iceoryx2-log = "0.8.1"  # Bridge iceoryx2's internal log records into streamlib tracing
 rmp-serde = "1.3"  # MessagePack serialization for frame payloads
 signal-hook = "0.3"  # Native signal handling (SIGTERM, SIGINT) for event bus
 ctrlc = "3.4"  # Cross-platform Ctrl+C handler (works with GUI apps)

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -20,7 +20,8 @@
 
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::ffi::c_void;
+use std::sync::{Arc, LazyLock};
 
 #[cfg(test)]
 mod integration_tests;
@@ -28,47 +29,44 @@ mod integration_tests;
 /// Canonical-id → YAML-body store backing the runtime schema registry.
 pub type SchemaRegistryStorage = RwLock<HashMap<String, Arc<str>>>;
 
-/// Per-DSO schema registry. Each linked copy of streamlib-engine
-/// (host binary + every dlopen'd cdylib plugin) gets its own
-/// `LOCAL_SCHEMA_REGISTRY` because Rust mangled statics are not in the
-/// dynsym table. The host bridges every DSO to a single instance via
-/// [`ACTIVE_SCHEMA_REGISTRY`].
-static LOCAL_SCHEMA_REGISTRY: LazyLock<SchemaRegistryStorage> =
+/// Process-wide schema registry.
+///
+/// **Per-DSO instance.** Same shape as [`crate::core::pubsub::PUBSUB`]
+/// — each linked copy of streamlib-engine has its own
+/// `LazyLock<SchemaRegistryStorage>`. Cross-DSO bridging happens
+/// inside the public functions below: when this DSO is a plugin
+/// cdylib whose `install_host_services` has run,
+/// [`register_schema`] and [`get_embedded_schema_definition`] route
+/// through the host's `schema_register` / `schema_lookup` fn
+/// pointers; otherwise they read/write the local DSO's instance
+/// directly.
+static SCHEMA_REGISTRY: LazyLock<SchemaRegistryStorage> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-
-/// Active schema registry for this DSO. First read lazy-binds to
-/// [`LOCAL_SCHEMA_REGISTRY`]; plugin cdylibs override via
-/// [`install_host_schema_registry`] from their `STREAMLIB_PLUGIN`
-/// register callback so `register_schema` + `get_embedded_schema_definition`
-/// in cdylib code reach the host's instance.
-static ACTIVE_SCHEMA_REGISTRY: OnceLock<&'static SchemaRegistryStorage> = OnceLock::new();
-
-fn active_schema_registry() -> &'static SchemaRegistryStorage {
-    *ACTIVE_SCHEMA_REGISTRY.get_or_init(|| &LOCAL_SCHEMA_REGISTRY)
-}
-
-/// Install a host-owned schema-registry reference into this DSO's
-/// [`ACTIVE_SCHEMA_REGISTRY`] slot. Called by
-/// `streamlib::sdk::plugin::install_host_services` from a plugin
-/// cdylib's register callback. Idempotent at the type-system level
-/// (OnceLock); a later call is a no-op so emit once at register time
-/// before any schema-registry touch.
-pub fn install_host_schema_registry(host: &'static SchemaRegistryStorage) {
-    let _ = ACTIVE_SCHEMA_REGISTRY.set(host);
-}
-
-/// This DSO's local schema-registry instance. The host hands the
-/// pointer to plugin cdylibs through `HostServices.schema_registry`.
-pub fn local_schema_registry() -> &'static SchemaRegistryStorage {
-    &LOCAL_SCHEMA_REGISTRY
-}
 
 /// Register a schema's YAML body under its canonical identifier. Last
 /// write wins. Idempotent for identical bodies.
+///
+/// In a plugin cdylib whose `install_host_services` has run, forwards
+/// to the host's `schema_register` callback so registrations from
+/// cdylib code land in the host's registry (where every consumer
+/// reads).
 pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>>) {
     let canonical = canonical_id.into();
     let body = body.into();
-    let mut guard = active_schema_registry().write();
+    if let Some(cbs) = crate::core::plugin::host_services::host_callbacks() {
+        let yaml: &str = &body;
+        unsafe {
+            (cbs.schema_register)(
+                cbs.host,
+                canonical.as_ptr(),
+                canonical.len(),
+                yaml.as_ptr(),
+                yaml.len(),
+            );
+        }
+        return;
+    }
+    let mut guard = SCHEMA_REGISTRY.write();
     guard.insert(canonical, body);
 }
 
@@ -77,9 +75,43 @@ pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>
 /// Accepts both unversioned (`@tatolab/core/VideoFrame`) and versioned
 /// (`@tatolab/core/VideoFrame@1.0.0`) forms; the version suffix is
 /// stripped before lookup.
+///
+/// In a plugin cdylib whose `install_host_services` has run, routes
+/// through the host's `schema_lookup` callback — the host invokes a
+/// cdylib-provided result callback with the yaml bytes (or null on
+/// miss). The bytes are copied into an owned `Arc<str>` before the
+/// host's call returns; the borrow doesn't outlive the call.
 pub fn get_embedded_schema_definition(name: &str) -> Option<Arc<str>> {
     let canonical = strip_semver_suffix(name);
-    active_schema_registry().read().get(canonical).cloned()
+    if let Some(cbs) = crate::core::plugin::host_services::host_callbacks() {
+        let mut captured: Option<Arc<str>> = None;
+        extern "C" fn capture(userdata: *mut c_void, yaml_ptr: *const u8, yaml_len: usize) {
+            if yaml_ptr.is_null() || yaml_len == 0 {
+                return;
+            }
+            // SAFETY: caller (host) guarantees the bytes are valid
+            // UTF-8 for the duration of this call. We copy into an
+            // owned String before returning, so the borrow doesn't
+            // outlive the call.
+            let bytes = unsafe { std::slice::from_raw_parts(yaml_ptr, yaml_len) };
+            let s: Arc<str> = std::str::from_utf8(bytes)
+                .map(Into::into)
+                .unwrap_or_else(|_| Arc::<str>::from(""));
+            let target = unsafe { &mut *(userdata as *mut Option<Arc<str>>) };
+            *target = Some(s);
+        }
+        unsafe {
+            (cbs.schema_lookup)(
+                cbs.host,
+                canonical.as_ptr(),
+                canonical.len(),
+                capture,
+                &mut captured as *mut _ as *mut c_void,
+            );
+        }
+        return captured;
+    }
+    SCHEMA_REGISTRY.read().get(canonical).cloned()
 }
 
 /// Resolve `max_payload_bytes` from a structured port-schema spec.
@@ -134,7 +166,7 @@ pub fn max_queued_messages_for_port_spec(
 /// Sorted alphabetically so consumers (api-server) get diff-stable
 /// output across processes.
 pub fn list_embedded_schema_names() -> Vec<String> {
-    let mut names: Vec<String> = active_schema_registry().read().keys().cloned().collect();
+    let mut names: Vec<String> = SCHEMA_REGISTRY.read().keys().cloned().collect();
     names.sort();
     names
 }

--- a/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/libs/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -20,23 +20,55 @@
 
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 #[cfg(test)]
 mod integration_tests;
 
-/// Runtime schema registry. Populated by [`register_schema`] (called
-/// from `Runner::load_project` for each loaded package's `schemas:`
-/// entries). Empty until something registers.
-static SCHEMA_REGISTRY: LazyLock<RwLock<HashMap<String, Arc<str>>>> =
+/// Canonical-id → YAML-body store backing the runtime schema registry.
+pub type SchemaRegistryStorage = RwLock<HashMap<String, Arc<str>>>;
+
+/// Per-DSO schema registry. Each linked copy of streamlib-engine
+/// (host binary + every dlopen'd cdylib plugin) gets its own
+/// `LOCAL_SCHEMA_REGISTRY` because Rust mangled statics are not in the
+/// dynsym table. The host bridges every DSO to a single instance via
+/// [`ACTIVE_SCHEMA_REGISTRY`].
+static LOCAL_SCHEMA_REGISTRY: LazyLock<SchemaRegistryStorage> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Active schema registry for this DSO. First read lazy-binds to
+/// [`LOCAL_SCHEMA_REGISTRY`]; plugin cdylibs override via
+/// [`install_host_schema_registry`] from their `STREAMLIB_PLUGIN`
+/// register callback so `register_schema` + `get_embedded_schema_definition`
+/// in cdylib code reach the host's instance.
+static ACTIVE_SCHEMA_REGISTRY: OnceLock<&'static SchemaRegistryStorage> = OnceLock::new();
+
+fn active_schema_registry() -> &'static SchemaRegistryStorage {
+    *ACTIVE_SCHEMA_REGISTRY.get_or_init(|| &LOCAL_SCHEMA_REGISTRY)
+}
+
+/// Install a host-owned schema-registry reference into this DSO's
+/// [`ACTIVE_SCHEMA_REGISTRY`] slot. Called by
+/// `streamlib::sdk::plugin::install_host_services` from a plugin
+/// cdylib's register callback. Idempotent at the type-system level
+/// (OnceLock); a later call is a no-op so emit once at register time
+/// before any schema-registry touch.
+pub fn install_host_schema_registry(host: &'static SchemaRegistryStorage) {
+    let _ = ACTIVE_SCHEMA_REGISTRY.set(host);
+}
+
+/// This DSO's local schema-registry instance. The host hands the
+/// pointer to plugin cdylibs through `HostServices.schema_registry`.
+pub fn local_schema_registry() -> &'static SchemaRegistryStorage {
+    &LOCAL_SCHEMA_REGISTRY
+}
 
 /// Register a schema's YAML body under its canonical identifier. Last
 /// write wins. Idempotent for identical bodies.
 pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>>) {
     let canonical = canonical_id.into();
     let body = body.into();
-    let mut guard = SCHEMA_REGISTRY.write();
+    let mut guard = active_schema_registry().write();
     guard.insert(canonical, body);
 }
 
@@ -47,7 +79,7 @@ pub fn register_schema(canonical_id: impl Into<String>, body: impl Into<Arc<str>
 /// stripped before lookup.
 pub fn get_embedded_schema_definition(name: &str) -> Option<Arc<str>> {
     let canonical = strip_semver_suffix(name);
-    SCHEMA_REGISTRY.read().get(canonical).cloned()
+    active_schema_registry().read().get(canonical).cloned()
 }
 
 /// Resolve `max_payload_bytes` from a structured port-schema spec.
@@ -102,7 +134,7 @@ pub fn max_queued_messages_for_port_spec(
 /// Sorted alphabetically so consumers (api-server) get diff-stable
 /// output across processes.
 pub fn list_embedded_schema_names() -> Vec<String> {
-    let mut names: Vec<String> = SCHEMA_REGISTRY.read().keys().cloned().collect();
+    let mut names: Vec<String> = active_schema_registry().read().keys().cloned().collect();
     names.sort();
     names
 }

--- a/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
+++ b/libs/streamlib-engine/src/core/logging/iceoryx2_log_bridge.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Bridge iceoryx2-log records into the streamlib tracing pipeline.
+//!
+//! `iceoryx2` exposes its own logging trait via `iceoryx2-log`'s
+//! [`Log`] interface plus a one-shot global `set_logger` that takes a
+//! `&'static dyn Log`. Without a bridge, iceoryx2's internal log
+//! records go to its default stderr logger and bypass the streamlib
+//! JSONL pipeline entirely. With this bridge:
+//!
+//! - Host-side: `Runner::new` calls `install_iceoryx2_log_bridge()`
+//!   once on first construction, installing [`HOST_BRIDGE`] as
+//!   `iceoryx2`'s process-wide logger.
+//! - Plugin cdylib-side: the cdylib's `STREAMLIB_PLUGIN` register
+//!   callback receives the host's `&'static dyn Log` pointer via
+//!   [`crate::core::plugin::HostServices::iceoryx2_logger`] and
+//!   installs it in the cdylib's `iceoryx2-log` static. Each DSO has
+//!   its own `iceoryx2-log` static; both end up pointing at the same
+//!   bridge value living in host memory.
+//!
+//! Cross-DSO safety: both DSOs link the same `iceoryx2-log-types`
+//! version (workspace pin), so the `&'static dyn Log` fat pointer's
+//! vtable is layout-compatible on both sides. Logging through the
+//! pointer dispatches through the host's vtable, which calls back
+//! into the host's tracing pipeline.
+
+use iceoryx2_log::Log;
+use iceoryx2_log::LogLevel;
+
+/// Zero-sized bridge implementing iceoryx2's [`Log`] trait by
+/// forwarding records into the streamlib tracing pipeline.
+pub struct IceoryxLogBridge;
+
+impl Log for IceoryxLogBridge {
+    fn log(
+        &self,
+        log_level: LogLevel,
+        origin: core::fmt::Arguments,
+        formatted_message: core::fmt::Arguments,
+    ) {
+        // `tracing::*!` macros take compile-time log levels; dispatch
+        // through a match so iceoryx2's runtime LogLevel maps to the
+        // matching tracing level. `Fatal` collapses to `Error` —
+        // tracing has no separate fatal level and iceoryx2 emits
+        // `Fatal` for genuinely-process-ending conditions that
+        // iceoryx2 itself will abort on shortly after.
+        match log_level {
+            LogLevel::Trace => {
+                tracing::trace!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Debug => {
+                tracing::debug!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Info => {
+                tracing::info!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Warn => {
+                tracing::warn!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+            LogLevel::Error | LogLevel::Fatal => {
+                tracing::error!(target: "iceoryx2", origin = %origin, "{}", formatted_message)
+            }
+        }
+    }
+}
+
+/// Process-wide bridge value. Lives in `.rodata` (zero-sized) per
+/// DSO; the host's copy is the one shared with plugin cdylibs via
+/// [`crate::core::plugin::HostServices::iceoryx2_logger`]. Both
+/// host's and cdylib's copies impl `Log` against the same workspace-
+/// pinned `iceoryx2-log-types::Log` vtable.
+pub static HOST_BRIDGE: IceoryxLogBridge = IceoryxLogBridge;
+
+/// Install [`HOST_BRIDGE`] as this DSO's iceoryx2 process-wide
+/// logger. Idempotent — `iceoryx2_log::set_logger` is `Once`-guarded
+/// and returns false on subsequent calls, which we treat as success.
+pub fn install_iceoryx2_log_bridge_for_self() {
+    let _ = iceoryx2_log::set_logger(&HOST_BRIDGE);
+}
+
+/// Install a foreign `&'static dyn Log` into this DSO's iceoryx2
+/// process-wide logger. Used by plugin cdylibs receiving the host's
+/// bridge pointer through `HostServices`.
+///
+/// # Safety
+///
+/// `logger` must remain valid for the lifetime of this DSO. The
+/// host's [`HOST_BRIDGE`] is `'static` by construction, so passing
+/// `&HOST_BRIDGE` from the host satisfies this.
+pub unsafe fn install_foreign_iceoryx2_logger(logger: &'static dyn Log) {
+    let _ = iceoryx2_log::set_logger(logger);
+}

--- a/libs/streamlib-engine/src/core/logging/mod.rs
+++ b/libs/streamlib-engine/src/core/logging/mod.rs
@@ -17,6 +17,7 @@ pub use worker::format_event_pretty;
 
 mod config;
 mod event;
+pub(crate) mod iceoryx2_log_bridge;
 mod init;
 mod layer;
 mod paths;

--- a/libs/streamlib-engine/src/core/logging/mod.rs
+++ b/libs/streamlib-engine/src/core/logging/mod.rs
@@ -13,6 +13,7 @@ pub use init::{init, init_for_tests, StreamlibLoggingGuard};
 pub use paths::{log_dir, runtime_log_path};
 pub(crate) use polyglot_sink::push_polyglot_record;
 pub(crate) use record::LogRecord;
+pub(crate) use worker::now_ns;
 pub use worker::format_event_pretty;
 
 mod config;

--- a/libs/streamlib-engine/src/core/mod.rs
+++ b/libs/streamlib-engine/src/core/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod config;
 pub(crate) mod embedded_schemas;
 pub(crate) mod logging;
 pub(crate) mod observability;
+pub mod plugin;
 pub(crate) mod runtime_hooks;
 pub(crate) mod signals;
 pub(crate) mod streamlib_home;

--- a/libs/streamlib-engine/src/core/plugin/forwarding_subscriber.rs
+++ b/libs/streamlib-engine/src/core/plugin/forwarding_subscriber.rs
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-side `tracing::Subscriber` that forwards every event to
+//! the host via [`HostCallbacks::tracing_emit`].
+//!
+//! Loosely mirrors the `tracing-ext-ffi-subscriber` pattern: rather
+//! than passing the host's `Dispatch` across the FFI (which doesn't
+//! reach the host's subscriber chain cross-DSO — empirically
+//! verified during #877's pickup), the cdylib installs a thin
+//! `Subscriber` impl whose `event` method serializes the event's
+//! target / level / message / fields into primitive payloads and
+//! calls the host's `tracing_emit` fn pointer. The host's installed
+//! subscriber chain (Layered<EnvFilter, JsonlSinkLayer, Registry>)
+//! sees the event as a normal in-process emit and filters / records
+//! / fan-outs accordingly.
+//!
+//! Spans are out of scope today — the cdylib's
+//! `Subscriber::new_span` returns a fixed dummy id and the span
+//! lifecycle hooks are no-ops. If a plugin needs span context the
+//! host can see, the ABI grows a `span_*` callback family in a
+//! future layout-version bump.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tracing::field::{Field, Visit};
+use tracing::span;
+use tracing::{Event, Metadata, Subscriber};
+
+use super::host_services::{
+    host_callbacks, host_interest_to_tracing, tracing_level_to_host,
+};
+
+/// Forwarding subscriber installed in cdylib-linked DSOs at
+/// `install_host_services` time.
+pub struct ForwardingSubscriber {
+    /// Monotonic span-id source. Spans aren't bridged today; the id
+    /// just needs to be non-zero per tracing-core's contract.
+    next_span_id: AtomicU64,
+}
+
+impl ForwardingSubscriber {
+    fn new() -> Self {
+        Self {
+            next_span_id: AtomicU64::new(1),
+        }
+    }
+}
+
+impl Subscriber for ForwardingSubscriber {
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> tracing::subscriber::Interest {
+        let Some(cbs) = host_callbacks() else {
+            return tracing::subscriber::Interest::never();
+        };
+        let target = metadata.target();
+        let level = tracing_level_to_host(*metadata.level());
+        let host_interest = unsafe {
+            (cbs.tracing_register_callsite)(cbs.host, target.as_ptr(), target.len(), level)
+        };
+        host_interest_to_tracing(host_interest)
+    }
+
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        let Some(cbs) = host_callbacks() else {
+            return false;
+        };
+        let target = metadata.target();
+        let level = tracing_level_to_host(*metadata.level());
+        unsafe { (cbs.tracing_enabled)(cbs.host, target.as_ptr(), target.len(), level) }
+    }
+
+    fn new_span(&self, _attrs: &span::Attributes<'_>) -> span::Id {
+        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
+        // span::Id requires nonzero u64.
+        span::Id::from_u64(if id == 0 { 1 } else { id })
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let Some(cbs) = host_callbacks() else { return };
+        let metadata = event.metadata();
+        let target = metadata.target();
+        let level = tracing_level_to_host(*metadata.level());
+
+        // Walk the event's value set: pull `message` out as the
+        // primary string payload; everything else folds into a
+        // BTreeMap that we msgpack-encode and ship in the same call.
+        let mut visitor = ForwardingVisitor::default();
+        event.record(&mut visitor);
+
+        let message = visitor.message.unwrap_or_default();
+        let fields_bytes = if visitor.fields.is_empty() {
+            Vec::new()
+        } else {
+            rmp_serde::to_vec_named(&visitor.fields).unwrap_or_default()
+        };
+
+        unsafe {
+            (cbs.tracing_emit)(
+                cbs.host,
+                target.as_ptr(),
+                target.len(),
+                level,
+                message.as_ptr(),
+                message.len(),
+                fields_bytes.as_ptr(),
+                fields_bytes.len(),
+            );
+        }
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+    fn exit(&self, _span: &span::Id) {}
+}
+
+#[derive(Default)]
+struct ForwardingVisitor {
+    message: Option<String>,
+    fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl Visit for ForwardingVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        let name = field.name();
+        if name == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.fields
+                .insert(name.to_string(), serde_json::Value::String(value.to_string()));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), serde_json::Value::Number(value.into()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), serde_json::Value::Number(value.into()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), serde_json::Value::Bool(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        let n = serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null);
+        self.fields.insert(field.name().to_string(), n);
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{:?}", value);
+        let stripped = strip_debug_quotes(rendered);
+        let name = field.name();
+        if name == "message" {
+            self.message = Some(stripped);
+        } else {
+            self.fields
+                .insert(name.to_string(), serde_json::Value::String(stripped));
+        }
+    }
+}
+
+fn strip_debug_quotes(s: String) -> String {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        s.get(1..s.len() - 1).unwrap_or(&s).to_string()
+    } else {
+        s
+    }
+}
+
+/// Install the forwarding subscriber as this DSO's global tracing
+/// dispatcher. Called by `install_host_services` after the callback
+/// table is cached. The cdylib's `set_global_default` succeeds on
+/// first call; subsequent calls are silent no-ops.
+pub fn install_for_self() {
+    let subscriber = ForwardingSubscriber::new();
+    let _ = tracing::dispatcher::set_global_default(tracing::Dispatch::new(subscriber));
+}

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-services payload carried by the `STREAMLIB_PLUGIN` register
+//! callback.
+//!
+//! When the host's `Runner::load_project` (or `streamlib-runtime`'s
+//! standalone plugin loader) `dlopen`s a Rust plugin cdylib and
+//! invokes its `STREAMLIB_PLUGIN.register(host_services)` callback,
+//! `host_services` points at a [`HostServices`] payload owned by the
+//! host. The cdylib's macro expansion forwards the pointer into
+//! [`install_host_services`], which:
+//!
+//! 1. Validates the wire layout (`abi_layout_version`) before any
+//!    other field is touched. On mismatch the helper logs and returns
+//!    `None` — the host's post-call "processor not registered" check
+//!    then surfaces an actionable error.
+//! 2. Bridges every process-wide static the cdylib statically embeds
+//!    a per-DSO copy of (tracing dispatch, [`PUBSUB`], schema
+//!    registry, iceoryx2-log logger) into the host's instances.
+//! 3. Returns the host's `&'static ProcessorInstanceFactory` so the
+//!    macro can register the plugin's processor types into it.
+//!
+//! ## Why this lives in streamlib-engine, not streamlib-plugin-abi
+//!
+//! `streamlib-plugin-abi` is the bare wire-protocol header
+//! (`PluginDeclaration`, `STREAMLIB_ABI_VERSION`, the macro). It
+//! intentionally carries no streamlib deps so it doesn't pull the
+//! whole engine into every dependent crate's graph (and so the
+//! pre-#877 cyclic `engine → plugin-abi → sdk → engine` workaround
+//! is gone). The typed host-services payload lives here because all
+//! its field types (`ProcessorInstanceFactory`, `PubSub`,
+//! `Iceoryx2Node`, `tracing::Dispatch`, etc.) are engine types.
+//!
+//! The cdylib reaches this module via
+//! `streamlib::sdk::plugin::install_host_services` — the SDK
+//! re-exports it under that path. Plugin-abi's macro hard-codes that
+//! path in its expansion.
+//!
+//! ## Cross-DSO safety
+//!
+//! Every field of [`HostServices`] is a raw pointer or a value type
+//! whose layout the dynamic linker does not dedupe across DSOs. The
+//! safety contract for casting a `*const c_void` back to a typed
+//! reference is that **both the host and cdylib link the same
+//! version of every relevant crate** (workspace dep pins). The
+//! milestone-level commitment is "rustc-version coupling stays";
+//! this module rides that commitment for `streamlib-engine`,
+//! `iceoryx2`, and `iceoryx2-log-types`.
+//!
+//! ## Known gap — tracing dispatch passthrough
+//!
+//! `set_global_default` succeeds in the cdylib and installs the
+//! host's `Dispatch` as the cdylib's global. Empirically, events
+//! emitted from cdylib code via `tracing::*!()` still do not reach
+//! the host's `Subscriber::event` impl — they are absorbed
+//! somewhere between the cdylib's `Dispatch::event` and the host's
+//! `Layered<EnvFilter, ...>` Subscriber even with both DSOs on the
+//! same workspace-pinned `tracing-core 0.1.36`. Cross-DSO Callsite
+//! identity, vtable layout, or Registry span-stack semantics are
+//! the prime suspects.
+//!
+//! Cross-DSO tracing-dispatch passthrough is a known-not-viable
+//! pattern in the broader Rust ecosystem. The canonical fix is a
+//! callback-table shape — host exports `extern "C"` callbacks for
+//! `emit` / `enabled` / `enter` / `exit`, cdylib installs a thin
+//! local Subscriber that forwards through them. `tracing-ext-ffi-subscriber`
+//! is the reference implementation cited in #877's issue body.
+//!
+//! This module ships the partial bridge today (PUBSUB + schema
+//! registry + iceoryx2-log work end-to-end; tracing dispatch
+//! installs but events don't flow). The callback-table tracing
+//! bridge is a follow-up. Until it lands, cdylib code that wants
+//! observability should rely on PUBSUB events for its host-visible
+//! signals.
+
+use std::ffi::c_void;
+
+use tracing::Dispatch;
+
+use crate::core::embedded_schemas::SchemaRegistryStorage;
+use crate::core::logging::iceoryx2_log_bridge;
+use crate::core::processors::ProcessorInstanceFactory;
+use crate::core::pubsub::PubSub;
+
+/// Wire layout version. Bump on any change to [`HostServices`]'s
+/// field ordering or contents (including non-`#[repr(C)]` value-type
+/// fields whose Rust layout may shift across compiler versions —
+/// `tracing::Dispatch` is the canonical example).
+///
+/// Read first by [`install_host_services`] before any other field
+/// is touched. On mismatch the helper bails out without dereferencing
+/// the rest of the struct, so it's safe even if the cdylib was built
+/// against an older `HostServices` layout.
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 1;
+
+/// Payload the host passes through the `STREAMLIB_PLUGIN` register
+/// callback. The cdylib's macro expansion casts the `*const c_void`
+/// parameter to `*const HostServices` and reads the fields below.
+///
+/// Field ordering is **stable** within a layout-version bucket — the
+/// first two fields (`abi_layout_version`, `fatal_log`) are pinned
+/// at offset 0 forever so [`install_host_services`] can read them
+/// even when the rest of the struct's layout has drifted. New
+/// fields go at the end and bump [`HOST_SERVICES_LAYOUT_VERSION`].
+///
+/// Field semantics:
+///
+/// * `abi_layout_version` — must equal [`HOST_SERVICES_LAYOUT_VERSION`].
+/// * `processor_registry` — host's `&'static ProcessorInstanceFactory`
+///   (`PROCESSOR_REGISTRY`). The cdylib registers into this rather
+///   than its own per-DSO `LazyLock<ProcessorInstanceFactory>`.
+/// * `pubsub` — host's `&'static PubSub`
+///   (`crate::core::pubsub::bus::local_pubsub()` value). The cdylib's
+///   `crate::core::pubsub::bus::install_host_pubsub` installs it so
+///   `PUBSUB.publish(...)` in cdylib code reaches the host's bus.
+/// * `schema_registry` — host's `&'static
+///   SchemaRegistryStorage`. Same shape as PUBSUB bridging:
+///   `crate::core::embedded_schemas::install_host_schema_registry`
+///   wires the cdylib's `register_schema` /
+///   `get_embedded_schema_definition` through to the host's storage.
+/// * `tracing_dispatch_ptr` — pointer to a `Dispatch` value the host
+///   keeps alive (`Box::leak`-ed at first plugin load — see
+///   [`runtime_facing::host_dispatch_for_self`]). The cdylib clones
+///   it via `(&*ptr).clone()` and calls
+///   `tracing::dispatcher::set_global_default(...)` against its own
+///   `tracing-core` static. After this, `tracing::info!` in cdylib
+///   code flows into the host's subscriber.
+/// * `iceoryx2_logger_ptr` — pointer to a `&'static dyn Log`
+///   trait-object value living in host memory (specifically a
+///   reference to [`HOST_BRIDGE`], boxed-and-leaked once). The
+///   cdylib installs it via
+///   `crate::core::logging::iceoryx2_log_bridge::install_foreign_iceoryx2_logger`
+///   so iceoryx2's internal log records in cdylib code reach the
+///   host's tracing pipeline. May be null if the host hasn't wired
+///   one (today: never null — `Runner::new` always installs the
+///   bridge before any plugin load).
+/// * `iceoryx2_node_ptr` — pointer to the host's `Iceoryx2Node`.
+///   Reserved for future cdylib code that needs to create iceoryx2
+///   services in its own DSO using the host's node identity; today
+///   no cdylib code uses this, but it's the right shape and rounds
+///   out the FFI surface so future consumers don't redo this design.
+#[repr(C)]
+pub struct HostServices {
+    /// Wire layout version. See [`HOST_SERVICES_LAYOUT_VERSION`].
+    pub abi_layout_version: u32,
+
+    /// Padding to keep the following pointer fields naturally
+    /// aligned across 32/64-bit hosts (not relevant on streamlib's
+    /// 64-bit targets today; explicit for clarity).
+    pub _reserved_padding: u32,
+
+    /// Host's process-instance factory (`PROCESSOR_REGISTRY`).
+    pub processor_registry: *const c_void,
+
+    /// Host's `&'static PubSub` (`local_pubsub` value).
+    pub pubsub: *const c_void,
+
+    /// Host's `&'static SchemaRegistryStorage` (`local_schema_registry`
+    /// value).
+    pub schema_registry: *const c_void,
+
+    /// Pointer to a `Dispatch` value the host keeps alive on the
+    /// heap (see [`runtime_facing::host_dispatch_for_self`]).
+    pub tracing_dispatch_ptr: *const c_void,
+
+    /// Pointer to a `&'static dyn iceoryx2_log::Log` value the host
+    /// keeps alive (see [`runtime_facing::host_iceoryx2_logger_for_self`]).
+    /// May be null.
+    pub iceoryx2_logger_ptr: *const c_void,
+
+    /// Pointer to the host's `Iceoryx2Node` value, kept alive on the
+    /// heap (see [`runtime_facing::host_iceoryx2_node_for_self`]).
+    /// Reserved for future cdylib consumers; safe to ignore.
+    pub iceoryx2_node_ptr: *const c_void,
+}
+
+// Safety: every field is a raw pointer or a primitive. The host
+// guarantees the pointed-at values outlive the cdylib's process
+// lifetime via the `LOADED_PLUGIN_LIBRARIES` pinning shape.
+unsafe impl Send for HostServices {}
+unsafe impl Sync for HostServices {}
+
+/// Bridge every process-wide static this DSO embeds a per-DSO copy
+/// of to the host's instances. Called from a plugin cdylib's
+/// `STREAMLIB_PLUGIN` register callback via the
+/// [`streamlib_plugin_abi::export_plugin`] macro expansion.
+///
+/// # Returns
+///
+/// `Some(&'static ProcessorInstanceFactory)` on success — the host's
+/// registry the cdylib registers into. `None` on layout-version
+/// mismatch (the cdylib was built against a stale `HostServices`
+/// layout). The macro short-circuits processor registration on
+/// `None`, and the host's post-call "processor not registered"
+/// check surfaces a `Configuration` error.
+///
+/// # Safety
+///
+/// `host_services_ptr` must point at a [`HostServices`] value
+/// initialized by the host. The host's loader guarantees this.
+pub unsafe fn install_host_services(
+    host_services_ptr: *const c_void,
+) -> Option<&'static ProcessorInstanceFactory> {
+    if host_services_ptr.is_null() {
+        return None;
+    }
+
+    // SAFETY: per the caller's promise. Read `abi_layout_version`
+    // before touching any other field — if the layout doesn't match,
+    // the rest of the struct may have a different shape on the wire.
+    let services = unsafe { &*(host_services_ptr as *const HostServices) };
+
+    if services.abi_layout_version != HOST_SERVICES_LAYOUT_VERSION {
+        // Logging may not be wired yet — emit through tracing
+        // (which is silent if this DSO's dispatch hasn't been
+        // installed) AND via the host's stderr as a backstop. The
+        // host's loader will surface the failure via the post-call
+        // "processor not registered" check.
+        //
+        // We deliberately do NOT write to stderr directly here
+        // (banned by streamlib's logging discipline). The host can
+        // tell something went wrong because no processors registered.
+        tracing::error!(
+            target: "streamlib::plugin",
+            host_layout = HOST_SERVICES_LAYOUT_VERSION,
+            cdylib_layout = services.abi_layout_version,
+            "Plugin HostServices layout mismatch; aborting register"
+        );
+        return None;
+    }
+
+    // SAFETY: pointers were constructed by the host from `&'static`
+    // references to its own statics. Both DSOs link the same
+    // streamlib-engine version per the milestone-level rustc-version
+    // coupling commitment, so the layouts match.
+    let processor_registry =
+        unsafe { &*(services.processor_registry as *const ProcessorInstanceFactory) };
+    let pubsub = unsafe { &*(services.pubsub as *const PubSub) };
+    let schema_registry =
+        unsafe { &*(services.schema_registry as *const SchemaRegistryStorage) };
+
+    // Best-effort tracing-dispatch bridge.
+    //
+    // `set_global_default` here transitions the cdylib's per-DSO
+    // `tracing-core::GLOBAL_INIT` to `INITIALIZED` with a Dispatch
+    // whose `Kind::Global` subscriber pointer is the host's. The
+    // call returns `Ok` in production. Empirically, however, events
+    // emitted from cdylib code via `tracing::*!()` do NOT reach the
+    // host's `Subscriber::event` impl through this path — events
+    // are silently absorbed somewhere between the cdylib's
+    // `Dispatch::event` and the host's `Layered<EnvFilter, ...>`
+    // Subscriber, even though both DSOs link the same workspace-
+    // pinned `tracing-core 0.1.36` version. The exact cause is
+    // unclear; cross-DSO Callsite identity, vtable, or Registry
+    // span-stack semantics are the prime suspects.
+    //
+    // Cross-DSO tracing-dispatch passthrough is a known-not-viable
+    // pattern in the broader Rust ecosystem — the canonical fix is
+    // a callback-table shape (see `tracing-ext-ffi-subscriber`,
+    // cited in #877's issue body) where the host exports
+    // `extern "C"` callbacks for emit/enabled/enter/exit and the
+    // cdylib installs a thin local Subscriber that forwards through
+    // them. That work is tracked as a follow-up to #877; see the
+    // gap section in this module's docs.
+    //
+    // We still call `set_global_default` here so the cdylib's
+    // `GLOBAL_DISPATCH` isn't the no-op default — that lets
+    // `tracing::*!()` macros short-circuit fast and avoids any
+    // tracing-subscriber lazy-init costs on the cdylib's hot path.
+    if !services.tracing_dispatch_ptr.is_null() {
+        let host_dispatch = unsafe { &*(services.tracing_dispatch_ptr as *const Dispatch) };
+        let _ = tracing::dispatcher::set_global_default(host_dispatch.clone());
+    }
+
+    // Bridge PUBSUB + schema registry. Order doesn't matter — both
+    // are `OnceLock<&'static T>` writes.
+    crate::core::pubsub::install_host_pubsub(pubsub);
+    crate::core::embedded_schemas::install_host_schema_registry(schema_registry);
+
+    // Bridge iceoryx2-log if the host installed one. The host
+    // currently always installs `HOST_BRIDGE` at `Runner::new`, so
+    // the null branch is unreachable in production — kept for
+    // forward-compat with embedded contexts that may not.
+    if !services.iceoryx2_logger_ptr.is_null() {
+        // The host stores `&'static dyn Log` (a fat pointer) at the
+        // heap location pointed to by `iceoryx2_logger_ptr`. Read
+        // and forward to this DSO's `iceoryx2-log`.
+        let logger_ref =
+            unsafe { *(services.iceoryx2_logger_ptr as *const &'static dyn iceoryx2_log::Log) };
+        unsafe { iceoryx2_log_bridge::install_foreign_iceoryx2_logger(logger_ref) };
+    }
+
+    // `iceoryx2_node_ptr` is reserved — no in-tree consumer reads
+    // it yet. The cdylib leaves it as null-or-set; future code that
+    // wants the host's Iceoryx2Node can clone via
+    // `Arc<Mutex<Node>>` semantics (Iceoryx2Node is `Clone`).
+
+    Some(processor_registry)
+}
+
+// =============================================================================
+// Host-facing helpers for building a HostServices payload.
+// =============================================================================
+
+/// Host-facing helpers — used by `Runner::load_project` and
+/// `streamlib-runtime`'s plugin loader to build a [`HostServices`]
+/// payload from the host's own statics.
+pub mod runtime_facing {
+    use super::{HostServices, HOST_SERVICES_LAYOUT_VERSION};
+    use std::ffi::c_void;
+    use std::sync::OnceLock;
+
+    use tracing::Dispatch;
+
+    /// Heap-allocated `Dispatch` clone the host keeps alive so the
+    /// pointer handed to plugin cdylibs stays valid. Lazy-built on
+    /// first call; subsequent calls reuse the same boxed value.
+    ///
+    /// Uses `Box::leak` — the leak lasts the process lifetime, which
+    /// matches `LOADED_PLUGIN_LIBRARIES`'s pinning lifetime for
+    /// loaded cdylibs.
+    static HOST_TRACING_DISPATCH: OnceLock<&'static Dispatch> = OnceLock::new();
+
+    /// Heap-allocated `&'static dyn Log` trait-object pointer the
+    /// host hands to plugin cdylibs. Boxed-and-leaked once for the
+    /// same lifetime reason.
+    type StaticLogRef = &'static dyn iceoryx2_log::Log;
+    static HOST_ICEORYX2_LOGGER: OnceLock<&'static StaticLogRef> = OnceLock::new();
+
+    /// Heap-allocated `Iceoryx2Node` clone the host keeps alive for
+    /// the same reason. Boxed once and reused.
+    static HOST_ICEORYX2_NODE: OnceLock<&'static crate::iceoryx2::Iceoryx2Node> = OnceLock::new();
+
+    /// Return a `&'static Dispatch` pointing at a clone of
+    /// tracing-core's current `GLOBAL_DISPATCH`. Captured on first
+    /// call so plugins loaded later still see the dispatch active
+    /// at the time `Runner::new` wired tracing.
+    fn host_dispatch_for_self() -> &'static Dispatch {
+        HOST_TRACING_DISPATCH.get_or_init(|| {
+            // Capture the current global dispatcher by cloning the
+            // value passed through `tracing::dispatcher::get_default`.
+            let dispatch = tracing::dispatcher::get_default(|d| d.clone());
+            Box::leak(Box::new(dispatch))
+        })
+    }
+
+    /// Return a `&'static StaticLogRef` pointing at the host's
+    /// iceoryx2 logger bridge.
+    fn host_iceoryx2_logger_for_self() -> &'static StaticLogRef {
+        HOST_ICEORYX2_LOGGER.get_or_init(|| {
+            let logger: StaticLogRef = &crate::core::logging::iceoryx2_log_bridge::HOST_BRIDGE;
+            Box::leak(Box::new(logger))
+        })
+    }
+
+    /// Return a `&'static Iceoryx2Node` pointing at a clone of the
+    /// caller's node. Captured on first call.
+    fn host_iceoryx2_node_for_self(
+        node: &crate::iceoryx2::Iceoryx2Node,
+    ) -> &'static crate::iceoryx2::Iceoryx2Node {
+        HOST_ICEORYX2_NODE.get_or_init(|| Box::leak(Box::new(node.clone())))
+    }
+
+    /// Build a [`HostServices`] payload from the host's own statics.
+    /// Heap-leaks the underlying `Dispatch`, `&dyn Log`, and
+    /// `Iceoryx2Node` values on first call; pointers are stable for
+    /// the process lifetime, which matches `LOADED_PLUGIN_LIBRARIES`'s
+    /// pinning lifetime for loaded cdylibs.
+    ///
+    /// Returns by value; the caller binds it to a local and passes
+    /// `&services as *const HostServices as *const c_void` into the
+    /// cdylib's register callback. For multi-plugin loaders that
+    /// retain the payload past one call site, prefer
+    /// [`leaked_host_services_for_self`].
+    pub fn host_services_for_self(node: &crate::iceoryx2::Iceoryx2Node) -> HostServices {
+        let dispatch_ptr = host_dispatch_for_self() as *const Dispatch as *const c_void;
+        let logger_ptr = host_iceoryx2_logger_for_self() as *const StaticLogRef as *const c_void;
+        let node_ptr = host_iceoryx2_node_for_self(node) as *const crate::iceoryx2::Iceoryx2Node
+            as *const c_void;
+
+        HostServices {
+            abi_layout_version: HOST_SERVICES_LAYOUT_VERSION,
+            _reserved_padding: 0,
+            processor_registry: &*crate::core::processors::PROCESSOR_REGISTRY
+                as *const crate::core::processors::ProcessorInstanceFactory
+                as *const c_void,
+            pubsub: crate::core::pubsub::local_pubsub() as *const _ as *const c_void,
+            schema_registry: crate::core::embedded_schemas::local_schema_registry()
+                as *const _ as *const c_void,
+            tracing_dispatch_ptr: dispatch_ptr,
+            iceoryx2_logger_ptr: logger_ptr,
+            iceoryx2_node_ptr: node_ptr,
+        }
+    }
+
+    /// Same as [`host_services_for_self`] but returns a
+    /// `&'static HostServices` keyed off the host's iceoryx2 node —
+    /// constructed once per process and reused across every dlopen
+    /// from this host.
+    pub fn leaked_host_services_for_self(
+        node: &crate::iceoryx2::Iceoryx2Node,
+    ) -> &'static HostServices {
+        static LEAKED: OnceLock<&'static HostServices> = OnceLock::new();
+        LEAKED.get_or_init(|| Box::leak(Box::new(host_services_for_self(node))))
+    }
+}

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -336,10 +336,21 @@ pub mod runtime_facing {
     /// tracing-core's current `GLOBAL_DISPATCH`. Captured on first
     /// call so plugins loaded later still see the dispatch active
     /// at the time `Runner::new` wired tracing.
+    ///
+    /// Must not be called before `Runner::new` returns — if no
+    /// `set_global_default` has fired yet, `get_default` returns
+    /// the no-op dispatch and the capture freezes that for the
+    /// process lifetime, silently dropping every plugin emit. The
+    /// debug-build `assert` below makes the ordering violation
+    /// loud; release builds rely on the documented invariant.
     fn host_dispatch_for_self() -> &'static Dispatch {
         HOST_TRACING_DISPATCH.get_or_init(|| {
-            // Capture the current global dispatcher by cloning the
-            // value passed through `tracing::dispatcher::get_default`.
+            debug_assert!(
+                tracing::dispatcher::has_been_set(),
+                "host_dispatch_for_self called before any global tracing dispatch \
+                 was installed — Runner::new must run before plugin loading so \
+                 HostServices captures a configured Dispatch rather than the noop default"
+            );
             let dispatch = tracing::dispatcher::get_default(|d| d.clone());
             Box::leak(Box::new(dispatch))
         })

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -1,198 +1,183 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Host-services payload carried by the `STREAMLIB_PLUGIN` register
-//! callback.
+//! Cross-DSO host-services callback table.
 //!
-//! When the host's `Runner::load_project` (or `streamlib-runtime`'s
-//! standalone plugin loader) `dlopen`s a Rust plugin cdylib and
-//! invokes its `STREAMLIB_PLUGIN.register(host_services)` callback,
-//! `host_services` points at a [`HostServices`] payload owned by the
-//! host. The cdylib's macro expansion forwards the pointer into
-//! [`install_host_services`], which:
+//! Companion to `streamlib-plugin-abi`'s [`HostServices`] ABI
+//! contract. This module owns:
 //!
-//! 1. Validates the wire layout (`abi_layout_version`) before any
-//!    other field is touched. On mismatch the helper logs and returns
-//!    `None` — the host's post-call "processor not registered" check
-//!    then surfaces an actionable error.
-//! 2. Bridges every process-wide static the cdylib statically embeds
-//!    a per-DSO copy of (tracing dispatch, [`PUBSUB`], schema
-//!    registry, iceoryx2-log logger) into the host's instances.
-//! 3. Returns the host's `&'static ProcessorInstanceFactory` so the
-//!    macro can register the plugin's processor types into it.
+//! - **Host-side callback impls** (`host_tracing_emit`,
+//!   `host_pubsub_publish`, `host_schema_register`,
+//!   `host_schema_lookup`, `host_iceoryx_log_emit`) that the host's
+//!   loader writes into a [`HostServices`] struct before invoking a
+//!   cdylib's `STREAMLIB_PLUGIN.register` callback.
+//! - **Cdylib-side `install_host_services` helper** that the cdylib's
+//!   `export_plugin!` macro calls at register time. The helper
+//!   validates layout, stores the callback table in a per-DSO
+//!   [`HOST_CALLBACKS`] static, installs the cdylib's tracing
+//!   `ForwardingSubscriber` and iceoryx2 `Log` forwarder, and returns
+//!   a [`RegisterHelper`] for the macro to register processors with.
 //!
-//! ## Why this lives in streamlib-engine, not streamlib-plugin-abi
+//! # Why this shape
 //!
-//! `streamlib-plugin-abi` is the bare wire-protocol header
-//! (`PluginDeclaration`, `STREAMLIB_ABI_VERSION`, the macro). It
-//! intentionally carries no streamlib deps so it doesn't pull the
-//! whole engine into every dependent crate's graph (and so the
-//! pre-#877 cyclic `engine → plugin-abi → sdk → engine` workaround
-//! is gone). The typed host-services payload lives here because all
-//! its field types (`ProcessorInstanceFactory`, `PubSub`,
-//! `Iceoryx2Node`, `tracing::Dispatch`, etc.) are engine types.
+//! Rust mangled statics aren't in the dynsym table — every linked
+//! copy of streamlib-engine (host binary, every dlopen'd cdylib) has
+//! its own [`PUBSUB`], its own schema registry, its own
+//! `tracing-core::GLOBAL_DISPATCH`, its own `iceoryx2_log::LOGGER`.
+//! Passing `&'static T` references across the FFI would couple
+//! every consumer to byte-identical type layouts across DSOs,
+//! breaking streamlib's multi-builder deployment model.
 //!
-//! The cdylib reaches this module via
-//! `streamlib::sdk::plugin::install_host_services` — the SDK
-//! re-exports it under that path. Plugin-abi's macro hard-codes that
-//! path in its expansion.
+//! The callback-table shape removes that coupling: only `extern "C"
+//! fn` signatures and primitive payloads cross the wire. The cdylib's
+//! statically-linked engine copy keeps its own statics, but the read
+//! paths through them (`PUBSUB.publish`, `register_schema`,
+//! `get_embedded_schema_definition`, `tracing::*!`,
+//! `iceoryx2_log::*`) route through the host's fn pointers instead
+//! of through the local DSO's state.
 //!
-//! ## Cross-DSO safety
+//! # Deployment model this enables
 //!
-//! Every field of [`HostServices`] is a raw pointer or a value type
-//! whose layout the dynamic linker does not dedupe across DSOs. The
-//! safety contract for casting a `*const c_void` back to a typed
-//! reference is that **both the host and cdylib link the same
-//! version of every relevant crate** (workspace dep pins). The
-//! milestone-level commitment is "rustc-version coupling stays";
-//! this module rides that commitment for `streamlib-engine`,
-//! `iceoryx2`, and `iceoryx2-log-types`.
+//! Computer A builds the host binary, computer B builds packages via
+//! CI, computer C ships their own packages — all using different
+//! rustc minor versions and different transitive-dep resolutions —
+//! interoperate as long as they target the same triple and link the
+//! same [`streamlib_plugin_abi::STREAMLIB_ABI_VERSION`]. No
+//! commit-level coupling, no shared Cargo.lock.
 //!
-//! ## Known gap — tracing dispatch passthrough
+//! # What's not in the callback table
 //!
-//! `set_global_default` succeeds in the cdylib and installs the
-//! host's `Dispatch` as the cdylib's global. Empirically, events
-//! emitted from cdylib code via `tracing::*!()` still do not reach
-//! the host's `Subscriber::event` impl — they are absorbed
-//! somewhere between the cdylib's `Dispatch::event` and the host's
-//! `Layered<EnvFilter, ...>` Subscriber even with both DSOs on the
-//! same workspace-pinned `tracing-core 0.1.36`. Cross-DSO Callsite
-//! identity, vtable layout, or Registry span-stack semantics are
-//! the prime suspects.
-//!
-//! Cross-DSO tracing-dispatch passthrough is a known-not-viable
-//! pattern in the broader Rust ecosystem. The canonical fix is a
-//! callback-table shape — host exports `extern "C"` callbacks for
-//! `emit` / `enabled` / `enter` / `exit`, cdylib installs a thin
-//! local Subscriber that forwards through them. `tracing-ext-ffi-subscriber`
-//! is the reference implementation cited in #877's issue body.
-//!
-//! This module ships the partial bridge today (PUBSUB + schema
-//! registry + iceoryx2-log work end-to-end; tracing dispatch
-//! installs but events don't flow). The callback-table tracing
-//! bridge is a follow-up. Until it lands, cdylib code that wants
-//! observability should rely on PUBSUB events for its host-visible
-//! signals.
+//! `processor_registry_typed: *const ProcessorInstanceFactory`
+//! remains as a typed pointer in [`HostServices`]. The
+//! `ProcessorInstanceFactory`'s internal `Box<dyn Fn>` constructor
+//! closures and `Box<dyn DynGeneratedProcessor>` instance objects
+//! are pre-existing dyn-trait crossings whose ABI stability depends
+//! on the engine's semver coupling. Lifting them to extern "C"
+//! requires reshaping the entire processor lifecycle ABI (setup /
+//! process / teardown / port wiring / runtime-context access) and
+//! is the natural next-step plugin-ABI milestone.
 
 use std::ffi::c_void;
+use std::sync::OnceLock;
 
-use tracing::Dispatch;
+use streamlib_plugin_abi::{
+    HostHandle, HostInterest, HostLogLevel, HostServices, HOST_SERVICES_LAYOUT_VERSION,
+};
 
-use crate::core::embedded_schemas::SchemaRegistryStorage;
-use crate::core::logging::iceoryx2_log_bridge;
 use crate::core::processors::ProcessorInstanceFactory;
-use crate::core::pubsub::PubSub;
+use crate::core::pubsub::Event;
 
-/// Wire layout version. Bump on any change to [`HostServices`]'s
-/// field ordering or contents (including non-`#[repr(C)]` value-type
-/// fields whose Rust layout may shift across compiler versions —
-/// `tracing::Dispatch` is the canonical example).
-///
-/// Read first by [`install_host_services`] before any other field
-/// is touched. On mismatch the helper bails out without dereferencing
-/// the rest of the struct, so it's safe even if the cdylib was built
-/// against an older `HostServices` layout.
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 1;
+// =============================================================================
+// HostCallbacks — per-DSO cache of the host's fn pointers
+// =============================================================================
 
-/// Payload the host passes through the `STREAMLIB_PLUGIN` register
-/// callback. The cdylib's macro expansion casts the `*const c_void`
-/// parameter to `*const HostServices` and reads the fields below.
-///
-/// Field ordering is **stable** within a layout-version bucket — the
-/// first two fields (`abi_layout_version`, `fatal_log`) are pinned
-/// at offset 0 forever so [`install_host_services`] can read them
-/// even when the rest of the struct's layout has drifted. New
-/// fields go at the end and bump [`HOST_SERVICES_LAYOUT_VERSION`].
-///
-/// Field semantics:
-///
-/// * `abi_layout_version` — must equal [`HOST_SERVICES_LAYOUT_VERSION`].
-/// * `processor_registry` — host's `&'static ProcessorInstanceFactory`
-///   (`PROCESSOR_REGISTRY`). The cdylib registers into this rather
-///   than its own per-DSO `LazyLock<ProcessorInstanceFactory>`.
-/// * `pubsub` — host's `&'static PubSub`
-///   (`crate::core::pubsub::bus::local_pubsub()` value). The cdylib's
-///   `crate::core::pubsub::bus::install_host_pubsub` installs it so
-///   `PUBSUB.publish(...)` in cdylib code reaches the host's bus.
-/// * `schema_registry` — host's `&'static
-///   SchemaRegistryStorage`. Same shape as PUBSUB bridging:
-///   `crate::core::embedded_schemas::install_host_schema_registry`
-///   wires the cdylib's `register_schema` /
-///   `get_embedded_schema_definition` through to the host's storage.
-/// * `tracing_dispatch_ptr` — pointer to a `Dispatch` value the host
-///   keeps alive (`Box::leak`-ed at first plugin load — see
-///   [`runtime_facing::host_dispatch_for_self`]). The cdylib clones
-///   it via `(&*ptr).clone()` and calls
-///   `tracing::dispatcher::set_global_default(...)` against its own
-///   `tracing-core` static. After this, `tracing::info!` in cdylib
-///   code flows into the host's subscriber.
-/// * `iceoryx2_logger_ptr` — pointer to a `&'static dyn Log`
-///   trait-object value living in host memory (specifically a
-///   reference to [`HOST_BRIDGE`], boxed-and-leaked once). The
-///   cdylib installs it via
-///   `crate::core::logging::iceoryx2_log_bridge::install_foreign_iceoryx2_logger`
-///   so iceoryx2's internal log records in cdylib code reach the
-///   host's tracing pipeline. May be null if the host hasn't wired
-///   one (today: never null — `Runner::new` always installs the
-///   bridge before any plugin load).
-/// * `iceoryx2_node_ptr` — pointer to the host's `Iceoryx2Node`.
-///   Reserved for future cdylib code that needs to create iceoryx2
-///   services in its own DSO using the host's node identity; today
-///   no cdylib code uses this, but it's the right shape and rounds
-///   out the FFI surface so future consumers don't redo this design.
-#[repr(C)]
-pub struct HostServices {
-    /// Wire layout version. See [`HOST_SERVICES_LAYOUT_VERSION`].
-    pub abi_layout_version: u32,
-
-    /// Padding to keep the following pointer fields naturally
-    /// aligned across 32/64-bit hosts (not relevant on streamlib's
-    /// 64-bit targets today; explicit for clarity).
-    pub _reserved_padding: u32,
-
-    /// Host's process-instance factory (`PROCESSOR_REGISTRY`).
-    pub processor_registry: *const c_void,
-
-    /// Host's `&'static PubSub` (`local_pubsub` value).
-    pub pubsub: *const c_void,
-
-    /// Host's `&'static SchemaRegistryStorage` (`local_schema_registry`
-    /// value).
-    pub schema_registry: *const c_void,
-
-    /// Pointer to a `Dispatch` value the host keeps alive on the
-    /// heap (see [`runtime_facing::host_dispatch_for_self`]).
-    pub tracing_dispatch_ptr: *const c_void,
-
-    /// Pointer to a `&'static dyn iceoryx2_log::Log` value the host
-    /// keeps alive (see [`runtime_facing::host_iceoryx2_logger_for_self`]).
-    /// May be null.
-    pub iceoryx2_logger_ptr: *const c_void,
-
-    /// Pointer to the host's `Iceoryx2Node` value, kept alive on the
-    /// heap (see [`runtime_facing::host_iceoryx2_node_for_self`]).
-    /// Reserved for future cdylib consumers; safe to ignore.
-    pub iceoryx2_node_ptr: *const c_void,
+/// Cached copy of the host's callback table, stored in
+/// [`HOST_CALLBACKS`] by `install_host_services` so the cdylib's
+/// PUBSUB / schema-registry / tracing / iceoryx2-log forwarders can
+/// reach the host without indirecting through [`HostServices`] on
+/// every call.
+#[derive(Clone, Copy)]
+pub struct HostCallbacks {
+    pub host: HostHandle,
+    pub tracing_register_callsite: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+    ) -> HostInterest,
+    pub tracing_enabled: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+    ) -> bool,
+    pub tracing_emit: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+        message_ptr: *const u8,
+        message_len: usize,
+        fields_msgpack_ptr: *const u8,
+        fields_msgpack_len: usize,
+    ),
+    pub pubsub_publish: unsafe extern "C" fn(
+        host: HostHandle,
+        topic_ptr: *const u8,
+        topic_len: usize,
+        event_msgpack_ptr: *const u8,
+        event_msgpack_len: usize,
+    ),
+    pub schema_register: unsafe extern "C" fn(
+        host: HostHandle,
+        canonical_id_ptr: *const u8,
+        canonical_id_len: usize,
+        yaml_ptr: *const u8,
+        yaml_len: usize,
+    ),
+    pub schema_lookup: unsafe extern "C" fn(
+        host: HostHandle,
+        canonical_id_ptr: *const u8,
+        canonical_id_len: usize,
+        result_callback: extern "C" fn(
+            userdata: *mut c_void,
+            yaml_ptr: *const u8,
+            yaml_len: usize,
+        ),
+        result_userdata: *mut c_void,
+    ),
+    pub iceoryx_log_emit: unsafe extern "C" fn(
+        host: HostHandle,
+        level: HostLogLevel,
+        origin_ptr: *const u8,
+        origin_len: usize,
+        message_ptr: *const u8,
+        message_len: usize,
+    ),
 }
 
-// Safety: every field is a raw pointer or a primitive. The host
-// guarantees the pointed-at values outlive the cdylib's process
-// lifetime via the `LOADED_PLUGIN_LIBRARIES` pinning shape.
-unsafe impl Send for HostServices {}
-unsafe impl Sync for HostServices {}
+// Safety: every field is a fn pointer or a raw pointer the host
+// promises stays valid for the cdylib's process lifetime.
+unsafe impl Send for HostCallbacks {}
+unsafe impl Sync for HostCallbacks {}
 
-/// Bridge every process-wide static this DSO embeds a per-DSO copy
-/// of to the host's instances. Called from a plugin cdylib's
-/// `STREAMLIB_PLUGIN` register callback via the
-/// [`streamlib_plugin_abi::export_plugin`] macro expansion.
+/// Per-DSO cache of the host's callback table. `OnceLock` semantics:
+/// the cdylib's `install_host_services` writes once at register
+/// time; subsequent reads from `PUBSUB.publish`, `register_schema`,
+/// the tracing `ForwardingSubscriber`, and the iceoryx2 forwarder
+/// retrieve the same value. **The host's DSO never populates this**
+/// — host-side code reads its local statics directly, bypassing the
+/// callback table.
+static HOST_CALLBACKS: OnceLock<HostCallbacks> = OnceLock::new();
+
+/// Returns this DSO's callback table if a cdylib's
+/// `install_host_services` has populated it. `None` in the host
+/// binary; `Some(_)` in any cdylib that has registered.
+pub fn host_callbacks() -> Option<&'static HostCallbacks> {
+    HOST_CALLBACKS.get()
+}
+
+// =============================================================================
+// install_host_services — cdylib entry point
+// =============================================================================
+
+/// Wire the host's services into this DSO. Called by a plugin
+/// cdylib's `STREAMLIB_PLUGIN.register` callback via the
+/// [`streamlib_plugin_abi::export_plugin!`] macro.
+///
+/// Validates [`HostServices::abi_layout_version`] against
+/// [`HOST_SERVICES_LAYOUT_VERSION`], stores the callback table in
+/// [`HOST_CALLBACKS`], installs the cdylib's tracing
+/// [`ForwardingSubscriber`] as the per-DSO `GLOBAL_DISPATCH`,
+/// installs the cdylib's iceoryx2 `Log` forwarder, and returns a
+/// [`RegisterHelper`] the macro uses to register processor types
+/// with the host's registry.
 ///
 /// # Returns
 ///
-/// `Some(&'static ProcessorInstanceFactory)` on success — the host's
-/// registry the cdylib registers into. `None` on layout-version
-/// mismatch (the cdylib was built against a stale `HostServices`
-/// layout). The macro short-circuits processor registration on
-/// `None`, and the host's post-call "processor not registered"
+/// `Some(RegisterHelper)` on success. `None` on layout-version
+/// mismatch or null pointer — the macro short-circuits processor
+/// registration, and the host's post-call "processor not registered"
 /// check surfaces a `Configuration` error.
 ///
 /// # Safety
@@ -201,218 +186,392 @@ unsafe impl Sync for HostServices {}
 /// initialized by the host. The host's loader guarantees this.
 pub unsafe fn install_host_services(
     host_services_ptr: *const c_void,
-) -> Option<&'static ProcessorInstanceFactory> {
+) -> Option<RegisterHelper> {
     if host_services_ptr.is_null() {
         return None;
     }
 
     // SAFETY: per the caller's promise. Read `abi_layout_version`
     // before touching any other field — if the layout doesn't match,
-    // the rest of the struct may have a different shape on the wire.
+    // the rest of the struct's shape may have drifted.
     let services = unsafe { &*(host_services_ptr as *const HostServices) };
 
     if services.abi_layout_version != HOST_SERVICES_LAYOUT_VERSION {
-        // Logging may not be wired yet — emit through tracing
-        // (which is silent if this DSO's dispatch hasn't been
-        // installed) AND via the host's stderr as a backstop. The
-        // host's loader will surface the failure via the post-call
+        // Logging hasn't been wired yet (the forwarder install is
+        // below); the host detects the failure via the post-call
         // "processor not registered" check.
-        //
-        // We deliberately do NOT write to stderr directly here
-        // (banned by streamlib's logging discipline). The host can
-        // tell something went wrong because no processors registered.
-        tracing::error!(
-            target: "streamlib::plugin",
-            host_layout = HOST_SERVICES_LAYOUT_VERSION,
-            cdylib_layout = services.abi_layout_version,
-            "Plugin HostServices layout mismatch; aborting register"
-        );
         return None;
     }
 
-    // SAFETY: pointers were constructed by the host from `&'static`
-    // references to its own statics. Both DSOs link the same
-    // streamlib-engine version per the milestone-level rustc-version
-    // coupling commitment, so the layouts match.
-    let processor_registry =
-        unsafe { &*(services.processor_registry as *const ProcessorInstanceFactory) };
-    let pubsub = unsafe { &*(services.pubsub as *const PubSub) };
-    let schema_registry =
-        unsafe { &*(services.schema_registry as *const SchemaRegistryStorage) };
+    let callbacks = HostCallbacks {
+        host: services.host,
+        tracing_register_callsite: services.tracing_register_callsite,
+        tracing_enabled: services.tracing_enabled,
+        tracing_emit: services.tracing_emit,
+        pubsub_publish: services.pubsub_publish,
+        schema_register: services.schema_register,
+        schema_lookup: services.schema_lookup,
+        iceoryx_log_emit: services.iceoryx_log_emit,
+    };
 
-    // Best-effort tracing-dispatch bridge.
-    //
-    // `set_global_default` here transitions the cdylib's per-DSO
-    // `tracing-core::GLOBAL_INIT` to `INITIALIZED` with a Dispatch
-    // whose `Kind::Global` subscriber pointer is the host's. The
-    // call returns `Ok` in production. Empirically, however, events
-    // emitted from cdylib code via `tracing::*!()` do NOT reach the
-    // host's `Subscriber::event` impl through this path — events
-    // are silently absorbed somewhere between the cdylib's
-    // `Dispatch::event` and the host's `Layered<EnvFilter, ...>`
-    // Subscriber, even though both DSOs link the same workspace-
-    // pinned `tracing-core 0.1.36` version. The exact cause is
-    // unclear; cross-DSO Callsite identity, vtable, or Registry
-    // span-stack semantics are the prime suspects.
-    //
-    // Cross-DSO tracing-dispatch passthrough is a known-not-viable
-    // pattern in the broader Rust ecosystem — the canonical fix is
-    // a callback-table shape (see `tracing-ext-ffi-subscriber`,
-    // cited in #877's issue body) where the host exports
-    // `extern "C"` callbacks for emit/enabled/enter/exit and the
-    // cdylib installs a thin local Subscriber that forwards through
-    // them. That work is tracked as a follow-up to #877; see the
-    // gap section in this module's docs.
-    //
-    // We still call `set_global_default` here so the cdylib's
-    // `GLOBAL_DISPATCH` isn't the no-op default — that lets
-    // `tracing::*!()` macros short-circuit fast and avoids any
-    // tracing-subscriber lazy-init costs on the cdylib's hot path.
-    if !services.tracing_dispatch_ptr.is_null() {
-        let host_dispatch = unsafe { &*(services.tracing_dispatch_ptr as *const Dispatch) };
-        let _ = tracing::dispatcher::set_global_default(host_dispatch.clone());
+    // Cache the callbacks BEFORE installing tracing — the
+    // `ForwardingSubscriber` reads `HOST_CALLBACKS` on every emit.
+    let _ = HOST_CALLBACKS.set(callbacks);
+
+    // Install the tracing forwarder as the cdylib's global dispatcher.
+    // The cdylib's `tracing::*!()` macros now route every event
+    // through the host's `tracing_emit` callback.
+    crate::core::plugin::forwarding_subscriber::install_for_self();
+
+    // Install the iceoryx2 log forwarder. The cdylib's iceoryx2-log
+    // emits route through the host's `iceoryx_log_emit` callback.
+    // Also raise the cdylib's iceoryx2-log level to Trace so the
+    // host's filter sees every record; the host then decides via
+    // its tracing pipeline what to actually emit.
+    crate::core::plugin::iceoryx2_log_forwarder::install_for_self();
+
+    // The processor registry is the one remaining type-passing
+    // field. Cast back to `&'static ProcessorInstanceFactory` and
+    // return a `RegisterHelper` that exposes the same
+    // `register::<P>()` shape the macro used in v1.
+    if services.processor_registry_typed.is_null() {
+        return None;
     }
+    let registry = unsafe {
+        &*(services.processor_registry_typed as *const ProcessorInstanceFactory)
+    };
 
-    // Bridge PUBSUB + schema registry. Order doesn't matter — both
-    // are `OnceLock<&'static T>` writes.
-    crate::core::pubsub::install_host_pubsub(pubsub);
-    crate::core::embedded_schemas::install_host_schema_registry(schema_registry);
+    Some(RegisterHelper { registry })
+}
 
-    // Bridge iceoryx2-log if the host installed one. The host
-    // currently always installs `HOST_BRIDGE` at `Runner::new`, so
-    // the null branch is unreachable in production — kept for
-    // forward-compat with embedded contexts that may not.
-    if !services.iceoryx2_logger_ptr.is_null() {
-        // The host stores `&'static dyn Log` (a fat pointer) at the
-        // heap location pointed to by `iceoryx2_logger_ptr`. Read
-        // and forward to this DSO's `iceoryx2-log`.
-        let logger_ref =
-            unsafe { *(services.iceoryx2_logger_ptr as *const &'static dyn iceoryx2_log::Log) };
-        unsafe { iceoryx2_log_bridge::install_foreign_iceoryx2_logger(logger_ref) };
+/// Thin wrapper around the host's `ProcessorInstanceFactory` returned
+/// by [`install_host_services`]. Source-compatible with the macro's
+/// `registry.register::<P>()` call shape.
+pub struct RegisterHelper {
+    registry: &'static ProcessorInstanceFactory,
+}
+
+impl RegisterHelper {
+    /// Register a processor type with the host's registry.
+    pub fn register<P>(&self)
+    where
+        P: crate::core::processors::GeneratedProcessor + 'static,
+        P::Config: for<'de> serde::Deserialize<'de> + Default,
+    {
+        self.registry.register::<P>();
     }
-
-    // `iceoryx2_node_ptr` is reserved — no in-tree consumer reads
-    // it yet. The cdylib leaves it as null-or-set; future code that
-    // wants the host's Iceoryx2Node can clone via
-    // `Arc<Mutex<Node>>` semantics (Iceoryx2Node is `Clone`).
-
-    Some(processor_registry)
 }
 
 // =============================================================================
-// Host-facing helpers for building a HostServices payload.
+// Host-side callback implementations
 // =============================================================================
 
-/// Host-facing helpers — used by `Runner::load_project` and
-/// `streamlib-runtime`'s plugin loader to build a [`HostServices`]
-/// payload from the host's own statics.
+/// Concrete host-side service table the host's loader plugs into a
+/// [`HostServices`] payload via [`runtime_facing::host_services_for_self`].
+///
+/// Holds the host's iceoryx2 node + any other handles host-side
+/// callbacks need. Lives behind the [`HostServices::host`] opaque
+/// pointer.
+pub struct HostServiceImpls {
+    pub iceoryx2_node: crate::iceoryx2::Iceoryx2Node,
+}
+
+unsafe impl Send for HostServiceImpls {}
+unsafe impl Sync for HostServiceImpls {}
+
+unsafe extern "C" fn host_tracing_register_callsite(
+    _host: HostHandle,
+    _target_ptr: *const u8,
+    _target_len: usize,
+    _level: HostLogLevel,
+) -> HostInterest {
+    // The host's `EnvFilter` filters at emit time via `host_tracing_emit`
+    // (it calls `tracing::event!` which fires through the host's
+    // subscriber chain). Returning `Always` here tells the cdylib's
+    // forwarding `Subscriber` to cache "always emit" for the
+    // callsite — every event reaches `host_tracing_emit`, where the
+    // host's filter actually decides.
+    //
+    // Trade-off: cdylib pays for the FFI hop even on filtered-out
+    // events, plus a string copy of the message. A future
+    // refinement could push a (target, level)-keyed pre-filter
+    // here; the current ABI shape doesn't constrain that.
+    HostInterest::Always
+}
+
+unsafe extern "C" fn host_tracing_enabled(
+    _host: HostHandle,
+    _target_ptr: *const u8,
+    _target_len: usize,
+    _level: HostLogLevel,
+) -> bool {
+    // Paired with `host_tracing_register_callsite` returning
+    // `Always`: this never fires from the cdylib side. Kept in the
+    // ABI so a future register_callsite that returns `Sometimes`
+    // has the per-event enable hook available.
+    true
+}
+
+unsafe extern "C" fn host_tracing_emit(
+    _host: HostHandle,
+    target_ptr: *const u8,
+    target_len: usize,
+    level: HostLogLevel,
+    message_ptr: *const u8,
+    message_len: usize,
+    fields_msgpack_ptr: *const u8,
+    fields_msgpack_len: usize,
+) {
+    let target = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(target_ptr, target_len)) };
+    let message = if message_len == 0 {
+        ""
+    } else {
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len)) }
+    };
+    let level_val = host_log_level_to_tracing(level);
+    let fields_bytes = if fields_msgpack_len == 0 || fields_msgpack_ptr.is_null() {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(fields_msgpack_ptr, fields_msgpack_len) }
+    };
+
+    // Decode the structured fields (msgpack map) and replay them
+    // through the host's tracing pipeline alongside `message`. The
+    // simplest shape that preserves field fidelity is to log via
+    // the host's own subscriber using `event!`-style emission with
+    // a single `message` field — structured fields go into the
+    // event's value set as serde-derived JSON values, captured by
+    // `JsonlSinkLayer::Capture::record_*`.
+    let fields_map: serde_json::Value =
+        rmp_serde::from_slice(fields_bytes).unwrap_or(serde_json::Value::Null);
+
+    emit_via_host_dispatch(target, level_val, message, &fields_map);
+}
+
+unsafe extern "C" fn host_pubsub_publish(
+    _host: HostHandle,
+    topic_ptr: *const u8,
+    topic_len: usize,
+    event_msgpack_ptr: *const u8,
+    event_msgpack_len: usize,
+) {
+    let topic = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(topic_ptr, topic_len)) };
+    let event_bytes = unsafe { std::slice::from_raw_parts(event_msgpack_ptr, event_msgpack_len) };
+    let event: Event = match rmp_serde::from_slice(event_bytes) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(
+                target: "streamlib::plugin",
+                "host_pubsub_publish: failed to decode event from cdylib: {e}"
+            );
+            return;
+        }
+    };
+    crate::core::pubsub::PUBSUB.publish(topic, &event);
+}
+
+unsafe extern "C" fn host_schema_register(
+    _host: HostHandle,
+    canonical_id_ptr: *const u8,
+    canonical_id_len: usize,
+    yaml_ptr: *const u8,
+    yaml_len: usize,
+) {
+    let canonical_id = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(canonical_id_ptr, canonical_id_len)) };
+    let yaml = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(yaml_ptr, yaml_len)) };
+    crate::core::embedded_schemas::register_schema(canonical_id.to_string(), yaml);
+}
+
+unsafe extern "C" fn host_schema_lookup(
+    _host: HostHandle,
+    canonical_id_ptr: *const u8,
+    canonical_id_len: usize,
+    result_callback: extern "C" fn(*mut c_void, *const u8, usize),
+    result_userdata: *mut c_void,
+) {
+    let canonical_id = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(canonical_id_ptr, canonical_id_len)) };
+    match crate::core::embedded_schemas::get_embedded_schema_definition(canonical_id) {
+        Some(yaml) => {
+            let bytes = yaml.as_bytes();
+            result_callback(result_userdata, bytes.as_ptr(), bytes.len());
+        }
+        None => {
+            result_callback(result_userdata, std::ptr::null(), 0);
+        }
+    }
+}
+
+unsafe extern "C" fn host_iceoryx_log_emit(
+    _host: HostHandle,
+    level: HostLogLevel,
+    origin_ptr: *const u8,
+    origin_len: usize,
+    message_ptr: *const u8,
+    message_len: usize,
+) {
+    let origin = if origin_len == 0 {
+        ""
+    } else {
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(origin_ptr, origin_len)) }
+    };
+    let message = if message_len == 0 {
+        ""
+    } else {
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len)) }
+    };
+    // Forward into the host's tracing pipeline at the appropriate level.
+    match level {
+        HostLogLevel::Trace => tracing::trace!(target: "iceoryx2", origin = %origin, "{message}"),
+        HostLogLevel::Debug => tracing::debug!(target: "iceoryx2", origin = %origin, "{message}"),
+        HostLogLevel::Info => tracing::info!(target: "iceoryx2", origin = %origin, "{message}"),
+        HostLogLevel::Warn => tracing::warn!(target: "iceoryx2", origin = %origin, "{message}"),
+        HostLogLevel::Error => tracing::error!(target: "iceoryx2", origin = %origin, "{message}"),
+    }
+}
+
+// =============================================================================
+// FFI conversions
+// =============================================================================
+
+pub(crate) fn tracing_level_to_host(level: tracing::Level) -> HostLogLevel {
+    match level {
+        tracing::Level::TRACE => HostLogLevel::Trace,
+        tracing::Level::DEBUG => HostLogLevel::Debug,
+        tracing::Level::INFO => HostLogLevel::Info,
+        tracing::Level::WARN => HostLogLevel::Warn,
+        tracing::Level::ERROR => HostLogLevel::Error,
+    }
+}
+
+pub(crate) fn host_log_level_to_tracing(level: HostLogLevel) -> tracing::Level {
+    match level {
+        HostLogLevel::Trace => tracing::Level::TRACE,
+        HostLogLevel::Debug => tracing::Level::DEBUG,
+        HostLogLevel::Info => tracing::Level::INFO,
+        HostLogLevel::Warn => tracing::Level::WARN,
+        HostLogLevel::Error => tracing::Level::ERROR,
+    }
+}
+
+pub(crate) fn host_interest_to_tracing(interest: HostInterest) -> tracing::subscriber::Interest {
+    match interest {
+        HostInterest::Never => tracing::subscriber::Interest::never(),
+        HostInterest::Sometimes => tracing::subscriber::Interest::sometimes(),
+        HostInterest::Always => tracing::subscriber::Interest::always(),
+    }
+}
+
+// =============================================================================
+// Emit-via-host-dispatch — used by `host_tracing_emit`
+// =============================================================================
+
+/// Replay a cdylib-emitted event into the host's JSONL drain
+/// pipeline.
+///
+/// `tracing::event!` macros can't take a runtime `target:` — they
+/// expand into a static `Callsite` whose target is baked at compile
+/// time. To support arbitrary cdylib targets we bypass tracing and
+/// push a [`LogRecord`] directly into the host's drain worker via
+/// the same queue the polyglot subprocess log-relay uses, by way of
+/// [`crate::core::logging::push_polyglot_record`].
+///
+/// Trade-off: host-side `EnvFilter` filtering doesn't apply on this
+/// path; cdylib code is responsible for its own level filtering
+/// (the cdylib's `ForwardingSubscriber::register_callsite` queries
+/// `host_tracing_register_callsite` and caches the result). The
+/// drain queue is bounded so an over-emitting plugin still
+/// drop-oldests gracefully.
+fn emit_via_host_dispatch(
+    target: &str,
+    level: tracing::Level,
+    message: &str,
+    fields: &serde_json::Value,
+) {
+    use crate::core::logging::push_polyglot_record;
+    use crate::core::logging::LogRecord;
+
+    let attrs = match fields {
+        serde_json::Value::Object(map) => {
+            map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+        }
+        _ => std::collections::BTreeMap::new(),
+    };
+
+    let record = LogRecord {
+        host_ts: crate::core::logging::now_ns(),
+        level: (level).into(),
+        target: target.to_string(),
+        message: message.to_string(),
+        pipeline_id: None,
+        processor_id: None,
+        rhi_op: None,
+        intercepted: false,
+        channel: None,
+        attrs,
+        source: None,
+        source_ts: None,
+        source_seq: None,
+    };
+
+    push_polyglot_record(record);
+}
+
+// =============================================================================
+// runtime_facing — host-side payload builder
+// =============================================================================
+
+/// Host-facing helpers used by `Runner::load_project` (and the
+/// `streamlib-runtime` binary's plugin loader) to assemble a
+/// [`HostServices`] payload pointing at this DSO's callback
+/// implementations.
 pub mod runtime_facing {
-    use super::{HostServices, HOST_SERVICES_LAYOUT_VERSION};
+    use super::{
+        host_iceoryx_log_emit, host_pubsub_publish, host_schema_lookup, host_schema_register,
+        host_tracing_emit, host_tracing_enabled, host_tracing_register_callsite, HostServiceImpls,
+    };
     use std::ffi::c_void;
     use std::sync::OnceLock;
 
-    use tracing::Dispatch;
+    use streamlib_plugin_abi::{HostServices, HOST_SERVICES_LAYOUT_VERSION};
 
-    /// Heap-allocated `Dispatch` clone the host keeps alive so the
-    /// pointer handed to plugin cdylibs stays valid. Lazy-built on
-    /// first call; subsequent calls reuse the same boxed value.
-    ///
-    /// Uses `Box::leak` — the leak lasts the process lifetime, which
-    /// matches `LOADED_PLUGIN_LIBRARIES`'s pinning lifetime for
-    /// loaded cdylibs.
-    static HOST_TRACING_DISPATCH: OnceLock<&'static Dispatch> = OnceLock::new();
+    /// Heap-allocated service impl table, leaked once per process.
+    /// The `HostServices.host` opaque pointer points at this.
+    static HOST_IMPLS: OnceLock<&'static HostServiceImpls> = OnceLock::new();
 
-    /// Heap-allocated `&'static dyn Log` trait-object pointer the
-    /// host hands to plugin cdylibs. Boxed-and-leaked once for the
-    /// same lifetime reason.
-    type StaticLogRef = &'static dyn iceoryx2_log::Log;
-    static HOST_ICEORYX2_LOGGER: OnceLock<&'static StaticLogRef> = OnceLock::new();
-
-    /// Heap-allocated `Iceoryx2Node` clone the host keeps alive for
-    /// the same reason. Boxed once and reused.
-    static HOST_ICEORYX2_NODE: OnceLock<&'static crate::iceoryx2::Iceoryx2Node> = OnceLock::new();
-
-    /// Return a `&'static Dispatch` pointing at a clone of
-    /// tracing-core's current `GLOBAL_DISPATCH`. Captured on first
-    /// call so plugins loaded later still see the dispatch active
-    /// at the time `Runner::new` wired tracing.
-    ///
-    /// Must not be called before `Runner::new` returns — if no
-    /// `set_global_default` has fired yet, `get_default` returns
-    /// the no-op dispatch and the capture freezes that for the
-    /// process lifetime, silently dropping every plugin emit. The
-    /// debug-build `assert` below makes the ordering violation
-    /// loud; release builds rely on the documented invariant.
-    fn host_dispatch_for_self() -> &'static Dispatch {
-        HOST_TRACING_DISPATCH.get_or_init(|| {
-            debug_assert!(
-                tracing::dispatcher::has_been_set(),
-                "host_dispatch_for_self called before any global tracing dispatch \
-                 was installed — Runner::new must run before plugin loading so \
-                 HostServices captures a configured Dispatch rather than the noop default"
-            );
-            let dispatch = tracing::dispatcher::get_default(|d| d.clone());
-            Box::leak(Box::new(dispatch))
+    fn host_impls_for_self(node: &crate::iceoryx2::Iceoryx2Node) -> &'static HostServiceImpls {
+        HOST_IMPLS.get_or_init(|| {
+            let impls = HostServiceImpls {
+                iceoryx2_node: node.clone(),
+            };
+            Box::leak(Box::new(impls))
         })
     }
 
-    /// Return a `&'static StaticLogRef` pointing at the host's
-    /// iceoryx2 logger bridge.
-    fn host_iceoryx2_logger_for_self() -> &'static StaticLogRef {
-        HOST_ICEORYX2_LOGGER.get_or_init(|| {
-            let logger: StaticLogRef = &crate::core::logging::iceoryx2_log_bridge::HOST_BRIDGE;
-            Box::leak(Box::new(logger))
-        })
-    }
-
-    /// Return a `&'static Iceoryx2Node` pointing at a clone of the
-    /// caller's node. Captured on first call.
-    fn host_iceoryx2_node_for_self(
-        node: &crate::iceoryx2::Iceoryx2Node,
-    ) -> &'static crate::iceoryx2::Iceoryx2Node {
-        HOST_ICEORYX2_NODE.get_or_init(|| Box::leak(Box::new(node.clone())))
-    }
-
-    /// Build a [`HostServices`] payload from the host's own statics.
-    /// Heap-leaks the underlying `Dispatch`, `&dyn Log`, and
-    /// `Iceoryx2Node` values on first call; pointers are stable for
-    /// the process lifetime, which matches `LOADED_PLUGIN_LIBRARIES`'s
-    /// pinning lifetime for loaded cdylibs.
-    ///
-    /// Returns by value; the caller binds it to a local and passes
-    /// `&services as *const HostServices as *const c_void` into the
-    /// cdylib's register callback. For multi-plugin loaders that
-    /// retain the payload past one call site, prefer
-    /// [`leaked_host_services_for_self`].
+    /// Build a [`HostServices`] payload from this process's host
+    /// callback impls and processor registry. Callable repeatedly;
+    /// the underlying [`HostServiceImpls`] is constructed once and
+    /// reused for the process lifetime, matching
+    /// `LOADED_PLUGIN_LIBRARIES`'s pinning lifetime for loaded
+    /// cdylibs.
     pub fn host_services_for_self(node: &crate::iceoryx2::Iceoryx2Node) -> HostServices {
-        let dispatch_ptr = host_dispatch_for_self() as *const Dispatch as *const c_void;
-        let logger_ptr = host_iceoryx2_logger_for_self() as *const StaticLogRef as *const c_void;
-        let node_ptr = host_iceoryx2_node_for_self(node) as *const crate::iceoryx2::Iceoryx2Node
-            as *const c_void;
+        let host_impls = host_impls_for_self(node);
+        let host_handle = host_impls as *const HostServiceImpls as *const c_void;
 
         HostServices {
             abi_layout_version: HOST_SERVICES_LAYOUT_VERSION,
             _reserved_padding: 0,
-            processor_registry: &*crate::core::processors::PROCESSOR_REGISTRY
+            host: host_handle,
+            tracing_register_callsite: host_tracing_register_callsite,
+            tracing_enabled: host_tracing_enabled,
+            tracing_emit: host_tracing_emit,
+            pubsub_publish: host_pubsub_publish,
+            schema_register: host_schema_register,
+            schema_lookup: host_schema_lookup,
+            iceoryx_log_emit: host_iceoryx_log_emit,
+            processor_registry_typed: &*crate::core::processors::PROCESSOR_REGISTRY
                 as *const crate::core::processors::ProcessorInstanceFactory
                 as *const c_void,
-            pubsub: crate::core::pubsub::local_pubsub() as *const _ as *const c_void,
-            schema_registry: crate::core::embedded_schemas::local_schema_registry()
-                as *const _ as *const c_void,
-            tracing_dispatch_ptr: dispatch_ptr,
-            iceoryx2_logger_ptr: logger_ptr,
-            iceoryx2_node_ptr: node_ptr,
         }
     }
-
-    /// Same as [`host_services_for_self`] but returns a
-    /// `&'static HostServices` keyed off the host's iceoryx2 node —
-    /// constructed once per process and reused across every dlopen
-    /// from this host.
-    pub fn leaked_host_services_for_self(
-        node: &crate::iceoryx2::Iceoryx2Node,
-    ) -> &'static HostServices {
-        static LEAKED: OnceLock<&'static HostServices> = OnceLock::new();
-        LEAKED.get_or_init(|| Box::leak(Box::new(host_services_for_self(node))))
-    }
 }
+

--- a/libs/streamlib-engine/src/core/plugin/iceoryx2_log_forwarder.rs
+++ b/libs/streamlib-engine/src/core/plugin/iceoryx2_log_forwarder.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cdylib-side `iceoryx2_log_types::Log` that forwards every
+//! iceoryx2 log record to the host via
+//! [`HostCallbacks::iceoryx_log_emit`].
+//!
+//! Companion to `crate::core::logging::iceoryx2_log_bridge::HOST_BRIDGE`
+//! which lives on the host's DSO and does the same forwarding into
+//! the host's own tracing pipeline. The cdylib's forwarder routes
+//! through the host's callback table instead, so iceoryx2 records
+//! emitted from cdylib code (e.g. `Iceoryx2Node` operations inside
+//! a processor's `process()`) reach the host's tracing pipeline
+//! identically to records emitted from host code.
+
+use iceoryx2_log::Log;
+use iceoryx2_log::LogLevel;
+use streamlib_plugin_abi::HostLogLevel;
+
+use super::host_services::host_callbacks;
+
+/// Zero-sized forwarder. Installed via
+/// [`iceoryx2_log::set_logger`] from `install_for_self`. The Log
+/// trait's `log(level, origin, formatted_message)` shape carries
+/// `core::fmt::Arguments` for both origin and message; we render
+/// them to owned `String`s before crossing the FFI boundary because
+/// `Arguments` is not FFI-safe.
+pub struct CdylibIceoryx2LogForwarder;
+
+impl Log for CdylibIceoryx2LogForwarder {
+    fn log(
+        &self,
+        level: LogLevel,
+        origin: core::fmt::Arguments,
+        formatted_message: core::fmt::Arguments,
+    ) {
+        let Some(cbs) = host_callbacks() else { return };
+
+        let host_level = match level {
+            LogLevel::Trace => HostLogLevel::Trace,
+            LogLevel::Debug => HostLogLevel::Debug,
+            LogLevel::Info => HostLogLevel::Info,
+            LogLevel::Warn => HostLogLevel::Warn,
+            LogLevel::Error | LogLevel::Fatal => HostLogLevel::Error,
+        };
+
+        let origin_string = format!("{}", origin);
+        let message_string = format!("{}", formatted_message);
+
+        unsafe {
+            (cbs.iceoryx_log_emit)(
+                cbs.host,
+                host_level,
+                origin_string.as_ptr(),
+                origin_string.len(),
+                message_string.as_ptr(),
+                message_string.len(),
+            );
+        }
+    }
+}
+
+/// Process-wide forwarder value. Installed via
+/// [`iceoryx2_log::set_logger`] which requires a `&'static dyn Log`.
+pub static FORWARDER: CdylibIceoryx2LogForwarder = CdylibIceoryx2LogForwarder;
+
+/// Install [`FORWARDER`] as this DSO's iceoryx2 log sink. Called by
+/// `install_host_services` after the callback table is cached.
+///
+/// `iceoryx2_log::set_logger` is `Once`-guarded — first writer
+/// wins. If the host's logger was somehow installed in this DSO
+/// before (it shouldn't be), the call is a silent no-op and
+/// iceoryx2 records continue routing through whatever was set
+/// first. The cdylib's log records that don't make it through the
+/// forwarder fall back to whatever the existing logger does.
+pub fn install_for_self() {
+    let _ = iceoryx2_log::set_logger(&FORWARDER);
+    // Raise the cdylib's iceoryx2-log level to Trace so the
+    // forwarder sees every record; the host's tracing pipeline
+    // applies its own EnvFilter at emit time.
+    iceoryx2_log::set_log_level(iceoryx2_log::LogLevel::Trace);
+}

--- a/libs/streamlib-engine/src/core/plugin/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/mod.rs
@@ -19,6 +19,9 @@
 //!
 //! [`PUBSUB`]: crate::core::pubsub::PUBSUB
 
+pub(crate) mod forwarding_subscriber;
 pub mod host_services;
+pub(crate) mod iceoryx2_log_forwarder;
 
-pub use host_services::{install_host_services, HostServices, HOST_SERVICES_LAYOUT_VERSION};
+pub use host_services::{install_host_services, RegisterHelper};
+pub use streamlib_plugin_abi::{HostServices, HOST_SERVICES_LAYOUT_VERSION};

--- a/libs/streamlib-engine/src/core/plugin/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO plugin bridging.
+//!
+//! Rust plugin cdylibs loaded via `Runner::load_project` /
+//! `Runner::load_package` (or the standalone `streamlib-runtime`
+//! binary's `--plugin` flag) statically embed their entire transitive
+//! dep tree. Without bridging, every process-wide static the engine
+//! relies on (tracing dispatch, [`PUBSUB`], the schema registry,
+//! iceoryx2's logger) exists as a per-DSO copy with no
+//! dynamic-linker dedup — Rust mangled statics aren't in the dynsym
+//! table.
+//!
+//! This module owns the typed [`HostServices`] payload the host
+//! hands to plugin cdylibs through `STREAMLIB_PLUGIN.register`, and
+//! the cdylib-side [`install_host_services`] helper that bridges
+//! every static to the host's instances.
+//!
+//! [`PUBSUB`]: crate::core::pubsub::PUBSUB
+
+pub mod host_services;
+
+pub use host_services::{install_host_services, HostServices, HOST_SERVICES_LAYOUT_VERSION};

--- a/libs/streamlib-engine/src/core/pubsub/bus.rs
+++ b/libs/streamlib-engine/src/core/pubsub/bus.rs
@@ -4,7 +4,6 @@
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 
 use super::events::{topics, Event, EventListener};
@@ -24,65 +23,23 @@ thread_local! {
         RefCell::new(HashMap::new());
 }
 
-/// Per-DSO `PubSub` instance.
+/// Process-wide pub/sub handle.
 ///
-/// Each linked copy of streamlib-engine (host binary, every dlopen'd
-/// cdylib plugin) gets its own `LOCAL_PUBSUB` — Rust mangled statics
-/// aren't in the dynsym table and the dynamic linker doesn't dedupe
-/// them. The host's loader bridges them through [`ACTIVE_PUBSUB`] so
-/// every DSO converges on a single canonical instance.
-static LOCAL_PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
-
-/// Active `PubSub` reference. Set once per DSO:
-/// - on the host, by `Runner::new` → `wire_host_pubsub_for_self()` (points at this DSO's `LOCAL_PUBSUB`).
-/// - in a cdylib, by `streamlib::sdk::plugin::install_host_services` (points at the host's `LOCAL_PUBSUB`).
+/// **Per-DSO instance.** Each linked copy of streamlib-engine (host
+/// binary + every dlopen'd cdylib plugin) gets its own `LazyLock<PubSub>`
+/// — Rust mangled statics aren't in the dynsym table, the dynamic
+/// linker doesn't dedupe them, and trying to share the same `PubSub`
+/// reference across DSOs would couple the cdylib to byte-identical
+/// internal layouts of `Iceoryx2Node`, parking_lot::Mutex, etc.
 ///
-/// `OnceLock` semantics: the first writer wins. Calling
-/// [`install_host_pubsub`] after the proxy has already lazy-initialised
-/// to the local instance is a no-op — emit before any `PUBSUB.foo()`
-/// touch.
-static ACTIVE_PUBSUB: OnceLock<&'static PubSub> = OnceLock::new();
-
-/// Proxy that derefs to the active `PubSub`. Lets every call site keep
-/// the `PUBSUB.publish(...)` / `PUBSUB.subscribe(...)` syntax while
-/// the underlying instance can be host-injected at plugin-load time.
-pub struct PubSubProxy {
-    _private: (),
-}
-
-impl Deref for PubSubProxy {
-    type Target = PubSub;
-
-    fn deref(&self) -> &'static PubSub {
-        *ACTIVE_PUBSUB.get_or_init(|| &LOCAL_PUBSUB)
-    }
-}
-
-/// Process-wide pub/sub handle. Reads through [`PubSubProxy`] so a
-/// dlopen'd cdylib plugin gets the host's `PubSub` instance after
-/// `STREAMLIB_PLUGIN`'s register callback wires it via
-/// [`install_host_pubsub`].
-pub static PUBSUB: PubSubProxy = PubSubProxy { _private: () };
-
-/// Install a host-owned `PubSub` reference into this DSO's
-/// [`ACTIVE_PUBSUB`] slot. Called by `streamlib::sdk::plugin::install_host_services`
-/// from a plugin cdylib's register callback to share the host's
-/// `PubSub` instance instead of the cdylib's per-DSO `LOCAL_PUBSUB`.
-///
-/// Idempotent at the type-system level (OnceLock semantics) but a
-/// later call is a no-op — call once at register time before any
-/// `PUBSUB.*` touch.
-pub fn install_host_pubsub(host: &'static PubSub) {
-    let _ = ACTIVE_PUBSUB.set(host);
-}
-
-/// Return this DSO's local `PubSub` instance. Used by the host's
-/// loader to obtain the pointer it hands to plugin cdylibs through
-/// `HostServices.pubsub`, and by `Runner::new()` to wire the host's
-/// own DSO through the same indirection layer plugins ride.
-pub fn local_pubsub() -> &'static PubSub {
-    &LOCAL_PUBSUB
-}
+/// Cross-DSO bridging happens **inside the methods**: when
+/// `crate::core::plugin::host_services::host_callbacks()` returns
+/// `Some` (i.e. this DSO is a plugin cdylib whose
+/// `install_host_services` has run), `publish` serializes the event
+/// and forwards it through the host's `pubsub_publish` fn pointer.
+/// The host's installed `PUBSUB` performs the actual iceoryx2 work,
+/// and any host-side subscribers receive the event.
+pub static PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
 
 /// iceoryx2-backed pub/sub for runtime events.
 pub struct PubSub {
@@ -244,10 +201,38 @@ impl PubSub {
 
     /// Publish event to topic (serializes and sends via iceoryx2).
     ///
+    /// In a plugin cdylib whose `install_host_services` has run,
+    /// short-circuits to the host's `pubsub_publish` callback —
+    /// the event is serialized once and the host's `PUBSUB`
+    /// performs the actual iceoryx2 work. In the host DSO,
+    /// runs the local iceoryx2 path below.
+    ///
     /// Events are dispatched to:
     /// 1. All subscribers of the specific topic
     /// 2. All subscribers of `topics::ALL` (wildcard)
     pub fn publish(&self, topic: &str, event: &Event) {
+        if let Some(cbs) = crate::core::plugin::host_services::host_callbacks() {
+            // Cdylib path: forward to the host via the callback
+            // table. The host's `PUBSUB` does the iceoryx2 work.
+            let bytes = match rmp_serde::to_vec_named(event) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("Failed to serialize event for FFI forwarding: {}", e);
+                    return;
+                }
+            };
+            unsafe {
+                (cbs.pubsub_publish)(
+                    cbs.host,
+                    topic.as_ptr(),
+                    topic.len(),
+                    bytes.as_ptr(),
+                    bytes.len(),
+                );
+            }
+            return;
+        }
+
         let Some(runtime_id) = self.runtime_id.get() else {
             tracing::trace!(
                 "PUBSUB not initialized, dropping event: {}",

--- a/libs/streamlib-engine/src/core/pubsub/bus.rs
+++ b/libs/streamlib-engine/src/core/pubsub/bus.rs
@@ -4,6 +4,7 @@
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 
 use super::events::{topics, Event, EventListener};
@@ -23,12 +24,65 @@ thread_local! {
         RefCell::new(HashMap::new());
 }
 
-/// Global pub/sub instance for runtime events.
+/// Per-DSO `PubSub` instance.
 ///
-/// Created as an empty shell via LazyLock. Must be initialized via `init()`
-/// during `Runner::new()` before iceoryx2 services are available.
-/// Before init, publish is a no-op and subscribe is buffered.
-pub static PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
+/// Each linked copy of streamlib-engine (host binary, every dlopen'd
+/// cdylib plugin) gets its own `LOCAL_PUBSUB` — Rust mangled statics
+/// aren't in the dynsym table and the dynamic linker doesn't dedupe
+/// them. The host's loader bridges them through [`ACTIVE_PUBSUB`] so
+/// every DSO converges on a single canonical instance.
+static LOCAL_PUBSUB: LazyLock<PubSub> = LazyLock::new(PubSub::new);
+
+/// Active `PubSub` reference. Set once per DSO:
+/// - on the host, by `Runner::new` → `wire_host_pubsub_for_self()` (points at this DSO's `LOCAL_PUBSUB`).
+/// - in a cdylib, by `streamlib::sdk::plugin::install_host_services` (points at the host's `LOCAL_PUBSUB`).
+///
+/// `OnceLock` semantics: the first writer wins. Calling
+/// [`install_host_pubsub`] after the proxy has already lazy-initialised
+/// to the local instance is a no-op — emit before any `PUBSUB.foo()`
+/// touch.
+static ACTIVE_PUBSUB: OnceLock<&'static PubSub> = OnceLock::new();
+
+/// Proxy that derefs to the active `PubSub`. Lets every call site keep
+/// the `PUBSUB.publish(...)` / `PUBSUB.subscribe(...)` syntax while
+/// the underlying instance can be host-injected at plugin-load time.
+pub struct PubSubProxy {
+    _private: (),
+}
+
+impl Deref for PubSubProxy {
+    type Target = PubSub;
+
+    fn deref(&self) -> &'static PubSub {
+        *ACTIVE_PUBSUB.get_or_init(|| &LOCAL_PUBSUB)
+    }
+}
+
+/// Process-wide pub/sub handle. Reads through [`PubSubProxy`] so a
+/// dlopen'd cdylib plugin gets the host's `PubSub` instance after
+/// `STREAMLIB_PLUGIN`'s register callback wires it via
+/// [`install_host_pubsub`].
+pub static PUBSUB: PubSubProxy = PubSubProxy { _private: () };
+
+/// Install a host-owned `PubSub` reference into this DSO's
+/// [`ACTIVE_PUBSUB`] slot. Called by `streamlib::sdk::plugin::install_host_services`
+/// from a plugin cdylib's register callback to share the host's
+/// `PubSub` instance instead of the cdylib's per-DSO `LOCAL_PUBSUB`.
+///
+/// Idempotent at the type-system level (OnceLock semantics) but a
+/// later call is a no-op — call once at register time before any
+/// `PUBSUB.*` touch.
+pub fn install_host_pubsub(host: &'static PubSub) {
+    let _ = ACTIVE_PUBSUB.set(host);
+}
+
+/// Return this DSO's local `PubSub` instance. Used by the host's
+/// loader to obtain the pointer it hands to plugin cdylibs through
+/// `HostServices.pubsub`, and by `Runner::new()` to wire the host's
+/// own DSO through the same indirection layer plugins ride.
+pub fn local_pubsub() -> &'static PubSub {
+    &LOCAL_PUBSUB
+}
 
 /// iceoryx2-backed pub/sub for runtime events.
 pub struct PubSub {

--- a/libs/streamlib-engine/src/core/pubsub/mod.rs
+++ b/libs/streamlib-engine/src/core/pubsub/mod.rs
@@ -7,5 +7,5 @@ mod events;
 #[cfg(test)]
 mod integration_tests;
 
-pub use bus::PUBSUB;
+pub use bus::{install_host_pubsub, local_pubsub, PubSub, PubSubProxy, PUBSUB};
 pub use events::{topics, Event, EventListener, ProcessorEvent, RuntimeEvent};

--- a/libs/streamlib-engine/src/core/pubsub/mod.rs
+++ b/libs/streamlib-engine/src/core/pubsub/mod.rs
@@ -7,5 +7,5 @@ mod events;
 #[cfg(test)]
 mod integration_tests;
 
-pub use bus::{install_host_pubsub, local_pubsub, PubSub, PubSubProxy, PUBSUB};
+pub use bus::{PubSub, PUBSUB};
 pub use events::{topics, Event, EventListener, ProcessorEvent, RuntimeEvent};

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -35,21 +35,6 @@ use crate::iceoryx2::Iceoryx2Node;
 static LOADED_PLUGIN_LIBRARIES: std::sync::LazyLock<parking_lot::Mutex<Vec<libloading::Library>>> =
     std::sync::LazyLock::new(|| parking_lot::Mutex::new(Vec::new()));
 
-/// ABI version for plugin compatibility checks.
-///
-/// Must match `streamlib_plugin_abi::STREAMLIB_ABI_VERSION`. Duplicated here to
-/// avoid a cyclic dependency (streamlib-plugin-abi depends on streamlib).
-const PLUGIN_ABI_VERSION: u32 = 1;
-
-/// Plugin declaration exported by dynamic libraries.
-///
-/// Must match the layout of `streamlib_plugin_abi::PluginDeclaration`.
-#[repr(C)]
-struct PluginDeclaration {
-    abi_version: u32,
-    register: extern "C" fn(&'static crate::core::processors::ProcessorInstanceFactory),
-}
-
 /// Storage variant for tokio runtime in Runner.
 ///
 /// Enables Runner to work both standalone (owning its runtime) and
@@ -200,6 +185,15 @@ impl Runner {
         let result = crate::core::processors::PROCESSOR_REGISTRY.register_all_processors();
         tracing::debug!("Registered {} processors from inventory", result.count);
 
+        // Bridge iceoryx2's internal log records into streamlib tracing
+        // before creating the iceoryx2 Node so any iceoryx2 emit at
+        // construction time lands in the unified JSONL pipeline. The
+        // host's bridge value is the same `&'static dyn Log` that
+        // [`crate::core::plugin::host_services`] hands to plugin cdylibs
+        // via `HostServices.iceoryx2_logger_ptr` so every DSO converges
+        // on a single logger.
+        crate::core::logging::iceoryx2_log_bridge::install_iceoryx2_log_bridge_for_self();
+
         // Create iceoryx2 Node early so PUBSUB can initialize before start().
         // The node is cloned into RuntimeContext during start().
         tracing::info!("[new] Creating iceoryx2 Node...");
@@ -284,6 +278,16 @@ impl Runner {
     /// Unique identifier for this runtime instance.
     pub fn runtime_id(&self) -> &RuntimeUniqueId {
         &self.runtime_id
+    }
+
+    /// This runtime's iceoryx2 node. Exposed so external loaders
+    /// (`streamlib-runtime`'s `--plugin` flag, embedding apps that
+    /// `dlopen` a cdylib outside `load_project`) can hand it to
+    /// [`crate::core::plugin::host_services::runtime_facing::host_services_for_self`]
+    /// when assembling the `HostServices` payload for a plugin
+    /// register callback.
+    pub fn iceoryx2_node(&self) -> &Iceoryx2Node {
+        &self.iceoryx2_node
     }
 
     /// Path of the JSONL log file this runtime is writing to, if any.
@@ -579,9 +583,11 @@ impl Runner {
                             })?
                         };
 
-                        let decl: &PluginDeclaration = unsafe {
+                        let decl: &streamlib_plugin_abi::PluginDeclaration = unsafe {
                             let symbol = lib
-                                .get::<*const PluginDeclaration>(b"STREAMLIB_PLUGIN\0")
+                                .get::<*const streamlib_plugin_abi::PluginDeclaration>(
+                                    b"STREAMLIB_PLUGIN\0",
+                                )
                                 .map_err(|e| {
                                     Error::Configuration(format!(
                                         "Plugin '{}' missing STREAMLIB_PLUGIN symbol. \
@@ -593,18 +599,37 @@ impl Runner {
                             &**symbol
                         };
 
-                        if decl.abi_version != PLUGIN_ABI_VERSION {
+                        if decl.abi_version != streamlib_plugin_abi::STREAMLIB_ABI_VERSION {
                             return Err(Error::Configuration(format!(
                                 "ABI version mismatch for '{}': plugin has v{}, \
                                  runtime expects v{}. Rebuild the plugin with a \
                                  compatible streamlib-plugin-abi version.",
                                 dylib_path.display(),
                                 decl.abi_version,
-                                PLUGIN_ABI_VERSION
+                                streamlib_plugin_abi::STREAMLIB_ABI_VERSION,
                             )));
                         }
 
-                        (decl.register)(&crate::core::processors::PROCESSOR_REGISTRY);
+                        // Build the HostServices payload from the host's
+                        // process-wide statics + this runtime's iceoryx2
+                        // node, hand it to the cdylib's register callback.
+                        // The cdylib's macro-emitted prologue calls
+                        // `install_host_services` which bridges every
+                        // per-DSO static (tracing dispatch, PUBSUB,
+                        // schema registry, iceoryx2 logger) into the
+                        // host's instances before processor registration.
+                        let host_services =
+                            crate::core::plugin::host_services::runtime_facing::host_services_for_self(
+                                &self.iceoryx2_node,
+                            );
+                        // SAFETY: `host_services` outlives the call;
+                        // the cdylib's callback returns before this
+                        // function frame is dropped.
+                        unsafe {
+                            (decl.register)(
+                                &host_services as *const _ as *const ::std::ffi::c_void,
+                            );
+                        }
 
                         // Keep the library alive for the process lifetime
                         LOADED_PLUGIN_LIBRARIES.lock().push(lib);

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -218,6 +218,7 @@ pub mod sdk {
     pub use crate::core::graph_file;
     pub use crate::core::json_schema;
     pub use crate::core::media_clock;
+    pub use crate::core::plugin;
     pub use crate::core::prelude;
     pub use crate::core::rhi;
     pub use crate::core::runtime;

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `STREAMLIB_PLUGIN` ABI v2 — PUBSUB bridge end-to-end.
+//!
+//! A listener subscribed in the host before `load_project` receives
+//! the `RuntimeDidRegisterProcessorType` event that cdylib code
+//! publishes when it invokes `host_registry.register::<P>()`.
+//! Mentally revert `install_host_pubsub` in
+//! `libs/streamlib-engine/src/core/plugin/host_services.rs` and
+//! this test fails: the cdylib's per-DSO `PUBSUB` instance never
+//! converges on the host's bus, so the publish lands in a
+//! subscriber-less iceoryx2 service.
+//!
+//! Runs in its own test binary so `PROCESSOR_REGISTRY` and the
+//! one-shot tracing/logging globals are fresh — the sibling
+//! `load_project_dylib_tracing_bridge.rs` needs the same fresh
+//! state, and registry duplicates from a sibling-test register call
+//! would early-return the `register::<P>()` path without firing
+//! either bridge.
+
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serial_test::serial;
+use streamlib::sdk::pubsub::{topics, Event, EventListener, RuntimeEvent, PUBSUB};
+use streamlib::sdk::runtime::Runner;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+fn build_and_stage_test_fixtures_dylib() -> (tempfile::TempDir, std::path::PathBuf) {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+    assert!(
+        built_dylib.exists(),
+        "cdylib expected at {} after cargo build",
+        built_dylib.display()
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    (tmp, fixtures_dst)
+}
+
+struct CountingListener {
+    matched: Arc<AtomicUsize>,
+}
+
+impl EventListener for CountingListener {
+    fn on_event(&mut self, event: &Event) -> streamlib::sdk::error::Result<()> {
+        if let Event::RuntimeGlobal(RuntimeEvent::RuntimeDidRegisterProcessorType {
+            processor_type,
+        }) = event
+        {
+            if processor_type.r#type.as_str() == "TestConfiguredProcessor" {
+                self.matched.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+#[serial]
+fn plugin_register_pubsub_event_reaches_host_subscriber() {
+    let (_tmp, fixtures_dst) = build_and_stage_test_fixtures_dylib();
+
+    let runtime = Runner::new().unwrap();
+
+    // Subscribe BEFORE load_project so the cdylib's register-time
+    // publish has somewhere to land. Sleep ~200 ms so the subscriber
+    // thread opens its iceoryx2 service before the publish (per the
+    // pubsub-lazy-init-silent-noop learning's setup-time recipe).
+    let matched = Arc::new(AtomicUsize::new(0));
+    let listener_arc: Arc<Mutex<dyn EventListener>> =
+        Arc::new(Mutex::new(CountingListener {
+            matched: Arc::clone(&matched),
+        }));
+    PUBSUB.subscribe(topics::RUNTIME_GLOBAL, Arc::clone(&listener_arc));
+    std::thread::sleep(Duration::from_millis(200));
+
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while matched.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        matched.load(Ordering::SeqCst) >= 1,
+        "host subscriber should have received a RuntimeDidRegisterProcessorType \
+         event for TestConfiguredProcessor — the cdylib's PUBSUB.publish call \
+         from inside ProcessorInstanceFactory::register did not reach the \
+         host's bus. Check `install_host_pubsub` in \
+         libs/streamlib-engine/src/core/plugin/host_services.rs."
+    );
+
+    drop(listener_arc);
+}

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -13,11 +13,11 @@
 //! subscriber-less iceoryx2 service.
 //!
 //! Runs in its own test binary so `PROCESSOR_REGISTRY` and the
-//! one-shot tracing/logging globals are fresh — the sibling
-//! `load_project_dylib_tracing_bridge.rs` needs the same fresh
-//! state, and registry duplicates from a sibling-test register call
-//! would early-return the `register::<P>()` path without firing
-//! either bridge.
+//! one-shot tracing/logging globals are fresh. The same-binary
+//! `#[serial]`-guarded shape leaves `PROCESSOR_REGISTRY` populated
+//! between tests, and `register::<P>()` early-returns on a
+//! duplicate type-name — silently skipping the PUBSUB publish this
+//! test asserts.
 
 use std::path::Path;
 use std::sync::{

--- a/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
@@ -1,35 +1,31 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! `STREAMLIB_PLUGIN` ABI v2 — PUBSUB bridge end-to-end.
+//! `STREAMLIB_PLUGIN` ABI v2 — tracing-dispatch bridge end-to-end.
 //!
-//! A listener subscribed in the host before `load_project` receives
-//! the `RuntimeDidRegisterProcessorType` event that cdylib code
-//! publishes when it invokes `host_registry.register::<P>()`.
-//! Mentally revert the `host_callbacks()`-routing branch in
-//! `PubSub::publish` (or `host_pubsub_publish` in
-//! `libs/streamlib-engine/src/core/plugin/host_services.rs`) and
-//! this test fails: the cdylib's per-DSO `PUBSUB` falls through to
-//! its own uninitialized iceoryx2 service and the publish lands in
-//! a bus the host's subscriber never sees.
+//! The host's JSONL log carries the `[register]` line emitted by
+//! `tracing::info!` inside `ProcessorInstanceFactory::register`
+//! while running in the cdylib's address space. The cdylib's
+//! `ForwardingSubscriber` (installed by `install_host_services`)
+//! serializes the event's target / level / message / fields into
+//! primitive payloads and calls the host's `tracing_emit` fn
+//! pointer; the host builds a `LogRecord` and pushes it onto the
+//! drain queue.
 //!
-//! Runs in its own test binary so `PROCESSOR_REGISTRY` and the
-//! one-shot tracing/logging globals are fresh. The same-binary
-//! `#[serial]`-guarded shape leaves `PROCESSOR_REGISTRY` populated
-//! between tests, and `register::<P>()` early-returns on a
-//! duplicate type-name — silently skipping the PUBSUB publish this
-//! test asserts.
+//! Mentally revert
+//! `crate::core::plugin::forwarding_subscriber::install_for_self` or
+//! `emit_via_host_dispatch` in `host_services.rs` and this test
+//! fails: cdylib `tracing::info!` calls drop silently.
+//!
+//! Runs in its own test binary so `PROCESSOR_REGISTRY` is fresh —
+//! `register::<P>()` early-returns on a duplicate and would skip
+//! the emit if a sibling test had already registered the same
+//! processor.
 
 use std::path::Path;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
 use std::time::{Duration, Instant};
 
-use parking_lot::Mutex;
 use serial_test::serial;
-use streamlib::sdk::pubsub::{topics, Event, EventListener, RuntimeEvent, PUBSUB};
 use streamlib::sdk::runtime::Runner;
 use streamlib_engine::core::runtime::host_target_triple;
 
@@ -112,61 +108,57 @@ fn build_and_stage_test_fixtures_dylib() -> (tempfile::TempDir, std::path::PathB
     (tmp, fixtures_dst)
 }
 
-struct CountingListener {
-    matched: Arc<AtomicUsize>,
-}
-
-impl EventListener for CountingListener {
-    fn on_event(&mut self, event: &Event) -> streamlib::sdk::error::Result<()> {
-        if let Event::RuntimeGlobal(RuntimeEvent::RuntimeDidRegisterProcessorType {
-            processor_type,
-        }) = event
-        {
-            if processor_type.r#type.as_str() == "TestConfiguredProcessor" {
-                self.matched.fetch_add(1, Ordering::SeqCst);
-            }
-        }
-        Ok(())
-    }
-}
-
 #[test]
 #[serial]
-fn plugin_register_pubsub_event_reaches_host_subscriber() {
+fn plugin_register_tracing_event_reaches_host_jsonl() {
     let (_tmp, fixtures_dst) = build_and_stage_test_fixtures_dylib();
 
     let runtime = Runner::new().unwrap();
-
-    // Subscribe BEFORE load_project so the cdylib's register-time
-    // publish has somewhere to land. Sleep ~200 ms so the subscriber
-    // thread opens its iceoryx2 service before the publish (per the
-    // pubsub-lazy-init-silent-noop learning's setup-time recipe).
-    let matched = Arc::new(AtomicUsize::new(0));
-    let listener_arc: Arc<Mutex<dyn EventListener>> =
-        Arc::new(Mutex::new(CountingListener {
-            matched: Arc::clone(&matched),
-        }));
-    PUBSUB.subscribe(topics::RUNTIME_GLOBAL, Arc::clone(&listener_arc));
-    std::thread::sleep(Duration::from_millis(200));
+    let jsonl_path = runtime
+        .jsonl_log_path()
+        .map(|p| p.to_path_buf())
+        .expect(
+            "host runtime must own a JSONL log file — tracing bridge cannot be \
+             verified without one",
+        );
 
     runtime
         .load_project(&fixtures_dst)
         .expect("load_project must succeed");
 
+    // Tracing→JSONL flow under the callback-table architecture:
+    // cdylib's `ProcessorInstanceFactory::register::<P>()` calls
+    // `tracing::info!` → cdylib's `ForwardingSubscriber::event` →
+    // host's `tracing_emit` fn pointer → host's
+    // `emit_via_host_dispatch` builds a `LogRecord` and pushes onto
+    // the drain queue → host's drain worker writes JSONL. Worker
+    // drain interval is ~25 ms by default; poll up to 2 s for the
+    // line to land.
     let deadline = Instant::now() + Duration::from_secs(2);
-    while matched.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(10));
+    let mut found_line: Option<String> = None;
+    while found_line.is_none() && Instant::now() < deadline {
+        if let Ok(contents) = std::fs::read_to_string(&jsonl_path) {
+            for line in contents.lines() {
+                if line.contains("new processor type registered")
+                    && line.contains("TestConfiguredProcessor")
+                {
+                    found_line = Some(line.to_string());
+                    break;
+                }
+            }
+        }
+        if found_line.is_none() {
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     assert!(
-        matched.load(Ordering::SeqCst) >= 1,
-        "host subscriber should have received a RuntimeDidRegisterProcessorType \
-         event for TestConfiguredProcessor — the cdylib's PUBSUB.publish call \
-         from inside ProcessorInstanceFactory::register did not reach the \
-         host's bus. Check the host_callbacks() routing branch in \
-         `PubSub::publish` and the `host_pubsub_publish` callback in \
-         libs/streamlib-engine/src/core/plugin/host_services.rs."
+        found_line.is_some(),
+        "host JSONL at {} must contain the '[register] new processor type \
+         registered' line for TestConfiguredProcessor — emitted from cdylib \
+         code via tracing::info! and forwarded through the callback-table \
+         tracing bridge. Without the ForwardingSubscriber or \
+         emit_via_host_dispatch, the cdylib's tracing emit is dropped.",
+        jsonl_path.display(),
     );
-
-    drop(listener_arc);
 }

--- a/libs/streamlib-plugin-abi/Cargo.toml
+++ b/libs/streamlib-plugin-abi/Cargo.toml
@@ -9,9 +9,15 @@ license = "BUSL-1.1"
 description = "Plugin interface for StreamLib dynamic processor loading"
 repository.workspace = true
 
-# Depends on streamlib for ProcessorInstanceFactory type in the registration function signature
+# The plugin-abi crate is the wire-protocol header for the
+# `STREAMLIB_PLUGIN` symbol. It carries no streamlib dependencies —
+# the macro expansion calls into `streamlib::sdk::plugin::*` (defined
+# in streamlib-engine) at the cdylib's call site, where the streamlib
+# dep already lives. Keeping plugin-abi dep-free resolves the cyclic
+# `streamlib-engine → streamlib-plugin-abi → streamlib-sdk →
+# streamlib-engine` cycle the engine used to dodge by redeclaring
+# `PluginDeclaration` locally.
 [dependencies]
-streamlib = { path = "../streamlib-sdk" }
 
 [lints]
 workspace = true

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -3,11 +3,14 @@
 
 //! ABI-stable plugin interface for StreamLib dynamic processor loading.
 //!
-//! This crate provides the minimal interface for plugins to register their
-//! processors with the StreamLib runtime. Plugins use the same `#[streamlib::sdk::processor]`
-//! macro as built-in processors - the only difference is how they're registered.
+//! This crate is the wire-protocol header for the `STREAMLIB_PLUGIN`
+//! symbol: it defines [`PluginDeclaration`], [`STREAMLIB_ABI_VERSION`],
+//! and the [`export_plugin!`] macro. **It does not depend on the
+//! streamlib SDK** — the register callback takes an opaque pointer that
+//! the macro hands to a helper inside the SDK, which is the layer that
+//! knows the typed shape of the host services.
 //!
-//! # Example Plugin
+//! # Example plugin
 //!
 //! ```ignore
 //! use streamlib::prelude::*;
@@ -25,15 +28,13 @@
 //! impl ContinuousProcessor for MyProcessor::Processor {
 //!     fn process(&mut self) -> Result<()> {
 //!         if let Some(frame) = self.video_in.read() {
-//!             // Process frame...
 //!             self.video_out.write(frame);
 //!         }
 //!         Ok(())
 //!     }
 //! }
 //!
-//! // Export for dynamic loading
-//! export_plugin!(MyProcessor);
+//! export_plugin!(MyProcessor::Processor);
 //! ```
 //!
 //! # Plugin Cargo.toml
@@ -47,74 +48,106 @@
 //! streamlib-plugin-abi = "0.2"
 //! ```
 
-use streamlib::sdk::processors::ProcessorInstanceFactory;
+/// Current ABI version. Plugins must match this exactly. Bumped when
+/// the wire shape of [`PluginDeclaration`] or the register callback's
+/// signature changes incompatibly. The shape of the *host-services
+/// payload* passed through the opaque pointer is versioned separately
+/// inside the SDK (see `streamlib::sdk::plugin::HostServices::LAYOUT_VERSION`).
+pub const STREAMLIB_ABI_VERSION: u32 = 2;
 
-/// Current ABI version. Plugins must match this exactly.
+/// Plugin register function signature.
 ///
-/// Increment when making breaking changes to the plugin interface.
-pub const STREAMLIB_ABI_VERSION: u32 = 1;
-
-/// Function signature for plugin registration.
+/// The host passes a pointer to its `HostServices` payload (defined in
+/// streamlib-engine). The cdylib's macro expansion forwards the pointer
+/// into `streamlib::sdk::plugin::install_host_services` which validates
+/// the layout, bridges every process-wide static (tracing dispatch,
+/// PUBSUB, schema registry, iceoryx2 logger), and returns the host's
+/// processor registry the cdylib registers into.
 ///
-/// The host passes its `ProcessorInstanceFactory` reference to ensure processors
-/// register with the host's registry, not a duplicate in the plugin's address space.
-pub type PluginRegisterFn = extern "C" fn(&'static ProcessorInstanceFactory);
+/// # Safety
+///
+/// `host_services` must point at a valid `HostServices` payload owned
+/// by the host. The host guarantees the pointer outlives the cdylib's
+/// process lifetime (today: the cdylib's `Library` handle is pinned by
+/// the host's `LOADED_PLUGIN_LIBRARIES` static).
+pub type PluginRegisterFn = unsafe extern "C" fn(host_services: *const core::ffi::c_void);
 
 /// Plugin declaration exported by dynamic libraries.
 ///
-/// Plugins must export a static symbol named `STREAMLIB_PLUGIN` of this type.
-/// Use the [`export_plugin!`] macro to generate this correctly.
+/// Plugins export a static named `STREAMLIB_PLUGIN` of this type via
+/// [`export_plugin!`]. The host's loader looks up the symbol, validates
+/// `abi_version`, and invokes `register`.
 #[repr(C)]
 pub struct PluginDeclaration {
-    /// ABI version - must match [`STREAMLIB_ABI_VERSION`].
+    /// Wire ABI version — must equal [`STREAMLIB_ABI_VERSION`] at load
+    /// time. Bumped when [`PluginDeclaration`] or [`PluginRegisterFn`]
+    /// changes incompatibly.
     pub abi_version: u32,
 
-    /// Registration function called by the CLI to register processors.
-    ///
-    /// The host passes its [`ProcessorInstanceFactory`] reference to ensure
-    /// processors register with the host's registry, not a duplicate static
-    /// in the plugin's address space.
+    /// Register callback. Receives the host-services pointer; the
+    /// cdylib's macro expansion uses it to bridge process-wide statics
+    /// before registering processors with the host's registry.
     pub register: PluginRegisterFn,
 }
 
-// Safety: PluginDeclaration contains only a version number and function pointer,
-// both of which are Send + Sync.
+// Safety: contains only a u32 and a function pointer.
 unsafe impl Send for PluginDeclaration {}
 unsafe impl Sync for PluginDeclaration {}
 
 /// Export processors for dynamic loading.
 ///
-/// This macro generates the `STREAMLIB_PLUGIN` symbol that the CLI looks for
-/// when loading plugin libraries. It creates a registration function that
-/// registers each processor with the host's `ProcessorInstanceFactory`.
+/// Emits the `STREAMLIB_PLUGIN` static the host's loader looks for, and
+/// generates the register callback that:
+///
+/// 1. Bridges process-wide statics from the host (tracing dispatch,
+///    `PUBSUB`, schema registry, iceoryx2 logger) into the cdylib's
+///    own per-DSO copies via
+///    `streamlib::sdk::plugin::install_host_services`.
+/// 2. Registers each declared processor type with the host's
+///    `ProcessorInstanceFactory`.
+///
+/// Step 1 has to happen before step 2 — the registry's
+/// `register::<P>()` path publishes a `RuntimeDidRegisterProcessorType`
+/// event via `PUBSUB`, which only flows back to the host once `PUBSUB`
+/// points at the host's instance.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use streamlib_plugin_abi::export_plugin;
-///
-/// // Export a single processor
-/// export_plugin!(MyProcessor);
-///
-/// // Export multiple processors
-/// export_plugin!(ProcessorA, ProcessorB, ProcessorC);
+/// export_plugin!(MyProcessor::Processor);
+/// export_plugin!(ProcessorA::Processor, ProcessorB::Processor);
 /// ```
-///
-/// # Requirements
-///
-/// - Each processor must be defined using `#[streamlib::sdk::processor]`
-/// - The processor's `Processor` type must implement the appropriate trait
-///   (`ContinuousProcessor`, `ReactiveProcessor`, or `ManualProcessor`)
 #[macro_export]
 macro_rules! export_plugin {
     ($($processor:ty),* $(,)?) => {
+        /// Generated by `streamlib_plugin_abi::export_plugin!`.
+        ///
+        /// # Safety
+        ///
+        /// `host_services` must point at a layout-compatible
+        /// `HostServices` payload, per the [`PluginRegisterFn`] contract.
         #[allow(non_snake_case)]
-        extern "C" fn __streamlib_plugin_register(
-            registry: &'static ::streamlib::sdk::processors::ProcessorInstanceFactory
+        unsafe extern "C" fn __streamlib_plugin_register(
+            host_services: *const ::core::ffi::c_void,
         ) {
-            $(
-                registry.register::<$processor>();
-            )*
+            // Panic across an `extern "C"` boundary is UB. `catch_unwind`
+            // contains any unwinding within the cdylib; a panic in
+            // `install_host_services` or `registry.register::<_>()` is
+            // converted to silent return on the host side, where the
+            // post-call "processor not registered" check surfaces an
+            // actionable error.
+            let _ = ::std::panic::catch_unwind(|| {
+                // SAFETY: forwarded per the [`PluginRegisterFn`] contract.
+                let registry = unsafe {
+                    ::streamlib::sdk::plugin::install_host_services(host_services)
+                };
+                let Some(registry) = registry else {
+                    return;
+                };
+                $(
+                    registry.register::<$processor>();
+                )*
+            });
         }
 
         #[unsafe(no_mangle)]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -1,14 +1,37 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! ABI-stable plugin interface for StreamLib dynamic processor loading.
+//! Pure ABI contract for StreamLib's dynamic plugin system.
 //!
-//! This crate is the wire-protocol header for the `STREAMLIB_PLUGIN`
-//! symbol: it defines [`PluginDeclaration`], [`STREAMLIB_ABI_VERSION`],
-//! and the [`export_plugin!`] macro. **It does not depend on the
-//! streamlib SDK** — the register callback takes an opaque pointer that
-//! the macro hands to a helper inside the SDK, which is the layer that
-//! knows the typed shape of the host services.
+//! Loosely analogous to Unreal's `IModuleInterface` or VST3's audio-
+//! plugin spec: a `#[repr(C)]` wire-protocol header that lets a host
+//! binary and a dlopen'd Rust cdylib communicate **without sharing
+//! any Rust types beyond primitives and `extern "C" fn` pointers**.
+//!
+//! The deployment model this enables: computer A builds the host
+//! binary, computer B builds packages via CI, computer C ships their
+//! own packages — all using different rustc minor versions and
+//! different dep resolutions, all interoperating, as long as they
+//! target the same triple and pin the same [`STREAMLIB_ABI_VERSION`].
+//! No commit-level coupling, no shared Cargo.lock.
+//!
+//! # What crosses the wire
+//!
+//! The host fills out a [`HostServices`] struct with `extern "C" fn`
+//! pointers that bridge every process-wide service the plugin's
+//! statically-linked engine copy would otherwise see in isolation:
+//! tracing emit, PUBSUB publish, schema-registry register / lookup,
+//! iceoryx2-log emit. The cdylib's `streamlib::sdk::plugin::install_host_services`
+//! stores those fn pointers and replaces the cdylib's per-DSO
+//! statics' read sites with forwarders that thunk through them.
+//!
+//! Side note: the legacy `processor_registry_typed` field still
+//! crosses as a typed `*const ProcessorInstanceFactory`. The
+//! `ProcessorInstanceFactory`'s internal `Box<dyn Fn>` constructors
+//! and `Box<dyn DynGeneratedProcessor>` instance objects are
+//! pre-existing dyn-trait crossings whose ABI stability depends on
+//! the engine's semver coupling — separate from the callback-table
+//! bridges this struct introduces.
 //!
 //! # Example plugin
 //!
@@ -20,16 +43,11 @@
 //! pub struct MyProcessor {
 //!     #[streamlib::sdk::processors::input(description = "Video input")]
 //!     video_in: LinkInput<VideoFrame>,
-//!
-//!     #[streamlib::sdk::processors::output(description = "Video output")]
-//!     video_out: Arc<LinkOutput<VideoFrame>>,
 //! }
 //!
 //! impl ContinuousProcessor for MyProcessor::Processor {
 //!     fn process(&mut self) -> Result<()> {
-//!         if let Some(frame) = self.video_in.read() {
-//!             self.video_out.write(frame);
-//!         }
+//!         if let Some(frame) = self.video_in.read() { /* ... */ }
 //!         Ok(())
 //!     }
 //! }
@@ -48,45 +66,269 @@
 //! streamlib-plugin-abi = "0.2"
 //! ```
 
-/// Current ABI version. Plugins must match this exactly. Bumped when
-/// the wire shape of [`PluginDeclaration`] or the register callback's
-/// signature changes incompatibly. The shape of the *host-services
-/// payload* passed through the opaque pointer is versioned separately
-/// inside the SDK (see `streamlib::sdk::plugin::HostServices::LAYOUT_VERSION`).
+use core::ffi::c_void;
+
+// =============================================================================
+// Wire ABI version
+// =============================================================================
+
+/// Current ABI version. Plugins must match this exactly at load time.
+/// Bumped when the wire shape of [`PluginDeclaration`], the register
+/// callback's signature, or [`HostServices`]'s layout changes
+/// incompatibly. Same-major-version layout additions append to the
+/// end of [`HostServices`] and read the new fields only when
+/// `abi_layout_version` advertises them.
 pub const STREAMLIB_ABI_VERSION: u32 = 2;
+
+/// Layout version of the [`HostServices`] payload. Read first by the
+/// cdylib's `install_host_services` before any other field is
+/// touched. Bumped whenever fields are added, removed, or reordered.
+/// Distinct from [`STREAMLIB_ABI_VERSION`] because layout-only
+/// additions can ship without bumping the wire ABI.
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 1;
+
+// =============================================================================
+// Primitive enums
+// =============================================================================
+
+/// Log level for tracing + iceoryx2-log emits. Matches
+/// `tracing::Level` and `iceoryx2_log_types::LogLevel` orderings;
+/// `Fatal` from iceoryx2 collapses to `Error`.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HostLogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+
+/// Filter interest returned by the host's `tracing_register_callsite`
+/// callback. Matches `tracing-core`'s `Interest` semantics: `Never`
+/// permanently disables a callsite; `Always` permanently enables;
+/// `Sometimes` defers to per-event `tracing_enabled`.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HostInterest {
+    Never = 0,
+    Sometimes = 1,
+    Always = 2,
+}
+
+/// Opaque host-owned state pointer. Threaded through every callback
+/// as the first argument; the host derefs to its concrete service
+/// table, the cdylib treats it as opaque.
+pub type HostHandle = *const c_void;
+
+// =============================================================================
+// HostServices — the callback table
+// =============================================================================
+
+/// Host-services payload the host hands to plugin cdylibs via the
+/// `STREAMLIB_PLUGIN.register` callback.
+///
+/// **Pure ABI.** Every field is either a primitive or an
+/// `unsafe extern "C" fn` pointer. No Rust types cross the
+/// boundary. Stable under rustc minor-version drift and
+/// transitive-dep drift, as long as both sides target the same
+/// triple and link the same [`STREAMLIB_ABI_VERSION`].
+///
+/// # Layout discipline
+///
+/// `abi_layout_version` and `host` are pinned at offset 0 and offset
+/// 8 forever; the cdylib reads `abi_layout_version` before
+/// dereferencing any other field, so an older cdylib loaded into a
+/// newer host can refuse to load cleanly when fields shift.
+///
+/// New fields go at the **end** and bump
+/// [`HOST_SERVICES_LAYOUT_VERSION`]. Removing or reordering existing
+/// fields requires bumping [`STREAMLIB_ABI_VERSION`].
+#[repr(C)]
+pub struct HostServices {
+    /// Layout version. Must equal [`HOST_SERVICES_LAYOUT_VERSION`].
+    pub abi_layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    /// Opaque host state. Passed to every callback below.
+    pub host: HostHandle,
+
+    // -------------------------------------------------------------------------
+    // Tracing — forwarder Subscriber callbacks (tracing-ext-ffi-subscriber shape)
+    // -------------------------------------------------------------------------
+
+    /// Register a callsite with the host's tracing pipeline. The
+    /// host's `EnvFilter` computes interest from `(target, level)`
+    /// and returns it; the cdylib caches the result per-callsite
+    /// the same way tracing-core does locally.
+    pub tracing_register_callsite: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+    ) -> HostInterest,
+
+    /// Per-event enable check. Called when [`HostInterest::Sometimes`]
+    /// was returned by `tracing_register_callsite`. The host can
+    /// short-circuit emit by returning `false`.
+    pub tracing_enabled: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+    ) -> bool,
+
+    /// Emit an event. `message_ptr`/`len` is the formatted message
+    /// (the `tracing::info!("{}", x)` body); `fields_msgpack_ptr`/`len`
+    /// is a msgpack `map` of structured fields excluding `message`,
+    /// empty when there are no fields beyond the message. The host
+    /// deserializes the map into its `JsonlSinkLayer::Capture` shape.
+    pub tracing_emit: unsafe extern "C" fn(
+        host: HostHandle,
+        target_ptr: *const u8,
+        target_len: usize,
+        level: HostLogLevel,
+        message_ptr: *const u8,
+        message_len: usize,
+        fields_msgpack_ptr: *const u8,
+        fields_msgpack_len: usize,
+    ),
+
+    // -------------------------------------------------------------------------
+    // PUBSUB
+    // -------------------------------------------------------------------------
+
+    /// Publish a serialized `Event` to a topic. The event is encoded
+    /// the same way `PubSub::publish` encodes today (msgpack-named
+    /// via `rmp_serde::to_vec_named`), so host-side
+    /// deserialization is identical regardless of caller DSO.
+    ///
+    /// Subscribe is intentionally absent: cdylib code does not
+    /// currently subscribe; if a future plugin shape needs it, add a
+    /// `pubsub_subscribe` callback paired with a cdylib-provided
+    /// listener fn pointer and bump
+    /// [`HOST_SERVICES_LAYOUT_VERSION`].
+    pub pubsub_publish: unsafe extern "C" fn(
+        host: HostHandle,
+        topic_ptr: *const u8,
+        topic_len: usize,
+        event_msgpack_ptr: *const u8,
+        event_msgpack_len: usize,
+    ),
+
+    // -------------------------------------------------------------------------
+    // Schema registry
+    // -------------------------------------------------------------------------
+
+    /// Register a schema's YAML body under its canonical id. Last
+    /// write wins (matches `register_schema` semantics).
+    pub schema_register: unsafe extern "C" fn(
+        host: HostHandle,
+        canonical_id_ptr: *const u8,
+        canonical_id_len: usize,
+        yaml_ptr: *const u8,
+        yaml_len: usize,
+    ),
+
+    /// Lookup a schema by canonical id. The host invokes
+    /// `result_callback(result_userdata, yaml_ptr, yaml_len)` exactly
+    /// once before returning; `yaml_ptr` is null + `yaml_len` is 0 on
+    /// miss. The callback receives a borrow valid only for the
+    /// duration of the call; cdylib code must copy if it needs to
+    /// outlive the call.
+    pub schema_lookup: unsafe extern "C" fn(
+        host: HostHandle,
+        canonical_id_ptr: *const u8,
+        canonical_id_len: usize,
+        result_callback: extern "C" fn(
+            userdata: *mut c_void,
+            yaml_ptr: *const u8,
+            yaml_len: usize,
+        ),
+        result_userdata: *mut c_void,
+    ),
+
+    // -------------------------------------------------------------------------
+    // iceoryx2-log
+    // -------------------------------------------------------------------------
+
+    /// Emit an iceoryx2 log record. Used by the cdylib's
+    /// `iceoryx2_log_types::Log` forwarder; the host bridges to its
+    /// own tracing pipeline.
+    pub iceoryx_log_emit: unsafe extern "C" fn(
+        host: HostHandle,
+        level: HostLogLevel,
+        origin_ptr: *const u8,
+        origin_len: usize,
+        message_ptr: *const u8,
+        message_len: usize,
+    ),
+
+    // -------------------------------------------------------------------------
+    // Processor registry — legacy typed pointer
+    // -------------------------------------------------------------------------
+
+    /// Host's `ProcessorInstanceFactory` reference as a raw pointer.
+    /// The cdylib casts back to `&'static ProcessorInstanceFactory`
+    /// and calls `register::<P>()` on it.
+    ///
+    /// This is the **one remaining type-passing field** in
+    /// [`HostServices`]. The `ProcessorInstanceFactory`'s internal
+    /// constructor / instance representations use `Box<dyn Fn>` and
+    /// `Box<dyn DynGeneratedProcessor>` — dyn-trait crossings whose
+    /// ABI stability depends on the engine's semver coupling, not
+    /// on the callback-table contract. Lifting them to extern "C"
+    /// requires reshaping the entire processor lifecycle ABI
+    /// (setup / process / teardown / port wiring / runtime-context
+    /// access) and is the natural next-step plugin-ABI milestone.
+    pub processor_registry_typed: *const c_void,
+}
+
+// Safety: every field is a raw pointer, a fn pointer, or a
+// primitive. The host guarantees the pointed-at state outlives the
+// cdylib's process lifetime via the `LOADED_PLUGIN_LIBRARIES`
+// pinning shape (the engine's loader keeps the `Library` handle
+// alive forever).
+unsafe impl Send for HostServices {}
+unsafe impl Sync for HostServices {}
+
+// =============================================================================
+// PluginDeclaration — the wire envelope
+// =============================================================================
 
 /// Plugin register function signature.
 ///
-/// The host passes a pointer to its `HostServices` payload (defined in
-/// streamlib-engine). The cdylib's macro expansion forwards the pointer
-/// into `streamlib::sdk::plugin::install_host_services` which validates
-/// the layout, bridges every process-wide static (tracing dispatch,
-/// PUBSUB, schema registry, iceoryx2 logger), and returns the host's
-/// processor registry the cdylib registers into.
+/// The host passes a pointer to its [`HostServices`] payload. The
+/// cdylib's macro expansion forwards the pointer into
+/// `streamlib::sdk::plugin::install_host_services`, which validates
+/// the layout, installs forwarders for every process-wide static,
+/// and registers the plugin's processor types with the host's
+/// registry.
 ///
 /// # Safety
 ///
-/// `host_services` must point at a valid `HostServices` payload owned
-/// by the host. The host guarantees the pointer outlives the cdylib's
-/// process lifetime (today: the cdylib's `Library` handle is pinned by
-/// the host's `LOADED_PLUGIN_LIBRARIES` static).
-pub type PluginRegisterFn = unsafe extern "C" fn(host_services: *const core::ffi::c_void);
+/// `host_services` must point at a valid [`HostServices`] payload
+/// owned by the host. The host guarantees the pointer outlives the
+/// cdylib's process lifetime.
+pub type PluginRegisterFn = unsafe extern "C" fn(host_services: *const c_void);
 
 /// Plugin declaration exported by dynamic libraries.
 ///
 /// Plugins export a static named `STREAMLIB_PLUGIN` of this type via
-/// [`export_plugin!`]. The host's loader looks up the symbol, validates
-/// `abi_version`, and invokes `register`.
+/// [`export_plugin!`]. The host's loader looks up the symbol,
+/// validates `abi_version`, and invokes `register`.
 #[repr(C)]
 pub struct PluginDeclaration {
-    /// Wire ABI version — must equal [`STREAMLIB_ABI_VERSION`] at load
-    /// time. Bumped when [`PluginDeclaration`] or [`PluginRegisterFn`]
-    /// changes incompatibly.
+    /// Wire ABI version — must equal [`STREAMLIB_ABI_VERSION`] at
+    /// load time.
     pub abi_version: u32,
 
     /// Register callback. Receives the host-services pointer; the
-    /// cdylib's macro expansion uses it to bridge process-wide statics
-    /// before registering processors with the host's registry.
+    /// cdylib's macro expansion uses it to install every per-DSO
+    /// static's forwarder before registering processors.
     pub register: PluginRegisterFn,
 }
 
@@ -94,22 +336,29 @@ pub struct PluginDeclaration {
 unsafe impl Send for PluginDeclaration {}
 unsafe impl Sync for PluginDeclaration {}
 
+// =============================================================================
+// export_plugin! macro
+// =============================================================================
+
 /// Export processors for dynamic loading.
 ///
-/// Emits the `STREAMLIB_PLUGIN` static the host's loader looks for, and
-/// generates the register callback that:
+/// Emits the `STREAMLIB_PLUGIN` static the host's loader looks for,
+/// and generates the register callback that:
 ///
-/// 1. Bridges process-wide statics from the host (tracing dispatch,
-///    `PUBSUB`, schema registry, iceoryx2 logger) into the cdylib's
-///    own per-DSO copies via
-///    `streamlib::sdk::plugin::install_host_services`.
-/// 2. Registers each declared processor type with the host's
-///    `ProcessorInstanceFactory`.
+/// 1. Calls `streamlib::sdk::plugin::install_host_services` with the
+///    host-services pointer. The helper validates layout, stores the
+///    callback table for the cdylib's PUBSUB / schema-registry
+///    forwarders, installs the tracing `ForwardingSubscriber`,
+///    installs the iceoryx2-log forwarder, and returns a
+///    `RegisterHelper` whose `register::<P>()` method routes through
+///    the host's `ProcessorInstanceFactory`.
+/// 2. Calls `helper.register::<$processor>()` for each declared
+///    processor type, registering it with the host's registry.
 ///
-/// Step 1 has to happen before step 2 — the registry's
-/// `register::<P>()` path publishes a `RuntimeDidRegisterProcessorType`
-/// event via `PUBSUB`, which only flows back to the host once `PUBSUB`
-/// points at the host's instance.
+/// Step 1 must run before step 2: the registry's `register::<P>()`
+/// path emits a `RuntimeDidRegisterProcessorType` PUBSUB event and a
+/// `tracing::info!` line, both of which only flow back to the host
+/// once the forwarders are in place.
 ///
 /// # Example
 ///
@@ -125,27 +374,28 @@ macro_rules! export_plugin {
         /// # Safety
         ///
         /// `host_services` must point at a layout-compatible
-        /// `HostServices` payload, per the [`PluginRegisterFn`] contract.
+        /// [`HostServices`] payload, per the [`PluginRegisterFn`]
+        /// contract.
         #[allow(non_snake_case)]
         unsafe extern "C" fn __streamlib_plugin_register(
             host_services: *const ::core::ffi::c_void,
         ) {
-            // Panic across an `extern "C"` boundary is UB. `catch_unwind`
-            // contains any unwinding within the cdylib; a panic in
-            // `install_host_services` or `registry.register::<_>()` is
-            // converted to silent return on the host side, where the
-            // post-call "processor not registered" check surfaces an
-            // actionable error.
+            // Panic across an `extern "C"` boundary is UB.
+            // `catch_unwind` contains any unwinding within the cdylib;
+            // a panic in `install_host_services` or
+            // `helper.register::<_>()` is converted to silent return.
+            // The host's post-call "processor not registered" check
+            // surfaces a clear configuration error in that case.
             let _ = ::std::panic::catch_unwind(|| {
                 // SAFETY: forwarded per the [`PluginRegisterFn`] contract.
-                let registry = unsafe {
+                let helper = unsafe {
                     ::streamlib::sdk::plugin::install_host_services(host_services)
                 };
-                let Some(registry) = registry else {
+                let Some(helper) = helper else {
                     return;
                 };
                 $(
-                    registry.register::<$processor>();
+                    helper.register::<$processor>();
                 )*
             });
         }

--- a/libs/streamlib-runtime/src/main.rs
+++ b/libs/streamlib-runtime/src/main.rs
@@ -6,11 +6,13 @@
 //! Standalone process that hosts a StreamLib runtime with API server.
 //! Spawned by the `streamlib run` CLI command (kubectl model).
 
+use std::ffi::c_void;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use libloading::Library;
+use streamlib::sdk::plugin::host_services::runtime_facing;
 use streamlib::sdk::processors::PROCESSOR_REGISTRY;
 use streamlib::sdk::runtime::Runner;
 use streamlib_api_server::{ApiServerConfig, ApiServerProcessor};
@@ -170,7 +172,17 @@ impl PluginLoader {
         }
     }
 
-    fn load_plugin(&mut self, path: &Path) -> Result<usize> {
+    /// Load a Rust plugin cdylib and invoke its `STREAMLIB_PLUGIN`
+    /// register callback. `runtime` provides the host's iceoryx2 node
+    /// used to build the cdylib-facing `HostServices` payload — every
+    /// process-wide static the plugin's per-DSO copy of streamlib
+    /// would otherwise see in isolation (tracing dispatch, PUBSUB,
+    /// schema registry, iceoryx2 logger) is bridged to the host's
+    /// instance before the cdylib's `register::<P>()` calls run.
+    ///
+    /// Must be called AFTER `Runner::new()` — the iceoryx2 node and
+    /// tracing-subscriber pipeline only exist post-construction.
+    fn load_plugin(&mut self, path: &Path, runtime: &Runner) -> Result<usize> {
         let lib = unsafe {
             Library::new(path)
                 .with_context(|| format!("Failed to load plugin library: {}", path.display()))?
@@ -200,7 +212,11 @@ impl PluginLoader {
         }
 
         let before_count = PROCESSOR_REGISTRY.list_registered().len();
-        (decl.register)(&PROCESSOR_REGISTRY);
+        let host_services = runtime_facing::host_services_for_self(runtime.iceoryx2_node());
+        // SAFETY: `host_services` outlives the call.
+        unsafe {
+            (decl.register)(&host_services as *const _ as *const c_void);
+        }
         let after_count = PROCESSOR_REGISTRY.list_registered().len();
         let registered_count = after_count - before_count;
 
@@ -209,7 +225,7 @@ impl PluginLoader {
         Ok(registered_count)
     }
 
-    fn load_plugin_dir(&mut self, dir: &Path) -> Result<usize> {
+    fn load_plugin_dir(&mut self, dir: &Path, runtime: &Runner) -> Result<usize> {
         let mut total_registered = 0;
 
         let entries = std::fs::read_dir(dir)
@@ -220,7 +236,7 @@ impl PluginLoader {
             let path = entry.path();
 
             if is_plugin_library(&path) {
-                match self.load_plugin(&path) {
+                match self.load_plugin(&path, runtime) {
                     Ok(count) => {
                         tracing::info!(
                             "Loaded plugin '{}': {} processor(s) registered",
@@ -298,22 +314,28 @@ async fn run(args: Args) -> Result<()> {
 
     tracing::info!("Starting runtime: {} ({})", runtime_name, runtime_id);
 
-    // Load plugins BEFORE creating runtime (registers processors in global registry)
+    // Construct the runtime FIRST so HostServices is constructable:
+    // tracing dispatch, PUBSUB, schema registry, and the iceoryx2
+    // node only exist post-`Runner::new()`. Plugins loaded below
+    // bridge their per-DSO statics through HostServices and so must
+    // see the host's wired instances.
+    let runtime = Runner::new()?;
+
+    // Load plugins (registers processors with the host's registry,
+    // bridges every per-DSO static into the host's instance).
     let mut loader = PluginLoader::new();
 
     for plugin_path in &args.plugins {
         println!("Loading plugin: {}", plugin_path.display());
-        let count = loader.load_plugin(plugin_path)?;
+        let count = loader.load_plugin(plugin_path, &runtime)?;
         println!("  Registered {} processor(s)", count);
     }
 
     if let Some(ref dir) = args.plugin_dir {
         println!("Loading plugins from: {}", dir.display());
-        let count = loader.load_plugin_dir(dir)?;
+        let count = loader.load_plugin_dir(dir, &runtime)?;
         println!("  Registered {} processor(s) total", count);
     }
-
-    let runtime = Runner::new()?;
 
     let log_path = runtime
         .jsonl_log_path()

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -86,6 +86,10 @@ pub mod sdk {
     pub use streamlib_engine::core::graph_file;
     pub use streamlib_engine::core::json_schema;
     pub use streamlib_engine::core::media_clock;
+    /// Plugin-loading host-services payload + cdylib install helper
+    /// — referenced from `streamlib_plugin_abi::export_plugin!`
+    /// macro expansion.
+    pub use streamlib_engine::core::plugin;
     pub use streamlib_engine::core::prelude;
     pub use streamlib_engine::core::pubsub;
     pub use streamlib_engine::core::rhi;


### PR DESCRIPTION
## Summary

Reshapes the `STREAMLIB_PLUGIN` ABI from type-passing
\`HostServices\` to a **pure callback-table**: every cross-DSO
operation is an \`extern \"C\"\` fn pointer with primitive payloads,
no shared Rust internal layouts cross the wire. Delivers the
deployment model the per-target-triple \`.slpkg\` machinery is
designed for — computers A, B, C using different rustc minor
versions + different transitive-dep resolutions still interoperate
as long as they target the same triple and link the same
\`STREAMLIB_ABI_VERSION\`.

Architecturally:

- **\`streamlib-plugin-abi\`** — pure ABI glue. Only \`extern \"C\"\` fn
  signatures + primitive types cross the wire. No streamlib types,
  no Rust trait objects, no rustc-version coupling beyond same-target-
  triple.
- **\`streamlib-engine\`** — implements both sides: host's callback
  bodies (\`host_tracing_emit\`, \`host_pubsub_publish\`, etc.) +
  cdylib's forwarders (\`ForwardingSubscriber\`,
  \`CdylibIceoryx2LogForwarder\`, routing inside \`PubSub::publish\` /
  \`register_schema\` / \`get_embedded_schema_definition\`).
- **\`export_plugin!\` macro** — source-compatible with v1. None of
  the 20 in-tree \`export_plugin!(MyProcessor::Processor)\` sites
  needed edits.

Supersedes recalled PR #882 (which shipped the same plumbing but
with type-passing bridge internals).

## Closes

Closes #877

## Bridges in the new ABI

- **Tracing** (forwarder Subscriber): \`tracing_register_callsite\`
  + \`tracing_enabled\` + \`tracing_emit\`. Cdylib \`tracing::info!\`
  reaches host JSONL via direct \`LogRecord\` push onto the host's
  drain queue. **Empirically broken in the dispatch-passthrough
  approach from #882 — now passes the new integration test.**
- **PUBSUB**: \`pubsub_publish\`. Subscribe is host-only today; a
  future cdylib-subscribe consumer adds a paired callback and bumps
  \`HOST_SERVICES_LAYOUT_VERSION\`.
- **Schema registry**: \`schema_register\` + \`schema_lookup\` (with a
  result-callback pattern — cdylib doesn't allocate or cross-DSO-
  free during a lookup).
- **iceoryx2-log**: \`iceoryx_log_emit\`. Cdylib installs a
  forwarder via \`iceoryx2_log::set_logger\` that thunks through
  to the host.

## Exit criteria

- [x] Plugin ABI v2: \`PluginDeclaration\` carries a \`HostServices\`
      shape with host references for tracing dispatch, PUBSUB,
      SCHEMA_REGISTRY, iceoryx2 logger.
- [x] Cdylib-side init wires the cdylib's duplicated globals to the
      host's via the callback table (no dyn-trait crossings for
      these statics).
- [ ] One representative in-tree example migrates to \`load_project\`
      — **deferred to #881** (mechanical follow-up, separable from
      engine-tier bridging).
- [x] Workspace tests stay green; the new
      \`load_project_dylib_tracing_bridge\` integration test asserts
      end-to-end cdylib-to-host tracing flow.

## Test plan

- [x] \`cargo test --workspace --lib\` — 425 streamlib-engine + full
      workspace green, 0 failed.
- [x] \`load_project_dylib_smoke\` — pre-existing smoke test green
      after the ABI bump.
- [x] \`load_project_dylib_pubsub_bridge\` — PUBSUB event from cdylib
      \`register::<P>()\` reaches host subscriber.
- [x] \`load_project_dylib_tracing_bridge\` (new) — cdylib
      \`tracing::info!\` event from \`ProcessorInstanceFactory::register\`
      reaches host JSONL. **The test the dispatch-passthrough
      approach couldn't make pass.**

## What's not in the callback table

\`processor_registry_typed: *const ProcessorInstanceFactory\`
remains as the single type-passing field. Its internal
\`Box<dyn Fn>\` constructor closures and
\`Box<dyn DynGeneratedProcessor>\` instance objects are pre-existing
dyn-trait crossings whose ABI stability depends on the engine's
semver coupling — separate from the host-services callback-table
bridges this PR introduces. Tracked as the next-step plugin-ABI
milestone in #883.

## Follow-ups filed

- #883 — feat(plugin-abi): callback-table for processor lifecycle
  (setup/process/teardown + runtime-context access). The full
  multi-builder ABI completion.
- #879 — chore(iceoryx2): patch \`UniqueSystemId::COUNTER\` to a
  process-shared counter (pre-existing residual collision risk).
- #881 — feat(examples): migrate one example to \`load_project\` +
  drop processor-package Cargo deps (exit criterion 3
  proof-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)