### PR TITLE
feat(plugin-abi): TextureRing per-type vtable shell + POD caching (#907 PR 1/5)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4050,12 +4050,26 @@ impl GpuContextFullAccess {
                         ));
                     }
                     // β-shape: bundle the raw handle
-                    // (`Arc::into_raw(Arc<TextureRingInner>)`-shaped) with
-                    // the host vtable. Cross-rustc-version safe because
+                    // (`Arc::into_raw(Arc<TextureRingInner>)`-shaped)
+                    // with the host vtables + cached POD descriptors.
+                    // The cached values come from the caller's own
+                    // inputs (we know `width` / `height` / `format` /
+                    // `count` — these are the args we just passed
+                    // through the FFI), avoiding an extra round-trip
+                    // for the getters. Cross-rustc-version safe because
                     // cdylib never derefs the Inner layout.
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.texture_ring_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::core::context::TextureRing {
                         handle: out_ring,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_len: count as u32,
+                        cached_width: width,
+                        cached_height: height,
+                        cached_format: format as u32,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/context/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/context/texture_ring.rs
@@ -257,21 +257,43 @@ impl Drop for TextureRingInner {
 // =============================================================================
 
 /// Pre-allocated ring of textures rotated per-frame on the decode hot
-/// path. Layout-stable `#[repr(C)] (handle, vtable)` β-shape so
-/// cdylibs can hold, refcount, and drop without sharing rustc-version
-/// or dep-graph with the host.
+/// path. Layout-stable `#[repr(C)]` β-shape so cdylibs can hold,
+/// refcount, drop, and read POD descriptors without sharing
+/// rustc-version or dep-graph with the host.
 ///
 /// The opaque handle points at an `Arc<TextureRingInner>`; lifecycle
-/// dispatches through the host-installed FullAccess vtable's
-/// `clone_texture_ring` / `drop_texture_ring` callbacks. Method
-/// dispatch is host-only via [`Self::host_inner`] until Phase E
-/// (#907) lifts it to per-method vtable slots.
+/// (Clone / Drop) dispatches through the host-installed parent
+/// [`GpuContextFullAccessVTable`]'s `clone_texture_ring` /
+/// `drop_texture_ring` callbacks (locked by PR #918's β-shape Phase D
+/// work). Per-method dispatch is reached through the dedicated
+/// [`streamlib_plugin_abi::TextureRingMethodsVTable`] pointed at by
+/// `methods_vtable` — issue #907 PR 1/5 lands the pointer plumbing
+/// + cached POD fields; follow-up PRs append method slots and route
+/// `acquire_next` / `copy_pixel_buffer_to_slot` / `slot` through
+/// them.
+///
+/// The four POD getters (`len`, `width`, `height`, `format`) read
+/// directly from cached fields on this struct — no FFI hop. The
+/// values are captured by [`Self::from_arc_into_raw`] at construction
+/// and never mutate over the ring's lifetime.
 #[repr(C)]
 pub struct TextureRing {
     /// Opaque handle to the host's `Arc<TextureRingInner>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    pub(crate) methods_vtable: *const streamlib_plugin_abi::TextureRingMethodsVTable,
+    /// Cached slot count. Set at construction; ring depth is fixed.
+    pub(crate) cached_len: u32,
+    /// Cached pixel width every slot's texture was allocated with.
+    pub(crate) cached_width: u32,
+    /// Cached pixel height every slot's texture was allocated with.
+    pub(crate) cached_height: u32,
+    /// Cached pixel format every slot's texture was allocated with.
+    /// Stored as the FFI-stable `u32` discriminant (matches
+    /// `TextureFormat`'s `#[repr(u32)]`).
+    pub(crate) cached_format: u32,
 }
 
 // SAFETY: handle points at an `Arc<TextureRingInner>`; inner state is
@@ -282,13 +304,29 @@ unsafe impl Sync for TextureRing {}
 
 impl TextureRing {
     /// Internal helper: leak an initial Arc strong count via
-    /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
-    /// assemble the cross-DSO shape.
+    /// `Arc::into_raw`, resolve the host-mode FullAccess vtable +
+    /// per-type methods vtable, snapshot the ring's POD descriptors
+    /// (len / width / height / format — fixed across the ring's
+    /// lifetime), and assemble the cross-DSO shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<TextureRingInner>) -> Self {
+        let cached_len = arc.len() as u32;
+        let cached_width = arc.width();
+        let cached_height = arc.height();
+        let cached_format = arc.format() as u32;
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_texture_ring_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+            cached_len,
+            cached_width,
+            cached_height,
+            cached_format,
+        }
     }
 
     /// Engine-internal borrow of the host-owned `TextureRingInner`.
@@ -323,29 +361,46 @@ impl TextureRing {
             .copy_pixel_buffer_to_slot(slot, pixel_buffer, width, height)
     }
 
-    /// Number of slots in the ring.
+    /// Number of slots in the ring. Cached POD — no FFI hop.
     pub fn len(&self) -> usize {
-        self.host_inner().len()
+        self.cached_len as usize
     }
 
     /// Ring is always non-empty in practice (construction rejects 0).
+    /// Cached POD — no FFI hop.
     pub fn is_empty(&self) -> bool {
-        self.host_inner().is_empty()
+        self.cached_len == 0
     }
 
-    /// Width of every slot's texture, in pixels.
+    /// Width of every slot's texture, in pixels. Cached POD — no FFI
+    /// hop.
     pub fn width(&self) -> u32 {
-        self.host_inner().width()
+        self.cached_width
     }
 
-    /// Height of every slot's texture, in pixels.
+    /// Height of every slot's texture, in pixels. Cached POD — no
+    /// FFI hop.
     pub fn height(&self) -> u32 {
-        self.host_inner().height()
+        self.cached_height
     }
 
-    /// Format every slot's texture was allocated with.
+    /// Format every slot's texture was allocated with. Cached POD —
+    /// no FFI hop. Decoded from the FFI-stable `u32` discriminant via
+    /// `match` (matches `TextureFormat`'s `#[repr(u32)]` layout).
     pub fn format(&self) -> TextureFormat {
-        self.host_inner().format()
+        match self.cached_format {
+            0 => TextureFormat::Rgba8Unorm,
+            1 => TextureFormat::Rgba8UnormSrgb,
+            2 => TextureFormat::Bgra8Unorm,
+            3 => TextureFormat::Bgra8UnormSrgb,
+            4 => TextureFormat::Rgba16Float,
+            5 => TextureFormat::Rgba32Float,
+            6 => TextureFormat::Nv12,
+            // Unknown discriminant — should be unreachable because
+            // `from_arc_into_raw` captures from a typed
+            // `TextureFormat`. Default to `Rgba8Unorm` defensively.
+            _ => TextureFormat::Rgba8Unorm,
+        }
     }
 
     /// Borrow a slot by index — engine-internal / debug only.
@@ -368,6 +423,11 @@ impl Clone for TextureRing {
         Self {
             handle: self.handle,
             vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_len: self.cached_len,
+            cached_width: self.cached_width,
+            cached_height: self.cached_height,
+            cached_format: self.cached_format,
         }
     }
 }
