### PR TITLE
feat(engine): codec converters onto VulkanComputeKernel + kernel API growth (#935, #821)

### DIFF
--- a/libs/streamlib-engine/build.rs
+++ b/libs/streamlib-engine/build.rs
@@ -106,6 +106,26 @@ fn compile_shaders() {
         assert!(status.success(), "glslc failed to compile {}", src);
     }
 
+    // Standalone test shader for the SampledImage binding kind.
+    {
+        let test_sampled_image_src = "src/vulkan/rhi/shaders/test_sampled_image.comp";
+        println!("cargo:rerun-if-changed={}", test_sampled_image_src);
+        let dst_path: PathBuf =
+            Path::new(&out_dir).join("test_sampled_image.spv");
+        let status = Command::new("glslc")
+            .arg("-fshader-stage=compute")
+            .arg("-O")
+            .arg(Path::new(test_sampled_image_src))
+            .arg("-o")
+            .arg(&dst_path)
+            .status()
+            .expect("Failed to run glslc for test_sampled_image.comp");
+        assert!(
+            status.success(),
+            "glslc failed to compile test_sampled_image.comp"
+        );
+    }
+
     // Parameterized test shaders: one .comp source compiled multiple times with
     // different `-DINPUT_COUNT=N` defines, producing one SPIR-V variant per
     // value. Used by parameterized descriptor-management tests.

--- a/libs/streamlib-engine/src/core/rhi/compute_kernel.rs
+++ b/libs/streamlib-engine/src/core/rhi/compute_kernel.rs
@@ -20,8 +20,14 @@ pub enum ComputeBindingKind {
     StorageBuffer,
     /// Uniform buffer (UBO) — read-only, fixed-size, fast-path.
     UniformBuffer,
-    /// Sampled image — read-only with a sampler (filtering, addressing).
+    /// Sampled image with a combined sampler — read-only with filtering /
+    /// addressing baked into the descriptor. GLSL `sampler2D` /
+    /// `samplerExternalOES` style.
     SampledTexture,
+    /// Sampled image without a combined sampler — read-only, addressed by
+    /// integer coordinates via GLSL `texture2D` + `texelFetch` (no
+    /// filtering). Backs Vulkan `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`.
+    SampledImage,
     /// Storage image — read/write, no filtering, exact pixel access.
     StorageImage,
 }
@@ -54,6 +60,13 @@ impl ComputeBindingSpec {
         Self {
             binding,
             kind: ComputeBindingKind::SampledTexture,
+        }
+    }
+
+    pub const fn sampled_image(binding: u32) -> Self {
+        Self {
+            binding,
+            kind: ComputeBindingKind::SampledImage,
         }
     }
 
@@ -150,6 +163,7 @@ fn spirv_type_to_kind(ty: RDescriptorType) -> Option<ComputeBindingKind> {
         RDescriptorType::COMBINED_IMAGE_SAMPLER => {
             Some(ComputeBindingKind::SampledTexture)
         }
+        RDescriptorType::SAMPLED_IMAGE => Some(ComputeBindingKind::SampledImage),
         RDescriptorType::STORAGE_IMAGE => Some(ComputeBindingKind::StorageImage),
         _ => None,
     }
@@ -186,6 +200,24 @@ mod tests {
             assert!(bindings.iter().any(|s| s.binding == 8));
             assert_eq!(push_size, 4);
         }
+    }
+
+    #[test]
+    fn sampled_image_spec_round_trips_kind() {
+        let spec = ComputeBindingSpec::sampled_image(7);
+        assert_eq!(spec.binding, 7);
+        assert_eq!(spec.kind, ComputeBindingKind::SampledImage);
+        // Lock the kind→SPIR-V descriptor type mapping: SAMPLED_IMAGE
+        // must reflect back to `ComputeBindingKind::SampledImage` and
+        // must NOT be conflated with COMBINED_IMAGE_SAMPLER / SampledTexture.
+        assert_eq!(
+            spirv_type_to_kind(RDescriptorType::SAMPLED_IMAGE),
+            Some(ComputeBindingKind::SampledImage)
+        );
+        assert_ne!(
+            spirv_type_to_kind(RDescriptorType::COMBINED_IMAGE_SAMPLER),
+            Some(ComputeBindingKind::SampledImage),
+        );
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
+++ b/libs/streamlib-engine/src/core/rhi/plugin_abi_bridge.rs
@@ -61,6 +61,7 @@ impl From<ComputeBindingKind> for ComputeBindingKindRepr {
             ComputeBindingKind::UniformBuffer => Self::UniformBuffer,
             ComputeBindingKind::SampledTexture => Self::SampledTexture,
             ComputeBindingKind::StorageImage => Self::StorageImage,
+            ComputeBindingKind::SampledImage => Self::SampledImage,
         }
     }
 }
