### PR TITLE
feat(plugin-abi): VulkanAccelerationStructure per-type vtable shell + POD caching (#907 PR 5/5)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4716,11 +4716,26 @@ impl GpuContextFullAccess {
                         ));
                     }
                     // β-shape: bundle the raw handle (`Arc::into_raw(Arc<Inner>)`-shaped)
-                    // with the host vtable. Cross-rustc-version safe because no Inner
-                    // layout knowledge is required cdylib-side.
+                    // with the host vtables. Cached POD descriptors
+                    // (`device_address`, `storage_size`, `kind`) are
+                    // populated with placeholder zeros today — the
+                    // `build_*_blas` FFI signature doesn't yet surface
+                    // them to the cdylib. The β-shape getters fall
+                    // back to `host_inner` when cached values are 0
+                    // (panics in cdylib) — fixed in the #907 follow-up
+                    // sub-issue (FFI extension with out-params).
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.vulkan_acceleration_structure_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::vulkan::rhi::VulkanAccelerationStructure {
                         handle: out_blas,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_kind: 0, // BottomLevel — placeholder; see comment above
+                        _reserved_padding: 0,
+                        cached_device_address: 0,
+                        cached_storage_size: 0,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(
@@ -4770,9 +4785,20 @@ impl GpuContextFullAccess {
                             "build_tlas: host signaled success but out_tlas is null".into(),
                         ));
                     }
