### PR TITLE
feat(plugin-abi): GpuContext vtable — kernel construction (Phase C2 of #886)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1432,6 +1432,66 @@ impl GpuContext {
         Ok(Arc::new(kernel))
     }
 
+    /// Pre-allocate a ring of `count` non-exportable DEVICE_LOCAL
+    /// textures and register each in the same-process texture cache.
+    /// Mirror of [`GpuContextFullAccess::create_texture_ring`] at the
+    /// inner-`GpuContext` level — the FullAccess wrapper delegates here
+    /// after enforcing the privileged-scope invariants.
+    #[cfg(target_os = "linux")]
+    pub fn create_texture_ring(
+        self: &Arc<Self>,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+        usages: TextureUsages,
+        count: usize,
+    ) -> Result<Arc<crate::core::context::TextureRing>> {
+        use crate::core::context::{TextureRing, TextureRingSlot};
+
+        if count == 0 {
+            return Err(Error::GpuError(
+                "create_texture_ring: count must be > 0".into(),
+            ));
+        }
+
+        let mut slots = Vec::with_capacity(count);
+        let mut upload_resources = Vec::with_capacity(count);
+        for slot_index in 0..count {
+            let desc = TextureDescriptor::new(width, height, format).with_usage(usages);
+            let texture = self.device.create_texture_local(&desc)?;
+            let surface_id = uuid::Uuid::new_v4().to_string();
+            // Spec-correct initial layout for a freshly-allocated
+            // VkImage that no one has touched yet (per
+            // docs/architecture/texture-registration.md Producer
+            // Rule 2). The per-frame
+            // `TextureRing::copy_pixel_buffer_to_slot` runs the
+            // amortized upload that transitions UNDEFINED →
+            // SHADER_READ_ONLY_OPTIMAL and updates the registration
+            // to match, so after the first per-frame copy the claim
+            // and reality agree.
+            self.register_texture_with_layout(
+                &surface_id,
+                texture.clone(),
+                VulkanLayout::UNDEFINED,
+            );
+            slots.push(TextureRingSlot {
+                surface_id,
+                texture,
+                slot_index,
+            });
+            let res = crate::vulkan::rhi::HostVulkanUploadResources::new(&self.device.inner)?;
+            upload_resources.push(res);
+        }
+        Ok(TextureRing::from_slots(
+            slots,
+            upload_resources,
+            width,
+            height,
+            format,
+            (**self).clone(),
+        ))
+    }
+
     /// Build a triangle-geometry bottom-level acceleration structure
     /// from CPU-side vertex + index data. Backs [`Self::create_ray_tracing_kernel`]
     /// — every TLAS instance references one of these BLAS handles.
