### PR TITLE
feat(plugin-abi): VulkanComputeKernel per-type vtable shell + POD caching (#907 PR 2/5)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4341,13 +4341,23 @@ impl GpuContextFullAccess {
                     }
                     // β-shape: bundle the raw handle (an
                     // `Arc::into_raw(Arc<VulkanComputeKernelInner>)`
-                    // pointer host-side, opaque to the cdylib) with the
-                    // host vtable. Lifecycle dispatches through the
-                    // vtable's clone/drop slots without ever crossing
-                    // the host's `Arc<X>` allocation-header layout.
+                    // pointer host-side, opaque to the cdylib) with
+                    // the host's parent vtable + per-type methods
+                    // vtable + cached `push_constant_size` POD
+                    // (#907 PR 2/5). The cached value comes from the
+                    // descriptor input the cdylib just handed across
+                    // — we know it without needing an FFI round-trip
+                    // to read it back.
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.vulkan_compute_kernel_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::vulkan::rhi::VulkanComputeKernel {
                         handle: out_kernel,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_push_constant_size: descriptor.push_constant_size,
+                        _reserved_padding: 0,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -188,6 +188,13 @@ pub struct HostCallbacks {
     /// [`HostServices::texture_ring_methods_vtable`] at install time
     /// (issue #907 Phase E PR 1/5).
     pub texture_ring_methods_vtable: *const streamlib_plugin_abi::TextureRingMethodsVTable,
+    /// Host-installed [`VulkanComputeKernelMethodsVTable`] pointer.
+    /// May be null on hosts that don't ship a GpuContext; cdylib
+    /// must check before dispatching. Sourced from
+    /// [`HostServices::vulkan_compute_kernel_methods_vtable`] at
+    /// install time (issue #907 Phase E PR 2/5).
+    pub vulkan_compute_kernel_methods_vtable:
+        *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -331,6 +338,18 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.vulkan_compute_kernel_methods_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe {
+            (*services.vulkan_compute_kernel_methods_vtable).layout_version
+        };
+        if v != streamlib_plugin_abi::VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION
+        {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -349,6 +368,8 @@ pub unsafe fn install_host_services(
         surface_store_vtable: services.surface_store_vtable,
         gpu_context_full_access_vtable: services.gpu_context_full_access_vtable,
         texture_ring_methods_vtable: services.texture_ring_methods_vtable,
+        vulkan_compute_kernel_methods_vtable: services
+            .vulkan_compute_kernel_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6294,7 +6315,7 @@ pub mod runtime_facing {
         host_tracing_register_callsite, HostServiceImpls, HOST_AUDIO_CLOCK_VTABLE,
         HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE, HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
         HOST_RUNTIME_CONTEXT_VTABLE, HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
-        HOST_TEXTURE_RING_METHODS_VTABLE,
+        HOST_TEXTURE_RING_METHODS_VTABLE, HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -6342,6 +6363,8 @@ pub mod runtime_facing {
             surface_store_vtable: &HOST_SURFACE_STORE_VTABLE,
             gpu_context_full_access_vtable: &HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE,
             texture_ring_methods_vtable: &HOST_TEXTURE_RING_METHODS_VTABLE,
+            vulkan_compute_kernel_methods_vtable:
+                &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
         }
     }
 }
@@ -6362,6 +6385,28 @@ pub static HOST_TEXTURE_RING_METHODS_VTABLE: streamlib_plugin_abi::TextureRingMe
 /// `methods_vtable` field.
 pub fn host_texture_ring_methods_vtable() -> *const streamlib_plugin_abi::TextureRingMethodsVTable {
     &HOST_TEXTURE_RING_METHODS_VTABLE
+}
+
+/// Host-side empty-shell `VulkanComputeKernelMethodsVTable` (issue
+/// #907 PR 2/5).
+///
+/// PR 2 establishes the pointer plumbing only. Subsequent PRs fill
+/// in method slots for the kernel's `set_*` / `dispatch` / `record`
+/// / `bindings` surface plus the ambitious CPU-reference dlopen
+/// integration test together.
+pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
+    streamlib_plugin_abi::VulkanComputeKernelMethodsVTable =
+    streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
+        layout_version: streamlib_plugin_abi::VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+    };
+
+/// Accessor for the host's static `VulkanComputeKernelMethodsVTable`
+/// — used by `VulkanComputeKernel::from_arc_into_raw` to populate
+/// the β-shape's `methods_vtable` field.
+pub fn host_vulkan_compute_kernel_methods_vtable(
+) -> *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
+    &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE
 }
 
 // =============================================================================

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_compute_kernel.rs
@@ -941,14 +941,42 @@ impl std::fmt::Debug for VulkanComputeKernelInner {
 // β-shape implementation (#917)
 // =============================================================================
 
-/// Compute kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape
-/// so cdylibs can hold, refcount, and drop without sharing rustc-version
-/// or dep-graph with the host. Method dispatch is host-only via
-/// [`Self::host_inner`] until Phase E (#907) lifts to vtable slots.
+/// Compute kernel — layout-stable `#[repr(C)]` β-shape so cdylibs
+/// can hold, refcount, drop, and read POD descriptors without
+/// sharing rustc-version or dep-graph with the host.
+///
+/// The opaque handle points at an `Arc<VulkanComputeKernelInner>`;
+/// lifecycle (Clone / Drop) dispatches through the host-installed
+/// parent [`GpuContextFullAccessVTable`]'s `clone_compute_kernel` /
+/// `drop_compute_kernel` callbacks (locked by PR #918's β-shape
+/// Phase D work). Per-method dispatch is reached through the
+/// dedicated
+/// [`streamlib_plugin_abi::VulkanComputeKernelMethodsVTable`] pointed
+/// at by `methods_vtable` — issue #907 PR 2/5 lands the pointer
+/// plumbing + cached POD fields; follow-up PRs append method slots
+/// and route `set_*` / `dispatch` / `record` / `bindings` through
+/// them, plus land the ambitious CPU-reference dlopen integration
+/// test.
+///
+/// The `push_constant_size()` POD getter reads from the cached
+/// field — no FFI hop. The value is captured by
+/// [`Self::from_arc_into_raw`] at construction and never mutates
+/// over the kernel's lifetime.
 #[repr(C)]
 pub struct VulkanComputeKernel {
+    /// Opaque handle to the host's `Arc<VulkanComputeKernelInner>`.
     pub(crate) handle: *const c_void,
+    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    pub(crate) methods_vtable:
+        *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable,
+    /// Cached push-constant size in bytes. Set at construction; fixed
+    /// for the kernel's lifetime.
+    pub(crate) cached_push_constant_size: u32,
+    /// Reserved padding so the struct stays 8-byte aligned and the
+    /// trailing bytes of the last 4-byte field are deterministic.
+    pub(crate) _reserved_padding: u32,
 }
 
 unsafe impl Send for VulkanComputeKernel {}
@@ -982,10 +1010,19 @@ impl VulkanComputeKernel {
     }
 
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanComputeKernelInner>) -> Self {
+        let cached_push_constant_size = arc.push_constant_size();
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_vulkan_compute_kernel_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+            cached_push_constant_size,
+            _reserved_padding: 0,
+        }
     }
 
     pub(crate) fn host_inner(&self) -> &VulkanComputeKernelInner {
@@ -1084,8 +1121,9 @@ impl VulkanComputeKernel {
         self.host_inner().bindings().to_vec()
     }
 
+    /// Push-constant range size in bytes. Cached POD — no FFI hop.
     pub fn push_constant_size(&self) -> u32 {
-        self.host_inner().push_constant_size()
+        self.cached_push_constant_size
     }
 }
 
