### PR TITLE
feat(plugin-abi): TextureRingSlot β-shape + acquire_next / copy_pixel_buffer_to_slot / slot method dispatch (#947)

### DIFF
--- a/libs/streamlib-cross-rustc-fixture/src/lib.rs
+++ b/libs/streamlib-cross-rustc-fixture/src/lib.rs
@@ -100,20 +100,73 @@ pub struct BetaShapeRoundTrip {}
 /// adding distinct vtable-surface coverage.
 #[cfg(target_os = "linux")]
 fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<String> {
-    ctx.gpu_limited_access().escalate(|full| {
-        let mut summary = String::new();
-
-        // -------- TextureRing (Arc-handle + Clone) --------
-        let ring = full.create_texture_ring(
+    let gpu_limited = ctx.gpu_limited_access();
+    let ring = gpu_limited.escalate(|full| {
+        full.create_texture_ring(
             64,
             64,
             TextureFormat::Rgba8Unorm,
-            TextureUsages::TEXTURE_BINDING | TextureUsages::STORAGE_BINDING,
+            TextureUsages::COPY_DST
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::STORAGE_BINDING,
             2,
-        )?;
-        let ring_clone = ring.clone();
-        drop(ring_clone);
-        drop(ring);
+        )
+    })?;
+
+    // -------- TextureRing slot β-shape end-to-end (#947) --------
+    //
+    // The slot β-shape's per-method dispatch (acquire_next /
+    // copy_pixel_buffer_to_slot / slot) routes through the per-type
+    // TextureRingMethodsVTable in cdylib mode. This block exercises
+    // every slot from cdylib code, asserts cached POD fields round-
+    // trip, then runs the per-frame copy_pixel_buffer_to_slot
+    // primitive against a Limited-safe pixel buffer — proving every
+    // v2 vtable slot survives the divergent-dep-graph build.
+    {
+        if ring.len() != 2 {
+            return Err(Error::Runtime(format!(
+                "TextureRing: expected len=2, got {}",
+                ring.len()
+            )));
+        }
+        let slot0 = ring.acquire_next();
+        let slot1 = ring.acquire_next();
+        if slot0.surface_id() == slot1.surface_id() {
+            return Err(Error::Runtime(
+                "TextureRing: acquire_next returned the same slot twice in a row".into(),
+            ));
+        }
+        if slot0.texture.width() != 64 || slot0.texture.height() != 64 {
+            return Err(Error::Runtime(format!(
+                "TextureRing: slot texture dims ({}, {}) don't match ring construction (64, 64)",
+                slot0.texture.width(),
+                slot0.texture.height()
+            )));
+        }
+        let direct_slot0 = ring
+            .slot(0)
+            .ok_or_else(|| Error::Runtime("TextureRing: ring.slot(0) returned None".into()))?;
+        if direct_slot0.slot_index() != 0 {
+            return Err(Error::Runtime(format!(
+                "TextureRing: ring.slot(0) returned slot with slot_index = {}",
+                direct_slot0.slot_index()
+            )));
+        }
+        // copy_pixel_buffer_to_slot: stage a pixel buffer, then write
+        // it into the slot's pre-allocated texture via the v2
+        // copy_pixel_buffer_to_slot vtable slot.
+        let (_pool_id, pixel_buffer) = gpu_limited
+            .acquire_pixel_buffer(64, 64, PixelFormat::Rgba32)
+            .map_err(|e| Error::Runtime(format!("acquire_pixel_buffer: {e}")))?;
+        ring.copy_pixel_buffer_to_slot(&slot0, &pixel_buffer, 64, 64)
+            .map_err(|e| Error::Runtime(format!("copy_pixel_buffer_to_slot: {e}")))?;
+    }
+
+    let ring_clone = ring.clone();
+    drop(ring_clone);
+    drop(ring);
+    gpu_limited.escalate(|full| {
+        let mut summary = String::new();
         summary.push_str("TextureRing:OK\n");
 
         // -------- RhiColorConverter (Arc-handle + Clone) --------

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -1580,11 +1580,11 @@ impl GpuContext {
                 texture.clone(),
                 VulkanLayout::UNDEFINED,
             );
-            slots.push(TextureRingSlot {
-                surface_id,
+            slots.push(TextureRingSlot::new(
                 texture,
-                slot_index,
-            });
+                &surface_id,
+                slot_index as u32,
+            ));
             let res = crate::vulkan::rhi::HostVulkanUploadResources::new(&self.device.inner)?;
             upload_resources.push(res);
         }

--- a/libs/streamlib-engine/src/core/context/mod.rs
+++ b/libs/streamlib-engine/src/core/context/mod.rs
@@ -59,5 +59,7 @@ pub use runtime_context::{
 pub use surface_store::SurfaceStore;
 pub use texture_pool::*;
 pub use texture_registration::TextureRegistration;
-pub use texture_ring::{TextureRing, TextureRingInner, TextureRingSlot};
+pub use texture_ring::{
+    TextureRing, TextureRingInner, TextureRingSlot, TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+};
 pub use time_context::TimeContext;

--- a/libs/streamlib-engine/src/core/context/texture_ring.rs
+++ b/libs/streamlib-engine/src/core/context/texture_ring.rs
@@ -28,27 +28,143 @@ use crate::vulkan::rhi::HostVulkanUploadResources;
 #[cfg(target_os = "linux")]
 use streamlib_consumer_rhi::VulkanLayout;
 
+/// Maximum on-the-wire `surface_id` length in bytes — fits any UUID
+/// representation (canonical 36-byte form plus generous headroom for
+/// future identifier shapes) without crossing the DSO boundary as a
+/// heap `String`.
+pub const TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES: usize = 64;
+
 /// A single slot in a [`TextureRing`].
 ///
-/// Cheap to clone — both data fields are `Arc`-backed (the `surface_id` is
-/// an owned `String` minted at ring construction and reused across frames;
-/// the `Texture` handle is `Arc<HostVulkanTexture>` under the hood); the
-/// `slot_index` is a `usize` used to look up the slot's pre-allocated
-/// `HostVulkanUploadResources` for amortized uploads.
-#[derive(Clone)]
+/// Layout-stable `#[repr(C)]` β-shape — cdylibs can hold, copy, and
+/// drop slots safely without sharing rustc-version or dep-graph with
+/// the host. The `Texture` is itself a `(handle, vtable, POD)` β-shape
+/// (Clone bumps its Arc through the parent limited-access vtable;
+/// Drop balances). The `surface_id` is stored inline as a fixed
+/// 64-byte buffer plus a length — UUIDs are pure ASCII so a single
+/// UTF-8 validation at construction time lets [`Self::surface_id`]
+/// use `from_utf8_unchecked` on every read.
+///
+/// `Clone` here is structural — `Texture`'s `Clone` impl runs (Arc-
+/// bumped through its own per-type vtable) and the POD bytes copy.
+/// `Drop` is also structural — `Texture::Drop` decrements the
+/// texture's Arc; the inline bytes have no destructor.
+#[repr(C)]
 pub struct TextureRingSlot {
+    /// Pre-allocated texture handle for this slot. β-shape
+    /// `(handle, vtable, POD)` triple; Clone/Drop dispatch through
+    /// the parent limited-access vtable.
+    pub texture: Texture,
     /// Stable per-slot `surface_id` registered in
     /// [`GpuContext::resolve_texture_registration_by_surface_id`]'s
-    /// same-process texture cache at ring construction. Downstream
-    /// consumers carry this id on the emitted `VideoFrame` and resolve
-    /// the texture through the cache by it.
-    pub surface_id: String,
-    /// Pre-allocated texture handle for this slot.
-    pub texture: Texture,
+    /// same-process texture cache at ring construction. Stored as
+    /// the first [`surface_id_len`](Self::surface_id_len) bytes of
+    /// this fixed buffer (UTF-8, validated once at construction).
+    /// Downstream consumers reach the str view via
+    /// [`Self::surface_id`].
+    pub(crate) surface_id_bytes: [u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    /// Valid UTF-8 byte length in
+    /// [`surface_id_bytes`](Self::surface_id_bytes).
+    pub(crate) surface_id_len: u32,
     /// Index of this slot within the ring's slot vector. Used to
     /// look up the slot's pre-allocated upload resources for
     /// [`TextureRing::copy_pixel_buffer_to_slot`].
-    pub(crate) slot_index: usize,
+    pub(crate) slot_index: u32,
+}
+
+// SAFETY: `Texture` is `Send + Sync` (β-shape over an Arc); the
+// inline POD bytes carry no thread-state. `TextureRingSlot` is Send
+// + Sync because every field is.
+unsafe impl Send for TextureRingSlot {}
+unsafe impl Sync for TextureRingSlot {}
+
+impl TextureRingSlot {
+    /// Construct a slot from owned fields. Engine-internal — public
+    /// construction is through
+    /// [`crate::core::context::GpuContextFullAccess::create_texture_ring`].
+    ///
+    /// Panics if `surface_id.len() > TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES`
+    /// — UUIDs are 36 bytes, so the 64-byte budget has comfortable
+    /// headroom; tripping the panic indicates the producer started
+    /// minting non-UUID identifiers and the budget needs a real
+    /// re-think (not silent truncation).
+    pub(crate) fn new(
+        texture: Texture,
+        surface_id: &str,
+        slot_index: u32,
+    ) -> Self {
+        let bytes = surface_id.as_bytes();
+        assert!(
+            bytes.len() <= TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+            "TextureRingSlot::new: surface_id length {} exceeds \
+             TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES = {} \
+             (UUIDs are 36 bytes; a longer id needs an explicit \
+             budget bump in the β-shape, not silent truncation)",
+            bytes.len(),
+            TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+        );
+        let mut surface_id_bytes = [0u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES];
+        surface_id_bytes[..bytes.len()].copy_from_slice(bytes);
+        Self {
+            texture,
+            surface_id_bytes,
+            surface_id_len: bytes.len() as u32,
+            slot_index,
+        }
+    }
+
+    /// The slot's `surface_id` as a UTF-8 string. Reads back the
+    /// bytes [`surface_id_bytes`](Self::surface_id_bytes) up to
+    /// `surface_id_len`. Uses `from_utf8_unchecked` because the
+    /// invariant is locked at construction: [`Self::new`] always
+    /// passes the bytes through `str::as_bytes()` (which produces
+    /// valid UTF-8 by construction), and the FFI ingestion path
+    /// (`acquire_next` / `slot` host wrappers) likewise sources
+    /// from a host-side `&str`.
+    pub fn surface_id(&self) -> &str {
+        // SAFETY: bytes [0, surface_id_len) are valid UTF-8 by the
+        // construction invariant (always sourced from `&str`-bytes
+        // via `TextureRingSlot::new`). `surface_id_len` is bounded
+        // by `TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES` per the
+        // assertion in `new`.
+        let len = (self.surface_id_len as usize)
+            .min(TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES);
+        unsafe {
+            std::str::from_utf8_unchecked(&self.surface_id_bytes[..len])
+        }
+    }
+
+    /// Index of this slot within the ring's slot vector. Public for
+    /// callers who need the slot identity beyond the `surface_id`
+    /// (e.g. third-party backends that cache per-slot CUDA imports —
+    /// see `libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs`).
+    pub fn slot_index(&self) -> u32 {
+        self.slot_index
+    }
+}
+
+impl Clone for TextureRingSlot {
+    fn clone(&self) -> Self {
+        // `Texture::clone` runs the texture's β-shape Clone (Arc-
+        // bumped through its parent limited-access vtable);
+        // remaining fields are POD bytes.
+        Self {
+            texture: self.texture.clone(),
+            surface_id_bytes: self.surface_id_bytes,
+            surface_id_len: self.surface_id_len,
+            slot_index: self.slot_index,
+        }
+    }
+}
+
+impl std::fmt::Debug for TextureRingSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TextureRingSlot")
+            .field("surface_id", &self.surface_id())
+            .field("slot_index", &self.slot_index)
+            .field("texture", &self.texture)
+            .finish()
+    }
 }
 
 /// Pre-allocated ring of textures rotated per-frame on the decode hot
@@ -178,7 +294,7 @@ impl TextureRingInner {
         width: u32,
         height: u32,
     ) -> Result<()> {
-        let resources = self.upload_resources.get(slot.slot_index).ok_or_else(|| {
+        let resources = self.upload_resources.get(slot.slot_index as usize).ok_or_else(|| {
             Error::GpuError(format!(
                 "TextureRing::copy_pixel_buffer_to_slot: slot_index {} out of range (ring has {} slots)",
                 slot.slot_index,
@@ -201,8 +317,62 @@ impl TextureRingInner {
             )?;
         }
         // upload_buffer_to_image leaves the image in SHADER_READ_ONLY_OPTIMAL.
-        self.gpu
-            .update_texture_registration_layout(&slot.surface_id, VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
+        self.gpu.update_texture_registration_layout(
+            slot.surface_id(),
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
+        Ok(())
+    }
+
+    /// Copy a host-visible pixel buffer's contents into a ring slot's
+    /// pre-allocated texture, identified by `(slot_index, surface_id)`
+    /// rather than a [`TextureRingSlot`] reference. Used by the cdylib
+    /// dispatch path so the slot's POD identity bytes flow across the
+    /// FFI without reconstituting a borrow on the host side.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn copy_pixel_buffer_to_slot_by_index(
+        &self,
+        slot_index: u32,
+        surface_id: &str,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        let idx = slot_index as usize;
+        let resources = self.upload_resources.get(idx).ok_or_else(|| {
+            Error::GpuError(format!(
+                "TextureRing::copy_pixel_buffer_to_slot: slot_index {} out of range (ring has {} slots)",
+                slot_index,
+                self.upload_resources.len()
+            ))
+        })?;
+        let slot = self.slots.get(idx).ok_or_else(|| {
+            Error::GpuError(format!(
+                "TextureRing::copy_pixel_buffer_to_slot: slot_index {} out of range (ring has {} slots)",
+                slot_index,
+                self.slots.len()
+            ))
+        })?;
+        use crate::host_rhi::{HostPixelBufferRefExt, HostTextureExt};
+        let image = slot.texture.vulkan_inner().image().ok_or_else(|| {
+            Error::GpuError("TextureRing slot texture has no VkImage".into())
+        })?;
+        let src_buffer = pixel_buffer.buffer_ref().vulkan_inner().buffer();
+        unsafe {
+            self.gpu.device().inner.upload_buffer_to_image_amortized(
+                resources.command_buffer(),
+                resources.fence(),
+                src_buffer,
+                image,
+                width,
+                height,
+            )?;
+        }
+        // upload_buffer_to_image leaves the image in SHADER_READ_ONLY_OPTIMAL.
+        self.gpu.update_texture_registration_layout(
+            surface_id,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
         Ok(())
     }
 
@@ -245,7 +415,7 @@ impl TextureRingInner {
 impl Drop for TextureRingInner {
     fn drop(&mut self) {
         for slot in &self.slots {
-            self.gpu.unregister_texture(&slot.surface_id);
+            self.gpu.unregister_texture(slot.surface_id());
         }
         // upload_resources drop themselves (each Drop waits on its fence
         // first, then destroys cb + pool + fence).
@@ -267,10 +437,9 @@ impl Drop for TextureRingInner {
 /// `drop_texture_ring` callbacks (locked by PR #918's β-shape Phase D
 /// work). Per-method dispatch is reached through the dedicated
 /// [`streamlib_plugin_abi::TextureRingMethodsVTable`] pointed at by
-/// `methods_vtable` — issue #907 PR 1/5 lands the pointer plumbing
-/// + cached POD fields; follow-up PRs append method slots and route
-/// `acquire_next` / `copy_pixel_buffer_to_slot` / `slot` through
-/// them.
+/// `methods_vtable` — the v2 vtable wires `acquire_next` /
+/// `copy_pixel_buffer_to_slot` / `slot` through to the host via
+/// caller-provided POD out-parameters.
 ///
 /// The four POD getters (`len`, `width`, `height`, `format`) read
 /// directly from cached fields on this struct — no FFI hop. The
@@ -343,12 +512,27 @@ impl TextureRing {
     }
 
     /// Rotate to the next slot. Thread-safe (atomic counter).
+    ///
+    /// In host mode, calls into `TextureRingInner::acquire_next`
+    /// directly. In cdylib mode, dispatches through the per-type
+    /// methods vtable's `acquire_next` slot — the host wrapper writes
+    /// the slot's POD bytes into a caller-provided buffer that
+    /// becomes the returned [`TextureRingSlot`].
     pub fn acquire_next(&self) -> TextureRingSlot {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self
+                .dispatch_acquire_next_via_vtable()
+                .expect("acquire_next vtable dispatch failed");
+        }
         self.host_inner().acquire_next()
     }
 
     /// Copy a host-visible pixel buffer's contents into a ring slot.
     /// See [`TextureRingInner::copy_pixel_buffer_to_slot`] for details.
+    ///
+    /// In cdylib mode, dispatches through the per-type methods
+    /// vtable; the slot's `(slot_index, surface_id)` POD identity is
+    /// what crosses the FFI, not a slot borrow.
     #[cfg(target_os = "linux")]
     pub fn copy_pixel_buffer_to_slot(
         &self,
@@ -357,6 +541,14 @@ impl TextureRing {
         width: u32,
         height: u32,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_copy_pixel_buffer_to_slot_via_vtable(
+                slot,
+                pixel_buffer,
+                width,
+                height,
+            );
+        }
         self.host_inner()
             .copy_pixel_buffer_to_slot(slot, pixel_buffer, width, height)
     }
@@ -404,9 +596,197 @@ impl TextureRing {
     }
 
     /// Borrow a slot by index — engine-internal / debug only.
+    ///
+    /// In cdylib mode, dispatches through the per-type methods
+    /// vtable's `slot` slot.
     #[doc(hidden)]
     pub fn slot(&self, index: usize) -> Option<TextureRingSlot> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_slot_via_vtable(index);
+        }
         self.host_inner().slot(index).cloned()
+    }
+
+    /// Cdylib path: dispatch `acquire_next` through the per-type
+    /// methods vtable. The host wrapper writes the slot's POD bytes
+    /// into the caller-provided out-parameter buffers; we then
+    /// assemble a [`TextureRingSlot`] from those bytes. The
+    /// `out_texture_handle` is a freshly-cloned Arc (the host
+    /// wrapper bumps the texture's Arc through its limited-access
+    /// vtable); the returned `TextureRingSlot`'s `Texture::Drop`
+    /// balances when the slot drops.
+    #[doc(hidden)]
+    fn dispatch_acquire_next_via_vtable(&self) -> Result<TextureRingSlot> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "acquire_next: ring methods vtable is null".into(),
+            ));
+        }
+        let mut out_texture_handle: *const c_void = std::ptr::null();
+        let mut out_texture_width: u32 = 0;
+        let mut out_texture_height: u32 = 0;
+        let mut out_texture_format_raw: u32 = 0;
+        let mut out_surface_id_bytes = [0u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES];
+        let mut out_surface_id_len: u32 = 0;
+        let mut out_slot_index: u32 = 0;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).acquire_next)(
+                self.handle,
+                &mut out_texture_handle as *mut *const c_void,
+                &mut out_texture_width as *mut u32,
+                &mut out_texture_height as *mut u32,
+                &mut out_texture_format_raw as *mut u32,
+                &mut out_surface_id_bytes as *mut [u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+                &mut out_surface_id_len as *mut u32,
+                &mut out_slot_index as *mut u32,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status != 0 {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            return Err(Error::GpuError(msg));
+        }
+        Ok(slot_from_out_params(
+            out_texture_handle,
+            out_texture_width,
+            out_texture_height,
+            out_texture_format_raw,
+            out_surface_id_bytes,
+            out_surface_id_len,
+            out_slot_index,
+        ))
+    }
+
+    /// Cdylib path: dispatch `slot(index)` through the per-type
+    /// methods vtable. Status code `-1` is the "index out of range"
+    /// signal (no err_buf write); `0` is success; any other non-zero
+    /// is a hard error.
+    #[doc(hidden)]
+    fn dispatch_slot_via_vtable(&self, index: usize) -> Option<TextureRingSlot> {
+        if self.methods_vtable.is_null() {
+            return None;
+        }
+        let mut out_texture_handle: *const c_void = std::ptr::null();
+        let mut out_texture_width: u32 = 0;
+        let mut out_texture_height: u32 = 0;
+        let mut out_texture_format_raw: u32 = 0;
+        let mut out_surface_id_bytes = [0u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES];
+        let mut out_surface_id_len: u32 = 0;
+        let mut out_slot_index: u32 = 0;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).slot)(
+                self.handle,
+                index,
+                &mut out_texture_handle as *mut *const c_void,
+                &mut out_texture_width as *mut u32,
+                &mut out_texture_height as *mut u32,
+                &mut out_texture_format_raw as *mut u32,
+                &mut out_surface_id_bytes as *mut [u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+                &mut out_surface_id_len as *mut u32,
+                &mut out_slot_index as *mut u32,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status != 0 {
+            return None;
+        }
+        Some(slot_from_out_params(
+            out_texture_handle,
+            out_texture_width,
+            out_texture_height,
+            out_texture_format_raw,
+            out_surface_id_bytes,
+            out_surface_id_len,
+            out_slot_index,
+        ))
+    }
+
+    /// Cdylib path: dispatch `copy_pixel_buffer_to_slot` through the
+    /// per-type methods vtable. Slot identity travels as
+    /// `(slot_index, surface_id_bytes, surface_id_len)`; the host
+    /// looks up upload_resources by `slot_index` and refreshes the
+    /// registration layout by `surface_id`.
+    #[cfg(target_os = "linux")]
+    #[doc(hidden)]
+    fn dispatch_copy_pixel_buffer_to_slot_via_vtable(
+        &self,
+        slot: &TextureRingSlot,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "copy_pixel_buffer_to_slot: ring methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).copy_pixel_buffer_to_slot)(
+                self.handle,
+                slot.slot_index,
+                slot.surface_id_bytes.as_ptr(),
+                slot.surface_id_len,
+                pixel_buffer.handle,
+                width,
+                height,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+}
+
+/// Assemble a `TextureRingSlot` from vtable out-parameters. The
+/// `texture_handle` is consumed (its strong-count is the freshly-
+/// cloned one the host wrapper produced); the resulting slot owns
+/// the Drop side of that clone via its `Texture` field.
+fn slot_from_out_params(
+    texture_handle: *const c_void,
+    texture_width: u32,
+    texture_height: u32,
+    texture_format_raw: u32,
+    surface_id_bytes: [u8; TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    surface_id_len: u32,
+    slot_index: u32,
+) -> TextureRingSlot {
+    // Build the Texture β-shape directly from the host-returned
+    // handle. Use the limited-access vtable installed in cdylib mode
+    // (or the host's static for in-process tests of this helper) —
+    // the host wrapper paired the Arc bump with that same vtable's
+    // `clone_texture`, so `Texture::Drop` calls the matching
+    // `drop_texture` to balance.
+    let texture = unsafe {
+        Texture::from_raw_handle_for_cdylib(
+            texture_handle,
+            texture_width,
+            texture_height,
+            texture_format_raw,
+        )
+    };
+    TextureRingSlot {
+        texture,
+        surface_id_bytes,
+        surface_id_len,
+        slot_index,
     }
 }
 
@@ -478,9 +858,33 @@ mod layout_tests {
     }
 
     #[test]
+    fn texture_ring_slot_layout() {
+        // β-shape struct (issue #947):
+        //   texture            @ 0   (32 bytes, Texture β-shape)
+        //   surface_id_bytes   @ 32  (64 bytes, [u8; 64])
+        //   surface_id_len     @ 96  (4 bytes, u32)
+        //   slot_index         @ 100 (4 bytes, u32)
+        // Total = 104, align = 8 (inherited from Texture).
+        assert_eq!(size_of::<TextureRingSlot>(), 104);
+        assert_eq!(align_of::<TextureRingSlot>(), 8);
+        assert_eq!(offset_of!(TextureRingSlot, texture), 0);
+        assert_eq!(offset_of!(TextureRingSlot, surface_id_bytes), 32);
+        assert_eq!(offset_of!(TextureRingSlot, surface_id_len), 96);
+        assert_eq!(offset_of!(TextureRingSlot, slot_index), 100);
+    }
+
+    #[test]
+    fn texture_ring_slot_surface_id_max_bytes_constant() {
+        // The constant must match the in-line buffer length on the
+        // β-shape and the FFI vtable's `out_surface_id_bytes` slot.
+        assert_eq!(TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES, 64);
+    }
+
+    #[test]
     fn texture_ring_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<TextureRing>();
+        assert_send_sync::<TextureRingSlot>();
     }
 }
 
@@ -545,8 +949,10 @@ mod tests {
             );
         }
 
-        let first_ids: Vec<String> =
-            first_slots.into_iter().map(|s| s.surface_id).collect();
+        let first_ids: Vec<String> = first_slots
+            .iter()
+            .map(|s| s.surface_id().to_string())
+            .collect();
         // Rotation visits every slot exactly once across `len()` calls.
         assert_eq!(
             first_ids.iter().collect::<std::collections::BTreeSet<_>>().len(),
@@ -559,8 +965,10 @@ mod tests {
         // slots are reused, NOT re-allocated.
         let second_pass: Vec<TextureRingSlot> =
             (0..ring.len()).map(|_| ring.acquire_next()).collect();
-        let second_ids: Vec<String> =
-            second_pass.iter().map(|s| s.surface_id.clone()).collect();
+        let second_ids: Vec<String> = second_pass
+            .iter()
+            .map(|s| s.surface_id().to_string())
+            .collect();
         assert_eq!(first_ids, second_ids, "slot rotation must repeat in order");
         for (i, slot) in second_pass.iter().enumerate() {
             assert_eq!(
@@ -587,8 +995,9 @@ mod tests {
             )
             .expect("create_texture_ring");
 
-        let ids: Vec<String> =
-            (0..ring.len()).map(|i| ring.slot(i).unwrap().surface_id.clone()).collect();
+        let ids: Vec<String> = (0..ring.len())
+            .map(|i| ring.slot(i).unwrap().surface_id().to_string())
+            .collect();
 
         // Each id resolves through GpuContext while the ring is alive.
         for id in &ids {
@@ -634,7 +1043,7 @@ mod tests {
         // docs/architecture/texture-registration.md Producer Rule 2.
         let slot0 = ring.acquire_next();
         let reg_pre = gpu
-            .resolve_texture_registration_by_surface_id(&slot0.surface_id, None, 32, 32)
+            .resolve_texture_registration_by_surface_id(slot0.surface_id(), None, 32, 32)
             .expect("registration in cache before first copy");
         assert_eq!(
             reg_pre.current_layout(),
@@ -663,7 +1072,7 @@ mod tests {
             .expect("amortized copy_pixel_buffer_to_slot must succeed");
 
         let reg_post = gpu
-            .resolve_texture_registration_by_surface_id(&slot0.surface_id, None, 32, 32)
+            .resolve_texture_registration_by_surface_id(slot0.surface_id(), None, 32, 32)
             .expect("registration in cache after copy");
         assert_eq!(
             reg_post.current_layout(),
@@ -679,7 +1088,7 @@ mod tests {
             .expect("amortized copy must succeed on slot reuse");
         // Rotate to the OTHER slot, exercise its independent resources.
         let slot1 = ring.acquire_next();
-        assert_ne!(slot1.surface_id, slot0.surface_id, "ring should rotate");
+        assert_ne!(slot1.surface_id(), slot0.surface_id(), "ring should rotate");
         ring.copy_pixel_buffer_to_slot(&slot1, &pixel_buffer, 32, 32)
             .expect("amortized copy on second slot must succeed");
     }
@@ -730,7 +1139,7 @@ mod tests {
         for _ in 0..16 {
             let slot = ring.acquire_next();
             limited
-                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, W, H)
+                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, slot.surface_id(), W, H)
                 .unwrap();
         }
 
@@ -747,7 +1156,7 @@ mod tests {
         for _ in 0..ITERS {
             let slot = ring.acquire_next();
             limited
-                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, W, H)
+                .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, slot.surface_id(), W, H)
                 .unwrap();
         }
         let generic_total = t0.elapsed();
@@ -800,11 +1209,11 @@ mod tests {
             std::ptr::write_bytes(mapped, 0x5A, (32u32 * 32 * 4) as usize);
         }
         limited
-            .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, &slot.surface_id, 32, 32)
+            .copy_pixel_buffer_to_texture(&pixel_buffer, &slot.texture, slot.surface_id(), 32, 32)
             .expect("generic copy primitive should still work");
 
         let reg = gpu
-            .resolve_texture_registration_by_surface_id(&slot.surface_id, None, 32, 32)
+            .resolve_texture_registration_by_surface_id(slot.surface_id(), None, 32, 32)
             .expect("registration in cache");
         assert_eq!(reg.current_layout(), VulkanLayout::SHADER_READ_ONLY_OPTIMAL);
     }
@@ -842,5 +1251,64 @@ mod tests {
         // We can't directly inspect the counter, but we can check that
         // acquire_next still returns a valid slot.
         let _slot = ring.acquire_next();
+    }
+
+    #[test]
+    fn slot_surface_id_round_trips_through_inline_buffer() {
+        // Lock the construction-time invariant the `surface_id`
+        // accessor's `from_utf8_unchecked` depends on. Mentally revert
+        // `TextureRingSlot::new` to skip the bytes-copy step (i.e.
+        // leave `surface_id_bytes` zeroed) — this assertion fires.
+        let Some((_gpu, full)) = fresh_full_access() else {
+            println!("Skipping - no GPU device available");
+            return;
+        };
+        let ring = full
+            .create_texture_ring(
+                16,
+                16,
+                TextureFormat::Rgba8Unorm,
+                TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                1,
+            )
+            .expect("create_texture_ring");
+        let slot = ring.acquire_next();
+        // UUID v4 canonical form is 36 ASCII bytes.
+        assert_eq!(
+            slot.surface_id().len(),
+            36,
+            "expected UUID v4 canonical 36-byte form"
+        );
+        assert_eq!(
+            slot.surface_id().as_bytes().len(),
+            slot.surface_id_len as usize,
+            "accessor length must match the cached length field"
+        );
+        // Assert actual UUID content shape: hex chars + dashes, no
+        // NUL bytes. If `TextureRingSlot::new` is mentally reverted
+        // to skip the bytes-copy step, `surface_id_bytes` stays
+        // zero-initialized and `surface_id()` returns 36 NUL bytes —
+        // these assertions fire. (The bare length check above passes
+        // either way.)
+        let sid = slot.surface_id();
+        assert!(
+            !sid.contains('\0'),
+            "surface_id must not contain NUL bytes; got {sid:?}"
+        );
+        assert!(
+            sid.chars()
+                .all(|c| c.is_ascii_hexdigit() || c == '-'),
+            "surface_id must be UUID-shaped (hex + dashes); got {sid:?}"
+        );
+        assert_eq!(
+            sid.matches('-').count(),
+            4,
+            "UUID v4 canonical form has exactly 4 dashes; got {sid:?}"
+        );
+        // Round-trip cloning the slot must preserve the surface_id
+        // identity (POD bytes copy + cached length).
+        let clone = slot.clone();
+        assert_eq!(slot.surface_id(), clone.surface_id());
+        assert_eq!(slot.slot_index(), clone.slot_index());
     }
 }

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -6445,15 +6445,371 @@ pub mod runtime_facing {
     }
 }
 
-/// Host-side empty-shell `TextureRingMethodsVTable` (issue #907 PR 1/5).
-///
-/// PR 1 establishes the pointer plumbing only. Subsequent PRs fill in
-/// method slots for `acquire_next` / `copy_pixel_buffer_to_slot` /
-/// `slot` once the cross-DSO `TextureRingSlot` representation lands.
+// =============================================================================
+// TextureRingMethodsVTable wrappers (issue #947 — slot β-shape + method
+// dispatch). Each wrapper reconstructs the ring borrow from the raw
+// `Arc::into_raw(Arc<TextureRingInner>)` handle the cdylib passes,
+// runs the inner method, and serializes the result into the FFI's
+// out-parameter buffers + `i32 + err_buf` shape. All bodies are
+// wrapped in `run_host_extern_c` so a panic in the inner method
+// becomes a non-zero return.
+// =============================================================================
+
+/// SAFETY: caller must hand a `handle` that came from
+/// `Arc::into_raw(Arc<TextureRingInner>)`. The leaked strong count
+/// keeps the ring alive for the call's duration.
+#[cfg(target_os = "linux")]
+unsafe fn handle_as_texture_ring(
+    handle: *const c_void,
+) -> Option<&'static crate::core::context::TextureRingInner> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const crate::core::context::TextureRingInner) })
+}
+
+/// Write the slot's POD identity bytes into the caller-provided
+/// out-parameter buffers. The texture handle is bumped through the
+/// host's limited-access `clone_texture` slot so the resulting
+/// cdylib-side `Texture` β-shape owns the matching `Drop`-side
+/// decrement.
+#[cfg(target_os = "linux")]
+unsafe fn write_slot_out_params(
+    slot: &crate::core::context::TextureRingSlot,
+    out_texture_handle: *mut *const c_void,
+    out_texture_width: *mut u32,
+    out_texture_height: *mut u32,
+    out_texture_format_raw: *mut u32,
+    out_surface_id_bytes: *mut [u8; crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    out_surface_id_len: *mut u32,
+    out_slot_index: *mut u32,
+) {
+    // Bump the texture's Arc through the parent limited-access
+    // vtable's `clone_texture` slot — same contract every cross-DSO
+    // Texture-bearing FFI return uses. The cdylib-side `Texture`
+    // β-shape's `Drop` will fire `drop_texture` to balance.
+    if !slot.texture.handle.is_null() && !slot.texture.vtable.is_null() {
+        unsafe {
+            ((*slot.texture.vtable).clone_texture)(slot.texture.handle);
+        }
+    }
+    unsafe {
+        *out_texture_handle = slot.texture.handle;
+        *out_texture_width = slot.texture.width_cached;
+        *out_texture_height = slot.texture.height_cached;
+        *out_texture_format_raw = slot.texture.format_raw;
+        // Copy the slot's full 64-byte surface_id buffer (inline POD).
+        // The cdylib reads it back through `TextureRingSlot::surface_id()`
+        // which slices to `surface_id_len`.
+        std::ptr::copy_nonoverlapping(
+            slot.surface_id_bytes.as_ptr(),
+            (*out_surface_id_bytes).as_mut_ptr(),
+            crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+        );
+        *out_surface_id_len = slot.surface_id_len;
+        *out_slot_index = slot.slot_index;
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_texture_ring_acquire_next(
+    ring_handle: *const c_void,
+    out_texture_handle: *mut *const c_void,
+    out_texture_width: *mut u32,
+    out_texture_height: *mut u32,
+    out_texture_format_raw: *mut u32,
+    out_surface_id_bytes: *mut [u8; crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    out_surface_id_len: *mut u32,
+    out_slot_index: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_texture_ring_acquire_next",
+        || -> i32 {
+            let Some(ring) = (unsafe { handle_as_texture_ring(ring_handle) }) else {
+                write_err(
+                    "acquire_next: null ring handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if out_texture_handle.is_null()
+                || out_texture_width.is_null()
+                || out_texture_height.is_null()
+                || out_texture_format_raw.is_null()
+                || out_surface_id_bytes.is_null()
+                || out_surface_id_len.is_null()
+                || out_slot_index.is_null()
+            {
+                write_err(
+                    "acquire_next: null out-parameter pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // `acquire_next` returns an owned slot (cloned from the
+            // pre-allocated `self.slots[idx]`). We write its POD
+            // identity bytes through the out-params and let the
+            // owned slot drop — `Texture::Drop` decrements the
+            // Arc strong count `clone_texture` bumped on this side,
+            // but `write_slot_out_params` already bumped a SECOND
+            // strong count for the cdylib's eventual `Drop`. Net
+            // effect: the cdylib's slot owns +1 strong count
+            // balanced by its own Drop, exactly as if the cdylib
+            // had called `Arc::into_raw(Arc::clone(...))` itself.
+            let slot = ring.acquire_next();
+            unsafe {
+                write_slot_out_params(
+                    &slot,
+                    out_texture_handle,
+                    out_texture_width,
+                    out_texture_height,
+                    out_texture_format_raw,
+                    out_surface_id_bytes,
+                    out_surface_id_len,
+                    out_slot_index,
+                );
+            }
+            0
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_texture_ring_copy_pixel_buffer_to_slot(
+    ring_handle: *const c_void,
+    slot_index: u32,
+    surface_id_bytes: *const u8,
+    surface_id_len: u32,
+    pixel_buffer_handle: *const c_void,
+    width: u32,
+    height: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_texture_ring_copy_pixel_buffer_to_slot",
+        || -> i32 {
+            let Some(ring) = (unsafe { handle_as_texture_ring(ring_handle) }) else {
+                write_err(
+                    "copy_pixel_buffer_to_slot: null ring handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if pixel_buffer_handle.is_null() {
+                write_err(
+                    "copy_pixel_buffer_to_slot: null pixel_buffer handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if surface_id_bytes.is_null() {
+                write_err(
+                    "copy_pixel_buffer_to_slot: null surface_id_bytes pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let id_len = (surface_id_len as usize).min(
+                crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES,
+            );
+            let id_bytes = unsafe { std::slice::from_raw_parts(surface_id_bytes, id_len) };
+            let Ok(surface_id) = std::str::from_utf8(id_bytes) else {
+                write_err(
+                    "copy_pixel_buffer_to_slot: surface_id_bytes is not valid UTF-8",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            let borrow = make_pixel_buffer_borrow(pixel_buffer_handle);
+            match ring.copy_pixel_buffer_to_slot_by_index(
+                slot_index,
+                surface_id,
+                &*borrow,
+                width,
+                height,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("copy_pixel_buffer_to_slot: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_texture_ring_slot(
+    ring_handle: *const c_void,
+    index: usize,
+    out_texture_handle: *mut *const c_void,
+    out_texture_width: *mut u32,
+    out_texture_height: *mut u32,
+    out_texture_format_raw: *mut u32,
+    out_surface_id_bytes: *mut [u8; crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    out_surface_id_len: *mut u32,
+    out_slot_index: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_texture_ring_slot",
+        || -> i32 {
+            let Some(ring) = (unsafe { handle_as_texture_ring(ring_handle) }) else {
+                write_err(
+                    "slot: null ring handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if out_texture_handle.is_null()
+                || out_texture_width.is_null()
+                || out_texture_height.is_null()
+                || out_texture_format_raw.is_null()
+                || out_surface_id_bytes.is_null()
+                || out_surface_id_len.is_null()
+                || out_slot_index.is_null()
+            {
+                write_err(
+                    "slot: null out-parameter pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // -1 signals "index out of range" without an err_buf
+            // write; the cdylib dispatch path translates this to
+            // `Option::None`. Any other non-zero is a hard error.
+            let Some(slot) = ring.slot(index) else {
+                return -1;
+            };
+            unsafe {
+                write_slot_out_params(
+                    slot,
+                    out_texture_handle,
+                    out_texture_width,
+                    out_texture_height,
+                    out_texture_format_raw,
+                    out_surface_id_bytes,
+                    out_surface_id_len,
+                    out_slot_index,
+                );
+            }
+            0
+        },
+        1,
+    )
+}
+
+// ---- Non-Linux platform stubs (vtable layout stays unconditional) ----------
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_texture_ring_acquire_next(
+    _ring_handle: *const c_void,
+    _out_texture_handle: *mut *const c_void,
+    _out_texture_width: *mut u32,
+    _out_texture_height: *mut u32,
+    _out_texture_format_raw: *mut u32,
+    _out_surface_id_bytes: *mut [u8; crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    _out_surface_id_len: *mut u32,
+    _out_slot_index: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "acquire_next: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_texture_ring_copy_pixel_buffer_to_slot(
+    _ring_handle: *const c_void,
+    _slot_index: u32,
+    _surface_id_bytes: *const u8,
+    _surface_id_len: u32,
+    _pixel_buffer_handle: *const c_void,
+    _width: u32,
+    _height: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "copy_pixel_buffer_to_slot: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_texture_ring_slot(
+    _ring_handle: *const c_void,
+    _index: usize,
+    _out_texture_handle: *mut *const c_void,
+    _out_texture_width: *mut u32,
+    _out_texture_height: *mut u32,
+    _out_texture_format_raw: *mut u32,
+    _out_surface_id_bytes: *mut [u8; crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES],
+    _out_surface_id_len: *mut u32,
+    _out_slot_index: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "slot: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+/// Host-side `TextureRingMethodsVTable` wired to the per-method
+/// wrappers above (issue #947 — `TextureRingSlot` β-shape +
+/// method dispatch).
 pub static HOST_TEXTURE_RING_METHODS_VTABLE: streamlib_plugin_abi::TextureRingMethodsVTable =
     streamlib_plugin_abi::TextureRingMethodsVTable {
         layout_version: streamlib_plugin_abi::TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION,
         _reserved_padding: 0,
+        acquire_next: host_texture_ring_acquire_next,
+        copy_pixel_buffer_to_slot: host_texture_ring_copy_pixel_buffer_to_slot,
+        slot: host_texture_ring_slot,
     };
 
 /// Accessor for the host's static `TextureRingMethodsVTable` — used
@@ -10020,6 +10376,125 @@ mod ray_tracing_kernel_methods_vtable_null_tests {
         assert!(
             err_buf_as_str(&buf, len)
                 .contains("trace_rays: null kernel handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod texture_ring_methods_vtable_null_tests {
+    //! Tier-1 wire-format tests for the v2 method slots on
+    //! `TextureRingMethodsVTable` (issue #947). Each wrapper must
+    //! reject a null ring handle before reaching any ring-side state
+    //! so cdylib callers get a clean error return on the wire-format
+    //! path instead of UB.
+    //!
+    //! End-to-end coverage (real ring + valid handles + slot
+    //! round-trip) is locked by the dlopen integration test for the
+    //! cross-rustc fixture, which exercises `acquire_next` +
+    //! `copy_pixel_buffer_to_slot` end-to-end after the v2 wire-up.
+
+    use super::*;
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_buf_as_str(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn acquire_next_rejects_null_ring_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut h: *const c_void = std::ptr::null();
+        let mut w: u32 = 0;
+        let mut hgt: u32 = 0;
+        let mut fmt: u32 = 0;
+        let mut id_bytes = [0u8;
+            crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES];
+        let mut id_len: u32 = 0;
+        let mut slot_index: u32 = 0;
+        let rc = unsafe {
+            (HOST_TEXTURE_RING_METHODS_VTABLE.acquire_next)(
+                std::ptr::null(),
+                &mut h as *mut *const c_void,
+                &mut w as *mut u32,
+                &mut hgt as *mut u32,
+                &mut fmt as *mut u32,
+                &mut id_bytes as *mut _,
+                &mut id_len as *mut u32,
+                &mut slot_index as *mut u32,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("acquire_next: null ring handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn copy_pixel_buffer_to_slot_rejects_null_ring_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_TEXTURE_RING_METHODS_VTABLE.copy_pixel_buffer_to_slot)(
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                32,
+                32,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("copy_pixel_buffer_to_slot: null ring handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn slot_rejects_null_ring_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut h: *const c_void = std::ptr::null();
+        let mut w: u32 = 0;
+        let mut hgt: u32 = 0;
+        let mut fmt: u32 = 0;
+        let mut id_bytes = [0u8;
+            crate::core::context::TEXTURE_RING_SLOT_SURFACE_ID_MAX_BYTES];
+        let mut id_len: u32 = 0;
+        let mut slot_index: u32 = 0;
+        let rc = unsafe {
+            (HOST_TEXTURE_RING_METHODS_VTABLE.slot)(
+                std::ptr::null(),
+                0,
+                &mut h as *mut *const c_void,
+                &mut w as *mut u32,
+                &mut hgt as *mut u32,
+                &mut fmt as *mut u32,
+                &mut id_bytes as *mut _,
+                &mut id_len as *mut u32,
+                &mut slot_index as *mut u32,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("slot: null ring handle"),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/libs/streamlib-engine/src/core/rhi/texture.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture.rs
@@ -222,6 +222,49 @@ impl Texture {
         }
     }
 
+    /// Assemble a [`Texture`] β-shape from a raw `Arc::into_raw`-
+    /// shaped handle plus cached POD bytes. Used by cdylib-side
+    /// dispatch paths that receive a freshly-cloned handle through
+    /// an FFI out-parameter (e.g.
+    /// [`crate::core::context::TextureRing::acquire_next`] in cdylib
+    /// mode) — the host wrapper bumped the texture's Arc through
+    /// the limited-access vtable's `clone_texture` slot, and the
+    /// returned [`Texture`] owns the matching `Drop`-side decrement
+    /// when it falls out of scope.
+    ///
+    /// The vtable pointer is resolved through the DSO-routed
+    /// accessor [`crate::core::plugin::host_services::host_gpu_context_limited_access_vtable`]
+    /// so cdylib code reaches the host's pointer (matching the
+    /// `clone_texture` slot used to mint the handle) and host code
+    /// reaches its own static.
+    ///
+    /// # Safety
+    ///
+    /// `handle` must come from a host-side
+    /// `Arc::into_raw(Arc<TextureInner>)` whose Arc strong count
+    /// the caller is responsible for (one strong count per
+    /// returned [`Texture`]). `format_raw` must match
+    /// [`TextureFormat`]'s `#[repr(u32)]` discriminant for the
+    /// texture's actual format; out-of-range values fall back to
+    /// `Rgba8Unorm` via [`Self::format`].
+    pub(crate) unsafe fn from_raw_handle_for_cdylib(
+        handle: *const c_void,
+        width: u32,
+        height: u32,
+        format_raw: u32,
+    ) -> Self {
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_limited_access_vtable();
+        Self {
+            handle,
+            vtable,
+            width_cached: width,
+            height_cached: height,
+            format_raw,
+            _padding: 0,
+        }
+    }
+
     /// Engine-internal borrow of the host-owned [`TextureInner`].
     ///
     /// **Panics if called from cdylib code.** The `TextureInner` type's

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -237,15 +237,16 @@ pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 7;
 
 /// Layout version of [`TextureRingMethodsVTable`].
 ///
-/// `TextureRing` β-shape gains a per-type vtable for method dispatch
-/// (issue #907 Phase E). PR 1 of 5 lands an empty shell — the
-/// vtable carries only `layout_version` + `_reserved_padding` so the
-/// pointer + struct layout are pinned for follow-up PRs that fill
-/// in `acquire_next` / `copy_pixel_buffer_to_slot` / `slot` method
-/// slots once the `TextureRingSlot` cross-DSO representation is
-/// figured out (today's slot carries a heap-allocated `String`
-/// surface_id, not cdylib-safe).
-pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+/// - v1: empty shell — pointer plumbing only.
+/// - v2: `TextureRingSlot` β-shape lands (fixed-size POD
+///   `surface_id_bytes: [u8; 64]` + `surface_id_len: u32` +
+///   `slot_index: u32`, replacing the heap `String` surface_id) and
+///   the method slots `acquire_next` / `copy_pixel_buffer_to_slot` /
+///   `slot` get wired through. Each cross-DSO call uses caller-
+///   provided out-parameter buffers for the slot's typed POD bytes;
+///   the slot's `texture` β-shape is itself a `(handle, vtable,
+///   POD)` triple cloned through its own per-type Clone vtable.
+pub const TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// Layout version of [`VulkanComputeKernelMethodsVTable`].
 ///
@@ -2569,7 +2570,7 @@ unsafe impl Sync for GpuContextFullAccessVTable {}
 // =============================================================================
 
 /// Per-type method-dispatch vtable for the `TextureRing` β-shape
-/// (issue #907 Phase E).
+/// (issue #907 Phase E + #947 slot β-shape + method dispatch).
 ///
 /// `TextureRing` keeps `clone_*` / `drop_*` dispatch on the parent
 /// [`GpuContextFullAccessVTable`] (PR #918's Phase D shape); this
@@ -2578,15 +2579,27 @@ unsafe impl Sync for GpuContextFullAccessVTable {}
 /// POD getters (`len`, `is_empty`, `width`, `height`, `format`) are
 /// cached on the β-shape struct itself and don't need vtable slots.
 ///
-/// **PR 1/5 ships the shell.** This vtable carries only the
-/// `layout_version` + `_reserved_padding` header today. Method slots
-/// arrive in follow-up sub-issues filed against #907 once the
-/// cross-DSO representation of `TextureRingSlot` (currently
-/// `surface_id: String`, not layout-stable) is settled. Pinning the
-/// shell now lets the β-shape struct grow the `methods_vtable`
-/// pointer field + cached-POD fields with locked offsets, so
-/// downstream PRs only append to this vtable + bump
-/// [`TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION`].
+/// **Slot-return shape (v2):** `acquire_next` and `slot` return the
+/// slot's owned typed POD bytes via caller-provided out-parameter
+/// buffers (`out_texture_handle` + cached POD slot for the slot's
+/// `Texture`, plus `out_surface_id_bytes` + `out_surface_id_len` +
+/// `out_slot_index`). The slot's `Texture` β-shape itself manages
+/// its Arc lifetime through the parent
+/// [`GpuContextLimitedAccessVTable`]'s `clone_texture` /
+/// `drop_texture` slots — when the host wrapper hands a cloned
+/// `Texture` handle back, the cdylib's `Texture::Drop` will fire
+/// `drop_texture` to balance the clone. Surface IDs travel inline
+/// as fixed 64-byte buffers (UUIDs are 36 ASCII chars; the 64-byte
+/// budget leaves headroom for the bytes + length without a heap
+/// allocation crossing the DSO boundary).
+///
+/// **`copy_pixel_buffer_to_slot` (v2):** the caller passes the
+/// slot's `slot_index` (looks up the slot's pre-allocated upload
+/// resources host-side) and `surface_id_bytes` + `surface_id_len`
+/// (used to refresh the texture-cache registration's layout to
+/// `SHADER_READ_ONLY_OPTIMAL` post-upload). No slot deref needed
+/// across the boundary — the cdylib's `TextureRingSlot` carries
+/// both fields as inline POD.
 #[repr(C)]
 pub struct TextureRingMethodsVTable {
     /// Vtable layout version. Must equal
@@ -2596,6 +2609,72 @@ pub struct TextureRingMethodsVTable {
     /// Reserved padding (keeps the following pointer naturally
     /// aligned on 32-bit hosts; zero today, never read).
     pub _reserved_padding: u32,
+
+    /// Rotate to the next slot. Writes the slot's `Texture` handle
+    /// (cloned through the parent limited-access vtable, so the
+    /// returned handle carries its own Arc strong count balanced
+    /// by `Texture::Drop`), the cached `Texture` POD descriptors
+    /// (width/height/format), the slot's `surface_id` bytes +
+    /// length, and the slot index into the caller-provided
+    /// out-parameter buffers. Returns 0 on success; non-zero with
+    /// UTF-8 message in `err_buf` on failure (e.g. null ring
+    /// handle).
+    pub acquire_next: unsafe extern "C" fn(
+        ring_handle: *const c_void,
+        out_texture_handle: *mut *const c_void,
+        out_texture_width: *mut u32,
+        out_texture_height: *mut u32,
+        out_texture_format_raw: *mut u32,
+        out_surface_id_bytes: *mut [u8; 64],
+        out_surface_id_len: *mut u32,
+        out_slot_index: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Write a host-staged pixel buffer's contents into the slot's
+    /// pre-allocated texture (the Limited-safe per-frame primitive).
+    /// `slot_index` identifies the slot's pre-allocated upload
+    /// resources host-side; `surface_id_bytes` + `surface_id_len`
+    /// identify the texture-cache registration whose layout is
+    /// refreshed to `SHADER_READ_ONLY_OPTIMAL` post-upload. Returns
+    /// 0 on success; non-zero with UTF-8 message in `err_buf` on
+    /// failure (slot_index out of range, surface_id not valid
+    /// UTF-8, GPU submit error, etc.).
+    pub copy_pixel_buffer_to_slot: unsafe extern "C" fn(
+        ring_handle: *const c_void,
+        slot_index: u32,
+        surface_id_bytes: *const u8,
+        surface_id_len: u32,
+        pixel_buffer_handle: *const c_void,
+        width: u32,
+        height: u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Look up a slot by index. Same out-parameter shape as
+    /// `acquire_next`. Returns 0 on success; returns -1 (NOT 1) with
+    /// no `err_buf` write when `index` is out of range — the
+    /// distinction lets the caller `Option::None` cleanly without
+    /// allocating an error string. Returns 1 on a hard failure
+    /// (null ring handle, etc.) with UTF-8 message in `err_buf`.
+    pub slot: unsafe extern "C" fn(
+        ring_handle: *const c_void,
+        index: usize,
+        out_texture_handle: *mut *const c_void,
+        out_texture_width: *mut u32,
+        out_texture_height: *mut u32,
+        out_texture_format_raw: *mut u32,
+        out_surface_id_bytes: *mut [u8; 64],
+        out_surface_id_len: *mut u32,
+        out_slot_index: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for TextureRingMethodsVTable {}
@@ -3877,7 +3956,7 @@ mod layout_tests {
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 7);
-        assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
@@ -3954,11 +4033,15 @@ mod layout_tests {
 
     #[test]
     fn texture_ring_methods_vtable_layout() {
-        // Empty shell — layout_version + _reserved_padding only.
-        // Subsequent #907 sub-PRs append method slots and bump
-        // TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION.
-        assert_eq!(size_of::<TextureRingMethodsVTable>(), 8);
-        assert_eq!(align_of::<TextureRingMethodsVTable>(), 4);
+        // v2 (slot β-shape + method-dispatch slots added):
+        //   layout_version              @ 0   (4 bytes, u32)
+        //   _reserved_padding           @ 4   (4 bytes, u32)
+        //   acquire_next                @ 8   (8 bytes, fn pointer)
+        //   copy_pixel_buffer_to_slot   @ 16
+        //   slot                        @ 24
+        // Total = 32 bytes, align = 8.
+        assert_eq!(size_of::<TextureRingMethodsVTable>(), 32);
+        assert_eq!(align_of::<TextureRingMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(TextureRingMethodsVTable, layout_version),
             0
@@ -3967,6 +4050,12 @@ mod layout_tests {
             offset_of!(TextureRingMethodsVTable, _reserved_padding),
             4
         );
+        assert_eq!(offset_of!(TextureRingMethodsVTable, acquire_next), 8);
+        assert_eq!(
+            offset_of!(TextureRingMethodsVTable, copy_pixel_buffer_to_slot),
+            16
+        );
+        assert_eq!(offset_of!(TextureRingMethodsVTable, slot), 24);
     }
 
     #[test]

--- a/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
+++ b/libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs
@@ -241,7 +241,7 @@ impl NvJpegResources {
             )?;
             recorder.submit_and_wait()?;
             full_access
-                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
+                .update_texture_registration_layout(slot.surface_id(), VulkanLayout::GENERAL);
         }
 
         // ── Per-slot OPAQUE_FD staging + CUDA imports ──────────────────
@@ -280,7 +280,7 @@ impl NvJpegResources {
             let result = build_slot(
                 &device,
                 &ring_slot.texture,
-                &ring_slot.surface_id,
+                ring_slot.surface_id(),
                 shared_size_bytes,
                 rgbi_size_bytes,
                 stream,

--- a/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
+++ b/libs/vulkan-jpeg/src/vulkan_compute_backend.rs
@@ -131,7 +131,7 @@ impl VulkanComputeBackend {
             )?;
             recorder.submit_and_wait()?;
             full_access
-                .update_texture_registration_layout(&slot.surface_id, VulkanLayout::GENERAL);
+                .update_texture_registration_layout(slot.surface_id(), VulkanLayout::GENERAL);
         }
 
         Ok(Self {
@@ -218,9 +218,10 @@ impl JpegDecodeBackend for VulkanComputeBackend {
             &resolved.info,
         )?;
 
+        let surface_id = slot.surface_id().to_string();
         Ok(JpegDecodeOutput {
             texture: slot.texture,
-            surface_id: slot.surface_id,
+            surface_id,
             width,
             height,
             color_source: resolved.source,

--- a/packages/debug-utilities/src/bgra_file_source.rs
+++ b/packages/debug-utilities/src/bgra_file_source.rs
@@ -182,7 +182,7 @@ fn source_thread_loop(
             tracing::error!("[BgraFileSource] Failed to upload frame texture: {e}");
             break;
         }
-        let surface_id = slot.surface_id;
+        let surface_id = slot.surface_id().to_string();
 
         let timestamp_ns =
             clock_start.elapsed().as_nanos() as i64 + frame_idx as i64 * frame_interval_ns;

--- a/packages/h264/src/linux/decoder.rs
+++ b/packages/h264/src/linux/decoder.rs
@@ -152,7 +152,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H264DecoderProcessor::Pro
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }
             ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
-            let surface_id = slot.surface_id;
+            let surface_id = slot.surface_id().to_string();
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 

--- a/packages/h265/src/linux/decoder.rs
+++ b/packages/h265/src/linux/decoder.rs
@@ -152,7 +152,7 @@ impl streamlib::sdk::processors::ReactiveProcessor for H265DecoderProcessor::Pro
                 std::ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr, src.len());
             }
             ring.copy_pixel_buffer_to_slot(&slot, &pixel_buffer, width, height)?;
-            let surface_id = slot.surface_id;
+            let surface_id = slot.surface_id().to_string();
 
             let timestamp_ns = encoded.timestamp_ns.clone();
 


### PR DESCRIPTION
Closes #947.

Fourth PR in the per-vtable method-dispatch stream (#949). **Different shape from the kernel PRs (#963/#951/#953)**: those wired vtable slots whose ARGS were already β-shape types. This PR makes \`TextureRingSlot\` *itself* cross-DSO-stable (replacing the heap-allocated \`surface_id: String\` with a fixed \`[u8; 64] + len\` representation), THEN wires the 3 ring methods through the per-type vtable. Also sweeps 5 in-tree consumers (camera, h264, h265, BgraFileSource, vulkan-jpeg) from direct \`slot.surface_id\` field reads to \`slot.surface_id()\` accessor.

**Unblocks shipping h264 / h265 / debug-utilities (BgraFileSource) / vulkan-jpeg as \`.slpkg\` cdylibs** — all four consume \`ring.acquire_next()\` / \`ring.copy_pixel_buffer_to_slot(...)\` on their hot path and would have panicked at the FFI boundary against the pre-PR shape.

## Scope

**Part 1 — TextureRingSlot is `#[repr(C)]`** (104 bytes total, align 8):

| Field | Type | Bytes |
|---|---|---|
| \`texture\` | \`Texture\` (β-shape: handle + vtable + cached POD) | 32 |
| \`surface_id_bytes\` | \`[u8; 64]\` | 64 |
| \`surface_id_len\` | \`u32\` | 4 |
| \`slot_index\` | \`u32\` (was \`usize\`, narrowed for FFI safety) | 4 |

\`surface_id()\` accessor uses \`from_utf8_unchecked\` after construction-time \`from_utf8\` validation (UUIDs are pure ASCII; invariant locked in \`TextureRingSlot::new\`). UUIDs are 36 bytes, the buffer is 64 for headroom.

**Part 2 — 3 vtable method slots** on \`TextureRingMethodsVTable\` (v1 → v2, 8 → 32 bytes):

- \`acquire_next(ring) -> (texture_handle, w, h, format_raw, surface_id_bytes, surface_id_len, slot_index)\` — primitives in out-params, no \`#[repr(C)] *mut Texture\` POD-by-value required at the FFI boundary.
- \`copy_pixel_buffer_to_slot(ring, pixel_buffer, surface_id_bytes, surface_id_len, slot_index, w, h)\` — slot identity is the \`(slot_index, surface_id)\` pair (slot_index for upload_resources lookup, surface_id for texture-cache registration layout refresh). Uses \`make_pixel_buffer_borrow\` (the cross-kernel-family \`ManuallyDrop\` helper from #965/#966/#967).
- \`slot(ring, index) -> Option<slot data>\` — same out-param shape as \`acquire_next\`.

**Part 3 — In-tree sweep** of 5 consumers (per CLAUDE.md "no bad patterns left behind on engine changes"):

- \`packages/h264/src/linux/decoder.rs\`
- \`packages/h265/src/linux/decoder.rs\`
- \`packages/debug-utilities/src/bgra_file_source.rs\`
- \`libs/vulkan-jpeg/src/vulkan_compute_backend.rs\`
- \`libs/vulkan-jpeg/src/nvjpeg_backend/resources.rs\`

Every \`slot.surface_id\` direct field read replaced with \`slot.surface_id()\`.

## Design decision (owned vs borrow return for `acquire_next`)

\`acquire_next\` already returned \`TextureRingSlot\` by value in \`TextureRingInner\` (cloned from pre-allocated \`self.slots[idx]\`). The β-shape keeps owned-return on both sides — host mode clones from the slot vector; cdylib mode reassembles from out-params with a host-side Arc-bump-then-Drop pair (one atomic increment per \`acquire_next\` call — the established β-shape contract, not new overhead). \`slot()\` lifts from \`Option<&TextureRingSlot>\` (borrow) to \`Option<TextureRingSlot>\` (owned) on the β-shape; the host-internal \`TextureRingInner::slot\` keeps the borrow shape.

All 5 in-tree consumers already accepted owned slots, so the migration cost was just \`slot.surface_id\` → \`slot.surface_id()\` plus the slot-by-value adaptation in jpeg-side ring traversal.

## Deviations from the issue spec

- **Added \`slot_index: u32\` to TextureRingSlot.** The host needs slot identity for upload_resources lookup; surface_id alone wasn't enough. (Field already existed as \`usize\` pre-PR — the PR narrows the type for FFI safety and exposes a public accessor.)
- **Vtable returns texture as 4 primitives** instead of \`*mut Texture\` POD-by-value. Same total bytes (32) but each scalar field individually addressable — FFI prefers explicit primitive types.

## Verification

- \`cargo test -p streamlib-plugin-abi --lib\` — 45/45 pass (incl bumped \`texture_ring_methods_vtable_layout\`, 32-byte v2 shape)
- \`cargo test -p streamlib-engine --lib texture_ring\` — 11/11 (4 layout tests, 6 GPU tests, 1 ignored bench)
- \`cargo test -p streamlib-engine --lib texture_ring_methods_vtable_null_tests\` — 3/3
- \`cargo test --release -p streamlib-engine --test load_project_dylib_cross_rustc\` — 1/1 (\`TextureRing:OK\` end-to-end through divergent dep graph: extends the cross-rustc fixture to grab a ring + rotate via \`acquire_next\` × 2 + \`slot(0)\` + \`copy_pixel_buffer_to_slot\`)
- \`cargo test --workspace --lib --exclude streamlib-python-native --exclude streamlib-deno-native\` — 1173 pass, zero PR-related failures
- \`cargo xtask check-boundaries\` — clean
- \`pr-review-gate\` (Opus max) — **PASS verdict**. Two DISCUSS items, both doc-quality. Strengthened the round-trip test to assert UUID content shape (NUL-byte free, hex+dashes, 4 dashes for UUID-v4) so a mentally-reverted bytes-copy actually fails the test; the slot-vs-None distinction (status -1 vs 1) was a deliberate match to pre-PR \`Option<&TextureRingSlot>\` semantics, kept as-is.

## Test plan

- [x] Layout regression test on the new 104-byte \`TextureRingSlot\` shape
- [x] 3 Tier-1 null-kernel-handle wire-format tests
- [x] Cross-rustc dlopen integration test extended with ring round-trip
- [x] In-tree sweep verified — 5 consumers all compile and tests pass
- [x] Existing dlopen integration tests stay green (compute / graphics / RT kernel + gpu_acquire + escalate_smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)