+                    // β-shape: see build_triangles_blas above. Same
+                    // placeholder-zeros caching story.
+                    let methods_vtable =
+                        crate::core::plugin::host_services::host_callbacks()
+                            .map(|c| c.vulkan_acceleration_structure_methods_vtable)
+                            .unwrap_or(std::ptr::null());
                     Ok(crate::vulkan::rhi::VulkanAccelerationStructure {
                         handle: out_tlas,
                         vtable: self.vtable,
+                        methods_vtable,
+                        cached_kind: 1, // TopLevel — placeholder; see comment above
+                        _reserved_padding: 0,
+                        cached_device_address: 0,
+                        cached_storage_size: 0,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -209,6 +209,14 @@ pub struct HostCallbacks {
     /// install time (issue #907 Phase E PR 4/5).
     pub vulkan_ray_tracing_kernel_methods_vtable:
         *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable,
+    /// Host-installed
+    /// [`VulkanAccelerationStructureMethodsVTable`] pointer. May be
+    /// null on hosts that don't ship a GpuContext; cdylib must check
+    /// before dispatching. Sourced from
+    /// [`HostServices::vulkan_acceleration_structure_methods_vtable`]
+    /// at install time (issue #907 Phase E PR 5/5).
+    pub vulkan_acceleration_structure_methods_vtable:
+        *const streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -388,6 +396,21 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services
+        .vulkan_acceleration_structure_methods_vtable
+        .is_null()
+    {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe {
+            (*services.vulkan_acceleration_structure_methods_vtable).layout_version
+        };
+        if v != streamlib_plugin_abi::VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION
+        {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -412,6 +435,8 @@ pub unsafe fn install_host_services(
             .vulkan_graphics_kernel_methods_vtable,
         vulkan_ray_tracing_kernel_methods_vtable: services
             .vulkan_ray_tracing_kernel_methods_vtable,
+        vulkan_acceleration_structure_methods_vtable: services
+            .vulkan_acceleration_structure_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6360,6 +6385,7 @@ pub mod runtime_facing {
         HOST_TEXTURE_RING_METHODS_VTABLE, HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
         HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
         HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE,
+        HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE,
     };
     use std::ffi::c_void;
     use std::sync::OnceLock;
@@ -6413,6 +6439,8 @@ pub mod runtime_facing {
                 &HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
             vulkan_ray_tracing_kernel_methods_vtable:
                 &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE,
+            vulkan_acceleration_structure_methods_vtable:
+                &HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE,
         }
     }
 }
@@ -6496,6 +6524,25 @@ pub static HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE:
 pub fn host_vulkan_ray_tracing_kernel_methods_vtable(
 ) -> *const streamlib_plugin_abi::VulkanRayTracingKernelMethodsVTable {
     &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE
+}
+
+/// Host-side empty-shell
+/// `VulkanAccelerationStructureMethodsVTable` (issue #907 PR 5/5).
+pub static HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE:
+    streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable =
+    streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable {
+        layout_version:
+            streamlib_plugin_abi::VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+    };
+
+/// Accessor for the host's static
+/// `VulkanAccelerationStructureMethodsVTable` — used by
+/// `VulkanAccelerationStructure::from_arc_into_raw` to populate the
+/// β-shape's `methods_vtable` field.
+pub fn host_vulkan_acceleration_structure_methods_vtable(
+) -> *const streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable {
+    &HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE
 }
 
 // =============================================================================

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
@@ -120,8 +120,20 @@ pub(crate) struct VulkanAccelerationStructureInner {
 pub struct VulkanAccelerationStructure {
     /// Opaque handle to the host's `Arc<VulkanAccelerationStructureInner>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Clone/Drop dispatch.
+    /// Parent vtable for cross-DSO Clone/Drop dispatch (#918 Phase D).
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (#907 Phase E).
+    pub(crate) methods_vtable:
+        *const streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable,
+    /// Cached AS kind discriminant (0 = BottomLevel, 1 = TopLevel).
+    /// Matches `AccelerationStructureKind`'s ordering.
+    pub(crate) cached_kind: u32,
+    /// Reserved padding so the next 8-byte field stays aligned.
+    pub(crate) _reserved_padding: u32,
+    /// Cached device address of the AS.
+    pub(crate) cached_device_address: u64,
+    /// Cached storage size in bytes.
+    pub(crate) cached_storage_size: u64,
 }
 
 // SAFETY: `handle` points at an `Arc<VulkanAccelerationStructureInner>`
@@ -672,10 +684,26 @@ impl VulkanAccelerationStructure {
     /// `Arc::into_raw`, resolve the host-mode FullAccess vtable, and
     /// assemble the cross-DSO shape.
     pub(crate) fn from_arc_into_raw(arc: Arc<VulkanAccelerationStructureInner>) -> Self {
+        let cached_kind = match arc.kind() {
+            AccelerationStructureKind::BottomLevel => 0u32,
+            AccelerationStructureKind::TopLevel => 1u32,
+        };
+        let cached_device_address = arc.device_address();
+        let cached_storage_size = arc.storage_size();
         let handle = Arc::into_raw(arc) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_vulkan_acceleration_structure_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+            cached_kind,
+            _reserved_padding: 0,
+            cached_device_address,
+            cached_storage_size,
+        }
     }
 
     /// Engine-internal borrow of the host-owned
@@ -725,24 +753,46 @@ impl VulkanAccelerationStructure {
         self.host_inner().vk_handle()
     }
 
-    /// Device address of the AS.
+    /// Device address of the AS. Host-mode reads the cached POD;
+    /// cdylib-mode currently routes through `host_inner` (panic in
+    /// cdylib) — the FFI signature for `build_*_blas` doesn't yet
+    /// surface the value to the cdylib. Tracked in the #907
+    /// follow-up sub-issue, which extends the create-side FFI
+    /// signatures with out-params for the cached POD descriptors.
     pub fn device_address(&self) -> u64 {
-        self.host_inner().device_address()
+        if self.cached_device_address != 0 {
+            self.cached_device_address
+        } else {
+            self.host_inner().device_address()
+        }
     }
 
-    /// `BottomLevel` or `TopLevel`.
+    /// `BottomLevel` or `TopLevel`. Same caching contract as
+    /// `device_address` — host mode reads cached, cdylib mode
+    /// currently falls back to `host_inner` until the follow-up
+    /// extends the FFI.
     pub fn kind(&self) -> AccelerationStructureKind {
+        // Sentinel-free path: kind is always either 0 or 1, so
+        // there's no "unset" value to detect. Routes through
+        // `host_inner` until the FFI signature surfaces the value.
         self.host_inner().kind()
     }
 
-    /// Human-readable label used in diagnostics.
+    /// Human-readable label used in diagnostics. Still routes
+    /// through `host_inner` — `String` layout isn't cdylib-safe;
+    /// vtable dispatch lands in the #907 follow-up sub-issue.
     pub fn label(&self) -> String {
         self.host_inner().label().to_string()
     }
 
-    /// Storage size in bytes.
+    /// Storage size in bytes. Same caching contract as
+    /// `device_address`.
     pub fn storage_size(&self) -> vk::DeviceSize {
-        self.host_inner().storage_size()
+        if self.cached_storage_size != 0 {
+            self.cached_storage_size
+        } else {
+            self.host_inner().storage_size()
+        }
     }
 }
 
@@ -759,6 +809,11 @@ impl Clone for VulkanAccelerationStructure {
         Self {
             handle: self.handle,
             vtable: self.vtable,
+            methods_vtable: self.methods_vtable,
+            cached_kind: self.cached_kind,
+            _reserved_padding: self._reserved_padding,
+            cached_device_address: self.cached_device_address,
+            cached_storage_size: self.cached_storage_size,
         }
     }
 }
@@ -789,11 +844,36 @@ mod layout_tests {
 
     #[test]
     fn vulkan_acceleration_structure_layout() {
-        // β-shape: handle + vtable, 16 bytes, 8-byte alignment.
-        assert_eq!(size_of::<VulkanAccelerationStructure>(), 16);
+        // β-shape struct as of #907 PR 5/5:
+        //   handle                @ 0  (8 bytes, *const c_void)
+        //   vtable                @ 8  (8 bytes, *const GpuContextFullAccessVTable)
+        //   methods_vtable        @ 16 (8 bytes, *const VulkanAccelerationStructureMethodsVTable)
+        //   cached_kind           @ 24 (4 bytes, u32)
+        //   _reserved_padding     @ 28 (4 bytes, u32)
+        //   cached_device_address @ 32 (8 bytes, u64)
+        //   cached_storage_size   @ 40 (8 bytes, u64)
+        // Total = 48, align = 8.
+        assert_eq!(size_of::<VulkanAccelerationStructure>(), 48);
         assert_eq!(align_of::<VulkanAccelerationStructure>(), 8);
         assert_eq!(offset_of!(VulkanAccelerationStructure, handle), 0);
         assert_eq!(offset_of!(VulkanAccelerationStructure, vtable), 8);
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructure, methods_vtable),
+            16
+        );
+        assert_eq!(offset_of!(VulkanAccelerationStructure, cached_kind), 24);
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructure, _reserved_padding),
+            28
+        );
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructure, cached_device_address),
+            32
+        );
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructure, cached_storage_size),
+            40
+        );
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   machinery lands in C3 — Phase C2 ships the vtable layout +
 ///   host wiring + cdylib β-shape, locking the wire format before
 ///   the scope machinery turns it on).
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 10;
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 11;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -279,6 +279,16 @@ pub const VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 /// β-shape's `set_*` / `trace_rays` / `bindings` surface through
 /// them.
 pub const VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`VulkanAccelerationStructureMethodsVTable`].
