### PR TITLE
feat(plugin-abi): processor lifecycle vtable (phase A of full callback-table ABI)

### DIFF
--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_deno_subprocess_op.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::core::error::{Result, Error};
 use crate::core::execution::ExecutionConfig;
 use crate::core::graph::ProcessorNode;
-use crate::core::processors::{DynamicProcessorConstructorFn, ProcessorInstance};
+use crate::core::processors::DynamicProcessorConstructorFn;
 use crate::core::runtime::BoxFuture;
 use crate::core::{
     ProcessorDescriptor, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
@@ -578,7 +578,7 @@ pub(crate) fn create_deno_subprocess_host_constructor(
             native_lib_path: String::new(),
             input_port_wiring: Vec::new(),
             output_port_wiring: Vec::new(),
-        }) as ProcessorInstance)
+        }) as Box<dyn crate::core::processors::DynGeneratedProcessor + Send>)
     })
 }
 

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -337,7 +337,12 @@ fn spawn_dedicated_thread(
                     runtime,
                 );
                 let setup_result = run_setup_phase(runtime, &runtime_ctx_clone.gpu, || {
-                    tokio_handle.block_on(guard.__generated_setup(&full_ctx))
+                    let _ = &tokio_handle; // block_on now happens inside the
+                    // ProcessorInstance::setup dispatch — VTable variant calls
+                    // through extern "C" (cdylib block_ons on its own tokio
+                    // handle pulled from ctx), LegacyDyn variant block_ons
+                    // here via the ctx's tokio handle.
+                    guard.setup(&full_ctx)
                 });
                 if let Err(e) = setup_result {
                     tracing::error!("[{}] Setup failed: {}", proc_id_clone, e);

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_python_native_subprocess_op.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::core::error::{Result, Error};
 use crate::core::execution::ExecutionConfig;
 use crate::core::graph::ProcessorNode;
-use crate::core::processors::{DynamicProcessorConstructorFn, ProcessorInstance};
+use crate::core::processors::DynamicProcessorConstructorFn;
 use crate::core::runtime::BoxFuture;
 use crate::core::{
     ProcessorDescriptor, RuntimeContextFullAccess, RuntimeContextLimitedAccess,
@@ -569,7 +569,7 @@ pub(crate) fn create_python_native_subprocess_host_constructor(
             native_lib_path: native_lib_path.clone(),
             input_port_wiring: Vec::new(),
             output_port_wiring: Vec::new(),
-        }) as ProcessorInstance)
+        }) as Box<dyn crate::core::processors::DynGeneratedProcessor + Send>)
     })
 }
 

--- a/libs/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/libs/streamlib-engine/src/core/execution/thread_runner.rs
@@ -76,10 +76,10 @@ pub fn run_processor_loop(
     {
         let full_ctx = RuntimeContextFullAccess::new(&runtime_ctx);
         let mut guard = processor.lock();
-        match runtime_ctx
-            .tokio_handle()
-            .block_on(guard.__generated_teardown(&full_ctx))
-        {
+        // block_on is now internal to ProcessorInstance::teardown's
+        // dispatch (LegacyDyn variant) or the cdylib's vtable
+        // wrapper (VTable variant).
+        match guard.teardown(&full_ctx) {
             Ok(()) => tracing::info!("[{}] teardown() completed successfully", id),
             Err(e) => tracing::warn!("[{}] teardown() failed: {}", id, e),
         }
@@ -468,10 +468,8 @@ fn dispatch_on_pause(
     tracing::info!("[{}] Invoking on_pause()...", id);
     let limited_ctx = RuntimeContextLimitedAccess::new(runtime_ctx);
     let mut guard = processor.lock();
-    match runtime_ctx
-        .tokio_handle()
-        .block_on(guard.__generated_on_pause(&limited_ctx))
-    {
+    // block_on is internal to ProcessorInstance::on_pause's dispatch.
+    match guard.on_pause(&limited_ctx) {
         Ok(()) => tracing::info!("[{}] on_pause() completed successfully", id),
         Err(e) => tracing::warn!("[{}] on_pause() failed: {}", id, e),
     }
@@ -485,10 +483,8 @@ fn dispatch_on_resume(
     tracing::info!("[{}] Invoking on_resume()...", id);
     let limited_ctx = RuntimeContextLimitedAccess::new(runtime_ctx);
     let mut guard = processor.lock();
-    match runtime_ctx
-        .tokio_handle()
-        .block_on(guard.__generated_on_resume(&limited_ctx))
-    {
+    // block_on is internal to ProcessorInstance::on_resume's dispatch.
+    match guard.on_resume(&limited_ctx) {
         Ok(()) => tracing::info!("[{}] on_resume() completed successfully", id),
         Err(e) => tracing::warn!("[{}] on_resume() failed: {}", id, e),
     }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -9,9 +9,9 @@
 //! - **Host-side callback impls** (`host_tracing_emit`,
 //!   `host_pubsub_publish`, `host_schema_register`,
 //!   `host_schema_lookup`, `host_iceoryx_log_emit`,
-//!   `host_processor_register`, `host_tokio_handle_clone`) that the
-//!   host's loader writes into a [`HostServices`] struct before
-//!   invoking a cdylib's `STREAMLIB_PLUGIN.register` callback.
+//!   `host_processor_register`) that the host's loader writes into a
+//!   [`HostServices`] struct before invoking a cdylib's
+//!   `STREAMLIB_PLUGIN.register` callback.
 //! - **Cdylib-side `install_host_services` helper** that the cdylib's
 //!   `export_plugin!` macro calls at register time. The helper
 //!   validates layout, stores the callback table in a per-DSO

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -8,15 +8,18 @@
 //!
 //! - **Host-side callback impls** (`host_tracing_emit`,
 //!   `host_pubsub_publish`, `host_schema_register`,
-//!   `host_schema_lookup`, `host_iceoryx_log_emit`) that the host's
-//!   loader writes into a [`HostServices`] struct before invoking a
-//!   cdylib's `STREAMLIB_PLUGIN.register` callback.
+//!   `host_schema_lookup`, `host_iceoryx_log_emit`,
+//!   `host_processor_register`, `host_tokio_handle_clone`) that the
+//!   host's loader writes into a [`HostServices`] struct before
+//!   invoking a cdylib's `STREAMLIB_PLUGIN.register` callback.
 //! - **Cdylib-side `install_host_services` helper** that the cdylib's
 //!   `export_plugin!` macro calls at register time. The helper
 //!   validates layout, stores the callback table in a per-DSO
-//!   [`HOST_CALLBACKS`] static, installs the cdylib's tracing
-//!   `ForwardingSubscriber` and iceoryx2 `Log` forwarder, and returns
-//!   a [`RegisterHelper`] for the macro to register processors with.
+//!   [`HOST_CALLBACKS`] static, caches the host's tokio handle in
+//!   [`HOST_TOKIO_HANDLE`] for cdylib-side async-lifecycle wrappers,
+//!   installs the cdylib's tracing `ForwardingSubscriber` and
+//!   iceoryx2 `Log` forwarder, and returns a [`RegisterHelper`] for
+//!   the macro to register processors with.
 //!
 //! # Why this shape
 //!
@@ -36,6 +39,14 @@
 //! `iceoryx2_log::*`) route through the host's fn pointers instead
 //! of through the local DSO's state.
 //!
+//! Processor registration follows the same shape: cdylib's
+//! `RegisterHelper::register::<P>()` monomorphizes a [`ProcessorVTable`]
+//! per processor type P and calls the host's `processor_register`
+//! callback with the descriptor msgpack + vtable. The host's factory
+//! stores `(descriptor, &'static ProcessorVTable)` and dispatches
+//! every host-called method through extern "C" — retiring the
+//! `Box<dyn DynGeneratedProcessor>` dyn-trait crossing class.
+//!
 //! # Deployment model this enables
 //!
 //! Computer A builds the host binary, computer B builds packages via
@@ -44,27 +55,23 @@
 //! interoperate as long as they target the same triple and link the
 //! same [`streamlib_plugin_abi::STREAMLIB_ABI_VERSION`]. No
 //! commit-level coupling, no shared Cargo.lock.
-//!
-//! # What's not in the callback table
-//!
-//! `processor_registry_typed: *const ProcessorInstanceFactory`
-//! remains as a typed pointer in [`HostServices`]. The
-//! `ProcessorInstanceFactory`'s internal `Box<dyn Fn>` constructor
-//! closures and `Box<dyn DynGeneratedProcessor>` instance objects
-//! are pre-existing dyn-trait crossings whose ABI stability depends
-//! on the engine's semver coupling. Lifting them to extern "C"
-//! requires reshaping the entire processor lifecycle ABI (setup /
-//! process / teardown / port wiring / runtime-context access) and
-//! is the natural next-step plugin-ABI milestone.
 
 use std::ffi::c_void;
 use std::sync::OnceLock;
 
 use streamlib_plugin_abi::{
-    HostHandle, HostInterest, HostLogLevel, HostServices, HOST_SERVICES_LAYOUT_VERSION,
+    HostHandle, HostInterest, HostLogLevel, HostServices, ProcessorVTable,
+    HOST_SERVICES_LAYOUT_VERSION, PROCESSOR_VTABLE_LAYOUT_VERSION,
 };
 
-use crate::core::processors::ProcessorInstanceFactory;
+// Note on tokio: cdylib-side async-lifecycle wrappers grab the tokio
+// handle from `ctx.tokio_handle()` rather than going through an
+// extern "C" callback. Tokio's `Handle` layout is host/cdylib-shared
+// via the workspace-pinned tokio version — one of the known
+// shared-type crossings Phase A leaves in place by design (Phase B
+// addresses RuntimeContext crossings if multi-builder tokio drift
+// becomes a real concern).
+
 use crate::core::pubsub::Event;
 
 // =============================================================================
@@ -134,6 +141,12 @@ pub struct HostCallbacks {
         message_ptr: *const u8,
         message_len: usize,
     ),
+    pub processor_register: unsafe extern "C" fn(
+        host: HostHandle,
+        descriptor_msgpack_ptr: *const u8,
+        descriptor_msgpack_len: usize,
+        vtable: *const ProcessorVTable,
+    ) -> i32,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -212,6 +225,7 @@ pub unsafe fn install_host_services(
         schema_register: services.schema_register,
         schema_lookup: services.schema_lookup,
         iceoryx_log_emit: services.iceoryx_log_emit,
+        processor_register: services.processor_register,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -230,35 +244,98 @@ pub unsafe fn install_host_services(
     // its tracing pipeline what to actually emit.
     crate::core::plugin::iceoryx2_log_forwarder::install_for_self();
 
-    // The processor registry is the one remaining type-passing
-    // field. Cast back to `&'static ProcessorInstanceFactory` and
-    // return a `RegisterHelper` that exposes the same
-    // `register::<P>()` shape the macro used in v1.
-    if services.processor_registry_typed.is_null() {
-        return None;
-    }
-    let registry = unsafe {
-        &*(services.processor_registry_typed as *const ProcessorInstanceFactory)
-    };
-
-    Some(RegisterHelper { registry })
+    Some(RegisterHelper {})
 }
 
-/// Thin wrapper around the host's `ProcessorInstanceFactory` returned
-/// by [`install_host_services`]. Source-compatible with the macro's
-/// `registry.register::<P>()` call shape.
-pub struct RegisterHelper {
-    registry: &'static ProcessorInstanceFactory,
-}
+/// Helper handed back to the cdylib's `export_plugin!` macro for
+/// registering processors with the host's registry. Source-compatible
+/// with v1's `helper.register::<P>()` call shape — the implementation
+/// now monomorphizes a [`ProcessorVTable`] per processor type and
+/// routes through the host's `processor_register` callback instead
+/// of dispatching through `&'static ProcessorInstanceFactory`.
+pub struct RegisterHelper {}
 
 impl RegisterHelper {
     /// Register a processor type with the host's registry.
+    ///
+    /// Builds the static per-P [`ProcessorVTable`], serializes
+    /// `P::descriptor()` to msgpack, and calls the host's
+    /// `processor_register` callback. Source-compatible at the call
+    /// site (`helper.register::<P::Processor>()`).
     pub fn register<P>(&self)
     where
         P: crate::core::processors::GeneratedProcessor + 'static,
-        P::Config: for<'de> serde::Deserialize<'de> + Default,
+        P::Config: crate::core::processors::Config,
     {
-        self.registry.register::<P>();
+        // Resolve the host's callback table. In a cdylib this was
+        // populated by `install_host_services` above. In the host
+        // process (where this code path also runs when a processor
+        // is registered inline via `PROCESSOR_REGISTRY.register::<P>()`),
+        // `HOST_CALLBACKS` is empty — the host-static path bypasses
+        // FFI and registers directly with the factory.
+        if let Some(callbacks) = host_callbacks() {
+            register_via_callback::<P>(callbacks);
+        } else {
+            // Host-static path: same vtable shape, but registered
+            // directly with the in-process factory (no FFI hop).
+            crate::core::processors::PROCESSOR_REGISTRY.register::<P>();
+        }
+    }
+}
+
+/// Cdylib-side registration: build a vtable + descriptor msgpack and
+/// call the host's `processor_register` callback.
+fn register_via_callback<P>(callbacks: &HostCallbacks)
+where
+    P: crate::core::processors::GeneratedProcessor + 'static,
+    P::Config: crate::core::processors::Config,
+{
+    let descriptor = match <P as crate::core::processors::GeneratedProcessor>::descriptor() {
+        Some(d) => d,
+        None => {
+            tracing::warn!(
+                "Processor {} has no descriptor, skipping registration",
+                std::any::type_name::<P>()
+            );
+            return;
+        }
+    };
+
+    let descriptor_msgpack = match rmp_serde::to_vec_named(&descriptor) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to serialize descriptor for {}: {}",
+                std::any::type_name::<P>(),
+                e
+            );
+            return;
+        }
+    };
+
+    let vtable = crate::core::plugin::processor_vtable::vtable_for::<P>();
+
+    // SAFETY: msgpack bytes and vtable pointer live in this DSO's
+    // process address space for the duration of the call. The host's
+    // implementation copies any data it needs to retain (the
+    // descriptor is decoded into a `ProcessorDescriptor`; the vtable
+    // pointer is stored as-is and the cdylib is pinned via
+    // `LOADED_PLUGIN_LIBRARIES`).
+    let rc = unsafe {
+        (callbacks.processor_register)(
+            callbacks.host,
+            descriptor_msgpack.as_ptr(),
+            descriptor_msgpack.len(),
+            vtable as *const ProcessorVTable,
+        )
+    };
+
+    if rc != 0 {
+        tracing::warn!(
+            "processor_register for {} returned non-zero rc={}",
+            descriptor.name,
+            rc
+        );
     }
 }
 
@@ -269,9 +346,8 @@ impl RegisterHelper {
 /// Concrete host-side service table the host's loader plugs into a
 /// [`HostServices`] payload via [`runtime_facing::host_services_for_self`].
 ///
-/// Holds the host's iceoryx2 node + any other handles host-side
-/// callbacks need. Lives behind the [`HostServices::host`] opaque
-/// pointer.
+/// Holds the host's iceoryx2 node. Lives behind the
+/// [`HostServices::host`] opaque pointer.
 pub struct HostServiceImpls {
     pub iceoryx2_node: crate::iceoryx2::Iceoryx2Node,
 }
@@ -322,11 +398,15 @@ unsafe extern "C" fn host_tracing_emit(
     fields_msgpack_ptr: *const u8,
     fields_msgpack_len: usize,
 ) {
-    let target = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(target_ptr, target_len)) };
+    let target = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(target_ptr, target_len))
+    };
     let message = if message_len == 0 {
         ""
     } else {
-        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len)) }
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len))
+        }
     };
     let level_val = host_log_level_to_tracing(level);
     let fields_bytes = if fields_msgpack_len == 0 || fields_msgpack_ptr.is_null() {
@@ -355,7 +435,9 @@ unsafe extern "C" fn host_pubsub_publish(
     event_msgpack_ptr: *const u8,
     event_msgpack_len: usize,
 ) {
-    let topic = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(topic_ptr, topic_len)) };
+    let topic = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(topic_ptr, topic_len))
+    };
     let event_bytes = unsafe { std::slice::from_raw_parts(event_msgpack_ptr, event_msgpack_len) };
     let event: Event = match rmp_serde::from_slice(event_bytes) {
         Ok(e) => e,
@@ -377,8 +459,14 @@ unsafe extern "C" fn host_schema_register(
     yaml_ptr: *const u8,
     yaml_len: usize,
 ) {
-    let canonical_id = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(canonical_id_ptr, canonical_id_len)) };
-    let yaml = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(yaml_ptr, yaml_len)) };
+    let canonical_id = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            canonical_id_ptr,
+            canonical_id_len,
+        ))
+    };
+    let yaml =
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(yaml_ptr, yaml_len)) };
     crate::core::embedded_schemas::register_schema(canonical_id.to_string(), yaml);
 }
 
