### PR TITLE
feat(examples): commit cdylib-camera manual gate harness + lock all 4 make_*_borrow helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,6 +636,14 @@ make sense if the surrounding files were renamed or restructured.
   buffers, publish drops) without `init()`. Read before writing any test
   that uses PUBSUB events (shutdown, reconfigure) outside a full
   `StreamRuntime`.
+- @docs/learnings/cdylib-make-borrow-cached-fields.md — Cdylib
+  pipeline runs end-to-end with zero errors / zero panics / zero
+  validation complaints but produces all-zero / black output. Trigger:
+  a host-side `make_*_borrow` helper constructed a `ManuallyDrop`'d
+  β-shape borrow with the cached POD fields zeroed; host-side code
+  then read a cached field off the borrow (`.width()` / `.byte_size()`
+  / etc.) and got zero. Read before adding a new host wrapper that
+  reconstructs a borrowed β-shape from a `*const c_void` handle.
 - @docs/learnings/cross-process-vkimage-layout.md — Cross-process
   `VkImage` layout coordination. `VkImageLayout` is independent state
   per `VkDevice` by Vulkan spec — no shared mutable tracker. The

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "examples/camera-rust-plugin/plugin", # Grayscale plugin cdylib for camera-rust-plugin example
     "examples/raytracing-showcase",       # Example: VulkanRayTracingKernel rotating-cube showcase (#610)
     "examples/vulkan-video-roundtrip",    # Example: Vulkan Video encode roundtrip (BgraFileSource → Encoder → MP4Writer)
+    "examples/vulkan-video-roundtrip-cdylib-camera",  # Example: same pipeline but camera loaded via runtime.load_project (cdylib)
     "examples/vulkan-video-psnr",         # Example: fixture-driven encode/decode PSNR rig (#305)
     "examples/jpeg-psnr",                 # Example: fixture-driven JPEG decode PSNR rig
     "tests/iceoryx2-cross-language",      # Test: Cross-language iceoryx2 validation (Rust ↔ Python)

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -62,6 +62,10 @@ Avoid the two failure modes:
   Cryptic `Cast` trait error when passing `&[]` to vulkanalia Vulkan methods
 - [@docs/learnings/pubsub-lazy-init-silent-noop.md](pubsub-lazy-init-silent-noop.md) —
   Test hangs indefinitely because PUBSUB silently no-ops without `init()`
+- [@docs/learnings/cdylib-make-borrow-cached-fields.md](cdylib-make-borrow-cached-fields.md) —
+  Cdylib pipeline runs end-to-end clean but produces zero/black output
+  when host-side `make_*_borrow` helpers leave the β-shape's cached
+  POD fields zeroed instead of mirroring the inner
 - [@docs/learnings/nvidia-dual-vulkan-device-crash.md](nvidia-dual-vulkan-device-crash.md) —
   SIGSEGV when two Vulkan devices have concurrent GPU work on NVIDIA Linux
 - [@docs/learnings/cross-process-vkimage-layout.md](cross-process-vkimage-layout.md) —

