### PR TITLE
fix(vulkan-video): edition 2024 unsafe_op_in_unsafe_fn cleanup (#352)

### DIFF
--- a/libs/vulkan-video/Cargo.toml
+++ b/libs/vulkan-video/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "vulkan-video"
 version.workspace = true
-# vulkan-video is a port of NVIDIA nvpro-samples and hasn't completed the
-# edition-2024 unsafe cleanup yet (unsafe_op_in_unsafe_fn,
-# #[unsafe(no_mangle)] attrs). It stays on 2021 until the ported codec code
-# gets its own migration pass — tracked as #352.
-edition = "2021"
+edition.workspace = true
 authors.workspace = true
 license-file.workspace = true
 repository.workspace = true

--- a/libs/vulkan-video/src/bin/pipeline_test.rs
+++ b/libs/vulkan-video/src/bin/pipeline_test.rs
@@ -190,7 +190,7 @@ unsafe fn probe_encode_support(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     codec: vk::VideoCodecOperationFlagsKHR,
-) -> bool {
+) -> bool { unsafe {
     use vulkanalia::vk::KhrVideoQueueExtensionInstanceCommands;
 
     let mut profile_info = vk::VideoProfileInfoKHR::builder()
@@ -233,14 +233,14 @@ unsafe fn probe_encode_support(
     instance.get_physical_device_video_capabilities_khr(
         physical_device, &profile_info, &mut caps,
     ).is_ok()
-}
+}}
 
 /// Check if a specific decode codec is supported by querying video capabilities.
 unsafe fn probe_decode_support(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     codec: vk::VideoCodecOperationFlagsKHR,
-) -> bool {
+) -> bool { unsafe {
     use vulkanalia::vk::KhrVideoQueueExtensionInstanceCommands;
 
     let mut profile_info = vk::VideoProfileInfoKHR::builder()
@@ -293,7 +293,7 @@ unsafe fn probe_decode_support(
     instance.get_physical_device_video_capabilities_khr(
         physical_device, &profile_info, &mut caps,
     ).is_ok()
-}
+}}
 
 // ---------------------------------------------------------------------------
 // ffprobe metadata validation

--- a/libs/vulkan-video/src/codec_utils/helpers.rs
+++ b/libs/vulkan-video/src/codec_utils/helpers.rs
@@ -206,13 +206,13 @@ impl Drop for NativeHandle {
 ///
 /// # Safety
 /// `fd` must be a valid open file descriptor that the caller owns.
-unsafe fn libc_close(fd: RawFd) {
+unsafe fn libc_close(fd: RawFd) { unsafe {
     // `close` is provided by libc which is always linked on Unix targets.
     unsafe extern "C" {
         fn close(fd: std::os::raw::c_int) -> std::os::raw::c_int;
     }
-    unsafe { let _ = close(fd); }
-}
+    let _ = close(fd);
+}}
 
 // ---------------------------------------------------------------------------
 // pNext chain helper
@@ -228,7 +228,7 @@ unsafe fn libc_close(fd: RawFd) {
 /// Both pointers must be valid and point to Vulkan structures whose first two
 /// fields are `s_type` and `next` (i.e. they extend `VkBaseInStructure`).
 /// `chained.next` must be null on entry.
-pub unsafe fn chain_next_vk_struct<N, C>(node: &mut N, chained: &mut C) {
+pub unsafe fn chain_next_vk_struct<N, C>(node: &mut N, chained: &mut C) { unsafe {
     let node_base = node as *mut N as *mut vk::BaseOutStructure;
     let chained_base = chained as *mut C as *mut vk::BaseOutStructure;
 
@@ -240,7 +240,7 @@ pub unsafe fn chain_next_vk_struct<N, C>(node: &mut N, chained: &mut C) {
     // Insert at the head: chained.next = node.next; node.next = chained
     (*chained_base).next = (*node_base).next;
     (*node_base).next = chained_base;
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Vulkan enumeration / query helpers
@@ -302,7 +302,7 @@ pub struct QueueFamilyInfo {
 pub unsafe fn get_physical_device_queue_family_properties2(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
-) -> Vec<QueueFamilyInfo> {
+) -> Vec<QueueFamilyInfo> { unsafe {
     // Use the raw function pointer because vulkanalia's high-level wrapper
     // doesn't support pNext chains on the output structures.
     let get_props_fn = instance.commands().get_physical_device_queue_family_properties2;
@@ -340,7 +340,7 @@ pub unsafe fn get_physical_device_queue_family_properties2(
     }
 
     infos
-}
+}}
 
 /// Get surface formats.
 ///
@@ -349,9 +349,9 @@ pub unsafe fn get_physical_device_surface_formats(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     surface: vk::SurfaceKHR,
-) -> Result<Vec<vk::SurfaceFormatKHR>, vk::ErrorCode> {
+) -> Result<Vec<vk::SurfaceFormatKHR>, vk::ErrorCode> { unsafe {
     instance.get_physical_device_surface_formats_khr(physical_device, surface)
-}
+}}
 
 /// Get present modes.
 ///
@@ -360,9 +360,9 @@ pub unsafe fn get_physical_device_surface_present_modes(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     surface: vk::SurfaceKHR,
-) -> Result<Vec<vk::PresentModeKHR>, vk::ErrorCode> {
+) -> Result<Vec<vk::PresentModeKHR>, vk::ErrorCode> { unsafe {
     instance.get_physical_device_surface_present_modes_khr(physical_device, surface)
-}
+}}
 
 /// Get swapchain images.
 ///
@@ -370,9 +370,9 @@ pub unsafe fn get_physical_device_surface_present_modes(
 pub unsafe fn get_swapchain_images(
     device: &vulkanalia::Device,
     swapchain: vk::SwapchainKHR,
-) -> Result<Vec<vk::Image>, vk::ErrorCode> {
+) -> Result<Vec<vk::Image>, vk::ErrorCode> { unsafe {
     device.get_swapchain_images_khr(swapchain)
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Memory type mapping
@@ -387,7 +387,7 @@ pub unsafe fn map_memory_type_to_index(
     physical_device: vk::PhysicalDevice,
     type_bits: u32,
     requirements_mask: vk::MemoryPropertyFlags,
-) -> Result<u32, vk::ErrorCode> {
+) -> Result<u32, vk::ErrorCode> { unsafe {
     let memory_properties = instance.get_physical_device_memory_properties(physical_device);
     let mut bits = type_bits;
     for i in 0..32u32 {
@@ -401,7 +401,7 @@ pub unsafe fn map_memory_type_to_index(
         bits >>= 1;
     }
     Err(vk::ErrorCode::VALIDATION_FAILED)
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Fence helpers
@@ -422,7 +422,7 @@ pub unsafe fn wait_and_reset_fence(
     fence_name: &str,
     fence_wait_timeout: u64,
     fence_total_wait_timeout: u64,
-) -> vk::Result {
+) -> vk::Result { unsafe {
     assert!(fence != vk::Fence::null());
 
     let mut current_wait: u64 = 0;
@@ -481,7 +481,7 @@ pub unsafe fn wait_and_reset_fence(
     }
 
     result
-}
+}}
 
 /// Wait for `fence`, check the video decode query-pool status, and retry on
 /// timeout.
@@ -498,7 +498,7 @@ pub unsafe fn wait_and_get_status(
     fence_wait_timeout: u64,
     fence_total_wait_timeout: u64,
     mut retry_count: u32,
-) -> vk::Result {
+) -> vk::Result { unsafe {
     let mut result;
 
     loop {
@@ -561,7 +561,7 @@ pub unsafe fn wait_and_get_status(
     }
 
     result
-}
+}}
 
 // ---------------------------------------------------------------------------
 // DeviceUuidUtils

--- a/libs/vulkan-video/src/codec_utils/vk_buffer_resource.rs
+++ b/libs/vulkan-video/src/codec_utils/vk_buffer_resource.rs
@@ -560,7 +560,7 @@ impl VkBufferResource {
         new_size: vk::DeviceSize,
         copy_size: vk::DeviceSize,
         copy_offset: vk::DeviceSize,
-    ) -> vk::DeviceSize {
+    ) -> vk::DeviceSize { unsafe {
         if self.buffer_size >= new_size {
             return self.buffer_size;
         }
@@ -601,7 +601,7 @@ impl VkBufferResource {
         self.buffer_size = aligned_size;
 
         aligned_size
-    }
+    }}
 
     /// Clone this buffer's configuration into a new `VkBufferResource`,
     /// optionally copying data.

--- a/libs/vulkan-video/src/codec_utils/vk_image_resource.rs
+++ b/libs/vulkan-video/src/codec_utils/vk_image_resource.rs
@@ -1378,9 +1378,9 @@ mod tests {
     /// panic on function pointers.
     ///
     /// SAFETY: Caller must never call Vulkan methods on the returned device.
-    unsafe fn dummy_device() -> vulkanalia::Device {
+    unsafe fn dummy_device() -> vulkanalia::Device { unsafe {
         std::mem::MaybeUninit::uninit().assume_init()
-    }
+    }}
 
     #[test]
     fn test_ycbcr_vk_format_info_nv12() {

--- a/libs/vulkan-video/src/codec_utils/vk_video_core_profile.rs
+++ b/libs/vulkan-video/src/codec_utils/vk_video_core_profile.rs
@@ -312,11 +312,11 @@ impl VkVideoCoreProfile {
     /// # Safety
     /// `p_next` chain of `video_profile` must point to a valid codec-specific
     /// profile struct if non-null.
-    pub unsafe fn from_profile_info(video_profile: &vk::VideoProfileInfoKHR) -> Self {
+    pub unsafe fn from_profile_info(video_profile: &vk::VideoProfileInfoKHR) -> Self { unsafe {
         let mut this = Self::new_default();
         this.init_from_profile(video_profile);
         this
-    }
+    }}
 
     // -- Static helpers -----------------------------------------------------
 
@@ -344,15 +344,15 @@ impl VkVideoCoreProfile {
         // We intentionally clear the codec ext's own p_next except where
         // encode usage info is chained.
         match &mut self.codec_ext {
-            CodecProfileExt::DecodeH264(ref mut p) => {
+            CodecProfileExt::DecodeH264(p) => {
                 p.next = std::ptr::null();
                 self.profile.next = p as *const _ as *const _;
             }
-            CodecProfileExt::DecodeH265(ref mut p) => {
+            CodecProfileExt::DecodeH265(p) => {
                 p.next = std::ptr::null();
                 self.profile.next = p as *const _ as *const _;
             }
-            CodecProfileExt::DecodeAv1(ref mut p) => {
+            CodecProfileExt::DecodeAv1(p) => {
                 p.next = std::ptr::null();
                 self.profile.next = p as *const _ as *const _;
             }
@@ -360,12 +360,12 @@ impl VkVideoCoreProfile {
                 // VP9 not in ash — cannot chain. Profile remains without p_next.
                 self.profile.next = std::ptr::null();
             }
-            CodecProfileExt::EncodeH264(ref mut p) => {
+            CodecProfileExt::EncodeH264(p) => {
                 // Chain encode usage info behind the codec ext.
                 p.next = &self.encode_usage_info as *const _ as *const _;
                 self.profile.next = p as *const _ as *const _;
             }
-            CodecProfileExt::EncodeH265(ref mut p) => {
+            CodecProfileExt::EncodeH265(p) => {
                 p.next = &self.encode_usage_info as *const _ as *const _;
                 self.profile.next = p as *const _ as *const _;
             }
@@ -392,7 +392,7 @@ impl VkVideoCoreProfile {
     pub unsafe fn populate_profile_ext(
         &mut self,
         video_profile_ext: *const vk::BaseInStructure,
-    ) -> bool {
+    ) -> bool { unsafe {
         let op = self.profile.video_codec_operation;
 
         let ext = if op == vk::VideoCodecOperationFlagsKHR::DECODE_H264 {
@@ -505,7 +505,7 @@ impl VkVideoCoreProfile {
 
         self.populate_profile_ext_inner(ext);
         true
-    }
+    }}
 
     /// Mirrors C++ `InitFromProfile`.
     ///
@@ -514,12 +514,12 @@ impl VkVideoCoreProfile {
     pub unsafe fn init_from_profile(
         &mut self,
         video_profile: &vk::VideoProfileInfoKHR,
-    ) -> bool {
+    ) -> bool { unsafe {
         self.profile = std::ptr::read(video_profile as *const _ as *const _);
         let next = video_profile.next;
         self.profile.next = std::ptr::null();
         self.populate_profile_ext(next as *const vk::BaseInStructure)
-    }
+    }}
 
     // -- Build a CodecProfileExt from constructor parameters -----------------
 

--- a/libs/vulkan-video/src/codec_utils/vulkan_bitstream_buffer_impl.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_bitstream_buffer_impl.rs
@@ -667,24 +667,24 @@ impl VulkanBitstreamBufferStream {
     ///
     /// # Safety
     /// Caller must ensure `index < max_size`.
-    pub unsafe fn read(&self, index: vk::DeviceSize) -> u8 {
+    pub unsafe fn read(&self, index: vk::DeviceSize) -> u8 { unsafe {
         debug_assert!(!self.data_ptr.is_null());
         debug_assert!(index < self.max_size);
         *self.data_ptr.add(index as usize)
-    }
+    }}
 
     /// Write a byte at the given index, updating the high-water mark.
     ///
     /// # Safety
     /// Caller must ensure `index < max_size`.
-    pub unsafe fn write(&mut self, index: vk::DeviceSize, value: u8) {
+    pub unsafe fn write(&mut self, index: vk::DeviceSize, value: u8) { unsafe {
         debug_assert!(!self.data_ptr.is_null());
         debug_assert!(index < self.max_size);
         if index > self.max_access_location {
             self.max_access_location = index;
         }
         *self.data_ptr.add(index as usize) = value;
-    }
+    }}
 
     pub fn is_valid(&self) -> bool {
         !self.data_ptr.is_null() && self.max_size != 0 && self.bitstream_buffer.is_some()

--- a/libs/vulkan-video/src/codec_utils/vulkan_command_buffer_pool.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_command_buffer_pool.rs
@@ -144,7 +144,7 @@ impl PoolNode {
         &mut self,
         cmd_buf: vk::CommandBuffer,
         begin_info: &vk::CommandBufferBeginInfo,
-    ) -> Result<vk::CommandBuffer, vk::Result> {
+    ) -> Result<vk::CommandBuffer, vk::Result> { unsafe {
         if !self.is_valid() {
             return Err(vk::Result::ERROR_INITIALIZATION_FAILED);
         }
@@ -156,7 +156,7 @@ impl PoolNode {
         device.begin_command_buffer(cmd_buf, begin_info)?;
         self.cmd_buf_state = CmdBufState::Recording;
         Ok(cmd_buf)
-    }
+    }}
 
     /// End command buffer recording.
     /// Mirrors C++ `PoolNode::EndCommandBufferRecording`.
@@ -166,7 +166,7 @@ impl PoolNode {
     pub unsafe fn end_command_buffer_recording(
         &mut self,
         cmd_buf: vk::CommandBuffer,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         if !self.is_valid() {
             return vk::Result::ERROR_INITIALIZATION_FAILED;
         }
@@ -182,7 +182,7 @@ impl PoolNode {
             }
             Err(e) => vk::Result::from(e),
         }
-    }
+    }}
 
     /// Mark the command buffer as submitted.
     /// Mirrors C++ `PoolNode::SetCommandBufferSubmitted`.
@@ -210,7 +210,7 @@ impl PoolNode {
         fence_name: &str,
         fence_wait_timeout_nsec: u64,
         fence_total_wait_timeout_nsec: u64,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         if self.cmd_buf_state != CmdBufState::Submitted {
             return vk::Result::ERROR_INITIALIZATION_FAILED;
         }
@@ -241,7 +241,7 @@ impl PoolNode {
         }
 
         result
-    }
+    }}
 
     /// Reset the command buffer state, optionally waiting for GPU completion.
     /// Mirrors C++ `PoolNode::ResetCommandBuffer`.
@@ -253,7 +253,7 @@ impl PoolNode {
         fence: vk::Fence,
         sync_with_host: bool,
         fence_name: &str,
-    ) -> bool {
+    ) -> bool { unsafe {
         if self.cmd_buf_state == CmdBufState::Reset {
             return false;
         }
@@ -270,7 +270,7 @@ impl PoolNode {
 
         self.cmd_buf_state = CmdBufState::Reset;
         true
-    }
+    }}
 }
 
 impl Default for PoolNode {
@@ -309,7 +309,7 @@ impl VulkanCommandBuffersSet {
         device: &vulkanalia::Device,
         queue_family_index: u32,
         count: u32,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         let pool_info = vk::CommandPoolCreateInfo::builder()
             .queue_family_index(queue_family_index)
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
@@ -335,7 +335,7 @@ impl VulkanCommandBuffersSet {
 
         self.device = Some(device.clone());
         vk::Result::SUCCESS
-    }
+    }}
 
     fn get_command_buffer(&self, index: u32) -> Option<vk::CommandBuffer> {
         self.cmd_buffers.get(index as usize).copied()
@@ -343,7 +343,7 @@ impl VulkanCommandBuffersSet {
 
     /// # Safety
     /// Must only be called when no command buffers are in use.
-    unsafe fn destroy(&mut self) {
+    unsafe fn destroy(&mut self) { unsafe {
         if let Some(ref device) = self.device {
             if !self.cmd_buffers.is_empty() {
                 device.free_command_buffers(self.cmd_pool, &self.cmd_buffers);
@@ -355,7 +355,7 @@ impl VulkanCommandBuffersSet {
             }
         }
         self.device = None;
-    }
+    }}
 }
 
 // ---------------------------------------------------------------------------
@@ -379,7 +379,7 @@ impl VulkanFenceSet {
 
     /// # Safety
     /// `device` must be valid and not destroyed for the lifetime of this set.
-    unsafe fn create_set(&mut self, device: &vulkanalia::Device, count: u32) -> vk::Result {
+    unsafe fn create_set(&mut self, device: &vulkanalia::Device, count: u32) -> vk::Result { unsafe {
         self.destroy();
 
         let fence_info = vk::FenceCreateInfo::default();
@@ -399,7 +399,7 @@ impl VulkanFenceSet {
         self.fences = fences;
         self.device = Some(device.clone());
         vk::Result::SUCCESS
-    }
+    }}
 
     fn get_fence(&self, index: u32) -> vk::Fence {
         self.fences
@@ -410,7 +410,7 @@ impl VulkanFenceSet {
 
     /// # Safety
     /// No fences may be in use on the GPU.
-    unsafe fn destroy(&mut self) {
+    unsafe fn destroy(&mut self) { unsafe {
         if let Some(ref device) = self.device {
             for f in &self.fences {
                 if *f != vk::Fence::null() {
@@ -420,7 +420,7 @@ impl VulkanFenceSet {
         }
         self.fences.clear();
         self.device = None;
-    }
+    }}
 }
 
 // ---------------------------------------------------------------------------
@@ -444,7 +444,7 @@ impl VulkanSemaphoreSet {
 
     /// # Safety
     /// `device` must be valid and not destroyed for the lifetime of this set.
-    unsafe fn create_set(&mut self, device: &vulkanalia::Device, count: u32) -> vk::Result {
+    unsafe fn create_set(&mut self, device: &vulkanalia::Device, count: u32) -> vk::Result { unsafe {
         self.destroy();
 
         let sem_info = vk::SemaphoreCreateInfo::default();
@@ -463,7 +463,7 @@ impl VulkanSemaphoreSet {
         self.semaphores = sems;
         self.device = Some(device.clone());
         vk::Result::SUCCESS
-    }
+    }}
 
     fn get_semaphore(&self, index: u32) -> vk::Semaphore {
         self.semaphores
@@ -474,7 +474,7 @@ impl VulkanSemaphoreSet {
 
     /// # Safety
     /// No semaphores may be in use on the GPU.
-    unsafe fn destroy(&mut self) {
+    unsafe fn destroy(&mut self) { unsafe {
         if let Some(ref device) = self.device {
             for s in &self.semaphores {
                 if *s != vk::Semaphore::null() {
@@ -484,7 +484,7 @@ impl VulkanSemaphoreSet {
         }
         self.semaphores.clear();
         self.device = None;
-    }
+    }}
 }
 
 // ---------------------------------------------------------------------------
@@ -517,7 +517,7 @@ impl VulkanQueryPoolSet {
         query_type: vk::QueryType,
         flags: vk::QueryPoolCreateFlags,
         next: *const std::ffi::c_void,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         self.destroy();
 
         let _ = flags; // C++ passes flags as VkQueryPoolCreateFlags (reserved, must be 0).
@@ -538,7 +538,7 @@ impl VulkanQueryPoolSet {
             }
             Err(e) => e.into(),
         }
-    }
+    }}
 
     fn get_query_pool(&self, query_idx: u32) -> vk::QueryPool {
         if query_idx < self.query_count {
@@ -550,7 +550,7 @@ impl VulkanQueryPoolSet {
 
     /// # Safety
     /// The query pool must not be in use on the GPU.
-    unsafe fn destroy(&mut self) {
+    unsafe fn destroy(&mut self) { unsafe {
         if let Some(ref device) = self.device {
             if self.query_pool != vk::QueryPool::null() {
                 device.destroy_query_pool(self.query_pool, None);
@@ -559,7 +559,7 @@ impl VulkanQueryPoolSet {
             }
         }
         self.device = None;
-    }
+    }}
 }
 
 // ---------------------------------------------------------------------------
@@ -579,7 +579,7 @@ pub unsafe fn wait_and_reset_fence(
     fence_name: &str,
     fence_wait_timeout: u64,
     fence_total_wait_timeout: u64,
-) -> vk::Result {
+) -> vk::Result { unsafe {
     debug_assert!(fence != vk::Fence::null());
 
     let mut current_wait: u64 = 0;
@@ -631,7 +631,7 @@ pub unsafe fn wait_and_reset_fence(
     }
 
     vk::Result::SUCCESS
-}
+}}
 
 // ---------------------------------------------------------------------------
 // VulkanCommandBufferPool
@@ -713,7 +713,7 @@ impl VulkanCommandBufferPool {
         next: *const std::ffi::c_void,
         create_semaphores: bool,
         create_fences: bool,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         let pool = Arc::get_mut(self)
             .expect("Cannot configure pool while other references exist");
 
@@ -766,7 +766,7 @@ impl VulkanCommandBufferPool {
         inner.pool_size = num_pool_nodes;
         inner.queue_family_index = queue_family_index;
         vk::Result::SUCCESS
-    }
+    }}
 
     /// Acquire an available pool node.
     /// Mirrors C++ `VulkanCommandBufferPool::GetAvailablePoolNode`.
@@ -878,7 +878,7 @@ impl VulkanCommandBufferPool {
     ///
     /// # Safety
     /// All GPU work using pool resources must be complete.
-    pub unsafe fn deinit(self: &mut Arc<Self>) {
+    pub unsafe fn deinit(self: &mut Arc<Self>) { unsafe {
         let pool = Arc::get_mut(self)
             .expect("Cannot deinit pool while other references exist");
         let inner = pool.mutex.lock().unwrap();
@@ -894,7 +894,7 @@ impl VulkanCommandBufferPool {
         pool.semaphore_set.destroy();
         pool.fence_set.destroy();
         pool.query_pool_set.destroy();
-    }
+    }}
 }
 
 // ---------------------------------------------------------------------------
@@ -942,10 +942,10 @@ impl PoolNodeHandle {
     /// This is safe in practice because `PoolNodeHandle` has exclusive ownership
     /// of the node index (guaranteed by the bitmask).
     #[allow(clippy::mut_from_ref)] // interior mutability via UnsafeCell; caller-guaranteed exclusivity
-    pub unsafe fn node_mut(&self) -> &mut PoolNode {
+    pub unsafe fn node_mut(&self) -> &mut PoolNode { unsafe {
         let nodes = &mut *self.pool.pool_nodes.get();
         &mut nodes[self.index as usize]
-    }
+    }}
 
     /// Begin command buffer recording.
     ///
@@ -954,21 +954,21 @@ impl PoolNodeHandle {
     pub unsafe fn begin_command_buffer_recording(
         &self,
         begin_info: &vk::CommandBufferBeginInfo,
-    ) -> Result<vk::CommandBuffer, vk::Result> {
+    ) -> Result<vk::CommandBuffer, vk::Result> { unsafe {
         let cmd_buf = self
             .get_command_buffer()
             .ok_or(vk::Result::ERROR_INITIALIZATION_FAILED)?;
         self.node_mut()
             .begin_command_buffer_recording(cmd_buf, begin_info)
-    }
+    }}
 
     /// End command buffer recording.
     ///
     /// # Safety
     /// The command buffer must be in recording state.
-    pub unsafe fn end_command_buffer_recording(&self, cmd_buf: vk::CommandBuffer) -> vk::Result {
+    pub unsafe fn end_command_buffer_recording(&self, cmd_buf: vk::CommandBuffer) -> vk::Result { unsafe {
         self.node_mut().end_command_buffer_recording(cmd_buf)
-    }
+    }}
 
     /// Mark the command buffer as submitted.
     pub fn set_command_buffer_submitted(&self) -> bool {
@@ -984,7 +984,7 @@ impl PoolNodeHandle {
         &self,
         reset_after_wait: bool,
         fence_name: &str,
-    ) -> vk::Result {
+    ) -> vk::Result { unsafe {
         let fence = self.get_fence();
         self.node_mut().sync_host_on_cmd_buff_complete(
             fence,
@@ -993,17 +993,17 @@ impl PoolNodeHandle {
             DEFAULT_FENCE_WAIT_TIMEOUT_NSEC,
             DEFAULT_FENCE_TOTAL_WAIT_TIMEOUT_NSEC,
         )
-    }
+    }}
 
     /// Reset the command buffer, optionally waiting for GPU completion first.
     ///
     /// # Safety
     /// If `sync_with_host` is true, the command buffer must have been submitted.
-    pub unsafe fn reset_command_buffer(&self, sync_with_host: bool, fence_name: &str) -> bool {
+    pub unsafe fn reset_command_buffer(&self, sync_with_host: bool, fence_name: &str) -> bool { unsafe {
         let fence = self.get_fence();
         self.node_mut()
             .reset_command_buffer(fence, sync_with_host, fence_name)
-    }
+    }}
 
     /// Get the command buffer state.
     pub fn cmd_buf_state(&self) -> CmdBufState {
@@ -1057,7 +1057,7 @@ impl PoolNodeHandler {
         pool: &Arc<VulkanCommandBufferPool>,
         operation_name: &str,
         wait_on_cpu_after_submit: bool,
-    ) -> Self {
+    ) -> Self { unsafe {
         let node_handle = pool.get_available_pool_node();
         let mut cmd_buf = vk::CommandBuffer::null();
 
@@ -1080,7 +1080,7 @@ impl PoolNodeHandler {
             wait_on_cpu_after_submit,
             command_ended: false,
         }
-    }
+    }}
 
     /// Create a handler with an existing pool node handle.
     ///
@@ -1091,7 +1091,7 @@ impl PoolNodeHandler {
         existing_node: Option<PoolNodeHandle>,
         operation_name: &str,
         wait_on_cpu_after_submit: bool,
-    ) -> Self {
+    ) -> Self { unsafe {
         let node_handle = existing_node.or_else(|| pool.get_available_pool_node());
         let mut cmd_buf = vk::CommandBuffer::null();
 
@@ -1114,14 +1114,14 @@ impl PoolNodeHandler {
             wait_on_cpu_after_submit,
             command_ended: false,
         }
-    }
+    }}
 
     /// End command buffer recording.
     /// Mirrors C++ `PoolNodeHandler::EndCmdBufferRecording`.
     ///
     /// # Safety
     /// The command buffer must be in recording state.
-    pub unsafe fn end_cmd_buffer_recording(&mut self) -> vk::Result {
+    pub unsafe fn end_cmd_buffer_recording(&mut self) -> vk::Result { unsafe {
         if let Some(ref handle) = self.node_handle {
             if self.cmd_buf == vk::CommandBuffer::null() {
                 return vk::Result::ERROR_INITIALIZATION_FAILED;
@@ -1134,7 +1134,7 @@ impl PoolNodeHandler {
         } else {
             vk::Result::ERROR_INITIALIZATION_FAILED
         }
-    }
+    }}
 
     /// Check if the handler is valid and has a command buffer ready for recording.
     pub fn is_valid(&self) -> bool {

--- a/libs/vulkan-video/src/codec_utils/vulkan_video_capabilities.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_video_capabilities.rs
@@ -86,7 +86,7 @@ pub unsafe fn get_video_decode_capabilities(
     video_queue_instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     video_profile: &vk::VideoProfileInfoKHR,
-) -> Result<VideoDecodeCapabilitiesResult, vk::ErrorCode> {
+) -> Result<VideoDecodeCapabilitiesResult, vk::ErrorCode> { unsafe {
     let video_codec = video_profile.video_codec_operation;
 
     let mut h264_capabilities = vk::VideoDecodeH264CapabilitiesKHR::default();
@@ -138,7 +138,7 @@ pub unsafe fn get_video_decode_capabilities(
         video_decode_capabilities,
         codec_capabilities,
     })
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetVideoEncodeCapabilities
@@ -172,7 +172,7 @@ pub unsafe fn get_video_encode_capabilities(
     video_queue_instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     video_profile: &vk::VideoProfileInfoKHR,
-) -> Result<VideoEncodeCapabilitiesResult, vk::ErrorCode> {
+) -> Result<VideoEncodeCapabilitiesResult, vk::ErrorCode> { unsafe {
     let video_codec = video_profile.video_codec_operation;
 
     let mut h264_capabilities = vk::VideoEncodeH264CapabilitiesKHR::default();
@@ -218,7 +218,7 @@ pub unsafe fn get_video_encode_capabilities(
         video_encode_capabilities,
         codec_capabilities,
     })
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetPhysicalDeviceVideoEncodeQualityLevelProperties
@@ -246,7 +246,7 @@ pub unsafe fn get_physical_device_video_encode_quality_level_properties(
     video_profile: &vk::VideoProfileInfoKHR,
     quality_level: u32,
     codec_quality_level_properties_ptr: *mut core::ffi::c_void,
-) -> Result<EncodeQualityLevelResult, vk::ErrorCode> {
+) -> Result<EncodeQualityLevelResult, vk::ErrorCode> { unsafe {
     let quality_level_info = vk::PhysicalDeviceVideoEncodeQualityLevelInfoKHR {
         s_type: vk::StructureType::PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR,
         next: core::ptr::null(),
@@ -278,7 +278,7 @@ pub unsafe fn get_physical_device_video_encode_quality_level_properties(
     Ok(EncodeQualityLevelResult {
         quality_level_properties,
     })
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetSupportedVideoFormats
@@ -303,7 +303,7 @@ pub unsafe fn get_supported_video_formats(
     physical_device: vk::PhysicalDevice,
     video_profile: &vk::VideoProfileInfoKHR,
     capability_flags: vk::VideoDecodeCapabilityFlagsKHR,
-) -> Result<SupportedVideoFormatsResult, vk::ErrorCode> {
+) -> Result<SupportedVideoFormatsResult, vk::ErrorCode> { unsafe {
     if capability_flags.contains(vk::VideoDecodeCapabilityFlagsKHR::DPB_AND_OUTPUT_COINCIDE) {
         // NV, Intel: DPB and output share the same images.
         let formats = get_video_formats(
@@ -363,7 +363,7 @@ pub unsafe fn get_supported_video_formats(
         );
         Err(vk::ErrorCode::VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR)
     }
-}
+}}
 
 /// Log warnings when queried formats are undefined or mismatched.
 fn validate_formats(reference_pictures_format: vk::Format, picture_format: vk::Format) {
@@ -403,7 +403,7 @@ pub unsafe fn get_video_capabilities(
     video_profile: &vk::VideoProfileInfoKHR,
     video_capabilities: &mut vk::VideoCapabilitiesKHR,
     dump_data: bool,
-) -> vk::Result {
+) -> vk::Result { unsafe {
     assert_eq!(
         video_capabilities.s_type,
         vk::StructureType::VIDEO_CAPABILITIES_KHR
@@ -484,7 +484,7 @@ pub unsafe fn get_video_capabilities(
     }
 
     vk::Result::SUCCESS
-}
+}}
 
 /// Dump capability data via tracing.
 ///
@@ -562,7 +562,7 @@ pub unsafe fn get_video_formats(
     physical_device: vk::PhysicalDevice,
     video_profile: &vk::VideoProfileInfoKHR,
     image_usage: vk::ImageUsageFlags,
-) -> Result<Vec<vk::VideoFormatPropertiesKHR>, vk::ErrorCode> {
+) -> Result<Vec<vk::VideoFormatPropertiesKHR>, vk::ErrorCode> { unsafe {
     let video_profiles = vk::VideoProfileListInfoKHR {
         s_type: vk::StructureType::VIDEO_PROFILE_LIST_INFO_KHR,
         next: core::ptr::null(),
@@ -593,7 +593,7 @@ pub unsafe fn get_video_formats(
     }
 
     Ok(supported_formats)
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetSupportedCodecs
@@ -634,7 +634,7 @@ pub unsafe fn get_supported_codecs(
     video_queue_family: Option<u32>,
     queue_flags_required: vk::QueueFlags,
     video_codec_operations: vk::VideoCodecOperationFlagsKHR,
-) -> (vk::VideoCodecOperationFlagsKHR, Option<u32>) {
+) -> (vk::VideoCodecOperationFlagsKHR, Option<u32>) { unsafe {
     let (queues, video_queues, _query_result_status) =
         get_queue_family_video_properties(instance, physical_device);
 
@@ -656,7 +656,7 @@ pub unsafe fn get_supported_codecs(
     }
 
     (vk::VideoCodecOperationFlagsKHR::NONE, None)
-}
+}}
 
 /// Convenience overload: check codecs supported on a known queue family.
 ///
@@ -669,7 +669,7 @@ pub unsafe fn get_supported_codecs_for_queue(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     video_queue_family: u32,
-) -> vk::VideoCodecOperationFlagsKHR {
+) -> vk::VideoCodecOperationFlagsKHR { unsafe {
     let (codecs, _) = get_supported_codecs(
         instance,
         physical_device,
@@ -678,7 +678,7 @@ pub unsafe fn get_supported_codecs_for_queue(
         ALL_CODEC_OPERATIONS,
     );
     codecs
-}
+}}
 
 /// Check whether a specific codec is supported on the given queue family.
 ///
@@ -692,10 +692,10 @@ pub unsafe fn is_codec_type_supported(
     physical_device: vk::PhysicalDevice,
     video_queue_family: u32,
     video_codec: vk::VideoCodecOperationFlagsKHR,
-) -> bool {
+) -> bool { unsafe {
     let codecs = get_supported_codecs_for_queue(instance, physical_device, video_queue_family);
     codecs.intersects(video_codec)
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetDecodeH264Capabilities / GetDecodeH265Capabilities / etc.
@@ -712,7 +712,7 @@ pub unsafe fn get_decode_capabilities_simple(
     video_queue_instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     video_profile: &vk::VideoProfileInfoKHR,
-) -> Result<vk::VideoCapabilitiesKHR, vk::ErrorCode> {
+) -> Result<vk::VideoCapabilitiesKHR, vk::ErrorCode> { unsafe {
     let mut video_capabilities = vk::VideoCapabilitiesKHR::default();
 
     video_queue_instance.get_physical_device_video_capabilities_khr(
@@ -722,7 +722,7 @@ pub unsafe fn get_decode_capabilities_simple(
     )?;
 
     Ok(video_capabilities)
-}
+}}
 
 /// Query encode H.264 capabilities with codec-specific output.
 ///
@@ -741,7 +741,7 @@ pub unsafe fn get_encode_h264_capabilities(
         vk::VideoEncodeH264CapabilitiesKHR,
     ),
     vk::ErrorCode,
-> {
+> { unsafe {
     let mut encode_264_capabilities = vk::VideoEncodeH264CapabilitiesKHR::default();
     let mut video_capabilities = vk::VideoCapabilitiesKHR {
         next: &mut encode_264_capabilities as *mut _ as *mut core::ffi::c_void,
@@ -755,7 +755,7 @@ pub unsafe fn get_encode_h264_capabilities(
     )?;
 
     Ok((video_capabilities, encode_264_capabilities))
-}
+}}
 
 // ---------------------------------------------------------------------------
 // GetVideoMaintenance1FeatureSupported
@@ -771,7 +771,7 @@ pub unsafe fn get_encode_h264_capabilities(
 pub unsafe fn get_video_maintenance1_feature_supported(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
-) -> bool {
+) -> bool { unsafe {
     let mut video_maintenance1_features =
         vk::PhysicalDeviceVideoMaintenance1FeaturesKHR::default();
     let mut device_features = vk::PhysicalDeviceFeatures2 {
@@ -782,7 +782,7 @@ pub unsafe fn get_video_maintenance1_feature_supported(
     instance.get_physical_device_features2(physical_device, &mut device_features);
 
     video_maintenance1_features.video_maintenance1 == vk::TRUE
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -802,7 +802,7 @@ unsafe fn get_queue_family_video_properties(
     Vec<vk::QueueFamilyProperties2>,
     Vec<vk::QueueFamilyVideoPropertiesKHR>,
     Vec<vk::QueueFamilyQueryResultStatusPropertiesKHR>,
-) {
+) { unsafe {
     // Use raw function pointer because vulkanalia's wrapper doesn't support
     // pNext chains on the output structures.
     let get_props_fn = instance.commands().get_physical_device_queue_family_properties2;
@@ -832,7 +832,7 @@ unsafe fn get_queue_family_video_properties(
     query_result_status.truncate(count as usize);
 
     (queues, video_queues, query_result_status)
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/libs/vulkan-video/src/codec_utils/vulkan_video_image_pool.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_video_image_pool.rs
@@ -191,7 +191,7 @@ impl VulkanVideoImagePoolNode {
         value: u64,
         stage_mask: vk::PipelineStageFlags2,
         device_index: u32,
-    ) -> vk::SemaphoreSubmitInfo {
+    ) -> vk::SemaphoreSubmitInfo { unsafe {
         if self.timeline_semaphore == vk::Semaphore::null() {
             let mut type_info = vk::SemaphoreTypeCreateInfo::builder()
                 .semaphore_type(vk::SemaphoreType::TIMELINE)
@@ -225,7 +225,7 @@ impl VulkanVideoImagePoolNode {
         self.semaphore_submit_info.device_index = device_index;
 
         self.semaphore_submit_info
-    }
+    }}
 
     /// Populate this node with an image.
     ///
@@ -304,7 +304,7 @@ impl VulkanVideoImagePoolNode {
     ///
     /// If a timeline semaphore was created, `device` must be the same device
     /// that was used to create it.
-    pub unsafe fn deinit(&mut self, device: Option<&vulkanalia::Device>) {
+    pub unsafe fn deinit(&mut self, device: Option<&vulkanalia::Device>) { unsafe {
         self.image_resource_view = None;
 
         if self.timeline_semaphore != vk::Semaphore::null() {
@@ -315,7 +315,7 @@ impl VulkanVideoImagePoolNode {
         }
 
         self.semaphore_submit_info = empty_semaphore_submit_info();
-    }
+    }}
 
     // -- private helpers --
 
@@ -720,13 +720,13 @@ impl VulkanVideoImagePool {
     ///
     /// `device` must be the device that was used to create any timeline
     /// semaphores in the pool nodes.
-    pub unsafe fn deinit(&self, device: Option<&vulkanalia::Device>) {
+    pub unsafe fn deinit(&self, device: Option<&vulkanalia::Device>) { unsafe {
         let mut inner = self.inner.lock().expect("pool lock poisoned");
         for ndx in 0..inner.pool_size as usize {
             inner.image_resources[ndx].deinit(device);
         }
         inner.pool_size = 0;
-    }
+    }}
 
     /// Number of images the pool is configured for.
     pub fn size(&self) -> u32 {

--- a/libs/vulkan-video/src/codec_utils/vulkan_video_session.rs
+++ b/libs/vulkan-video/src/codec_utils/vulkan_video_session.rs
@@ -97,7 +97,7 @@ impl VulkanVideoSession {
         allocator: &Arc<vma::Allocator>,
         submitter: &Arc<dyn crate::rhi::RhiQueueSubmitter>,
         params: &VideoSessionCreateParams,
-    ) -> Result<Arc<Self>, vk::Result> {
+    ) -> Result<Arc<Self>, vk::Result> { unsafe {
         // --- Build the std header version based on codec type ---------
         let std_header_version = std_header_version_for_codec(params.codec_operation)?;
 
@@ -124,7 +124,7 @@ impl VulkanVideoSession {
             *result_ref = Self::create_locked(device, allocator, params, &create_info);
         });
         result
-    }
+    }}
 
     /// Must be called while holding the host's device-level resource lock.
     unsafe fn create_locked(
@@ -132,7 +132,7 @@ impl VulkanVideoSession {
         allocator: &Arc<vma::Allocator>,
         params: &VideoSessionCreateParams,
         create_info: &vk::VideoSessionCreateInfoKHRBuilder,
-    ) -> Result<Arc<Self>, vk::Result> {
+    ) -> Result<Arc<Self>, vk::Result> { unsafe {
         // --- Create the VkVideoSessionKHR ----------------------------
         let video_session = device
             .create_video_session_khr(create_info, None)
@@ -219,7 +219,7 @@ impl VulkanVideoSession {
             video_session,
             allocations,
         }))
-    }
+    }}
 
     // ------------------------------------------------------------------
     // Accessors
@@ -328,14 +328,14 @@ unsafe fn cleanup_on_failure(
     video_session: vk::VideoSessionKHR,
     device: &vulkanalia::Device,
     allocations: &[vma::Allocation],
-) {
+) { unsafe {
     for &allocation in allocations {
         allocator.free_memory(allocation);
     }
     if video_session != vk::VideoSessionKHR::null() {
         device.destroy_video_session_khr(video_session, None);
     }
-}
+}}
 
 /// Return the `VkExtensionProperties` (std header version) for a given codec
 /// operation type, matching the C++ switch statement in `VulkanVideoSession::Create`.

--- a/libs/vulkan-video/src/decode/mod.rs
+++ b/libs/vulkan-video/src/decode/mod.rs
@@ -267,7 +267,7 @@ impl SimpleDecoder {
     }
 
     /// Create the decoder (all Vulkan setup, unsafe due to raw Vulkan calls).
-    unsafe fn create_internal(config: SimpleDecoderConfig) -> Result<Self, VideoError> {
+    unsafe fn create_internal(config: SimpleDecoderConfig) -> Result<Self, VideoError> { unsafe {
         // 1. Load Vulkan
         let loader = vulkanalia::loader::LibloadingLoader::new(vulkanalia::loader::LIBRARY)
             .map_err(|e| VideoError::BitstreamError(format!("Failed to load Vulkan library: {}", e)))?;
@@ -283,7 +283,7 @@ impl SimpleDecoder {
         let layer_props = entry.enumerate_instance_layer_properties()
             .unwrap_or_default();
         let has_validation = layer_props.iter().any(|p| {
-            let name = unsafe { std::ffi::CStr::from_ptr(p.layer_name.as_ptr()) };
+            let name = std::ffi::CStr::from_ptr(p.layer_name.as_ptr());
             name.to_bytes() == b"VK_LAYER_KHRONOS_validation"
         });
 
@@ -481,7 +481,7 @@ impl SimpleDecoder {
             compute_queue_family: compute_qf,
             submitter,
         })
-    }
+    }}
 
     /// Feed arbitrary bytes of H.264 Annex B bitstream data.
     ///

--- a/libs/vulkan-video/src/decode/session.rs
+++ b/libs/vulkan-video/src/decode/session.rs
@@ -275,7 +275,7 @@ impl SimpleDecoder {
     /// Build StdVideoH264SequenceParameterSet from the ported parser's SPS.
     unsafe fn build_std_sps_from_parsed(
         sps: &H264Sps,
-    ) -> vk::video::StdVideoH264SequenceParameterSet {
+    ) -> vk::video::StdVideoH264SequenceParameterSet { unsafe {
         let mut flags: vk::video::StdVideoH264SpsFlags = std::mem::zeroed();
         flags.set_direct_8x8_inference_flag(sps.flags.direct_8x8_inference_flag as u32);
         flags.set_frame_mbs_only_flag(sps.flags.frame_mbs_only_flag as u32);
@@ -367,12 +367,12 @@ impl SimpleDecoder {
             pScalingLists: ptr::null(),
             pSequenceParameterSetVui: ptr::null(),
         }
-    }
+    }}
 
     /// Build StdVideoH264PictureParameterSet from the ported parser's PPS.
     unsafe fn build_std_pps_from_parsed(
         pps: &H264Pps,
-    ) -> vk::video::StdVideoH264PictureParameterSet {
+    ) -> vk::video::StdVideoH264PictureParameterSet { unsafe {
         let mut flags: vk::video::StdVideoH264PpsFlags = std::mem::zeroed();
         flags.set_entropy_coding_mode_flag(pps.flags.entropy_coding_mode_flag as u32);
         flags.set_deblocking_filter_control_present_flag(pps.flags.deblocking_filter_control_present_flag as u32);
@@ -403,12 +403,12 @@ impl SimpleDecoder {
             second_chroma_qp_index_offset: pps.second_chroma_qp_index_offset,
             pScalingLists: ptr::null(),
         }
-    }
+    }}
 
     /// Build a default PPS when no PPS NAL has been received yet.
     unsafe fn build_std_pps_default(
         sps_id: u8,
-    ) -> vk::video::StdVideoH264PictureParameterSet {
+    ) -> vk::video::StdVideoH264PictureParameterSet { unsafe {
         let mut flags: vk::video::StdVideoH264PpsFlags = std::mem::zeroed();
         flags.set_deblocking_filter_control_present_flag(1);
         flags.set_entropy_coding_mode_flag(1);
@@ -426,7 +426,7 @@ impl SimpleDecoder {
             second_chroma_qp_index_offset: 0,
             pScalingLists: ptr::null(),
         }
-    }
+    }}
 
     /// Create H.264 session parameters on VkVideoDecoder's video session.
     pub(crate) fn create_session_params_h264_vk(&mut self) -> Result<(), VideoError> {

--- a/libs/vulkan-video/src/encode/gop.rs
+++ b/libs/vulkan-video/src/encode/gop.rs
@@ -32,7 +32,7 @@ impl SimpleEncoder {
         &mut self,
         nv12_data: &[u8],
         timestamp_ns: Option<i64>,
-    ) -> Result<Vec<EncodePacket>, VideoError> {
+    ) -> Result<Vec<EncodePacket>, VideoError> { unsafe {
         let display_pts = self.frame_counter;
         let frame_type = self.decide_frame_type();
 
@@ -70,7 +70,7 @@ impl SimpleEncoder {
         }
 
         Ok(packets)
-    }
+    }}
 
     /// Flush any remaining frames.
     ///

--- a/libs/vulkan-video/src/encode/session.rs
+++ b/libs/vulkan-video/src/encode/session.rs
@@ -34,7 +34,7 @@ impl SimpleEncoder {
     ///
     /// The caller must ensure the `VideoContext` device has the required video
     /// encode extensions enabled and that the queue family supports encode.
-    pub(crate) unsafe fn configure(&mut self, config: &EncodeConfig) -> VideoResult<()> {
+    pub(crate) unsafe fn configure(&mut self, config: &EncodeConfig) -> VideoResult<()> { unsafe {
         config.validate()?;
 
         tracing::info!(
@@ -398,7 +398,7 @@ impl SimpleEncoder {
         );
 
         Ok(())
-    }
+    }}
 
     /// Returns whether the encoder has been configured.
     #[allow(dead_code)] // Public API for callers that check state
@@ -436,7 +436,7 @@ impl SimpleEncoder {
     ///
     /// The encoder must be configured and the video session parameters
     /// must be valid.
-    pub(crate) unsafe fn extract_header(&self) -> VideoResult<Vec<u8>> {
+    pub(crate) unsafe fn extract_header(&self) -> VideoResult<Vec<u8>> { unsafe {
         if !self.configured {
             return Err(VideoError::BitstreamError(
                 "Encoder not configured".to_string(),
@@ -483,7 +483,7 @@ impl SimpleEncoder {
         );
 
         Ok(data)
-    }
+    }}
 
     /// Create codec-specific session parameters (SPS/PPS for H.264,
     /// VPS/SPS/PPS for H.265).
@@ -500,7 +500,7 @@ impl SimpleEncoder {
         aligned_w: u32,
         aligned_h: u32,
         quality_level: u32,
-    ) -> VideoResult<vk::VideoSessionParametersKHR> {
+    ) -> VideoResult<vk::VideoSessionParametersKHR> { unsafe {
         let device = self.ctx.device();
 
         let mut params_create = vk::VideoSessionParametersCreateInfoKHR::builder()
@@ -906,7 +906,7 @@ impl SimpleEncoder {
         let params = device.create_video_session_parameters_khr(&params_create, None)?;
 
         Ok(params)
-    }
+    }}
 
     /// Create DPB images for the video session.
     ///
@@ -922,7 +922,7 @@ impl SimpleEncoder {
         height: u32,
         profile_info: &vk::VideoProfileInfoKHR,
         use_separate_images: bool,
-    ) -> VideoResult<(vk::Image, vma::Allocation, Vec<vk::Image>, Vec<vma::Allocation>, Vec<DpbSlot>)> {
+    ) -> VideoResult<(vk::Image, vma::Allocation, Vec<vk::Image>, Vec<vma::Allocation>, Vec<DpbSlot>)> { unsafe {
         let device = self.ctx.device();
         let allocator = self.ctx.allocator();
         let mut slots = Vec::with_capacity(count as usize);
@@ -1000,7 +1000,7 @@ impl SimpleEncoder {
                 });
             }
 
-            Ok((vk::Image::null(), unsafe { std::mem::zeroed() }, images, allocations, slots))
+            Ok((vk::Image::null(), std::mem::zeroed(), images, allocations, slots))
         } else {
             // Create a SINGLE VkImage with `count` array layers.
             let mut image_create_info = vk::ImageCreateInfo::builder()
@@ -1062,7 +1062,7 @@ impl SimpleEncoder {
 
             Ok((image, allocation, Vec::new(), Vec::new(), slots))
         }
-    }
+    }}
 
     /// Create the host-visible bitstream output buffer.
     ///
@@ -1073,7 +1073,7 @@ impl SimpleEncoder {
         &self,
         size: usize,
         profile_info: &vk::VideoProfileInfoKHR,
-    ) -> VideoResult<(vk::Buffer, vma::Allocation, *mut u8)> {
+    ) -> VideoResult<(vk::Buffer, vma::Allocation, *mut u8)> { unsafe {
         let allocator = self.ctx.allocator();
 
         let profile_list =
@@ -1115,5 +1115,5 @@ impl SimpleEncoder {
         }
 
         Ok((buffer, allocation, mapped))
-    }
+    }}
 }

--- a/libs/vulkan-video/src/encode/staging.rs
+++ b/libs/vulkan-video/src/encode/staging.rs
@@ -18,7 +18,7 @@ use super::SimpleEncoder;
 
 impl SimpleEncoder {
     /// Create the encoder (all Vulkan setup, unsafe due to raw Vulkan calls).
-    pub(crate) unsafe fn create_internal(config: SimpleEncoderConfig) -> Result<SimpleEncoder, VideoError> {
+    pub(crate) unsafe fn create_internal(config: SimpleEncoderConfig) -> Result<SimpleEncoder, VideoError> { unsafe {
         // 1. Load Vulkan
         let entry = vulkanalia::Entry::new(
             vulkanalia::loader::LibloadingLoader::new(vulkanalia::loader::LIBRARY)
@@ -108,7 +108,7 @@ impl SimpleEncoder {
         };
 
         let video_maint1_name =
-            unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_maintenance1\0") };
+            CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_maintenance1\0");
 
         let required_extensions: Vec<&CStr> = vec![
             vk::KHR_VIDEO_QUEUE_EXTENSION.name.as_cstr(),
@@ -125,7 +125,7 @@ impl SimpleEncoder {
             .map_err(VideoError::from)?;
         for req in &required_extensions {
             let found = available.iter().any(|ext| {
-                let name = unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) };
+                let name = CStr::from_ptr(ext.extension_name.as_ptr());
                 name == *req
             });
             if !found {
@@ -201,12 +201,12 @@ impl SimpleEncoder {
             session_memory: Vec::new(),
             session_params: vk::VideoSessionParametersKHR::null(),
             dpb_image: vk::Image::null(),
-            dpb_allocation: unsafe { std::mem::zeroed() },
+            dpb_allocation: std::mem::zeroed(),
             dpb_separate_images: Vec::new(),
             dpb_separate_allocations: Vec::new(),
             dpb_slots: Vec::new(),
             bitstream_buffer: vk::Buffer::null(),
-            bitstream_allocation: unsafe { std::mem::zeroed() },
+            bitstream_allocation: std::mem::zeroed(),
             bitstream_buffer_size: 0,
             bitstream_mapped_ptr: ptr::null_mut(),
             command_pool: vk::CommandPool::null(),
@@ -228,9 +228,9 @@ impl SimpleEncoder {
             // SimpleEncoder's own fields
             source_image: vk::Image::null(),
             source_view: vk::ImageView::null(),
-            source_allocation: unsafe { std::mem::zeroed() },
+            source_allocation: std::mem::zeroed(),
             staging_buffer: vk::Buffer::null(),
-            staging_allocation: unsafe { std::mem::zeroed() },
+            staging_allocation: std::mem::zeroed(),
             staging_mapped_ptr: ptr::null_mut(),
             staging_size: 0,
             transfer_pool: vk::CommandPool::null(),
@@ -429,7 +429,7 @@ impl SimpleEncoder {
         this.transfer_fence = transfer_fence;
 
         Ok(this)
-    }
+    }}
 
     /// Create the encoder from an externally-owned Vulkan device (skips device creation).
     pub(crate) unsafe fn create_from_external(
@@ -445,7 +445,7 @@ impl SimpleEncoder {
         transfer_queue_family: u32,
         compute_queue: vk::Queue,
         compute_queue_family: u32,
-    ) -> Result<SimpleEncoder, VideoError> {
+    ) -> Result<SimpleEncoder, VideoError> { unsafe {
         let codec_flag = match config.codec {
             Codec::H264 => vk::VideoCodecOperationFlagsKHR::ENCODE_H264,
             Codec::H265 => vk::VideoCodecOperationFlagsKHR::ENCODE_H265,
@@ -481,12 +481,12 @@ impl SimpleEncoder {
             session_memory: Vec::new(),
             session_params: vk::VideoSessionParametersKHR::null(),
             dpb_image: vk::Image::null(),
-            dpb_allocation: unsafe { std::mem::zeroed() },
+            dpb_allocation: std::mem::zeroed(),
             dpb_separate_images: Vec::new(),
             dpb_separate_allocations: Vec::new(),
             dpb_slots: Vec::new(),
             bitstream_buffer: vk::Buffer::null(),
-            bitstream_allocation: unsafe { std::mem::zeroed() },
+            bitstream_allocation: std::mem::zeroed(),
             bitstream_buffer_size: 0,
             bitstream_mapped_ptr: ptr::null_mut(),
             command_pool: vk::CommandPool::null(),
@@ -507,9 +507,9 @@ impl SimpleEncoder {
             h264_config: None,
             source_image: vk::Image::null(),
             source_view: vk::ImageView::null(),
-            source_allocation: unsafe { std::mem::zeroed() },
+            source_allocation: std::mem::zeroed(),
             staging_buffer: vk::Buffer::null(),
-            staging_allocation: unsafe { std::mem::zeroed() },
+            staging_allocation: std::mem::zeroed(),
             staging_mapped_ptr: ptr::null_mut(),
             staging_size: 0,
             transfer_pool: vk::CommandPool::null(),
@@ -679,7 +679,7 @@ impl SimpleEncoder {
         this.transfer_fence = transfer_fence;
 
         Ok(this)
-    }
+    }}
 
     /// Upload NV12 data, encode one frame, return the packet.
     pub(crate) unsafe fn upload_and_encode(
@@ -688,7 +688,7 @@ impl SimpleEncoder {
         frame_type: FrameType,
         display_pts: u64,
         timestamp_ns: Option<i64>,
-    ) -> Result<EncodePacket, VideoError> {
+    ) -> Result<EncodePacket, VideoError> { unsafe {
         let width = self.config.width;
         let height = self.config.height;
         let enc_cfg = self.encode_config().unwrap();
@@ -846,14 +846,14 @@ impl SimpleEncoder {
             is_keyframe,
             timestamp_ns,
         })
-    }
+    }}
 
     /// Internal implementation of encode_image (GPU-resident RGBA path).
     pub(crate) unsafe fn encode_image_internal(
         &mut self,
         rgba_image_view: vk::ImageView,
         timestamp_ns: Option<i64>,
-    ) -> Result<Vec<EncodePacket>, VideoError> {
+    ) -> Result<Vec<EncodePacket>, VideoError> { unsafe {
         // Lazily create the RGB→NV12 converter on first call, unless the caller
         // pre-allocated it via `prepare_gpu_encode_resources()`.
         if self.rgb_to_nv12.is_none() {
@@ -893,5 +893,5 @@ impl SimpleEncoder {
             is_keyframe,
             timestamp_ns,
         }])
-    }
+    }}
 }

--- a/libs/vulkan-video/src/encode/submit.rs
+++ b/libs/vulkan-video/src/encode/submit.rs
@@ -38,7 +38,7 @@ impl SimpleEncoder {
         _source_image: vk::Image,
         source_view: vk::ImageView,
         frame_type: FrameType,
-    ) -> VideoResult<EncodedOutput> {
+    ) -> VideoResult<EncodedOutput> { unsafe {
         if !self.configured {
             return Err(VideoError::BitstreamError(
                 "Encoder not configured -- call configure() first".to_string(),
@@ -1255,5 +1255,5 @@ impl SimpleEncoder {
             bitstream_offset: feedback.bitstream_offset,
             bitstream_size: feedback.bitstream_bytes_written,
         })
-    }
+    }}
 }

--- a/libs/vulkan-video/src/nv12_to_rgb.rs
+++ b/libs/vulkan-video/src/nv12_to_rgb.rs
@@ -94,7 +94,7 @@ impl Nv12ToRgbConverter {
         compute_queue: vk::Queue,
         decode_queue_family: u32,
         submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
-    ) -> Result<Self, VideoError> {
+    ) -> Result<Self, VideoError> { unsafe {
         let device = ctx.device().clone();
         let allocator = ctx.allocator().clone();
 
@@ -293,7 +293,7 @@ impl Nv12ToRgbConverter {
             width,
             height,
         })
-    }
+    }}
 
     /// Convert an NV12 DPB image layer to RGBA.
     ///
@@ -311,7 +311,7 @@ impl Nv12ToRgbConverter {
         nv12_image: vk::Image,
         array_layer: u32,
         src_layout: vk::ImageLayout,
-    ) -> Result<(vk::Image, vk::ImageView), VideoError> {
+    ) -> Result<(vk::Image, vk::ImageView), VideoError> { unsafe {
         // Create a sampled view for this layer with YCbCr conversion info
         let mut ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
             .conversion(self.ycbcr_conversion);
@@ -487,7 +487,7 @@ impl Nv12ToRgbConverter {
             .destroy_image_view(nv12_sampled_view, None);
 
         Ok((self.rgba_image, self.rgba_view))
-    }
+    }}
 
     /// Returns the RGBA output image handle.
     pub fn rgba_image(&self) -> vk::Image {

--- a/libs/vulkan-video/src/rgb_to_nv12.rs
+++ b/libs/vulkan-video/src/rgb_to_nv12.rs
@@ -99,7 +99,7 @@ impl RgbToNv12Converter {
         encode_queue_family: u32,
         codec_flag: vk::VideoCodecOperationFlagsKHR,
         submitter: Arc<dyn crate::rhi::RhiQueueSubmitter>,
-    ) -> Result<Self, VideoError> {
+    ) -> Result<Self, VideoError> { unsafe {
         let device = ctx.device().clone();
         let allocator = ctx.allocator().clone();
         // --- 1. Create shader module ---
@@ -360,7 +360,7 @@ impl RgbToNv12Converter {
             width,
             height,
         })
-    }
+    }}
 
     /// Convert an RGBA VkImage to NV12.
     ///
@@ -373,7 +373,7 @@ impl RgbToNv12Converter {
     pub unsafe fn convert(
         &mut self,
         rgba_image_view: vk::ImageView,
-    ) -> Result<(vk::Image, vk::ImageView), VideoError> {
+    ) -> Result<(vk::Image, vk::ImageView), VideoError> { unsafe {
         let cb = self.command_buffer;
 
         self.device
@@ -603,7 +603,7 @@ impl RgbToNv12Converter {
             .wait_for_fences(&[self.fence], true, u64::MAX)?;
 
         Ok((self.encode_nv12_image, self.encode_nv12_color_view))
-    }
+    }}
 
     /// Returns the encode-src NV12 image handle (the one bound to the encoder).
     pub fn nv12_image(&self) -> vk::Image {

--- a/libs/vulkan-video/src/rhi.rs
+++ b/libs/vulkan-video/src/rhi.rs
@@ -58,9 +58,9 @@ impl RhiQueueSubmitter for RawQueueSubmitter {
         queue: vk::Queue,
         submits: &[vk::SubmitInfo2],
         fence: vk::Fence,
-    ) -> VkResult<()> {
+    ) -> VkResult<()> { unsafe {
         self.device.queue_submit2(queue, submits, fence).map(|_| ())
-    }
+    }}
 
     fn with_device_resource_lock(&self, f: &mut dyn FnMut()) {
         // Standalone mode owns the Vulkan device exclusively; no concurrent

--- a/libs/vulkan-video/src/vk_video_decoder/vk_parser_video_picture_parameters.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_parser_video_picture_parameters.rs
@@ -625,7 +625,7 @@ impl VkParserVideoPictureParameters {
         current: &mut Option<Arc<VkParserVideoPictureParameters>>,
     ) -> vk::Result {
         // Flush the current object's queue first.
-        if let Some(ref mut _cur) = current {
+        if let Some(_cur) = current {
             // NOTE: requires interior mutability in production code (Arc<Mutex<...>>).
             // Omitted here to keep the port faithful to C++ structure.
             let _ = video_session; // would call cur.flush_picture_parameters_queue(video_session)
@@ -872,7 +872,7 @@ mod tests {
         params.create_parameters_object(std::ptr::null(), vk::VideoSessionKHR::null(), &sps, None);
         params.session_parameters = {
             use vulkanalia::vk::Handle;
-            unsafe { vk::VideoSessionParametersKHR::from_raw(1) }
+            vk::VideoSessionParametersKHR::from_raw(1)
         };
 
         // Now update with PPS 10.

--- a/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
+++ b/libs/vulkan-video/src/vk_video_decoder/vk_video_decoder.rs
@@ -851,7 +851,7 @@ impl VkVideoDecoder {
     /// for actual decode operations.
     /// Wait for any in-flight decode to complete. Must be called before
     /// reading the staging buffer from the previous submission.
-    pub unsafe fn wait_for_decode(&mut self) -> VideoResult<()> {
+    pub unsafe fn wait_for_decode(&mut self) -> VideoResult<()> { unsafe {
         if self.decode_in_flight {
             let device = self.ctx.device();
             device.wait_for_fences(&[self.fence], true, LONG_TIMEOUT)
@@ -859,14 +859,14 @@ impl VkVideoDecoder {
             self.decode_in_flight = false;
         }
         Ok(())
-    }
+    }}
 
     #[allow(unused_assignments, unused_mut)]
     pub unsafe fn decode_frame(
         &mut self,
         submit: &DecodeSubmitInfo,
         output: &mut DecodedFrame,
-    ) -> VideoResult<()> {
+    ) -> VideoResult<()> { unsafe {
         // Wait for any previous in-flight decode before reusing the command buffer
         self.wait_for_decode()?;
 
@@ -900,9 +900,7 @@ impl VkVideoDecoder {
             let resize_result_ref = &mut resize_result;
             let resize_allocator = self.ctx.allocator();
             self.submitter.with_device_resource_lock(&mut || {
-                *resize_result_ref = unsafe {
-                    resize_allocator.create_buffer(bs_create, &bs_alloc)
-                };
+                *resize_result_ref = resize_allocator.create_buffer(bs_create, &bs_alloc);
             });
             let (buf, alloc) = resize_result.map_err(VideoError::from)?;
             let info = self.ctx.allocator().get_allocation_info(alloc);
@@ -1410,7 +1408,7 @@ impl VkVideoDecoder {
 
         self.decode_pic_count += 1;
         Ok(())
-    }
+    }}
 
     /// Get the session parameters handle.
     pub fn session_parameters(&self) -> vk::VideoSessionParametersKHR {

--- a/libs/vulkan-video/src/vk_video_encoder/vk_encoder_config_h264.rs
+++ b/libs/vulkan-video/src/vk_video_encoder/vk_encoder_config_h264.rs
@@ -575,7 +575,7 @@ mod tests {
 
     #[test]
     fn test_compute_aspect_ratio_square() {
-        let (idc, sw, sh) = EncoderConfigH264::compute_aspect_ratio(1920, 1080, 16, 9);
+        let (idc, _sw, _sh) = EncoderConfigH264::compute_aspect_ratio(1920, 1080, 16, 9);
         // 16:9 at 1920x1080 => SAR 1:1
         assert_eq!(idc, 1); // SQUARE
     }

--- a/libs/vulkan-video/tests/shared_device_test.rs
+++ b/libs/vulkan-video/tests/shared_device_test.rs
@@ -154,7 +154,7 @@ unsafe fn probe_encode_support(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     codec: vk::VideoCodecOperationFlagsKHR,
-) -> bool {
+) -> bool { unsafe {
     use vulkanalia::vk::KhrVideoQueueExtensionInstanceCommands;
 
     let mut h265_profile = vk::VideoEncodeH265ProfileInfoKHR::builder()
@@ -189,13 +189,13 @@ unsafe fn probe_encode_support(
     instance
         .get_physical_device_video_capabilities_khr(physical_device, &profile_info, &mut caps)
         .is_ok()
-}
+}}
 
 unsafe fn probe_decode_support(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     codec: vk::VideoCodecOperationFlagsKHR,
-) -> bool {
+) -> bool { unsafe {
     use vulkanalia::vk::KhrVideoQueueExtensionInstanceCommands;
 
     let mut h265_profile = vk::VideoDecodeH265ProfileInfoKHR::builder()
@@ -231,7 +231,7 @@ unsafe fn probe_decode_support(
     instance
         .get_physical_device_video_capabilities_khr(physical_device, &profile_info, &mut caps)
         .is_ok()
-}
+}}
 
 // ---------------------------------------------------------------------------
 // Check if a device extension is available
@@ -241,7 +241,7 @@ unsafe fn has_device_extension(
     instance: &vulkanalia::Instance,
     physical_device: vk::PhysicalDevice,
     name: &CStr,
-) -> bool {
+) -> bool { unsafe {
     let available = instance
         .enumerate_device_extension_properties(physical_device, None)
         .unwrap_or_default();
@@ -249,7 +249,7 @@ unsafe fn has_device_extension(
         let ext_name = CStr::from_ptr(ext.extension_name.as_ptr());
         ext_name == name
     })
-}
+}}
 
 // ===========================================================================
 // Test: H.265 encode -> ffprobe validate -> decode -> PSNR (shared device)


### PR DESCRIPTION
## Summary

Migrates `libs/vulkan-video` off its edition-2021 exception onto the workspace's edition 2024. **Closes #352.**

This is **PR-1 of a 4-PR sequence** executing #915 Option B (fold `vulkan-video` into `streamlib-engine`). PR-1 is the blocker — the fold itself requires both halves on the same edition.

## Work landed

Two classes of changes:

1. **`unsafe_op_in_unsafe_fn` body-wrap** (option 2 from the #352 issue body). Applied `cargo fix --lib --tests --bins` to insert `{ unsafe { ... } }` around each `unsafe fn` body. ~324 warnings resolved by one body-wrap per function (~83 functions across 20 files); subsequently-redundant inner `unsafe { ... }` blocks removed where they sat in scope of the wrap.
2. **Pattern-binding-mode fixes**: `ref mut x` → bare identifier in implicitly-borrowing patterns. Edition 2024's stricter pattern semantics. 6 hard errors fixed in `vk_video_core_profile.rs` and `vk_parser_video_picture_parameters.rs`. Semantics preserved — `p` still binds as `&mut T` inside the outer `match &mut self.codec_ext` borrow.

## Out of scope (per the #352 issue body)

Pre-existing `invalid_value` warnings in `vk_image_resource.rs:876` and `:1382` (`MaybeUninit::uninit().assume_init::<vulkanalia::Device>()`) — they would have warned under edition 2021 too. The issue body explicitly says "None of these are correctness issues — they're style / explicitness improvements"; auditing the unsafe ops for correctness is a separate effort.

## Test plan

- [x] `cargo check --workspace`: clean
- [x] `cargo test -p vulkan-video --lib`: 626 passed; 0 failed; 5 ignored
- [x] `cargo xtask check-boundaries`: no violations
- [x] `cargo xtask lint-logging`: no violations
- [x] `pr-review-gate`: PASS (two stylistic consistency items raised, both addressed in the same commit before push)

## Related

- Milestone: Vulkan Video RHI Coupling
- Closes: #352
- Unblocks: #915 (Option B fold — PR-2 mechanical file moves), #916 (encoder/decoder consumer migration onto the new constructor — PR-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)