@@ -389,7 +477,12 @@ unsafe extern "C" fn host_schema_lookup(
     result_callback: extern "C" fn(*mut c_void, *const u8, usize),
     result_userdata: *mut c_void,
 ) {
-    let canonical_id = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(canonical_id_ptr, canonical_id_len)) };
+    let canonical_id = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            canonical_id_ptr,
+            canonical_id_len,
+        ))
+    };
     match crate::core::embedded_schemas::get_embedded_schema_definition(canonical_id) {
         Some(yaml) => {
             let bytes = yaml.as_bytes();
@@ -412,12 +505,16 @@ unsafe extern "C" fn host_iceoryx_log_emit(
     let origin = if origin_len == 0 {
         ""
     } else {
-        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(origin_ptr, origin_len)) }
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(origin_ptr, origin_len))
+        }
     };
     let message = if message_len == 0 {
         ""
     } else {
-        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len)) }
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(message_ptr, message_len))
+        }
     };
     // Forward into the host's tracing pipeline at the appropriate level.
     match level {
@@ -426,6 +523,61 @@ unsafe extern "C" fn host_iceoryx_log_emit(
         HostLogLevel::Info => tracing::info!(target: "iceoryx2", origin = %origin, "{message}"),
         HostLogLevel::Warn => tracing::warn!(target: "iceoryx2", origin = %origin, "{message}"),
         HostLogLevel::Error => tracing::error!(target: "iceoryx2", origin = %origin, "{message}"),
+    }
+}
+
+/// Host-side `processor_register` callback. Decodes the descriptor
+/// msgpack and routes to the in-process registry's
+/// `register_via_vtable` path. Returns 0 on success, non-zero on
+/// descriptor decode failure, vtable layout-version mismatch, or
+/// duplicate registration.
+unsafe extern "C" fn host_processor_register(
+    _host: HostHandle,
+    descriptor_msgpack_ptr: *const u8,
+    descriptor_msgpack_len: usize,
+    vtable: *const ProcessorVTable,
+) -> i32 {
+    if vtable.is_null() {
+        tracing::warn!("host_processor_register: null vtable pointer");
+        return -1;
+    }
+
+    let vtable_layout = unsafe { (*vtable).layout_version };
+    if vtable_layout != PROCESSOR_VTABLE_LAYOUT_VERSION {
+        tracing::warn!(
+            "host_processor_register: vtable layout version mismatch (got {}, expected {})",
+            vtable_layout,
+            PROCESSOR_VTABLE_LAYOUT_VERSION
+        );
+        return -2;
+    }
+
+    let descriptor_bytes =
+        unsafe { std::slice::from_raw_parts(descriptor_msgpack_ptr, descriptor_msgpack_len) };
+    let descriptor: crate::core::descriptors::ProcessorDescriptor =
+        match rmp_serde::from_slice(descriptor_bytes) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    "host_processor_register: failed to decode descriptor msgpack: {e}"
+                );
+                return -3;
+            }
+        };
+
+    // SAFETY: `vtable` is `&'static ProcessorVTable` on the cdylib
+    // side; the cdylib is pinned via `LOADED_PLUGIN_LIBRARIES`, so
+    // the pointer outlives the host's usage.
+    let vtable_ref: &'static ProcessorVTable = unsafe { &*vtable };
+
+    match crate::core::processors::PROCESSOR_REGISTRY
+        .register_via_vtable(descriptor, vtable_ref)
+    {
+        Ok(()) => 0,
+        Err(e) => {
+            tracing::warn!("host_processor_register: register_via_vtable failed: {e}");
+            -4
+        }
     }
 }
 
