### PR TITLE
test(plugin-abi): panic-injection + dlopen process/on_pause/on_resume lifecycle (#961)

### DIFF
--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -13268,3 +13268,128 @@ mod runtime_ops_vtable_tier1_wire_format_tests {
         unsafe { reclaim_sink(user_data) };
     }
 }
+
+#[cfg(test)]
+mod run_host_extern_c_panic_safety_net_tests {
+    //! Phase G (#961) panic-injection coverage.
+    //!
+    //! Every `host_*` extern "C" callback wraps its body in
+    //! [`run_host_extern_c`], whose `catch_unwind` safety net is
+    //! the only thing standing between a panic in cdylib-author
+    //! code path and an `extern "C"` unwind across the FFI
+    //! boundary (UB). This module locks the safety-net contract:
+    //!
+    //!   - A body that panics with a `&'static str` payload is
+    //!     caught and the documented default is returned.
+    //!   - A body that panics with a `String` payload is caught
+    //!     and the default is returned.
+    //!   - A body that panics with an arbitrary non-string
+    //!     payload (e.g. a custom Debug type) is caught and the
+    //!     default is returned.
+    //!   - Successful (non-panicking) bodies still return their
+    //!     value as expected — proves the safety net isn't
+    //!     intercepting normal control flow.
+    //!
+    //! Mental-revert: removing the `catch_unwind` wrap (i.e.
+    //! calling `body()` directly inside `run_host_extern_c`)
+    //! reverts every test below to a `panic!()` that aborts the
+    //! test process. The harness reports each as a hard process
+    //! abort rather than a fail.
+    //!
+    //! Why this module instead of a per-vtable-callback test:
+    //! every host_* callback delegates to the same
+    //! `run_host_extern_c` helper. Locking the helper's contract
+    //! once covers every callback that rides it. Per-callback
+    //! panic-injection would require deliberately corrupting
+    //! handle state in production-shaped ways (UB) and would
+    //! re-test the same `catch_unwind` machinery a hundred times.
+    //! This is the engine-tier fix per CLAUDE.md ("Engine-wide
+    //! bugs get fixed at the engine layer").
+
+    use super::*;
+
+    #[test]
+    fn panic_with_static_str_returns_default_i32() {
+        let rc = run_host_extern_c::<_, i32>(
+            "test_static_str_panic",
+            || panic!("deliberate test panic with &'static str"),
+            42i32,
+        );
+        assert_eq!(rc, 42, "catch_unwind must return the default on panic");
+    }
+
+    #[test]
+    fn panic_with_string_returns_default_i32() {
+        let rc = run_host_extern_c::<_, i32>(
+            "test_string_panic",
+            || panic!("{}", String::from("deliberate dynamic panic")),
+            7i32,
+        );
+        assert_eq!(rc, 7);
+    }
+
+    #[test]
+    fn panic_with_non_string_payload_returns_default_i32() {
+        // The wrapper's downcast chain handles `&'static str` and
+        // `String` explicitly and falls through to a generic
+        // "<non-string panic payload>" tracing message for anything
+        // else. The catch_unwind contract is the load-bearing part:
+        // even with an exotic payload the default must come back.
+        #[derive(Debug)]
+        struct CustomPayload;
+        let rc = run_host_extern_c::<_, i32>(
+            "test_custom_payload_panic",
+            || std::panic::panic_any(CustomPayload),
+            -1i32,
+        );
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn non_panicking_body_returns_its_value() {
+        // Locks the "safety net doesn't intercept normal control
+        // flow" invariant. Mental-revert: making `run_host_extern_c`
+        // always return `default_on_panic` (no Ok branch) would
+        // fail this test.
+        let rc = run_host_extern_c::<_, i32>(
+            "test_ok_path",
+            || 99i32,
+            -1i32,
+        );
+        assert_eq!(rc, 99);
+    }
+
+    #[test]
+    fn panic_with_unit_default_returns_unit() {
+        // Locks the panic-default for `()`-returning callbacks
+        // (the entire RuntimeOps / clone/drop / null-handle-no-op
+        // shape). The () default is trivially "the same value as
+        // before"; what matters is that the body's panic doesn't
+        // propagate past the FFI boundary.
+        let mut hit = false;
+        run_host_extern_c::<_, ()>(
+            "test_unit_default_panic",
+            || {
+                hit = true;
+                panic!("unit-default panic");
+            },
+            (),
+        );
+        assert!(hit, "body must have run before panicking");
+    }
+
+    #[test]
+    fn panic_with_null_ptr_default_returns_null() {
+        // Locks the panic-default for `*const c_void`-returning
+        // callbacks (e.g. `host_gpu_lim_clone_handle`,
+        // `host_rcv_audio_clock_handle`). The default is a null
+        // pointer; the assertion confirms a panicking body returns
+        // null rather than dangling memory.
+        let p = run_host_extern_c::<_, *const c_void>(
+            "test_null_ptr_default_panic",
+            || panic!("null-ptr-default panic"),
+            std::ptr::null(),
+        );
+        assert!(p.is_null());
+    }
+}

--- a/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Phase G (#961) dlopen `ProcessorVTable::on_pause` /
+//! `ProcessorVTable::on_resume` integration test.
+//!
+//! Loads a dlopen'd `LifecycleProbeProcessor` from test-fixtures,
+//! starts the runtime, calls `runtime.pause()`, waits for the
+//! processor thread to observe the pause-gate flip and dispatch
+//! `on_pause` through the cdylib `ProcessorVTable`, then
+//! `runtime.resume()` and waits for the `on_resume` dispatch.
+//!
+//! Asserts the probe's output file contains exactly one `PAUSE`
+//! marker (proving `on_pause` fired through the vtable) and at
+//! least one `RESUME` marker (proving `on_resume` fired). Mental-
+//! revert: if either slot is removed from the `ProcessorVTable`
+//! static or wired to a no-op, the corresponding marker never
+//! appears and this test fails.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use serial_test::serial;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+fn wait_for_line_count<F: Fn(&str) -> bool>(
+    output_path: &Path,
+    matches_target: F,
+    target: usize,
+    timeout: Duration,
+) -> usize {
+    let deadline = Instant::now() + timeout;
+    let mut last = 0;
+    while Instant::now() < deadline {
+        if let Ok(contents) = std::fs::read_to_string(output_path) {
+            last = contents.lines().filter(|l| matches_target(l)).count();
+            if last >= target {
+                return last;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    last
+}
+
+#[test]
+#[serial]
+fn dlopen_processor_pause_resume_hooks_fire_through_vtable() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let output_path = tmp.path().join("pause_resume_lifecycle.txt");
+    let output_path_str = output_path.to_string_lossy().to_string();
+
+    let runtime = Runner::new().unwrap();
+    runtime.load_project(&fixtures_dst).expect("load_project");
+
+    let ident = schema_ident!(
+        "tatolab",
+        "test-fixtures",
+        "LifecycleProbeProcessor",
+        "1.0.0"
+    );
+
+    runtime
+        .add_processor(ProcessorSpec::new(
+            ident,
+            json!({
+                "output_path": output_path_str,
+                // Allow plenty of headroom so we don't race the cap.
+                "max_iterations": 1000u32,
+            }),
+        ))
+        .expect("add_processor");
+
+    runtime.start().expect("runtime.start");
+
+    // Wait for at least one PROCESS line to confirm the loop is running
+    // before exercising pause/resume.
+    let initial = wait_for_line_count(
+        &output_path,
+        |l| l.starts_with("PROCESS:"),
+        1,
+        Duration::from_secs(5),
+    );
+    assert!(
+        initial >= 1,
+        "expected at least one PROCESS line before pause; got {initial}"
+    );
+
+    // Pause the runtime — pauses every processor, which flips the
+    // pause-gate atomic. The continuous-loop thread observes the
+    // flip on its next tick and dispatches `on_pause` through the
+    // ProcessorVTable.
+    runtime.pause().expect("runtime.pause");
+
+    let pause_count = wait_for_line_count(
+        &output_path,
+        |l| l == "PAUSE",
+        1,
+        Duration::from_secs(5),
+    );
+    assert_eq!(
+        pause_count, 1,
+        "expected exactly one PAUSE marker after runtime.pause(); \
+         on_pause must dispatch through the cdylib ProcessorVTable"
+    );
+
+    // Now resume — pause-gate flips back, continuous loop observes
+    // the flip and dispatches `on_resume`.
+    runtime.resume().expect("runtime.resume");
+
+    let resume_count = wait_for_line_count(
+        &output_path,
+        |l| l == "RESUME",
+        1,
+        Duration::from_secs(5),
+    );
+    assert!(
+        resume_count >= 1,
+        "expected at least one RESUME marker after runtime.resume(); \
+         on_resume must dispatch through the cdylib ProcessorVTable"
+    );
+
+    runtime.stop().ok();
+
+    // Final read for the report contents.
+    let contents = std::fs::read_to_string(&output_path).unwrap();
+    assert!(
+        contents.contains("SETUP"),
+        "expected SETUP marker before PAUSE; got:\n{contents}"
+    );
+    assert!(
+        contents.contains("PAUSE") && contents.contains("RESUME"),
+        "expected both PAUSE and RESUME markers; got:\n{contents}"
+    );
+}

--- a/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Phase G (#961) dlopen `ProcessorVTable::process` integration test.
+//!
+//! Loads a dlopen'd `LifecycleProbeProcessor` from test-fixtures,
+//! starts the runtime, sleeps briefly to let the continuous-loop
+//! thread fire `process()` repeatedly, then stops and inspects the
+//! probe's output file. Asserts:
+//!
+//!   - At least one `SETUP` marker (proves
+//!     `ProcessorVTable::setup` dispatched through the cdylib).
+//!   - At least one `PROCESS:<n>` marker (proves
+//!     `ProcessorVTable::process` dispatched through the cdylib
+//!     hot path — the slot none of the existing smoke tests
+//!     exercised).
+//!   - At least one `TEARDOWN` marker (proves
+//!     `ProcessorVTable::teardown` dispatched on the runtime stop
+//!     path).
+//!
+//! Mental-revert: if `process` is removed from the
+//! `ProcessorVTable` static or wired to a no-op, the probe never
+//! writes a `PROCESS:<n>` line and this test fails.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use serial_test::serial;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn dlopen_processor_process_hook_fires_through_vtable() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let output_path = tmp.path().join("process_lifecycle.txt");
+    let output_path_str = output_path.to_string_lossy().to_string();
+
+    let runtime = Runner::new().unwrap();
+    runtime.load_project(&fixtures_dst).expect("load_project");
+
+    let ident = schema_ident!(
+        "tatolab",
+        "test-fixtures",
+        "LifecycleProbeProcessor",
+        "1.0.0"
+    );
+
+    runtime
+        .add_processor(ProcessorSpec::new(
+            ident,
+            json!({
+                "output_path": output_path_str,
+                "max_iterations": 5u32,
+            }),
+        ))
+        .expect("add_processor");
+
+    runtime
+        .start()
+        .expect("runtime.start must succeed (requires Vulkan device on this host)");
+
+    // Wait for at least 3 PROCESS lines or 5s. The probe's process()
+    // hook fires on every iteration of the continuous loop (default
+    // sleep ~100us); 3 iterations is far below the 5s budget unless
+    // the vtable slot regressed.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(contents) = std::fs::read_to_string(&output_path) {
+            let process_count = contents
+                .lines()
+                .filter(|l| l.starts_with("PROCESS:"))
+                .count();
+            if process_count >= 3 {
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    runtime.stop().ok();
+
+    let contents = std::fs::read_to_string(&output_path)
+        .expect("LifecycleProbe output file must exist after runtime.start()");
+
+    let setup_count = contents.lines().filter(|l| *l == "SETUP").count();
+    let process_count = contents
+        .lines()
+        .filter(|l| l.starts_with("PROCESS:"))
+        .count();
+    let teardown_count = contents.lines().filter(|l| *l == "TEARDOWN").count();
+
+    assert_eq!(
+        setup_count, 1,
+        "expected exactly one SETUP marker; got contents:\n{contents}"
+    );
+    assert!(
+        process_count >= 3,
+        "expected >= 3 PROCESS:<n> markers (vtable process dispatch); \
+         got {process_count}. Contents:\n{contents}"
+    );
+    assert_eq!(
+        teardown_count, 1,
+        "expected exactly one TEARDOWN marker (vtable teardown dispatch); \
+         got contents:\n{contents}"
+    );
+}

--- a/packages/test-fixtures/schemas/lifecycle_probe_processor_config.yaml
+++ b/packages/test-fixtures/schemas/lifecycle_probe_processor_config.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Test-only config schema for the Phase G (#961) dlopen-cdylib
+# lifecycle-probe processor. The processor is a ContinuousProcessor
+# whose process / on_pause / on_resume / setup / teardown hooks
+# append a marker line to `output_path`. The integration test parses
+# the file to confirm each ProcessorVTable lifecycle slot dispatched
+# correctly from cdylib code.
+
+metadata:
+  type: LifecycleProbeProcessorConfig
+  description: "Test config schema for the Phase G dlopen-cdylib lifecycle-probe processor (#961)."
+
+properties:
+  output_path:
+    metadata:
+      description: "Filesystem path the probe appends marker lines to. Each lifecycle hook (SETUP, PROCESS:n, PAUSE, RESUME, TEARDOWN) writes one line."
+    type: string
+  max_iterations:
+    metadata:
+      description: "Hard cap on process() iterations after which the probe stops appending PROCESS lines. Lets the test deterministically observe a bounded count rather than racing the runtime stop."
+    type: uint32

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -14,6 +14,7 @@ pub mod compute_kernel_test_processor;
 pub mod escalate_smoke_test_processor;
 pub mod gpu_acquire_test_processor;
 pub mod graphics_kernel_smoke_test_processor;
+pub mod lifecycle_probe_processor;
 pub mod ray_tracing_kernel_smoke_test_processor;
 pub mod tcp_bind_test_processor;
 pub mod test_configured_processor;
@@ -22,6 +23,7 @@ pub use compute_kernel_test_processor::ComputeKernelTest;
 pub use escalate_smoke_test_processor::EscalateSmokeTest;
 pub use gpu_acquire_test_processor::GpuAcquireTest;
 pub use graphics_kernel_smoke_test_processor::GraphicsKernelSmokeTest;
+pub use lifecycle_probe_processor::LifecycleProbe;
 pub use ray_tracing_kernel_smoke_test_processor::RayTracingKernelSmokeTest;
 pub use tcp_bind_test_processor::TcpBindTest;
 pub use test_configured_processor::ConfiguredProcessor;
@@ -35,4 +37,5 @@ streamlib_plugin_abi::export_plugin!(
     crate::ComputeKernelTest::Processor,
     crate::GraphicsKernelSmokeTest::Processor,
     crate::RayTracingKernelSmokeTest::Processor,
+    crate::LifecycleProbe::Processor,
 );

--- a/packages/test-fixtures/src/lifecycle_probe_processor.rs
+++ b/packages/test-fixtures/src/lifecycle_probe_processor.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Phase G (#961) dlopen-cdylib lifecycle-probe processor fixture.
+//!
+//! ContinuousProcessor whose lifecycle hooks (`setup`, `process`,
+//! `on_pause`, `on_resume`, `teardown`) each append a single marker
+//! line to `config.output_path`. The integration tests in
+//! `libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs`
+//! and `..._pause_resume.rs` parse the file to assert each hook
+//! dispatched correctly through the `ProcessorVTable` from cdylib
+//! code.
+//!
+//! `config.max_iterations` caps the number of `PROCESS:n` lines
+//! the probe will append — once the counter hits the cap the
+//! `process()` body becomes a no-op (still returns Ok). Keeps the
+//! file size bounded so the test reads a stable known content
+//! after a sleep.
+//!
+//! What this fixture locks: regressions in `ProcessorVTable::process`,
+//! `on_pause`, or `on_resume` wire-format at the cdylib boundary
+//! either surface as missing marker lines (the host's
+//! `run_host_extern_c` swallowed a panic at the FFI boundary) or
+//! the hooks fire on the wrong thread / wrong order. Smoke-only —
+//! the lines are observed for presence, not pixel correctness or
+//! timing.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use streamlib::sdk::context::{
+    RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ContinuousProcessor;
+
+#[streamlib::sdk::processor("LifecycleProbeProcessor")]
+pub struct LifecycleProbe {
+    iter_count: AtomicU32,
+}
+
+impl LifecycleProbe::Processor {
+    fn append_line(&self, line: &str) -> Result<()> {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.config.output_path)
+            .map_err(|e| {
+                Error::Runtime(format!(
+                    "LifecycleProbe: open {}: {e}",
+                    self.config.output_path
+                ))
+            })?;
+        writeln!(f, "{line}").map_err(|e| {
+            Error::Runtime(format!(
+                "LifecycleProbe: write {}: {e}",
+                self.config.output_path
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+impl ContinuousProcessor for LifecycleProbe::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.append_line("SETUP")
+    }
+
+    fn process(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        let n = self.iter_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if n > self.config.max_iterations {
+            // Stop appending once the cap is hit so the test reads
+            // a stable file. The runtime keeps calling process()
+            // until shutdown — that's fine; we just no-op.
+            return Ok(());
+        }
+        self.append_line(&format!("PROCESS:{n}"))
+    }
+
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        self.append_line("PAUSE")
+    }
+
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        self.append_line("RESUME")
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        self.append_line("TEARDOWN")
+    }
+}

--- a/packages/test-fixtures/streamlib.yaml
+++ b/packages/test-fixtures/streamlib.yaml
@@ -32,6 +32,8 @@ schemas:
     file: schemas/graphics_kernel_smoke_test_processor_config.yaml
   RayTracingKernelSmokeTestProcessorConfig:
     file: schemas/ray_tracing_kernel_smoke_test_processor_config.yaml
+  LifecycleProbeProcessorConfig:
+    file: schemas/lifecycle_probe_processor_config.yaml
 
 processors:
   - name: TestConfiguredProcessor
@@ -89,3 +91,11 @@ processors:
     config:
       name: config
       schema: RayTracingKernelSmokeTestProcessorConfig
+
+  - name: LifecycleProbeProcessor
+    version: 1.0.0
+    description: "Phase G (#961) dlopen-cdylib lifecycle-probe processor — appends marker lines for each ProcessorVTable lifecycle hook (setup / process / on_pause / on_resume / teardown) to a file so the integration test can confirm every hook dispatched through the cdylib boundary correctly."
+    execution: continuous
+    config:
+      name: config
+      schema: LifecycleProbeProcessorConfig


### PR DESCRIPTION
## Summary

Closes #961 — the remaining Phase G coverage gaps. After this merges, #909 closes.

Three test slices bundled per the goal ("3 tests bundled is OK — all dlopen-lifecycle-shaped"):

1. **`run_host_extern_c_panic_safety_net_tests`** (6 unit tests in `host_services.rs`). Locks the `catch_unwind` safety net across panic-payload-type × default-return-type variants (`&'static str` / `String` / non-string custom payload × `i32` / `()` / `*const c_void`). Plus an "Ok-path returns its value" test to lock the not-intercepting-normal-flow invariant. Engine-tier rationale: every `host_*` callback delegates to `run_host_extern_c`, so locking the helper once covers them all (vs. re-testing the same machinery 100x).

2. **`load_project_dylib_process_lifecycle.rs`** (integration test). Loads a dlopen'd `LifecycleProbeProcessor`, starts the runtime, lets it tick, then stops. Asserts SETUP / ≥3 PROCESS:n / TEARDOWN markers — proves `ProcessorVTable::process` dispatches through the cdylib hot path (the slot none of the existing smoke tests exercised).

3. **`load_project_dylib_pause_resume.rs`** (integration test). Loads the same probe, starts it, calls `runtime.pause()`, waits for PAUSE marker, calls `runtime.resume()`, waits for RESUME marker. Locks `ProcessorVTable::on_pause` / `on_resume` dispatch through the cdylib boundary.

New fixture: `LifecycleProbeProcessor` in `packages/test-fixtures` — ContinuousProcessor whose setup / process / on_pause / on_resume / teardown hooks append marker lines. Bounded by `max_iterations` so the file content is deterministic.

## Test plan

- [x] `cargo test -p streamlib-engine --lib run_host_extern_c_panic_safety_net_tests` — 6/6 passed.
- [x] `cargo test -p streamlib-engine --test load_project_dylib_process_lifecycle` — 1/1 passed.
- [x] `cargo test -p streamlib-engine --test load_project_dylib_pause_resume` — 1/1 passed.
- [x] `cargo test -p streamlib-engine --lib` — 1295 passed, 124 ignored, 0 failed.
- [x] Mental-revert: removing `catch_unwind` from `run_host_extern_c` aborts every panic test via uncaught extern "C" unwind; wiring `ProcessorVTable::process`/`on_pause`/`on_resume` to no-ops makes the marker assertions fail.
- [x] pr-review-gate PASS verdict.

Closes #909 (parent Phase G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)