### PR TITLE
feat(plugin-abi): GpuContext vtable — escalate scope-token + acquire_render_target (Phase C3 of #886)

### DIFF
--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -408,12 +408,12 @@ where
         // Subprocess host setup does no host-side GPU work — it spawns
         // the child, constructs the bridge, sends a `setup` lifecycle,
         // then blocks on the subprocess's `ready` reply. Wrapping that
-        // IPC wait in escalate would hold `processor_setup_lock` against
+        // IPC wait in escalate would hold the escalate gate against
         // every FullAccess escalate the subprocess issues during its own
         // init: the bridge-reader thread dispatches each
         // `escalate_request` inline through `sandbox.escalate(|full|
-        // ...)` and deadlocks on the same mutex. Per-call bridge-handler
-        // escalates still acquire the lock + wait device idle on their
+        // ...)` and deadlocks on the same gate. Per-call bridge-handler
+        // escalates still acquire the gate + wait device idle on their
         // own, so GPU-resource serialization is preserved (#867).
         ProcessorRuntime::Python | ProcessorRuntime::TypeScript => setup_body(),
     }
@@ -464,8 +464,8 @@ mod tests {
         }
     }
 
-    /// Regression for #867 — subprocess host setup must not hold
-    /// `processor_setup_lock` against a concurrent escalate from the
+    /// Regression for #867 — subprocess host setup must not hold the
+    /// escalate gate against a concurrent escalate from the
     /// bridge-reader thread.
     ///
     /// Reproduces the deadlock the engine fix prevents: a setup body

