### PR TITLE
feat(plugin-abi): VulkanRayTracingKernel per-type vtable shell + POD caching (#907 PR 4/5)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4648,10 +4648,18 @@ impl GpuContextFullAccess {
                             "create_ray_tracing_kernel: host signaled success but out_kernel is null".into(),
                         ));
                     }
-                    // β-shape: see compute_kernel above.
+                    // β-shape: see compute_kernel above. Cached PODs
+                    // come from the caller's descriptor (#907 PR 4/5).
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.vulkan_ray_tracing_kernel_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::vulkan::rhi::VulkanRayTracingKernel {
                         handle: out_kernel,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_push_constant_size: descriptor.push_constants.size,
+                        _reserved_padding: 0,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -202,6 +202,13 @@ pub struct HostCallbacks {
     /// install time (issue #907 Phase E PR 3/5).
     pub vulkan_graphics_kernel_methods_vtable:
         *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable,
+    /// Host-installed [`VulkanRayTracingKernelMethodsVTable`] pointer.
+    /// May be null on hosts that don't ship a GpuContext; cdylib
+    /// must check before dispatching. Sourced from
+    /// [`HostServices::vulkan_ray_tracing_kernel_methods_vtable`] at
+    /// install time (issue #907 Phase E PR 4/5).
+    pub vulkan_ray_tracing_kernel_methods_vtable:
+        *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -369,6 +376,18 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.vulkan_ray_tracing_kernel_methods_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe {
+            (*services.vulkan_ray_tracing_kernel_methods_vtable).layout_version
+        };
+        if v != streamlib_plugin_abi::VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION
+        {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -391,6 +410,8 @@ pub unsafe fn install_host_services(
             .vulkan_compute_kernel_methods_vtable,
         vulkan_graphics_kernel_methods_vtable: services
             .vulkan_graphics_kernel_methods_vtable,
+        vulkan_ray_tracing_kernel_methods_vtable: services
+            .vulkan_ray_tracing_kernel_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6338,6 +6359,7 @@ pub mod runtime_facing {
         HOST_RUNTIME_CONTEXT_VTABLE, HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
         HOST_TEXTURE_RING_METHODS_VTABLE, HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
         HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
+        HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -6389,6 +6411,8 @@ pub mod runtime_facing {
                 &HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
             vulkan_graphics_kernel_methods_vtable:
                 &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
+            vulkan_ray_tracing_kernel_methods_vtable:
+                &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE,
         }
     }
 }
@@ -6453,6 +6477,25 @@ pub static HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE:
 pub fn host_vulkan_graphics_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanGraphicsKernelMethodsVTable {
     &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE
+}
+
+/// Host-side empty-shell `VulkanRayTracingKernelMethodsVTable`
+/// (issue #907 PR 4/5).
+pub static HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE:
+    streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable =
+    streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable {
+        layout_version:
+            streamlib_plugin_abi::VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+    };
+
+/// Accessor for the host's static
+/// `VulkanRayTracingKernelMethodsVTable` — used by
+/// `VulkanRayTracingKernel::from_arc_into_raw` to populate the
+/// β-shape's `methods_vtable` field.
+pub fn host_vulkan_ray_tracing_kernel_methods_vtable(
+) -> *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable {
+    &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE
 }
 
 // =============================================================================

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_ray_tracing_kernel.rs
@@ -912,11 +912,22 @@ impl std::fmt::Debug for VulkanRayTracingKernelInner {
 // β-shape implementation (#917)
 // =============================================================================
 
-/// Ray-tracing kernel — layout-stable `#[repr(C)] (handle, vtable)` β-shape.
+/// Ray-tracing kernel — layout-stable `#[repr(C)]` β-shape (#907
+/// Phase E PR 4/5). Mirrors the compute kernel shape.
 #[repr(C)]
 pub struct VulkanRayTracingKernel {
+    /// Opaque handle to the host's `Arc<VulkanRayTracingKernelInner>`.
     pub(crate) handle: *const c_void,
+    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    pub(crate) methods_vtable:
+        *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable,
+    /// Cached push-constant size in bytes. Set at construction.
+    pub(crate) cached_push_constant_size: u32,
+    /// Reserved padding so the struct stays 8-byte aligned and the
+    /// trailing 4 bytes are deterministic.
+    pub(crate) _reserved_padding: u32,
 }
 
 unsafe impl Send for VulkanRayTracingKernel {}
@@ -932,10 +943,19 @@ impl VulkanRayTracingKernel {
     }
 
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanRayTracingKernelInner>) -> Self {
+        let cached_push_constant_size = arc.push_constant_size();
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_vulkan_ray_tracing_kernel_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+            cached_push_constant_size,
+            _reserved_padding: 0,
+        }
     }
 
     pub(crate) fn host_inner(&self) -> &VulkanRayTracingKernelInner {
@@ -994,8 +1014,9 @@ impl VulkanRayTracingKernel {
         self.host_inner().bindings().to_vec()
     }
 
+    /// Push-constant range size in bytes. Cached POD — no FFI hop.
     pub fn push_constant_size(&self) -> u32 {
-        self.host_inner().push_constant_size()
+        self.cached_push_constant_size
     }
 }
 
@@ -1009,6 +1030,9 @@ impl Clone for VulkanRayTracingKernel {
         Self {
             handle: self.handle,
             vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_push_constant_size: self.cached_push_constant_size,
+            _reserved_padding: self._reserved_padding,
         }
     }
 }
@@ -1036,10 +1060,23 @@ mod beta_shape_layout_tests {
 
     #[test]
     fn vulkan_ray_tracing_kernel_layout() {
-        assert_eq!(size_of::<VulkanRayTracingKernel>(), 16);
+        // β-shape struct as of #907 PR 4/5:
+        //   handle                       @ 0  (8 bytes, *const c_void)
+        //   vtable                       @ 8  (8 bytes, *const GpuContextFullAccessVTable)
+        //   methods_vtable               @ 16 (8 bytes, *const VulkanRayTracingKernelMethodsVTable)
+        //   cached_push_constant_size    @ 24 (4 bytes, u32)
+        //   _reserved_padding            @ 28 (4 bytes, u32)
+        // Total = 32, align = 8.
+        assert_eq!(size_of::<VulkanRayTracingKernel>(), 32);
         assert_eq!(align_of::<VulkanRayTracingKernel>(), 8);
         assert_eq!(offset_of!(VulkanRayTracingKernel, handle), 0);
         assert_eq!(offset_of!(VulkanRayTracingKernel, vtable), 8);
+        assert_eq!(offset_of!(VulkanRayTracingKernel, methods_vtable), 16);
+        assert_eq!(
+            offset_of!(VulkanRayTracingKernel, cached_push_constant_size),
+            24
+        );
+        assert_eq!(offset_of!(VulkanRayTracingKernel, _reserved_padding), 28);
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
 ///   host wiring + cdylib β-shape, locking the wire format before
 ///   the scope machinery turns it on).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 9;
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 10;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -269,6 +269,16 @@ pub const VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// `set_*` / `cmd_bind_and_draw` / `offscreen_render` / `bindings`
 /// surface through them.
 pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`VulkanRayTracingKernelMethodsVTable`].
+///
+/// `VulkanRayTracingKernel` β-shape gains a per-type vtable for
+/// method dispatch (issue #907 Phase E PR 4/5). Mirrors the
+/// `VulkanGraphicsKernelMethodsVTable` shape: this PR lands the
+/// empty shell; follow-up PRs append method slots and route the
+/// β-shape's `set_*` / `trace_rays` / `bindings` surface through
+/// them.
+pub const VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -2634,6 +2644,33 @@ unsafe impl Send for VulkanGraphicsKernelMethodsVTable {}
 unsafe impl Sync for VulkanGraphicsKernelMethodsVTable {}
 
 // =============================================================================
+// VulkanRayTracingKernelMethodsVTable — per-type vtable for RT-kernel method dispatch
+// =============================================================================
+
+/// Per-type method-dispatch vtable for the `VulkanRayTracingKernel`
+/// β-shape (issue #907 Phase E PR 4/5).
+///
+/// Mirrors the compute/graphics shape. Empty shell today; follow-up
+/// PRs append slots for `set_acceleration_structure` /
+/// `set_storage_buffer` / `set_uniform_buffer` /
+/// `set_sampled_texture` / `set_storage_image` /
+/// `set_push_constants` / `trace_rays` / `bindings` and route the
+/// β-shape methods through them.
+#[repr(C)]
+pub struct VulkanRayTracingKernelMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+}
+
+unsafe impl Send for VulkanRayTracingKernelMethodsVTable {}
+unsafe impl Sync for VulkanRayTracingKernelMethodsVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -3117,6 +3154,21 @@ pub struct HostServices {
     /// empty-shell vtable + pointer plumbing; follow-up PRs append
     /// the actual method slots.
     pub vulkan_graphics_kernel_methods_vtable: *const VulkanGraphicsKernelMethodsVTable,
+
+    // -------------------------------------------------------------------------
+    // VulkanRayTracingKernelMethodsVTable surface (v10 — issue #907 Phase E PR 4/5)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `VulkanRayTracingKernel` β-shape
+    /// method dispatch. Paired with the per-`VulkanRayTracingKernel`
+    /// handle the cdylib carries on its β-shape struct
+    /// (`methods_vtable` field). Set once at install time; non-null
+    /// for hosts that ship a GpuContext, null otherwise (cdylib
+    /// must check before dispatching). PR 4 of issue #907 lands the
+    /// empty-shell vtable + pointer plumbing; follow-up PRs append
+    /// the actual method slots.
+    pub vulkan_ray_tracing_kernel_methods_vtable:
+        *const VulkanRayTracingKernelMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -3235,7 +3287,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 9);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 10);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -3248,10 +3300,11 @@ mod layout_tests {
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_nine_vtable_pointers() {
+    fn host_services_tail_carries_ten_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
@@ -3259,7 +3312,8 @@ mod layout_tests {
         //   2. They appear in the order RuntimeContext → AudioClock →
         //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
         //      GpuContextFullAccess → TextureRingMethods →
-        //      VulkanComputeKernelMethods → VulkanGraphicsKernelMethods.
+        //      VulkanComputeKernelMethods → VulkanGraphicsKernelMethods →
+        //      VulkanRayTracingKernelMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -3270,6 +3324,7 @@ mod layout_tests {
         assert_eq!(size_of::<*const TextureRingMethodsVTable>(), 8);
         assert_eq!(size_of::<*const VulkanComputeKernelMethodsVTable>(), 8);
         assert_eq!(size_of::<*const VulkanGraphicsKernelMethodsVTable>(), 8);
+        assert_eq!(size_of::<*const VulkanRayTracingKernelMethodsVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -3282,6 +3337,8 @@ mod layout_tests {
             offset_of!(HostServices, vulkan_compute_kernel_methods_vtable);
         let graphics_kernel_off =
             offset_of!(HostServices, vulkan_graphics_kernel_methods_vtable);
+        let rt_kernel_off =
+            offset_of!(HostServices, vulkan_ray_tracing_kernel_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
@@ -3290,6 +3347,7 @@ mod layout_tests {
         assert!(gpu_full_off < texture_ring_off);
         assert!(texture_ring_off < compute_kernel_off);
         assert!(compute_kernel_off < graphics_kernel_off);
+        assert!(graphics_kernel_off < rt_kernel_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
@@ -3298,10 +3356,11 @@ mod layout_tests {
         assert_eq!(texture_ring_off - gpu_full_off, 8);
         assert_eq!(compute_kernel_off - texture_ring_off, 8);
         assert_eq!(graphics_kernel_off - compute_kernel_off, 8);
+        assert_eq!(rt_kernel_off - graphics_kernel_off, 8);
 
-        // The VulkanGraphicsKernelMethods pointer must end at the
-        // end of the struct (it is the last field added in v9).
-        assert_eq!(graphics_kernel_off + 8, size_of::<HostServices>());
+        // The VulkanRayTracingKernelMethods pointer must end at the
+        // end of the struct (it is the last field added in v10).
+        assert_eq!(rt_kernel_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -3353,6 +3412,24 @@ mod layout_tests {
         );
         assert_eq!(
             offset_of!(VulkanGraphicsKernelMethodsVTable, _reserved_padding),
+            4
+        );
+    }
+
+    #[test]
+    fn vulkan_ray_tracing_kernel_methods_vtable_layout() {
+        // Empty shell — layout_version + _reserved_padding only.
+        // Mirrors the compute/graphics-kernel layout. Subsequent
+        // #907 sub-PRs append method slots and bump
+        // VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION.
+        assert_eq!(size_of::<VulkanRayTracingKernelMethodsVTable>(), 8);
+        assert_eq!(align_of::<VulkanRayTracingKernelMethodsVTable>(), 4);
+        assert_eq!(
+            offset_of!(VulkanRayTracingKernelMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(VulkanRayTracingKernelMethodsVTable, _reserved_padding),
             4
         );
     }


### PR DESCRIPTION
## Summary

Fourth of five PRs for issue #907 (Phase E β-newtypes). Mirrors PR 1/5 (#946), PR 2/5 (#948), PR 3/5 (#950) exactly.

## What lands

- New `VulkanRayTracingKernelMethodsVTable` struct (empty shell).
- `VulkanRayTracingKernel` β-shape grows from 16 → 32 bytes: `methods_vtable` + `cached_push_constant_size` + `_reserved_padding`.
- `push_constant_size()` POD getter reads cached field.
- `HostServices` / `HostCallbacks` carry the new vtable pointer with version validation.
- `HOST_SERVICES_LAYOUT_VERSION`: 9 → 10.

## Deliberately deferred

`set_*` / `trace_rays` / `bindings()` still dispatch via `host_inner()`. Follow-up sub-issue to be filed alongside #947 / #949 / #951.

## Validation

- 37/37 plugin-abi tests, 1147/1147 engine lib tests, boundary check all clean.

Refs #907. PR 4 of 5. Same scope shape as #946 / #948 / #950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)