@@ -397,10 +457,24 @@ mod layout_tests {
 
     #[test]
     fn texture_ring_layout() {
-        assert_eq!(size_of::<TextureRing>(), 16);
+        // β-shape struct as of #907 PR 1/5:
+        //   handle              @ 0  (8 bytes, *const c_void)
+        //   vtable              @ 8  (8 bytes, *const GpuContextFullAccessVTable)
+        //   methods_vtable      @ 16 (8 bytes, *const TextureRingMethodsVTable)
+        //   cached_len          @ 24 (4 bytes, u32)
+        //   cached_width        @ 28 (4 bytes, u32)
+        //   cached_height       @ 32 (4 bytes, u32)
+        //   cached_format       @ 36 (4 bytes, u32)
+        // Total = 40, align = 8.
+        assert_eq!(size_of::<TextureRing>(), 40);
         assert_eq!(align_of::<TextureRing>(), 8);
         assert_eq!(offset_of!(TextureRing, handle), 0);
         assert_eq!(offset_of!(TextureRing, vtable), 8);
+        assert_eq!(offset_of!(TextureRing, methods_vtable), 16);
+        assert_eq!(offset_of!(TextureRing, cached_len), 24);
+        assert_eq!(offset_of!(TextureRing, cached_width), 28);
+        assert_eq!(offset_of!(TextureRing, cached_height), 32);
+        assert_eq!(offset_of!(TextureRing, cached_format), 36);
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -182,6 +182,12 @@ pub struct HostCallbacks {
     /// [`HostServices::gpu_context_full_access_vtable`] at install
     /// time.
     pub gpu_context_full_access_vtable: *const GpuContextFullAccessVTable,
+    /// Host-installed [`TextureRingMethodsVTable`] pointer. May be
+    /// null on hosts that don't ship a GpuContext; cdylib must check
+    /// before dispatching. Sourced from
+    /// [`HostServices::texture_ring_methods_vtable`] at install time
+    /// (issue #907 Phase E PR 1/5).
+    pub texture_ring_methods_vtable: *const streamlib_plugin_abi::TextureRingMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -316,6 +322,15 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.texture_ring_methods_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe { (*services.texture_ring_methods_vtable).layout_version };
+        if v != streamlib_plugin_abi::TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -333,6 +348,7 @@ pub unsafe fn install_host_services(
         gpu_context_limited_access_vtable: services.gpu_context_limited_access_vtable,
         surface_store_vtable: services.surface_store_vtable,
         gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
+        texture_ring_methods_vtable: services.texture_ring_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6278,6 +6294,7 @@ pub mod runtime_facing {
         host_tracing_register_callsite, HostServiceImpls, HOST_AUDIO_CLOCK_VTABLE,
         HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE, HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
         HOST_RUNTIME_CONTEXT_VTABLE, HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
+        HOST_TEXTURE_RING_METHODS_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -6324,8 +6341,27 @@ pub mod runtime_facing {
             gpu_context_limited_access_vtable: &HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
             surface_store_vtable: &HOST_SURFACE_STORE_VTABLE,
             gpu_context_full_access_vtable: &HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE,
+            texture_ring_methods_vtable: &HOST_TEXTURE_RING_METHODS_VTABLE,
         }
     }
+}
+
+/// Host-side empty-shell `TextureRingMethodsVTable` (issue #907 PR 1/5).
+///
+/// PR 1 establishes the pointer plumbing only. Subsequent PRs fill in
+/// method slots for `acquire_next` / `copy_pixel_buffer_to_slot` /
+/// `slot` once the cross-DSO `TextureRingSlot` representation lands.
+pub static HOST_TEXTURE_RING_METHODS_VTABLE: streamlib_plugin_abi::TextureRingMethodsVTable =
+    streamlib_plugin_abi::TextureRingMethodsVTable {
+        layout_version: streamlib_plugin_abi::TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+    };
+
+/// Accessor for the host's static `TextureRingMethodsVTable` — used
+/// by `TextureRing::from_arc_into_raw` to populate the β-shape's
+/// `methods_vtable` field.
+pub fn host_texture_ring_methods_vtable() -> *const streamlib_plugin_abi::TextureRingMethodsVTable {
+    &HOST_TEXTURE_RING_METHODS_VTABLE
 }
 
 // =============================================================================

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
 ///   host wiring + cdylib β-shape, locking the wire format before
 ///   the scope machinery turns it on).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 6;
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 7;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -234,6 +234,18 @@ pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 ///   into `*out_buffer`. Camera processor's V4L2 zero-copy path
 ///   uses this; the host consumes the fd on success.
 pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 7;
+
+/// Layout version of [`TextureRingMethodsVTable`].
+///
+/// `TextureRing` β-shape gains a per-type vtable for method dispatch
+/// (issue #907 Phase E). PR 1 of 5 lands an empty shell — the
+/// vtable carries only `layout_version` + `_reserved_padding` so the
+/// pointer + struct layout are pinned for follow-up PRs that fill
+/// in `acquire_next` / `copy_pixel_buffer_to_slot` / `slot` method
+/// slots once the `TextureRingSlot` cross-DSO representation is
+/// figured out (today's slot carries a heap-allocated `String`
+/// surface_id, not cdylib-safe).
+pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -2494,6 +2506,43 @@ unsafe impl Send for GpuContextFullAccessVTable {}
 unsafe impl Sync for GpuContextFullAccessVTable {}
 
 // =============================================================================
+// TextureRingMethodsVTable — per-type vtable for TextureRing method dispatch
+// =============================================================================
+
+/// Per-type method-dispatch vtable for the `TextureRing` β-shape
+/// (issue #907 Phase E).
+///
+/// `TextureRing` keeps `clone_*` / `drop_*` dispatch on the parent
+/// [`GpuContextFullAccessVTable`] (PR #918's Phase D shape); this
+/// vtable adds per-method slots for everything *else* the β-shape
+/// exposes — `acquire_next`, `copy_pixel_buffer_to_slot`, `slot`.
+/// POD getters (`len`, `is_empty`, `width`, `height`, `format`) are
+/// cached on the β-shape struct itself and don't need vtable slots.
+///
+/// **PR 1/5 ships the shell.** This vtable carries only the
+/// `layout_version` + `_reserved_padding` header today. Method slots
+/// arrive in follow-up sub-issues filed against #907 once the
+/// cross-DSO representation of `TextureRingSlot` (currently
+/// `surface_id: String`, not layout-stable) is settled. Pinning the
+/// shell now lets the β-shape struct grow the `methods_vtable`
+/// pointer field + cached-POD fields with locked offsets, so
+/// downstream PRs only append to this vtable + bump
+/// [`TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION`].
+#[repr(C)]
+pub struct TextureRingMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+}
+
+unsafe impl Send for TextureRingMethodsVTable {}
+unsafe impl Sync for TextureRingMethodsVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -2935,6 +2984,20 @@ pub struct HostServices {
     /// makes the methods reachable from `escalate(|full| ...)` call
     /// sites.
     pub gpu_context_full_access_vtable: *const GpuContextFullAccessVTable,
+
+    // -------------------------------------------------------------------------
+    // TextureRingMethodsVTable surface (v7 — issue #907 Phase E PR 1/5)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `TextureRing` β-shape method
+    /// dispatch. Paired with the per-`TextureRing` handle the
+    /// cdylib carries on its β-shape struct (`methods_vtable`
+    /// field). Set once at install time; non-null for hosts that
+    /// ship a GpuContext, null otherwise (cdylib must check before
+    /// dispatching). PR 1 of issue #907 lands the empty-shell
+    /// vtable + pointer plumbing; follow-up PRs append the actual
+    /// method slots.
+    pub texture_ring_methods_vtable: *const TextureRingMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -3053,7 +3116,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 6);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 7);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -3063,17 +3126,18 @@ mod layout_tests {
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 7);
+        assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_six_vtable_pointers() {
+    fn host_services_tail_carries_seven_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
         //   1. Each vtable is a single 8-byte pointer.
         //   2. They appear in the order RuntimeContext → AudioClock →
         //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
-        //      GpuContextFullAccess.
+        //      GpuContextFullAccess → TextureRingMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -3081,6 +3145,7 @@ mod layout_tests {
         assert_eq!(size_of::<*const GpuContextLimitedAccessVTable>(), 8);
         assert_eq!(size_of::<*const SurfaceStoreVTable>(), 8);
         assert_eq!(size_of::<*const GpuContextFullAccessVTable>(), 8);
+        assert_eq!(size_of::<*const TextureRingMethodsVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -3088,20 +3153,40 @@ mod layout_tests {
         let gpu_lim_off = offset_of!(HostServices, gpu_context_limited_access_vtable);
         let surface_store_off = offset_of!(HostServices, surface_store_vtable);
         let gpu_full_off = offset_of!(HostServices, gpu_context_full_access_vtable);
+        let texture_ring_off = offset_of!(HostServices, texture_ring_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
         assert!(gpu_lim_off < surface_store_off);
         assert!(surface_store_off < gpu_full_off);
+        assert!(gpu_full_off < texture_ring_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
         assert_eq!(surface_store_off - gpu_lim_off, 8);
         assert_eq!(gpu_full_off - surface_store_off, 8);
+        assert_eq!(texture_ring_off - gpu_full_off, 8);
 
-        // The full-access pointer must end at the end of the struct
-        // (it is the last field added in v6).
-        assert_eq!(gpu_full_off + 8, size_of::<HostServices>());
+        // The TextureRingMethods pointer must end at the end of the
+        // struct (it is the last field added in v7).
+        assert_eq!(texture_ring_off + 8, size_of::<HostServices>());
+    }
+
+    #[test]
+    fn texture_ring_methods_vtable_layout() {
+        // Empty shell — layout_version + _reserved_padding only.
+        // Subsequent #907 sub-PRs append method slots and bump
+        // TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION.
+        assert_eq!(size_of::<TextureRingMethodsVTable>(), 8);
+        assert_eq!(align_of::<TextureRingMethodsVTable>(), 4);
+        assert_eq!(
+            offset_of!(TextureRingMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(TextureRingMethodsVTable, _reserved_padding),
+            4
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First of five PRs for issue #907 (Phase E β-newtypes). Establishes the per-type method-dispatch vtable pattern subsequent PRs (compute / graphics / RT kernels + acceleration structure) will follow, using `TextureRing` — the simplest cdylib-callable β-shape — as the proof-of-concept type.

## What lands

- New `TextureRingMethodsVTable` struct in `streamlib-plugin-abi`. **Empty shell today** (`layout_version` + `_reserved_padding`); subsequent PRs append method slots for `acquire_next` / `copy_pixel_buffer_to_slot` / `slot` once the cross-DSO representation of `TextureRingSlot` is settled.
- `TextureRing` β-shape grows from 16 → 40 bytes:
  - `methods_vtable` field pointing at the per-type vtable.
  - Cached POD descriptors (`cached_len`, `cached_width`, `cached_height`, `cached_format`) populated at `from_arc_into_raw` in host mode and from the caller's own inputs in cdylib mode (we pass `width`/`height`/`format`/`count` into `create_texture_ring`, so the cdylib already knows them — no FFI round-trip).
- POD getters `len()`, `is_empty()`, `width()`, `height()`, `format()` now read cached fields — zero FFI hops, host-side and cdylib-side alike.
- `HostServices` / `HostCallbacks` carry the new vtable pointer; both validate `TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION` at install time.
- `HOST_SERVICES_LAYOUT_VERSION`: 6 → 7.
- Layout regression tests in plugin-abi + `texture_ring.rs` locking every new offset.

## Deliberately deferred

`acquire_next` / `copy_pixel_buffer_to_slot` / `slot` continue to dispatch via `host_inner()` and panic if reached from cdylib code. The issue's exit criterion "every public method dispatches via vtable in cdylib mode" is **not** yet met for these three — they require a `TextureRingSlot` cross-DSO representation (the heap-allocated `surface_id: String` field today is not layout-stable).

This is per **AskUserQuestion-confirmed narrow scope** for PR 1 of 5. The deferred work is real for `h264` / `h265` / `debug-utilities`'s `bgra_file_source` if they're ever loaded as cdylib plugins (`load_project()` / `.slpkg`), since all three call `ring.acquire_next()` + `ring.copy_pixel_buffer_to_slot(...)`. The follow-up sub-issue should be filed before any of those three packages ship as `.slpkg` files for cdylib loading.

## pr-review-gate

Verdict: **PASS** with one cosmetic typo (fixed: `pumbing` → `plumbing`) and one DISCUSS noting that the cdylib panic surface for the three deferred methods is real for h264/h265/bgra_file_source — pre-existing as of Phase D, not introduced here, but worth tracking in a follow-up sub-issue.

## Test plan

- [x] `cargo test --lib -p streamlib-engine` — 1147/1147 pass.
- [x] `cargo test --lib -p streamlib-plugin-abi` — 34/34 pass (incl. new `texture_ring_methods_vtable_layout`).
- [x] All 5 sibling dlopen integration tests pass: `smoke`, `lifecycle`, `gpu_acquire`, `escalate_smoke`, `cross_rustc` (the #927 fixture exercising TextureRing Create+Clone+Drop across a divergent dep graph).
- [x] `cargo xtask check-boundaries` — clean.
- [x] `cargo check --workspace --all-targets` — clean.

Refs #907. PR 1 of 5; closes the Phase E plumbing milestone for `TextureRing` (cached POD + per-type vtable shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)