@@ -1099,6 +1137,9 @@ impl Clone for VulkanComputeKernel {
         Self {
             handle: self.handle,
             vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_push_constant_size: self.cached_push_constant_size,
+            _reserved_padding: self._reserved_padding,
         }
     }
 }
@@ -1126,10 +1167,23 @@ mod beta_shape_layout_tests {
 
     #[test]
     fn vulkan_compute_kernel_layout() {
-        assert_eq!(size_of::<VulkanComputeKernel>(), 16);
+        // β-shape struct as of #907 PR 2/5:
+        //   handle                       @ 0  (8 bytes, *const c_void)
+        //   vtable                       @ 8  (8 bytes, *const GpuContextFullAccessVTable)
+        //   methods_vtable               @ 16 (8 bytes, *const VulkanComputeKernelMethodsVTable)
+        //   cached_push_constant_size    @ 24 (4 bytes, u32)
+        //   _reserved_padding            @ 28 (4 bytes, u32)
+        // Total = 32, align = 8.
+        assert_eq!(size_of::<VulkanComputeKernel>(), 32);
         assert_eq!(align_of::<VulkanComputeKernel>(), 8);
         assert_eq!(offset_of!(VulkanComputeKernel, handle), 0);
         assert_eq!(offset_of!(VulkanComputeKernel, vtable), 8);
+        assert_eq!(offset_of!(VulkanComputeKernel, methods_vtable), 16);
+        assert_eq!(
+            offset_of!(VulkanComputeKernel, cached_push_constant_size),
+            24
+        );
+        assert_eq!(offset_of!(VulkanComputeKernel, _reserved_padding), 28);
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
 ///   host wiring + cdylib β-shape, locking the wire format before
 ///   the scope machinery turns it on).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 7;
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 8;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -246,6 +246,18 @@ pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 7;
 /// figured out (today's slot carries a heap-allocated `String`
 /// surface_id, not cdylib-safe).
 pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`VulkanComputeKernelMethodsVTable`].
+///
+/// `VulkanComputeKernel` β-shape gains a per-type vtable for method
+/// dispatch (issue #907 Phase E PR 2/5). Mirrors the
+/// `TextureRingMethodsVTable` shape: this PR lands the empty shell
+/// so the pointer + struct layout are pinned; follow-up PRs append
+/// `set_storage_buffer` / `set_uniform_buffer` /
+/// `set_sampled_texture` / `set_storage_image` /
+/// `set_push_constants` / `dispatch` / `record` / `bindings` method
+/// slots and route the β-shape methods through them.
+pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -2543,6 +2555,44 @@ unsafe impl Send for TextureRingMethodsVTable {}
 unsafe impl Sync for TextureRingMethodsVTable {}
 
 // =============================================================================
+// VulkanComputeKernelMethodsVTable — per-type vtable for compute-kernel method dispatch
+// =============================================================================
+
+/// Per-type method-dispatch vtable for the `VulkanComputeKernel`
+/// β-shape (issue #907 Phase E PR 2/5).
+///
+/// `VulkanComputeKernel` keeps `clone_*` / `drop_*` dispatch on the
+/// parent [`GpuContextFullAccessVTable`] (PR #918's Phase D shape);
+/// this vtable adds per-method slots for `set_storage_buffer` /
+/// `set_uniform_buffer` / `set_sampled_texture` / `set_storage_image`
+/// / `set_push_constants` / `dispatch` / `record` / `bindings`. POD
+/// getters (`push_constant_size`) are cached on the β-shape struct
+/// and don't need vtable slots.
+///
+/// **PR 2/5 ships the shell.** This vtable carries only the
+/// `layout_version` + `_reserved_padding` header today. Method slots
+/// arrive in follow-up sub-issues filed against #907 once the
+/// vtable-routed `set_*` / `dispatch` / `record` paths plus the
+/// ambitious CPU-reference dlopen integration test land together.
+/// Pinning the shell now lets the β-shape struct grow the
+/// `methods_vtable` pointer + cached `push_constant_size` field with
+/// locked offsets, so downstream PRs only append to this vtable +
+/// bump [`VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION`].
+#[repr(C)]
+pub struct VulkanComputeKernelMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+}
+
+unsafe impl Send for VulkanComputeKernelMethodsVTable {}
+unsafe impl Sync for VulkanComputeKernelMethodsVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -2998,6 +3048,20 @@ pub struct HostServices {
     /// vtable + pointer plumbing; follow-up PRs append the actual
     /// method slots.
     pub texture_ring_methods_vtable: *const TextureRingMethodsVTable,
+
+    // -------------------------------------------------------------------------
+    // VulkanComputeKernelMethodsVTable surface (v8 — issue #907 Phase E PR 2/5)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `VulkanComputeKernel` β-shape
+    /// method dispatch. Paired with the per-`VulkanComputeKernel`
+    /// handle the cdylib carries on its β-shape struct
+    /// (`methods_vtable` field). Set once at install time; non-null
+    /// for hosts that ship a GpuContext, null otherwise (cdylib
+    /// must check before dispatching). PR 2 of issue #907 lands the
+    /// empty-shell vtable + pointer plumbing; follow-up PRs append
+    /// the actual method slots.
+    pub vulkan_compute_kernel_methods_vtable: *const VulkanComputeKernelMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -3116,7 +3180,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 7);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 8);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -3127,17 +3191,19 @@ mod layout_tests {
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 7);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_seven_vtable_pointers() {
+    fn host_services_tail_carries_eight_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
         //   1. Each vtable is a single 8-byte pointer.
         //   2. They appear in the order RuntimeContext → AudioClock →
         //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
-        //      GpuContextFullAccess → TextureRingMethods.
+        //      GpuContextFullAccess → TextureRingMethods →
+        //      VulkanComputeKernelMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -3146,6 +3212,7 @@ mod layout_tests {
         assert_eq!(size_of::<*const SurfaceStoreVTable>(), 8);
         assert_eq!(size_of::<*const GpuContextFullAccessVTable>(), 8);
         assert_eq!(size_of::<*const TextureRingMethodsVTable>(), 8);
+        assert_eq!(size_of::<*const VulkanComputeKernelMethodsVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -3154,22 +3221,26 @@ mod layout_tests {
         let surface_store_off = offset_of!(HostServices, surface_store_vtable);
         let gpu_full_off = offset_of!(HostServices, gpu_context_full_access_vtable);
         let texture_ring_off = offset_of!(HostServices, texture_ring_methods_vtable);
+        let compute_kernel_off =
+            offset_of!(HostServices, vulkan_compute_kernel_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
         assert!(gpu_lim_off < surface_store_off);
         assert!(surface_store_off < gpu_full_off);
         assert!(gpu_full_off < texture_ring_off);
+        assert!(texture_ring_off < compute_kernel_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
         assert_eq!(surface_store_off - gpu_lim_off, 8);
         assert_eq!(gpu_full_off - surface_store_off, 8);
         assert_eq!(texture_ring_off - gpu_full_off, 8);
+        assert_eq!(compute_kernel_off - texture_ring_off, 8);
 
-        // The TextureRingMethods pointer must end at the end of the
-        // struct (it is the last field added in v7).
-        assert_eq!(texture_ring_off + 8, size_of::<HostServices>());
+        // The VulkanComputeKernelMethods pointer must end at the end
+        // of the struct (it is the last field added in v8).
+        assert_eq!(compute_kernel_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -3185,6 +3256,24 @@ mod layout_tests {
         );
         assert_eq!(
             offset_of!(TextureRingMethodsVTable, _reserved_padding),
+            4
+        );
+    }
+
+    #[test]
+    fn vulkan_compute_kernel_methods_vtable_layout() {
+        // Empty shell — layout_version + _reserved_padding only.
+        // Mirrors `texture_ring_methods_vtable_layout`. Subsequent
+        // #907 sub-PRs append method slots and bump
+        // VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION.
+        assert_eq!(size_of::<VulkanComputeKernelMethodsVTable>(), 8);
+        assert_eq!(align_of::<VulkanComputeKernelMethodsVTable>(), 4);
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(VulkanComputeKernelMethodsVTable, _reserved_padding),
             4
         );
     }


### PR DESCRIPTION
## Summary

Second of five PRs for issue #907 (Phase E β-newtypes). Mirrors PR 1/5's `TextureRing` shape exactly — per AskUserQuestion-confirmed narrow scope: establish the per-type method-dispatch vtable + POD caching, defer the full method dispatch and the ambitious CPU-reference integration test to a follow-up sub-issue.

## What lands

- New `VulkanComputeKernelMethodsVTable` struct in `streamlib-plugin-abi`. **Empty shell today** (`layout_version` + `_reserved_padding`); subsequent PRs append method slots for `set_storage_buffer` / `set_uniform_buffer` / `set_sampled_texture` / `set_storage_image` / `set_push_constants` / `dispatch` / `record` / `bindings` plus land the ambitious CPU-reference dlopen integration test together.
- `VulkanComputeKernel` β-shape grows from 16 → 32 bytes:
  - `methods_vtable` field pointing at the per-type vtable.
  - `cached_push_constant_size` POD populated at `from_arc_into_raw` in host mode and from the caller's descriptor in cdylib mode.
  - `_reserved_padding` keeps the struct 8-byte aligned.
- `push_constant_size()` POD getter reads cached field — zero FFI hops, host- or cdylib-side.
- `HostServices` / `HostCallbacks` carry the new vtable pointer; both validate `VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION` at install time.
- `HOST_SERVICES_LAYOUT_VERSION`: 7 → 8.
- Layout regression tests in plugin-abi + `vulkan_compute_kernel.rs` locking every new offset.

## Deliberately deferred

The β-shape's `set_*` / `dispatch` / `record` / `bindings()` methods continue to dispatch via `host_inner()` and panic if reached from cdylib code. The issue's exit criterion "every public method dispatches via vtable in cdylib mode" is **not** yet met for these — they need real method slots on the new vtable plus the ambitious CPU-reference integration test. Follow-up sub-issue to be filed alongside the equivalent for TextureRing (#947).

## Test plan

- [x] `cargo test --lib -p streamlib-plugin-abi` — 35/35 pass (incl. new `vulkan_compute_kernel_methods_vtable_layout` + refreshed `host_services_tail_carries_eight_vtable_pointers`).
- [x] `cargo test --lib -p streamlib-engine` — 1147/1147 pass.
- [x] `load_project_dylib_smoke` + `cross_rustc` integration tests pass.
- [x] `cargo xtask check-boundaries` — clean.
- [x] `cargo check --workspace --all-targets` — clean.

Refs #907. PR 2 of 5. Same scope shape as PR #946 (which closed PR 1/5 with the equivalent TextureRing plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)