### PR TITLE
fix(plugin-abi): SurfaceStore engine-only registration moves to HostSurfaceStoreExt (#970)

### DIFF
--- a/examples/camera-python-display/src/blending_compositor.rs
+++ b/examples/camera-python-display/src/blending_compositor.rs
@@ -35,7 +35,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use streamlib::sdk::engine::host_rhi::HostVulkanTexture;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostSurfaceStoreExt, HostTextureExt};
 
 use streamlib::sdk::color::TransferId;
 use streamlib::sdk::display_info;

--- a/examples/camera-python-display/src/camera_to_cuda_copy.rs
+++ b/examples/camera-python-display/src/camera_to_cuda_copy.rs
@@ -23,6 +23,8 @@ use streamlib::sdk::error::{Result, Error};
 use streamlib::sdk::context::{RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use crate::_generated_::VideoFrame;
 use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
+#[cfg(target_os = "linux")]
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 #[cfg(target_os = "linux")]
 use streamlib::sdk::rhi::{PixelFormat, PixelBuffer};

--- a/examples/camera-python-display/src/crt_film_grain.rs
+++ b/examples/camera-python-display/src/crt_film_grain.rs
@@ -27,6 +27,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::rhi::{Texture, TextureFormat, VulkanLayout};
 use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess, RuntimeContextLimitedAccess};

--- a/examples/camera-python-display/src/linux.rs
+++ b/examples/camera-python-display/src/linux.rs
@@ -61,6 +61,7 @@
 use std::path::PathBuf;
 
 use streamlib::sdk::context::GpuContext;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 use streamlib::sdk::rhi::TextureFormat;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;

