### PR TITLE
feat(plugin-abi): VulkanGraphicsKernel per-type vtable shell + POD caching (#907 PR 3/5)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4581,10 +4581,20 @@ impl GpuContextFullAccess {
                             "create_graphics_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // β-shape: see compute_kernel above.
+                    // β-shape: see compute_kernel above. Cached PODs
+                    // come from the caller's descriptor — we know
+                    // them without an FFI round-trip (#907 PR 3/5).
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.vulkan_graphics_kernel_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::vulkan::rhi::VulkanGraphicsKernel {
                         handle: out_kernel,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_push_constant_size: descriptor.push_constants.size,
+                        cached_descriptor_sets_in_flight: descriptor
+                            .descriptor_sets_in_flight,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -195,6 +195,13 @@ pub struct HostCallbacks {
     /// install time (issue #907 Phase E PR 2/5).
     pub vulkan_compute_kernel_methods_vtable:
         *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable,
+    /// Host-installed [`VulkanGraphicsKernelMethodsVTable`] pointer.
+    /// May be null on hosts that don't ship a GpuContext; cdylib
+    /// must check before dispatching. Sourced from
+    /// [`HostServices::vulkan_graphics_kernel_methods_vtable`] at
+    /// install time (issue #907 Phase E PR 3/5).
+    pub vulkan_graphics_kernel_methods_vtable:
+        *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -350,6 +357,18 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.vulkan_graphics_kernel_methods_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe {
+            (*services.vulkan_graphics_kernel_methods_vtable).layout_version
+        };
+        if v != streamlib_plugin_abi::VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION
+        {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -370,6 +389,8 @@ pub unsafe fn install_host_services(
         texture_ring_methods_vtable: services.texture_ring_methods_vtable,
         vulkan_compute_kernel_methods_vtable: services
             .vulkan_compute_kernel_methods_vtable,
+        vulkan_graphics_kernel_methods_vtable: services
+            .vulkan_graphics_kernel_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6316,6 +6337,7 @@ pub mod runtime_facing {
         HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE, HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
         HOST_RUNTIME_CONTEXT_VTABLE, HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
         HOST_TEXTURE_RING_METHODS_VTABLE, HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
+        HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -6365,6 +6387,8 @@ pub mod runtime_facing {
             texture_ring_methods_vtable: &HOST_TEXTURE_RING_METHODS_VTABLE,
             vulkan_compute_kernel_methods_vtable:
                 &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
+            vulkan_graphics_kernel_methods_vtable:
+                &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
         }
     }
 }
@@ -6407,6 +6431,28 @@ pub static HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE:
 pub fn host_vulkan_compute_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanComputeKernelMethodsVTable {
     &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE
+}
+
+/// Host-side empty-shell `VulkanGraphicsKernelMethodsVTable` (issue
+/// #907 PR 3/5).
+///
+/// PR 3 establishes the pointer plumbing only. Subsequent PRs fill
+/// in method slots for the kernel's graphics-pipeline `set_*` /
+/// `cmd_bind_and_draw` / `offscreen_render` / `bindings` surface.
+pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
+    streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable =
+    streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
+        layout_version:
+            streamlib_plugin_abi::VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+    };
+
+/// Accessor for the host's static `VulkanGraphicsKernelMethodsVTable`
+/// — used by `VulkanGraphicsKernel::from_arc_into_raw` to populate
+/// the β-shape's `methods_vtable` field.
+pub fn host_vulkan_graphics_kernel_methods_vtable(
+) -> *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
+    &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE
 }
 
 // =============================================================================

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_graphics_kernel.rs
@@ -1231,11 +1231,22 @@ impl std::fmt::Debug for VulkanGraphicsKernelInner {
 // β-shape implementation (#917)
 // =============================================================================
 
-/// Graphics kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape.
+/// Graphics kernel — layout-stable `#[repr(C)]` β-shape (#907 Phase
+/// E PR 3/5). Mirrors `VulkanComputeKernel`'s shape: handle + parent
+/// vtable + per-type methods vtable + cached PODs.
 #[repr(C)]
 pub struct VulkanGraphicsKernel {
+    /// Opaque handle to the host's `Arc<VulkanGraphicsKernelInner>`.
     pub(crate) handle: *const c_void,
+    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    pub(crate) methods_vtable:
+        *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable,
+    /// Cached push-constant size in bytes. Set at construction.
+    pub(crate) cached_push_constant_size: u32,
+    /// Cached descriptor-set ring depth. Set at construction.
+    pub(crate) cached_descriptor_sets_in_flight: u32,
 }
 
 unsafe impl Send for VulkanGraphicsKernel {}
@@ -1251,10 +1262,20 @@ impl VulkanGraphicsKernel {
     }
 
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanGraphicsKernelInner>) -> Self {
+        let cached_push_constant_size = arc.push_constant_size();
+        let cached_descriptor_sets_in_flight = arc.descriptor_sets_in_flight();
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_vulkan_graphics_kernel_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+            cached_push_constant_size,
+            cached_descriptor_sets_in_flight,
+        }
     }
 
     pub(crate) fn host_inner(&self) -> &VulkanGraphicsKernelInner {
@@ -1271,12 +1292,14 @@ impl VulkanGraphicsKernel {
         self.host_inner().bindings().to_vec()
     }
 
+    /// Push-constant range size in bytes. Cached POD — no FFI hop.
     pub fn push_constant_size(&self) -> u32 {
-        self.host_inner().push_constant_size()
+        self.cached_push_constant_size
     }
 
+    /// Descriptor-set ring depth. Cached POD — no FFI hop.
     pub fn descriptor_sets_in_flight(&self) -> u32 {
-        self.host_inner().descriptor_sets_in_flight()
+        self.cached_descriptor_sets_in_flight
     }
 
     pub fn set_sampled_texture(
@@ -1402,6 +1425,9 @@ impl Clone for VulkanGraphicsKernel {
         Self {
             handle: self.handle,
             vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_push_constant_size: self.cached_push_constant_size,
+            cached_descriptor_sets_in_flight: self.cached_descriptor_sets_in_flight,
         }
     }
 }
@@ -1429,10 +1455,26 @@ mod beta_shape_layout_tests {
 
     #[test]
     fn vulkan_graphics_kernel_layout() {
-        assert_eq!(size_of::<VulkanGraphicsKernel>(), 16);
+        // β-shape struct as of #907 PR 3/5:
+        //   handle                              @ 0  (8 bytes, *const c_void)
+        //   vtable                              @ 8  (8 bytes, *const GpuContextFullAccessVTable)
+        //   methods_vtable                      @ 16 (8 bytes, *const VulkanGraphicsKernelMethodsVTable)
+        //   cached_push_constant_size           @ 24 (4 bytes, u32)
+        //   cached_descriptor_sets_in_flight    @ 28 (4 bytes, u32)
+        // Total = 32, align = 8.
+        assert_eq!(size_of::<VulkanGraphicsKernel>(), 32);
         assert_eq!(align_of::<VulkanGraphicsKernel>(), 8);
         assert_eq!(offset_of!(VulkanGraphicsKernel, handle), 0);
         assert_eq!(offset_of!(VulkanGraphicsKernel, vtable), 8);
+        assert_eq!(offset_of!(VulkanGraphicsKernel, methods_vtable), 16);
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernel, cached_push_constant_size),
+            24
+        );
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernel, cached_descriptor_sets_in_flight),
+            28
+        );
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
 ///   host wiring + cdylib β-shape, locking the wire format before
 ///   the scope machinery turns it on).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 8;
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 9;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -258,6 +258,17 @@ pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// `set_push_constants` / `dispatch` / `record` / `bindings` method
 /// slots and route the β-shape methods through them.
 pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`VulkanGraphicsKernelMethodsVTable`].
