### PR TITLE
feat(plugin-abi): RhiCommandRecorder methods vtable (Phase E Slice B, #984)

### DIFF
--- a/libs/streamlib-engine/src/core/context/gpu_context.rs
+++ b/libs/streamlib-engine/src/core/context/gpu_context.rs
@@ -4578,8 +4578,13 @@ impl GpuContextFullAccess {
                 if status == 0 {
                     // SAFETY: host signaled success and wrote the
                     // RhiCommandRecorder by value via std::ptr::write.
-                    // Layout is byte-identical under rustc-version
-                    // coupling (CLAUDE.md).
+                    // Layout is byte-identical by `#[repr(C)]`
+                    // invariant. The host's `from_inner` populated
+                    // both `vtable` and `methods_vtable` (Phase E
+                    // sub-lift slice B — #984) with host-static
+                    // addresses; cdylib dispatch through those
+                    // pointers resolves to host-resident functions
+                    // in the shared process address space.
                     Ok(unsafe { out_recorder.assume_init() })
                 } else {
                     let msg = String::from_utf8_lossy(

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -224,6 +224,13 @@ pub struct HostCallbacks {
     /// install time (Phase E sub-lift slice A).
     pub rhi_color_converter_methods_vtable:
         *const streamlib_plugin_abi::RhiColorConverterMethodsVTable,
+    /// Host-installed [`RhiCommandRecorderMethodsVTable`] pointer.
+    /// May be null on hosts that don't ship a GpuContext; cdylib
+    /// must check before dispatching. Sourced from
+    /// [`HostServices::rhi_command_recorder_methods_vtable`] at
+    /// install time (Phase E sub-lift slice B).
+    pub rhi_command_recorder_methods_vtable:
+        *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable,
 }
 
 // Safety: every field is a fn pointer or a raw pointer the host
@@ -430,6 +437,18 @@ pub unsafe fn install_host_services(
             return None;
         }
     }
+    if !services.rhi_command_recorder_methods_vtable.is_null() {
+        // SAFETY: same shape as the other vtable validations. Null
+        // is allowed (host has no GpuContext); only non-null pointers
+        // are version-validated.
+        let v = unsafe {
+            (*services.rhi_command_recorder_methods_vtable).layout_version
+        };
+        if v != streamlib_plugin_abi::RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION
+        {
+            return None;
+        }
+    }
 
     let callbacks = HostCallbacks {
         host: services.host,
@@ -458,6 +477,8 @@ pub unsafe fn install_host_services(
             .vulkan_acceleration_structure_methods_vtable,
         rhi_color_converter_methods_vtable: services
             .rhi_color_converter_methods_vtable,
+        rhi_command_recorder_methods_vtable: services
+            .rhi_command_recorder_methods_vtable,
     };
 
     // Cache the callbacks BEFORE installing tracing — the
@@ -6717,7 +6738,8 @@ pub mod runtime_facing {
         host_schema_register, host_tracing_emit, host_tracing_enabled,
         host_tracing_register_callsite, HostServiceImpls, HOST_AUDIO_CLOCK_VTABLE,
         HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE, HOST_GPU_CONTEXT_LIMITED_ACCESS_VTABLE,
-        HOST_RHI_COLOR_CONVERTER_METHODS_VTABLE, HOST_RUNTIME_CONTEXT_VTABLE,
+        HOST_RHI_COLOR_CONVERTER_METHODS_VTABLE,
+        HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE, HOST_RUNTIME_CONTEXT_VTABLE,
         HOST_RUNTIME_OPS_VTABLE, HOST_SURFACE_STORE_VTABLE,
         HOST_TEXTURE_RING_METHODS_VTABLE, HOST_VULKAN_COMPUTE_KERNEL_METHODS_VTABLE,
         HOST_VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE,
@@ -6780,6 +6802,8 @@ pub mod runtime_facing {
                 &HOST_VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE,
             rhi_color_converter_methods_vtable:
                 &HOST_RHI_COLOR_CONVERTER_METHODS_VTABLE,
+            rhi_command_recorder_methods_vtable:
+                &HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE,
         }
     }
 }
@@ -9783,6 +9807,599 @@ pub fn host_rhi_color_converter_methods_vtable(
 }
 
 // =============================================================================
+// RhiCommandRecorderMethodsVTable wrappers (Phase E sub-lift slice B — #984).
+// Each wrapper reconstructs the recorder borrow from the raw
+// `Box::into_raw(Box<RhiCommandRecorderInner>)` handle the cdylib
+// passes, reconstructs the texture / buffer / kernel borrows via the
+// same `make_*_borrow` ManuallyDrop pattern the compute / graphics
+// kernel wrappers use, decodes the typed integer enum payloads
+// (`VulkanLayout` / `VulkanStage` / `VulkanAccess`), runs the inner
+// method, and converts the `Result<()>` into the FFI's `i32 +
+// err_buf` shape. All bodies are wrapped in `run_host_extern_c` so a
+// panic in the inner method becomes a non-zero return.
+// =============================================================================
+
+/// SAFETY: caller must hand a `handle` that came from
+/// `Box::into_raw(Box<RhiCommandRecorderInner>)` (the β-shape's
+/// `handle` field). The host borrows mutably for the call's duration;
+/// the cdylib retains ownership and the next `Drop` runs
+/// `Box::from_raw + drop` via the parent vtable's
+/// `drop_command_recorder` slot.
+#[cfg(target_os = "linux")]
+unsafe fn handle_as_command_recorder_mut(
+    handle: *const c_void,
+) -> Option<&'static mut crate::vulkan::rhi::RhiCommandRecorderInner> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe {
+        &mut *(handle as *mut crate::vulkan::rhi::RhiCommandRecorderInner)
+    })
+}
+
+/// Reconstruct a stack-allocated `VulkanComputeKernel` β-shape
+/// borrow from an `Arc::into_raw(Arc<VulkanComputeKernelInner>)`
+/// handle. Same ManuallyDrop contract as `make_storage_buffer_borrow`
+/// / `make_texture_borrow` — the borrow's Drop must NOT run, or it
+/// would decrement the kernel's Arc refcount through the vtable
+/// while the cdylib still holds an outstanding plugin handle.
+///
+/// The cached POD fields (`cached_push_constant_size`,
+/// `_reserved_padding`) are filled with zeros. The
+/// `RhiCommandRecorderInner::record_dispatch` path only deref's
+/// `self.handle` to reach the underlying `VulkanComputeKernelInner`
+/// (via the engine-side `VulkanComputeKernel::record` →
+/// `host_inner()` chain that runs on host code, NOT through the
+/// vtable). If a future record-dispatch path starts reading
+/// `kernel.push_constant_size()` through the wrapper, the zeroed POD
+/// silently produces wrong results — extend this helper to populate
+/// the field at that point.
+///
+/// The vtable + methods_vtable pointers are filled with the host's
+/// own statics (matching what `from_arc_into_raw` would have written
+/// in host mode) so the borrow is well-formed for any field-only
+/// read even though no vtable callback is supposed to fire while the
+/// borrow is alive.
+#[cfg(target_os = "linux")]
+fn make_compute_kernel_borrow(
+    handle: *const c_void,
+) -> std::mem::ManuallyDrop<crate::vulkan::rhi::VulkanComputeKernel> {
+    std::mem::ManuallyDrop::new(crate::vulkan::rhi::VulkanComputeKernel {
+        handle,
+        vtable: host_gpu_context_full_access_vtable(),
+        methods_vtable: host_vulkan_compute_kernel_methods_vtable(),
+        cached_push_constant_size: 0,
+        _reserved_padding: 0,
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_begin(
+    recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_begin",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "begin: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            match recorder.begin() {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(&format!("begin: {e}"), err_buf, err_buf_cap, err_len);
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_begin(
+    _recorder_handle: *const c_void,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err("begin: Linux-only", err_buf, err_buf_cap, err_len);
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_image_barrier(
+    recorder_handle: *const c_void,
+    texture_handle: *const c_void,
+    from_layout_raw: i32,
+    to_layout_raw: i32,
+    from_stage_raw: i64,
+    to_stage_raw: i64,
+    from_access_raw: i64,
+    to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_image_barrier",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_image_barrier: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if texture_handle.is_null() {
+                write_err(
+                    "record_image_barrier: null texture handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let texture_borrow = make_texture_borrow(texture_handle);
+            let from_layout =
+                streamlib_consumer_rhi::VulkanLayout(from_layout_raw);
+            let to_layout = streamlib_consumer_rhi::VulkanLayout(to_layout_raw);
+            let from_stage =
+                crate::vulkan::rhi::VulkanStage(from_stage_raw as u64);
+            let to_stage = crate::vulkan::rhi::VulkanStage(to_stage_raw as u64);
+            let from_access =
+                crate::vulkan::rhi::VulkanAccess(from_access_raw as u64);
+            let to_access =
+                crate::vulkan::rhi::VulkanAccess(to_access_raw as u64);
+            match recorder.record_image_barrier(
+                &*texture_borrow,
+                from_layout,
+                to_layout,
+                from_stage,
+                to_stage,
+                from_access,
+                to_access,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_image_barrier: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_image_barrier(
+    _recorder_handle: *const c_void,
+    _texture_handle: *const c_void,
+    _from_layout_raw: i32,
+    _to_layout_raw: i32,
+    _from_stage_raw: i64,
+    _to_stage_raw: i64,
+    _from_access_raw: i64,
+    _to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_image_barrier: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_buffer_barrier(
+    recorder_handle: *const c_void,
+    storage_buffer_handle: *const c_void,
+    from_stage_raw: i64,
+    to_stage_raw: i64,
+    from_access_raw: i64,
+    to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_buffer_barrier",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_buffer_barrier: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if storage_buffer_handle.is_null() {
+                write_err(
+                    "record_buffer_barrier: null storage_buffer handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let buffer_borrow =
+                make_storage_buffer_borrow(storage_buffer_handle);
+            let from_stage =
+                crate::vulkan::rhi::VulkanStage(from_stage_raw as u64);
+            let to_stage = crate::vulkan::rhi::VulkanStage(to_stage_raw as u64);
+            let from_access =
+                crate::vulkan::rhi::VulkanAccess(from_access_raw as u64);
+            let to_access =
+                crate::vulkan::rhi::VulkanAccess(to_access_raw as u64);
+            match recorder.record_buffer_barrier(
+                &*buffer_borrow,
+                from_stage,
+                to_stage,
+                from_access,
+                to_access,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_buffer_barrier: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_buffer_barrier(
+    _recorder_handle: *const c_void,
+    _storage_buffer_handle: *const c_void,
+    _from_stage_raw: i64,
+    _to_stage_raw: i64,
+    _from_access_raw: i64,
+    _to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_buffer_barrier: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_dispatch(
+    recorder_handle: *const c_void,
+    kernel_handle: *const c_void,
+    group_x: u32,
+    group_y: u32,
+    group_z: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_dispatch",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_dispatch: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if kernel_handle.is_null() {
+                write_err(
+                    "record_dispatch: null kernel handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let kernel_borrow = make_compute_kernel_borrow(kernel_handle);
+            match recorder.record_dispatch(
+                &*kernel_borrow,
+                group_x,
+                group_y,
+                group_z,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_dispatch: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_dispatch(
+    _recorder_handle: *const c_void,
+    _kernel_handle: *const c_void,
+    _group_x: u32,
+    _group_y: u32,
+    _group_z: u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err("record_dispatch: Linux-only", err_buf, err_buf_cap, err_len);
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_copy_image_to_buffer(
+    recorder_handle: *const c_void,
+    src_texture_handle: *const c_void,
+    src_layout_raw: i32,
+    dst_storage_buffer_handle: *const c_void,
+    region: *const streamlib_plugin_abi::ImageCopyRegionRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_copy_image_to_buffer",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_copy_image_to_buffer: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if src_texture_handle.is_null() {
+                write_err(
+                    "record_copy_image_to_buffer: null src texture handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if dst_storage_buffer_handle.is_null() {
+                write_err(
+                    "record_copy_image_to_buffer: null dst storage_buffer handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if region.is_null() {
+                write_err(
+                    "record_copy_image_to_buffer: null region pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let region_ref = unsafe { &*region };
+            let src_borrow = make_texture_borrow(src_texture_handle);
+            let dst_borrow =
+                make_storage_buffer_borrow(dst_storage_buffer_handle);
+            let src_layout =
+                streamlib_consumer_rhi::VulkanLayout(src_layout_raw);
+            let region_rust = crate::vulkan::rhi::ImageCopyRegion {
+                width: region_ref.width,
+                height: region_ref.height,
+                buffer_offset: region_ref.buffer_offset,
+                buffer_row_length: region_ref.buffer_row_length,
+                buffer_image_height: region_ref.buffer_image_height,
+                mip_level: region_ref.mip_level,
+                array_layer: region_ref.array_layer,
+            };
+            match recorder.record_copy_image_to_buffer(
+                &*src_borrow,
+                src_layout,
+                &*dst_borrow,
+                region_rust,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_copy_image_to_buffer: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_copy_image_to_buffer(
+    _recorder_handle: *const c_void,
+    _src_texture_handle: *const c_void,
+    _src_layout_raw: i32,
+    _dst_storage_buffer_handle: *const c_void,
+    _region: *const streamlib_plugin_abi::ImageCopyRegionRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_copy_image_to_buffer: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_submit_signaling_timeline(
+    recorder_handle: *const c_void,
+    timeline_handle: *const c_void,
+    signal_value: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_submit_signaling_timeline",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "submit_signaling_timeline: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if timeline_handle.is_null() {
+                write_err(
+                    "submit_signaling_timeline: null timeline handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            // SAFETY: `timeline_handle` is a borrowed pointer from
+            // the cdylib's
+            // `RhiCommandRecorder::dispatch_submit_signaling_timeline_via_vtable`
+            // (which gets it via `self as *const Self` on the
+            // β-shape's outer `HostVulkanTimelineSemaphore` borrow,
+            // same convention as the v13
+            // `wait_timeline_semaphore` slot). The borrow lasts
+            // only for the duration of this call.
+            let timeline = unsafe {
+                &*(timeline_handle
+                    as *const crate::vulkan::rhi::HostVulkanTimelineSemaphore)
+            };
+            match recorder.submit_signaling_timeline(timeline, signal_value) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("submit_signaling_timeline: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_submit_signaling_timeline(
+    _recorder_handle: *const c_void,
+    _timeline_handle: *const c_void,
+    _signal_value: u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "submit_signaling_timeline: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+/// Host-side `RhiCommandRecorderMethodsVTable` wired to the
+/// per-method wrappers above (Phase E sub-lift slice B — #984).
+pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
+    streamlib_plugin_abi::RhiCommandRecorderMethodsVTable =
+    streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
+        layout_version:
+            streamlib_plugin_abi::RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        begin: host_command_recorder_begin,
+        record_image_barrier: host_command_recorder_record_image_barrier,
+        record_buffer_barrier: host_command_recorder_record_buffer_barrier,
+        record_dispatch: host_command_recorder_record_dispatch,
+        record_copy_image_to_buffer:
+            host_command_recorder_record_copy_image_to_buffer,
+        submit_signaling_timeline:
+            host_command_recorder_submit_signaling_timeline,
+    };
+
+/// Accessor for the host's static `RhiCommandRecorderMethodsVTable`
+/// — used by `RhiCommandRecorder::from_inner` to populate the
+/// β-shape's `methods_vtable` field.
+pub fn host_rhi_command_recorder_methods_vtable(
+) -> *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable {
+    &HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE
+}
+
+// =============================================================================
 // FullAccess vtable callback-body tests (tier-1 — no GPU required)
 // =============================================================================
 //
@@ -10945,6 +11562,186 @@ mod gpu_rhi_color_converter_methods_vtable_null_tests {
         assert!(
             err_buf_as_str(&buf, len)
                 .contains("prepare_buffer_to_image_storage: null converter handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod gpu_rhi_command_recorder_methods_vtable_null_tests {
+    //! Tier-1 wire-format tests for the v1 method slots on
+    //! `RhiCommandRecorderMethodsVTable`. Each wrapper must reject a
+    //! null recorder handle before reaching any recorder-side state
+    //! (i.e. before any deref) so cdylib callers get a clean error
+    //! return on the wire-format path instead of UB.
+    //!
+    //! The secondary null-handle guards (texture / storage_buffer /
+    //! kernel / timeline) live in the same wrappers and fire when the
+    //! recorder handle is valid; they're exercised end-to-end by the
+    //! camera-package dlopen smoke test (which holds a real recorder).
+    //! Tier-1 cannot reach them without first passing the recorder-
+    //! handle deref — passing a non-null garbage handle for the
+    //! recorder trips a misaligned-pointer-deref panic before any
+    //! subsequent guard runs. This mirrors the precedent set by
+    //! `gpu_rhi_color_converter_methods_vtable_null_tests`.
+    //!
+    //! Success-path coverage (real Box<RhiCommandRecorderInner>, a
+    //! full begin → record_* → submit_signaling_timeline cycle)
+    //! requires a real Vulkan device and arrives in the camera-
+    //! package dlopen smoke test.
+
+    use super::*;
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_buf_as_str(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    fn dummy_region() -> streamlib_plugin_abi::ImageCopyRegionRepr {
+        streamlib_plugin_abi::ImageCopyRegionRepr::default()
+    }
+
+    #[test]
+    fn begin_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.begin)(
+                std::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len).contains("begin: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_image_barrier_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.record_image_barrier)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_image_barrier: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_buffer_barrier_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.record_buffer_barrier)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_buffer_barrier: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_dispatch_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.record_dispatch)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_dispatch: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_copy_image_to_buffer_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let region = dummy_region();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.record_copy_image_to_buffer)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                &region,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_copy_image_to_buffer: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn submit_signaling_timeline_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.submit_signaling_timeline)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("submit_signaling_timeline: null recorder handle"),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/libs/streamlib-engine/src/core/rhi/storage_buffer.rs
+++ b/libs/streamlib-engine/src/core/rhi/storage_buffer.rs
@@ -121,6 +121,17 @@ impl StorageBuffer {
     pub fn mapped_ptr(&self) -> *mut u8 {
         self.mapped_ptr_cached
     }
+
+    /// Engine-internal accessor for the raw
+    /// `Arc::into_raw(Arc<HostVulkanBuffer>)` handle. Used by
+    /// cdylib-mode dispatch paths
+    /// (`RhiCommandRecorder::record_buffer_barrier` /
+    /// `record_copy_image_to_buffer`) that need to forward the
+    /// underlying Arc-shaped pointer across the FFI without
+    /// reaching for `self.handle` directly.
+    pub(crate) fn cdylib_handle(&self) -> *const c_void {
+        self.handle
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
@@ -35,6 +35,21 @@ use crate::core::rhi::{IndexBuffer, StorageBuffer, UniformBuffer, VertexBuffer};
 pub trait VulkanBufferLike {
     fn vk_buffer(&self) -> vk::Buffer;
     fn vk_buffer_size(&self) -> vk::DeviceSize;
+
+    /// Cdylib-mode handle accessor: if this buffer flavor is
+    /// reachable as a [`crate::core::rhi::StorageBuffer`] β-shape,
+    /// return the underlying `Arc::into_raw(Arc<HostVulkanBufferInner>)`
+    /// pointer for cross-DSO dispatch (Phase E sub-lift slice B —
+    /// #984). Default is `None`; only [`crate::core::rhi::StorageBuffer`]
+    /// overrides today. The cdylib-side
+    /// [`crate::vulkan::rhi::RhiCommandRecorder::record_buffer_barrier`]
+    /// / `record_copy_image_to_buffer` paths surface a typed
+    /// "unsupported buffer flavor" error when this returns `None`,
+    /// matching the slot coverage of
+    /// [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`].
+    fn cdylib_storage_buffer_handle(&self) -> Option<*const std::ffi::c_void> {
+        None
+    }
 }
 
 impl VulkanBufferLike for PixelBuffer {
@@ -68,6 +83,9 @@ impl VulkanBufferLike for StorageBuffer {
     }
     fn vk_buffer_size(&self) -> vk::DeviceSize {
         self.host_inner().size()
+    }
+    fn cdylib_storage_buffer_handle(&self) -> Option<*const std::ffi::c_void> {
+        Some(self.cdylib_handle())
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -728,14 +728,36 @@ impl std::fmt::Debug for RhiCommandRecorderInner {
 /// assert_clone::<streamlib_engine::vulkan::rhi::RhiCommandRecorder>();
 /// ```
 ///
-/// Method dispatch is host-only via [`Self::host_inner_mut`] until
-/// Phase E (#907) lifts to per-method vtable slots.
+/// Method dispatch routes through three different vtables depending
+/// on the method and call site:
+///
+/// - Drop runs through [`GpuContextFullAccessVTable::drop_command_recorder`]
+///   (the parent vtable).
+/// - The six camera-hot-path methods (`begin`, `record_image_barrier`,
+///   `record_buffer_barrier`, `record_dispatch`,
+///   `record_copy_image_to_buffer`, `submit_signaling_timeline`)
+///   route through the per-type
+///   [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`] when
+///   called from cdylib code (Phase E sub-lift slice B — #984).
+/// - The remaining host-only methods (`record_draw`,
+///   `record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
+///   `submit_and_wait`, the engine-internal `submit_with_semaphores`
+///   / `command_buffer_raw` / `vulkan_device_ref` accessors) keep
+///   their cdylib-mode panic via [`Self::host_inner_mut`] /
+///   [`Self::host_inner`]; a follow-up slice lifts each as a
+///   consumer arrives.
 #[repr(C)]
 pub struct RhiCommandRecorder {
     /// Opaque handle to the host's `Box<RhiCommandRecorderInner>`.
     pub(crate) handle: *const c_void,
-    /// Vtable for cross-DSO Drop dispatch.
+    /// Parent vtable for cross-DSO Drop dispatch.
     pub(crate) vtable: *const GpuContextFullAccessVTable,
+    /// Per-type vtable for cross-DSO method dispatch (Phase E
+    /// sub-lift slice B — #984). Null in host mode; populated by
+    /// [`Self::from_inner`] via
+    /// [`crate::core::plugin::host_services::host_rhi_command_recorder_methods_vtable`].
+    pub(crate) methods_vtable:
+        *const streamlib_plugin_abi::RhiCommandRecorderMethodsVTable,
 }
 
 // SAFETY: handle points at a `Box<RhiCommandRecorderInner>`; Inner
@@ -752,12 +774,19 @@ impl RhiCommandRecorder {
     }
 
     /// Internal helper: leak a `Box<RhiCommandRecorderInner>` as the
-    /// opaque handle and resolve the host-mode FullAccess vtable.
+    /// opaque handle and resolve the host-mode FullAccess + per-type
+    /// methods vtables.
     pub(crate) fn from_inner(inner: RhiCommandRecorderInner) -> Self {
         let handle = Box::into_raw(Box::new(inner)) as *const c_void;
         let vtable =
             crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
-        Self { handle, vtable }
+        let methods_vtable =
+            crate::core::plugin::host_services::host_rhi_command_recorder_methods_vtable();
+        Self {
+            handle,
+            vtable,
+            methods_vtable,
+        }
     }
 
     /// Engine-internal mutable borrow of the host-owned
@@ -788,18 +817,32 @@ impl RhiCommandRecorder {
     }
 
     // -------------------------------------------------------------------------
-    // Method mirrors — route via host_inner_mut() with cdylib panic-guard.
-    // Phase E (#907) lifts these to per-method vtable slots; until then,
-    // method dispatch on the β-shape is host-only.
+    // Method mirrors. The six camera-hot-path methods (`begin`,
+    // `record_image_barrier`, `record_buffer_barrier`,
+    // `record_dispatch`, `record_copy_image_to_buffer`,
+    // `submit_signaling_timeline`) route through the per-type
+    // methods vtable when called from cdylib code (Phase E sub-lift
+    // slice B — #984). The remaining methods route via host_inner_mut()
+    // with cdylib panic-guard until a future slice lifts them as
+    // consumers arrive.
     // -------------------------------------------------------------------------
 
     /// Begin a new recording. See [`RhiCommandRecorderInner::begin`].
+    ///
+    /// Mode-routed: in-process callers dispatch through
+    /// `host_inner_mut`; cdylib callers dispatch through the per-type
+    /// methods vtable (Phase E sub-lift slice B).
     pub fn begin(&mut self) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_begin_via_vtable();
+        }
         self.host_inner_mut().begin()
     }
 
     /// Record an image layout transition. See
     /// [`RhiCommandRecorderInner::record_image_barrier`].
+    ///
+    /// Mode-routed; see [`Self::begin`] for the dispatch contract.
     pub fn record_image_barrier(
         &mut self,
         texture: &Texture,
@@ -810,12 +853,31 @@ impl RhiCommandRecorder {
         from_access: VulkanAccess,
         to_access: VulkanAccess,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_image_barrier_via_vtable(
+                texture,
+                from_layout,
+                to_layout,
+                from_stage,
+                to_stage,
+                from_access,
+                to_access,
+            );
+        }
         self.host_inner_mut().record_image_barrier(
             texture, from_layout, to_layout, from_stage, to_stage, from_access, to_access,
         )
     }
 
     /// Buffer memory barrier covering the whole buffer.
+    ///
+    /// Mode-routed; see [`Self::begin`] for the dispatch contract.
+    /// **Cdylib path only supports
+    /// [`crate::core::rhi::StorageBuffer`]-flavored buffers today**
+    /// — the buffer must report a non-`None`
+    /// [`VulkanBufferLike::cdylib_storage_buffer_handle`] or the
+    /// dispatch returns a typed error. Future buffer flavors add
+    /// sibling vtable slots; the host path is unchanged.
     pub fn record_buffer_barrier(
         &mut self,
         buffer: &(impl VulkanBufferLike + ?Sized),
@@ -824,12 +886,27 @@ impl RhiCommandRecorder {
         from_access: VulkanAccess,
         to_access: VulkanAccess,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_buffer_barrier_via_vtable(
+                buffer,
+                from_stage,
+                to_stage,
+                from_access,
+                to_access,
+            );
+        }
         self.host_inner_mut().record_buffer_barrier(
             buffer, from_stage, to_stage, from_access, to_access,
         )
     }
 
     /// Copy image → buffer. See [`RhiCommandRecorderInner::record_copy_image_to_buffer`].
+    ///
+    /// Mode-routed; see [`Self::begin`] for the dispatch contract.
+    /// **Cdylib path only supports
+    /// [`crate::core::rhi::StorageBuffer`]-flavored destinations
+    /// today** — the same buffer-flavor constraint as
+    /// [`Self::record_buffer_barrier`].
     pub fn record_copy_image_to_buffer(
         &mut self,
         src: &Texture,
@@ -837,11 +914,17 @@ impl RhiCommandRecorder {
         dst: &(impl VulkanBufferLike + ?Sized),
         region: ImageCopyRegion,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_copy_image_to_buffer_via_vtable(
+                src, src_layout, dst, region,
+            );
+        }
         self.host_inner_mut()
             .record_copy_image_to_buffer(src, src_layout, dst, region)
     }
 
-    /// Copy buffer → image.
+    /// Copy buffer → image. Host-only until a cdylib consumer
+    /// arrives; cdylib callers panic at [`Self::host_inner_mut`].
     pub fn record_copy_buffer_to_image(
         &mut self,
         src: &(impl VulkanBufferLike + ?Sized),
@@ -854,6 +937,8 @@ impl RhiCommandRecorder {
     }
 
     /// Compute dispatch.
+    ///
+    /// Mode-routed; see [`Self::begin`] for the dispatch contract.
     pub fn record_dispatch(
         &mut self,
         kernel: &VulkanComputeKernel,
@@ -861,11 +946,17 @@ impl RhiCommandRecorder {
         group_y: u32,
         group_z: u32,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_record_dispatch_via_vtable(
+                kernel, group_x, group_y, group_z,
+            );
+        }
         self.host_inner_mut()
             .record_dispatch(kernel, group_x, group_y, group_z)
     }
 
-    /// Draw call.
+    /// Draw call. Host-only until a cdylib consumer arrives;
+    /// cdylib callers panic at [`Self::host_inner_mut`].
     pub fn record_draw(
         &mut self,
         kernel: &VulkanGraphicsKernel,
@@ -875,7 +966,8 @@ impl RhiCommandRecorder {
         self.host_inner_mut().record_draw(kernel, frame_index, draw)
     }
 
-    /// Indexed-draw variant.
+    /// Indexed-draw variant. Host-only until a cdylib consumer
+    /// arrives; cdylib callers panic at [`Self::host_inner_mut`].
     pub fn record_draw_indexed(
         &mut self,
         kernel: &VulkanGraphicsKernel,
@@ -887,13 +979,266 @@ impl RhiCommandRecorder {
     }
 
     /// Submit signaling a timeline semaphore.
+    ///
+    /// Mode-routed; see [`Self::begin`] for the dispatch contract.
     pub fn submit_signaling_timeline(
         &mut self,
         timeline: &HostVulkanTimelineSemaphore,
         signal_value: u64,
     ) -> Result<()> {
+        if crate::core::plugin::host_services::host_callbacks().is_some() {
+            return self.dispatch_submit_signaling_timeline_via_vtable(
+                timeline,
+                signal_value,
+            );
+        }
         self.host_inner_mut()
             .submit_signaling_timeline(timeline, signal_value)
+    }
+
+    // -------------------------------------------------------------------------
+    // Cdylib-mode dispatch helpers (Phase E sub-lift slice B — #984).
+    // Each helper validates the methods vtable pointer, marshals
+    // arguments into the wire-format integer types, dispatches
+    // through the vtable, and converts the host's `i32 + err_buf`
+    // return into `Result<()>`.
+    // -------------------------------------------------------------------------
+
+    fn dispatch_begin_via_vtable(&self) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "begin: command recorder methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).begin)(
+                self.handle,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch_record_image_barrier_via_vtable(
+        &self,
+        texture: &Texture,
+        from_layout: VulkanLayout,
+        to_layout: VulkanLayout,
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_image_barrier: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_image_barrier)(
+                self.handle,
+                texture.handle,
+                from_layout.0,
+                to_layout.0,
+                from_stage.0 as i64,
+                to_stage.0 as i64,
+                from_access.0 as i64,
+                to_access.0 as i64,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_record_buffer_barrier_via_vtable(
+        &self,
+        buffer: &(impl VulkanBufferLike + ?Sized),
+        from_stage: VulkanStage,
+        to_stage: VulkanStage,
+        from_access: VulkanAccess,
+        to_access: VulkanAccess,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_buffer_barrier: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let Some(storage_handle) = buffer.cdylib_storage_buffer_handle() else {
+            return Err(Error::GpuError(
+                "record_buffer_barrier: cdylib path only supports StorageBuffer-flavored \
+                 buffers today (extend the methods vtable with a sibling slot for other \
+                 flavors)"
+                    .into(),
+            ));
+        };
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_buffer_barrier)(
+                self.handle,
+                storage_handle,
+                from_stage.0 as i64,
+                to_stage.0 as i64,
+                from_access.0 as i64,
+                to_access.0 as i64,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_record_dispatch_via_vtable(
+        &self,
+        kernel: &VulkanComputeKernel,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_dispatch: command recorder methods vtable is null".into(),
+            ));
+        }
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_dispatch)(
+                self.handle,
+                kernel.handle,
+                group_x,
+                group_y,
+                group_z,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_record_copy_image_to_buffer_via_vtable(
+        &self,
+        src: &Texture,
+        src_layout: VulkanLayout,
+        dst: &(impl VulkanBufferLike + ?Sized),
+        region: ImageCopyRegion,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "record_copy_image_to_buffer: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let Some(dst_storage_handle) = dst.cdylib_storage_buffer_handle() else {
+            return Err(Error::GpuError(
+                "record_copy_image_to_buffer: cdylib path only supports \
+                 StorageBuffer-flavored destinations today (extend the methods vtable \
+                 with a sibling slot for other flavors)"
+                    .into(),
+            ));
+        };
+        let region_repr = streamlib_plugin_abi::ImageCopyRegionRepr {
+            width: region.width,
+            height: region.height,
+            buffer_offset: region.buffer_offset,
+            buffer_row_length: region.buffer_row_length,
+            buffer_image_height: region.buffer_image_height,
+            mip_level: region.mip_level,
+            array_layer: region.array_layer,
+            _reserved_padding: 0,
+        };
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).record_copy_image_to_buffer)(
+                self.handle,
+                src.handle,
+                src_layout.0,
+                dst_storage_handle,
+                &region_repr,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
+    }
+
+    fn dispatch_submit_signaling_timeline_via_vtable(
+        &self,
+        timeline: &HostVulkanTimelineSemaphore,
+        signal_value: u64,
+    ) -> Result<()> {
+        if self.methods_vtable.is_null() {
+            return Err(Error::GpuError(
+                "submit_signaling_timeline: command recorder methods vtable is null"
+                    .into(),
+            ));
+        }
+        let timeline_handle = timeline as *const HostVulkanTimelineSemaphore
+            as *const c_void;
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = unsafe {
+            ((*self.methods_vtable).submit_signaling_timeline)(
+                self.handle,
+                timeline_handle,
+                signal_value,
+                err_buf.as_mut_ptr(),
+                err_buf.len(),
+                &mut err_len as *mut usize,
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            let msg = String::from_utf8_lossy(&err_buf[..err_len.min(err_buf.len())])
+                .into_owned();
+            Err(Error::GpuError(msg))
+        }
     }
 
     /// Submit without semaphore signaling.
@@ -953,10 +1298,15 @@ mod layout_tests {
 
     #[test]
     fn rhi_command_recorder_layout() {
-        assert_eq!(size_of::<RhiCommandRecorder>(), 16);
+        // Phase E sub-lift slice B (#984) appended `methods_vtable`
+        // (16 → 24 bytes); the β-shape now mirrors the
+        // `(handle, vtable, methods_vtable)` triple used by every
+        // per-type kernel β-shape and `RhiColorConverter`.
+        assert_eq!(size_of::<RhiCommandRecorder>(), 24);
         assert_eq!(align_of::<RhiCommandRecorder>(), 8);
         assert_eq!(offset_of!(RhiCommandRecorder, handle), 0);
         assert_eq!(offset_of!(RhiCommandRecorder, vtable), 8);
+        assert_eq!(offset_of!(RhiCommandRecorder, methods_vtable), 16);
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -121,7 +121,18 @@ pub const STREAMLIB_ABI_VERSION: u32 = 4;
 ///   `prepare_buffer_to_image_storage` method through it so cdylib
 ///   camera processors can prepare a color-conversion kernel without
 ///   tripping the host-mode-only `host_inner()` panic.
-pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 12;
+/// - v13: [`RhiCommandRecorderMethodsVTable`] reference appended.
+///   The cdylib-side `RhiCommandRecorder` β-shape's `methods_vtable`
+///   field sources its pointer from this field. Non-null for hosts
+///   that ship a GpuContext; null otherwise (cdylib code must check
+///   before dispatching). Phase E sub-lift slice B wires the six
+///   camera-hot-path methods (`begin`, `record_image_barrier`,
+///   `record_buffer_barrier`, `record_dispatch`,
+///   `record_copy_image_to_buffer`, `submit_signaling_timeline`)
+///   through it so cdylib camera processors can drive the
+///   host-owned recorder per frame without tripping the
+///   host-mode-only `host_inner_mut()` panic.
+pub const HOST_SERVICES_LAYOUT_VERSION: u32 = 13;
 
 /// Layout version of the [`ProcessorVTable`] struct. Read by the
 /// host's `processor_register` impl before dereferencing any vtable
@@ -380,6 +391,17 @@ pub const VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 ///   `VulkanComputeKernel` β-shape via the parent FullAccess vtable's
 ///   per-type methods vtable lookup.
 pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`RhiCommandRecorderMethodsVTable`].
+///
+/// - v1: ships six method slots a cdylib camera processor needs
+///   to drive the host-owned `RhiCommandRecorder` per frame —
+///   `begin`, `record_image_barrier`, `record_buffer_barrier`,
+///   `record_dispatch`, `record_copy_image_to_buffer`,
+///   `submit_signaling_timeline`. Without these the β-shape's
+///   `host_inner()` / `host_inner_mut()` panic-guards fire from
+///   cdylib code on every per-frame call.
+pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 
 // =============================================================================
 // Primitive enums
@@ -3164,6 +3186,40 @@ pub struct SourceLayoutInfoRepr {
     pub _reserved_padding: u32,
 }
 
+/// `#[repr(C)]` mirror of
+/// `streamlib::vulkan::rhi::vulkan_command_recorder::ImageCopyRegion`.
+///
+/// Buffer↔image copy region — single mip level, single array layer,
+/// color aspect, full image. Used by
+/// [`RhiCommandRecorderMethodsVTable::record_copy_image_to_buffer`]
+/// to cross the cdylib boundary without dragging callers through
+/// `vulkanalia` imports. Layout-locked by the regression test in
+/// `layout_tests`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ImageCopyRegionRepr {
+    /// Image extent width in pixels.
+    pub width: u32,
+    /// Image extent height in pixels.
+    pub height: u32,
+    /// Byte offset within the buffer where the copy begins.
+    pub buffer_offset: u64,
+    /// Buffer row length in pixels (matches image width for tightly
+    /// packed copies).
+    pub buffer_row_length: u32,
+    /// Buffer image height in pixels (matches image height for
+    /// tightly packed copies).
+    pub buffer_image_height: u32,
+    /// Mip level to copy into / out of.
+    pub mip_level: u32,
+    /// Array layer to copy into / out of.
+    pub array_layer: u32,
+    /// Reserved padding so the struct stays 8-byte-aligned and the
+    /// trailing bytes of the last 4-byte field are deterministic;
+    /// zero today, never read.
+    pub _reserved_padding: u32,
+}
+
 /// `#[repr(C)]` mirror of `streamlib::core::color::ResolvedColorInfo`.
 ///
 /// Each field is the matching engine-side `#[repr(u32)]` enum's
@@ -3252,6 +3308,161 @@ pub struct RhiColorConverterMethodsVTable {
 
 unsafe impl Send for RhiColorConverterMethodsVTable {}
 unsafe impl Sync for RhiColorConverterMethodsVTable {}
+
+/// Per-type method-dispatch vtable for the `RhiCommandRecorder`
+/// β-shape (Phase E sub-lift slice B — #984).
+///
+/// `RhiCommandRecorder` keeps `clone_command_recorder` /
+/// `drop_command_recorder` dispatch on the parent
+/// [`GpuContextFullAccessVTable`]; this vtable carries per-method
+/// slots for the six camera-hot-path methods cdylib code needs to
+/// dispatch through (`begin`, `record_image_barrier`,
+/// `record_buffer_barrier`, `record_dispatch`,
+/// `record_copy_image_to_buffer`, `submit_signaling_timeline`).
+/// Without these the β-shape's `host_inner_mut()` / `host_inner()`
+/// panic-guards fire from cdylib code on every per-frame call.
+///
+/// The remaining `RhiCommandRecorder` methods (`record_draw`,
+/// `record_draw_indexed`, `record_copy_buffer_to_image`, `submit`,
+/// `submit_and_wait`, `submit_with_semaphores`, `command_buffer_raw`,
+/// `vulkan_device_ref`) keep their cdylib-mode panic in place — they
+/// don't sit on the camera hot path and a follow-up slice lifts
+/// them when a consumer arrives.
+///
+/// **Buffer-flavor coverage today:** `record_buffer_barrier` and
+/// `record_copy_image_to_buffer` accept a `StorageBuffer`-shaped
+/// handle. Today's camera per-frame call site copies into a
+/// `StorageBuffer`; future consumers needing uniform / vertex /
+/// index buffer barriers add sibling slots rather than discriminating
+/// on these.
+#[repr(C)]
+pub struct RhiCommandRecorderMethodsVTable {
+    /// Vtable layout version. Must equal
+    /// [`RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    /// Begin a new recording. `recorder_handle` is the
+    /// `Box::into_raw(Box<RhiCommandRecorderInner>)` pointer from
+    /// the β-shape's `handle` field. Returns 0 on success; non-zero
+    /// with UTF-8 message in `err_buf` on failure. Linux-only on the
+    /// host side; non-Linux stubs return non-zero.
+    pub begin: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record an image layout transition. Layout / stage / access
+    /// enumerants travel as their raw integer types: `VulkanLayout`
+    /// is `i32` (matches the `VkImageLayout` enumerant);
+    /// `VulkanStage` and `VulkanAccess` are `i64` (the
+    /// `VK_PIPELINE_STAGE_2_*` and `VK_ACCESS_2_*` bitmasks are
+    /// 64-bit).
+    ///
+    /// - `recorder_handle` is the
+    ///   `Box::into_raw(Box<RhiCommandRecorderInner>)` pointer.
+    /// - `texture_handle` is
+    ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the
+    ///   `Texture` β-shape's `handle` field (borrowed).
+    pub record_image_barrier: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        texture_handle: *const c_void,
+        from_layout_raw: i32,
+        to_layout_raw: i32,
+        from_stage_raw: i64,
+        to_stage_raw: i64,
+        from_access_raw: i64,
+        to_access_raw: i64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record a buffer memory barrier covering the whole buffer.
+    /// Today the camera only uses storage-buffer barriers; this
+    /// slot accepts a `StorageBuffer`-shaped handle. The host
+    /// reconstructs the typed borrow via
+    /// `make_storage_buffer_borrow`. Future consumers needing
+    /// uniform / vertex / index buffer barriers add sibling slots,
+    /// not a discriminator on this one.
+    ///
+    /// - `storage_buffer_handle` is
+    ///   `Arc::into_raw(Arc<HostVulkanBufferInner>)`-shaped from
+    ///   the `StorageBuffer` β-shape's `handle` field (borrowed).
+    pub record_buffer_barrier: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        storage_buffer_handle: *const c_void,
+        from_stage_raw: i64,
+        to_stage_raw: i64,
+        from_access_raw: i64,
+        to_access_raw: i64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record a compute dispatch via
+    /// `VulkanComputeKernel::record`. `kernel_handle` is the
+    /// `Arc::into_raw(Arc<VulkanComputeKernelInner>)` pointer from
+    /// the kernel β-shape's `handle` field (borrowed).
+    pub record_dispatch: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        kernel_handle: *const c_void,
+        group_x: u32,
+        group_y: u32,
+        group_z: u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Record `vkCmdCopyImageToBuffer`. Storage-buffer-shape
+    /// destination only today; mirrors the
+    /// `record_buffer_barrier` constraint.
+    ///
+    /// - `src_texture_handle` is
+    ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the source
+    ///   `Texture` β-shape's `handle` field (borrowed).
+    /// - `dst_storage_buffer_handle` is
+    ///   `Arc::into_raw(Arc<HostVulkanBufferInner>)`-shaped from the
+    ///   destination `StorageBuffer` β-shape's `handle` field
+    ///   (borrowed).
+    /// - `region` points at an [`ImageCopyRegionRepr`] the host
+    ///   reads once at call time.
+    pub record_copy_image_to_buffer: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        src_texture_handle: *const c_void,
+        src_layout_raw: i32,
+        dst_storage_buffer_handle: *const c_void,
+        region: *const ImageCopyRegionRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// End recording and submit, signaling `timeline` at
+    /// `signal_value` on completion. `timeline_handle` is a borrow
+    /// of `&HostVulkanTimelineSemaphore` (`self as *const Self`
+    /// shape — same pattern as the v13 `wait_timeline_semaphore`
+    /// slot on `GpuContextLimitedAccessVTable`). The host does not
+    /// bump the timeline's refcount.
+    pub submit_signaling_timeline: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        timeline_handle: *const c_void,
+        signal_value: u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+}
+
+unsafe impl Send for RhiCommandRecorderMethodsVTable {}
+unsafe impl Sync for RhiCommandRecorderMethodsVTable {}
 
 /// Per-type method-dispatch vtable for the `VulkanGraphicsKernel`
 /// β-shape (issue #907 Phase E PR 3/5 + #951 method-dispatch slice).
@@ -4155,6 +4366,26 @@ pub struct HostServices {
     /// tripping the β-shape's host-mode-only `host_inner()` panic.
     pub rhi_color_converter_methods_vtable:
         *const RhiColorConverterMethodsVTable,
+
+    // -------------------------------------------------------------------------
+    // RhiCommandRecorderMethodsVTable surface (v13 — Phase E sub-lift slice B)
+    // -------------------------------------------------------------------------
+
+    /// Static dispatch table for `RhiCommandRecorder` β-shape
+    /// method dispatch. Paired with the per-`RhiCommandRecorder`
+    /// handle the cdylib carries on its β-shape struct
+    /// (`methods_vtable` field). Set once at install time; non-null
+    /// for hosts that ship a GpuContext, null otherwise (cdylib
+    /// must check before dispatching). Phase E sub-lift slice B
+    /// lands six camera-hot-path slots (`begin`,
+    /// `record_image_barrier`, `record_buffer_barrier`,
+    /// `record_dispatch`, `record_copy_image_to_buffer`,
+    /// `submit_signaling_timeline`) so cdylib camera processors
+    /// can drive the host-owned recorder per frame without
+    /// tripping the β-shape's host-mode-only `host_inner_mut()`
+    /// panic.
+    pub rhi_command_recorder_methods_vtable:
+        *const RhiCommandRecorderMethodsVTable,
 }
 
 // Note: under v3 the ABI eliminates the tokio shared-type crossing
@@ -4315,7 +4546,7 @@ mod layout_tests {
 
     #[test]
     fn host_services_layout_versions_pinned() {
-        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 12);
+        assert_eq!(HOST_SERVICES_LAYOUT_VERSION, 13);
         assert_eq!(STREAMLIB_ABI_VERSION, 4);
         assert_eq!(RUNTIME_CONTEXT_VTABLE_LAYOUT_VERSION, 1);
         assert_eq!(AUDIO_CLOCK_VTABLE_LAYOUT_VERSION, 1);
@@ -4331,10 +4562,11 @@ mod layout_tests {
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 1);
     }
 
     #[test]
-    fn host_services_tail_carries_twelve_vtable_pointers() {
+    fn host_services_tail_carries_thirteen_vtable_pointers() {
         // Trailing vtable pointers on HostServices. We don't pin the
         // absolute offsets (earlier fields carry their own layout
         // audit), but we do pin:
@@ -4344,7 +4576,7 @@ mod layout_tests {
         //      GpuContextFullAccess → TextureRingMethods →
         //      VulkanComputeKernelMethods → VulkanGraphicsKernelMethods →
         //      VulkanRayTracingKernelMethods → VulkanAccelerationStructureMethods →
-        //      RhiColorConverterMethods.
+        //      RhiColorConverterMethods → RhiCommandRecorderMethods.
         //   3. They are contiguous (no padding inserted between them).
         assert_eq!(size_of::<*const RuntimeContextVTable>(), 8);
         assert_eq!(size_of::<*const AudioClockVTable>(), 8);
@@ -4361,6 +4593,7 @@ mod layout_tests {
             8
         );
         assert_eq!(size_of::<*const RhiColorConverterMethodsVTable>(), 8);
+        assert_eq!(size_of::<*const RhiCommandRecorderMethodsVTable>(), 8);
 
         let runtime_ctx_off = offset_of!(HostServices, runtime_context_vtable);
         let audio_clock_off = offset_of!(HostServices, audio_clock_vtable);
@@ -4379,6 +4612,8 @@ mod layout_tests {
             offset_of!(HostServices, vulkan_acceleration_structure_methods_vtable);
         let color_converter_off =
             offset_of!(HostServices, rhi_color_converter_methods_vtable);
+        let command_recorder_off =
+            offset_of!(HostServices, rhi_command_recorder_methods_vtable);
         assert!(runtime_ctx_off < audio_clock_off);
         assert!(audio_clock_off < runtime_ops_off);
         assert!(runtime_ops_off < gpu_lim_off);
@@ -4390,6 +4625,7 @@ mod layout_tests {
         assert!(graphics_kernel_off < rt_kernel_off);
         assert!(rt_kernel_off < accel_struct_off);
         assert!(accel_struct_off < color_converter_off);
+        assert!(color_converter_off < command_recorder_off);
         assert_eq!(audio_clock_off - runtime_ctx_off, 8);
         assert_eq!(runtime_ops_off - audio_clock_off, 8);
         assert_eq!(gpu_lim_off - runtime_ops_off, 8);
@@ -4401,10 +4637,11 @@ mod layout_tests {
         assert_eq!(rt_kernel_off - graphics_kernel_off, 8);
         assert_eq!(accel_struct_off - rt_kernel_off, 8);
         assert_eq!(color_converter_off - accel_struct_off, 8);
+        assert_eq!(command_recorder_off - color_converter_off, 8);
 
-        // The RhiColorConverterMethods pointer must end at the end of
-        // the struct (it is the last field added in v12).
-        assert_eq!(color_converter_off + 8, size_of::<HostServices>());
+        // The RhiCommandRecorderMethods pointer must end at the end of
+        // the struct (it is the last field added in v13).
+        assert_eq!(command_recorder_off + 8, size_of::<HostServices>());
     }
 
     #[test]
@@ -4750,6 +4987,86 @@ mod layout_tests {
                 prepare_buffer_to_image_storage
             ),
             8
+        );
+    }
+
+    #[test]
+    fn image_copy_region_repr_layout() {
+        // Field layout:
+        //   width                @ 0   (4 bytes, u32)
+        //   height               @ 4   (4 bytes, u32)
+        //   buffer_offset        @ 8   (8 bytes, u64)
+        //   buffer_row_length    @ 16  (4 bytes, u32)
+        //   buffer_image_height  @ 20  (4 bytes, u32)
+        //   mip_level            @ 24  (4 bytes, u32)
+        //   array_layer          @ 28  (4 bytes, u32)
+        //   _reserved_padding    @ 32  (4 bytes, u32)
+        // Total = 40 bytes with 4-byte tail padding rounded up to
+        // align(8) = 40 bytes. The struct's alignment is 8 because
+        // of the `u64` field.
+        assert_eq!(size_of::<ImageCopyRegionRepr>(), 40);
+        assert_eq!(align_of::<ImageCopyRegionRepr>(), 8);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, width), 0);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, height), 4);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, buffer_offset), 8);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, buffer_row_length), 16);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, buffer_image_height), 20);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, mip_level), 24);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, array_layer), 28);
+        assert_eq!(offset_of!(ImageCopyRegionRepr, _reserved_padding), 32);
+    }
+
+    #[test]
+    fn rhi_command_recorder_methods_vtable_layout() {
+        // v1:
+        //   layout_version                @ 0   (4 bytes, u32)
+        //   _reserved_padding             @ 4   (4 bytes, u32)
+        //   begin                         @ 8   (8 bytes, fn pointer)
+        //   record_image_barrier          @ 16  (8 bytes, fn pointer)
+        //   record_buffer_barrier         @ 24  (8 bytes, fn pointer)
+        //   record_dispatch               @ 32  (8 bytes, fn pointer)
+        //   record_copy_image_to_buffer   @ 40  (8 bytes, fn pointer)
+        //   submit_signaling_timeline     @ 48  (8 bytes, fn pointer)
+        // Total = 56 bytes, align = 8.
+        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 56);
+        assert_eq!(align_of::<RhiCommandRecorderMethodsVTable>(), 8);
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, layout_version),
+            0
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, _reserved_padding),
+            4
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, begin),
+            8
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, record_image_barrier),
+            16
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, record_buffer_barrier),
+            24
+        );
+        assert_eq!(
+            offset_of!(RhiCommandRecorderMethodsVTable, record_dispatch),
+            32
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                record_copy_image_to_buffer
+            ),
+            40
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                submit_signaling_timeline
+            ),
+            48
         );
     }
 
@@ -5582,6 +5899,7 @@ mod layout_tests {
         assert_send_sync::<SurfaceStoreVTable>();
         assert_send_sync::<GpuContextFullAccessVTable>();
         assert_send_sync::<RhiColorConverterMethodsVTable>();
+        assert_send_sync::<RhiCommandRecorderMethodsVTable>();
         assert_send_sync::<HostServices>();
         assert_send_sync::<ProcessorVTable>();
     }


### PR DESCRIPTION
## Summary

- Adds `RhiCommandRecorderMethodsVTable` with 6 method slots so the cdylib-side `RhiCommandRecorder` β-shape's per-frame capture-loop methods dispatch through the host. Mirrors #907's per-β-shape methods vtable pattern and Slice A's `RhiColorConverterMethodsVTable` from #983.
- Closes #984. Completes the Phase E sub-lift sequence (#983 = Slice A + v12/v13 LimitedAccess; #984 = Slice B).

## What's lifted

Six recorder methods used by the camera processor's per-frame capture loop:
1. `begin`
2. `record_image_barrier` (layout/stage/access enumerants → i32/i64 raws)
3. `record_buffer_barrier` (storage-buffer flavor only today)
4. `record_dispatch` (compute kernel borrow + group counts)
5. `record_copy_image_to_buffer` (storage-buffer flavor only today)
6. `submit_signaling_timeline` (host timeline borrow + signal value)

Other `RhiCommandRecorder` methods (`record_draw`, `record_draw_indexed`, `record_copy_buffer_to_image`, `submit`, `submit_and_wait`, `submit_with_semaphores`) keep their cdylib-mode panic — no in-tree cdylib consumer, future lifts add per-method.

## Empirical verification

Camera smoke test (`load_project_dylib_camera_smoke`) now reaches frame 2 cleanly. Before Slice B (with Slice A only), it reached frame 1 then crashed at `RhiCommandRecorder::host_inner_mut`. No panics in tracing output.

## Design notes

- **Buffer-flavor coverage:** `record_buffer_barrier` and `record_copy_image_to_buffer` cdylib paths accept only `StorageBuffer`-flavored buffers today via a new `VulkanBufferLike::cdylib_storage_buffer_handle()` default-`None` extension point. The camera per-frame call site only uses StorageBuffer; future consumers needing UniformBuffer / VertexBuffer / IndexBuffer barriers add sibling vtable slots (host path is unchanged).
- **ManuallyDrop borrow helpers:** texture / storage-buffer / compute-kernel borrows reconstruct the β-shape with zeroed POD fields; the inner methods only deref `.handle`, so the zeroed fields are safe. Doc-comment on `make_compute_kernel_borrow` flags this as a trip-wire to extend if a future inner method reads cached POD.
- **`submit_signaling_timeline`:** borrow shape matches the v13 `wait_timeline_semaphore` from #983 (`self as *const HostVulkanTimelineSemaphore`).
- **β-shape growth:** `RhiCommandRecorder` grows 16 → 24 bytes (new `methods_vtable` field). `GpuContextFullAccess::create_command_recorder` writes the whole struct via `ptr::write`; both vtable pointers flow through naturally because they're host-static addresses in the shared process address space.

## Tests

- [x] `cargo test -p streamlib-plugin-abi --lib` — 50 pass (4 new: ImageCopyRegionRepr layout, RhiCommandRecorderMethodsVTable layout, HOST_SERVICES_LAYOUT_VERSION pin, tail-pointer-count rename)
- [x] `cargo test --lib -p streamlib-engine -- gpu_rhi_command_recorder_methods_vtable_null_tests` — 6 tier-1 null-handle tests pass
- [x] `cargo build -p streamlib-engine` clean
- [x] `cargo build -p streamlib-camera --features plugin` clean
- [x] `cargo test --test load_project_dylib_camera_smoke` — passes; capture thread reaches frame 2 without panic
- [x] `/pr-review-gate` PASS, no issues flagged
- [ ] `vulkan-video-roundtrip` h264 + h265 with camera-as-cdylib (manual gate, goal-03 final criterion) — will run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)