### PR TITLE
fix(plugin-abi): PixelBuffer::buffer_ref cdylib panic guard (#908)

### DIFF
--- a/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/pixel_buffer.rs
@@ -171,14 +171,33 @@ impl PixelBuffer {
         }
     }
 
-    /// Borrow the underlying [`PixelBufferRef`]. Engine-internal —
-    /// cdylib code reaches platform-specific data through
+    /// Borrow the underlying [`PixelBufferRef`]. **Engine-only.**
+    /// Cdylib code reaches platform-specific data through
     /// [`crate::host_rhi::HostPixelBufferRefExt`] which itself is
     /// engine-only.
+    ///
+    /// Panics if reached from cdylib code (#908). `PixelBufferRef`
+    /// is a host-internal type whose layout is rustc-version-
+    /// dependent — dereffing the handle as `*const PixelBufferRef`
+    /// from a cdylib compiled with a different rustc would be
+    /// undefined behavior. The panic guard turns the UB into a
+    /// clean abort.
     pub fn buffer_ref(&self) -> &PixelBufferRef {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            panic!(
+                "PixelBuffer::buffer_ref() reached from cdylib code; \
+                 PixelBufferRef is a host-internal type and its layout \
+                 is not cross-DSO safe. Cdylibs reach platform-specific \
+                 data through vtable callbacks (plane_base_address, \
+                 plane_size, plane_count, format)."
+            );
+        }
         // SAFETY: `self.handle` is `Arc::into_raw(Arc<PixelBufferRef>)`
         // (see `from_arc_into_raw`). The leaked strong count keeps
-        // the `PixelBufferRef` alive at least until `Drop` runs.
+        // the `PixelBufferRef` alive at least until `Drop` runs. The
+        // panic guard above rejects cdylib callers so the deref runs
+        // only in host-compiled code where `PixelBufferRef`'s layout
+        // is known.
         unsafe { &*(self.handle as *const PixelBufferRef) }
     }
 


### PR DESCRIPTION
## Summary

First slice of #908 Phase F. Adds the missing cdylib panic guard on `PixelBuffer::buffer_ref()` — the one pub-fn audit-target I found that derefs the handle as `*const PixelBufferRef` (a host-internal type) without going through the `host_inner()` helper.

## What lands

- Panic guard on `PixelBuffer::buffer_ref` matching the established `host_inner()` shape elsewhere in the codebase.
- Documented engine-only contract: cdylibs reach platform-specific data through vtable callbacks (`plane_base_address`, `plane_size`, `plane_count`, `format`) — not by dereffing `PixelBufferRef`.

## Phase F scope notes

`#908` originally listed several β-shape pub-fn audit targets. After surveying the actual code:

- ✅ `PixelBuffer::buffer_ref` — fixed in this PR.
- Already-safe: `Texture::native_handle`, `SurfaceStore::register_*`, `GpuContextLimitedAccess::*_video_source_timeline_semaphore` — each calls a `vulkan_inner()` / `host_inner()` / equivalent helper that already panics in cdylib. Documented engine-only contracts via inherited panics. Not UB.
- Real cdylib use case: `Texture::native_handle` Linux DMA-BUF FD export. **Out of scope here** — wiring a vtable accessor is its own follow-up because it requires plugin-abi vtable extension + cdylib β-shape routing + tier-1 tests, not just a panic guard.
- Deferred: macOS-only methods (`as_metal_*`, `iosurface_id`, `from_metal`). Documented in #908 as "host-only until macOS plugin support lands".

So this PR closes the UB-shaped gap; the consumer-shaped gap (DMA-BUF export from cdylib) becomes a follow-up.

## Validation

- 1147/1147 `cargo test --lib -p streamlib-engine` pass.
- `cross_rustc` dlopen integration test stays green.
- `cargo xtask check-boundaries` — clean.

Refs #908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)