### PR TITLE
feat(plugin-abi): VulkanAccelerationStructure build_*_blas out-params + label method dispatch (#955)

### DIFF
--- a/libs/streamlib-cross-rustc-fixture/src/lib.rs
+++ b/libs/streamlib-cross-rustc-fixture/src/lib.rs
@@ -235,17 +235,58 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
         // VulkanComputeKernel which IS exercised on every host.
         if full.supports_ray_tracing_pipeline() {
             // VulkanAccelerationStructure: trivial single-triangle BLAS.
+            // Exercises the #955 v8 build_triangles_blas out-params:
+            // the cdylib-minted β-shape must carry real device_address,
+            // storage_size, and kind (no placeholder zeros), and its
+            // label() method must round-trip through the new
+            // VulkanAccelerationStructureMethodsVTable::label slot.
             let vertices = [
                 0.0f32, 0.0, 0.0, //
                 1.0, 0.0, 0.0, //
                 0.0, 1.0, 0.0, //
             ];
             let indices = [0u32, 1, 2];
+            let blas_label = "cross-rustc-fixture-blas";
             let blas = full.build_triangles_blas(
-                "cross-rustc-fixture-blas",
+                blas_label,
                 &vertices,
                 &indices,
             )?;
+            // Real device address from the v8 out-param (not the
+            // placeholder zero the pre-v8 cdylib path produced).
+            if blas.device_address() == 0 {
+                return Err(Error::Runtime(
+                    "VulkanAccelerationStructure: build_triangles_blas                      produced cached_device_address=0 (v8 out-param                      not surfaced or BLAS truly has no device address)"
+                        .into(),
+                ));
+            }
+            if blas.storage_size() == 0 {
+                return Err(Error::Runtime(
+                    "VulkanAccelerationStructure: build_triangles_blas                      produced cached_storage_size=0 (v8 out-param not                      surfaced or BLAS build skipped storage allocation)"
+                        .into(),
+                ));
+            }
+            // kind() reads cached_kind; build_triangles_blas always
+            // mints BottomLevel (the host's from_arc_into_raw writes
+            // out_kind = 0 for BLAS, 1 for TLAS).
+            if blas.kind()
+                != streamlib::sdk::engine::host_rhi::AccelerationStructureKind::BottomLevel
+            {
+                return Err(Error::Runtime(format!(
+                    "VulkanAccelerationStructure: build_triangles_blas                      produced kind = {:?}, expected BottomLevel",
+                    blas.kind()
+                )));
+            }
+            // label() routes through the v2 methods vtable slot in
+            // cdylib mode (host_inner panics if reached). Round-trip
+            // must match what we passed at build time exactly.
+            let round_tripped = blas.label();
+            if round_tripped != blas_label {
+                return Err(Error::Runtime(format!(
+                    "VulkanAccelerationStructure: label round-trip                      mismatch — passed {blas_label:?} but got {:?}",
+                    round_tripped
+                )));
+            }
             let blas_clone = blas.clone();
             drop(blas_clone);
             drop(blas);

--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4692,6 +4692,9 @@ impl GpuContextFullAccess {
                     ));
                 }
                 let mut out_blas: *const std::ffi::c_void = std::ptr::null();
+                let mut out_device_address: u64 = 0;
+                let mut out_storage_size: u64 = 0;
+                let mut out_kind: u32 = 0;
                 let mut err_buf = [0u8; 512];
                 let mut err_len: usize = 0;
                 let status = unsafe {
@@ -4704,6 +4707,9 @@ impl GpuContextFullAccess {
                         indices.as_ptr(),
                         indices.len(),
                         &mut out_blas,
+                        &mut out_device_address as *mut u64,
+                        &mut out_storage_size as *mut u64,
+                        &mut out_kind as *mut u32,
                         err_buf.as_mut_ptr(),
                         err_buf.len(),
                         &mut err_len as *mut usize,
@@ -4716,14 +4722,11 @@ impl GpuContextFullAccess {
                         ));
                     }
                     // β-shape: bundle the raw handle (`Arc::into_raw(Arc<Inner>)`-shaped)
-                    // with the host vtables. Cached POD descriptors
-                    // (`device_address`, `storage_size`, `kind`) are
-                    // populated with placeholder zeros today — the
-                    // `build_*_blas` FFI signature doesn't yet surface
-                    // them to the cdylib. The β-shape getters fall
-                    // back to `host_inner` when cached values are 0
-                    // (panics in cdylib) — fixed in the #907 follow-up
-                    // sub-issue (FFI extension with out-params).
+                    // with the host vtables. The cached POD descriptors
+                    // (`device_address`, `storage_size`, `kind`) come
+                    // from the host's β-shape post-mint (see
+                    // `host_gpu_full_build_triangles_blas`); they are
+                    // always real values, never placeholder zeros.
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
                             .map(|c| c.vulkan_acceleration_structure_methods_vtable)
@@ -4732,10 +4735,10 @@ impl GpuContextFullAccess {
                         handle: out_blas,
                         vtable: self.vtable,
                         methods_vtable,
-                        cached_kind: 0, // BottomLevel — placeholder; see comment above
+                        cached_kind: out_kind,
                         _reserved_padding: 0,
-                        cached_device_address: 0,
-                        cached_storage_size: 0,
+                        cached_device_address: out_device_address,
+                        cached_storage_size: out_storage_size,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(
@@ -4764,6 +4767,9 @@ impl GpuContextFullAccess {
                     ));
                 }
                 let mut out_tlas: *const std::ffi::c_void = std::ptr::null();
