### PR TITLE
feat(plugin-abi): vulkan adapter callback table (#887)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "libs/streamlib-adapter-abi", # ABI-stable surface adapter contract (in-tree + 3rd-party adapters)
     "libs/streamlib-consumer-rhi", # Consumer-side carve-out of the Vulkan RHI — DMA-BUF FD import + bind + map. cdylibs depend on this NOT the full streamlib so the FullAccess capability boundary is type-system enforced (Linux)
     "libs/streamlib-adapter-vulkan", # Vulkan-native surface adapter — canonical implementor of VulkanWritable / VulkanImageInfoExt (Linux)
+    "libs/streamlib-adapter-vulkan-abi", # Cross-DSO callback table for streamlib-adapter-vulkan — extern "C" vtable consumed by host wiring + cdylib shim (#887)
     "libs/streamlib-adapter-vulkan-helpers", # Test-helper binaries for streamlib-adapter-vulkan — held in a dedicated crate so streamlib doesn't leak into adapter-vulkan's runtime dep graph (Linux)
     "libs/streamlib-adapter-opengl", # OpenGL/EGL surface adapter — canonical implementor of GlWritable; DMA-BUF + DRM modifier import (Linux)
     "libs/streamlib-adapter-cpu-readback", # Explicit GPU→CPU surface adapter — sole implementor of CpuReadable / CpuWritable (Linux)

--- a/libs/streamlib-adapter-vulkan-abi/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan-abi/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-vulkan-abi"
+description = "Cross-DSO callback table for streamlib-adapter-vulkan. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to VulkanSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_vulkan_abi"
+path = "src/lib.rs"
+
+# Pure ABI crate — same dep posture as streamlib-plugin-abi: no
+# streamlib-engine, no vulkanalia, no streamlib-adapter-vulkan, no
+# tokio. Keeps layout regression tests trivially runnable on any host
+# and the crate cross-DSO-safe.
+[dependencies]
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-vulkan-abi/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan-abi/src/lib.rs
@@ -202,9 +202,9 @@ pub struct RawVulkanHandlesRepr {
 /// The cdylib holds an opaque `*const c_void` handle (an
 /// `Arc::into_raw(Arc<VulkanSurfaceAdapter<D>>)`-shaped pointer
 /// produced by the host) plus a `*const VulkanSurfaceAdapterVTable`
-/// it reads from [`HostServices::vulkan_surface_adapter_vtable`]
-/// when the cdylib boundary lift lands. Method-dispatch callbacks
-/// cover every cdylib-callable inherent method on
+/// it reads from the `HostServices` payload when the cdylib β-shape
+/// lift lands (sibling slice to this trunk PR). Method-dispatch
+/// callbacks cover every cdylib-callable inherent method on
 /// `VulkanSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
 ///
 /// # Handle lifetime
@@ -253,13 +253,14 @@ pub struct VulkanSurfaceAdapterVTable {
     // Handle lifetime
     // -----------------------------------------------------------------
 
-    /// Take a borrowed handle (typically returned by a future
-    /// `RuntimeContextVTable::vulkan_surface_adapter` accessor) and
-    /// return a new owned handle with an Arc refcount bump on the
-    /// underlying `Arc<VulkanSurfaceAdapter<D>>`. The owned handle
-    /// remains valid even after the originating context is dropped
-    /// and MUST be released exactly once via [`Self::drop_handle`].
-    /// Calling on a null pointer returns null.
+    /// Take a borrowed handle (typically minted by the host's
+    /// runtime context when wiring the cdylib-side `VulkanContext`
+    /// β-shape) and return a new owned handle with an Arc refcount
+    /// bump on the underlying `Arc<VulkanSurfaceAdapter<D>>`. The
+    /// owned handle remains valid even after the originating
+    /// context is dropped and MUST be released exactly once via
+    /// [`Self::drop_handle`]. Calling on a null pointer returns
+    /// null.
     pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
 
     /// Release an owned handle previously obtained from

--- a/libs/streamlib-adapter-vulkan-abi/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan-abi/src/lib.rs
@@ -1,0 +1,574 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO callback table for `streamlib-adapter-vulkan`.
+//!
+//! Trunk piece of the per-adapter vtable lift kicked off by
+//! [`streamlib-plugin-abi`]'s `GpuContextLimitedAccessVTable`
+//! (issue #886). The companion 5 adapter ABIs follow this shape
+//! mechanically (issues #888, #889, #890, #891, #894).
+//!
+//! # What this crate is
+//!
+//! A pure ABI contract describing how a host (`streamlib-engine`)
+//! exposes its `VulkanSurfaceAdapter` to a cdylib plugin without
+//! sharing any Rust types beyond `#[repr(C)]` payloads and
+//! `unsafe extern "C" fn` pointers. The cdylib carries a
+//! `(handle, vtable)` β-shape; the host dispatches every method
+//! through host-compiled code so layout drift between rustc-minor
+//! versions and divergent dep graphs is contained inside the host
+//! DSO.
+//!
+//! Dep posture mirrors [`streamlib-plugin-abi`]: zero streamlib
+//! crates pulled, zero vulkanalia, zero rustc-version-coupled
+//! types. This keeps layout regression tests trivially runnable on
+//! any host and the crate cross-DSO-safe.
+//!
+//! # Audited cdylib-callable surface
+//!
+//! Every method on the cdylib-facing side of
+//! `VulkanSurfaceAdapter<D>` / `VulkanContext<D>` / its acquire
+//! guards is covered by exactly one slot below. The audit at
+//! pickup time (against `libs/streamlib-adapter-vulkan/src/`)
+//! enumerated:
+//!
+//! 1. `SurfaceAdapter` trait methods (from
+//!    `streamlib-adapter-abi`) implemented on `VulkanSurfaceAdapter`:
+//!    `acquire_read`, `acquire_write`, `try_acquire_read`,
+//!    `try_acquire_write`, `end_read_access`, `end_write_access`.
+//! 2. Inherent methods on `VulkanSurfaceAdapter<D>` /
+//!    `VulkanContext<D>`: `register_host_surface`,
+//!    `unregister_host_surface`, `release_to_foreign`,
+//!    `surface_image_info`, `registered_count`, `raw_handles`.
+//! 3. RAII guard `Drop` paths (`ReadGuard::drop` /
+//!    `WriteGuard::drop`) route back through
+//!    `SurfaceAdapter::end_*_access` — covered by the same vtable
+//!    slots.
+//! 4. View capability accessors (`VulkanWritable::vk_image`,
+//!    `vk_image_layout`, `VulkanImageInfoExt::vk_image_info`) are
+//!    pure reads against the [`VulkanViewRepr`] payload returned
+//!    by `acquire_*`. No vtable hop on the view itself.
+//!
+//! Power-user `with_acquire_timeout` (chaining-builder, sets
+//! `Duration` at construction) is host-side only and not
+//! cdylib-callable; an `Arc<VulkanSurfaceAdapter<_>>` already
+//! configured with the desired timeout is what crosses the vtable
+//! handle. No slot is required.
+
+#![no_std]
+
+use core::ffi::c_void;
+
+// ============================================================================
+// Layout version constants
+// ============================================================================
+
+/// Layout version of [`VulkanSurfaceAdapterVTable`].
+///
+/// Pinned at offset 0 forever; new methods append to the end and
+/// bump this constant. Host wiring asserts equality at install
+/// time; cdylib code reads it before dereferencing any slot and
+/// refuses to proceed on mismatch.
+///
+/// - v1: trunk lift — handle lifetime (`clone_handle` /
+///   `drop_handle`) + 12 method slots covering the full
+///   cdylib-callable surface (audit above). Locked by
+///   [`tests::vulkan_surface_adapter_vtable_layout`] and the
+///   tier-1 null-handle tests next to it.
+pub const VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+// ============================================================================
+// View payload — pure data the host writes into a caller-provided slot
+// ============================================================================
+
+/// Vulkan `VkImageLayout` enumerant value.
+///
+/// Mirrors `streamlib_adapter_abi::VkImageLayoutValue` as a
+/// dependency-free repeat so this crate stays free of streamlib
+/// deps. `VkImageLayout` is a 32-bit signed enum per the Vulkan
+/// spec; the value is interpreted by the host's `vulkanalia`
+/// binding (or any other Vulkan binding) on either side of the
+/// ABI.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct VkImageLayoutValueRepr(pub i32);
+
+/// `#[repr(C)]` mirror of `streamlib_adapter_abi::VkImageInfo`.
+///
+/// Layout MUST match `VkImageInfo` byte-for-byte — the host
+/// implementation populates this struct directly from the existing
+/// adapter and the cdylib reads the same offsets through its
+/// β-shape view payload. Adding fields requires a coordinated bump
+/// in both this crate AND `streamlib-adapter-abi`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct VkImageInfoRepr {
+    /// `VkFormat` enumerant. `i32` per spec.
+    pub format: i32,
+    /// `VkImageTiling` enumerant. `i32` per spec.
+    pub tiling: i32,
+    /// `VkImageUsageFlags` bitmask.
+    pub usage_flags: u32,
+    /// `VkSampleCountFlagBits` bitmask (1 = `VK_SAMPLE_COUNT_1_BIT`).
+    pub sample_count: u32,
+    /// Number of mip levels.
+    pub level_count: u32,
+    /// Owning `VkQueue` family index.
+    pub queue_family: u32,
+    /// Opaque `VkDeviceMemory` handle.
+    pub memory_handle: u64,
+    /// Byte offset of the image within `memory_handle`.
+    pub memory_offset: u64,
+    /// Byte size of the image's region within `memory_handle`.
+    pub memory_size: u64,
+    /// `VkMemoryPropertyFlags` bitmask of the backing allocation.
+    pub memory_property_flags: u32,
+    /// 1 if the image was allocated `VK_IMAGE_CREATE_PROTECTED_BIT`.
+    pub protected: u32,
+    /// Opaque `VkSamplerYcbcrConversion` handle, or 0 if unused.
+    pub ycbcr_conversion: u64,
+    /// Reserved bytes for additive ABI extensions. MUST be zeroed.
+    pub _reserved: [u8; 16],
+}
+
+/// `#[repr(C)]` payload returned by `acquire_read` / `acquire_write` /
+/// `try_acquire_*`.
+///
+/// Carries the live `VkImage` handle, the post-transition layout
+/// the adapter left the image in, and the per-image
+/// [`VkImageInfoRepr`] descriptor. The cdylib's `VulkanReadView`
+/// / `VulkanWriteView` β-shapes deref these fields directly as
+/// POD reads (mirrors the cached-fields pattern on `Texture` /
+/// `PixelBuffer` from `streamlib-plugin-abi`).
+///
+/// Lifetime: valid for the duration of the matching acquire scope
+/// — the host's underlying `VulkanReadView<'g>` /
+/// `VulkanWriteView<'g>` keeps the `VkImage` alive via the
+/// adapter's registry until `end_*_access` is called.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct VulkanViewRepr {
+    /// Opaque `VkImage` handle (Vulkan handles are 64-bit per spec).
+    pub vk_image: u64,
+    /// `VkImageLayout` the adapter transitioned the image into.
+    pub vk_image_layout: VkImageLayoutValueRepr,
+    /// Padding so [`Self::info`] is naturally aligned. Zero today,
+    /// never read.
+    pub _padding: u32,
+    /// Full image descriptor for compositors that need to wrap the
+    /// underlying `VkImage` as a framework-native render target
+    /// (Skia's `GrVkImageInfo` shape).
+    pub info: VkImageInfoRepr,
+}
+
+/// `#[repr(C)]` mirror of `streamlib_adapter_vulkan::RawVulkanHandles`.
+///
+/// Power-user surface — every field is the raw Vulkan handle bits
+/// (`as_raw()`) so the cdylib can reconstruct the typed wrapper
+/// its binding wants (`ash::Image::from_raw`,
+/// `vulkanalia::vk::Image::from_raw`, custom FFI shims).
+///
+/// Layout MUST match the in-crate `RawVulkanHandles` byte-for-byte
+/// — the host populates this via `raw_handles()`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct RawVulkanHandlesRepr {
+    /// `VkInstance` handle.
+    pub vk_instance: u64,
+    /// `VkPhysicalDevice` handle.
+    pub vk_physical_device: u64,
+    /// `VkDevice` handle.
+    pub vk_device: u64,
+    /// `VkQueue` of the graphics-and-present queue family. Caller
+    /// MUST take the per-queue mutex if they intend to submit
+    /// work — the streamlib RHI does this internally; raw users
+    /// assume the responsibility.
+    pub vk_queue: u64,
+    /// Queue family index for `vk_queue`. Used in
+    /// `VkImageMemoryBarrier::srcQueueFamilyIndex` /
+    /// `dstQueueFamilyIndex` for cross-queue ownership transitions.
+    pub vk_queue_family_index: u32,
+    /// Vulkan API version the streamlib runtime requested at
+    /// instance creation. Encoded per `VK_MAKE_API_VERSION`.
+    pub api_version: u32,
+}
+
+// ============================================================================
+// VulkanSurfaceAdapterVTable
+// ============================================================================
+
+/// Dispatch table for the host's `VulkanSurfaceAdapter<D>`.
+///
+/// The cdylib holds an opaque `*const c_void` handle (an
+/// `Arc::into_raw(Arc<VulkanSurfaceAdapter<D>>)`-shaped pointer
+/// produced by the host) plus a `*const VulkanSurfaceAdapterVTable`
+/// it reads from [`HostServices::vulkan_surface_adapter_vtable`]
+/// when the cdylib boundary lift lands. Method-dispatch callbacks
+/// cover every cdylib-callable inherent method on
+/// `VulkanSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
+///
+/// # Handle lifetime
+///
+/// `clone_handle` / `drop_handle` mirror the
+/// `GpuContextLimitedAccessVTable` v2 pattern from
+/// `streamlib-plugin-abi`: `clone_handle(borrowed) -> owned` bumps
+/// the host's `Arc<VulkanSurfaceAdapter<D>>` refcount;
+/// `drop_handle(owned)` releases. The owned handle remains valid
+/// even after the originating runtime context is dropped, which
+/// matches the existing `VulkanContext: Clone` contract — a plugin
+/// can stash a clone in `setup()` and hand it to a worker thread
+/// that outlives the lifecycle call.
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. New methods
+/// append to the end and bump
+/// [`VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+///
+/// # Error crossing
+///
+/// Every fallible slot returns `i32` (0 = success, non-zero =
+/// error). On error the host writes a UTF-8 message into the
+/// caller-provided `err_buf` (clamped to `err_buf_cap`) and sets
+/// `*err_len` to the bytes written. The wire shape mirrors the
+/// host-side error-buffer convention already established by
+/// `GpuContextLimitedAccessVTable::acquire_texture` and siblings;
+/// truncation never trips a panic.
+///
+/// Non-error sentinels: `try_acquire_*` distinguishes "contended,
+/// retry later" (status = 0, `*out_acquired = 0`) from "real
+/// failure" (status = 1, error written) so the host's `Ok(None)`
+/// vs `Err(...)` distinction survives the i32 crossing.
+#[repr(C)]
+pub struct VulkanSurfaceAdapterVTable {
+    /// Vtable layout version. Must equal
+    /// [`VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -----------------------------------------------------------------
+    // Handle lifetime
+    // -----------------------------------------------------------------
+
+    /// Take a borrowed handle (typically returned by a future
+    /// `RuntimeContextVTable::vulkan_surface_adapter` accessor) and
+    /// return a new owned handle with an Arc refcount bump on the
+    /// underlying `Arc<VulkanSurfaceAdapter<D>>`. The owned handle
+    /// remains valid even after the originating context is dropped
+    /// and MUST be released exactly once via [`Self::drop_handle`].
+    /// Calling on a null pointer returns null.
+    pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
+
+    /// Release an owned handle previously obtained from
+    /// [`Self::clone_handle`]. Calling on a null pointer is a
+    /// no-op. Calling on the same owned handle twice is undefined
+    /// behaviour (double-free of the Arc refcount).
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // -----------------------------------------------------------------
+    // Registry management (inherent on VulkanSurfaceAdapter)
+    // -----------------------------------------------------------------
+
+    /// Register a surface with the adapter.
+    ///
+    /// `texture_handle` is an
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::Texture>)`-shaped
+    /// opaque pointer produced by the host; the host implementation
+    /// bumps the Arc refcount (`Arc::increment_strong_count`) and
+    /// stores a clone in the adapter's internal registry. The
+    /// caller's `texture_handle` Arc remains owned by the caller.
+    ///
+    /// `timeline_handle` is an
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
+    /// opaque pointer with identical ownership semantics.
+    ///
+    /// `initial_layout_raw` is the i32 `VkImageLayout` enumerant
+    /// the texture is in at registration time.
+    ///
+    /// Returns 0 on success, non-zero on failure (e.g. surface_id
+    /// already registered). On error writes a UTF-8 message into
+    /// `err_buf`.
+    pub register_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        texture_handle: *const c_void,
+        timeline_handle: *const c_void,
+        initial_layout_raw: i32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Drop a registered surface from the adapter. Idempotent —
+    /// missing entries return 0 via `*out_was_present = 0`. Calls
+    /// against a null handle return 0 with `*out_was_present = 0`.
+    pub unregister_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_was_present: *mut u32,
+    ),
+
+    /// Snapshot the adapter's registry size (number of currently-
+    /// registered surfaces). Returns 0 on null handle. Used for
+    /// host-side tests and observability; cdylibs can call it
+    /// today but the read is informational, not synchronizing.
+    pub registered_count: unsafe extern "C" fn(handle: *const c_void) -> usize,
+
+    // -----------------------------------------------------------------
+    // SurfaceAdapter trait methods
+    // -----------------------------------------------------------------
+
+    /// Blocking read acquire.
+    ///
+    /// `surface_ptr` is a `*const StreamlibSurface` borrowed from
+    /// the caller's stack; valid for the duration of the call. On
+    /// success writes the populated [`VulkanViewRepr`] into
+    /// `*out_view` and returns 0. On contention (Ok(None) shape)
+    /// the host returns 1 with a "writer contended" message; the
+    /// blocking variant never returns the contended-but-not-error
+    /// case (`try_acquire_*` does).
+    pub acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut VulkanViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Blocking write acquire. Same shape as [`Self::acquire_read`]
+    /// but exclusive-write semantics.
+    pub acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut VulkanViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking read acquire.
+    ///
+    /// Returns 0 on success and writes `*out_acquired = 1` plus a
+    /// populated view. Returns 0 with `*out_acquired = 0` on
+    /// contention (Ok(None) shape) without writing the view.
+    /// Returns non-zero with an error message on real failure.
+    pub try_acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut VulkanViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking write acquire. Same shape as
+    /// [`Self::try_acquire_read`].
+    pub try_acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut VulkanViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Sealed: signal the release-side timeline semaphore for a
+    /// read. Called by the cdylib's `ReadGuard::drop`. Idempotent
+    /// against unknown surface IDs (the host logs and returns; no
+    /// error surfaced because Drop can't propagate).
+    pub end_read_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    /// Sealed: signal the release-side timeline semaphore for a
+    /// write. Called by the cdylib's `WriteGuard::drop`.
+    pub end_write_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    // -----------------------------------------------------------------
+    // Cross-process publishing helpers
+    // -----------------------------------------------------------------
+
+    /// Producer-side QFOT release for cross-process publishing.
+    /// Wraps [`streamlib_adapter_vulkan::VulkanSurfaceAdapter::release_to_foreign`].
+    ///
+    /// On success writes the resulting layout into
+    /// `*out_resulting_layout_raw` and returns 0. On failure
+    /// writes a UTF-8 message into `err_buf` and returns non-zero.
+    pub release_to_foreign: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        post_release_layout_raw: i32,
+        out_resulting_layout_raw: *mut i32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    // -----------------------------------------------------------------
+    // Per-surface descriptor accessors
+    // -----------------------------------------------------------------
+
+    /// Resolve the full [`VkImageInfoRepr`] descriptor for a
+    /// registered surface. Sets `*out_found = 1` and writes the
+    /// descriptor on hit; `*out_found = 0` on miss (in which case
+    /// `*out_info` is left untouched). Calling on a null handle
+    /// sets `*out_found = 0`.
+    pub surface_image_info: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_info: *mut VkImageInfoRepr,
+        out_found: *mut u32,
+    ),
+
+    // -----------------------------------------------------------------
+    // Power-user raw handles
+    // -----------------------------------------------------------------
+
+    /// Snapshot the underlying device's raw Vulkan handles. The
+    /// handles are valid for the lifetime of the device; the
+    /// caller MUST NOT outlive the runtime that owns it. There is
+    /// intentionally no destructor or refcount — power-user
+    /// "you own the consequences" surface. Calling on a null
+    /// handle writes a zeroed [`RawVulkanHandlesRepr`].
+    pub raw_handles:
+        unsafe extern "C" fn(handle: *const c_void, out_handles: *mut RawVulkanHandlesRepr),
+}
+
+// Safety: every field is a primitive integer or an `unsafe extern "C" fn`
+// pointer; no thread-local state, no interior mutability. The host
+// guarantees the pointed-at adapter state outlives every cdylib that
+// holds a clone of the handle via the loader's pinning shape.
+unsafe impl Send for VulkanSurfaceAdapterVTable {}
+unsafe impl Sync for VulkanSurfaceAdapterVTable {}
+
+// ============================================================================
+// Layout regression tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    /// `VkImageInfoRepr` mirrors `streamlib_adapter_abi::VkImageInfo`
+    /// byte-for-byte. Locks the contract one of the four cross-DSO
+    /// payloads in this crate rides on.
+    #[test]
+    fn vk_image_info_repr_layout() {
+        // format: i32 @ 0
+        // tiling: i32 @ 4
+        // usage_flags: u32 @ 8
+        // sample_count: u32 @ 12
+        // level_count: u32 @ 16
+        // queue_family: u32 @ 20
+        // memory_handle: u64 @ 24
+        // memory_offset: u64 @ 32
+        // memory_size: u64 @ 40
+        // memory_property_flags: u32 @ 48
+        // protected: u32 @ 52
+        // ycbcr_conversion: u64 @ 56
+        // _reserved: [u8; 16] @ 64
+        // total: 80 bytes, align 8
+        assert_eq!(offset_of!(VkImageInfoRepr, format), 0);
+        assert_eq!(offset_of!(VkImageInfoRepr, tiling), 4);
+        assert_eq!(offset_of!(VkImageInfoRepr, usage_flags), 8);
+        assert_eq!(offset_of!(VkImageInfoRepr, sample_count), 12);
+        assert_eq!(offset_of!(VkImageInfoRepr, level_count), 16);
+        assert_eq!(offset_of!(VkImageInfoRepr, queue_family), 20);
+        assert_eq!(offset_of!(VkImageInfoRepr, memory_handle), 24);
+        assert_eq!(offset_of!(VkImageInfoRepr, memory_offset), 32);
+        assert_eq!(offset_of!(VkImageInfoRepr, memory_size), 40);
+        assert_eq!(offset_of!(VkImageInfoRepr, memory_property_flags), 48);
+        assert_eq!(offset_of!(VkImageInfoRepr, protected), 52);
+        assert_eq!(offset_of!(VkImageInfoRepr, ycbcr_conversion), 56);
+        assert_eq!(offset_of!(VkImageInfoRepr, _reserved), 64);
+        assert_eq!(size_of::<VkImageInfoRepr>(), 80);
+        assert_eq!(align_of::<VkImageInfoRepr>(), 8);
+    }
+
+    /// `VulkanViewRepr` carries (`vk_image: u64`,
+    /// `vk_image_layout: i32`, padding `u32`, `info:
+    /// VkImageInfoRepr`). Padding lands the `info` block on a
+    /// natural 8-byte boundary.
+    #[test]
+    fn vulkan_view_repr_layout() {
+        // vk_image: u64 @ 0
+        // vk_image_layout: i32 @ 8 (VkImageLayoutValueRepr is #[repr(transparent)] i32)
+        // _padding: u32 @ 12
+        // info: VkImageInfoRepr (80 B, align 8) @ 16
+        // total: 96 bytes, align 8
+        assert_eq!(offset_of!(VulkanViewRepr, vk_image), 0);
+        assert_eq!(offset_of!(VulkanViewRepr, vk_image_layout), 8);
+        assert_eq!(offset_of!(VulkanViewRepr, _padding), 12);
+        assert_eq!(offset_of!(VulkanViewRepr, info), 16);
+        assert_eq!(size_of::<VulkanViewRepr>(), 96);
+        assert_eq!(align_of::<VulkanViewRepr>(), 8);
+    }
+
+    #[test]
+    fn vk_image_layout_value_repr_is_transparent_i32() {
+        assert_eq!(size_of::<VkImageLayoutValueRepr>(), 4);
+        assert_eq!(align_of::<VkImageLayoutValueRepr>(), 4);
+    }
+
+    /// `RawVulkanHandlesRepr` matches `RawVulkanHandles` —
+    /// `u64×4, u32×2` = 32 + 8 = 40 bytes, align 8.
+    #[test]
+    fn raw_vulkan_handles_repr_layout() {
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, vk_instance), 0);
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, vk_physical_device), 8);
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, vk_device), 16);
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, vk_queue), 24);
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, vk_queue_family_index), 32);
+        assert_eq!(offset_of!(RawVulkanHandlesRepr, api_version), 36);
+        assert_eq!(size_of::<RawVulkanHandlesRepr>(), 40);
+        assert_eq!(align_of::<RawVulkanHandlesRepr>(), 8);
+    }
+
+    /// Locks the vtable's binary layout. Anchors every method slot
+    /// at a fixed byte offset so a host built against vtable v1
+    /// and a cdylib built against vtable v1 dispatch through the
+    /// same offsets regardless of rustc-minor / dep-graph drift.
+    /// New methods must append after `raw_handles` and bump
+    /// [`VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    #[test]
+    fn vulkan_surface_adapter_vtable_layout() {
+        // layout_version: u32 @ 0
+        // _reserved_padding: u32 @ 4
+        // 14 fn pointers (8 bytes each) @ 8..120
+        // total: 4 + 4 + 14*8 = 120 bytes, align 8
+        assert_eq!(VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(size_of::<VulkanSurfaceAdapterVTable>(), 120);
+        assert_eq!(align_of::<VulkanSurfaceAdapterVTable>(), 8);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, layout_version), 0);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, clone_handle), 8);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, drop_handle), 16);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, register_host_surface), 24);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, unregister_host_surface), 32);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, registered_count), 40);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, acquire_read), 48);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, acquire_write), 56);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, try_acquire_read), 64);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, try_acquire_write), 72);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, end_read_access), 80);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, end_write_access), 88);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, release_to_foreign), 96);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, surface_image_info), 104);
+        assert_eq!(offset_of!(VulkanSurfaceAdapterVTable, raw_handles), 112);
+    }
+
+    /// Compile-time witness that the vtable is `Send + Sync`. A
+    /// future regression that adds an interior-mutable or non-thread-
+    /// safe field would break the unsafe impl above and trip this
+    /// test at build time.
+    #[test]
+    fn vtable_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VulkanSurfaceAdapterVTable>();
+    }
+}

