### PR TITLE
feat(plugin-abi): cdylib dispatch for every GpuContextFullAccess method (Phase D of #886) (#906)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,31 @@ StreamLib is built like a game engine: a small set of **core systems** are reuse
 
 Past models repeatedly created parallel abstractions without reading existing code, producing module and crate sprawl where the same concern was solved N different ways. **Do not do this.** Before introducing any new abstraction, you must prove no existing core system already covers the concern — and if one does, extend it rather than build a parallel.
 
+### Plugin Distribution Model — the cross-repo dream
+
+The engine is a pure substrate. It ships with **no processors, no schemas, no `streamlib.yaml` of its own** — `Runner::new()` starts with an empty registry, and every processor / schema / link is contributed by `.slpkg` packages loaded at runtime via `runtime.load_project(...)` or `runtime.load_package(...)`.
+
+**The target distribution shape**: a plugin author in a completely separate GitHub repo, building on a completely different machine with a different rustc version and different transitive Cargo dep graph, can publish a `.slpkg` file. A streamlib host (e.g. tatolab/drone-racer, or any third-party host that Cargo-deps `streamlib`) loads that `.slpkg` at runtime via `dlopen` and the plugin's processors register cleanly into the host's runtime graph. The plugin author and the host author **never coordinate toolchains**.
+
+What makes this work: every type that crosses the plugin / engine FFI boundary is `#[repr(C)]`, with its byte layout pinned by a layout regression test in `streamlib-plugin-abi`. The plugin and the host must agree on:
+
+- Target triple (`x86_64-unknown-linux-gnu`, etc.) — for the obvious reasons
+- `streamlib-plugin-abi` version — the C-ABI vtable contract
+- `streamlib-consumer-rhi` version — the consumer-side carve-out (β-shape texture / buffer / device types)
+
+They do NOT need to agree on:
+
+- rustc version
+- Cargo dep graph resolution
+- Feature flags on shared transitive deps
+- Optimization profile
+
+**Where the dream currently leaks**: Phase D (#906) and Phase C2 (#905) shipped some FullAccess methods that return `Arc<HostInternalType>` via `Arc::into_raw` / `Arc::from_raw` raw-pointer transit. Those code paths DO require rustc-version coupling because the host-internal types aren't `#[repr(C)]`. Issue #917 closes that gap by β-shape-refactoring the affected return types into `#[repr(C)] { handle, vtable }` pairs (mirroring `RhiCommandQueue` / `CommandBuffer`). After #917 lands, no FFI return type leaks host layout, and the cross-repo dream is fully real.
+
+**What's NOT in scope** (deferred to its own milestone): a hosted marketplace / registry / index. Today's distribution model is "package author hands you an `.slpkg` directly, or you clone the repo and run `streamlib pack` yourself". A managed registry where you'd run `streamlib install @tatolab/camera` is a separate future deliverable.
+
+**Implication for new architectural work**: any cross-FFI surface added in this codebase MUST be `#[repr(C)]` end-to-end. If you're tempted to return `Arc<SomeHostInternalType>` from a cdylib-callable method, stop — the answer is to β-shape the type. The dormant `clone_*` / `drop_*` slots already present on the FullAccess vtable are infrastructure for this. The "rustc-version coupling stays" framing that previously appeared in the All-Dynamic Package Loading milestone body was a permissive fallback while β-shape coverage was incomplete; it's superseded as of 2026-05-22.
+
 ### Before Creating Any New Abstraction
 
 "Abstraction" here means: a new trait, struct, helper method, utility function, or module intended to be reused across more than one call site.

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -2032,6 +2032,28 @@ pub struct GpuContextFullAccess {
     /// Set by the constructor ([`Self::new`] vs
     /// [`Self::from_scope_token`]).
     pub(crate) handle_kind: HandleKind,
+    /// Inherited LimitedAccess handle (scope-token mode only).
+    ///
+    /// Phase D — Option B (Limited-handle inheritance): the
+    /// FullAccess wrappers for the LimitedAccess-mirror methods
+    /// (`acquire_pixel_buffer`, `register_texture_with_layout`,
+    /// `surface_store`, etc.) dispatch through the **inherited**
+    /// LimitedAccess vtable using this handle, rather than through a
+    /// parallel FullAccess vtable slot. Reuses the C1-proven
+    /// LimitedAccess dispatch surface instead of mirroring it on
+    /// FullAccess. The LimitedAccess that originated the escalate
+    /// scope outlives the FullAccess (closure scope), so borrowing
+    /// the handle without bumping its refcount is sound.
+    ///
+    /// `null` in [`HandleKind::Boxed`] (in-process) mode — engine
+    /// callers use `host_inner()` directly and don't need this.
+    pub(crate) inherited_lim_handle: *const std::ffi::c_void,
+    /// Inherited LimitedAccess vtable pointer paired with
+    /// [`Self::inherited_lim_handle`]. See its doc for the role.
+    ///
+    /// `null` in [`HandleKind::Boxed`] (in-process) mode.
+    pub(crate) inherited_lim_vtable:
+        *const streamlib_plugin_abi::GpuContextLimitedAccessVTable,
 }
 
 /// Discriminator for [`GpuContextFullAccess`]'s `handle` field. The
@@ -2060,7 +2082,11 @@ pub(crate) enum HandleKind {
 // or an opaque scope token (vtable-dispatched shape); both are
 // `Send + Sync` (the scope token is a u64 reinterpreted as
 // `*const c_void`; the boxed Arc<GpuContext> is Send + Sync). The
-// vtable pointer is `&'static`.
+// vtable pointer is `&'static`. The inherited LimitedAccess fields
+// either point at the same host-owned `Box<Arc<GpuContext>>` the
+// originating LimitedAccess holds (scope-token mode) — borrowed for
+// the closure's lifetime, no refcount bump — or are null (Boxed
+// mode); both are `Send + Sync` for the same reason as `handle`.
 unsafe impl Send for GpuContextFullAccess {}
 unsafe impl Sync for GpuContextFullAccess {}
 
@@ -2304,7 +2330,18 @@ impl GpuContextLimitedAccess {
         }
 
         let closure_start = std::time::Instant::now();
-        let full = GpuContextFullAccess::from_scope_token(scope_token);
+        // Pass through the originating LimitedAccess (handle, vtable)
+        // so the FullAccess wrappers for the LimitedAccess-mirror
+        // methods (Phase D Option B) can dispatch through the C1-
+        // proven LimitedAccess vtable. The originating LimitedAccess
+        // owns the handle for the lifetime of this scope (we hold
+        // `&self` across the closure), so borrowing without bumping
+        // the refcount is sound.
+        let full = GpuContextFullAccess::from_scope_token(
+            scope_token,
+            self.handle,
+            self.vtable,
+        );
         // catch_unwind so a closure panic still fires escalate_end —
         // otherwise the host's escalate gate would leak. We lean on
         // AssertUnwindSafe because `escalate`'s public signature
@@ -2435,6 +2472,11 @@ impl GpuContextFullAccess {
             handle,
             vtable,
             handle_kind: HandleKind::Boxed,
+            // In-process Boxed mode never consults the inherited
+            // LimitedAccess vtable — `host_inner()` is the direct path.
+            // Null sentinels match the field doc on the struct.
+            inherited_lim_handle: std::ptr::null(),
+            inherited_lim_vtable: std::ptr::null(),
         }
     }
 
@@ -2451,8 +2493,20 @@ impl GpuContextFullAccess {
     /// (release the escalate gate + `wait_device_idle`) runs inside
     /// `escalate_end` rather than [`Drop`], so the FullAccess's
     /// [`Drop`] short-circuits.
+    ///
+    /// `inherited_lim_handle` / `inherited_lim_vtable` are the
+    /// originating `GpuContextLimitedAccess`'s handle + vtable. Phase
+    /// D's Option-B dispatch shape for the LimitedAccess-mirror
+    /// methods (e.g. [`Self::acquire_pixel_buffer`],
+    /// [`Self::register_texture_with_layout`], [`Self::surface_store`])
+    /// borrows these to dispatch through the C1-proven LimitedAccess
+    /// vtable, avoiding ~20 duplicate slot entries on the FullAccess
+    /// vtable. See the struct doc for the inheritance rationale.
     pub(in crate::core::context) fn from_scope_token(
         scope_token: *const std::ffi::c_void,
+        inherited_lim_handle: *const std::ffi::c_void,
+        inherited_lim_vtable:
+            *const streamlib_plugin_abi::GpuContextLimitedAccessVTable,
     ) -> Self {
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
@@ -2460,6 +2514,8 @@ impl GpuContextFullAccess {
             handle: scope_token,
             vtable,
             handle_kind: HandleKind::ScopeToken,
+            inherited_lim_handle,
+            inherited_lim_vtable,
         }
     }
 
@@ -2495,6 +2551,28 @@ impl GpuContextFullAccess {
     /// lands.
     pub(crate) fn inner(&self) -> &GpuContext {
         self.host_inner()
+    }
+
+    /// Phase D Option B helper — construct a non-dropping view of
+    /// the originating [`GpuContextLimitedAccess`] for cdylib
+    /// dispatch through the inherited vtable.
+    ///
+    /// Used by the FullAccess mirror methods (`acquire_pixel_buffer`,
+    /// `register_texture_with_layout`, `surface_store`, etc.) to
+    /// dispatch through the C1-proven LimitedAccess vtable instead
+    /// of mirroring those slots on the FullAccess vtable.
+    ///
+    /// **Must be wrapped in [`std::mem::ManuallyDrop`] at the call
+    /// site** so the borrowed handle isn't double-released — the
+    /// originating LimitedAccess outlives the FullAccess scope and
+    /// owns the only Drop responsibility for the handle.
+    pub(crate) fn inherited_limited_unchecked(
+        &self,
+    ) -> std::mem::ManuallyDrop<GpuContextLimitedAccess> {
+        std::mem::ManuallyDrop::new(GpuContextLimitedAccess {
+            handle: self.inherited_lim_handle,
+            vtable: self.inherited_lim_vtable,
+        })
     }
 
     /// Produce a [`GpuContextLimitedAccess`] view of the same
@@ -3334,18 +3412,59 @@ impl GpuContextLimitedAccess {
 
 impl GpuContextFullAccess {
     /// Wait for the GPU device to become idle.
+    ///
+    /// Mode-routed; see [`Self::create_compute_kernel`] for the
+    /// dispatch contract.
     pub fn wait_device_idle(&self) -> Result<()> {
-        self.host_inner().wait_device_idle()
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().wait_device_idle(),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "wait_device_idle: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).wait_device_idle)(
+                        self.handle,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Acquire a pixel buffer from the shared pool.
+    ///
+    /// LimitedAccess mirror — cdylib dispatch inherits the C1-proven
+    /// `acquire_pixel_buffer` slot via [`Self::inherited_limited_unchecked`].
     pub fn acquire_pixel_buffer(
         &self,
         width: u32,
         height: u32,
         format: PixelFormat,
     ) -> Result<(PixelBufferPoolId, PixelBuffer)> {
-        self.host_inner().acquire_pixel_buffer(width, height, format)
+        match self.handle_kind {
+            HandleKind::Boxed => {
+                self.host_inner().acquire_pixel_buffer(width, height, format)
+            }
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .acquire_pixel_buffer(width, height, format),
+        }
     }
 
     /// Acquire a HOST_VISIBLE storage buffer for CPU→GPU SSBO upload.
@@ -3355,7 +3474,12 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::StorageBuffer> {
-        self.host_inner().acquire_storage_buffer(byte_size)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().acquire_storage_buffer(byte_size),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .acquire_storage_buffer(byte_size),
+        }
     }
 
     /// Acquire a HOST_VISIBLE uniform buffer.
@@ -3364,7 +3488,12 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::UniformBuffer> {
-        self.host_inner().acquire_uniform_buffer(byte_size)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().acquire_uniform_buffer(byte_size),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .acquire_uniform_buffer(byte_size),
+        }
     }
 
     /// Acquire a HOST_VISIBLE vertex buffer.
@@ -3373,7 +3502,12 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::VertexBuffer> {
-        self.host_inner().acquire_vertex_buffer(byte_size)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().acquire_vertex_buffer(byte_size),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .acquire_vertex_buffer(byte_size),
+        }
     }
 
     /// Acquire a HOST_VISIBLE index buffer.
@@ -3382,12 +3516,26 @@ impl GpuContextFullAccess {
         &self,
         byte_size: u64,
     ) -> Result<crate::core::rhi::IndexBuffer> {
-        self.host_inner().acquire_index_buffer(byte_size)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().acquire_index_buffer(byte_size),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .acquire_index_buffer(byte_size),
+        }
     }
 
     /// Allocate a render-target-capable DMA-BUF VkImage (privileged path —
     /// host-only adapter primitive, customers never see this directly).
     /// See [`GpuContext::acquire_render_target_dma_buf_image`].
+    ///
+    /// Mode-routed:
+    /// - [`HandleKind::Boxed`] (in-process): direct dispatch via
+    ///   [`Self::host_inner`].
+    /// - [`HandleKind::ScopeToken`] (cdylib): dispatch through the
+    ///   [`GpuContextFullAccessVTable`](streamlib_plugin_abi::GpuContextFullAccessVTable)'s
+    ///   `acquire_render_target_dma_buf_image` slot, which validates the
+    ///   scope token via [`super::escalate_scope_registry::with_scope`]
+    ///   before calling the host's privileged surface path.
     #[cfg(target_os = "linux")]
     pub fn acquire_render_target_dma_buf_image(
         &self,
@@ -3395,23 +3543,79 @@ impl GpuContextFullAccess {
         height: u32,
         format: TextureFormat,
     ) -> Result<Texture> {
-        self.host_inner()
-            .acquire_render_target_dma_buf_image(width, height, format)
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .acquire_render_target_dma_buf_image(width, height, format),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "acquire_render_target_dma_buf_image: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_texture: std::mem::MaybeUninit<Texture> =
+                    std::mem::MaybeUninit::uninit();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                // SAFETY: vtable + handle (scope_token) were paired at
+                // construction; the host writes a valid Texture into
+                // `out_texture` on success.
+                let status = unsafe {
+                    ((*self.vtable).acquire_render_target_dma_buf_image)(
+                        self.handle,
+                        width,
+                        height,
+                        format as u32,
+                        out_texture.as_mut_ptr() as *mut std::ffi::c_void,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    // SAFETY: host signaled success and wrote a valid value.
+                    Ok(unsafe { out_texture.assume_init() })
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Get a pixel buffer by its pool id.
     pub fn get_pixel_buffer(&self, pool_id: &PixelBufferPoolId) -> Result<PixelBuffer> {
-        self.host_inner().get_pixel_buffer(pool_id)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().get_pixel_buffer(pool_id),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().get_pixel_buffer(pool_id)
+            }
+        }
     }
 
     /// Resolve a VideoFrame's buffer from its surface_id.
     pub fn resolve_pixel_buffer_by_surface_id(&self, surface_id: &str) -> Result<PixelBuffer> {
-        self.host_inner().resolve_pixel_buffer_by_surface_id(surface_id)
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .resolve_pixel_buffer_by_surface_id(surface_id),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .resolve_pixel_buffer_by_surface_id(surface_id),
+        }
     }
 
     /// Register a texture in the same-process texture cache.
     pub fn register_texture(&self, id: &str, texture: Texture) {
-        self.host_inner().register_texture(id, texture);
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().register_texture(id, texture),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .register_texture(id, texture),
+        }
     }
 
     /// Register a texture with a declared initial Vulkan image layout.
@@ -3423,15 +3627,28 @@ impl GpuContextFullAccess {
         texture: Texture,
         initial_layout: VulkanLayout,
     ) {
-        self.host_inner()
-            .register_texture_with_layout(id, texture, initial_layout);
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .register_texture_with_layout(id, texture, initial_layout),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .register_texture_with_layout(id, texture, initial_layout),
+        }
     }
 
     /// Update a registered texture's tracked layout after a transition.
     /// See [`GpuContext::update_texture_registration_layout`].
     #[cfg(target_os = "linux")]
     pub fn update_texture_registration_layout(&self, id: &str, layout: VulkanLayout) {
-        self.host_inner().update_texture_registration_layout(id, layout);
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .update_texture_registration_layout(id, layout),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .update_texture_registration_layout(id, layout),
+        }
     }
 
     /// Resolve a VideoFrame's full registration record (texture + layout).
@@ -3442,8 +3659,22 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<TextureRegistration> {
-        self.host_inner()
-            .resolve_texture_registration_by_surface_id(surface_id, texture_layout, width, height)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().resolve_texture_registration_by_surface_id(
+                surface_id,
+                texture_layout,
+                width,
+                height,
+            ),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .resolve_texture_registration_by_surface_id(
+                    surface_id,
+                    texture_layout,
+                    width,
+                    height,
+                ),
+        }
     }
 
     /// Resolve a VideoFrame's texture.