--- a/docs/learnings/cdylib-make-borrow-cached-fields.md
+++ b/docs/learnings/cdylib-make-borrow-cached-fields.md
@@ -1,0 +1,141 @@
+# Cdylib β-shape `make_*_borrow` MUST populate cached POD fields
+
+## Symptom
+
+A cdylib (Rust plugin loaded via `runtime.load_project(...)`) runs
+end-to-end with **zero errors, zero panics, zero validation layer
+complaints** — and produces **all-zero output**. Examples:
+
+- Camera-as-cdylib pipeline runs 60 frames clean, encoder + decoder
+  report 60 frames each, display surfaces 2 PNG samples — every
+  sample is fully black.
+- A compute kernel reports successful dispatch but downstream
+  consumers see a buffer of zeros where pixel data is expected.
+
+The pipeline LOGS look healthy. The PNG output is the only thing
+that surfaces the bug.
+
+## Trigger condition
+
+You added a new cdylib-callable code path that hands a host-side
+β-shape resource (`Texture`, `PixelBuffer`, `StorageBuffer`,
+`UniformBuffer`) back through a vtable callback. The host wrapper
+constructs a borrowed β-shape via one of the
+`make_*_borrow(handle: *const c_void)` helpers in
+`libs/streamlib-engine/src/core/plugin/host_services.rs` and passes
+that borrow to host-side code (e.g. a recorder method, a kernel
+binding method) that internally calls a POD getter like
+`.width()` / `.height()` / `.byte_size()` / `.mapped_ptr()` on the
+borrow.
+
+## Root cause
+
+The cdylib β-shape carries cached POD fields (`width_cached`,
+`height_cached`, `format_raw`, `byte_size_cached`,
+`mapped_ptr_cached`, `plane_count_cached`, ...) so the cdylib's
+public POD getters resolve as pure field reads with no FFI hop. The
+fields are populated at construction time via `from_arc_into_raw`
+from the underlying inner.
+
+A `make_*_borrow` helper reconstructs a `ManuallyDrop<β-shape>`
+that wraps the SAME inner via `handle`. The deref still works for
+methods that route through `host_inner()` / `buffer_ref()` /
+`vulkan_inner()` — but the **cached POD fields are zero-initialized
+on the borrow**. Any host-side code path that reads those fields
+off the borrow gets `width == 0` instead of `width == 1920`.
+
+## Where this bit streamlib
+
+`color_converter::finish_buffer_to_image` reads
+`dst.width()` / `dst.height()` to stuff width/height into
+`ColorConverterPushConstants`. In cdylib mode, the dst Texture
+borrow had `width_cached = 0`, push constants encoded 0×0
+dimensions, the compute shader ran on a 0×0 texture region and
+wrote nothing visible. The subsequent `vkCmdCopyImageToBuffer`
+copied 1920×1080 of zero-initialized device-local memory into the
+HOST_VISIBLE pixel buffer the camera publishes for IPC. Encoder
+encoded all-zero frames. Decoder decoded all-zero frames. Display
+showed black.
+
+Empirical evidence (push-constant dump during investigation):
+
+```
+CDYLIB    push_const_u32s[16..18] = [0, 0]      ← width=0, height=0
+BASELINE  push_const_u32s[16..18] = [1920, 1080]
+```
+
+## Fix
+
+Each `make_*_borrow` must populate the cached POD fields from the
+host-side inner via the engine-internal accessor for that resource
+type. The pattern is:
+
+```rust
+fn make_texture_borrow(handle: *const c_void) -> ManuallyDrop<Texture> {
+    // 1. Construct a minimal borrow first — just enough to deref
+    //    through `host_inner()` / `vulkan_inner()` / `buffer_ref()`.
+    use crate::host_rhi::HostTextureExt;
+    let tex_for_inner = ManuallyDrop::new(Texture {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        width_cached: 0,
+        height_cached: 0,
+        format_raw: 0,
+        _padding: 0,
+    });
+    // 2. Read the real values off the inner.
+    let hvt = tex_for_inner.vulkan_inner();
+    let width = hvt.width();
+    let height = hvt.height();
+    let format = hvt.format();
+    // 3. Construct the final borrow with cached fields populated.
+    ManuallyDrop::new(Texture {
+        handle,
+        vtable: host_gpu_context_limited_access_vtable(),
+        width_cached: width,
+        height_cached: height,
+        format_raw: format as u32,
+        _padding: 0,
+    })
+}
+```
+
+The two-step dance is intentional: `host_inner()` (and siblings)
+only deref `self.handle` and ignore the cached fields, so the
+intermediate "minimal" borrow is sufficient to reach the inner. The
+second borrow is what the caller receives.
+
+## Detection
+
+The bug fails silently in CDYLIB mode and passes in BASELINE mode
+(direct Rust-dep version of the same processor). When you see the
+trigger pattern "cdylib pipeline clean / output zeros", first
+verify: does any host-side code read a cached POD field off a
+borrow returned by `make_*_borrow`? If yes, this is your bug.
+
+A focused regression test that allocates a real resource of known
+dimensions, constructs a `make_*_borrow(handle)`, and asserts the
+borrow's POD getters return the real values catches the bug at the
+data-structure level. See
+`make_borrow_cached_field_regression_tests` in
+`libs/streamlib-engine/src/core/plugin/host_services.rs`.
+
+## Why the panic-guards on `host_inner()` don't catch this
+
+`host_inner()` panics from cdylib code (per the panic-guard in
+`Texture::host_inner` and siblings). But the panic only fires when
+called FROM cdylib code; inside a host-mode vtable callback,
+`host_callbacks().is_some()` returns `false` and the deref proceeds
+normally. The borrow goes through fine — it just resolves to zero
+on the cached-field reads, with no error path firing.
+
+## Reference
+
+- Borrow helpers + the canonical fix pattern: `make_*_borrow` in
+  `libs/streamlib-engine/src/core/plugin/host_services.rs`.
+- Regression tests: `make_borrow_cached_field_regression_tests` in
+  the same file. Covers all four borrow helpers (texture,
+  pixel_buffer, storage_buffer, uniform_buffer).
+- The cdylib β-shape's `from_arc_into_raw` constructors populate
+  cached fields at construction — the borrow helpers must mirror
+  that contract.