--- a/libs/streamlib-adapter-vulkan/Cargo.toml
+++ b/libs/streamlib-adapter-vulkan/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-vulkan-abi = { path = "../streamlib-adapter-vulkan-abi" }
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-vulkan/src/host_vtable.rs
+++ b/libs/streamlib-adapter-vulkan/src/host_vtable.rs
@@ -1,0 +1,1089 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side wiring of [`streamlib_adapter_vulkan_abi::VulkanSurfaceAdapterVTable`].
+//!
+//! Hosts that want to expose a `VulkanSurfaceAdapter<D>` to a
+//! cdylib plugin do this:
+//!
+//! 1. Construct an `Arc<VulkanSurfaceAdapter<D>>` on the host side
+//!    (allocate textures, register surfaces, install setup hook —
+//!    same as today).
+//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//!    - `handle = Arc::into_raw(arc.clone())`
+//!    - `vtable = host_vulkan_surface_adapter_vtable::<D>()`
+//! 3. The cdylib invokes the vtable methods exactly as if it held
+//!    a Rust `&VulkanSurfaceAdapter<D>` — every method dispatches
+//!    through host-compiled code, so layout drift between
+//!    rustc-minor versions and divergent dep graphs is contained
+//!    inside the host DSO.
+//!
+//! Generic over `D: VulkanRhiDevice + 'static` so the same wiring
+//! works whether the host is exposing a
+//! `VulkanSurfaceAdapter<HostVulkanDevice>` (canonical host-side
+//! adapter) or a `VulkanSurfaceAdapter<ConsumerVulkanDevice>`
+//! (cdylib-internal subprocess adapter). Each monomorphization
+//! materializes its own `static` vtable; cdylib code never sees
+//! the type parameter — only the `*const VulkanSurfaceAdapterVTable`
+//! pointer.
+//!
+//! Panic guards inside each fn body mirror the
+//! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
+//! host code is caught at the FFI boundary and converted to a
+//! clean error return instead of corrupting the cdylib's stack.
+//! Tier-1 null-handle tests next to this module verify the guards
+//! fire correctly without an actual `Arc<VulkanSurfaceAdapter>`.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{StreamlibSurface, SurfaceAdapter, VkImageInfo};
+use streamlib_adapter_vulkan_abi::{
+    RawVulkanHandlesRepr, VkImageInfoRepr, VkImageLayoutValueRepr,
+    VulkanSurfaceAdapterVTable, VulkanViewRepr,
+    VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+};
+use streamlib_consumer_rhi::{DevicePrivilege, VulkanLayout, VulkanRhiDevice};
+
+use crate::adapter::VulkanSurfaceAdapter;
+use crate::raw_handles::raw_handles;
+
+/// Returns a `&'static VulkanSurfaceAdapterVTable` whose method
+/// slots dispatch against an `Arc<VulkanSurfaceAdapter<D>>`-shaped
+/// handle.
+///
+/// The vtable is `const`-initialized per `D` monomorphization;
+/// every call for the same `D` returns the same pointer. Multiple
+/// `D`s coexist in the same host process with their own vtables.
+pub fn host_vulkan_surface_adapter_vtable<D: VulkanRhiDevice + 'static>(
+) -> *const VulkanSurfaceAdapterVTable {
+    &MonoVTable::<D>::VTABLE
+}
+
+/// Type-keyed monomorphizer. The `const VTABLE` is materialized at
+/// codegen time for each `D` that calls
+/// [`host_vulkan_surface_adapter_vtable`] elsewhere in the binary;
+/// the fn-pointer slots resolve to the matching monomorphizations
+/// of the free fns below.
+struct MonoVTable<D: VulkanRhiDevice + 'static>(PhantomData<D>);
+
+impl<D: VulkanRhiDevice + 'static> MonoVTable<D> {
+    const VTABLE: VulkanSurfaceAdapterVTable = VulkanSurfaceAdapterVTable {
+        layout_version: VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        clone_handle: host_clone_handle::<D>,
+        drop_handle: host_drop_handle::<D>,
+        register_host_surface: host_register_host_surface::<D>,
+        unregister_host_surface: host_unregister_host_surface::<D>,
+        registered_count: host_registered_count::<D>,
+        acquire_read: host_acquire_read::<D>,
+        acquire_write: host_acquire_write::<D>,
+        try_acquire_read: host_try_acquire_read::<D>,
+        try_acquire_write: host_try_acquire_write::<D>,
+        end_read_access: host_end_read_access::<D>,
+        end_write_access: host_end_write_access::<D>,
+        release_to_foreign: host_release_to_foreign::<D>,
+        surface_image_info: host_surface_image_info::<D>,
+        raw_handles: host_raw_handles::<D>,
+    };
+}
+
+// =============================================================================
+// FFI helpers — error buffer writer + panic guard
+// =============================================================================
+
+/// Catch panics at the extern "C" boundary so a host-side panic
+/// doesn't unwind into cdylib code. On panic the body returns
+/// `default_on_panic`; the panic message is logged via `tracing`
+/// for post-mortem visibility.
+#[inline]
+fn run_host_extern_c<F, T>(callback_name: &'static str, body: F, default_on_panic: T) -> T
+where
+    F: FnOnce() -> T,
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            tracing::error!(
+                target: "streamlib_adapter_vulkan::ffi",
+                callback = callback_name,
+                panic = %msg,
+                "host extern \"C\" callback panicked; FFI boundary converted panic to default return"
+            );
+            default_on_panic
+        }
+    }
+}
+
+/// Write a UTF-8 error message into a caller-provided buffer.
+/// Truncates to `cap`; sets `*err_len` to the bytes actually
+/// written. Null pointers are tolerated (the message is simply
+/// dropped).
+unsafe fn write_err(msg: &str, err_buf: *mut u8, err_buf_cap: usize, err_len: *mut usize) {
+    if err_buf.is_null() || err_buf_cap == 0 {
+        if !err_len.is_null() {
+            unsafe { *err_len = 0 };
+        }
+        return;
+    }
+    let bytes = msg.as_bytes();
+    let n = bytes.len().min(err_buf_cap);
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), err_buf, n);
+        if !err_len.is_null() {
+            *err_len = n;
+        }
+    }
+}
+
+// =============================================================================
+// Payload helpers — VkImageInfo / VulkanReadView / VulkanWriteView → repr
+// =============================================================================
+
+fn vk_image_info_to_repr(info: VkImageInfo) -> VkImageInfoRepr {
+    VkImageInfoRepr {
+        format: info.format,
+        tiling: info.tiling,
+        usage_flags: info.usage_flags,
+        sample_count: info.sample_count,
+        level_count: info.level_count,
+        queue_family: info.queue_family,
+        memory_handle: info.memory_handle,
+        memory_offset: info.memory_offset,
+        memory_size: info.memory_size,
+        memory_property_flags: info.memory_property_flags,
+        protected: info.protected,
+        ycbcr_conversion: info.ycbcr_conversion,
+        _reserved: info._reserved,
+    }
+}
+
+/// Borrow the adapter from a `*const c_void` handle. Returns
+/// `None` on null. SAFETY: caller asserts the handle is one of:
+/// (a) a borrowed pointer produced by `Arc::as_ptr` against a live
+/// host-owned Arc, or (b) an owned pointer minted by
+/// [`host_clone_handle`] still in its valid lifetime. Both are
+/// dereferenceable for read while the underlying Arc has at least
+/// one strong refcount; the panic guard wrapping every call site
+/// converts any UB-shaped mistake into a clean tracing log + the
+/// callback's default return.
+unsafe fn adapter_borrow<'a, D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> Option<&'a VulkanSurfaceAdapter<D>> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const VulkanSurfaceAdapter<D>) })
+}
+
+// =============================================================================
+// Handle lifetime (mirrors GpuContextLimitedAccessVTable::clone_handle / drop_handle)
+// =============================================================================
+
+unsafe extern "C" fn host_clone_handle<D: VulkanRhiDevice + 'static>(
+    borrowed_handle: *const c_void,
+) -> *const c_void {
+    run_host_extern_c(
+        "vulkan_surface_adapter::clone_handle",
+        || {
+            if borrowed_handle.is_null() {
+                return core::ptr::null();
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<VulkanSurfaceAdapter<D>>)-shaped.
+            unsafe {
+                Arc::increment_strong_count(borrowed_handle as *const VulkanSurfaceAdapter<D>);
+            }
+            borrowed_handle
+        },
+        core::ptr::null(),
+    )
+}
+
+unsafe extern "C" fn host_drop_handle<D: VulkanRhiDevice + 'static>(owned_handle: *const c_void) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::drop_handle",
+        || {
+            if owned_handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<VulkanSurfaceAdapter<D>>)-shaped
+            // with at least one host-side refcount remaining.
+            unsafe {
+                Arc::decrement_strong_count(owned_handle as *const VulkanSurfaceAdapter<D>);
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Registry management
+// =============================================================================
+
+unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    texture_handle: *const c_void,
+    timeline_handle: *const c_void,
+    initial_layout_raw: i32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "vulkan_surface_adapter::register_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "register_host_surface: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if texture_handle.is_null() || timeline_handle.is_null() {
+                unsafe {
+                    write_err(
+                        "register_host_surface: null texture or timeline handle",
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the handles are
+            // Arc::into_raw-shaped against the correct privilege
+            // family for D. The host bumps the refcount and stashes
+            // a clone in the registry; the caller's Arcs remain
+            // owned by the caller.
+            let texture: Arc<<D::Privilege as DevicePrivilege>::Texture> = unsafe {
+                Arc::increment_strong_count(
+                    texture_handle as *const <D::Privilege as DevicePrivilege>::Texture,
+                );
+                Arc::from_raw(texture_handle as *const <D::Privilege as DevicePrivilege>::Texture)
+            };
+            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                Arc::increment_strong_count(
+                    timeline_handle as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                );
+                Arc::from_raw(
+                    timeline_handle
+                        as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore,
+                )
+            };
+            let registration = crate::state::HostSurfaceRegistration {
+                texture,
+                timeline,
+                initial_layout: VulkanLayout(initial_layout_raw),
+            };
+            match adapter.register_host_surface(surface_id, registration) {
+                Ok(()) => 0,
+                Err(e) => {
+                    let msg = format!("register_host_surface: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_unregister_host_surface<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    out_was_present: *mut u32,
+) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::unregister_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    if !out_was_present.is_null() {
+                        unsafe { *out_was_present = 0 };
+                    }
+                    return;
+                }
+            };
+            let was_present = adapter.unregister_host_surface(surface_id);
+            if !out_was_present.is_null() {
+                unsafe { *out_was_present = u32::from(was_present) };
+            }
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_registered_count<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> usize {
+    run_host_extern_c(
+        "vulkan_surface_adapter::registered_count",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return 0usize,
+            };
+            adapter.registered_count()
+        },
+        0usize,
+    )
+}
+
+// =============================================================================
+// SurfaceAdapter trait methods
+// =============================================================================
+
+/// Common shape for `acquire_read` / `acquire_write` /
+/// `try_acquire_*`: borrow the adapter, validate the surface
+/// pointer, call the inner method, write the view + status. The
+/// closure receives the adapter + a `&StreamlibSurface` and
+/// returns either:
+///   - `Ok(Some(view))`  → status 0, `*out_acquired = 1`, view written
+///   - `Ok(None)`        → status 0, `*out_acquired = 0` (try_* only;
+///                          blocking variants reject via the caller)
+///   - `Err(msg)`        → status 1, error message written
+unsafe fn run_acquire<D, F>(
+    callback_name: &'static str,
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut VulkanViewRepr,
+    out_acquired: Option<*mut u32>,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    body: F,
+) -> i32
+where
+    D: VulkanRhiDevice + 'static,
+    F: FnOnce(
+        &VulkanSurfaceAdapter<D>,
+        &StreamlibSurface,
+    ) -> Result<Option<VulkanViewRepr>, String>,
+{
+    run_host_extern_c(
+        callback_name,
+        || {
+            if let Some(p) = out_acquired {
+                if !p.is_null() {
+                    unsafe { *p = 0 };
+                }
+            }
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            &format!("{callback_name}: null adapter handle"),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if surface_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        &format!("{callback_name}: null surface pointer"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // StreamlibSurface from its own stack/heap, valid for
+            // the duration of the call.
+            let surface: &StreamlibSurface =
+                unsafe { &*(surface_ptr as *const StreamlibSurface) };
+            match body(adapter, surface) {
+                Ok(Some(view)) => {
+                    if !out_view.is_null() {
+                        unsafe { *out_view = view };
+                    }
+                    if let Some(p) = out_acquired {
+                        if !p.is_null() {
+                            unsafe { *p = 1 };
+                        }
+                    }
+                    0
+                }
+                Ok(None) => {
+                    // Contended — try_* shape. Blocking variants
+                    // never reach here (the body errors instead).
+                    0
+                }
+                Err(msg) => {
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+fn read_guard_to_repr<D: VulkanRhiDevice + 'static>(
+    guard: streamlib_adapter_abi::ReadGuard<'_, VulkanSurfaceAdapter<D>>,
+) -> VulkanViewRepr {
+    let view = guard.view();
+    // SAFETY: we deliberately leak the guard's `end_read_access`
+    // signal — the cdylib will fire `end_read_access` itself from
+    // its own ReadGuard::drop via the vtable. Calling Drop here
+    // would double-signal.
+    let view_repr = VulkanViewRepr {
+        vk_image: streamlib_adapter_abi::VulkanWritable::vk_image(view).0,
+        vk_image_layout: VkImageLayoutValueRepr(
+            streamlib_adapter_abi::VulkanWritable::vk_image_layout(view).0,
+        ),
+        _padding: 0,
+        info: vk_image_info_to_repr(streamlib_adapter_abi::VulkanImageInfoExt::vk_image_info(
+            view,
+        )),
+    };
+    core::mem::forget(guard);
+    view_repr
+}
+
+fn write_guard_to_repr<D: VulkanRhiDevice + 'static>(
+    guard: streamlib_adapter_abi::WriteGuard<'_, VulkanSurfaceAdapter<D>>,
+) -> VulkanViewRepr {
+    let view = guard.view();
+    let view_repr = VulkanViewRepr {
+        vk_image: streamlib_adapter_abi::VulkanWritable::vk_image(view).0,
+        vk_image_layout: VkImageLayoutValueRepr(
+            streamlib_adapter_abi::VulkanWritable::vk_image_layout(view).0,
+        ),
+        _padding: 0,
+        info: vk_image_info_to_repr(streamlib_adapter_abi::VulkanImageInfoExt::vk_image_info(
+            view,
+        )),
+    };
+    core::mem::forget(guard);
+    view_repr
+}
+
+unsafe extern "C" fn host_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut VulkanViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "vulkan_surface_adapter::acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_read(surface) {
+                Ok(guard) => Ok(Some(read_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut VulkanViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "vulkan_surface_adapter::acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_write(surface) {
+                Ok(guard) => Ok(Some(write_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut VulkanViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "vulkan_surface_adapter::try_acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_read(surface) {
+                Ok(Some(guard)) => Ok(Some(read_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut VulkanViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "vulkan_surface_adapter::try_acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_write(surface) {
+                Ok(Some(guard)) => Ok(Some(write_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_end_read_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::end_read_access",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_read_access(surface_id);
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_end_write_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::end_write_access",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_write_access(surface_id);
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Cross-process publishing
+// =============================================================================
+
+unsafe extern "C" fn host_release_to_foreign<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    post_release_layout_raw: i32,
+    out_resulting_layout_raw: *mut i32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "vulkan_surface_adapter::release_to_foreign",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "release_to_foreign: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            match adapter.release_to_foreign(surface_id, VulkanLayout(post_release_layout_raw)) {
+                Ok(layout) => {
+                    if !out_resulting_layout_raw.is_null() {
+                        unsafe { *out_resulting_layout_raw = layout.0 };
+                    }
+                    0
+                }
+                Err(e) => {
+                    let msg = format!("release_to_foreign: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+// =============================================================================
+// surface_image_info
+// =============================================================================
+
+unsafe extern "C" fn host_surface_image_info<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    out_info: *mut VkImageInfoRepr,
+    out_found: *mut u32,
+) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::surface_image_info",
+        || {
+            if !out_found.is_null() {
+                unsafe { *out_found = 0 };
+            }
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            if let Some(info) = adapter.surface_image_info(surface_id) {
+                if !out_info.is_null() {
+                    unsafe { *out_info = vk_image_info_to_repr(info) };
+                }
+                if !out_found.is_null() {
+                    unsafe { *out_found = 1 };
+                }
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// raw_handles
+// =============================================================================
+
+unsafe extern "C" fn host_raw_handles<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    out_handles: *mut RawVulkanHandlesRepr,
+) {
+    run_host_extern_c(
+        "vulkan_surface_adapter::raw_handles",
+        || {
+            if out_handles.is_null() {
+                return;
+            }
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    // Zero the slot so the caller sees the
+                    // "no handles available" sentinel rather than
+                    // garbage.
+                    unsafe {
+                        *out_handles = RawVulkanHandlesRepr {
+                            vk_instance: 0,
+                            vk_physical_device: 0,
+                            vk_device: 0,
+                            vk_queue: 0,
+                            vk_queue_family_index: 0,
+                            api_version: 0,
+                        };
+                    }
+                    return;
+                }
+            };
+            let raw = raw_handles(adapter.device().as_ref());
+            unsafe {
+                *out_handles = RawVulkanHandlesRepr {
+                    vk_instance: raw.vk_instance,
+                    vk_physical_device: raw.vk_physical_device,
+                    vk_device: raw.vk_device,
+                    vk_queue: raw.vk_queue,
+                    vk_queue_family_index: raw.vk_queue_family_index,
+                    api_version: raw.api_version,
+                };
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Tier-1 host-side wire-format tests (null-handle guards)
+// =============================================================================
+//
+// Each test invokes a vtable slot directly with a null handle and
+// asserts the slot's documented null-handle behaviour fires. The
+// success-path tests require an actual `Arc<VulkanSurfaceAdapter>`
+// + a live `HostVulkanDevice` and live in the existing
+// `streamlib-adapter-vulkan/tests/` integration tests as those
+// scenarios get wired through this vtable in follow-up issues.
+
+#[cfg(test)]
+mod tier1_null_handle_tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+    use streamlib_consumer_rhi::ConsumerVulkanDevice;
+
+    // Pick a concrete D to materialize the monomorphized vtable.
+    // The null-handle tests don't care which D — they exercise the
+    // panic guards before any device-shape work fires.
+    type D = ConsumerVulkanDevice;
+
+    /// `VkImageInfoRepr` (defined in `streamlib-adapter-vulkan-abi`)
+    /// MUST mirror `streamlib_adapter_abi::VkImageInfo` byte-for-byte.
+    /// This crate has both in scope so it's the natural place to
+    /// lock the contract; the abi crate is dep-free by design and
+    /// can't import the source type itself.
+    #[test]
+    fn vk_image_info_repr_matches_adapter_abi_layout() {
+        assert_eq!(size_of::<VkImageInfoRepr>(), size_of::<VkImageInfo>());
+        assert_eq!(align_of::<VkImageInfoRepr>(), align_of::<VkImageInfo>());
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, format),
+            offset_of!(VkImageInfo, format)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, tiling),
+            offset_of!(VkImageInfo, tiling)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, usage_flags),
+            offset_of!(VkImageInfo, usage_flags)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, sample_count),
+            offset_of!(VkImageInfo, sample_count)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, level_count),
+            offset_of!(VkImageInfo, level_count)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, queue_family),
+            offset_of!(VkImageInfo, queue_family)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, memory_handle),
+            offset_of!(VkImageInfo, memory_handle)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, memory_offset),
+            offset_of!(VkImageInfo, memory_offset)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, memory_size),
+            offset_of!(VkImageInfo, memory_size)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, memory_property_flags),
+            offset_of!(VkImageInfo, memory_property_flags)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, protected),
+            offset_of!(VkImageInfo, protected)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, ycbcr_conversion),
+            offset_of!(VkImageInfo, ycbcr_conversion)
+        );
+        assert_eq!(
+            offset_of!(VkImageInfoRepr, _reserved),
+            offset_of!(VkImageInfo, _reserved)
+        );
+    }
+
+    /// `RawVulkanHandlesRepr` MUST mirror `RawVulkanHandles` from
+    /// this crate byte-for-byte. The host's `raw_handles` slot
+    /// projects between them via a field-by-field copy; this test
+    /// locks the source layout so a future field reorder doesn't
+    /// silently desync the wire format.
+    #[test]
+    fn raw_vulkan_handles_repr_matches_source_layout() {
+        use crate::raw_handles::RawVulkanHandles;
+        assert_eq!(
+            size_of::<RawVulkanHandlesRepr>(),
+            size_of::<RawVulkanHandles>()
+        );
+        assert_eq!(
+            align_of::<RawVulkanHandlesRepr>(),
+            align_of::<RawVulkanHandles>()
+        );
+    }
+
+    fn vtable() -> &'static VulkanSurfaceAdapterVTable {
+        // SAFETY: the returned pointer is `&'static`-shaped per the
+        // `const VTABLE` construction in `MonoVTable<D>`.
+        unsafe { &*host_vulkan_surface_adapter_vtable::<D>() }
+    }
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_msg(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn layout_version_matches_constant() {
+        assert_eq!(vtable().layout_version, VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION);
+        assert_eq!(vtable()._reserved_padding, 0);
+    }
+
+    #[test]
+    fn clone_handle_returns_null_on_null_input() {
+        unsafe {
+            let out = (vtable().clone_handle)(core::ptr::null());
+            assert!(out.is_null());
+        }
+    }
+
+    #[test]
+    fn drop_handle_null_is_no_op() {
+        // Documented contract — must not crash on null.
+        unsafe {
+            (vtable().drop_handle)(core::ptr::null());
+        }
+    }
+
+    #[test]
+    fn register_host_surface_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (vtable().register_host_surface)(
+                core::ptr::null(),
+                42,
+                core::ptr::null(),
+                core::ptr::null(),
+                0,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("register_host_surface: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unregister_host_surface_null_handle_returns_zero_was_present() {
+        let mut was_present: u32 = 0xFFFF_FFFF;
+        unsafe {
+            (vtable().unregister_host_surface)(core::ptr::null(), 42, &mut was_present);
+        }
+        assert_eq!(was_present, 0);
+    }
+
+    #[test]
+    fn registered_count_null_handle_returns_zero() {
+        let n = unsafe { (vtable().registered_count)(core::ptr::null()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: VulkanViewRepr = unsafe { core::mem::zeroed() };
+        let rc = unsafe {
+            (vtable().acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(msg.contains("acquire_read: null adapter handle"), "got: {msg}");
+    }
+
+    #[test]
+    fn acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: VulkanViewRepr = unsafe { core::mem::zeroed() };
+        let rc = unsafe {
+            (vtable().acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: VulkanViewRepr = unsafe { core::mem::zeroed() };
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: VulkanViewRepr = unsafe { core::mem::zeroed() };
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn end_read_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_read_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn end_write_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_write_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn release_to_foreign_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut layout: i32 = 0;
+        let rc = unsafe {
+            (vtable().release_to_foreign)(
+                core::ptr::null(),
+                42,
+                0,
+                &mut layout,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("release_to_foreign: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn surface_image_info_null_handle_sets_out_found_zero() {
+        let mut info: VkImageInfoRepr = unsafe { core::mem::zeroed() };
+        let mut found: u32 = 99;
+        unsafe {
+            (vtable().surface_image_info)(core::ptr::null(), 42, &mut info, &mut found);
+        }
+        assert_eq!(found, 0);
+    }
+
+    #[test]
+    fn raw_handles_null_handle_writes_zeroed_struct() {
+        let mut handles: RawVulkanHandlesRepr = RawVulkanHandlesRepr {
+            vk_instance: 0xDEAD,
+            vk_physical_device: 0xBEEF,
+            vk_device: 0xCAFE,
+            vk_queue: 0xBABE,
+            vk_queue_family_index: 0xFF,
+            api_version: 0xFF,
+        };
+        unsafe { (vtable().raw_handles)(core::ptr::null(), &mut handles) };
+        assert_eq!(handles.vk_instance, 0);
+        assert_eq!(handles.vk_physical_device, 0);
+        assert_eq!(handles.vk_device, 0);
+        assert_eq!(handles.vk_queue, 0);
+        assert_eq!(handles.vk_queue_family_index, 0);
+        assert_eq!(handles.api_version, 0);
+    }
+}

--- a/libs/streamlib-adapter-vulkan/src/lib.rs
+++ b/libs/streamlib-adapter-vulkan/src/lib.rs
@@ -18,12 +18,14 @@
 
 mod adapter;
 mod context;
+mod host_vtable;
 mod raw_handles;
 mod state;
 mod view;
 
 pub use adapter::VulkanSurfaceAdapter;
 pub use context::VulkanContext;
+pub use host_vtable::host_vulkan_surface_adapter_vtable;
 pub use raw_handles::{raw_handles, RawVulkanHandles};
 pub use state::HostSurfaceRegistration;
 pub use streamlib_consumer_rhi::VulkanLayout;

--- a/libs/streamlib-adapter-vulkan/src/raw_handles.rs
+++ b/libs/streamlib-adapter-vulkan/src/raw_handles.rs
@@ -23,6 +23,14 @@ use vulkanalia::vk;
 /// can cross any binding boundary — `ash::Image::from_raw`,
 /// `vulkanalia::vk::Image::from_raw`, custom FFI shims, polyglot SDKs.
 /// The customer reconstructs the typed wrapper their binding wants.
+///
+/// `#[repr(C)]` so the layout matches
+/// [`streamlib_adapter_vulkan_abi::RawVulkanHandlesRepr`] byte-for-byte
+/// — the host's cdylib-facing `raw_handles` vtable slot writes through
+/// the repr type and consumers projecting between them rely on the
+/// shared layout. Locked by
+/// `host_vtable::tier1_null_handle_tests::raw_vulkan_handles_repr_matches_source_layout`.
+#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct RawVulkanHandles {
     /// `VkInstance` handle.


### PR DESCRIPTION
## Summary

- Trunk piece of the per-adapter vtable lift (issue #887; sibling slices land in #888 / #889 / #890 / #891 / #894).
- New crate `streamlib-adapter-vulkan-abi` — pure ABI, dep-free, no vulkanalia, no streamlib-engine. Same dep posture as `streamlib-plugin-abi`.
- Host wiring `host_vulkan_surface_adapter_vtable::<D>()` in `streamlib-adapter-vulkan` delegates every extern \"C\" slot to the existing `VulkanSurfaceAdapter<D>` impl. Per-monomorphization const vtable; cdylib never sees `D`.

Closes #887.

## What's in the vtable

Audited surface (enumerated in the new crate's module docs):

1. `SurfaceAdapter` trait methods on `VulkanSurfaceAdapter`: `acquire_read`, `acquire_write`, `try_acquire_read`, `try_acquire_write`, `end_read_access`, `end_write_access`.
2. Inherent methods on `VulkanSurfaceAdapter<D>` / `VulkanContext<D>`: `register_host_surface`, `unregister_host_surface`, `registered_count`, `release_to_foreign`, `surface_image_info`, `raw_handles`.
3. RAII guard `Drop` paths route back through the sealed `end_*_access` slots.
4. View capability accessors (`vk_image`, `vk_image_layout`, `vk_image_info`) are pure POD reads against `VulkanViewRepr` — no vtable hop on the view itself.

Methods deliberately not exposed (audit findings):

- `VulkanSurfaceAdapter::new` / `with_acquire_timeout` — host-side construction / chaining builder, the cdylib receives a vtable+handle, doesn't construct adapters.
- `submit_pool_create_count` — `#[doc(hidden)]`, test-only.
- `device` / `VulkanContext::adapter` — return `Arc<D>` / `&Arc<...>`, can't cross extern \"C\" without `D` parameterization; cdylibs reach the raw handles via the dedicated `raw_handles` slot.

## Vtable shape

| Type | Size | Anchor offsets |
|---|---|---|
| `VulkanSurfaceAdapterVTable` | 120 B (14 fn pointer slots + 8 B header) | locked by `vulkan_surface_adapter_vtable_layout` |
| `VulkanViewRepr` | 96 B | `vk_image: u64 @0`, `vk_image_layout: i32 @8`, padding `u32 @12`, `info @16` |
| `VkImageInfoRepr` | 80 B | byte-for-byte mirror of `streamlib_adapter_abi::VkImageInfo` |
| `RawVulkanHandlesRepr` | 40 B | byte-for-byte mirror of in-crate `RawVulkanHandles` (now `#[repr(C)]`) |

`VULKAN_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION = 1`. Future additions append after `raw_handles` and bump.

## Error / contention crossing

- Every fallible slot returns `i32` (0 = success, 1 = error). Error message written to caller's `err_buf` + `err_buf_cap` + `err_len`. Same shape `GpuContextLimitedAccessVTable::acquire_texture` and siblings already established.
- `try_acquire_*` distinguishes \"contended\" from \"failed\" via `*out_acquired` (0 = contended, 1 = success), keeping the `Result<Option<Guard>, AdapterError>` semantics across the i32 boundary.
- Host-side panic guards on every callback (mirrors `streamlib-plugin-abi::run_host_extern_c`): panics become tracing logs + default returns, never unwind into cdylib code.

## Test coverage

- **6 layout regression tests** in the abi crate locking `VkImageInfoRepr`, `VulkanViewRepr`, `RawVulkanHandlesRepr`, `VulkanSurfaceAdapterVTable` byte offsets + the `Send + Sync` witnesses.
- **15 tier-1 null-handle tests** on the host wiring exercising the panic guards on every vtable slot — pre-validation runs without a real `Arc<VulkanSurfaceAdapter>` or `HostVulkanDevice`.
- **2 cross-crate layout-equivalence tests** asserting `VkImageInfoRepr ≡ VkImageInfo` and `RawVulkanHandlesRepr ≡ RawVulkanHandles` byte-for-byte — locks the contract the abi crate is dep-light by design and can't verify itself.

23 new tests total. `cargo test --workspace --lib` stays green (full baseline run completed locally).

## Boundary discipline

- `cargo tree -p streamlib-adapter-vulkan-abi | grep -c \"^streamlib v\"` returns 0 — abi crate has zero streamlib deps.
- `cargo xtask check-boundaries` clean (4165 files scanned, no violations).
- Host wiring lives in `streamlib-adapter-vulkan` which is already permitted to use vulkanalia per the RHI-boundary rules.

## Architectural lock-in for siblings

This PR pins decisions the five sibling adapters (`#888` opengl, `#889` skia, `#890` cpu-readback, `#891` cuda, `#894` OutputWriter/InputMailboxes flip) ride on:

- **New `-abi` crate per adapter**, alongside the adapter crate, dep-free shape (`bitflags`-only if needed; no streamlib deps).
- **`#[repr(C)] AdapterXxxVTable { layout_version: u32, _reserved_padding: u32, fn pointers... }`** with layout regression locking byte offsets.
- **Generic host fn `host_<adapter>_vtable::<D>()`** when the adapter is generic over device flavor; non-generic helper otherwise.
- **Per-monomorphization `const VTABLE`** via a private `MonoVTable<D>` struct so each `D` gets its own static.
- **Tier-1 null-handle tests on every slot** following the `gpu_full_access_vtable_tests` pattern in `streamlib-plugin-abi`.
- **Cross-crate layout-equivalence tests** when the abi crate mirrors a source-crate `#[repr(C)]` struct.
- **`tracing` target string MUST avoid `streamlib::*`** (only `streamlib::sdk` / `streamlib::engine_internal` allowed); use `streamlib_<adapter>::ffi` style.

## Issue body — supersession note

The 2026-05-20 \"Resolved design — defer pending consumer\" section in #887's body is **superseded** by the user goal file `.claude/goals/04-adapter-callback-tables.md`:

> EXECUTE IN ANY ORDER (all 6 independent):
> 1. #887 — vulkan adapter callback table (streamlib-adapter-vulkan).
>    Start here; smallest scope. Surface includes SurfaceAdapter trait
>    (acquire_write / acquire_read / release) + setup-hook helpers.

The goal file restates the milestone's pre-planning posture per CLAUDE.md's `feedback_consumer_first_rule_softened.md`: a filed issue is sufficient consumer attestation; the right shape lands now so the five sibling adapters follow this shape mechanically.

## What's deliberately out of scope (next slice)

The issue body's exit criterion \"Cdylib-side shims forward through the vtable\" is the trunk-vs-slice cut point.

- **In this PR (trunk):** ABI vtable + host wiring + layout/null-handle tests. Locks the wire format end-to-end so the five siblings can mechanically copy the shape.
- **Sibling slice (follow-up):** cdylib β-shape `VulkanContext<ConsumerVulkanDevice>` that forwards through the vtable, `HostServices` v14 field append for `vulkan_surface_adapter_vtable`, `install_host_services` wiring, source-compatible imports for cdylib processors.

This mirrors the canonical Phase E sub-lift pattern (#985 / RhiCommandRecorderMethodsVTable Slice B, #957 / Texture::native_handle, etc.): trunk PR lands the ABI artifact + host wiring; cdylib β-shape integration is its own slice once the vtable is locked. Carving the cdylib β-shape into a separate PR keeps the diff focused, avoids forcing five sibling PRs to coordinate on a single `HostServices` field append, and preserves the multi-builder guarantee per the goal file's directive to build the right shape end-to-end.

## Test plan

- [x] `cargo test -p streamlib-adapter-vulkan-abi --lib` — 6/6 layout tests pass
- [x] `cargo test -p streamlib-adapter-vulkan --lib` — 15/15 tier-1 null-handle + 2 cross-crate layout-equivalence tests pass
- [x] `cargo test --workspace --lib --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — full baseline green
- [x] `cargo build --workspace --lib` — clean
- [x] `cargo xtask check-boundaries` — 4165 files scanned, no violations
- [x] `cargo tree -p streamlib-adapter-vulkan-abi | grep -c \"^streamlib v\"` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)