@@ -3454,8 +3685,22 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<Texture> {
-        self.host_inner()
-            .resolve_texture_by_surface_id(surface_id, texture_layout, width, height)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().resolve_texture_by_surface_id(
+                surface_id,
+                texture_layout,
+                width,
+                height,
+            ),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .resolve_texture_by_surface_id(
+                    surface_id,
+                    texture_layout,
+                    width,
+                    height,
+                ),
+        }
     }
 
     /// Acquire a new output texture with a UUID and register it in the cache.
@@ -3465,7 +3710,58 @@ impl GpuContextFullAccess {
         height: u32,
         format: TextureFormat,
     ) -> Result<(String, Texture)> {
-        self.host_inner().acquire_output_texture(width, height, format)
+        match self.handle_kind {
+            HandleKind::Boxed => {
+                self.host_inner().acquire_output_texture(width, height, format)
+            }
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "acquire_output_texture: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut id_buf = [0u8; 1024];
+                let mut id_len: usize = 0;
+                let mut out_texture: std::mem::MaybeUninit<Texture> =
+                    std::mem::MaybeUninit::uninit();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).acquire_output_texture)(
+                        self.handle,
+                        width,
+                        height,
+                        format as u32,
+                        id_buf.as_mut_ptr(),
+                        id_buf.len(),
+                        &mut id_len as *mut usize,
+                        out_texture.as_mut_ptr() as *mut std::ffi::c_void,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    let id = match std::str::from_utf8(&id_buf[..id_len]) {
+                        Ok(s) => s.to_string(),
+                        Err(e) => {
+                            return Err(Error::GpuError(format!(
+                                "acquire_output_texture: surface id not UTF-8: {e}"
+                            )));
+                        }
+                    };
+                    // SAFETY: host signaled success and wrote a Texture.
+                    let texture = unsafe { out_texture.assume_init() };
+                    Ok((id, texture))
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Upload a pixel buffer's contents to a GPU texture and register it.
@@ -3477,8 +3773,42 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        self.host_inner()
-            .upload_pixel_buffer_as_texture(surface_id, pixel_buffer, width, height)
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .upload_pixel_buffer_as_texture(surface_id, pixel_buffer, width, height),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "upload_pixel_buffer_as_texture: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).upload_pixel_buffer_as_texture)(
+                        self.handle,
+                        surface_id.as_ptr(),
+                        surface_id.len(),
+                        pixel_buffer as *const PixelBuffer as *const std::ffi::c_void,
+                        width,
+                        height,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    Ok(())
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Copy a host-visible pixel buffer's contents into an *already-allocated*
@@ -3498,13 +3828,24 @@ impl GpuContextFullAccess {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        self.host_inner().copy_pixel_buffer_to_texture(
-            pixel_buffer,
-            texture,
-            surface_id,
-            width,
-            height,
-        )
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().copy_pixel_buffer_to_texture(
+                pixel_buffer,
+                texture,
+                surface_id,
+                width,
+                height,
+            ),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .copy_pixel_buffer_to_texture(
+                    pixel_buffer,
+                    texture,
+                    surface_id,
+                    width,
+                    height,
+                ),
+        }
     }
 
     /// Pre-allocate a ring of `count` non-exportable DEVICE_LOCAL
@@ -3531,16 +3872,84 @@ impl GpuContextFullAccess {
         usages: TextureUsages,
         count: usize,
     ) -> Result<Arc<crate::core::context::TextureRing>> {
-        self.host_inner()
-            .create_texture_ring(width, height, format, usages, count)
+        match self.handle_kind {
+            HandleKind::Boxed => self
+                .host_inner()
+                .create_texture_ring(width, height, format, usages, count),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_texture_ring: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_ring: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_texture_ring)(
+                        self.handle,
+                        width,
+                        height,
+                        format as u32,
+                        usages.bits(),
+                        count,
+                        &mut out_ring,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_ring.is_null() {
+                        return Err(Error::GpuError(
+                            "create_texture_ring: host signaled success but out_ring is null"
+                                .into(),
+                        ));
+                    }
+                    // SAFETY: host returned
+                    // `Arc::into_raw(Arc<TextureRing>)`. Rebuilding via
+                    // `Arc::from_raw` is sound under the rustc-version
+                    // coupling contract documented in CLAUDE.md (host
+                    // and cdylib share the toolchain + dep graph, so
+                    // `TextureRing`'s layout is byte-identical and the
+                    // host's `Arc` strong-count machinery survives the
+                    // cross-DSO transit). The host transferred its
+                    // strong reference to us; `Arc<TextureRing>::drop`
+                    // running in cdylib code releases that reference.
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_ring as *const crate::core::context::TextureRing,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// See [`GpuContext::unregister_texture`].
     pub fn unregister_texture(&self, id: &str) {
-        self.host_inner().unregister_texture(id);
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().unregister_texture(id),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().unregister_texture(id);
+            }
+        }
     }
 
     /// See [`GpuContext::set_video_source_timeline_semaphore`].
+    ///
+    /// **Engine-only** — parameter is `&Arc<HostVulkanTimelineSemaphore>`
+    /// (host-internal type from `crate::vulkan::rhi`). Calling from a
+    /// cdylib panics inside [`Self::host_inner`]; the panic is caught by
+    /// `run_host_extern_c` at the FFI boundary, so it surfaces as a
+    /// clean "callback panicked" log rather than UB.
     #[cfg(target_os = "linux")]
     pub fn set_video_source_timeline_semaphore(
         &self,
@@ -3550,12 +3959,21 @@ impl GpuContextFullAccess {
     }
 
     /// See [`GpuContext::clear_video_source_timeline_semaphore`].
+    ///
+    /// **Engine-only** — pairs with
+    /// [`Self::set_video_source_timeline_semaphore`]; that method is
+    /// engine-only, so this one is too. Calling from a cdylib panics
+    /// inside [`Self::host_inner`].
     #[cfg(target_os = "linux")]
     pub fn clear_video_source_timeline_semaphore(&self) {
         self.host_inner().clear_video_source_timeline_semaphore();
     }
 
     /// See [`GpuContext::video_source_timeline_semaphore`].
+    ///
+    /// **Engine-only** — return type is
+    /// `Option<Arc<HostVulkanTimelineSemaphore>>` (host-internal type).
+    /// Calling from a cdylib panics inside [`Self::host_inner`].
     #[cfg(target_os = "linux")]
     pub fn video_source_timeline_semaphore(
         &self,
@@ -3564,11 +3982,23 @@ impl GpuContextFullAccess {
     }
 
     /// Get a reference to the RHI GPU device.
+    ///
+    /// **Engine-only** — returns `&Arc<GpuDevice>` which borrows into
+    /// host-private state (the `Box<Arc<GpuContext>>` behind the
+    /// handle). The borrow can't cross the FFI boundary; cdylib code
+    /// that needs GPU device capabilities should use the higher-level
+    /// FullAccess methods (kernel construction, buffer/texture
+    /// allocation, etc.) which dispatch through the vtable. Calling
+    /// from a cdylib panics inside [`Self::host_inner`].
     pub fn device(&self) -> &Arc<GpuDevice> {
         self.host_inner().device()
     }
 
     /// Get the texture pool for acquiring pooled textures.
+    ///
+    /// **Engine-only** — returns `&TexturePool` which borrows into
+    /// host-private state. Cdylib code uses [`Self::acquire_texture`]
+    /// instead. Calling from a cdylib panics inside [`Self::host_inner`].
     pub fn texture_pool(&self) -> &TexturePool {
         self.host_inner().texture_pool()
     }
@@ -3578,17 +4008,40 @@ impl GpuContextFullAccess {
     /// host adapter layer wants on Linux, see
     /// [`Self::acquire_render_target_dma_buf_image`].
     pub fn acquire_texture(&self, desc: &TexturePoolDescriptor) -> Result<PooledTextureHandle> {
-        self.host_inner().acquire_texture(desc)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().acquire_texture(desc),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().acquire_texture(desc)
+            }
+        }
     }
 
     /// Get the shared command queue.
-    pub fn command_queue(&self) -> &RhiCommandQueue {
-        self.host_inner().command_queue()
+    ///
+    /// Phase D adopts the owned β-shape return that matches
+    /// [`GpuContextLimitedAccess::command_queue`] — borrowed
+    /// references can't cross the FFI boundary, so a cdylib-callable
+    /// `command_queue` must hand out a refcount-bumped owned
+    /// [`RhiCommandQueue`] regardless of mode. The β-shape's Drop
+    /// dispatches through the LimitedAccess vtable's
+    /// `drop_rhi_command_queue` callback.
+    pub fn command_queue(&self) -> RhiCommandQueue {
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().command_queue().clone(),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().command_queue()
+            }
+        }
     }
 
     /// Create a command buffer from the shared queue.
     pub fn create_command_buffer(&self) -> Result<CommandBuffer> {
-        self.host_inner().create_command_buffer()
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_command_buffer(),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().create_command_buffer()
+            }
+        }
     }
 
     /// Acquire a cached `(src, dst)`-keyed color converter. See