+                let mut out_device_address: u64 = 0;
+                let mut out_storage_size: u64 = 0;
+                let mut out_kind: u32 = 0;
                 let mut err_buf = [0u8; 512];
                 let mut err_len: usize = 0;
                 let status = unsafe {
@@ -4774,6 +4780,9 @@ impl GpuContextFullAccess {
                         instances.as_ptr() as *const std::ffi::c_void,
                         instances.len(),
                         &mut out_tlas,
+                        &mut out_device_address as *mut u64,
+                        &mut out_storage_size as *mut u64,
+                        &mut out_kind as *mut u32,
                         err_buf.as_mut_ptr(),
                         err_buf.len(),
                         &mut err_len as *mut usize,
@@ -4785,8 +4794,9 @@ impl GpuContextFullAccess {
                             "build_tlas: host signaled success but out_tlas is null".into(),
                         ));
                     }
-                    // β-shape: see build_triangles_blas above. Same
-                    // placeholder-zeros caching story.
+                    // β-shape: see build_triangles_blas above. Cached
+                    // PODs come from the host's β-shape post-mint via
+                    // the v8 out-params; always real values.
                     let methods_vtable =
                         crate::core::plugin::host_services::host_callbacks()
                             .map(|c| c.vulkan_acceleration_structure_methods_vtable)
