### PR TITLE
feat(plugin-abi): Texture::native_handle DMA-BUF FD vtable accessor (#957)

### DIFF
--- a/libs/streamlib-cross-rustc-fixture/src/lib.rs
+++ b/libs/streamlib-cross-rustc-fixture/src/lib.rs
@@ -64,8 +64,8 @@ use streamlib::sdk::rhi::{
     AttachmentFormats, ColorBlendState, ColorWriteMask, ComputeBindingSpec,
     ComputeKernelDescriptor, DepthStencilState, GraphicsBindingSpec, GraphicsDynamicState,
     GraphicsKernelDescriptor, GraphicsPipelineState, GraphicsPushConstants,
-    GraphicsShaderStageFlags, GraphicsStage, MultisampleState, PixelFormat, PrimitiveTopology,
-    RasterizationState, RayTracingBindingSpec, RayTracingKernelDescriptor,
+    GraphicsShaderStageFlags, GraphicsStage, MultisampleState, NativeTextureHandle, PixelFormat,
+    PrimitiveTopology, RasterizationState, RayTracingBindingSpec, RayTracingKernelDescriptor,
     RayTracingPushConstants, RayTracingShaderGroup, RayTracingShaderStageFlags, RayTracingStage,
     TextureFormat, TextureUsages, VertexInputState,
 };
@@ -165,9 +165,59 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
     let ring_clone = ring.clone();
     drop(ring_clone);
     drop(ring);
+
+    // -------- Texture::native_handle DMA-BUF FD export (#957) --------
+    //
+    // Acquire a render-target DMA-BUF texture inside an escalate scope
+    // (FullAccess-only allocation), then call `Texture::native_handle()`
+    // from cdylib code outside the scope. The cdylib-side method
+    // dispatches through the Phase F `texture_native_dma_buf_fd` vtable
+    // slot — host_inner() would panic in cdylib mode, so a successful
+    // Some(DmaBuf { fd }) with `fd >= 0` proves the slot is wired and
+    // the divergent-dep-graph build agreed on the i64 return signature.
+    //
+    // The acquire itself is feature-gated on EGL exposing a render-
+    // target-capable DRM modifier (see
+    // docs/learnings/nvidia-egl-dmabuf-render-target.md). On hosts
+    // without one, record SKIPPED_NO_DMA_BUF the same way RT-kernel
+    // construction records SKIPPED_NO_RT_SUPPORT.
+    let native_handle_summary =
+        match gpu_limited.escalate(|full| {
+            full.acquire_render_target_dma_buf_image(64, 64, TextureFormat::Bgra8Unorm)
+        }) {
+            Ok(dma_buf_texture) => {
+                match dma_buf_texture.native_handle() {
+                    Some(NativeTextureHandle::DmaBuf { fd }) if fd >= 0 => {
+                        drop(dma_buf_texture);
+                        "Texture::native_handle:OK\n"
+                    }
+                    Some(NativeTextureHandle::DmaBuf { fd }) => {
+                        return Err(Error::Runtime(format!(
+                            "Texture::native_handle returned DmaBuf with negative fd = {fd}",
+                        )));
+                    }
+                    Some(other) => {
+                        return Err(Error::Runtime(format!(
+                            "Texture::native_handle returned unexpected variant on Linux: \
+                             {other:?}",
+                        )));
+                    }
+                    None => {
+                        return Err(Error::Runtime(
+                            "Texture::native_handle returned None for an acquired \
+                             DMA-BUF render-target — slot dispatched but host export failed."
+                                .into(),
+                        ));
+                    }
+                }
+            }
+            Err(_) => "Texture::native_handle:SKIPPED_NO_DMA_BUF\n",
+        };
+
     gpu_limited.escalate(|full| {
         let mut summary = String::new();
         summary.push_str("TextureRing:OK\n");
+        summary.push_str(native_handle_summary);
 
         // -------- RhiColorConverter (Arc-handle + Clone) --------
         let cc = full.color_converter(PixelFormat::Bgra32, PixelFormat::Rgba32)?;

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -1919,6 +1919,48 @@ unsafe extern "C" fn host_gpu_lim_drop_texture(handle: *const c_void) {
 }
 
 // -------------------------------------------------------------------------
+// Texture::native_handle DMA-BUF FD export (Phase F, #957)
+// -------------------------------------------------------------------------
+
+unsafe extern "C" fn host_gpu_lim_texture_native_dma_buf_fd(
+    texture_handle: *const c_void,
+) -> i64 {
+    run_host_extern_c(
+        "host_gpu_lim_texture_native_dma_buf_fd",
+        || {
+            if texture_handle.is_null() {
+                return -1;
+            }
+            #[cfg(target_os = "linux")]
+            {
+                // SAFETY: `texture_handle` is the
+                // `Arc::into_raw(Arc<TextureInner>)` pointer carried as the
+                // cdylib-side `Texture::handle` field. Borrowing as
+                // `&TextureInner` does not touch the refcount — the
+                // caller's `Texture` keeps the Arc alive for the duration
+                // of this dispatch.
+                let inner = unsafe {
+                    &*(texture_handle as *const crate::core::rhi::texture::TextureInner)
+                };
+                match inner.inner.export_dma_buf_fd() {
+                    Ok(fd) => i64::from(fd),
+                    Err(_) => -1,
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                // DMA-BUF is a Linux concept. macOS / Windows native
+                // handles are deferred until those cdylib adapter paths
+                // resume (see #908's AI Agent Notes).
+                let _ = texture_handle;
+                -1
+            }
+        },
+        -1,
+    )
+}
+
+// -------------------------------------------------------------------------
 // PooledTextureHandle lifecycle — drop-only (v4)
 // -------------------------------------------------------------------------
 
@@ -6379,6 +6421,7 @@ pub static HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE: GpuContextLimitedAccessVTable
         resolve_pixel_buffer_by_surface_id: host_gpu_lim_resolve_pixel_buffer_by_surface_id,
         escalate_begin: host_gpu_lim_escalate_begin,
         escalate_end: host_gpu_lim_escalate_end,
+        texture_native_dma_buf_fd: host_gpu_lim_texture_native_dma_buf_fd,
     };
 
 /// Pointer to the [`GpuContextLimitedAccessVTable`] this DSO should
@@ -10005,6 +10048,35 @@ mod gpu_lim_escalate_vtable_tests {
         );
 
         unsafe { free_host_handle(handle) };
+    }
+}
+
+#[cfg(test)]
+mod gpu_lim_texture_native_dma_buf_fd_tests {
+    //! Tier-1 wire-format test for the Phase F
+    //! `texture_native_dma_buf_fd` slot (#908 / #957). The slot is the
+    //! cross-DSO landing for `Texture::native_handle` on Linux and
+    //! returns the DMA-BUF FD widened to `i64`; sentinel `-1` encodes
+    //! the `Option::None` case. A null texture handle must be a clean
+    //! `-1` (no panic, no UB) — the wrapper short-circuits before any
+    //! cast through `*const TextureInner`.
+
+    use super::*;
+
+    #[test]
+    fn texture_native_dma_buf_fd_returns_minus_one_on_null_handle() {
+        // Null texture_handle is the cdylib-shaped "Texture wasn't
+        // minted yet / was already dropped" case. The slot returns
+        // `-1` (= `Option::None` in the Rust-side wrapper) without
+        // panicking and without touching the null pointer.
+        let fd = unsafe {
+            (HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE
+                .texture_native_dma_buf_fd)(std::ptr::null())
+        };
+        assert_eq!(
+            fd, -1,
+            "null texture_handle must produce -1 sentinel (None)"
+        );
     }
 }
 

--- a/libs/streamlib-engine/src/core/rhi/texture.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture.rs
@@ -41,6 +41,12 @@ pub enum NativeTextureHandle {
 
     /// Linux: DMA-BUF file descriptor for GPU memory sharing.
     /// Import via `EGL_EXT_image_dma_buf_import` or Vulkan external memory.
+    ///
+    /// **The FD is borrowed from the host-owning [`Texture`]**: it
+    /// stays valid only while that [`Texture`] keeps the underlying
+    /// allocation alive, and the host closes it on drop. Callers
+    /// handing the FD to an API that takes ownership on success
+    /// (e.g. `vkImportMemoryFdKHR`) MUST `dup(2)` it first.
     DmaBuf { fd: i32 },
 
     /// Windows: DXGI shared handle for cross-process GPU memory sharing.
@@ -365,8 +371,12 @@ impl Texture {
         {
             // macOS / iOS native-handle path stays host-only until
             // macOS cdylib adapter work resumes (#908 deferred list).
-            // The `host_inner()` panic guard catches the cdylib case
-            // at the FFI boundary.
+            // `host_inner()` panics in cdylib mode; the panic
+            // propagates through the cdylib's Rust stack until it
+            // crosses the next FFI boundary (the plugin entry point
+            // or any host vtable callback the cdylib calls), where
+            // `catch_unwind` converts it to a "callback panicked"
+            // log entry instead of UB.
             self.host_inner()
                 .metal_texture
                 .as_ref()
@@ -397,7 +407,14 @@ impl Texture {
             if fd_i64 < 0 {
                 None
             } else {
-                Some(NativeTextureHandle::DmaBuf { fd: fd_i64 as i32 })
+                // `get_memory_fd_khr` returns standard kernel FDs
+                // which always fit in i32; the i64 widening is purely
+                // forward-compat. A truncating cast here would
+                // silently corrupt the FD, so reject and treat as
+                // `None` rather than hand back garbage.
+                i32::try_from(fd_i64)
+                    .ok()
+                    .map(|fd| NativeTextureHandle::DmaBuf { fd })
             }
         }
         #[cfg(target_os = "windows")]

--- a/libs/streamlib-engine/src/core/rhi/texture.rs
+++ b/libs/streamlib-engine/src/core/rhi/texture.rs
@@ -351,13 +351,22 @@ impl Texture {
     ///
     /// Returns the appropriate handle type for the current platform:
     /// - macOS/iOS: `IOSurface { id }`
-    /// - Linux: `DmaBuf { fd }` (when implemented)
-    /// - Windows: `DxgiSharedHandle { handle }` (when implemented)
+    /// - Linux: `DmaBuf { fd }` (cross-DSO safe — dispatches through
+    ///   [`GpuContextLimitedAccessVTable::texture_native_dma_buf_fd`]
+    ///   so cdylib subprocess adapters can export DMA-BUF FDs to a
+    ///   different GPU API — CUDA, OpenGL, downstream IPC — without
+    ///   touching host-internal `TextureInner` layout).
+    /// - Windows: `DxgiSharedHandle { handle }` (when implemented).
     ///
-    /// Returns `None` if no sharing handle is available.
+    /// Returns `None` if no sharing handle is available (no Vulkan
+    /// backing, export failed, or the platform doesn't expose one).
     pub fn native_handle(&self) -> Option<NativeTextureHandle> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
+            // macOS / iOS native-handle path stays host-only until
+            // macOS cdylib adapter work resumes (#908 deferred list).
+            // The `host_inner()` panic guard catches the cdylib case
+            // at the FFI boundary.
             self.host_inner()
                 .metal_texture
                 .as_ref()
@@ -366,15 +375,35 @@ impl Texture {
         }
         #[cfg(target_os = "linux")]
         {
-            self.host_inner()
-                .inner
-                .export_dma_buf_fd()
-                .ok()
-                .map(|fd| NativeTextureHandle::DmaBuf { fd })
+            // Linux DMA-BUF export is cross-DSO safe: the slot returns
+            // the FD as a primitive `i64` (sentinel `-1` encodes
+            // `None`), which never crosses an Arc<TextureInner>
+            // layout boundary. Host mode resolves the slot pointer
+            // to `&HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE`'s callback
+            // (which in turn calls `HostVulkanTexture::export_dma_buf_fd`);
+            // cdylib mode resolves to the host-installed pointer
+            // routed through `HostServices::gpu_context_limited_access_vtable`.
+            if self.handle.is_null() || self.vtable.is_null() {
+                return None;
+            }
+            // SAFETY: `vtable` and `handle` were paired at construction
+            // by `from_arc_into_raw` / `from_raw_handle_for_cdylib`;
+            // the `texture_native_dma_buf_fd` slot accepts the texture
+            // handle directly and returns `-1` (no FD) or a non-
+            // negative `RawFd` widened to `i64`.
+            let fd_i64 = unsafe {
+                ((*self.vtable).texture_native_dma_buf_fd)(self.handle)
+            };
+            if fd_i64 < 0 {
+                None
+            } else {
+                Some(NativeTextureHandle::DmaBuf { fd: fd_i64 as i32 })
+            }
         }
         #[cfg(target_os = "windows")]
         {
-            // TODO: Return DxgiSharedHandle when implemented
+            // Windows DXGI shared handle: deferred until Windows
+            // cdylib adapter work begins.
             None
         }
         #[cfg(not(any(

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -309,6 +309,21 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
         );
     }
 
+    // `Texture::native_handle` (#957, Phase F) is gated on EGL exposing
+    // a render-target-capable DRM modifier
+    // (`docs/learnings/nvidia-egl-dmabuf-render-target.md`). Accept
+    // either OK or SKIPPED_NO_DMA_BUF; anything else (no line at all,
+    // ERR, etc.) fails.
+    {
+        let ok = "Texture::native_handle:OK";
+        let skipped = "Texture::native_handle:SKIPPED_NO_DMA_BUF";
+        assert!(
+            contents.contains(ok) || contents.contains(skipped),
+            "missing β-shape round-trip line for Texture::native_handle: \
+             expected one of {ok:?} or {skipped:?} — full body:\n{contents}"
+        );
+    }
+
     // VulkanAccelerationStructure + VulkanRayTracingKernel are
     // RT-feature-gated. Accept either OK or SKIPPED_NO_RT_SUPPORT;
     // anything else (no line at all, ERR, etc.) fails.

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -172,7 +172,17 @@ pub const SURFACE_STORE_VTABLE_LAYOUT_VERSION: u32 = 1;
 ///   scope token on every FullAccess vtable call lives on the
 ///   FullAccess vtable side (each callback short-circuits to
 ///   `Error::InvalidEscalateScope` when the token is stale).
-pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
+/// - v11: Phase F (#908 / #957) adds `texture_native_dma_buf_fd`
+///   for the cdylib-facing
+///   [`crate::core::rhi::Texture::native_handle`] DMA-BUF FD export
+///   path. Real cdylib use case: subprocess adapters that need to
+///   hand a `Texture`'s DMA-BUF FD to a different GPU API (CUDA,
+///   OpenGL, downstream IPC) without falling through `host_inner()`
+///   and panicking. Returns the FD widened to `i64`; `-1` encodes
+///   `Option::None`. Non-Linux hosts return `-1` unconditionally;
+///   the macOS / Windows native-handle variants are deferred per
+///   #908's AI Agent Notes.
+pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 11;
 
 /// Layout version of [`GpuContextFullAccessVTable`].
 ///
@@ -1538,6 +1548,49 @@ pub struct GpuContextLimitedAccessVTable {
         err_buf_cap: usize,
         err_len: *mut usize,
     ) -> i32,
+
+    // -------------------------------------------------------------------------
+    // Texture method dispatch — DMA-BUF FD export (Phase F)
+    // -------------------------------------------------------------------------
+
+    /// Export the texture's GPU memory as a Linux DMA-BUF file
+    /// descriptor for cross-framework / cross-process sharing.
+    ///
+    /// **The returned FD is borrowed — owned by the host-side
+    /// texture for as long as the cdylib-side [`Texture`] keeps its
+    /// `Arc<TextureInner>` strong count > 0.** The host caches the
+    /// FD on the first call and closes it in `HostVulkanTexture`'s
+    /// `Drop`; callers that need to hand the FD to a different
+    /// process or to an API that consumes it (e.g.
+    /// `vkImportMemoryFdKHR` takes ownership on success) MUST
+    /// `dup(2)` the returned FD first.
+    ///
+    /// `texture_handle` is the `*const Arc<TextureInner>`-shaped
+    /// `handle` field on a cdylib-side [`Texture`] (the same handle
+    /// the cdylib already passes to `clone_texture` / `drop_texture`
+    /// — see [`crate::core::rhi::Texture`]). The host derefs it as a
+    /// borrow without touching the refcount, calls the platform-
+    /// specific Vulkan export path, and returns the FD via the i64
+    /// return value.
+    ///
+    /// Encoding:
+    ///   - `>= 0` — valid DMA-BUF FD (always fits in `i32` on Linux,
+    ///     widened to `i64` for forward-compat with any future
+    ///     platform that exposes wider FD-like identifiers via the
+    ///     same slot).
+    ///   - `-1` — texture has no DMA-BUF FD (not Linux, or no Vulkan
+    ///     backing, or export failed). Equivalent to `Option::None`
+    ///     on the cdylib-facing
+    ///     [`crate::core::rhi::Texture::native_handle`].
+    ///
+    /// Non-Linux hosts return `-1` unconditionally — DMA-BUF is a
+    /// Linux concept; macOS IOSurface and Windows DXGI shared handles
+    /// are deferred to future slots when their respective cdylib
+    /// adapter work resumes (see #908's deferred macOS list).
+    ///
+    /// Calling with a null `texture_handle` returns `-1` (no panic).
+    pub texture_native_dma_buf_fd:
+        unsafe extern "C" fn(texture_handle: *const c_void) -> i64,
 }
 
 unsafe impl Send for GpuContextLimitedAccessVTable {}
@@ -4014,7 +4067,7 @@ mod layout_tests {
         // v2: added owning-Arc handle lifetime callbacks
         // (`clone_handle` / `drop_handle`).
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
-        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 10);
+        assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 11);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 8);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
@@ -4392,11 +4445,11 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_limited_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 52 fn
-        // pointers (8 bytes each) = 4 + 4 + 416 = 424 bytes.
-        // (C3 appended escalate_begin + escalate_end, taking the
-        // count from 50 → 52.)
-        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 424);
+        // layout_version (u32) + _reserved_padding (u32) + 53 fn
+        // pointers (8 bytes each) = 4 + 4 + 424 = 432 bytes.
+        // (Phase F #957 appended texture_native_dma_buf_fd, taking the
+        // count from 52 → 53.)
+        assert_eq!(size_of::<GpuContextLimitedAccessVTable>(), 432);
         assert_eq!(align_of::<GpuContextLimitedAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextLimitedAccessVTable, layout_version), 0);
         assert_eq!(
@@ -4611,6 +4664,11 @@ mod layout_tests {
         assert_eq!(
             offset_of!(GpuContextLimitedAccessVTable, escalate_end),
             416
+        );
+        // Phase F entry (#908 / #957).
+        assert_eq!(
+            offset_of!(GpuContextLimitedAccessVTable, texture_native_dma_buf_fd),
+            424
         );
     }
 


### PR DESCRIPTION
Second slice of #908 Phase F. Wires a vtable accessor for `Texture::native_handle()` on Linux so cdylib subprocess adapters that need to export a `Texture`'s DMA-BUF FD (CUDA / OpenGL / downstream IPC) reach the host's `HostVulkanTexture::export_dma_buf_fd` without falling through `host_inner()` and panicking. Cross-DSO safe: the slot returns the FD widened to `i64` (sentinel `-1` encodes `Option::None`), so nothing crosses an `Arc<TextureInner>` layout boundary.

The macOS variants (`iosurface_id`, `as_metal_texture`, `as_iosurface`, `from_metal`) stay deferred per #908's AI Agent Notes — they remain `host_inner()`-routed until macOS cdylib support resumes. Windows DXGI shared handles likewise.

## Wire shape

- `GpuContextLimitedAccessVTable::texture_native_dma_buf_fd` (slot 53, offset 424). Layout version bumped 10 → 11.
- FD is **borrowed** from the host-side `HostVulkanTexture` (cached, closed in `Drop`); callers that hand the FD to an ownership-taking API (`vkImportMemoryFdKHR`) must `dup(2)` first. Both the vtable doc and the user-facing `NativeTextureHandle::DmaBuf` enum doc carry this contract.
- Non-Linux hosts return `-1` unconditionally.
- `i32::try_from` rather than `as i32` on the way back to the public enum, so a hypothetical future driver that returns a wider FD-like identifier surfaces as `None` rather than a silently-corrupt FD.

## Validation

- 1177/1177 `cargo test --lib -p streamlib-engine` pass (+1 new tier-1 null-handle test in `gpu_lim_texture_native_dma_buf_fd_tests`).
- 45/45 `cargo test --lib -p streamlib-plugin-abi` pass (offset + size assertions updated: 424 → 432, new entry at offset 424).
- `cargo xtask check-boundaries` clean.
- Cross-rustc dlopen fixture compile-checks cleanly; the runtime sweep gains a `Texture::native_handle:OK` line (with `SKIPPED_NO_DMA_BUF` fallback for hosts without a render-target-capable DRM modifier, matching the existing RT-feature gating pattern).

## Test plan

- [ ] `cargo test --lib -p streamlib-engine` green
- [ ] `cargo test --lib -p streamlib-plugin-abi` green
- [ ] `cargo xtask check-boundaries` clean
- [ ] Cross-rustc dlopen integration test (`load_project_dylib_cross_rustc`) passes on a Vulkan-capable host with `Texture::native_handle:OK` in the round-trip summary

Refs #908 (Phase F).
Closes #957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)