### PR TITLE
feat(packages): sync-lifecycle + own-runtime sweep (#895)

### DIFF
--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -224,23 +224,16 @@ pub struct BlendingCompositorProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for BlendingCompositorProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = self.setup_inner(ctx);
-        std::future::ready(result)
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.setup_inner(ctx)
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "BlendingCompositor: teardown ({} frames)",
             self.frame_count.load(Ordering::Relaxed)
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -97,23 +97,16 @@ pub struct CameraToCudaCopyProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for CameraToCudaCopyProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = self.setup_inner(ctx);
-        std::future::ready(result)
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.setup_inner(ctx)
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "CameraToCudaCopy: shutdown ({} frames)",
             self.frame_count.load(Ordering::Relaxed)
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -113,23 +113,16 @@ pub struct CrtFilmGrainProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for CrtFilmGrainProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = self.setup_inner(ctx);
-        std::future::ready(result)
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.setup_inner(ctx)
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "CrtFilmGrain: Shutdown ({} frames)",
             self.frame_count.load(Ordering::Relaxed)
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/examples/camera-rust-plugin/plugin/src/lib.rs
+++ b/examples/camera-rust-plugin/plugin/src/lib.rs
@@ -39,14 +39,11 @@ pub struct GrayscaleProcessor {
 }
 
 impl ManualProcessor for GrayscaleProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         self.running = Arc::new(AtomicBool::new(false));
         tracing::info!("GrayscaleProcessor: setup complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/examples/polyglot-manual-source/plugin/src/lib.rs
+++ b/examples/polyglot-manual-source/plugin/src/lib.rs
@@ -40,10 +40,7 @@ pub struct PolyglotManualSourceCountingSink {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCountingSink::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let output = std::env::var(OUTPUT_ENV_VAR)
             .ok()
             .filter(|s| !s.is_empty())
@@ -54,7 +51,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCount
             );
         }
         self.output_file = output;
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -78,10 +75,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCount
         Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let result = match &self.output_file {
             Some(path) => {
                 // JSON has no native u64 — emit timestamps as decimal
@@ -107,7 +101,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for PolyglotManualSourceCount
             "[CountingSink] teardown — frames_received={}",
             self.frame_counter,
         );
-        std::future::ready(result)
+        result
     }
 }
 

--- a/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
+++ b/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration test for the architectural claim from #885 / #895: a
+//! dlopen'd processor whose `tokio` crate is statically linked into
+//! the cdylib can spin up its OWN `tokio::runtime::Runtime` in `setup`
+//! and call `tokio::net::TcpListener::bind` against it — even though
+//! the host runtime never exposes its tokio handle across the plugin
+//! ABI (the locked design from #885).
+//!
+//! What this locks: a refactor that removes the plugin-owned runtime
+//! from `TcpBindTestProcessor`, or one that breaks the cdylib's
+//! `start` lifecycle so the bind never fires, makes this test fail
+//! by either not writing the output file at all or writing an
+//! `ERR:<message>` line. Mentally revert the
+//! `tokio::runtime::Builder::new_current_thread().enable_all().build()`
+//! call in `tcp_bind_test_processor.rs` to a `tokio::runtime::Handle`
+//! borrow from the engine and the bind future fails to find its TLS
+//! and panics — this test catches that regression.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use serial_test::serial;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let output_path = tmp.path().join("tcp_bind_result.txt");
+    let output_path_str = output_path.to_string_lossy().to_string();
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed against a real test-fixtures cdylib");
+
+    let ident = schema_ident!(
+        "tatolab",
+        "test-fixtures",
+        "TcpBindTestProcessor",
+        "1.0.0"
+    );
+
+    runtime
+        .add_processor(ProcessorSpec::new(
+            ident,
+            json!({ "output_path": output_path_str }),
+        ))
+        .expect("add_processor must succeed for the dlopened TcpBindTestProcessor");
+
+    runtime.start().expect("runtime.start() must succeed");
+
+    // Manual processors fire setup then start synchronously inside the
+    // runtime's processor-spawn path — by the time `start()` returns,
+    // the bind has been driven on the plugin's own runtime. Poll for
+    // the file with a short timeout to absorb any scheduling jitter
+    // from the spawn op without making the test flaky.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !output_path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    runtime.stop().ok();
+
+    assert!(
+        output_path.exists(),
+        "TcpBindTestProcessor.start() did not write {} within 5s — \
+         either the cdylib's `start` lifecycle didn't fire, or the \
+         plugin-owned tokio runtime couldn't drive the TcpListener::bind future",
+        output_path.display()
+    );
+
+    let contents = std::fs::read_to_string(&output_path).unwrap();
+    assert!(
+        !contents.starts_with("ERR:"),
+        "TcpBindTestProcessor reported a bind error: {contents}"
+    );
+    let port: u16 = contents
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("expected a bound port, got {contents:?}: {e}"));
+    assert!(
+        port > 0,
+        "kernel-assigned ephemeral port must be non-zero, got {port}"
+    );
+}

--- a/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
+++ b/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
@@ -12,11 +12,12 @@
 //! from `TcpBindTestProcessor`, or one that breaks the cdylib's
 //! `start` lifecycle so the bind never fires, makes this test fail
 //! by either not writing the output file at all or writing an
-//! `ERR:<message>` line. Mentally revert the
-//! `tokio::runtime::Builder::new_current_thread().enable_all().build()`
-//! call in `tcp_bind_test_processor.rs` to a `tokio::runtime::Handle`
-//! borrow from the engine and the bind future fails to find its TLS
-//! and panics — this test catches that regression.
+//! `ERR:<message>` line. The dlopened plugin has no way to reach the
+//! host's tokio handle (it was removed from the cdylib-visible
+//! context by #885), so the only way `tokio::net::TcpListener::bind`
+//! finds its TLS slots is the plugin building its own runtime and
+//! driving the future on that runtime's worker threads — this test
+//! exercises that path end-to-end.
 
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/packages/api-server/src/processor.rs
+++ b/packages/api-server/src/processor.rs
@@ -4,7 +4,6 @@
 //! The `ApiServer` processor — owns the HTTP listener lifecycle and binds the
 //! shared [`crate::state::AppState`] to per-request handlers.
 
-use std::future::Future;
 use std::sync::Arc;
 
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -13,6 +12,9 @@ use streamlib::sdk::processors::ManualProcessor;
 use streamlib::sdk::runtime::RuntimeOperations;
 
 /// Handles cloned from the setup-time context for use in start().
+/// The `tokio_handle` points at the plugin's own runtime (constructed in
+/// `setup()`); the host's tokio runtime is not reachable from cdylib code
+/// across the plugin ABI by design.
 struct StashedHandles {
     runtime: Arc<dyn RuntimeOperations>,
     tokio_handle: tokio::runtime::Handle,
@@ -103,6 +105,12 @@ fn generate_runtime_name() -> String {
 #[streamlib::sdk::processor("ApiServer")]
 pub struct ApiServerProcessor {
     handles: Option<StashedHandles>,
+    /// Plugin-owned tokio runtime. Constructed in `setup()`, dropped in
+    /// `teardown()`. axum / hyper / tokio::net all run inside this runtime
+    /// — their thread-local state is set when the runtime's worker
+    /// threads enter the runtime, which only works because the cdylib
+    /// statically links its own tokio crate.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     runtime_id: Option<String>,
     resolved_name: Option<String>,
@@ -110,39 +118,47 @@ pub struct ApiServerProcessor {
 }
 
 impl ManualProcessor for ApiServerProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // Construct this plugin's own tokio runtime — the host's runtime
+        // is not reachable across the plugin ABI (see #885). axum::serve
+        // and tokio::net::TcpListener::bind need their thread-local state
+        // set by this runtime's worker threads, which only works because
+        // the cdylib statically links its own tokio crate.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Runtime(format!("ApiServer: failed to build tokio runtime: {e}"))
+            })?;
+        let tokio_handle = runtime.handle().clone();
+        self.tokio_runtime = Some(runtime);
+
         // Capture just the narrow handles the HTTP server task needs;
         // the long-lived task never holds a `RuntimeContext`.
         self.handles = Some(StashedHandles {
             runtime: ctx.runtime(),
-            tokio_handle: ctx.tokio_handle().clone(),
+            tokio_handle,
             runtime_id: ctx.runtime_id().to_string(),
         });
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // Drop the runtime — shuts down worker threads and waits for any
+        // outstanding spawned tasks to finish. `stop()` already signalled
+        // the HTTP server to exit, so this is the cleanup step.
+        self.tokio_runtime.take();
+        self.handles.take();
+        Ok(())
     }
 