--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vulkan-video-roundtrip-cdylib-camera"
+version = "0.1.0"
+edition = "2024"
+
+# Deliberately NOT taking streamlib-camera as a Rust dep. The camera
+# is loaded at runtime via `Runner::load_project(...)` against a
+# staged copy of `packages/camera/` (built with --features plugin).
+# Linking streamlib-camera as a Rust dep would auto-register the
+# `Camera` processor at link time, conflicting with the cdylib's
+# registration at load time.
+[dependencies]
+streamlib = { path = "../../libs/streamlib-sdk" }
+streamlib-display = { path = "../../packages/display" }
+streamlib-h264 = { path = "../../packages/h264" }
+streamlib-h265 = { path = "../../packages/h265" }
+tempfile = "3.14"
+serde_json = "1"

--- a/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Vulkan Video Encode/Decode Roundtrip Pipeline — camera-as-cdylib variant.
+//!
+//! Sibling of `examples/vulkan-video-roundtrip` that loads the
+//! `@tatolab/camera` processor via `runtime.load_project(...)` (the
+//! cdylib plugin path) instead of taking `streamlib-camera` as a
+//! Rust dep. Exists to exercise the v12 + v13 + Phase E Slice A
+//! (`RhiColorConverterMethodsVTable`) + Phase E Slice B
+//! (`RhiCommandRecorderMethodsVTable`) cdylib dispatch end-to-end
+//! through the encode → decode → display pipeline.
+//!
+//!   CameraProcessor (cdylib) → Encoder → Decoder → Display
+//!
+//! Usage:
+//!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h264 [device] [seconds]
+//!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h265 /dev/video0 10
+
+use std::path::{Path, PathBuf};
+
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::graph::{OutputLinkPortRef, ProcessorUniqueId};
+use streamlib::sdk::processors::{input, output, ProcessorSpec};
+use streamlib::sdk::runtime::{host_target_triple, Runner};
+use streamlib::sdk::schema_ident;
+use streamlib_display::DisplayProcessor;
+use streamlib_h264::{H264DecoderProcessor, H264EncoderProcessor};
+use streamlib_h265::{H265DecoderProcessor, H265EncoderProcessor};
+
+fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry)?;
+        } else {
+            std::fs::copy(entry.path(), &dst_entry)?;
+        }
+    }
+    Ok(())
+}
+
+fn stage_camera_project(workspace_root: &Path) -> Result<PathBuf> {
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_camera.{dylib_ext}");
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+    if !built_dylib.exists() {
+        return Err(Error::Configuration(format!(
+            "camera cdylib not at {} — run \
+             `cargo build -p streamlib-camera --features plugin` first",
+            built_dylib.display()
+        )));
+    }
+
+    let tmp = tempfile::tempdir()
+        .map_err(|e| Error::Configuration(format!("tempdir: {e}")))?;
+    let staged_root = tmp.keep();
+
+    let camera_src = workspace_root.join("packages/camera");
+    let core_src = workspace_root.join("packages/core");
+    let camera_dst = staged_root.join("packages/camera");
+    let core_dst = staged_root.join("packages/core");
+
+    std::fs::create_dir_all(&camera_dst)
+        .map_err(|e| Error::Configuration(format!("mkdir camera dst: {e}")))?;
+    std::fs::copy(
+        camera_src.join("streamlib.yaml"),
+        camera_dst.join("streamlib.yaml"),
+    )
+    .map_err(|e| Error::Configuration(format!("copy camera streamlib.yaml: {e}")))?;
+    copy_dir_contents(&camera_src.join("schemas"), &camera_dst.join("schemas"))
+        .map_err(|e| Error::Configuration(format!("copy camera schemas: {e}")))?;
+
+    std::fs::create_dir_all(&core_dst)
+        .map_err(|e| Error::Configuration(format!("mkdir core dst: {e}")))?;
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .map_err(|e| Error::Configuration(format!("copy core streamlib.yaml: {e}")))?;
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"))
+        .map_err(|e| Error::Configuration(format!("copy core schemas: {e}")))?;
+
+    let triple_dir = camera_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir)
+        .map_err(|e| Error::Configuration(format!("mkdir triple dir: {e}")))?;
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name))
+        .map_err(|e| Error::Configuration(format!("copy camera cdylib: {e}")))?;
+
+    Ok(camera_dst)
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let codec = args.get(1).map(|s| s.as_str()).unwrap_or("h264");
+    let device = args.get(2).map(|s| s.as_str()).unwrap_or("/dev/video0");
+    let duration_secs: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(30);
+    let is_h265 = codec == "h265";
+
+    println!(
+        "=== Vulkan Video {} Roundtrip (cdylib camera) ===",
+        codec.to_uppercase()
+    );
+    println!("Camera:   {device} (loaded as cdylib via runtime.load_project)");
+    println!("Duration: {duration_secs}s\n");
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| {
+            Error::Configuration("CARGO_MANIFEST_DIR has no two parents".into())
+        })?;
+
+    let runtime = Runner::new()?;
+
+    // 1) Stage @tatolab/camera as a project with its cdylib placed
+    //    under `lib/<target-triple>/`, then load it.
+    let camera_project = stage_camera_project(workspace_root)?;
+    println!("+ Camera staged at: {}", camera_project.display());
+    runtime.load_project(&camera_project)?;
+    println!("+ Camera project loaded (cdylib path)");
+
+    // 2) Also load the example's own streamlib.yaml so the
+    //    `@tatolab/core` wire vocabulary is registered (the
+    //    vulkan-video-roundtrip baseline does this too — see its
+    //    comment on the EncodedVideoFrame max-payload-bytes hookup).
+    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+    println!("+ Wire vocabulary registered\n");
+
+    // 3) Camera processor — minted from the cdylib's registration,
+    //    addressed by its structured schema_ident, configured via
+    //    JSON payload (matches camera_config.yaml).
+    let camera_ident = schema_ident!("tatolab", "camera", "Camera", "1.0.0");
+    let camera_config = serde_json::json!({
+        "device_id": device,
+        "max_width": std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(1920),
+        "max_height": std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(1080),
+    });
+    let camera = runtime.add_processor(ProcessorSpec::new(camera_ident, camera_config))?;
+    println!("+ Camera (cdylib): {camera}");
+
+    // 4) Encoder / decoder / display — typed Rust deps as in the
+    //    baseline vulkan-video-roundtrip.
+    let effort_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_EFFORT_LEVEL")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    let encoder = if is_h265 {
+        runtime.add_processor(H265EncoderProcessor::node(
+            H265EncoderProcessor::Config {
+                effort_level,
+                ..Default::default()
+            },
+        ))?
+    } else {
+        runtime.add_processor(H264EncoderProcessor::node(
+            H264EncoderProcessor::Config {
+                effort_level,
+                ..Default::default()
+            },
+        ))?
+    };
+    println!("+ {}Encoder: {encoder}", codec.to_uppercase());
+
+    let decoder = if is_h265 {
+        runtime.add_processor(H265DecoderProcessor::node(
+            H265DecoderProcessor::Config::default(),
+        ))?
+    } else {
+        runtime.add_processor(H264DecoderProcessor::node(
+            H264DecoderProcessor::Config::default(),
+        ))?
+    };
+    println!("+ {}Decoder: {decoder}", codec.to_uppercase());
+
+    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
+        width: 1920,
+        height: 1080,
+        title: Some(format!("streamlib {} Roundtrip (cdylib camera)", codec.to_uppercase())),
+        ..Default::default()
+    }))?;
+    println!("+ Display: {display}");
+
+    // 5) Wire — the camera output uses the runtime-typed
+    //    `OutputLinkPortRef::new(camera_id, "video")` form since the
+    //    cdylib-loaded camera has no compile-time-typed
+    //    `CameraProcessor::OutputLink::video` symbol in this crate.
+    if is_h265 {
+        runtime.connect(
+            OutputLinkPortRef::new(&camera, "video"),
+            input::<H265EncoderProcessor::InputLink::video_in>(&encoder),
+        )?;
+        runtime.connect(
+            output_typed_h265_encoder(&encoder),
+            input::<H265DecoderProcessor::InputLink::encoded_video_in>(&decoder),
+        )?;
+        runtime.connect(
+            output_typed_h265_decoder(&decoder),
+            input::<DisplayProcessor::InputLink::video>(&display),
+        )?;
+    } else {
+        runtime.connect(
+            OutputLinkPortRef::new(&camera, "video"),
+            input::<H264EncoderProcessor::InputLink::video_in>(&encoder),
+        )?;
+        runtime.connect(
+            output_typed_h264_encoder(&encoder),
+            input::<H264DecoderProcessor::InputLink::encoded_video_in>(&decoder),
+        )?;
+        runtime.connect(
+            output_typed_h264_decoder(&decoder),
+            input::<DisplayProcessor::InputLink::video>(&display),
+        )?;
+    }
+    println!("\nPipeline: camera(cdylib) -> encoder -> decoder -> display");
+
+    println!("Starting pipeline for {duration_secs}s...\n");
+    runtime.start()?;
+
+    std::thread::sleep(std::time::Duration::from_secs(duration_secs as u64));
+
+    println!("\nStopping pipeline...");
+    runtime.stop()?;
+
+    Ok(())
+}
+
+// Small typed-output helpers so the main flow reads symmetrically
+// with the runtime-typed camera output.
+
+fn output_typed_h264_encoder(
+    encoder: &ProcessorUniqueId,
+) -> impl Into<OutputLinkPortRef> {
+    output::<H264EncoderProcessor::OutputLink::encoded_video_out>(
+        encoder,
+    )
+}
+
+fn output_typed_h264_decoder(
+    decoder: &ProcessorUniqueId,
+) -> impl Into<OutputLinkPortRef> {
+    output::<H264DecoderProcessor::OutputLink::video_out>(decoder)
+}
+
+fn output_typed_h265_encoder(
+    encoder: &ProcessorUniqueId,
+) -> impl Into<OutputLinkPortRef> {
+    output::<H265EncoderProcessor::OutputLink::encoded_video_out>(
+        encoder,
+    )
+}
+
+fn output_typed_h265_decoder(
+    decoder: &ProcessorUniqueId,
+) -> impl Into<OutputLinkPortRef> {
+    output::<H265DecoderProcessor::OutputLink::video_out>(decoder)
+}