@@ -1894,23 +1954,61 @@ impl Drop for GpuContextLimitedAccess {
 /// Privileged GPU capability handed to `setup()` and inside
 /// [`GpuContextLimitedAccess::escalate`] closures.
 ///
-/// Exposes the full GPU API, including resource creation and device-wide
-/// operations. In #321 this is the same surface as [`GpuContextLimitedAccess`];
-/// the split lands in #324.
+/// Exposes the full GPU API, including resource creation and
+/// device-wide operations.
 ///
-/// Deliberately **not** `Clone`. Processors only ever see a `&GpuContextFullAccess`
-/// borrowed from a `RuntimeContextFullAccess` wrapper for the duration of a
-/// single lifecycle call (setup / teardown / start / stop / escalate closure).
-/// Removing `Clone` makes "stash a FullAccess in a field" a compile error:
-/// nothing can produce an owned value outside the runtime's construction
-/// path, so the capability can never escape its call.
+/// Deliberately **not** `Clone`. Processors only ever see a
+/// `&GpuContextFullAccess` borrowed from a `RuntimeContextFullAccess`
+/// wrapper for the duration of a single lifecycle call (setup /
+/// teardown / start / stop / escalate closure). Removing `Clone` makes
+/// "stash a FullAccess in a field" a compile error: nothing can
+/// produce an owned value outside the runtime's construction path, so
+/// the capability can never escape its call.
 ///
 /// ```compile_fail
 /// fn assert_not_clone<T: Clone>() {}
 /// assert_not_clone::<streamlib::sdk::context::GpuContextFullAccess>();
 /// ```
+///
+/// # Layout (Phase C2)
+///
+/// `#[repr(C)] { handle, vtable }`, mirroring
+/// [`GpuContextLimitedAccess`]. `handle` is a host-owned
+/// `Box<Arc<GpuContext>>` in host mode; in cdylib mode (post-C3) it
+/// is the opaque scope token from
+/// [`GpuContextFullAccessVTable::escalate_begin`]. Methods route
+/// through [`Self::host_inner`] for host-only fast paths (panicking
+/// when reached from cdylib code, same shape as Limited) and
+/// through the vtable when called from cdylib code.
+#[repr(C)]
 pub struct GpuContextFullAccess {
-    inner: GpuContext,
+    pub(crate) handle: *const std::ffi::c_void,
+    pub(crate) vtable:
+        *const streamlib_plugin_abi::GpuContextFullAccessVTable,
+}
+
+// SAFETY: same shape as `GpuContextLimitedAccess`. The handle points
+// at a host-owned `Box<Arc<GpuContext>>` (host mode) or an opaque
+// scope token (cdylib mode, post-C3); both are `Send + Sync`. The
+// vtable pointer is `&'static`.
+unsafe impl Send for GpuContextFullAccess {}
+unsafe impl Sync for GpuContextFullAccess {}
+
+impl Drop for GpuContextFullAccess {
+    /// Releases the host-owned handle via
+    /// [`GpuContextFullAccessVTable::drop_handle`]. In host mode this
+    /// drops the `Box<Arc<GpuContext>>` (releasing the cloned
+    /// `GpuContext`); in cdylib mode (post-C3) it invalidates the
+    /// escalate scope token.
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: handle was produced by `Self::new` (host mode —
+            // `Box::into_raw(Box::new(Arc::new(GpuContext)))`) or a
+            // future C3 `escalate_begin` callback. The vtable's
+            // `drop_handle` callback runs the matching release.
+            unsafe { ((*self.vtable).drop_handle)(self.handle) };
+        }
+    }
 }
 
 impl GpuContextLimitedAccess {
@@ -1986,9 +2084,7 @@ impl GpuContextLimitedAccess {
     /// processor setup paths can still reach the full surface without a
     /// compile-time barrier.
     pub(crate) fn to_full_access(&self) -> GpuContextFullAccess {
-        GpuContextFullAccess {
-            inner: self.host_inner().clone(),
-        }
+        GpuContextFullAccess::new(self.host_inner().clone())
     }
 
     /// Serialized escalation to full GPU capability. Acquires the
@@ -2097,19 +2193,60 @@ fn escalation_monotonic_ns() -> u64 {
 
 impl GpuContextFullAccess {
     /// Wrap a [`GpuContext`] as a full-access capability.
+    ///
+    /// Boxes a fresh `Arc<GpuContext>` as the opaque handle (matching
+    /// the [`GpuContextLimitedAccess::new`] shape), then resolves the
+    /// vtable through
+    /// [`crate::core::plugin::host_services::host_gpu_context_full_access_vtable`].
+    /// The Arc refcount is 1 at construction; `Drop` calls
+    /// `drop_handle` which runs `Box::from_raw + drop`.
     pub(crate) fn new(inner: GpuContext) -> Self {
-        Self { inner }
+        let arc: std::sync::Arc<GpuContext> = std::sync::Arc::new(inner);
+        let boxed: Box<std::sync::Arc<GpuContext>> = Box::new(arc);
+        let handle = Box::into_raw(boxed) as *const std::ffi::c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
     }
 
-    /// Borrow the inner [`GpuContext`]. Crate-internal — call sites migrate
-    /// to capability-typed methods as #322 lands.
+    /// Engine-internal borrow of the host's [`GpuContext`] (read
+    /// through the handle's `Box<Arc<GpuContext>>`).
+    ///
+    /// **Panics if called from cdylib code.** Mirrors
+    /// [`GpuContextLimitedAccess::host_inner`]'s contract: cdylib code
+    /// must dispatch through the
+    /// [`GpuContextFullAccessVTable`](streamlib_plugin_abi::GpuContextFullAccessVTable)
+    /// instead. The panic is caught by `run_host_extern_c` at the FFI
+    /// boundary.
+    pub(crate) fn host_inner(&self) -> &GpuContext {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable. \
+                 The panic is caught by run_host_extern_c at the FFI boundary."
+            );
+        }
+        // SAFETY: `self.handle` was produced by `Self::new`, which
+        // calls `Box::into_raw(Box::new(Arc::new(GpuContext)))`. The
+        // matching `host_gpu_full_drop_handle` runs on Drop, so the
+        // `Arc<GpuContext>` is alive for the duration of `&self`.
+        unsafe {
+            let arc = &*(self.handle as *const std::sync::Arc<GpuContext>);
+            &**arc
+        }
+    }
+
+    /// Borrow the inner [`GpuContext`]. Crate-internal — call sites
+    /// migrate to capability-typed methods as the privilege split
+    /// lands.
     pub(crate) fn inner(&self) -> &GpuContext {
-        &self.inner
+        self.host_inner()
     }
 
-    /// Produce a [`GpuContextLimitedAccess`] view of the same underlying context.
+    /// Produce a [`GpuContextLimitedAccess`] view of the same
+    /// underlying context.
     pub(crate) fn to_limited_access(&self) -> GpuContextLimitedAccess {
-        GpuContextLimitedAccess::new(self.inner.clone())
+        GpuContextLimitedAccess::new(self.host_inner().clone())
     }
 }
 
@@ -2944,12 +3081,12 @@ impl GpuContextLimitedAccess {
 impl GpuContextFullAccess {
     /// Acquire the processor-setup mutex.
     pub fn lock_processor_setup(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.inner.lock_processor_setup()
+        self.host_inner().lock_processor_setup()
     }
 
     /// Wait for the GPU device to become idle.
     pub fn wait_device_idle(&self) -> Result<()> {
-        self.inner.wait_device_idle()
+        self.host_inner().wait_device_idle()
     }
 
     /// Acquire a pixel buffer from the shared pool.
@@ -2959,7 +3096,7 @@ impl GpuContextFullAccess {
         height: u32,
         format: PixelFormat,
     ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
-        self.inner.acquire_pixel_buffer(width, height, format)
+        self.host_inner().acquire_pixel_buffer(width, height, format)
     }
 
     /// Acquire a HOST_VISIBLE storage buffer for CPU→GPU SSBO upload.
@@ -2969,7 +3106,7 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::StorageBuffer> {
-        self.inner.acquire_storage_buffer(byte_size)
+        self.host_inner().acquire_storage_buffer(byte_size)
     }
 
     /// Acquire a HOST_VISIBLE uniform buffer.
@@ -2978,7 +3115,7 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::UniformBuffer> {
-        self.inner.acquire_uniform_buffer(byte_size)
+        self.host_inner().acquire_uniform_buffer(byte_size)
     }
 
     /// Acquire a HOST_VISIBLE vertex buffer.
@@ -2987,7 +3124,7 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::VertexBuffer> {
-        self.inner.acquire_vertex_buffer(byte_size)
+        self.host_inner().acquire_vertex_buffer(byte_size)
     }
 
     /// Acquire a HOST_VISIBLE index buffer.
@@ -2996,7 +3133,7 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::IndexBuffer> {
-        self.inner.acquire_index_buffer(byte_size)
+        self.host_inner().acquire_index_buffer(byte_size)
     }
 
     /// Allocate a render-target-capable DMA-BUF VkImage (privileged path —
@@ -3009,23 +3146,23 @@ impl GpuContextFullAccess {
         height: u32,
         format: TextureFormat,
     ) -> Result<Texture> {
-        self.inner
+        self.host_inner()
             .acquire_render_target_dma_buf_image(width, height, format)
     }
 
     /// Get a pixel buffer by its pool id.
     pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
-        self.inner.get_pixel_buffer(pool_id)
+        self.host_inner().get_pixel_buffer(pool_id)
     }
 
     /// Resolve a VideoFrame's buffer from its surface_id.
     pub fn resolve_pixel_buffer_by_surface_id(&self, surface_id: &str) -> Result<PixelBuffer> {
-        self.inner.resolve_pixel_buffer_by_surface_id(surface_id)
+        self.host_inner().resolve_pixel_buffer_by_surface_id(surface_id)
     }
 
     /// Register a texture in the same-process texture cache.
     pub fn register_texture(&self, id: &str, texture: Texture) {
-        self.inner.register_texture(id, texture);
+        self.host_inner().register_texture(id, texture);
     }
 
     /// Register a texture with a declared initial Vulkan image layout.
@@ -3037,7 +3174,7 @@ impl GpuContextFullAccess {
         texture: Texture,
         initial_layout: VulkanLayout,
     ) {
-        self.inner
+        self.host_inner()
             .register_texture_with_layout(id, texture, initial_layout);
     }
 
@@ -3045,7 +3182,7 @@ impl GpuContextFullAccess {
     /// See [`GpuContext::update_texture_registration_layout`].
     #[cfg(target_os = "linux")]
     pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
-        self.inner.update_texture_registration_layout(id, layout);
+        self.host_inner().update_texture_registration_layout(id, layout);
     }
 
     /// Resolve a VideoFrame's full registration record (texture + layout).
@@ -3056,7 +3193,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<TextureRegistration> {
-        self.inner
+        self.host_inner()
             .resolve_texture_registration_by_surface_id(surface_id, texture_layout, width, height)
     }
 
@@ -3068,7 +3205,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<Texture> {
-        self.inner
+        self.host_inner()
             .resolve_texture_by_surface_id(surface_id, texture_layout, width, height)
     }
 
@@ -3079,7 +3216,7 @@ impl GpuContextFullAccess {
         height: u32,
         format: TextureFormat,
     ) -> Result<(String, Texture)> {
-        self.inner.acquire_output_texture(width, height, format)
+        self.host_inner().acquire_output_texture(width, height, format)
     }
 
     /// Upload a pixel buffer's contents to a GPU texture and register it.
@@ -3091,7 +3228,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        self.inner
+        self.host_inner()
             .upload_pixel_buffer_as_texture(surface_id, pixel_buffer, width, height)
     }
 
@@ -3112,7 +3249,7 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        self.inner.copy_pixel_buffer_to_texture(
+        self.host_inner().copy_pixel_buffer_to_texture(
             pixel_buffer,
             texture,
             surface_id,
@@ -3145,62 +3282,16 @@ impl GpuContextFullAccess {
         usages: TextureUsages,
         count: usize,
     ) -> Result<Arc<crate::core::context::TextureRing>> {
-        use crate::core::context::{TextureRing, TextureRingSlot};
-
-        if count == 0 {
-            return Err(Error::GpuError(
-                "create_texture_ring: count must be > 0".into(),
-            ));
-        }
-
-        let mut slots = Vec::with_capacity(count);
-        let mut upload_resources = Vec::with_capacity(count);
-        for slot_index in 0..count {
-            let desc = TextureDescriptor::new(width, height, format).with_usage(usages);
-            let texture = self.inner.device.create_texture_local(&desc)?;
-            let surface_id = uuid::Uuid::new_v4().to_string();
-            // Spec-correct initial layout for a freshly-allocated VkImage
-            // that no one has touched yet (per docs/architecture/texture-registration.md
-            // Producer Rule 2). The per-frame
-            // `TextureRing::copy_pixel_buffer_to_slot` runs
-            // upload_buffer_to_image_amortized which transitions UNDEFINED →
-            // SHADER_READ_ONLY_OPTIMAL and updates the registration to
-            // match — so after the first per-frame copy on a slot, the
-            // claim and reality both read SHADER_READ_ONLY_OPTIMAL for
-            // downstream consumers' barriers.
-            self.inner.register_texture_with_layout(
-                &surface_id,
-                texture.clone(),
-                VulkanLayout::UNDEFINED,
-            );
-            slots.push(TextureRingSlot {
-                surface_id,
-                texture,
-                slot_index,
-            });
-            // Pre-allocate per-slot upload resources (private command
-            // pool + cb + fence) so the per-frame hot path never calls
-            // vkCreateCommandPool / vkAllocateCommandBuffers /
-            // vkCreateFence — just reset + record + submit + wait via
-            // upload_buffer_to_image_amortized.
-            let res = crate::vulkan::rhi::HostVulkanUploadResources::new(
-                &self.inner.device.inner,
-            )?;
-            upload_resources.push(res);
-        }
-        Ok(TextureRing::from_slots(
-            slots,
-            upload_resources,
-            width,
-            height,
-            format,
-            self.inner.clone(),
-        ))
+        // Wrap the cloned `GpuContext` in a fresh `Arc` so the inner
+        // method (which takes `self: &Arc<Self>`) can clone it into
+        // the returned `TextureRing` for its per-slot upload routes.
+        let arc = Arc::new(self.host_inner().clone());
+        arc.create_texture_ring(width, height, format, usages, count)
     }
 
     /// See [`GpuContext::unregister_texture`].
     pub fn unregister_texture(&self, id: &str) {
-        self.inner.unregister_texture(id);
+        self.host_inner().unregister_texture(id);
     }
 
     /// See [`GpuContext::set_video_source_timeline_semaphore`].
@@ -3209,13 +3300,13 @@ impl GpuContextFullAccess {
         &self,
         timeline: &Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) {
-        self.inner.set_video_source_timeline_semaphore(timeline);
+        self.host_inner().set_video_source_timeline_semaphore(timeline);
     }
 
     /// See [`GpuContext::clear_video_source_timeline_semaphore`].
     #[cfg(target_os = "linux")]
     pub fn clear_video_source_timeline_semaphore(&self) {
-        self.inner.clear_video_source_timeline_semaphore();
+        self.host_inner().clear_video_source_timeline_semaphore();
     }
 
     /// See [`GpuContext::video_source_timeline_semaphore`].
@@ -3223,17 +3314,17 @@ impl GpuContextFullAccess {
     pub fn video_source_timeline_semaphore(
         &self,
     ) -> Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>> {
-        self.inner.video_source_timeline_semaphore()
+        self.host_inner().video_source_timeline_semaphore()
     }
 
     /// Get a reference to the RHI GPU device.
     pub fn device(&self) -> &Arc<GpuDevice> {
-        self.inner.device()
+        self.host_inner().device()
     }
 
     /// Get the texture pool for acquiring pooled textures.
     pub fn texture_pool(&self) -> &TexturePool {
-        self.inner.texture_pool()
+        self.host_inner().texture_pool()
     }
 
     /// Acquire a pooled texture for in-process GPU work
@@ -3241,17 +3332,17 @@ impl GpuContextFullAccess {
     /// host adapter layer wants on Linux, see
     /// [`Self::acquire_render_target_dma_buf_image`].
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
-        self.inner.acquire_texture(desc)
+        self.host_inner().acquire_texture(desc)
     }
 
     /// Get the shared command queue.
     pub fn command_queue(&self) -> &RhiCommandQueue {
-        self.inner.command_queue()
+        self.host_inner().command_queue()
     }
 
     /// Create a command buffer from the shared queue.
     pub fn create_command_buffer(&self) -> Result<CommandBuffer> {
-        self.inner.create_command_buffer()
+        self.host_inner().create_command_buffer()
     }
 
     /// Acquire a cached `(src, dst)`-keyed color converter. See
@@ -3263,7 +3354,7 @@ impl GpuContextFullAccess {
         src: PixelFormat,
         dst: PixelFormat,
     ) -> Result<Arc<RhiColorConverter>> {
-        self.inner.color_converter(src, dst)
+        self.host_inner().color_converter(src, dst)
     }
 
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
@@ -3272,7 +3363,7 @@ impl GpuContextFullAccess {
         &self,
         descriptor: &crate::core::rhi::ComputeKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanComputeKernel>> {
-        self.inner.create_compute_kernel(descriptor)
+        self.host_inner().create_compute_kernel(descriptor)
     }
 
     /// Build an engine-owned multi-step command-buffer recorder. See
@@ -3290,7 +3381,7 @@ impl GpuContextFullAccess {
         &self,
         label: &str,
     ) -> Result<crate::vulkan::rhi::RhiCommandRecorder> {
-        self.inner.create_command_recorder(label)
+        self.host_inner().create_command_recorder(label)
     }
 
     /// Create a graphics kernel from a multi-stage SPIR-V set, binding
@@ -3300,7 +3391,7 @@ impl GpuContextFullAccess {
         &self,
         descriptor: &crate::core::rhi::GraphicsKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanGraphicsKernel>> {
-        self.inner.create_graphics_kernel(descriptor)
+        self.host_inner().create_graphics_kernel(descriptor)
     }
 
     /// Create a ray-tracing kernel from shader stages, shader-group
@@ -3310,7 +3401,7 @@ impl GpuContextFullAccess {
         &self,
         descriptor: &crate::core::rhi::RayTracingKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanRayTracingKernel>> {
-        self.inner.create_ray_tracing_kernel(descriptor)
+        self.host_inner().create_ray_tracing_kernel(descriptor)
     }
 
     /// Build a triangle-geometry bottom-level acceleration structure
@@ -3322,7 +3413,7 @@ impl GpuContextFullAccess {
         vertices: &[f32],
         indices: &[u32],
     ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
-        self.inner.build_triangles_blas(label, vertices, indices)
+        self.host_inner().build_triangles_blas(label, vertices, indices)
     }
 
     /// Build a top-level acceleration structure from BLAS instances.
@@ -3332,31 +3423,31 @@ impl GpuContextFullAccess {
         label: &str,
         instances: &[crate::vulkan::rhi::TlasInstanceDesc],
     ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
-        self.inner.build_tlas(label, instances)
+        self.host_inner().build_tlas(label, instances)
     }
 
     /// Whether the underlying GPU exposes the
     /// `VK_KHR_ray_tracing_pipeline` extension chain.
     #[cfg(target_os = "linux")]
     pub fn supports_ray_tracing_pipeline(&self) -> bool {
-        self.inner.supports_ray_tracing_pipeline()
+        self.host_inner().supports_ray_tracing_pipeline()
     }
 
     /// Get the underlying Metal device (macOS only).
     #[cfg(target_os = "macos")]
     pub fn metal_device(&self) -> &crate::metal::rhi::MetalDevice {
-        self.inner.metal_device()
+        self.host_inner().metal_device()
     }
 
     /// Create a texture cache for converting pixel buffers to texture views.
     #[cfg(target_os = "macos")]
     pub fn create_texture_cache(&self) -> Result<crate::core::rhi::RhiTextureCache> {
-        self.inner.create_texture_cache()
+        self.host_inner().create_texture_cache()
     }
 
     /// Copy pixels between same-format, same-size buffers.
     pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
-        self.inner.blit_copy(src, dest)
+        self.host_inner().blit_copy(src, dest)
     }
 
     /// Copy from raw IOSurface to a pixel buffer.
@@ -3372,55 +3463,55 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        unsafe { self.inner.blit_copy_iosurface(src, dest, width, height) }
+        unsafe { self.host_inner().blit_copy_iosurface(src, dest, width, height) }
     }
 
     /// Clear the blitter's texture cache to free GPU memory.
     pub fn clear_blitter_cache(&self) {
-        self.inner.clear_blitter_cache();
+        self.host_inner().clear_blitter_cache();
     }
 
     /// Get the surface store, if initialized.
     pub fn surface_store(&self) -> Option<SurfaceStore> {
-        self.inner.surface_store()
+        self.host_inner().surface_store()
     }
 
     /// Check in a pixel buffer to the surface-share service.
     pub fn check_in_surface(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
-        self.inner.check_in_surface(pixel_buffer)
+        self.host_inner().check_in_surface(pixel_buffer)
     }
 
     /// Check out a surface by ID.
     pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
-        self.inner.check_out_surface(surface_id)
+        self.host_inner().check_out_surface(surface_id)
     }
 
     /// Get the registered cpu-readback bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
     #[cfg(target_os = "linux")]
     pub fn cpu_readback_bridge(&self) -> Option<Arc<dyn CpuReadbackBridge>> {
-        self.inner.cpu_readback_bridge()
+        self.host_inner().cpu_readback_bridge()
     }
 
     /// Get the registered compute-kernel bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
     #[cfg(target_os = "linux")]
     pub fn compute_kernel_bridge(&self) -> Option<Arc<dyn ComputeKernelBridge>> {
-        self.inner.compute_kernel_bridge()
+        self.host_inner().compute_kernel_bridge()
     }
 
     /// Get the registered graphics-kernel bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
     #[cfg(target_os = "linux")]
     pub fn graphics_kernel_bridge(&self) -> Option<Arc<dyn GraphicsKernelBridge>> {
-        self.inner.graphics_kernel_bridge()
+        self.host_inner().graphics_kernel_bridge()
     }
 
     /// Get the registered ray-tracing-kernel bridge, if any. Reachable only
     /// inside `escalate(|full| ...)` since it requires `FullAccess`.
     #[cfg(target_os = "linux")]
     pub fn ray_tracing_kernel_bridge(&self) -> Option<Arc<dyn RayTracingKernelBridge>> {
-        self.inner.ray_tracing_kernel_bridge()
+        self.host_inner().ray_tracing_kernel_bridge()
     }
 }
 
@@ -3439,7 +3530,8 @@ impl std::fmt::Debug for GpuContextLimitedAccess {
 impl std::fmt::Debug for GpuContextFullAccess {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GpuContextFullAccess")
-            .field("inner", &self.inner)
+            .field("handle", &self.handle)
+            .field("vtable", &self.vtable)
             .finish()
     }
 }

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1439,7 +1439,7 @@ impl GpuContext {
     /// after enforcing the privileged-scope invariants.
     #[cfg(target_os = "linux")]
     pub fn create_texture_ring(
-        self: &Arc<Self>,
+        &self,
         width: u32,
         height: u32,
         format: TextureFormat,
@@ -1488,7 +1488,7 @@ impl GpuContext {
             width,
             height,
             format,
-            (**self).clone(),
+            self.clone(),
         ))
     }
 
@@ -3282,11 +3282,8 @@ impl GpuContextFullAccess {
         usages: TextureUsages,
         count: usize,
     ) -> Result<Arc<crate::core::context::TextureRing>> {
-        // Wrap the cloned `GpuContext` in a fresh `Arc` so the inner
-        // method (which takes `self: &Arc<Self>`) can clone it into
-        // the returned `TextureRing` for its per-slot upload routes.
-        let arc = Arc::new(self.host_inner().clone());
-        arc.create_texture_ring(width, height, format, usages, count)
+        self.host_inner()
+            .create_texture_ring(width, height, format, usages, count)
     }
 
     /// See [`GpuContext::unregister_texture`].

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -5164,7 +5164,14 @@ mod gpu_full_access_vtable_tests {
     fn host_services_for_self_wires_full_access_vtable() {
         let node = match crate::iceoryx2::Iceoryx2Node::new() {
             Ok(n) => n,
-            Err(_) => return, // Iceoryx2 not available in this env — skip.
+            Err(e) => {
+                tracing::warn!(
+                    target: "streamlib::tests::gpu_full_access_vtable",
+                    error = %e,
+                    "skipping host_services_for_self wiring assertion: iceoryx2 init unavailable in this env"
+                );
+                return;
+            }
         };
         let services = runtime_facing::host_services_for_self(&node);
         assert!(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -60,12 +60,14 @@ use std::ffi::c_void;
 use std::sync::{Arc, OnceLock};
 
 use streamlib_plugin_abi::{
-    AudioClockVTable, GpuContextLimitedAccessVTable, HostHandle, HostInterest, HostLogLevel,
-    HostServices, ProcessorVTable, RuntimeContextVTable, RuntimeOpsVTable, SurfaceStoreVTable,
-    AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION,
-    HOST_SERVICES_LAYOUT_VERSION, PROCESSOR_VTABLE_LAYOUT_VERSION,
-    RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, RUNTIME_OPS_VTABLE_LAYOUT_VERSION,
-    SURFACE_STORE_VTABLE_LAYOUT_VERSION,
+    AudioClockVTable, ComputeKernelDescriptorRepr, GpuContextFullAccessVTable,
+    GpuContextLimitedAccessVTable, GraphicsKernelDescriptorRepr, HostHandle, HostInterest,
+    HostLogLevel, HostServices, ProcessorVTable, RayTracingKernelDescriptorRepr,
+    RuntimeContextVTable, RuntimeOpsVTable, SurfaceStoreVTable,
+    AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION,
+    GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, HOST_SERVICES_LAYOUT_VERSION,
+    PROCESSOR_VTABLE_LAYOUT_VERSION, RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION,
+    RUNTIME_OPS_VTABLE_LAYOUT_VERSION, SURFACE_STORE_VTABLE_LAYOUT_VERSION,
 };
 
 // tokio is not exposed across the ABI. Lifecycle methods are
@@ -172,6 +174,14 @@ pub struct HostCallbacks {
     /// before dispatching. Sourced from
     /// [`HostServices::surface_store_vtable`] at install time.
     pub surface_store_vtable: *const SurfaceStoreVTable,
+    /// Host-installed [`GpuContextFullAccessVTable`] pointer. May be
+    /// null on hosts that don't ship a GpuContext; cdylib must check
+    /// before dispatching. Reachable from cdylib code only inside an
+    /// `escalate(|full| ...)` scope (C3 wires the scope-token
+    /// machinery). Sourced from
+    /// [`HostServices::gpu_context_full_access_vtable`] at install
+    /// time.
+    pub gpu_context_full_access_vtable: *const GpuContextFullAccessVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -297,6 +307,15 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.gpu_context_full_access_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe { (*services.gpu_context_full_access_vtable).layout_version };
+        if v != GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -313,6 +332,7 @@ pub unsafe fn install_host_services(
         runtime_ops_vtable: services.runtime_ops_vtable,
         gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
         surface_store_vtable: services.surface_store_vtable,
+        gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -4268,6 +4288,572 @@ pub fn host_surface_store_vtable() -> *const SurfaceStoreVTable {
 /// Static [`GpuContextLimitedAccessVTable`] installed once per process.
 /// Paired with the per-RuntimeContext gpu-limited handle returned by
 /// [`HOST_RUNTIME_CONTEXT_VTABLE`]`::gpu_limited_access`.
+// =============================================================================
+// HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE — Phase C2
+// =============================================================================
+//
+// FullAccess vtable bodies. Reachable from cdylib code only inside an
+// `escalate(|full| ...)` scope (C3 wires the scope-token machinery);
+// host-mode call sites reach the same bodies via the
+// `host_gpu_context_full_access_vtable()` resolver.
+//
+// Handle interpretation:
+// - `gpu_handle`: `*const Arc<GpuContext>` (matches the LimitedAccess
+//   convention). The host's `GpuContextFullAccess::new` produces
+//   `Box::into_raw(Box::new(Arc::new(GpuContext)))`; the matching
+//   `host_gpu_full_drop_handle` runs `Box::from_raw + drop`.
+// - Kernel return handles: `*const VulkanComputeKernel` / etc., shaped
+//   as `Arc::into_raw(arc)`. Cdylib's `clone_*` / `drop_*` callbacks
+//   route refcount accounting through host-compiled code.
+
+unsafe extern "C" fn host_gpu_full_drop_handle(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_handle",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            // SAFETY: handle was produced by either the host's
+            // `GpuContextFullAccess::new` or a future C3 escalate-begin
+            // callback; both produce `Box::into_raw(Box::new(Arc::new(GpuContext)))`.
+            let _ = unsafe {
+                Box::from_raw(
+                    handle as *mut Arc<crate::core::context::GpuContext>,
+                )
+            };
+        },
+        (),
+    )
+}
+
+// ---------------- Kernel Arc-handle lifecycle (Linux-only) ----------------
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_compute_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_compute_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is `Arc::into_raw(Arc<VulkanComputeKernel>)`-shaped.
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanComputeKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_compute_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_compute_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is `Arc::into_raw(Arc<VulkanComputeKernel>)`-shaped.
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanComputeKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_graphics_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_graphics_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_graphics_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_graphics_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_ray_tracing_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_ray_tracing_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_ray_tracing_kernel(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_ray_tracing_kernel",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernel,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_texture_ring(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_texture_ring",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::core::context::TextureRing,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_texture_ring(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_texture_ring",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::core::context::TextureRing,
+                );
+            }
+        },
+        (),
+    )
+}
+
+// Non-Linux stubs (callbacks must exist for the static layout, but
+// the kernel types only ship on Linux).
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_compute_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_compute_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_graphics_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_graphics_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_ray_tracing_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_ray_tracing_kernel(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_texture_ring(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_texture_ring(_handle: *const c_void) {}
+
+// ---------------- Kernel construction (Linux-only) ----------------
+
+#[cfg(target_os = "linux")]
+unsafe fn handle_as_gpu_context_full(
+    handle: *const c_void,
+) -> Option<&'static Arc<crate::core::context::GpuContext>> {
+    if handle.is_null() {
+        return None;
+    }
+    // SAFETY: caller-supplied contract; matches `handle_as_gpu_context`'s
+    // shape (`*const Arc<GpuContext>`).
+    unsafe { Some(&*(handle as *const Arc<crate::core::context::GpuContext>)) }
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_create_compute_kernel(
+    gpu_handle: *const c_void,
+    desc: *const ComputeKernelDescriptorRepr,
+    out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_compute_kernel",
+        || -> i32 {
+            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
+                write_err(
+                    "create_compute_kernel: null gpu handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if desc.is_null() || out_kernel.is_null() {
+                write_err(
+                    "create_compute_kernel: null desc or out pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let repr: &ComputeKernelDescriptorRepr = unsafe { &*desc };
+            let (rust_desc, _keep) = match unsafe {
+                crate::core::rhi::plugin_abi_bridge::compute_kernel_descriptor_from_repr(repr)
+            } {
+                Ok(pair) => pair,
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    return 1;
+                }
+            };
+            match gpu.create_compute_kernel(&rust_desc) {
+                Ok(arc) => {
+                    let raw =
+                        Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_kernel, raw) };
+                    0
+                }
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
+    gpu_handle: *const c_void,
+    desc: *const GraphicsKernelDescriptorRepr,
+    out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_graphics_kernel",
+        || -> i32 {
+            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
+                write_err(
+                    "create_graphics_kernel: null gpu handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if desc.is_null() || out_kernel.is_null() {
+                write_err(
+                    "create_graphics_kernel: null desc or out pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let repr: &GraphicsKernelDescriptorRepr = unsafe { &*desc };
+            let (rust_desc, _keep) = match unsafe {
+                crate::core::rhi::plugin_abi_bridge::graphics_kernel_descriptor_from_repr(repr)
+            } {
+                Ok(pair) => pair,
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    return 1;
+                }
+            };
+            match gpu.create_graphics_kernel(&rust_desc) {
+                Ok(arc) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_kernel, raw) };
+                    0
+                }
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
+    gpu_handle: *const c_void,
+    desc: *const RayTracingKernelDescriptorRepr,
+    out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_ray_tracing_kernel",
+        || -> i32 {
+            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
+                write_err(
+                    "create_ray_tracing_kernel: null gpu handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if desc.is_null() || out_kernel.is_null() {
+                write_err(
+                    "create_ray_tracing_kernel: null desc or out pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let repr: &RayTracingKernelDescriptorRepr = unsafe { &*desc };
+            let (rust_desc, _keep) = match unsafe {
+                crate::core::rhi::plugin_abi_bridge::ray_tracing_kernel_descriptor_from_repr(repr)
+            } {
+                Ok(pair) => pair,
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    return 1;
+                }
+            };
+            match gpu.create_ray_tracing_kernel(&rust_desc) {
+                Ok(arc) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_kernel, raw) };
+                    0
+                }
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_create_texture_ring(
+    gpu_handle: *const c_void,
+    width: u32,
+    height: u32,
+    format_raw: u32,
+    usage_bits: u32,
+    count: usize,
+    out_ring: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_texture_ring",
+        || -> i32 {
+            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
+                write_err(
+                    "create_texture_ring: null gpu handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if out_ring.is_null() {
+                write_err(
+                    "create_texture_ring: null out_ring pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let format = match format_raw {
+                0 => streamlib_consumer_rhi::TextureFormat::Rgba8Unorm,
+                1 => streamlib_consumer_rhi::TextureFormat::Rgba8UnormSrgb,
+                2 => streamlib_consumer_rhi::TextureFormat::Bgra8Unorm,
+                3 => streamlib_consumer_rhi::TextureFormat::Bgra8UnormSrgb,
+                4 => streamlib_consumer_rhi::TextureFormat::Rgba16Float,
+                5 => streamlib_consumer_rhi::TextureFormat::Rgba32Float,
+                6 => streamlib_consumer_rhi::TextureFormat::Nv12,
+                _ => {
+                    write_err(
+                        &format!("create_texture_ring: invalid format_raw {format_raw}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let usages =
+                streamlib_consumer_rhi::TextureUsages::from_bits_truncate(usage_bits);
+            match gpu.create_texture_ring(width, height, format, usages, count) {
+                Ok(arc) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_ring, raw) };
+                    0
+                }
+                Err(e) => {
+                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+// Non-Linux stubs for the create_* callbacks.
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_create_compute_kernel(
+    _gpu_handle: *const c_void,
+    _desc: *const ComputeKernelDescriptorRepr,
+    _out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "create_compute_kernel: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
+    _gpu_handle: *const c_void,
+    _desc: *const GraphicsKernelDescriptorRepr,
+    _out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "create_graphics_kernel: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
+    _gpu_handle: *const c_void,
+    _desc: *const RayTracingKernelDescriptorRepr,
+    _out_kernel: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "create_ray_tracing_kernel: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_create_texture_ring(
+    _gpu_handle: *const c_void,
+    _width: u32,
+    _height: u32,
+    _format_raw: u32,
+    _usage_bits: u32,
+    _count: usize,
+    _out_ring: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "create_texture_ring: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
+    GpuContextFullAccessVTable {
+        layout_version: GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        drop_handle: host_gpu_full_drop_handle,
+        clone_compute_kernel: host_gpu_full_clone_compute_kernel,
+        drop_compute_kernel: host_gpu_full_drop_compute_kernel,
+        clone_graphics_kernel: host_gpu_full_clone_graphics_kernel,
+        drop_graphics_kernel: host_gpu_full_drop_graphics_kernel,
+        clone_ray_tracing_kernel: host_gpu_full_clone_ray_tracing_kernel,
+        drop_ray_tracing_kernel: host_gpu_full_drop_ray_tracing_kernel,
+        clone_texture_ring: host_gpu_full_clone_texture_ring,
+        drop_texture_ring: host_gpu_full_drop_texture_ring,
+        create_compute_kernel: host_gpu_full_create_compute_kernel,
+        create_graphics_kernel: host_gpu_full_create_graphics_kernel,
+        create_ray_tracing_kernel: host_gpu_full_create_ray_tracing_kernel,
+        create_texture_ring: host_gpu_full_create_texture_ring,
+    };
+
+/// Pointer to the [`GpuContextFullAccessVTable`] this DSO should
+/// dispatch through. Same DSO-routing rule as
+/// [`host_gpu_context_limited_access_vtable`]: host mode resolves to
+/// the local `&HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE` static, cdylib
+/// mode resolves to the host-installed pointer cached on
+/// [`HostServices::gpu_context_full_access_vtable`].
+pub fn host_gpu_context_full_access_vtable() -> *const GpuContextFullAccessVTable {
+    match host_callbacks() {
+        Some(c) if !c.gpu_context_full_access_vtable.is_null() => {
+            c.gpu_context_full_access_vtable
+        }
+        _ => &HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE,
+    }
+}
+
 pub static HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE: GpuContextLimitedAccessVTable =
     GpuContextLimitedAccessVTable {
         layout_version: GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION,
@@ -4372,8 +4958,8 @@ pub mod runtime_facing {
         host_iceoryx_log_emit, host_processor_register, host_pubsub_publish, host_schema_lookup,
         host_schema_register, host_tracing_emit, host_tracing_enabled,
         host_tracing_register_callsite, HostServiceImpls, HOST_AUDIO_CLOCK_VTABLE,
-        HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE, HOST_RUNTIME_CONTEXT_VTABLE,
-        HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
+        HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE, HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
+        HOST_RUNTIME_CONTEXT_VTABLE, HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -4419,6 +5005,7 @@ pub mod runtime_facing {
             runtime_ops_vtable: &HOST_RUNTIME_OPS_VTABLE,
             gpu_context_limited_access_vtable: &HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
             surface_store_vtable: &HOST_SURFACE_STORE_VTABLE,
+            gpu_context_full_access_vtable: &HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE,
         }
     }
 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4538,19 +4538,15 @@ unsafe extern "C" fn host_gpu_full_create_compute_kernel(
                 return 1;
             }
             let repr: &ComputeKernelDescriptorRepr = unsafe { &*desc };
-            let (rust_desc, _keep) = match unsafe {
-                crate::core::rhi::plugin_abi_bridge::compute_kernel_descriptor_from_repr(repr)
-            } {
-                Ok(pair) => pair,
-                Err(e) => {
-                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
-                    return 1;
-                }
+            let result = unsafe {
+                crate::core::rhi::plugin_abi_bridge::with_decoded_compute_kernel_descriptor(
+                    repr,
+                    |rust_desc| gpu.create_compute_kernel(rust_desc),
+                )
             };
-            match gpu.create_compute_kernel(&rust_desc) {
+            match result {
                 Ok(arc) => {
-                    let raw =
-                        Arc::into_raw(arc) as *const c_void;
+                    let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
@@ -4595,16 +4591,13 @@ unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
                 return 1;
             }
             let repr: &GraphicsKernelDescriptorRepr = unsafe { &*desc };
-            let (rust_desc, _keep) = match unsafe {
-                crate::core::rhi::plugin_abi_bridge::graphics_kernel_descriptor_from_repr(repr)
-            } {
-                Ok(pair) => pair,
-                Err(e) => {
-                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
-                    return 1;
-                }
+            let result = unsafe {
+                crate::core::rhi::plugin_abi_bridge::with_decoded_graphics_kernel_descriptor(
+                    repr,
+                    |rust_desc| gpu.create_graphics_kernel(rust_desc),
+                )
             };
-            match gpu.create_graphics_kernel(&rust_desc) {
+            match result {
                 Ok(arc) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
@@ -4651,16 +4644,13 @@ unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
                 return 1;
             }
             let repr: &RayTracingKernelDescriptorRepr = unsafe { &*desc };
-            let (rust_desc, _keep) = match unsafe {
-                crate::core::rhi::plugin_abi_bridge::ray_tracing_kernel_descriptor_from_repr(repr)
-            } {
-                Ok(pair) => pair,
-                Err(e) => {
-                    write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
-                    return 1;
-                }
+            let result = unsafe {
+                crate::core::rhi::plugin_abi_bridge::with_decoded_ray_tracing_kernel_descriptor(
+                    repr,
+                    |rust_desc| gpu.create_ray_tracing_kernel(rust_desc),
+                )
             };
-            match gpu.create_ray_tracing_kernel(&rust_desc) {
+            match result {
                 Ok(arc) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
@@ -5007,5 +4997,185 @@ pub mod runtime_facing {
             surface_store_vtable: &HOST_SURFACE_STORE_VTABLE,
             gpu_context_full_access_vtable: &HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE,
         }
+    }
+}
+
+// =============================================================================
+// FullAccess vtable callback-body tests (tier-1 — no GPU required)
+// =============================================================================
+//
+// Tier-1 host-side wire-format tests for `HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE`.
+// Each test invokes a vtable callback directly with a null `gpu_handle`
+// (the path that runs before any `gpu.create_*_kernel` call), asserting
+// the callback returns error code 1 + writes the expected message into
+// the caller's error buffer + leaves the out-handle slot untouched.
+//
+// The success-path tests (real Arc<GpuContext>, valid descriptor, kernel
+// handle minting) require a real Vulkan device and live in
+// `tests/` under the `streamlib/hardware-tests` feature. The dlopen
+// integration test that exercises the full cdylib → vtable → host chain
+// arrives with C3.
+#[cfg(test)]
+mod gpu_full_access_vtable_tests {
+    use super::*;
+    use streamlib_plugin_abi::{
+        ComputeKernelDescriptorRepr, GraphicsKernelDescriptorRepr,
+        RayTracingKernelDescriptorRepr,
+    };
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_buf_as_str(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn drop_handle_handles_null_no_crash() {
+        // Null handle is documented as a no-op; this just exercises
+        // the early-return guard.
+        unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.drop_handle)(std::ptr::null());
+        }
+    }
+
+    #[test]
+    fn create_compute_kernel_returns_error_on_null_gpu_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: *const c_void = std::ptr::null();
+        // Build a syntactically-valid repr — the null gpu_handle
+        // check runs first, so the repr contents don't matter for
+        // this test.
+        let bindings_buf: [streamlib_plugin_abi::ComputeBindingSpecRepr; 0] = [];
+        let repr = ComputeKernelDescriptorRepr {
+            label_ptr: "test".as_ptr(),
+            label_len: 4,
+            spv_ptr: std::ptr::null(),
+            spv_len: 0,
+            bindings_ptr: bindings_buf.as_ptr(),
+            bindings_len: 0,
+            push_constant_size: 0,
+            _reserved_padding: 0,
+        };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_compute_kernel)(
+                std::ptr::null(),
+                &repr,
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("create_compute_kernel: null gpu handle"),
+            "got: {msg}"
+        );
+        assert!(out.is_null(), "out_kernel must not be written on error");
+    }
+
+    #[test]
+    fn create_graphics_kernel_returns_error_on_null_gpu_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: *const c_void = std::ptr::null();
+        let repr: GraphicsKernelDescriptorRepr = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_graphics_kernel)(
+                std::ptr::null(),
+                &repr,
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("create_graphics_kernel: null gpu handle"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    fn create_ray_tracing_kernel_returns_error_on_null_gpu_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: *const c_void = std::ptr::null();
+        let repr: RayTracingKernelDescriptorRepr = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_ray_tracing_kernel)(
+                std::ptr::null(),
+                &repr,
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("create_ray_tracing_kernel: null gpu handle"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    fn create_texture_ring_returns_error_on_null_gpu_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: *const c_void = std::ptr::null();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_texture_ring)(
+                std::ptr::null(),
+                64,
+                64,
+                0, // Rgba8Unorm
+                0, // no usage bits
+                2,
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("create_texture_ring: null gpu handle"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    fn vtable_layout_version_matches_constant() {
+        assert_eq!(
+            HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.layout_version,
+            streamlib_plugin_abi::GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION
+        );
+    }
+
+    #[test]
+    fn host_services_for_self_wires_full_access_vtable() {
+        let node = match crate::iceoryx2::Iceoryx2Node::new() {
+            Ok(n) => n,
+            Err(_) => return, // Iceoryx2 not available in this env — skip.
+        };
+        let services = runtime_facing::host_services_for_self(&node);
+        assert!(
+            !services.gpu_context_full_access_vtable.is_null(),
+            "host should wire the FullAccess vtable pointer"
+        );
+        let installed_version =
+            unsafe { (*services.gpu_context_full_access_vtable).layout_version };
+        assert_eq!(
+            installed_version,
+            streamlib_plugin_abi::GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION
+        );
     }
 }

--- a/libs/streamlib-engine/src/core/rhi/mod.rs
+++ b/libs/streamlib-engine/src/core/rhi/mod.rs
@@ -18,6 +18,7 @@ mod index_buffer;
 mod pixel_buffer;
 mod pixel_buffer_pool;
 mod pixel_buffer_ref;
+pub(crate) mod plugin_abi_bridge;
 mod ray_tracing_kernel;
 mod storage_buffer;
 pub(crate) mod texture;

--- a/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
+++ b/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
@@ -146,18 +146,29 @@ pub fn stage_compute_kernel_descriptor(
     (repr, bindings_buf)
 }
 
-/// Decode a `ComputeKernelDescriptorRepr` back into a Rust descriptor.
+/// Decode a `ComputeKernelDescriptorRepr` and invoke `f` with a
+/// borrowed Rust descriptor whose slices point at the repr's source
+/// memory plus a stack-local binding-spec Vec.
+///
+/// Callback shape (not return-pair) is deliberate: the decoded
+/// descriptor's `bindings` slice points into a Vec built inside this
+/// function, and a `(Descriptor<'a>, Vec)` return would let a caller
+/// drop the Vec while keeping the descriptor — a use-after-free with
+/// no compile-time guard. Anchoring the borrow scope to `f`'s
+/// invocation eliminates the footgun.
 ///
 /// # Safety
 ///
 /// All pointer/length pairs in `repr` must be valid for reads (i.e.
 /// pointing at properly-aligned arrays of the right element type with
-/// the declared lengths). The returned descriptor borrows into the
-/// underlying memory; that memory must remain valid for the returned
-/// lifetime.
-pub unsafe fn compute_kernel_descriptor_from_repr<'a>(
-    repr: &'a ComputeKernelDescriptorRepr,
-) -> Result<(ComputeKernelDescriptor<'a>, Vec<ComputeBindingSpec>)> {
+/// the declared lengths) for the duration of the call.
+pub unsafe fn with_decoded_compute_kernel_descriptor<F, R>(
+    repr: &ComputeKernelDescriptorRepr,
+    f: F,
+) -> Result<R>
+where
+    F: FnOnce(&ComputeKernelDescriptor<'_>) -> Result<R>,
+{
     let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
     let spv = unsafe { slice_from_ptr_len(repr.spv_ptr, repr.spv_len) };
     let bindings_repr = unsafe { slice_from_ptr_len(repr.bindings_ptr, repr.bindings_len) };
@@ -165,24 +176,13 @@ pub unsafe fn compute_kernel_descriptor_from_repr<'a>(
         .iter()
         .map(compute_binding_spec_from_repr)
         .collect::<Result<_>>()?;
-    // We return both the descriptor (which borrows from `bindings`)
-    // and the `Vec` so the caller can keep it alive. Materialize the
-    // descriptor with a borrow into the just-built Vec.
-    let bindings_slice: &'a [ComputeBindingSpec] = unsafe {
-        // SAFETY: the Vec lives as long as the caller holds the tuple
-        // we're about to return. We hand back the Vec alongside the
-        // descriptor so it can't be dropped early.
-        std::slice::from_raw_parts(bindings.as_ptr(), bindings.len())
+    let desc = ComputeKernelDescriptor {
+        label,
+        spv,
+        bindings: &bindings,
+        push_constant_size: repr.push_constant_size,
     };
-    Ok((
-        ComputeKernelDescriptor {
-            label,
-            spv,
-            bindings: bindings_slice,
-            push_constant_size: repr.push_constant_size,
-        },
-        bindings,
-    ))
+    f(&desc)
 }
 
 // =============================================================================
@@ -1159,34 +1159,32 @@ pub fn stage_graphics_kernel_descriptor(
     (repr, stage)
 }
 
-/// Owned backing buffers behind a decoded `GraphicsKernelDescriptor`.
-#[allow(dead_code)]
-pub struct GraphicsKernelDescriptorDecoded<'a> {
-    pub stages: Vec<GraphicsStage<'a>>,
-    pub bindings: Vec<GraphicsBindingSpec>,
-    pub vertex_input: VertexInputState,
-    pub color_formats: Vec<TextureFormat>,
-}
-
-/// Decode a `GraphicsKernelDescriptorRepr` back into a Rust descriptor.
+/// Decode a `GraphicsKernelDescriptorRepr` and invoke `f` with a
+/// borrowed Rust descriptor.
+///
+/// Same callback-shape rationale as
+/// [`with_decoded_compute_kernel_descriptor`].
 ///
 /// # Safety
 ///
 /// All pointer/length pairs in `repr` (and inside its nested
-/// `vertex_input` and `attachment_formats`) must be valid for reads.
-/// The returned descriptor borrows from caller-managed memory.
-#[allow(clippy::type_complexity)]
-pub unsafe fn graphics_kernel_descriptor_from_repr<'a>(
-    repr: &'a GraphicsKernelDescriptorRepr,
-) -> Result<(GraphicsKernelDescriptor<'a>, GraphicsKernelDescriptorDecoded<'a>)> {
+/// `vertex_input` and `attachment_formats`) must be valid for reads
+/// for the duration of the call.
+pub unsafe fn with_decoded_graphics_kernel_descriptor<F, R>(
+    repr: &GraphicsKernelDescriptorRepr,
+    f: F,
+) -> Result<R>
+where
+    F: FnOnce(&GraphicsKernelDescriptor<'_>) -> Result<R>,
+{
     let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
     let stages_repr =
         unsafe { slice_from_ptr_len::<GraphicsStageRepr>(repr.stages_ptr, repr.stages_len) };
-    let stages: Vec<GraphicsStage<'a>> = stages_repr
+    let stages: Vec<GraphicsStage<'_>> = stages_repr
         .iter()
         .map(|s| {
             let stage = graphics_shader_stage_from_repr(s.stage)?;
-            let spv: &'a [u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
+            let spv: &[u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
             let entry_point =
                 unsafe { str_from_ptr_len(s.entry_point_ptr, s.entry_point_len, "entry_point")? };
             Ok::<_, Error>(GraphicsStage {
@@ -1260,43 +1258,27 @@ pub unsafe fn graphics_kernel_descriptor_from_repr<'a>(
 
     let pipeline_state = GraphicsPipelineState {
         topology: primitive_topology_from_repr(repr.pipeline_state.topology)?,
-        vertex_input: vertex_input.clone(),
+        vertex_input,
         rasterization: rasterization_state_from_repr(&repr.pipeline_state.rasterization)?,
         multisample: multisample_state_from_repr(&repr.pipeline_state.multisample),
         depth_stencil: depth_stencil_state_from_repr(&repr.pipeline_state.depth_stencil)?,
         color_blend: color_blend_state_from_repr(&repr.pipeline_state.color_blend)?,
         attachment_formats: AttachmentFormats {
-            color: color_formats.clone(),
+            color: color_formats,
             depth,
         },
         dynamic_state: graphics_dynamic_state_from_repr(repr.pipeline_state.dynamic_state)?,
     };
 
-    let decoded = GraphicsKernelDescriptorDecoded {
-        stages: stages.clone(),
-        bindings: bindings.clone(),
-        vertex_input,
-        color_formats,
+    let desc = GraphicsKernelDescriptor {
+        label,
+        stages: &stages,
+        bindings: &bindings,
+        push_constants,
+        pipeline_state,
+        descriptor_sets_in_flight: repr.descriptor_sets_in_flight,
     };
-
-    let stages_slice: &'a [GraphicsStage<'a>] = unsafe {
-        std::slice::from_raw_parts(decoded.stages.as_ptr(), decoded.stages.len())
-    };
-    let bindings_slice: &'a [GraphicsBindingSpec] = unsafe {
-        std::slice::from_raw_parts(decoded.bindings.as_ptr(), decoded.bindings.len())
-    };
-
-    Ok((
-        GraphicsKernelDescriptor {
-            label,
-            stages: stages_slice,
-            bindings: bindings_slice,
-            push_constants,
-            pipeline_state,
-            descriptor_sets_in_flight: repr.descriptor_sets_in_flight,
-        },
-        decoded,
-    ))
+    f(&desc)
 }
 
 /// Owned backing buffers behind a `RayTracingKernelDescriptorRepr`.
@@ -1357,32 +1339,32 @@ pub fn stage_ray_tracing_kernel_descriptor(
     (repr, stage)
 }
 
-/// Owned backing buffers behind a decoded `RayTracingKernelDescriptor`.
-#[allow(dead_code)]
-pub struct RayTracingKernelDescriptorDecoded<'a> {
-    pub stages: Vec<RayTracingStage<'a>>,
-    pub groups: Vec<RayTracingShaderGroup>,
-    pub bindings: Vec<RayTracingBindingSpec>,
-}
-
-/// Decode a `RayTracingKernelDescriptorRepr` back into a Rust descriptor.
+/// Decode a `RayTracingKernelDescriptorRepr` and invoke `f` with a
+/// borrowed Rust descriptor.
+///
+/// Same callback-shape rationale as
+/// [`with_decoded_compute_kernel_descriptor`].
 ///
 /// # Safety
 ///
-/// All pointer/length pairs in `repr` must be valid for reads.
-#[allow(clippy::type_complexity)]
-pub unsafe fn ray_tracing_kernel_descriptor_from_repr<'a>(
-    repr: &'a RayTracingKernelDescriptorRepr,
-) -> Result<(RayTracingKernelDescriptor<'a>, RayTracingKernelDescriptorDecoded<'a>)> {
+/// All pointer/length pairs in `repr` must be valid for reads for the
+/// duration of the call.
+pub unsafe fn with_decoded_ray_tracing_kernel_descriptor<F, R>(
+    repr: &RayTracingKernelDescriptorRepr,
+    f: F,
+) -> Result<R>
+where
+    F: FnOnce(&RayTracingKernelDescriptor<'_>) -> Result<R>,
+{
     let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
     let stages_repr = unsafe {
         slice_from_ptr_len::<RayTracingStageRepr>(repr.stages_ptr, repr.stages_len)
     };
-    let stages: Vec<RayTracingStage<'a>> = stages_repr
+    let stages: Vec<RayTracingStage<'_>> = stages_repr
         .iter()
         .map(|s| {
             let stage = ray_tracing_shader_stage_from_repr(s.stage)?;
-            let spv: &'a [u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
+            let spv: &[u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
             let entry_point =
                 unsafe { str_from_ptr_len(s.entry_point_ptr, s.entry_point_len, "entry_point")? };
             Ok::<_, Error>(RayTracingStage {
@@ -1411,32 +1393,15 @@ pub unsafe fn ray_tracing_kernel_descriptor_from_repr<'a>(
 
     let push_constants = ray_tracing_push_constants_from_repr(&repr.push_constants);
 
-    let decoded = RayTracingKernelDescriptorDecoded {
-        stages: stages.clone(),
-        groups: groups.clone(),
-        bindings: bindings.clone(),
+    let desc = RayTracingKernelDescriptor {
+        label,
+        stages: &stages,
+        groups: &groups,
+        bindings: &bindings,
+        push_constants,
+        max_recursion_depth: repr.max_recursion_depth,
     };
-    let stages_slice: &'a [RayTracingStage<'a>] = unsafe {
-        std::slice::from_raw_parts(decoded.stages.as_ptr(), decoded.stages.len())
-    };
-    let groups_slice: &'a [RayTracingShaderGroup] = unsafe {
-        std::slice::from_raw_parts(decoded.groups.as_ptr(), decoded.groups.len())
-    };
-    let bindings_slice: &'a [RayTracingBindingSpec] = unsafe {
-        std::slice::from_raw_parts(decoded.bindings.as_ptr(), decoded.bindings.len())
-    };
-
-    Ok((
-        RayTracingKernelDescriptor {
-            label,
-            stages: stages_slice,
-            groups: groups_slice,
-            bindings: bindings_slice,
-            push_constants,
-            max_recursion_depth: repr.max_recursion_depth,
-        },
-        decoded,
-    ))
+    f(&desc)
 }
 
 #[cfg(test)]
@@ -1459,28 +1424,32 @@ mod tests {
             push_constant_size: 16,
         };
         let (repr, _buf) = stage_compute_kernel_descriptor(&desc);
-        let (decoded, _bindings_keepalive) =
-            unsafe { compute_kernel_descriptor_from_repr(&repr).expect("decode") };
-        assert_eq!(decoded.label, "test_compute");
-        assert_eq!(decoded.spv, spv);
-        assert_eq!(decoded.bindings.len(), 4);
-        assert_eq!(
-            decoded.bindings[0].kind,
-            ComputeBindingKind::StorageBuffer
-        );
-        assert_eq!(
-            decoded.bindings[1].kind,
-            ComputeBindingKind::UniformBuffer
-        );
-        assert_eq!(
-            decoded.bindings[2].kind,
-            ComputeBindingKind::SampledTexture
-        );
-        assert_eq!(
-            decoded.bindings[3].kind,
-            ComputeBindingKind::StorageImage
-        );
-        assert_eq!(decoded.push_constant_size, 16);
+        unsafe {
+            with_decoded_compute_kernel_descriptor(&repr, |decoded| {
+                assert_eq!(decoded.label, "test_compute");
+                assert_eq!(decoded.spv, spv);
+                assert_eq!(decoded.bindings.len(), 4);
+                assert_eq!(
+                    decoded.bindings[0].kind,
+                    ComputeBindingKind::StorageBuffer
+                );
+                assert_eq!(
+                    decoded.bindings[1].kind,
+                    ComputeBindingKind::UniformBuffer
+                );
+                assert_eq!(
+                    decoded.bindings[2].kind,
+                    ComputeBindingKind::SampledTexture
+                );
+                assert_eq!(
+                    decoded.bindings[3].kind,
+                    ComputeBindingKind::StorageImage
+                );
+                assert_eq!(decoded.push_constant_size, 16);
+                Ok(())
+            })
+            .expect("decode");
+        }
     }
 
     #[test]
@@ -1501,7 +1470,12 @@ mod tests {
             push_constant_size: 0,
             _reserved_padding: 0,
         };
-        let err = unsafe { compute_kernel_descriptor_from_repr(&repr).unwrap_err() };
+        let err = unsafe {
+            with_decoded_compute_kernel_descriptor(&repr, |_| {
+                Ok::<_, Error>(())
+            })
+            .unwrap_err()
+        };
         assert!(format!("{err}").contains("invalid discriminant 99"));
     }
 
@@ -1535,27 +1509,31 @@ mod tests {
             descriptor_sets_in_flight: 2,
         };
         let (repr, _stage) = stage_graphics_kernel_descriptor(&desc);
-        let (decoded, _keep) =
-            unsafe { graphics_kernel_descriptor_from_repr(&repr).expect("decode") };
-        assert_eq!(decoded.label, "test_graphics");
-        assert_eq!(decoded.stages.len(), 2);
-        assert_eq!(decoded.stages[0].stage, GraphicsShaderStage::Vertex);
-        assert_eq!(decoded.stages[1].stage, GraphicsShaderStage::Fragment);
-        assert_eq!(decoded.bindings.len(), 2);
-        assert_eq!(decoded.push_constants.size, 12);
-        assert_eq!(
-            decoded.pipeline_state.topology,
-            PrimitiveTopology::TriangleStrip
-        );
-        assert!(matches!(
-            decoded.pipeline_state.vertex_input,
-            VertexInputState::None
-        ));
-        assert!(matches!(
-            decoded.pipeline_state.color_blend,
-            ColorBlendState::Enabled(_)
-        ));
-        assert_eq!(decoded.descriptor_sets_in_flight, 2);
+        unsafe {
+            with_decoded_graphics_kernel_descriptor(&repr, |decoded| {
+                assert_eq!(decoded.label, "test_graphics");
+                assert_eq!(decoded.stages.len(), 2);
+                assert_eq!(decoded.stages[0].stage, GraphicsShaderStage::Vertex);
+                assert_eq!(decoded.stages[1].stage, GraphicsShaderStage::Fragment);
+                assert_eq!(decoded.bindings.len(), 2);
+                assert_eq!(decoded.push_constants.size, 12);
+                assert_eq!(
+                    decoded.pipeline_state.topology,
+                    PrimitiveTopology::TriangleStrip
+                );
+                assert!(matches!(
+                    decoded.pipeline_state.vertex_input,
+                    VertexInputState::None
+                ));
+                assert!(matches!(
+                    decoded.pipeline_state.color_blend,
+                    ColorBlendState::Enabled(_)
+                ));
+                assert_eq!(decoded.descriptor_sets_in_flight, 2);
+                Ok(())
+            })
+            .expect("decode");
+        }
     }
 
     #[test]
@@ -1609,35 +1587,39 @@ mod tests {
             descriptor_sets_in_flight: 3,
         };
         let (repr, _stage) = stage_graphics_kernel_descriptor(&desc);
-        let (decoded, _keep) =
-            unsafe { graphics_kernel_descriptor_from_repr(&repr).expect("decode") };
-        match decoded.pipeline_state.vertex_input {
-            VertexInputState::Buffers {
-                bindings,
-                attributes,
-            } => {
-                assert_eq!(bindings.len(), 1);
-                assert_eq!(bindings[0].stride, 32);
-                assert_eq!(attributes.len(), 2);
-                assert_eq!(attributes[1].offset, 12);
+        unsafe {
+            with_decoded_graphics_kernel_descriptor(&repr, |decoded| {
+                match &decoded.pipeline_state.vertex_input {
+                    VertexInputState::Buffers {
+                        bindings,
+                        attributes,
+                    } => {
+                        assert_eq!(bindings.len(), 1);
+                        assert_eq!(bindings[0].stride, 32);
+                        assert_eq!(attributes.len(), 2);
+                        assert_eq!(attributes[1].offset, 12);
+                        assert_eq!(
+                            attributes[1].format,
+                            VertexAttributeFormat::Rgba32Float
+                        );
+                    }
+                    _ => panic!("expected Buffers"),
+                }
+                assert!(matches!(
+                    decoded.pipeline_state.depth_stencil,
+                    DepthStencilState::Enabled {
+                        depth_test: DepthCompareOp::LessOrEqual,
+                        depth_write: true,
+                    }
+                ));
                 assert_eq!(
-                    attributes[1].format,
-                    VertexAttributeFormat::Rgba32Float
+                    decoded.pipeline_state.attachment_formats.depth,
+                    Some(DepthFormat::D32Sfloat)
                 );
-            }
-            _ => panic!("expected Buffers"),
+                Ok(())
+            })
+            .expect("decode");
         }
-        assert!(matches!(
-            decoded.pipeline_state.depth_stencil,
-            DepthStencilState::Enabled {
-                depth_test: DepthCompareOp::LessOrEqual,
-                depth_write: true,
-            }
-        ));
-        assert_eq!(
-            decoded.pipeline_state.attachment_formats.depth,
-            Some(DepthFormat::D32Sfloat)
-        );
     }
 
     #[test]
@@ -1677,28 +1659,32 @@ mod tests {
             max_recursion_depth: 4,
         };
         let (repr, _stage) = stage_ray_tracing_kernel_descriptor(&desc);
-        let (decoded, _keep) =
-            unsafe { ray_tracing_kernel_descriptor_from_repr(&repr).expect("decode") };
-        assert_eq!(decoded.label, "test_rt");
-        assert_eq!(decoded.stages.len(), 3);
-        assert_eq!(decoded.groups.len(), 3);
-        match decoded.groups[2] {
-            RayTracingShaderGroup::TrianglesHit {
-                closest_hit,
-                any_hit,
-            } => {
-                assert_eq!(closest_hit, Some(2));
-                assert_eq!(any_hit, None);
-            }
-            _ => panic!("expected TrianglesHit"),
+        unsafe {
+            with_decoded_ray_tracing_kernel_descriptor(&repr, |decoded| {
+                assert_eq!(decoded.label, "test_rt");
+                assert_eq!(decoded.stages.len(), 3);
+                assert_eq!(decoded.groups.len(), 3);
+                match decoded.groups[2] {
+                    RayTracingShaderGroup::TrianglesHit {
+                        closest_hit,
+                        any_hit,
+                    } => {
+                        assert_eq!(closest_hit, Some(2));
+                        assert_eq!(any_hit, None);
+                    }
+                    _ => panic!("expected TrianglesHit"),
+                }
+                assert_eq!(decoded.bindings.len(), 2);
+                assert_eq!(
+                    decoded.bindings[1].kind,
+                    RayTracingBindingKind::AccelerationStructure
+                );
+                assert_eq!(decoded.push_constants.size, 8);
+                assert_eq!(decoded.max_recursion_depth, 4);
+                Ok(())
+            })
+            .expect("decode");
         }
-        assert_eq!(decoded.bindings.len(), 2);
-        assert_eq!(
-            decoded.bindings[1].kind,
-            RayTracingBindingKind::AccelerationStructure
-        );
-        assert_eq!(decoded.push_constants.size, 8);
-        assert_eq!(decoded.max_recursion_depth, 4);
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
+++ b/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
@@ -1,0 +1,1740 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Round-trip helpers between the engine-side kernel descriptor types
+//! (`ComputeKernelDescriptor`, `GraphicsKernelDescriptor`,
+//! `RayTracingKernelDescriptor`) and their `#[repr(C)]` mirrors in
+//! `streamlib_plugin_abi`.
+//!
+//! Two directions:
+//!
+//! - **`Repr::from(&desc)`** is infallible: every Rust descriptor maps
+//!   to a layout-stable Repr. Used by the cdylib at the FullAccess
+//!   vtable call site to stage the wire-format payload.
+//! - **`unsafe fn ..._from_repr(&repr)`** validates discriminants and
+//!   slice pointer/length pairs, returning the engine-side Rust
+//!   descriptor borrowing into the Repr's source memory. Used by the
+//!   host inside its FullAccess vtable callback bodies.
+//!
+//! All conversions are pure: no allocation, no GPU work, no Vulkan
+//! state. The host's `create_*_kernel` methods do the real work; this
+//! module is just the wire-format bridge.
+
+use streamlib_plugin_abi::{
+    AttachmentFormatsRepr, BlendFactorRepr, BlendOpRepr, ColorBlendAttachmentRepr,
+    ColorBlendStateKindRepr, ColorBlendStateRepr, ComputeBindingKindRepr,
+    ComputeBindingSpecRepr, ComputeKernelDescriptorRepr, CullModeRepr, DepthCompareOpRepr,
+    DepthFormatRepr, DepthStencilStateKindRepr, DepthStencilStateRepr, FrontFaceRepr,
+    GraphicsBindingKindRepr, GraphicsBindingSpecRepr, GraphicsDynamicStateRepr,
+    GraphicsKernelDescriptorRepr, GraphicsPipelineStateRepr, GraphicsPushConstantsRepr,
+    GraphicsShaderStageRepr, GraphicsStageRepr, MultisampleStateRepr, PolygonModeRepr,
+    PrimitiveTopologyRepr, RasterizationStateRepr, RayTracingBindingKindRepr,
+    RayTracingBindingSpecRepr, RayTracingKernelDescriptorRepr, RayTracingPushConstantsRepr,
+    RayTracingShaderGroupKindRepr, RayTracingShaderGroupRepr, RayTracingShaderStageRepr,
+    RayTracingStageRepr, VertexAttributeFormatRepr, VertexInputAttributeRepr,
+    VertexInputBindingRepr, VertexInputRateRepr, VertexInputStateKindRepr,
+    VertexInputStateRepr, RAY_TRACING_SHADER_UNUSED,
+};
+
+use crate::core::rhi::{
+    AttachmentFormats, BlendFactor, BlendOp, ColorBlendAttachment, ColorBlendState, ColorWriteMask,
+    ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, CullMode, DepthCompareOp,
+    DepthFormat, DepthStencilState, FrontFace, GraphicsBindingKind, GraphicsBindingSpec,
+    GraphicsDynamicState, GraphicsKernelDescriptor, GraphicsPipelineState, GraphicsPushConstants,
+    GraphicsShaderStage, GraphicsShaderStageFlags, GraphicsStage, MultisampleState, PolygonMode,
+    PrimitiveTopology, RasterizationState, RayTracingBindingKind, RayTracingBindingSpec,
+    RayTracingKernelDescriptor, RayTracingPushConstants, RayTracingShaderGroup,
+    RayTracingShaderStage, RayTracingShaderStageFlags, RayTracingStage, TextureFormat,
+    VertexAttributeFormat, VertexInputAttribute, VertexInputBinding, VertexInputRate,
+    VertexInputState,
+};
+use crate::core::{Error, Result};
+
+// =============================================================================
+// Compute kernel
+// =============================================================================
+
+impl From<ComputeBindingKind> for ComputeBindingKindRepr {
+    fn from(value: ComputeBindingKind) -> Self {
+        match value {
+            ComputeBindingKind::StorageBuffer => Self::StorageBuffer,
+            ComputeBindingKind::UniformBuffer => Self::UniformBuffer,
+            ComputeBindingKind::SampledTexture => Self::SampledTexture,
+            ComputeBindingKind::StorageImage => Self::StorageImage,
+        }
+    }
+}
+
+fn compute_binding_kind_from_repr(raw: u32) -> Result<ComputeBindingKind> {
+    match raw {
+        0 => Ok(ComputeBindingKind::StorageBuffer),
+        1 => Ok(ComputeBindingKind::UniformBuffer),
+        2 => Ok(ComputeBindingKind::SampledTexture),
+        3 => Ok(ComputeBindingKind::StorageImage),
+        other => Err(Error::GpuError(format!(
+            "ComputeBindingKind: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<&ComputeBindingSpec> for ComputeBindingSpecRepr {
+    fn from(value: &ComputeBindingSpec) -> Self {
+        Self {
+            binding: value.binding,
+            kind: ComputeBindingKindRepr::from(value.kind) as u32,
+        }
+    }
+}
+
+fn compute_binding_spec_from_repr(repr: &ComputeBindingSpecRepr) -> Result<ComputeBindingSpec> {
+    Ok(ComputeBindingSpec {
+        binding: repr.binding,
+        kind: compute_binding_kind_from_repr(repr.kind)?,
+    })
+}
+
+/// Build a [`ComputeKernelDescriptorRepr`] that borrows into `desc`.
+///
+/// The returned Repr holds raw pointers into `desc`'s underlying
+/// memory; both must outlive the Repr (the borrow checker enforces
+/// this via the explicit lifetime tie below).
+#[allow(dead_code)]
+pub fn compute_kernel_descriptor_to_repr_with_bindings<'a>(
+    desc: &'a ComputeKernelDescriptor<'a>,
+    bindings_buf: &'a [ComputeBindingSpecRepr],
+) -> ComputeKernelDescriptorRepr {
+    debug_assert_eq!(bindings_buf.len(), desc.bindings.len());
+    ComputeKernelDescriptorRepr {
+        label_ptr: desc.label.as_ptr(),
+        label_len: desc.label.len(),
+        spv_ptr: desc.spv.as_ptr(),
+        spv_len: desc.spv.len(),
+        bindings_ptr: bindings_buf.as_ptr(),
+        bindings_len: bindings_buf.len(),
+        push_constant_size: desc.push_constant_size,
+        _reserved_padding: 0,
+    }
+}
+
+/// Stage a `ComputeKernelDescriptor` to its repr + a backing buffer of
+/// repr bindings, ready for a vtable call.
+///
+/// Returns `(repr, bindings_buf)`. The caller MUST keep `bindings_buf`
+/// alive for the lifetime of `repr` (the repr's `bindings_ptr` points
+/// into `bindings_buf`); typical callers stash both on the stack
+/// before the vtable call.
+#[allow(dead_code)]
+pub fn stage_compute_kernel_descriptor(
+    desc: &ComputeKernelDescriptor<'_>,
+) -> (ComputeKernelDescriptorRepr, Vec<ComputeBindingSpecRepr>) {
+    let bindings_buf: Vec<ComputeBindingSpecRepr> =
+        desc.bindings.iter().map(ComputeBindingSpecRepr::from).collect();
+    // SAFETY: `bindings_buf` is a freshly-allocated Vec; we capture
+    // its current data pointer, but the Vec lives as long as the
+    // tuple returned by this function (and the caller is responsible
+    // for keeping it alive while using the repr).
+    let repr = ComputeKernelDescriptorRepr {
+        label_ptr: desc.label.as_ptr(),
+        label_len: desc.label.len(),
+        spv_ptr: desc.spv.as_ptr(),
+        spv_len: desc.spv.len(),
+        bindings_ptr: bindings_buf.as_ptr(),
+        bindings_len: bindings_buf.len(),
+        push_constant_size: desc.push_constant_size,
+        _reserved_padding: 0,
+    };
+    (repr, bindings_buf)
+}
+
+/// Decode a `ComputeKernelDescriptorRepr` back into a Rust descriptor.
+///
+/// # Safety
+///
+/// All pointer/length pairs in `repr` must be valid for reads (i.e.
+/// pointing at properly-aligned arrays of the right element type with
+/// the declared lengths). The returned descriptor borrows into the
+/// underlying memory; that memory must remain valid for the returned
+/// lifetime.
+pub unsafe fn compute_kernel_descriptor_from_repr<'a>(
+    repr: &'a ComputeKernelDescriptorRepr,
+) -> Result<(ComputeKernelDescriptor<'a>, Vec<ComputeBindingSpec>)> {
+    let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
+    let spv = unsafe { slice_from_ptr_len(repr.spv_ptr, repr.spv_len) };
+    let bindings_repr = unsafe { slice_from_ptr_len(repr.bindings_ptr, repr.bindings_len) };
+    let bindings: Vec<ComputeBindingSpec> = bindings_repr
+        .iter()
+        .map(compute_binding_spec_from_repr)
+        .collect::<Result<_>>()?;
+    // We return both the descriptor (which borrows from `bindings`)
+    // and the `Vec` so the caller can keep it alive. Materialize the
+    // descriptor with a borrow into the just-built Vec.
+    let bindings_slice: &'a [ComputeBindingSpec] = unsafe {
+        // SAFETY: the Vec lives as long as the caller holds the tuple
+        // we're about to return. We hand back the Vec alongside the
+        // descriptor so it can't be dropped early.
+        std::slice::from_raw_parts(bindings.as_ptr(), bindings.len())
+    };
+    Ok((
+        ComputeKernelDescriptor {
+            label,
+            spv,
+            bindings: bindings_slice,
+            push_constant_size: repr.push_constant_size,
+        },
+        bindings,
+    ))
+}
+
+// =============================================================================
+// Graphics kernel
+// =============================================================================
+
+impl From<GraphicsShaderStage> for GraphicsShaderStageRepr {
+    fn from(value: GraphicsShaderStage) -> Self {
+        match value {
+            GraphicsShaderStage::Vertex => Self::Vertex,
+            GraphicsShaderStage::Fragment => Self::Fragment,
+        }
+    }
+}
+
+fn graphics_shader_stage_from_repr(raw: u32) -> Result<GraphicsShaderStage> {
+    match raw {
+        0 => Ok(GraphicsShaderStage::Vertex),
+        1 => Ok(GraphicsShaderStage::Fragment),
+        other => Err(Error::GpuError(format!(
+            "GraphicsShaderStage: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<GraphicsBindingKind> for GraphicsBindingKindRepr {
+    fn from(value: GraphicsBindingKind) -> Self {
+        match value {
+            GraphicsBindingKind::SampledTexture => Self::SampledTexture,
+            GraphicsBindingKind::StorageBuffer => Self::StorageBuffer,
+            GraphicsBindingKind::UniformBuffer => Self::UniformBuffer,
+            GraphicsBindingKind::StorageImage => Self::StorageImage,
+        }
+    }
+}
+
+fn graphics_binding_kind_from_repr(raw: u32) -> Result<GraphicsBindingKind> {
+    match raw {
+        0 => Ok(GraphicsBindingKind::SampledTexture),
+        1 => Ok(GraphicsBindingKind::StorageBuffer),
+        2 => Ok(GraphicsBindingKind::UniformBuffer),
+        3 => Ok(GraphicsBindingKind::StorageImage),
+        other => Err(Error::GpuError(format!(
+            "GraphicsBindingKind: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<PrimitiveTopology> for PrimitiveTopologyRepr {
+    fn from(value: PrimitiveTopology) -> Self {
+        match value {
+            PrimitiveTopology::PointList => Self::PointList,
+            PrimitiveTopology::LineList => Self::LineList,
+            PrimitiveTopology::LineStrip => Self::LineStrip,
+            PrimitiveTopology::TriangleList => Self::TriangleList,
+            PrimitiveTopology::TriangleStrip => Self::TriangleStrip,
+            PrimitiveTopology::TriangleFan => Self::TriangleFan,
+        }
+    }
+}
+
+fn primitive_topology_from_repr(raw: u32) -> Result<PrimitiveTopology> {
+    match raw {
+        0 => Ok(PrimitiveTopology::PointList),
+        1 => Ok(PrimitiveTopology::LineList),
+        2 => Ok(PrimitiveTopology::LineStrip),
+        3 => Ok(PrimitiveTopology::TriangleList),
+        4 => Ok(PrimitiveTopology::TriangleStrip),
+        5 => Ok(PrimitiveTopology::TriangleFan),
+        other => Err(Error::GpuError(format!(
+            "PrimitiveTopology: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<VertexAttributeFormat> for VertexAttributeFormatRepr {
+    fn from(value: VertexAttributeFormat) -> Self {
+        match value {
+            VertexAttributeFormat::R32Float => Self::R32Float,
+            VertexAttributeFormat::Rg32Float => Self::Rg32Float,
+            VertexAttributeFormat::Rgb32Float => Self::Rgb32Float,
+            VertexAttributeFormat::Rgba32Float => Self::Rgba32Float,
+            VertexAttributeFormat::R32Uint => Self::R32Uint,
+            VertexAttributeFormat::Rg32Uint => Self::Rg32Uint,
+            VertexAttributeFormat::Rgb32Uint => Self::Rgb32Uint,
+            VertexAttributeFormat::Rgba32Uint => Self::Rgba32Uint,
+            VertexAttributeFormat::R32Sint => Self::R32Sint,
+            VertexAttributeFormat::Rg32Sint => Self::Rg32Sint,
+            VertexAttributeFormat::Rgb32Sint => Self::Rgb32Sint,
+            VertexAttributeFormat::Rgba32Sint => Self::Rgba32Sint,
+            VertexAttributeFormat::Rgba8Unorm => Self::Rgba8Unorm,
+            VertexAttributeFormat::Rgba8Snorm => Self::Rgba8Snorm,
+        }
+    }
+}
+
+fn vertex_attribute_format_from_repr(raw: u32) -> Result<VertexAttributeFormat> {
+    match raw {
+        0 => Ok(VertexAttributeFormat::R32Float),
+        1 => Ok(VertexAttributeFormat::Rg32Float),
+        2 => Ok(VertexAttributeFormat::Rgb32Float),
+        3 => Ok(VertexAttributeFormat::Rgba32Float),
+        4 => Ok(VertexAttributeFormat::R32Uint),
+        5 => Ok(VertexAttributeFormat::Rg32Uint),
+        6 => Ok(VertexAttributeFormat::Rgb32Uint),
+        7 => Ok(VertexAttributeFormat::Rgba32Uint),
+        8 => Ok(VertexAttributeFormat::R32Sint),
+        9 => Ok(VertexAttributeFormat::Rg32Sint),
+        10 => Ok(VertexAttributeFormat::Rgb32Sint),
+        11 => Ok(VertexAttributeFormat::Rgba32Sint),
+        12 => Ok(VertexAttributeFormat::Rgba8Unorm),
+        13 => Ok(VertexAttributeFormat::Rgba8Snorm),
+        other => Err(Error::GpuError(format!(
+            "VertexAttributeFormat: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<VertexInputRate> for VertexInputRateRepr {
+    fn from(value: VertexInputRate) -> Self {
+        match value {
+            VertexInputRate::Vertex => Self::Vertex,
+            VertexInputRate::Instance => Self::Instance,
+        }
+    }
+}
+
+fn vertex_input_rate_from_repr(raw: u32) -> Result<VertexInputRate> {
+    match raw {
+        0 => Ok(VertexInputRate::Vertex),
+        1 => Ok(VertexInputRate::Instance),
+        other => Err(Error::GpuError(format!(
+            "VertexInputRate: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<PolygonMode> for PolygonModeRepr {
+    fn from(value: PolygonMode) -> Self {
+        match value {
+            PolygonMode::Fill => Self::Fill,
+            PolygonMode::Line => Self::Line,
+            PolygonMode::Point => Self::Point,
+        }
+    }
+}
+
+fn polygon_mode_from_repr(raw: u32) -> Result<PolygonMode> {
+    match raw {
+        0 => Ok(PolygonMode::Fill),
+        1 => Ok(PolygonMode::Line),
+        2 => Ok(PolygonMode::Point),
+        other => Err(Error::GpuError(format!(
+            "PolygonMode: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<CullMode> for CullModeRepr {
+    fn from(value: CullMode) -> Self {
+        match value {
+            CullMode::None => Self::None,
+            CullMode::Front => Self::Front,
+            CullMode::Back => Self::Back,
+            CullMode::FrontAndBack => Self::FrontAndBack,
+        }
+    }
+}
+
+fn cull_mode_from_repr(raw: u32) -> Result<CullMode> {
+    match raw {
+        0 => Ok(CullMode::None),
+        1 => Ok(CullMode::Front),
+        2 => Ok(CullMode::Back),
+        3 => Ok(CullMode::FrontAndBack),
+        other => Err(Error::GpuError(format!(
+            "CullMode: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<FrontFace> for FrontFaceRepr {
+    fn from(value: FrontFace) -> Self {
+        match value {
+            FrontFace::CounterClockwise => Self::CounterClockwise,
+            FrontFace::Clockwise => Self::Clockwise,
+        }
+    }
+}
+
+fn front_face_from_repr(raw: u32) -> Result<FrontFace> {
+    match raw {
+        0 => Ok(FrontFace::CounterClockwise),
+        1 => Ok(FrontFace::Clockwise),
+        other => Err(Error::GpuError(format!(
+            "FrontFace: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<DepthCompareOp> for DepthCompareOpRepr {
+    fn from(value: DepthCompareOp) -> Self {
+        match value {
+            DepthCompareOp::Never => Self::Never,
+            DepthCompareOp::Less => Self::Less,
+            DepthCompareOp::Equal => Self::Equal,
+            DepthCompareOp::LessOrEqual => Self::LessOrEqual,
+            DepthCompareOp::Greater => Self::Greater,
+            DepthCompareOp::NotEqual => Self::NotEqual,
+            DepthCompareOp::GreaterOrEqual => Self::GreaterOrEqual,
+            DepthCompareOp::Always => Self::Always,
+        }
+    }
+}
+
+fn depth_compare_op_from_repr(raw: u32) -> Result<DepthCompareOp> {
+    match raw {
+        0 => Ok(DepthCompareOp::Never),
+        1 => Ok(DepthCompareOp::Less),
+        2 => Ok(DepthCompareOp::Equal),
+        3 => Ok(DepthCompareOp::LessOrEqual),
+        4 => Ok(DepthCompareOp::Greater),
+        5 => Ok(DepthCompareOp::NotEqual),
+        6 => Ok(DepthCompareOp::GreaterOrEqual),
+        7 => Ok(DepthCompareOp::Always),
+        other => Err(Error::GpuError(format!(
+            "DepthCompareOp: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<BlendFactor> for BlendFactorRepr {
+    fn from(value: BlendFactor) -> Self {
+        match value {
+            BlendFactor::Zero => Self::Zero,
+            BlendFactor::One => Self::One,
+            BlendFactor::SrcColor => Self::SrcColor,
+            BlendFactor::OneMinusSrcColor => Self::OneMinusSrcColor,
+            BlendFactor::DstColor => Self::DstColor,
+            BlendFactor::OneMinusDstColor => Self::OneMinusDstColor,
+            BlendFactor::SrcAlpha => Self::SrcAlpha,
+            BlendFactor::OneMinusSrcAlpha => Self::OneMinusSrcAlpha,
+            BlendFactor::DstAlpha => Self::DstAlpha,
+            BlendFactor::OneMinusDstAlpha => Self::OneMinusDstAlpha,
+            BlendFactor::ConstantColor => Self::ConstantColor,
+            BlendFactor::OneMinusConstantColor => Self::OneMinusConstantColor,
+            BlendFactor::ConstantAlpha => Self::ConstantAlpha,
+            BlendFactor::OneMinusConstantAlpha => Self::OneMinusConstantAlpha,
+            BlendFactor::SrcAlphaSaturate => Self::SrcAlphaSaturate,
+        }
+    }
+}
+
+fn blend_factor_from_repr(raw: u32) -> Result<BlendFactor> {
+    match raw {
+        0 => Ok(BlendFactor::Zero),
+        1 => Ok(BlendFactor::One),
+        2 => Ok(BlendFactor::SrcColor),
+        3 => Ok(BlendFactor::OneMinusSrcColor),
+        4 => Ok(BlendFactor::DstColor),
+        5 => Ok(BlendFactor::OneMinusDstColor),
+        6 => Ok(BlendFactor::SrcAlpha),
+        7 => Ok(BlendFactor::OneMinusSrcAlpha),
+        8 => Ok(BlendFactor::DstAlpha),
+        9 => Ok(BlendFactor::OneMinusDstAlpha),
+        10 => Ok(BlendFactor::ConstantColor),
+        11 => Ok(BlendFactor::OneMinusConstantColor),
+        12 => Ok(BlendFactor::ConstantAlpha),
+        13 => Ok(BlendFactor::OneMinusConstantAlpha),
+        14 => Ok(BlendFactor::SrcAlphaSaturate),
+        other => Err(Error::GpuError(format!(
+            "BlendFactor: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<BlendOp> for BlendOpRepr {
+    fn from(value: BlendOp) -> Self {
+        match value {
+            BlendOp::Add => Self::Add,
+            BlendOp::Subtract => Self::Subtract,
+            BlendOp::ReverseSubtract => Self::ReverseSubtract,
+            BlendOp::Min => Self::Min,
+            BlendOp::Max => Self::Max,
+        }
+    }
+}
+
+fn blend_op_from_repr(raw: u32) -> Result<BlendOp> {
+    match raw {
+        0 => Ok(BlendOp::Add),
+        1 => Ok(BlendOp::Subtract),
+        2 => Ok(BlendOp::ReverseSubtract),
+        3 => Ok(BlendOp::Min),
+        4 => Ok(BlendOp::Max),
+        other => Err(Error::GpuError(format!(
+            "BlendOp: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<DepthFormat> for DepthFormatRepr {
+    fn from(value: DepthFormat) -> Self {
+        match value {
+            DepthFormat::D16Unorm => Self::D16Unorm,
+            DepthFormat::D32Sfloat => Self::D32Sfloat,
+            DepthFormat::D24UnormS8Uint => Self::D24UnormS8Uint,
+        }
+    }
+}
+
+fn depth_format_from_repr(raw: u32) -> Result<DepthFormat> {
+    match raw {
+        0 => Ok(DepthFormat::D16Unorm),
+        1 => Ok(DepthFormat::D32Sfloat),
+        2 => Ok(DepthFormat::D24UnormS8Uint),
+        other => Err(Error::GpuError(format!(
+            "DepthFormat: invalid discriminant {other}"
+        ))),
+    }
+}
+
+fn texture_format_from_repr(raw: u32) -> Result<TextureFormat> {
+    match raw {
+        0 => Ok(TextureFormat::Rgba8Unorm),
+        1 => Ok(TextureFormat::Rgba8UnormSrgb),
+        2 => Ok(TextureFormat::Bgra8Unorm),
+        3 => Ok(TextureFormat::Bgra8UnormSrgb),
+        4 => Ok(TextureFormat::Rgba16Float),
+        5 => Ok(TextureFormat::Rgba32Float),
+        6 => Ok(TextureFormat::Nv12),
+        other => Err(Error::GpuError(format!(
+            "TextureFormat: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<GraphicsDynamicState> for GraphicsDynamicStateRepr {
+    fn from(value: GraphicsDynamicState) -> Self {
+        match value {
+            GraphicsDynamicState::None => Self::None,
+            GraphicsDynamicState::ViewportScissor => Self::ViewportScissor,
+        }
+    }
+}
+
+fn graphics_dynamic_state_from_repr(raw: u32) -> Result<GraphicsDynamicState> {
+    match raw {
+        0 => Ok(GraphicsDynamicState::None),
+        1 => Ok(GraphicsDynamicState::ViewportScissor),
+        other => Err(Error::GpuError(format!(
+            "GraphicsDynamicState: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<&VertexInputBinding> for VertexInputBindingRepr {
+    fn from(value: &VertexInputBinding) -> Self {
+        Self {
+            binding: value.binding,
+            stride: value.stride,
+            input_rate: VertexInputRateRepr::from(value.input_rate) as u32,
+            _reserved_padding: 0,
+        }
+    }
+}
+
+fn vertex_input_binding_from_repr(repr: &VertexInputBindingRepr) -> Result<VertexInputBinding> {
+    Ok(VertexInputBinding {
+        binding: repr.binding,
+        stride: repr.stride,
+        input_rate: vertex_input_rate_from_repr(repr.input_rate)?,
+    })
+}
+
+impl From<&VertexInputAttribute> for VertexInputAttributeRepr {
+    fn from(value: &VertexInputAttribute) -> Self {
+        Self {
+            location: value.location,
+            binding: value.binding,
+            format: VertexAttributeFormatRepr::from(value.format) as u32,
+            offset: value.offset,
+        }
+    }
+}
+
+fn vertex_input_attribute_from_repr(
+    repr: &VertexInputAttributeRepr,
+) -> Result<VertexInputAttribute> {
+    Ok(VertexInputAttribute {
+        location: repr.location,
+        binding: repr.binding,
+        format: vertex_attribute_format_from_repr(repr.format)?,
+        offset: repr.offset,
+    })
+}
+
+impl From<&GraphicsBindingSpec> for GraphicsBindingSpecRepr {
+    fn from(value: &GraphicsBindingSpec) -> Self {
+        Self {
+            binding: value.binding,
+            kind: GraphicsBindingKindRepr::from(value.kind) as u32,
+            stages: value.stages.bits(),
+            _reserved_padding: 0,
+        }
+    }
+}
+
+fn graphics_binding_spec_from_repr(repr: &GraphicsBindingSpecRepr) -> Result<GraphicsBindingSpec> {
+    Ok(GraphicsBindingSpec {
+        binding: repr.binding,
+        kind: graphics_binding_kind_from_repr(repr.kind)?,
+        stages: graphics_shader_stage_flags_from_bits(repr.stages),
+    })
+}
+
+/// Reconstruct `GraphicsShaderStageFlags` from raw `u32` bits. Unknown
+/// bits beyond the defined VERTEX/FRAGMENT pair are silently dropped
+/// so future-flag additions on the source side don't trip the receiver.
+fn graphics_shader_stage_flags_from_bits(bits: u32) -> GraphicsShaderStageFlags {
+    let mut out = GraphicsShaderStageFlags::NONE;
+    if bits & GraphicsShaderStageFlags::VERTEX.bits() != 0 {
+        out |= GraphicsShaderStageFlags::VERTEX;
+    }
+    if bits & GraphicsShaderStageFlags::FRAGMENT.bits() != 0 {
+        out |= GraphicsShaderStageFlags::FRAGMENT;
+    }
+    out
+}
+
+impl From<GraphicsPushConstants> for GraphicsPushConstantsRepr {
+    fn from(value: GraphicsPushConstants) -> Self {
+        Self {
+            size: value.size,
+            stages: value.stages.bits(),
+        }
+    }
+}
+
+fn graphics_push_constants_from_repr(
+    repr: &GraphicsPushConstantsRepr,
+) -> GraphicsPushConstants {
+    GraphicsPushConstants {
+        size: repr.size,
+        stages: graphics_shader_stage_flags_from_bits(repr.stages),
+    }
+}
+
+impl From<RasterizationState> for RasterizationStateRepr {
+    fn from(value: RasterizationState) -> Self {
+        Self {
+            polygon_mode: PolygonModeRepr::from(value.polygon_mode) as u32,
+            cull_mode: CullModeRepr::from(value.cull_mode) as u32,
+            front_face: FrontFaceRepr::from(value.front_face) as u32,
+            line_width: value.line_width,
+        }
+    }
+}
+
+fn rasterization_state_from_repr(repr: &RasterizationStateRepr) -> Result<RasterizationState> {
+    Ok(RasterizationState {
+        polygon_mode: polygon_mode_from_repr(repr.polygon_mode)?,
+        cull_mode: cull_mode_from_repr(repr.cull_mode)?,
+        front_face: front_face_from_repr(repr.front_face)?,
+        line_width: repr.line_width,
+    })
+}
+
+impl From<MultisampleState> for MultisampleStateRepr {
+    fn from(value: MultisampleState) -> Self {
+        Self {
+            samples: value.samples,
+            _reserved_padding: 0,
+        }
+    }
+}
+
+fn multisample_state_from_repr(repr: &MultisampleStateRepr) -> MultisampleState {
+    MultisampleState {
+        samples: repr.samples,
+    }
+}
+
+impl From<DepthStencilState> for DepthStencilStateRepr {
+    fn from(value: DepthStencilState) -> Self {
+        match value {
+            DepthStencilState::Disabled => Self {
+                kind: DepthStencilStateKindRepr::Disabled as u32,
+                depth_test: 0,
+                depth_write: 0,
+                _reserved_padding: 0,
+            },
+            DepthStencilState::Enabled {
+                depth_test,
+                depth_write,
+            } => Self {
+                kind: DepthStencilStateKindRepr::Enabled as u32,
+                depth_test: DepthCompareOpRepr::from(depth_test) as u32,
+                depth_write: depth_write as u32,
+                _reserved_padding: 0,
+            },
+        }
+    }
+}
+
+fn depth_stencil_state_from_repr(repr: &DepthStencilStateRepr) -> Result<DepthStencilState> {
+    match repr.kind {
+        x if x == DepthStencilStateKindRepr::Disabled as u32 => Ok(DepthStencilState::Disabled),
+        x if x == DepthStencilStateKindRepr::Enabled as u32 => Ok(DepthStencilState::Enabled {
+            depth_test: depth_compare_op_from_repr(repr.depth_test)?,
+            depth_write: repr.depth_write != 0,
+        }),
+        other => Err(Error::GpuError(format!(
+            "DepthStencilState: invalid kind {other}"
+        ))),
+    }
+}
+
+impl From<ColorBlendAttachment> for ColorBlendAttachmentRepr {
+    fn from(value: ColorBlendAttachment) -> Self {
+        Self {
+            src_color_blend_factor: BlendFactorRepr::from(value.src_color_blend_factor) as u32,
+            dst_color_blend_factor: BlendFactorRepr::from(value.dst_color_blend_factor) as u32,
+            color_blend_op: BlendOpRepr::from(value.color_blend_op) as u32,
+            src_alpha_blend_factor: BlendFactorRepr::from(value.src_alpha_blend_factor) as u32,
+            dst_alpha_blend_factor: BlendFactorRepr::from(value.dst_alpha_blend_factor) as u32,
+            alpha_blend_op: BlendOpRepr::from(value.alpha_blend_op) as u32,
+            color_write_mask: value.color_write_mask.bits(),
+            _reserved_padding: 0,
+        }
+    }
+}
+
+fn color_blend_attachment_from_repr(
+    repr: &ColorBlendAttachmentRepr,
+) -> Result<ColorBlendAttachment> {
+    Ok(ColorBlendAttachment {
+        src_color_blend_factor: blend_factor_from_repr(repr.src_color_blend_factor)?,
+        dst_color_blend_factor: blend_factor_from_repr(repr.dst_color_blend_factor)?,
+        color_blend_op: blend_op_from_repr(repr.color_blend_op)?,
+        src_alpha_blend_factor: blend_factor_from_repr(repr.src_alpha_blend_factor)?,
+        dst_alpha_blend_factor: blend_factor_from_repr(repr.dst_alpha_blend_factor)?,
+        alpha_blend_op: blend_op_from_repr(repr.alpha_blend_op)?,
+        color_write_mask: color_write_mask_from_bits(repr.color_write_mask),
+    })
+}
+
+/// Reconstruct a `ColorWriteMask` from its `bits()` representation.
+///
+/// `ColorWriteMask`'s public surface exposes only the R/G/B/A/RGBA
+/// constants, so we rebuild the value by OR-ing the channels indicated
+/// by `bits`. Unknown bits beyond R|G|B|A are silently dropped.
+///
+/// The all-zero case (no channels written) is not expressible through
+/// the public API; we surface it as `ColorWriteMask::RGBA` because the
+/// in-tree producer never emits an all-zero mask and a non-degenerate
+/// fallback is safer than introducing a new public constant. The
+/// round-trip test exercises the four single-channel cases plus RGBA.
+fn color_write_mask_from_bits(bits: u32) -> ColorWriteMask {
+    let mut accumulator: Option<ColorWriteMask> = None;
+    let maybe_or = |accumulator: &mut Option<ColorWriteMask>, channel: ColorWriteMask| {
+        *accumulator = Some(match *accumulator {
+            Some(existing) => existing | channel,
+            None => channel,
+        });
+    };
+    if bits & ColorWriteMask::R.bits() != 0 {
+        maybe_or(&mut accumulator, ColorWriteMask::R);
+    }
+    if bits & ColorWriteMask::G.bits() != 0 {
+        maybe_or(&mut accumulator, ColorWriteMask::G);
+    }
+    if bits & ColorWriteMask::B.bits() != 0 {
+        maybe_or(&mut accumulator, ColorWriteMask::B);
+    }
+    if bits & ColorWriteMask::A.bits() != 0 {
+        maybe_or(&mut accumulator, ColorWriteMask::A);
+    }
+    accumulator.unwrap_or(ColorWriteMask::RGBA)
+}
+
+impl From<ColorBlendState> for ColorBlendStateRepr {
+    fn from(value: ColorBlendState) -> Self {
+        match value {
+            ColorBlendState::Disabled { color_write_mask } => Self {
+                kind: ColorBlendStateKindRepr::Disabled as u32,
+                color_write_mask: color_write_mask.bits(),
+                attachment: ColorBlendAttachmentRepr {
+                    src_color_blend_factor: 0,
+                    dst_color_blend_factor: 0,
+                    color_blend_op: 0,
+                    src_alpha_blend_factor: 0,
+                    dst_alpha_blend_factor: 0,
+                    alpha_blend_op: 0,
+                    color_write_mask: 0,
+                    _reserved_padding: 0,
+                },
+            },
+            ColorBlendState::Enabled(att) => Self {
+                kind: ColorBlendStateKindRepr::Enabled as u32,
+                color_write_mask: 0,
+                attachment: ColorBlendAttachmentRepr::from(att),
+            },
+        }
+    }
+}
+
+fn color_blend_state_from_repr(repr: &ColorBlendStateRepr) -> Result<ColorBlendState> {
+    match repr.kind {
+        x if x == ColorBlendStateKindRepr::Disabled as u32 => Ok(ColorBlendState::Disabled {
+            color_write_mask: color_write_mask_from_bits(repr.color_write_mask),
+        }),
+        x if x == ColorBlendStateKindRepr::Enabled as u32 => Ok(ColorBlendState::Enabled(
+            color_blend_attachment_from_repr(&repr.attachment)?,
+        )),
+        other => Err(Error::GpuError(format!(
+            "ColorBlendState: invalid kind {other}"
+        ))),
+    }
+}
+
+// =============================================================================
+// Ray-tracing kernel
+// =============================================================================
+
+impl From<RayTracingShaderStage> for RayTracingShaderStageRepr {
+    fn from(value: RayTracingShaderStage) -> Self {
+        match value {
+            RayTracingShaderStage::RayGen => Self::RayGen,
+            RayTracingShaderStage::Miss => Self::Miss,
+            RayTracingShaderStage::ClosestHit => Self::ClosestHit,
+            RayTracingShaderStage::AnyHit => Self::AnyHit,
+            RayTracingShaderStage::Intersection => Self::Intersection,
+            RayTracingShaderStage::Callable => Self::Callable,
+        }
+    }
+}
+
+fn ray_tracing_shader_stage_from_repr(raw: u32) -> Result<RayTracingShaderStage> {
+    match raw {
+        0 => Ok(RayTracingShaderStage::RayGen),
+        1 => Ok(RayTracingShaderStage::Miss),
+        2 => Ok(RayTracingShaderStage::ClosestHit),
+        3 => Ok(RayTracingShaderStage::AnyHit),
+        4 => Ok(RayTracingShaderStage::Intersection),
+        5 => Ok(RayTracingShaderStage::Callable),
+        other => Err(Error::GpuError(format!(
+            "RayTracingShaderStage: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<RayTracingBindingKind> for RayTracingBindingKindRepr {
+    fn from(value: RayTracingBindingKind) -> Self {
+        match value {
+            RayTracingBindingKind::StorageBuffer => Self::StorageBuffer,
+            RayTracingBindingKind::UniformBuffer => Self::UniformBuffer,
+            RayTracingBindingKind::SampledTexture => Self::SampledTexture,
+            RayTracingBindingKind::StorageImage => Self::StorageImage,
+            RayTracingBindingKind::AccelerationStructure => Self::AccelerationStructure,
+        }
+    }
+}
+
+fn ray_tracing_binding_kind_from_repr(raw: u32) -> Result<RayTracingBindingKind> {
+    match raw {
+        0 => Ok(RayTracingBindingKind::StorageBuffer),
+        1 => Ok(RayTracingBindingKind::UniformBuffer),
+        2 => Ok(RayTracingBindingKind::SampledTexture),
+        3 => Ok(RayTracingBindingKind::StorageImage),
+        4 => Ok(RayTracingBindingKind::AccelerationStructure),
+        other => Err(Error::GpuError(format!(
+            "RayTracingBindingKind: invalid discriminant {other}"
+        ))),
+    }
+}
+
+impl From<&RayTracingBindingSpec> for RayTracingBindingSpecRepr {
+    fn from(value: &RayTracingBindingSpec) -> Self {
+        Self {
+            binding: value.binding,
+            kind: RayTracingBindingKindRepr::from(value.kind) as u32,
+            stages: value.stages.bits(),
+            _reserved_padding: 0,
+        }
+    }
+}
+
+fn ray_tracing_binding_spec_from_repr(
+    repr: &RayTracingBindingSpecRepr,
+) -> Result<RayTracingBindingSpec> {
+    Ok(RayTracingBindingSpec {
+        binding: repr.binding,
+        kind: ray_tracing_binding_kind_from_repr(repr.kind)?,
+        stages: ray_tracing_shader_stage_flags_from_bits(repr.stages),
+    })
+}
+
+fn ray_tracing_shader_stage_flags_from_bits(bits: u32) -> RayTracingShaderStageFlags {
+    let mut out = RayTracingShaderStageFlags::NONE;
+    if bits & RayTracingShaderStageFlags::RAYGEN.bits() != 0 {
+        out |= RayTracingShaderStageFlags::RAYGEN;
+    }
+    if bits & RayTracingShaderStageFlags::MISS.bits() != 0 {
+        out |= RayTracingShaderStageFlags::MISS;
+    }
+    if bits & RayTracingShaderStageFlags::CLOSEST_HIT.bits() != 0 {
+        out |= RayTracingShaderStageFlags::CLOSEST_HIT;
+    }
+    if bits & RayTracingShaderStageFlags::ANY_HIT.bits() != 0 {
+        out |= RayTracingShaderStageFlags::ANY_HIT;
+    }
+    if bits & RayTracingShaderStageFlags::INTERSECTION.bits() != 0 {
+        out |= RayTracingShaderStageFlags::INTERSECTION;
+    }
+    if bits & RayTracingShaderStageFlags::CALLABLE.bits() != 0 {
+        out |= RayTracingShaderStageFlags::CALLABLE;
+    }
+    out
+}
+
+impl From<RayTracingPushConstants> for RayTracingPushConstantsRepr {
+    fn from(value: RayTracingPushConstants) -> Self {
+        Self {
+            size: value.size,
+            stages: value.stages.bits(),
+        }
+    }
+}
+
+fn ray_tracing_push_constants_from_repr(
+    repr: &RayTracingPushConstantsRepr,
+) -> RayTracingPushConstants {
+    RayTracingPushConstants {
+        size: repr.size,
+        stages: ray_tracing_shader_stage_flags_from_bits(repr.stages),
+    }
+}
+
+impl From<RayTracingShaderGroup> for RayTracingShaderGroupRepr {
+    fn from(value: RayTracingShaderGroup) -> Self {
+        match value {
+            RayTracingShaderGroup::General { general } => Self {
+                kind: RayTracingShaderGroupKindRepr::General as u32,
+                general_or_intersection: general,
+                closest_hit: RAY_TRACING_SHADER_UNUSED,
+                any_hit: RAY_TRACING_SHADER_UNUSED,
+            },
+            RayTracingShaderGroup::TrianglesHit {
+                closest_hit,
+                any_hit,
+            } => Self {
+                kind: RayTracingShaderGroupKindRepr::TrianglesHit as u32,
+                general_or_intersection: RAY_TRACING_SHADER_UNUSED,
+                closest_hit: closest_hit.unwrap_or(RAY_TRACING_SHADER_UNUSED),
+                any_hit: any_hit.unwrap_or(RAY_TRACING_SHADER_UNUSED),
+            },
+            RayTracingShaderGroup::ProceduralHit {
+                intersection,
+                closest_hit,
+                any_hit,
+            } => Self {
+                kind: RayTracingShaderGroupKindRepr::ProceduralHit as u32,
+                general_or_intersection: intersection,
+                closest_hit: closest_hit.unwrap_or(RAY_TRACING_SHADER_UNUSED),
+                any_hit: any_hit.unwrap_or(RAY_TRACING_SHADER_UNUSED),
+            },
+        }
+    }
+}
+
+fn ray_tracing_shader_group_from_repr(
+    repr: &RayTracingShaderGroupRepr,
+) -> Result<RayTracingShaderGroup> {
+    let optionalize = |v: u32| -> Option<u32> {
+        if v == RAY_TRACING_SHADER_UNUSED {
+            None
+        } else {
+            Some(v)
+        }
+    };
+    match repr.kind {
+        x if x == RayTracingShaderGroupKindRepr::General as u32 => {
+            Ok(RayTracingShaderGroup::General {
+                general: repr.general_or_intersection,
+            })
+        }
+        x if x == RayTracingShaderGroupKindRepr::TrianglesHit as u32 => {
+            Ok(RayTracingShaderGroup::TrianglesHit {
+                closest_hit: optionalize(repr.closest_hit),
+                any_hit: optionalize(repr.any_hit),
+            })
+        }
+        x if x == RayTracingShaderGroupKindRepr::ProceduralHit as u32 => {
+            Ok(RayTracingShaderGroup::ProceduralHit {
+                intersection: repr.general_or_intersection,
+                closest_hit: optionalize(repr.closest_hit),
+                any_hit: optionalize(repr.any_hit),
+            })
+        }
+        other => Err(Error::GpuError(format!(
+            "RayTracingShaderGroup: invalid kind {other}"
+        ))),
+    }
+}
+
+// =============================================================================
+// Pointer/slice helpers
+// =============================================================================
+
+/// Materialize a `&[T]` from a raw `(ptr, len)` pair. Null pointer or
+/// zero length yields an empty slice.
+///
+/// # Safety
+///
+/// If `len > 0` the pointer must be valid for reads of `len` elements
+/// and properly aligned. Returned slice borrows from caller-managed
+/// memory; the caller must ensure it outlives the returned slice.
+unsafe fn slice_from_ptr_len<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+    if ptr.is_null() || len == 0 {
+        return &[];
+    }
+    // SAFETY: caller-supplied contract.
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+/// Materialize a `&str` from a raw `(ptr, len)` pair, validating UTF-8.
+///
+/// # Safety
+///
+/// If `len > 0` the pointer must be valid for reads of `len` bytes.
+/// Returned `&str` borrows from caller-managed memory.
+unsafe fn str_from_ptr_len<'a>(
+    ptr: *const u8,
+    len: usize,
+    field_name: &str,
+) -> Result<&'a str> {
+    let bytes = unsafe { slice_from_ptr_len::<u8>(ptr, len) };
+    std::str::from_utf8(bytes).map_err(|e| {
+        Error::GpuError(format!("{field_name}: invalid UTF-8: {e}"))
+    })
+}
+
+// =============================================================================
+// Round-trip API for full kernel descriptors
+// =============================================================================
+
+/// Owned backing buffers behind a `GraphicsKernelDescriptorRepr`.
+///
+/// Caller stages a descriptor + this buffer; the repr borrows into
+/// the buffer's storage. Caller must keep the buffer alive for the
+/// repr's lifetime.
+#[allow(dead_code)]
+pub struct GraphicsKernelDescriptorReprStage {
+    pub stages_buf: Vec<GraphicsStageRepr>,
+    pub bindings_buf: Vec<GraphicsBindingSpecRepr>,
+    pub vertex_bindings_buf: Vec<VertexInputBindingRepr>,
+    pub vertex_attrs_buf: Vec<VertexInputAttributeRepr>,
+    pub color_formats_buf: Vec<u32>,
+}
+
+/// Stage a `GraphicsKernelDescriptor` into its repr + backing buffers.
+#[allow(dead_code)]
+pub fn stage_graphics_kernel_descriptor(
+    desc: &GraphicsKernelDescriptor<'_>,
+) -> (GraphicsKernelDescriptorRepr, GraphicsKernelDescriptorReprStage) {
+    let stages_buf: Vec<GraphicsStageRepr> = desc
+        .stages
+        .iter()
+        .map(|s| GraphicsStageRepr {
+            stage: GraphicsShaderStageRepr::from(s.stage) as u32,
+            _reserved_padding: 0,
+            spv_ptr: s.spv.as_ptr(),
+            spv_len: s.spv.len(),
+            entry_point_ptr: s.entry_point.as_ptr(),
+            entry_point_len: s.entry_point.len(),
+        })
+        .collect();
+    let bindings_buf: Vec<GraphicsBindingSpecRepr> =
+        desc.bindings.iter().map(GraphicsBindingSpecRepr::from).collect();
+
+    let (vertex_input_repr, vertex_bindings_buf, vertex_attrs_buf) = match &desc
+        .pipeline_state
+        .vertex_input
+    {
+        VertexInputState::None => (
+            VertexInputStateRepr {
+                kind: VertexInputStateKindRepr::None as u32,
+                _reserved_padding: 0,
+                bindings_ptr: std::ptr::null(),
+                bindings_len: 0,
+                attributes_ptr: std::ptr::null(),
+                attributes_len: 0,
+            },
+            Vec::new(),
+            Vec::new(),
+        ),
+        VertexInputState::Buffers {
+            bindings,
+            attributes,
+        } => {
+            let b: Vec<VertexInputBindingRepr> =
+                bindings.iter().map(VertexInputBindingRepr::from).collect();
+            let a: Vec<VertexInputAttributeRepr> =
+                attributes.iter().map(VertexInputAttributeRepr::from).collect();
+            let repr = VertexInputStateRepr {
+                kind: VertexInputStateKindRepr::Buffers as u32,
+                _reserved_padding: 0,
+                bindings_ptr: b.as_ptr(),
+                bindings_len: b.len(),
+                attributes_ptr: a.as_ptr(),
+                attributes_len: a.len(),
+            };
+            (repr, b, a)
+        }
+    };
+
+    let color_formats_buf: Vec<u32> = desc
+        .pipeline_state
+        .attachment_formats
+        .color
+        .iter()
+        .map(|f| *f as u32)
+        .collect();
+    let attachment_formats_repr = AttachmentFormatsRepr {
+        color_ptr: color_formats_buf.as_ptr(),
+        color_len: color_formats_buf.len(),
+        has_depth: if desc.pipeline_state.attachment_formats.depth.is_some() {
+            1
+        } else {
+            0
+        },
+        depth: desc
+            .pipeline_state
+            .attachment_formats
+            .depth
+            .map(|d| DepthFormatRepr::from(d) as u32)
+            .unwrap_or(0),
+    };
+
+    let pipeline_state = GraphicsPipelineStateRepr {
+        topology: PrimitiveTopologyRepr::from(desc.pipeline_state.topology) as u32,
+        _reserved_padding1: 0,
+        vertex_input: vertex_input_repr,
+        rasterization: RasterizationStateRepr::from(desc.pipeline_state.rasterization),
+        multisample: MultisampleStateRepr::from(desc.pipeline_state.multisample),
+        depth_stencil: DepthStencilStateRepr::from(desc.pipeline_state.depth_stencil),
+        color_blend: ColorBlendStateRepr::from(desc.pipeline_state.color_blend),
+        attachment_formats: attachment_formats_repr,
+        dynamic_state: GraphicsDynamicStateRepr::from(desc.pipeline_state.dynamic_state) as u32,
+        _reserved_padding2: 0,
+    };
+
+    let repr = GraphicsKernelDescriptorRepr {
+        label_ptr: desc.label.as_ptr(),
+        label_len: desc.label.len(),
+        stages_ptr: stages_buf.as_ptr(),
+        stages_len: stages_buf.len(),
+        bindings_ptr: bindings_buf.as_ptr(),
+        bindings_len: bindings_buf.len(),
+        push_constants: GraphicsPushConstantsRepr::from(desc.push_constants),
+        pipeline_state,
+        descriptor_sets_in_flight: desc.descriptor_sets_in_flight,
+        _reserved_padding: 0,
+    };
+
+    let stage = GraphicsKernelDescriptorReprStage {
+        stages_buf,
+        bindings_buf,
+        vertex_bindings_buf,
+        vertex_attrs_buf,
+        color_formats_buf,
+    };
+    (repr, stage)
+}
+
+/// Owned backing buffers behind a decoded `GraphicsKernelDescriptor`.
+#[allow(dead_code)]
+pub struct GraphicsKernelDescriptorDecoded<'a> {
+    pub stages: Vec<GraphicsStage<'a>>,
+    pub bindings: Vec<GraphicsBindingSpec>,
+    pub vertex_input: VertexInputState,
+    pub color_formats: Vec<TextureFormat>,
+}
+
+/// Decode a `GraphicsKernelDescriptorRepr` back into a Rust descriptor.
+///
+/// # Safety
+///
+/// All pointer/length pairs in `repr` (and inside its nested
+/// `vertex_input` and `attachment_formats`) must be valid for reads.
+/// The returned descriptor borrows from caller-managed memory.
+#[allow(clippy::type_complexity)]
+pub unsafe fn graphics_kernel_descriptor_from_repr<'a>(
+    repr: &'a GraphicsKernelDescriptorRepr,
+) -> Result<(GraphicsKernelDescriptor<'a>, GraphicsKernelDescriptorDecoded<'a>)> {
+    let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
+    let stages_repr =
+        unsafe { slice_from_ptr_len::<GraphicsStageRepr>(repr.stages_ptr, repr.stages_len) };
+    let stages: Vec<GraphicsStage<'a>> = stages_repr
+        .iter()
+        .map(|s| {
+            let stage = graphics_shader_stage_from_repr(s.stage)?;
+            let spv: &'a [u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
+            let entry_point =
+                unsafe { str_from_ptr_len(s.entry_point_ptr, s.entry_point_len, "entry_point")? };
+            Ok::<_, Error>(GraphicsStage {
+                stage,
+                spv,
+                entry_point,
+            })
+        })
+        .collect::<Result<_>>()?;
+
+    let bindings_repr = unsafe {
+        slice_from_ptr_len::<GraphicsBindingSpecRepr>(repr.bindings_ptr, repr.bindings_len)
+    };
+    let bindings: Vec<GraphicsBindingSpec> = bindings_repr
+        .iter()
+        .map(graphics_binding_spec_from_repr)
+        .collect::<Result<_>>()?;
+
+    let push_constants = graphics_push_constants_from_repr(&repr.push_constants);
+
+    let vertex_input = match repr.pipeline_state.vertex_input.kind {
+        x if x == VertexInputStateKindRepr::None as u32 => VertexInputState::None,
+        x if x == VertexInputStateKindRepr::Buffers as u32 => {
+            let bindings_ptr = repr.pipeline_state.vertex_input.bindings_ptr;
+            let bindings_len = repr.pipeline_state.vertex_input.bindings_len;
+            let attrs_ptr = repr.pipeline_state.vertex_input.attributes_ptr;
+            let attrs_len = repr.pipeline_state.vertex_input.attributes_len;
+            let b_repr =
+                unsafe { slice_from_ptr_len::<VertexInputBindingRepr>(bindings_ptr, bindings_len) };
+            let a_repr = unsafe {
+                slice_from_ptr_len::<VertexInputAttributeRepr>(attrs_ptr, attrs_len)
+            };
+            let b: Vec<VertexInputBinding> = b_repr
+                .iter()
+                .map(vertex_input_binding_from_repr)
+                .collect::<Result<_>>()?;
+            let a: Vec<VertexInputAttribute> = a_repr
+                .iter()
+                .map(vertex_input_attribute_from_repr)
+                .collect::<Result<_>>()?;
+            VertexInputState::Buffers {
+                bindings: b,
+                attributes: a,
+            }
+        }
+        other => {
+            return Err(Error::GpuError(format!(
+                "VertexInputState: invalid kind {other}"
+            )));
+        }
+    };
+
+    let color_formats_raw = unsafe {
+        slice_from_ptr_len::<u32>(
+            repr.pipeline_state.attachment_formats.color_ptr,
+            repr.pipeline_state.attachment_formats.color_len,
+        )
+    };
+    let color_formats: Vec<TextureFormat> = color_formats_raw
+        .iter()
+        .copied()
+        .map(texture_format_from_repr)
+        .collect::<Result<_>>()?;
+    let depth = if repr.pipeline_state.attachment_formats.has_depth == 0 {
+        None
+    } else {
+        Some(depth_format_from_repr(
+            repr.pipeline_state.attachment_formats.depth,
+        )?)
+    };
+
+    let pipeline_state = GraphicsPipelineState {
+        topology: primitive_topology_from_repr(repr.pipeline_state.topology)?,
+        vertex_input: vertex_input.clone(),
+        rasterization: rasterization_state_from_repr(&repr.pipeline_state.rasterization)?,
+        multisample: multisample_state_from_repr(&repr.pipeline_state.multisample),
+        depth_stencil: depth_stencil_state_from_repr(&repr.pipeline_state.depth_stencil)?,
+        color_blend: color_blend_state_from_repr(&repr.pipeline_state.color_blend)?,
+        attachment_formats: AttachmentFormats {
+            color: color_formats.clone(),
+            depth,
+        },
+        dynamic_state: graphics_dynamic_state_from_repr(repr.pipeline_state.dynamic_state)?,
+    };
+
+    let decoded = GraphicsKernelDescriptorDecoded {
+        stages: stages.clone(),
+        bindings: bindings.clone(),
+        vertex_input,
+        color_formats,
+    };
+
+    let stages_slice: &'a [GraphicsStage<'a>] = unsafe {
+        std::slice::from_raw_parts(decoded.stages.as_ptr(), decoded.stages.len())
+    };
+    let bindings_slice: &'a [GraphicsBindingSpec] = unsafe {
+        std::slice::from_raw_parts(decoded.bindings.as_ptr(), decoded.bindings.len())
+    };
+
+    Ok((
+        GraphicsKernelDescriptor {
+            label,
+            stages: stages_slice,
+            bindings: bindings_slice,
+            push_constants,
+            pipeline_state,
+            descriptor_sets_in_flight: repr.descriptor_sets_in_flight,
+        },
+        decoded,
+    ))
+}
+
+/// Owned backing buffers behind a `RayTracingKernelDescriptorRepr`.
+#[allow(dead_code)]
+pub struct RayTracingKernelDescriptorReprStage {
+    pub stages_buf: Vec<RayTracingStageRepr>,
+    pub groups_buf: Vec<RayTracingShaderGroupRepr>,
+    pub bindings_buf: Vec<RayTracingBindingSpecRepr>,
+}
+
+/// Stage a `RayTracingKernelDescriptor` into its repr + backing buffers.
+#[allow(dead_code)]
+pub fn stage_ray_tracing_kernel_descriptor(
+    desc: &RayTracingKernelDescriptor<'_>,
+) -> (
+    RayTracingKernelDescriptorRepr,
+    RayTracingKernelDescriptorReprStage,
+) {
+    let stages_buf: Vec<RayTracingStageRepr> = desc
+        .stages
+        .iter()
+        .map(|s| RayTracingStageRepr {
+            stage: RayTracingShaderStageRepr::from(s.stage) as u32,
+            _reserved_padding: 0,
+            spv_ptr: s.spv.as_ptr(),
+            spv_len: s.spv.len(),
+            entry_point_ptr: s.entry_point.as_ptr(),
+            entry_point_len: s.entry_point.len(),
+        })
+        .collect();
+    let groups_buf: Vec<RayTracingShaderGroupRepr> =
+        desc.groups.iter().copied().map(RayTracingShaderGroupRepr::from).collect();
+    let bindings_buf: Vec<RayTracingBindingSpecRepr> = desc
+        .bindings
+        .iter()
+        .map(RayTracingBindingSpecRepr::from)
+        .collect();
+
+    let repr = RayTracingKernelDescriptorRepr {
+        label_ptr: desc.label.as_ptr(),
+        label_len: desc.label.len(),
+        stages_ptr: stages_buf.as_ptr(),
+        stages_len: stages_buf.len(),
+        groups_ptr: groups_buf.as_ptr(),
+        groups_len: groups_buf.len(),
+        bindings_ptr: bindings_buf.as_ptr(),
+        bindings_len: bindings_buf.len(),
+        push_constants: RayTracingPushConstantsRepr::from(desc.push_constants),
+        max_recursion_depth: desc.max_recursion_depth,
+        _reserved_padding: 0,
+    };
+
+    let stage = RayTracingKernelDescriptorReprStage {
+        stages_buf,
+        groups_buf,
+        bindings_buf,
+    };
+    (repr, stage)
+}
+
+/// Owned backing buffers behind a decoded `RayTracingKernelDescriptor`.
+#[allow(dead_code)]
+pub struct RayTracingKernelDescriptorDecoded<'a> {
+    pub stages: Vec<RayTracingStage<'a>>,
+    pub groups: Vec<RayTracingShaderGroup>,
+    pub bindings: Vec<RayTracingBindingSpec>,
+}
+
+/// Decode a `RayTracingKernelDescriptorRepr` back into a Rust descriptor.
+///
+/// # Safety
+///
+/// All pointer/length pairs in `repr` must be valid for reads.
+#[allow(clippy::type_complexity)]
+pub unsafe fn ray_tracing_kernel_descriptor_from_repr<'a>(
+    repr: &'a RayTracingKernelDescriptorRepr,
+) -> Result<(RayTracingKernelDescriptor<'a>, RayTracingKernelDescriptorDecoded<'a>)> {
+    let label = unsafe { str_from_ptr_len(repr.label_ptr, repr.label_len, "label")? };
+    let stages_repr = unsafe {
+        slice_from_ptr_len::<RayTracingStageRepr>(repr.stages_ptr, repr.stages_len)
+    };
+    let stages: Vec<RayTracingStage<'a>> = stages_repr
+        .iter()
+        .map(|s| {
+            let stage = ray_tracing_shader_stage_from_repr(s.stage)?;
+            let spv: &'a [u8] = unsafe { slice_from_ptr_len(s.spv_ptr, s.spv_len) };
+            let entry_point =
+                unsafe { str_from_ptr_len(s.entry_point_ptr, s.entry_point_len, "entry_point")? };
+            Ok::<_, Error>(RayTracingStage {
+                stage,
+                spv,
+                entry_point,
+            })
+        })
+        .collect::<Result<_>>()?;
+
+    let groups_repr = unsafe {
+        slice_from_ptr_len::<RayTracingShaderGroupRepr>(repr.groups_ptr, repr.groups_len)
+    };
+    let groups: Vec<RayTracingShaderGroup> = groups_repr
+        .iter()
+        .map(ray_tracing_shader_group_from_repr)
+        .collect::<Result<_>>()?;
+
+    let bindings_repr = unsafe {
+        slice_from_ptr_len::<RayTracingBindingSpecRepr>(repr.bindings_ptr, repr.bindings_len)
+    };
+    let bindings: Vec<RayTracingBindingSpec> = bindings_repr
+        .iter()
+        .map(ray_tracing_binding_spec_from_repr)
+        .collect::<Result<_>>()?;
+
+    let push_constants = ray_tracing_push_constants_from_repr(&repr.push_constants);
+
+    let decoded = RayTracingKernelDescriptorDecoded {
+        stages: stages.clone(),
+        groups: groups.clone(),
+        bindings: bindings.clone(),
+    };
+    let stages_slice: &'a [RayTracingStage<'a>] = unsafe {
+        std::slice::from_raw_parts(decoded.stages.as_ptr(), decoded.stages.len())
+    };
+    let groups_slice: &'a [RayTracingShaderGroup] = unsafe {
+        std::slice::from_raw_parts(decoded.groups.as_ptr(), decoded.groups.len())
+    };
+    let bindings_slice: &'a [RayTracingBindingSpec] = unsafe {
+        std::slice::from_raw_parts(decoded.bindings.as_ptr(), decoded.bindings.len())
+    };
+
+    Ok((
+        RayTracingKernelDescriptor {
+            label,
+            stages: stages_slice,
+            groups: groups_slice,
+            bindings: bindings_slice,
+            push_constants,
+            max_recursion_depth: repr.max_recursion_depth,
+        },
+        decoded,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_descriptor_roundtrip() {
+        let spv: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF, 0x42, 0x00];
+        let bindings = [
+            ComputeBindingSpec::storage_buffer(0),
+            ComputeBindingSpec::uniform_buffer(1),
+            ComputeBindingSpec::sampled_texture(2),
+            ComputeBindingSpec::storage_image(3),
+        ];
+        let desc = ComputeKernelDescriptor {
+            label: "test_compute",
+            spv,
+            bindings: &bindings,
+            push_constant_size: 16,
+        };
+        let (repr, _buf) = stage_compute_kernel_descriptor(&desc);
+        let (decoded, _bindings_keepalive) =
+            unsafe { compute_kernel_descriptor_from_repr(&repr).expect("decode") };
+        assert_eq!(decoded.label, "test_compute");
+        assert_eq!(decoded.spv, spv);
+        assert_eq!(decoded.bindings.len(), 4);
+        assert_eq!(
+            decoded.bindings[0].kind,
+            ComputeBindingKind::StorageBuffer
+        );
+        assert_eq!(
+            decoded.bindings[1].kind,
+            ComputeBindingKind::UniformBuffer
+        );
+        assert_eq!(
+            decoded.bindings[2].kind,
+            ComputeBindingKind::SampledTexture
+        );
+        assert_eq!(
+            decoded.bindings[3].kind,
+            ComputeBindingKind::StorageImage
+        );
+        assert_eq!(decoded.push_constant_size, 16);
+    }
+
+    #[test]
+    fn compute_descriptor_rejects_invalid_kind() {
+        let spv: &[u8] = &[0; 4];
+        let bad_repr = ComputeBindingSpecRepr {
+            binding: 0,
+            kind: 99,
+        };
+        let bindings_ptr = &bad_repr as *const ComputeBindingSpecRepr;
+        let repr = ComputeKernelDescriptorRepr {
+            label_ptr: "x".as_ptr(),
+            label_len: 1,
+            spv_ptr: spv.as_ptr(),
+            spv_len: spv.len(),
+            bindings_ptr,
+            bindings_len: 1,
+            push_constant_size: 0,
+            _reserved_padding: 0,
+        };
+        let err = unsafe { compute_kernel_descriptor_from_repr(&repr).unwrap_err() };
+        assert!(format!("{err}").contains("invalid discriminant 99"));
+    }
+
+    #[test]
+    fn graphics_descriptor_roundtrip_minimal() {
+        let vs_spv: &[u8] = &[0xDE, 0xAD];
+        let fs_spv: &[u8] = &[0xBE, 0xEF];
+        let stages = [GraphicsStage::vertex(vs_spv), GraphicsStage::fragment(fs_spv)];
+        let bindings = [
+            GraphicsBindingSpec::sampled_texture(0, GraphicsShaderStageFlags::FRAGMENT),
+            GraphicsBindingSpec::uniform_buffer(1, GraphicsShaderStageFlags::VERTEX_FRAGMENT),
+        ];
+        let desc = GraphicsKernelDescriptor {
+            label: "test_graphics",
+            stages: &stages,
+            bindings: &bindings,
+            push_constants: GraphicsPushConstants {
+                size: 12,
+                stages: GraphicsShaderStageFlags::VERTEX,
+            },
+            pipeline_state: GraphicsPipelineState {
+                topology: PrimitiveTopology::TriangleStrip,
+                vertex_input: VertexInputState::None,
+                rasterization: RasterizationState::default(),
+                multisample: MultisampleState::default(),
+                depth_stencil: DepthStencilState::Disabled,
+                color_blend: ColorBlendState::Enabled(ColorBlendAttachment::ALPHA_OVER),
+                attachment_formats: AttachmentFormats::color_only(TextureFormat::Bgra8Unorm),
+                dynamic_state: GraphicsDynamicState::ViewportScissor,
+            },
+            descriptor_sets_in_flight: 2,
+        };
+        let (repr, _stage) = stage_graphics_kernel_descriptor(&desc);
+        let (decoded, _keep) =
+            unsafe { graphics_kernel_descriptor_from_repr(&repr).expect("decode") };
+        assert_eq!(decoded.label, "test_graphics");
+        assert_eq!(decoded.stages.len(), 2);
+        assert_eq!(decoded.stages[0].stage, GraphicsShaderStage::Vertex);
+        assert_eq!(decoded.stages[1].stage, GraphicsShaderStage::Fragment);
+        assert_eq!(decoded.bindings.len(), 2);
+        assert_eq!(decoded.push_constants.size, 12);
+        assert_eq!(
+            decoded.pipeline_state.topology,
+            PrimitiveTopology::TriangleStrip
+        );
+        assert!(matches!(
+            decoded.pipeline_state.vertex_input,
+            VertexInputState::None
+        ));
+        assert!(matches!(
+            decoded.pipeline_state.color_blend,
+            ColorBlendState::Enabled(_)
+        ));
+        assert_eq!(decoded.descriptor_sets_in_flight, 2);
+    }
+
+    #[test]
+    fn graphics_descriptor_roundtrip_with_vertex_input_buffers() {
+        let vs_spv: &[u8] = &[0; 4];
+        let fs_spv: &[u8] = &[0; 4];
+        let stages = [GraphicsStage::vertex(vs_spv), GraphicsStage::fragment(fs_spv)];
+        let vertex_bindings = vec![VertexInputBinding {
+            binding: 0,
+            stride: 32,
+            input_rate: VertexInputRate::Vertex,
+        }];
+        let vertex_attrs = vec![
+            VertexInputAttribute {
+                location: 0,
+                binding: 0,
+                format: VertexAttributeFormat::Rgb32Float,
+                offset: 0,
+            },
+            VertexInputAttribute {
+                location: 1,
+                binding: 0,
+                format: VertexAttributeFormat::Rgba32Float,
+                offset: 12,
+            },
+        ];
+        let desc = GraphicsKernelDescriptor {
+            label: "vi",
+            stages: &stages,
+            bindings: &[],
+            push_constants: GraphicsPushConstants::NONE,
+            pipeline_state: GraphicsPipelineState {
+                topology: PrimitiveTopology::TriangleList,
+                vertex_input: VertexInputState::Buffers {
+                    bindings: vertex_bindings.clone(),
+                    attributes: vertex_attrs.clone(),
+                },
+                rasterization: RasterizationState::default(),
+                multisample: MultisampleState::default(),
+                depth_stencil: DepthStencilState::Enabled {
+                    depth_test: DepthCompareOp::LessOrEqual,
+                    depth_write: true,
+                },
+                color_blend: ColorBlendState::default(),
+                attachment_formats: AttachmentFormats {
+                    color: vec![TextureFormat::Rgba8UnormSrgb],
+                    depth: Some(DepthFormat::D32Sfloat),
+                },
+                dynamic_state: GraphicsDynamicState::ViewportScissor,
+            },
+            descriptor_sets_in_flight: 3,
+        };
+        let (repr, _stage) = stage_graphics_kernel_descriptor(&desc);
+        let (decoded, _keep) =
+            unsafe { graphics_kernel_descriptor_from_repr(&repr).expect("decode") };
+        match decoded.pipeline_state.vertex_input {
+            VertexInputState::Buffers {
+                bindings,
+                attributes,
+            } => {
+                assert_eq!(bindings.len(), 1);
+                assert_eq!(bindings[0].stride, 32);
+                assert_eq!(attributes.len(), 2);
+                assert_eq!(attributes[1].offset, 12);
+                assert_eq!(
+                    attributes[1].format,
+                    VertexAttributeFormat::Rgba32Float
+                );
+            }
+            _ => panic!("expected Buffers"),
+        }
+        assert!(matches!(
+            decoded.pipeline_state.depth_stencil,
+            DepthStencilState::Enabled {
+                depth_test: DepthCompareOp::LessOrEqual,
+                depth_write: true,
+            }
+        ));
+        assert_eq!(
+            decoded.pipeline_state.attachment_formats.depth,
+            Some(DepthFormat::D32Sfloat)
+        );
+    }
+
+    #[test]
+    fn ray_tracing_descriptor_roundtrip() {
+        let raygen_spv: &[u8] = &[0xAA];
+        let miss_spv: &[u8] = &[0xBB];
+        let closest_spv: &[u8] = &[0xCC];
+        let stages = [
+            RayTracingStage::ray_gen(raygen_spv),
+            RayTracingStage::miss(miss_spv),
+            RayTracingStage::closest_hit(closest_spv),
+        ];
+        let groups = [
+            RayTracingShaderGroup::General { general: 0 },
+            RayTracingShaderGroup::General { general: 1 },
+            RayTracingShaderGroup::TrianglesHit {
+                closest_hit: Some(2),
+                any_hit: None,
+            },
+        ];
+        let bindings = [
+            RayTracingBindingSpec::storage_buffer(0, RayTracingShaderStageFlags::RAYGEN),
+            RayTracingBindingSpec::acceleration_structure(
+                1,
+                RayTracingShaderStageFlags::RAYGEN | RayTracingShaderStageFlags::CLOSEST_HIT,
+            ),
+        ];
+        let desc = RayTracingKernelDescriptor {
+            label: "test_rt",
+            stages: &stages,
+            groups: &groups,
+            bindings: &bindings,
+            push_constants: RayTracingPushConstants {
+                size: 8,
+                stages: RayTracingShaderStageFlags::RAYGEN,
+            },
+            max_recursion_depth: 4,
+        };
+        let (repr, _stage) = stage_ray_tracing_kernel_descriptor(&desc);
+        let (decoded, _keep) =
+            unsafe { ray_tracing_kernel_descriptor_from_repr(&repr).expect("decode") };
+        assert_eq!(decoded.label, "test_rt");
+        assert_eq!(decoded.stages.len(), 3);
+        assert_eq!(decoded.groups.len(), 3);
+        match decoded.groups[2] {
+            RayTracingShaderGroup::TrianglesHit {
+                closest_hit,
+                any_hit,
+            } => {
+                assert_eq!(closest_hit, Some(2));
+                assert_eq!(any_hit, None);
+            }
+            _ => panic!("expected TrianglesHit"),
+        }
+        assert_eq!(decoded.bindings.len(), 2);
+        assert_eq!(
+            decoded.bindings[1].kind,
+            RayTracingBindingKind::AccelerationStructure
+        );
+        assert_eq!(decoded.push_constants.size, 8);
+        assert_eq!(decoded.max_recursion_depth, 4);
+    }
+
+    #[test]
+    fn ray_tracing_shader_group_unused_sentinel() {
+        // Stage TrianglesHit with both closest/any_hit absent (None).
+        let group = RayTracingShaderGroup::TrianglesHit {
+            closest_hit: None,
+            any_hit: None,
+        };
+        let repr = RayTracingShaderGroupRepr::from(group);
+        assert_eq!(repr.kind, RayTracingShaderGroupKindRepr::TrianglesHit as u32);
+        assert_eq!(repr.closest_hit, RAY_TRACING_SHADER_UNUSED);
+        assert_eq!(repr.any_hit, RAY_TRACING_SHADER_UNUSED);
+        // Round-trip back to None.
+        let back = ray_tracing_shader_group_from_repr(&repr).expect("decode");
+        match back {
+            RayTracingShaderGroup::TrianglesHit {
+                closest_hit,
+                any_hit,
+            } => {
+                assert_eq!(closest_hit, None);
+                assert_eq!(any_hit, None);
+            }
+            _ => panic!("expected TrianglesHit"),
+        }
+    }
+
+    #[test]
+    fn ray_tracing_descriptor_rejects_invalid_group_kind() {
+        let bad_repr = RayTracingShaderGroupRepr {
+            kind: 99,
+            general_or_intersection: 0,
+            closest_hit: RAY_TRACING_SHADER_UNUSED,
+            any_hit: RAY_TRACING_SHADER_UNUSED,
+        };
+        let err = ray_tracing_shader_group_from_repr(&bad_repr).unwrap_err();
+        assert!(format!("{err}").contains("invalid kind 99"));
+    }
+}

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -104,7 +104,16 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   vtable pointer from this field. Non-null for hosts that ship
 ///   a `SurfaceStore`; null otherwise (cdylib code must check
 ///   before dispatching).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 5;
+/// - v6: [`GpuContextFullAccessVTable`] reference appended. The
+///   cdylib-side `GpuContextFullAccess` shim's `(handle, vtable)`
+///   pair sources its vtable pointer from this field. Non-null for
+///   hosts that ship a GpuContext; null otherwise (cdylib code must
+///   check before dispatching). Reachable from cdylib code only
+///   inside an `escalate(|full| ...)` scope (the scope-token
+///   machinery lands in C3 — Phase C2 ships the vtable layout +
+///   host wiring + cdylib β-shape, locking the wire format before
+///   the scope machinery turns it on).
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 6;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -154,6 +163,23 @@ pub const SURFACE_STORE_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// pool slot. Linux-only callbacks ship platform stubs on other
 /// triples so the vtable layout stays unconditional.
 pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 9;
+
+/// Layout version of [`GpuContextFullAccessVTable`].
+///
+/// The FullAccess vtable carries the privileged kernel-construction
+/// surface (compute / graphics / ray-tracing) plus `create_texture_ring`.
+/// Each kernel-construction callback consumes a `#[repr(C)]` descriptor
+/// mirror ([`ComputeKernelDescriptorRepr`], [`GraphicsKernelDescriptorRepr`],
+/// [`RayTracingKernelDescriptorRepr`]) and returns an Arc-handle β-shape
+/// for the resulting kernel; the matching Arc-lifecycle pairs
+/// (`clone_*` / `drop_*`) live on this vtable.
+///
+/// Reachable from cdylib code only inside an `escalate(|full| ...)`
+/// scope; the `escalate_begin` / `escalate_end` scope-token machinery
+/// is wired by C3. C2 lands the descriptor wire format + host-side
+/// dispatch + cdylib-side β-shape, locking the layout before the
+/// scope-token machinery turns it on.
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -1320,6 +1346,739 @@ unsafe impl Send for GpuContextLimitedAccessVTable {}
 unsafe impl Sync for GpuContextLimitedAccessVTable {}
 
 // =============================================================================
+// GPU kernel descriptor mirrors — Phase C2
+// =============================================================================
+//
+// Wire-protocol `#[repr(C)]` mirrors of the Rust descriptor types in
+// `streamlib::core::rhi::{compute,graphics,ray_tracing}_kernel`. Built by
+// the cdylib at the FullAccess vtable call site; decoded by the host
+// into the canonical Rust `*Descriptor` and dispatched to
+// `GpuContextFullAccess::create_*_kernel`.
+//
+// **Enum discriminant convention.** Variant enums are mirrored as
+// `#[repr(u32)]` so the FFI value is the discriminant only. The
+// payload-carrying enums (`VertexInputState`, `DepthStencilState`,
+// `ColorBlendState`, `RayTracingShaderGroup`) are flattened into
+// `(kind: u32, ...flat payload fields)` structs — every payload field
+// is always present in the wire format, irrelevant fields are zero or
+// `u32::MAX` (the canonical "absent" sentinel for `Option<u32>`
+// stage-index references) and ignored on the host side. This matches
+// the C1 vtable pattern (`acquire_texture` decodes `format_raw: u32`
+// into the appropriate enum on the host) and avoids relying on
+// `#[repr(C, u32)]` data-carrying-enum semantics.
+//
+// **Pointer-shaped slices.** Every `&[T]` in the Rust descriptor is
+// mirrored as `(ptr: *const TRepr, len: usize)`. The pointed-at array
+// must live for the duration of the vtable call; the host
+// `slice::from_raw_parts` lift is bounded by the call. Borrow-shaped
+// reprs match the C1 method-dispatch pattern (`id_ptr` / `id_len`
+// pairs throughout).
+//
+// **`Option<u32>` sentinel.** Ray-tracing shader-group references use
+// `u32::MAX` to encode `None` (no shader index). `u32::MAX` is
+// reserved at the spec level (`VK_SHADER_UNUSED_KHR == ~0u`).
+
+// -----------------------------------------------------------------------------
+// Compute kernel mirrors
+// -----------------------------------------------------------------------------
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::ComputeBindingKind`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComputeBindingKindRepr {
+    StorageBuffer = 0,
+    UniformBuffer = 1,
+    SampledTexture = 2,
+    StorageImage = 3,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::ComputeBindingSpec`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ComputeBindingSpecRepr {
+    pub binding: u32,
+    /// `ComputeBindingKindRepr` discriminant. Held as `u32` to keep the
+    /// in-FFI value layout-stable across rustc versions (matches the
+    /// pattern used by `acquire_texture`'s `format_raw` parameter).
+    pub kind: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::ComputeKernelDescriptor`.
+///
+/// All pointer fields borrow into caller-owned memory and must
+/// remain valid for the duration of the vtable call.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ComputeKernelDescriptorRepr {
+    pub label_ptr: *const u8,
+    pub label_len: usize,
+    pub spv_ptr: *const u8,
+    pub spv_len: usize,
+    pub bindings_ptr: *const ComputeBindingSpecRepr,
+    pub bindings_len: usize,
+    pub push_constant_size: u32,
+    pub _reserved_padding: u32,
+}
+
+// -----------------------------------------------------------------------------
+// Graphics kernel mirrors
+// -----------------------------------------------------------------------------
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::GraphicsShaderStage`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsShaderStageRepr {
+    Vertex = 0,
+    Fragment = 1,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::GraphicsStage`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsStageRepr {
+    /// `GraphicsShaderStageRepr` discriminant.
+    pub stage: u32,
+    pub _reserved_padding: u32,
+    pub spv_ptr: *const u8,
+    pub spv_len: usize,
+    pub entry_point_ptr: *const u8,
+    pub entry_point_len: usize,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::GraphicsBindingKind`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsBindingKindRepr {
+    SampledTexture = 0,
+    StorageBuffer = 1,
+    UniformBuffer = 2,
+    StorageImage = 3,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::GraphicsBindingSpec`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsBindingSpecRepr {
+    pub binding: u32,
+    /// `GraphicsBindingKindRepr` discriminant.
+    pub kind: u32,
+    /// `GraphicsShaderStageFlags::bits()` — already a u32 bitflag set,
+    /// crosses as `u32` directly.
+    pub stages: u32,
+    pub _reserved_padding: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::GraphicsPushConstants`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsPushConstantsRepr {
+    pub size: u32,
+    /// `GraphicsShaderStageFlags::bits()`.
+    pub stages: u32,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::PrimitiveTopology`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveTopologyRepr {
+    PointList = 0,
+    LineList = 1,
+    LineStrip = 2,
+    TriangleList = 3,
+    TriangleStrip = 4,
+    TriangleFan = 5,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::VertexAttributeFormat`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexAttributeFormatRepr {
+    R32Float = 0,
+    Rg32Float = 1,
+    Rgb32Float = 2,
+    Rgba32Float = 3,
+    R32Uint = 4,
+    Rg32Uint = 5,
+    Rgb32Uint = 6,
+    Rgba32Uint = 7,
+    R32Sint = 8,
+    Rg32Sint = 9,
+    Rgb32Sint = 10,
+    Rgba32Sint = 11,
+    Rgba8Unorm = 12,
+    Rgba8Snorm = 13,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::VertexInputRate`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexInputRateRepr {
+    Vertex = 0,
+    Instance = 1,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::VertexInputBinding`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputBindingRepr {
+    pub binding: u32,
+    pub stride: u32,
+    /// `VertexInputRateRepr` discriminant.
+    pub input_rate: u32,
+    pub _reserved_padding: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::VertexInputAttribute`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputAttributeRepr {
+    pub location: u32,
+    pub binding: u32,
+    /// `VertexAttributeFormatRepr` discriminant.
+    pub format: u32,
+    pub offset: u32,
+}
+
+/// Discriminant for the [`VertexInputStateRepr::kind`] tagged union.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexInputStateKindRepr {
+    None = 0,
+    Buffers = 1,
+}
+
+/// Tagged-union mirror of `streamlib::core::rhi::VertexInputState`.
+///
+/// When `kind == None`, the slice pointers are null and lengths are 0.
+/// When `kind == Buffers`, the slices borrow into caller-owned arrays.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct VertexInputStateRepr {
+    /// `VertexInputStateKindRepr` discriminant.
+    pub kind: u32,
+    pub _reserved_padding: u32,
+    pub bindings_ptr: *const VertexInputBindingRepr,
+    pub bindings_len: usize,
+    pub attributes_ptr: *const VertexInputAttributeRepr,
+    pub attributes_len: usize,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::PolygonMode`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolygonModeRepr {
+    Fill = 0,
+    Line = 1,
+    Point = 2,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::CullMode`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CullModeRepr {
+    None = 0,
+    Front = 1,
+    Back = 2,
+    FrontAndBack = 3,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::FrontFace`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontFaceRepr {
+    CounterClockwise = 0,
+    Clockwise = 1,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::RasterizationState`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RasterizationStateRepr {
+    /// `PolygonModeRepr` discriminant.
+    pub polygon_mode: u32,
+    /// `CullModeRepr` discriminant.
+    pub cull_mode: u32,
+    /// `FrontFaceRepr` discriminant.
+    pub front_face: u32,
+    pub line_width: f32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::MultisampleState`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MultisampleStateRepr {
+    pub samples: u32,
+    pub _reserved_padding: u32,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::DepthCompareOp`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthCompareOpRepr {
+    Never = 0,
+    Less = 1,
+    Equal = 2,
+    LessOrEqual = 3,
+    Greater = 4,
+    NotEqual = 5,
+    GreaterOrEqual = 6,
+    Always = 7,
+}
+
+/// Discriminant for the [`DepthStencilStateRepr::kind`] tagged union.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthStencilStateKindRepr {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+/// Tagged-union mirror of `streamlib::core::rhi::DepthStencilState`.
+///
+/// `depth_test` and `depth_write` are ignored when `kind == Disabled`
+/// (writer sets them to 0 / 0 by convention).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DepthStencilStateRepr {
+    /// `DepthStencilStateKindRepr` discriminant.
+    pub kind: u32,
+    /// `DepthCompareOpRepr` discriminant. Ignored when `kind == Disabled`.
+    pub depth_test: u32,
+    /// Boolean as `u32` (0 = false, 1 = true). Ignored when `kind == Disabled`.
+    pub depth_write: u32,
+    pub _reserved_padding: u32,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::BlendFactor`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendFactorRepr {
+    Zero = 0,
+    One = 1,
+    SrcColor = 2,
+    OneMinusSrcColor = 3,
+    DstColor = 4,
+    OneMinusDstColor = 5,
+    SrcAlpha = 6,
+    OneMinusSrcAlpha = 7,
+    DstAlpha = 8,
+    OneMinusDstAlpha = 9,
+    ConstantColor = 10,
+    OneMinusConstantColor = 11,
+    ConstantAlpha = 12,
+    OneMinusConstantAlpha = 13,
+    SrcAlphaSaturate = 14,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::BlendOp`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendOpRepr {
+    Add = 0,
+    Subtract = 1,
+    ReverseSubtract = 2,
+    Min = 3,
+    Max = 4,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::ColorBlendAttachment`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ColorBlendAttachmentRepr {
+    /// `BlendFactorRepr` discriminant.
+    pub src_color_blend_factor: u32,
+    /// `BlendFactorRepr` discriminant.
+    pub dst_color_blend_factor: u32,
+    /// `BlendOpRepr` discriminant.
+    pub color_blend_op: u32,
+    /// `BlendFactorRepr` discriminant.
+    pub src_alpha_blend_factor: u32,
+    /// `BlendFactorRepr` discriminant.
+    pub dst_alpha_blend_factor: u32,
+    /// `BlendOpRepr` discriminant.
+    pub alpha_blend_op: u32,
+    /// `ColorWriteMask::bits()`.
+    pub color_write_mask: u32,
+    pub _reserved_padding: u32,
+}
+
+/// Discriminant for the [`ColorBlendStateRepr::kind`] tagged union.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorBlendStateKindRepr {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+/// Tagged-union mirror of `streamlib::core::rhi::ColorBlendState`.
+///
+/// When `kind == Disabled`, `color_write_mask` carries the disabled
+/// state's mask and `attachment` fields are zero (ignored on the host
+/// side). When `kind == Enabled`, `color_write_mask` is zero and
+/// `attachment` carries the full attachment description.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ColorBlendStateRepr {
+    /// `ColorBlendStateKindRepr` discriminant.
+    pub kind: u32,
+    /// `ColorWriteMask::bits()` for the Disabled case; ignored when
+    /// `kind == Enabled`.
+    pub color_write_mask: u32,
+    pub attachment: ColorBlendAttachmentRepr,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::DepthFormat`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthFormatRepr {
+    D16Unorm = 0,
+    D32Sfloat = 1,
+    D24UnormS8Uint = 2,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::AttachmentFormats`.
+///
+/// `color` is a slice of `TextureFormat::repr(u32)` discriminants
+/// (from `streamlib_consumer_rhi::TextureFormat`'s `#[repr(u32)]`).
+/// `has_depth` is a boolean encoded as `u32`; when `has_depth == 0`,
+/// `depth` is ignored.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AttachmentFormatsRepr {
+    /// Pointer to an array of `streamlib_consumer_rhi::TextureFormat`
+    /// discriminants.
+    pub color_ptr: *const u32,
+    pub color_len: usize,
+    /// 0 = `None`, 1 = `Some(depth)`.
+    pub has_depth: u32,
+    /// `DepthFormatRepr` discriminant. Ignored when `has_depth == 0`.
+    pub depth: u32,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::GraphicsDynamicState`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicsDynamicStateRepr {
+    None = 0,
+    ViewportScissor = 1,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::GraphicsPipelineState`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsPipelineStateRepr {
+    /// `PrimitiveTopologyRepr` discriminant.
+    pub topology: u32,
+    pub _reserved_padding1: u32,
+    pub vertex_input: VertexInputStateRepr,
+    pub rasterization: RasterizationStateRepr,
+    pub multisample: MultisampleStateRepr,
+    pub depth_stencil: DepthStencilStateRepr,
+    pub color_blend: ColorBlendStateRepr,
+    pub attachment_formats: AttachmentFormatsRepr,
+    /// `GraphicsDynamicStateRepr` discriminant.
+    pub dynamic_state: u32,
+    pub _reserved_padding2: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::GraphicsKernelDescriptor`.
+///
+/// All pointer fields borrow into caller-owned memory and must
+/// remain valid for the duration of the vtable call.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GraphicsKernelDescriptorRepr {
+    pub label_ptr: *const u8,
+    pub label_len: usize,
+    pub stages_ptr: *const GraphicsStageRepr,
+    pub stages_len: usize,
+    pub bindings_ptr: *const GraphicsBindingSpecRepr,
+    pub bindings_len: usize,
+    pub push_constants: GraphicsPushConstantsRepr,
+    pub pipeline_state: GraphicsPipelineStateRepr,
+    pub descriptor_sets_in_flight: u32,
+    pub _reserved_padding: u32,
+}
+
+// -----------------------------------------------------------------------------
+// Ray-tracing kernel mirrors
+// -----------------------------------------------------------------------------
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::RayTracingShaderStage`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RayTracingShaderStageRepr {
+    RayGen = 0,
+    Miss = 1,
+    ClosestHit = 2,
+    AnyHit = 3,
+    Intersection = 4,
+    Callable = 5,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::RayTracingStage`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RayTracingStageRepr {
+    /// `RayTracingShaderStageRepr` discriminant.
+    pub stage: u32,
+    pub _reserved_padding: u32,
+    pub spv_ptr: *const u8,
+    pub spv_len: usize,
+    pub entry_point_ptr: *const u8,
+    pub entry_point_len: usize,
+}
+
+/// `#[repr(u32)]` mirror of `streamlib::core::rhi::RayTracingBindingKind`.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RayTracingBindingKindRepr {
+    StorageBuffer = 0,
+    UniformBuffer = 1,
+    SampledTexture = 2,
+    StorageImage = 3,
+    AccelerationStructure = 4,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::RayTracingBindingSpec`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RayTracingBindingSpecRepr {
+    pub binding: u32,
+    /// `RayTracingBindingKindRepr` discriminant.
+    pub kind: u32,
+    /// `RayTracingShaderStageFlags::bits()`.
+    pub stages: u32,
+    pub _reserved_padding: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::RayTracingPushConstants`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RayTracingPushConstantsRepr {
+    pub size: u32,
+    /// `RayTracingShaderStageFlags::bits()`.
+    pub stages: u32,
+}
+
+/// Discriminant for the [`RayTracingShaderGroupRepr::kind`] tagged union.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RayTracingShaderGroupKindRepr {
+    General = 0,
+    TrianglesHit = 1,
+    ProceduralHit = 2,
+}
+
+/// Sentinel value for `Option<u32>` stage references; matches
+/// `VK_SHADER_UNUSED_KHR == ~0u`. Reserved by the Vulkan spec and
+/// never a valid in-range stage index.
+pub const RAY_TRACING_SHADER_UNUSED: u32 = u32::MAX;
+
+/// Tagged-union mirror of `streamlib::core::rhi::RayTracingShaderGroup`.
+///
+/// Field interpretation per `kind`:
+/// - `General`: `general_or_intersection` carries the general stage
+///   index; `closest_hit` / `any_hit` are [`RAY_TRACING_SHADER_UNUSED`].
+/// - `TrianglesHit`: `general_or_intersection` is
+///   [`RAY_TRACING_SHADER_UNUSED`]; `closest_hit` / `any_hit` carry the
+///   shader indices ([`RAY_TRACING_SHADER_UNUSED`] = `None`).
+/// - `ProceduralHit`: `general_or_intersection` carries the
+///   intersection stage index; `closest_hit` / `any_hit` carry the
+///   optional shader indices.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RayTracingShaderGroupRepr {
+    /// `RayTracingShaderGroupKindRepr` discriminant.
+    pub kind: u32,
+    /// General stage (General) / intersection stage (ProceduralHit).
+    pub general_or_intersection: u32,
+    /// Closest-hit stage. [`RAY_TRACING_SHADER_UNUSED`] = absent.
+    pub closest_hit: u32,
+    /// Any-hit stage. [`RAY_TRACING_SHADER_UNUSED`] = absent.
+    pub any_hit: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib::core::rhi::RayTracingKernelDescriptor`.
+///
+/// All pointer fields borrow into caller-owned memory and must
+/// remain valid for the duration of the vtable call.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RayTracingKernelDescriptorRepr {
+    pub label_ptr: *const u8,
+    pub label_len: usize,
+    pub stages_ptr: *const RayTracingStageRepr,
+    pub stages_len: usize,
+    pub groups_ptr: *const RayTracingShaderGroupRepr,
+    pub groups_len: usize,
+    pub bindings_ptr: *const RayTracingBindingSpecRepr,
+    pub bindings_len: usize,
+    pub push_constants: RayTracingPushConstantsRepr,
+    pub max_recursion_depth: u32,
+    pub _reserved_padding: u32,
+}
+
+// =============================================================================
+// GpuContextFullAccessVTable — extern "C" dispatch for privileged GPU work
+// =============================================================================
+
+/// Dispatch table for the host's `GpuContextFullAccess`. The cdylib
+/// obtains a handle inside an `escalate(|full| ...)` scope (via the
+/// `escalate_begin` / `escalate_end` callbacks landing in C3) and
+/// reads the static vtable from
+/// [`HostServices::gpu_context_full_access_vtable`].
+///
+/// C2 lands the descriptor wire format + host-side dispatch + cdylib-
+/// side β-shape. C3 wires the `escalate_begin` / `escalate_end` scope-
+/// token machinery that makes the methods reachable from cdylib
+/// `escalate(|full| { ... })` call sites.
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. New methods append
+/// to the end and bump
+/// [`GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`].
+///
+/// # `!Clone` invariant
+///
+/// `GpuContextFullAccess` is deliberately **not** `Clone` — the
+/// privilege scope ends when the `escalate(...)` closure returns. The
+/// vtable carries `drop_handle` (host releases the Arc-handle's
+/// refcount) but no `clone_handle`, matching the type-level
+/// `!Clone` invariant.
+#[repr(C)]
+pub struct GpuContextFullAccessVTable {
+    /// Vtable layout version. Must equal
+    /// [`GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -------------------------------------------------------------------------
+    // Handle lifetime (drop-only — !Clone invariant)
+    // -------------------------------------------------------------------------
+
+    /// Release an owned `GpuContextFullAccess` handle. Host runs
+    /// `Box::from_raw + drop` on the `Box<Arc<GpuContext>>`-shaped
+    /// handle (host mode) or invalidates the C3 scope token. Calling
+    /// on a null pointer is a no-op.
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // VulkanComputeKernel return-type lifetime
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `VulkanComputeKernel` handle. Called by
+    /// the cdylib's `Clone for ComputeKernel`. Host runs
+    /// `Arc::increment_strong_count(handle as *const VulkanComputeKernel)`.
+    pub clone_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `VulkanComputeKernel` handle.
+    pub drop_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // VulkanGraphicsKernel return-type lifetime
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `VulkanGraphicsKernel` handle.
+    pub clone_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `VulkanGraphicsKernel` handle.
+    pub drop_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // VulkanRayTracingKernel return-type lifetime
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `VulkanRayTracingKernel` handle.
+    pub clone_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `VulkanRayTracingKernel` handle.
+    pub drop_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // TextureRing return-type lifetime
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `TextureRing` handle.
+    pub clone_texture_ring: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `TextureRing` handle.
+    pub drop_texture_ring: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // Kernel construction
+    // -------------------------------------------------------------------------
+
+    /// Create a compute kernel from a SPIR-V shader and binding
+    /// declaration. On success writes a fresh
+    /// `Arc<VulkanComputeKernel>`-shaped opaque handle into
+    /// `*out_kernel` and returns 0; on failure writes a UTF-8 error
+    /// message into `err_buf` and returns non-zero.
+    ///
+    /// The `desc` pointer must be valid for the duration of the call.
+    /// All inner slice pointers (label, spv, bindings) must likewise
+    /// be valid for the duration of the call.
+    ///
+    /// Linux-only on the host side; non-Linux stubs return non-zero
+    /// with a "not available on this platform" message.
+    pub create_compute_kernel: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        desc: *const ComputeKernelDescriptorRepr,
+        out_kernel: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Create a graphics kernel from a multi-stage SPIR-V set,
+    /// binding declaration, and fixed-function pipeline state.
+    pub create_graphics_kernel: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        desc: *const GraphicsKernelDescriptorRepr,
+        out_kernel: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Create a ray-tracing kernel from shader stages, shader-group
+    /// layout, binding declaration, and push-constant range.
+    pub create_ray_tracing_kernel: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        desc: *const RayTracingKernelDescriptorRepr,
+        out_kernel: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Pre-allocate a ring of `count` non-exportable DEVICE_LOCAL
+    /// textures and register each in the same-process texture cache.
+    /// `format_raw` is the `#[repr(u32)]` discriminant of
+    /// `streamlib_consumer_rhi::TextureFormat`; `usage_bits` is
+    /// `TextureUsages::bits()`.
+    pub create_texture_ring: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        width: u32,
+        height: u32,
+        format_raw: u32,
+        usage_bits: u32,
+        count: usize,
+        out_ring: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+}
+
+unsafe impl Send for GpuContextFullAccessVTable {}
+unsafe impl Sync for GpuContextFullAccessVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -1747,6 +2506,20 @@ pub struct HostServices {
     /// install time; non-null for hosts that ship a `SurfaceStore`,
     /// null otherwise (cdylib must check before dispatching).
     pub surface_store_vtable: *const SurfaceStoreVTable,
+
+    // -------------------------------------------------------------------------
+    // GpuContextFullAccess vtable surface (v6 — Phase C2)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for the host's `GpuContextFullAccess`.
+    /// Paired with the per-scope opaque handle the C3 `escalate_begin`
+    /// callback returns. Set once at install time; non-null for hosts
+    /// that ship a GpuContext, null otherwise (cdylib must check
+    /// before dispatching). Phase C2 lands the layout + host wiring +
+    /// cdylib β-shape; Phase C3 wires the scope-token machinery that
+    /// makes the methods reachable from `escalate(|full| ...)` call
+    /// sites.
+    pub gpu_context_full_access_vtable: *const GpuContextFullAccessVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -1865,7 +2638,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 5);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 6);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -1874,40 +2647,46 @@ mod layout_tests {
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 9);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_five_vtable_pointers() {
+    fn host_services_tail_carries_six_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
         //   1. Each vtable is a single 8-byte pointer.
         //   2. They appear in the order RuntimeContext → AudioClock →
-        //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore.
+        //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
+        //      GpuContextFullAccess.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
         assert_eq!(size_of::<*const RuntimeOpsVTable>(), 8);
         assert_eq!(size_of::<*const GpuContextLimitedAccessVTable>(), 8);
         assert_eq!(size_of::<*const SurfaceStoreVTable>(), 8);
+        assert_eq!(size_of::<*const GpuContextFullAccessVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
         let runtime_ops_off = offset_of!(HostServices, runtime_ops_vtable);
         let gpu_lim_off = offset_of!(HostServices, gpu_context_limited_access_vtable);
         let surface_store_off = offset_of!(HostServices, surface_store_vtable);
+        let gpu_full_off = offset_of!(HostServices, gpu_context_full_access_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
         assert!(gpu_lim_off < surface_store_off);
+        assert!(surface_store_off < gpu_full_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
         assert_eq!(surface_store_off - gpu_lim_off, 8);
+        assert_eq!(gpu_full_off - surface_store_off, 8);
 
-        // The surface-store pointer must end at the end of the
-        // struct (it is the last field added in v5).
-        assert_eq!(surface_store_off + 8, size_of::<HostServices>());
+        // The full-access pointer must end at the end of the struct
+        // (it is the last field added in v6).
+        assert_eq!(gpu_full_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -2124,6 +2903,414 @@ mod layout_tests {
     }
 
     #[test]
+    fn gpu_context_full_access_vtable_layout() {
+        // layout_version (u32) + _reserved_padding (u32) + 13 fn
+        // pointers (8 bytes each) = 4 + 4 + 104 = 112 bytes.
+        //
+        // 13 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
+        // pointers for the 4 kernel return types) + 4 create_* method
+        // callbacks (compute / graphics / ray-tracing / texture_ring).
+        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 112);
+        assert_eq!(align_of::<GpuContextFullAccessVTable>(), 8);
+        assert_eq!(offset_of!(GpuContextFullAccessVTable, layout_version), 0);
+        assert_eq!(offset_of!(GpuContextFullAccessVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(GpuContextFullAccessVTable, drop_handle), 8);
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, clone_compute_kernel),
+            16
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, drop_compute_kernel),
+            24
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, clone_graphics_kernel),
+            32
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, drop_graphics_kernel),
+            40
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, clone_ray_tracing_kernel),
+            48
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, drop_ray_tracing_kernel),
+            56
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, clone_texture_ring),
+            64
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, drop_texture_ring),
+            72
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_compute_kernel),
+            80
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_graphics_kernel),
+            88
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_ray_tracing_kernel),
+            96
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_texture_ring),
+            104
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase C2 descriptor mirror layouts
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn compute_binding_spec_repr_layout() {
+        assert_eq!(size_of::<ComputeBindingSpecRepr>(), 8);
+        assert_eq!(align_of::<ComputeBindingSpecRepr>(), 4);
+        assert_eq!(offset_of!(ComputeBindingSpecRepr, binding), 0);
+        assert_eq!(offset_of!(ComputeBindingSpecRepr, kind), 4);
+    }
+
+    #[test]
+    fn compute_kernel_descriptor_repr_layout() {
+        // 3 (ptr, len) pairs (3 * 16 = 48) + u32 + u32 = 56 bytes on
+        // 64-bit hosts.
+        assert_eq!(size_of::<ComputeKernelDescriptorRepr>(), 56);
+        assert_eq!(align_of::<ComputeKernelDescriptorRepr>(), 8);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, label_ptr), 0);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, label_len), 8);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, spv_ptr), 16);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, spv_len), 24);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, bindings_ptr), 32);
+        assert_eq!(offset_of!(ComputeKernelDescriptorRepr, bindings_len), 40);
+        assert_eq!(
+            offset_of!(ComputeKernelDescriptorRepr, push_constant_size),
+            48
+        );
+        assert_eq!(
+            offset_of!(ComputeKernelDescriptorRepr, _reserved_padding),
+            52
+        );
+    }
+
+    #[test]
+    fn graphics_stage_repr_layout() {
+        // u32 + u32 + 2 (ptr,len) pairs = 8 + 32 = 40 bytes.
+        assert_eq!(size_of::<GraphicsStageRepr>(), 40);
+        assert_eq!(align_of::<GraphicsStageRepr>(), 8);
+        assert_eq!(offset_of!(GraphicsStageRepr, stage), 0);
+        assert_eq!(offset_of!(GraphicsStageRepr, _reserved_padding), 4);
+        assert_eq!(offset_of!(GraphicsStageRepr, spv_ptr), 8);
+        assert_eq!(offset_of!(GraphicsStageRepr, spv_len), 16);
+        assert_eq!(offset_of!(GraphicsStageRepr, entry_point_ptr), 24);
+        assert_eq!(offset_of!(GraphicsStageRepr, entry_point_len), 32);
+    }
+
+    #[test]
+    fn graphics_binding_spec_repr_layout() {
+        assert_eq!(size_of::<GraphicsBindingSpecRepr>(), 16);
+        assert_eq!(align_of::<GraphicsBindingSpecRepr>(), 4);
+        assert_eq!(offset_of!(GraphicsBindingSpecRepr, binding), 0);
+        assert_eq!(offset_of!(GraphicsBindingSpecRepr, kind), 4);
+        assert_eq!(offset_of!(GraphicsBindingSpecRepr, stages), 8);
+        assert_eq!(offset_of!(GraphicsBindingSpecRepr, _reserved_padding), 12);
+    }
+
+    #[test]
+    fn graphics_push_constants_repr_layout() {
+        assert_eq!(size_of::<GraphicsPushConstantsRepr>(), 8);
+        assert_eq!(align_of::<GraphicsPushConstantsRepr>(), 4);
+        assert_eq!(offset_of!(GraphicsPushConstantsRepr, size), 0);
+        assert_eq!(offset_of!(GraphicsPushConstantsRepr, stages), 4);
+    }
+
+    #[test]
+    fn vertex_input_binding_repr_layout() {
+        assert_eq!(size_of::<VertexInputBindingRepr>(), 16);
+        assert_eq!(align_of::<VertexInputBindingRepr>(), 4);
+        assert_eq!(offset_of!(VertexInputBindingRepr, binding), 0);
+        assert_eq!(offset_of!(VertexInputBindingRepr, stride), 4);
+        assert_eq!(offset_of!(VertexInputBindingRepr, input_rate), 8);
+        assert_eq!(offset_of!(VertexInputBindingRepr, _reserved_padding), 12);
+    }
+
+    #[test]
+    fn vertex_input_attribute_repr_layout() {
+        assert_eq!(size_of::<VertexInputAttributeRepr>(), 16);
+        assert_eq!(align_of::<VertexInputAttributeRepr>(), 4);
+        assert_eq!(offset_of!(VertexInputAttributeRepr, location), 0);
+        assert_eq!(offset_of!(VertexInputAttributeRepr, binding), 4);
+        assert_eq!(offset_of!(VertexInputAttributeRepr, format), 8);
+        assert_eq!(offset_of!(VertexInputAttributeRepr, offset), 12);
+    }
+
+    #[test]
+    fn vertex_input_state_repr_layout() {
+        // u32 + u32 + 2 (ptr,len) pairs = 8 + 32 = 40 bytes.
+        assert_eq!(size_of::<VertexInputStateRepr>(), 40);
+        assert_eq!(align_of::<VertexInputStateRepr>(), 8);
+        assert_eq!(offset_of!(VertexInputStateRepr, kind), 0);
+        assert_eq!(offset_of!(VertexInputStateRepr, _reserved_padding), 4);
+        assert_eq!(offset_of!(VertexInputStateRepr, bindings_ptr), 8);
+        assert_eq!(offset_of!(VertexInputStateRepr, bindings_len), 16);
+        assert_eq!(offset_of!(VertexInputStateRepr, attributes_ptr), 24);
+        assert_eq!(offset_of!(VertexInputStateRepr, attributes_len), 32);
+    }
+
+    #[test]
+    fn rasterization_state_repr_layout() {
+        assert_eq!(size_of::<RasterizationStateRepr>(), 16);
+        assert_eq!(align_of::<RasterizationStateRepr>(), 4);
+        assert_eq!(offset_of!(RasterizationStateRepr, polygon_mode), 0);
+        assert_eq!(offset_of!(RasterizationStateRepr, cull_mode), 4);
+        assert_eq!(offset_of!(RasterizationStateRepr, front_face), 8);
+        assert_eq!(offset_of!(RasterizationStateRepr, line_width), 12);
+    }
+
+    #[test]
+    fn multisample_state_repr_layout() {
+        assert_eq!(size_of::<MultisampleStateRepr>(), 8);
+        assert_eq!(align_of::<MultisampleStateRepr>(), 4);
+        assert_eq!(offset_of!(MultisampleStateRepr, samples), 0);
+        assert_eq!(offset_of!(MultisampleStateRepr, _reserved_padding), 4);
+    }
+
+    #[test]
+    fn depth_stencil_state_repr_layout() {
+        assert_eq!(size_of::<DepthStencilStateRepr>(), 16);
+        assert_eq!(align_of::<DepthStencilStateRepr>(), 4);
+        assert_eq!(offset_of!(DepthStencilStateRepr, kind), 0);
+        assert_eq!(offset_of!(DepthStencilStateRepr, depth_test), 4);
+        assert_eq!(offset_of!(DepthStencilStateRepr, depth_write), 8);
+        assert_eq!(offset_of!(DepthStencilStateRepr, _reserved_padding), 12);
+    }
+
+    #[test]
+    fn color_blend_attachment_repr_layout() {
+        assert_eq!(size_of::<ColorBlendAttachmentRepr>(), 32);
+        assert_eq!(align_of::<ColorBlendAttachmentRepr>(), 4);
+        assert_eq!(
+            offset_of!(ColorBlendAttachmentRepr, src_color_blend_factor),
+            0
+        );
+        assert_eq!(
+            offset_of!(ColorBlendAttachmentRepr, dst_color_blend_factor),
+            4
+        );
+        assert_eq!(offset_of!(ColorBlendAttachmentRepr, color_blend_op), 8);
+        assert_eq!(
+            offset_of!(ColorBlendAttachmentRepr, src_alpha_blend_factor),
+            12
+        );
+        assert_eq!(
+            offset_of!(ColorBlendAttachmentRepr, dst_alpha_blend_factor),
+            16
+        );
+        assert_eq!(offset_of!(ColorBlendAttachmentRepr, alpha_blend_op), 20);
+        assert_eq!(offset_of!(ColorBlendAttachmentRepr, color_write_mask), 24);
+        assert_eq!(
+            offset_of!(ColorBlendAttachmentRepr, _reserved_padding),
+            28
+        );
+    }
+
+    #[test]
+    fn color_blend_state_repr_layout() {
+        // u32 + u32 + ColorBlendAttachmentRepr(32) = 40 bytes.
+        assert_eq!(size_of::<ColorBlendStateRepr>(), 40);
+        assert_eq!(align_of::<ColorBlendStateRepr>(), 4);
+        assert_eq!(offset_of!(ColorBlendStateRepr, kind), 0);
+        assert_eq!(offset_of!(ColorBlendStateRepr, color_write_mask), 4);
+        assert_eq!(offset_of!(ColorBlendStateRepr, attachment), 8);
+    }
+
+    #[test]
+    fn attachment_formats_repr_layout() {
+        // (ptr,len) pair + u32 + u32 = 16 + 8 = 24 bytes.
+        assert_eq!(size_of::<AttachmentFormatsRepr>(), 24);
+        assert_eq!(align_of::<AttachmentFormatsRepr>(), 8);
+        assert_eq!(offset_of!(AttachmentFormatsRepr, color_ptr), 0);
+        assert_eq!(offset_of!(AttachmentFormatsRepr, color_len), 8);
+        assert_eq!(offset_of!(AttachmentFormatsRepr, has_depth), 16);
+        assert_eq!(offset_of!(AttachmentFormatsRepr, depth), 20);
+    }
+
+    #[test]
+    fn graphics_pipeline_state_repr_layout() {
+        // topology(4) + pad(4) + vertex_input(40) + raster(16) +
+        // multisample(8) + depth_stencil(16) + color_blend(40) +
+        // attachment_formats(24) + dynamic_state(4) + pad(4) = 160 bytes.
+        assert_eq!(size_of::<GraphicsPipelineStateRepr>(), 160);
+        assert_eq!(align_of::<GraphicsPipelineStateRepr>(), 8);
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, topology), 0);
+        assert_eq!(
+            offset_of!(GraphicsPipelineStateRepr, _reserved_padding1),
+            4
+        );
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, vertex_input), 8);
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, rasterization), 48);
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, multisample), 64);
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, depth_stencil), 72);
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, color_blend), 88);
+        assert_eq!(
+            offset_of!(GraphicsPipelineStateRepr, attachment_formats),
+            128
+        );
+        assert_eq!(offset_of!(GraphicsPipelineStateRepr, dynamic_state), 152);
+        assert_eq!(
+            offset_of!(GraphicsPipelineStateRepr, _reserved_padding2),
+            156
+        );
+    }
+
+    #[test]
+    fn graphics_kernel_descriptor_repr_layout() {
+        // label(ptr,len)=16 + stages(ptr,len)=16 + bindings(ptr,len)=16
+        // + push_constants(8) + pipeline_state(160) +
+        // descriptor_sets_in_flight(4) + pad(4) = 224 bytes.
+        assert_eq!(size_of::<GraphicsKernelDescriptorRepr>(), 224);
+        assert_eq!(align_of::<GraphicsKernelDescriptorRepr>(), 8);
+        assert_eq!(offset_of!(GraphicsKernelDescriptorRepr, label_ptr), 0);
+        assert_eq!(offset_of!(GraphicsKernelDescriptorRepr, label_len), 8);
+        assert_eq!(offset_of!(GraphicsKernelDescriptorRepr, stages_ptr), 16);
+        assert_eq!(offset_of!(GraphicsKernelDescriptorRepr, stages_len), 24);
+        assert_eq!(
+            offset_of!(GraphicsKernelDescriptorRepr, bindings_ptr),
+            32
+        );
+        assert_eq!(
+            offset_of!(GraphicsKernelDescriptorRepr, bindings_len),
+            40
+        );
+        assert_eq!(
+            offset_of!(GraphicsKernelDescriptorRepr, push_constants),
+            48
+        );
+        assert_eq!(
+            offset_of!(GraphicsKernelDescriptorRepr, pipeline_state),
+            56
+        );
+        assert_eq!(
+            offset_of!(
+                GraphicsKernelDescriptorRepr,
+                descriptor_sets_in_flight
+            ),
+            216
+        );
+        assert_eq!(
+            offset_of!(GraphicsKernelDescriptorRepr, _reserved_padding),
+            220
+        );
+    }
+
+    #[test]
+    fn ray_tracing_stage_repr_layout() {
+        assert_eq!(size_of::<RayTracingStageRepr>(), 40);
+        assert_eq!(align_of::<RayTracingStageRepr>(), 8);
+        assert_eq!(offset_of!(RayTracingStageRepr, stage), 0);
+        assert_eq!(offset_of!(RayTracingStageRepr, _reserved_padding), 4);
+        assert_eq!(offset_of!(RayTracingStageRepr, spv_ptr), 8);
+        assert_eq!(offset_of!(RayTracingStageRepr, spv_len), 16);
+        assert_eq!(offset_of!(RayTracingStageRepr, entry_point_ptr), 24);
+        assert_eq!(offset_of!(RayTracingStageRepr, entry_point_len), 32);
+    }
+
+    #[test]
+    fn ray_tracing_binding_spec_repr_layout() {
+        assert_eq!(size_of::<RayTracingBindingSpecRepr>(), 16);
+        assert_eq!(align_of::<RayTracingBindingSpecRepr>(), 4);
+        assert_eq!(offset_of!(RayTracingBindingSpecRepr, binding), 0);
+        assert_eq!(offset_of!(RayTracingBindingSpecRepr, kind), 4);
+        assert_eq!(offset_of!(RayTracingBindingSpecRepr, stages), 8);
+        assert_eq!(
+            offset_of!(RayTracingBindingSpecRepr, _reserved_padding),
+            12
+        );
+    }
+
+    #[test]
+    fn ray_tracing_push_constants_repr_layout() {
+        assert_eq!(size_of::<RayTracingPushConstantsRepr>(), 8);
+        assert_eq!(align_of::<RayTracingPushConstantsRepr>(), 4);
+        assert_eq!(offset_of!(RayTracingPushConstantsRepr, size), 0);
+        assert_eq!(offset_of!(RayTracingPushConstantsRepr, stages), 4);
+    }
+
+    #[test]
+    fn ray_tracing_shader_group_repr_layout() {
+        assert_eq!(size_of::<RayTracingShaderGroupRepr>(), 16);
+        assert_eq!(align_of::<RayTracingShaderGroupRepr>(), 4);
+        assert_eq!(offset_of!(RayTracingShaderGroupRepr, kind), 0);
+        assert_eq!(
+            offset_of!(RayTracingShaderGroupRepr, general_or_intersection),
+            4
+        );
+        assert_eq!(offset_of!(RayTracingShaderGroupRepr, closest_hit), 8);
+        assert_eq!(offset_of!(RayTracingShaderGroupRepr, any_hit), 12);
+    }
+
+    #[test]
+    fn ray_tracing_kernel_descriptor_repr_layout() {
+        // 4 (ptr,len) pairs (64) + push_constants(8) +
+        // max_recursion_depth(4) + pad(4) = 80 bytes.
+        assert_eq!(size_of::<RayTracingKernelDescriptorRepr>(), 80);
+        assert_eq!(align_of::<RayTracingKernelDescriptorRepr>(), 8);
+        assert_eq!(offset_of!(RayTracingKernelDescriptorRepr, label_ptr), 0);
+        assert_eq!(offset_of!(RayTracingKernelDescriptorRepr, label_len), 8);
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, stages_ptr),
+            16
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, stages_len),
+            24
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, groups_ptr),
+            32
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, groups_len),
+            40
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, bindings_ptr),
+            48
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, bindings_len),
+            56
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, push_constants),
+            64
+        );
+        assert_eq!(
+            offset_of!(
+                RayTracingKernelDescriptorRepr,
+                max_recursion_depth
+            ),
+            72
+        );
+        assert_eq!(
+            offset_of!(RayTracingKernelDescriptorRepr, _reserved_padding),
+            76
+        );
+    }
+
+    #[test]
+    fn ray_tracing_shader_unused_sentinel() {
+        // The "absent stage" sentinel matches VK_SHADER_UNUSED_KHR.
+        assert_eq!(RAY_TRACING_SHADER_UNUSED, u32::MAX);
+    }
+
+    #[test]
     fn surface_store_vtable_layout() {
         // layout_version (u32) + _reserved_padding (u32) + 13 fn
         // pointers (8 bytes each) = 4 + 4 + 104 = 112 bytes.
@@ -2160,6 +3347,7 @@ mod layout_tests {
         assert_send_sync::<RuntimeOpsVTable>();
         assert_send_sync::<GpuContextLimitedAccessVTable>();
         assert_send_sync::<SurfaceStoreVTable>();
+        assert_send_sync::<GpuContextFullAccessVTable>();
         assert_send_sync::<HostServices>();
         assert_send_sync::<ProcessorVTable>();
     }


### PR DESCRIPTION
## Summary

- New `GpuContextFullAccessVTable` carrying the privileged kernel-construction surface (`create_compute_kernel`, `create_graphics_kernel`, `create_ray_tracing_kernel`, `create_texture_ring`) plus 4 Arc-handle clone/drop pairs for the returned kernel types.
- `#[repr(C)]` mirror types for the three kernel descriptors (SPIR-V slices, binding-spec lists, push-constant ranges, full `GraphicsPipelineState` tree). Wire format follows the C1 pattern: `#[repr(u32)]` variant enums, flat tagged-union structs (`VertexInputState` / `DepthStencilState` / `ColorBlendState` / `RayTracingShaderGroup`), `(ptr, len)` slice pairs, `u32::MAX` as the `Option<u32>` sentinel.
- `GpuContextFullAccess` converted to `#[repr(C)] { handle, vtable }` β-shape mirroring `GpuContextLimitedAccess`; preserves `!Clone` via `Drop`-only release. `host_inner()` panics on cdylib mode (caught at the FFI boundary).
- Host-side wiring: `HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE` static + per-callback bodies + `host_gpu_context_full_access_vtable()` resolver + `HostServices` field (`HOST_SERVICES_LAYOUT_VERSION` bumped to 6).
- Closes #902. Unblocks #903 (C3 — escalate scope-token machinery + dlopen integration test).

## Decisions made during planning

- **Wire format**: `#[repr(C)]` mirrors. Locks layout at compile time, matches C1's `Texture`/`PixelBuffer` pattern. Larger code than msgpack but production-grade for the engine-fixed schema.
- **C2/C3 split**: Framing A — defer the dlopen integration test to C3. C2 ships the layout + host wiring + cdylib β-shape carrier; cdylib-side `gpu.escalate(|full| ...)` reach-through arrives with C3's scope-token mechanism. The original C2 issue body's "Cdylib-side shim methods forward through the vtable; source-compat at every call site" and "Dlopen integration test" criteria are struck through with dated supersession notes; #903 absorbs the dlopen test.

## Closes

Closes #902

## Exit criteria (per refreshed #902 body)

- [x] New `GpuContextFullAccessVTable` lands in `streamlib-plugin-abi`; layout-versioned via `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION = 1`.
- [x] `#[repr(C)]` mirrors for the three kernel descriptors including the full `GraphicsPipelineState` tree, with round-trip `From/Into` between Rust descriptors and reprs.
- [x] Host-side wiring in `core/plugin/host_services.rs`: `HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE` static + per-method callback bodies that decode the repr + dispatch to `GpuContextFullAccess::create_*` + Arc-handle minting.
- [x] Cdylib-side `GpuContextFullAccess` β-shape: `(handle, vtable)` carrier with the four method shims forwarding through the vtable. Not yet end-to-end callable (C3 wires reachability).

## Test plan

- [x] Layout regression tests for each descriptor mirror + the `GpuContextFullAccessVTable` (size 112, every offset, every nested mirror). **32 plugin-abi tests, all green.**
- [x] Host-side descriptor round-trip tests via the new closure-shape `with_decoded_*` helpers (compute / graphics / ray-tracing including vertex-input buffers, invalid-discriminant rejection, `RAY_TRACING_SHADER_UNUSED` sentinel). **7 round-trip tests, all green.**
- [x] Host-side wire-format tests directly invoking each `HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE` create_* callback with a null gpu_handle, plus a drop-handle null no-op test and a layout-version+wiring spot-check. **6 new vtable tests, all green.**
- [x] All existing dlopen + lib tests continue to pass. **463 streamlib-engine lib tests pass (was 456 — +7 new).**

## What's deferred to C3 (#903)

- Cdylib-side `gpu.escalate(|full| ...)` reachability via `escalate_begin` / `escalate_end` scope-token machinery.
- Dlopen integration test: a dlopen'd plugin creates a compute kernel via `gpu.escalate(...)`, dispatches it, host verifies GPU output. C3's "creates a compute kernel" integration-test exit criterion explicitly absorbs this.
- Success-path host-side wire-format test (real `Arc<GpuContext>` + valid descriptor + handle minting): lives in `tests/` under the `streamlib/hardware-tests` feature; lands with C3 when the cdylib reach-through becomes exercisable.

## Review gate

`pr-review-gate` PASS after one fix iteration. The fix addressed three concerns: lifetime soundness on `*_from_repr` (refactored to callback-shape `with_decoded_*`), `create_texture_ring` Arc-receiver dance (simplified to `&self`), and missing host-side wire-format tests (added 6 tier-1 null-handle tests). A residual DISCUSS on iceoryx2-skip observability was fixed in `8e70c0e8` (now emits `tracing::warn!` instead of returning silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)