### PR TITLE
feat(engine): HostVulkanQueryPool — generic VkQueryPool RHI primitive (#937)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1470,6 +1470,19 @@ impl GpuContext {
         crate::vulkan::rhi::HostVulkanBuffer::new_video_bitstream(vulkan_device, descriptor)
     }
 
+    /// Allocate a Vulkan query pool. Backs
+    /// [`GpuContextFullAccess::create_query_pool`]. Generic over
+    /// `VkQueryType` — services timestamp, occlusion, pipeline-statistics,
+    /// and video-encode-feedback queries through one primitive.
+    #[cfg(target_os = "linux")]
+    pub fn create_query_pool(
+        &self,
+        descriptor: &crate::vulkan::rhi::QueryPoolDescriptor<'_>,
+    ) -> Result<crate::vulkan::rhi::HostVulkanQueryPool> {
+        let vulkan_device = &self.device.inner;
+        crate::vulkan::rhi::HostVulkanQueryPool::new(vulkan_device, descriptor)
+    }
+
     /// Create a graphics kernel from a multi-stage SPIR-V set + binding
     /// declaration + pipeline state. Graphics counterpart to
     /// [`Self::create_compute_kernel`].
@@ -4420,6 +4433,28 @@ impl GpuContextFullAccess {
                  is host-only; subprocess customers consume codec output \
                  through the surface-share registry, not by constructing \
                  bitstream buffers"
+                    .into(),
+            )),
+        }
+    }
+
+    /// Allocate a Vulkan query pool — the generic engine-RHI primitive
+    /// servicing every query class (timestamp, occlusion,
+    /// pipeline-statistics, video-encode-feedback). FullAccess-only;
+    /// subprocess cdylibs do not construct query pools — they consume
+    /// codec results (when applicable) through the surface-share /
+    /// escalate IPC channels, not by reaching into pool primitives.
+    #[cfg(target_os = "linux")]
+    pub fn create_query_pool(
+        &self,
+        descriptor: &crate::vulkan::rhi::QueryPoolDescriptor<'_>,
+    ) -> Result<crate::vulkan::rhi::HostVulkanQueryPool> {
+        match self.handle_kind {
+            HandleKind::Boxed => self.host_inner().create_query_pool(descriptor),
+            HandleKind::ScopeToken => Err(Error::GpuError(
+                "create_query_pool: query pool creation is host-only; \
+                 subprocess customers don't reach the GPU query API \
+                 surface directly"
                     .into(),
             )),
         }

--- a/libs/streamlib-engine/src/vulkan/rhi/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/mod.rs
@@ -147,6 +147,13 @@ pub use vulkan_video_session::{
 };
 
 #[cfg(target_os = "linux")]
+mod vulkan_query_pool;
+#[cfg(target_os = "linux")]
+pub use vulkan_query_pool::{
+    HostVulkanQueryPool, QueryPoolDescriptor, VideoEncodeFeedbackResult,
+};
+
+#[cfg(target_os = "linux")]
 pub mod drm_modifier_probe;
 
 #[cfg(all(test, target_os = "linux"))]

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_query_pool.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_query_pool.rs
@@ -1,0 +1,589 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Generic Vulkan query-pool primitive.
+//!
+//! `HostVulkanQueryPool` wraps a single `VkQueryPool` parameterized by
+//! `VkQueryType` plus the per-type pNext chain (pipeline-statistics
+//! flags, video-encode-feedback flags + profile). One wrapper services
+//! every query class — timestamp, occlusion, pipeline-statistics,
+//! video-encode-feedback — per the engine-model rule "design for the
+//! class of use case, not the example."
+
+use std::sync::Arc;
+
+use vulkanalia::prelude::v1_4::*;
+use vulkanalia::vk;
+
+use crate::core::{Error, Result};
+
+use super::HostVulkanDevice;
+
+/// Inputs for [`HostVulkanQueryPool::new`].
+///
+/// `query_type` selects the underlying Vulkan query class. Three
+/// optional fields each apply to a single query type and are ignored
+/// for the others; checked at construction so a misconfigured
+/// descriptor fails fast rather than producing a query pool whose
+/// results don't decode correctly.
+pub struct QueryPoolDescriptor<'a> {
+    pub label: &'a str,
+    pub query_type: vk::QueryType,
+    pub query_count: u32,
+    /// Required when `query_type == PIPELINE_STATISTICS`; ignored
+    /// otherwise.
+    pub pipeline_statistics: vk::QueryPipelineStatisticFlags,
+    /// Required when `query_type == VIDEO_ENCODE_FEEDBACK_KHR` — the
+    /// feedback flags the codec wants to measure (offset / bytes
+    /// written / has overrides). Ignored otherwise.
+    pub video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR,
+    /// Required when `query_type == VIDEO_ENCODE_FEEDBACK_KHR` — the
+    /// codec profile the queries serve. Vulkan validation requires
+    /// both the encode-feedback create info AND the profile chained
+    /// on the pool's `pNext`. Ignored otherwise.
+    pub video_profile: Option<&'a vk::VideoProfileInfoKHR>,
+}
+
+/// Snapshot of the per-pool encode-feedback flags, kept on the
+/// wrapper so [`HostVulkanQueryPool::fetch_video_encode_feedback`]
+/// can decode the per-query result without the caller re-passing
+/// what was already declared at construction.
+#[derive(Clone, Copy, Debug, Default)]
+struct EncodeFeedbackLayout {
+    has_buffer_offset: bool,
+    has_bytes_written: bool,
+    has_overrides: bool,
+}
+
+impl EncodeFeedbackLayout {
+    fn from_flags(flags: vk::VideoEncodeFeedbackFlagsKHR) -> Self {
+        Self {
+            has_buffer_offset: flags
+                .contains(vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET),
+            has_bytes_written: flags
+                .contains(vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN),
+            has_overrides: flags
+                .contains(vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_HAS_OVERRIDES),
+        }
+    }
+
+    /// One u32 per requested bit, in declaration order per Vulkan
+    /// spec for `VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR`.
+    fn slot_count(&self) -> usize {
+        (self.has_buffer_offset as usize)
+            + (self.has_bytes_written as usize)
+            + (self.has_overrides as usize)
+    }
+}
+
+/// Typed result of a single video-encode-feedback query. Each field
+/// is `Some(value)` if the corresponding bit was declared in
+/// [`QueryPoolDescriptor::video_encode_feedback_flags`] at pool
+/// construction; `None` otherwise.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct VideoEncodeFeedbackResult {
+    /// Byte offset into the bitstream buffer where the encoded
+    /// frame begins. From `BITSTREAM_BUFFER_OFFSET_BIT_KHR`.
+    pub bitstream_buffer_offset: Option<u32>,
+    /// Number of encoded bytes written. From
+    /// `BITSTREAM_BYTES_WRITTEN_BIT_KHR`.
+    pub bitstream_bytes_written: Option<u32>,
+    /// Whether the encoder overrode any rate-control / quality
+    /// parameters for this frame. From `HAS_OVERRIDES_BIT_KHR`.
+    pub has_overrides: Option<bool>,
+}
+
+impl VideoEncodeFeedbackResult {
+    /// Decode the raw u32 slots returned by `vkGetQueryPoolResults`
+    /// into typed fields, using the layout the pool was constructed
+    /// with. Public for unit testing — production callers go through
+    /// [`HostVulkanQueryPool::fetch_video_encode_feedback`].
+    fn decode(slots: &[u32], layout: EncodeFeedbackLayout) -> Self {
+        let mut next = 0usize;
+        let take = |next: &mut usize| -> Option<u32> {
+            let v = slots.get(*next).copied();
+            *next += 1;
+            v
+        };
+        let bitstream_buffer_offset = if layout.has_buffer_offset {
+            take(&mut next)
+        } else {
+            None
+        };
+        let bitstream_bytes_written = if layout.has_bytes_written {
+            take(&mut next)
+        } else {
+            None
+        };
+        let has_overrides = if layout.has_overrides {
+            take(&mut next).map(|v| v != 0)
+        } else {
+            None
+        };
+        Self {
+            bitstream_buffer_offset,
+            bitstream_bytes_written,
+            has_overrides,
+        }
+    }
+}
+
+/// Privileged RHI handle for a `VkQueryPool`. Mirrors the shape of
+/// [`super::HostVulkanVideoSession`] and the new
+/// [`super::HostVulkanTexture::new_video_dpb`] /
+/// [`super::HostVulkanBuffer::new_video_bitstream`] constructors:
+/// an `Arc<HostVulkanDevice>` back-reference, the raw Vulkan
+/// handle, and a `Drop` impl that tears it down.
+pub struct HostVulkanQueryPool {
+    #[allow(dead_code)] // surfaced via tracing on construction
+    label: String,
+    vulkan_device: Arc<HostVulkanDevice>,
+    handle: vk::QueryPool,
+    query_type: vk::QueryType,
+    query_count: u32,
+    encode_feedback_layout: EncodeFeedbackLayout,
+}
+
+unsafe impl Send for HostVulkanQueryPool {}
+unsafe impl Sync for HostVulkanQueryPool {}
+
+impl HostVulkanQueryPool {
+    /// Build a new query pool. Runs `vkCreateQueryPool` under the
+    /// host's device-level resource lock so concurrent processor
+    /// submissions can't race the create on NVIDIA Linux — same
+    /// threading discipline the other privileged RHI primitives
+    /// inherit (`HostVulkanVideoSession`, `HostVulkanTexture::new_video_dpb`,
+    /// `HostVulkanBuffer::new_video_bitstream`).
+    ///
+    /// The descriptor's per-query-type optional fields are checked
+    /// for consistency: `PIPELINE_STATISTICS` requires non-empty
+    /// `pipeline_statistics`; `VIDEO_ENCODE_FEEDBACK_KHR` requires
+    /// non-empty `video_encode_feedback_flags` AND a non-`None`
+    /// `video_profile`. Mismatches surface as a clean
+    /// [`Error::Configuration`] before any Vulkan API call.
+    #[tracing::instrument(level = "trace", skip(vulkan_device, descriptor), fields(label = descriptor.label, query_type = ?descriptor.query_type, query_count = descriptor.query_count))]
+    pub fn new(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &QueryPoolDescriptor<'_>,
+    ) -> Result<Self> {
+        if descriptor.query_count == 0 {
+            return Err(Error::Configuration(format!(
+                "HostVulkanQueryPool::new ({}): query_count must be > 0",
+                descriptor.label,
+            )));
+        }
+
+        let mut layout = EncodeFeedbackLayout::default();
+        let mut create_info = vk::QueryPoolCreateInfo::builder()
+            .query_type(descriptor.query_type)
+            .query_count(descriptor.query_count);
+
+        match descriptor.query_type {
+            vk::QueryType::PIPELINE_STATISTICS => {
+                if descriptor.pipeline_statistics.is_empty() {
+                    return Err(Error::Configuration(format!(
+                        "HostVulkanQueryPool::new ({}): PIPELINE_STATISTICS requires \
+                         non-empty pipeline_statistics flags",
+                        descriptor.label,
+                    )));
+                }
+                create_info = create_info.pipeline_statistics(descriptor.pipeline_statistics);
+            }
+            vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR => {
+                if descriptor.video_encode_feedback_flags.is_empty() {
+                    return Err(Error::Configuration(format!(
+                        "HostVulkanQueryPool::new ({}): VIDEO_ENCODE_FEEDBACK_KHR \
+                         requires non-empty video_encode_feedback_flags",
+                        descriptor.label,
+                    )));
+                }
+                if descriptor.video_profile.is_none() {
+                    return Err(Error::Configuration(format!(
+                        "HostVulkanQueryPool::new ({}): VIDEO_ENCODE_FEEDBACK_KHR \
+                         requires a video_profile (chained as pNext)",
+                        descriptor.label,
+                    )));
+                }
+                layout = EncodeFeedbackLayout::from_flags(descriptor.video_encode_feedback_flags);
+            }
+            _ => {}
+        }
+
+        // The per-type pNext extensions live on this function's
+        // stack for the duration of the create call. Vulkan spec
+        // for `VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR` requires both
+        // `VkQueryPoolVideoEncodeFeedbackCreateInfoKHR` AND the
+        // `VkVideoProfileInfoKHR` itself chained onto the pool's
+        // `pNext` (the profile is chained directly, NOT through a
+        // `VkVideoProfileListInfoKHR` wrapper as for images / buffers).
+        let mut feedback_create_info = vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR::builder()
+            .encode_feedback_flags(descriptor.video_encode_feedback_flags)
+            .build();
+        // Copy the profile by value so `push_next` can take `&mut`.
+        // The copy preserves `p_next` (and any codec-specific
+        // extension structs the caller chained onto the profile),
+        // which remain valid via the descriptor's `'a` lifetime for
+        // the duration of this function call.
+        let mut profile_for_chain: Option<vk::VideoProfileInfoKHR> =
+            descriptor.video_profile.copied();
+        if descriptor.query_type == vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR {
+            create_info = create_info.push_next(&mut feedback_create_info);
+            if let Some(stored) = profile_for_chain.as_mut() {
+                create_info = create_info.push_next(stored);
+            }
+        }
+
+        let device = vulkan_device.device();
+
+        let _device_lock = vulkan_device.lock_device();
+        let handle = unsafe { device.create_query_pool(&create_info, None) }.map_err(|e| {
+            Error::GpuError(format!(
+                "HostVulkanQueryPool::new ({}): vkCreateQueryPool failed: {e}",
+                descriptor.label,
+            ))
+        })?;
+
+        Ok(Self {
+            label: descriptor.label.to_string(),
+            vulkan_device: Arc::clone(vulkan_device),
+            handle,
+            query_type: descriptor.query_type,
+            query_count: descriptor.query_count,
+            encode_feedback_layout: layout,
+        })
+    }
+
+    /// Raw `VkQueryPool` handle. Caller may pass it into
+    /// `vkCmdBeginQuery` / `vkCmdEndQuery` / `vkCmdResetQueryPool`
+    /// but must NOT destroy it — the `Drop` impl owns destruction.
+    #[inline]
+    pub fn handle(&self) -> vk::QueryPool {
+        self.handle
+    }
+
+    /// Number of query slots the pool was created with.
+    #[inline]
+    pub fn query_count(&self) -> u32 {
+        self.query_count
+    }
+
+    /// Underlying `VkQueryType`.
+    #[inline]
+    pub fn query_type(&self) -> vk::QueryType {
+        self.query_type
+    }
+
+    /// Fetch a single video-encode-feedback query's results into a
+    /// typed [`VideoEncodeFeedbackResult`]. Blocks until the GPU
+    /// signals the query (`vk::QueryResultFlags::WAIT`).
+    ///
+    /// Errors when `query_type != VIDEO_ENCODE_FEEDBACK_KHR` or
+    /// `query_index >= query_count`. The result's `Some(...)` fields
+    /// correspond to the flags requested at construction; un-requested
+    /// fields are `None`.
+    pub fn fetch_video_encode_feedback(
+        &self,
+        query_index: u32,
+    ) -> Result<VideoEncodeFeedbackResult> {
+        if self.query_type != vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR {
+            return Err(Error::Configuration(format!(
+                "HostVulkanQueryPool::fetch_video_encode_feedback ({}): \
+                 query_type is {:?}, expected VIDEO_ENCODE_FEEDBACK_KHR",
+                self.label, self.query_type,
+            )));
+        }
+        if query_index >= self.query_count {
+            return Err(Error::Configuration(format!(
+                "HostVulkanQueryPool::fetch_video_encode_feedback ({}): \
+                 query_index {query_index} >= query_count {}",
+                self.label, self.query_count,
+            )));
+        }
+
+        let slot_count = self.encode_feedback_layout.slot_count();
+        if slot_count == 0 {
+            return Ok(VideoEncodeFeedbackResult::default());
+        }
+
+        let mut slots = vec![0u32; slot_count];
+        let bytes = unsafe {
+            std::slice::from_raw_parts_mut(
+                slots.as_mut_ptr() as *mut u8,
+                slot_count * std::mem::size_of::<u32>(),
+            )
+        };
+
+        let device = self.vulkan_device.device();
+        unsafe {
+            device.get_query_pool_results(
+                self.handle,
+                query_index,
+                1,
+                bytes,
+                (slot_count * std::mem::size_of::<u32>()) as u64,
+                vk::QueryResultFlags::WAIT,
+            )
+        }
+        .map_err(|e| {
+            Error::GpuError(format!(
+                "HostVulkanQueryPool::fetch_video_encode_feedback ({}): \
+                 vkGetQueryPoolResults failed: {e}",
+                self.label,
+            ))
+        })?;
+
+        Ok(VideoEncodeFeedbackResult::decode(
+            &slots,
+            self.encode_feedback_layout,
+        ))
+    }
+}
+
+impl Drop for HostVulkanQueryPool {
+    fn drop(&mut self) {
+        if self.handle != vk::QueryPool::null() {
+            let device = self.vulkan_device.device();
+            let _device_lock = self.vulkan_device.lock_device();
+            unsafe { device.destroy_query_pool(self.handle, None) };
+            self.handle = vk::QueryPool::null();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pure-logic decode test. Each layout permutation maps the input
+    /// u32 array to the correct typed fields. Mentally reverting the
+    /// `if layout.has_*` checks in [`VideoEncodeFeedbackResult::decode`]
+    /// would shift slot indices and break these assertions.
+    #[test]
+    fn decode_buffer_offset_and_bytes_written() {
+        let layout = EncodeFeedbackLayout {
+            has_buffer_offset: true,
+            has_bytes_written: true,
+            has_overrides: false,
+        };
+        let result = VideoEncodeFeedbackResult::decode(&[123, 456], layout);
+        assert_eq!(result.bitstream_buffer_offset, Some(123));
+        assert_eq!(result.bitstream_bytes_written, Some(456));
+        assert_eq!(result.has_overrides, None);
+    }
+
+    #[test]
+    fn decode_only_bytes_written() {
+        let layout = EncodeFeedbackLayout {
+            has_buffer_offset: false,
+            has_bytes_written: true,
+            has_overrides: false,
+        };
+        let result = VideoEncodeFeedbackResult::decode(&[789], layout);
+        assert_eq!(result.bitstream_buffer_offset, None);
+        assert_eq!(result.bitstream_bytes_written, Some(789));
+        assert_eq!(result.has_overrides, None);
+    }
+
+    #[test]
+    fn decode_all_three_bits() {
+        let layout = EncodeFeedbackLayout {
+            has_buffer_offset: true,
+            has_bytes_written: true,
+            has_overrides: true,
+        };
+        let result = VideoEncodeFeedbackResult::decode(&[100, 200, 1], layout);
+        assert_eq!(result.bitstream_buffer_offset, Some(100));
+        assert_eq!(result.bitstream_bytes_written, Some(200));
+        assert_eq!(result.has_overrides, Some(true));
+    }
+
+    #[test]
+    fn decode_has_overrides_false() {
+        let layout = EncodeFeedbackLayout {
+            has_buffer_offset: false,
+            has_bytes_written: false,
+            has_overrides: true,
+        };
+        let result = VideoEncodeFeedbackResult::decode(&[0], layout);
+        assert_eq!(result.has_overrides, Some(false));
+    }
+
+    #[test]
+    fn slot_count_matches_bits_set() {
+        assert_eq!(EncodeFeedbackLayout::default().slot_count(), 0);
+        assert_eq!(
+            EncodeFeedbackLayout {
+                has_buffer_offset: true,
+                has_bytes_written: false,
+                has_overrides: false,
+            }
+            .slot_count(),
+            1
+        );
+        assert_eq!(
+            EncodeFeedbackLayout {
+                has_buffer_offset: true,
+                has_bytes_written: true,
+                has_overrides: true,
+            }
+            .slot_count(),
+            3
+        );
+    }
+
+    /// `EncodeFeedbackLayout::from_flags` round-trips the
+    /// `VkVideoEncodeFeedbackFlagsKHR` bits into the typed snapshot.
+    /// Catches future spec drift if the vulkanalia bitflag values change.
+    #[test]
+    fn from_flags_round_trip() {
+        let layout = EncodeFeedbackLayout::from_flags(
+            vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
+                | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
+        );
+        assert!(layout.has_buffer_offset);
+        assert!(layout.has_bytes_written);
+        assert!(!layout.has_overrides);
+    }
+
+    /// `new_query_pool` rejects `query_count = 0` with a Configuration
+    /// error before reaching `vkCreateQueryPool`. Hardware-gated because
+    /// constructing the descriptor requires a `HostVulkanDevice`.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn new_rejects_zero_query_count() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        let descriptor = QueryPoolDescriptor {
+            label: "test/zero-count",
+            query_type: vk::QueryType::TIMESTAMP,
+            query_count: 0,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR::empty(),
+            video_profile: None,
+        };
+        match HostVulkanQueryPool::new(&device, &descriptor) {
+            Err(Error::Configuration(msg)) => {
+                assert!(msg.contains("query_count must be > 0"));
+                assert!(msg.contains("test/zero-count"));
+            }
+            Err(e) => panic!("expected Configuration error, got {e}"),
+            Ok(_) => panic!("query_count=0 must be rejected, got Ok"),
+        }
+    }
+
+    /// `PIPELINE_STATISTICS` rejects an empty `pipeline_statistics`
+    /// bitmask — the Vulkan spec requires at least one stat bit,
+    /// and an empty mask produces a pool whose results are
+    /// silently empty.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn new_rejects_pipeline_stats_empty_flags() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        let descriptor = QueryPoolDescriptor {
+            label: "test/empty-stats",
+            query_type: vk::QueryType::PIPELINE_STATISTICS,
+            query_count: 4,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR::empty(),
+            video_profile: None,
+        };
+        match HostVulkanQueryPool::new(&device, &descriptor) {
+            Err(Error::Configuration(msg)) => {
+                assert!(msg.contains("PIPELINE_STATISTICS"));
+                assert!(msg.contains("test/empty-stats"));
+            }
+            Err(e) => panic!("expected Configuration error, got {e}"),
+            Ok(_) => panic!("empty pipeline_statistics must be rejected, got Ok"),
+        }
+    }
+
+    /// `VIDEO_ENCODE_FEEDBACK_KHR` rejects an empty feedback-flag
+    /// mask AND missing video profile.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn new_rejects_encode_feedback_missing_fields() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        let profile = vk::VideoProfileInfoKHR::default();
+
+        let no_flags = QueryPoolDescriptor {
+            label: "test/no-feedback-flags",
+            query_type: vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR,
+            query_count: 1,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR::empty(),
+            video_profile: Some(&profile),
+        };
+        match HostVulkanQueryPool::new(&device, &no_flags) {
+            Err(Error::Configuration(msg)) => {
+                assert!(msg.contains("video_encode_feedback_flags"));
+            }
+            Err(e) => panic!("expected Configuration error, got {e}"),
+            Ok(_) => panic!("empty feedback flags must be rejected, got Ok"),
+        }
+
+        let no_profile = QueryPoolDescriptor {
+            label: "test/no-profile",
+            query_type: vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR,
+            query_count: 1,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET,
+            video_profile: None,
+        };
+        match HostVulkanQueryPool::new(&device, &no_profile) {
+            Err(Error::Configuration(msg)) => {
+                assert!(msg.contains("video_profile"));
+            }
+            Err(e) => panic!("expected Configuration error, got {e}"),
+            Ok(_) => panic!("missing video_profile must be rejected, got Ok"),
+        }
+    }
+
+    /// Positive: `TIMESTAMP` query pool with a small count constructs
+    /// cleanly against a real device. Locks the "non-video query types
+    /// don't need the video-specific pNext" path.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn new_timestamp_query_pool_succeeds() {
+        let device = match HostVulkanDevice::new() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Skipping - no Vulkan device available");
+                return;
+            }
+        };
+        let descriptor = QueryPoolDescriptor {
+            label: "test/timestamp",
+            query_type: vk::QueryType::TIMESTAMP,
+            query_count: 8,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR::empty(),
+            video_profile: None,
+        };
+        let pool = HostVulkanQueryPool::new(&device, &descriptor)
+            .expect("timestamp query pool construction must succeed");
+        assert_ne!(pool.handle(), vk::QueryPool::null());
+        assert_eq!(pool.query_count(), 8);
+        assert_eq!(pool.query_type(), vk::QueryType::TIMESTAMP);
+    }
+}