--- a/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/streamlib.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# vulkan-video-roundtrip example. Declares `@tatolab/core` so
+# `Runner::load_project(.)` registers the wire-vocabulary schemas
+# (VideoFrame, EncodedVideoFrame, …) with the engine's runtime schema
+# registry. Without that, iceoryx2 publishers size to the 64 KiB default
+# from `streamlib-ipc-types::MAX_PAYLOAD_SIZE` and the encoder's first
+# IDR (which carries SPS+PPS) is rejected with ExceedsMaxLoanSize, so the
+# decoder never sees the session parameters and decodes zero frames.
+
+package:
+  org: tatolab
+  name: vulkan-video-roundtrip-cdylib-camera
+  version: "0.1.0"
+  description: "Camera → encoder → decoder → display roundtrip with the camera processor loaded via runtime.load_project (cdylib) instead of as a Rust dep. Manual gate that exercises the full cdylib FFI surface end-to-end through encode/decode, validating that the cdylib's per-frame compute kernel + recorder dispatch + pixel-buffer flow matches the baseline non-cdylib variant."
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../../packages/core
+
+schemas:
+  ColorInfo:
+    package: "@tatolab/core"
+  ContentLight:
+    package: "@tatolab/core"
+  EncodedVideoFrame:
+    package: "@tatolab/core"
+  MasteringDisplay:
+    package: "@tatolab/core"
+  VideoFrame:
+    package: "@tatolab/core"