+///
+/// `VulkanGraphicsKernel` β-shape gains a per-type vtable for
+/// method dispatch (issue #907 Phase E PR 3/5). Mirrors the
+/// `VulkanComputeKernelMethodsVTable` shape: this PR lands the
+/// empty shell so the pointer + struct layout are pinned; follow-up
+/// PRs append method slots and route the β-shape's
+/// `set_*` / `cmd_bind_and_draw` / `offscreen_render` / `bindings`
+/// surface through them.
+pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -2593,6 +2604,36 @@ unsafe impl Send for VulkanComputeKernelMethodsVTable {}
 unsafe impl Sync for VulkanComputeKernelMethodsVTable {}
 
 // =============================================================================
+// VulkanGraphicsKernelMethodsVTable — per-type vtable for graphics-kernel method dispatch
+// =============================================================================
+
+/// Per-type method-dispatch vtable for the `VulkanGraphicsKernel`
+/// β-shape (issue #907 Phase E PR 3/5).
+///
+/// Mirrors `VulkanComputeKernelMethodsVTable`: this PR ships the
+/// empty shell so the pointer + struct layout are pinned. Follow-up
+/// PRs append slots for the graphics-pipeline surface
+/// (`set_storage_buffer` / `set_uniform_buffer` /
+/// `set_sampled_texture` / `set_storage_image` /
+/// `set_vertex_buffer` / `set_index_buffer` / `set_push_constants` /
+/// `cmd_bind_and_draw` / `cmd_bind_and_draw_indexed` /
+/// `offscreen_render` / `bindings` / `pipeline_state`) and route the
+/// β-shape methods through them.
+#[repr(C)]
+pub struct VulkanGraphicsKernelMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+}
+
+unsafe impl Send for VulkanGraphicsKernelMethodsVTable {}
+unsafe impl Sync for VulkanGraphicsKernelMethodsVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -3062,6 +3103,20 @@ pub struct HostServices {
     /// empty-shell vtable + pointer plumbing; follow-up PRs append
     /// the actual method slots.
     pub vulkan_compute_kernel_methods_vtable: *const VulkanComputeKernelMethodsVTable,
+
+    // -------------------------------------------------------------------------
+    // VulkanGraphicsKernelMethodsVTable surface (v9 — issue #907 Phase E PR 3/5)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `VulkanGraphicsKernel` β-shape
+    /// method dispatch. Paired with the per-`VulkanGraphicsKernel`
+    /// handle the cdylib carries on its β-shape struct
+    /// (`methods_vtable` field). Set once at install time; non-null
+    /// for hosts that ship a GpuContext, null otherwise (cdylib
+    /// must check before dispatching). PR 3 of issue #907 lands the
+    /// empty-shell vtable + pointer plumbing; follow-up PRs append
+    /// the actual method slots.
+    pub vulkan_graphics_kernel_methods_vtable: *const VulkanGraphicsKernelMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -3180,7 +3235,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 8);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 9);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -3192,10 +3247,11 @@ mod layout_tests {
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 7);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_eight_vtable_pointers() {
+    fn host_services_tail_carries_nine_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
@@ -3203,7 +3259,7 @@ mod layout_tests {
         //   2. They appear in the order RuntimeContext → AudioClock →
         //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
         //      GpuContextFullAccess → TextureRingMethods →
-        //      VulkanComputeKernelMethods.
+        //      VulkanComputeKernelMethods → VulkanGraphicsKernelMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -3213,6 +3269,7 @@ mod layout_tests {
         assert_eq!(size_of::<*const GpuContextFullAccessVTable>(), 8);
         assert_eq!(size_of::<*const TextureRingMethodsVTable>(), 8);
         assert_eq!(size_of::<*const VulkanComputeKernelMethodsVTable>(), 8);
+        assert_eq!(size_of::<*const VulkanGraphicsKernelMethodsVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -3223,6 +3280,8 @@ mod layout_tests {
         let texture_ring_off = offset_of!(HostServices, texture_ring_methods_vtable);
         let compute_kernel_off =
             offset_of!(HostServices, vulkan_compute_kernel_methods_vtable);
+        let graphics_kernel_off =
+            offset_of!(HostServices, vulkan_graphics_kernel_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
@@ -3230,6 +3289,7 @@ mod layout_tests {
         assert!(surface_store_off < gpu_full_off);
         assert!(gpu_full_off < texture_ring_off);
         assert!(texture_ring_off < compute_kernel_off);
+        assert!(compute_kernel_off < graphics_kernel_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
@@ -3237,10 +3297,11 @@ mod layout_tests {
         assert_eq!(gpu_full_off - surface_store_off, 8);
         assert_eq!(texture_ring_off - gpu_full_off, 8);
         assert_eq!(compute_kernel_off - texture_ring_off, 8);
+        assert_eq!(graphics_kernel_off - compute_kernel_off, 8);
 
-        // The VulkanComputeKernelMethods pointer must end at the end
-        // of the struct (it is the last field added in v8).
-        assert_eq!(compute_kernel_off + 8, size_of::<HostServices>());
+        // The VulkanGraphicsKernelMethods pointer must end at the
+        // end of the struct (it is the last field added in v9).
+        assert_eq!(graphics_kernel_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -3274,6 +3335,24 @@ mod layout_tests {
         );
         assert_eq!(
             offset_of!(VulkanComputeKernelMethodsVTable, _reserved_padding),
+            4
+        );
+    }
+
+    #[test]
+    fn vulkan_graphics_kernel_methods_vtable_layout() {
+        // Empty shell — layout_version + _reserved_padding only.
+        // Mirrors the compute-kernel layout. Subsequent #907 sub-PRs
+        // append method slots and bump
+        // VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION.
+        assert_eq!(size_of::<VulkanGraphicsKernelMethodsVTable>(), 8);
+        assert_eq!(align_of::<VulkanGraphicsKernelMethodsVTable>(), 4);
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernelMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(VulkanGraphicsKernelMethodsVTable, _reserved_padding),
             4
         );
     }


### PR DESCRIPTION
## Summary

Third of five PRs for issue #907 (Phase E β-newtypes). Mirrors PR 1/5 (TextureRing, PR #946) and PR 2/5 (VulkanComputeKernel, PR #948) exactly.

## What lands

- New `VulkanGraphicsKernelMethodsVTable` struct in `streamlib-plugin-abi` (empty shell).
- `VulkanGraphicsKernel` β-shape grows from 16 → 32 bytes: `methods_vtable` + `cached_push_constant_size` + `cached_descriptor_sets_in_flight`.
- `push_constant_size()` + `descriptor_sets_in_flight()` POD getters read cached fields — zero FFI hops.
- `HostServices` / `HostCallbacks` carry the new vtable pointer with version validation.
- `HOST_SERVICES_LAYOUT_VERSION`: 8 → 9.

## Deliberately deferred

`set_*` / `cmd_bind_and_draw*` / `offscreen_render` / `bindings()` still dispatch via `host_inner()`. Follow-up sub-issue to be filed alongside #947 / #949.

## Validation

- 36/36 `cargo test --lib -p streamlib-plugin-abi` pass.
- 1147/1147 `cargo test --lib -p streamlib-engine` pass.
- `cross_rustc` dlopen integration test green.
- `cargo xtask check-boundaries` — clean.

Refs #907. PR 3 of 5. Same scope shape as #946 (PR 1/5) and #948 (PR 2/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)