--- a/libs/streamlib-engine/src/vulkan/video/codec_utils/vulkan_command_buffer_pool.rs
+++ b/libs/streamlib-engine/src/vulkan/video/codec_utils/vulkan_command_buffer_pool.rs
@@ -491,75 +491,72 @@ impl VulkanSemaphoreSet {
 // VulkanQueryPoolSet (inline helper)
 // ---------------------------------------------------------------------------
 
-/// Manages a single `VkQueryPool`.
-/// Mirrors C++ `VulkanQueryPoolSet`.
+/// Manages a single `VkQueryPool`. Thin adapter around the engine RHI
+/// primitive [`crate::vulkan::rhi::HostVulkanQueryPool`] — preserves
+/// the codec_utils wrapping pattern while routing creation +
+/// destruction through the RHI's `lock_device`-protected paths.
 struct VulkanQueryPoolSet {
-    device: Option<vulkanalia::Device>,
-    query_pool: vk::QueryPool,
+    query_pool: Option<crate::vulkan::rhi::HostVulkanQueryPool>,
     query_count: u32,
 }
 
 impl VulkanQueryPoolSet {
     fn new() -> Self {
         Self {
-            device: None,
-            query_pool: vk::QueryPool::null(),
+            query_pool: None,
             query_count: 0,
         }
     }
 
-    /// # Safety
-    /// `device` must be valid and not destroyed for the lifetime of this set.
-    unsafe fn create_set(
+    /// Construct the underlying query pool through the engine RHI
+    /// primitive. The previous `flags: vk::QueryPoolCreateFlags`
+    /// parameter is dropped — Vulkan reserves the field as 0 (unused)
+    /// and the RHI descriptor doesn't carry it.
+    ///
+    /// `video_profile` is required when `query_type ==
+    /// VIDEO_ENCODE_FEEDBACK_KHR` and ignored otherwise; the RHI
+    /// constructor checks the combination.
+    fn create_set(
         &mut self,
-        device: &vulkanalia::Device,
+        vulkan_device: &std::sync::Arc<crate::vulkan::rhi::HostVulkanDevice>,
         count: u32,
         query_type: vk::QueryType,
-        flags: vk::QueryPoolCreateFlags,
-        next: *const std::ffi::c_void,
-    ) -> vk::Result { unsafe {
+        video_encode_feedback_flags: vk::VideoEncodeFeedbackFlagsKHR,
+        video_profile: Option<&vk::VideoProfileInfoKHR>,
+    ) -> crate::core::Result<()> {
         self.destroy();
 
-        let _ = flags; // C++ passes flags as VkQueryPoolCreateFlags (reserved, must be 0).
-        let mut create_info = vk::QueryPoolCreateInfo::builder()
-            .query_type(query_type)
-            .query_count(count);
-
-        if !next.is_null() {
-            create_info.next = next;
-        }
-
-        match device.create_query_pool(&create_info, None) {
-            Ok(pool) => {
-                self.query_pool = pool;
-                self.query_count = count;
-                self.device = Some(device.clone());
-                vk::Result::SUCCESS
-            }
-            Err(e) => e.into(),
-        }
-    }}
+        let descriptor = crate::vulkan::rhi::QueryPoolDescriptor {
+            label: "codec_utils/query_pool_set",
+            query_type,
+            query_count: count,
+            pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+            video_encode_feedback_flags,
+            video_profile,
+        };
+        let pool = crate::vulkan::rhi::HostVulkanQueryPool::new(vulkan_device, &descriptor)?;
+        self.query_pool = Some(pool);
+        self.query_count = count;
+        Ok(())
+    }
 
     fn get_query_pool(&self, query_idx: u32) -> vk::QueryPool {
         if query_idx < self.query_count {
             self.query_pool
+                .as_ref()
+                .map(|p| p.handle())
+                .unwrap_or(vk::QueryPool::null())
         } else {
             vk::QueryPool::null()
         }
     }
 
-    /// # Safety
-    /// The query pool must not be in use on the GPU.
-    unsafe fn destroy(&mut self) { unsafe {
-        if let Some(ref device) = self.device {
-            if self.query_pool != vk::QueryPool::null() {
-                device.destroy_query_pool(self.query_pool, None);
-                self.query_pool = vk::QueryPool::null();
-                self.query_count = 0;
-            }
-        }
-        self.device = None;
-    }}
+    /// Drop the underlying RHI primitive — `HostVulkanQueryPool::Drop`
+    /// runs `vkDestroyQueryPool` under the device resource lock.
+    fn destroy(&mut self) {
+        self.query_pool = None;
+        self.query_count = 0;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -702,15 +699,18 @@ impl VulkanCommandBufferPool {
     /// Mirrors C++ `VulkanCommandBufferPool::Configure`.
     ///
     /// # Safety
-    /// The `device` must be valid. If `create_query_pool` is true, `p_next`
-    /// must point to a valid Vulkan structure chain (e.g., video profile).
+    /// The `device` must be valid. If `create_query_pool` is true,
+    /// `video_profile` must be `Some(...)` carrying the codec profile the
+    /// query pool will serve (Vulkan spec requires the profile chained on
+    /// the pool's `pNext` for `VIDEO_ENCODE_FEEDBACK_KHR`).
     pub unsafe fn configure(
         self: &mut Arc<Self>,
+        vulkan_device: &Arc<crate::vulkan::rhi::HostVulkanDevice>,
         device: &vulkanalia::Device,
         num_pool_nodes: u32,
         queue_family_index: u32,
         create_query_pool: bool,
-        next: *const std::ffi::c_void,
+        video_profile: Option<&vk::VideoProfileInfoKHR>,
         create_semaphores: bool,
         create_fences: bool,
     ) -> vk::Result { unsafe {
@@ -748,13 +748,20 @@ impl VulkanCommandBufferPool {
         }
 
         if create_query_pool {
-            let _result = pool.query_pool_set.create_set(
-                device,
-                num_pool_nodes,
-                vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR,
-                vk::QueryPoolCreateFlags::empty(),
-                next,
-            );
+            if pool
+                .query_pool_set
+                .create_set(
+                    vulkan_device,
+                    num_pool_nodes,
+                    vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR,
+                    vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
+                        | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
+                    video_profile,
+                )
+                .is_err()
+            {
+                return vk::Result::ERROR_INITIALIZATION_FAILED;
+            }
         }
 
         for i in 0..num_pool_nodes {

--- a/libs/streamlib-engine/src/vulkan/video/encode/config.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/config.rs
@@ -281,22 +281,6 @@ impl Default for DpbSlot {
 }
 
 // ---------------------------------------------------------------------------
-// Encode feedback query result layout
-// ---------------------------------------------------------------------------
-
-/// Layout of the query pool result for `VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR`.
-///
-/// When `VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR` and
-/// `VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR` are both
-/// requested, the result contains these two u32 fields in order.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct EncodeFeedback {
-    pub(crate) bitstream_offset: u32,
-    pub(crate) bitstream_bytes_written: u32,
-}
-
-// ---------------------------------------------------------------------------
 // Codec / Preset / EncodePacket
 // ---------------------------------------------------------------------------
 

--- a/libs/streamlib-engine/src/vulkan/video/encode/mod.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/mod.rs
@@ -127,8 +127,11 @@ pub struct SimpleEncoder {
     pub(crate) command_pool: vk::CommandPool,
     pub(crate) command_buffer: vk::CommandBuffer,
 
-    // Query pool for encode feedback (offset + size)
-    pub(crate) query_pool: vk::QueryPool,
+    // Query pool for encode feedback (offset + size). Owned via the
+    // engine RHI primitive — `HostVulkanQueryPool::Drop` runs
+    // `vkDestroyQueryPool` so the encoder's teardown path doesn't
+    // touch it directly. `None` before `configure()` populates it.
+    pub(crate) query_pool: Option<crate::vulkan::rhi::HostVulkanQueryPool>,
 
     // Synchronization
     pub(crate) fence: vk::Fence,
@@ -464,10 +467,9 @@ impl Drop for SimpleEncoder {
                     self.device.destroy_fence(self.fence, None);
                 }
 
-                // Destroy query pool
-                if self.query_pool != vk::QueryPool::null() {
-                    self.device.destroy_query_pool(self.query_pool, None);
-                }
+                // Query pool teardown is owned by HostVulkanQueryPool::Drop
+                // (runs vkDestroyQueryPool under the device resource lock).
+                self.query_pool = None;
 
                 // Destroy command pool (frees command buffers)
                 if self.command_pool != vk::CommandPool::null() {

--- a/libs/streamlib-engine/src/vulkan/video/encode/session.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/session.rs
@@ -297,20 +297,24 @@ impl SimpleEncoder {
         let command_buffers = device.allocate_command_buffers(&alloc_info)?;
 
         // --- Query pool for encode feedback ---
-        // Build the create info with the video encode feedback flags and profile.
-        let mut query_pool_video = vk::QueryPoolVideoEncodeFeedbackCreateInfoKHR::builder()
-            .encode_feedback_flags(
-                vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
-                    | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
-            );
-
-        let query_pool_info = vk::QueryPoolCreateInfo::builder()
-            .query_type(vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR)
-            .query_count(1)
-            .push_next(&mut query_pool_video)
-            .push_next(&mut profile_info);
-
-        let query_pool = device.create_query_pool(&query_pool_info, None)?;
+        // Through the engine RHI primitive: it chains
+        // `VkQueryPoolVideoEncodeFeedbackCreateInfoKHR` + the profile
+        // onto `pNext` and runs `vkCreateQueryPool` under the device
+        // resource lock.
+        let query_pool = crate::vulkan::rhi::HostVulkanQueryPool::new(
+            self.ctx.host_device(),
+            &crate::vulkan::rhi::QueryPoolDescriptor {
+                label: "simple_encoder/feedback",
+                query_type: vk::QueryType::VIDEO_ENCODE_FEEDBACK_KHR,
+                query_count: 1,
+                pipeline_statistics: vk::QueryPipelineStatisticFlags::empty(),
+                video_encode_feedback_flags:
+                    vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BUFFER_OFFSET
+                        | vk::VideoEncodeFeedbackFlagsKHR::BITSTREAM_BYTES_WRITTEN,
+                video_profile: Some(&profile_info),
+            },
+        )
+        .map_err(|e| VideoError::BitstreamError(format!("encoder query pool: {e}")))?;
 
         // --- Fence ---
         let fence_info = vk::FenceCreateInfo::default();
@@ -330,7 +334,7 @@ impl SimpleEncoder {
         self.bitstream_buffer_size = bs_size;
         self.command_pool = command_pool;
         self.command_buffer = command_buffers[0];
-        self.query_pool = query_pool;
+        self.query_pool = Some(query_pool);
         self.fence = fence;
         self.encode_config = Some(config.clone());
         self.configured = true;

--- a/libs/streamlib-engine/src/vulkan/video/encode/staging.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/staging.rs
@@ -75,7 +75,7 @@ impl SimpleEncoder {
             bitstream_buffer_size: 0,
             command_pool: vk::CommandPool::null(),
             command_buffer: vk::CommandBuffer::null(),
-            query_pool: vk::QueryPool::null(),
+            query_pool: None,
             fence: vk::Fence::null(),
             frame_count: 0,
             encode_order_count: 0,

--- a/libs/streamlib-engine/src/vulkan/video/encode/submit.rs
+++ b/libs/streamlib-engine/src/vulkan/video/encode/submit.rs
@@ -17,7 +17,7 @@ use crate::vulkan::video::vk_video_encoder::vk_encoder_dpb_h265::{
     NO_REFERENCE_PICTURE_H265, MAX_NUM_LIST_REF_H265,
 };
 
-use super::config::{EncodedOutput, EncodeFeedback, FrameType, RateControlMode};
+use super::config::{EncodedOutput, FrameType, RateControlMode};
 use super::SimpleEncoder;
 
 impl SimpleEncoder {
@@ -378,7 +378,12 @@ impl SimpleEncoder {
         device.begin_command_buffer(self.command_buffer, &begin_info)?;
 
         // --- Reset query ---
-        device.cmd_reset_query_pool(self.command_buffer, self.query_pool, 0, 1);
+        let query_pool_handle = self
+            .query_pool
+            .as_ref()
+            .expect("query_pool must be configured")
+            .handle();
+        device.cmd_reset_query_pool(self.command_buffer, query_pool_handle, 0, 1);
 
         // --- Build reference slot info structures ---
         let mut dpb_resource_infos: Vec<vk::VideoPictureResourceInfoKHR> = Vec::new();
@@ -1133,7 +1138,7 @@ impl SimpleEncoder {
         // --- Begin query ---
         device.cmd_begin_query(
             self.command_buffer,
-            self.query_pool,
+            query_pool_handle,
             0,
             vk::QueryControlFlags::empty(),
         );
@@ -1142,7 +1147,7 @@ impl SimpleEncoder {
         device.cmd_encode_video_khr(self.command_buffer, &encode_info);
 
         // --- End query ---
-        device.cmd_end_query(self.command_buffer, self.query_pool, 0);
+        device.cmd_end_query(self.command_buffer, query_pool_handle, 0);
 
         // --- vkCmdEndVideoCodingKHR ---
         let end_coding_info = vk::VideoEndCodingInfoKHR::default();
@@ -1166,23 +1171,21 @@ impl SimpleEncoder {
         device.wait_for_fences(&[self.fence], true, u64::MAX)?;
 
         // --- Query encode feedback ---
-        let mut feedback = EncodeFeedback::default();
-        let feedback_bytes = std::slice::from_raw_parts_mut(
-            &mut feedback as *mut EncodeFeedback as *mut u8,
-            std::mem::size_of::<EncodeFeedback>(),
-        );
+        let feedback = self
+            .query_pool
+            .as_ref()
+            .expect("query_pool must be configured")
+            .fetch_video_encode_feedback(0)
+            .map_err(|e| VideoError::BitstreamError(format!("encoder feedback: {e}")))?;
 
-        device.get_query_pool_results(
-            self.query_pool,
-            0,
-            1,
-            feedback_bytes,
-            std::mem::size_of::<EncodeFeedback>() as u64,
-            vk::QueryResultFlags::WAIT,
-        )?;
-
-        let offset = feedback.bitstream_offset as usize;
-        let size = feedback.bitstream_bytes_written as usize;
+        let offset = feedback
+            .bitstream_buffer_offset
+            .expect("BITSTREAM_BUFFER_OFFSET flag was requested at construction")
+            as usize;
+        let size = feedback
+            .bitstream_bytes_written
+            .expect("BITSTREAM_BYTES_WRITTEN flag was requested at construction")
+            as usize;
 
         tracing::debug!(offset = offset, size = size, "Encode feedback");
         if is_h265 {
@@ -1262,8 +1265,8 @@ impl SimpleEncoder {
             frame_type,
             pts,
             encode_order,
-            bitstream_offset: feedback.bitstream_offset,
-            bitstream_size: feedback.bitstream_bytes_written,
+            bitstream_offset: offset as u32,
+            bitstream_size: size as u32,
         })
     }}
 }


### PR DESCRIPTION
## Summary

- Lift `VkQueryPool` creation + result-fetch out of the codec interior into a new generic engine RHI primitive — `HostVulkanQueryPool` — parameterized by `VkQueryType` plus the per-query-type pNext chain. One wrapper services every query class: timestamp, occlusion, pipeline-statistics, video-encode-feedback. Per CLAUDE.md "design for the class of use case, not the example."
- Codec sweep in the same PR per "no bad patterns left behind": both raw `device.create_query_pool` call sites (encoder + codec_utils helper) migrate; the encoder's `EncodeFeedback` `repr(C)` byte-blit struct retires in favor of a typed `VideoEncodeFeedbackResult` whose fields are `Option<…>` keyed by which feedback flags the pool was constructed with.
- After this lands, the codec layer carries **zero** remaining raw `device.create_query_pool` calls.

Closes #937. Part of the **Vulkan Video RHI Coupling** milestone (#270 umbrella).

## Engine RHI surface

`libs/streamlib-engine/src/vulkan/rhi/vulkan_query_pool.rs` (new):

- `pub struct QueryPoolDescriptor<'a> { label, query_type, query_count, pipeline_statistics, video_encode_feedback_flags, video_profile: Option<&'a vk::VideoProfileInfoKHR> }` — generic; per-query-type optional fields validated at construction. `PIPELINE_STATISTICS` requires non-empty stats; `VIDEO_ENCODE_FEEDBACK_KHR` requires non-empty feedback flags AND a profile. Mismatches surface as a clean `Error::Configuration` before any Vulkan API call.
- `pub struct HostVulkanQueryPool { vulkan_device, handle, query_type, query_count, encode_feedback_layout }` — owns the `VkQueryPool` lifecycle via Drop.
- `HostVulkanQueryPool::new(device, descriptor)` chains pNext correctly:
  - `PIPELINE_STATISTICS` → `pipeline_statistics(flags)`
  - `VIDEO_ENCODE_FEEDBACK_KHR` → `push_next(VkQueryPoolVideoEncodeFeedbackCreateInfoKHR)` + `push_next(VkVideoProfileInfoKHR)` (chained directly, NOT through a `VkVideoProfileListInfoKHR` wrapper as for images / buffers — per Vulkan spec for query-pool encode feedback)
  - Other query types → no extra pNext
- Runs `vkCreateQueryPool` under `HostVulkanDevice::lock_device` — same threading discipline the codec previously got via `RhiQueueSubmitter::with_device_resource_lock`.
- `fetch_video_encode_feedback(query_index) -> Result<VideoEncodeFeedbackResult>` — blocks (`WAIT`), decodes the per-query u32 array into typed fields based on the layout the pool was constructed with.
- `pub struct VideoEncodeFeedbackResult { bitstream_buffer_offset: Option<u32>, bitstream_bytes_written: Option<u32>, has_overrides: Option<bool> }`.

`GpuContextFullAccess::create_query_pool(descriptor)` wrapper. ScopeToken mode (cdylib customers) returns an explicit error — query pools are codec-host-only.

## Codec migration

- `encode/mod.rs`: `query_pool` field `vk::QueryPool` → `Option<HostVulkanQueryPool>`. Manual `destroy_query_pool` in Drop becomes `self.query_pool = None;` (RHI Drop owns teardown).
- `encode/session.rs`: raw `vk::QueryPoolCreateInfo::builder() + push_next + device.create_query_pool` replaced with a single `HostVulkanQueryPool::new(...)` call against a typed descriptor.
- `encode/submit.rs`: cached raw handle once at the top of `encode_frame` for the `cmd_reset_query_pool` / `cmd_begin_query` / `cmd_end_query` use sites; result retrieval routes through `fetch_video_encode_feedback(0)?` rather than the byte-blit decode.
- `encode/config.rs`: `EncodeFeedback` struct **deleted** (sole consumer was `submit.rs`; grep confirmed no other callers).
- `codec_utils/vulkan_command_buffer_pool.rs`: kept the `VulkanQueryPoolSet` codec-side helper as a thin adapter over `Option<HostVulkanQueryPool>` — mirrors the pattern with `vk_image_resource.rs` / `vk_buffer_resource.rs` staying as codec_utils wrappers around the new RHI primitives. `configure()` signature gained `&Arc<HostVulkanDevice>` and replaced the `*const c_void` `next` parameter with `Option<&vk::VideoProfileInfoKHR>` for type safety.

## Test plan

- [x] **10 unit tests** in `vulkan_query_pool.rs::tests`:
  - 6 pure-logic tests covering `EncodeFeedbackLayout::from_flags` + `VideoEncodeFeedbackResult::decode` permutations. Each mentally-reverts cleanly — slot-index shifts or bit-mapping bugs would fail the relevant permutation.
  - 4 hardware-gated tests: `new_rejects_zero_query_count`, `new_rejects_pipeline_stats_empty_flags`, `new_rejects_encode_feedback_missing_fields`, `new_timestamp_query_pool_succeeds`.
- [x] `cargo test -p streamlib-engine --lib -- --test-threads=1`: **1145 passed, 0 failed, 123 ignored** (= 1139 main baseline + 6 new pure-logic + 4 newly-ignored hardware-gated).
- [x] `cargo test -p streamlib-engine --lib --features streamlib-engine/hardware-tests vulkan_query_pool -- --test-threads=1`: **10 passed, 0 failed**.
- [x] `cargo xtask check-boundaries`: **3981 files scanned, no violations**.
- [x] `cargo xtask lint-logging`: **442 files scanned, no violations**.
- [x] `grep -rn '\.create_query_pool(' libs/streamlib-engine/src/vulkan/video/`: **zero hits**.

## E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip` + `e2e_fixture_psnr.sh` + `e2e_fixture_psnr_vivid.sh`
- **Codec**: h264 + h265
- **Camera device**: `/dev/video0` (vivid, `n_devs=1 node_types=0x1`)
- **Resolution**: 1920x1080
- **Duration / frame limit**: `STREAMLIB_DISPLAY_FRAME_LIMIT=300`, 15s
- **Build profile**: release
- **Driver**: NVIDIA 595.71.05 (kernel/DKMS/userspace aligned)

### Log signals (vulkan-video-roundtrip)

- `OUT_OF_DEVICE_MEMORY`: 0 (both codecs)
- `DEVICE_LOST`: 0
- `process() failed`: 0
- `llvmpipe`: 0
- `No video encode queue`: 0
- `First frame encoded` / `First frame decoded`: present for both codecs.

### PNG samples

- Read frame 60 with Read tool. Shows vivid SMPTE colorbar pattern (white/gray, mustard-yellow, cyan, green, magenta, red, blue, black) with vivid status overlay in the top-left: timecode `00:00:12:003 60`, `1920x1080, input 0`, brightness/contrast/saturation diagnostics. Colors crisp, no banding, no tearing.
- Anomalies: none.

### PSNR (h264 fixture rig)

All 9 references PASS. Exit 0.

### PSNR (h265 fixture rig)

All 9 references PASS. Exit 0.

### Vivid color regression gate

R drift 0.0001, G drift 0.0000, B drift 0.0000 — orders of magnitude under the ±0.05 tolerance that would flag bt.601↔bt.709 matrix mis-interpretation. Exit 0.

### Cam Link 4K

Not plugged in on the dev host at run time (no USB device, no `/dev/video*` nodes when vivid unloaded). Vivid + PSNR fixture rigs are the achievable scope for this branch; physical-camera coverage will land with the milestone capstone (#938) E2E.

### Outcome

**Pass.** Query-pool migration preserves encoder/decoder mathematical correctness (PSNR rigs at 35+ dB Y across every fixture), color-management path didn't drift (vivid color regression gate clean), no validation errors, no llvmpipe fallback, no OOM/DEVICE_LOST.

## Follow-ups (pr-review-gate DISCUSS items, neither blocking)

- `frame_buffer/vulkan_video_frame_buffer.rs` still carries a stub `create_video_queries` / `destroy_video_queries` pair on the decoder side that never calls `vkCreateQueryPool` today (the decoder doesn't enable `GetVideoDecodeQueryResultStatusSupport`). Exit criterion 3 of #937 ("`decode/session.rs` uses the new primitive") is vacuously satisfied. A future migration to route the stub through `HostVulkanQueryPool` when query-result-status is enabled.
- `VulkanCommandBufferPool` in `codec_utils/vulkan_command_buffer_pool.rs` has no callers anywhere in the workspace — it's C++-mirror dead code. Separate cleanup concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