--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -15223,4 +15223,46 @@ mod make_borrow_cached_field_regression_tests {
             "mapped_ptr_cached must mirror the inner HOST_VISIBLE pointer"
         );
     }
+
+    #[test]
+    fn make_pixel_buffer_borrow_populates_cached_pod_fields() {
+        let Some(device) = try_vulkan_device() else {
+            return;
+        };
+        // Bgra8 = 4 bytes/pixel, 320x240 = 307_200 bytes
+        let host_buffer =
+            crate::vulkan::rhi::HostVulkanBuffer::new_storage_buffer_host_visible(
+                &device, 320 * 240 * 4,
+            )
+            .expect("backing buffer allocate");
+        let pb = crate::core::rhi::PixelBuffer::from_host_vulkan_buffer(
+            Arc::new(host_buffer),
+            320,
+            240,
+            4,
+            crate::core::rhi::PixelFormat::Bgra32,
+        );
+        let borrow = make_pixel_buffer_borrow(pb.handle);
+        assert_eq!(borrow.width, 320, "width must mirror the inner");
+        assert_eq!(borrow.height, 240, "height must mirror the inner");
+        assert!(
+            matches!(borrow.format(), crate::core::rhi::PixelFormat::Bgra32),
+            "format_raw must mirror the inner"
+        );
+    }
+
+    #[test]
+    fn make_uniform_buffer_borrow_populates_cached_pod_fields() {
+        let Some(device) = try_vulkan_device() else {
+            return;
+        };
+        let buffer = crate::core::rhi::UniformBuffer::new_host_visible(&device, 4_096)
+            .expect("uniform buffer allocate");
+        let borrow = make_uniform_buffer_borrow(buffer.handle);
+        assert_eq!(borrow.byte_size(), 4_096, "byte_size_cached must mirror the inner");
+        assert!(
+            !borrow.mapped_ptr().is_null(),
+            "mapped_ptr_cached must mirror the inner HOST_VISIBLE pointer"
+        );
+    }
 }