+///
+/// `VulkanAccelerationStructure` β-shape gains a per-type vtable
+/// for method dispatch (issue #907 Phase E PR 5/5). Mirrors the
+/// kernel methods-vtable shape: empty shell today; follow-up PRs
+/// append method slots for `vk_handle` / `label` (the methods that
+/// can't be POD-cached cleanly because they return host-internal
+/// or String types) and route the β-shape methods through them.
+pub const VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -2671,6 +2681,34 @@ unsafe impl Send for VulkanRayTracingKernelMethodsVTable {}
 unsafe impl Sync for VulkanRayTracingKernelMethodsVTable {}
 
 // =============================================================================
+// VulkanAccelerationStructureMethodsVTable — per-type vtable for AS method dispatch
+// =============================================================================
+
+/// Per-type method-dispatch vtable for the
+/// `VulkanAccelerationStructure` β-shape (issue #907 Phase E PR 5/5).
+///
+/// Mirrors the kernel methods-vtable shape. Empty shell today;
+/// follow-up PRs append slots for `vk_handle` / `label` (the
+/// methods returning host-internal `vk::AccelerationStructureKHR`
+/// and heap-allocated `String` that can't be POD-cached) and route
+/// the β-shape methods through them. POD getters (`device_address`,
+/// `kind`, `storage_size`) are cached on the β-shape struct and
+/// don't need vtable slots.
+#[repr(C)]
+pub struct VulkanAccelerationStructureMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+}
+
+unsafe impl Send for VulkanAccelerationStructureMethodsVTable {}
+unsafe impl Sync for VulkanAccelerationStructureMethodsVTable {}
+
+// =============================================================================
 // SurfaceStoreVTable — extern "C" dispatch for cross-process surface sharing
 // =============================================================================
 