-    fn on_pause(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
-    fn on_resume(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/audio/src/apple/audio_capture.rs
+++ b/packages/audio/src/apple/audio_capture.rs
@@ -29,19 +29,13 @@ pub struct AppleAudioCaptureProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for AppleAudioCaptureProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[AudioCapture] setup() called - will set up stream in process()");
         self.stream_setup_done = false;
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let device_name = self
             .device_info
             .as_ref()
@@ -57,7 +51,7 @@ impl streamlib::sdk::processors::ManualProcessor for AppleAudioCaptureProcessor:
 
         self._stream = None;
         self._device = None;
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/audio/src/apple/audio_output.rs
+++ b/packages/audio/src/apple/audio_output.rs
@@ -66,10 +66,7 @@ pub struct AppleAudioOutputProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for AppleAudioOutputProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.device_id = self
             .config
             .device_id
@@ -79,13 +76,10 @@ impl streamlib::sdk::processors::ManualProcessor for AppleAudioOutputProcessor::
         tracing::info!(
             "AudioOutput: start() called (Pull mode - will query device for native config)"
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.stop_polling.store(true, Ordering::SeqCst);
 
         if let Some(handle) = self.polling_thread.take() {
@@ -94,7 +88,7 @@ impl streamlib::sdk::processors::ManualProcessor for AppleAudioOutputProcessor::
 
         self.stream = None;
         tracing::info!("AudioOutput {}: Stopped", self.device_name);
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/audio/src/audio_channel_converter.rs
+++ b/packages/audio/src/audio_channel_converter.rs
@@ -12,26 +12,20 @@ pub struct AudioChannelConverterProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for AudioChannelConverterProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "[AudioChannelConverter] setup() - mode: {:?}",
             self.config.mode
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "[AudioChannelConverter] Stopped (processed {} frames)",
             self.frame_counter
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/packages/audio/src/audio_mixer.rs
+++ b/packages/audio/src/audio_mixer.rs
@@ -14,10 +14,7 @@ pub struct AudioMixerProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for AudioMixerProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.sample_rate = 0;
         self.buffer_size = 0;
         self.frame_counter = 0;
@@ -26,15 +23,12 @@ impl streamlib::sdk::processors::ReactiveProcessor for AudioMixerProcessor::Proc
             "AudioMixer: Starting (sample_rate and buffer_size will be inferred from first input, strategy: {:?})",
             self.config.strategy
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("AudioMixer: Stopped");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/packages/audio/src/audio_resampler.rs
+++ b/packages/audio/src/audio_resampler.rs
@@ -24,10 +24,7 @@ pub struct AudioResamplerProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for AudioResamplerProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.output_sample_rate = self.config.target_sample_rate;
 
         tracing::info!(
@@ -36,18 +33,15 @@ impl streamlib::sdk::processors::ReactiveProcessor for AudioResamplerProcessor::
             self.config.quality
         );
 
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             "[AudioResampler] Stopped (processed {} output frames)",
             self.frame_counter
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/packages/audio/src/buffer_rechunker.rs
+++ b/packages/audio/src/buffer_rechunker.rs
@@ -14,25 +14,19 @@ pub struct BufferRechunkerProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for BufferRechunkerProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let target_size = self.config.target_buffer_size as usize;
         self.buffer = Vec::with_capacity(target_size * 16);
         tracing::info!(
             "[BufferRechunker] Initialized with target buffer size: {} samples per channel",
             target_size
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[BufferRechunker] Stopped");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/packages/audio/src/chord_generator.rs
+++ b/packages/audio/src/chord_generator.rs
@@ -68,10 +68,7 @@ impl ChordGeneratorProcessor::Processor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for ChordGeneratorProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let audio_clock = ctx.audio_clock();
         self.sample_rate = audio_clock.sample_rate();
 
@@ -90,16 +87,13 @@ impl streamlib::sdk::processors::ManualProcessor for ChordGeneratorProcessor::Pr
             audio_clock.buffer_size()
         );
 
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.is_active.store(false, Ordering::SeqCst);
         tracing::info!("ChordGenerator: teardown complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/audio/src/linux/audio_capture.rs
+++ b/packages/audio/src/linux/audio_capture.rs
@@ -29,19 +29,13 @@ pub struct LinuxAudioCaptureProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for LinuxAudioCaptureProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[AudioCapture] setup() called - will set up stream in start()");
         self.stream_setup_done = false;
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let device_name = self
             .device_info
             .as_ref()
@@ -57,7 +51,7 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxAudioCaptureProcessor:
 
         self._stream = None;
         self._device = None;
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/audio/src/linux/audio_output.rs
+++ b/packages/audio/src/linux/audio_output.rs
@@ -66,10 +66,7 @@ pub struct LinuxAudioOutputProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.device_id = self
             .config
             .device_id
@@ -79,13 +76,10 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::
         tracing::info!(
             "AudioOutput: start() called (Pull mode - will query device for native config)"
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.stop_polling.store(true, Ordering::SeqCst);
 
         if let Some(handle) = self.polling_thread.take() {
@@ -94,7 +88,7 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxAudioOutputProcessor::
 
         self.stream = None;
         tracing::info!("AudioOutput {}: Stopped", self.device_name);
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/camera/src/apple/camera.rs
+++ b/packages/camera/src/apple/camera.rs
@@ -337,20 +337,14 @@ pub struct AppleCameraProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for AppleCameraProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         // Store GPU context for surface store access in start()
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!("Camera: setup() complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let frame_count = CAMERA_CALLBACK_CONTEXT
             .get()
             .map(|ctx| ctx.frame_count.load(Ordering::Relaxed))
@@ -360,7 +354,7 @@ impl streamlib::sdk::processors::ManualProcessor for AppleCameraProcessor::Proce
             self.camera_name,
             frame_count
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     // Callback-driven start - initializes AVFoundation, returns immediately

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -51,19 +51,13 @@ pub struct LinuxCameraProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for LinuxCameraProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!("Camera: setup() complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let frame_count = self.frame_counter.load(Ordering::Relaxed);
         tracing::info!(
             "Camera {}: Teardown (generated {} frames)",
@@ -74,7 +68,7 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxCameraProcessor::Proce
         if let Some(handle) = self.capture_thread_handle.take() {
             let _ = handle.join();
         }
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/clap/src/clap_effect.rs
+++ b/packages/clap/src/clap_effect.rs
@@ -135,48 +135,39 @@ impl ClapEffectProcessor::Processor {
 }
 
 impl ManualProcessor for ClapEffectProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
-            self.buffer_size = self.config.buffer_size as usize;
-            self.audio = Some(ProcessorAudioConverter::new());
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.buffer_size = self.config.buffer_size as usize;
+        self.audio = Some(ProcessorAudioConverter::new());
 
-            // Load CLAP plugin with placeholder sample_rate — activate() will set the real rate
-            // when the first input frame arrives in the polling thread
-            let host = if let Some(name) = self.config.plugin_name.as_deref() {
-                ClapPluginHost::load_by_name(
-                    &self.config.plugin_path,
-                    name,
-                    48000,
-                    self.buffer_size,
-                )?
-            } else if let Some(index) = self.config.plugin_index {
-                ClapPluginHost::load_by_index(
-                    &self.config.plugin_path,
-                    index as usize,
-                    48000,
-                    self.buffer_size,
-                )?
-            } else {
-                ClapPluginHost::load(&self.config.plugin_path, 48000, self.buffer_size)?
-            };
+        // Load CLAP plugin with placeholder sample_rate — activate() will set the real rate
+        // when the first input frame arrives in the polling thread
+        let host = if let Some(name) = self.config.plugin_name.as_deref() {
+            ClapPluginHost::load_by_name(
+                &self.config.plugin_path,
+                name,
+                48000,
+                self.buffer_size,
+            )?
+        } else if let Some(index) = self.config.plugin_index {
+            ClapPluginHost::load_by_index(
+                &self.config.plugin_path,
+                index as usize,
+                48000,
+                self.buffer_size,
+            )?
+        } else {
+            ClapPluginHost::load(&self.config.plugin_path, 48000, self.buffer_size)?
+        };
 
-            tracing::info!(
-                "[ClapEffect] Loaded plugin '{}' (activation deferred to first input frame)",
-                host.plugin_info().name,
-            );
-            self.host = Some(host);
-            Ok(())
-        })();
-        std::future::ready(result)
+        tracing::info!(
+            "[ClapEffect] Loaded plugin '{}' (activation deferred to first input frame)",
+            host.plugin_info().name,
+        );
+        self.host = Some(host);
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.stop_polling.store(true, Ordering::SeqCst);
 
         if let Some(handle) = self.polling_thread.take() {
@@ -184,7 +175,7 @@ impl ManualProcessor for ClapEffectProcessor::Processor {
         }
 
         // Safe to access self.host now — polling thread is joined
-        let result = if let Some(ref mut host) = self.host {
+        if let Some(ref mut host) = self.host {
             let name = host.plugin_info().name.clone();
             match host.deactivate() {
                 Ok(()) => {
@@ -195,9 +186,7 @@ impl ManualProcessor for ClapEffectProcessor::Processor {
             }
         } else {
             Ok(())
-        };
-
-        std::future::ready(result)
+        }
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -34,10 +34,7 @@ pub struct BgraFileSourceProcessor {
 }
 
 impl ManualProcessor for BgraFileSourceProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
             "[BgraFileSource] Setup (file: {}, {}x{}@{}fps, {} frames)",
@@ -47,20 +44,17 @@ impl ManualProcessor for BgraFileSourceProcessor::Processor {
             self.config.fps,
             self.config.frame_count
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let frames = self.frame_counter.load(Ordering::Relaxed);
         tracing::info!("[BgraFileSource] Teardown ({frames} frames streamed)");
         self.is_running.store(false, Ordering::Release);
         if let Some(handle) = self.source_thread_handle.take() {
             let _ = handle.join();
         }
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/debug-utilities/src/jpeg_bytes_source.rs
+++ b/packages/debug-utilities/src/jpeg_bytes_source.rs
@@ -33,34 +33,23 @@ pub struct JpegBytesSourceProcessor {
 }
 
 impl ManualProcessor for JpegBytesSourceProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = std::fs::read(&self.config.file_path).map_err(|e| {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let bytes = std::fs::read(&self.config.file_path).map_err(|e| {
             Error::Configuration(format!(
                 "JpegBytesSource: failed to read {}: {e}",
                 self.config.file_path
             ))
-        });
-        match result {
-            Ok(bytes) => {
-                tracing::info!(
-                    path = %self.config.file_path,
-                    bytes = bytes.len(),
-                    "[JpegBytesSource] Loaded fixture JPEG"
-                );
-                self.jpeg_bytes = Some(Arc::new(bytes));
-                std::future::ready(Ok(()))
-            }
-            Err(e) => std::future::ready(Err(e)),
-        }
+        })?;
+        tracing::info!(
+            path = %self.config.file_path,
+            bytes = bytes.len(),
+            "[JpegBytesSource] Loaded fixture JPEG"
+        );
+        self.jpeg_bytes = Some(Arc::new(bytes));
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let frames = self.frame_counter.load(Ordering::Relaxed);
         tracing::info!("[JpegBytesSource] Teardown ({frames} frames emitted)");
         self.is_running.store(false, Ordering::Release);
@@ -68,7 +57,7 @@ impl ManualProcessor for JpegBytesSourceProcessor::Processor {
             let _ = handle.join();
         }
         self.jpeg_bytes.take();
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/debug-utilities/src/video_frame_counter.rs
+++ b/packages/debug-utilities/src/video_frame_counter.rs
@@ -66,11 +66,11 @@ impl streamlib::sdk::processors::ReactiveProcessor for VideoFrameCounterProcesso
         Ok(())
     }
 
-    async fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/packages/display/src/apple/display.rs
+++ b/packages/display/src/apple/display.rs
@@ -54,11 +54,8 @@ pub struct AppleDisplayProcessor {
 }
 
 impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        (|| {
             tracing::trace!("Display: setup() called");
             self.gpu_context = Some(ctx.gpu_limited_access().clone());
             self.window_id = AppleWindowId(NEXT_WINDOW_ID.fetch_add(1, Ordering::SeqCst));
@@ -166,16 +163,12 @@ impl crate::core::ManualProcessor for AppleDisplayProcessor::Processor {
             self.initialize_window()?;
 
             Ok(())
-        })();
-        std::future::ready(result)
+        })()
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("Display {}: Teardown", self.window_title);
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     // Game loop start - spawns a dedicated render thread that runs at native display refresh rate

--- a/packages/display/src/linux/display.rs
+++ b/packages/display/src/linux/display.rs
@@ -63,44 +63,35 @@ pub struct LinuxDisplayProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for LinuxDisplayProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
-            tracing::trace!("Display: setup() called");
-            self.gpu_context = Some(ctx.gpu_limited_access().clone());
-            self.window_id = LinuxWindowId(NEXT_WINDOW_ID.fetch_add(1, Ordering::SeqCst));
-            self.width = self.config.width;
-            self.height = self.config.height;
-            self.window_title = self
-                .config
-                .title
-                .clone()
-                .unwrap_or_else(|| "streamlib Display".to_string());
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        tracing::trace!("Display: setup() called");
+        self.gpu_context = Some(ctx.gpu_limited_access().clone());
+        self.window_id = LinuxWindowId(NEXT_WINDOW_ID.fetch_add(1, Ordering::SeqCst));
+        self.width = self.config.width;
+        self.height = self.config.height;
+        self.window_title = self
+            .config
+            .title
+            .clone()
+            .unwrap_or_else(|| "streamlib Display".to_string());
 
-            self.running = Arc::new(AtomicBool::new(false));
-            self.event_loop_proxy = Arc::new(OnceLock::new());
-            self.stop_called = Arc::new(AtomicBool::new(false));
+        self.running = Arc::new(AtomicBool::new(false));
+        self.event_loop_proxy = Arc::new(OnceLock::new());
+        self.stop_called = Arc::new(AtomicBool::new(false));
 
-            tracing::info!(
-                "Display {}: Setup complete ({}x{})",
-                self.window_title,
-                self.width,
-                self.height
-            );
+        tracing::info!(
+            "Display {}: Setup complete ({}x{})",
+            self.window_title,
+            self.width,
+            self.height
+        );
 
-            Ok(())
-        })();
-        std::future::ready(result)
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("Display {}: Teardown", self.window_title);
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -46,7 +46,7 @@ pub struct H264DecoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
         // Decoder dimensions come from H.264 SPS — leaving `max_width` /
@@ -100,7 +100,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_decoded = self.frames_decoded,
             "[H264Decoder] Shutting down"

--- a/packages/h264/src/linux/encoder.rs
+++ b/packages/h264/src/linux/encoder.rs
@@ -47,7 +47,7 @@ pub struct H264EncoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
             "[H264Encoder] Setup complete (encoder construction deferred to first frame)"
@@ -55,7 +55,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264EncoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_encoded = self.frames_encoded,
             "[H264Encoder] Shutting down"

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -46,7 +46,7 @@ pub struct H265DecoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
 
         // Decoder dimensions come from H.265 SPS — leaving `max_width` /
@@ -100,7 +100,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_decoded = self.frames_decoded,
             "[H265Decoder] Shutting down"

--- a/packages/h265/src/linux/encoder.rs
+++ b/packages/h265/src/linux/encoder.rs
@@ -47,7 +47,7 @@ pub struct H265EncoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
             "[H265Encoder] Setup complete (encoder construction deferred to first frame)"
@@ -55,7 +55,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265EncoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_encoded = self.frames_encoded,
             "[H265Encoder] Shutting down"

--- a/packages/jpeg/src/linux/decoder.rs
+++ b/packages/jpeg/src/linux/decoder.rs
@@ -38,7 +38,7 @@ pub struct JpegDecoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for JpegDecoderProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let max_width = self.config.max_width.unwrap_or(DEFAULT_MAX_WIDTH);
         let max_height = self.config.max_height.unwrap_or(DEFAULT_MAX_HEIGHT);
 
@@ -60,7 +60,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for JpegDecoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_decoded = self.frames_decoded,
             "[JpegDecoder] Shutting down"

--- a/packages/mavlink/src/mavlink_decoder.rs
+++ b/packages/mavlink/src/mavlink_decoder.rs
@@ -29,15 +29,12 @@ pub struct MavlinkDecoderProcessor {
 }
 
 impl ReactiveProcessor for MavlinkDecoderProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             warn_on_parse_error = ?self.config.warn_on_parse_error,
             "MavlinkDecoder: setup",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -74,16 +71,13 @@ impl ReactiveProcessor for MavlinkDecoderProcessor::Processor {
         }
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             messages_decoded = self.messages_decoded.load(Ordering::Relaxed),
             parse_errors = self.parse_errors.load(Ordering::Relaxed),
             "MavlinkDecoder: teardown",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 }
 

--- a/packages/mavlink/src/mavlink_encoder.rs
+++ b/packages/mavlink/src/mavlink_encoder.rs
@@ -33,16 +33,13 @@ pub struct MavlinkEncoderProcessor {
 }
 
 impl ReactiveProcessor for MavlinkEncoderProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             default_system_id = self.config.default_system_id,
             default_component_id = self.config.default_component_id,
             "MavlinkEncoder: setup",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -116,16 +113,13 @@ impl ReactiveProcessor for MavlinkEncoderProcessor::Processor {
         Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             messages_encoded = self.messages_encoded.load(Ordering::Relaxed),
             encode_errors = self.encode_errors.load(Ordering::Relaxed),
             "MavlinkEncoder: teardown",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 }
 

--- a/packages/moq/src/moq_publish_track.rs
+++ b/packages/moq/src/moq_publish_track.rs
@@ -16,10 +16,24 @@ pub struct MoqPublishTrackProcessor {
     sessions: Option<SharedMoqSessions>,
     track_name: String,
     frames_published: u64,
+    /// Plugin-owned tokio runtime. Constructed in `setup()`; the host's
+    /// runtime is not reachable across the plugin ABI per #885.
+    /// Used to drive `get_publish_session().await` from sync `setup()`.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for MoqPublishTrackProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Runtime(format!(
+                    "MoqPublishTrack: failed to build tokio runtime: {e}"
+                ))
+            })?;
+
         // Track name: explicit config, or auto-generate from processor id.
         self.track_name = self.config.track_name.clone().unwrap_or_else(|| {
             ctx.processor_id()
@@ -28,7 +42,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for MoqPublishTrackProcessor:
         });
 
         let sessions = sessions_for_runtime(&ctx.runtime_id().to_string());
-        let session = sessions.get_publish_session().await?;
+        let session = runtime.block_on(sessions.get_publish_session())?;
         sessions.register_published_track(&self.track_name);
 
         tracing::info!(
@@ -39,16 +53,18 @@ impl streamlib::sdk::processors::ReactiveProcessor for MoqPublishTrackProcessor:
 
         self.shared_publish_session = Some(session);
         self.sessions = Some(sessions);
+        self.tokio_runtime = Some(runtime);
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_published = self.frames_published,
             "[MoqPublishTrack] Shutting down"
         );
         self.shared_publish_session.take();
         self.sessions.take();
+        self.tokio_runtime.take();
         Ok(())
     }
 

--- a/packages/moq/src/moq_subscribe_track.rs
+++ b/packages/moq/src/moq_subscribe_track.rs
@@ -7,7 +7,6 @@
 //! deserialization. Reconnects on connection loss with exponential backoff.
 
 use crate::moq_session::{sessions_for_runtime, MoqTrackReader};
-use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
@@ -22,17 +21,28 @@ const MAX_RETRY_DELAY_MS: u64 = 10_000;
 #[streamlib::sdk::processor("MoqSubscribeTrack")]
 pub struct MoqSubscribeTrackProcessor {
     runtime_id: Option<String>,
+    /// Plugin-owned tokio runtime. Constructed in `setup()`; the host's
+    /// runtime is not reachable across the plugin ABI per #885.
+    /// MoQ uses QUIC transport whose futures require this runtime's TLS.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
     tokio_handle: Option<tokio::runtime::Handle>,
     shutdown_signal_sender: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 impl streamlib::sdk::processors::ManualProcessor for MoqSubscribeTrackProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Runtime(format!(
+                    "MoqSubscribeTrack: failed to build tokio runtime: {e}"
+                ))
+            })?;
+        self.tokio_handle = Some(runtime.handle().clone());
+        self.tokio_runtime = Some(runtime);
         self.runtime_id = Some(ctx.runtime_id().to_string());
-        self.tokio_handle = Some(ctx.tokio_handle().clone());
 
         let sessions = sessions_for_runtime(self.runtime_id.as_ref().unwrap());
         tracing::info!(
@@ -40,13 +50,10 @@ impl streamlib::sdk::processors::ManualProcessor for MoqSubscribeTrackProcessor:
             track = %self.config.track_name,
             "[MoqSubscribeTrack] Configured (will connect on start)"
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[MoqSubscribeTrack] Shutting down");
 
         if let Some(tx) = self.shutdown_signal_sender.take() {
@@ -55,22 +62,17 @@ impl streamlib::sdk::processors::ManualProcessor for MoqSubscribeTrackProcessor:
 
         self.runtime_id.take();
         self.tokio_handle.take();
+        self.tokio_runtime.take();
         tracing::info!("[MoqSubscribeTrack] Shutdown complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn on_pause(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
-    fn on_resume(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/mp4/src/_apple_impl_pending_/mp4_writer.rs
+++ b/packages/mp4/src/_apple_impl_pending_/mp4_writer.rs
@@ -82,11 +82,8 @@ pub struct AppleMp4WriterProcessor {
 }
 
 impl crate::core::ReactiveProcessor for AppleMp4WriterProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        (|| {
             info!("Setting up MP4 writer processor");
 
             // Store RuntimeContext for main thread dispatch
@@ -107,8 +104,7 @@ impl crate::core::ReactiveProcessor for AppleMp4WriterProcessor::Processor {
             // so run_on_runtime_thread_blocking() would deadlock
             info!("MP4 writer setup complete, will initialize AVAssetWriter in process()");
             Ok(())
-        })();
-        std::future::ready(result)
+        })()
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -337,22 +333,16 @@ impl crate::core::ReactiveProcessor for AppleMp4WriterProcessor::Processor {
         Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let result = (|| {
-            info!("Tearing down MP4 writer processor");
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        info!("Tearing down MP4 writer processor");
 
-            // No buffering, so nothing to flush - just finalize
-            self.finalize_writer()?;
+        // No buffering, so nothing to flush - just finalize
+        self.finalize_writer()?;
 
-            // Cleanup: AVFoundation objects will be dropped on main thread
-            // when self.asset_writer is dropped (happens automatically)
+        // Cleanup: AVFoundation objects will be dropped on main thread
+        // when self.asset_writer is dropped (happens automatically)
 
-            Ok(())
-        })();
-        std::future::ready(result)
+        Ok(())
     }
 }
 

--- a/packages/mp4/src/linux/mp4_writer.rs
+++ b/packages/mp4/src/linux/mp4_writer.rs
@@ -21,7 +21,7 @@ pub struct LinuxMp4WriterProcessor {
 }
 
 impl ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
-    async fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!(
             "[LinuxMp4Writer] Initialized (output: {}, config fps: {})",
@@ -31,7 +31,7 @@ impl ReactiveProcessor for LinuxMp4WriterProcessor::Processor {
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         if let Some(mut child) = self.ffmpeg_process.take() {
             // Closing stdin signals ffmpeg that input is done.
             drop(child.stdin.take());

--- a/packages/network/src/udp_sink.rs
+++ b/packages/network/src/udp_sink.rs
@@ -29,6 +29,9 @@ struct OutboundDatagram {
 
 #[streamlib::sdk::processor("UdpSink")]
 pub struct UdpSinkProcessor {
+    /// Plugin-owned tokio runtime. Constructed in `setup()`; the host's
+    /// runtime is not reachable across the plugin ABI per #885.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
     tokio_handle: Option<tokio::runtime::Handle>,
     /// Resolved at setup time so we don't re-parse on every send.
     default_destination: Option<SocketAddr>,
@@ -42,12 +45,19 @@ pub struct UdpSinkProcessor {
 }
 
 impl ReactiveProcessor for UdpSinkProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let tokio_handle = ctx.tokio_handle().clone();
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Configuration(format!(
+                    "UdpSink: failed to build tokio runtime: {e}"
+                ))
+            })?;
+        let tokio_handle = runtime.handle().clone();
         self.tokio_handle = Some(tokio_handle.clone());
+        self.tokio_runtime = Some(runtime);
 
         let bind_str = self
             .config
@@ -57,7 +67,7 @@ impl ReactiveProcessor for UdpSinkProcessor::Processor {
 
         // Parse default_destination eagerly so a misconfig surfaces at
         // setup rather than on first packet.
-        let default_destination_result = self
+        let default_destination = self
             .config
             .default_destination
             .as_deref()
@@ -68,40 +78,33 @@ impl ReactiveProcessor for UdpSinkProcessor::Processor {
                     ))
                 })
             })
-            .transpose();
+            .transpose()?;
+        self.default_destination = default_destination;
+
+        let bind_addr: SocketAddr = bind_str.parse().map_err(|e| {
+            Error::Configuration(format!("UdpSink: invalid bind_addr {bind_str:?}: {e}"))
+        })?;
 
         let send_buffer_bytes = self.config.send_buffer_bytes;
         let packets_sent = Arc::clone(&self.packets_sent);
-        let outbound_tx_slot = &mut self.outbound_tx;
-        let send_task_slot = &mut self.send_task_handle;
-        let default_destination_slot = &mut self.default_destination;
 
-        std::future::ready((|| -> Result<()> {
-            let default_destination = default_destination_result?;
-            *default_destination_slot = default_destination;
+        let socket = build_udp_socket(bind_addr, send_buffer_bytes, &tokio_handle)?;
 
-            let bind_addr: SocketAddr = bind_str.parse().map_err(|e| {
-                Error::Configuration(format!("UdpSink: invalid bind_addr {bind_str:?}: {e}"))
-            })?;
+        let (tx, rx) = mpsc::channel::<OutboundDatagram>(OUTBOUND_MPSC_CAPACITY);
+        self.outbound_tx = Some(tx);
 
-            let socket = build_udp_socket(bind_addr, send_buffer_bytes, &tokio_handle)?;
+        let handle = tokio_handle.spawn(async move {
+            send_loop(socket, rx, packets_sent).await;
+        });
+        self.send_task_handle = Some(handle);
 
-            let (tx, rx) = mpsc::channel::<OutboundDatagram>(OUTBOUND_MPSC_CAPACITY);
-            *outbound_tx_slot = Some(tx);
-
-            let handle = tokio_handle.spawn(async move {
-                send_loop(socket, rx, packets_sent).await;
-            });
-            *send_task_slot = Some(handle);
-
-            tracing::info!(
-                bind_addr = %bind_addr,
-                default_destination = ?default_destination_slot.as_ref().map(|d| d.to_string()),
-                send_buffer_bytes = ?send_buffer_bytes,
-                "UdpSink: bound + send task spawned",
-            );
-            Ok(())
-        })())
+        tracing::info!(
+            bind_addr = %bind_addr,
+            default_destination = ?self.default_destination.as_ref().map(|d| d.to_string()),
+            send_buffer_bytes = ?send_buffer_bytes,
+            "UdpSink: bound + send task spawned",
+        );
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -156,10 +159,7 @@ impl ReactiveProcessor for UdpSinkProcessor::Processor {
         }
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         // Drop the sender so the send loop sees `Closed` and exits.
         self.outbound_tx.take();
         if let Some(handle) = self.send_task_handle.take() {
@@ -174,7 +174,10 @@ impl ReactiveProcessor for UdpSinkProcessor::Processor {
             packets_dropped_no_destination = dropped_nodst,
             "UdpSink: teardown",
         );
-        std::future::ready(Ok(()))
+        // Drop the plugin-owned tokio runtime — joins worker threads.
+        self.tokio_handle.take();
+        self.tokio_runtime.take();
+        Ok(())
     }
 }
 

--- a/packages/network/src/udp_source.rs
+++ b/packages/network/src/udp_source.rs
@@ -54,6 +54,11 @@ fn monotonic_ns() -> i64 {
 
 #[streamlib::sdk::processor("UdpSource")]
 pub struct UdpSourceProcessor {
+    /// Plugin-owned tokio runtime. Constructed in `setup()`; the host's
+    /// runtime is not reachable across the plugin ABI per #885.
+    /// `tokio::net::UdpSocket` requires this runtime's TLS to be set
+    /// while polling its futures.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
     tokio_handle: Option<tokio::runtime::Handle>,
     shutdown: Arc<Notify>,
     packets_received: Arc<AtomicU64>,
@@ -61,11 +66,18 @@ pub struct UdpSourceProcessor {
 }
 
 impl ManualProcessor for UdpSourceProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        self.tokio_handle = Some(ctx.tokio_handle().clone());
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Configuration(format!(
+                    "UdpSource: failed to build tokio runtime: {e}"
+                ))
+            })?;
+        self.tokio_handle = Some(runtime.handle().clone());
+        self.tokio_runtime = Some(runtime);
         // Touch the lazy anchor so the first packet's timestamp is
         // genuinely relative to setup-time, not to first-recv-time.
         let _ = monotonic_ns();
@@ -75,7 +87,7 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
             batch_size = ?self.config.batch_size,
             "UdpSource: setup",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
@@ -126,6 +138,14 @@ impl ManualProcessor for UdpSourceProcessor::Processor {
         }
         let n = self.packets_received.load(Ordering::Relaxed);
         tracing::info!(packets_received = n, "UdpSource: stopped");
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        // Drop the plugin-owned tokio runtime — joins worker threads
+        // and finalizes any aborted task cleanup.
+        self.tokio_handle.take();
+        self.tokio_runtime.take();
         Ok(())
     }
 }