--- a/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -33,21 +33,27 @@
 //!
 //! What this test does NOT lock — guarded separately:
 //!
-//! - End-to-end per-frame capture through the color converter +
-//!   command recorder. Those β-shape return-type methods
-//!   (`RhiColorConverter::prepare_buffer_to_image_storage`,
-//!   `RhiCommandRecorder::record_*` / `submit_*`,
-//!   `HostVulkanTimelineSemaphore::wait`) still panic in cdylib mode
-//!   via their `host_inner()` short-circuits — Phase E follow-on
-//!   work that lifts method dispatch to the FullAccess vtable per
-//!   #907's shape. The capture thread therefore crashes shortly
-//!   after the first frame; a panic-hook strengthening on the test
-//!   side can't catch it because the cdylib carries its own libstd
-//!   panic-hook static (in-process panic hooks set on the host don't
-//!   chain into a statically-linked cdylib's std).
-//! - The vulkan-video-roundtrip manual gate from `docs/testing.md`
-//!   with camera loaded as a cdylib — blocked by the same Phase E
-//!   follow-on.
+//! > ~~End-to-end per-frame capture through the color converter +
+//! > command recorder. Those β-shape return-type methods
+//! > (`RhiColorConverter::prepare_buffer_to_image_storage`,
+//! > `RhiCommandRecorder::record_*` / `submit_*`,
+//! > `HostVulkanTimelineSemaphore::wait`) still panic in cdylib mode
+//! > via their `host_inner()` short-circuits — Phase E follow-on
+//! > work that lifts method dispatch to the FullAccess vtable per
+//! > #907's shape. The capture thread therefore crashes shortly
+//! > after the first frame.~~
+//! > ~~The vulkan-video-roundtrip manual gate from `docs/testing.md`
+//! > with camera loaded as a cdylib — blocked by the same Phase E
+//! > follow-on.~~ — Superseded 2026-05-24. The recorder methods
+//! > vtable (`RhiCommandRecorderMethodsVTable`), the color-converter
+//! > methods vtable's `prepare_buffer_to_image_storage` slot, the
+//! > timeline-semaphore wait dispatch, the PortSchemaSpec lossless
+//! > wire serde, and the `make_*_borrow` cached-fields contract all
+//! > landed; the per-frame path now completes cleanly in cdylib mode,
+//! > and the manual gate
+//! > (`examples/vulkan-video-roundtrip-cdylib-camera` against vivid)
+//! > produces valid SMPTE color-bar output matching the baseline
+//! > non-cdylib variant.
 //!
 //! What the test actually surfaces:
 //!