@@ -526,8 +678,9 @@ fn emit_via_host_dispatch(
 /// implementations.
 pub mod runtime_facing {
     use super::{
-        host_iceoryx_log_emit, host_pubsub_publish, host_schema_lookup, host_schema_register,
-        host_tracing_emit, host_tracing_enabled, host_tracing_register_callsite, HostServiceImpls,
+        host_iceoryx_log_emit, host_processor_register, host_pubsub_publish, host_schema_lookup,
+        host_schema_register, host_tracing_emit, host_tracing_enabled,
+        host_tracing_register_callsite, HostServiceImpls,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -548,11 +701,10 @@ pub mod runtime_facing {
     }
 
     /// Build a [`HostServices`] payload from this process's host
-    /// callback impls and processor registry. Callable repeatedly;
-    /// the underlying [`HostServiceImpls`] is constructed once and
-    /// reused for the process lifetime, matching
-    /// `LOADED_PLUGIN_LIBRARIES`'s pinning lifetime for loaded
-    /// cdylibs.
+    /// callback impls. Callable repeatedly; the underlying
+    /// [`HostServiceImpls`] is constructed once and reused for the
+    /// process lifetime, matching `LOADED_PLUGIN_LIBRARIES`'s pinning
+    /// lifetime for loaded cdylibs.
     pub fn host_services_for_self(node: &crate::iceoryx2::Iceoryx2Node) -> HostServices {
         let host_impls = host_impls_for_self(node);
         let host_handle = host_impls as *const HostServiceImpls as *const c_void;
@@ -568,10 +720,7 @@ pub mod runtime_facing {
             schema_register: host_schema_register,
             schema_lookup: host_schema_lookup,
             iceoryx_log_emit: host_iceoryx_log_emit,
-            processor_registry_typed: &*crate::core::processors::PROCESSOR_REGISTRY
-                as *const crate::core::processors::ProcessorInstanceFactory
-                as *const c_void,
+            processor_register: host_processor_register,
         }
     }
 }
-

--- a/libs/streamlib-engine/src/core/plugin/mod.rs
+++ b/libs/streamlib-engine/src/core/plugin/mod.rs
@@ -22,6 +22,7 @@
 pub(crate) mod forwarding_subscriber;
 pub mod host_services;
 pub(crate) mod iceoryx2_log_forwarder;
+pub(crate) mod processor_vtable;
 
 pub use host_services::{install_host_services, RegisterHelper};
 pub use streamlib_plugin_abi::{HostServices, HOST_SERVICES_LAYOUT_VERSION};

--- a/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
+++ b/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
@@ -1,0 +1,438 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Per-processor [`ProcessorVTable`] construction.
+//!
+//! [`vtable_for::<P>()`] returns a `&'static ProcessorVTable` whose
+//! extern "C" fn pointers all dispatch to `P`'s implementations of
+//! [`GeneratedProcessor`]'s methods. Each P gets its own monomorphized
+//! wrapper set and its own leaked vtable (looked up by `TypeId`); two
+//! calls with the same P return the same `&'static` pointer.
+//!
+//! The wrappers cast the opaque `*mut c_void` instance handle back
+//! to `*mut P` and call through `P`'s methods. Lifecycle errors are
+//! written into a caller-provided UTF-8 scratch buffer; async
+//! lifecycle wrappers `block_on` using the tokio handle they pull
+//! from the `RuntimeContext*Access` they receive as a parameter.
+//!
+//! # Where this fits in the engine model
+//!
+//! This module is the shared monomorphization point for the new
+//! plugin ABI's processor dispatch. Both the cdylib path
+//! (`RegisterHelper::register::<P>()` in `host_services`) and the
+//! host-static path (`ProcessorInstanceFactory::register::<P>()`)
+//! call [`vtable_for::<P>()`] — the resulting vtable lives in the
+//! DSO of the caller, but the shape is identical.
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::sync::{Mutex, OnceLock};
+
+use streamlib_plugin_abi::{ProcessorVTable, PROCESSOR_VTABLE_LAYOUT_VERSION};
+
+use crate::core::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use crate::core::processors::{Config, GeneratedProcessor};
+
+/// Map from `TypeId::of::<P>()` to the leaked `&'static
+/// ProcessorVTable` for that P. One vtable per processor type in
+/// the DSO's process address space; rebuilt only on the first
+/// `vtable_for::<P>()` call (subsequent calls hit the cache).
+static VTABLES: OnceLock<Mutex<HashMap<TypeId, &'static ProcessorVTable>>> = OnceLock::new();
+
+/// Returns a `&'static ProcessorVTable` whose entries dispatch
+/// every host-called method to `P`'s implementation. Looked up by
+/// `TypeId` and cached per process.
+pub fn vtable_for<P>() -> &'static ProcessorVTable
+where
+    P: GeneratedProcessor + 'static,
+    P::Config: Config,
+{
+    let cache = VTABLES.get_or_init(|| Mutex::new(HashMap::new()));
+    let type_id = TypeId::of::<P>();
+
+    if let Some(vtable) = cache.lock().unwrap().get(&type_id) {
+        return *vtable;
+    }
+
+    let new_vtable: &'static ProcessorVTable = Box::leak(Box::new(build_vtable::<P>()));
+    let mut guard = cache.lock().unwrap();
+    *guard.entry(type_id).or_insert(new_vtable)
+}
+
+fn build_vtable<P>() -> ProcessorVTable
+where
+    P: GeneratedProcessor + 'static,
+    P::Config: Config,
+{
+    ProcessorVTable {
+        layout_version: PROCESSOR_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        construct: ProcessorWrappers::<P>::construct,
+        destroy: ProcessorWrappers::<P>::destroy,
+        setup: ProcessorWrappers::<P>::setup,
+        teardown: ProcessorWrappers::<P>::teardown,
+        on_pause: ProcessorWrappers::<P>::on_pause,
+        on_resume: ProcessorWrappers::<P>::on_resume,
+        process: ProcessorWrappers::<P>::process,
+        start: ProcessorWrappers::<P>::start,
+        stop: ProcessorWrappers::<P>::stop,
+        execution_config_msgpack: ProcessorWrappers::<P>::execution_config_msgpack,
+        has_iceoryx2_outputs: ProcessorWrappers::<P>::has_iceoryx2_outputs,
+        has_iceoryx2_inputs: ProcessorWrappers::<P>::has_iceoryx2_inputs,
+        get_iceoryx2_output_writer_arc:
+            ProcessorWrappers::<P>::get_iceoryx2_output_writer_arc,
+        get_iceoryx2_input_mailboxes_mut:
+            ProcessorWrappers::<P>::get_iceoryx2_input_mailboxes_mut,
+        apply_config_msgpack: ProcessorWrappers::<P>::apply_config_msgpack,
+        to_runtime_msgpack: ProcessorWrappers::<P>::to_runtime_msgpack,
+        config_msgpack: ProcessorWrappers::<P>::config_msgpack,
+    }
+}
+
+// =============================================================================
+// ProcessorWrappers<P> — per-P monomorphized extern "C" wrappers
+// =============================================================================
+
+struct ProcessorWrappers<P>(std::marker::PhantomData<P>);
+
+impl<P> ProcessorWrappers<P>
+where
+    P: GeneratedProcessor + 'static,
+    P::Config: Config,
+{
+    unsafe extern "C" fn construct(
+        config_msgpack_ptr: *const u8,
+        config_msgpack_len: usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> *mut c_void {
+        let config: P::Config = if config_msgpack_len == 0 || config_msgpack_ptr.is_null() {
+            P::Config::default()
+        } else {
+            let bytes = unsafe {
+                std::slice::from_raw_parts(config_msgpack_ptr, config_msgpack_len)
+            };
+            match rmp_serde::from_slice(bytes) {
+                Ok(c) => c,
+                Err(e) => {
+                    write_err(err_buf, err_buf_cap, err_len, &format!("config deser: {e}"));
+                    return std::ptr::null_mut();
+                }
+            }
+        };
+
+        match P::from_config(config) {
+            Ok(processor) => Box::into_raw(Box::new(processor)) as *mut c_void,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                std::ptr::null_mut()
+            }
+        }
+    }
+
+    unsafe extern "C" fn destroy(instance: *mut c_void) {
+        if !instance.is_null() {
+            // SAFETY: instance was produced by Box::into_raw above on this
+            // DSO's heap. Box::from_raw + drop releases on the same heap.
+            unsafe {
+                drop(Box::from_raw(instance as *mut P));
+            }
+        }
+    }
+
+    unsafe extern "C" fn setup(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_full as *const RuntimeContextFullAccess<'_>) };
+        let result = ctx
+            .tokio_handle()
+            .block_on(<P as GeneratedProcessor>::__generated_setup(processor, ctx));
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn teardown(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_full as *const RuntimeContextFullAccess<'_>) };
+        let result = ctx
+            .tokio_handle()
+            .block_on(<P as GeneratedProcessor>::__generated_teardown(
+                processor, ctx,
+            ));
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn on_pause(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_limited as *const RuntimeContextLimitedAccess<'_>) };
+        let result = ctx
+            .tokio_handle()
+            .block_on(<P as GeneratedProcessor>::__generated_on_pause(
+                processor, ctx,
+            ));
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn on_resume(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_limited as *const RuntimeContextLimitedAccess<'_>) };
+        let result = ctx
+            .tokio_handle()
+            .block_on(<P as GeneratedProcessor>::__generated_on_resume(
+                processor, ctx,
+            ));
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn process(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_limited as *const RuntimeContextLimitedAccess<'_>) };
+        match <P as GeneratedProcessor>::process(processor, ctx) {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn start(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_full as *const RuntimeContextFullAccess<'_>) };
+        match <P as GeneratedProcessor>::start(processor, ctx) {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn stop(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let ctx = unsafe { &*(ctx_full as *const RuntimeContextFullAccess<'_>) };
+        match <P as GeneratedProcessor>::stop(processor, ctx) {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -1
+            }
+        }
+    }
+
+    unsafe extern "C" fn execution_config_msgpack(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize {
+        let processor = unsafe { &*(instance as *const P) };
+        let cfg = <P as GeneratedProcessor>::execution_config(processor);
+        let bytes = match rmp_serde::to_vec_named(&cfg) {
+            Ok(b) => b,
+            Err(_) => return 0,
+        };
+        write_out_bytes(&bytes, out_buf, out_cap, out_len)
+    }
+
+    unsafe extern "C" fn has_iceoryx2_outputs(instance: *const c_void) -> bool {
+        let processor = unsafe { &*(instance as *const P) };
+        <P as GeneratedProcessor>::has_iceoryx2_outputs(processor)
+    }
+
+    unsafe extern "C" fn has_iceoryx2_inputs(instance: *const c_void) -> bool {
+        let processor = unsafe { &*(instance as *const P) };
+        <P as GeneratedProcessor>::has_iceoryx2_inputs(processor)
+    }
+
+    unsafe extern "C" fn get_iceoryx2_output_writer_arc(
+        instance: *const c_void,
+    ) -> *const c_void {
+        let processor = unsafe { &*(instance as *const P) };
+        match <P as GeneratedProcessor>::get_iceoryx2_output_writer(processor) {
+            // SAFETY: into_raw transfers one strong reference to the
+            // caller. Caller must `Arc::from_raw` exactly once.
+            Some(arc) => std::sync::Arc::into_raw(arc) as *const c_void,
+            None => std::ptr::null(),
+        }
+    }
+
+    unsafe extern "C" fn get_iceoryx2_input_mailboxes_mut(
+        instance: *mut c_void,
+    ) -> *mut c_void {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        match <P as GeneratedProcessor>::get_iceoryx2_input_mailboxes(processor) {
+            Some(mailboxes) => mailboxes as *mut _ as *mut c_void,
+            None => std::ptr::null_mut(),
+        }
+    }
+
+    unsafe extern "C" fn apply_config_msgpack(
+        instance: *mut c_void,
+        config_msgpack_ptr: *const u8,
+        config_msgpack_len: usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32 {
+        let processor = unsafe { &mut *(instance as *mut P) };
+        let bytes = if config_msgpack_len == 0 || config_msgpack_ptr.is_null() {
+            &[][..]
+        } else {
+            unsafe { std::slice::from_raw_parts(config_msgpack_ptr, config_msgpack_len) }
+        };
+        let config: P::Config = match rmp_serde::from_slice(bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                write_err(
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                    &format!("apply_config_msgpack deser: {e}"),
+                );
+                return -1;
+            }
+        };
+        match <P as GeneratedProcessor>::update_config(processor, config) {
+            Ok(()) => 0,
+            Err(e) => {
+                write_err(err_buf, err_buf_cap, err_len, &e.to_string());
+                -2
+            }
+        }
+    }
+
+    unsafe extern "C" fn to_runtime_msgpack(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize {
+        let processor = unsafe { &*(instance as *const P) };
+        let value = <P as GeneratedProcessor>::to_runtime_json(processor);
+        let bytes = match rmp_serde::to_vec_named(&value) {
+            Ok(b) => b,
+            Err(_) => return 0,
+        };
+        write_out_bytes(&bytes, out_buf, out_cap, out_len)
+    }
+
+    unsafe extern "C" fn config_msgpack(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize {
+        let processor = unsafe { &*(instance as *const P) };
+        let value = <P as GeneratedProcessor>::config_json(processor);
+        let bytes = match rmp_serde::to_vec_named(&value) {
+            Ok(b) => b,
+            Err(_) => return 0,
+        };
+        write_out_bytes(&bytes, out_buf, out_cap, out_len)
+    }
+}
+
+// =============================================================================
+// Scratch-buffer helpers
+// =============================================================================
+
+fn write_err(buf: *mut u8, cap: usize, out_len: *mut usize, msg: &str) {
+    if buf.is_null() || out_len.is_null() {
+        return;
+    }
+    let bytes = msg.as_bytes();
+    let n = bytes.len().min(cap);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, n);
+        *out_len = n;
+    }
+}
+
+/// Writes `bytes` to `out_buf` when it fits within `out_cap`. Always
+/// returns the **required** buffer size (`bytes.len()`); the caller
+/// inspects that value vs. `out_cap` to detect truncation.
+fn write_out_bytes(
+    bytes: &[u8],
+    out_buf: *mut u8,
+    out_cap: usize,
+    out_len: *mut usize,
+) -> usize {
+    if bytes.len() <= out_cap && !out_buf.is_null() && !out_len.is_null() {
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, bytes.len());
+            *out_len = bytes.len();
+        }
+    } else if !out_len.is_null() {
+        unsafe {
+            *out_len = 0;
+        }
+    }
+    bytes.len()
+}

--- a/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
+++ b/libs/streamlib-engine/src/core/plugin/processor_vtable.rs
@@ -51,13 +51,13 @@ where
     let cache = VTABLES.get_or_init(|| Mutex::new(HashMap::new()));
     let type_id = TypeId::of::<P>();
 
-    if let Some(vtable) = cache.lock().unwrap().get(&type_id) {
-        return *vtable;
-    }
-
-    let new_vtable: &'static ProcessorVTable = Box::leak(Box::new(build_vtable::<P>()));
+    // Single lock acquire: existing entry returns immediately; otherwise
+    // construct + leak + insert under the lock so two concurrent first-
+    // callers don't both leak a `ProcessorVTable`.
     let mut guard = cache.lock().unwrap();
-    *guard.entry(type_id).or_insert(new_vtable)
+    *guard
+        .entry(type_id)
+        .or_insert_with(|| Box::leak(Box::new(build_vtable::<P>())))
 }
 
 fn build_vtable<P>() -> ProcessorVTable

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -2,20 +2,460 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use std::collections::{HashMap, HashSet};
-use std::sync::LazyLock;
+use std::ffi::c_void;
+use std::sync::{Arc, LazyLock};
 
 use parking_lot::RwLock;
 
+use crate::core::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use crate::core::descriptors::SchemaIdent;
-use crate::core::error::{Result, Error};
+use crate::core::error::{Error, Result};
+use crate::core::execution::ExecutionConfig;
 use crate::core::graph::{PortInfo, ProcessorNode};
-use crate::core::processors::{DynGeneratedProcessor, GeneratedProcessor};
+use crate::core::processors::{Config, DynGeneratedProcessor, GeneratedProcessor};
 use crate::core::pubsub::{topics, Event, RuntimeEvent, PUBSUB};
 use crate::core::ProcessorDescriptor;
+use streamlib_plugin_abi::ProcessorVTable;
 use streamlib_processor_schema::PortSchemaSpec;
 
+/// Scratch buffer the vtable's error-out-params write into. 512 B is
+/// enough for the typical "config deserialize failed" message; the
+/// vtable's `write_err` truncates cleanly past that.
+const VTABLE_ERR_BUF_CAP: usize = 512;
+
 /// A created processor instance for runtime use.
-pub type ProcessorInstance = Box<dyn DynGeneratedProcessor + Send>;
+///
+/// Two-variant: cdylib + inventory-registered processors land in
+/// [`Self::VTable`] (dispatch via extern "C" fn pointers, retiring
+/// the dyn-trait crossing class); legacy non-generic registrations
+/// (subprocess host wrappers via [`ProcessorInstanceFactory::register_dynamic`])
+/// land in [`Self::LegacyDyn`] (dispatch via Rust trait-object
+/// methods, host-DSO-only).
+pub enum ProcessorInstance {
+    /// Cdylib- or inventory-registered processor. `instance_ptr` is
+    /// a `Box::into_raw(Box::<P>::new(...))` allocation on the
+    /// registering DSO's heap (cdylib for cross-DSO loads, host for
+    /// inventory). Dropped via `vtable.destroy`.
+    ///
+    /// `any_placeholder` is a ZST anchor whose `&mut` reference
+    /// satisfies the `as_any_mut() -> &mut dyn Any` shape without
+    /// touching the cdylib-side processor. Downcasts to host-only
+    /// subprocess-host types fall through to `None` as expected
+    /// (cdylib processors are never subprocess hosts).
+    VTable {
+        instance_ptr: *mut c_void,
+        vtable: &'static ProcessorVTable,
+        any_placeholder: (),
+    },
+    /// Host-static dyn-trait registration. Used by subprocess host
+    /// wrappers (Python / Deno) that register a `Box<dyn Fn>`
+    /// constructor via [`ProcessorInstanceFactory::register_dynamic`].
+    /// No cross-DSO crossing — these live in the host's DSO and
+    /// dispatch via standard Rust trait objects.
+    LegacyDyn(Box<dyn DynGeneratedProcessor + Send>),
+}
+
+// Safety: VTable's `*mut c_void` is bound to the registering DSO's
+// process address space, which lives for the process lifetime
+// (cdylibs are pinned via `LOADED_PLUGIN_LIBRARIES`). LegacyDyn's
+// inner Box<dyn ... + Send> is already Send.
+unsafe impl Send for ProcessorInstance {}
+
+impl Drop for ProcessorInstance {
+    fn drop(&mut self) {
+        if let Self::VTable {
+            instance_ptr,
+            vtable,
+            ..
+        } = self
+        {
+            if !instance_ptr.is_null() {
+                // SAFETY: instance_ptr came from the same DSO's
+                // Box::into_raw via vtable.construct; destroy
+                // performs Box::from_raw + drop on that DSO's heap.
+                unsafe {
+                    (vtable.destroy)(*instance_ptr);
+                }
+            }
+        }
+    }
+}
+
+impl ProcessorInstance {
+    /// Issue one vtable lifecycle call against the VTable variant.
+    /// Returns the host-side error chained off the extern "C" return
+    /// code + scratch buffer.
+    fn vtable_call_full(
+        instance_ptr: *mut c_void,
+        method: unsafe extern "C" fn(
+            *mut c_void,
+            *const c_void,
+            *mut u8,
+            usize,
+            *mut usize,
+        ) -> i32,
+        ctx: &RuntimeContextFullAccess<'_>,
+        method_name: &str,
+    ) -> Result<()> {
+        let mut err_buf = [0u8; VTABLE_ERR_BUF_CAP];
+        let mut err_len = 0usize;
+        let rc = unsafe {
+            method(
+                instance_ptr,
+                ctx as *const RuntimeContextFullAccess<'_> as *const c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if rc == 0 {
+            Ok(())
+        } else {
+            let msg = std::str::from_utf8(&err_buf[..err_len])
+                .unwrap_or("<non-utf8 error>")
+                .to_string();
+            Err(Error::Runtime(format!("{method_name}: {msg}")))
+        }
+    }
+
+    fn vtable_call_limited(
+        instance_ptr: *mut c_void,
+        method: unsafe extern "C" fn(
+            *mut c_void,
+            *const c_void,
+            *mut u8,
+            usize,
+            *mut usize,
+        ) -> i32,
+        ctx: &RuntimeContextLimitedAccess<'_>,
+        method_name: &str,
+    ) -> Result<()> {
+        let mut err_buf = [0u8; VTABLE_ERR_BUF_CAP];
+        let mut err_len = 0usize;
+        let rc = unsafe {
+            method(
+                instance_ptr,
+                ctx as *const RuntimeContextLimitedAccess<'_> as *const c_void,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if rc == 0 {
+            Ok(())
+        } else {
+            let msg = std::str::from_utf8(&err_buf[..err_len])
+                .unwrap_or("<non-utf8 error>")
+                .to_string();
+            Err(Error::Runtime(format!("{method_name}: {msg}")))
+        }
+    }
+
+    /// Run the processor's `setup` lifecycle.
+    pub fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_full(*instance_ptr, vtable.setup, ctx, "setup")
+            }
+            Self::LegacyDyn(inner) => {
+                ctx.tokio_handle().block_on(inner.__generated_setup(ctx))
+            }
+        }
+    }
+
+    /// Run the processor's `teardown` lifecycle.
+    pub fn teardown(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_full(*instance_ptr, vtable.teardown, ctx, "teardown")
+            }
+            Self::LegacyDyn(inner) => {
+                ctx.tokio_handle().block_on(inner.__generated_teardown(ctx))
+            }
+        }
+    }
+
+    /// Run the processor's `on_pause` hook.
+    pub fn on_pause(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_limited(*instance_ptr, vtable.on_pause, ctx, "on_pause")
+            }
+            Self::LegacyDyn(inner) => {
+                ctx.tokio_handle().block_on(inner.__generated_on_pause(ctx))
+            }
+        }
+    }
+
+    /// Run the processor's `on_resume` hook.
+    pub fn on_resume(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_limited(*instance_ptr, vtable.on_resume, ctx, "on_resume")
+            }
+            Self::LegacyDyn(inner) => {
+                ctx.tokio_handle().block_on(inner.__generated_on_resume(ctx))
+            }
+        }
+    }
+
+    /// Run one tick of the processor's `process` body.
+    pub fn process(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_limited(*instance_ptr, vtable.process, ctx, "process")
+            }
+            Self::LegacyDyn(inner) => inner.process(ctx),
+        }
+    }
+
+    /// Start a Manual-mode processor.
+    pub fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_full(*instance_ptr, vtable.start, ctx, "start")
+            }
+            Self::LegacyDyn(inner) => inner.start(ctx),
+        }
+    }
+
+    /// Stop a Manual-mode processor.
+    pub fn stop(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        match self {
+            Self::VTable { instance_ptr, vtable, .. } => {
+                Self::vtable_call_full(*instance_ptr, vtable.stop, ctx, "stop")
+            }
+            Self::LegacyDyn(inner) => inner.stop(ctx),
+        }
+    }
+
+    /// Read the processor's execution config. For VTable variants
+    /// the call crosses extern "C" once; for LegacyDyn it dispatches
+    /// through the trait object.
+    pub fn execution_config(&self) -> ExecutionConfig {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let mut buf = [0u8; 64];
+                let mut out_len = 0usize;
+                let required = unsafe {
+                    (vtable.execution_config_msgpack)(
+                        *instance_ptr,
+                        buf.as_mut_ptr(),
+                        buf.len(),
+                        &mut out_len as *mut usize,
+                    )
+                };
+                if required == 0 || required > buf.len() {
+                    // Either no payload or too-big payload (won't
+                    // happen for ExecutionConfig in practice). Fall
+                    // back to default.
+                    return ExecutionConfig::default();
+                }
+                rmp_serde::from_slice(&buf[..out_len]).unwrap_or_default()
+            }
+            Self::LegacyDyn(inner) => inner.execution_config(),
+        }
+    }
+
+    pub fn has_iceoryx2_outputs(&self) -> bool {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => unsafe { (vtable.has_iceoryx2_outputs)(*instance_ptr) },
+            Self::LegacyDyn(inner) => inner.has_iceoryx2_outputs(),
+        }
+    }
+
+    pub fn has_iceoryx2_inputs(&self) -> bool {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => unsafe { (vtable.has_iceoryx2_inputs)(*instance_ptr) },
+            Self::LegacyDyn(inner) => inner.has_iceoryx2_inputs(),
+        }
+    }
+
+    pub fn get_iceoryx2_output_writer(
+        &self,
+    ) -> Option<Arc<crate::iceoryx2::OutputWriter>> {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let raw = unsafe { (vtable.get_iceoryx2_output_writer_arc)(*instance_ptr) };
+                if raw.is_null() {
+                    None
+                } else {
+                    // SAFETY: the vtable wrapper called Arc::into_raw on a
+                    // clone of the processor's OutputWriter Arc, transferring
+                    // one strong reference. We take ownership here.
+                    Some(unsafe {
+                        Arc::from_raw(raw as *const crate::iceoryx2::OutputWriter)
+                    })
+                }
+            }
+            Self::LegacyDyn(inner) => inner.get_iceoryx2_output_writer(),
+        }
+    }
+
+    pub fn get_iceoryx2_input_mailboxes(
+        &mut self,
+    ) -> Option<&mut crate::iceoryx2::InputMailboxes> {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let raw = unsafe { (vtable.get_iceoryx2_input_mailboxes_mut)(*instance_ptr) };
+                if raw.is_null() {
+                    None
+                } else {
+                    // SAFETY: the vtable wrapper returned &mut self.inputs
+                    // on the same instance; we hold a &mut to the processor
+                    // through `instance_ptr`, so the borrow is exclusive.
+                    Some(unsafe { &mut *(raw as *mut crate::iceoryx2::InputMailboxes) })
+                }
+            }
+            Self::LegacyDyn(inner) => inner.get_iceoryx2_input_mailboxes(),
+        }
+    }
+
+    pub fn apply_config_json(&mut self, config_json: &serde_json::Value) -> Result<()> {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let bytes = rmp_serde::to_vec_named(config_json).map_err(|e| {
+                    Error::Configuration(format!("apply_config_json msgpack encode: {e}"))
+                })?;
+                let mut err_buf = [0u8; VTABLE_ERR_BUF_CAP];
+                let mut err_len = 0usize;
+                let rc = unsafe {
+                    (vtable.apply_config_msgpack)(
+                        *instance_ptr,
+                        bytes.as_ptr(),
+                        bytes.len(),
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if rc == 0 {
+                    Ok(())
+                } else {
+                    let msg = std::str::from_utf8(&err_buf[..err_len])
+                        .unwrap_or("<non-utf8 error>")
+                        .to_string();
+                    Err(Error::Configuration(format!("apply_config_json: {msg}")))
+                }
+            }
+            Self::LegacyDyn(inner) => inner.apply_config_json(config_json),
+        }
+    }
+
+    pub fn to_runtime_json(&self) -> serde_json::Value {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let mut buf = vec![0u8; 4096];
+                let mut out_len = 0usize;
+                let required = unsafe {
+                    (vtable.to_runtime_msgpack)(
+                        *instance_ptr,
+                        buf.as_mut_ptr(),
+                        buf.len(),
+                        &mut out_len as *mut usize,
+                    )
+                };
+                if required == 0 {
+                    return serde_json::Value::Null;
+                }
+                if required > buf.len() {
+                    // Resize and retry. Runtime-state payloads in
+                    // practice fit well under 4 KiB, but this keeps
+                    // the contract honest.
+                    buf.resize(required, 0);
+                    let _ = unsafe {
+                        (vtable.to_runtime_msgpack)(
+                            *instance_ptr,
+                            buf.as_mut_ptr(),
+                            buf.len(),
+                            &mut out_len as *mut usize,
+                        )
+                    };
+                }
+                rmp_serde::from_slice(&buf[..out_len]).unwrap_or(serde_json::Value::Null)
+            }
+            Self::LegacyDyn(inner) => inner.to_runtime_json(),
+        }
+    }
+
+    pub fn config_json(&self) -> serde_json::Value {
+        match self {
+            Self::VTable {
+                instance_ptr,
+                vtable,
+                ..
+            } => {
+                let mut buf = vec![0u8; 4096];
+                let mut out_len = 0usize;
+                let required = unsafe {
+                    (vtable.config_msgpack)(
+                        *instance_ptr,
+                        buf.as_mut_ptr(),
+                        buf.len(),
+                        &mut out_len as *mut usize,
+                    )
+                };
+                if required == 0 {
+                    return serde_json::Value::Null;
+                }
+                if required > buf.len() {
+                    buf.resize(required, 0);
+                    let _ = unsafe {
+                        (vtable.config_msgpack)(
+                            *instance_ptr,
+                            buf.as_mut_ptr(),
+                            buf.len(),
+                            &mut out_len as *mut usize,
+                        )
+                    };
+                }
+                rmp_serde::from_slice(&buf[..out_len]).unwrap_or(serde_json::Value::Null)
+            }
+            Self::LegacyDyn(inner) => inner.config_json(),
+        }
+    }
+
+    /// Downcast handle. Only meaningful for the LegacyDyn variant —
+    /// cdylib-registered processors return a placeholder reference
+    /// that downcasts to nothing. Used by the host's compiler ops to
+    /// reach host-only subprocess host wrappers
+    /// (`PythonNativeSubprocessHostProcessor`, `DenoSubprocessHostProcessor`)
+    /// which only register via the legacy path.
+    pub fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        match self {
+            Self::LegacyDyn(inner) => inner.as_any_mut(),
+            Self::VTable { any_placeholder, .. } => any_placeholder,
+        }
+    }
+}
 
 /// Types used by macro-generated code. Not for direct use.
 pub mod macro_codegen {
@@ -29,16 +469,13 @@ pub mod macro_codegen {
     inventory::collect!(FactoryRegistration);
 }
 
-/// Factory function signature for creating processor instances.
-///
-/// Used by `register_dynamic()` for runtime processor registration from plugins.
-pub type DynamicProcessorConstructorFn =
-    Box<dyn Fn(&ProcessorNode) -> Result<ProcessorInstance> + Send + Sync>;
-
-mod private {
-    /// Factory function signature for creating processors (internal alias).
-    pub type ConstructorFn = super::DynamicProcessorConstructorFn;
-}
+/// Legacy-path factory function signature used by
+/// [`ProcessorInstanceFactory::register_dynamic`] for subprocess
+/// host wrappers (Python / Deno) that don't fit the generic vtable
+/// monomorphization shape.
+pub type DynamicProcessorConstructorFn = Box<
+    dyn Fn(&ProcessorNode) -> Result<Box<dyn DynGeneratedProcessor + Send>> + Send + Sync,
+>;
 
 /// Result of processor registration.
 #[derive(Debug, Clone)]
@@ -47,9 +484,25 @@ pub struct RegisterResult {
     pub count: usize,
 }
 
+/// Per-type registration entry the factory stores.
+enum RegistrationKind {
+    /// VTable-based dispatch. Used by both cdylib registrations
+    /// (extern "C" wrappers landing in the cdylib's DSO) and
+    /// inventory-registered host processors (extern "C" wrappers
+    /// landing in the host's DSO).
+    VTable {
+        vtable: &'static ProcessorVTable,
+    },
+    /// Box<dyn Fn> closure constructor — used for subprocess host
+    /// wrappers via `register_dynamic`.
+    LegacyDyn {
+        constructor: DynamicProcessorConstructorFn,
+    },
+}
+
 /// Factory for compile-time registered Rust processors.
 pub struct ProcessorInstanceFactory {
-    constructors: RwLock<HashMap<SchemaIdent, private::ConstructorFn>>,
+    registrations: RwLock<HashMap<SchemaIdent, RegistrationKind>>,
     port_info: RwLock<HashMap<SchemaIdent, (Vec<PortInfo>, Vec<PortInfo>)>>,
     descriptors: RwLock<HashMap<SchemaIdent, ProcessorDescriptor>>,
     /// Set of port-data-type schema specs ([`PortSchemaSpec`]).
@@ -79,7 +532,7 @@ impl Default for ProcessorInstanceFactory {
 impl ProcessorInstanceFactory {
     pub fn new() -> Self {
         Self {
-            constructors: RwLock::new(HashMap::new()),
+            registrations: RwLock::new(HashMap::new()),
             port_info: RwLock::new(HashMap::new()),
             descriptors: RwLock::new(HashMap::new()),
             schemas: RwLock::new(HashSet::new()),
@@ -95,15 +548,17 @@ impl ProcessorInstanceFactory {
         for registration in inventory::iter::<macro_codegen::FactoryRegistration> {
             (registration.register_fn)(self);
         }
-        let count = self.constructors.read().len();
+        let count = self.registrations.read().len();
         RegisterResult { count }
     }
 
-    /// Register a processor type with its constructor.
+    /// Register a processor type with the vtable shape. Monomorphizes a
+    /// `&'static ProcessorVTable` for `P` and stores it alongside the
+    /// processor's descriptor + port info.
     pub fn register<P>(&self)
     where
         P: GeneratedProcessor + 'static,
-        P::Config: for<'de> serde::Deserialize<'de> + Default,
+        P::Config: Config,
     {
         let descriptor = match <P as GeneratedProcessor>::descriptor() {
             Some(d) => d,
@@ -116,6 +571,32 @@ impl ProcessorInstanceFactory {
             }
         };
 
+        let vtable = crate::core::plugin::processor_vtable::vtable_for::<P>();
+
+        if let Err(e) = self.register_via_vtable(descriptor, vtable) {
+            tracing::warn!(
+                "Processor registration for {} failed: {}",
+                std::any::type_name::<P>(),
+                e
+            );
+        }
+    }
+
+    /// Insert a descriptor + vtable pair under the descriptor's
+    /// structured ident. Idempotent on `(ident)` keys — a duplicate
+    /// registration logs `debug!` and skips.
+    ///
+    /// Used by:
+    /// - `register::<P>()` (inventory + in-tree host-side
+    ///   registrations) — passes the vtable from `vtable_for::<P>()`.
+    /// - The cdylib-bridge `processor_register` callback in
+    ///   `core::plugin::host_services` — passes the cdylib's
+    ///   `&'static ProcessorVTable`.
+    pub fn register_via_vtable(
+        &self,
+        descriptor: ProcessorDescriptor,
+        vtable: &'static ProcessorVTable,
+    ) -> Result<()> {
         let type_name = descriptor.name.clone();
 
         let inputs: Vec<PortInfo> = descriptor
@@ -153,31 +634,16 @@ impl ProcessorInstanceFactory {
             .write()
             .insert(type_name.clone(), descriptor);
 
-        let constructor: private::ConstructorFn = Box::new(move |node: &ProcessorNode| {
-            let config: P::Config = match &node.config {
-                Some(json) => serde_json::from_value(json.clone()).map_err(|e| {
-                    Error::Configuration(format!(
-                        "Failed to deserialize config for '{}': {}",
-                        node.id, e
-                    ))
-                })?,
-                None => P::Config::default(),
-            };
-
-            let processor = P::from_config(config)?;
-            Ok(Box::new(processor) as ProcessorInstance)
-        });
-
         {
-            let mut constructors = self.constructors.write();
-            if constructors.contains_key(&type_name) {
+            let mut registrations = self.registrations.write();
+            if registrations.contains_key(&type_name) {
                 tracing::debug!(
                     "Processor '{}' already registered, skipping duplicate",
                     type_name
                 );
-                return;
+                return Ok(());
             }
-            constructors.insert(type_name.clone(), constructor);
+            registrations.insert(type_name.clone(), RegistrationKind::VTable { vtable });
         }
 
         tracing::info!("[register] new processor type registered '{}'", type_name);
@@ -188,12 +654,14 @@ impl ProcessorInstanceFactory {
                 processor_type: type_name.clone(),
             }),
         );
+
+        Ok(())
     }
 
-    /// Register a processor dynamically at runtime (for plugins).
-    ///
-    /// Unlike `register<P>()` which requires compile-time knowledge of the processor type,
-    /// this method accepts pre-built descriptor and constructor for runtime registration.
+    /// Register a processor dynamically at runtime with a non-generic
+    /// `Box<dyn Fn>` constructor. Used for subprocess host wrappers
+    /// (Python / Deno) where the constructor isn't expressible as a
+    /// generic `register::<P>()` call.
     ///
     /// # Arguments
     /// * `descriptor` - Processor metadata including name, ports, and config schema
@@ -204,12 +672,12 @@ impl ProcessorInstanceFactory {
     pub fn register_dynamic(
         &self,
         descriptor: ProcessorDescriptor,
-        constructor: private::ConstructorFn,
+        constructor: DynamicProcessorConstructorFn,
     ) -> Result<()> {
         let type_name = descriptor.name.clone();
 
         // Check for duplicate registration
-        if self.constructors.read().contains_key(&type_name) {
+        if self.registrations.read().contains_key(&type_name) {
             return Err(Error::Configuration(format!(
                 "Processor '{}' already registered",
                 type_name
@@ -252,9 +720,9 @@ impl ProcessorInstanceFactory {
             .write()
             .insert(type_name.clone(), descriptor);
 
-        self.constructors
+        self.registrations
             .write()
-            .insert(type_name.clone(), constructor);
+            .insert(type_name.clone(), RegistrationKind::LegacyDyn { constructor });
 
         tracing::info!(
             "[register_dynamic] new processor type registered '{}'",
@@ -340,19 +808,64 @@ impl ProcessorInstanceFactory {
     }
 
     pub fn can_create(&self, processor_type: &SchemaIdent) -> bool {
-        self.constructors.read().contains_key(processor_type)
+        self.registrations.read().contains_key(processor_type)
     }
 
     pub fn create(&self, node: &ProcessorNode) -> Result<ProcessorInstance> {
-        let constructors = self.constructors.read();
-        let constructor = constructors.get(&node.processor_type).ok_or_else(|| {
+        let registrations = self.registrations.read();
+        let registration = registrations.get(&node.processor_type).ok_or_else(|| {
             Error::ProcessorNotFound(format!(
                 "No factory registered for processor type '{}'",
                 node.processor_type
             ))
         })?;
 
-        constructor(node)
+        match registration {
+            RegistrationKind::VTable { vtable } => {
+                // Serialize node.config (serde_json::Value) to msgpack
+                // for the cdylib's construct fn to deserialize into
+                // P::Config.
+                let config_msgpack = match &node.config {
+                    Some(json) => rmp_serde::to_vec_named(json).map_err(|e| {
+                        Error::Configuration(format!(
+                            "Failed to encode config to msgpack for '{}': {}",
+                            node.id, e
+                        ))
+                    })?,
+                    None => Vec::new(),
+                };
+
+                let mut err_buf = [0u8; VTABLE_ERR_BUF_CAP];
+                let mut err_len = 0usize;
+                let ptr = unsafe {
+                    (vtable.construct)(
+                        config_msgpack.as_ptr(),
+                        config_msgpack.len(),
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if ptr.is_null() {
+                    let msg = std::str::from_utf8(&err_buf[..err_len])
+                        .unwrap_or("<non-utf8 error>")
+                        .to_string();
+                    return Err(Error::Configuration(format!(
+                        "construct for '{}': {}",
+                        node.processor_type, msg
+                    )));
+                }
+                Ok(ProcessorInstance::VTable {
+                    instance_ptr: ptr,
+                    vtable: *vtable,
+                    any_placeholder: (),
+                })
+            }
+            RegistrationKind::LegacyDyn { constructor } => {
+                let inner = constructor(node)?;
+                Ok(ProcessorInstance::LegacyDyn(inner))
+            }
+        }
     }
 
     pub fn port_info(
@@ -363,7 +876,7 @@ impl ProcessorInstanceFactory {
     }
 
     pub fn is_registered(&self, processor_type: &SchemaIdent) -> bool {
-        self.constructors.read().contains_key(processor_type)
+        self.registrations.read().contains_key(processor_type)
     }
 
     /// Get the descriptor for a processor type, if registered.
@@ -381,7 +894,7 @@ impl ProcessorInstanceFactory {
     /// [`Error::UnknownProcessorType`] when nothing matches.
     ///
     /// Iterates over `descriptors` (the truth for registered idents),
-    /// not `constructors`, so subprocess-only processors registered via
+    /// not `registrations`, so subprocess-only processors registered via
     /// [`Self::register_descriptor_only`] participate in resolution.
     pub fn resolve_any_version(
         &self,

--- a/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Lifecycle smoke test for the dynamic Rust-plugin vtable path.
+//!
+//! Where `load_project_dylib_smoke.rs` asserts the registration
+//! callback fired, this test goes one step further: it walks the
+//! registered `TestConfiguredProcessor` through `factory.create(&node)`
+//! to confirm the cdylib-side `extern "C" fn construct(...)` wrapper
+//! returns a non-null instance pointer, then drops it to exercise
+//! `extern "C" fn destroy(...)` — the cross-DSO heap dance that the
+//! vtable shape introduces.
+//!
+//! Mentally revert the `Drop` impl in
+//! `processor_instance_factory.rs::ProcessorInstance` and this test
+//! still passes (no crash on drop today), but a future regression
+//! that breaks the construct→destroy contract would surface as a
+//! double-free / leak in this test plus the runtime.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::processors::{ProcessorInstance, PROCESSOR_REGISTRY};
+use streamlib::sdk::runtime::Runner;
+use streamlib_engine::core::graph::ProcessorNode;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn dylib_processor_create_and_drop_round_trips_through_vtable() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // Build test-fixtures with the `plugin` feature so the cdylib carries
+    // the `STREAMLIB_PLUGIN` symbol.
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed against a real test-fixtures cdylib");
+
+    // Locate the registered TestConfiguredProcessor's descriptor so we
+    // can build a ProcessorNode against the exact structured ident the
+    // cdylib emitted at registration time.
+    let descriptor = PROCESSOR_REGISTRY
+        .list_registered()
+        .into_iter()
+        .find(|d| d.name.r#type.as_str() == "TestConfiguredProcessor")
+        .expect("TestConfiguredProcessor must be registered after load_project");
+
+    // Build a minimal ProcessorNode. The factory's `create()` path
+    // serializes `node.config` to msgpack and hands it to the
+    // cdylib's `extern "C" fn construct(...)` wrapper, which
+    // deserializes into `P::Config`. Default config (empty bytes) is
+    // sufficient — the wrapper falls back to `P::Config::default()`.
+    let node = ProcessorNode::new(
+        descriptor.name.clone(),
+        "TestConfiguredProcessor",
+        None,
+        Vec::new(),
+        Vec::new(),
+    );
+
+    // Cross the FFI boundary: cdylib's vtable.construct allocates a
+    // Box<P> on the cdylib's heap and returns a thin pointer.
+    let instance = PROCESSOR_REGISTRY
+        .create(&node)
+        .expect("factory.create() must succeed for a registered cdylib processor");
+
+    // Verify we got the VTable variant (cdylib path, not LegacyDyn).
+    assert!(
+        matches!(instance, ProcessorInstance::VTable { .. }),
+        "create() must return ProcessorInstance::VTable for cdylib-registered processors"
+    );
+
+    // Drop the instance — this fires the cdylib's vtable.destroy
+    // wrapper, which Box::from_raw + drops on the cdylib's heap. A
+    // mismatched alloc/free across DSO heaps would surface as a
+    // double-free or heap corruption.
+    drop(instance);
+
+    // Final sanity: registry still reports the processor as
+    // registered (drop on instance must not touch the registry).
+    assert!(
+        PROCESSOR_REGISTRY.is_registered(&descriptor.name),
+        "registry must still hold the processor type after instance drop"
+    );
+}

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -21,17 +21,12 @@
 //! pointers that bridge every process-wide service the plugin's
 //! statically-linked engine copy would otherwise see in isolation:
 //! tracing emit, PUBSUB publish, schema-registry register / lookup,
-//! iceoryx2-log emit. The cdylib's `streamlib::sdk::plugin::install_host_services`
-//! stores those fn pointers and replaces the cdylib's per-DSO
-//! statics' read sites with forwarders that thunk through them.
-//!
-//! Side note: the legacy `processor_registry_typed` field still
-//! crosses as a typed `*const ProcessorInstanceFactory`. The
-//! `ProcessorInstanceFactory`'s internal `Box<dyn Fn>` constructors
-//! and `Box<dyn DynGeneratedProcessor>` instance objects are
-//! pre-existing dyn-trait crossings whose ABI stability depends on
-//! the engine's semver coupling — separate from the callback-table
-//! bridges this struct introduces.
+//! iceoryx2-log emit. Cdylib registration of processor types crosses
+//! via [`HostServices::processor_register`], which carries a msgpack-
+//! encoded `ProcessorDescriptor` plus a [`ProcessorVTable`] of
+//! extern "C" fn pointers covering the full host-called
+//! `DynGeneratedProcessor` surface — constructor + lifecycle plus
+//! iceoryx2 wiring, execution-config, and config-json IO.
 //!
 //! # Example plugin
 //!
@@ -78,14 +73,26 @@ use core::ffi::c_void;
 /// incompatibly. Same-major-version layout additions append to the
 /// end of [`HostServices`] and read the new fields only when
 /// `abi_layout_version` advertises them.
-pub const STREAMLIB_ABI_VERSION: u32 = 2;
+pub const STREAMLIB_ABI_VERSION: u32 = 3;
 
 /// Layout version of the [`HostServices`] payload. Read first by the
 /// cdylib's `install_host_services` before any other field is
 /// touched. Bumped whenever fields are added, removed, or reordered.
 /// Distinct from [`STREAMLIB_ABI_VERSION`] because layout-only
 /// additions can ship without bumping the wire ABI.
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 1;
+///
+/// - v1: tracing / PUBSUB / schema / iceoryx2-log callbacks +
+///   `processor_registry_typed` typed pointer.
+/// - v2: `processor_registry_typed` removed; replaced with
+///   [`HostServices::processor_register`] callback + [`ProcessorVTable`].
+///   Adds [`HostServices::host_tokio_handle_clone`] so cdylib-side
+///   async-lifecycle wrappers can block_on on the host's tokio runtime.
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 2;
+
+/// Layout version of the [`ProcessorVTable`] struct. Read by the
+/// host's `processor_register` impl before dereferencing any vtable
+/// entry; mismatching versions abort the registration cleanly.
+pub const PROCESSOR_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -120,6 +127,230 @@ pub enum HostInterest {
 /// as the first argument; the host derefs to its concrete service
 /// table, the cdylib treats it as opaque.
 pub type HostHandle = *const c_void;
+
+// =============================================================================
+// ProcessorVTable — extern "C" dispatch table for processor instances
+// =============================================================================
+
+/// `extern "C" fn` dispatch table the host uses to call methods on a
+/// dlopen'd processor instance. Replaces the `Box<dyn
+/// DynGeneratedProcessor>` dyn-trait crossing the host used to
+/// dispatch through.
+///
+/// The vtable covers the full host-called surface — constructor +
+/// lifecycle (setup / teardown / on_pause / on_resume / process /
+/// start / stop / destroy) plus the static-info, iceoryx2-wiring,
+/// and config-IO methods compiler ops invoke on every processor.
+/// Methods bodies still receive `&RuntimeContext*Access` references
+/// crossing via Rust trait-object dispatch; those are Phase B + C
+/// (see `streamlib-plugin-abi`'s parent issue).
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. The host's
+/// `processor_register` impl reads it before dereferencing any other
+/// field; older vtables loaded into newer hosts are rejected
+/// cleanly. New fields go at the **end** and bump
+/// [`PROCESSOR_VTABLE_LAYOUT_VERSION`].
+///
+/// # Error convention
+///
+/// Sync lifecycle methods (`process`, `start`, `stop`) and async
+/// lifecycle methods (`setup`, `teardown`, `on_pause`, `on_resume`)
+/// share the error convention: return `0` on success, non-zero on
+/// failure. `err_buf` / `err_buf_cap` is a caller-provided UTF-8
+/// scratch buffer the callee writes a message into; `*err_len`
+/// receives the actual byte count written. Truncation is benign
+/// (caller's buffer was too small).
+///
+/// `construct` follows the same convention but returns a `*mut
+/// c_void` instance handle (null on failure).
+///
+/// `to_runtime_json`, `config_json`, `execution_config` return a
+/// byte count: 0 = "no payload"; a value larger than `out_cap` = the
+/// required buffer size (caller should resize and retry). On
+/// success, `*out_len` receives the bytes written.
+#[repr(C)]
+pub struct ProcessorVTable {
+    /// Vtable layout version. Must equal
+    /// [`PROCESSOR_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -------------------------------------------------------------------------
+    // Constructor + lifetime
+    // -------------------------------------------------------------------------
+
+    /// Build a processor instance from msgpack-encoded `Config`
+    /// bytes. Returns a thin opaque pointer the cdylib's wrappers
+    /// cast back to `*mut P::Processor`. Null = failure (message in
+    /// `err_buf`).
+    pub construct: unsafe extern "C" fn(
+        config_msgpack_ptr: *const u8,
+        config_msgpack_len: usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> *mut c_void,
+
+    /// Free the heap allocation `construct` returned. Equivalent to
+    /// `Box::from_raw(instance as *mut P::Processor)` + drop on the
+    /// cdylib side.
+    pub destroy: unsafe extern "C" fn(instance: *mut c_void),
+
+    // -------------------------------------------------------------------------
+    // Async lifecycle (block_on'd inside cdylib using host's tokio handle)
+    // -------------------------------------------------------------------------
+
+    pub setup: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    pub teardown: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    pub on_pause: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    pub on_resume: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Sync lifecycle
+    // -------------------------------------------------------------------------
+
+    pub process: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_limited: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Manual-mode start. Returns non-zero with an error message for
+    /// non-Manual processors.
+    pub start: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Manual-mode stop. Returns non-zero with an error message for
+    /// non-Manual processors.
+    pub stop: unsafe extern "C" fn(
+        instance: *mut c_void,
+        ctx_full: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Static info
+    // -------------------------------------------------------------------------
+
+    /// Serialize the processor's [`ExecutionConfig`] to msgpack bytes.
+    /// Return value follows the byte-count convention documented on
+    /// the struct.
+    pub execution_config_msgpack: unsafe extern "C" fn(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize,
+
+    // -------------------------------------------------------------------------
+    // Iceoryx2 wiring (returns Rust types via raw pointer — known
+    // source-coupling for OutputWriter / InputMailboxes; see Phase A
+    // AI Agent Notes for the deferred-flip rationale)
+    // -------------------------------------------------------------------------
+
+    pub has_iceoryx2_outputs: unsafe extern "C" fn(instance: *const c_void) -> bool,
+    pub has_iceoryx2_inputs: unsafe extern "C" fn(instance: *const c_void) -> bool,
+
+    /// Returns `Arc::into_raw(arc.clone()).cast()` for the
+    /// `OutputWriter` arc the processor exposes, or null for "no
+    /// output writer". The host casts back via `Arc::from_raw`,
+    /// taking ownership of the cloned reference. Cdylib MUST clone
+    /// from its own Arc (so its internal Arc remains valid) before
+    /// `Arc::into_raw`.
+    pub get_iceoryx2_output_writer_arc:
+        unsafe extern "C" fn(instance: *const c_void) -> *const c_void,
+
+    /// Returns `&mut self.inputs as *mut InputMailboxes` cast to
+    /// `*mut c_void`, or null for "no input mailboxes". The pointer
+    /// is valid for the lifetime of `instance` — caller must not
+    /// hold across other vtable calls (the cdylib could mutate
+    /// during a `process()` call from another thread). In practice
+    /// the compiler op holds the lock on `instance` and so the
+    /// borrow is sound.
+    pub get_iceoryx2_input_mailboxes_mut:
+        unsafe extern "C" fn(instance: *mut c_void) -> *mut c_void,
+
+    // -------------------------------------------------------------------------
+    // Config / state IO (msgpack bytes on the wire)
+    // -------------------------------------------------------------------------
+
+    /// Apply a runtime-reconfigure update. The bytes are
+    /// msgpack-encoded `P::Config` (matches `construct`'s payload
+    /// shape).
+    pub apply_config_msgpack: unsafe extern "C" fn(
+        instance: *mut c_void,
+        config_msgpack_ptr: *const u8,
+        config_msgpack_len: usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Serialize the processor's runtime state to msgpack. Return
+    /// value follows the byte-count convention; 0 = no state.
+    pub to_runtime_msgpack: unsafe extern "C" fn(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize,
+
+    /// Serialize the processor's current config to msgpack. Return
+    /// value follows the byte-count convention; 0 = no config.
+    pub config_msgpack: unsafe extern "C" fn(
+        instance: *const c_void,
+        out_buf: *mut u8,
+        out_cap: usize,
+        out_len: *mut usize,
+    ) -> usize,
+}
+
+// Safety: every field is a primitive or a fn pointer. The vtable's
+// `&'static` storage on the cdylib side outlives the cdylib's
+// process lifetime via `LOADED_PLUGIN_LIBRARIES` pinning.
+unsafe impl Send for ProcessorVTable {}
+unsafe impl Sync for ProcessorVTable {}
 
 // =============================================================================
 // HostServices — the callback table
@@ -268,24 +499,42 @@ pub struct HostServices {
     ),
 
     // -------------------------------------------------------------------------
-    // Processor registry — legacy typed pointer
+    // Processor registration (v2 — replaces the v1 typed pointer)
     // -------------------------------------------------------------------------
 
-    /// Host's `ProcessorInstanceFactory` reference as a raw pointer.
-    /// The cdylib casts back to `&'static ProcessorInstanceFactory`
-    /// and calls `register::<P>()` on it.
+    /// Register a processor type with the host's registry. The
+    /// `descriptor_msgpack` bytes encode a `ProcessorDescriptor`
+    /// (using `streamlib-processor-schema`'s serde derives) — the
+    /// host decodes them and stores the descriptor + vtable +
+    /// constructor.
     ///
-    /// This is the **one remaining type-passing field** in
-    /// [`HostServices`]. The `ProcessorInstanceFactory`'s internal
-    /// constructor / instance representations use `Box<dyn Fn>` and
-    /// `Box<dyn DynGeneratedProcessor>` — dyn-trait crossings whose
-    /// ABI stability depends on the engine's semver coupling, not
-    /// on the callback-table contract. Lifting them to extern "C"
-    /// requires reshaping the entire processor lifecycle ABI
-    /// (setup / process / teardown / port wiring / runtime-context
-    /// access) and is the natural next-step plugin-ABI milestone.
-    pub processor_registry_typed: *const c_void,
+    /// `vtable` is a `&'static ProcessorVTable` on the cdylib side;
+    /// the host pins the loaded library forever via
+    /// `LOADED_PLUGIN_LIBRARIES`, so the pointer outlives the host's
+    /// usage.
+    ///
+    /// Returns `0` on success. Non-zero indicates the descriptor
+    /// was malformed, the vtable layout version mismatched, or the
+    /// processor type was already registered; the cdylib's macro
+    /// expansion treats failures as silent (the host's "processor
+    /// not registered" check surfaces the error to the user).
+    pub processor_register: unsafe extern "C" fn(
+        host: HostHandle,
+        descriptor_msgpack_ptr: *const u8,
+        descriptor_msgpack_len: usize,
+        vtable: *const ProcessorVTable,
+    ) -> i32,
 }
+
+// Note: cdylib-side async-lifecycle wrappers (`setup` / `teardown` /
+// `on_pause` / `on_resume`) grab the tokio handle from the
+// `RuntimeContext*Access` they receive as a parameter
+// (`ctx.tokio_handle()`). Tokio handle layout is host/cdylib-shared
+// via the workspace-pinned tokio version. Phase B's RuntimeContext
+// callback table will lift that crossing to extern "C" if /
+// when multi-builder tokio drift becomes a real concern; until then,
+// the tokio handle is one of the few remaining shared-type
+// crossings Phase A leaves in place by design.
 
 // Safety: every field is a raw pointer, a fn pointer, or a
 // primitive. The host guarantees the pointed-at state outlives the
@@ -350,8 +599,9 @@ unsafe impl Sync for PluginDeclaration {}
 ///    callback table for the cdylib's PUBSUB / schema-registry
 ///    forwarders, installs the tracing `ForwardingSubscriber`,
 ///    installs the iceoryx2-log forwarder, and returns a
-///    `RegisterHelper` whose `register::<P>()` method routes through
-///    the host's `ProcessorInstanceFactory`.
+///    `RegisterHelper` whose `register::<P>()` method assembles the
+///    processor vtable + descriptor and routes through the host's
+///    `processor_register` callback.
 /// 2. Calls `helper.register::<$processor>()` for each declared
 ///    processor type, registering it with the host's registry.
 ///

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -85,8 +85,8 @@ pub const STREAMLIB_ABI_VERSION: u32 = 3;
 ///   `processor_registry_typed` typed pointer.
 /// - v2: `processor_registry_typed` removed; replaced with
 ///   [`HostServices::processor_register`] callback + [`ProcessorVTable`].
-///   Adds [`HostServices::host_tokio_handle_clone`] so cdylib-side
-///   async-lifecycle wrappers can block_on on the host's tokio runtime.
+///   Async-lifecycle wrappers grab the tokio handle from
+///   `ctx.tokio_handle()` rather than via a separate callback.
 pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 2;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
@@ -292,12 +292,13 @@ pub struct ProcessorVTable {
     pub has_iceoryx2_outputs: unsafe extern "C" fn(instance: *const c_void) -> bool,
     pub has_iceoryx2_inputs: unsafe extern "C" fn(instance: *const c_void) -> bool,
 
-    /// Returns `Arc::into_raw(arc.clone()).cast()` for the
-    /// `OutputWriter` arc the processor exposes, or null for "no
-    /// output writer". The host casts back via `Arc::from_raw`,
-    /// taking ownership of the cloned reference. Cdylib MUST clone
-    /// from its own Arc (so its internal Arc remains valid) before
-    /// `Arc::into_raw`.
+    /// Returns `Arc::into_raw(arc).cast()` of an `OutputWriter` arc
+    /// the processor exposes, or null for "no output writer". The
+    /// host casts back via `Arc::from_raw`, taking ownership of one
+    /// strong reference. The cdylib wrapper consumes the `Arc<...>`
+    /// returned by `<P as GeneratedProcessor>::get_iceoryx2_output_writer`
+    /// directly — that trait method is responsible for returning a
+    /// clone (the macro emits `Some(self.outputs.clone())`).
     pub get_iceoryx2_output_writer_arc:
         unsafe extern "C" fn(instance: *const c_void) -> *const c_void,
 


### PR DESCRIPTION
## Summary

- Lifts `HostServices.processor_registry_typed` — the last typed-pointer crossing in the cdylib↔host plugin ABI — to a pure extern "C" callback-table shape. Cdylibs now hand the host a msgpack-encoded `ProcessorDescriptor` + a `&'static ProcessorVTable` of extern "C" fn pointers covering the full host-called `DynGeneratedProcessor` surface (constructor + lifecycle + iceoryx2-wiring + execution_config + config-json IO). `HOST_SERVICES_LAYOUT_VERSION` bumped 1 → 2; `STREAMLIB_ABI_VERSION` bumped 2 → 3.
- `ProcessorInstance` becomes an enum: `VTable { instance_ptr, vtable, any_placeholder }` for cdylib + inventory-registered processors (extern "C" dispatch retires the multi-builder fragile dyn-trait vtable layout for the bulk of processors), `LegacyDyn(Box<dyn DynGeneratedProcessor + Send>)` for `register_dynamic`-registered subprocess host wrappers (Python/Deno) which are host-DSO-only and not subject to the cross-DSO ABI concern.
- New `core/plugin/processor_vtable.rs` module monomorphizes a `&'static ProcessorVTable` per `P` (cached by `TypeId`); host-static `register::<P>()` and the cdylib's `RegisterHelper::register::<P>()` share the same shape.

## Scope extension vs. issue body

Issue body's original framing scoped Phase A to "constructor + lifecycle crossings specifically." Step 2.5 audit during pickup showed that 9 non-lifecycle methods on `DynGeneratedProcessor` (execution_config, iceoryx2 wiring x4, apply_config_json, to_runtime_json, config_json, name/descriptor) are called on every cdylib-loaded processor at thread-spawn time + by compiler ops for processors with iceoryx2 outputs — i.e. nearly every package emitting `export_plugin!` per #874. Phases B/C target RuntimeContext + GpuContext, not these non-lifecycle DynGeneratedProcessor methods. Phase A as literally specified would have left the bug class half-fixed indefinitely.

User explicitly approved extending Phase A scope to cover the full host-called surface before implementation started. Issue body updated in place with dated supersession note.

## Closes

Closes #883

## Exit criteria (per issue body, all met)

- [x] `ProcessorVTable` lives in `streamlib-plugin-abi` with extern "C" fn pointers for the full host-called `DynGeneratedProcessor` surface. Layout-versioned.
- [x] Constructor signature on the wire is `extern "C" fn(config_msgpack_ptr, config_msgpack_len, err_buf, err_buf_cap, err_len) -> *mut c_void`.
- [x] `ProcessorDescriptor` msgpack via `streamlib-processor-schema`'s existing serde derives.
- [x] `HostServices.processor_registry_typed` removed; replaced with `processor_register: extern "C" fn(host, descriptor_msgpack_ptr, descriptor_msgpack_len, vtable) -> i32`. `HOST_SERVICES_LAYOUT_VERSION` bumped 1 → 2.
- [x] Async-lifecycle wrappers grab the tokio handle from `ctx.tokio_handle()` rather than via a separate `host_tokio_handle_clone` callback. The issue body's "Resolved design" originally specified a callback; during implementation I took the simpler path — `ctx` already exposes `tokio_handle()` so no extra ABI surface is needed. Issue body updated to reflect this choice.
- [x] Cdylib's `RegisterHelper::register::<P>()` generates the `ProcessorVTable` + extern "C" constructor for `P` and calls `processor_register`. Source-compatible at the macro invocation site.
- [x] Host's `ProcessorInstanceFactory` stores the vtable + descriptor and dispatches through them at runtime. `register_dynamic` + `register_descriptor_only` keep their legacy paths (host-DSO-only subprocess host wrappers).
- [x] All in-tree plugins continue to register + run cleanly.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `cargo test --lib -p streamlib-engine`: **425 passed; 0 failed**. There's a pre-existing flaky SIGABRT in `cargo test --workspace` (heap corruption from a non-deterministic test interaction) that reproduces on `main` without my changes — explicitly **not** a regression from this PR.
- [x] `load_project_dylib_smoke` (registration via new vtable path through `STREAMLIB_PLUGIN`): pass.
- [x] `load_project_dylib_pubsub_bridge` (PUBSUB callback bridge): pass.
- [x] `load_project_dylib_tracing_bridge` (tracing callback bridge): pass.
- [x] **New** `load_project_dylib_lifecycle`: builds the test-fixtures cdylib, loads via `load_project`, calls `PROCESSOR_REGISTRY.create(&node)`, verifies the returned `ProcessorInstance::VTable` variant, drops it (cross-DSO heap alloc → free round-trip via `extern "C" fn destroy`). Pass.

## Known limitations / deferred to future siblings

- The vtable's `get_iceoryx2_output_writer_arc` returns `Option<Arc<OutputWriter>>` via raw pointer; `get_iceoryx2_input_mailboxes_mut` returns `Option<&mut InputMailboxes>` via raw pointer. Both Rust types defined in `streamlib-engine` that host and cdylib must agree on source-layout for. Phase A retains this source-coupling for those two methods; the rest of the surface is pure ABI. Flipping ownership so the host allocates and the cdylib uses opaque handles is a meaningful refactor (touches the macro's port-wiring emission) and can be filed as a follow-up sibling if/when the source-coupling becomes a practical blocker.
- Tokio handle layout shared via the workspace-pinned tokio version is the other remaining known shared-type crossing. Phase B's RuntimeContext callback table will lift that crossing to extern "C" if/when multi-builder tokio drift becomes a real concern.

## pr-review-gate

Ran `pr-review-gate` (Opus). Verdict: DISCUSS with 5 items. Verified each independently:

- **(addressed)** Stale doc references to un-implemented `host_tokio_handle_clone` cleaned up in `streamlib-plugin-abi/src/lib.rs:88` and `host_services.rs:12`.
- **(addressed)** `get_iceoryx2_output_writer_arc` vtable doc tightened to match the wrapper (which consumes the Arc the trait impl returns — the macro emits `Some(self.outputs.clone())` already).
- **(addressed)** `vtable_for::<P>()` race window closed via single-lock `entry().or_insert_with(|| Box::leak(...))`.
- **(deliberate)** Design divergence for tokio handle (no separate callback, ctx-driven instead). Issue body updated.
- **(scope-cut acknowledged)** Drop semantics in the new test catch construct/destroy round-trip but not a Drop=noop regression specifically. Phase A scope — runtime tests covering full processor lifecycle exercise the Drop path under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)