@@ -4795,10 +4805,10 @@ impl GpuContextFullAccess {
                         handle: out_tlas,
                         vtable: self.vtable,
                         methods_vtable,
-                        cached_kind: 1, // TopLevel — placeholder; see comment above
+                        cached_kind: out_kind,
                         _reserved_padding: 0,
-                        cached_device_address: 0,
-                        cached_storage_size: 0,
+                        cached_device_address: out_device_address,
+                        cached_storage_size: out_storage_size,
                     })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -5706,6 +5706,9 @@ unsafe extern "C" fn host_gpu_full_build_triangles_blas(
     indices_ptr: *const u32,
     indices_len: usize,
     out_blas: *mut *const c_void,
+    out_device_address: *mut u64,
+    out_storage_size: *mut u64,
+    out_kind: *mut u32,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -5713,9 +5716,14 @@ unsafe extern "C" fn host_gpu_full_build_triangles_blas(
     run_host_extern_c(
         "host_gpu_full_build_triangles_blas",
         || -> i32 {
-            if out_blas.is_null() || label_ptr.is_null() {
+            if out_blas.is_null()
+                || label_ptr.is_null()
+                || out_device_address.is_null()
+                || out_storage_size.is_null()
+                || out_kind.is_null()
+            {
                 write_err(
-                    "build_triangles_blas: null label_ptr / out_blas",
+                    "build_triangles_blas: null label_ptr / out-parameter pointer",
                     err_buf,
                     err_buf_cap,
                     err_len,
@@ -5757,13 +5765,26 @@ unsafe extern "C" fn host_gpu_full_build_triangles_blas(
             match result {
                 Some(Ok(blas)) => {
                     // `blas` is the β-shape — its `handle` is already
-                    // `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`-shaped.
-                    // Forget the β-shape to keep the Arc strong count
-                    // bumped; cdylib reconstructs its own β-shape from
-                    // the handle + vtable.
+                    // `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`-shaped
+                    // and its cached POD fields were populated by
+                    // `VulkanAccelerationStructure::from_arc_into_raw`
+                    // (host-mode mint path). Write them through the
+                    // out-params so the cdylib's β-shape carries the
+                    // real values instead of placeholder zeros. Forget
+                    // the β-shape to keep the Arc strong count bumped;
+                    // cdylib reconstructs its own β-shape from the
+                    // handle + vtable + cached PODs.
                     let raw = blas.handle;
+                    let device_address = blas.cached_device_address;
+                    let storage_size = blas.cached_storage_size;
+                    let kind = blas.cached_kind;
                     std::mem::forget(blas);
-                    unsafe { std::ptr::write(out_blas, raw) };
+                    unsafe {
+                        std::ptr::write(out_blas, raw);
+                        std::ptr::write(out_device_address, device_address);
+                        std::ptr::write(out_storage_size, storage_size);
+                        std::ptr::write(out_kind, kind);
+                    }
                     0
                 }
                 Some(Err(e)) => {
@@ -5787,6 +5808,9 @@ unsafe extern "C" fn host_gpu_full_build_triangles_blas(
     _indices_ptr: *const u32,
     _indices_len: usize,
     _out_blas: *mut *const c_void,
+    _out_device_address: *mut u64,
+    _out_storage_size: *mut u64,
+    _out_kind: *mut u32,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -5808,6 +5832,9 @@ unsafe extern "C" fn host_gpu_full_build_tlas(
     instances_ptr: *const c_void,
     instances_len: usize,
     out_tlas: *mut *const c_void,
+    out_device_address: *mut u64,
+    out_storage_size: *mut u64,
+    out_kind: *mut u32,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -5815,9 +5842,14 @@ unsafe extern "C" fn host_gpu_full_build_tlas(
     run_host_extern_c(
         "host_gpu_full_build_tlas",
         || -> i32 {
-            if out_tlas.is_null() || label_ptr.is_null() {
+            if out_tlas.is_null()
+                || label_ptr.is_null()
+                || out_device_address.is_null()
+                || out_storage_size.is_null()
+                || out_kind.is_null()
+            {
                 write_err(
-                    "build_tlas: null label_ptr / out_tlas",
+                    "build_tlas: null label_ptr / out-parameter pointer",
                     err_buf,
                     err_buf_cap,
                     err_len,
@@ -5864,9 +5896,22 @@ unsafe extern "C" fn host_gpu_full_build_tlas(
             );
             match result {
                 Some(Ok(tlas)) => {
+                    // Same shape as `host_gpu_full_build_triangles_blas`:
+                    // the β-shape's cached PODs are real (populated by
+                    // `from_arc_into_raw` host-side); write them
+                    // through the out-params so the cdylib's reassembled
+                    // β-shape carries real values.
                     let raw = tlas.handle;
+                    let device_address = tlas.cached_device_address;
+                    let storage_size = tlas.cached_storage_size;
+                    let kind = tlas.cached_kind;
                     std::mem::forget(tlas);
-                    unsafe { std::ptr::write(out_tlas, raw) };
+                    unsafe {
+                        std::ptr::write(out_tlas, raw);
+                        std::ptr::write(out_device_address, device_address);
+                        std::ptr::write(out_storage_size, storage_size);
+                        std::ptr::write(out_kind, kind);
+                    }
                     0
                 }
                 Some(Err(e)) => {
@@ -5888,6 +5933,9 @@ unsafe extern "C" fn host_gpu_full_build_tlas(
     _instances_ptr: *const c_void,
     _instances_len: usize,
     _out_tlas: *mut *const c_void,
+    _out_device_address: *mut u64,
+    _out_storage_size: *mut u64,
+    _out_kind: *mut u32,
     err_buf: *mut u8,
     err_buf_cap: usize,
     err_len: *mut usize,
@@ -8120,13 +8168,15 @@ unsafe extern "C" fn host_graphics_kernel_offscreen_render(
 //
 // The AS-binding wrapper reconstructs an AS borrow via
 // `make_acceleration_structure_borrow` — same `ManuallyDrop` shape
-// as the buffer/texture helpers; the inner kernel only reads
-// `vk_handle()` + `kind()` off the wrapper, both of which trampoline
-// through the methods vtable when the AS has its own vtable hooked
-// up. In the host-path this PR exercises, the borrow is constructed
-// against the host's static vtables so the dispatch goes straight to
-// `host_inner()` and reads the inner's cached `handle` + `kind` —
-// no recursive FFI call.
+// as the buffer/texture helpers. The β-shape's `kind()` /
+// `device_address()` / `storage_size()` getters read the cached
+// fields on the borrow directly (no vtable dispatch); the helper
+// populates those fields at construction time from the host-internal
+// `Inner`, so the inner kernel's `set_acceleration_structure` reads
+// the real values rather than the placeholder zeros that would
+// trip the kernel's `TopLevel` check. `vk_handle()` stays host-only
+// (vulkanalia handle, no cdylib path) and is only called from the
+// host wrapper here, after the kind check passes.
 
 /// SAFETY: caller must hand a `handle` that came from
 /// `Arc::into_raw(Arc<VulkanRayTracingKernelInner>)`. The leaked
@@ -8145,14 +8195,39 @@ unsafe fn handle_as_ray_tracing_kernel(
 fn make_acceleration_structure_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::vulkan::rhi::VulkanAccelerationStructure> {
+    // Read the cached POD descriptors directly from the host-internal
+    // Inner. With #955 the β-shape's `kind()` / `device_address()` /
+    // `storage_size()` getters read the cached fields (no host_inner()
+    // fallback), so the borrow MUST carry real values — the
+    // ray-tracing kernel's `set_acceleration_structure` check reads
+    // `tlas.kind()` and would see BottomLevel for every borrow if the
+    // cached field stayed 0.
+    let (cached_kind, cached_device_address, cached_storage_size) =
+        if handle.is_null() {
+            (0u32, 0u64, 0u64)
+        } else {
+            // SAFETY: caller hands us a `handle` minted by
+            // `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`,
+            // so dereferencing through the host-internal Inner is
+            // sound on the host side (this helper is host-only;
+            // cdylib borrows would never reach this code path).
+            let as_inner = unsafe {
+                &*(handle as *const crate::vulkan::rhi::VulkanAccelerationStructureInner)
+            };
+            let kind = match as_inner.kind() {
+                crate::vulkan::rhi::AccelerationStructureKind::BottomLevel => 0u32,
+                crate::vulkan::rhi::AccelerationStructureKind::TopLevel => 1u32,
+            };
+            (kind, as_inner.device_address(), as_inner.storage_size())
+        };
     std::mem::ManuallyDrop::new(crate::vulkan::rhi::VulkanAccelerationStructure {
         handle,
         vtable: host_gpu_context_full_access_vtable(),
         methods_vtable: host_vulkan_acceleration_structure_methods_vtable(),
-        cached_kind: 0,
+        cached_kind,
         _reserved_padding: 0,
-        cached_device_address: 0,
-        cached_storage_size: 0,
+        cached_device_address,
+        cached_storage_size,
     })
 }
 
@@ -8936,14 +9011,122 @@ pub fn host_vulkan_ray_tracing_kernel_methods_vtable(
     &HOST_VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE
 }
 
-/// Host-side empty-shell
-/// `VulkanAccelerationStructureMethodsVTable` (issue #907 PR 5/5).
+// ---------------------------------------------------------------------------
+// VulkanAccelerationStructureMethodsVTable wrappers (issue #955)
+//
+// The per-type vtable currently carries one method slot — `label` —
+// because:
+//   * POD getters (`device_address`, `storage_size`, `kind`) are
+//     populated at mint time via the v8 build_triangles_blas /
+//     build_tlas out-params; the β-shape's cached fields are always
+//     real values, no vtable dispatch needed.
+//   * `vk_handle` stays host-only (vulkanalia handle layout couples
+//     to vulkanalia minor version; no in-tree cdylib consumer reads
+//     it — every binding goes through the ray-tracing kernel's
+//     host-side `set_acceleration_structure` slot which dereferences
+//     the AS host-side).
+//
+// `label` uses the same caller-provided byte-buffer out-param shape
+// as `TextureRingSlot.surface_id` from #947 — labels longer than
+// `out_buf_cap` are silently truncated (fine for diagnostic strings).
+// ---------------------------------------------------------------------------
+
+/// SAFETY: caller must hand a `handle` that came from
+/// `Arc::into_raw(Arc<VulkanAccelerationStructureInner>)`. The
+/// leaked strong count keeps the AS alive for the call's duration.
+#[cfg(target_os = "linux")]
+unsafe fn handle_as_acceleration_structure(
+    handle: *const c_void,
+) -> Option<&'static crate::vulkan::rhi::VulkanAccelerationStructureInner> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe {
+        &*(handle as *const crate::vulkan::rhi::VulkanAccelerationStructureInner)
+    })
+}
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_vulkan_acceleration_structure_label(
+    as_handle: *const c_void,
+    out_buf: *mut u8,
+    out_buf_cap: usize,
+    out_len: *mut usize,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_vulkan_acceleration_structure_label",
+        || -> i32 {
+            let Some(as_inner) =
+                (unsafe { handle_as_acceleration_structure(as_handle) })
+            else {
+                write_err(
+                    "label: null acceleration_structure handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if out_buf.is_null() || out_len.is_null() {
+                write_err(
+                    "label: null out-parameter pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let label_bytes = as_inner.label().as_bytes();
+            // Silent truncation at buffer cap — labels are diagnostic
+            // strings, not load-bearing data; an over-large label
+            // just shows the prefix in logs.
+            let copy_len = label_bytes.len().min(out_buf_cap);
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    label_bytes.as_ptr(),
+                    out_buf,
+                    copy_len,
+                );
+                std::ptr::write(out_len, copy_len);
+            }
+            0
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_vulkan_acceleration_structure_label(
+    _as_handle: *const c_void,
+    _out_buf: *mut u8,
+    _out_buf_cap: usize,
+    _out_len: *mut usize,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "label: not available on this platform",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+/// Host-side `VulkanAccelerationStructureMethodsVTable` wired to the
+/// per-method wrappers above (issue #907 PR 5/5 shell + #955 method
+/// dispatch).
 pub static HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE:
     streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable =
     streamlib_plugin_abi::VulkanAccelerationStructureMethodsVTable {
         layout_version:
             streamlib_plugin_abi::VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION,
         _reserved_padding: 0,
+        label: host_vulkan_acceleration_structure_label,
     };
 
 /// Accessor for the host's static
@@ -9345,6 +9528,9 @@ mod gpu_full_access_vtable_tests {
         let vertices = [0.0f32, 0.0, 0.0];
         let indices = [0u32, 1, 2];
         let mut out: *const c_void = std::ptr::null();
+        let mut out_device_address: u64 = 0;
+        let mut out_storage_size: u64 = 0;
+        let mut out_kind: u32 = 0;
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.build_triangles_blas)(
                 std::ptr::null(),
@@ -9355,6 +9541,9 @@ mod gpu_full_access_vtable_tests {
                 indices.as_ptr(),
                 indices.len(),
                 &mut out,
+                &mut out_device_address as *mut u64,
+                &mut out_storage_size as *mut u64,
+                &mut out_kind as *mut u32,
                 buf.as_mut_ptr(),
                 buf.len(),
                 &mut len,
@@ -9367,6 +9556,10 @@ mod gpu_full_access_vtable_tests {
             "got: {msg}"
         );
         assert!(out.is_null());
+        // Out-params untouched on failure.
+        assert_eq!(out_device_address, 0);
+        assert_eq!(out_storage_size, 0);
+        assert_eq!(out_kind, 0);
     }
 
     #[test]
@@ -9375,6 +9568,9 @@ mod gpu_full_access_vtable_tests {
         let (mut buf, mut len) = make_err_buf();
         let label = b"test_tlas";
         let mut out: *const c_void = std::ptr::null();
+        let mut out_device_address: u64 = 0;
+        let mut out_storage_size: u64 = 0;
+        let mut out_kind: u32 = 0;
         let rc = unsafe {
             (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.build_tlas)(
                 std::ptr::null(),
@@ -9383,6 +9579,9 @@ mod gpu_full_access_vtable_tests {
                 std::ptr::null(),
                 0,
                 &mut out,
+                &mut out_device_address as *mut u64,
+                &mut out_storage_size as *mut u64,
+                &mut out_kind as *mut u32,
                 buf.as_mut_ptr(),
                 buf.len(),
                 &mut len,
@@ -9395,6 +9594,10 @@ mod gpu_full_access_vtable_tests {
             "got: {msg}"
         );
         assert!(out.is_null());
+        // Out-params untouched on failure.
+        assert_eq!(out_device_address, 0);
+        assert_eq!(out_storage_size, 0);
+        assert_eq!(out_kind, 0);
     }
 
     #[test]
@@ -10495,6 +10698,55 @@ mod texture_ring_methods_vtable_null_tests {
         assert_eq!(rc, 1);
         assert!(
             err_buf_as_str(&buf, len).contains("slot: null ring handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod acceleration_structure_methods_vtable_null_tests {
+    //! Tier-1 wire-format tests for the v2 `label` method slot on
+    //! `VulkanAccelerationStructureMethodsVTable` (issue #955). The
+    //! wrapper must reject a null AS handle before reaching any
+    //! Inner state so cdylib callers get a clean error return
+    //! instead of UB.
+    //!
+    //! End-to-end coverage (real AS + label round-trip) is locked
+    //! by the dlopen integration test for the cross-rustc fixture,
+    //! which builds a real BLAS and asserts the round-tripped label
+    //! matches the one passed at build time.
+
+    use super::*;
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_buf_as_str(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn label_rejects_null_acceleration_structure_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut out_buf = [0u8; 64];
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            (HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE.label)(
+                std::ptr::null(),
+                out_buf.as_mut_ptr(),
+                out_buf.len(),
+                &mut out_len as *mut usize,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("label: null acceleration_structure handle"),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_acceleration_structure.rs
@@ -748,51 +748,89 @@ impl VulkanAccelerationStructure {
             .map(Self::from_arc_into_raw)
     }
 
-    /// `VkAccelerationStructureKHR` handle.
+    /// `VkAccelerationStructureKHR` handle. **Host-only** — the
+    /// vulkanalia handle layout couples to the vulkanalia minor
+    /// version and isn't safe to surface across a DSO boundary.
+    /// There is no in-tree cdylib consumer that reads this; every
+    /// binding flows through the ray-tracing kernel's
+    /// `set_acceleration_structure` slot, which dereferences the AS
+    /// on the host side. Panics if called from cdylib code.
     pub fn vk_handle(&self) -> vk::AccelerationStructureKHR {
         self.host_inner().vk_handle()
     }
 
-    /// Device address of the AS. Host-mode reads the cached POD;
-    /// cdylib-mode currently routes through `host_inner` (panic in
-    /// cdylib) — the FFI signature for `build_*_blas` doesn't yet
-    /// surface the value to the cdylib. Tracked in the #907
-    /// follow-up sub-issue, which extends the create-side FFI
-    /// signatures with out-params for the cached POD descriptors.
+    /// Device address of the AS. Reads the cached POD value
+    /// populated at mint time (host-mode via `from_arc_into_raw`;
+    /// cdylib-mode via the v8 `build_*_blas` out-params).
     pub fn device_address(&self) -> u64 {
-        if self.cached_device_address != 0 {
-            self.cached_device_address
-        } else {
-            self.host_inner().device_address()
-        }
+        self.cached_device_address
     }
 
-    /// `BottomLevel` or `TopLevel`. Same caching contract as
-    /// `device_address` — host mode reads cached, cdylib mode
-    /// currently falls back to `host_inner` until the follow-up
-    /// extends the FFI.
+    /// `BottomLevel` or `TopLevel`. Reads the cached POD value
+    /// populated at mint time. The discriminant is 0 = `BottomLevel`,
+    /// 1 = `TopLevel`; any other value is a corruption bug we
+    /// surface as `BottomLevel` rather than panic (host-side mint
+    /// paths are the source of truth and only ever write 0 or 1).
     pub fn kind(&self) -> AccelerationStructureKind {
-        // Sentinel-free path: kind is always either 0 or 1, so
-        // there's no "unset" value to detect. Routes through
-        // `host_inner` until the FFI signature surfaces the value.
-        self.host_inner().kind()
-    }
-
-    /// Human-readable label used in diagnostics. Still routes
-    /// through `host_inner` — `String` layout isn't cdylib-safe;
-    /// vtable dispatch lands in the #907 follow-up sub-issue.
-    pub fn label(&self) -> String {
-        self.host_inner().label().to_string()
-    }
-
-    /// Storage size in bytes. Same caching contract as
-    /// `device_address`.
-    pub fn storage_size(&self) -> vk::DeviceSize {
-        if self.cached_storage_size != 0 {
-            self.cached_storage_size
-        } else {
-            self.host_inner().storage_size()
+        match self.cached_kind {
+            0 => AccelerationStructureKind::BottomLevel,
+            1 => AccelerationStructureKind::TopLevel,
+            _ => AccelerationStructureKind::BottomLevel,
         }
+    }
+
+    /// Human-readable label used in diagnostics. Host-mode reads
+    /// from the host-internal Inner; cdylib-mode dispatches through
+    /// the per-type `VulkanAccelerationStructureMethodsVTable::label`
+    /// slot using a fixed-cap caller-allocated byte buffer (same
+    /// shape as `TextureRingSlot.surface_id`). Labels longer than
+    /// the buffer are silently truncated (diagnostic strings, not
+    /// load-bearing).
+    pub fn label(&self) -> String {
+        if crate::core::plugin::host_services::host_callbacks().is_some()
+            && !self.methods_vtable.is_null()
+            && !self.handle.is_null()
+        {
+            // Cdylib mode — dispatch through the methods vtable.
+            // 256 bytes covers every realistic AS label (callers in
+            // tree use names like "rt-smoke-blas", "drone-racer-tlas").
+            let mut out_buf = [0u8; 256];
+            let mut out_len: usize = 0;
+            let mut err_buf = [0u8; 256];
+            let mut err_len: usize = 0;
+            let status = unsafe {
+                ((*self.methods_vtable).label)(
+                    self.handle,
+                    out_buf.as_mut_ptr(),
+                    out_buf.len(),
+                    &mut out_len as *mut usize,
+                    err_buf.as_mut_ptr(),
+                    err_buf.len(),
+                    &mut err_len as *mut usize,
+                )
+            };
+            if status == 0 {
+                let bytes = &out_buf[..out_len.min(out_buf.len())];
+                String::from_utf8_lossy(bytes).into_owned()
+            } else {
+                // Best-effort: surface the error string as the
+                // label so log lines reading `.label()` still make
+                // sense, rather than panic. Labels are diagnostic.
+                let msg = String::from_utf8_lossy(
+                    &err_buf[..err_len.min(err_buf.len())],
+                )
+                .into_owned();
+                format!("<label dispatch failed: {msg}>")
+            }
+        } else {
+            self.host_inner().label().to_string()
+        }
+    }
+
+    /// Storage size in bytes. Reads the cached POD value populated
+    /// at mint time.
+    pub fn storage_size(&self) -> vk::DeviceSize {
+        self.cached_storage_size
     }
 }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -233,7 +233,18 @@ pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 ///   a `StorageBuffer` β-shape (already layout-stable from C1)
 ///   into `*out_buffer`. Camera processor's V4L2 zero-copy path
 ///   uses this; the host consumes the fd on success.
-pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 7;
+/// - v8: `build_triangles_blas` and `build_tlas` signatures extended
+///   with three new out-params each (`out_device_address: *mut u64`,
+///   `out_storage_size: *mut u64`, `out_kind: *mut u32`). Prior to
+///   v8 cdylib mint paths populated the `VulkanAccelerationStructure`
+///   β-shape's cached POD fields with placeholder zeros; the β-shape
+///   getters (`device_address()`, `storage_size()`, `kind()`) then
+///   fell back to `host_inner()` which panics in cdylib mode. v8
+///   surfaces the real values across the FFI so the cached fields
+///   are populated correctly at mint time. **ABI-breaking** — plugins
+///   built against v7 are not load-compatible with a v8 host (the fn
+///   pointer signatures differ).
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 8;
 
 /// Layout version of [`TextureRingMethodsVTable`].
 ///
@@ -299,13 +310,20 @@ pub const VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 /// Layout version of [`VulkanAccelerationStructureMethodsVTable`].
 ///
-/// `VulkanAccelerationStructure` β-shape gains a per-type vtable
-/// for method dispatch (issue #907 Phase E PR 5/5). Mirrors the
-/// kernel methods-vtable shape: empty shell today; follow-up PRs
-/// append method slots for `vk_handle` / `label` (the methods that
-/// can't be POD-cached cleanly because they return host-internal
-/// or String types) and route the β-shape methods through them.
-pub const VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+/// - v1: empty shell — pointer plumbing only (issue #907 Phase E
+///   PR 5/5).
+/// - v2: appended `label` slot returning the AS's human-readable
+///   label via a caller-provided byte buffer (same shape as
+///   `TextureRingSlot.surface_id` from #947 — `String` layout
+///   isn't cdylib-safe). `vk_handle` stays host-only — the
+///   `vk::AccelerationStructureKHR` is a vulkanalia handle that
+///   can't safely cross a DSO boundary without vulkanalia
+///   version coupling, and no in-tree cdylib consumer reads it.
+///   The POD getters (`device_address`, `storage_size`, `kind`)
+///   are populated at mint time via the v8
+///   [`GpuContextFullAccessVTable::build_triangles_blas`] /
+///   `build_tlas` out-params and don't need vtable slots.
+pub const VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 // =============================================================================
 // Primitive enums
@@ -2436,7 +2454,13 @@ pub struct GpuContextFullAccessVTable {
     /// Build a triangle-geometry bottom-level acceleration structure
     /// from CPU-side vertex + index data. Writes an
     /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
-    /// into `*out_blas` on success. Linux-only.
+    /// into `*out_blas` on success, plus the cached POD descriptors
+    /// the cdylib's `VulkanAccelerationStructure` β-shape carries:
+    /// `*out_device_address` (BLAS device address — used as the
+    /// `accelerationStructureReference` when wiring into a TLAS),
+    /// `*out_storage_size` (build-time storage allocation), and
+    /// `*out_kind` (0 = `BottomLevel`, 1 = `TopLevel`; always 0 for
+    /// `build_triangles_blas`). Linux-only.
     pub build_triangles_blas: unsafe extern "C" fn(
         gpu_handle: *const c_void,
         label_ptr: *const u8,
@@ -2446,6 +2470,9 @@ pub struct GpuContextFullAccessVTable {
         indices_ptr: *const u32,
         indices_len: usize,
         out_blas: *mut *const c_void,
+        out_device_address: *mut u64,
+        out_storage_size: *mut u64,
+        out_kind: *mut u32,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -2456,7 +2483,11 @@ pub struct GpuContextFullAccessVTable {
     /// host's `TlasInstanceDesc` struct (layout-stable under the
     /// rustc-version coupling contract). Writes an
     /// `Arc::into_raw(Arc<VulkanAccelerationStructure>)` raw pointer
-    /// into `*out_tlas` on success. Linux-only.
+    /// into `*out_tlas` on success, plus the cached POD descriptors
+    /// (`*out_device_address`, `*out_storage_size`, `*out_kind`) the
+    /// cdylib's β-shape carries — same shape as
+    /// `build_triangles_blas`; `*out_kind` is always 1 (`TopLevel`)
+    /// for `build_tlas`. Linux-only.
     pub build_tlas: unsafe extern "C" fn(
         gpu_handle: *const c_void,
         label_ptr: *const u8,
@@ -2464,6 +2495,9 @@ pub struct GpuContextFullAccessVTable {
         instances_ptr: *const c_void,
         instances_len: usize,
         out_tlas: *mut *const c_void,
+        out_device_address: *mut u64,
+        out_storage_size: *mut u64,
+        out_kind: *mut u32,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -3252,15 +3286,25 @@ unsafe impl Sync for VulkanRayTracingKernelMethodsVTable {}
 // =============================================================================
 
 /// Per-type method-dispatch vtable for the
-/// `VulkanAccelerationStructure` β-shape (issue #907 Phase E PR 5/5).
+/// `VulkanAccelerationStructure` β-shape (issue #907 Phase E PR 5/5
+/// + #955 method dispatch).
 ///
-/// Mirrors the kernel methods-vtable shape. Empty shell today;
-/// follow-up PRs append slots for `vk_handle` / `label` (the
-/// methods returning host-internal `vk::AccelerationStructureKHR`
-/// and heap-allocated `String` that can't be POD-cached) and route
-/// the β-shape methods through them. POD getters (`device_address`,
-/// `kind`, `storage_size`) are cached on the β-shape struct and
-/// don't need vtable slots.
+/// Mirrors the kernel methods-vtable shape. POD getters
+/// (`device_address`, `kind`, `storage_size`) are populated at mint
+/// time via the v8 [`GpuContextFullAccessVTable::build_triangles_blas`]
+/// / `build_tlas` out-params and don't need vtable slots — the
+/// cached values on the β-shape struct are always real, never
+/// placeholder zeros.
+///
+/// The single vtable slot is `label`, which uses the same byte-
+/// buffer out-param shape as `TextureRingSlot.surface_id` from #947.
+/// `vk_handle` stays host-only — the
+/// `vk::AccelerationStructureKHR` is a vulkanalia handle whose
+/// layout couples to the vulkanalia minor version, and there is no
+/// in-tree cdylib consumer that reads it (every binding into a
+/// ray-tracing kernel goes through the host-side
+/// `set_acceleration_structure` slot, which dereferences the AS on
+/// the host side and reads `vk_handle` there).
 #[repr(C)]
 pub struct VulkanAccelerationStructureMethodsVTable {
     /// Vtable layout version. Must equal
@@ -3270,6 +3314,23 @@ pub struct VulkanAccelerationStructureMethodsVTable {
     /// Reserved padding (keeps the following pointer naturally
     /// aligned on 32-bit hosts; zero today, never read).
     pub _reserved_padding: u32,
+
+    /// Read the AS's human-readable label into a caller-provided
+    /// byte buffer. `out_buf` / `out_buf_cap` describe the buffer;
+    /// `*out_len` receives the number of bytes written (≤ `out_buf_cap`
+    /// — labels longer than the buffer are silently truncated, which
+    /// is fine for diagnostic strings). Returns 0 on success;
+    /// non-zero with UTF-8 message in `err_buf` on failure (null AS
+    /// handle, null out-buffer pointer, etc.).
+    pub label: unsafe extern "C" fn(
+        as_handle: *const c_void,
+        out_buf: *mut u8,
+        out_buf_cap: usize,
+        out_len: *mut usize,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
 }
 
 unsafe impl Send for VulkanAccelerationStructureMethodsVTable {}
@@ -3955,12 +4016,12 @@ mod layout_tests {
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 7);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 8);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
-        assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 2);
     }
 
     #[test]
@@ -4308,12 +4369,13 @@ mod layout_tests {
 
     #[test]
     fn vulkan_acceleration_structure_methods_vtable_layout() {
-        // Empty shell — layout_version + _reserved_padding only.
-        // Mirrors the kernel methods-vtable layouts. Subsequent
-        // #907 sub-PRs append method slots and bump
-        // VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION.
-        assert_eq!(size_of::<VulkanAccelerationStructureMethodsVTable>(), 8);
-        assert_eq!(align_of::<VulkanAccelerationStructureMethodsVTable>(), 4);
+        // v2 (`label` slot added — #955):
+        //   layout_version       @ 0 (4 bytes, u32)
+        //   _reserved_padding    @ 4 (4 bytes, u32)
+        //   label                @ 8 (8 bytes, fn pointer)
+        // Total = 16 bytes, align = 8.
+        assert_eq!(size_of::<VulkanAccelerationStructureMethodsVTable>(), 16);
+        assert_eq!(align_of::<VulkanAccelerationStructureMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(VulkanAccelerationStructureMethodsVTable, layout_version),
             0
@@ -4321,6 +4383,10 @@ mod layout_tests {
         assert_eq!(
             offset_of!(VulkanAccelerationStructureMethodsVTable, _reserved_padding),
             4
+        );
+        assert_eq!(
+            offset_of!(VulkanAccelerationStructureMethodsVTable, label),
+            8
         );
     }
 


### PR DESCRIPTION
Closes #955.

**FINAL PR in the per-vtable method-dispatch stream (#949).** With this merged, parent #949 closes, and every β-shape method on the 5 #907-Phase-E types (TextureRing, VulkanComputeKernel, VulkanGraphicsKernel, VulkanRayTracingKernel, VulkanAccelerationStructure) dispatches correctly in cdylib mode without panic-on-host_inner fallbacks.

## Two pieces

### 1. FullAccess vtable bump (`GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION` 7→8)

Extends `build_triangles_blas` / `build_tlas` FFI signatures with 3 new out-params each:
- `out_device_address: *mut u64`
- `out_storage_size: *mut u64`
- `out_kind: *mut u32` (AccelerationStructureKind discriminant)

Cdylib mint paths now populate the β-shape's `cached_device_address` / `cached_storage_size` / `cached_kind` from real values instead of placeholder zeros. The β-shape's `device_address()` / `storage_size()` / `kind()` getters now read cached fields directly — the `host_inner()` fallback (which panicked in cdylib mode) is removed.

**ABI break — \"must rebuild\" plugin policy.** Plugins built against v7 won't load against v8; the codebase has no v7-compat path by design (one host-installed vtable, fail-fast on layout-version mismatch). The cross-rustc fixture is the v8 contract regression lock.

### 2. AS method dispatch (`VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION` 1→2)

Adds `label` method slot using #947's byte-buffer pattern (caller-provided `[u8; 256]` + `out_len: *mut usize`). β-shape's `label() -> String` branches on cdylib mode; cdylib path stack-allocates the buffer, dispatches via vtable, returns `String::from_utf8_lossy(...).into_owned()`.

`vk_handle()` stays host-only per the issue body's AI Agent Notes (vulkanalia handle, can't safely cross DSO without vulkanalia version coupling; verified no in-tree cdylib consumer reads it).

## Mid-flight catch

First run of `load_project_dylib_ray_tracing_kernel_smoke` failed after removing the `host_inner()` fallback from `kind()` — `make_acceleration_structure_borrow` in host_services.rs was building borrows with `cached_kind: 0`. Fix: the borrow now reads kind / device_address / storage_size from the host-internal Inner at construction (host-only path; sound). This is the engine-model rule in action — \"no bad patterns left behind on engine changes\" caught + addressed in the same PR.

## What landed

| Layer | Change |
|---|---|
| `streamlib-plugin-abi` | Bumped both layout versions (7→8, 1→2). Extended `build_triangles_blas` / `build_tlas` signatures. Added `label` slot. Updated 2 layout regression tests. |
| `host_services.rs` | Extended `host_gpu_full_build_triangles_blas` / `host_gpu_full_build_tlas` to write new out-params. Added `host_vulkan_acceleration_structure_label` wrapper + static vtable wiring. Fixed `make_acceleration_structure_borrow` to populate cached fields from host inner. 2 updated null-scope-token tests. 1 new Tier-1 null-handle test. |
| `gpu_context.rs` | Cdylib mint paths allocate locals for new out-params, populate β-shape's cached fields from real values. |
| `vulkan_acceleration_structure.rs` | Simplified `device_address()` / `storage_size()` / `kind()` to direct cached-field reads (removed `host_inner()` fallback). Added cdylib-mode `label()` dispatch through v2 methods vtable. `vk_handle()` doc updated to make host-only intent deliberate. |
| `streamlib-cross-rustc-fixture` | Extended BLAS construction with assertions on every getter: `device_address() != 0`, `storage_size() != 0`, `kind() == BottomLevel`, `label() == \"cross-rustc-fixture-blas\"`. Round-trips the v8 out-params + v2 label slot end-to-end through divergent dep-graph compile. |

## Verification

- `cargo test -p streamlib-plugin-abi --lib layout_tests` — 27/27 pass (v8 + v2 layout regressions both updated)
- `cargo test -p streamlib-engine --lib vulkan_acceleration_structure` — 2/2 pass
- `cargo test -p streamlib-engine --lib label_rejects_null_acceleration_structure_handle` — 1/1 pass
- `cargo test --release -p streamlib-engine --test load_project_dylib_ray_tracing_kernel_smoke` — 1/1 pass (BLAS+TLAS build + set_acceleration_structure binding + trace_rays end-to-end)
- `cargo test --release -p streamlib-engine --test load_project_dylib_cross_rustc` — 1/1 pass (extended fixture round-trips every BLAS getter through v8 + v2 surfaces under divergent dep-graph compile)
- All sibling kernel dlopen smoke tests pass (compute / graphics / RT + gpu_acquire + escalate_smoke)
- `cargo test --workspace --lib --exclude streamlib-python-native --exclude streamlib-deno-native` — 1174 pass, 2 pre-existing Deno-subprocess failures (same baseline as PR #968)
- `cargo xtask check-boundaries` — clean (4129 files scanned, no violations)
- `pr-review-gate` (Opus max) — **PASS verdict**. 2 DISCUSS items, both non-blocking doc-quality notes. Addressed the stale-comment one by updating the `make_acceleration_structure_borrow` doc block to reflect the new direct-cached-field-read shape.

## Test plan

- [x] Tier-1 null-kernel-handle wire-format test for the new `label` vtable slot
- [x] Layout regression tests updated for v8 FullAccess vtable + v2 AS methods vtable
- [x] Cross-rustc dlopen fixture extended with full BLAS-getter round-trip
- [x] Existing dlopen integration tests stay green (compute / graphics / RT smoke + gpu_acquire + escalate_smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)