### PR DESCRIPTION
## Summary

Goal-03 follow-ups bundle. Two blocking gaps from an independent
adversarial review of an earlier "goal complete" claim, plus three
hygiene items.

### Blocking (2)

1. **Commit the manual-gate harness.**
   `examples/vulkan-video-roundtrip-cdylib-camera/` was authored
   locally to satisfy the goal's manual gate but never committed.
   Prior PRs shipped the engine-tier fixes the gate exercises, but
   the harness that proves the gate passes sat only on the
   implementer's disk. Fresh clones of `main` could not re-run the
   gate. This PR adds the full crate (Cargo.toml + src/main.rs +
   streamlib.yaml) plus the workspace-member entry.

2. **Add regression tests for `make_pixel_buffer_borrow` +
   `make_uniform_buffer_borrow`.** The prior
   `make_borrow_cached_field_regression_tests` module only locked 2
   of the 4 swept borrow helpers. Two new tests close the
   symmetry; mental-revert of either remaining helper now fails an
   assertion.

### Hygiene (3)

3. **Strike-through annotation** on the stale "blocked by Phase E
   follow-on" claim in
   `libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs`
   per CLAUDE.md's markdown editing rules — annotate dated, don't
   silently overwrite.

4. **New `docs/learnings/cdylib-make-borrow-cached-fields.md`**
   capturing the bug class so future agents recognize the trigger
   ("cdylib pipeline clean / output zeros") and reach for the
   right diagnosis. Indexed in `docs/learnings/README.md` and
   `CLAUDE.md`'s hard-won-learnings list.

5. **Deprecation warning fix.** Swap
   `tempfile::TempDir::into_path` → `.keep()` in the example's
   `main.rs` (one-line silence of the compiler warning).

## Test plan

- [x] `cargo test -p streamlib-engine --lib make_borrow_cached_field_regression_tests`
      — all 4 tests pass (texture + storage_buffer + pixel_buffer +
      uniform_buffer).
- [x] `cargo build -p vulkan-video-roundtrip-cdylib-camera` — clean.
- [x] **Manual gate** (cdylib-camera through vulkan-video-roundtrip
      against vivid at `/dev/video0`):

```
### E2E Test Report

- Scenario: encoder/decoder (cdylib-loaded camera)
- Example: `vulkan-video-roundtrip-cdylib-camera`
- Codec: h264
- Camera device: `/dev/video0` (vivid)
- Resolution: 1920×1080
- Duration / frame limit: STREAMLIB_DISPLAY_FRAME_LIMIT=150, 10s
- Build profile: debug
- Log signals:
  - OUT_OF_DEVICE_MEMORY: 0
  - DEVICE_LOST: 0
  - process() failed: 0
  - frames_encoded / frames_decoded: 50 / 50
- PNG samples: 2 (frame 0, frame 30)
- PNGs read with Read tool: `display_001_frame_000030_input_000032.png`
  - **What was in the image**: vivid SMPTE-style color bars
    (gray / yellow / cyan / green / magenta / red / blue / black)
    with V4L2 metadata overlay (`1920x1080 input 0`,
    brightness/contrast/saturation/hue knobs) and timecode
    `00:00:06:404 32`. Matches the baseline non-cdylib variant's
    output exactly.
  - Anomalies: none.
- PSNR: n/a — vivid synthetic source, no ground-truth reference
  for the cdylib variant.
- Outcome: **Pass**.
```

## After this PR merges

All three CLOSES-WHEN criteria from `.claude/goals/03-camera-dlopen-smoke.md`
are reproducible from a fresh clone of `main`:

1. Camera dlopen integration test against vivid — closed by the
   smoke test (was already on main).
2. Smoke test passes locally against vivid — green.
3. Manual gate of camera-loaded-as-cdylib through
   vulkan-video-roundtrip — green, harness now committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