@@ -3169,6 +3207,18 @@ pub struct HostServices {
     /// the actual method slots.
     pub vulkan_ray_tracing_kernel_methods_vtable:
         *const VulkanRayTracingKernelMethodsVTable,
+
+    // -------------------------------------------------------------------------
+    // VulkanAccelerationStructureMethodsVTable surface (v11 — issue #907 Phase E PR 5/5)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `VulkanAccelerationStructure`
+    /// β-shape method dispatch. Set once at install time; non-null
+    /// for hosts that ship a GpuContext, null otherwise. PR 5 of
+    /// issue #907 lands the empty-shell vtable + pointer plumbing;
+    /// follow-up PRs append the actual method slots.
+    pub vulkan_acceleration_structure_methods_vtable:
+        *const VulkanAccelerationStructureMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -3287,7 +3337,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 10);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 11);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -3301,10 +3351,11 @@ mod layout_tests {
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_ten_vtable_pointers() {
+    fn host_services_tail_carries_eleven_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
@@ -3313,7 +3364,7 @@ mod layout_tests {
         //      RuntimeOps → GpuContextLimitedAccess → SurfaceStore →
         //      GpuContextFullAccess → TextureRingMethods →
         //      VulkanComputeKernelMethods → VulkanGraphicsKernelMethods →
-        //      VulkanRayTracingKernelMethods.
+        //      VulkanRayTracingKernelMethods → VulkanAccelerationStructureMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -3325,6 +3376,10 @@ mod layout_tests {
         assert_eq!(size_of::<*const VulkanComputeKernelMethodsVTable>(), 8);
         assert_eq!(size_of::<*const VulkanGraphicsKernelMethodsVTable>(), 8);
         assert_eq!(size_of::<*const VulkanRayTracingKernelMethodsVTable>(), 8);
+        assert_eq!(
+            size_of::<*const VulkanAccelerationStructureMethodsVTable>(),
+            8
+        );
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -3339,6 +3394,8 @@ mod layout_tests {
             offset_of!(HostServices, vulkan_graphics_kernel_methods_vtable);
         let rt_kernel_off =
             offset_of!(HostServices, vulkan_ray_tracing_kernel_methods_vtable);
+        let accel_struct_off =
+            offset_of!(HostServices, vulkan_acceleration_structure_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
@@ -3348,6 +3405,7 @@ mod layout_tests {
         assert!(texture_ring_off < compute_kernel_off);
         assert!(compute_kernel_off < graphics_kernel_off);
         assert!(graphics_kernel_off < rt_kernel_off);
+        assert!(rt_kernel_off < accel_struct_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
@@ -3357,10 +3415,11 @@ mod layout_tests {
         assert_eq!(compute_kernel_off - texture_ring_off, 8);
         assert_eq!(graphics_kernel_off - compute_kernel_off, 8);
         assert_eq!(rt_kernel_off - graphics_kernel_off, 8);
+        assert_eq!(accel_struct_off - rt_kernel_off, 8);
 
-        // The VulkanRayTracingKernelMethods pointer must end at the
-        // end of the struct (it is the last field added in v10).
-        assert_eq!(rt_kernel_off + 8, size_of::<HostServices>());
+        // The VulkanAccelerationStructureMethods pointer must end at
+        // the end of the struct (it is the last field added in v11).
+        assert_eq!(accel_struct_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -3430,6 +3489,24 @@ mod layout_tests {
         );
         assert_eq!(
             offset_of!(VulkanRayTracingKernelMethodsVTable, _reserved_padding),
+            4
+        );
+    }
+
+    #[test]
+    fn vulkan_acceleration_structure_methods_vtable_layout() {
+        // Empty shell — layout_version + _reserved_padding only.
+        // Mirrors the kernel methods-vtable layouts. Subsequent
+        // #907 sub-PRs append method slots and bump
+        // VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION.
+        assert_eq!(size_of::<VulkanAccelerationStructureMethodsVTable>(), 8);
+        assert_eq!(align_of::<VulkanAccelerationStructureMethodsVTable>(), 4);
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructureMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructureMethodsVTable, _reserved_padding),
             4
         );
     }


### PR DESCRIPTION
## Summary

**Fifth and final** of the #907 Phase E β-newtype PRs. Same shape as #946 / #948 / #950 / #952.

## What lands

- New `VulkanAccelerationStructureMethodsVTable` struct (empty shell).
- `VulkanAccelerationStructure` β-shape: 16 → 48 bytes with `methods_vtable`, `cached_kind`, `cached_device_address`, `cached_storage_size`.
- `HostServices` / `HostCallbacks` carry the new vtable pointer with version validation.
- `HOST_SERVICES_LAYOUT_VERSION`: 10 → 11.

## Caching contract — slightly different from the kernel β-shapes

`device_address` / `storage_size` are host-computed at construction — cdylib can't derive them from inputs. Cdylib mint paths populate placeholder zeros; getters fall back to `host_inner` (panic in cdylib) when the cached value is 0. Host-mode `from_arc_into_raw` reads real values from `Arc<Inner>` so in-process is fully correct. Follow-up sub-issue extends the `build_*_blas` FFI signatures with out-params for the real values.

## Validation

- 38/38 plugin-abi tests pass.
- 1147/1147 engine lib tests pass.
- check-boundaries clean.

Refs #907. **PR 5 of 5** — closes the per-type vtable shell phase for all five #918 β-shapes. Method-dispatch follow-ups tracked at #947, #949, #951, #953 + one more to file for the AS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)