--- a/examples/cuda-fisheye-detection/runner/src/main.rs
+++ b/examples/cuda-fisheye-detection/runner/src/main.rs
@@ -42,7 +42,7 @@ use streamlib::sdk::engine::host_rhi::{
     HostMarker, HostVulkanBuffer, HostVulkanTexture, HostVulkanTimelineSemaphore,
     ImageCopyRegion, RhiCommandRecorder, VulkanAccess, VulkanStage,
 };
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostSurfaceStoreExt, HostTextureExt};
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::processors::ProcessorSpec;

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -46,7 +46,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use streamlib::sdk::engine::{HostGpuDeviceExt, HostTextureExt};
+use streamlib::sdk::engine::{HostGpuDeviceExt, HostSurfaceStoreExt, HostTextureExt};
 
 use streamlib::sdk::context::{CpuReadbackBridge, CpuReadbackCopyDirection, GpuContext};
 use streamlib::sdk::descriptors::SchemaIdent;

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -49,6 +49,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::context::GpuContext;
 use streamlib::sdk::descriptors::SchemaIdent;

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -30,6 +30,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::descriptors::SchemaIdent;
 use streamlib::sdk::rhi::{TextureFormat, TextureReadbackDescriptor, TextureSourceLayout};

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -47,6 +47,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::rhi::{
     TextureFormat,

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -35,6 +35,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::context::ComputeKernelBridge;
 use streamlib::sdk::descriptors::SchemaIdent;

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -37,6 +37,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use streamlib::sdk::engine::HostGpuDeviceExt;
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 
 use streamlib::sdk::context::{
     BlendFactorWire,

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/subprocess_escalate.rs
@@ -21,6 +21,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use uuid::Uuid;
 
+#[cfg(target_os = "linux")]
+use crate::host_rhi::HostSurfaceStoreExt;
+
 use crate::_generated_::tatolab__escalate::escalate_request::{
     EscalateRequestAcquireImage, EscalateRequestAcquirePixelBuffer, EscalateRequestAcquireTexture,
     EscalateRequestLog, EscalateRequestLogLevel, EscalateRequestLogSource,

--- a/libs/streamlib-engine/src/core/context/surface_store.rs
+++ b/libs/streamlib-engine/src/core/context/surface_store.rs
@@ -2101,9 +2101,17 @@ impl SurfaceStore {
         }
     }
 
-    /// Register a texture for cross-process sharing (Linux).
+    /// **Engine-only** — public surface lives on the
+    /// [`crate::host_rhi::HostSurfaceStoreExt`] extension trait
+    /// (`register_texture`). The parameter type
+    /// `Option<&HostVulkanTimelineSemaphore>` is host-internal —
+    /// cdylib subprocess customers cannot construct it and so cannot
+    /// call this through typed Rust; the engine-only extension
+    /// trait makes that constraint explicit at the type-system
+    /// layer (mirrors [`crate::host_rhi::HostTextureExt`]
+    /// /[`crate::host_rhi::HostPixelBufferRefExt`]).
     #[cfg(target_os = "linux")]
-    pub fn register_texture(
+    pub(crate) fn host_register_texture(
         &self,
         surface_id: &str,
         texture: &crate::core::rhi::Texture,
@@ -2145,9 +2153,12 @@ impl SurfaceStore {
         }
     }
 
-    /// Register a pixel buffer with an optional timeline-semaphore (Linux).
+    /// **Engine-only** — public surface lives on the
+    /// [`crate::host_rhi::HostSurfaceStoreExt`] extension trait
+    /// (`register_pixel_buffer_with_timeline`). Same engine-only
+    /// rationale as [`Self::host_register_texture`].
     #[cfg(target_os = "linux")]
-    pub fn register_pixel_buffer_with_timeline(
+    pub(crate) fn host_register_pixel_buffer_with_timeline(
         &self,
         surface_id: &str,
         pixel_buffer: &PixelBuffer,

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -138,3 +138,93 @@ impl HostGpuDeviceExt for GpuDevice {
         &self.inner
     }
 }
+
+/// Privileged engine-side accessors for [`SurfaceStore`] surface
+/// registration paths whose parameter types are host-internal.
+///
+/// `register_texture` and `register_pixel_buffer_with_timeline` both
+/// take `Option<&HostVulkanTimelineSemaphore>` — timeline-semaphore
+/// construction is FullAccess-privileged and the type is host-
+/// internal by construction, so these methods are unreachable from
+/// cdylib code through typed Rust. The extension-trait pattern
+/// mirrors [`HostTextureExt`] / [`HostPixelBufferRefExt`] /
+/// [`HostGpuDeviceExt`] to lock the engine-only contract at the
+/// type-system layer rather than by convention.
+///
+/// Cdylib subprocess customers reach surfaces by `surface_id`
+/// lookup (`lookup_texture` / `check_out`), not by re-registering;
+/// the dual-registration shape documented in
+/// `docs/architecture/adapter-runtime-integration.md` is host-side
+/// `install_setup_hook` plumbing only.
+///
+/// # Boundary lock
+///
+/// Without the trait in scope, the privileged accessors are
+/// unreachable from the [`SurfaceStore`] β-shape's inherent impl:
+///
+/// ```compile_fail
+/// # #[cfg(target_os = "linux")]
+/// # fn _check(
+/// #     store: &streamlib::sdk::context::SurfaceStore,
+/// #     texture: &streamlib::sdk::rhi::Texture,
+/// # ) -> Result<(), Box<dyn std::error::Error>> {
+/// // Without `use streamlib::sdk::engine::HostSurfaceStoreExt;`
+/// // `register_texture` is not visible — boundary held.
+/// store.register_texture(
+///     "id",
+///     texture,
+///     None,
+///     streamlib::sdk::rhi::VulkanLayout::UNDEFINED,
+/// )?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`SurfaceStore`]: crate::core::context::SurfaceStore
+#[cfg(target_os = "linux")]
+pub trait HostSurfaceStoreExt {
+    /// Register a texture for cross-process sharing with an optional
+    /// timeline-semaphore (host-side adapter `install_setup_hook`
+    /// path). See
+    /// [`crate::core::context::SurfaceStore`]'s former inherent
+    /// impl for the wire shape; the method body is unchanged, only
+    /// the visibility surface moved here.
+    fn register_texture(
+        &self,
+        surface_id: &str,
+        texture: &Texture,
+        timeline: Option<&HostVulkanTimelineSemaphore>,
+        current_image_layout: streamlib_consumer_rhi::VulkanLayout,
+    ) -> crate::core::error::Result<()>;
+
+    /// Register a pixel buffer with an optional timeline-semaphore
+    /// (host-side adapter `install_setup_hook` path).
+    fn register_pixel_buffer_with_timeline(
+        &self,
+        surface_id: &str,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        timeline: Option<&HostVulkanTimelineSemaphore>,
+    ) -> crate::core::error::Result<()>;
+}
+
+#[cfg(target_os = "linux")]
+impl HostSurfaceStoreExt for crate::core::context::SurfaceStore {
+    fn register_texture(
+        &self,
+        surface_id: &str,
+        texture: &Texture,
+        timeline: Option<&HostVulkanTimelineSemaphore>,
+        current_image_layout: streamlib_consumer_rhi::VulkanLayout,
+    ) -> crate::core::error::Result<()> {
+        self.host_register_texture(surface_id, texture, timeline, current_image_layout)
+    }
+
+    fn register_pixel_buffer_with_timeline(
+        &self,
+        surface_id: &str,
+        pixel_buffer: &crate::core::rhi::PixelBuffer,
+        timeline: Option<&HostVulkanTimelineSemaphore>,
+    ) -> crate::core::error::Result<()> {
+        self.host_register_pixel_buffer_with_timeline(surface_id, pixel_buffer, timeline)
+    }
+}

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -137,6 +137,9 @@ pub mod host_rhi;
 ))]
 pub use host_rhi::{HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt};
 
+#[cfg(target_os = "linux")]
+pub use host_rhi::HostSurfaceStoreExt;
+
 /// Vulkan Video codec layer — engine-tier H.264/H.265 encode/decode
 /// primitives. Public surface lives at `crate::vulkan::video::*`; this
 /// facade re-exports the codec types at engine root so the SDK's
@@ -277,6 +280,8 @@ pub mod sdk {
     pub mod engine {
         pub use crate::host_rhi;
         pub use crate::{HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt};
+        #[cfg(target_os = "linux")]
+        pub use crate::HostSurfaceStoreExt;
         #[cfg(target_os = "linux")]
         pub use crate::linux_surface_share;
     }

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -202,10 +202,16 @@ pub mod sdk {
         /// Privileged extension traits surfacing raw `Host*` handles
         /// on SDK-bucket types. Importing one unlocks `vulkan_inner()`
         /// / `from_vulkan()` / `vulkan_device()` on
-        /// `Texture` / `PixelBufferRef` / `GpuDevice`.
+        /// `Texture` / `PixelBufferRef` / `GpuDevice`, or the
+        /// engine-only timeline-semaphore registration paths on
+        /// `SurfaceStore` (`register_texture` /
+        /// `register_pixel_buffer_with_timeline`).
         pub use streamlib_engine::{
             HostGpuDeviceExt, HostPixelBufferRefExt, HostTextureExt,
         };
+
+        #[cfg(target_os = "linux")]
+        pub use streamlib_engine::HostSurfaceStoreExt;
 
         /// Per-runtime surface-share service primitives. For adapter
         /// integration tests and 3rd-party tooling that needs to drive

--- a/packages/camera/src/linux/camera.rs
+++ b/packages/camera/src/linux/camera.rs
@@ -14,6 +14,7 @@ use streamlib::sdk::context::{GpuContextLimitedAccess, RuntimeContextFullAccess}
 use streamlib::sdk::engine::host_rhi::{
     HostVulkanTimelineSemaphore, ImageCopyRegion, RhiCommandRecorder, VulkanAccess, VulkanStage,
 };
+use streamlib::sdk::engine::HostSurfaceStoreExt;
 use streamlib::sdk::error::{Error, Result};
 use streamlib::sdk::iceoryx2::OutputWriter;
 use streamlib::sdk::rhi::{PixelFormat, RhiColorConverter, StorageBuffer, Texture, TextureFormat};


### PR DESCRIPTION
Third slice of #908 Phase F. Closes the cdylib audit gap on `SurfaceStore::register_texture` and `SurfaceStore::register_pixel_buffer_with_timeline` — both take `Option<&HostVulkanTimelineSemaphore>` (host-internal Arc, never cross-DSO safe). Cdylib subprocess code cannot legitimately construct that parameter type through typed Rust, so the methods are engine-only by parameter construction.

The previous `pub` exposure on the cdylib β-shape `SurfaceStore` relied on convention; the boundary now lives at the type-system layer, matching the precedent set by `HostTextureExt` / `HostPixelBufferRefExt` / `HostGpuDeviceExt`.

## Issue body offered two options; chose a third

The issue's exit criteria listed (a) `pub(crate)` tighten or (b) vtable bridge. The grep evidence justifies "no cdylib caller" (`streamlib-python-native` / `streamlib-deno-native` only mention these methods in error message strings) — but pure `pub(crate)` would break 11 in-tree host-side example callers + `streamlib-camera` + the engine-internal `subprocess_escalate` that legitimately rely on these methods through `streamlib::sdk::context::SurfaceStore`. The extension-trait pattern is the engine-grade type-system-enforced answer that:

- Locks the engine-only contract at the trait level (callers must `use streamlib::sdk::engine::HostSurfaceStoreExt;` to surface the methods).
- Matches the existing `Host*Ext` precedent in `host_rhi.rs` exactly.
- Carries a `compile_fail` doctest that proves the boundary holds.
- Doesn't ship a new vtable slot for a non-existent cdylib consumer.

## Changes

- New `HostSurfaceStoreExt` trait in `host_rhi.rs` exposing both methods, with a `compile_fail` boundary-lock doctest.
- `SurfaceStore::register_texture` / `register_pixel_buffer_with_timeline` renamed to `host_register_texture` / `host_register_pixel_buffer_with_timeline`, tightened to `pub(crate)`, with engine-only doc-comments. Trait impls forward unchanged.
- Re-exported through `streamlib_engine::HostSurfaceStoreExt` and `streamlib::sdk::engine::HostSurfaceStoreExt` (Linux-only).
- 11 example crates + `streamlib-camera` package + engine-internal `subprocess_escalate.rs` updated to import the trait. Engine-internal callers of `SurfaceStoreInner::register_texture` (not on the cdylib β-shape) are unaffected.

## Grep evidence

```
grep -rn "\.register_texture(\|\.register_pixel_buffer_with_timeline("
```

Returns ONLY in-tree host-side callers (examples + camera package + subprocess_escalate + the engine-internal `SurfaceStoreInner` impl). Cdylib crates mention these methods only in error message strings, never as function calls.

## Validation

- 1176/1176 `cargo test --lib -p streamlib-engine` pass (baseline unchanged).
- 11/11 `cargo test --doc -p streamlib-engine` pass, including the new `HostSurfaceStoreExt` `compile_fail` boundary lock.
- `cargo build --workspace` clean across all examples, packages, and adapters.
- `cargo xtask check-boundaries` clean.

## Test plan

- [ ] `cargo test --lib -p streamlib-engine` green
- [ ] `cargo test --doc -p streamlib-engine` green (incl. new boundary lock)
- [ ] `cargo build --workspace` green
- [ ] `cargo xtask check-boundaries` clean

Refs #908 (Phase F).
Closes #970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)