### PR TITLE
test(plugin-abi): RuntimeContextVTable layout-version tier-1 lock (#960 PR B)

### DIFF
--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -12683,3 +12683,32 @@ mod runtime_ops_vtable_null_handle_guards {
         unsafe { reclaim_sink(user_data) };
     }
 }
+
+#[cfg(test)]
+mod runtime_context_vtable_tier1_wire_format_tests {
+    //! Tier-1 wire-format tests for [`HOST_RUNTIME_CONTEXT_VTABLE`].
+    //!
+    //! Per-callback null-handle coverage lives in
+    //! [`runtime_context_vtable_null_handle_guards`] above — that
+    //! module landed alongside the engine PR that added the
+    //! null-handle guards each test relies on (mental-revert removes
+    //! the guard, the wrapper SIGSEGVs the test runner). This module
+    //! completes the tier-1 set with the wire-format invariant the
+    //! null-handle suite doesn't cover: the static vtable's
+    //! `layout_version` field must match the constant cdylibs read
+    //! against.
+    //!
+    //! No callback on `RuntimeContextVTable` takes an out-param or
+    //! a variant-typed input, so the "null out-param" and
+    //! "invalid input" tier-1 categories don't apply here.
+
+    use super::*;
+
+    #[test]
+    fn layout_version_matches_constant() {
+        assert_eq!(
+            HOST_RUNTIME_CONTEXT_VTABLE.layout_version,
+            streamlib_plugin_abi::RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- PR B of #960's 5-PR split. Completes tier-1 wire-format coverage on `HOST_RUNTIME_CONTEXT_VTABLE`.
- Per-callback null-handle coverage landed in the prerequisite engine PR (#977) inside `runtime_context_vtable_null_handle_guards`. This PR adds the missing `layout_version_matches_constant` lock so a cdylib-side ABI bump can't drift from the host's wiring.
- No callback on `RuntimeContextVTable` takes an out-param or variant-typed input, so the "null out-param" / "invalid input" tier-1 categories don't apply.

PR A: #976 (merged), PR B: this, C / D / E follow.

## Test plan

- [x] `cargo test -p streamlib-engine --lib runtime_context_vtable_tier1_wire_format_tests` — 1 passed.
- [x] `cargo test -p streamlib-engine --lib` — full suite green.
- [x] Locks the `RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION` ↔ static wiring; mental-revert: change either side and the test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)