@@ -71,6 +72,7 @@ fn compute_binding_kind_from_repr(raw: u32) -> Result<ComputeBindingKind> {
         1 => Ok(ComputeBindingKind::UniformBuffer),
         2 => Ok(ComputeBindingKind::SampledTexture),
         3 => Ok(ComputeBindingKind::StorageImage),
+        4 => Ok(ComputeBindingKind::SampledImage),
         other => Err(Error::GpuError(format!(
             "ComputeBindingKind: invalid discriminant {other}"
         ))),

--- a/libs/streamlib-engine/src/vulkan/rhi/shaders/test_sampled_image.comp
+++ b/libs/streamlib-engine/src/vulkan/rhi/shaders/test_sampled_image.comp
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+// Test shader for the SampledImage binding kind (Vulkan
+// `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE` — GLSL `texture2D`, no combined
+// sampler). Exercises `VulkanComputeKernel::set_sampled_image_view` end-
+// to-end via descriptor-layout creation, descriptor write, bind, and
+// dispatch. The shader body is a no-op `texelFetch`; we only need the
+// declared binding to exist so the kernel sees a real SAMPLED_IMAGE
+// slot through SPIR-V reflection.
+
+#version 450
+#extension GL_EXT_samplerless_texture_functions : require
+
+layout(local_size_x = 1, local_size_y = 1) in;
+
+layout(set = 0, binding = 0) uniform texture2D uImage;
+layout(set = 0, binding = 1, rgba8) writeonly uniform image2D uOut;
+
+void main() {
+    // texelFetch with explicit LOD — no sampler required. Result is
+    // immediately discarded; the dispatch is single-thread.
+    vec4 texel = texelFetch(uImage, ivec2(0, 0), 0);
+    imageStore(uOut, ivec2(0, 0), texel);
+}

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -396,9 +396,24 @@ impl VulkanComputeKernelInner {
     }
 
     /// Bind a sampled texture at `binding`, using the kernel's default
-    /// linear-clamp sampler.
+    /// linear-clamp sampler. Errors if the binding was declared with
+    /// an immutable sampler at construction time (in that case use
+    /// [`Self::set_combined_image_sampler_view`] — Vulkan would
+    /// silently ignore the default sampler in favor of the
+    /// layout-baked one, and a caller passing a non-default sampler
+    /// in `texture` would not get it applied).
     pub fn set_sampled_texture(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::SampledTexture)?;
+        if self.immutable_sampler_bindings.contains(&binding) {
+            return Err(Error::GpuError(format!(
+                "Compute kernel '{}': binding {} has an immutable sampler from \
+                 the descriptor-set layout (`new_with_immutable_samplers`); \
+                 use set_combined_image_sampler_view instead — the default \
+                 sampler set_sampled_texture would supply is silently ignored \
+                 by Vulkan when an immutable sampler is present",
+                self.label, binding,
+            )));
+        }
         let view = vk_image_view_for(texture)?;
         let sampler = self.default_sampler()?;
         self.pending.lock().bindings.insert(

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -68,6 +68,13 @@ pub struct VulkanComputeKernelInner {
     /// Default sampler used for [`ComputeBindingKind::SampledTexture`] bindings.
     /// Created on-demand when the first sampled-texture binding is set.
     default_sampler: Mutex<Option<vk::Sampler>>,
+    /// Binding indices that were declared with `pImmutableSamplers` at
+    /// descriptor-set-layout creation time. Callers binding such a slot
+    /// must use [`Self::set_combined_image_sampler_view`] (view-only) —
+    /// the immutable sampler is baked into the layout and any sampler in
+    /// the descriptor write is ignored. Empty when the kernel was built
+    /// via [`Self::new`].
+    immutable_sampler_bindings: Vec<u32>,
     pending: Mutex<PendingState>,
 }
 
@@ -82,9 +89,18 @@ enum BindingResource {
         buffer: vk::Buffer,
         size: vk::DeviceSize,
     },
+    /// `COMBINED_IMAGE_SAMPLER` write — `sampler` may be `VK_NULL_HANDLE`
+    /// when the descriptor-set layout slot uses an immutable sampler
+    /// (per `pImmutableSamplers` at layout-creation time; the sampler
+    /// field in the write is then ignored by the implementation).
     SampledImage {
         view: vk::ImageView,
         sampler: vk::Sampler,
+    },
+    /// `SAMPLED_IMAGE` write — image view only, no sampler. GLSL
+    /// `texture2D` / `texelFetch` style.
+    SampledImageOnly {
+        view: vk::ImageView,
     },
     StorageImage {
         view: vk::ImageView,
@@ -100,6 +116,63 @@ impl VulkanComputeKernelInner {
     pub fn new(
         vulkan_device: &Arc<HostVulkanDevice>,
         descriptor: &ComputeKernelDescriptor<'_>,
+    ) -> Result<Self> {
+        Self::new_inner(vulkan_device, descriptor, &[])
+    }
+
+    /// Variant of [`Self::new`] that bakes one or more immutable
+    /// samplers into the descriptor-set layout, via `pImmutableSamplers`.
+    ///
+    /// Each `(binding, sampler)` pair attaches `sampler` to the matching
+    /// declared binding at layout-creation time; the binding must be
+    /// declared as [`ComputeBindingKind::SampledTexture`] (combined
+    /// image-sampler, the only shape Vulkan permits an immutable sampler
+    /// to bake into for compute today).
+    ///
+    /// **Lifetime contract.** The caller owns each `vk::Sampler` and is
+    /// responsible for keeping it alive for the kernel's lifetime —
+    /// the kernel records the handle in the layout but does not
+    /// duplicate or refcount it. Dropping a sampler before the kernel
+    /// is undefined behavior.
+    ///
+    /// Callers binding an immutable-sampler slot per-frame use
+    /// [`Self::set_combined_image_sampler_view`], which writes the
+    /// image view only — Vulkan ignores the sampler field in the write
+    /// whenever the layout slot has an immutable sampler.
+    pub fn new_with_immutable_samplers(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &ComputeKernelDescriptor<'_>,
+        immutable_samplers: &[(u32, vk::Sampler)],
+    ) -> Result<Self> {
+        // Pre-validate: every (binding, sampler) pair must refer to a
+        // declared SampledTexture binding. We catch this before going to
+        // Vulkan so the error names the offending binding directly.
+        for (binding, _) in immutable_samplers {
+            let spec = descriptor
+                .bindings
+                .iter()
+                .find(|b| b.binding == *binding)
+                .ok_or_else(|| {
+                    Error::GpuError(format!(
+                        "Compute kernel '{}': immutable sampler refers to undeclared binding {}",
+                        descriptor.label, binding
+                    ))
+                })?;
+            if spec.kind != ComputeBindingKind::SampledTexture {
+                return Err(Error::GpuError(format!(
+                    "Compute kernel '{}': immutable sampler attached to binding {} \
+                     declared as {:?}; only `SampledTexture` is supported",
+                    descriptor.label, binding, spec.kind
+                )));
+            }
+        }
+        Self::new_inner(vulkan_device, descriptor, immutable_samplers)
+    }
+
+    fn new_inner(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &ComputeKernelDescriptor<'_>,
+        immutable_samplers: &[(u32, vk::Sampler)],
     ) -> Result<Self> {
         let queue = vulkan_device.queue();
         let queue_family_index = vulkan_device.queue_family_index();
@@ -119,7 +192,11 @@ impl VulkanComputeKernelInner {
 
         let shader_module = create_shader_module(device, &spirv, descriptor.label)?;
 
-        let descriptor_set_layout = match create_descriptor_set_layout(device, descriptor.bindings)
+        let descriptor_set_layout = match create_descriptor_set_layout(
+            device,
+            descriptor.bindings,
+            immutable_samplers,
+        )
         {
             Ok(layout) => layout,
             Err(e) => {
@@ -259,6 +336,10 @@ impl VulkanComputeKernelInner {
             command_buffer,
             fence,
             default_sampler: Mutex::new(None),
+            immutable_sampler_bindings: immutable_samplers
+                .iter()
+                .map(|(b, _)| *b)
+                .collect(),
             pending: Mutex::new(PendingState {
                 bindings: HashMap::new(),
                 push_constants: Vec::new(),
@@ -332,6 +413,81 @@ impl VulkanComputeKernelInner {
     pub fn set_storage_image(&self, binding: u32, texture: &Texture) -> Result<()> {
         self.expect_kind(binding, ComputeBindingKind::StorageImage)?;
         let view = vk_image_view_for(texture)?;
+        self.pending
+            .lock()
+            .bindings
+            .insert(binding, BindingResource::StorageImage { view });
+        Ok(())
+    }
+
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::SampledImage`]
+    /// slot (Vulkan `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE` — GLSL `texture2D`).
+    ///
+    /// Escape hatch for callers (codec converters, video sessions) that
+    /// build per-plane reinterpreted-format views by hand against a
+    /// multi-planar image — those views can't be expressed through the
+    /// higher-level [`Self::set_sampled_texture`] / [`Self::set_storage_image`]
+    /// setters that take engine `Texture` handles. The view must be in
+    /// `SHADER_READ_ONLY_OPTIMAL` at dispatch time; caller is responsible
+    /// for the layout transition.
+    pub fn set_sampled_image_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.expect_kind(binding, ComputeBindingKind::SampledImage)?;
+        self.pending
+            .lock()
+            .bindings
+            .insert(binding, BindingResource::SampledImageOnly { view });
+        Ok(())
+    }
+
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::SampledTexture`]
+    /// slot (`VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`) whose sampler
+    /// is baked into the descriptor-set layout via `pImmutableSamplers`
+    /// (see [`Self::new_with_immutable_samplers`]).
+    ///
+    /// The descriptor write supplies the view; the sampler field in the
+    /// write is `VK_NULL_HANDLE` because Vulkan ignores it whenever the
+    /// layout slot has an immutable sampler. The view must be in
+    /// `SHADER_READ_ONLY_OPTIMAL` at dispatch time.
+    ///
+    /// Errors if the binding wasn't declared with an immutable sampler.
+    pub fn set_combined_image_sampler_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.expect_kind(binding, ComputeBindingKind::SampledTexture)?;
+        if !self.immutable_sampler_bindings.contains(&binding) {
+            return Err(Error::GpuError(format!(
+                "Compute kernel '{}': binding {} is SampledTexture but has no \
+                 immutable sampler; use set_sampled_texture (engine Texture) \
+                 or rebuild via new_with_immutable_samplers",
+                self.label, binding
+            )));
+        }
+        self.pending.lock().bindings.insert(
+            binding,
+            BindingResource::SampledImage {
+                view,
+                sampler: vk::Sampler::null(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::StorageImage`]
+    /// slot. Escape hatch for callers that build per-plane reinterpreted-
+    /// format storage views by hand against a multi-planar image. The
+    /// view must be in `GENERAL` layout at dispatch time.
+    pub fn set_storage_image_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.expect_kind(binding, ComputeBindingKind::StorageImage)?;
         self.pending
             .lock()
             .bindings
@@ -664,6 +820,24 @@ impl VulkanComputeKernelInner {
                         image_idx: Some(idx),
                     });
                 }
+                (
+                    ComputeBindingKind::SampledImage,
+                    BindingResource::SampledImageOnly { view },
+                ) => {
+                    let idx = image_infos.len();
+                    image_infos.push(
+                        vk::DescriptorImageInfo::builder()
+                            .image_view(*view)
+                            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+                            .build(),
+                    );
+                    slots.push(Slot {
+                        binding: spec.binding,
+                        ty: vk::DescriptorType::SAMPLED_IMAGE,
+                        buffer_idx: None,
+                        image_idx: Some(idx),
+                    });
+                }
                 (ComputeBindingKind::StorageImage, BindingResource::StorageImage { view }) => {
                     let idx = image_infos.len();
                     image_infos.push(
@@ -776,6 +950,22 @@ impl VulkanComputeKernel {
         Ok(Self::from_arc_into_raw(Arc::new(inner)))
     }
 
+    /// Create from a SPIR-V descriptor and a list of immutable samplers
+    /// to bake into the descriptor-set layout. Mirrors
+    /// [`VulkanComputeKernelInner::new_with_immutable_samplers`].
+    pub fn new_with_immutable_samplers(
+        vulkan_device: &Arc<HostVulkanDevice>,
+        descriptor: &ComputeKernelDescriptor<'_>,
+        immutable_samplers: &[(u32, vk::Sampler)],
+    ) -> Result<Self> {
+        let inner = VulkanComputeKernelInner::new_with_immutable_samplers(
+            vulkan_device,
+            descriptor,
+            immutable_samplers,
+        )?;
+        Ok(Self::from_arc_into_raw(Arc::new(inner)))
+    }
+
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanComputeKernelInner>) -> Self {
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
@@ -815,6 +1005,38 @@ impl VulkanComputeKernel {
         self.host_inner().set_storage_image(binding, texture)
     }
 
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::SampledImage`]
+    /// slot. See [`VulkanComputeKernelInner::set_sampled_image_view`].
+    pub fn set_sampled_image_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.host_inner().set_sampled_image_view(binding, view)
+    }
+
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::SampledTexture`]
+    /// slot that was created with an immutable sampler. See
+    /// [`VulkanComputeKernelInner::set_combined_image_sampler_view`].
+    pub fn set_combined_image_sampler_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.host_inner()
+            .set_combined_image_sampler_view(binding, view)
+    }
+
+    /// Bind a raw `vk::ImageView` to a [`ComputeBindingKind::StorageImage`]
+    /// slot. See [`VulkanComputeKernelInner::set_storage_image_view`].
+    pub fn set_storage_image_view(
+        &self,
+        binding: u32,
+        view: vk::ImageView,
+    ) -> Result<()> {
+        self.host_inner().set_storage_image_view(binding, view)
+    }
+
     pub fn set_push_constants(&self, bytes: &[u8]) -> Result<()> {
         self.host_inner().set_push_constants(bytes)
     }
@@ -833,7 +1055,7 @@ impl VulkanComputeKernel {
             .dispatch(group_count_x, group_count_y, group_count_z)
     }
 
-    pub(crate) fn record(
+    pub fn record(
         &self,
         command_buffer: vk::CommandBuffer,
         group_x: u32,
@@ -993,6 +1215,7 @@ fn expected_spirv_type(kind: ComputeBindingKind) -> RDescriptorType {
         ComputeBindingKind::StorageBuffer => RDescriptorType::STORAGE_BUFFER,
         ComputeBindingKind::UniformBuffer => RDescriptorType::UNIFORM_BUFFER,
         ComputeBindingKind::SampledTexture => RDescriptorType::COMBINED_IMAGE_SAMPLER,
+        ComputeBindingKind::SampledImage => RDescriptorType::SAMPLED_IMAGE,
         ComputeBindingKind::StorageImage => RDescriptorType::STORAGE_IMAGE,
     }
 }
@@ -1002,6 +1225,7 @@ fn descriptor_kind_to_vk(kind: ComputeBindingKind) -> vk::DescriptorType {
         ComputeBindingKind::StorageBuffer => vk::DescriptorType::STORAGE_BUFFER,
         ComputeBindingKind::UniformBuffer => vk::DescriptorType::UNIFORM_BUFFER,
         ComputeBindingKind::SampledTexture => vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+        ComputeBindingKind::SampledImage => vk::DescriptorType::SAMPLED_IMAGE,
         ComputeBindingKind::StorageImage => vk::DescriptorType::STORAGE_IMAGE,
     }
 }
@@ -1022,24 +1246,45 @@ fn create_shader_module(
 fn create_descriptor_set_layout(
     device: &vulkanalia::Device,
     bindings: &[ComputeBindingSpec],
+    immutable_samplers: &[(u32, vk::Sampler)],
 ) -> Result<vk::DescriptorSetLayout> {
+    // Builder borrows `pImmutableSamplers` from the slice provided to
+    // `.immutable_samplers(...)`. Hold each [vk::Sampler; 1] in a stable
+    // slot for the duration of the `info.build()` call so the pointers
+    // baked into `layout_bindings` are valid through layout creation.
+    let immutable_slots: Vec<[vk::Sampler; 1]> = immutable_samplers
+        .iter()
+        .map(|(_, sampler)| [*sampler])
+        .collect();
+
     let layout_bindings: Vec<vk::DescriptorSetLayoutBinding> = bindings
         .iter()
         .map(|spec| {
-            vk::DescriptorSetLayoutBinding::builder()
+            let mut b = vk::DescriptorSetLayoutBinding::builder()
                 .binding(spec.binding)
                 .descriptor_type(descriptor_kind_to_vk(spec.kind))
                 .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .build()
+                .stage_flags(vk::ShaderStageFlags::COMPUTE);
+            if let Some(idx) = immutable_samplers
+                .iter()
+                .position(|(b, _)| *b == spec.binding)
+            {
+                b = b.immutable_samplers(&immutable_slots[idx]);
+            }
+            b.build()
         })
         .collect();
 
     let info = vk::DescriptorSetLayoutCreateInfo::builder()
         .bindings(&layout_bindings)
         .build();
-    unsafe { device.create_descriptor_set_layout(&info, None) }
-        .map_err(|e| Error::GpuError(format!("Failed to create descriptor set layout: {e}")))
+    let layout = unsafe { device.create_descriptor_set_layout(&info, None) }
+        .map_err(|e| Error::GpuError(format!("Failed to create descriptor set layout: {e}")))?;
+    // Keep `immutable_slots` alive until `create_descriptor_set_layout`
+    // has consumed the pointers. (The driver copies the samplers into
+    // its internal layout state; the slice can be freed afterward.)
+    drop(immutable_slots);
+    Ok(layout)
 }
 
 fn create_pipeline_layout(
@@ -1941,5 +2186,206 @@ mod tests {
             );
         });
     }
+
+    // ---- Sampled-image binding kind tests ------------------------------------
+
+    const SAMPLED_IMAGE_SPV: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/test_sampled_image.spv"));
+
+    #[cfg_attr(not(feature = "hardware-tests"), ignore = "hardware integration — set --features streamlib/hardware-tests + run with --test-threads=1. See docs/testing-hardware.md")]
+    #[test]
+    fn sampled_image_binding_dispatches_with_raw_view() {
+        let device = match try_vulkan_device() { Some(d) => d, None => return };
+
+        let bindings = [
+            ComputeBindingSpec::sampled_image(0),
+            ComputeBindingSpec::storage_image(1),
+        ];
+        let kernel = VulkanComputeKernel::new(
+            &device,
+            &ComputeKernelDescriptor {
+                label: "test-sampled-image",
+                spv: SAMPLED_IMAGE_SPV,
+                bindings: &bindings,
+                push_constant_size: 0,
+            },
+        )
+        .expect("kernel construction with SampledImage binding");
+
+        // Lock the reflected kind so the SPIR-V → ComputeBindingKind path
+        // continues to produce SampledImage. Reverts to SampledTexture
+        // would be silently wrong before this test ran.
+        assert!(
+            kernel
+                .bindings()
+                .iter()
+                .any(|s| s.binding == 0 && s.kind == ComputeBindingKind::SampledImage),
+            "expected binding 0 reflected as SampledImage, got {:?}",
+            kernel.bindings()
+        );
+
+        // Build a tiny 1x1 RGBA8 SAMPLED image (the input) and a 1x1
+        // RGBA8 STORAGE image (the output). Each gets its own VkImageView.
+        let device_handle = device.device().clone();
+        let allocator = device.allocator().clone();
+        let make_image = |usage: vk::ImageUsageFlags|
+            -> (vk::Image, vulkanalia_vma::Allocation, vk::ImageView) {
+                let info = vk::ImageCreateInfo::builder()
+                    .image_type(vk::ImageType::_2D)
+                    .format(vk::Format::R8G8B8A8_UNORM)
+                    .extent(vk::Extent3D { width: 1, height: 1, depth: 1 })
+                    .mip_levels(1)
+                    .array_layers(1)
+                    .samples(vk::SampleCountFlags::_1)
+                    .tiling(vk::ImageTiling::OPTIMAL)
+                    .usage(usage)
+                    .sharing_mode(vk::SharingMode::EXCLUSIVE)
+                    .initial_layout(vk::ImageLayout::UNDEFINED)
+                    .build();
+                let alloc_opts = vulkanalia_vma::AllocationOptions {
+                    required_flags: vk::MemoryPropertyFlags::DEVICE_LOCAL,
+                    ..Default::default()
+                };
+                use vulkanalia_vma::Alloc;
+                let (image, alloc) = unsafe {
+                    allocator.create_image(info, &alloc_opts)
+                }
+                .expect("create_image");
+                let view_info = vk::ImageViewCreateInfo::builder()
+                    .image(image)
+                    .view_type(vk::ImageViewType::_2D)
+                    .format(vk::Format::R8G8B8A8_UNORM)
+                    .subresource_range(vk::ImageSubresourceRange {
+                        aspect_mask: vk::ImageAspectFlags::COLOR,
+                        base_mip_level: 0,
+                        level_count: 1,
+                        base_array_layer: 0,
+                        layer_count: 1,
+                    })
+                    .build();
+                let view = unsafe {
+                    device_handle.create_image_view(&view_info, None)
+                }
+                .expect("create_image_view");
+                (image, alloc, view)
+            };
+
+        let (in_image, in_alloc, in_view) =
+            make_image(vk::ImageUsageFlags::SAMPLED | vk::ImageUsageFlags::TRANSFER_DST);
+        let (out_image, out_alloc, out_view) =
+            make_image(vk::ImageUsageFlags::STORAGE);
+
+        // Transition both images out of UNDEFINED so the shader can sample
+        // / write without producing undefined contents on debug drivers.
+        // One-shot command buffer.
+        use vulkanalia::vk::HasBuilder;
+        let queue_family_index = device.queue_family_index();
+        let pool_info = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(queue_family_index)
+            .flags(vk::CommandPoolCreateFlags::TRANSIENT)
+            .build();
+        let pool = unsafe { device_handle.create_command_pool(&pool_info, None) }
+            .expect("create_command_pool");
+        let alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1)
+            .build();
+        let cb = unsafe { device_handle.allocate_command_buffers(&alloc_info) }
+            .expect("allocate_command_buffers")[0];
+        let begin = vk::CommandBufferBeginInfo::builder()
+            .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+            .build();
+        unsafe { device_handle.begin_command_buffer(cb, &begin) }
+            .expect("begin_command_buffer");
+
+        let barriers = [
+            vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::NONE)
+                .src_access_mask(vk::AccessFlags2::empty())
+                .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+                .dst_access_mask(vk::AccessFlags2::SHADER_SAMPLED_READ)
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(in_image)
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                })
+                .build(),
+            vk::ImageMemoryBarrier2::builder()
+                .src_stage_mask(vk::PipelineStageFlags2::NONE)
+                .src_access_mask(vk::AccessFlags2::empty())
+                .dst_stage_mask(vk::PipelineStageFlags2::COMPUTE_SHADER)
+                .dst_access_mask(vk::AccessFlags2::SHADER_STORAGE_WRITE)
+                .old_layout(vk::ImageLayout::UNDEFINED)
+                .new_layout(vk::ImageLayout::GENERAL)
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(out_image)
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                })
+                .build(),
+        ];
+        let dep = vk::DependencyInfo::builder().image_memory_barriers(&barriers).build();
+        unsafe { device_handle.cmd_pipeline_barrier2(cb, &dep) };
+        unsafe { device_handle.end_command_buffer(cb) }
+            .expect("end_command_buffer");
+
+        let fence_info = vk::FenceCreateInfo::builder().build();
+        let fence = unsafe { device_handle.create_fence(&fence_info, None) }
+            .expect("create_fence");
+        let cb_submit = vk::CommandBufferSubmitInfo::builder()
+            .command_buffer(cb)
+            .build();
+        let cb_submits = [cb_submit];
+        let submit = vk::SubmitInfo2::builder()
+            .command_buffer_infos(&cb_submits)
+            .build();
+        unsafe {
+            device
+                .submit_to_queue(device.queue(), &[submit], fence)
+                .expect("submit_to_queue");
+        }
+        unsafe {
+            device_handle
+                .wait_for_fences(&[fence], true, u64::MAX)
+                .expect("wait_for_fences");
+            device_handle.destroy_fence(fence, None);
+            device_handle.destroy_command_pool(pool, None);
+        }
+
+        // Bind via the raw-view setters and dispatch. The shader is a
+        // single-thread no-op-ish texelFetch — what we lock is that
+        // descriptor-layout + descriptor write + bind + dispatch run
+        // end-to-end without validation errors.
+        kernel
+            .set_sampled_image_view(0, in_view)
+            .expect("set_sampled_image_view");
+        kernel
+            .set_storage_image_view(1, out_view)
+            .expect("set_storage_image_view");
+        kernel.dispatch(1, 1, 1).expect("dispatch");
+
+        // Cleanup the test resources we allocated outside the kernel.
+        unsafe {
+            device_handle.destroy_image_view(in_view, None);
+            device_handle.destroy_image_view(out_view, None);
+            use vulkanalia_vma::Alloc;
+            allocator.destroy_image(in_image, in_alloc);
+            allocator.destroy_image(out_image, out_alloc);
+        }
+    }
+
 }
 

--- a/libs/streamlib-engine/src/vulkan/video/nv12_to_rgb.rs
+++ b/libs/streamlib-engine/src/vulkan/video/nv12_to_rgb.rs
@@ -5,25 +5,40 @@
 //!
 //! The reverse of [`crate::vulkan::video::rgb_to_nv12::RgbToNv12Converter`].
 //!
-//! Uses a `VkSamplerYcbcrConversion` combined image sampler so the hardware
-//! handles plane separation, chroma upsampling (4:2:0 → 4:4:4), and
-//! YCbCr→RGB conversion automatically (BT.709 / ITU narrow range).
+//! Uses a `VkSamplerYcbcrConversion` combined image sampler baked into the
+//! descriptor-set layout via `pImmutableSamplers` so the hardware handles
+//! plane separation, chroma upsampling (4:2:0 → 4:4:4), and YCbCr→RGB
+//! conversion automatically (BT.709 / ITU narrow range).
 //!
 //! The converter creates an RGBA output image with `STORAGE` usage for compute
 //! writes and `TRANSFER_SRC` for CPU readback, using `CONCURRENT` sharing
 //! between the compute and decode queue families.
+//!
+//! Compute dispatch is owned by [`VulkanComputeKernel`]; the converter
+//! holds the YCbCr conversion + sampler + per-call NV12 sampled view, plus
+//! its own command-buffer / fence for recording the surrounding barriers.
 
 use std::sync::Arc;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
-use vulkanalia::vk::KhrPushDescriptorExtensionDeviceCommands;
 use vulkanalia_vma::{self as vma, Alloc};
 
+use crate::core::rhi::{ComputeBindingSpec, ComputeKernelDescriptor};
+use crate::vulkan::rhi::VulkanComputeKernel;
 use crate::vulkan::video::video_context::{VideoContext, VideoError};
 
 /// Pre-compiled SPIR-V bytecode for the NV12→RGB compute shader.
 const SHADER_SPIRV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/nv12_to_rgb.spv"));
+
+/// Binding shape of `nv12_to_rgb.comp`:
+/// - 0: COMBINED_IMAGE_SAMPLER — NV12 input via an immutable YCbCr sampler
+///   chained at descriptor-set-layout creation time.
+/// - 1: STORAGE_IMAGE — RGBA output (R8G8B8A8_UNORM).
+const BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::sampled_texture(0),
+    ComputeBindingSpec::storage_image(1),
+];
 
 /// Push constants passed to the compute shader.
 #[repr(C)]
@@ -34,7 +49,7 @@ struct PushConstants {
 
 /// GPU NV12 → RGBA converter.
 ///
-/// Owns a compute pipeline with an immutable YCbCr sampler, an RGBA output
+/// Owns a compute kernel with an immutable YCbCr sampler, an RGBA output
 /// image, and a command buffer for recording conversion dispatches. The
 /// output image uses `CONCURRENT` sharing between compute and decode queue
 /// families so the NV12 DPB image can be sampled directly without queue
@@ -43,22 +58,24 @@ pub struct Nv12ToRgbConverter {
     device: vulkanalia::Device,
     allocator: Arc<vma::Allocator>,
 
-    // YCbCr conversion objects
+    // YCbCr conversion objects — `sampler` is baked into the kernel's
+    // descriptor-set layout via `pImmutableSamplers` and must outlive the
+    // kernel.
     ycbcr_conversion: vk::SamplerYcbcrConversion,
     sampler: vk::Sampler,
 
-    // Pipeline objects
-    descriptor_set_layout: vk::DescriptorSetLayout,
-    pipeline_layout: vk::PipelineLayout,
-    pipeline: vk::Pipeline,
-    shader_module: vk::ShaderModule,
+    // Engine-managed compute pipeline (descriptor set / pipeline layout /
+    // pipeline / pipeline cache / SPIR-V reflection all live inside).
+    kernel: VulkanComputeKernel,
 
     // RGBA output image
     rgba_image: vk::Image,
     rgba_allocation: vma::Allocation,
     rgba_view: vk::ImageView,
 
-    // Command recording
+    // Command recording (separate from the kernel's own internal command
+    // buffer so the converter can wrap `kernel.record(cb, ...)` with its
+    // own barriers).
     command_pool: vk::CommandPool,
     command_buffer: vk::CommandBuffer,
     fence: vk::Fence,
@@ -132,76 +149,24 @@ impl Nv12ToRgbConverter {
             None,
         )?;
 
-        // --- 3. Create shader module ---
-        let spirv_words = Self::spirv_to_words(SHADER_SPIRV);
-        let shader_module = device.create_shader_module(
-            &vk::ShaderModuleCreateInfo::builder()
-                .code_size(SHADER_SPIRV.len())
-                .code(&spirv_words),
-            None,
+        // --- 3. Compute kernel via the engine RHI, with the YCbCr
+        // sampler baked into the descriptor-set layout as an immutable
+        // sampler. Lifetime contract: `sampler` is owned by Self and is
+        // not dropped until after `kernel` (Drop runs fields in
+        // declaration order, so `sampler` is declared AFTER `kernel` in
+        // the struct body for that reason).
+        let kernel = VulkanComputeKernel::new_with_immutable_samplers(
+            ctx.host_device(),
+            &ComputeKernelDescriptor {
+                label: "nv12_to_rgb",
+                spv: SHADER_SPIRV,
+                bindings: BINDINGS,
+                push_constant_size: std::mem::size_of::<PushConstants>() as u32,
+            },
+            &[(0, sampler)],
         )?;
 
-        // --- 4. Descriptor set layout (push descriptors, immutable sampler) ---
-        let immutable_samplers = [sampler];
-
-        let bindings = [
-            // binding 0: NV12 input (combined image sampler with immutable YCbCr sampler)
-            vk::DescriptorSetLayoutBinding::builder()
-                .binding(0)
-                .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-                .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .immutable_samplers(&immutable_samplers)
-                .build(),
-            // binding 1: RGBA output (image2D, RGBA8)
-            vk::DescriptorSetLayoutBinding::builder()
-                .binding(1)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .build(),
-        ];
-
-        let descriptor_set_layout = device.create_descriptor_set_layout(
-            &vk::DescriptorSetLayoutCreateInfo::builder()
-                .flags(vk::DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR)
-                .bindings(&bindings),
-            None,
-        )?;
-
-        // --- 5. Pipeline layout (push constants + push descriptors) ---
-        let push_range = vk::PushConstantRange::builder()
-            .stage_flags(vk::ShaderStageFlags::COMPUTE)
-            .offset(0)
-            .size(std::mem::size_of::<PushConstants>() as u32);
-
-        let pipeline_layout = device.create_pipeline_layout(
-            &vk::PipelineLayoutCreateInfo::builder()
-                .set_layouts(std::slice::from_ref(&descriptor_set_layout))
-                .push_constant_ranges(std::slice::from_ref(&push_range)),
-            None,
-        )?;
-
-        // --- 6. Compute pipeline ---
-        let stage = vk::PipelineShaderStageCreateInfo::builder()
-            .stage(vk::ShaderStageFlags::COMPUTE)
-            .module(shader_module)
-            .name(b"main\0");
-
-        let pipeline_info = vk::ComputePipelineCreateInfo::builder()
-            .stage(stage)
-            .layout(pipeline_layout);
-
-        let (pipelines, _) = device
-            .create_compute_pipelines(
-                vk::PipelineCache::null(),
-                std::slice::from_ref(&pipeline_info),
-                None,
-            )
-            .map_err(|e| VideoError::Vulkan(vk::Result::from(e)))?;
-        let pipeline = pipelines[0];
-
-        // --- 7. RGBA output image ---
+        // --- 4. RGBA output image ---
         let queue_families = [compute_queue_family, decode_queue_family];
         let concurrent = compute_queue_family != decode_queue_family;
 
@@ -239,7 +204,7 @@ impl Nv12ToRgbConverter {
         let (rgba_image, rgba_allocation) =
             allocator.create_image(rgba_image_info, &alloc_options)?;
 
-        // --- 8. RGBA image view ---
+        // --- 5. RGBA image view ---
         let rgba_view = device.create_image_view(
             &vk::ImageViewCreateInfo::builder()
                 .image(rgba_image)
@@ -255,7 +220,7 @@ impl Nv12ToRgbConverter {
             None,
         )?;
 
-        // --- 9. Command pool / buffer / fence ---
+        // --- 6. Command pool / buffer / fence ---
         let command_pool = device.create_command_pool(
             &vk::CommandPoolCreateInfo::builder()
                 .queue_family_index(compute_queue_family)
@@ -277,10 +242,7 @@ impl Nv12ToRgbConverter {
             allocator,
             ycbcr_conversion,
             sampler,
-            descriptor_set_layout,
-            pipeline_layout,
-            pipeline,
-            shader_module,
+            kernel,
             rgba_image,
             rgba_allocation,
             rgba_view,
@@ -312,7 +274,9 @@ impl Nv12ToRgbConverter {
         array_layer: u32,
         src_layout: vk::ImageLayout,
     ) -> Result<(vk::Image, vk::ImageView), VideoError> { unsafe {
-        // Create a sampled view for this layer with YCbCr conversion info
+        // Create a sampled view for this layer with YCbCr conversion info.
+        // The YCbCr conversion chained on the view must match the immutable
+        // sampler's conversion exactly (VUID-VkImageView/VkSampler-format-..).
         let mut ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
             .conversion(self.ycbcr_conversion);
 
@@ -333,6 +297,18 @@ impl Nv12ToRgbConverter {
         )?;
 
         let cb = self.command_buffer;
+
+        // --- Stage descriptor writes ---
+        // Binding 0: COMBINED_IMAGE_SAMPLER with view-only write (sampler
+        // is the immutable YCbCr one baked into the descriptor-set
+        // layout; Vulkan ignores the sampler field in the write).
+        // Binding 1: STORAGE_IMAGE for RGBA output.
+        self.kernel
+            .set_combined_image_sampler_view(0, nv12_sampled_view)?;
+        self.kernel.set_storage_image_view(1, self.rgba_view)?;
+        self.kernel.set_push_constants_value(&PushConstants {
+            resolution: [self.width as i32, self.height as i32],
+        })?;
 
         self.device
             .reset_command_buffer(cb, vk::CommandBufferResetFlags::empty())?;
@@ -385,61 +361,15 @@ impl Nv12ToRgbConverter {
             .image_memory_barriers(&pre_barriers);
         self.device.cmd_pipeline_barrier2(cb, &pre_dep);
 
-        // --- Bind compute pipeline ---
-        self.device
-            .cmd_bind_pipeline(cb, vk::PipelineBindPoint::COMPUTE, self.pipeline);
-
-        // --- Push descriptors ---
-        let input_image_info = vk::DescriptorImageInfo::builder()
-            .sampler(self.sampler)
-            .image_view(nv12_sampled_view)
-            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
-
-        let output_image_info = vk::DescriptorImageInfo::builder()
-            .image_view(self.rgba_view)
-            .image_layout(vk::ImageLayout::GENERAL);
-
-        let writes = [
-            vk::WriteDescriptorSet::builder()
-                .dst_binding(0)
-                .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-                .image_info(std::slice::from_ref(&input_image_info))
-                .build(),
-            vk::WriteDescriptorSet::builder()
-                .dst_binding(1)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .image_info(std::slice::from_ref(&output_image_info))
-                .build(),
-        ];
-
-        self.device.cmd_push_descriptor_set_khr(
-            cb,
-            vk::PipelineBindPoint::COMPUTE,
-            self.pipeline_layout,
-            0,
-            &writes,
-        );
-
-        // --- Push constants ---
-        let push = PushConstants {
-            resolution: [self.width as i32, self.height as i32],
-        };
-        self.device.cmd_push_constants(
-            cb,
-            self.pipeline_layout,
-            vk::ShaderStageFlags::COMPUTE,
-            0,
-            std::slice::from_raw_parts(
-                &push as *const PushConstants as *const u8,
-                std::mem::size_of::<PushConstants>(),
-            ),
-        );
-
-        // --- Dispatch ---
+        // --- Bind compute pipeline + push descriptors + push constants + dispatch ---
         // Each thread handles one pixel, workgroup is 8x8.
         let group_x = (self.width + 7) / 8;
         let group_y = (self.height + 7) / 8;
-        self.device.cmd_dispatch(cb, group_x, group_y, 1);
+        self.kernel
+            .record(cb, group_x, group_y, 1)
+            .map_err(|e| {
+                VideoError::Other(format!("nv12_to_rgb kernel record failed: {e}"))
+            })?;
 
         // --- Barrier: RGBA GENERAL → TRANSFER_SRC_OPTIMAL (for readback) ---
         let barrier_to_transfer = vk::ImageMemoryBarrier2::builder()
@@ -503,15 +433,6 @@ impl Nv12ToRgbConverter {
     pub fn dimensions(&self) -> (u32, u32) {
         (self.width, self.height)
     }
-
-    /// Convert SPIR-V byte slice to u32 word slice.
-    fn spirv_to_words(bytes: &[u8]) -> Vec<u32> {
-        assert!(bytes.len() % 4 == 0, "SPIR-V size must be multiple of 4");
-        bytes
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-            .collect()
-    }
 }
 
 impl Drop for Nv12ToRgbConverter {
@@ -533,23 +454,14 @@ impl Drop for Nv12ToRgbConverter {
                 self.allocator
                     .destroy_image(self.rgba_image, self.rgba_allocation);
             }
-
-            if self.pipeline != vk::Pipeline::null() {
-                self.device.destroy_pipeline(self.pipeline, None);
-            }
-            if self.pipeline_layout != vk::PipelineLayout::null() {
-                self.device
-                    .destroy_pipeline_layout(self.pipeline_layout, None);
-            }
-            if self.descriptor_set_layout != vk::DescriptorSetLayout::null() {
-                self.device
-                    .destroy_descriptor_set_layout(self.descriptor_set_layout, None);
-            }
-            if self.shader_module != vk::ShaderModule::null() {
-                self.device
-                    .destroy_shader_module(self.shader_module, None);
-            }
-
+            // The compute kernel (descriptor layout / pipeline / pipeline
+            // layout / shader module / descriptor pool / command pool /
+            // fence) is torn down by its own Drop when `self.kernel` is
+            // dropped after this function returns. The kernel's
+            // descriptor-set layout retains the immutable `sampler`
+            // handle via `pImmutableSamplers`; the `device_wait_idle`
+            // above guarantees no GPU work is still using it, so
+            // destroying the sampler here is safe.
             if self.sampler != vk::Sampler::null() {
                 self.device.destroy_sampler(self.sampler, None);
             }
@@ -567,14 +479,6 @@ unsafe impl Send for Nv12ToRgbConverter {}
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_spirv_to_words() {
-        let bytes = [0x03, 0x02, 0x23, 0x07, 0x00, 0x00, 0x01, 0x00];
-        let words = Nv12ToRgbConverter::spirv_to_words(&bytes);
-        assert_eq!(words.len(), 2);
-        assert_eq!(words[0], 0x07230203); // SPIR-V magic number
-    }
 
     #[test]
     fn test_push_constants_size() {
@@ -595,5 +499,20 @@ mod tests {
             SHADER_SPIRV[3],
         ]);
         assert_eq!(magic, 0x07230203, "Invalid SPIR-V magic number");
+    }
+
+    #[test]
+    fn bindings_match_shader_declaration() {
+        // Lock the binding shape against the shader: any drift between
+        // BINDINGS and nv12_to_rgb.comp will fail SPIR-V reflection at
+        // kernel construction time (rejecting silently-wrong dispatches),
+        // but locking it here at the data level catches regressions
+        // without needing a GPU.
+        use crate::core::rhi::ComputeBindingKind;
+        assert_eq!(BINDINGS.len(), 2);
+        assert_eq!(BINDINGS[0].binding, 0);
+        assert_eq!(BINDINGS[0].kind, ComputeBindingKind::SampledTexture);
+        assert_eq!(BINDINGS[1].binding, 1);
+        assert_eq!(BINDINGS[1].kind, ComputeBindingKind::StorageImage);
     }
 }

--- a/libs/streamlib-engine/src/vulkan/video/nv12_to_rgb.rs
+++ b/libs/streamlib-engine/src/vulkan/video/nv12_to_rgb.rs
@@ -151,10 +151,14 @@ impl Nv12ToRgbConverter {
 
         // --- 3. Compute kernel via the engine RHI, with the YCbCr
         // sampler baked into the descriptor-set layout as an immutable
-        // sampler. Lifetime contract: `sampler` is owned by Self and is
-        // not dropped until after `kernel` (Drop runs fields in
-        // declaration order, so `sampler` is declared AFTER `kernel` in
-        // the struct body for that reason).
+        // sampler. Lifetime contract: `sampler` is destroyed manually
+        // in `Self::drop` (after `device_wait_idle`, before
+        // `self.kernel` auto-drops). Vulkan spec permits this order —
+        // `vkDestroyDescriptorSetLayout` does not dereference the
+        // sampler handles a layout was created with via
+        // `pImmutableSamplers`; the handles are used at
+        // descriptor-write / dispatch time only, and `device_wait_idle`
+        // guarantees there is none of that in flight.
         let kernel = VulkanComputeKernel::new_with_immutable_samplers(
             ctx.host_device(),
             &ComputeKernelDescriptor {
@@ -368,7 +372,7 @@ impl Nv12ToRgbConverter {
         self.kernel
             .record(cb, group_x, group_y, 1)
             .map_err(|e| {
-                VideoError::Other(format!("nv12_to_rgb kernel record failed: {e}"))
+                VideoError::Engine(format!("nv12_to_rgb kernel record failed: {e}"))
             })?;
 
         // --- Barrier: RGBA GENERAL → TRANSFER_SRC_OPTIMAL (for readback) ---

--- a/libs/streamlib-engine/src/vulkan/video/rgb_to_nv12.rs
+++ b/libs/streamlib-engine/src/vulkan/video/rgb_to_nv12.rs
@@ -5,7 +5,7 @@
 //!
 //! Based on pyroenc's `rgb_to_yuv.comp` shader (MIT, Arntzen Software AS).
 //! Uses BT.709 color matrix with TV range (16-235 luma, 16-240 chroma),
-//! 6-tap left-sited chroma filter, and push descriptors for zero allocation.
+//! 6-tap left-sited chroma filter.
 //!
 //! Two NV12 images are owned: a STORAGE compute-output image (no video
 //! profile chained) and a VIDEO_ENCODE_SRC_KHR image (profile chained). A
@@ -13,18 +13,34 @@
 //! frame. The split is required because no NVIDIA encode profile reports
 //! `STORAGE` as a supported usage via vkGetPhysicalDeviceVideoFormatPropertiesKHR
 //! (VUID-VkImageCreateInfo-pNext-06811).
+//!
+//! Compute dispatch is owned by [`VulkanComputeKernel`]; the converter
+//! holds the per-plane reinterpreted-format storage views the kernel
+//! writes through plus its own command-buffer / fence for recording the
+//! surrounding barriers + copy.
 
 use std::sync::Arc;
 
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
-use vulkanalia::vk::KhrPushDescriptorExtensionDeviceCommands;
 use vulkanalia_vma::{self as vma, Alloc};
 
+use crate::core::rhi::{ComputeBindingSpec, ComputeKernelDescriptor};
+use crate::vulkan::rhi::VulkanComputeKernel;
 use crate::vulkan::video::video_context::{VideoContext, VideoError};
 
 /// Pre-compiled SPIR-V bytecode for the RGB→NV12 compute shader.
 const SHADER_SPIRV: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/rgb_to_nv12.spv"));
+
+/// Binding shape of `rgb_to_nv12.comp`:
+/// - 0: SAMPLED_IMAGE — input RGBA texture (texture2D, texelFetch).
+/// - 1: STORAGE_IMAGE — luma output plane (R8, reinterpreted view of NV12 plane 0).
+/// - 2: STORAGE_IMAGE — chroma output plane (RG8, reinterpreted view of NV12 plane 1).
+const BINDINGS: &[ComputeBindingSpec] = &[
+    ComputeBindingSpec::sampled_image(0),
+    ComputeBindingSpec::storage_image(1),
+    ComputeBindingSpec::storage_image(2),
+];
 
 /// Push constants passed to the compute shader.
 #[repr(C)]
@@ -35,7 +51,7 @@ struct PushConstants {
 
 /// GPU RGB(A) → NV12 converter.
 ///
-/// Owns a compute pipeline plus two NV12 images (compute-output + encode-src)
+/// Owns a compute kernel plus two NV12 images (compute-output + encode-src)
 /// joined by a per-plane vkCmdCopyImage. The encode-src image uses
 /// `CONCURRENT` sharing between the compute and encode queue families so it
 /// can be used as `VIDEO_ENCODE_SRC` without queue family ownership transfers.
@@ -43,11 +59,9 @@ pub struct RgbToNv12Converter {
     device: vulkanalia::Device,
     allocator: Arc<vma::Allocator>,
 
-    // Pipeline objects
-    descriptor_set_layout: vk::DescriptorSetLayout,
-    pipeline_layout: vk::PipelineLayout,
-    pipeline: vk::Pipeline,
-    shader_module: vk::ShaderModule,
+    // Engine-managed compute pipeline (descriptor set / pipeline layout /
+    // pipeline / pipeline cache / SPIR-V reflection all live inside).
+    kernel: VulkanComputeKernel,
 
     // Compute-output NV12 image — STORAGE + TRANSFER_SRC, no video profile.
     compute_nv12_image: vk::Image,
@@ -61,7 +75,9 @@ pub struct RgbToNv12Converter {
     encode_nv12_allocation: vma::Allocation,
     encode_nv12_color_view: vk::ImageView,
 
-    // Command recording
+    // Command recording (separate from the kernel's own internal command
+    // buffer so the converter can wrap `kernel.record(cb, ...)` with its
+    // own barriers + multi-plane copy).
     command_pool: vk::CommandPool,
     command_buffer: vk::CommandBuffer,
     fence: vk::Fence,
@@ -102,79 +118,24 @@ impl RgbToNv12Converter {
     ) -> Result<Self, VideoError> { unsafe {
         let device = ctx.device().clone();
         let allocator = ctx.allocator().clone();
-        // --- 1. Create shader module ---
-        let spirv_words = Self::spirv_to_words(SHADER_SPIRV);
-        let shader_module = device.create_shader_module(
-            &vk::ShaderModuleCreateInfo::builder()
-                .code_size(SHADER_SPIRV.len())
-                .code(&spirv_words),
-            None,
+
+        // --- 1. Compute kernel via the engine RHI ---
+        // Descriptor-set layout, pipeline layout, compute pipeline, descriptor
+        // pool, command buffer + fence (for `dispatch`) all live inside the
+        // kernel. The converter uses `kernel.record(...)` instead of
+        // `kernel.dispatch(...)` so the surrounding barriers + multi-plane
+        // copy land in the converter's own command buffer in one submit.
+        let kernel = VulkanComputeKernel::new(
+            ctx.host_device(),
+            &ComputeKernelDescriptor {
+                label: "rgb_to_nv12",
+                spv: SHADER_SPIRV,
+                bindings: BINDINGS,
+                push_constant_size: std::mem::size_of::<PushConstants>() as u32,
+            },
         )?;
 
-        // --- 2. Descriptor set layout (push descriptors) ---
-        let bindings = [
-            // binding 0: sampled input image (texture2D)
-            vk::DescriptorSetLayoutBinding::builder()
-                .binding(0)
-                .descriptor_type(vk::DescriptorType::SAMPLED_IMAGE)
-                .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .build(),
-            // binding 1: luma output (image2D, R8)
-            vk::DescriptorSetLayoutBinding::builder()
-                .binding(1)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .build(),
-            // binding 2: chroma output (image2D, RG8)
-            vk::DescriptorSetLayoutBinding::builder()
-                .binding(2)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .descriptor_count(1)
-                .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                .build(),
-        ];
-
-        let descriptor_set_layout = device.create_descriptor_set_layout(
-            &vk::DescriptorSetLayoutCreateInfo::builder()
-                .flags(vk::DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR)
-                .bindings(&bindings),
-            None,
-        )?;
-        // --- 3. Pipeline layout (push constants + push descriptors) ---
-        let push_range = vk::PushConstantRange::builder()
-            .stage_flags(vk::ShaderStageFlags::COMPUTE)
-            .offset(0)
-            .size(std::mem::size_of::<PushConstants>() as u32);
-
-        let pipeline_layout = device.create_pipeline_layout(
-            &vk::PipelineLayoutCreateInfo::builder()
-                .set_layouts(std::slice::from_ref(&descriptor_set_layout))
-                .push_constant_ranges(std::slice::from_ref(&push_range)),
-            None,
-        )?;
-
-        // --- 4. Compute pipeline ---
-        let stage = vk::PipelineShaderStageCreateInfo::builder()
-            .stage(vk::ShaderStageFlags::COMPUTE)
-            .module(shader_module)
-            .name(b"main\0");
-
-        let pipeline_info = vk::ComputePipelineCreateInfo::builder()
-            .stage(stage)
-            .layout(pipeline_layout);
-
-        let (pipelines, _) = device
-            .create_compute_pipelines(
-                vk::PipelineCache::null(),
-                std::slice::from_ref(&pipeline_info),
-                None,
-            )
-            .map_err(|e| VideoError::Vulkan(vk::Result::from(e)))?;
-        let pipeline = pipelines[0];
-
-        // --- 5a. Compute-output NV12 image (STORAGE | TRANSFER_SRC) ---
+        // --- 2a. Compute-output NV12 image (STORAGE | TRANSFER_SRC) ---
         // No video profile chained here — STORAGE on a VIDEO_ENCODE_SRC image is
         // not reported as a supported video format by NVIDIA encode profiles
         // (VUID-VkImageCreateInfo-pNext-06811). Compute writes go here, then a
@@ -206,7 +167,7 @@ impl RgbToNv12Converter {
         let (compute_nv12_image, compute_nv12_allocation) =
             allocator.create_image(compute_nv12_image_info, &alloc_options)?;
 
-        // --- 5b. Encode-src NV12 image (VIDEO_ENCODE_SRC | TRANSFER_DST | SAMPLED) ---
+        // --- 2b. Encode-src NV12 image (VIDEO_ENCODE_SRC | TRANSFER_DST | SAMPLED) ---
         // Profile list MUST match the video session profile exactly, including
         // the encode_usage pNext chain. Without this, the validation layer
         // reports VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206. Keep every field
@@ -262,7 +223,7 @@ impl RgbToNv12Converter {
         let (encode_nv12_image, encode_nv12_allocation) =
             allocator.create_image(encode_nv12_image_info, &alloc_options)?;
 
-        // --- 6. Image views ---
+        // --- 3. Image views ---
 
         // COLOR view of the encode-src image for vkCmdEncodeVideoKHR.
         let mut color_view_ycbcr_info = vk::SamplerYcbcrConversionInfo::builder()
@@ -320,7 +281,7 @@ impl RgbToNv12Converter {
             None,
         )?;
 
-        // --- 7. Command pool / buffer / fence ---
+        // --- 4. Command pool / buffer / fence ---
         let command_pool = device.create_command_pool(
             &vk::CommandPoolCreateInfo::builder()
                 .queue_family_index(compute_queue_family)
@@ -340,10 +301,7 @@ impl RgbToNv12Converter {
         Ok(Self {
             device,
             allocator,
-            descriptor_set_layout,
-            pipeline_layout,
-            pipeline,
-            shader_module,
+            kernel,
             compute_nv12_image,
             compute_nv12_allocation,
             luma_view,
@@ -375,6 +333,16 @@ impl RgbToNv12Converter {
         rgba_image_view: vk::ImageView,
     ) -> Result<(vk::Image, vk::ImageView), VideoError> { unsafe {
         let cb = self.command_buffer;
+
+        // --- Stage descriptor writes for this dispatch ---
+        // The kernel drains its pending state on `record(...)`; setting
+        // before recording is the contract.
+        self.kernel.set_sampled_image_view(0, rgba_image_view)?;
+        self.kernel.set_storage_image_view(1, self.luma_view)?;
+        self.kernel.set_storage_image_view(2, self.chroma_view)?;
+        self.kernel.set_push_constants_value(&PushConstants {
+            resolution: [self.width as i32, self.height as i32],
+        })?;
 
         self.device
             .reset_command_buffer(cb, vk::CommandBufferResetFlags::empty())?;
@@ -408,70 +376,16 @@ impl RgbToNv12Converter {
             .image_memory_barriers(&pre_barriers);
         self.device.cmd_pipeline_barrier2(cb, &pre_dep);
 
-        // --- Bind compute pipeline ---
-        self.device
-            .cmd_bind_pipeline(cb, vk::PipelineBindPoint::COMPUTE, self.pipeline);
-
-        // --- Push descriptors ---
-        let input_image_info = vk::DescriptorImageInfo::builder()
-            .image_view(rgba_image_view)
-            .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
-
-        let luma_image_info = vk::DescriptorImageInfo::builder()
-            .image_view(self.luma_view)
-            .image_layout(vk::ImageLayout::GENERAL);
-
-        let chroma_image_info = vk::DescriptorImageInfo::builder()
-            .image_view(self.chroma_view)
-            .image_layout(vk::ImageLayout::GENERAL);
-
-        let writes = [
-            vk::WriteDescriptorSet::builder()
-                .dst_binding(0)
-                .descriptor_type(vk::DescriptorType::SAMPLED_IMAGE)
-                .image_info(std::slice::from_ref(&input_image_info))
-                .build(),
-            vk::WriteDescriptorSet::builder()
-                .dst_binding(1)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .image_info(std::slice::from_ref(&luma_image_info))
-                .build(),
-            vk::WriteDescriptorSet::builder()
-                .dst_binding(2)
-                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
-                .image_info(std::slice::from_ref(&chroma_image_info))
-                .build(),
-        ];
-
-        self.device.cmd_push_descriptor_set_khr(
-            cb,
-            vk::PipelineBindPoint::COMPUTE,
-            self.pipeline_layout,
-            0,
-            &writes,
-        );
-
-        // --- Push constants ---
-        let push = PushConstants {
-            resolution: [self.width as i32, self.height as i32],
-        };
-        self.device.cmd_push_constants(
-            cb,
-            self.pipeline_layout,
-            vk::ShaderStageFlags::COMPUTE,
-            0,
-            std::slice::from_raw_parts(
-                &push as *const PushConstants as *const u8,
-                std::mem::size_of::<PushConstants>(),
-            ),
-        );
-
-        // --- Dispatch ---
+        // --- Bind compute pipeline + push descriptors + push constants + dispatch ---
         // Each thread handles a 2x2 luma block, so we need
         // (width/2 + 7) / 8 x (height/2 + 7) / 8 workgroups.
         let group_x = (self.width / 2 + 7) / 8;
         let group_y = (self.height / 2 + 7) / 8;
-        self.device.cmd_dispatch(cb, group_x, group_y, 1);
+        self.kernel
+            .record(cb, group_x, group_y, 1)
+            .map_err(|e| {
+                VideoError::Other(format!("rgb_to_nv12 kernel record failed: {e}"))
+            })?;
 
         // --- Barriers: compute_nv12 → TRANSFER_SRC, encode_nv12 → TRANSFER_DST ---
         let barrier_compute_to_transfer = vk::ImageMemoryBarrier2::builder()
@@ -614,15 +528,6 @@ impl RgbToNv12Converter {
     pub fn nv12_color_view(&self) -> vk::ImageView {
         self.encode_nv12_color_view
     }
-
-    /// Convert SPIR-V byte slice to u32 word slice.
-    fn spirv_to_words(bytes: &[u8]) -> Vec<u32> {
-        assert!(bytes.len() % 4 == 0, "SPIR-V size must be multiple of 4");
-        bytes
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-            .collect()
-    }
 }
 
 impl Drop for RgbToNv12Converter {
@@ -654,22 +559,10 @@ impl Drop for RgbToNv12Converter {
                 self.allocator
                     .destroy_image(self.compute_nv12_image, self.compute_nv12_allocation);
             }
-
-            if self.pipeline != vk::Pipeline::null() {
-                self.device.destroy_pipeline(self.pipeline, None);
-            }
-            if self.pipeline_layout != vk::PipelineLayout::null() {
-                self.device
-                    .destroy_pipeline_layout(self.pipeline_layout, None);
-            }
-            if self.descriptor_set_layout != vk::DescriptorSetLayout::null() {
-                self.device
-                    .destroy_descriptor_set_layout(self.descriptor_set_layout, None);
-            }
-            if self.shader_module != vk::ShaderModule::null() {
-                self.device
-                    .destroy_shader_module(self.shader_module, None);
-            }
+            // The compute kernel (descriptor layout / pipeline / pipeline
+            // layout / shader module / descriptor pool / command pool /
+            // fence) is torn down by its own Drop when `self.kernel` is
+            // dropped after this function returns.
         }
     }
 }
@@ -680,14 +573,6 @@ unsafe impl Send for RgbToNv12Converter {}
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_spirv_to_words() {
-        let bytes = [0x03, 0x02, 0x23, 0x07, 0x00, 0x00, 0x01, 0x00];
-        let words = RgbToNv12Converter::spirv_to_words(&bytes);
-        assert_eq!(words.len(), 2);
-        assert_eq!(words[0], 0x07230203); // SPIR-V magic number
-    }
 
     #[test]
     fn test_push_constants_size() {
@@ -709,5 +594,22 @@ mod tests {
             SHADER_SPIRV[3],
         ]);
         assert_eq!(magic, 0x07230203, "Invalid SPIR-V magic number");
+    }
+
+    #[test]
+    fn bindings_match_shader_declaration() {
+        // Lock the binding shape against the shader: any drift between
+        // BINDINGS and rgb_to_nv12.comp will fail SPIR-V reflection at
+        // kernel construction time (rejecting silently-wrong dispatches),
+        // but locking it here at the data level catches regressions
+        // without needing a GPU.
+        use crate::core::rhi::ComputeBindingKind;
+        assert_eq!(BINDINGS.len(), 3);
+        assert_eq!(BINDINGS[0].binding, 0);
+        assert_eq!(BINDINGS[0].kind, ComputeBindingKind::SampledImage);
+        assert_eq!(BINDINGS[1].binding, 1);
+        assert_eq!(BINDINGS[1].kind, ComputeBindingKind::StorageImage);
+        assert_eq!(BINDINGS[2].binding, 2);
+        assert_eq!(BINDINGS[2].kind, ComputeBindingKind::StorageImage);
     }
 }

--- a/libs/streamlib-engine/src/vulkan/video/rgb_to_nv12.rs
+++ b/libs/streamlib-engine/src/vulkan/video/rgb_to_nv12.rs
@@ -384,7 +384,7 @@ impl RgbToNv12Converter {
         self.kernel
             .record(cb, group_x, group_y, 1)
             .map_err(|e| {
-                VideoError::Other(format!("rgb_to_nv12 kernel record failed: {e}"))
+                VideoError::Engine(format!("rgb_to_nv12 kernel record failed: {e}"))
             })?;
 
         // --- Barriers: compute_nv12 → TRANSFER_SRC, encode_nv12 → TRANSFER_DST ---

--- a/libs/streamlib-engine/src/vulkan/video/video_context.rs
+++ b/libs/streamlib-engine/src/vulkan/video/video_context.rs
@@ -80,6 +80,9 @@ pub enum VideoError {
     BitstreamError(String),
     /// A required video format is not supported.
     FormatNotSupported(vk::Format),
+    /// An error surfaced from the engine RHI layer (compute-kernel
+    /// construction, descriptor management, etc.).
+    Other(String),
 }
 
 impl std::fmt::Display for VideoError {
@@ -91,6 +94,7 @@ impl std::fmt::Display for VideoError {
             Self::NoSuitableMemoryType => write!(f, "No suitable memory type found"),
             Self::BitstreamError(msg) => write!(f, "Bitstream error: {}", msg),
             Self::FormatNotSupported(fmt) => write!(f, "Format not supported: {:?}", fmt),
+            Self::Other(msg) => write!(f, "{}", msg),
         }
     }
 }
@@ -106,6 +110,12 @@ impl From<vk::Result> for VideoError {
 impl From<vk::ErrorCode> for VideoError {
     fn from(e: vk::ErrorCode) -> Self {
         Self::Vulkan(vk::Result::from(e))
+    }
+}
+
+impl From<crate::core::Error> for VideoError {
+    fn from(e: crate::core::Error) -> Self {
+        Self::Other(format!("{e}"))
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/video/video_context.rs
+++ b/libs/streamlib-engine/src/vulkan/video/video_context.rs
@@ -82,7 +82,7 @@ pub enum VideoError {
     FormatNotSupported(vk::Format),
     /// An error surfaced from the engine RHI layer (compute-kernel
     /// construction, descriptor management, etc.).
-    Other(String),
+    Engine(String),
 }
 
 impl std::fmt::Display for VideoError {
@@ -94,7 +94,7 @@ impl std::fmt::Display for VideoError {
             Self::NoSuitableMemoryType => write!(f, "No suitable memory type found"),
             Self::BitstreamError(msg) => write!(f, "Bitstream error: {}", msg),
             Self::FormatNotSupported(fmt) => write!(f, "Format not supported: {:?}", fmt),
-            Self::Other(msg) => write!(f, "{}", msg),
+            Self::Engine(msg) => write!(f, "{}", msg),
         }
     }
 }
@@ -115,7 +115,7 @@ impl From<vk::ErrorCode> for VideoError {
 
 impl From<crate::core::Error> for VideoError {
     fn from(e: crate::core::Error) -> Self {
-        Self::Other(format!("{e}"))
+        Self::Engine(format!("{e}"))
     }
 }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -1498,6 +1498,9 @@ pub enum ComputeBindingKindRepr {
     UniformBuffer = 1,
     SampledTexture = 2,
     StorageImage = 3,
+    /// `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE` — sampled image without a
+    /// combined sampler. GLSL `texture2D` / `texelFetch` style.
+    SampledImage = 4,
 }
 
 /// GPU capability snapshot returned by


### PR DESCRIPTION
## Summary

- **Two-part PR closing #935 and #821**, paired because both converters needed the same kernel-API extensions.
- Part 1 extends `VulkanComputeKernel` with new binding kinds the codec converters need (`ComputeBindingKind::SampledImage`, `new_with_immutable_samplers` constructor, raw-view setters). Two concrete in-tree consumers attest the need — not speculative.
- Part 2 migrates `rgb_to_nv12.rs` (encode-side RGBA → NV12) and `nv12_to_rgb.rs` (decode-side NV12 → RGBA) off their hand-rolled descriptor-set / pipeline-layout / pipeline / push-descriptor / shader-module plumbing onto the extended kernel.

Closes #935. Closes #821. Part of the **Vulkan Video RHI Coupling** milestone (#270 umbrella).

## Design call surfaced + approved

User approved the API-extension path 2026-05-22 over the alternative (rewriting shaders to fit the current kernel surface). The shapes the converters need — `texture2D` (Vulkan `SAMPLED_IMAGE`, separate-from-sampler) and immutable-`VkSamplerYcbcrConversion` baked into the descriptor-set layout — weren't expressible through the kernel's pre-PR surface. Extending the kernel is the production-grade-by-default answer per CLAUDE.md and matches what every modern RHI surfaces; rewriting shaders would have changed color-correctness math (manual NV12→RGB matrix in shader instead of the spec-correct YCbCr-conversion sampler).

## Engine RHI surface — Part 1

### `core/rhi/compute_kernel.rs` (vulkanalia-free)

- New variant `ComputeBindingKind::SampledImage` — Vulkan `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`, GLSL `texture2D` style (no sampler attached).
- Const helper `ComputeBindingSpec::sampled_image(binding)`.
- SPIR-V reflection validator extended: `RDescriptorType::SAMPLED_IMAGE` → `ComputeBindingKind::SampledImage`. Distinct from the existing `COMBINED_IMAGE_SAMPLER` → `SampledTexture` map.

### `libs/streamlib-plugin-abi`

- Mirror `ComputeBindingKindRepr::SampledImage = 4` (additive — discriminants 0..3 unchanged).
- `plugin_abi_bridge` bidirectional conversion updated.

### `vulkan/rhi/vulkan_compute_kernel.rs`

- `VulkanComputeKernel::new_with_immutable_samplers(device, descriptor, &[(binding, vk::Sampler)])` — sibling constructor that bakes immutable samplers into the descriptor-set layout's `pImmutableSamplers`. Caller owns the sampler handle's lifetime: it must stay alive for the kernel's lifetime. Pre-validates each `(binding, sampler)` pair binds to a `SampledTexture` slot.
- `set_sampled_image_view(binding, vk::ImageView)` — view-only setter for `SAMPLED_IMAGE` slots.
- `set_combined_image_sampler_view(binding, vk::ImageView)` — view-only setter for `SampledTexture` slots that use an immutable sampler (descriptor write supplies the view; sampler field set to `VK_NULL_HANDLE`, Vulkan picks the immutable one from the layout). Errors if the binding wasn't declared with an immutable sampler.
- `set_storage_image_view(binding, vk::ImageView)` — view-only setter for `StorageImage` slots, complementing the existing `set_storage_image(&Texture)`.
- `set_sampled_texture` now errors if the slot has an immutable sampler — symmetric to `set_combined_image_sampler_view`'s converse rejection. Vulkan would silently ignore a default sampler in favor of the immutable one; the new check surfaces that as an error.
- `record(...)` lifted from `pub(crate)` to `pub` so codec converters can record dispatch into their own command buffer.
- Inner tracks `immutable_sampler_bindings: Vec<u32>` so the runtime checks above can dispatch on whether a binding declared an immutable sampler.

### New shader + hardware-gated test

- `vulkan/rhi/shaders/test_sampled_image.comp` — minimal `texture2D` + storage image shader, compiled by `build.rs` into `OUT_DIR/test_sampled_image.spv`.
- `sampled_image_binding_dispatches_with_raw_view` — hardware-gated test: build kernel from the test SPIR-V, assert the SPIR-V reflection produces `ComputeBindingKind::SampledImage` (not `SampledTexture`), allocate real 1×1 `VkImage`s + views, layout-transition, call `set_sampled_image_view(0, …)` + `set_storage_image_view(1, …)` + `dispatch(1,1,1)`, clean up. End-to-end exercise of the new path.

## Codec migration — Part 2

### `rgb_to_nv12.rs`

- Binding shape: `sampled_image(0)`, `storage_image(1)`, `storage_image(2)`. Matches the existing `rgb_to_nv12.comp` (input `texture2D` + two write-only `image2D` planes).
- Kernel via `VulkanComputeKernel::new(...)` — no immutable samplers needed.
- Per-frame: `set_sampled_image_view(0, rgba_view)` + two `set_storage_image_view` + `set_push_constants_value` + `kernel.record(cb, gx, gy, 1)`.
- Per-plane PLANE_0 / PLANE_1 reinterpreted-format storage views (`R8_UNORM`, `R8G8_UNORM`) the converter builds at setup-time are **unchanged** — only descriptor/pipeline machinery moved.
- `KhrPushDescriptorExtensionDeviceCommands` import + `cmd_push_descriptor_set_khr` call removed.
- Drop strips destruction of the four pipeline objects; kernel's Drop handles them.

### `nv12_to_rgb.rs`

- Binding shape: `sampled_texture(0)`, `storage_image(1)`. Binding 0 declares the `sampler2D` slot with the YCbCr-conversion sampler baked in via `pImmutableSamplers`.
- Kernel via `VulkanComputeKernel::new_with_immutable_samplers(host_device, descriptor, &[(0, ycbcr_sampler)])`. The `VkSamplerYcbcrConversion` + `VkSampler` creation stays in the converter (codec-specific, format `G8_B8R8_2PLANE_420_UNORM`, BT.709 / ITU narrow).
- Per-frame: `set_combined_image_sampler_view(0, nv12_view)` (view-only — Vulkan ignores the descriptor write's sampler field because the layout has the immutable one) + `set_storage_image_view(1, rgba_view)` + push constants + `kernel.record(cb, gx, gy, 1)`.
- Per-array-layer YCbCr-chained sampled view is still built per-call in the converter.
- Drop sequence: `device_wait_idle` → destroy converter-owned views/images → destroy sampler (while kernel is still live, before kernel's auto-drop). `vkDestroyDescriptorSetLayout` doesn't dereference sampler handles per Vulkan spec, so this order is safe.

### `video_context.rs`

- Add `VideoError::Engine(String)` + `From<core::Error> for VideoError` so the kernel constructor's `Result` propagates cleanly through the converters' `?` operator. (Originally `Other`; renamed to `Engine` after pr-review-gate flagged the generic name.)

## Test plan

- [x] **2 new unit tests** — `sampled_image_spec_round_trips_kind` (pure logic, locks the SPIR-V → kind mapping) + `sampled_image_binding_dispatches_with_raw_view` (hardware-gated, dispatches the new binding path end-to-end). Plus `bindings_match_shader_declaration` on each converter (pure logic) locks the binding-spec constant against the shader.
- [x] `cargo test -p streamlib-engine --lib -- --test-threads=1`: **1146 passed, 0 failed, 124 ignored** (= 1145 prior baseline + 1 new pure-logic; 1 new hardware-gated newly-ignored).
- [x] `cargo test -p streamlib-engine --lib --features streamlib-engine/hardware-tests vulkan_compute_kernel`: **21 passed, 0 failed**.
- [x] `cargo xtask check-boundaries`: 3981 files scanned, no violations.
- [x] `cargo xtask lint-logging`: 442 files scanned, no violations.
- [x] `grep -nE 'create_descriptor_set_layout|create_pipeline_layout|create_compute_pipelines|create_shader_module'` in the two converters: zero hits.

## E2E Test Report

- **Scenario**: encoder/decoder
- **Example**: `vulkan-video-roundtrip` + `e2e_fixture_psnr.sh` + `e2e_fixture_psnr_vivid.sh`
- **Codec**: h264 + h265
- **Camera device**: `/dev/video0` (vivid)
- **Resolution**: 1920x1080
- **Driver**: NVIDIA 595.71.05

### Log signals (vulkan-video-roundtrip)

0 `OUT_OF_DEVICE_MEMORY`, 0 `DEVICE_LOST`, 0 `process() failed`, 0 `llvmpipe`, 0 `No video encode queue`. `First frame encoded` / `First frame decoded` for both codecs.

### PNG samples

Read frame 60. Vivid SMPTE colorbar pattern, timecode `00:00:12:003 60`, brightness/contrast/saturation diagnostics, crisp colors. No green/magenta tint, no banding, no tearing — the YCbCr-conversion path through the immutable sampler reproduces colors identically to pre-PR.

### PSNR fixture rigs

- h264: all 9 references PASS (complex_pattern 43.16 dB Y).
- h265: all 9 references PASS.

### Vivid color regression gate

R/G/B drift 0.0000 / 0.0000 / 0.0000 vs baseline (under ±0.05 tolerance).

### Cam Link 4K

Not plugged in on the dev host. Vivid + PSNR fixture rigs are the achievable scope; physical-camera coverage lands with the milestone capstone (#938).

### Outcome

**Pass.** Codec converters preserve roundtrip fidelity through the migrated path; YCbCr-conversion + matrix math reproduce identically to pre-PR; no validation errors; 4-of-6 raw-VMA hits remaining in `vulkan/video/` (intermediate images in the converters + submit-side staging) are scope of the #938 capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
