### PR TITLE
feat(rhi): #922 prereqs — RhiCommandRecorder pub access + new_with_queue constructor

### DIFF
--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -153,7 +153,7 @@ impl RuntimeKind {
 /// Holds three caches:
 /// - UUID → `Texture` for resolving non-AS run-time bindings to
 ///   host-side images (storage_image, sampled_texture).
-/// - `as_id` → `Arc<VulkanAccelerationStructure>` for resolving AS
+/// - `as_id` → `VulkanAccelerationStructure` (β-shape) for resolving AS
 ///   bindings AND for chaining BLAS → TLAS construction (TLAS instance
 ///   `blas_id` lookup).
 /// - SHA-256 over canonical kernel descriptor bytes →
@@ -162,7 +162,7 @@ impl RuntimeKind {
 struct SceneKernelBridge {
     device: Arc<HostVulkanDevice>,
     surfaces: HashMap<String, Texture>,
-    as_handles: parking_lot::Mutex<HashMap<String, Arc<VulkanAccelerationStructure>>>,
+    as_handles: parking_lot::Mutex<HashMap<String, VulkanAccelerationStructure>>,
     kernels: parking_lot::Mutex<HashMap<String, Arc<VulkanRayTracingKernel>>>,
 }
 

--- a/examples/raytracing-showcase/src/main.rs
+++ b/examples/raytracing-showcase/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> Result<()> {
     )?;
 
     let tlas_instances = vec![{
-        let mut inst = TlasInstanceDesc::identity(Arc::clone(&blas));
+        let mut inst = TlasInstanceDesc::identity(blas.clone());
         inst.custom_index = 0;
         inst
     }];

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -407,7 +407,7 @@ pub struct GpuContext {
     /// on miss matches that read/write skew.
     #[cfg(target_os = "linux")]
     color_converter_cache:
-        Arc<RwLock<HashMap<(PixelFormat, PixelFormat), Arc<RhiColorConverter>>>>,
+        Arc<RwLock<HashMap<(PixelFormat, PixelFormat), Arc<crate::core::rhi::RhiColorConverterInner>>>>,
     /// Engine-tier publication slot for an in-process producer's timeline
     /// semaphore. The producer (today: the camera; in principle any in-tree
     /// video source) publishes a typed handle here so an in-process consumer
@@ -1315,30 +1315,31 @@ impl GpuContext {
         &self,
         src: PixelFormat,
         dst: PixelFormat,
-    ) -> Result<Arc<RhiColorConverter>> {
-        // Fast path: read lock.
+    ) -> Result<RhiColorConverter> {
+        // Fast path: read lock; cache stores Arc<Inner> so we can build
+        // a fresh β-shape via from_arc_into_raw per request.
         {
             let cache = self.color_converter_cache.read().unwrap();
             if let Some(c) = cache.get(&(src, dst)) {
-                return Ok(Arc::clone(c));
+                return Ok(RhiColorConverter::from_arc_into_raw(Arc::clone(c)));
             }
         }
         // Slow path: build under write lock with double-check.
         let mut cache = self.color_converter_cache.write().unwrap();
         if let Some(c) = cache.get(&(src, dst)) {
-            return Ok(Arc::clone(c));
+            return Ok(RhiColorConverter::from_arc_into_raw(Arc::clone(c)));
         }
         let vulkan_device = &self.device.inner;
         let inner = crate::vulkan::rhi::VulkanColorConverter::new(vulkan_device, src, dst)?;
-        let converter = Arc::new(RhiColorConverter { inner });
-        cache.insert((src, dst), Arc::clone(&converter));
+        let inner_arc = Arc::new(crate::core::rhi::RhiColorConverterInner { inner });
+        cache.insert((src, dst), Arc::clone(&inner_arc));
         tracing::debug!(
             rhi_op = "color_converter",
             ?src,
             ?dst,
             "GpuContext::color_converter — converter constructed"
         );
-        Ok(converter)
+        Ok(RhiColorConverter::from_arc_into_raw(inner_arc))
     }
 
     /// Create a compute kernel from a SPIR-V shader and a binding declaration.
@@ -4095,7 +4096,7 @@ impl GpuContextFullAccess {
         &self,
         src: PixelFormat,
         dst: PixelFormat,
-    ) -> Result<Arc<RhiColorConverter>> {
+    ) -> Result<RhiColorConverter> {
         match self.handle_kind {
             HandleKind::Boxed => self.host_inner().color_converter(src, dst),
             HandleKind::ScopeToken => {
@@ -4124,10 +4125,11 @@ impl GpuContextFullAccess {
                             "color_converter: host signaled success but out_converter is null".into(),
                         ));
                     }
-                    // SAFETY: host wrote `Arc::into_raw(Arc<RhiColorConverter>)`.
-                    let arc =
-                        unsafe { Arc::from_raw(out_converter as *const RhiColorConverter) };
-                    Ok(arc)
+                    // β-shape: bundle the raw handle with the host vtable.
+                    Ok(RhiColorConverter {
+                        handle: out_converter,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1516,7 +1516,7 @@ impl GpuContext {
         label: &str,
         vertices: &[f32],
         indices: &[u32],
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
+    ) -> Result<crate::vulkan::rhi::VulkanAccelerationStructure> {
         tracing::debug!(
             rhi_op = "build_triangles_blas",
             label,
@@ -1542,7 +1542,7 @@ impl GpuContext {
         &self,
         label: &str,
         instances: &[crate::vulkan::rhi::TlasInstanceDesc],
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
+    ) -> Result<crate::vulkan::rhi::VulkanAccelerationStructure> {
         tracing::debug!(
             rhi_op = "build_tlas",
             label,
@@ -4394,7 +4394,7 @@ impl GpuContextFullAccess {
         label: &str,
         vertices: &[f32],
         indices: &[u32],
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
+    ) -> Result<crate::vulkan::rhi::VulkanAccelerationStructure> {
         match self.handle_kind {
             HandleKind::Boxed => {
                 self.host_inner().build_triangles_blas(label, vertices, indices)
@@ -4429,13 +4429,13 @@ impl GpuContextFullAccess {
                             "build_triangles_blas: host signaled success but out_blas is null".into(),
                         ));
                     }
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_blas
-                                as *const crate::vulkan::rhi::VulkanAccelerationStructure,
-                        )
-                    };
-                    Ok(arc)
+                    // β-shape: bundle the raw handle (`Arc::into_raw(Arc<Inner>)`-shaped)
+                    // with the host vtable. Cross-rustc-version safe because no Inner
+                    // layout knowledge is required cdylib-side.
+                    Ok(crate::vulkan::rhi::VulkanAccelerationStructure {
+                        handle: out_blas,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],
@@ -4453,7 +4453,7 @@ impl GpuContextFullAccess {
         &self,
         label: &str,
         instances: &[crate::vulkan::rhi::TlasInstanceDesc],
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanAccelerationStructure>> {
+    ) -> Result<crate::vulkan::rhi::VulkanAccelerationStructure> {
         match self.handle_kind {
             HandleKind::Boxed => self.host_inner().build_tlas(label, instances),
             HandleKind::ScopeToken => {
@@ -4484,13 +4484,10 @@ impl GpuContextFullAccess {
                             "build_tlas: host signaled success but out_tlas is null".into(),
                         ));
                     }
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_tlas
-                                as *const crate::vulkan::rhi::VulkanAccelerationStructure,
-                        )
-                    };
-                    Ok(arc)
+                    Ok(crate::vulkan::rhi::VulkanAccelerationStructure {
+                        handle: out_tlas,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1354,7 +1354,7 @@ impl GpuContext {
     pub fn create_compute_kernel(
         &self,
         descriptor: &crate::core::rhi::ComputeKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanComputeKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanComputeKernel> {
         tracing::debug!(
             rhi_op = "create_compute_kernel",
             label = descriptor.label,
@@ -1363,8 +1363,7 @@ impl GpuContext {
             "GpuContext::create_compute_kernel"
         );
         let vulkan_device = &self.device.inner;
-        let kernel = crate::vulkan::rhi::VulkanComputeKernel::new(vulkan_device, descriptor)?;
-        Ok(Arc::new(kernel))
+        crate::vulkan::rhi::VulkanComputeKernel::new(vulkan_device, descriptor)
     }
 
     /// Build an engine-owned command-buffer recorder bound to the
@@ -1402,7 +1401,7 @@ impl GpuContext {
     pub fn create_graphics_kernel(
         &self,
         descriptor: &crate::core::rhi::GraphicsKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanGraphicsKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanGraphicsKernel> {
         tracing::debug!(
             rhi_op = "create_graphics_kernel",
             label = descriptor.label,
@@ -1413,8 +1412,7 @@ impl GpuContext {
             "GpuContext::create_graphics_kernel"
         );
         let vulkan_device = &self.device.inner;
-        let kernel = crate::vulkan::rhi::VulkanGraphicsKernel::new(vulkan_device, descriptor)?;
-        Ok(Arc::new(kernel))
+        crate::vulkan::rhi::VulkanGraphicsKernel::new(vulkan_device, descriptor)
     }
 
     /// Create a ray-tracing kernel from shader stages, shader-group
@@ -1431,7 +1429,7 @@ impl GpuContext {
     pub fn create_ray_tracing_kernel(
         &self,
         descriptor: &crate::core::rhi::RayTracingKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanRayTracingKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanRayTracingKernel> {
         tracing::debug!(
             rhi_op = "create_ray_tracing_kernel",
             label = descriptor.label,
@@ -1443,8 +1441,7 @@ impl GpuContext {
             "GpuContext::create_ray_tracing_kernel"
         );
         let vulkan_device = &self.device.inner;
-        let kernel = crate::vulkan::rhi::VulkanRayTracingKernel::new(vulkan_device, descriptor)?;
-        Ok(Arc::new(kernel))
+        crate::vulkan::rhi::VulkanRayTracingKernel::new(vulkan_device, descriptor)
     }
 
     /// Pre-allocate a ring of `count` non-exportable DEVICE_LOCAL
@@ -4148,7 +4145,7 @@ impl GpuContextFullAccess {
     pub fn create_compute_kernel(
         &self,
         descriptor: &crate::core::rhi::ComputeKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanComputeKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanComputeKernel> {
         match self.handle_kind {
             HandleKind::Boxed => self.host_inner().create_compute_kernel(descriptor),
             HandleKind::ScopeToken => {
@@ -4184,16 +4181,16 @@ impl GpuContextFullAccess {
                             "create_compute_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // SAFETY: host wrote
-                    // `Arc::into_raw(Arc<VulkanComputeKernel>)`. The
-                    // strong reference transfers ownership to the
-                    // cdylib via this reconstruction.
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_kernel as *const crate::vulkan::rhi::VulkanComputeKernel,
-                        )
-                    };
-                    Ok(arc)
+                    // β-shape: bundle the raw handle (an
+                    // `Arc::into_raw(Arc<VulkanComputeKernelInner>)`
+                    // pointer host-side, opaque to the cdylib) with the
+                    // host vtable. Lifecycle dispatches through the
+                    // vtable's clone/drop slots without ever crossing
+                    // the host's `Arc<X>` allocation-header layout.
+                    Ok(crate::vulkan::rhi::VulkanComputeKernel {
+                        handle: out_kernel,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],
@@ -4270,7 +4267,7 @@ impl GpuContextFullAccess {
     pub fn create_graphics_kernel(
         &self,
         descriptor: &crate::core::rhi::GraphicsKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanGraphicsKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanGraphicsKernel> {
         match self.handle_kind {
             HandleKind::Boxed => self.host_inner().create_graphics_kernel(descriptor),
             HandleKind::ScopeToken => {
@@ -4302,14 +4299,11 @@ impl GpuContextFullAccess {
                             "create_graphics_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // SAFETY: host wrote
-                    // `Arc::into_raw(Arc<VulkanGraphicsKernel>)`.
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_kernel as *const crate::vulkan::rhi::VulkanGraphicsKernel,
-                        )
-                    };
-                    Ok(arc)
+                    // β-shape: see compute_kernel above.
+                    Ok(crate::vulkan::rhi::VulkanGraphicsKernel {
+                        handle: out_kernel,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],
@@ -4330,7 +4324,7 @@ impl GpuContextFullAccess {
     pub fn create_ray_tracing_kernel(
         &self,
         descriptor: &crate::core::rhi::RayTracingKernelDescriptor<'_>,
-    ) -> Result<Arc<crate::vulkan::rhi::VulkanRayTracingKernel>> {
+    ) -> Result<crate::vulkan::rhi::VulkanRayTracingKernel> {
         match self.handle_kind {
             HandleKind::Boxed => self.host_inner().create_ray_tracing_kernel(descriptor),
             HandleKind::ScopeToken => {
@@ -4362,14 +4356,11 @@ impl GpuContextFullAccess {
                             "create_ray_tracing_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // SAFETY: host wrote
-                    // `Arc::into_raw(Arc<VulkanRayTracingKernel>)`.
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_kernel as *const crate::vulkan::rhi::VulkanRayTracingKernel,
-                        )
-                    };
-                    Ok(arc)
+                    // β-shape: see compute_kernel above.
+                    Ok(crate::vulkan::rhi::VulkanRayTracingKernel {
+                        handle: out_kernel,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1460,8 +1460,8 @@ impl GpuContext {
         format: TextureFormat,
         usages: TextureUsages,
         count: usize,
-    ) -> Result<Arc<crate::core::context::TextureRing>> {
-        use crate::core::context::{TextureRing, TextureRingSlot};
+    ) -> Result<crate::core::context::TextureRing> {
+        use crate::core::context::{TextureRing, TextureRingInner, TextureRingSlot};
 
         if count == 0 {
             return Err(Error::GpuError(
@@ -1497,14 +1497,15 @@ impl GpuContext {
             let res = crate::vulkan::rhi::HostVulkanUploadResources::new(&self.device.inner)?;
             upload_resources.push(res);
         }
-        Ok(TextureRing::from_slots(
+        let inner_arc = TextureRingInner::from_slots(
             slots,
             upload_resources,
             width,
             height,
             format,
             self.clone(),
-        ))
+        );
+        Ok(TextureRing::from_arc_into_raw(inner_arc))
     }
 
     /// Build a triangle-geometry bottom-level acceleration structure
@@ -3872,7 +3873,7 @@ impl GpuContextFullAccess {
         format: TextureFormat,
         usages: TextureUsages,
         count: usize,
-    ) -> Result<Arc<crate::core::context::TextureRing>> {
+    ) -> Result<crate::core::context::TextureRing> {
         match self.handle_kind {
             HandleKind::Boxed => self
                 .host_inner()
@@ -3907,22 +3908,14 @@ impl GpuContextFullAccess {
                                 .into(),
                         ));
                     }
-                    // SAFETY: host returned
-                    // `Arc::into_raw(Arc<TextureRing>)`. Rebuilding via
-                    // `Arc::from_raw` is sound under the rustc-version
-                    // coupling contract documented in CLAUDE.md (host
-                    // and cdylib share the toolchain + dep graph, so
-                    // `TextureRing`'s layout is byte-identical and the
-                    // host's `Arc` strong-count machinery survives the
-                    // cross-DSO transit). The host transferred its
-                    // strong reference to us; `Arc<TextureRing>::drop`
-                    // running in cdylib code releases that reference.
-                    let arc = unsafe {
-                        Arc::from_raw(
-                            out_ring as *const crate::core::context::TextureRing,
-                        )
-                    };
-                    Ok(arc)
+                    // β-shape: bundle the raw handle
+                    // (`Arc::into_raw(Arc<TextureRingInner>)`-shaped) with
+                    // the host vtable. Cross-rustc-version safe because
+                    // cdylib never derefs the Inner layout.
+                    Ok(crate::core::context::TextureRing {
+                        handle: out_ring,
+                        vtable: self.vtable,
+                    })
                 } else {
                     let msg = String::from_utf8_lossy(
                         &err_buf[..err_len.min(err_buf.len())],

--- a/libs/streamlib-engine/src/core/context/mod.rs
+++ b/libs/streamlib-engine/src/core/context/mod.rs
@@ -57,5 +57,5 @@ pub use runtime_context::{
 pub use surface_store::SurfaceStore;
 pub use texture_pool::*;
 pub use texture_registration::TextureRegistration;
-pub use texture_ring::{TextureRing, TextureRingSlot};
+pub use texture_ring::{TextureRing, TextureRingInner, TextureRingSlot};
 pub use time_context::TimeContext;

--- a/libs/streamlib-engine/src/core/context/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/context/texture_ring.rs
@@ -10,8 +10,11 @@
 //! is Limited-safe and never escalates. See
 //! `docs/architecture/texture-ring.md` for the recipe.
 
+use std::ffi::c_void;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
 
 use crate::core::context::GpuContext;
 use crate::core::rhi::{Texture, TextureFormat};
@@ -72,7 +75,10 @@ pub struct TextureRingSlot {
 ///
 /// On drop, the ring unregisters its `surface_id`s from
 /// [`GpuContext`]'s texture cache.
-pub struct TextureRing {
+/// Host-only rich data backing a [`TextureRing`]. Cdylib code never
+/// sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct TextureRingInner {
     slots: Vec<TextureRingSlot>,
     /// Per-slot pre-allocated upload resources (command pool + command
     /// buffer + fence), parallel to `slots`. `None` on non-Linux
@@ -87,7 +93,7 @@ pub struct TextureRing {
     gpu: GpuContext,
 }
 
-impl TextureRing {
+impl TextureRingInner {
     /// Construct a ring from pre-built slots. Crate-internal: public
     /// construction goes through
     /// [`crate::core::context::GpuContextFullAccess::create_texture_ring`].
@@ -236,13 +242,171 @@ impl TextureRing {
     }
 }
 
-impl Drop for TextureRing {
+impl Drop for TextureRingInner {
     fn drop(&mut self) {
         for slot in &self.slots {
             self.gpu.unregister_texture(&slot.surface_id);
         }
         // upload_resources drop themselves (each Drop waits on its fence
         // first, then destroys cb + pool + fence).
+    }
+}
+
+// =============================================================================
+// β-shape implementation
+// =============================================================================
+
+/// Pre-allocated ring of textures rotated per-frame on the decode hot
+/// path. Layout-stable `#[repr(C)] (handle, vtable)` β-shape so
+/// cdylibs can hold, refcount, and drop without sharing rustc-version
+/// or dep-graph with the host.
+///
+/// The opaque handle points at an `Arc<TextureRingInner>`; lifecycle
+/// dispatches through the host-installed FullAccess vtable's
+/// `clone_texture_ring` / `drop_texture_ring` callbacks. Method
+/// dispatch is host-only via [`Self::host_inner`] until Phase E
+/// (#907) lifts it to per-method vtable slots.
+#[repr(C)]
+pub struct TextureRing {
+    /// Opaque handle to the host's `Arc<TextureRingInner>`.
+    pub(crate) handle: *const c_void,
+    /// Vtable for cross-DSO Clone/Drop dispatch.
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+// SAFETY: handle points at an `Arc<TextureRingInner>`; inner state is
+// Send+Sync (atomic counter + GPU resources guarded by host queue
+// mutex).
+unsafe impl Send for TextureRing {}
+unsafe impl Sync for TextureRing {}
+
+impl TextureRing {
+    /// Internal helper: leak an initial Arc strong count via
+    /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
+    /// assemble the cross-DSO shape.
+    pub(crate) fn from_arc_into_raw(arc: Arc<TextureRingInner>) -> Self {
+        let handle = Arc::into_raw(arc) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    /// Engine-internal borrow of the host-owned `TextureRingInner`.
+    /// **Panics if called from cdylib code.**
+    pub(crate) fn host_inner(&self) -> &TextureRingInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "TextureRing::host_inner() reached from cdylib code; this method \
+                 must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        // SAFETY: `self.handle` is `Arc::into_raw(Arc<TextureRingInner>)`.
+        unsafe { &*(self.handle as *const TextureRingInner) }
+    }
+
+    /// Rotate to the next slot. Thread-safe (atomic counter).
+    pub fn acquire_next(&self) -> TextureRingSlot {
+        self.host_inner().acquire_next()
+    }
+
+    /// Copy a host-visible pixel buffer's contents into a ring slot.
+    /// See [`TextureRingInner::copy_pixel_buffer_to_slot`] for details.
+    #[cfg(target_os = "linux")]
+    pub fn copy_pixel_buffer_to_slot(
+        &self,
+        slot: &TextureRingSlot,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        self.host_inner()
+            .copy_pixel_buffer_to_slot(slot, pixel_buffer, width, height)
+    }
+
+    /// Number of slots in the ring.
+    pub fn len(&self) -> usize {
+        self.host_inner().len()
+    }
+
+    /// Ring is always non-empty in practice (construction rejects 0).
+    pub fn is_empty(&self) -> bool {
+        self.host_inner().is_empty()
+    }
+
+    /// Width of every slot's texture, in pixels.
+    pub fn width(&self) -> u32 {
+        self.host_inner().width()
+    }
+
+    /// Height of every slot's texture, in pixels.
+    pub fn height(&self) -> u32 {
+        self.host_inner().height()
+    }
+
+    /// Format every slot's texture was allocated with.
+    pub fn format(&self) -> TextureFormat {
+        self.host_inner().format()
+    }
+
+    /// Borrow a slot by index — engine-internal / debug only.
+    #[doc(hidden)]
+    pub fn slot(&self, index: usize) -> Option<TextureRingSlot> {
+        self.host_inner().slot(index).cloned()
+    }
+}
+
+impl Clone for TextureRing {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle paired at construction; the
+            // vtable's `clone_texture_ring` contract is
+            // `Arc::increment_strong_count(handle)` host-side.
+            unsafe {
+                ((*self.vtable).clone_texture_ring)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for TextureRing {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the `Arc::into_raw` in
+            // `from_arc_into_raw` and any `clone_texture_ring` bumps.
+            unsafe {
+                ((*self.vtable).drop_texture_ring)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for TextureRing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextureRing").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn texture_ring_layout() {
+        assert_eq!(size_of::<TextureRing>(), 16);
+        assert_eq!(align_of::<TextureRing>(), 8);
+        assert_eq!(offset_of!(TextureRing, handle), 0);
+        assert_eq!(offset_of!(TextureRing, vtable), 8);
+    }
+
+    #[test]
+    fn texture_ring_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TextureRing>();
     }
 }
 
@@ -587,10 +751,9 @@ mod tests {
             )
             .expect("create_texture_ring");
 
-        let ring_clone = Arc::clone(&ring);
         let handles: Vec<_> = (0..4)
             .map(|_| {
-                let ring = Arc::clone(&ring_clone);
+                let ring = ring.clone();
                 std::thread::spawn(move || {
                     for _ in 0..100 {
                         let _ = ring.acquire_next();

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4547,7 +4547,7 @@ unsafe extern "C" fn host_gpu_full_clone_texture_ring(handle: *const c_void) {
             }
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::core::context::TextureRing,
+                    handle as *const crate::core::context::TextureRingInner,
                 );
             }
         },
@@ -4565,7 +4565,7 @@ unsafe extern "C" fn host_gpu_full_drop_texture_ring(handle: *const c_void) {
             }
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::core::context::TextureRing,
+                    handle as *const crate::core::context::TextureRingInner,
                 );
             }
         },
@@ -4968,8 +4968,11 @@ unsafe extern "C" fn host_gpu_full_create_texture_ring(
                 |gpu| gpu.create_texture_ring(width, height, format, usages, count),
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(ring)) => {
+                    // `ring` is the β-shape; its handle is
+                    // `Arc::into_raw(Arc<TextureRingInner>)`-shaped.
+                    let raw = ring.handle;
+                    std::mem::forget(ring);
                     unsafe { std::ptr::write(out_ring, raw) };
                     0
                 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4797,8 +4797,15 @@ unsafe extern "C" fn host_gpu_full_create_compute_kernel(
                 },
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(kernel)) => {
+                    // `kernel` is the β-shape; its `handle` is the
+                    // `Arc::into_raw(Arc<<Type>Inner>)` raw pointer
+                    // already. Forget the β-shape so the strong ref
+                    // transfers to cdylib; the cdylib reconstructs its
+                    // own β-shape from { handle: raw, vtable } and
+                    // never sees the `Arc<X>` internal layout.
+                    let raw = kernel.handle;
+                    std::mem::forget(kernel);
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
@@ -4849,8 +4856,15 @@ unsafe extern "C" fn host_gpu_full_create_graphics_kernel(
                 },
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(kernel)) => {
+                    // β-shape: extract the opaque handle (which is
+                    // already `Arc::into_raw(Arc<<Type>Inner>)`-shaped)
+                    // and `mem::forget` the wrapper so the strong ref
+                    // transfers to cdylib. The cdylib reconstructs a
+                    // fresh β-shape from { handle, vtable } and never
+                    // sees the host's `Arc<X>` allocation header.
+                    let raw = kernel.handle;
+                    std::mem::forget(kernel);
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
@@ -4901,8 +4915,15 @@ unsafe extern "C" fn host_gpu_full_create_ray_tracing_kernel(
                 },
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(kernel)) => {
+                    // β-shape: extract the opaque handle (which is
+                    // already `Arc::into_raw(Arc<<Type>Inner>)`-shaped)
+                    // and `mem::forget` the wrapper so the strong ref
+                    // transfers to cdylib. The cdylib reconstructs a
+                    // fresh β-shape from { handle, vtable } and never
+                    // sees the host's `Arc<X>` allocation header.
+                    let raw = kernel.handle;
+                    std::mem::forget(kernel);
                     unsafe { std::ptr::write(out_kernel, raw) };
                     0
                 }
@@ -5524,13 +5545,15 @@ unsafe extern "C" fn host_gpu_full_create_command_recorder(
             );
             match result {
                 Some(Ok(recorder)) => {
-                    // SAFETY: host writes the RhiCommandRecorder struct
-                    // by value into the cdylib's MaybeUninit slot;
-                    // layout is byte-identical under the rustc-version
-                    // coupling contract (CLAUDE.md). The cdylib's
-                    // Drop will run when the value falls out of scope
-                    // (in cdylib code), accessing host-loader Vulkan
-                    // handles which are globally addressable.
+                    // SAFETY: `recorder` is the β-shape — a
+                    // `#[repr(C)] { handle: *const c_void, vtable: *const VTable }`
+                    // 16-byte POD. Layout is byte-identical
+                    // by `#[repr(C)]` invariant, not by rustc-version
+                    // coupling. The cdylib reads the bits via
+                    // `MaybeUninit::assume_init`; its `Drop` later
+                    // dispatches through the vtable's
+                    // `drop_command_recorder` slot which runs
+                    // `Box::from_raw + drop` host-side.
                     unsafe {
                         std::ptr::write(
                             out_recorder as *mut crate::vulkan::rhi::RhiCommandRecorder,

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4438,7 +4438,7 @@ unsafe extern "C" fn host_gpu_full_clone_compute_kernel(handle: *const c_void) {
             // SAFETY: handle is `Arc::into_raw(Arc<VulkanComputeKernel>)`-shaped.
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanComputeKernel,
+                    handle as *const crate::vulkan::rhi::VulkanComputeKernelInner,
                 );
             }
         },
@@ -4457,7 +4457,7 @@ unsafe extern "C" fn host_gpu_full_drop_compute_kernel(handle: *const c_void) {
             // SAFETY: handle is `Arc::into_raw(Arc<VulkanComputeKernel>)`-shaped.
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanComputeKernel,
+                    handle as *const crate::vulkan::rhi::VulkanComputeKernelInner,
                 );
             }
         },
@@ -4475,7 +4475,7 @@ unsafe extern "C" fn host_gpu_full_clone_graphics_kernel(handle: *const c_void) 
             }
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernel,
+                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernelInner,
                 );
             }
         },
@@ -4493,7 +4493,7 @@ unsafe extern "C" fn host_gpu_full_drop_graphics_kernel(handle: *const c_void) {
             }
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernel,
+                    handle as *const crate::vulkan::rhi::VulkanGraphicsKernelInner,
                 );
             }
         },
@@ -4511,7 +4511,7 @@ unsafe extern "C" fn host_gpu_full_clone_ray_tracing_kernel(handle: *const c_voi
             }
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernel,
+                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernelInner,
                 );
             }
         },
@@ -4529,7 +4529,7 @@ unsafe extern "C" fn host_gpu_full_drop_ray_tracing_kernel(handle: *const c_void
             }
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernel,
+                    handle as *const crate::vulkan::rhi::VulkanRayTracingKernelInner,
                 );
             }
         },

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4654,18 +4654,19 @@ unsafe extern "C" fn host_gpu_full_drop_acceleration_structure(handle: *const c_
 }
 
 #[cfg(target_os = "linux")]
-unsafe extern "C" fn host_gpu_full_clone_command_recorder(handle: *const c_void) {
+unsafe extern "C" fn host_gpu_full_clone_command_recorder(_handle: *const c_void) {
+    // RhiCommandRecorder is Box-shaped (single-owner) — deliberately
+    // NOT Clone per CommandBuffer precedent. This slot is reserved
+    // infrastructure; the type-level absence of `Clone` for
+    // `RhiCommandRecorder` ensures the host callback is never invoked
+    // from typesafe code. If reached, it's a bug somewhere.
     run_host_extern_c(
         "host_gpu_full_clone_command_recorder",
         || {
-            if handle.is_null() {
-                return;
-            }
-            unsafe {
-                Arc::increment_strong_count(
-                    handle as *const crate::vulkan::rhi::RhiCommandRecorder,
-                );
-            }
+            tracing::error!(
+                "host_gpu_full_clone_command_recorder invoked — RhiCommandRecorder is \
+                 not Clone-able (Box-shaped, single-owner). This is a bug."
+            );
         },
         (),
     )
@@ -4679,9 +4680,11 @@ unsafe extern "C" fn host_gpu_full_drop_command_recorder(handle: *const c_void) 
             if handle.is_null() {
                 return;
             }
+            // SAFETY: handle is `Box::into_raw(Box<RhiCommandRecorderInner>)`-shaped.
+            // Reconstruct the Box and let Drop run.
             unsafe {
-                Arc::decrement_strong_count(
-                    handle as *const crate::vulkan::rhi::RhiCommandRecorder,
+                let _ = Box::from_raw(
+                    handle as *mut crate::vulkan::rhi::RhiCommandRecorderInner,
                 );
             }
         },

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4589,7 +4589,7 @@ unsafe extern "C" fn host_gpu_full_clone_color_converter(handle: *const c_void) 
             }
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::core::rhi::RhiColorConverter,
+                    handle as *const crate::core::rhi::RhiColorConverterInner,
                 );
             }
         },
@@ -4607,7 +4607,7 @@ unsafe extern "C" fn host_gpu_full_drop_color_converter(handle: *const c_void) {
             }
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::core::rhi::RhiColorConverter,
+                    handle as *const crate::core::rhi::RhiColorConverterInner,
                 );
             }
         },
@@ -5434,8 +5434,11 @@ unsafe extern "C" fn host_gpu_full_color_converter(
                 |gpu| gpu.color_converter(src, dst),
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(converter)) => {
+                    // `converter` is the β-shape; its `handle` is the
+                    // `Arc::into_raw(Arc<RhiColorConverterInner>)` pointer.
+                    let raw = converter.handle;
+                    std::mem::forget(converter);
                     unsafe { std::ptr::write(out_converter, raw) };
                     0
                 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4573,6 +4573,120 @@ unsafe extern "C" fn host_gpu_full_drop_texture_ring(handle: *const c_void) {
     )
 }
 
+// β-shape v4 (#917) lifecycle callbacks. The handle is
+// `Arc::into_raw(Arc<<Type>Inner>)`-shaped on the host side; cdylib
+// code never sees the Inner layout, only the opaque handle paired
+// with its β-shape vtable. Increment/decrement runs in host-compiled
+// code where the Inner layout is known statically.
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_color_converter(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_color_converter",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::core::rhi::RhiColorConverter,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_color_converter(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_color_converter",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::core::rhi::RhiColorConverter,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_acceleration_structure(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_acceleration_structure",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_acceleration_structure(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_acceleration_structure",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_clone_command_recorder(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_clone_command_recorder",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::increment_strong_count(
+                    handle as *const crate::vulkan::rhi::RhiCommandRecorder,
+                );
+            }
+        },
+        (),
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_drop_command_recorder(handle: *const c_void) {
+    run_host_extern_c(
+        "host_gpu_full_drop_command_recorder",
+        || {
+            if handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(
+                    handle as *const crate::vulkan::rhi::RhiCommandRecorder,
+                );
+            }
+        },
+        (),
+    )
+}
+
 // Non-Linux stubs (callbacks must exist for the static layout, but
 // the kernel types only ship on Linux).
 #[cfg(not(target_os = "linux"))]
@@ -4591,6 +4705,18 @@ unsafe extern "C" fn host_gpu_full_drop_ray_tracing_kernel(_handle: *const c_voi
 unsafe extern "C" fn host_gpu_full_clone_texture_ring(_handle: *const c_void) {}
 #[cfg(not(target_os = "linux"))]
 unsafe extern "C" fn host_gpu_full_drop_texture_ring(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_color_converter(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_color_converter(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_acceleration_structure(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_acceleration_structure(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_clone_command_recorder(_handle: *const c_void) {}
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_drop_command_recorder(_handle: *const c_void) {}
 
 // ---------------- Kernel construction (Linux-only) ----------------
 
@@ -5747,6 +5873,13 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         drop_ray_tracing_kernel: host_gpu_full_drop_ray_tracing_kernel,
         clone_texture_ring: host_gpu_full_clone_texture_ring,
         drop_texture_ring: host_gpu_full_drop_texture_ring,
+        // v4 β-shape lifecycle slots (#917).
+        clone_color_converter: host_gpu_full_clone_color_converter,
+        drop_color_converter: host_gpu_full_drop_color_converter,
+        clone_acceleration_structure: host_gpu_full_clone_acceleration_structure,
+        drop_acceleration_structure: host_gpu_full_drop_acceleration_structure,
+        clone_command_recorder: host_gpu_full_clone_command_recorder,
+        drop_command_recorder: host_gpu_full_drop_command_recorder,
         create_compute_kernel: host_gpu_full_create_compute_kernel,
         create_graphics_kernel: host_gpu_full_create_graphics_kernel,
         create_ray_tracing_kernel: host_gpu_full_create_ray_tracing_kernel,

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -4625,7 +4625,8 @@ unsafe extern "C" fn host_gpu_full_clone_acceleration_structure(handle: *const c
             }
             unsafe {
                 Arc::increment_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                    handle
+                        as *const crate::vulkan::rhi::VulkanAccelerationStructureInner,
                 );
             }
         },
@@ -4643,7 +4644,8 @@ unsafe extern "C" fn host_gpu_full_drop_acceleration_structure(handle: *const c_
             }
             unsafe {
                 Arc::decrement_strong_count(
-                    handle as *const crate::vulkan::rhi::VulkanAccelerationStructure,
+                    handle
+                        as *const crate::vulkan::rhi::VulkanAccelerationStructureInner,
                 );
             }
         },
@@ -5617,8 +5619,14 @@ unsafe extern "C" fn host_gpu_full_build_triangles_blas(
                 |gpu| gpu.build_triangles_blas(label, vertices, indices),
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(blas)) => {
+                    // `blas` is the β-shape — its `handle` is already
+                    // `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`-shaped.
+                    // Forget the β-shape to keep the Arc strong count
+                    // bumped; cdylib reconstructs its own β-shape from
+                    // the handle + vtable.
+                    let raw = blas.handle;
+                    std::mem::forget(blas);
                     unsafe { std::ptr::write(out_blas, raw) };
                     0
                 }
@@ -5719,8 +5727,9 @@ unsafe extern "C" fn host_gpu_full_build_tlas(
                 |gpu| gpu.build_tlas(label, instances),
             );
             match result {
-                Some(Ok(arc)) => {
-                    let raw = Arc::into_raw(arc) as *const c_void;
+                Some(Ok(tlas)) => {
+                    let raw = tlas.handle;
+                    std::mem::forget(tlas);
                     unsafe { std::ptr::write(out_tlas, raw) };
                     0
                 }

--- a/libs/streamlib-engine/src/core/rhi/color_converter.rs
+++ b/libs/streamlib-engine/src/core/rhi/color_converter.rs
@@ -199,18 +199,10 @@ pub fn pixel_format_color_kind(format: PixelFormat) -> ColorSpaceKind {
     }
 }
 
-/// Stateless color converter — a `(src, dst)`-keyed handle that knows
-/// how to convert pixel buffers / textures of the source format into
-/// the destination format, with per-frame [`ResolvedColorInfo`] driving
-/// the math via push constants.
-///
-/// Created on demand via [`crate::core::context::GpuContext::color_converter`]
-/// and cached for reuse. The cache key is `(src_format, dst_format)`;
-/// mid-stream `ResolvedColorInfo` changes do not invalidate the cache.
-///
-/// Thread-safe — internal compute kernels serialize their own submits
-/// via the host queue mutex.
-pub struct RhiColorConverter {
+/// Host-only rich data backing a [`RhiColorConverter`]. Cdylib code
+/// never sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct RhiColorConverterInner {
     #[cfg(target_os = "linux")]
     pub(crate) inner: crate::vulkan::rhi::VulkanColorConverter,
 
@@ -223,13 +215,8 @@ pub struct RhiColorConverter {
     _marker: std::marker::PhantomData<()>,
 }
 
-impl RhiColorConverter {
+impl RhiColorConverterInner {
     /// Convert a YCbCr or RGB pixel buffer into an RGBA storage image.
-    ///
-    /// `src` must have the same dimensions as `dst`. `info` is the
-    /// fully-resolved color description for `src`; defaults are
-    /// applied by [`crate::core::color::resolve_color_defaults`] before
-    /// dispatch.
     #[cfg(target_os = "linux")]
     pub fn convert_buffer_to_image<B>(
         &self,
@@ -245,13 +232,7 @@ impl RhiColorConverter {
     }
 
     /// Bind source / destination / push-constants on the buffer→image
-    /// kernel and return it for recorder-driven dispatch. Use when the
-    /// caller already has an [`crate::vulkan::rhi::RhiCommandRecorder`]
-    /// and wants the compute step to nest inside its own barriers
-    /// rather than spawning a separate queue submit.
-    ///
-    /// `dst_transfer` is the destination output curve; matching it to
-    /// `info.transfer` bypasses the shader transfer path.
+    /// kernel and return it for recorder-driven dispatch.
     #[cfg(target_os = "linux")]
     pub fn prepare_buffer_to_image<B>(
         &self,
@@ -316,29 +297,193 @@ impl RhiColorConverter {
     }
 }
 
-impl std::fmt::Debug for RhiColorConverter {
+impl std::fmt::Debug for RhiColorConverterInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RhiColorConverter")
+        f.debug_struct("RhiColorConverterInner")
             .field("src", &self.src_format())
             .field("dst", &self.dst_format())
             .finish()
     }
 }
 
-// Compute-kernel submissions serialize through the host queue mutex.
+// =============================================================================
+// β-shape implementation
+// =============================================================================
+
+/// Stateless color converter — a `(src, dst)`-keyed handle that knows
+/// how to convert pixel buffers / textures of the source format into
+/// the destination format, with per-frame [`ResolvedColorInfo`] driving
+/// the math via push constants.
+///
+/// Layout-stable: `#[repr(C)] (handle, vtable)`. Cdylibs can hold,
+/// refcount, and drop without sharing rustc-version or dep-graph with
+/// the host. The opaque handle points at an `Arc<RhiColorConverterInner>`;
+/// lifecycle dispatches through the host-installed FullAccess vtable's
+/// `clone_color_converter` / `drop_color_converter` callbacks.
+#[repr(C)]
+pub struct RhiColorConverter {
+    /// Opaque handle to the host's `Arc<RhiColorConverterInner>`.
+    pub(crate) handle: *const std::ffi::c_void,
+    /// Vtable for cross-DSO Clone/Drop dispatch.
+    pub(crate) vtable: *const streamlib_plugin_abi::GpuContextFullAccessVTable,
+}
+
+// SAFETY: handle points at an Arc<RhiColorConverterInner>; the Inner's
+// internal VulkanColorConverter is Send+Sync (queue submits serialize
+// via host queue mutex).
 unsafe impl Send for RhiColorConverter {}
 unsafe impl Sync for RhiColorConverter {}
+
+impl RhiColorConverter {
+    /// Internal helper: leak an initial Arc strong count via
+    /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
+    /// assemble the cross-DSO shape.
+    pub(crate) fn from_arc_into_raw(arc: std::sync::Arc<RhiColorConverterInner>) -> Self {
+        let handle = std::sync::Arc::into_raw(arc) as *const std::ffi::c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    /// Engine-internal borrow of the host-owned `RhiColorConverterInner`.
+    /// **Panics if called from cdylib code.**
+    pub(crate) fn host_inner(&self) -> &RhiColorConverterInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "RhiColorConverter::host_inner() reached from cdylib code; this method \
+                 must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        // SAFETY: `self.handle` is `Arc::into_raw(Arc<RhiColorConverterInner>)`.
+        unsafe { &*(self.handle as *const RhiColorConverterInner) }
+    }
+
+    /// Convert a YCbCr or RGB pixel buffer into an RGBA storage image.
+    /// Mirrors `RhiColorConverterInner::convert_buffer_to_image` via
+    /// `host_inner()` — host-mode only until Phase E (#907) lifts
+    /// method dispatch to the vtable.
+    #[cfg(target_os = "linux")]
+    pub fn convert_buffer_to_image<B>(
+        &self,
+        src: &B,
+        src_layout: SourceLayoutInfo,
+        dst: &Texture,
+        info: &ResolvedColorInfo,
+    ) -> Result<()>
+    where
+        B: crate::vulkan::rhi::VulkanStorageBindable + ?Sized,
+    {
+        self.host_inner()
+            .convert_buffer_to_image(src, src_layout, dst, info)
+    }
+
+    /// Bind source / destination / push-constants on the buffer→image
+    /// kernel and return it for recorder-driven dispatch.
+    #[cfg(target_os = "linux")]
+    pub fn prepare_buffer_to_image<B>(
+        &self,
+        src: &B,
+        src_layout: SourceLayoutInfo,
+        dst: &Texture,
+        info: &ResolvedColorInfo,
+        dst_transfer: TransferId,
+    ) -> Result<std::sync::Arc<crate::vulkan::rhi::VulkanComputeKernel>>
+    where
+        B: crate::vulkan::rhi::VulkanStorageBindable + ?Sized,
+    {
+        self.host_inner()
+            .prepare_buffer_to_image(src, src_layout, dst, info, dst_transfer)
+    }
+
+    /// macOS stub.
+    #[cfg(target_os = "macos")]
+    pub fn convert_buffer_to_image<S, D>(
+        &self,
+        _src: &S,
+        _dst: &D,
+        _info: &ResolvedColorInfo,
+    ) -> crate::core::Result<()> {
+        Err(crate::core::Error::NotSupported(
+            "color conversion not implemented on macOS".into(),
+        ))
+    }
+
+    /// Source pixel format this converter accepts.
+    pub fn src_format(&self) -> PixelFormat {
+        self.host_inner().src_format()
+    }
+
+    /// Destination pixel format this converter produces.
+    pub fn dst_format(&self) -> PixelFormat {
+        self.host_inner().dst_format()
+    }
+}
+
+impl Clone for RhiColorConverter {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle were paired at construction; the
+            // vtable's `clone_color_converter` contract is
+            // `Arc::increment_strong_count(handle)` host-side.
+            unsafe {
+                ((*self.vtable).clone_color_converter)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for RhiColorConverter {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the `Arc::into_raw` in
+            // `from_arc_into_raw` and any `clone_color_converter` bumps.
+            unsafe {
+                ((*self.vtable).drop_color_converter)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for RhiColorConverter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RhiColorConverter").finish()
+    }
+}
 
 /// Unused on macOS today; kept here so the symbol stays referenced
 /// when the cdylib builds against `target_os = "macos"`.
 #[cfg(target_os = "macos")]
-impl RhiColorConverter {
+impl RhiColorConverterInner {
     #[allow(dead_code)]
     pub(crate) fn new_macos_stub(src: PixelFormat, dst: PixelFormat) -> Result<Self, crate::core::Error> {
         let _ = (src, dst);
         Err(crate::core::Error::NotSupported(
             "RhiColorConverter not yet implemented on macOS".into(),
         ))
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn rhi_color_converter_layout() {
+        assert_eq!(size_of::<RhiColorConverter>(), 16);
+        assert_eq!(align_of::<RhiColorConverter>(), 8);
+        assert_eq!(offset_of!(RhiColorConverter, handle), 0);
+        assert_eq!(offset_of!(RhiColorConverter, vtable), 8);
+    }
+
+    #[test]
+    fn rhi_color_converter_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RhiColorConverter>();
     }
 }
 

--- a/libs/streamlib-engine/src/core/rhi/mod.rs
+++ b/libs/streamlib-engine/src/core/rhi/mod.rs
@@ -32,8 +32,8 @@ pub use blitter::RhiBlitter;
 pub use command_buffer::CommandBuffer;
 pub use command_queue::RhiCommandQueue;
 pub use color_converter::{
-    pixel_format_color_kind, ColorConverterPushConstants, RhiColorConverter, SourceLayoutInfo,
-    COLOR_CONVERTER_PUSH_CONSTANT_SIZE,
+    pixel_format_color_kind, ColorConverterPushConstants, RhiColorConverter,
+    RhiColorConverterInner, SourceLayoutInfo, COLOR_CONVERTER_PUSH_CONSTANT_SIZE,
 };
 pub use tone_mapper::{
     RhiToneMapper, ToneCurveId, ToneMapperPushConstants, TONE_MAPPER_PUSH_CONSTANT_SIZE,

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -75,6 +75,9 @@ pub use vulkan_pipeline_flags::{VulkanAccess, VulkanStage};
 mod vulkan_command_recorder;
 #[cfg(target_os = "linux")]
 pub use vulkan_command_recorder::{ImageCopyRegion, RhiCommandRecorder};
+// `RhiCommandRecorderInner` is needed by `core::plugin::host_services`
+// for `Box::from_raw` in `drop_command_recorder`. Crate-scope export.
+pub(crate) use vulkan_command_recorder::RhiCommandRecorderInner;
 
 #[cfg(target_os = "linux")]
 mod vulkan_present_target;

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -110,6 +110,12 @@ mod vulkan_acceleration_structure;
 pub use vulkan_acceleration_structure::{
     AccelerationStructureKind, TlasInstanceDesc, VulkanAccelerationStructure, IDENTITY_TRANSFORM,
 };
+// `VulkanAccelerationStructureInner` is `pub(crate)`-shaped — only
+// the host's clone/drop callbacks in `core::plugin::host_services`
+// need to reference it for `Arc::increment_strong_count` /
+// `Arc::decrement_strong_count`. Re-export at crate scope.
+#[cfg(target_os = "linux")]
+pub(crate) use vulkan_acceleration_structure::VulkanAccelerationStructureInner;
 
 #[cfg(target_os = "linux")]
 mod vulkan_ray_tracing_kernel;

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -75,6 +75,9 @@ pub use vulkan_pipeline_flags::{VulkanAccess, VulkanStage};
 mod vulkan_command_recorder;
 #[cfg(target_os = "linux")]
 pub use vulkan_command_recorder::{ImageCopyRegion, RhiCommandRecorder};
+pub(crate) use vulkan_compute_kernel::VulkanComputeKernelInner;
+pub(crate) use vulkan_graphics_kernel::VulkanGraphicsKernelInner;
+pub(crate) use vulkan_ray_tracing_kernel::VulkanRayTracingKernelInner;
 // `RhiCommandRecorderInner` is needed by `core::plugin::host_services`
 // for `Box::from_raw` in `drop_command_recorder`. Crate-scope export.
 pub(crate) use vulkan_command_recorder::RhiCommandRecorderInner;

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
@@ -12,9 +12,11 @@
 
 #![cfg(target_os = "linux")]
 
+use std::ffi::c_void;
 use std::mem;
 use std::sync::Arc;
 
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 use vulkanalia::vk::KhrAccelerationStructureExtensionDeviceCommands as _;
@@ -37,7 +39,7 @@ pub enum AccelerationStructureKind {
 /// the hit shader can read via `gl_InstanceCustomIndexEXT`, a visibility
 /// mask, an SBT record offset, and the BLAS this instance points to.
 ///
-/// The BLAS reference is by `&Arc<VulkanAccelerationStructure>` so the
+/// The BLAS reference is by `VulkanAccelerationStructure` β-shape so the
 /// lifetime contract is "the TLAS holds a strong reference to every
 /// referenced BLAS for as long as the TLAS lives."
 #[derive(Clone)]
@@ -57,13 +59,13 @@ pub struct TlasInstanceDesc {
     /// Default: opaque + counterclockwise front face.
     pub flags: vk::GeometryInstanceFlagsKHR,
     /// BLAS this instance references. Kept alive by the TLAS via a clone.
-    pub blas: Arc<VulkanAccelerationStructure>,
+    pub blas: VulkanAccelerationStructure,
 }
 
 impl TlasInstanceDesc {
     /// Identity transform, opaque + counterclockwise front face. The
     /// most common TLAS-instance shape.
-    pub fn identity(blas: Arc<VulkanAccelerationStructure>) -> Self {
+    pub fn identity(blas: VulkanAccelerationStructure) -> Self {
         Self {
             transform: IDENTITY_TRANSFORM,
             custom_index: 0,
@@ -83,9 +85,10 @@ pub const IDENTITY_TRANSFORM: [[f32; 4]; 3] = [
     [0.0, 0.0, 1.0, 0.0],
 ];
 
-/// One built `VkAccelerationStructureKHR` (BLAS or TLAS) with its owning
-/// storage buffer + allocation.
-pub struct VulkanAccelerationStructure {
+/// Host-only rich data backing a [`VulkanAccelerationStructure`].
+/// Cdylib code never sees this type; it reaches the public surface
+/// through the `(handle, vtable)` β-shape.
+pub(crate) struct VulkanAccelerationStructureInner {
     label: String,
     kind: AccelerationStructureKind,
     vulkan_device: Arc<HostVulkanDevice>,
@@ -99,10 +102,35 @@ pub struct VulkanAccelerationStructure {
     storage_allocation: Option<vma::Allocation>,
     storage_size: vk::DeviceSize,
     /// BLAS references this TLAS keeps alive. Empty for BLAS.
-    referenced_blases: Vec<Arc<VulkanAccelerationStructure>>,
+    referenced_blases: Vec<VulkanAccelerationStructure>,
 }
 
-impl VulkanAccelerationStructure {
+/// Acceleration-structure (BLAS or TLAS) RHI handle — layout-stable
+/// `#[repr(C)] (handle, vtable)` shape so cdylibs can hold, refcount,
+/// and drop without sharing rustc-version or dep-graph with the host.
+///
+/// The opaque handle points at an
+/// `Arc<VulkanAccelerationStructureInner>`; lifecycle dispatches
+/// through the host-installed
+/// [`GpuContextFullAccessVTable::clone_acceleration_structure`] /
+/// `drop_acceleration_structure` callbacks, which run
+/// `Arc::increment_strong_count` / `Arc::decrement_strong_count` in
+/// host-compiled code where the Inner layout is known.
+#[repr(C)]
+pub struct VulkanAccelerationStructure {
+    /// Opaque handle to the host's `Arc<VulkanAccelerationStructureInner>`.
+    pub(crate) handle: *const c_void,
+    /// Vtable for cross-DSO Clone/Drop dispatch.
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+// SAFETY: `handle` points at an `Arc<VulkanAccelerationStructureInner>`
+// whose interior is Send+Sync (Vulkan handles + queue submissions are
+// guarded by the host queue mutex; BLAS refs are owned `Arc`s).
+unsafe impl Send for VulkanAccelerationStructure {}
+unsafe impl Sync for VulkanAccelerationStructure {}
+
+impl VulkanAccelerationStructureInner {
     /// Build a triangle-geometry bottom-level acceleration structure from
     /// CPU-side vertex + index data. Vertices are interleaved
     /// `[x, y, z, x, y, z, ...]` (R32G32B32_SFLOAT, stride 12 bytes);
@@ -112,7 +140,7 @@ impl VulkanAccelerationStructure {
     /// `vkCmdCopyBuffer`, then submits a `vkCmdBuildAccelerationStructuresKHR`
     /// build and waits before returning. The staging + scratch buffers
     /// are freed on success.
-    pub fn build_triangles_blas(
+    pub(crate) fn build_triangles_blas(
         vulkan_device: &Arc<HostVulkanDevice>,
         label: &str,
         vertices: &[f32],
@@ -268,7 +296,7 @@ impl VulkanAccelerationStructure {
     /// instances. Each instance references a `VulkanAccelerationStructure`
     /// of [`AccelerationStructureKind::BottomLevel`]; the TLAS keeps a
     /// strong reference to every BLAS for its lifetime.
-    pub fn build_tlas(
+    pub(crate) fn build_tlas(
         vulkan_device: &Arc<HostVulkanDevice>,
         label: &str,
         instances: &[TlasInstanceDesc],
@@ -284,7 +312,7 @@ impl VulkanAccelerationStructure {
             )));
         }
         for (i, inst) in instances.iter().enumerate() {
-            if inst.blas.kind != AccelerationStructureKind::BottomLevel {
+            if inst.blas.kind() != AccelerationStructureKind::BottomLevel {
                 return Err(Error::GpuError(format!(
                     "Acceleration structure '{label}': instance {i} references a TLAS as its BLAS"
                 )));
@@ -292,8 +320,8 @@ impl VulkanAccelerationStructure {
         }
 
         let device = vulkan_device.device();
-        let referenced_blases: Vec<Arc<VulkanAccelerationStructure>> =
-            instances.iter().map(|i| Arc::clone(&i.blas)).collect();
+        let referenced_blases: Vec<VulkanAccelerationStructure> =
+            instances.iter().map(|i| i.blas.clone()).collect();
 
         // Serialize each instance to its spec-defined 64-byte layout.
         // See `instance_bytes` doc comment for why we don't use
@@ -387,7 +415,7 @@ impl VulkanAccelerationStructure {
         mut build_geometry_info: vk::AccelerationStructureBuildGeometryInfoKHR,
         geometries: [vk::AccelerationStructureGeometryKHR; 1],
         range_info: vk::AccelerationStructureBuildRangeInfoKHR,
-        referenced_blases: Vec<Arc<VulkanAccelerationStructure>>,
+        referenced_blases: Vec<VulkanAccelerationStructure>,
         transient_inputs: Vec<AsBuffer>,
     ) -> Result<Arc<Self>> {
         let device = vulkan_device.device();
@@ -608,7 +636,7 @@ impl VulkanAccelerationStructure {
     }
 }
 
-impl Drop for VulkanAccelerationStructure {
+impl Drop for VulkanAccelerationStructureInner {
     fn drop(&mut self) {
         unsafe {
             let device = self.vulkan_device.device();
@@ -623,18 +651,155 @@ impl Drop for VulkanAccelerationStructure {
     }
 }
 
-unsafe impl Send for VulkanAccelerationStructure {}
-unsafe impl Sync for VulkanAccelerationStructure {}
-
-impl std::fmt::Debug for VulkanAccelerationStructure {
+impl std::fmt::Debug for VulkanAccelerationStructureInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VulkanAccelerationStructure")
+        f.debug_struct("VulkanAccelerationStructureInner")
             .field("label", &self.label)
             .field("kind", &self.kind)
             .field("device_address", &format_args!("{:#x}", self.device_address))
             .field("storage_size", &self.storage_size)
             .field("instances", &self.referenced_blases.len())
             .finish()
+    }
+}
+
+// =============================================================================
+// β-shape implementation
+// =============================================================================
+
+impl VulkanAccelerationStructure {
+    /// Internal helper: leak an initial Arc strong count via
+    /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
+    /// assemble the cross-DSO shape.
+    pub(crate) fn from_arc_into_raw(arc: Arc<VulkanAccelerationStructureInner>) -> Self {
+        let handle = Arc::into_raw(arc) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    /// Engine-internal borrow of the host-owned
+    /// `VulkanAccelerationStructureInner`. **Panics if called from
+    /// cdylib code.**
+    pub(crate) fn host_inner(&self) -> &VulkanAccelerationStructureInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "VulkanAccelerationStructure::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        // SAFETY: `self.handle` is `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`.
+        unsafe { &*(self.handle as *const VulkanAccelerationStructureInner) }
+    }
+
+    /// Build a triangle-geometry BLAS. Engine-side entry — the
+    /// FullAccess vtable's `build_triangles_blas` slot dispatches
+    /// through this on host mode.
+    pub fn build_triangles_blas(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        label: &str,
+        vertices: &[f32],
+        indices: &[u32],
+    ) -> Result<Self> {
+        VulkanAccelerationStructureInner::build_triangles_blas(
+            vulkan_device,
+            label,
+            vertices,
+            indices,
+        )
+        .map(Self::from_arc_into_raw)
+    }
+
+    /// Build a TLAS from a list of TLAS instances. Engine-side entry.
+    pub fn build_tlas(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        label: &str,
+        instances: &[TlasInstanceDesc],
+    ) -> Result<Self> {
+        VulkanAccelerationStructureInner::build_tlas(vulkan_device, label, instances)
+            .map(Self::from_arc_into_raw)
+    }
+
+    /// `VkAccelerationStructureKHR` handle.
+    pub fn vk_handle(&self) -> vk::AccelerationStructureKHR {
+        self.host_inner().vk_handle()
+    }
+
+    /// Device address of the AS.
+    pub fn device_address(&self) -> u64 {
+        self.host_inner().device_address()
+    }
+
+    /// `BottomLevel` or `TopLevel`.
+    pub fn kind(&self) -> AccelerationStructureKind {
+        self.host_inner().kind()
+    }
+
+    /// Human-readable label used in diagnostics.
+    pub fn label(&self) -> String {
+        self.host_inner().label().to_string()
+    }
+
+    /// Storage size in bytes.
+    pub fn storage_size(&self) -> vk::DeviceSize {
+        self.host_inner().storage_size()
+    }
+}
+
+impl Clone for VulkanAccelerationStructure {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: vtable + handle were paired at construction; the
+            // vtable's `clone_acceleration_structure` contract is
+            // `Arc::increment_strong_count(handle)` host-side.
+            unsafe {
+                ((*self.vtable).clone_acceleration_structure)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for VulkanAccelerationStructure {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with the `Arc::into_raw` in
+            // `from_arc_into_raw` and any `clone_acceleration_structure`
+            // bumps.
+            unsafe {
+                ((*self.vtable).drop_acceleration_structure)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VulkanAccelerationStructure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanAccelerationStructure").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn vulkan_acceleration_structure_layout() {
+        // β-shape: handle + vtable, 16 bytes, 8-byte alignment.
+        assert_eq!(size_of::<VulkanAccelerationStructure>(), 16);
+        assert_eq!(align_of::<VulkanAccelerationStructure>(), 8);
+        assert_eq!(offset_of!(VulkanAccelerationStructure, handle), 0);
+        assert_eq!(offset_of!(VulkanAccelerationStructure, vtable), 8);
+    }
+
+    #[test]
+    fn vulkan_acceleration_structure_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanAccelerationStructure>();
     }
 }
 
@@ -859,7 +1024,7 @@ fn instance_bytes(desc: &TlasInstanceDesc) -> [u8; INSTANCE_BYTES] {
     out[52..56].copy_from_slice(&(sbt | flags).to_ne_bytes());
 
     // bytes 56..64 — accelerationStructureReference (BLAS device address).
-    out[56..64].copy_from_slice(&desc.blas.device_address.to_ne_bytes());
+    out[56..64].copy_from_slice(&desc.blas.device_address().to_ne_bytes());
 
     out
 }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -141,6 +141,36 @@ impl RhiCommandRecorderInner {
     pub(crate) fn new(vulkan_device: &Arc<HostVulkanDevice>, label: &str) -> Result<Self> {
         let queue = vulkan_device.queue();
         let queue_family_index = vulkan_device.queue_family_index();
+        Self::new_with_queue_inner(vulkan_device, label, queue, queue_family_index)
+    }
+
+    /// Build a recorder against a specific queue + queue family.
+    /// Used by `libs/vulkan-video/` for encode / decode / transfer
+    /// queues that differ from the device's default queue.
+    ///
+    /// **The caller is responsible** for ensuring `queue` /
+    /// `queue_family_index` actually exist on the device. Typical
+    /// callers obtain these from `HostVulkanDevice::video_encode_queue()` /
+    /// `video_decode_queue()` / etc. The recorder will submit work
+    /// against the supplied queue; per-queue mutex serialization is
+    /// handled by the host queue mutex registry inside
+    /// `submit_to_queue`.
+    #[tracing::instrument(level = "trace", skip(vulkan_device), fields(label, queue_family_index))]
+    pub(crate) fn new_with_queue(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        label: &str,
+        queue: vk::Queue,
+        queue_family_index: u32,
+    ) -> Result<Self> {
+        Self::new_with_queue_inner(vulkan_device, label, queue, queue_family_index)
+    }
+
+    fn new_with_queue_inner(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        label: &str,
+        queue: vk::Queue,
+        queue_family_index: u32,
+    ) -> Result<Self> {
         let device = vulkan_device.device().clone();
 
         let pool_info = vk::CommandPoolCreateInfo::builder()
@@ -761,6 +791,25 @@ impl RhiCommandRecorder {
     /// Build a recorder against the device's default queue.
     pub fn new(vulkan_device: &Arc<HostVulkanDevice>, label: &str) -> Result<Self> {
         let inner = RhiCommandRecorderInner::new(vulkan_device, label)?;
+        Ok(Self::from_inner(inner))
+    }
+
+    /// Build a recorder against a specific queue + queue family.
+    /// Used by `libs/vulkan-video/` for encode / decode / transfer
+    /// queues that differ from the device's default. See
+    /// [`RhiCommandRecorderInner::new_with_queue`] for the contract.
+    pub fn new_with_queue(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        label: &str,
+        queue: vk::Queue,
+        queue_family_index: u32,
+    ) -> Result<Self> {
+        let inner = RhiCommandRecorderInner::new_with_queue(
+            vulkan_device,
+            label,
+            queue,
+            queue_family_index,
+        )?;
         Ok(Self::from_inner(inner))
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -3,9 +3,11 @@
 
 //! Engine-owned multi-step command-buffer recorder.
 
+use std::ffi::c_void;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
@@ -101,7 +103,10 @@ enum RecorderState {
 /// Recording is serial (one recording in flight at a time per
 /// recorder handle). For parallel recording, hold one recorder per
 /// in-flight slot.
-pub struct RhiCommandRecorder {
+/// Host-only rich data backing a [`RhiCommandRecorder`]. Cdylib code
+/// never sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct RhiCommandRecorderInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
@@ -127,13 +132,13 @@ pub struct RhiCommandRecorder {
     state: Mutex<RecorderState>,
 }
 
-impl RhiCommandRecorder {
+impl RhiCommandRecorderInner {
     /// Build a recorder against the device's default queue.
     ///
     /// `label` flows into `tracing` spans on every public method —
     /// pick something processor-scoped (e.g. `"camera"`, `"display"`).
     #[tracing::instrument(level = "trace", skip(vulkan_device), fields(label))]
-    pub fn new(vulkan_device: &Arc<HostVulkanDevice>, label: &str) -> Result<Self> {
+    pub(crate) fn new(vulkan_device: &Arc<HostVulkanDevice>, label: &str) -> Result<Self> {
         let queue = vulkan_device.queue();
         let queue_family_index = vulkan_device.queue_family_index();
         let device = vulkan_device.device().clone();
@@ -670,7 +675,7 @@ impl RhiCommandRecorder {
     }
 }
 
-impl Drop for RhiCommandRecorder {
+impl Drop for RhiCommandRecorderInner {
     fn drop(&mut self) {
         unsafe {
             // Wait for any in-flight submission to drain so command-buffer
@@ -688,15 +693,278 @@ impl Drop for RhiCommandRecorder {
 // fence + state machine; the `Mutex<RecorderState>` serializes state
 // transitions across threads. `&mut self` on every public method
 // further enforces single-thread use.
-unsafe impl Send for RhiCommandRecorder {}
-unsafe impl Sync for RhiCommandRecorder {}
+unsafe impl Send for RhiCommandRecorderInner {}
+unsafe impl Sync for RhiCommandRecorderInner {}
 
-impl std::fmt::Debug for RhiCommandRecorder {
+impl std::fmt::Debug for RhiCommandRecorderInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RhiCommandRecorder")
+        f.debug_struct("RhiCommandRecorderInner")
             .field("label", &self.label)
             .field("state", &*self.state.lock())
             .finish()
+    }
+}
+
+// =============================================================================
+// β-shape implementation
+// =============================================================================
+
+/// Multi-step command-buffer recorder.
+///
+/// Layout-stable `#[repr(C)] (handle, vtable)` β-shape. The opaque
+/// handle points at a `Box<RhiCommandRecorderInner>`; lifecycle
+/// dispatches through the host-installed FullAccess vtable's
+/// `drop_command_recorder` callback (Box::from_raw + drop host-side).
+///
+/// **Single-owner; deliberately NOT `Clone`.** Recording carries
+/// mutable state (`begin()` → `record_*(&mut self)` → `submit_*(&mut
+/// self)`) that doesn't survive duplication. The
+/// `clone_command_recorder` vtable slot is reserved but never invoked
+/// — calling `.clone()` on the public β-shape is a compile error.
+///
+/// Method dispatch is host-only via [`Self::host_inner_mut`] until
+/// Phase E (#907) lifts to per-method vtable slots.
+#[repr(C)]
+pub struct RhiCommandRecorder {
+    /// Opaque handle to the host's `Box<RhiCommandRecorderInner>`.
+    pub(crate) handle: *const c_void,
+    /// Vtable for cross-DSO Drop dispatch.
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+// SAFETY: handle points at a `Box<RhiCommandRecorderInner>`; Inner
+// is Send+Sync (Mutex-guarded state, &mut self method dispatch
+// further restricts mutation to one thread at a time).
+unsafe impl Send for RhiCommandRecorder {}
+unsafe impl Sync for RhiCommandRecorder {}
+
+impl RhiCommandRecorder {
+    /// Build a recorder against the device's default queue.
+    pub fn new(vulkan_device: &Arc<HostVulkanDevice>, label: &str) -> Result<Self> {
+        let inner = RhiCommandRecorderInner::new(vulkan_device, label)?;
+        Ok(Self::from_inner(inner))
+    }
+
+    /// Internal helper: leak a `Box<RhiCommandRecorderInner>` as the
+    /// opaque handle and resolve the host-mode FullAccess vtable.
+    pub(crate) fn from_inner(inner: RhiCommandRecorderInner) -> Self {
+        let handle = Box::into_raw(Box::new(inner)) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    /// Engine-internal mutable borrow of the host-owned
+    /// `RhiCommandRecorderInner`. **Panics if called from cdylib code.**
+    pub(crate) fn host_inner_mut(&mut self) -> &mut RhiCommandRecorderInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "RhiCommandRecorder::host_inner_mut() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        // SAFETY: `self.handle` is `Box::into_raw(Box<RhiCommandRecorderInner>)`
+        // and `&mut self` guarantees no other reference exists.
+        unsafe { &mut *(self.handle as *mut RhiCommandRecorderInner) }
+    }
+
+    /// Engine-internal shared borrow of the host-owned
+    /// `RhiCommandRecorderInner`. **Panics if called from cdylib code.**
+    pub(crate) fn host_inner(&self) -> &RhiCommandRecorderInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "RhiCommandRecorder::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        // SAFETY: `self.handle` is `Box::into_raw(Box<RhiCommandRecorderInner>)`.
+        unsafe { &*(self.handle as *const RhiCommandRecorderInner) }
+    }
+
+    // -------------------------------------------------------------------------
+    // Method mirrors — route via host_inner_mut() with cdylib panic-guard.
+    // Phase E (#907) lifts these to per-method vtable slots; until then,
+    // method dispatch on the β-shape is host-only.
+    // -------------------------------------------------------------------------
+
+    /// Begin a new recording. See [`RhiCommandRecorderInner::begin`].
+    pub fn begin(&mut self) -> Result<()> {
+        self.host_inner_mut().begin()
+    }
+
+    /// Record an image layout transition. See
+    /// [`RhiCommandRecorderInner::record_image_barrier`].
+    pub fn record_image_barrier(
+        &mut self,
+        texture: &Texture,
+        from_layout: VulkanLayout,
+        to_layout: VulkanLayout,
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        self.host_inner_mut().record_image_barrier(
+            texture, from_layout, to_layout, from_stage, to_stage, from_access, to_access,
+        )
+    }
+
+    /// Buffer memory barrier covering the whole buffer.
+    pub fn record_buffer_barrier(
+        &mut self,
+        buffer: &(impl VulkanBufferLike + ?Sized),
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        self.host_inner_mut().record_buffer_barrier(
+            buffer, from_stage, to_stage, from_access, to_access,
+        )
+    }
+
+    /// Copy image → buffer. See [`RhiCommandRecorderInner::record_copy_image_to_buffer`].
+    pub fn record_copy_image_to_buffer(
+        &mut self,
+        src: &Texture,
+        src_layout: VulkanLayout,
+        dst: &(impl VulkanBufferLike + ?Sized),
+        region: ImageCopyRegion,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .record_copy_image_to_buffer(src, src_layout, dst, region)
+    }
+
+    /// Copy buffer → image.
+    pub fn record_copy_buffer_to_image(
+        &mut self,
+        src: &(impl VulkanBufferLike + ?Sized),
+        dst: &Texture,
+        dst_layout: VulkanLayout,
+        region: ImageCopyRegion,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .record_copy_buffer_to_image(src, dst, dst_layout, region)
+    }
+
+    /// Compute dispatch.
+    pub fn record_dispatch(
+        &mut self,
+        kernel: &VulkanComputeKernel,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .record_dispatch(kernel, group_x, group_y, group_z)
+    }
+
+    /// Draw call.
+    pub fn record_draw(
+        &mut self,
+        kernel: &VulkanGraphicsKernel,
+        frame_index: u32,
+        draw: &DrawCall,
+    ) -> Result<()> {
+        self.host_inner_mut().record_draw(kernel, frame_index, draw)
+    }
+
+    /// Indexed-draw variant.
+    pub fn record_draw_indexed(
+        &mut self,
+        kernel: &VulkanGraphicsKernel,
+        frame_index: u32,
+        draw: &DrawIndexedCall,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .record_draw_indexed(kernel, frame_index, draw)
+    }
+
+    /// Submit signaling a timeline semaphore.
+    pub fn submit_signaling_timeline(
+        &mut self,
+        timeline: &HostVulkanTimelineSemaphore,
+        signal_value: u64,
+    ) -> Result<()> {
+        self.host_inner_mut()
+            .submit_signaling_timeline(timeline, signal_value)
+    }
+
+    /// Submit without semaphore signaling.
+    pub fn submit(&mut self) -> Result<()> {
+        self.host_inner_mut().submit()
+    }
+
+    /// Submit and block until the GPU completes.
+    pub fn submit_and_wait(&mut self) -> Result<()> {
+        self.host_inner_mut().submit_and_wait()
+    }
+
+    /// Engine-internal accessor for the underlying command buffer.
+    /// **Engine-only** — for `VulkanPresentTarget`.
+    pub(crate) fn command_buffer_raw(&self) -> vk::CommandBuffer {
+        self.host_inner().command_buffer_raw()
+    }
+
+    /// Engine-internal accessor for the recorder's `HostVulkanDevice`.
+    /// **Engine-only** — for `VulkanPresentTarget::begin_rendering` etc.
+    pub(crate) fn vulkan_device_ref(&self) -> &Arc<HostVulkanDevice> {
+        self.host_inner().vulkan_device_ref()
+    }
+
+    /// Engine-internal submit path supporting binary + timeline waits.
+    /// **Engine-only** — for `VulkanPresentTarget`'s render submit.
+    pub(crate) fn submit_with_semaphores(
+        &mut self,
+        waits: &[vk::SemaphoreSubmitInfo],
+        signals: &[vk::SemaphoreSubmitInfo],
+    ) -> Result<()> {
+        self.host_inner_mut().submit_with_semaphores(waits, signals)
+    }
+}
+
+impl Drop for RhiCommandRecorder {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            // SAFETY: matched with `Box::into_raw` in `from_inner`.
+            unsafe {
+                ((*self.vtable).drop_command_recorder)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for RhiCommandRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RhiCommandRecorder").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn rhi_command_recorder_layout() {
+        assert_eq!(size_of::<RhiCommandRecorder>(), 16);
+        assert_eq!(align_of::<RhiCommandRecorder>(), 8);
+        assert_eq!(offset_of!(RhiCommandRecorder, handle), 0);
+        assert_eq!(offset_of!(RhiCommandRecorder, vtable), 8);
+    }
+
+    #[test]
+    fn rhi_command_recorder_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RhiCommandRecorder>();
+    }
+
+    /// `RhiCommandRecorder` is intentionally NOT `Clone` — recording
+    /// state doesn't survive duplication. Marker test for `cargo test`
+    /// discoverability; the type-level absence-of-Clone enforces it.
+    #[test]
+    fn rhi_command_recorder_is_not_clone_marker() {
+        // No-op; the type has no Clone impl.
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -720,7 +720,13 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 /// mutable state (`begin()` → `record_*(&mut self)` → `submit_*(&mut
 /// self)`) that doesn't survive duplication. The
 /// `clone_command_recorder` vtable slot is reserved but never invoked
-/// — calling `.clone()` on the public β-shape is a compile error.
+/// — calling `.clone()` on the public β-shape is a compile error,
+/// locked by the `compile_fail` doctest below:
+///
+/// ```compile_fail
+/// fn assert_clone<T: Clone>() {}
+/// assert_clone::<streamlib_engine::vulkan::rhi::RhiCommandRecorder>();
+/// ```
 ///
 /// Method dispatch is host-only via [`Self::host_inner_mut`] until
 /// Phase E (#907) lifts to per-method vtable slots.

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -476,20 +476,33 @@ impl RhiCommandRecorderInner {
         kernel.cmd_bind_and_draw_indexed(self.command_buffer, frame_index, draw)
     }
 
-    /// Engine-internal accessor for the underlying command buffer.
-    /// Used by [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
-    /// to record swapchain-image transitions + `cmd_begin/end_rendering`
-    /// alongside the user's recorded draws.
-    pub(crate) fn command_buffer_raw(&self) -> vk::CommandBuffer {
+    /// Raw `VkCommandBuffer` accessor — **escape hatch for power
+    /// users** who need to record commands the RHI doesn't expose
+    /// directly (e.g. `vkCmd*VideoCodingKHR` / `vkCmdEncodeVideoKHR`
+    /// / `vkCmdDecodeVideoKHR` from `libs/vulkan-video/`) alongside
+    /// the recorder's RHI-shaped records.
+    ///
+    /// Used by:
+    /// - [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)
+    ///   for swapchain image transitions + `cmd_begin/end_rendering`.
+    /// - `libs/vulkan-video/` for video-codec cmds the RHI doesn't
+    ///   expose (#922 — RhiCommandRecorder migration of vulkan-video
+    ///   interior).
+    ///
+    /// **Contract**: caller must NOT call `begin_command_buffer` /
+    /// `end_command_buffer` / `vkQueueSubmit*` against this buffer
+    /// directly — the recorder owns those lifecycle calls. Caller may
+    /// only record commands between the recorder's `begin()` and
+    /// `submit*()`.
+    pub fn command_buffer_raw(&self) -> vk::CommandBuffer {
         self.command_buffer
     }
 
-    /// Engine-internal accessor for the underlying [`HostVulkanDevice`].
-    /// Used by [`VulkanPresentTarget`](super::vulkan_present_target::VulkanPresentTarget)'s
-    /// `PresentFrame::begin_rendering` / `end_rendering` to issue
-    /// `cmd_begin_rendering` / `cmd_end_rendering` on the same command
-    /// buffer this recorder owns.
-    pub(crate) fn vulkan_device_ref(&self) -> &Arc<HostVulkanDevice> {
+    /// Raw `HostVulkanDevice` accessor — **engine-internal + in-tree
+    /// codec power-user escape hatch.** Same constraints as
+    /// [`Self::command_buffer_raw`]; used by VulkanPresentTarget
+    /// (begin/end_rendering) and vulkan-video (video-codec cmds).
+    pub fn vulkan_device_ref(&self) -> &Arc<HostVulkanDevice> {
         &self.vulkan_device
     }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -24,6 +24,10 @@ use vulkanalia::vk;
 
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
+use std::ffi::c_void;
+
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
+
 use crate::core::rhi::{
     ComputeBindingKind, ComputeBindingSpec, ComputeKernelDescriptor, Texture,
 };
@@ -42,7 +46,10 @@ use super::HostVulkanDevice;
 /// holds a single descriptor set, so dispatches against it are serial — that's
 /// fine for the format-converter / compositor / codec-pre-process workloads
 /// this abstraction targets.
-pub struct VulkanComputeKernel {
+/// Host-only rich data backing a [`VulkanComputeKernel`]. Cdylib code
+/// never sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct VulkanComputeKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
@@ -84,7 +91,7 @@ enum BindingResource {
     },
 }
 
-impl VulkanComputeKernel {
+impl VulkanComputeKernelInner {
     /// Create a new compute kernel from a SPIR-V shader and a binding declaration.
     ///
     /// Reflects the SPIR-V via `rspirv-reflect`, validates that the declared
@@ -703,7 +710,7 @@ impl VulkanComputeKernel {
     }
 }
 
-impl Drop for VulkanComputeKernel {
+impl Drop for VulkanComputeKernelInner {
     fn drop(&mut self) {
         unsafe {
             let _ = self.device.device_wait_idle();
@@ -728,16 +735,170 @@ impl Drop for VulkanComputeKernel {
 // only one dispatch is in-flight at a time, and `dispatch()` blocks until
 // the GPU completes. The `Mutex` around `pending` serializes setter writes
 // across threads.
-unsafe impl Send for VulkanComputeKernel {}
-unsafe impl Sync for VulkanComputeKernel {}
+unsafe impl Send for VulkanComputeKernelInner {}
+unsafe impl Sync for VulkanComputeKernelInner {}
 
-impl std::fmt::Debug for VulkanComputeKernel {
+impl std::fmt::Debug for VulkanComputeKernelInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VulkanComputeKernel")
+        f.debug_struct("VulkanComputeKernelInner")
             .field("label", &self.label)
             .field("bindings", &self.bindings)
             .field("push_constant_size", &self.push_constant_size)
             .finish()
+    }
+}
+
+// =============================================================================
+// β-shape implementation (#917)
+// =============================================================================
+
+/// Compute kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape
+/// so cdylibs can hold, refcount, and drop without sharing rustc-version
+/// or dep-graph with the host. Method dispatch is host-only via
+/// [`Self::host_inner`] until Phase E (#907) lifts to vtable slots.
+#[repr(C)]
+pub struct VulkanComputeKernel {
+    pub(crate) handle: *const c_void,
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+unsafe impl Send for VulkanComputeKernel {}
+unsafe impl Sync for VulkanComputeKernel {}
+
+impl VulkanComputeKernel {
+    /// Create from a SPIR-V descriptor. Engine-side entry; mirrors
+    /// `VulkanComputeKernelInner::new`.
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &ComputeKernelDescriptor<'_>,
+    ) -> Result<Self> {
+        let inner = VulkanComputeKernelInner::new(vulkan_device, descriptor)?;
+        Ok(Self::from_arc_into_raw(Arc::new(inner)))
+    }
+
+    pub(crate) fn from_arc_into_raw(arc: Arc<VulkanComputeKernelInner>) -> Self {
+        let handle = Arc::into_raw(arc) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    pub(crate) fn host_inner(&self) -> &VulkanComputeKernelInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "VulkanComputeKernel::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        unsafe { &*(self.handle as *const VulkanComputeKernelInner) }
+    }
+
+    pub fn set_storage_buffer<B>(&self, binding: u32, buffer: &B) -> Result<()>
+    where
+        B: super::VulkanStorageBindable + ?Sized,
+    {
+        self.host_inner().set_storage_buffer(binding, buffer)
+    }
+
+    pub fn set_uniform_buffer<B>(&self, binding: u32, buffer: &B) -> Result<()>
+    where
+        B: super::VulkanUniformBindable + ?Sized,
+    {
+        self.host_inner().set_uniform_buffer(binding, buffer)
+    }
+
+    pub fn set_sampled_texture(&self, binding: u32, texture: &Texture) -> Result<()> {
+        self.host_inner().set_sampled_texture(binding, texture)
+    }
+
+    pub fn set_storage_image(&self, binding: u32, texture: &Texture) -> Result<()> {
+        self.host_inner().set_storage_image(binding, texture)
+    }
+
+    pub fn set_push_constants(&self, bytes: &[u8]) -> Result<()> {
+        self.host_inner().set_push_constants(bytes)
+    }
+
+    pub fn set_push_constants_value<T: Copy>(&self, value: &T) -> Result<()> {
+        self.host_inner().set_push_constants_value(value)
+    }
+
+    pub fn dispatch(
+        &self,
+        group_count_x: u32,
+        group_count_y: u32,
+        group_count_z: u32,
+    ) -> Result<()> {
+        self.host_inner()
+            .dispatch(group_count_x, group_count_y, group_count_z)
+    }
+
+    pub(crate) fn record(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<()> {
+        self.host_inner().record(command_buffer, group_x, group_y, group_z)
+    }
+
+    pub fn bindings(&self) -> Vec<ComputeBindingSpec> {
+        self.host_inner().bindings().to_vec()
+    }
+
+    pub fn push_constant_size(&self) -> u32 {
+        self.host_inner().push_constant_size()
+    }
+}
+
+impl Clone for VulkanComputeKernel {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).clone_compute_kernel)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for VulkanComputeKernel {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).drop_compute_kernel)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VulkanComputeKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanComputeKernel").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod beta_shape_layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn vulkan_compute_kernel_layout() {
+        assert_eq!(size_of::<VulkanComputeKernel>(), 16);
+        assert_eq!(align_of::<VulkanComputeKernel>(), 8);
+        assert_eq!(offset_of!(VulkanComputeKernel, handle), 0);
+        assert_eq!(offset_of!(VulkanComputeKernel, vtable), 8);
+    }
+
+    #[test]
+    fn vulkan_compute_kernel_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanComputeKernel>();
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -42,6 +42,10 @@ use vulkanalia::vk;
 
 use rspirv_reflect::{DescriptorType as RDescriptorType, Reflection};
 
+use std::ffi::c_void;
+
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
+
 use crate::core::rhi::{
     BlendFactor, BlendOp, ColorBlendState, ColorWriteMask, CullMode, DepthCompareOp, DepthFormat,
     DepthStencilState, DrawCall, DrawIndexedCall, FrontFace, GraphicsBindingKind,
@@ -59,9 +63,10 @@ use super::HostVulkanDevice;
 /// kinds live under the same root.
 pub const PIPELINE_CACHE_DIR_ENV: &str = "STREAMLIB_PIPELINE_CACHE_DIR";
 
-/// One graphics kernel: multi-stage pipeline + descriptor-set ring + per-frame
-/// draw primitives.
-pub struct VulkanGraphicsKernel {
+/// Host-only rich data backing a [`VulkanGraphicsKernel`]. Cdylib code
+/// never sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct VulkanGraphicsKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
@@ -154,7 +159,7 @@ pub enum OffscreenDraw {
     DrawIndexed(DrawIndexedCall),
 }
 
-impl VulkanGraphicsKernel {
+impl VulkanGraphicsKernelInner {
     /// Create a new graphics kernel from a multi-stage SPIR-V set + binding
     /// declaration + pipeline state.
     ///
@@ -1175,7 +1180,7 @@ enum DrawKind {
     DrawIndexed(DrawIndexedCall),
 }
 
-impl Drop for VulkanGraphicsKernel {
+impl Drop for VulkanGraphicsKernelInner {
     fn drop(&mut self) {
         unsafe {
             let _ = self.device.device_wait_idle();
@@ -1208,17 +1213,232 @@ impl Drop for VulkanGraphicsKernel {
 //   - `descriptor_sets[i]` is logically owned by frame slot `i`; serialized
 //     across threads by `pending` mutex.
 //   - `offscreen` scaffold is fence-protected for serial use.
-unsafe impl Send for VulkanGraphicsKernel {}
-unsafe impl Sync for VulkanGraphicsKernel {}
+unsafe impl Send for VulkanGraphicsKernelInner {}
+unsafe impl Sync for VulkanGraphicsKernelInner {}
 
-impl std::fmt::Debug for VulkanGraphicsKernel {
+impl std::fmt::Debug for VulkanGraphicsKernelInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VulkanGraphicsKernel")
+        f.debug_struct("VulkanGraphicsKernelInner")
             .field("label", &self.label)
             .field("bindings", &self.bindings)
             .field("push_constant_size", &self.push_constant_size)
             .field("descriptor_sets_in_flight", &self.descriptor_sets_in_flight)
             .finish()
+    }
+}
+
+// =============================================================================
+// β-shape implementation (#917)
+// =============================================================================
+
+/// Graphics kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape.
+#[repr(C)]
+pub struct VulkanGraphicsKernel {
+    pub(crate) handle: *const c_void,
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+unsafe impl Send for VulkanGraphicsKernel {}
+unsafe impl Sync for VulkanGraphicsKernel {}
+
+impl VulkanGraphicsKernel {
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &GraphicsKernelDescriptor<'_>,
+    ) -> Result<Self> {
+        let inner = VulkanGraphicsKernelInner::new(vulkan_device, descriptor)?;
+        Ok(Self::from_arc_into_raw(Arc::new(inner)))
+    }
+
+    pub(crate) fn from_arc_into_raw(arc: Arc<VulkanGraphicsKernelInner>) -> Self {
+        let handle = Arc::into_raw(arc) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    pub(crate) fn host_inner(&self) -> &VulkanGraphicsKernelInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "VulkanGraphicsKernel::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        unsafe { &*(self.handle as *const VulkanGraphicsKernelInner) }
+    }
+
+    pub fn bindings(&self) -> Vec<GraphicsBindingSpec> {
+        self.host_inner().bindings().to_vec()
+    }
+
+    pub fn push_constant_size(&self) -> u32 {
+        self.host_inner().push_constant_size()
+    }
+
+    pub fn descriptor_sets_in_flight(&self) -> u32 {
+        self.host_inner().descriptor_sets_in_flight()
+    }
+
+    pub fn set_sampled_texture(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        texture: &Texture,
+    ) -> Result<()> {
+        self.host_inner().set_sampled_texture(frame_index, binding, texture)
+    }
+
+    pub fn set_storage_buffer<B>(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        buffer: &B,
+    ) -> Result<()>
+    where
+        B: super::VulkanStorageBindable + ?Sized,
+    {
+        self.host_inner().set_storage_buffer(frame_index, binding, buffer)
+    }
+
+    pub fn set_uniform_buffer<B>(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        buffer: &B,
+    ) -> Result<()>
+    where
+        B: super::VulkanUniformBindable + ?Sized,
+    {
+        self.host_inner().set_uniform_buffer(frame_index, binding, buffer)
+    }
+
+    pub fn set_storage_image(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        texture: &Texture,
+    ) -> Result<()> {
+        self.host_inner().set_storage_image(frame_index, binding, texture)
+    }
+
+    pub fn set_push_constants(&self, frame_index: u32, bytes: &[u8]) -> Result<()> {
+        self.host_inner().set_push_constants(frame_index, bytes)
+    }
+
+    pub fn set_push_constants_value<T: Copy>(
+        &self,
+        frame_index: u32,
+        value: &T,
+    ) -> Result<()> {
+        self.host_inner().set_push_constants_value(frame_index, value)
+    }
+
+    pub fn set_vertex_buffer<B>(
+        &self,
+        frame_index: u32,
+        binding: u32,
+        buffer: &B,
+        offset: u64,
+    ) -> Result<()>
+    where
+        B: super::VulkanVertexBindable + ?Sized,
+    {
+        self.host_inner()
+            .set_vertex_buffer(frame_index, binding, buffer, offset)
+    }
+
+    pub fn set_index_buffer<B>(
+        &self,
+        frame_index: u32,
+        buffer: &B,
+        offset: u64,
+        index_type: IndexType,
+    ) -> Result<()>
+    where
+        B: super::VulkanIndexBindable + ?Sized,
+    {
+        self.host_inner()
+            .set_index_buffer(frame_index, buffer, offset, index_type)
+    }
+
+    pub fn cmd_bind_and_draw(
+        &self,
+        cmd: vk::CommandBuffer,
+        frame_index: u32,
+        draw: &DrawCall,
+    ) -> Result<()> {
+        self.host_inner().cmd_bind_and_draw(cmd, frame_index, draw)
+    }
+
+    pub fn cmd_bind_and_draw_indexed(
+        &self,
+        cmd: vk::CommandBuffer,
+        frame_index: u32,
+        draw: &DrawIndexedCall,
+    ) -> Result<()> {
+        self.host_inner().cmd_bind_and_draw_indexed(cmd, frame_index, draw)
+    }
+
+    /// Offscreen render. See [`VulkanGraphicsKernelInner::offscreen_render`].
+    pub fn offscreen_render(
+        &self,
+        frame_index: u32,
+        color_targets: &[super::OffscreenColorTarget<'_>],
+        extent: (u32, u32),
+        draw: super::OffscreenDraw,
+    ) -> Result<()> {
+        self.host_inner()
+            .offscreen_render(frame_index, color_targets, extent, draw)
+    }
+}
+
+impl Clone for VulkanGraphicsKernel {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).clone_graphics_kernel)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for VulkanGraphicsKernel {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).drop_graphics_kernel)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VulkanGraphicsKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanGraphicsKernel").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod beta_shape_layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn vulkan_graphics_kernel_layout() {
+        assert_eq!(size_of::<VulkanGraphicsKernel>(), 16);
+        assert_eq!(align_of::<VulkanGraphicsKernel>(), 8);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, handle), 0);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, vtable), 8);
+    }
+
+    #[test]
+    fn vulkan_graphics_kernel_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanGraphicsKernel>();
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -94,8 +94,9 @@ enum BindingResource {
     },
     AccelerationStructure {
         handle: vk::AccelerationStructureKHR,
-        // The strong reference keeps the AS alive while bound.
-        _keep_alive: Arc<VulkanAccelerationStructure>,
+        // The β-shape clone keeps the AS alive while bound (β-shape's
+        // Clone bumps the underlying Arc strong count via vtable).
+        _keep_alive: VulkanAccelerationStructure,
     },
 }
 
@@ -396,7 +397,7 @@ impl VulkanRayTracingKernel {
     pub fn set_acceleration_structure(
         &self,
         binding: u32,
-        tlas: &Arc<VulkanAccelerationStructure>,
+        tlas: &VulkanAccelerationStructure,
     ) -> Result<()> {
         self.expect_kind(binding, RayTracingBindingKind::AccelerationStructure)?;
         if tlas.kind() != super::AccelerationStructureKind::TopLevel {
@@ -409,7 +410,7 @@ impl VulkanRayTracingKernel {
             binding,
             BindingResource::AccelerationStructure {
                 handle: tlas.vk_handle(),
-                _keep_alive: Arc::clone(tlas),
+                _keep_alive: tlas.clone(),
             },
         );
         Ok(())
@@ -1814,7 +1815,7 @@ mod tests {
             blas.device_address()
         );
 
-        let instance = TlasInstanceDesc::identity(Arc::clone(&blas));
+        let instance = TlasInstanceDesc::identity(blas.clone());
         let tlas = VulkanAccelerationStructure::build_tlas(
             &device,
             "rt-test-tlas",

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -29,6 +29,10 @@ use vulkanalia::vk::KhrRayTracingPipelineExtensionDeviceCommands as _;
 use vulkanalia_vma as vma;
 use vma::Alloc as _;
 
+use std::ffi::c_void;
+
+use streamlib_plugin_abi::GpuContextFullAccessVTable;
+
 use crate::core::rhi::{
     validate_shader_groups, RayTracingBindingKind, RayTracingBindingSpec,
     RayTracingKernelDescriptor, RayTracingShaderGroup, RayTracingShaderStage,
@@ -38,8 +42,10 @@ use crate::core::{Result, Error};
 
 use super::{HostVulkanDevice, VulkanAccelerationStructure};
 
-/// One ray-tracing kernel: pipeline + descriptor set + SBT + per-dispatch primitives.
-pub struct VulkanRayTracingKernel {
+/// Host-only rich data backing a [`VulkanRayTracingKernel`]. Cdylib code
+/// never sees this type; it reaches the public surface through the
+/// `(handle, vtable)` β-shape.
+pub struct VulkanRayTracingKernelInner {
     label: String,
     vulkan_device: Arc<HostVulkanDevice>,
     device: vulkanalia::Device,
@@ -100,7 +106,7 @@ enum BindingResource {
     },
 }
 
-impl VulkanRayTracingKernel {
+impl VulkanRayTracingKernelInner {
     /// Create a new ray-tracing kernel from a shader-stage list, group
     /// layout, and binding declaration.
     pub fn new(
@@ -863,7 +869,7 @@ impl VulkanRayTracingKernel {
     }
 }
 
-impl Drop for VulkanRayTracingKernel {
+impl Drop for VulkanRayTracingKernelInner {
     fn drop(&mut self) {
         unsafe {
             let _ = self.device.device_wait_idle();
@@ -889,16 +895,157 @@ impl Drop for VulkanRayTracingKernel {
     }
 }
 
-unsafe impl Send for VulkanRayTracingKernel {}
-unsafe impl Sync for VulkanRayTracingKernel {}
+unsafe impl Send for VulkanRayTracingKernelInner {}
+unsafe impl Sync for VulkanRayTracingKernelInner {}
 
-impl std::fmt::Debug for VulkanRayTracingKernel {
+impl std::fmt::Debug for VulkanRayTracingKernelInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VulkanRayTracingKernel")
+        f.debug_struct("VulkanRayTracingKernelInner")
             .field("label", &self.label)
             .field("bindings", &self.bindings)
             .field("push_constant_size", &self.push_constant_size)
             .finish()
+    }
+}
+
+// =============================================================================
+// β-shape implementation (#917)
+// =============================================================================
+
+/// Ray-tracing kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape.
+#[repr(C)]
+pub struct VulkanRayTracingKernel {
+    pub(crate) handle: *const c_void,
+    pub(crate) vtable: *const GpuContextFullAccessVTable,
+}
+
+unsafe impl Send for VulkanRayTracingKernel {}
+unsafe impl Sync for VulkanRayTracingKernel {}
+
+impl VulkanRayTracingKernel {
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &RayTracingKernelDescriptor<'_>,
+    ) -> Result<Self> {
+        let inner = VulkanRayTracingKernelInner::new(vulkan_device, descriptor)?;
+        Ok(Self::from_arc_into_raw(Arc::new(inner)))
+    }
+
+    pub(crate) fn from_arc_into_raw(arc: Arc<VulkanRayTracingKernelInner>) -> Self {
+        let handle = Arc::into_raw(arc) as *const c_void;
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        Self { handle, vtable }
+    }
+
+    pub(crate) fn host_inner(&self) -> &VulkanRayTracingKernelInner {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "VulkanRayTracingKernel::host_inner() reached from cdylib code; \
+                 this method must dispatch through the GpuContextFullAccessVTable."
+            );
+        }
+        unsafe { &*(self.handle as *const VulkanRayTracingKernelInner) }
+    }
+
+    pub fn set_acceleration_structure(
+        &self,
+        binding: u32,
+        tlas: &VulkanAccelerationStructure,
+    ) -> Result<()> {
+        self.host_inner().set_acceleration_structure(binding, tlas)
+    }
+
+    pub fn set_storage_buffer<B>(&self, binding: u32, buffer: &B) -> Result<()>
+    where
+        B: super::VulkanStorageBindable + ?Sized,
+    {
+        self.host_inner().set_storage_buffer(binding, buffer)
+    }
+
+    pub fn set_uniform_buffer<B>(&self, binding: u32, buffer: &B) -> Result<()>
+    where
+        B: super::VulkanUniformBindable + ?Sized,
+    {
+        self.host_inner().set_uniform_buffer(binding, buffer)
+    }
+
+    pub fn set_sampled_texture(&self, binding: u32, texture: &Texture) -> Result<()> {
+        self.host_inner().set_sampled_texture(binding, texture)
+    }
+
+    pub fn set_storage_image(&self, binding: u32, texture: &Texture) -> Result<()> {
+        self.host_inner().set_storage_image(binding, texture)
+    }
+
+    pub fn set_push_constants(&self, bytes: &[u8]) -> Result<()> {
+        self.host_inner().set_push_constants(bytes)
+    }
+
+    pub fn set_push_constants_value<T: Copy>(&self, value: &T) -> Result<()> {
+        self.host_inner().set_push_constants_value(value)
+    }
+
+    pub fn trace_rays(&self, width: u32, height: u32, depth: u32) -> Result<()> {
+        self.host_inner().trace_rays(width, height, depth)
+    }
+
+    pub fn bindings(&self) -> Vec<RayTracingBindingSpec> {
+        self.host_inner().bindings().to_vec()
+    }
+
+    pub fn push_constant_size(&self) -> u32 {
+        self.host_inner().push_constant_size()
+    }
+}
+
+impl Clone for VulkanRayTracingKernel {
+    fn clone(&self) -> Self {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).clone_ray_tracing_kernel)(self.handle);
+            }
+        }
+        Self {
+            handle: self.handle,
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Drop for VulkanRayTracingKernel {
+    fn drop(&mut self) {
+        if !self.handle.is_null() && !self.vtable.is_null() {
+            unsafe {
+                ((*self.vtable).drop_ray_tracing_kernel)(self.handle);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VulkanRayTracingKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VulkanRayTracingKernel").finish()
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod beta_shape_layout_tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn vulkan_ray_tracing_kernel_layout() {
+        assert_eq!(size_of::<VulkanRayTracingKernel>(), 16);
+        assert_eq!(align_of::<VulkanRayTracingKernel>(), 8);
+        assert_eq!(offset_of!(VulkanRayTracingKernel, handle), 0);
+        assert_eq!(offset_of!(VulkanRayTracingKernel, vtable), 8);
+    }
+
+    #[test]
+    fn vulkan_ray_tracing_kernel_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanRayTracingKernel>();
     }
 }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -211,7 +211,13 @@ pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 ///   inherit through the originating LimitedAccess vtable per the
 ///   `inherited_lim_*` fields on `GpuContextFullAccess` — they do
 ///   not get parallel slots here.
-pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 3;
+/// - v4: β-shape Phase D return types (`RhiColorConverter`,
+///   `VulkanAccelerationStructure`, `RhiCommandRecorder`) gain
+///   `clone_*` / `drop_*` slot pairs alongside the existing kernel +
+///   texture-ring pairs. The slots activate the layout-stable
+///   `(handle, vtable)` β-shape pattern so cdylibs can hold +
+///   refcount + drop these handles without rustc-version coupling.
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 4;
 
 // =============================================================================
 // Primitive enums
@@ -2096,6 +2102,37 @@ pub struct GpuContextFullAccessVTable {
     pub drop_texture_ring: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
+    // RhiColorConverter return-type lifetime (v4)
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `RhiColorConverter` handle. Host runs
+    /// `Arc::increment_strong_count(handle as *const RhiColorConverterInner)`.
+    pub clone_color_converter: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `RhiColorConverter` handle.
+    pub drop_color_converter: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // VulkanAccelerationStructure return-type lifetime (v4)
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `VulkanAccelerationStructure` handle.
+    pub clone_acceleration_structure: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `VulkanAccelerationStructure` handle.
+    pub drop_acceleration_structure: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
+    // RhiCommandRecorder return-type lifetime (v4)
+    // -------------------------------------------------------------------------
+
+    /// Bump the refcount on a `RhiCommandRecorder` handle.
+    pub clone_command_recorder: unsafe extern "C" fn(handle: *const c_void),
+
+    /// Decrement the refcount on a `RhiCommandRecorder` handle.
+    pub drop_command_recorder: unsafe extern "C" fn(handle: *const c_void),
+
+    // -------------------------------------------------------------------------
     // Kernel construction
     // -------------------------------------------------------------------------
 
@@ -2902,7 +2939,7 @@ mod layout_tests {
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 3);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 4);
     }
 
     #[test]
@@ -3170,18 +3207,20 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_full_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 23 fn
-        // pointers (8 bytes each) = 4 + 4 + 184 = 192 bytes.
+        // layout_version (u32) + _reserved_padding (u32) + 29 fn
+        // pointers (8 bytes each) = 4 + 4 + 232 = 240 bytes.
         //
-        // 23 entries = 1 drop_handle + 4 clone/drop pairs (8 fn
-        // pointers for the 4 kernel return types) + 4 create_* method
+        // 29 entries = 1 drop_handle + 7 clone/drop pairs (14 fn
+        // pointers for the 7 β-shape return types: compute / graphics /
+        // ray-tracing kernels, texture ring, color converter,
+        // acceleration structure, command recorder) + 4 create_* method
         // callbacks (compute / graphics / ray-tracing / texture_ring)
         // + 1 acquire_render_target_dma_buf_image (C3) + 9 Phase D
         // privileged methods (wait_device_idle, acquire_output_texture,
         // upload_pixel_buffer_as_texture, color_converter,
         // create_command_recorder, build_triangles_blas, build_tlas,
         // supports_ray_tracing_pipeline, check_in_surface).
-        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 192);
+        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 240);
         assert_eq!(align_of::<GpuContextFullAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, layout_version), 0);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, _reserved_padding), 4);
@@ -3218,21 +3257,52 @@ mod layout_tests {
             offset_of!(GpuContextFullAccessVTable, drop_texture_ring),
             72
         );
+        // v4-added β-shape clone/drop pairs (#917).
         assert_eq!(
-            offset_of!(GpuContextFullAccessVTable, create_compute_kernel),
+            offset_of!(GpuContextFullAccessVTable, clone_color_converter),
             80
         );
         assert_eq!(
-            offset_of!(GpuContextFullAccessVTable, create_graphics_kernel),
+            offset_of!(GpuContextFullAccessVTable, drop_color_converter),
             88
         );
         assert_eq!(
-            offset_of!(GpuContextFullAccessVTable, create_ray_tracing_kernel),
+            offset_of!(
+                GpuContextFullAccessVTable,
+                clone_acceleration_structure
+            ),
             96
         );
         assert_eq!(
-            offset_of!(GpuContextFullAccessVTable, create_texture_ring),
+            offset_of!(
+                GpuContextFullAccessVTable,
+                drop_acceleration_structure
+            ),
             104
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, clone_command_recorder),
+            112
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, drop_command_recorder),
+            120
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_compute_kernel),
+            128
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_graphics_kernel),
+            136
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_ray_tracing_kernel),
+            144
+        );
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, create_texture_ring),
+            152
         );
         // C3-added entry (Phase C3, #903).
         assert_eq!(
@@ -3240,47 +3310,47 @@ mod layout_tests {
                 GpuContextFullAccessVTable,
                 acquire_render_target_dma_buf_image
             ),
-            112
+            160
         );
         // Phase D entries (#906).
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, wait_device_idle),
-            120
+            168
         );
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, acquire_output_texture),
-            128
+            176
         );
         assert_eq!(
             offset_of!(
                 GpuContextFullAccessVTable,
                 upload_pixel_buffer_as_texture
             ),
-            136
+            184
         );
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, color_converter),
-            144
+            192
         );
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, create_command_recorder),
-            152
+            200
         );
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, build_triangles_blas),
-            160
+            208
         );
-        assert_eq!(offset_of!(GpuContextFullAccessVTable, build_tlas), 168);
+        assert_eq!(offset_of!(GpuContextFullAccessVTable, build_tlas), 216);
         assert_eq!(
             offset_of!(
                 GpuContextFullAccessVTable,
                 supports_ray_tracing_pipeline
             ),
-            176
+            224
         );
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, check_in_surface),
-            184
+            232
         );
     }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -2063,42 +2063,48 @@ pub struct GpuContextFullAccessVTable {
     // VulkanComputeKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanComputeKernel` handle. Called by
-    /// the cdylib's `Clone for ComputeKernel`. Host runs
-    /// `Arc::increment_strong_count(handle as *const VulkanComputeKernel)`.
+    /// Bump the refcount on a `VulkanComputeKernel` β-shape handle.
+    /// Called by the cdylib's `Clone for VulkanComputeKernel`. Host
+    /// runs `Arc::increment_strong_count(handle as *const VulkanComputeKernelInner)`
+    /// against the host-internal Inner type — cdylib never sees the
+    /// Inner layout.
     pub clone_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanComputeKernel` handle.
+    /// Decrement the refcount on a `VulkanComputeKernel` β-shape handle.
+    /// Host runs `Arc::decrement_strong_count` against the Inner type.
     pub drop_compute_kernel: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
     // VulkanGraphicsKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanGraphicsKernel` handle.
+    /// Bump the refcount on a `VulkanGraphicsKernel` β-shape handle.
+    /// Host runs `Arc::increment_strong_count(handle as *const VulkanGraphicsKernelInner)`.
     pub clone_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanGraphicsKernel` handle.
+    /// Decrement the refcount on a `VulkanGraphicsKernel` β-shape handle.
     pub drop_graphics_kernel: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
     // VulkanRayTracingKernel return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `VulkanRayTracingKernel` handle.
+    /// Bump the refcount on a `VulkanRayTracingKernel` β-shape handle.
+    /// Host runs `Arc::increment_strong_count(handle as *const VulkanRayTracingKernelInner)`.
     pub clone_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `VulkanRayTracingKernel` handle.
+    /// Decrement the refcount on a `VulkanRayTracingKernel` β-shape handle.
     pub drop_ray_tracing_kernel: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------
     // TextureRing return-type lifetime
     // -------------------------------------------------------------------------
 
-    /// Bump the refcount on a `TextureRing` handle.
+    /// Bump the refcount on a `TextureRing` β-shape handle.
+    /// Host runs `Arc::increment_strong_count(handle as *const TextureRingInner)`.
     pub clone_texture_ring: unsafe extern "C" fn(handle: *const c_void),
 
-    /// Decrement the refcount on a `TextureRing` handle.
+    /// Decrement the refcount on a `TextureRing` β-shape handle.
     pub drop_texture_ring: unsafe extern "C" fn(handle: *const c_void),
 
     // -------------------------------------------------------------------------

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
@@ -125,7 +125,7 @@ pub(super) struct NvJpegResources {
 
     /// Held to back the slots' `texture` references and to drop after
     /// every per-slot CUDA handle is torn down. Unused after construction.
-    _ring: Arc<TextureRing>,
+    _ring: TextureRing,
 
     slots: Vec<NvJpegSlot>,
     current_slot: usize,

--- a/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
+++ b/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
@@ -40,7 +40,7 @@ pub struct VulkanComputeBackend {
     kernel: JpegDecodeKernel,
     coef_buf: Arc<HostVulkanBuffer>,
     qt_buf: Arc<HostVulkanBuffer>,
-    ring: Arc<TextureRing>,
+    ring: TextureRing,
     max_width: u32,
     max_height: u32,
     /// Latch for the "non-sRGB declaration → JFIF fallback" warning.
@@ -148,7 +148,7 @@ impl VulkanComputeBackend {
     /// Borrow the underlying [`TextureRing`] — for tests and
     /// introspection.
     #[doc(hidden)]
-    pub fn ring(&self) -> &Arc<TextureRing> {
+    pub fn ring(&self) -> &TextureRing {
         &self.ring
     }
 

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -392,7 +392,7 @@ impl streamlib::sdk::processors::ManualProcessor for LinuxCameraProcessor::Proce
 }
 
 struct CameraGpuResources {
-    color_converter: Arc<RhiColorConverter>,
+    color_converter: RhiColorConverter,
     recorder: RhiCommandRecorder,
     timeline: Arc<HostVulkanTimelineSemaphore>,
     input_storage_buffers: Vec<StorageBuffer>,

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -132,7 +132,7 @@ fn source_thread_loop(
     frame_counter: Arc<AtomicU64>,
     outputs: Arc<OutputWriter>,
     gpu_context: GpuContextLimitedAccess,
-    texture_ring: Arc<TextureRing>,
+    texture_ring: TextureRing,
 ) {
     let frame_size = (width * height * 4) as usize;
 

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -39,7 +39,7 @@ pub struct H264DecoderProcessor {
     /// Pre-allocated output texture ring. Built lazily on the first
     /// decoded frame (dimensions come from the SPS), rebuilt only on
     /// mid-stream resolution change.
-    texture_ring: Option<Arc<TextureRing>>,
+    texture_ring: Option<TextureRing>,
 
     /// Frames decoded counter.
     frames_decoded: u64,

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -39,7 +39,7 @@ pub struct H265DecoderProcessor {
     /// Pre-allocated output texture ring. Built lazily on the first
     /// decoded frame (dimensions come from the SPS), rebuilt only on
     /// mid-stream resolution change.
-    texture_ring: Option<Arc<TextureRing>>,
+    texture_ring: Option<TextureRing>,
 
     /// Frames decoded counter.
     frames_decoded: u64,


### PR DESCRIPTION
## Summary

Two prereq commits for #922 (vulkan-video interior RhiCommandRecorder migration). Each is independently mergeable.

### Commit 1 — `command_buffer_raw` / `vulkan_device_ref` → `pub`

Promotes the two engine-internal escape-hatch accessors on `RhiCommandRecorder` from `pub(crate)` to `pub`, enabling cross-crate access from `libs/vulkan-video/`. Updated doc comments make the escape-hatch contract explicit: the recorder owns `begin_command_buffer` / `end_command_buffer` / `vkQueueSubmit*` calls; callers may only record commands between `begin()` and `submit*()`.

Per CLAUDE.md "Make the right way easy and the wrong way hard. 'Hard' — not 'impossible'. Some escape hatches are legitimate" — vulkan-video's `vkCmd*VideoCodingKHR` / `vkCmdEncodeVideoKHR` / `vkCmdDecodeVideoKHR` are exactly the kind of codec-API-specific commands the RHI doesn't generalize and shouldn't try to. The escape hatch is the right shape.

### Commit 2 — `RhiCommandRecorder::new_with_queue` constructor

Adds a sibling constructor `RhiCommandRecorder::new_with_queue(vulkan_device, label, queue, queue_family_index)` that builds a recorder against a caller-provided queue instead of the device's default queue.

**Discovered during #922 implementation**: `RhiCommandRecorder::new` hardcoded `vulkan_device.queue()` + `queue_family_index()`. vulkan-video has three distinct queues (`encode_queue`, `transfer_queue`, `compute_queue`) that may differ from the default. Without this variant, migrating vulkan-video's raw command-pool/buffer/fence triples to RhiCommandRecorder would silently submit encode / decode work to the wrong queue.

The new constructor shares its body with `new()` via a private `new_with_queue_inner` helper. Default `new()` continues to use the device's default queue (one-line forward).

## What's NOT in this PR

The actual #922 migration — replacing vulkan-video's 5 raw command-pool/buffer/fence triples with `RhiCommandRecorder::new_with_queue(...)` calls — is the next sub-PR. This PR delivers the two enabling prereqs that surface during attempting the migration.

The migration scope (5 triples × encode/decode call sites in `libs/vulkan-video/src/encode/` and `decode/`) is multi-hundred-LOC across `session.rs`, `staging.rs`, `submit.rs`, and decoder counterparts. Each migration also needs to preserve the encode/decode submit semantics (specific fence + queue + timeline behavior). Doing that work in-PR risks breaking video encode/decode without extremely careful integration testing.

## Test plan

- [x] `cargo check --workspace --all-targets` clean.
- [x] `cargo test --lib -p streamlib-engine layout_tests` passes (45 layout tests).
- [x] Existing `vulkan-video-roundtrip` E2E unaffected (this PR doesn't touch vulkan-video).

Refs #922. Branch base: `feat/917-beta-shape-phase-d` (PR #918).

🤖 Generated with [Claude Code](https://claude.com/claude-code)