--- a/packages/opus/src/opus_decoder.rs
+++ b/packages/opus/src/opus_decoder.rs
@@ -190,7 +190,7 @@ pub struct OpusDecoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for OpusDecoderProcessor::Processor {
-    async fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let sample_rate = self.config.sample_rate.unwrap_or(48000);
         let channels = self.config.channels.unwrap_or(2) as usize;
 
@@ -206,7 +206,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for OpusDecoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_decoded = self.frames_decoded,
             "[OpusDecoder] Shutting down"

--- a/packages/opus/src/opus_encoder.rs
+++ b/packages/opus/src/opus_encoder.rs
@@ -207,7 +207,7 @@ pub struct OpusEncoderProcessor {
 }
 
 impl streamlib::sdk::processors::ReactiveProcessor for OpusEncoderProcessor::Processor {
-    async fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let encoder_config = AudioEncoderConfig {
             sample_rate: 48000,
             channels: 2,
@@ -225,7 +225,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for OpusEncoderProcessor::Pro
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!(
             frames_encoded = self.frames_encoded,
             "[OpusEncoder] Shutting down"

--- a/packages/screen-capture/src/apple/screen_capture.rs
+++ b/packages/screen-capture/src/apple/screen_capture.rs
@@ -282,25 +282,19 @@ pub struct AppleScreenCaptureProcessor {
 }
 
 impl streamlib::sdk::processors::ManualProcessor for AppleScreenCaptureProcessor::Processor {
-    fn setup(
-        &mut self,
-        ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         self.gpu_context = Some(ctx.gpu_limited_access().clone());
         tracing::info!("ScreenCapture: setup() complete");
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let frame_count = SCREEN_CAPTURE_CALLBACK_CONTEXT
             .get()
             .map(|ctx| ctx.frame_count.load(Ordering::Relaxed))
             .unwrap_or(0);
         tracing::info!("ScreenCapture: teardown() ({} frames)", frame_count);
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -40,5 +40,11 @@ streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
 # Serialization (config dataclass ships as serde-derived).
 serde.workspace = true
 
+# `TcpBindTestProcessor` uses the plugin's own tokio runtime to verify
+# the dlopen-owns-tokio claim from #885 — the cdylib statically links
+# its own tokio crate so `tokio::net::*` has working TLS slots inside
+# the plugin's runtime even when the host has its own separate tokio.
+tokio = { workspace = true, features = ["rt", "net", "macros"] }
+
 [lints]
 workspace = true

--- a/packages/test-fixtures/schemas/tcp_bind_test_processor_config.yaml
+++ b/packages/test-fixtures/schemas/tcp_bind_test_processor_config.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Test-only config schema for the dlopen-owns-tokio integration test.
+# The processor binds a `tokio::net::TcpListener` on its own runtime and
+# writes the bound port (or an error string) to `output_path`, so the
+# integration test can verify the bind succeeded even when the
+# processor's tokio crate is statically linked into a dlopen'd cdylib
+# (the locked design from #885).
+
+metadata:
+  type: TcpBindTestProcessorConfig
+  description: "Test config schema for the dlopen-owns-tokio integration test."
+
+properties:
+  output_path:
+    metadata:
+      description: "Filesystem path where the processor writes its result. Format: '<port>' on success, 'ERR:<message>' on failure."
+    type: string

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -1,16 +1,23 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Attribute-macro test fixtures (TestConfiguredProcessor) for streamlib SDK macro contract tests.
+//! Attribute-macro test fixtures (TestConfiguredProcessor, TcpBindTestProcessor)
+//! for streamlib SDK macro contract tests and the #885 dlopen-owns-tokio
+//! integration test.
 
 #[allow(non_snake_case, unused_imports, clippy::all)]
 pub mod _generated_ {
     include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
 }
 
+pub mod tcp_bind_test_processor;
 pub mod test_configured_processor;
 
+pub use tcp_bind_test_processor::TcpBindTest;
 pub use test_configured_processor::ConfiguredProcessor;
 
 #[cfg(feature = "plugin")]
-streamlib_plugin_abi::export_plugin!(crate::ConfiguredProcessor::Processor);
+streamlib_plugin_abi::export_plugin!(
+    crate::ConfiguredProcessor::Processor,
+    crate::TcpBindTest::Processor,
+);

--- a/packages/test-fixtures/src/tcp_bind_test_processor.rs
+++ b/packages/test-fixtures/src/tcp_bind_test_processor.rs
@@ -4,8 +4,10 @@
 //! Integration-test fixture for the dlopen-owns-tokio claim from #885.
 //!
 //! In its `start()` lifecycle method this processor:
-//!   1. Builds its own `tokio::runtime::Runtime` (`new_current_thread`,
-//!      single worker).
+//!   1. Builds its own `tokio::runtime::Runtime` (multi-thread,
+//!      single worker — matches the shape every in-tree own-runtime
+//!      migration uses so the regression lock exercises the real
+//!      production shape).
 //!   2. Calls `tokio::net::TcpListener::bind("127.0.0.1:0")` on that
 //!      runtime via `block_on`.
 //!   3. Writes the bound port (or an error string) to the configured
@@ -30,7 +32,8 @@ pub struct TcpBindTest {
 
 impl ManualProcessor for TcpBindTest::Processor {
     fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
             .build()
             .map_err(|e| Error::Runtime(format!("TcpBindTest: build runtime: {e}")))?;

--- a/packages/test-fixtures/src/tcp_bind_test_processor.rs
+++ b/packages/test-fixtures/src/tcp_bind_test_processor.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Integration-test fixture for the dlopen-owns-tokio claim from #885.
+//!
+//! In its `start()` lifecycle method this processor:
+//!   1. Builds its own `tokio::runtime::Runtime` (`new_current_thread`,
+//!      single worker).
+//!   2. Calls `tokio::net::TcpListener::bind("127.0.0.1:0")` on that
+//!      runtime via `block_on`.
+//!   3. Writes the bound port (or an error string) to the configured
+//!      `output_path` so the integration test can verify the bind
+//!      succeeded even though the processor's `tokio` crate is
+//!      statically linked into a dlopen'd cdylib.
+//!
+//! The architectural claim this proves: a plugin's own runtime is the
+//! only way `tokio::net::*` futures can find their TLS slots, because
+//! the host runtime's TLS lives in a different crate instance (one
+//! statically linked into the host binary, one statically linked into
+//! the cdylib).
+
+use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ManualProcessor;
+
+#[streamlib::sdk::processor("TcpBindTestProcessor")]
+pub struct TcpBindTest {
+    tokio_runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl ManualProcessor for TcpBindTest::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| Error::Runtime(format!("TcpBindTest: build runtime: {e}")))?;
+        self.tokio_runtime = Some(runtime);
+        Ok(())
+    }
+
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let output_path = self.config.output_path.clone();
+        let runtime = self
+            .tokio_runtime
+            .as_ref()
+            .ok_or_else(|| Error::Runtime("TcpBindTest: setup() didn't build runtime".into()))?;
+
+        let result: std::io::Result<u16> = runtime.block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+            listener.local_addr().map(|addr| addr.port())
+        });
+
+        let line = match result {
+            Ok(port) => port.to_string(),
+            Err(e) => format!("ERR:{e}"),
+        };
+        std::fs::write(&output_path, &line).map_err(|e| {
+            Error::Runtime(format!("TcpBindTest: write {output_path}: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.tokio_runtime.take();
+        Ok(())
+    }
+
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/packages/test-fixtures/src/test_configured_processor.rs
+++ b/packages/test-fixtures/src/test_configured_processor.rs
@@ -13,18 +13,12 @@ use streamlib::sdk::processors::ContinuousProcessor;
 pub struct ConfiguredProcessor;
 
 impl ContinuousProcessor for ConfiguredProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {

--- a/packages/test-fixtures/streamlib.yaml
+++ b/packages/test-fixtures/streamlib.yaml
@@ -20,6 +20,8 @@ schemas:
   # Local config schema this package owns.
   TestConfiguredProcessorConfig:
     file: schemas/test_configured_processor_config.yaml
+  TcpBindTestProcessorConfig:
+    file: schemas/tcp_bind_test_processor_config.yaml
 
 processors:
   - name: TestConfiguredProcessor
@@ -29,3 +31,11 @@ processors:
     config:
       name: config
       schema: TestConfiguredProcessorConfig
+
+  - name: TcpBindTestProcessor
+    version: 1.0.0
+    description: "dlopen-owns-tokio integration test fixture from #885 — binds a tokio::net::TcpListener on the plugin's own runtime"
+    execution: manual
+    config:
+      name: config
+      schema: TcpBindTestProcessorConfig

--- a/packages/vadr-vision/src/depayloader.rs
+++ b/packages/vadr-vision/src/depayloader.rs
@@ -39,10 +39,7 @@ pub struct VadrVisionDepayloaderProcessor {
 }
 
 impl ReactiveProcessor for VadrVisionDepayloaderProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let timeout = self
             .config
             .reassembly_timeout_ms
@@ -62,7 +59,7 @@ impl ReactiveProcessor for VadrVisionDepayloaderProcessor::Processor {
             warn_on_drop = self.config.warn_on_drop.unwrap_or(true),
             "VadrVisionDepayloader: setup",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 
     fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
@@ -104,10 +101,7 @@ impl ReactiveProcessor for VadrVisionDepayloaderProcessor::Processor {
         Ok(())
     }
 
-    fn teardown(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let metrics = self
             .state
             .as_ref()
@@ -122,7 +116,7 @@ impl ReactiveProcessor for VadrVisionDepayloaderProcessor::Processor {
             frames_dropped_metadata_conflict = metrics.frames_dropped_metadata_conflict,
             "VadrVisionDepayloader: teardown",
         );
-        std::future::ready(Ok(()))
+        Ok(())
     }
 }
 

--- a/packages/webrtc/src/webrtc_whep.rs
+++ b/packages/webrtc/src/webrtc_whep.rs
@@ -9,7 +9,6 @@
 
 use crate::_generated_::{EncodedAudioFrame, EncodedVideoFrame};
 use crate::streaming::{H264RtpDepacketizer, RtpSample, WhepClient, WhepConfig};
-use std::future::Future;
 use std::sync::Arc;
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use streamlib::sdk::error::{Error, Result};
@@ -32,67 +31,77 @@ pub struct WebRtcWhepProcessor {
 
     // Shutdown signaling
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+
+    // Plugin-owned tokio runtime. Constructed in `setup()`; the host's
+    // runtime is not reachable across the plugin ABI per #885.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
+    tokio_handle: Option<tokio::runtime::Handle>,
 }
 
 impl ManualProcessor for WebRtcWhepProcessor::Processor {
-    fn setup(
-        &mut self,
-        _ctx: &RuntimeContextFullAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        async move {
-            // Convert generated config to WhepConfig
-            let whep_config = WhepConfig {
-                endpoint_url: self.config.whep.endpoint_url.clone(),
-                auth_token: self.config.whep.auth_token.clone(),
-                timeout_ms: self.config.whep.timeout_ms as u64,
-            };
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Runtime(format!("WebRtcWhep: failed to build tokio runtime: {e}"))
+            })?;
+        let tokio_handle = runtime.handle().clone();
+        self.tokio_runtime = Some(runtime);
+        self.tokio_handle = Some(tokio_handle.clone());
 
-            // Create and connect WHEP client
-            let mut whep_client = WhepClient::new(whep_config)?;
-            whep_client.connect().await?;
+        // Convert generated config to WhepConfig
+        let whep_config = WhepConfig {
+            endpoint_url: self.config.whep.endpoint_url.clone(),
+            auth_token: self.config.whep.auth_token.clone(),
+            timeout_ms: self.config.whep.timeout_ms as u64,
+        };
 
-            // Get audio configuration from SDP negotiation
-            let (sample_rate, _channels) = whep_client.audio_config();
-            self.audio_sample_rate = sample_rate;
+        // Create and connect WHEP client on the plugin's own runtime.
+        let mut whep_client = WhepClient::new(whep_config)?;
+        tokio_handle.block_on(whep_client.connect())?;
 
-            self.whep_client = Some(whep_client);
+        // Get audio configuration from SDP negotiation
+        let (sample_rate, _channels) = whep_client.audio_config();
+        self.audio_sample_rate = sample_rate;
 
-            tracing::info!(
-                "[WebRtcWhep] Connected to {}",
-                self.config.whep.endpoint_url
-            );
-            Ok(())
-        }
+        self.whep_client = Some(whep_client);
+
+        tracing::info!(
+            "[WebRtcWhep] Connected to {}",
+            self.config.whep.endpoint_url
+        );
+        Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[WebRtcWhep] Shutting down");
 
         if let Some(mut client) = self.whep_client.take() {
-            if let Err(e) = client.terminate().await {
-                tracing::warn!("[WebRtcWhep] Error terminating WHEP session: {}", e);
+            if let Some(handle) = self.tokio_handle.as_ref() {
+                if let Err(e) = handle.block_on(client.terminate()) {
+                    tracing::warn!("[WebRtcWhep] Error terminating WHEP session: {}", e);
+                }
             }
         }
+
+        self.tokio_handle.take();
+        self.tokio_runtime.take();
 
         tracing::info!("[WebRtcWhep] Shutdown complete");
         Ok(())
     }
 
-    fn on_pause(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
-    fn on_resume(
-        &mut self,
-        _ctx: &RuntimeContextLimitedAccess<'_>,
-    ) -> impl Future<Output = Result<()>> + Send {
-        std::future::ready(Ok(()))
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
     }
 
-    fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         // Take ownership of receivers from WHEP client
         let client = self
             .whep_client
@@ -112,7 +121,12 @@ impl ManualProcessor for WebRtcWhepProcessor::Processor {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         self.shutdown_tx = Some(shutdown_tx);
 
-        ctx.tokio_handle().spawn(async move {
+        let tokio_handle = self
+            .tokio_handle
+            .as_ref()
+            .ok_or_else(|| Error::Runtime("tokio runtime not initialized in setup()".into()))?;
+
+        tokio_handle.spawn(async move {
             run_whep_receive_loop(video_rx, audio_rx, outputs, audio_sample_rate, shutdown_rx).await;
         });
 

--- a/packages/webrtc/src/webrtc_whip.rs
+++ b/packages/webrtc/src/webrtc_whip.rs
@@ -45,12 +45,30 @@ pub struct WebRtcWhipProcessor {
     // Peer connection reference for stats (cloned before client moves to async task)
     peer_connection_for_stats: Option<Arc<webrtc::peer_connection::RTCPeerConnection>>,
 
+    // Plugin-owned tokio runtime. Constructed in `setup()` (the host's
+    // runtime is not reachable across the plugin ABI per #885).
+    // `webrtc-rs` requires tokio TLS to be set while polling its futures;
+    // running them on this runtime works because the cdylib statically
+    // links its own tokio crate.
+    tokio_runtime: Option<tokio::runtime::Runtime>,
+    tokio_handle: Option<tokio::runtime::Handle>,
+
     // Stats tracking
     last_stats_time_ns: i64,
 }
 
 impl ReactiveProcessor for WebRtcWhipProcessor::Processor {
-    async fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                Error::Runtime(format!("WebRtcWhip: failed to build tokio runtime: {e}"))
+            })?;
+        self.tokio_handle = Some(runtime.handle().clone());
+        self.tokio_runtime = Some(runtime);
+
         // Convert generated config to WhipConfig
         let whip_config = WhipConfig {
             endpoint_url: self.config.whip.endpoint_url.clone(),
@@ -64,19 +82,28 @@ impl ReactiveProcessor for WebRtcWhipProcessor::Processor {
         Ok(())
     }
 
-    async fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         tracing::info!("[WebRtcWhip] Shutting down");
 
         // Drop the channel sender to signal the async task to terminate.
         self.whip_client_message_sender.take();
         self.peer_connection_for_stats.take();
 
-        // If the client was never moved to the async task, terminate directly.
+        // If the client was never moved to the async task, terminate
+        // directly on the plugin's own runtime.
         if let Some(mut client) = self.whip_client.take() {
-            if let Err(e) = client.terminate().await {
-                tracing::warn!("[WebRtcWhip] Error terminating WHIP session: {}", e);
+            if let Some(handle) = self.tokio_handle.as_ref() {
+                if let Err(e) = handle.block_on(client.terminate()) {
+                    tracing::warn!("[WebRtcWhip] Error terminating WHIP session: {}", e);
+                }
             }
         }
+
+        // Drop the runtime — gives spawned tasks a chance to drain
+        // their channel and shut down their `terminate()` future before
+        // worker threads are joined.
+        self.tokio_handle.take();
+        self.tokio_runtime.take();
 
         tracing::info!("[WebRtcWhip] Shutdown complete");
         Ok(())
@@ -130,8 +157,11 @@ impl ReactiveProcessor for WebRtcWhipProcessor::Processor {
 
 impl WebRtcWhipProcessor::Processor {
     /// Starts the WebRTC WHIP session.
-    fn start_session(&mut self, ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
-        let tokio_handle = ctx.tokio_handle().clone();
+    fn start_session(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let tokio_handle = self
+            .tokio_handle
+            .clone()
+            .ok_or_else(|| Error::Runtime("tokio runtime not initialized in setup()".into()))?;
         let client = self
             .whip_client
             .as_mut()
@@ -234,9 +264,12 @@ impl WebRtcWhipProcessor::Processor {
         Ok(())
     }
 
-    fn log_stats(&self, ctx: &RuntimeContextLimitedAccess<'_>) {
+    fn log_stats(&self, _ctx: &RuntimeContextLimitedAccess<'_>) {
         if let Some(pc) = &self.peer_connection_for_stats {
-            let tokio_handle = ctx.tokio_handle();
+            let Some(tokio_handle) = self.tokio_handle.as_ref() else {
+                tracing::debug!("[WebRtcWhip] tokio runtime gone, skipping stats");
+                return;
+            };
             let stats = tokio_handle.block_on(pc.get_stats());
             let mut video_bytes_sent = 0u64;
             let mut audio_bytes_sent = 0u64;


### PR DESCRIPTION
## Summary

- Convert every Rust processor in `packages/` (+ Linux example plugins + Apple-gated reference paths) from the old `async fn setup/teardown/on_pause/on_resume` lifecycle (or `impl Future<...>` shape) to the new sync `fn` signatures #885's plugin-ABI Phase B landed.
- Six packages that previously borrowed the host's tokio handle via `ctx.tokio_handle()` (api-server, webrtc whip+whep, network udp_source+sink, moq subscribe+publish) now construct and own their own `tokio::runtime::Runtime` in `setup()` and drop it in `teardown()` — no tokio types cross the plugin ABI per #885's locked design.
- Land the EC#5 dlopen + `tokio::net::TcpListener::bind` integration test at `libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs`, backed by a new `TcpBindTestProcessor` in `streamlib-test-fixtures` that exercises the plugin-owned-runtime path end-to-end.

## Closes

Closes #895

## Exit criteria

- [x] Every package's `async fn` lifecycle methods are converted to sync `fn`. Trivial cases (bodies returning `std::future::ready(...)`) become plain sync bodies.
- [x] Every package that previously called `ctx.tokio_handle()` now owns its own `tokio::runtime::Runtime` constructed in `setup`, stashed on the processor struct, dropped in `teardown`. `ctx.tokio_handle()` calls are replaced with `self.tokio_handle.as_ref().unwrap().clone()` (or equivalent).
- [x] `cargo check --workspace` is clean.
- [x] `cargo test --lib` (workspace baseline per `docs/testing-baseline.md`) is clean.
- [x] Dlopen + `TcpListener::bind` integration test passes (architectural lock for #885's locked design).

## What changed vs. issue body

- Issue says "32 files in `packages/` and `libs/test-fixtures/`"; reality on Linux + Apple sweep is 47 files (31 packages, 5 example-only files in `examples/camera-python-display/` + `examples/polyglot-manual-source/` + `examples/camera-rust-plugin/`, 7 Apple-gated files in `packages/{audio,camera,display,mp4,screen-capture}/{apple,_apple_impl_pending_}/`). `test-fixtures` lives in `packages/`, not `libs/`.
- Issue lists 5 own-runtime packages; reality is 6 files across 5 packages (webrtc has 2 files: whip + whep) plus `moq_publish_track.rs` which the original audit classified as trivial but actually has a `.await` in setup — promoted it to own-runtime.
- Added the Apple sweep and example-plugin sweep per CLAUDE.md "no bad patterns left behind on engine changes" — the new sync trait shape is canonical and every consumer of the old pattern rides it now.

## Test plan

- [x] **Workspace baseline**: `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — every binary reports `test result: ok` with zero failures.
- [x] **dlopen + TcpListener integration test**: `cargo test -p streamlib-engine --test cdylib_owns_tokio_runtime` — passes, processor spins up its own multi-thread tokio runtime, binds `127.0.0.1:0`, writes the bound port to a file the test reads back.
- [x] **E2E camera→display (vivid sanity)**: `STREAMLIB_CAMERA_DEVICE=/dev/video0 STREAMLIB_DISPLAY_FRAME_LIMIT=120 cargo run -p camera-display` — 96 captured frames, clean shutdown, vivid SMPTE bars sampled every 30 frames, zero `OUT_OF_DEVICE_MEMORY` / `DEVICE_LOST` / `process() failed` signals. Sampled frames below (vivid timecode advances ~1s per 30 frames at 30fps, as expected):

  | Frame 0 | Frame 30 | Frame 60 | Frame 90 |
  |---|---|---|---|
  | ![frame 0](https://gh-artifact.tatolab.com/pr-900/display_001_frame_000000_input_000001.jpg) | ![frame 30](https://gh-artifact.tatolab.com/pr-900/display_001_frame_000030_input_000033.jpg) | ![frame 60](https://gh-artifact.tatolab.com/pr-900/display_001_frame_000060_input_000064.jpg) | ![frame 90](https://gh-artifact.tatolab.com/pr-900/display_001_frame_000090_input_000095.jpg) |

- [x] **API server runtime smoke test**: `cargo run -p api-server` followed by `curl http://127.0.0.1:9000/{health,api/graph,api/registry}` — all three endpoints returned `200 OK`. Clean SIGINT shutdown. Real proof that api-server's plugin-owned tokio runtime successfully bound the `TcpListener`, spawned `axum::serve` against it, and serviced HTTP requests through the new sync `setup` / `start` lifecycle.

  <details>
  <summary><code>curl http://127.0.0.1:9000/health</code></summary>

  ```
  ok
  ```
  </details>

  <details>
  <summary><code>curl http://127.0.0.1:9000/api/graph</code></summary>

  ```json
  {
    "nodes": [
      {
        "id": "Pgwe1nmmdzx9nag2z06xf41nj",
        "type": {
          "org": "tatolab",
          "package": "api-server",
          "type": "ApiServer",
          "version": { "major": 1, "minor": 0, "patch": 0 }
        },
        "display_name": "ApiServer",
        "config": { "host": "127.0.0.1", "port": 9000 },
        "config_checksum": 16756075036466146124,
        "ports": { "inputs": [], "outputs": [] },
        "components": {
          "shutdown_channel": { "attached": true, "receiver_taken": true },
          "state": "Running",
          "paused": false,
          "thread_handle": {
            "attached": true,
            "thread_id": "ThreadId(32)",
            "thread_name": "<unnamed>"
          },
          "processor_instance": {
            "attached": true,
            "arc_strong_count": 2,
            "arc_weak_count": 0
          }
        }
      }
    ],
    "links": []
  }
  ```
  </details>

  <details>
  <summary><code>curl http://127.0.0.1:9000/api/registry</code></summary>

  ```json
  {
    "processors": [
      {
        "name": {
          "org": "tatolab",
          "package": "api-server",
          "type": "ApiServer",
          "version": { "major": 1, "minor": 0, "patch": 0 }
        },
        "description": "Runtime API server — HTTP + WebSocket control plane",
        "version": "1.0.0",
        "repository": "https://github.com/tatolab/streamlib",
        "runtime": "rust",
        "config_schema": "@tatolab/api-server/ApiServerConfig@1.0.0",
        "inputs": [],
        "outputs": [],
        "examples": { "rust": "", "python": "", "typescript": "" }
      }
    ],
    "schemas": []
  }
  ```
  </details>

- [x] **Pre-PR review gate**: `pr-review-gate` returned PASS with three DISCUSS items; addressed two in a follow-up commit (test fixture's tokio runtime shape aligned with production `new_multi_thread().worker_threads(1)`; integration-test doc updated to describe the actual mechanism instead of a counterfactual that no longer compiles). Third DISCUSS (WHEP setup now blocks on its own runtime for the WHEP connect) is design-correct per #885's locked design and a non-change in observable stall semantics: the engine's pre-PR lifecycle wrapper already `block_on`'d the async `setup` future, so total stall time at `add_processor` is equivalent.

## macOS verification

- **Cross-compile** (`cargo check --target aarch64-apple-darwin`): blocked on this Linux host (host's `cc` doesn't accept macOS `-arch arm64 -mmacosx-version-min=11.0` flags; `bzip2-sys` and `ring` fail to build their C deps without a real macOS-compatible toolchain). Apple file changes are pure mechanical signature conversions matching the verified Linux pattern.
- **Runtime verified**: no — requires a macOS CI runner / host (not available here). Apple sweep is in scope per "no bad patterns left behind" but verification is deferred to a macOS-host run.
- **Apple paths touched**: `packages/audio/src/apple/{audio_capture,audio_output}.rs`, `packages/camera/src/apple/camera.rs`, `packages/display/src/apple/display.rs`, `packages/mp4/src/_apple_impl_pending_/mp4_writer.rs`, `packages/screen-capture/src/apple/screen_capture.rs`, `examples/camera-rust-plugin/plugin/src/lib.rs`.
- **RHI boundary preserved**: yes (no Metal calls outside `apple/rhi/` — this PR only touches lifecycle method signatures).

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