@@ -3600,16 +4053,118 @@ impl GpuContextFullAccess {
         src: PixelFormat,
         dst: PixelFormat,
     ) -> Result<Arc<RhiColorConverter>> {
-        self.host_inner().color_converter(src, dst)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().color_converter(src, dst),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "color_converter: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_converter: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).color_converter)(
+                        self.handle,
+                        src as u32,
+                        dst as u32,
+                        &mut out_converter,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_converter.is_null() {
+                        return Err(Error::GpuError(
+                            "color_converter: host signaled success but out_converter is null".into(),
+                        ));
+                    }
+                    // SAFETY: host wrote `Arc::into_raw(Arc<RhiColorConverter>)`.
+                    let arc =
+                        unsafe { Arc::from_raw(out_converter as *const RhiColorConverter) };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
+    ///
+    /// Mode-routed: in-process callers use [`Self::host_inner`]; cdylib
+    /// callers dispatch through the FullAccess vtable's
+    /// `create_compute_kernel` slot, which validates the scope token and
+    /// runs the host's [`GpuContext::create_compute_kernel`]. The host
+    /// returns the kernel as `Arc::into_raw`; this wrapper reconstructs
+    /// it via `Arc::from_raw` under the rustc-version coupling contract
+    /// (CLAUDE.md "Cross-cutting decisions") that keeps layouts byte-
+    /// identical between host and cdylib.
     #[cfg(target_os = "linux")]
     pub fn create_compute_kernel(
         &self,
         descriptor: &crate::core::rhi::ComputeKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanComputeKernel>> {
-        self.host_inner().create_compute_kernel(descriptor)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_compute_kernel(descriptor),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_compute_kernel: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                // Stage the descriptor into its repr + backing
+                // bindings_buf; the backing Vec must stay alive for the
+                // vtable call because the repr's bindings_ptr borrows
+                // into it.
+                let (repr, _bindings_buf) =
+                    crate::core::rhi::plugin_abi_bridge::stage_compute_kernel_descriptor(
+                        descriptor,
+                    );
+                let mut out_kernel: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_compute_kernel)(
+                        self.handle,
+                        &repr,
+                        &mut out_kernel,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_kernel.is_null() {
+                        return Err(Error::GpuError(
+                            "create_compute_kernel: host signaled success but out_kernel is null".into(),
+                        ));
+                    }
+                    // SAFETY: host wrote
+                    // `Arc::into_raw(Arc<VulkanComputeKernel>)`. The
+                    // strong reference transfers ownership to the
+                    // cdylib via this reconstruction.
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_kernel as *const crate::vulkan::rhi::VulkanComputeKernel,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Build an engine-owned multi-step command-buffer recorder. See
@@ -3627,27 +4182,165 @@ impl GpuContextFullAccess {
         &self,
         label: &str,
     ) -> Result<crate::vulkan::rhi::RhiCommandRecorder> {
-        self.host_inner().create_command_recorder(label)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_command_recorder(label),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_command_recorder: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_recorder: std::mem::MaybeUninit<
+                    crate::vulkan::rhi::RhiCommandRecorder,
+                > = std::mem::MaybeUninit::uninit();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_command_recorder)(
+                        self.handle,
+                        label.as_ptr(),
+                        label.len(),
+                        out_recorder.as_mut_ptr() as *mut std::ffi::c_void,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    // SAFETY: host signaled success and wrote the
+                    // RhiCommandRecorder by value via std::ptr::write.
+                    // Layout is byte-identical under rustc-version
+                    // coupling (CLAUDE.md).
+                    Ok(unsafe { out_recorder.assume_init() })
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Create a graphics kernel from a multi-stage SPIR-V set, binding
     /// declaration, and fixed-function pipeline state.
+    ///
+    /// Mode-routed; see [`Self::create_compute_kernel`] for the
+    /// dispatch contract.
     #[cfg(target_os = "linux")]
     pub fn create_graphics_kernel(
         &self,
         descriptor: &crate::core::rhi::GraphicsKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanGraphicsKernel>> {
-        self.host_inner().create_graphics_kernel(descriptor)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_graphics_kernel(descriptor),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_graphics_kernel: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let (repr, _stage) =
+                    crate::core::rhi::plugin_abi_bridge::stage_graphics_kernel_descriptor(
+                        descriptor,
+                    );
+                let mut out_kernel: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_graphics_kernel)(
+                        self.handle,
+                        &repr,
+                        &mut out_kernel,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_kernel.is_null() {
+                        return Err(Error::GpuError(
+                            "create_graphics_kernel: host signaled success but out_kernel is null".into(),
+                        ));
+                    }
+                    // SAFETY: host wrote
+                    // `Arc::into_raw(Arc<VulkanGraphicsKernel>)`.
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_kernel as *const crate::vulkan::rhi::VulkanGraphicsKernel,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Create a ray-tracing kernel from shader stages, shader-group
     /// layout, binding declaration, and push-constant range.
+    ///
+    /// Mode-routed; see [`Self::create_compute_kernel`] for the
+    /// dispatch contract.
     #[cfg(target_os = "linux")]
     pub fn create_ray_tracing_kernel(
         &self,
         descriptor: &crate::core::rhi::RayTracingKernelDescriptor<'_>,
     ) -> Result<Arc<crate::vulkan::rhi::VulkanRayTracingKernel>> {
-        self.host_inner().create_ray_tracing_kernel(descriptor)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_ray_tracing_kernel(descriptor),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "create_ray_tracing_kernel: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let (repr, _stage) =
+                    crate::core::rhi::plugin_abi_bridge::stage_ray_tracing_kernel_descriptor(
+                        descriptor,
+                    );
+                let mut out_kernel: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).create_ray_tracing_kernel)(
+                        self.handle,
+                        &repr,
+                        &mut out_kernel,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_kernel.is_null() {
+                        return Err(Error::GpuError(
+                            "create_ray_tracing_kernel: host signaled success but out_kernel is null".into(),
+                        ));
+                    }
+                    // SAFETY: host wrote
+                    // `Arc::into_raw(Arc<VulkanRayTracingKernel>)`.
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_kernel as *const crate::vulkan::rhi::VulkanRayTracingKernel,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Build a triangle-geometry bottom-level acceleration structure
@@ -3659,7 +4352,56 @@ impl GpuContextFullAccess {
         vertices: &[f32],
         indices: &[u32],
     ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
-        self.host_inner().build_triangles_blas(label, vertices, indices)
+        match self.handle_kind {
+            HandleKind::Boxed => {
+                self.host_inner().build_triangles_blas(label, vertices, indices)
+            }
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "build_triangles_blas: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_blas: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).build_triangles_blas)(
+                        self.handle,
+                        label.as_ptr(),
+                        label.len(),
+                        vertices.as_ptr(),
+                        vertices.len(),
+                        indices.as_ptr(),
+                        indices.len(),
+                        &mut out_blas,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_blas.is_null() {
+                        return Err(Error::GpuError(
+                            "build_triangles_blas: host signaled success but out_blas is null".into(),
+                        ));
+                    }
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_blas
+                                as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Build a top-level acceleration structure from BLAS instances.
@@ -3669,14 +4411,78 @@ impl GpuContextFullAccess {
         label: &str,
         instances: &[crate::vulkan::rhi::TlasInstanceDesc],
     ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
-        self.host_inner().build_tlas(label, instances)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().build_tlas(label, instances),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "build_tlas: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut out_tlas: *const std::ffi::c_void = std::ptr::null();
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).build_tlas)(
+                        self.handle,
+                        label.as_ptr(),
+                        label.len(),
+                        instances.as_ptr() as *const std::ffi::c_void,
+                        instances.len(),
+                        &mut out_tlas,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    if out_tlas.is_null() {
+                        return Err(Error::GpuError(
+                            "build_tlas: host signaled success but out_tlas is null".into(),
+                        ));
+                    }
+                    let arc = unsafe {
+                        Arc::from_raw(
+                            out_tlas
+                                as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                        )
+                    };
+                    Ok(arc)
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Whether the underlying GPU exposes the
     /// `VK_KHR_ray_tracing_pipeline` extension chain.
     #[cfg(target_os = "linux")]
     pub fn supports_ray_tracing_pipeline(&self) -> bool {
-        self.host_inner().supports_ray_tracing_pipeline()
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().supports_ray_tracing_pipeline(),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return false;
+                }
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let rc = unsafe {
+                    ((*self.vtable).supports_ray_tracing_pipeline)(
+                        self.handle,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                // 1 = true, 0 = false, -1 = error (treat as false).
+                rc == 1
+            }
+        }
     }
 
     /// Get the underlying Metal device (macOS only).
@@ -3693,7 +4499,12 @@ impl GpuContextFullAccess {
 
     /// Copy pixels between same-format, same-size buffers.
     pub fn blit_copy(&self, src: &PixelBuffer, dest: &PixelBuffer) -> Result<()> {
-        self.host_inner().blit_copy(src, dest)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().blit_copy(src, dest),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().blit_copy(src, dest)
+            }
+        }
     }
 
     /// Copy from raw IOSurface to a pixel buffer.
@@ -3713,27 +4524,87 @@ impl GpuContextFullAccess {
     }
 
     /// Clear the blitter's texture cache to free GPU memory.
+    ///
+    /// **Engine-only** — engine setup-time housekeeping; no cdylib
+    /// path needs to invoke it. Calling from a cdylib panics inside
+    /// [`Self::host_inner`].
     pub fn clear_blitter_cache(&self) {
         self.host_inner().clear_blitter_cache();
     }
 
     /// Get the surface store, if initialized.
     pub fn surface_store(&self) -> Option<SurfaceStore> {
-        self.host_inner().surface_store()
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().surface_store(),
+            HandleKind::ScopeToken => {
+                self.inherited_limited_unchecked().surface_store()
+            }
+        }
     }
 
     /// Check in a pixel buffer to the surface-share service.
     pub fn check_in_surface(&self, pixel_buffer: &PixelBuffer) -> Result<String> {
-        self.host_inner().check_in_surface(pixel_buffer)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().check_in_surface(pixel_buffer),
+            HandleKind::ScopeToken => {
+                if self.vtable.is_null() {
+                    return Err(Error::GpuError(
+                        "check_in_surface: GpuContextFullAccess has null vtable".into(),
+                    ));
+                }
+                let mut id_buf = [0u8; 1024];
+                let mut id_len: usize = 0;
+                let mut err_buf = [0u8; 512];
+                let mut err_len: usize = 0;
+                let status = unsafe {
+                    ((*self.vtable).check_in_surface)(
+                        self.handle,
+                        pixel_buffer as *const PixelBuffer as *const std::ffi::c_void,
+                        id_buf.as_mut_ptr(),
+                        id_buf.len(),
+                        &mut id_len as *mut usize,
+                        err_buf.as_mut_ptr(),
+                        err_buf.len(),
+                        &mut err_len as *mut usize,
+                    )
+                };
+                if status == 0 {
+                    match std::str::from_utf8(&id_buf[..id_len]) {
+                        Ok(s) => Ok(s.to_string()),
+                        Err(e) => Err(Error::GpuError(format!(
+                            "check_in_surface: surface id not UTF-8: {e}"
+                        ))),
+                    }
+                } else {
+                    let msg = String::from_utf8_lossy(
+                        &err_buf[..err_len.min(err_buf.len())],
+                    )
+                    .into_owned();
+                    Err(Error::GpuError(msg))
+                }
+            }
+        }
     }
 
     /// Check out a surface by ID.
     pub fn check_out_surface(&self, surface_id: &str) -> Result<PixelBuffer> {
-        self.host_inner().check_out_surface(surface_id)
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().check_out_surface(surface_id),
+            HandleKind::ScopeToken => self
+                .inherited_limited_unchecked()
+                .check_out_surface(surface_id),
+        }
     }
 
     /// Get the registered cpu-readback bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
+    ///
+    /// **Engine-only** — return type is `Option<Arc<dyn CpuReadbackBridge>>`,
+    /// a trait object whose vtable layout is rustc-private (no `#[repr(C)]`
+    /// shape that crosses the FFI boundary). The bridge is registered by
+    /// host code via `set_cpu_readback_bridge` and read by host adapter
+    /// machinery; cdylib code doesn't need to read it. Calling from a
+    /// cdylib panics inside [`Self::host_inner`].
     #[cfg(target_os = "linux")]
     pub fn cpu_readback_bridge(&self) -> Option<Arc<dyn CpuReadbackBridge>> {
         self.host_inner().cpu_readback_bridge()
@@ -3741,6 +4612,9 @@ impl GpuContextFullAccess {
 
     /// Get the registered compute-kernel bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
+    ///
+    /// **Engine-only** — trait-object return; same rationale as
+    /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn compute_kernel_bridge(&self) -> Option<Arc<dyn ComputeKernelBridge>> {
         self.host_inner().compute_kernel_bridge()
@@ -3748,6 +4622,9 @@ impl GpuContextFullAccess {
 
     /// Get the registered graphics-kernel bridge, if any. Reachable only inside
     /// `escalate(|full| ...)` since it requires `FullAccess`.
+    ///
+    /// **Engine-only** — trait-object return; same rationale as
+    /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn graphics_kernel_bridge(&self) -> Option<Arc<dyn GraphicsKernelBridge>> {
         self.host_inner().graphics_kernel_bridge()
@@ -3755,6 +4632,9 @@ impl GpuContextFullAccess {
 
     /// Get the registered ray-tracing-kernel bridge, if any. Reachable only
     /// inside `escalate(|full| ...)` since it requires `FullAccess`.
+    ///
+    /// **Engine-only** — trait-object return; same rationale as
+    /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn ray_tracing_kernel_bridge(&self) -> Option<Arc<dyn RayTracingKernelBridge>> {
         self.host_inner().ray_tracing_kernel_bridge()

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -3955,6 +3955,14 @@ impl GpuContextFullAccess {
         &self,
         timeline: &Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>,
     ) {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::set_video_source_timeline_semaphore(): \
+                 parameter `&Arc<HostVulkanTimelineSemaphore>` is host-internal \
+                 (crate::vulkan::rhi) and cannot cross the FFI boundary; this \
+                 method is engine-only and cdylib code must not call it."
+            );
+        }
         self.host_inner().set_video_source_timeline_semaphore(timeline);
     }
 
@@ -3963,9 +3971,17 @@ impl GpuContextFullAccess {
     /// **Engine-only** — pairs with
     /// [`Self::set_video_source_timeline_semaphore`]; that method is
     /// engine-only, so this one is too. Calling from a cdylib panics
-    /// inside [`Self::host_inner`].
+    /// at the explicit guard below.
     #[cfg(target_os = "linux")]
     pub fn clear_video_source_timeline_semaphore(&self) {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::clear_video_source_timeline_semaphore(): \
+                 pairs with set_video_source_timeline_semaphore which takes a \
+                 host-internal `&Arc<HostVulkanTimelineSemaphore>`; engine-only \
+                 by inheritance — cdylib code must not call it."
+            );
+        }
         self.host_inner().clear_video_source_timeline_semaphore();
     }
 
@@ -3973,11 +3989,19 @@ impl GpuContextFullAccess {
     ///
     /// **Engine-only** — return type is
     /// `Option<Arc<HostVulkanTimelineSemaphore>>` (host-internal type).
-    /// Calling from a cdylib panics inside [`Self::host_inner`].
+    /// Calling from a cdylib panics at the explicit guard below.
     #[cfg(target_os = "linux")]
     pub fn video_source_timeline_semaphore(
         &self,
     ) -> Option<Arc<crate::vulkan::rhi::HostVulkanTimelineSemaphore>> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::video_source_timeline_semaphore(): \
+                 return type `Option<Arc<HostVulkanTimelineSemaphore>>` is \
+                 host-internal (crate::vulkan::rhi) and cannot cross the FFI \
+                 boundary; engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().video_source_timeline_semaphore()
     }
 
@@ -3989,8 +4013,18 @@ impl GpuContextFullAccess {
     /// that needs GPU device capabilities should use the higher-level
     /// FullAccess methods (kernel construction, buffer/texture
     /// allocation, etc.) which dispatch through the vtable. Calling
-    /// from a cdylib panics inside [`Self::host_inner`].
+    /// from a cdylib panics at the explicit guard below.
     pub fn device(&self) -> &Arc<GpuDevice> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::device(): return type `&Arc<GpuDevice>` \
+                 borrows into host-private state and cannot cross the FFI \
+                 boundary; engine-only. Cdylib code that needs GPU device \
+                 capabilities must use higher-level FullAccess methods (kernel \
+                 construction, buffer/texture allocation) which dispatch \
+                 through the FullAccess vtable."
+            );
+        }
         self.host_inner().device()
     }
 
@@ -3998,8 +4032,17 @@ impl GpuContextFullAccess {
     ///
     /// **Engine-only** — returns `&TexturePool` which borrows into
     /// host-private state. Cdylib code uses [`Self::acquire_texture`]
-    /// instead. Calling from a cdylib panics inside [`Self::host_inner`].
+    /// instead. Calling from a cdylib panics at the explicit guard below.
     pub fn texture_pool(&self) -> &TexturePool {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::texture_pool(): return type \
+                 `&TexturePool` borrows into host-private state and cannot \
+                 cross the FFI boundary; engine-only. Cdylib code uses \
+                 acquire_texture() which dispatches through the FullAccess \
+                 vtable."
+            );
+        }
         self.host_inner().texture_pool()
     }
 
@@ -4526,9 +4569,16 @@ impl GpuContextFullAccess {
     /// Clear the blitter's texture cache to free GPU memory.
     ///
     /// **Engine-only** — engine setup-time housekeeping; no cdylib
-    /// path needs to invoke it. Calling from a cdylib panics inside
-    /// [`Self::host_inner`].
+    /// path needs to invoke it. Calling from a cdylib panics at the
+    /// explicit guard below.
     pub fn clear_blitter_cache(&self) {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::clear_blitter_cache(): engine setup-time \
+                 housekeeping that operates on host-internal blitter cache; \
+                 engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().clear_blitter_cache();
     }
 
@@ -4604,9 +4654,17 @@ impl GpuContextFullAccess {
     /// shape that crosses the FFI boundary). The bridge is registered by
     /// host code via `set_cpu_readback_bridge` and read by host adapter
     /// machinery; cdylib code doesn't need to read it. Calling from a
-    /// cdylib panics inside [`Self::host_inner`].
+    /// cdylib panics at the explicit guard below.
     #[cfg(target_os = "linux")]
     pub fn cpu_readback_bridge(&self) -> Option<Arc<dyn CpuReadbackBridge>> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::cpu_readback_bridge(): return type \
+                 `Option<Arc<dyn CpuReadbackBridge>>` is a trait object whose \
+                 vtable layout is rustc-private and cannot cross the FFI \
+                 boundary; engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().cpu_readback_bridge()
     }
 
@@ -4617,6 +4675,14 @@ impl GpuContextFullAccess {
     /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn compute_kernel_bridge(&self) -> Option<Arc<dyn ComputeKernelBridge>> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::compute_kernel_bridge(): return type \
+                 `Option<Arc<dyn ComputeKernelBridge>>` is a trait object whose \
+                 vtable layout is rustc-private and cannot cross the FFI \
+                 boundary; engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().compute_kernel_bridge()
     }
 
@@ -4627,6 +4693,14 @@ impl GpuContextFullAccess {
     /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn graphics_kernel_bridge(&self) -> Option<Arc<dyn GraphicsKernelBridge>> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::graphics_kernel_bridge(): return type \
+                 `Option<Arc<dyn GraphicsKernelBridge>>` is a trait object \
+                 whose vtable layout is rustc-private and cannot cross the FFI \
+                 boundary; engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().graphics_kernel_bridge()
     }
 
@@ -4637,6 +4711,14 @@ impl GpuContextFullAccess {
     /// [`Self::cpu_readback_bridge`].
     #[cfg(target_os = "linux")]
     pub fn ray_tracing_kernel_bridge(&self) -> Option<Arc<dyn RayTracingKernelBridge>> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "GpuContextFullAccess::ray_tracing_kernel_bridge(): return type \
+                 `Option<Arc<dyn RayTracingKernelBridge>>` is a trait object \
+                 whose vtable layout is rustc-private and cannot cross the FFI \
+                 boundary; engine-only — cdylib code must not call it."
+            );
+        }
         self.host_inner().ray_tracing_kernel_bridge()
     }
 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -5032,6 +5032,708 @@ unsafe extern "C" fn host_gpu_full_acquire_render_target_dma_buf_image(
     1
 }
 
+// ============================================================================
+// Phase D (#906) — privileged-only FullAccess host callbacks.
+// Each callback validates the `scope_token` via `with_full_scope_or_err`
+// (resolving the bound `Arc<GpuContext>` from the escalate-scope registry)
+// before dispatching to the resolved context.
+// ============================================================================
+
+unsafe extern "C" fn host_gpu_full_wait_device_idle(
+    scope_token: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_wait_device_idle",
+        || -> i32 {
+            let result = with_full_scope_or_err(
+                scope_token,
+                "wait_device_idle",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.wait_device_idle(),
+            );
+            match result {
+                Some(Ok(())) => 0,
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_gpu_full_acquire_output_texture(
+    scope_token: *const c_void,
+    width: u32,
+    height: u32,
+    format_raw: u32,
+    out_id_buf: *mut u8,
+    out_id_cap: usize,
+    out_id_len: *mut usize,
+    out_texture: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_acquire_output_texture",
+        || -> i32 {
+            if out_texture.is_null() || out_id_buf.is_null() || out_id_len.is_null() {
+                write_err(
+                    "acquire_output_texture: null out_texture / out_id_buf / out_id_len",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let format = match format_raw {
+                0 => streamlib_consumer_rhi::TextureFormat::Rgba8Unorm,
+                1 => streamlib_consumer_rhi::TextureFormat::Rgba8UnormSrgb,
+                2 => streamlib_consumer_rhi::TextureFormat::Bgra8Unorm,
+                3 => streamlib_consumer_rhi::TextureFormat::Bgra8UnormSrgb,
+                4 => streamlib_consumer_rhi::TextureFormat::Rgba16Float,
+                5 => streamlib_consumer_rhi::TextureFormat::Rgba32Float,
+                6 => streamlib_consumer_rhi::TextureFormat::Nv12,
+                _ => {
+                    write_err(
+                        &format!(
+                            "acquire_output_texture: invalid format_raw {}",
+                            format_raw
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "acquire_output_texture",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.acquire_output_texture(width, height, format),
+            );
+            match result {
+                Some(Ok((id, texture))) => {
+                    let id_bytes = id.as_bytes();
+                    if id_bytes.len() > out_id_cap {
+                        write_err(
+                            "acquire_output_texture: surface id buffer too small",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                        return 1;
+                    }
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            id_bytes.as_ptr(),
+                            out_id_buf,
+                            id_bytes.len(),
+                        );
+                        std::ptr::write(out_id_len, id_bytes.len());
+                        std::ptr::write(
+                            out_texture as *mut crate::core::rhi::Texture,
+                            texture,
+                        );
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_upload_pixel_buffer_as_texture(
+    scope_token: *const c_void,
+    surface_id_ptr: *const u8,
+    surface_id_len: usize,
+    pixel_buffer: *const c_void,
+    width: u32,
+    height: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_upload_pixel_buffer_as_texture",
+        || -> i32 {
+            if surface_id_ptr.is_null() || pixel_buffer.is_null() {
+                write_err(
+                    "upload_pixel_buffer_as_texture: null surface_id / pixel_buffer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let id_slice =
+                unsafe { std::slice::from_raw_parts(surface_id_ptr, surface_id_len) };
+            let surface_id = match std::str::from_utf8(id_slice) {
+                Ok(s) => s,
+                Err(e) => {
+                    write_err(
+                        &format!(
+                            "upload_pixel_buffer_as_texture: surface_id not UTF-8: {e}"
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            // SAFETY: pixel_buffer is a borrowed `*const PixelBuffer`
+            // pointer from the cdylib; valid for the duration of the call.
+            let pb = unsafe { &*(pixel_buffer as *const crate::core::rhi::PixelBuffer) };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "upload_pixel_buffer_as_texture",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.upload_pixel_buffer_as_texture(surface_id, pb, width, height),
+            );
+            match result {
+                Some(Ok(())) => 0,
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_upload_pixel_buffer_as_texture(
+    _scope_token: *const c_void,
+    _surface_id_ptr: *const u8,
+    _surface_id_len: usize,
+    _pixel_buffer: *const c_void,
+    _width: u32,
+    _height: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "upload_pixel_buffer_as_texture: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_color_converter(
+    scope_token: *const c_void,
+    src_format_raw: u32,
+    dst_format_raw: u32,
+    out_converter: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_color_converter",
+        || -> i32 {
+            if out_converter.is_null() {
+                write_err(
+                    "color_converter: null out_converter",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let src = match pixel_format_from_raw(src_format_raw) {
+                Some(f) => f,
+                None => {
+                    write_err(
+                        &format!(
+                            "color_converter: invalid src_format_raw {}",
+                            src_format_raw
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let dst = match pixel_format_from_raw(dst_format_raw) {
+                Some(f) => f,
+                None => {
+                    write_err(
+                        &format!(
+                            "color_converter: invalid dst_format_raw {}",
+                            dst_format_raw
+                        ),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "color_converter",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.color_converter(src, dst),
+            );
+            match result {
+                Some(Ok(arc)) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_converter, raw) };
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_color_converter(
+    _scope_token: *const c_void,
+    _src_format_raw: u32,
+    _dst_format_raw: u32,
+    _out_converter: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "color_converter: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_create_command_recorder(
+    scope_token: *const c_void,
+    label_ptr: *const u8,
+    label_len: usize,
+    out_recorder: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_create_command_recorder",
+        || -> i32 {
+            if out_recorder.is_null() || label_ptr.is_null() {
+                write_err(
+                    "create_command_recorder: null label_ptr / out_recorder",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let label_slice =
+                unsafe { std::slice::from_raw_parts(label_ptr, label_len) };
+            let label = match std::str::from_utf8(label_slice) {
+                Ok(s) => s,
+                Err(e) => {
+                    write_err(
+                        &format!("create_command_recorder: label not UTF-8: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "create_command_recorder",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.create_command_recorder(label),
+            );
+            match result {
+                Some(Ok(recorder)) => {
+                    // SAFETY: host writes the RhiCommandRecorder struct
+                    // by value into the cdylib's MaybeUninit slot;
+                    // layout is byte-identical under the rustc-version
+                    // coupling contract (CLAUDE.md). The cdylib's
+                    // Drop will run when the value falls out of scope
+                    // (in cdylib code), accessing host-loader Vulkan
+                    // handles which are globally addressable.
+                    unsafe {
+                        std::ptr::write(
+                            out_recorder as *mut crate::vulkan::rhi::RhiCommandRecorder,
+                            recorder,
+                        );
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_create_command_recorder(
+    _scope_token: *const c_void,
+    _label_ptr: *const u8,
+    _label_len: usize,
+    _out_recorder: *mut c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "create_command_recorder: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_build_triangles_blas(
+    scope_token: *const c_void,
+    label_ptr: *const u8,
+    label_len: usize,
+    vertices_ptr: *const f32,
+    vertices_len: usize,
+    indices_ptr: *const u32,
+    indices_len: usize,
+    out_blas: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_build_triangles_blas",
+        || -> i32 {
+            if out_blas.is_null() || label_ptr.is_null() {
+                write_err(
+                    "build_triangles_blas: null label_ptr / out_blas",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let label_slice =
+                unsafe { std::slice::from_raw_parts(label_ptr, label_len) };
+            let label = match std::str::from_utf8(label_slice) {
+                Ok(s) => s,
+                Err(e) => {
+                    write_err(
+                        &format!("build_triangles_blas: label not UTF-8: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let vertices: &[f32] = if vertices_len == 0 {
+                &[]
+            } else {
+                unsafe { std::slice::from_raw_parts(vertices_ptr, vertices_len) }
+            };
+            let indices: &[u32] = if indices_len == 0 {
+                &[]
+            } else {
+                unsafe { std::slice::from_raw_parts(indices_ptr, indices_len) }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "build_triangles_blas",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.build_triangles_blas(label, vertices, indices),
+            );
+            match result {
+                Some(Ok(arc)) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_blas, raw) };
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_build_triangles_blas(
+    _scope_token: *const c_void,
+    _label_ptr: *const u8,
+    _label_len: usize,
+    _vertices_ptr: *const f32,
+    _vertices_len: usize,
+    _indices_ptr: *const u32,
+    _indices_len: usize,
+    _out_blas: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "build_triangles_blas: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_build_tlas(
+    scope_token: *const c_void,
+    label_ptr: *const u8,
+    label_len: usize,
+    instances_ptr: *const c_void,
+    instances_len: usize,
+    out_tlas: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_build_tlas",
+        || -> i32 {
+            if out_tlas.is_null() || label_ptr.is_null() {
+                write_err(
+                    "build_tlas: null label_ptr / out_tlas",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let label_slice =
+                unsafe { std::slice::from_raw_parts(label_ptr, label_len) };
+            let label = match std::str::from_utf8(label_slice) {
+                Ok(s) => s,
+                Err(e) => {
+                    write_err(
+                        &format!("build_tlas: label not UTF-8: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    return 1;
+                }
+            };
+            let instances: &[crate::vulkan::rhi::TlasInstanceDesc] = if instances_len
+                == 0
+            {
+                &[]
+            } else {
+                // SAFETY: `instances_ptr` is `*const TlasInstanceDesc`
+                // from the cdylib; layout is byte-identical under
+                // rustc-version coupling. The slice is borrowed for
+                // the call's duration.
+                unsafe {
+                    std::slice::from_raw_parts(
+                        instances_ptr as *const crate::vulkan::rhi::TlasInstanceDesc,
+                        instances_len,
+                    )
+                }
+            };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "build_tlas",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.build_tlas(label, instances),
+            );
+            match result {
+                Some(Ok(arc)) => {
+                    let raw = Arc::into_raw(arc) as *const c_void;
+                    unsafe { std::ptr::write(out_tlas, raw) };
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_build_tlas(
+    _scope_token: *const c_void,
+    _label_ptr: *const u8,
+    _label_len: usize,
+    _instances_ptr: *const c_void,
+    _instances_len: usize,
+    _out_tlas: *mut *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "build_tlas: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_supports_ray_tracing_pipeline(
+    scope_token: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_supports_ray_tracing_pipeline",
+        || -> i32 {
+            let result = with_full_scope_or_err(
+                scope_token,
+                "supports_ray_tracing_pipeline",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| Ok::<bool, crate::core::Error>(gpu.supports_ray_tracing_pipeline()),
+            );
+            match result {
+                Some(Ok(true)) => 1,
+                Some(Ok(false)) => 0,
+                Some(Err(_)) | None => -1,
+            }
+        },
+        -1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_supports_ray_tracing_pipeline(
+    _scope_token: *const c_void,
+    _err_buf: *mut u8,
+    _err_buf_cap: usize,
+    _err_len: *mut usize,
+) -> i32 {
+    0
+}
+
+unsafe extern "C" fn host_gpu_full_check_in_surface(
+    scope_token: *const c_void,
+    pixel_buffer: *const c_void,
+    out_id_buf: *mut u8,
+    out_id_cap: usize,
+    out_id_len: *mut usize,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_gpu_full_check_in_surface",
+        || -> i32 {
+            if pixel_buffer.is_null() || out_id_buf.is_null() || out_id_len.is_null() {
+                write_err(
+                    "check_in_surface: null pixel_buffer / out_id_buf / out_id_len",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // SAFETY: pixel_buffer is borrowed from the cdylib for the
+            // duration of the call.
+            let pb = unsafe { &*(pixel_buffer as *const crate::core::rhi::PixelBuffer) };
+            let result = with_full_scope_or_err(
+                scope_token,
+                "check_in_surface",
+                err_buf,
+                err_buf_cap,
+                err_len,
+                |gpu| gpu.check_in_surface(pb),
+            );
+            match result {
+                Some(Ok(id)) => {
+                    let id_bytes = id.as_bytes();
+                    if id_bytes.len() > out_id_cap {
+                        write_err(
+                            "check_in_surface: surface id buffer too small",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                        return 1;
+                    }
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            id_bytes.as_ptr(),
+                            out_id_buf,
+                            id_bytes.len(),
+                        );
+                        std::ptr::write(out_id_len, id_bytes.len());
+                    }
+                    0
+                }
+                Some(Err(e)) => {
+                    write_err(&format!("{}", e), err_buf, err_buf_cap, err_len);
+                    1
+                }
+                None => 1,
+            }
+        },
+        1,
+    )
+}
+
 pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
     GpuContextFullAccessVTable {
         layout_version: GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION,
@@ -5051,6 +5753,16 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         create_texture_ring: host_gpu_full_create_texture_ring,
         acquire_render_target_dma_buf_image:
             host_gpu_full_acquire_render_target_dma_buf_image,
+        // Phase D (#906) entries.
+        wait_device_idle: host_gpu_full_wait_device_idle,
+        acquire_output_texture: host_gpu_full_acquire_output_texture,
+        upload_pixel_buffer_as_texture: host_gpu_full_upload_pixel_buffer_as_texture,
+        color_converter: host_gpu_full_color_converter,
+        create_command_recorder: host_gpu_full_create_command_recorder,
+        build_triangles_blas: host_gpu_full_build_triangles_blas,
+        build_tlas: host_gpu_full_build_tlas,
+        supports_ray_tracing_pipeline: host_gpu_full_supports_ray_tracing_pipeline,
+        check_in_surface: host_gpu_full_check_in_surface,
     };
 
 /// Pointer to the [`GpuContextFullAccessVTable`] this DSO should
@@ -5435,6 +6147,279 @@ mod gpu_full_access_vtable_tests {
             msg.contains(
                 "acquire_render_target_dma_buf_image: invalid format_raw"
             ),
+            "got: {msg}"
+        );
+    }
+
+    // ============================================================================
+    // Phase D (#906) — tier-1 wire-format tests for the 9 new FullAccess slots
+    // ============================================================================
+
+    #[test]
+    fn wait_device_idle_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.wait_device_idle)(
+                std::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("wait_device_idle: invalid escalate scope"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn acquire_output_texture_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut id_buf = [0u8; 256];
+        let mut id_len: usize = 0;
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.acquire_output_texture)(
+                std::ptr::null(),
+                64,
+                64,
+                0,
+                id_buf.as_mut_ptr(),
+                id_buf.len(),
+                &mut id_len,
+                &mut out as *mut _ as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("acquire_output_texture: invalid escalate scope"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn acquire_output_texture_returns_error_on_invalid_format() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut id_buf = [0u8; 256];
+        let mut id_len: usize = 0;
+        let mut out: crate::core::rhi::texture::Texture =
+            unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.acquire_output_texture)(
+                std::ptr::null(),
+                64,
+                64,
+                99,
+                id_buf.as_mut_ptr(),
+                id_buf.len(),
+                &mut id_len,
+                &mut out as *mut _ as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("acquire_output_texture: invalid format_raw"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn upload_pixel_buffer_as_texture_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        // We pass non-null surface_id + a "borrowed" PixelBuffer placeholder
+        // through the null-pointer guard; the scope-token check then fires
+        // because the token is null/zero.
+        let sid = b"abc";
+        let pb: crate::core::rhi::PixelBuffer = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.upload_pixel_buffer_as_texture)(
+                std::ptr::null(),
+                sid.as_ptr(),
+                sid.len(),
+                &pb as *const _ as *const c_void,
+                64,
+                64,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        // Leak the zeroed PixelBuffer to avoid running its (cdylib-mode)
+        // Drop on a null handle — that would dispatch through a null
+        // vtable. The null-handle Drop guard short-circuits, but
+        // mem::forget makes the intent explicit.
+        std::mem::forget(pb);
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("upload_pixel_buffer_as_texture: invalid escalate scope"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn color_converter_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out: *const c_void = std::ptr::null();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.color_converter)(
+                std::ptr::null(),
+                0, // src
+                0, // dst
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("color_converter: invalid escalate scope"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn create_command_recorder_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let label = b"test_recorder";
+        let mut out: std::mem::MaybeUninit<crate::vulkan::rhi::RhiCommandRecorder> =
+            std::mem::MaybeUninit::uninit();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.create_command_recorder)(
+                std::ptr::null(),
+                label.as_ptr(),
+                label.len(),
+                out.as_mut_ptr() as *mut c_void,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("create_command_recorder: invalid escalate scope"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn build_triangles_blas_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let label = b"test_blas";
+        let vertices = [0.0f32, 0.0, 0.0];
+        let indices = [0u32, 1, 2];
+        let mut out: *const c_void = std::ptr::null();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.build_triangles_blas)(
+                std::ptr::null(),
+                label.as_ptr(),
+                label.len(),
+                vertices.as_ptr(),
+                vertices.len(),
+                indices.as_ptr(),
+                indices.len(),
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("build_triangles_blas: invalid escalate scope"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn build_tlas_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let label = b"test_tlas";
+        let mut out: *const c_void = std::ptr::null();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.build_tlas)(
+                std::ptr::null(),
+                label.as_ptr(),
+                label.len(),
+                std::ptr::null(),
+                0,
+                &mut out,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("build_tlas: invalid escalate scope"),
+            "got: {msg}"
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn supports_ray_tracing_pipeline_returns_negative_one_on_null_scope_token() {
+        // Returns -1 for "invalid scope token" (since 1/0 are valid yes/no
+        // bool returns). The error message goes to err_buf.
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.supports_ray_tracing_pipeline)(
+                std::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, -1, "null scope token must return -1, got {rc}");
+    }
+
+    #[test]
+    fn check_in_surface_returns_error_on_null_scope_token() {
+        let (mut buf, mut len) = make_err_buf();
+        let pb: crate::core::rhi::PixelBuffer = unsafe { std::mem::zeroed() };
+        let mut id_buf = [0u8; 256];
+        let mut id_len: usize = 0;
+        let rc = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.check_in_surface)(
+                std::ptr::null(),
+                &pb as *const _ as *const c_void,
+                id_buf.as_mut_ptr(),
+                id_buf.len(),
+                &mut id_len,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        std::mem::forget(pb);
+        assert_eq!(rc, 1);
+        let msg = err_buf_as_str(&buf, len);
+        assert!(
+            msg.contains("check_in_surface: invalid escalate scope"),
             "got: {msg}"
         );
     }

--- a/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
@@ -1,12 +1,14 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Phase C3 (#903) cdylib-resident escalate vtable smoke test.
+//! Phase C3 (#903) + Phase D (#906) cdylib-resident escalate vtable
+//! smoke test.
 //!
 //! Loads a dlopen'd `EscalateSmokeTestProcessor` from test-fixtures
 //! and drives it through `start()`. The processor's `start()` body
-//! runs `gpu.escalate(|_full| Ok(()))` once, which exercises the
-//! full scope-token machinery end-to-end across the FFI:
+//! runs `gpu.escalate(|full| full.wait_device_idle())` once, which
+//! exercises the full scope-token machinery AND a real FullAccess
+//! vtable slot end-to-end across the FFI:
 //!
 //!   1. Cdylib's `GpuContextLimitedAccess::escalate` detects cdylib
 //!      mode (`host_callbacks().is_some()`) and routes through
@@ -18,7 +20,14 @@
 //!   3. `escalate_via_vtable` constructs a cdylib-side
 //!      `GpuContextFullAccess` via `from_scope_token` (HandleKind::
 //!      ScopeToken).
-//!   4. The closure runs (empty body — just exits cleanly).
+//!   4. The closure runs — `full.wait_device_idle()` dispatches
+//!      through the FullAccess vtable's `wait_device_idle` slot,
+//!      which on the host side validates the scope token via
+//!      `with_full_scope_or_err` and runs
+//!      `gpu.wait_device_idle()` on the bound `Arc<GpuContext>`.
+//!      **This is the load-bearing Phase D end-to-end assertion** —
+//!      if Phase D's wrapper rewrite or vtable slot wiring
+//!      regresses, this step fails.
 //!   5. The cdylib drops the FullAccess. Drop dispatches on the
 //!      `handle_kind` discriminator: for ScopeToken it's a no-op
 //!      (cleanup happens in `escalate_end`, not here).
@@ -33,12 +42,11 @@
 //!     error — typically "invalid escalate scope" if a scope-token
 //!     check failed).
 //!
-//! What this test does NOT cover: cdylib-side dispatch on
-//! `GpuContextFullAccess` methods (`create_compute_kernel`, etc.) —
-//! those still call `host_inner()` and panic from cdylib code. That
-//! gap is the scope of Phase D (#906); the richer "create kernel +
-//! dispatch + compare CPU reference" test originally specced for
-//! #903 lives in Phase E (#907).
+//! What this test does NOT cover: per-method dispatch on the kernel
+//! / acceleration-structure / command-recorder handles returned by
+//! Phase D's `create_*` and `build_*` methods (Phase E #907 wires
+//! that). Phase D itself ensures the handles can be obtained from
+//! cdylib; using them is Phase E's scope.
 //!
 //! Requires a working Vulkan device (Runner::start() initializes
 //! GpuContext::init_for_platform_sync()). On GPU-less hardware the

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -200,7 +200,18 @@ pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 ///   `*const Arc<GpuContext>`" to "`gpu_handle` is an opaque scope
 ///   token" semantically — same `*const c_void`, different lookup
 ///   path on the host side.
-pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 2;
+/// - v3: Phase D appends the privileged-only FullAccess methods that
+///   previously stayed `host_inner`-only:
+///   `wait_device_idle`, `acquire_output_texture`,
+///   `upload_pixel_buffer_as_texture`, `color_converter`,
+///   `create_command_recorder`, `build_triangles_blas`, `build_tlas`,
+///   `supports_ray_tracing_pipeline`, `check_in_surface`. The
+///   LimitedAccess-mirror FullAccess methods
+///   (`acquire_pixel_buffer`, `register_texture_with_layout`, etc.)
+///   inherit through the originating LimitedAccess vtable per the
+///   `inherited_lim_*` fields on `GpuContextFullAccess` — they do
+///   not get parallel slots here.
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 3;
 
 // =============================================================================
 // Primitive enums
@@ -2176,6 +2187,147 @@ pub struct GpuContextFullAccessVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Phase D (#906) — privileged-only FullAccess methods that don't appear on
+    // LimitedAccess. Each callback validates the `gpu_handle` scope token via
+    // the host's `escalate_scope_registry::with_scope` before dispatching to
+    // the resolved `Arc<GpuContext>`.
+    // -------------------------------------------------------------------------
+
+    /// Block until the GPU device drains every in-flight submission.
+    /// Returns 0 on success, non-zero with an error message on failure
+    /// (invalid scope token, `vkDeviceWaitIdle` failure, etc.).
+    pub wait_device_idle: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Acquire a new output texture with a freshly-minted surface id,
+    /// register the texture in the same-process texture cache, and
+    /// return both. `out_id_buf` receives the UTF-8 surface id (
+    /// `out_id_len` records the byte count; truncation is an error);
+    /// `out_texture` receives the [`crate::Texture`] β-shape.
+    pub acquire_output_texture: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        width: u32,
+        height: u32,
+        format_raw: u32,
+        out_id_buf: *mut u8,
+        out_id_cap: usize,
+        out_id_len: *mut usize,
+        out_texture: *mut c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Upload a HOST_VISIBLE pixel buffer's contents to a new GPU
+    /// texture and register it under the caller-provided surface id.
+    /// Linux-only on the host side; non-Linux stubs return non-zero
+    /// with a "not available on this platform" message.
+    pub upload_pixel_buffer_as_texture: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        surface_id_ptr: *const u8,
+        surface_id_len: usize,
+        pixel_buffer: *const c_void,
+        width: u32,
+        height: u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Acquire a cached `(src, dst)`-keyed color converter. Writes an
+    /// `Arc::into_raw(Arc<RhiColorConverter>)` raw pointer into
+    /// `*out_converter` on success. Linux-only.
+    pub color_converter: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        src_format_raw: u32,
+        dst_format_raw: u32,
+        out_converter: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Build an engine-owned multi-step command-buffer recorder.
+    /// Writes a [`crate::RhiCommandRecorder`]-shaped value (host's
+    /// `RhiCommandRecorder` struct, layout-stable under the rustc-
+    /// version coupling contract in CLAUDE.md) into the caller's
+    /// `*out_recorder` `MaybeUninit` slot on success. Linux-only.
+    pub create_command_recorder: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        label_ptr: *const u8,
+        label_len: usize,
+        out_recorder: *mut c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Build a triangle-geometry bottom-level acceleration structure
+    /// from CPU-side vertex + index data. Writes an
+    /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
+    /// into `*out_blas` on success. Linux-only.
+    pub build_triangles_blas: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        label_ptr: *const u8,
+        label_len: usize,
+        vertices_ptr: *const f32,
+        vertices_len: usize,
+        indices_ptr: *const u32,
+        indices_len: usize,
+        out_blas: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Build a top-level acceleration structure from BLAS instances.
+    /// `instances_ptr` is a `*const TlasInstanceDesc` carrying the
+    /// host's `TlasInstanceDesc` struct (layout-stable under the
+    /// rustc-version coupling contract). Writes an
+    /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
+    /// into `*out_tlas` on success. Linux-only.
+    pub build_tlas: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        label_ptr: *const u8,
+        label_len: usize,
+        instances_ptr: *const c_void,
+        instances_len: usize,
+        out_tlas: *mut *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Whether the underlying GPU exposes the
+    /// `VK_KHR_ray_tracing_pipeline` extension chain. Returns 1 = true,
+    /// 0 = false, -1 = invalid scope token or other error (with
+    /// message in `err_buf`).
+    pub supports_ray_tracing_pipeline: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Check in a pixel buffer to the surface-share service and return
+    /// the surface id. `out_id_buf` receives the UTF-8 id;
+    /// `out_id_len` records the byte count (truncation is an error).
+    pub check_in_surface: unsafe extern "C" fn(
+        gpu_handle: *const c_void,
+        pixel_buffer: *const c_void,
+        out_id_buf: *mut u8,
+        out_id_cap: usize,
+        out_id_len: *mut usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for GpuContextFullAccessVTable {}
@@ -2750,7 +2902,7 @@ mod layout_tests {
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 2);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 3);
     }
 
     #[test]
@@ -3018,14 +3170,18 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_full_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 14 fn
-        // pointers (8 bytes each) = 4 + 4 + 112 = 120 bytes.
+        // layout_version (u32) + _reserved_padding (u32) + 23 fn
+        // pointers (8 bytes each) = 4 + 4 + 184 = 192 bytes.
         //
-        // 14 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
+        // 23 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
         // pointers for the 4 kernel return types) + 4 create_* method
         // callbacks (compute / graphics / ray-tracing / texture_ring)
-        // + 1 acquire_render_target_dma_buf_image (C3-added, #903).
-        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 120);
+        // + 1 acquire_render_target_dma_buf_image (C3) + 9 Phase D
+        // privileged methods (wait_device_idle, acquire_output_texture,
+        // upload_pixel_buffer_as_texture, color_converter,
+        // create_command_recorder, build_triangles_blas, build_tlas,
+        // supports_ray_tracing_pipeline, check_in_surface).
+        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 192);
         assert_eq!(align_of::<GpuContextFullAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, layout_version), 0);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, _reserved_padding), 4);
@@ -3085,6 +3241,46 @@ mod layout_tests {
                 acquire_render_target_dma_buf_image
             ),
             112
+        );
+        // Phase D entries (#906).
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, wait_device_idle),
+            120
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, acquire_output_texture),
+            128
+        );
+        assert_eq!(
+            offset_of!(
+                GpuContextFullAccessVTable,
+                upload_pixel_buffer_as_texture
+            ),
+            136
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, color_converter),
+            144
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_command_recorder),
+            152
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, build_triangles_blas),
+            160
+        );
+        assert_eq!(offset_of!(GpuContextFullAccessVTable, build_tlas), 168);
+        assert_eq!(
+            offset_of!(
+                GpuContextFullAccessVTable,
+                supports_ray_tracing_pipeline
+            ),
+            176
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, check_in_surface),
+            184
         );
     }
 

--- a/packages/test-fixtures/src/escalate_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/escalate_smoke_test_processor.rs
@@ -4,25 +4,30 @@
 //! Phase C3 + Phase D dlopen-cdylib escalate smoke test fixture.
 //!
 //! Proves the scope-token machinery fires end-to-end through the FFI
-//! boundary AND that at least one `GpuContextFullAccess` vtable slot
-//! dispatches correctly from cdylib code. The processor's `start()` runs:
+//! boundary AND that representative `GpuContextFullAccess` vtable
+//! slots — both Phase D Bucket B (new FullAccess slots) and Bucket C
+//! (Option B Limited-vtable inheritance) — dispatch correctly from
+//! cdylib code. The processor's `start()` runs an escalate scope that
+//! exercises:
 //!
-//! ```ignore
-//! ctx.gpu_limited_access().escalate(|full| full.wait_device_idle())
-//! ```
-//!
-//! which exercises:
 //!   1. `escalate_begin` vtable callback (host mints a scope token,
 //!      enters the escalate gate, registers the per-scope Arc).
 //!   2. Cdylib-side `GpuContextFullAccess::from_scope_token`
 //!      construction (vtable-dispatched path).
-//!   3. The closure body — Phase D's `full.wait_device_idle()` —
-//!      dispatches through the FullAccess vtable's `wait_device_idle`
-//!      slot. The host callback validates the scope token via
-//!      `with_full_scope_or_err` and runs `gpu.wait_device_idle()` on
-//!      the bound `Arc<GpuContext>`. **This is the load-bearing Phase
-//!      D end-to-end coverage** — if any FullAccess method dispatch
-//!      regresses, this test fails.
+//!   3. Inside the closure:
+//!      - `full.wait_device_idle()` — Phase D Bucket B (new FullAccess
+//!        vtable slot). Validates the scope-token resolution path via
+//!        `with_full_scope_or_err`.
+//!      - `full.acquire_pixel_buffer(...)` — Phase D Bucket C
+//!        (Option B inherited LimitedAccess vtable dispatch).
+//!        Returns a `PixelBuffer` β-shape through the FFI.
+//!      - `full.acquire_output_texture(...)` — Phase D Bucket B
+//!        (new FullAccess vtable slot returning `(String, Texture)`).
+//!      - `full.register_texture_with_layout(...)` — Phase D Bucket C
+//!        (Option B inherited dispatch). Per #906 exit criterion #4
+//!        explicitly names this method.
+//!      **This is the load-bearing Phase D end-to-end coverage** — if
+//!      any FullAccess method dispatch regresses, this test fails.
 //!   4. Cdylib-side `GpuContextFullAccess::drop` short-circuits for
 //!      the `HandleKind::ScopeToken` case (cleanup happens in
 //!      `escalate_end`, not Drop).
@@ -36,7 +41,7 @@
 //! using them is Phase E's scope.
 //!
 //! Output format:
-//!   - "OK" — full escalate round-trip + `wait_device_idle` succeeded.
+//!   - "OK" — escalate round-trip + all four method calls succeeded.
 //!   - "ERR:<message>" — any step failed.
 
 use streamlib::sdk::context::{
@@ -44,6 +49,9 @@ use streamlib::sdk::context::{
 };
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::processors::ManualProcessor;
+use streamlib::sdk::rhi::{PixelFormat, TextureFormat};
+#[cfg(target_os = "linux")]
+use streamlib::engine_internal::sdk::rhi::VulkanLayout;
 
 #[streamlib::sdk::processor("EscalateSmokeTestProcessor")]
 pub struct EscalateSmokeTest {}
@@ -56,23 +64,59 @@ impl ManualProcessor for EscalateSmokeTest::Processor {
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let output_path = self.config.output_path.clone();
 
-        // Escalate and exercise one FullAccess vtable slot end-to-end.
-        // In cdylib mode this routes through `escalate_via_vtable`:
-        // vtable.escalate_begin → mint scope_token → construct
-        // GpuContextFullAccess via from_scope_token →
-        // full.wait_device_idle() dispatches through the FullAccess
-        // vtable → vtable.escalate_end. A panic at any FFI boundary
-        // surfaces as a panic in the closure or a non-zero escalate
-        // return; both produce an "ERR:" line.
+        // Escalate and exercise both Phase D vtable dispatch paths
+        // end-to-end. In cdylib mode this routes through
+        // `escalate_via_vtable`: vtable.escalate_begin → mint
+        // scope_token → construct GpuContextFullAccess via
+        // from_scope_token → four FullAccess methods dispatch through
+        // the FullAccess vtable / inherited LimitedAccess vtable →
+        // vtable.escalate_end. A panic at any FFI boundary surfaces
+        // as a panic in the closure or a non-zero escalate return;
+        // both produce an "ERR:" line.
         //
-        // `wait_device_idle` is the cheapest Phase D vtable slot
-        // (parameterless, no allocations) but exercises the full
-        // `with_full_scope_or_err` scope-resolution path — so if the
-        // Phase D wiring regresses (cdylib wrapper calls host_inner,
-        // scope-token registry breaks, etc.), this test fails.
-        let result: Result<()> = ctx
-            .gpu_limited_access()
-            .escalate(|full| full.wait_device_idle());
+        // Coverage:
+        //   - wait_device_idle: Phase D Bucket B (new FullAccess slot).
+        //   - acquire_pixel_buffer: Phase D Bucket C (inherited
+        //     LimitedAccess vtable via Option B).
+        //   - acquire_output_texture: Phase D Bucket B (new FullAccess
+        //     slot). Used to mint a Texture for the next call.
+        //   - register_texture_with_layout: Phase D Bucket C (inherited
+        //     LimitedAccess vtable). Per #906 exit criterion #4 this
+        //     method is explicitly required.
+        let result: Result<()> = ctx.gpu_limited_access().escalate(|full| {
+            // Bucket B — new FullAccess vtable slot.
+            full.wait_device_idle()?;
+
+            // Bucket C — inherited LimitedAccess dispatch.
+            let (_pool_id, _pb) =
+                full.acquire_pixel_buffer(64, 64, PixelFormat::Rgba32)?;
+
+            // Bucket B — new FullAccess vtable slot returning a Texture
+            // we can hand to register_texture_with_layout below.
+            let (id, texture) =
+                full.acquire_output_texture(64, 64, TextureFormat::Rgba8Unorm)?;
+
+            // Bucket C — inherited LimitedAccess dispatch with an
+            // explicit non-UNDEFINED layout to exercise the layout
+            // argument path. Picks SHADER_READ_ONLY_OPTIMAL as a
+            // representative non-default value.
+            #[cfg(target_os = "linux")]
+            full.register_texture_with_layout(
+                &id,
+                texture,
+                VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            );
+            #[cfg(not(target_os = "linux"))]
+            {
+                // VulkanLayout doesn't exist on non-Linux; on those
+                // platforms the test still exercises the other three
+                // methods.
+                drop(id);
+                drop(texture);
+            }
+
+            Ok(())
+        });
 
         let line = match result {
             Ok(()) => "OK".to_string(),

--- a/packages/test-fixtures/src/escalate_smoke_test_processor.rs
+++ b/packages/test-fixtures/src/escalate_smoke_test_processor.rs
@@ -1,13 +1,14 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-//! Phase C3 (#903) dlopen-cdylib escalate smoke test fixture.
+//! Phase C3 + Phase D dlopen-cdylib escalate smoke test fixture.
 //!
 //! Proves the scope-token machinery fires end-to-end through the FFI
-//! boundary. The processor's `start()` runs:
+//! boundary AND that at least one `GpuContextFullAccess` vtable slot
+//! dispatches correctly from cdylib code. The processor's `start()` runs:
 //!
 //! ```ignore
-//! ctx.gpu_limited_access().escalate(|_full| Ok(()))
+//! ctx.gpu_limited_access().escalate(|full| full.wait_device_idle())
 //! ```
 //!
 //! which exercises:
@@ -15,24 +16,27 @@
 //!      enters the escalate gate, registers the per-scope Arc).
 //!   2. Cdylib-side `GpuContextFullAccess::from_scope_token`
 //!      construction (vtable-dispatched path).
-//!   3. Closure runs (empty body — just verifies the FullAccess
-//!      borrow is reachable).
+//!   3. The closure body — Phase D's `full.wait_device_idle()` —
+//!      dispatches through the FullAccess vtable's `wait_device_idle`
+//!      slot. The host callback validates the scope token via
+//!      `with_full_scope_or_err` and runs `gpu.wait_device_idle()` on
+//!      the bound `Arc<GpuContext>`. **This is the load-bearing Phase
+//!      D end-to-end coverage** — if any FullAccess method dispatch
+//!      regresses, this test fails.
 //!   4. Cdylib-side `GpuContextFullAccess::drop` short-circuits for
 //!      the `HandleKind::ScopeToken` case (cleanup happens in
 //!      `escalate_end`, not Drop).
 //!   5. `escalate_end` vtable callback (host removes the scope,
 //!      releases the gate, runs `wait_device_idle`).
 //!
-//! What this test does NOT cover: cdylib-side dispatch on
-//! `GpuContextFullAccess` methods (`create_compute_kernel`, etc.) —
-//! those still call `host_inner()` and panic in cdylib mode. That
-//! gap is the work of Phase D (#906) and Phase E (#907). The richer
-//! "create kernel + dispatch + verify CPU reference" test originally
-//! specced for #903 lives in #907.
+//! What this test does NOT cover: per-method dispatch on the kernel /
+//! acceleration-structure / command-recorder *handles* returned by
+//! Phase D's `create_*` and `build_*` methods (Phase E #907 wires that).
+//! Phase D itself ensures the handles can be obtained from cdylib;
+//! using them is Phase E's scope.
 //!
 //! Output format:
-//!   - "OK" — both `escalate_begin` and `escalate_end` succeeded and
-//!     the closure ran.
+//!   - "OK" — full escalate round-trip + `wait_device_idle` succeeded.
 //!   - "ERR:<message>" — any step failed.
 
 use streamlib::sdk::context::{
@@ -52,15 +56,23 @@ impl ManualProcessor for EscalateSmokeTest::Processor {
     fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         let output_path = self.config.output_path.clone();
 
-        // Escalate with an empty closure. In cdylib mode this routes
-        // through `escalate_via_vtable`: vtable.escalate_begin → mint
-        // scope_token → construct GpuContextFullAccess via
-        // from_scope_token → run closure → vtable.escalate_end. A
-        // panic at any FFI boundary surfaces as a panic in the
-        // closure or a non-zero escalate return; both produce an
-        // "ERR:" line.
-        let result: Result<()> =
-            ctx.gpu_limited_access().escalate(|_full| Ok(()));
+        // Escalate and exercise one FullAccess vtable slot end-to-end.
+        // In cdylib mode this routes through `escalate_via_vtable`:
+        // vtable.escalate_begin → mint scope_token → construct
+        // GpuContextFullAccess via from_scope_token →
+        // full.wait_device_idle() dispatches through the FullAccess
+        // vtable → vtable.escalate_end. A panic at any FFI boundary
+        // surfaces as a panic in the closure or a non-zero escalate
+        // return; both produce an "ERR:" line.
+        //
+        // `wait_device_idle` is the cheapest Phase D vtable slot
+        // (parameterless, no allocations) but exercises the full
+        // `with_full_scope_or_err` scope-resolution path — so if the
+        // Phase D wiring regresses (cdylib wrapper calls host_inner,
+        // scope-token registry breaks, etc.), this test fails.
+        let result: Result<()> = ctx
+            .gpu_limited_access()
+            .escalate(|full| full.wait_device_idle());
 
         let line = match result {
             Ok(()) => "OK".to_string(),


### PR DESCRIPTION
## Summary

Closes the cdylib-side wrapper rewrite that C2 (#905) and C3 (#912) prepared the substrate for. Every cdylib-callable `GpuContextFullAccess` method now dispatches through the FullAccess vtable instead of calling `host_inner()` (which panics in cdylib mode). After this lands, the elevated-access surface is genuinely cdylib-callable end-to-end — proven by the updated dlopen smoke test below.

## Closes

Closes #906

**Note on Phase C umbrella (#886):** the original Phase D issue body said this PR would close #886. Mid-implementation it surfaced that #886's exit-criterion-#2 ("every in-tree cdylib-callable plugin completes setup/start without panicking") cannot be fully met in this PR for camera + h264/h265 encoder plugins — they reach into `full.device().vulkan_device()` for host-internal `HostVulkanDevice` state that Phase D (correctly) keeps in Bucket D. #886 stays open until the two follow-ups below land:

- #914 — camera cdylib-loadability (`All-Dynamic Package Loading`)
- #915 — `vulkan-video::SimpleEncoder` RHI lift (`Vulkan Video RHI Coupling`)

This PR delivers the FullAccess vtable surface (#886 exit criterion #1, #3, #4) and partial exit-criterion-#2 (h264/h265 decoder + jpeg decoder are now cdylib-loadable). #914 + #915 close the remaining piece of #2.

## Architectural choices (decided in advance with the user)

- **Option B — Limited-handle inheritance.** `GpuContextFullAccess` now carries `inherited_lim_handle` + `inherited_lim_vtable` fields plumbed from the originating `GpuContextLimitedAccess` through `escalate_via_vtable` → `from_scope_token`. The 20 LimitedAccess-mirror FullAccess methods dispatch through a `ManuallyDrop<GpuContextLimitedAccess>` view of the inherited handle, reusing the C1-proven dispatch instead of mirroring 20 parallel slots on the FullAccess vtable. Saves ~160 bytes of vtable layout, ~600 lines of duplicate tier-1 tests, and aligns with CLAUDE.md's engine-model rule ("extend the canonical core system; don't build a parallel one").
- **macOS-only methods deferred** (`metal_device`, `create_texture_cache`, `blit_copy_iosurface`) — out of scope; to be addressed under Polyglot macOS milestone.
- **β-shape refactoring not needed.** C2 set the canonical pattern for Arc-returning methods: `Arc::into_raw` on the host side, `Arc::from_raw` on the cdylib side, relying on the rustc-version coupling contract documented in CLAUDE.md. Same pattern applies to `RhiColorConverter`, `VulkanAccelerationStructure`, `RhiCommandRecorder` — no β-shape refactor of those types is required, and the existing clone/drop slots on the FullAccess vtable remain as future infrastructure if a layout-stable shape becomes necessary later.

## Exit criteria

- [x] Every cdylib-callable FullAccess method dispatches via vtable.
- [x] Tier-1 host-side null-handle / null-out-param wire-format tests for every new vtable entry (10 new tests in `gpu_full_access_vtable_tests`).
- [x] Dlopen integration test: cdylib runs an escalate scope calling `full.acquire_pixel_buffer` AND `full.register_texture_with_layout`, plus `full.wait_device_idle` and `full.acquire_output_texture`, verifies no panic and correct return values. (`load_project_dylib_escalate_smoke` test — passes.)
- [x] Plugins whose only FullAccess usage is via the methods Phase D wires (h264/h265 decoder + jpeg decoder) are cdylib-loadable. Plugins that reach into `full.device().vulkan_device()` (camera + h264/h265 encoders) deferred to #914 + #915.

## Follow-ups (filed)

- **#914 — Camera cdylib-loadability** (`All-Dynamic Package Loading` milestone). Camera reaches `HostVulkanTimelineSemaphore::new`, `HostVulkanTexture::new`, `HostVulkanBuffer::from_dma_buf_fd_as_storage_buffer`, and capability queries through `full.device().vulkan_device()`. The fix: new FullAccess primitives for timeline construction, DMA-BUF FD import, capability queries — then migrate the camera processor onto them. Engine-model end-state: camera reaches the GPU exclusively through `full.<method>`.
- **#915 — `vulkan-video::SimpleEncoder` RHI lift** (`Vulkan Video RHI Coupling` milestone). h264/h265 encoders pass `HostVulkanDevice` directly into `vulkan_video::SimpleEncoder::from_device(instance, device, physical_device, allocator, submitter, queues...)`. The fix is in `libs/vulkan-video/`: drop the raw-Vulkan public constructor in favor of a higher-level RHI-shaped one. Once this lands, the h264/h265 encoder packages drop their direct `HostVulkanDevice` usage in a small migration follow-up.
- **macOS-only FullAccess methods.** `metal_device`, `create_texture_cache`, `blit_copy_iosurface` are not in this PR's published list and stay calling `host_inner()`. Polyglot macOS milestone.
- **Phase E (#907) — kernel-handle method dispatch.** This PR ensures `create_compute_kernel` / `create_graphics_kernel` / `create_ray_tracing_kernel` / `create_command_recorder` / `build_*_blas` work end-to-end from cdylib (the handles can be obtained, held, and dropped correctly). Using methods on those handles from cdylib code (`kernel.set_storage_buffer(...)`, `kernel.dispatch(...)`, `recorder.record_image_barrier(...)`, etc.) is Phase E's scope.

## Scope

### Bucket A — 5 cdylib wrappers rewired against existing FullAccess vtable slots

`create_compute_kernel`, `create_graphics_kernel`, `create_ray_tracing_kernel`, `create_texture_ring`, `acquire_render_target_dma_buf_image`. C2/C3 built the host-side substrate; Phase D wires the cdylib side.

### Bucket B — 9 new FullAccess vtable slots + host callbacks + cdylib wrappers

`wait_device_idle`, `acquire_output_texture`, `upload_pixel_buffer_as_texture`, `color_converter`, `create_command_recorder`, `build_triangles_blas`, `build_tlas`, `supports_ray_tracing_pipeline`, `check_in_surface`. Each callback validates the scope token via `with_full_scope_or_err` and dispatches to the bound `Arc<GpuContext>`. `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION` bumped 2 → 3; layout regression test extended with 9 new offset assertions (vtable grows 120 → 192 bytes, 14 → 23 entries).

### Bucket C — 20 LimitedAccess-mirror wrappers via Option B inheritance

`acquire_pixel_buffer`, `acquire_{storage,uniform,vertex,index}_buffer`, `get_pixel_buffer`, `resolve_pixel_buffer_by_surface_id`, `register_texture` + `register_texture_with_layout`, `update_texture_registration_layout`, `resolve_texture_{,registration_}by_surface_id`, `unregister_texture`, `acquire_texture`, `command_queue`, `create_command_buffer`, `copy_pixel_buffer_to_texture`, `blit_copy`, `surface_store`, `check_out_surface`. Wrappers dispatch through the inherited LimitedAccess vtable via the `inherited_limited_unchecked()` helper (returns `ManuallyDrop<GpuContextLimitedAccess>` so the borrowed handle isn't double-released).

### Bucket D — 10 engine-only methods with explicit per-method panic guards

`device`, `texture_pool`, `clear_blitter_cache`, `{set,clear,get}_video_source_timeline_semaphore`, four `*_bridge` accessors. Each carries an explicit `if host_callbacks().is_some() { panic!("method_name: <specific reason>"); }` guard naming the parameter/return that makes the method host-only. The transitive `host_inner()` panic remains as a backstop.

### Special case: `command_queue` signature

Changed FullAccess return from `&RhiCommandQueue` (borrow) to owned `RhiCommandQueue` (β-shape with refcount bump). Borrowed references can't cross the FFI boundary; the owned shape matches LimitedAccess. No in-tree consumer of `full.command_queue()` exists, so the API change has zero blast radius.

## Test plan

- [x] `cargo test --lib -p streamlib-plugin-abi` — 32/32 layout regression tests pass.
- [x] `cargo test --lib -p streamlib-engine -- gpu_full_access_vtable_tests --test-threads=1` — 19/19 module tests pass (incl. 10 new Phase D tier-1 tests).
- [x] `cargo test --test load_project_dylib_escalate_smoke -p streamlib-engine` — 1/1 passes. **Smoke fixture now runs `wait_device_idle` (Bucket B) → `acquire_pixel_buffer` (Bucket C) → `acquire_output_texture` (Bucket B) → `register_texture_with_layout` (Bucket C) end-to-end through the FFI.** Per #906 exit criterion #4.
- [x] `cargo test --lib -p streamlib-engine -- --test-threads=1` — 489/489 streamlib-engine lib tests pass. (Multi-threaded run hits a pre-existing SIGSEGV in static destructors / cleanup, reproduced on `main` — unrelated to this branch.)
- [x] `cargo check -p streamlib` clean.

## pr-review-gate audit trail

Ran `pr-review-gate` after the initial Phase D commit (`6c5ebdd2`). Reviewer returned **PASS** with 3 DISCUSS items:

1. **Smoke test only exercised `wait_device_idle`** — issue body's exit criterion #4 explicitly named `acquire_pixel_buffer` + `register_texture_with_layout`. **Addressed in `61eb0b8f`**: smoke fixture now runs all four methods, covering both Bucket B (new FullAccess vtable slots) and Bucket C (Option B inherited LimitedAccess dispatch). `VulkanLayout` reached through SDK Tier 3 (`streamlib::engine_internal::sdk::rhi::VulkanLayout`) rather than adding `streamlib-consumer-rhi` to test-fixtures' Cargo.toml for one constant.
2. **Bucket D doc-only rather than explicit per-method panic guards** — issue body asked for explicit `if host_callbacks().is_some() { panic!(...) }` guards. **Addressed in `61eb0b8f`**: all 10 engine-only methods now carry method-specific panic guards naming the offending type (e.g. for `device()`: "return type `&Arc<GpuDevice>` borrows into host-private state and cannot cross the FFI boundary"). The transitive `host_inner()` panic remains as backstop.
3. **`TlasInstanceDesc` transit on non-`#[repr(C)]` struct** — flagged as sanity check. **Sound under CLAUDE.md's rustc-version coupling contract** (host and cdylib share the toolchain + dep graph, so the struct's layout is byte-identical; same pattern C2 uses for `VulkanComputeKernel` Arc transit). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
