### PR TITLE
feat(plugin-abi): RhiCommandRecorderMethodsVTable PixelBuffer sibling slots + cdylib pixel-flow fix (#988)

### DIFF
--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -10294,6 +10294,207 @@ unsafe extern "C" fn host_command_recorder_record_copy_image_to_buffer(
 
 #[cfg(target_os = "linux")]
 #[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_pixel_buffer_barrier(
+    recorder_handle: *const c_void,
+    pixel_buffer_handle: *const c_void,
+    from_stage_raw: i64,
+    to_stage_raw: i64,
+    from_access_raw: i64,
+    to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_pixel_buffer_barrier",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_pixel_buffer_barrier: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if pixel_buffer_handle.is_null() {
+                write_err(
+                    "record_pixel_buffer_barrier: null pixel_buffer handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let buffer_borrow =
+                make_pixel_buffer_borrow(pixel_buffer_handle);
+            let from_stage =
+                crate::vulkan::rhi::VulkanStage(from_stage_raw as u64);
+            let to_stage = crate::vulkan::rhi::VulkanStage(to_stage_raw as u64);
+            let from_access =
+                crate::vulkan::rhi::VulkanAccess(from_access_raw as u64);
+            let to_access =
+                crate::vulkan::rhi::VulkanAccess(to_access_raw as u64);
+            match recorder.record_buffer_barrier(
+                &*buffer_borrow,
+                from_stage,
+                to_stage,
+                from_access,
+                to_access,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_pixel_buffer_barrier: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_pixel_buffer_barrier(
+    _recorder_handle: *const c_void,
+    _pixel_buffer_handle: *const c_void,
+    _from_stage_raw: i64,
+    _to_stage_raw: i64,
+    _from_access_raw: i64,
+    _to_access_raw: i64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_pixel_buffer_barrier: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_copy_image_to_pixel_buffer(
+    recorder_handle: *const c_void,
+    src_texture_handle: *const c_void,
+    src_layout_raw: i32,
+    dst_pixel_buffer_handle: *const c_void,
+    region: *const streamlib_plugin_abi::ImageCopyRegionRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "host_command_recorder_record_copy_image_to_pixel_buffer",
+        || -> i32 {
+            let Some(recorder) =
+                (unsafe { handle_as_command_recorder_mut(recorder_handle) })
+            else {
+                write_err(
+                    "record_copy_image_to_pixel_buffer: null recorder handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            };
+            if src_texture_handle.is_null() {
+                write_err(
+                    "record_copy_image_to_pixel_buffer: null src texture handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if dst_pixel_buffer_handle.is_null() {
+                write_err(
+                    "record_copy_image_to_pixel_buffer: null dst pixel_buffer handle",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            if region.is_null() {
+                write_err(
+                    "record_copy_image_to_pixel_buffer: null region pointer",
+                    err_buf,
+                    err_buf_cap,
+                    err_len,
+                );
+                return 1;
+            }
+            let region_ref = unsafe { &*region };
+            let src_borrow = make_texture_borrow(src_texture_handle);
+            let dst_borrow =
+                make_pixel_buffer_borrow(dst_pixel_buffer_handle);
+            let src_layout =
+                streamlib_consumer_rhi::VulkanLayout(src_layout_raw);
+            let region_rust = crate::vulkan::rhi::ImageCopyRegion {
+                width: region_ref.width,
+                height: region_ref.height,
+                buffer_offset: region_ref.buffer_offset,
+                buffer_row_length: region_ref.buffer_row_length,
+                buffer_image_height: region_ref.buffer_image_height,
+                mip_level: region_ref.mip_level,
+                array_layer: region_ref.array_layer,
+            };
+            match recorder.record_copy_image_to_buffer(
+                &*src_borrow,
+                src_layout,
+                &*dst_borrow,
+                region_rust,
+            ) {
+                Ok(()) => 0,
+                Err(e) => {
+                    write_err(
+                        &format!("record_copy_image_to_pixel_buffer: {e}"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn host_command_recorder_record_copy_image_to_pixel_buffer(
+    _recorder_handle: *const c_void,
+    _src_texture_handle: *const c_void,
+    _src_layout_raw: i32,
+    _dst_pixel_buffer_handle: *const c_void,
+    _region: *const streamlib_plugin_abi::ImageCopyRegionRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    write_err(
+        "record_copy_image_to_pixel_buffer: Linux-only",
+        err_buf,
+        err_buf_cap,
+        err_len,
+    );
+    1
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 unsafe extern "C" fn host_command_recorder_submit_signaling_timeline(
     recorder_handle: *const c_void,
     timeline_handle: *const c_void,
@@ -10389,6 +10590,10 @@ pub static HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE:
             host_command_recorder_record_copy_image_to_buffer,
         submit_signaling_timeline:
             host_command_recorder_submit_signaling_timeline,
+        record_pixel_buffer_barrier:
+            host_command_recorder_record_pixel_buffer_barrier,
+        record_copy_image_to_pixel_buffer:
+            host_command_recorder_record_copy_image_to_pixel_buffer,
     };
 
 /// Accessor for the host's static `RhiCommandRecorderMethodsVTable`
@@ -11742,6 +11947,57 @@ mod gpu_rhi_command_recorder_methods_vtable_null_tests {
         assert!(
             err_buf_as_str(&buf, len)
                 .contains("submit_signaling_timeline: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_pixel_buffer_barrier_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE.record_pixel_buffer_barrier)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                0,
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_pixel_buffer_barrier: null recorder handle"),
+            "got: {}",
+            err_buf_as_str(&buf, len)
+        );
+    }
+
+    #[test]
+    fn record_copy_image_to_pixel_buffer_rejects_null_recorder_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let region = dummy_region();
+        let rc = unsafe {
+            (HOST_RHI_COMMAND_RECORDER_METHODS_VTABLE
+                .record_copy_image_to_pixel_buffer)(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                &region,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert!(
+            err_buf_as_str(&buf, len)
+                .contains("record_copy_image_to_pixel_buffer: null recorder handle"),
             "got: {}",
             err_buf_as_str(&buf, len)
         );

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -15164,3 +15164,63 @@ mod run_host_extern_c_panic_safety_net_tests {
         assert!(p.is_null());
     }
 }
+
+#[cfg(all(test, target_os = "linux"))]
+mod make_borrow_cached_field_regression_tests {
+    //! Locks the issue #988 bug: `make_*_borrow` helpers MUST populate
+    //! the β-shape's cached POD fields from the host-side inner —
+    //! NOT leave them zeroed. Reverting any `make_*_borrow` to
+    //! `width_cached: 0` / `byte_size_cached: 0` / etc. trips these
+    //! assertions.
+    //!
+    //! Requires a working Vulkan device; skips cleanly when one isn't
+    //! available (per `project_ci_strategy_no_gpu`).
+    use super::*;
+    use std::sync::Arc;
+
+    fn try_vulkan_device() -> Option<Arc<crate::vulkan::rhi::HostVulkanDevice>> {
+        crate::vulkan::rhi::HostVulkanDevice::new().ok()
+    }
+
+    #[test]
+    fn make_texture_borrow_populates_cached_pod_fields() {
+        let Some(device) = try_vulkan_device() else {
+            return;
+        };
+        let desc = crate::core::rhi::TextureDescriptor::new(
+            640,
+            480,
+            crate::core::rhi::TextureFormat::Rgba8Unorm,
+        );
+        let host_texture = crate::vulkan::rhi::HostVulkanTexture::new(&device, &desc)
+            .expect("texture allocate");
+        use crate::host_rhi::HostTextureExt;
+        let texture = crate::core::rhi::Texture::from_vulkan(host_texture);
+        let borrow = make_texture_borrow(texture.handle);
+        assert_eq!(borrow.width(), 640, "width_cached must mirror the inner");
+        assert_eq!(borrow.height(), 480, "height_cached must mirror the inner");
+        assert!(
+            matches!(borrow.format(), crate::core::rhi::TextureFormat::Rgba8Unorm),
+            "format_raw must mirror the inner"
+        );
+    }
+
+    #[test]
+    fn make_storage_buffer_borrow_populates_cached_pod_fields() {
+        let Some(device) = try_vulkan_device() else {
+            return;
+        };
+        let host_buffer =
+            crate::vulkan::rhi::HostVulkanBuffer::new_storage_buffer_host_visible(
+                &device, 16_384,
+            )
+            .expect("storage buffer allocate");
+        let buffer = crate::core::rhi::StorageBuffer::from_arc_into_raw(Arc::new(host_buffer));
+        let borrow = make_storage_buffer_borrow(buffer.handle);
+        assert_eq!(borrow.byte_size(), 16_384, "byte_size_cached must mirror the inner");
+        assert!(
+            !borrow.mapped_ptr().is_null(),
+            "mapped_ptr_cached must mirror the inner HOST_VISIBLE pointer"
+        );
+    }
+}

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -7325,17 +7325,42 @@ unsafe extern "C" fn host_compute_kernel_dispatch(
 // borrow is well-formed for any field-only read, even though no
 // vtable callback is supposed to fire while the borrow is alive.
 
+// Each `make_*_borrow` populates the cached POD fields on the
+// reconstructed β-shape from the host-side inner we hold via
+// `handle`. Cdylib β-shapes carry these cached for free-on-deref
+// POD getters (`width()`, `height()`, `mapped_ptr()`, etc.); when
+// the host reconstructs a borrow inside a vtable callback for code
+// that reads those getters host-side, the borrow's cached fields
+// MUST hold the real values — not zero. Reading zero from a "borrow"
+// of an otherwise-valid resource was the bug behind issue #988
+// (camera-as-cdylib color converter received width=0/height=0 in
+// push constants → kernel produced zero-filled output).
 #[cfg(target_os = "linux")]
 fn make_pixel_buffer_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::core::rhi::PixelBuffer> {
-    std::mem::ManuallyDrop::new(crate::core::rhi::PixelBuffer {
+    use crate::host_rhi::HostPixelBufferRefExt;
+    // Reconstruct a minimal Pixel-buffer borrow whose `buffer_ref()`
+    // can read the host-side `PixelBufferRef` we already hold via
+    // `handle`.
+    let pb_for_inner = std::mem::ManuallyDrop::new(crate::core::rhi::PixelBuffer {
         handle,
         vtable: host_gpu_context_limited_access_vtable(),
         width: 0,
         height: 0,
         format_raw: 0,
         plane_count_cached: 0,
+    });
+    let pb_ref = pb_for_inner.buffer_ref();
+    let hvb = pb_ref.vulkan_inner();
+    let format = pb_ref.format();
+    std::mem::ManuallyDrop::new(crate::core::rhi::PixelBuffer {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        width: pb_ref.width(),
+        height: pb_ref.height(),
+        format_raw: format as u32,
+        plane_count_cached: hvb.plane_count() as u32,
     })
 }
 
@@ -7343,11 +7368,18 @@ fn make_pixel_buffer_borrow(
 fn make_storage_buffer_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::core::rhi::StorageBuffer> {
-    std::mem::ManuallyDrop::new(crate::core::rhi::StorageBuffer {
+    let sb_for_inner = std::mem::ManuallyDrop::new(crate::core::rhi::StorageBuffer {
         handle,
         vtable: host_gpu_context_limited_access_vtable(),
         byte_size_cached: 0,
         mapped_ptr_cached: std::ptr::null_mut(),
+    });
+    let hvb = sb_for_inner.host_inner();
+    std::mem::ManuallyDrop::new(crate::core::rhi::StorageBuffer {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        byte_size_cached: hvb.size() as u64,
+        mapped_ptr_cached: hvb.mapped_ptr(),
     })
 }
 
@@ -7355,11 +7387,18 @@ fn make_storage_buffer_borrow(
 fn make_uniform_buffer_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::core::rhi::UniformBuffer> {
-    std::mem::ManuallyDrop::new(crate::core::rhi::UniformBuffer {
+    let ub_for_inner = std::mem::ManuallyDrop::new(crate::core::rhi::UniformBuffer {
         handle,
         vtable: host_gpu_context_limited_access_vtable(),
         byte_size_cached: 0,
         mapped_ptr_cached: std::ptr::null_mut(),
+    });
+    let hvb = ub_for_inner.host_inner();
+    std::mem::ManuallyDrop::new(crate::core::rhi::UniformBuffer {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        byte_size_cached: hvb.size() as u64,
+        mapped_ptr_cached: hvb.mapped_ptr(),
     })
 }
 
@@ -7367,12 +7406,36 @@ fn make_uniform_buffer_borrow(
 fn make_texture_borrow(
     handle: *const c_void,
 ) -> std::mem::ManuallyDrop<crate::core::rhi::Texture> {
-    std::mem::ManuallyDrop::new(crate::core::rhi::Texture {
+    // Populate the cached POD fields from the host-side TextureInner
+    // we already have via `handle`. Cdylib β-shapes carry these cached
+    // for free-on-deref POD getters (`Texture::width()`, etc.); when
+    // the host reconstructs a borrow inside a vtable callback for
+    // host-side code that reads `Texture::width()` / `height()`, the
+    // borrow's cached fields MUST hold the real values — not zero —
+    // because that's what those POD getters return. Reading zero from
+    // a "borrow" of an otherwise-valid texture caused the camera-as-
+    // cdylib color-converter push constants to encode width=0/height=0
+    // and the compute kernel produced zero-filled output (issue #988
+    // debug).
+    use crate::host_rhi::HostTextureExt;
+    let tex_for_inner = std::mem::ManuallyDrop::new(crate::core::rhi::Texture {
         handle,
         vtable: host_gpu_context_limited_access_vtable(),
         width_cached: 0,
         height_cached: 0,
         format_raw: 0,
+        _padding: 0,
+    });
+    let hvt = tex_for_inner.vulkan_inner();
+    let width = hvt.width();
+    let height = hvt.height();
+    let format = hvt.format();
+    std::mem::ManuallyDrop::new(crate::core::rhi::Texture {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        width_cached: width,
+        height_cached: height,
+        format_raw: format as u32,
         _padding: 0,
     })
 }

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer_binding.rs
@@ -43,11 +43,31 @@ pub trait VulkanBufferLike {
     /// #984). Default is `None`; only [`crate::core::rhi::StorageBuffer`]
     /// overrides today. The cdylib-side
     /// [`crate::vulkan::rhi::RhiCommandRecorder::record_buffer_barrier`]
-    /// / `record_copy_image_to_buffer` paths surface a typed
-    /// "unsupported buffer flavor" error when this returns `None`,
-    /// matching the slot coverage of
-    /// [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`].
+    /// / `record_copy_image_to_buffer` paths route to the
+    /// StorageBuffer-flavored vtable slot when this returns `Some`.
     fn cdylib_storage_buffer_handle(&self) -> Option<*const std::ffi::c_void> {
+        None
+    }
+
+    /// Cdylib-mode handle accessor for the [`PixelBuffer`] β-shape
+    /// (issue #988 sibling-slot extension of Phase E sub-lift slice
+    /// B). Returns the underlying
+    /// `Arc::into_raw(Arc<PixelBufferRef>)` pointer when this buffer
+    /// flavor is a [`PixelBuffer`]. The cdylib-side
+    /// `record_buffer_barrier` / `record_copy_image_to_buffer` paths
+    /// route to the PixelBuffer-flavored vtable slot
+    /// (`record_pixel_buffer_barrier`,
+    /// `record_copy_image_to_pixel_buffer`) when this returns `Some`.
+    ///
+    /// At most one of [`Self::cdylib_storage_buffer_handle`] /
+    /// [`Self::cdylib_pixel_buffer_handle`] returns `Some` for any
+    /// given implementor; the recorder's dispatch logic checks both
+    /// in order and errors with a typed "unsupported buffer flavor"
+    /// message when neither matches, matching the slot coverage of
+    /// [`streamlib_plugin_abi::RhiCommandRecorderMethodsVTable`].
+    ///
+    /// [`PixelBuffer`]: crate::core::rhi::PixelBuffer
+    fn cdylib_pixel_buffer_handle(&self) -> Option<*const std::ffi::c_void> {
         None
     }
 }
@@ -73,6 +93,10 @@ impl VulkanBufferLike for PixelBuffer {
         {
             0
         }
+    }
+
+    fn cdylib_pixel_buffer_handle(&self) -> Option<*const std::ffi::c_void> {
+        Some(self.handle)
     }
 }
 

--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_command_recorder.rs
@@ -872,12 +872,14 @@ impl RhiCommandRecorder {
     /// Buffer memory barrier covering the whole buffer.
     ///
     /// Mode-routed; see [`Self::begin`] for the dispatch contract.
-    /// **Cdylib path only supports
-    /// [`crate::core::rhi::StorageBuffer`]-flavored buffers today**
-    /// — the buffer must report a non-`None`
-    /// [`VulkanBufferLike::cdylib_storage_buffer_handle`] or the
+    /// **Cdylib path supports
+    /// [`crate::core::rhi::StorageBuffer`]- and
+    /// [`crate::core::rhi::PixelBuffer`]-flavored buffers today** —
+    /// the buffer must report a non-`None`
+    /// [`VulkanBufferLike::cdylib_storage_buffer_handle`] or
+    /// [`VulkanBufferLike::cdylib_pixel_buffer_handle`] or the
     /// dispatch returns a typed error. Future buffer flavors add
-    /// sibling vtable slots; the host path is unchanged.
+    /// further sibling vtable slots; the host path is unchanged.
     pub fn record_buffer_barrier(
         &mut self,
         buffer: &(impl VulkanBufferLike + ?Sized),
@@ -903,9 +905,10 @@ impl RhiCommandRecorder {
     /// Copy image → buffer. See [`RhiCommandRecorderInner::record_copy_image_to_buffer`].
     ///
     /// Mode-routed; see [`Self::begin`] for the dispatch contract.
-    /// **Cdylib path only supports
-    /// [`crate::core::rhi::StorageBuffer`]-flavored destinations
-    /// today** — the same buffer-flavor constraint as
+    /// **Cdylib path supports
+    /// [`crate::core::rhi::StorageBuffer`]- and
+    /// [`crate::core::rhi::PixelBuffer`]-flavored destinations
+    /// today** — same buffer-flavor coverage as
     /// [`Self::record_buffer_barrier`].
     pub fn record_copy_image_to_buffer(
         &mut self,
@@ -1086,28 +1089,48 @@ impl RhiCommandRecorder {
                     .into(),
             ));
         }
-        let Some(storage_handle) = buffer.cdylib_storage_buffer_handle() else {
+        let mut err_buf = [0u8; 256];
+        let mut err_len: usize = 0;
+        let status = if let Some(storage_handle) =
+            buffer.cdylib_storage_buffer_handle()
+        {
+            unsafe {
+                ((*self.methods_vtable).record_buffer_barrier)(
+                    self.handle,
+                    storage_handle,
+                    from_stage.0 as i64,
+                    to_stage.0 as i64,
+                    from_access.0 as i64,
+                    to_access.0 as i64,
+                    err_buf.as_mut_ptr(),
+                    err_buf.len(),
+                    &mut err_len as *mut usize,
+                )
+            }
+        } else if let Some(pixel_handle) =
+            buffer.cdylib_pixel_buffer_handle()
+        {
+            unsafe {
+                ((*self.methods_vtable).record_pixel_buffer_barrier)(
+                    self.handle,
+                    pixel_handle,
+                    from_stage.0 as i64,
+                    to_stage.0 as i64,
+                    from_access.0 as i64,
+                    to_access.0 as i64,
+                    err_buf.as_mut_ptr(),
+                    err_buf.len(),
+                    &mut err_len as *mut usize,
+                )
+            }
+        } else {
             return Err(Error::GpuError(
-                "record_buffer_barrier: cdylib path only supports StorageBuffer-flavored \
-                 buffers today (extend the methods vtable with a sibling slot for other \
+                "record_buffer_barrier: cdylib path only supports \
+                 StorageBuffer- or PixelBuffer-flavored buffers today \
+                 (extend the methods vtable with a sibling slot for other \
                  flavors)"
                     .into(),
             ));
-        };
-        let mut err_buf = [0u8; 256];
-        let mut err_len: usize = 0;
-        let status = unsafe {
-            ((*self.methods_vtable).record_buffer_barrier)(
-                self.handle,
-                storage_handle,
-                from_stage.0 as i64,
-                to_stage.0 as i64,
-                from_access.0 as i64,
-                to_access.0 as i64,
-                err_buf.as_mut_ptr(),
-                err_buf.len(),
-                &mut err_len as *mut usize,
-            )
         };
         if status == 0 {
             Ok(())
@@ -1166,14 +1189,6 @@ impl RhiCommandRecorder {
                     .into(),
             ));
         }
-        let Some(dst_storage_handle) = dst.cdylib_storage_buffer_handle() else {
-            return Err(Error::GpuError(
-                "record_copy_image_to_buffer: cdylib path only supports \
-                 StorageBuffer-flavored destinations today (extend the methods vtable \
-                 with a sibling slot for other flavors)"
-                    .into(),
-            ));
-        };
         let region_repr = streamlib_plugin_abi::ImageCopyRegionRepr {
             width: region.width,
             height: region.height,
@@ -1186,17 +1201,44 @@ impl RhiCommandRecorder {
         };
         let mut err_buf = [0u8; 256];
         let mut err_len: usize = 0;
-        let status = unsafe {
-            ((*self.methods_vtable).record_copy_image_to_buffer)(
-                self.handle,
-                src.handle,
-                src_layout.0,
-                dst_storage_handle,
-                &region_repr,
-                err_buf.as_mut_ptr(),
-                err_buf.len(),
-                &mut err_len as *mut usize,
-            )
+        let status = if let Some(dst_storage_handle) =
+            dst.cdylib_storage_buffer_handle()
+        {
+            unsafe {
+                ((*self.methods_vtable).record_copy_image_to_buffer)(
+                    self.handle,
+                    src.handle,
+                    src_layout.0,
+                    dst_storage_handle,
+                    &region_repr,
+                    err_buf.as_mut_ptr(),
+                    err_buf.len(),
+                    &mut err_len as *mut usize,
+                )
+            }
+        } else if let Some(dst_pixel_handle) =
+            dst.cdylib_pixel_buffer_handle()
+        {
+            unsafe {
+                ((*self.methods_vtable).record_copy_image_to_pixel_buffer)(
+                    self.handle,
+                    src.handle,
+                    src_layout.0,
+                    dst_pixel_handle,
+                    &region_repr,
+                    err_buf.as_mut_ptr(),
+                    err_buf.len(),
+                    &mut err_len as *mut usize,
+                )
+            }
+        } else {
+            return Err(Error::GpuError(
+                "record_copy_image_to_buffer: cdylib path only supports \
+                 StorageBuffer- or PixelBuffer-flavored destinations today \
+                 (extend the methods vtable with a sibling slot for other \
+                 flavors)"
+                    .into(),
+            ));
         };
         if status == 0 {
             Ok(())

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -4624,7 +4624,11 @@ mod layout_tests {
         assert_eq!(VULKAN_RAY_TRACING_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_ACCELERATION_STRUCTURE_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 1);
+        // v2: appended PixelBuffer-flavored sibling slots
+        // (`record_pixel_buffer_barrier`,
+        // `record_copy_image_to_pixel_buffer`) for cdylib camera
+        // per-frame copy into pooled `PixelBuffer` destinations.
+        assert_eq!(RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION, 2);
     }
 
     #[test]

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -401,7 +401,18 @@ pub const RHI_COLOR_CONVERTER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
 ///   `submit_signaling_timeline`. Without these the β-shape's
 ///   `host_inner()` / `host_inner_mut()` panic-guards fire from
 ///   cdylib code on every per-frame call.
-pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 1;
+/// - v2: appends two PixelBuffer-flavored sibling slots —
+///   `record_pixel_buffer_barrier` and
+///   `record_copy_image_to_pixel_buffer` — so cdylibs can barrier
+///   and copy-image-to into a `PixelBuffer` destination. The v1
+///   StorageBuffer-flavored slots are unchanged; the new slots
+///   are appended at the end of the struct. This is the
+///   "sibling-slot per buffer flavor" pattern documented on
+///   `RhiCommandRecorderMethodsVTable` and already used by
+///   `VulkanGraphicsKernelMethodsVTable`'s
+///   `set_storage_buffer_pixel` / `set_storage_buffer_storage`
+///   pair.
+pub const RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION: u32 = 2;
 
 // =============================================================================
 // Primitive enums
@@ -3329,12 +3340,16 @@ unsafe impl Sync for RhiColorConverterMethodsVTable {}
 /// don't sit on the camera hot path and a follow-up slice lifts
 /// them when a consumer arrives.
 ///
-/// **Buffer-flavor coverage today:** `record_buffer_barrier` and
-/// `record_copy_image_to_buffer` accept a `StorageBuffer`-shaped
-/// handle. Today's camera per-frame call site copies into a
-/// `StorageBuffer`; future consumers needing uniform / vertex /
-/// index buffer barriers add sibling slots rather than discriminating
-/// on these.
+/// **Buffer-flavor coverage today:** the v1 `record_buffer_barrier`
+/// and `record_copy_image_to_buffer` slots accept a
+/// `StorageBuffer`-shaped handle. v2 added `record_pixel_buffer_barrier`
+/// and `record_copy_image_to_pixel_buffer` sibling slots — the
+/// camera's per-frame path copies the compute output into a pooled
+/// `PixelBuffer` and barriers it through `HOST_READ`. Future
+/// consumers needing uniform / vertex / index buffer barriers add
+/// further sibling slots rather than discriminating on these (same
+/// pattern as `VulkanGraphicsKernelMethodsVTable`'s
+/// `set_storage_buffer_pixel` / `set_storage_buffer_storage`).
 #[repr(C)]
 pub struct RhiCommandRecorderMethodsVTable {
     /// Vtable layout version. Must equal
@@ -3455,6 +3470,53 @@ pub struct RhiCommandRecorderMethodsVTable {
         recorder_handle: *const c_void,
         timeline_handle: *const c_void,
         signal_value: u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// v2 sibling of `record_buffer_barrier` for `PixelBuffer`-shaped
+    /// destinations. The camera's per-frame path uses this after the
+    /// `vkCmdCopyImageToBuffer` to barrier the pooled pixel buffer
+    /// from `TRANSFER_WRITE` to `HOST_READ` so the IPC consumer can
+    /// map it.
+    ///
+    /// - `pixel_buffer_handle` is
+    ///   `Arc::into_raw(Arc<PixelBufferRef>)`-shaped from the
+    ///   `PixelBuffer` β-shape's `handle` field (borrowed).
+    pub record_pixel_buffer_barrier: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        pixel_buffer_handle: *const c_void,
+        from_stage_raw: i64,
+        to_stage_raw: i64,
+        from_access_raw: i64,
+        to_access_raw: i64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// v2 sibling of `record_copy_image_to_buffer` for
+    /// `PixelBuffer`-shaped destinations. The camera's per-frame
+    /// path copies the compute output (a host-allocated
+    /// `Texture` ring slot) into a pooled `PixelBuffer` for
+    /// cross-process IPC.
+    ///
+    /// - `src_texture_handle` is
+    ///   `Arc::into_raw(Arc<TextureInner>)`-shaped from the source
+    ///   `Texture` β-shape's `handle` field (borrowed).
+    /// - `dst_pixel_buffer_handle` is
+    ///   `Arc::into_raw(Arc<PixelBufferRef>)`-shaped from the
+    ///   destination `PixelBuffer` β-shape's `handle` field
+    ///   (borrowed).
+    /// - `region` points at an [`ImageCopyRegionRepr`] the host
+    ///   reads once at call time.
+    pub record_copy_image_to_pixel_buffer: unsafe extern "C" fn(
+        recorder_handle: *const c_void,
+        src_texture_handle: *const c_void,
+        src_layout_raw: i32,
+        dst_pixel_buffer_handle: *const c_void,
+        region: *const ImageCopyRegionRepr,
         err_buf: *mut u8,
         err_buf_cap: usize,
         err_len: *mut usize,
@@ -5018,17 +5080,19 @@ mod layout_tests {
 
     #[test]
     fn rhi_command_recorder_methods_vtable_layout() {
-        // v1:
-        //   layout_version                @ 0   (4 bytes, u32)
-        //   _reserved_padding             @ 4   (4 bytes, u32)
-        //   begin                         @ 8   (8 bytes, fn pointer)
-        //   record_image_barrier          @ 16  (8 bytes, fn pointer)
-        //   record_buffer_barrier         @ 24  (8 bytes, fn pointer)
-        //   record_dispatch               @ 32  (8 bytes, fn pointer)
-        //   record_copy_image_to_buffer   @ 40  (8 bytes, fn pointer)
-        //   submit_signaling_timeline     @ 48  (8 bytes, fn pointer)
-        // Total = 56 bytes, align = 8.
-        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 56);
+        // v2 (v1 unchanged through @48, sibling slots appended):
+        //   layout_version                       @ 0   (4 bytes, u32)
+        //   _reserved_padding                    @ 4   (4 bytes, u32)
+        //   begin                                @ 8   (8 bytes, fn pointer)
+        //   record_image_barrier                 @ 16  (8 bytes, fn pointer)
+        //   record_buffer_barrier                @ 24  (8 bytes, fn pointer)
+        //   record_dispatch                      @ 32  (8 bytes, fn pointer)
+        //   record_copy_image_to_buffer          @ 40  (8 bytes, fn pointer)
+        //   submit_signaling_timeline            @ 48  (8 bytes, fn pointer)
+        //   record_pixel_buffer_barrier          @ 56  (8 bytes, fn pointer, v2)
+        //   record_copy_image_to_pixel_buffer    @ 64  (8 bytes, fn pointer, v2)
+        // Total = 72 bytes, align = 8.
+        assert_eq!(size_of::<RhiCommandRecorderMethodsVTable>(), 72);
         assert_eq!(align_of::<RhiCommandRecorderMethodsVTable>(), 8);
         assert_eq!(
             offset_of!(RhiCommandRecorderMethodsVTable, layout_version),
@@ -5067,6 +5131,20 @@ mod layout_tests {
                 submit_signaling_timeline
             ),
             48
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                record_pixel_buffer_barrier
+            ),
+            56
+        );
+        assert_eq!(
+            offset_of!(
+                RhiCommandRecorderMethodsVTable,
+                record_copy_image_to_pixel_buffer
+            ),
+            64
         );
     }
 


### PR DESCRIPTION
Closes #988.

## Summary

Phase E sub-lift extension that closes the goal-03 manual gate: extends
`RhiCommandRecorderMethodsVTable` v1 → v2 with two PixelBuffer-flavored
sibling slots so cdylibs can barrier and `vkCmdCopyImageToBuffer` into a
`PixelBuffer` destination, AND fixes a critical engine-tier bug surfaced
by running the gate (cdylib pipeline produced black frames).

Three commits, layered:

### 1. Sibling-slot lift (`d0085fcd`)

- `RHI_COMMAND_RECORDER_METHODS_VTABLE_LAYOUT_VERSION` 1 → 2
- Two new fn-pointer slots appended at end of struct (v1 layout
  unchanged on the wire):
  - `record_pixel_buffer_barrier` — sibling of `record_buffer_barrier`
  - `record_copy_image_to_pixel_buffer` — sibling of `record_copy_image_to_buffer`
- `VulkanBufferLike::cdylib_pixel_buffer_handle()` accessor, overridden
  on `PixelBuffer` to return `Some(self.handle)`.
- Dispatch helpers in `vulkan_command_recorder.rs` route on flavor
  (StorageBuffer slot, then PixelBuffer slot, then typed
  "unsupported flavor" error). Host-mode path unchanged.
- Two new host wrappers using the existing `make_pixel_buffer_borrow`.
- Layout regression test: size 56 → 72 bytes, version 1 → 2,
  new fields at offsets 56 and 64.
- Tier-1 null-handle tests for both new wrappers, matching the v1
  pattern from PR #985.

### 2. Cached-fields-from-inner bug fix (`21c89547`)

Manual gate after commit 1 ran end-to-end with 0 errors but produced
all-black PNGs. Root cause: `make_*_borrow` helpers in
`host_services.rs` constructed `ManuallyDrop'd` β-shape borrows with
the cached POD fields zeroed (`width_cached: 0`, `byte_size_cached:
0`, `mapped_ptr_cached: null`, etc.). Cdylib β-shapes carry these
cached for free-on-deref POD getters; when host-side code reads
`texture.width()` / `.height()` / `.byte_size()` on a borrow, it
gets ZERO instead of the real value.

Concretely, `color_converter::finish_buffer_to_image` reads
`dst.width()` / `.height()` to stuff into `ColorConverterPushConstants`.
With width=0/height=0 in push constants, the compute shader ran on a
0x0 texture region and the subsequent copy moved 1920×1080 of
zero-initialized memory into the pixel buffer.

Empirical evidence (push-constant dump during investigation):

```
CDYLIB  push_const_u32s[16..18] = [0, 0]      ← width=0, height=0
BASELINE push_const_u32s[16..18] = [1920, 1080]
```

Fix: each `make_*_borrow` now reconstructs a minimal borrow first,
uses `host_inner()` / `vulkan_inner()` / `buffer_ref()` to reach the
real host-side resource, then builds the final borrow with cached
fields populated from the real values. Restores parity with
`from_arc_into_raw`.

Sibling fixes applied across all 4 critical helpers (texture,
pixel_buffer, storage_buffer, uniform_buffer) — same bug class, same
shape, defensive sweep to prevent the next consumer rediscovering it.

### 3. Version-pin bump + regression tests (`3292ae72`)

Two follow-ups from pr-review-gate:

- `host_services_layout_versions_pinned` was still asserting
  `LAYOUT_VERSION == 1`; bumped to 2 with a one-line v2 annotation.
- Added `make_borrow_cached_field_regression_tests` — focused
  host-mode tests that allocate real textures + storage buffers,
  construct a `make_*_borrow`, and assert the borrow's cached
  getters return the real values. Fails if `make_*_borrow` ever
  goes back to zeroing the fields. Uses `try_vulkan_device()` to
  skip cleanly on hosts without a Vulkan device per
  `project_ci_strategy_no_gpu`.

## Test plan

- [x] `cargo test -p streamlib-plugin-abi --lib` — all 50 tests pass
      (layout regression bumped to size 72 / version 2,
      `host_services_layout_versions_pinned` updated).
- [x] `cargo test -p streamlib-engine --lib gpu_rhi_command_recorder_methods_vtable_null_tests`
      — all 8 null-handle tests pass (including the 2 new
      PixelBuffer-flavored ones).
- [x] `cargo test -p streamlib-engine --lib make_borrow_cached_field_regression_tests`
      — both new regression tests pass.
- [x] **Manual gate** (`vulkan-video-roundtrip-cdylib-camera` against
      vivid at `/dev/video0`):

```
### E2E Test Report

- Scenario: encoder/decoder (cdylib-loaded camera)
- Example: `vulkan-video-roundtrip-cdylib-camera`
- Codec: h264
- Camera device: `/dev/video0` (vivid)
- Resolution: 1920×1080
- Duration / frame limit: STREAMLIB_DISPLAY_FRAME_LIMIT=150, 10s
- Build profile: debug
- Log signals:
  - OUT_OF_DEVICE_MEMORY: 0
  - DEVICE_LOST: 0
  - process() failed: 0
  - Validation Error: pre-existing TRANSFER_SRC VUIDs (same as
    baseline non-cdylib variant; documented as unrelated)
  - First frame captured / encoded / decoded: all present
  - frames_encoded / frames_decoded: 50 / 50
- PNG samples: directory `/tmp/cdylib-final-1779595482/png_samples/`,
  2 samples (frame 0, frame 30 — every 30 displayed frames).
- PNGs read with Read tool: `display_001_frame_000030_input_000032.png`.
  - **What was in the image**: vivid SMPTE-style color bars
    (gray / yellow / cyan / green / magenta / red / blue / black)
    with timecode overlay `00:00:06:404 32` and V4L2 metadata
    block (`1920x1080 input 0`, brightness/contrast/saturation/hue
    knobs, etc.). Matches the baseline non-cdylib variant's
    output exactly.
  - Anomalies: none.
- PSNR: n/a — real V4L2 source (vivid synthetic pattern), no
  ground-truth reference frame against the cdylib variant.
- Outcome: **Pass**.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