--- a/libs/streamlib-engine/src/core/context/escalate_gate.rs
+++ b/libs/streamlib-engine/src/core/context/escalate_gate.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Exclusivity gate that serializes
+//! [`GpuContextLimitedAccess::escalate`] scopes against each other
+//! across both the engine-internal in-process dispatch path and the
+//! cdylib vtable-dispatched path.
+//!
+//! Unlike a [`std::sync::Mutex`] guard, this gate doesn't materialize
+//! an OS-level lock guard that has to be held across a stack frame —
+//! enter and exit are independent calls that can run on different
+//! threads. The cdylib's vtable-dispatched path needs that
+//! flexibility because the FFI `escalate_begin` callback returns
+//! (unwinding its stack) before the cdylib runs its closure; the
+//! matching `escalate_end` callback can reach `exit` from a different
+//! thread (panic recovery, async runtimes). A regular Mutex guard
+//! would have to live in shared state crossing threads, which
+//! `std::sync::MutexGuard` is `!Send` for — this gate sidesteps that
+//! with a `Mutex<bool>` flag + `Condvar`.
+//!
+//! [`GpuContextLimitedAccess::escalate`]: super::gpu_context::GpuContextLimitedAccess::escalate
+
+use std::sync::{Condvar, Mutex};
+
+/// Exclusivity gate for escalate scopes on a single
+/// [`GpuContext`](super::gpu_context::GpuContext).
+///
+/// `enter` blocks until any active scope releases (via `exit`), then
+/// marks the gate as in-scope. `exit` clears the in-scope flag and
+/// wakes one waiter. Same-thread re-entry is NOT supported — calling
+/// `enter` twice from the same thread without an intervening `exit`
+/// deadlocks.
+pub(crate) struct EscalateGate {
+    in_scope: Mutex<bool>,
+    cv: Condvar,
+}
+
+impl EscalateGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            in_scope: Mutex::new(false),
+            cv: Condvar::new(),
+        }
+    }
+
+    /// Block until the gate is free, then claim it. Pairs with
+    /// [`Self::exit`]. The companion [`Self::enter_scoped`] returns
+    /// an RAII guard that releases on drop (engine-internal use).
+    pub(crate) fn enter(&self) {
+        let mut guard = self
+            .in_scope
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        while *guard {
+            guard = self
+                .cv
+                .wait(guard)
+                .unwrap_or_else(|e| e.into_inner());
+        }
+        *guard = true;
+        // Mutex<bool> drops here — the gate is held by the `true`
+        // flag, not by any guard. Other `enter` callers see `true` on
+        // their `while` check and wait on the Condvar.
+    }
+
+    /// Release the gate. Wakes one waiter (if any).
+    ///
+    /// Calling `exit` without a matching `enter` clears a flag that
+    /// was already false — harmless but indicates a bug at the call
+    /// site.
+    pub(crate) fn exit(&self) {
+        let mut guard = self
+            .in_scope
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *guard = false;
+        self.cv.notify_one();
+    }
+
+    /// Enter the gate and return an RAII guard that releases on drop.
+    /// Suited for the engine-internal in-process
+    /// [`GpuContextLimitedAccess::escalate`] path, where the scope
+    /// lives within a single Rust stack frame. The cdylib
+    /// vtable-dispatched path uses bare [`Self::enter`] /
+    /// [`Self::exit`] via the
+    /// [`escalate_scope_registry`](super::escalate_scope_registry)
+    /// (the FFI boundary precludes RAII across it).
+    ///
+    /// [`GpuContextLimitedAccess::escalate`]: super::gpu_context::GpuContextLimitedAccess::escalate
+    pub(crate) fn enter_scoped(&self) -> EscalateGateGuard<'_> {
+        self.enter();
+        EscalateGateGuard { gate: self }
+    }
+}
+
+impl Default for EscalateGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard returned by [`EscalateGate::enter_scoped`] that calls
+/// [`EscalateGate::exit`] on drop.
+pub(crate) struct EscalateGateGuard<'a> {
+    gate: &'a EscalateGate,
+}
+
+impl Drop for EscalateGateGuard<'_> {
+    fn drop(&mut self) {
+        self.gate.exit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn enter_exit_pair_unblocks_subsequent_enter() {
+        let gate = EscalateGate::new();
+        gate.enter();
+        gate.exit();
+        // Second enter must not block — gate is free again.
+        gate.enter();
+        gate.exit();
+    }
+
+    #[test]
+    fn enter_scoped_releases_on_drop() {
+        let gate = EscalateGate::new();
+        {
+            let _guard = gate.enter_scoped();
+            // gate is held inside this scope
+        }
+        // After guard drop, second enter must not block.
+        gate.enter();
+        gate.exit();
+    }
+
+    #[test]
+    fn enter_serializes_concurrent_callers() {
+        let gate = Arc::new(EscalateGate::new());
+        let overlap = Arc::new(AtomicUsize::new(0));
+        let active = Arc::new(AtomicUsize::new(0));
+
+        const THREADS: usize = 8;
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let gate = Arc::clone(&gate);
+                let overlap = Arc::clone(&overlap);
+                let active = Arc::clone(&active);
+                std::thread::spawn(move || {
+                    gate.enter();
+                    if active.fetch_add(1, Ordering::SeqCst) != 0 {
+                        overlap.fetch_add(1, Ordering::SeqCst);
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    gate.exit();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+        assert_eq!(
+            overlap.load(Ordering::SeqCst),
+            0,
+            "EscalateGate must serialize concurrent enters"
+        );
+    }
+
+    #[test]
+    fn cross_thread_enter_exit_pair_works() {
+        // Mirrors the cdylib FFI pattern: one thread calls enter
+        // (escalate_begin); a different thread may call exit
+        // (escalate_end), e.g. when the cdylib delegates the close to
+        // a worker thread for panic recovery.
+        let gate = Arc::new(EscalateGate::new());
+        gate.enter();
+        let g2 = Arc::clone(&gate);
+        std::thread::spawn(move || g2.exit())
+            .join()
+            .expect("worker panicked");
+        // Gate must be free again.
+        gate.enter();
+        gate.exit();
+    }
+}

--- a/libs/streamlib-engine/src/core/context/escalate_scope_registry.rs
+++ b/libs/streamlib-engine/src/core/context/escalate_scope_registry.rs
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Engine-side registry that mints opaque scope tokens for the
+//! cdylib vtable-dispatched
+//! [`GpuContextLimitedAccess::escalate`] path.
+//!
+//! Two dispatch shapes coexist for [`GpuContextFullAccess`]:
+//! engine-internal callers reach it directly via
+//! [`GpuContextLimitedAccess::escalate`]'s in-process path
+//! ([`GpuContextFullAccess::new`] wrapping an `Arc<GpuContext>`
+//! clone); cdylib-resident callers cross the FFI through the
+//! [`GpuContextLimitedAccessVTable`]'s `escalate_begin` callback,
+//! which reaches this registry to bind a fresh `Arc<GpuContext>`
+//! clone to a new `ScopeToken`. Every FullAccess vtable callback
+//! validates the supplied scope token against the registry before
+//! dispatch; the matching `escalate_end` callback removes the scope.
+//!
+//! Tokens are monotonically incrementing u64 serials (no ABA risk —
+//! 2^64 unique tokens). The registry is a single global static; per-
+//! GpuContext serialization is provided by each [`GpuContext`]'s own
+//! [`EscalateGate`](crate::core::context::escalate_gate::EscalateGate)
+//! which `begin_escalate_scope` enters and `end_escalate_scope`
+//! releases. The registry holds only `Arc<GpuContext>` — no mutex
+//! guard, no Send-cross-thread footgun — so a scope minted on one
+//! thread can be released on another (panic recovery, async runtimes).
+//!
+//! [`GpuContextLimitedAccess::escalate`]: super::gpu_context::GpuContextLimitedAccess::escalate
+//! [`GpuContextFullAccess`]: super::gpu_context::GpuContextFullAccess
+//! [`GpuContextFullAccess::new`]: super::gpu_context::GpuContextFullAccess::new
+//! [`GpuContextLimitedAccessVTable`]: streamlib_plugin_abi::GpuContextLimitedAccessVTable
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use super::gpu_context::GpuContext;
+
+/// Opaque scope token identifying an active escalate scope.
+///
+/// Issued by [`begin_escalate_scope`], invalidated by
+/// [`end_escalate_scope`]. Crosses the FFI as `*const c_void`; the
+/// engine stores it as `u64` for HashMap keying.
+pub(crate) type ScopeToken = u64;
+
+struct EscalateScopeRegistry {
+    scopes: Mutex<HashMap<ScopeToken, Arc<GpuContext>>>,
+    next_serial: AtomicU64,
+}
+
+static REGISTRY: OnceLock<EscalateScopeRegistry> = OnceLock::new();
+
+fn registry() -> &'static EscalateScopeRegistry {
+    REGISTRY.get_or_init(|| EscalateScopeRegistry {
+        scopes: Mutex::new(HashMap::new()),
+        // Start at 1 so a 0 token is reserved for "invalid / never issued".
+        next_serial: AtomicU64::new(1),
+    })
+}
+
+/// Begin a fresh escalate scope. Enters the supplied context's
+/// [`EscalateGate`](super::escalate_gate::EscalateGate) (blocking
+/// until any prior scope ends), mints a unique token, and stores the
+/// bound `Arc<GpuContext>` in the registry.
+///
+/// The returned token is opaque to the caller; the cdylib side holds
+/// it for the duration of its escalate scope and passes it back to
+/// [`end_escalate_scope`] when the scope completes.
+pub(crate) fn begin_escalate_scope(arc_ctx: Arc<GpuContext>) -> ScopeToken {
+    arc_ctx.escalate_gate().enter();
+    let token = registry().next_serial.fetch_add(1, Ordering::Relaxed);
+    let mut scopes = registry()
+        .scopes
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    scopes.insert(token, arc_ctx);
+    token
+}
+
+/// End an escalate scope. Removes the bound `Arc<GpuContext>` from
+/// the registry and releases that context's escalate gate.
+///
+/// Returns `true` if the token was present (normal completion);
+/// `false` if it was already removed (e.g. double `escalate_end` or a
+/// never-issued token). Idempotent on the registry — duplicate calls
+/// don't release another scope's gate.
+pub(crate) fn end_escalate_scope(token: ScopeToken) -> bool {
+    let removed = {
+        let mut scopes = registry()
+            .scopes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        scopes.remove(&token)
+    };
+    match removed {
+        Some(arc_ctx) => {
+            arc_ctx.escalate_gate().exit();
+            true
+        }
+        None => false,
+    }
+}
+
+/// Look up the `Arc<GpuContext>` bound to an active scope, then invoke
+/// the closure against it. Returns `None` if the token is invalidated
+/// or never-issued (vtable callbacks return
+/// [`crate::core::error::Error::InvalidEscalateScope`] in that case).
+///
+/// The registry lock is released before the closure runs — the Arc
+/// clone keeps the `GpuContext` alive for the closure's duration even
+/// if a concurrent `end_escalate_scope` removes the scope mid-call.
+pub(crate) fn with_scope<F, R>(token: ScopeToken, f: F) -> Option<R>
+where
+    F: FnOnce(&Arc<GpuContext>) -> R,
+{
+    let arc_clone = {
+        let scopes = registry()
+            .scopes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        scopes.get(&token).cloned()
+    };
+    arc_clone.as_ref().map(f)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests that construct a real `GpuContext` carry `#[serial]` to
+    //! prevent the NVIDIA Linux dual-`VkDevice` SIGSEGV
+    //! (`docs/learnings/nvidia-dual-vulkan-device-crash.md`) when run
+    //! against other VkDevice-creating tests in the workspace lib
+    //! suite. The single test that doesn't create a context
+    //! (`with_scope_returns_none_for_never_issued_token`) doesn't
+    //! need it.
+
+    use super::*;
+    use crate::core::context::GpuContext;
+    use serial_test::serial;
+
+    fn new_arc_ctx() -> Option<Arc<GpuContext>> {
+        // GpuContext::init_for_platform skips cleanly when no GPU
+        // device is available; the gpu_context-level escalate tests
+        // (test_escalate_serializes_concurrent_callers,
+        // test_escalate_propagates_closure_error) exercise the registry
+        // end-to-end under real Vulkan, while these unit tests pin the
+        // registry's data-structure invariants when a device is
+        // present.
+        GpuContext::init_for_platform().ok().map(Arc::new)
+    }
+
+    #[test]
+    #[serial]
+    fn begin_returns_distinct_tokens_per_call() {
+        let Some(arc) = new_arc_ctx() else {
+            tracing::warn!(
+                "escalate_scope_registry test skipped: init_for_platform failed (no GPU)"
+            );
+            return;
+        };
+        let t1 = begin_escalate_scope(Arc::clone(&arc));
+        // First scope holds the lock; end it before begin-2 to avoid a
+        // deadlock — begin acquires the processor-setup lock and
+        // calling begin again on the same Arc would block until t1
+        // ends.
+        assert!(end_escalate_scope(t1));
+        let t2 = begin_escalate_scope(Arc::clone(&arc));
+        assert!(end_escalate_scope(t2));
+        assert_ne!(t1, t2, "tokens must be unique per begin call");
+    }
+
+    #[test]
+    #[serial]
+    fn with_scope_returns_none_after_end() {
+        let Some(arc) = new_arc_ctx() else {
+            tracing::warn!(
+                "escalate_scope_registry test skipped: init_for_platform failed (no GPU)"
+            );
+            return;
+        };
+        let token = begin_escalate_scope(Arc::clone(&arc));
+        assert!(
+            with_scope(token, |_| ()).is_some(),
+            "with_scope must succeed during an active scope"
+        );
+        assert!(end_escalate_scope(token));
+        assert!(
+            with_scope(token, |_| ()).is_none(),
+            "with_scope must fail after end_escalate_scope"
+        );
+    }
+
+    #[test]
+    fn with_scope_returns_none_for_never_issued_token() {
+        // Token u64::MAX is never issued in any practical test (the
+        // serial would need to reach 2^64). Validates the missing-key
+        // path independent of any active scope state. No GpuContext
+        // construction, so no #[serial] needed.
+        assert!(with_scope(u64::MAX, |_| ()).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn end_returns_false_for_stale_token() {
+        let Some(arc) = new_arc_ctx() else {
+            tracing::warn!(
+                "escalate_scope_registry test skipped: init_for_platform failed (no GPU)"
+            );
+            return;
+        };
+        let token = begin_escalate_scope(Arc::clone(&arc));
+        assert!(end_escalate_scope(token));
+        // Double-end is idempotent — returns false rather than
+        // panicking or releasing another scope's lock.
+        assert!(!end_escalate_scope(token));
+    }
+}

--- a/libs/streamlib-engine/src/core/context/escalate_scope_registry.rs
+++ b/libs/streamlib-engine/src/core/context/escalate_scope_registry.rs
@@ -84,6 +84,17 @@ pub(crate) fn begin_escalate_scope(arc_ctx: Arc<GpuContext>) -> ScopeToken {
 /// `false` if it was already removed (e.g. double `escalate_end` or a
 /// never-issued token). Idempotent on the registry — duplicate calls
 /// don't release another scope's gate.
+///
+/// **Caller contract.** The caller MUST ensure no FullAccess vtable
+/// call against this scope token is still in-flight on another
+/// thread when `end_escalate_scope` runs. Releasing the gate early
+/// while a FullAccess method is mid-execution would let a fresh
+/// `begin_escalate_scope` overlap with the tail of the prior scope's
+/// GPU work. The cdylib's `escalate_via_vtable` wrapper enforces
+/// this naturally — the closure runs synchronously and returns
+/// before `escalate_end` fires. Cdylib code that spawns a thread
+/// inside an escalate closure and lets it outlive the scope is a
+/// caller bug.
 pub(crate) fn end_escalate_scope(token: ScopeToken) -> bool {
     let removed = {
         let mut scopes = registry()

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -418,11 +418,20 @@ pub struct GpuContext {
     #[cfg(target_os = "linux")]
     video_source_timeline_semaphore:
         Arc<Mutex<Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>>>>,
-    /// Serializes processor setup() across threads so concurrent GPU resource
-    /// creation (video sessions, DPB images, swapchain) can't race on the
-    /// device. The compiler acquires this during Phase 4 of spawn_processor
-    /// and releases it after waiting for the device to go idle.
-    processor_setup_lock: Arc<Mutex<()>>,
+    /// Serializes [`GpuContextLimitedAccess::escalate`] scopes across
+    /// threads (and across the in-process and vtable dispatch paths —
+    /// engine-internal callers using `host_inner` direct dispatch and
+    /// cdylib plugin callers using vtable FFI dispatch serialize
+    /// against each other) so concurrent GPU resource creation (video
+    /// sessions, DPB images, swapchain) can't race on the device. The
+    /// compiler acquires this during Phase 4 of spawn_processor and
+    /// releases it after waiting for the device to go idle. Replaces
+    /// the older `std::sync::Mutex<()>`-based `processor_setup_lock`
+    /// — a [`Mutex`] guard can't cross thread boundaries (the cdylib
+    /// FFI escalate_begin / escalate_end pair may run on different
+    /// threads), so this gate uses a flag + Condvar that enter and
+    /// exit can hit independently.
+    escalate_gate: Arc<super::escalate_gate::EscalateGate>,
     /// Host-side bridge for the cpu-readback escalate op. Set by application
     /// code that wires a `CpuReadbackSurfaceAdapter` into the runtime; left
     /// unset on hosts that don't expose cpu-readback to subprocess customers
@@ -476,7 +485,7 @@ impl GpuContext {
             color_converter_cache: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(target_os = "linux")]
             video_source_timeline_semaphore: Arc::new(Mutex::new(None)),
-            processor_setup_lock: Arc::new(Mutex::new(())),
+            escalate_gate: Arc::new(super::escalate_gate::EscalateGate::new()),
             #[cfg(target_os = "linux")]
             cpu_readback_bridge: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "linux")]
@@ -505,7 +514,7 @@ impl GpuContext {
             color_converter_cache: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(target_os = "linux")]
             video_source_timeline_semaphore: Arc::new(Mutex::new(None)),
-            processor_setup_lock: Arc::new(Mutex::new(())),
+            escalate_gate: Arc::new(super::escalate_gate::EscalateGate::new()),
             #[cfg(target_os = "linux")]
             cpu_readback_bridge: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "linux")]
@@ -517,13 +526,18 @@ impl GpuContext {
         }
     }
 
-    /// Acquire the processor-setup mutex. The compiler wraps each processor's
-    /// `setup()` call with this lock and a subsequent wait-for-idle so
-    /// concurrent setups can't race on GPU resource creation.
-    pub fn lock_processor_setup(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.processor_setup_lock
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+    /// Borrow this context's escalate gate. The gate serializes
+    /// [`GpuContextLimitedAccess::escalate`] scopes across both
+    /// dispatch paths — engine-internal in-process escalate (the
+    /// host-mode caller; uses
+    /// [`super::escalate_gate::EscalateGate::enter_scoped`] for RAII
+    /// release) and cdylib FFI-dispatched escalate (the plugin
+    /// caller; uses bare `enter` / `exit` through
+    /// [`super::escalate_scope_registry::begin_escalate_scope`] /
+    /// [`super::escalate_scope_registry::end_escalate_scope`] because
+    /// the FFI boundary precludes RAII across it).
+    pub(crate) fn escalate_gate(&self) -> &super::escalate_gate::EscalateGate {
+        &self.escalate_gate
     }
 
     /// Wrap this `GpuContext` in a [`GpuContextLimitedAccess`] view.
@@ -1970,43 +1984,118 @@ impl Drop for GpuContextLimitedAccess {
 /// assert_not_clone::<streamlib::sdk::context::GpuContextFullAccess>();
 /// ```
 ///
-/// # Layout (Phase C2)
+/// # In-process vs vtable dispatch (Phase C3)
 ///
-/// `#[repr(C)] { handle, vtable }`, mirroring
-/// [`GpuContextLimitedAccess`]. `handle` is a host-owned
-/// `Box<Arc<GpuContext>>` in host mode; in cdylib mode (post-C3) it
-/// is the opaque scope token from
-/// [`GpuContextFullAccessVTable::escalate_begin`]. Methods route
-/// through [`Self::host_inner`] for host-only fast paths (panicking
-/// when reached from cdylib code, same shape as Limited) and
-/// through the vtable when called from cdylib code.
+/// Two construction paths populate this struct depending on which
+/// side of the FFI boundary the caller lives on; the same surface
+/// methods work from either:
+///
+/// - **In-process dispatch** ([`Self::new`], `pub(in
+///   crate::core::context)` so only
+///   [`GpuContextLimitedAccess::escalate`]'s engine-internal body
+///   can construct it). `handle` is a host-allocated
+///   `Box<Arc<GpuContext>>` and `handle_kind` is
+///   [`HandleKind::Boxed`]. Every method routes through
+///   [`Self::host_inner`] for direct dispatch — no FFI hop, no
+///   scope-registry lookup. Drop runs
+///   [`std::boxed::Box::from_raw`] on the boxed Arc.
+/// - **Vtable dispatch** ([`Self::from_scope_token`], reached from
+///   the cdylib path of [`GpuContextLimitedAccess::escalate`]).
+///   `handle` is an opaque scope token issued by the host's
+///   [`GpuContextLimitedAccessVTable`]'s `escalate_begin` callback
+///   and `handle_kind` is [`HandleKind::ScopeToken`]. Every method
+///   routes through the vtable; the host validates the token against
+///   [`super::escalate_scope_registry::with_scope`] before dispatch.
+///   Drop is a no-op — cleanup runs in the matching `escalate_end`
+///   callback the cdylib's wrapper invokes after the closure returns.
+///
+/// New methods that any cdylib code can reach MUST add a matching
+/// vtable entry on [`GpuContextFullAccessVTable`] (otherwise the
+/// vtable-dispatched path silently can't reach them).
+/// Engine-internal methods that no cdylib path ever needs can be
+/// host_inner-only.
+///
+/// [`GpuContextFullAccessVTable`]: streamlib_plugin_abi::GpuContextFullAccessVTable
+/// [`GpuContextLimitedAccessVTable`]: streamlib_plugin_abi::GpuContextLimitedAccessVTable
 #[repr(C)]
 pub struct GpuContextFullAccess {
     pub(crate) handle: *const std::ffi::c_void,
     pub(crate) vtable:
         *const streamlib_plugin_abi::GpuContextFullAccessVTable,
+    /// Discriminator for [`Drop`]:
+    /// - [`HandleKind::Boxed`] (in-process dispatch shape): Drop
+    ///   runs `Box::from_raw` on the boxed `Arc<GpuContext>`.
+    /// - [`HandleKind::ScopeToken`] (vtable-dispatched shape): Drop
+    ///   is a no-op; the cdylib's escalate wrapper handles cleanup
+    ///   via the LimitedAccess vtable's `escalate_end` callback.
+    ///
+    /// Set by the constructor ([`Self::new`] vs
+    /// [`Self::from_scope_token`]).
+    pub(crate) handle_kind: HandleKind,
+}
+
+/// Discriminator for [`GpuContextFullAccess`]'s `handle` field. The
+/// engine-internal in-process constructor sets [`Self::Boxed`]; the
+/// cdylib vtable-dispatched constructor sets [`Self::ScopeToken`].
+/// [`GpuContextFullAccess::drop`] dispatches on this kind.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HandleKind {
+    /// Handle is a host-allocated `Box<Arc<GpuContext>>` from
+    /// [`GpuContextFullAccess::new`]. Methods on the cdylib-facing
+    /// `GpuContextFullAccess` surface dispatch through `host_inner`
+    /// directly (no FFI hop). Used by engine-internal escalate
+    /// scopes.
+    Boxed = 0,
+    /// Handle is an opaque scope token from the host's
+    /// `GpuContextLimitedAccessVTable::escalate_begin` callback.
+    /// Methods dispatch through the FullAccess vtable; the host
+    /// validates the token against the scope registry before
+    /// dispatch. Used by cdylib escalate scopes.
+    ScopeToken = 1,
 }
 
 // SAFETY: same shape as `GpuContextLimitedAccess`. The handle points
-// at a host-owned `Box<Arc<GpuContext>>` (host mode) or an opaque
-// scope token (cdylib mode, post-C3); both are `Send + Sync`. The
+// at a host-owned `Box<Arc<GpuContext>>` (in-process dispatch shape)
+// or an opaque scope token (vtable-dispatched shape); both are
+// `Send + Sync` (the scope token is a u64 reinterpreted as
+// `*const c_void`; the boxed Arc<GpuContext> is Send + Sync). The
 // vtable pointer is `&'static`.
 unsafe impl Send for GpuContextFullAccess {}
 unsafe impl Sync for GpuContextFullAccess {}
 
 impl Drop for GpuContextFullAccess {
-    /// Releases the host-owned handle via
-    /// [`GpuContextFullAccessVTable::drop_handle`]. In host mode this
-    /// drops the `Box<Arc<GpuContext>>` (releasing the cloned
-    /// `GpuContext`); in cdylib mode (post-C3) it invalidates the
-    /// escalate scope token.
+    /// Releases the handle.
+    ///
+    /// - [`HandleKind::Boxed`] (in-process dispatch shape): runs
+    ///   `Box::from_raw` on the boxed `Arc<GpuContext>` directly,
+    ///   without going through the vtable. No FFI hop;
+    ///   engine-internal cleanup.
+    /// - [`HandleKind::ScopeToken`] (vtable-dispatched shape):
+    ///   no-op. The cdylib's escalate wrapper that constructed this
+    ///   `GpuContextFullAccess` calls `escalate_end` on the
+    ///   LimitedAccess vtable after the closure returns, which
+    ///   removes the scope from the registry and releases the
+    ///   escalate gate. Doing it here too would double-release.
     fn drop(&mut self) {
-        if !self.handle.is_null() && !self.vtable.is_null() {
-            // SAFETY: handle was produced by `Self::new` (host mode —
-            // `Box::into_raw(Box::new(Arc::new(GpuContext)))`) or a
-            // future C3 `escalate_begin` callback. The vtable's
-            // `drop_handle` callback runs the matching release.
-            unsafe { ((*self.vtable).drop_handle)(self.handle) };
+        if self.handle.is_null() {
+            return;
+        }
+        match self.handle_kind {
+            HandleKind::Boxed => {
+                // SAFETY: handle was produced by `Self::new` via
+                // `Box::into_raw(Box::new(Arc::new(GpuContext)))`.
+                // `Box::from_raw` releases the box; the resulting
+                // Arc<GpuContext>'s Drop releases the per-scope clone.
+                let _ = unsafe {
+                    Box::from_raw(
+                        self.handle as *mut std::sync::Arc<GpuContext>,
+                    )
+                };
+            }
+            HandleKind::ScopeToken => {
+                // No-op — escalate_end is the authority. See doc.
+            }
         }
     }
 }
@@ -2087,30 +2176,61 @@ impl GpuContextLimitedAccess {
         GpuContextFullAccess::new(self.host_inner().clone())
     }
 
-    /// Serialized escalation to full GPU capability. Acquires the
-    /// processor-setup mutex, hands the closure a [`GpuContextFullAccess`]
-    /// scoped to its body, then waits for the device to go idle before
-    /// releasing the lock.
+    /// Serialized escalation to full GPU capability. Hands the
+    /// closure a [`GpuContextFullAccess`] scoped to its body, with
+    /// the host's escalate gate held for the duration; after the
+    /// closure returns the gate releases and the device waits idle.
     ///
-    /// This is the single primitive for GPU resource-creation work outside
-    /// `setup()` — used by the compiler to run each processor's setup()
-    /// and by running processors that need to reconfigure (acquire a new
-    /// video session, resize a swapchain, etc.).
+    /// This is the single primitive for GPU resource-creation work
+    /// outside `setup()` — used by the compiler to run each
+    /// processor's setup() and by running processors that need to
+    /// reconfigure (acquire a new video session, resize a swapchain,
+    /// etc.).
     ///
-    /// The `device_wait_idle` fires exactly once per escalation (after the
-    /// closure returns). On closure failure its error is returned; a
-    /// follow-up `wait_device_idle` failure is returned only when the
-    /// closure succeeded.
+    /// Mode-routed:
+    /// - **In-process dispatch** (engine-internal callers): acquires
+    ///   the gate directly, constructs [`GpuContextFullAccess::new`]
+    ///   (Boxed), runs the closure with method dispatch via
+    ///   [`GpuContextFullAccess::host_inner`] (no FFI hop), then
+    ///   waits device idle and releases the gate.
+    /// - **Vtable dispatch** (cdylib callers): dispatches through
+    ///   the [`GpuContextLimitedAccessVTable`]'s `escalate_begin` /
+    ///   `escalate_end` callback pair. Constructs
+    ///   [`GpuContextFullAccess::from_scope_token`] (ScopeToken) so
+    ///   method dispatch crosses through the FullAccess vtable; the
+    ///   host's `escalate_end` callback handles `wait_device_idle`
+    ///   and releases the gate. A closure panic still unwinds; the
+    ///   matching `escalate_end` fires through a guard so the gate
+    ///   never leaks.
+    ///
+    /// The runtime mode is selected by `host_callbacks().is_some()`:
+    /// true in cdylib code (callbacks installed by the host), false
+    /// in engine-internal code.
+    ///
+    /// Closure failure returns the closure's error; on closure
+    /// success a follow-up `wait_device_idle` error is propagated.
+    ///
+    /// [`GpuContextLimitedAccessVTable`]: streamlib_plugin_abi::GpuContextLimitedAccessVTable
     pub fn escalate<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&GpuContextFullAccess) -> Result<T>,
     {
-        // Engine-only call surface — cdylib code hitting this path
-        // panics via `host_inner()`'s `host_callbacks()` guard, which
-        // is caught by `run_host_extern_c`.
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            self.escalate_via_vtable(f)
+        } else {
+            self.escalate_in_process(f)
+        }
+    }
+
+    /// Engine-internal escalate path. Direct in-process dispatch —
+    /// no FFI hop. See [`Self::escalate`] for the mode router.
+    fn escalate_in_process<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&GpuContextFullAccess) -> Result<T>,
+    {
         let inner = self.host_inner();
         let lock_start = std::time::Instant::now();
-        let _setup_guard = inner.lock_processor_setup();
+        let _gate_guard = inner.escalate_gate().enter_scoped();
         let mutex_wait_ns = lock_start.elapsed().as_nanos() as u64;
 
         let closure_start = std::time::Instant::now();
@@ -2125,6 +2245,7 @@ impl GpuContextLimitedAccess {
 
         tracing::trace!(
             target: "streamlib::gpu_context::escalate",
+            dispatch = "in_process",
             mutex_wait_ns,
             closure_duration_ns,
             wait_idle_ns,
@@ -2138,6 +2259,109 @@ impl GpuContextLimitedAccess {
             (Ok(value), Ok(())) => Ok(value),
             (Err(e), _) => Err(e),
             (Ok(_), Err(e)) => Err(e),
+        }
+    }
+
+    /// Cdylib escalate path. Dispatches through the LimitedAccess
+    /// vtable's `escalate_begin` / `escalate_end` pair; constructs
+    /// `GpuContextFullAccess::from_scope_token` so the closure's
+    /// FullAccess method calls cross the FFI boundary through the
+    /// FullAccess vtable. See [`Self::escalate`] for the mode router.
+    fn escalate_via_vtable<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&GpuContextFullAccess) -> Result<T>,
+    {
+        if self.handle.is_null() || self.vtable.is_null() {
+            return Err(Error::GpuError(
+                "escalate (vtable): GpuContextLimitedAccess has null handle/vtable"
+                    .into(),
+            ));
+        }
+        // SAFETY: vtable + handle were paired at construction; vtable
+        // is `&'static`.
+        let vt = unsafe { &*self.vtable };
+
+        let lock_start = std::time::Instant::now();
+        let mut scope_token: *const std::ffi::c_void = std::ptr::null();
+        let mut err_buf = [0u8; 512];
+        let mut err_len: usize = 0;
+        let begin_rc = unsafe {
+            (vt.escalate_begin)(
+                self.handle,
+                &mut scope_token,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        let mutex_wait_ns = lock_start.elapsed().as_nanos() as u64;
+        if begin_rc != 0 {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            return Err(Error::GpuError(format!(
+                "escalate (vtable): escalate_begin failed: {msg}"
+            )));
+        }
+
+        let closure_start = std::time::Instant::now();
+        let full = GpuContextFullAccess::from_scope_token(scope_token);
+        // catch_unwind so a closure panic still fires escalate_end —
+        // otherwise the host's escalate gate would leak. We lean on
+        // AssertUnwindSafe because `escalate`'s public signature
+        // doesn't add an `UnwindSafe` bound on `F` (the in-process
+        // path doesn't need it; only this path catches the unwind to
+        // pair with `escalate_end`).
+        let closure_result = std::panic::catch_unwind(
+            std::panic::AssertUnwindSafe(|| f(&full)),
+        );
+        drop(full);
+        let closure_duration_ns = closure_start.elapsed().as_nanos() as u64;
+
+        let wait_start = std::time::Instant::now();
+        let mut end_err_buf = [0u8; 512];
+        let mut end_err_len: usize = 0;
+        let end_rc = unsafe {
+            (vt.escalate_end)(
+                self.handle,
+                scope_token,
+                end_err_buf.as_mut_ptr(),
+                end_err_buf.len(),
+                &mut end_err_len as *mut usize,
+            )
+        };
+        let wait_idle_ns = wait_start.elapsed().as_nanos() as u64;
+
+        tracing::trace!(
+            target: "streamlib::gpu_context::escalate",
+            dispatch = "vtable",
+            mutex_wait_ns,
+            closure_duration_ns,
+            wait_idle_ns,
+            closure_ok = closure_result.is_ok(),
+            "GpuContextLimitedAccess::escalate completed"
+        );
+
+        check_sustained_escalation_rate();
+
+        let wait_result: Result<()> = if end_rc != 0 {
+            let msg = String::from_utf8_lossy(
+                &end_err_buf[..end_err_len.min(end_err_buf.len())],
+            )
+            .into_owned();
+            Err(Error::GpuError(format!(
+                "escalate (vtable): escalate_end failed: {msg}"
+            )))
+        } else {
+            Ok(())
+        };
+
+        match closure_result {
+            Ok(Ok(value)) => match wait_result {
+                Ok(()) => Ok(value),
+                Err(e) => Err(e),
+            },
+            Ok(Err(e)) => Err(e),
+            Err(panic) => std::panic::resume_unwind(panic),
         }
     }
 }
@@ -2192,21 +2416,51 @@ fn escalation_monotonic_ns() -> u64 {
 }
 
 impl GpuContextFullAccess {
-    /// Wrap a [`GpuContext`] as a full-access capability.
+    /// Back-room constructor. Wraps an in-process [`GpuContext`] as a
+    /// full-access capability whose methods route through
+    /// [`Self::host_inner`] for direct dispatch.
     ///
-    /// Boxes a fresh `Arc<GpuContext>` as the opaque handle (matching
-    /// the [`GpuContextLimitedAccess::new`] shape), then resolves the
-    /// vtable through
-    /// [`crate::core::plugin::host_services::host_gpu_context_full_access_vtable`].
-    /// The Arc refcount is 1 at construction; `Drop` calls
-    /// `drop_handle` which runs `Box::from_raw + drop`.
-    pub(crate) fn new(inner: GpuContext) -> Self {
+    /// Scope tightened to `pub(in crate::core::context)` so only
+    /// [`GpuContextLimitedAccess::escalate`]'s host-mode body can
+    /// construct one. Other engine code that wants FullAccess goes
+    /// through `escalate(|full| ...)`; the privilege gate enforces
+    /// serialization + `wait_device_idle`.
+    pub(in crate::core::context) fn new(inner: GpuContext) -> Self {
         let arc: std::sync::Arc<GpuContext> = std::sync::Arc::new(inner);
         let boxed: Box<std::sync::Arc<GpuContext>> = Box::new(arc);
         let handle = Box::into_raw(boxed) as *const std::ffi::c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        Self {
+            handle,
+            vtable,
+            handle_kind: HandleKind::Boxed,
+        }
+    }
+
+    /// Lobby constructor. Wraps an opaque scope token (issued by the
+    /// host's
+    /// [`GpuContextLimitedAccessVTable`](streamlib_plugin_abi::GpuContextLimitedAccessVTable)'s
+    /// `escalate_begin` callback) as a full-access capability whose
+    /// methods route through the
+    /// [`GpuContextFullAccessVTable`](streamlib_plugin_abi::GpuContextFullAccessVTable)
+    /// for cross-DSO dispatch.
+    ///
+    /// Used by the cdylib-mode path of
+    /// [`GpuContextLimitedAccess::escalate`]; the matching cleanup
+    /// (release the escalate gate + `wait_device_idle`) runs inside
+    /// `escalate_end` rather than [`Drop`], so the FullAccess's
+    /// [`Drop`] short-circuits.
+    pub(in crate::core::context) fn from_scope_token(
+        scope_token: *const std::ffi::c_void,
+    ) -> Self {
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self {
+            handle: scope_token,
+            vtable,
+            handle_kind: HandleKind::ScopeToken,
+        }
     }
 
     /// Engine-internal borrow of the host's [`GpuContext`] (read
@@ -3079,11 +3333,6 @@ impl GpuContextLimitedAccess {
 }
 
 impl GpuContextFullAccess {
-    /// Acquire the processor-setup mutex.
-    pub fn lock_processor_setup(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.host_inner().lock_processor_setup()
-    }
-
     /// Wait for the GPU device to become idle.
     pub fn wait_device_idle(&self) -> Result<()> {
         self.host_inner().wait_device_idle()

--- a/libs/streamlib-engine/src/core/context/mod.rs
+++ b/libs/streamlib-engine/src/core/context/mod.rs
@@ -7,6 +7,8 @@ mod audio_clock_shim;
 mod compute_kernel_bridge;
 #[cfg(target_os = "linux")]
 mod cpu_readback_bridge;
+pub(crate) mod escalate_gate;
+pub(crate) mod escalate_scope_registry;
 mod gpu_context;
 #[cfg(target_os = "linux")]
 mod graphics_kernel_bridge;

--- a/libs/streamlib-engine/src/core/error.rs
+++ b/libs/streamlib-engine/src/core/error.rs
@@ -81,6 +81,9 @@ pub enum Error {
     #[error("Runtime error: {0}")]
     Runtime(String),
 
+    #[error("Invalid escalate scope: {0}")]
+    InvalidEscalateScope(String),
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -2142,6 +2142,106 @@ unsafe extern "C" fn host_gpu_lim_unregister_texture(
 }
 
 // -------------------------------------------------------------------------
+// Escalate scope transition (Phase C3)
+// -------------------------------------------------------------------------
+
+/// Begin an escalate scope on the supplied `gpu_handle`. Mints a
+/// unique opaque token via
+/// [`crate::core::context::escalate_scope_registry::begin_escalate_scope`]
+/// and writes it into `*out_scope_token`. Blocking on the gate is
+/// expected — the host's escalate gate serializes against any
+/// concurrent escalate scope on the same `GpuContext`.
+unsafe extern "C" fn host_gpu_lim_escalate_begin(
+    handle: *const c_void,
+    out_scope_token: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_lim_escalate_begin",
+        || {
+            let Some(gpu) = (unsafe { handle_as_gpu_context(handle) }) else {
+                write_err(
+                    "escalate_begin: null gpu handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1i32;
+            };
+            if out_scope_token.is_null() {
+                write_err(
+                    "escalate_begin: null out_scope_token",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1i32;
+            }
+            // begin_escalate_scope clones the Arc into the registry
+            // and enters the gate; both operations succeed without
+            // returning a fallible value.
+            let token = crate::core::context::escalate_scope_registry::begin_escalate_scope(
+                Arc::clone(gpu),
+            );
+            // SAFETY: out_scope_token is non-null per the check above.
+            // Token encoding is just the u64 serial reinterpreted as
+            // pointer-shaped; cdylib treats it as opaque.
+            unsafe { *out_scope_token = token as *const c_void };
+            0
+        },
+        1,
+    )
+}
+
+/// End an escalate scope. Removes the bound `Arc<GpuContext>` from
+/// the registry (releasing the escalate gate), then runs
+/// [`GpuContext::wait_device_idle`] to match the host-mode escalate
+/// path's scope-end semantics. Idempotent for stale or never-issued
+/// tokens.
+unsafe extern "C" fn host_gpu_lim_escalate_end(
+    _handle: *const c_void,
+    scope_token: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_lim_escalate_end",
+        || {
+            let token = scope_token as u64;
+            // Resolve the Arc BEFORE removing it from the registry so
+            // we can call wait_device_idle. If the token is stale or
+            // never-issued, this returns None — silently no-op (the
+            // gate was never acquired by this token, so there's
+            // nothing to release).
+            let arc_clone = crate::core::context::escalate_scope_registry::with_scope(
+                token,
+                Arc::clone,
+            );
+            let removed = crate::core::context::escalate_scope_registry::end_escalate_scope(token);
+            if !removed {
+                return 0i32;
+            }
+            match arc_clone.as_ref().map(|arc| arc.wait_device_idle()) {
+                Some(Ok(())) | None => 0,
+                Some(Err(e)) => {
+                    write_err(
+                        &format!("escalate_end: wait_device_idle failed: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+// -------------------------------------------------------------------------
 // Linux-only buffer Arc-handle lifecycle
 // -------------------------------------------------------------------------
 //
@@ -4292,35 +4392,34 @@ pub fn host_surface_store_vtable() -> *const SurfaceStoreVTable {
 // HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE — Phase C2
 // =============================================================================
 //
-// FullAccess vtable bodies. Reachable from cdylib code only inside an
-// `escalate(|full| ...)` scope (C3 wires the scope-token machinery);
-// host-mode call sites reach the same bodies via the
-// `host_gpu_context_full_access_vtable()` resolver.
+// FullAccess vtable bodies. Reached from cdylib code via the
+// vtable-dispatched path of `GpuContextLimitedAccess::escalate`; the
+// `gpu_handle` slot on every method is an opaque scope token issued
+// by the LimitedAccess vtable's `escalate_begin` callback (Phase C3).
+// Each body resolves the token to its bound `Arc<GpuContext>` via
+// `with_full_scope_or_err`; missing tokens return
+// `Error::InvalidEscalateScope`. The engine-internal in-process path
+// constructs `GpuContextFullAccess` via `Self::new(GpuContext)` and
+// reaches the same engine methods through `host_inner` rather than
+// the vtable, so these callback bodies don't ever see an
+// engine-internal `Box<Arc<GpuContext>>`-shaped handle.
 //
-// Handle interpretation:
-// - `gpu_handle`: `*const Arc<GpuContext>` (matches the LimitedAccess
-//   convention). The host's `GpuContextFullAccess::new` produces
-//   `Box::into_raw(Box::new(Arc::new(GpuContext)))`; the matching
-//   `host_gpu_full_drop_handle` runs `Box::from_raw + drop`.
-// - Kernel return handles: `*const VulkanComputeKernel` / etc., shaped
-//   as `Arc::into_raw(arc)`. Cdylib's `clone_*` / `drop_*` callbacks
-//   route refcount accounting through host-compiled code.
+// Kernel return handles: `*const VulkanComputeKernel` / etc., shaped
+// as `Arc::into_raw(arc)`. Cdylib's `clone_*` / `drop_*` callbacks
+// route refcount accounting through host-compiled code.
 
+/// Defensive no-op. `GpuContextFullAccess::Drop` dispatches on the
+/// struct's `handle_kind` discriminator directly without routing
+/// through this vtable slot — host-mode (Boxed) runs `Box::from_raw`
+/// in-process; cdylib-mode (ScopeToken) is a no-op (the cdylib's
+/// escalate wrapper releases the gate via the LimitedAccess vtable's
+/// `escalate_end` callback). The slot is preserved at the same vtable
+/// offset for layout-version stability; calling it has no effect.
 unsafe extern "C" fn host_gpu_full_drop_handle(handle: *const c_void) {
     run_host_extern_c(
         "host_gpu_full_drop_handle",
         || {
-            if handle.is_null() {
-                return;
-            }
-            // SAFETY: handle was produced by either the host's
-            // `GpuContextFullAccess::new` or a future C3 escalate-begin
-            // callback; both produce `Box::into_raw(Box::new(Arc::new(GpuContext)))`.
-            let _ = unsafe {
-                Box::from_raw(
-                    handle as *mut Arc<crate::core::context::GpuContext>,
-                )
-            };
+            let _ = handle;
         },
         (),
     )
@@ -4495,21 +4594,45 @@ unsafe extern "C" fn host_gpu_full_drop_texture_ring(_handle: *const c_void) {}
 
 // ---------------- Kernel construction (Linux-only) ----------------
 
-#[cfg(target_os = "linux")]
-unsafe fn handle_as_gpu_context_full(
-    handle: *const c_void,
-) -> Option<&'static Arc<crate::core::context::GpuContext>> {
-    if handle.is_null() {
-        return None;
+/// Resolve a scope token to its bound `Arc<GpuContext>` and run the
+/// closure. On miss (null token, stale token, never-issued token)
+/// writes an "invalid escalate scope" message into `err_buf` and
+/// returns `None`. FullAccess vtable callback bodies use this in
+/// place of [`handle_as_gpu_context_full`] (which derefs a host-mode
+/// `Box<Arc<GpuContext>>` directly — never reached from cdylib code
+/// post-C3, kept for tier-1 wire-format tests until they migrate).
+fn with_full_scope_or_err<F, R>(
+    scope_token: *const c_void,
+    op: &str,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    f: F,
+) -> Option<R>
+where
+    F: FnOnce(&Arc<crate::core::context::GpuContext>) -> R,
+{
+    let token = scope_token as u64;
+    match crate::core::context::escalate_scope_registry::with_scope(token, f) {
+        Some(r) => Some(r),
+        None => {
+            write_err(
+                &format!(
+                    "{op}: invalid escalate scope (token stale, never-issued, \
+                     or null)"
+                ),
+                err_buf,
+                err_buf_cap,
+                err_len,
+            );
+            None
+        }
     }
-    // SAFETY: caller-supplied contract; matches `handle_as_gpu_context`'s
-    // shape (`*const Arc<GpuContext>`).
-    unsafe { Some(&*(handle as *const Arc<crate::core::context::GpuContext>)) }
 }
 
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn host_gpu_full_create_compute_kernel(
-    gpu_handle: *const c_void,
+    scope_token: *const c_void,
     desc: *const ComputeKernelDescriptorRepr,
     out_kernel: *mut *const c_void,
     err_buf: *mut u8,
@@ -4519,15 +4642,6 @@ unsafe extern "C" fn host_gpu_full_create_compute_kernel(
     run_host_extern_c(
         "host_gpu_full_create_compute_kernel",
         || -> i32 {
-            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
-                write_err(
-                    "create_compute_kernel: null gpu handle",
-                    err_buf,
-                    err_buf_cap,
-                    err_len,
-                );
-                return 1;
-            };
             if desc.is_null() || out_kernel.is_null() {
                 write_err(
                     "create_compute_kernel: null desc or out pointer",
@@ -4538,22 +4652,30 @@ unsafe extern "C" fn host_gpu_full_create_compute_kernel(
                 return 1;
             }
             let repr: &ComputeKernelDescriptorRepr = unsafe { &*desc };
-            let result = unsafe {
-                crate::core::rhi::plugin_abi_bridge::with_decoded_compute_kernel_descriptor(
-                    repr,
-                    |rust_desc| gpu.create_compute_kernel(rust_desc),
-                )
-            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "create_compute_kernel",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| unsafe {
+                    crate::core::rhi::plugin_abi_bridge::with_decoded_compute_kernel_descriptor(
+                        repr,
+                        |rust_desc| gpu.create_compute_kernel(rust_desc),
+                    )
+                },
+            );
             match result {
-                Ok(arc) => {
+                Some(Ok(arc)) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
                     1
                 }
+                None => 1, // err_buf populated by helper
             }
         },
         1,
@@ -4562,7 +4684,7 @@ unsafe extern "C" fn host_gpu_full_create_compute_kernel(
 
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
-    gpu_handle: *const c_void,
+    scope_token: *const c_void,
     desc: *const GraphicsKernelDescriptorRepr,
     out_kernel: *mut *const c_void,
     err_buf: *mut u8,
@@ -4572,15 +4694,6 @@ unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
     run_host_extern_c(
         "host_gpu_full_create_graphics_kernel",
         || -> i32 {
-            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
-                write_err(
-                    "create_graphics_kernel: null gpu handle",
-                    err_buf,
-                    err_buf_cap,
-                    err_len,
-                );
-                return 1;
-            };
             if desc.is_null() || out_kernel.is_null() {
                 write_err(
                     "create_graphics_kernel: null desc or out pointer",
@@ -4591,22 +4704,30 @@ unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
                 return 1;
             }
             let repr: &GraphicsKernelDescriptorRepr = unsafe { &*desc };
-            let result = unsafe {
-                crate::core::rhi::plugin_abi_bridge::with_decoded_graphics_kernel_descriptor(
-                    repr,
-                    |rust_desc| gpu.create_graphics_kernel(rust_desc),
-                )
-            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "create_graphics_kernel",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| unsafe {
+                    crate::core::rhi::plugin_abi_bridge::with_decoded_graphics_kernel_descriptor(
+                        repr,
+                        |rust_desc| gpu.create_graphics_kernel(rust_desc),
+                    )
+                },
+            );
             match result {
-                Ok(arc) => {
+                Some(Ok(arc)) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
                     1
                 }
+                None => 1,
             }
         },
         1,
@@ -4625,15 +4746,6 @@ unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
     run_host_extern_c(
         "host_gpu_full_create_ray_tracing_kernel",
         || -> i32 {
-            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
-                write_err(
-                    "create_ray_tracing_kernel: null gpu handle",
-                    err_buf,
-                    err_buf_cap,
-                    err_len,
-                );
-                return 1;
-            };
             if desc.is_null() || out_kernel.is_null() {
                 write_err(
                     "create_ray_tracing_kernel: null desc or out pointer",
@@ -4644,22 +4756,30 @@ unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
                 return 1;
             }
             let repr: &RayTracingKernelDescriptorRepr = unsafe { &*desc };
-            let result = unsafe {
-                crate::core::rhi::plugin_abi_bridge::with_decoded_ray_tracing_kernel_descriptor(
-                    repr,
-                    |rust_desc| gpu.create_ray_tracing_kernel(rust_desc),
-                )
-            };
+            let result = with_full_scope_or_err(
+                gpu_handle,
+                "create_ray_tracing_kernel",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| unsafe {
+                    crate::core::rhi::plugin_abi_bridge::with_decoded_ray_tracing_kernel_descriptor(
+                        repr,
+                        |rust_desc| gpu.create_ray_tracing_kernel(rust_desc),
+                    )
+                },
+            );
             match result {
-                Ok(arc) => {
+                Some(Ok(arc)) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
                     1
                 }
+                None => 1,
             }
         },
         1,
@@ -4668,7 +4788,7 @@ unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
 
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn host_gpu_full_create_texture_ring(
-    gpu_handle: *const c_void,
+    scope_token: *const c_void,
     width: u32,
     height: u32,
     format_raw: u32,
@@ -4682,15 +4802,6 @@ unsafe extern "C" fn host_gpu_full_create_texture_ring(
     run_host_extern_c(
         "host_gpu_full_create_texture_ring",
         || -> i32 {
-            let Some(gpu) = (unsafe { handle_as_gpu_context_full(gpu_handle) }) else {
-                write_err(
-                    "create_texture_ring: null gpu handle",
-                    err_buf,
-                    err_buf_cap,
-                    err_len,
-                );
-                return 1;
-            };
             if out_ring.is_null() {
                 write_err(
                     "create_texture_ring: null out_ring pointer",
@@ -4720,16 +4831,25 @@ unsafe extern "C" fn host_gpu_full_create_texture_ring(
             };
             let usages =
                 streamlib_consumer_rhi::TextureUsages::from_bits_truncate(usage_bits);
-            match gpu.create_texture_ring(width, height, format, usages, count) {
-                Ok(arc) => {
+            let result = with_full_scope_or_err(
+                scope_token,
+                "create_texture_ring",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.create_texture_ring(width, height, format, usages, count),
+            );
+            match result {
+                Some(Ok(arc)) => {
                     let raw = Arc::into_raw(arc) as *const c_void;
                     unsafe { std::ptr::write(out_ring, raw) };
                     0
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     write_err(&format!("{e}"), err_buf, err_buf_cap, err_len);
                     1
                 }
+                None => 1,
             }
         },
         1,
@@ -4810,6 +4930,108 @@ unsafe extern "C" fn host_gpu_full_create_texture_ring(
     1
 }
 
+// ---------------- Render-target allocation (Phase C3, Linux-only) ---------
+
+/// Allocate a render-target-capable DMA-BUF-backed `VkImage`. Looks
+/// up the bound `Arc<GpuContext>` via the scope_token; runs
+/// [`crate::core::context::GpuContext::acquire_render_target_dma_buf_image`]
+/// (which picks a tiled DRM modifier via the EGL probe and allocates
+/// through the privileged RHI path), and writes the resulting
+/// `Texture` β-shape into `*out_texture` on success.
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_acquire_render_target_dma_buf_image(
+    scope_token: *const c_void,
+    width: u32,
+    height: u32,
+    format_raw: u32,
+    out_texture: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_acquire_render_target_dma_buf_image",
+        || -> i32 {
+            if out_texture.is_null() {
+                write_err(
+                    "acquire_render_target_dma_buf_image: null out_texture",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let format = match format_raw {
+                0 => streamlib_consumer_rhi::TextureFormat::Rgba8Unorm,
+                1 => streamlib_consumer_rhi::TextureFormat::Rgba8UnormSrgb,
+                2 => streamlib_consumer_rhi::TextureFormat::Bgra8Unorm,
+                3 => streamlib_consumer_rhi::TextureFormat::Bgra8UnormSrgb,
+                4 => streamlib_consumer_rhi::TextureFormat::Rgba16Float,
+                5 => streamlib_consumer_rhi::TextureFormat::Rgba32Float,
+                6 => streamlib_consumer_rhi::TextureFormat::Nv12,
+                _ => {
+                    write_err(
+                        &format!(
+                            "acquire_render_target_dma_buf_image: invalid \
+                             format_raw {}",
+                            format_raw
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "acquire_render_target_dma_buf_image",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.acquire_render_target_dma_buf_image(width, height, format),
+            );
+            match result {
+                Some(Ok(texture)) => {
+                    unsafe {
+                        std::ptr::write(
+                            out_texture as *mut crate::core::rhi::Texture,
+                            texture,
+                        );
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1, // err_buf already populated by helper
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_acquire_render_target_dma_buf_image(
+    _scope_token: *const c_void,
+    _width: u32,
+    _height: u32,
+    _format_raw: u32,
+    _out_texture: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "acquire_render_target_dma_buf_image: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
 pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
     GpuContextFullAccessVTable {
         layout_version: GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION,
@@ -4827,6 +5049,8 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         create_graphics_kernel: host_gpu_full_create_graphics_kernel,
         create_ray_tracing_kernel: host_gpu_full_create_ray_tracing_kernel,
         create_texture_ring: host_gpu_full_create_texture_ring,
+        acquire_render_target_dma_buf_image:
+            host_gpu_full_acquire_render_target_dma_buf_image,
     };
 
 /// Pointer to the [`GpuContextFullAccessVTable`] this DSO should
@@ -4899,6 +5123,8 @@ pub static HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE: GpuContextLimitedAccessVTable
         acquire_pixel_buffer: host_gpu_lim_acquire_pixel_buffer,
         get_pixel_buffer: host_gpu_lim_get_pixel_buffer,
         resolve_pixel_buffer_by_surface_id: host_gpu_lim_resolve_pixel_buffer_by_surface_id,
+        escalate_begin: host_gpu_lim_escalate_begin,
+        escalate_end: host_gpu_lim_escalate_end,
     };
 
 /// Pointer to the [`GpuContextLimitedAccessVTable`] this DSO should
@@ -5041,12 +5267,13 @@ mod gpu_full_access_vtable_tests {
     }
 
     #[test]
-    fn create_compute_kernel_returns_error_on_null_gpu_handle() {
+    fn create_compute_kernel_returns_error_on_null_scope_token() {
+        // Post-C3: gpu_handle is interpreted as a scope_token; a null
+        // pointer corresponds to scope_token = 0, which is reserved as
+        // "never issued" — `with_scope` returns None and the callback
+        // returns an "invalid escalate scope" error.
         let (mut buf, mut len) = make_err_buf();
         let mut out: *const c_void = std::ptr::null();
-        // Build a syntactically-valid repr — the null gpu_handle
-        // check runs first, so the repr contents don't matter for
-        // this test.
         let bindings_buf: [streamlib_plugin_abi::ComputeBindingSpecRepr; 0] = [];
         let repr = ComputeKernelDescriptorRepr {
             label_ptr: "test".as_ptr(),
@@ -5071,14 +5298,14 @@ mod gpu_full_access_vtable_tests {
         assert_eq!(rc, 1);
         let msg = err_buf_as_str(&buf, len);
         assert!(
-            msg.contains("create_compute_kernel: null gpu handle"),
+            msg.contains("create_compute_kernel: invalid escalate scope"),
             "got: {msg}"
         );
         assert!(out.is_null(), "out_kernel must not be written on error");
     }
 
     #[test]
-    fn create_graphics_kernel_returns_error_on_null_gpu_handle() {
+    fn create_graphics_kernel_returns_error_on_null_scope_token() {
         let (mut buf, mut len) = make_err_buf();
         let mut out: *const c_void = std::ptr::null();
         let repr: GraphicsKernelDescriptorRepr = unsafe { std::mem::zeroed() };
@@ -5095,14 +5322,14 @@ mod gpu_full_access_vtable_tests {
         assert_eq!(rc, 1);
         let msg = err_buf_as_str(&buf, len);
         assert!(
-            msg.contains("create_graphics_kernel: null gpu handle"),
+            msg.contains("create_graphics_kernel: invalid escalate scope"),
             "got: {msg}"
         );
         assert!(out.is_null());
     }
 
     #[test]
-    fn create_ray_tracing_kernel_returns_error_on_null_gpu_handle() {
+    fn create_ray_tracing_kernel_returns_error_on_null_scope_token() {
         let (mut buf, mut len) = make_err_buf();
         let mut out: *const c_void = std::ptr::null();
         let repr: RayTracingKernelDescriptorRepr = unsafe { std::mem::zeroed() };
@@ -5119,14 +5346,14 @@ mod gpu_full_access_vtable_tests {
         assert_eq!(rc, 1);
         let msg = err_buf_as_str(&buf, len);
         assert!(
-            msg.contains("create_ray_tracing_kernel: null gpu handle"),
+            msg.contains("create_ray_tracing_kernel: invalid escalate scope"),
             "got: {msg}"
         );
         assert!(out.is_null());
     }
 
     #[test]
-    fn create_texture_ring_returns_error_on_null_gpu_handle() {
+    fn create_texture_ring_returns_error_on_null_scope_token() {
         let (mut buf, mut len) = make_err_buf();
         let mut out: *const c_void = std::ptr::null();
         let rc = unsafe {
@@ -5146,10 +5373,70 @@ mod gpu_full_access_vtable_tests {
         assert_eq!(rc, 1);
         let msg = err_buf_as_str(&buf, len);
         assert!(
-            msg.contains("create_texture_ring: null gpu handle"),
+            msg.contains("create_texture_ring: invalid escalate scope"),
             "got: {msg}"
         );
         assert!(out.is_null());
+    }
+
+    #[test]
+    fn acquire_render_target_dma_buf_image_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE
+                .acquire_render_target_dma_buf_image)(
+                std::ptr::null(),
+                64,
+                64,
+                0, // Rgba8Unorm
+                &mut out as *mut _ as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains(
+                "acquire_render_target_dma_buf_image: invalid escalate scope"
+            ),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn acquire_render_target_dma_buf_image_returns_error_on_invalid_format() {
+        // Even with an invalid format, the null scope-token check would
+        // run after the format decode — so feeding a token of 0 (which
+        // would later fail scope lookup) but an invalid format ensures
+        // the format-validation path fires.
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE
+                .acquire_render_target_dma_buf_image)(
+                std::ptr::null(),
+                64,
+                64,
+                99, // invalid format_raw
+                &mut out as *mut _ as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains(
+                "acquire_render_target_dma_buf_image: invalid format_raw"
+            ),
+            "got: {msg}"
+        );
     }
 
     #[test]
@@ -5184,5 +5471,318 @@ mod gpu_full_access_vtable_tests {
             installed_version,
             streamlib_plugin_abi::GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION
         );
+    }
+}
+
+#[cfg(test)]
+mod gpu_lim_escalate_vtable_tests {
+    //! Tier-1 wire-format + round-trip tests for C3's escalate_begin
+    //! and escalate_end vtable entries.
+    //!
+    //! Tests that construct a real `GpuContext` carry `#[serial]` to
+    //! prevent the NVIDIA Linux dual-`VkDevice` SIGSEGV
+    //! (`docs/learnings/nvidia-dual-vulkan-device-crash.md`) when run
+    //! against other VkDevice-creating tests in the workspace lib
+    //! suite.
+
+    use super::*;
+    use serial_test::serial;
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_buf_as_str(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    /// Build a host-mode gpu_handle (the `Box<Arc<GpuContext>>`-shaped
+    /// pointer that `GpuContextLimitedAccess::new` produces) so the
+    /// `escalate_begin` callback can run end-to-end against a real
+    /// `Arc<GpuContext>`. Skips when no GPU device is available.
+    fn make_host_handle() -> Option<(*const c_void, Arc<crate::core::context::GpuContext>)> {
+        let gpu = crate::core::context::GpuContext::init_for_platform().ok()?;
+        let arc = Arc::new(gpu);
+        let boxed: Box<Arc<crate::core::context::GpuContext>> = Box::new(Arc::clone(&arc));
+        let handle = Box::into_raw(boxed) as *const c_void;
+        Some((handle, arc))
+    }
+
+    /// Free a host_handle minted by `make_host_handle` — pairs with
+    /// the `Box::into_raw`.
+    unsafe fn free_host_handle(handle: *const c_void) {
+        let _ = unsafe {
+            Box::from_raw(handle as *mut Arc<crate::core::context::GpuContext>)
+        };
+    }
+
+    #[test]
+    fn escalate_begin_returns_error_on_null_gpu_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut token: *const c_void = std::ptr::null();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                std::ptr::null(),
+                &mut token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(msg.contains("escalate_begin: null gpu handle"), "got: {msg}");
+        assert!(token.is_null(), "scope token must not be written on error");
+    }
+
+    #[test]
+    #[serial]
+    fn escalate_begin_returns_error_on_null_out_param() {
+        let Some((handle, _arc)) = make_host_handle() else {
+            tracing::warn!(
+                target: "streamlib::tests::escalate_vtable",
+                "skipping escalate_begin null-out test: no GPU device"
+            );
+            return;
+        };
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                handle,
+                std::ptr::null_mut(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("escalate_begin: null out_scope_token"),
+            "got: {msg}"
+        );
+        unsafe { free_host_handle(handle) };
+    }
+
+    #[test]
+    fn escalate_end_is_idempotent_for_stale_token() {
+        // escalate_end with a never-issued token is a clean no-op
+        // (returns 0; doesn't release any gate). Documented as
+        // idempotent in the registry.
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_end)(
+                std::ptr::null(),
+                u64::MAX as *const c_void, // never-issued token
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_eq!(len, 0, "no error message expected for stale token");
+    }
+
+    #[test]
+    #[serial]
+    fn round_trip_begin_then_end_releases_gate() {
+        let Some((handle, _arc)) = make_host_handle() else {
+            tracing::warn!(
+                target: "streamlib::tests::escalate_vtable",
+                "skipping round-trip test: no GPU device"
+            );
+            return;
+        };
+
+        let (mut buf, mut len) = make_err_buf();
+        let mut token: *const c_void = std::ptr::null();
+        let begin_rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                handle,
+                &mut token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(begin_rc, 0);
+        assert!(!token.is_null(), "scope token must be written on success");
+
+        let end_rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_end)(
+                handle,
+                token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(end_rc, 0);
+
+        // Begin again on the same handle — gate must have been
+        // released, so this succeeds without blocking. (If the gate
+        // hadn't released, this would deadlock.)
+        let mut token2: *const c_void = std::ptr::null();
+        let begin2_rc = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                handle,
+                &mut token2,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(begin2_rc, 0);
+        assert!(!token2.is_null());
+        assert_ne!(token, token2, "tokens must be unique per begin call");
+
+        let _ = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_end)(
+                handle,
+                token2,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        unsafe { free_host_handle(handle) };
+    }
+
+    #[test]
+    #[serial]
+    fn full_access_callback_with_valid_token_resolves_scope() {
+        // End-to-end: begin a scope, get a valid token, invoke a
+        // FullAccess vtable callback with the token. The callback's
+        // scope lookup should succeed (no "invalid escalate scope"
+        // error). The actual create_compute_kernel will fail on the
+        // bogus descriptor — but the failure message proves the
+        // scope lookup passed (different error class).
+        let Some((handle, _arc)) = make_host_handle() else {
+            tracing::warn!(
+                target: "streamlib::tests::escalate_vtable",
+                "skipping valid-token test: no GPU device"
+            );
+            return;
+        };
+
+        let (mut buf, mut len) = make_err_buf();
+        let mut token: *const c_void = std::ptr::null();
+        unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                handle,
+                &mut token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            );
+        }
+        assert!(!token.is_null());
+
+        // Use the token against the FullAccess vtable's
+        // acquire_render_target_dma_buf_image with an invalid format.
+        // The scope lookup should succeed; the format decode should
+        // fail. (We pick this path because it doesn't actually allocate
+        // a real DMA-BUF — easier to test without a full GPU
+        // pipeline.)
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let mut buf2 = [0u8; 256];
+        let mut len2 = 0usize;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE
+                .acquire_render_target_dma_buf_image)(
+                token,
+                64,
+                64,
+                99, // invalid format_raw — fails after scope lookup succeeds
+                &mut out as *mut _ as *mut c_void,
+                buf2.as_mut_ptr(),
+                buf2.len(),
+                &mut len2,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf2, len2);
+        assert!(
+            msg.contains("invalid format_raw"),
+            "expected format-validation error (proving scope lookup passed); got: {msg}"
+        );
+
+        // Clean up the scope.
+        unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_end)(
+                handle,
+                token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            );
+        }
+        unsafe { free_host_handle(handle) };
+    }
+
+    #[test]
+    #[serial]
+    fn full_access_callback_fails_after_escalate_end() {
+        // Closes the scope-token validation loop: a token used after
+        // escalate_end fires returns the InvalidEscalateScope error
+        // (matches the "calls after escalate_end return
+        // InvalidEscalateScope" exit criterion).
+        let Some((handle, _arc)) = make_host_handle() else {
+            tracing::warn!(
+                target: "streamlib::tests::escalate_vtable",
+                "skipping post-end test: no GPU device"
+            );
+            return;
+        };
+
+        let (mut buf, mut len) = make_err_buf();
+        let mut token: *const c_void = std::ptr::null();
+        unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_begin)(
+                handle,
+                &mut token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            );
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE.escalate_end)(
+                handle,
+                token,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            );
+        }
+
+        // Token is now stale — using it on any FullAccess callback
+        // returns "invalid escalate scope".
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let mut buf2 = [0u8; 256];
+        let mut len2 = 0usize;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE
+                .acquire_render_target_dma_buf_image)(
+                token,
+                64,
+                64,
+                0, // valid format
+                &mut out as *mut _ as *mut c_void,
+                buf2.as_mut_ptr(),
+                buf2.len(),
+                &mut len2,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf2, len2);
+        assert!(
+            msg.contains(
+                "acquire_render_target_dma_buf_image: invalid escalate scope"
+            ),
+            "got: {msg}"
+        );
+
+        unsafe { free_host_handle(handle) };
     }
 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -5652,11 +5652,19 @@ mod gpu_lim_escalate_vtable_tests {
     #[serial]
     fn full_access_callback_with_valid_token_resolves_scope() {
         // End-to-end: begin a scope, get a valid token, invoke a
-        // FullAccess vtable callback with the token. The callback's
-        // scope lookup should succeed (no "invalid escalate scope"
-        // error). The actual create_compute_kernel will fail on the
-        // bogus descriptor — but the failure message proves the
-        // scope lookup passed (different error class).
+        // FullAccess vtable callback with the token + a valid
+        // descriptor. The callback's scope-token lookup must succeed
+        // (no "invalid escalate scope" error). The actual allocation
+        // may succeed or fail depending on the Vulkan environment
+        // (render-target DMA-BUF availability, EGL DRM modifier
+        // probe), but EITHER outcome proves the scope lookup passed:
+        // a success returns rc=0 with `out_texture` populated; a
+        // failure returns rc=1 with an error message that does NOT
+        // contain "invalid escalate scope".
+        //
+        // (Mentally revert `with_full_scope_or_err` to always return
+        // None — this test fails because the error message would
+        // then contain "invalid escalate scope".)
         let Some((handle, _arc)) = make_host_handle() else {
             tracing::warn!(
                 target: "streamlib::tests::escalate_vtable",
@@ -5678,12 +5686,6 @@ mod gpu_lim_escalate_vtable_tests {
         }
         assert!(!token.is_null());
 
-        // Use the token against the FullAccess vtable's
-        // acquire_render_target_dma_buf_image with an invalid format.
-        // The scope lookup should succeed; the format decode should
-        // fail. (We pick this path because it doesn't actually allocate
-        // a real DMA-BUF — easier to test without a full GPU
-        // pipeline.)
         let mut out: crate::core::rhi::texture::Texture =
             unsafe { std::mem::zeroed() };
         let mut buf2 = [0u8; 256];
@@ -5694,19 +5696,33 @@ mod gpu_lim_escalate_vtable_tests {
                 token,
                 64,
                 64,
-                99, // invalid format_raw — fails after scope lookup succeeds
+                0, // Rgba8Unorm — valid format; forces scope lookup to run
                 &mut out as *mut _ as *mut c_void,
                 buf2.as_mut_ptr(),
                 buf2.len(),
                 &mut len2,
             )
         };
-        assert_eq!(rc, 1);
-        let msg = err_buf_as_str(&buf2, len2);
-        assert!(
-            msg.contains("invalid format_raw"),
-            "expected format-validation error (proving scope lookup passed); got: {msg}"
-        );
+
+        if rc != 0 {
+            // Allocation failed for an environment reason; assert the
+            // failure was NOT a scope-lookup miss.
+            let msg = err_buf_as_str(&buf2, len2);
+            assert!(
+                !msg.contains("invalid escalate scope"),
+                "scope-token lookup must succeed inside an active \
+                 scope; got: {msg}"
+            );
+        } else {
+            // Allocation succeeded — definitively proves scope lookup
+            // worked. The Texture in `out` owns a live handle; its
+            // Drop will fire the vtable's drop_texture as the test
+            // returns.
+            assert!(!out.handle.is_null(), "out_texture handle populated");
+            // SAFETY: `out` was overwritten by `ptr::write` from the
+            // callback with a valid Texture; let its normal Drop run
+            // to release the underlying handle via the vtable.
+        }
 
         // Clean up the scope.
         unsafe {

--- a/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Phase C3 (#903) cdylib-resident escalate vtable smoke test.
+//!
+//! Loads a dlopen'd `EscalateSmokeTestProcessor` from test-fixtures
+//! and drives it through `start()`. The processor's `start()` body
+//! runs `gpu.escalate(|_full| Ok(()))` once, which exercises the
+//! full scope-token machinery end-to-end across the FFI:
+//!
+//!   1. Cdylib's `GpuContextLimitedAccess::escalate` detects cdylib
+//!      mode (`host_callbacks().is_some()`) and routes through
+//!      `escalate_via_vtable`.
+//!   2. `escalate_via_vtable` calls the `escalate_begin` vtable callback,
+//!      which on the host side enters the escalate gate, clones the
+//!      bound `Arc<GpuContext>`, mints an opaque scope token, and
+//!      registers the scope.
+//!   3. `escalate_via_vtable` constructs a cdylib-side
+//!      `GpuContextFullAccess` via `from_scope_token` (HandleKind::
+//!      ScopeToken).
+//!   4. The closure runs (empty body — just exits cleanly).
+//!   5. The cdylib drops the FullAccess. Drop dispatches on the
+//!      `handle_kind` discriminator: for ScopeToken it's a no-op
+//!      (cleanup happens in `escalate_end`, not here).
+//!   6. `escalate_via_vtable` calls the `escalate_end` vtable callback,
+//!      which removes the scope from the registry, releases the
+//!      escalate gate, and runs `wait_device_idle`.
+//!
+//! A regression in any of the steps above surfaces as either:
+//!   - Missing output file (the cdylib's `start()` panicked at the
+//!     FFI boundary and `run_host_extern_c` swallowed the panic).
+//!   - `ERR:<message>` in the file (the escalate call returned an
+//!     error — typically "invalid escalate scope" if a scope-token
+//!     check failed).
+//!
+//! What this test does NOT cover: cdylib-side dispatch on
+//! `GpuContextFullAccess` methods (`create_compute_kernel`, etc.) —
+//! those still call `host_inner()` and panic from cdylib code. That
+//! gap is the scope of Phase D (#906); the richer "create kernel +
+//! dispatch + compare CPU reference" test originally specced for
+//! #903 lives in Phase E (#907).
+//!
+//! Requires a working Vulkan device (Runner::start() initializes
+//! GpuContext::init_for_platform_sync()). On GPU-less hardware the
+//! runtime start fails with a clean error and the assertion below
+//! surfaces it; CI has no GPU runner planned
+//! (`project_ci_strategy_no_gpu`), so this test runs locally.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use serial_test::serial;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn dlopen_processor_round_trips_escalate_vtable_callbacks() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let output_path = tmp.path().join("escalate_smoke_result.txt");
+    let output_path_str = output_path.to_string_lossy().to_string();
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed against the test-fixtures cdylib");
+
+    let ident = schema_ident!(
+        "tatolab",
+        "test-fixtures",
+        "EscalateSmokeTestProcessor",
+        "1.0.0"
+    );
+
+    runtime
+        .add_processor(ProcessorSpec::new(
+            ident,
+            json!({
+                "output_path": output_path_str,
+            }),
+        ))
+        .expect(
+            "add_processor must succeed for the dlopened EscalateSmokeTestProcessor",
+        );
+
+    runtime
+        .start()
+        .expect("runtime.start() must succeed (requires Vulkan device on this host)");
+
+    // Manual processors fire setup then start synchronously inside
+    // the runtime's processor-spawn path — by the time `start()`
+    // returns, the escalate round-trip has run. Poll briefly to
+    // absorb scheduling jitter.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !output_path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    runtime.stop().ok();
+
+    assert!(
+        output_path.exists(),
+        "EscalateSmokeTestProcessor.start() did not write {} within 5s — \
+         either the cdylib's start() lifecycle didn't fire, or the \
+         escalate vtable dispatch path panicked at the FFI boundary",
+        output_path.display()
+    );
+
+    let contents = std::fs::read_to_string(&output_path).unwrap();
+    assert!(
+        !contents.starts_with("ERR:"),
+        "EscalateSmokeTestProcessor reported an error: {contents}. \
+         Expected 'OK' — any error means the scope-token machinery \
+         (escalate_begin / from_scope_token / escalate_end) failed \
+         end-to-end."
+    );
+    assert_eq!(
+        contents.trim(),
+        "OK",
+        "escalate_smoke_result must be 'OK', got {contents:?}"
+    );
+
+    // Re-running another escalate scope on the same Runner would
+    // dead-lock here if `escalate_end` failed to release the gate.
+    // We don't run a second scope explicitly because `runtime.stop()`
+    // above has already taken the runtime back through the shutdown
+    // path; the lock-leak failure mode would have surfaced as a hang
+    // in the polling loop above (which has a 5s timeout, surfacing
+    // as the "did not write" assertion).
+}

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -162,24 +162,45 @@ pub const SURFACE_STORE_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// a no-op); `PooledTextureHandle::Drop` releases the underlying
 /// pool slot. Linux-only callbacks ship platform stubs on other
 /// triples so the vtable layout stays unconditional.
-pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 9;
+///
+/// - v10: Phase C3 adds `escalate_begin` / `escalate_end` so the
+///   cdylib-side `GpuContextLimitedAccess::escalate(|full| ...)` can
+///   acquire the host's escalate gate, mint an opaque scope token,
+///   and pair it with the FullAccess vtable for the
+///   vtable-dispatched transition into `GpuContextFullAccess`.
+///   Validation of the
+///   scope token on every FullAccess vtable call lives on the
+///   FullAccess vtable side (each callback short-circuits to
+///   `Error::InvalidEscalateScope` when the token is stale).
+pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 
 /// Layout version of [`GpuContextFullAccessVTable`].
 ///
 /// The FullAccess vtable carries the privileged kernel-construction
-/// surface (compute / graphics / ray-tracing) plus `create_texture_ring`.
-/// Each kernel-construction callback consumes a `#[repr(C)]` descriptor
-/// mirror ([`ComputeKernelDescriptorRepr`], [`GraphicsKernelDescriptorRepr`],
+/// surface (compute / graphics / ray-tracing) plus `create_texture_ring`
+/// and `acquire_render_target_dma_buf_image`. Each kernel-construction
+/// callback consumes a `#[repr(C)]` descriptor mirror
+/// ([`ComputeKernelDescriptorRepr`], [`GraphicsKernelDescriptorRepr`],
 /// [`RayTracingKernelDescriptorRepr`]) and returns an Arc-handle β-shape
 /// for the resulting kernel; the matching Arc-lifecycle pairs
 /// (`clone_*` / `drop_*`) live on this vtable.
 ///
 /// Reachable from cdylib code only inside an `escalate(|full| ...)`
-/// scope; the `escalate_begin` / `escalate_end` scope-token machinery
-/// is wired by C3. C2 lands the descriptor wire format + host-side
-/// dispatch + cdylib-side β-shape, locking the layout before the
-/// scope-token machinery turns it on.
-pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 1;
+/// scope established via the LimitedAccess vtable's `escalate_begin` /
+/// `escalate_end` pair. Each FullAccess callback's `gpu_handle`
+/// argument is the opaque scope token issued by `escalate_begin`; the
+/// host validates the token against
+/// `escalate_scope_registry::with_scope` before dispatch and returns
+/// `Error::InvalidEscalateScope` if it's stale or never-issued.
+///
+/// - v2: Phase C3 adds `acquire_render_target_dma_buf_image` (the
+///   one privileged DMA-BUF render-target allocator not yet on this
+///   vtable). The four existing `create_*` callbacks keep their wire
+///   signatures unchanged but switch from "`gpu_handle` is
+///   `*const Arc<GpuContext>`" to "`gpu_handle` is an opaque scope
+///   token" semantically — same `*const c_void`, different lookup
+///   path on the host side.
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 // =============================================================================
 // Primitive enums
@@ -1340,6 +1361,60 @@ pub struct GpuContextLimitedAccessVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Escalate scope transition (Phase C3)
+    // -------------------------------------------------------------------------
+
+    /// Begin an escalate scope. Acquires the host's escalate gate on
+    /// the supplied `gpu_handle`, mints an opaque scope token, and
+    /// writes it into `*out_scope_token` on success. Returns 0 on
+    /// success, non-zero on failure (message in `err_buf`).
+    ///
+    /// The token is opaque to the caller; the cdylib's
+    /// [`GpuContextLimitedAccess::escalate`] wrapper passes it as the
+    /// `gpu_handle` slot when constructing a cdylib-side
+    /// [`GpuContextFullAccess`] and back to `escalate_end` when the
+    /// scope completes. Every FullAccess vtable callback validates
+    /// the token against the host's
+    /// `escalate_scope_registry` before dispatch; calls after
+    /// `escalate_end` (or against a never-issued token) return a
+    /// `Error::InvalidEscalateScope`-flavored error in the callback's
+    /// `err_buf`.
+    ///
+    /// Blocking: the gate's `enter` serializes against any other
+    /// escalate scope on the same `GpuContext` (host-mode or
+    /// cdylib-mode), so `escalate_begin` may block for the duration
+    /// of a prior scope.
+    ///
+    /// [`GpuContextLimitedAccess::escalate`]: streamlib_plugin_abi::GpuContextLimitedAccessVTable
+    /// [`GpuContextFullAccess`]: streamlib_plugin_abi::GpuContextFullAccessVTable
+    pub escalate_begin: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        out_scope_token: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// End an escalate scope. Releases the host's escalate gate and
+    /// invalidates the token, then waits for the GPU device to go
+    /// idle (matching the host-mode escalate path's
+    /// `wait_device_idle` at scope end). Returns 0 on success,
+    /// non-zero on failure (message in `err_buf`); a non-zero return
+    /// indicates `wait_device_idle` failed — the scope is still
+    /// invalidated and the gate is still released.
+    ///
+    /// Idempotent against a never-issued or already-ended token —
+    /// the call returns 0 cleanly without releasing another scope's
+    /// gate.
+    pub escalate_end: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        scope_token: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for GpuContextLimitedAccessVTable {}
@@ -2073,6 +2148,34 @@ pub struct GpuContextFullAccessVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Render-target surface allocation (Phase C3 — Linux-only privileged
+    // primitive)
+    // -------------------------------------------------------------------------
+
+    /// Allocate a render-target-capable DMA-BUF-backed `VkImage` from
+    /// the host's privileged surface path. The cdylib's
+    /// `GpuContextFullAccess::acquire_render_target_dma_buf_image`
+    /// dispatches through this slot inside an active escalate scope;
+    /// the host picks a tiled DRM modifier via the EGL probe, runs the
+    /// allocation through the RHI's render-target pool, and writes a
+    /// fresh `Texture` β-shape into `*out_texture` on success.
+    ///
+    /// `format_raw` is the `#[repr(u32)]` discriminant of
+    /// `streamlib_consumer_rhi::TextureFormat`. Linux-only; non-Linux
+    /// stubs return non-zero with a "not available on this platform"
+    /// message.
+    pub acquire_render_target_dma_buf_image: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        width: u32,
+        height: u32,
+        format_raw: u32,
+        out_texture: *mut c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for GpuContextFullAccessVTable {}
@@ -2645,9 +2748,9 @@ mod layout_tests {
         // v2: added owning-Arc handle lifetime callbacks
         // (`clone_handle` / `drop_handle`).
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
-        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 9);
+        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 2);
     }
 
     #[test]
@@ -2691,9 +2794,11 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_limited_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 50 fn
-        // pointers (8 bytes each) = 4 + 4 + 400 = 408 bytes.
-        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 408);
+        // layout_version (u32) + _reserved_padding (u32) + 52 fn
+        // pointers (8 bytes each) = 4 + 4 + 416 = 424 bytes.
+        // (C3 appended escalate_begin + escalate_end, taking the
+        // count from 50 → 52.)
+        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 424);
         assert_eq!(align_of::<GpuContextLimitedAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextLimitedAccessVTable, layout_version), 0);
         assert_eq!(
@@ -2900,17 +3005,27 @@ mod layout_tests {
             offset_of!(GpuContextLimitedAccessVTable, resolve_pixel_buffer_by_surface_id),
             400
         );
+        // C3-added entries (Phase C3, #903).
+        assert_eq!(
+            offset_of!(GpuContextLimitedAccessVTable, escalate_begin),
+            408
+        );
+        assert_eq!(
+            offset_of!(GpuContextLimitedAccessVTable, escalate_end),
+            416
+        );
     }
 
     #[test]
     fn gpu_context_full_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 13 fn
-        // pointers (8 bytes each) = 4 + 4 + 104 = 112 bytes.
+        // layout_version (u32) + _reserved_padding (u32) + 14 fn
+        // pointers (8 bytes each) = 4 + 4 + 112 = 120 bytes.
         //
-        // 13 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
+        // 14 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
         // pointers for the 4 kernel return types) + 4 create_* method
-        // callbacks (compute / graphics / ray-tracing / texture_ring).
-        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 112);
+        // callbacks (compute / graphics / ray-tracing / texture_ring)
+        // + 1 acquire_render_target_dma_buf_image (C3-added, #903).
+        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 120);
         assert_eq!(align_of::<GpuContextFullAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, layout_version), 0);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, _reserved_padding), 4);
@@ -2962,6 +3077,14 @@ mod layout_tests {
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, create_texture_ring),
             104
+        );
+        // C3-added entry (Phase C3, #903).
+        assert_eq!(
+            offset_of!(
+                GpuContextFullAccessVTable,
+                acquire_render_target_dma_buf_image
+            ),
+            112
         );
     }
 

--- a/packages/test-fixtures/schemas/escalate_smoke_test_processor_config.yaml
+++ b/packages/test-fixtures/schemas/escalate_smoke_test_processor_config.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Test-only config schema for the Phase C3 dlopen-cdylib escalate
+# smoke test. The processor runs `gpu.escalate(|_full| Ok(()))` once
+# from cdylib code and writes "OK" or "ERR:<msg>" to `output_path`,
+# exercising the full escalate_begin → from_scope_token → FullAccess
+# Drop (no-op for ScopeToken) → escalate_end chain end-to-end.
+
+metadata:
+  type: EscalateSmokeTestProcessorConfig
+  description: "Test config schema for the cdylib escalate smoke test (Phase C3)."
+
+properties:
+  output_path:
+    metadata:
+      description: "Filesystem path where the processor writes its result. Format: 'OK' on success, 'ERR:<message>' on failure."
+    type: string

--- a/packages/test-fixtures/src/escalate_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/escalate_smoke_test_processor.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Phase C3 (#903) dlopen-cdylib escalate smoke test fixture.
+//!
+//! Proves the scope-token machinery fires end-to-end through the FFI
+//! boundary. The processor's `start()` runs:
+//!
+//! ```ignore
+//! ctx.gpu_limited_access().escalate(|_full| Ok(()))
+//! ```
+//!
+//! which exercises:
+//!   1. `escalate_begin` vtable callback (host mints a scope token,
+//!      enters the escalate gate, registers the per-scope Arc).
+//!   2. Cdylib-side `GpuContextFullAccess::from_scope_token`
+//!      construction (vtable-dispatched path).
+//!   3. Closure runs (empty body — just verifies the FullAccess
+//!      borrow is reachable).
+//!   4. Cdylib-side `GpuContextFullAccess::drop` short-circuits for
+//!      the `HandleKind::ScopeToken` case (cleanup happens in
+//!      `escalate_end`, not Drop).
+//!   5. `escalate_end` vtable callback (host removes the scope,
+//!      releases the gate, runs `wait_device_idle`).
+//!
+//! What this test does NOT cover: cdylib-side dispatch on
+//! `GpuContextFullAccess` methods (`create_compute_kernel`, etc.) —
+//! those still call `host_inner()` and panic in cdylib mode. That
+//! gap is the work of Phase D (#906) and Phase E (#907). The richer
+//! "create kernel + dispatch + verify CPU reference" test originally
+//! specced for #903 lives in #907.
+//!
+//! Output format:
+//!   - "OK" — both `escalate_begin` and `escalate_end` succeeded and
+//!     the closure ran.
+//!   - "ERR:<message>" — any step failed.
+
+use streamlib::sdk::context::{
+    RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ManualProcessor;
+
+#[streamlib::sdk::processor("EscalateSmokeTestProcessor")]
+pub struct EscalateSmokeTest {}
+
+impl ManualProcessor for EscalateSmokeTest::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let output_path = self.config.output_path.clone();
+
+        // Escalate with an empty closure. In cdylib mode this routes
+        // through `escalate_via_vtable`: vtable.escalate_begin → mint
+        // scope_token → construct GpuContextFullAccess via
+        // from_scope_token → run closure → vtable.escalate_end. A
+        // panic at any FFI boundary surfaces as a panic in the
+        // closure or a non-zero escalate return; both produce an
+        // "ERR:" line.
+        let result: Result<()> =
+            ctx.gpu_limited_access().escalate(|_full| Ok(()));
+
+        let line = match result {
+            Ok(()) => "OK".to_string(),
+            Err(e) => format!("ERR:{e}"),
+        };
+        std::fs::write(&output_path, &line).map_err(|e| {
+            Error::Runtime(format!("EscalateSmokeTest: write {output_path}: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -10,10 +10,12 @@ pub mod _generated_ {
     include!(concat!(env!("OUT_DIR"), "/_generated_shim.rs"));
 }
 
+pub mod escalate_smoke_test_processor;
 pub mod gpu_acquire_test_processor;
 pub mod tcp_bind_test_processor;
 pub mod test_configured_processor;
 
+pub use escalate_smoke_test_processor::EscalateSmokeTest;
 pub use gpu_acquire_test_processor::GpuAcquireTest;
 pub use tcp_bind_test_processor::TcpBindTest;
 pub use test_configured_processor::ConfiguredProcessor;
@@ -23,4 +25,5 @@ streamlib_plugin_abi::export_plugin!(
     crate::ConfiguredProcessor::Processor,
     crate::TcpBindTest::Processor,
     crate::GpuAcquireTest::Processor,
+    crate::EscalateSmokeTest::Processor,
 );

--- a/packages/test-fixtures/streamlib.yaml
+++ b/packages/test-fixtures/streamlib.yaml
@@ -24,6 +24,8 @@ schemas:
     file: schemas/tcp_bind_test_processor_config.yaml
   GpuAcquireTestProcessorConfig:
     file: schemas/gpu_acquire_test_processor_config.yaml
+  EscalateSmokeTestProcessorConfig:
+    file: schemas/escalate_smoke_test_processor_config.yaml
 
 processors:
   - name: TestConfiguredProcessor
@@ -49,3 +51,11 @@ processors:
     config:
       name: config
       schema: GpuAcquireTestProcessorConfig
+
+  - name: EscalateSmokeTestProcessor
+    version: 1.0.0
+    description: "Phase C3 (#903) dlopen-cdylib escalate smoke test fixture — runs gpu.escalate(|_full| Ok(())) end-to-end through the escalate_begin/escalate_end vtable + cdylib-side FullAccess construction via from_scope_token"
+    execution: manual
+    config:
+      name: config
+      schema: EscalateSmokeTestProcessorConfig


### PR DESCRIPTION
## Summary

Phase C3 of the GpuContext callback-table migration — the architecturally novel piece. Wires the privileged `escalate(|full| ...)` transition across the plugin ABI via an opaque scope-token mechanism + a `Condvar`-based escalate gate, and adds the one remaining FullAccess-only primitive (`acquire_render_target_dma_buf_image`) to the FullAccess vtable.

- **`EscalateScopeRegistry`** (global) + **`EscalateGate`** (per-`GpuContext`, Condvar-based) replace `processor_setup_lock`. The gate's enter/exit semantics are independent of any one stack frame — required for the cdylib vtable-dispatched path where `escalate_begin` returns before the closure runs and `escalate_end` may fire from a different thread.
- **`GpuContextLimitedAccess::escalate` is mode-routed.** Engine-internal callers use direct in-process dispatch (`host_inner` deref, no FFI). Cdylib callers route through new `escalate_begin` / `escalate_end` vtable callbacks. The router uses the existing `host_callbacks().is_some()` check. Closure panics in the vtable path `catch_unwind` so `escalate_end` always fires and the gate never leaks.
- **`GpuContextFullAccess`** gains a `handle_kind: HandleKind` discriminator (`Boxed` | `ScopeToken`). `Drop` dispatches on the kind directly — no vtable hop for the engine-internal Boxed shape, no-op for the cdylib `ScopeToken` shape (cleanup runs in `escalate_end`). New `from_scope_token` constructor for the cdylib path; the existing `new(GpuContext)` is tightened to `pub(in crate::core::context)` so only `escalate`'s engine-internal body can construct one.
- **Vtable surface:** `GpuContextLimitedAccessVTable` 9 → 10 (adds `escalate_begin` / `escalate_end`); `GpuContextFullAccessVTable` 1 → 2 (adds `acquire_render_target_dma_buf_image`). C2's four FullAccess `create_*` callbacks switch `gpu_handle` semantics from `*const Arc<GpuContext>` to opaque scope_token; every body now resolves the token via `with_full_scope_or_err` and returns `Error::InvalidEscalateScope` on miss.

## Closes

Closes #903
Closes #886

## What's deferred (filed as follow-ups)

The original #903 body's "create kernel + dispatch + verify CPU reference" dlopen test was downgraded to a smoke shape (`escalate(|_full| Ok(()))`). The richer test required cdylib-side dispatch on `GpuContextFullAccess` methods (#906, Phase D) plus β-newtypes for kernel return handles (#907, Phase E) — both C2-deferred work this PR's audit surfaced.

- **#906** — Phase D: cdylib dispatch for every `GpuContextFullAccess` method
- **#907** — Phase E: kernel / ring / acceleration-structure handle β-newtypes (lands the richer dlopen test)
- **#908** — Phase F: close β-shape `pub fn` cdylib panic-or-UB gaps
- **#909** — Phase G: tier-1 + layout regression + dlopen lifecycle test backfill
- **#910** — Phase H: comprehensive completeness + test-coverage sweep (the "are we done?" gate)
- **#911** — pre-existing `cargo test` parallel-execution SIGSEGV flake (NVIDIA dual-VkDevice race); separate from the plugin ABI work

Each follow-up enumerates every method / surface / test in scope explicitly so the picker has a complete checklist. Dependencies are wired natively in GitHub: D blocks E + F; E blocks G; D/E/F/G all block H.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test -p streamlib-plugin-abi --lib` — 32 layout regression tests (bumped vtable size + offset assertions for new slots)
- [x] `cargo test -p streamlib-engine --lib -- --test-threads=1` — 479 passed (includes 4 new `EscalateScopeRegistry` tests, 4 new `EscalateGate` tests, 6 new `gpu_lim_escalate_vtable_tests`, 9 FullAccess vtable tier-1 tests with 2 new for `acquire_render_target_dma_buf_image`)
- [x] All 7 dlopen integration tests pass (existing 6 + new `load_project_dylib_escalate_smoke`). Trace on a passing run reads `dispatch=\"vtable\" closure_ok=true` end-to-end
- [x] pr-review-gate: PASS (3 DISCUSS items; one was a real test-quality concern that I fixed in a follow-up commit, two were minor doc improvements / Phase H sweep work)

### E2E Test Report

- **Scenario**: dlopen integration smoke
- **Example**: `libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs`
- **Codec**: n/a
- **Build profile**: debug
- **Command**:
    ```
    cargo test -p streamlib-engine --test load_project_dylib_escalate_smoke
    ```

#### Log signals

- `OUT_OF_DEVICE_MEMORY`: 0
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `escalate completed dispatch=\"vtable\" closure_ok=true mutex_wait_ns=11201 wait_idle_ns=21551`

#### Outcome

- **Pass**
- Caveats / follow-ups filed: #906, #907, #908, #909, #910, #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)