### PR TITLE
feat(plugin-abi): skia adapter callback table (#889)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "libs/streamlib-adapter-cuda", # CUDA surface adapter — Vulkan↔CUDA OPAQUE_FD interop foundation for GPU-resident AI inference (Linux, #587)
     "libs/streamlib-adapter-cuda-helpers", # Test-helper crate for streamlib-adapter-cuda — held in a dedicated crate so streamlib (and the optional CUDA SDK) don't leak into adapter-cuda's runtime dep graph (Linux)
     "libs/streamlib-adapter-skia", # Skia surface adapter — composes on streamlib-adapter-vulkan; customer sees skia::Surface directly, never GrVkImageInfo / VkImageLayout (Linux)
+    "libs/streamlib-adapter-skia-abi", # Cross-DSO callback table for streamlib-adapter-skia — extern "C" vtable consumed by host wiring + cdylib shim (#889)
     "libs/streamlib-deno-native", # FFI cdylib for Deno subprocess iceoryx2 access
     "libs/streamlib-python-native", # FFI cdylib for Python subprocess iceoryx2 access
     "libs/streamlib-ipc-types",  # Shared iceoryx2 payload types for cross-process IPC

--- a/libs/streamlib-adapter-skia-abi/Cargo.toml
+++ b/libs/streamlib-adapter-skia-abi/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-skia-abi"
+description = "Cross-DSO callback table for streamlib-adapter-skia. Sibling of streamlib-plugin-abi / streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to SkiaSurfaceAdapter / SkiaGlSurfaceAdapter) and cdylib shims. Skia is host-side-only — its view types (skia_safe::Surface / Image) cannot cross DSO, so the vtable surface covers only the SurfaceAdapter trait scoping contract."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_skia_abi"
+path = "src/lib.rs"
+
+# Pure ABI crate — same dep posture as streamlib-plugin-abi /
+# streamlib-adapter-vulkan-abi: no streamlib-engine, no vulkanalia,
+# no skia-safe, no streamlib-adapter-skia, no tokio. Keeps layout
+# regression tests trivially runnable on any host and the crate
+# cross-DSO-safe.
+[dependencies]
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-skia-abi/src/lib.rs
+++ b/libs/streamlib-adapter-skia-abi/src/lib.rs
@@ -1,0 +1,510 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO callback table for `streamlib-adapter-skia`.
+//!
+//! Sibling of [`streamlib-adapter-vulkan-abi`] and
+//! [`streamlib-plugin-abi`] in the per-adapter vtable lift family
+//! (`GpuContextLimitedAccessVTable` and friends from issue #886; the
+//! per-adapter trunk in issue #887 / PR #994 established the
+//! mechanical shape this crate follows).
+//!
+//! # What this crate is
+//!
+//! Pure ABI contract describing how a host (`streamlib-engine`)
+//! exposes its Skia surface adapters — `SkiaSurfaceAdapter<D>`
+//! (Vulkan-backed, generic over device flavor) and
+//! `SkiaGlSurfaceAdapter` (OpenGL-backed, non-generic) — to a cdylib
+//! plugin without sharing any Rust types beyond `#[repr(C)]` payloads
+//! and `unsafe extern "C" fn` pointers.
+//!
+//! Dep posture mirrors [`streamlib-plugin-abi`]: zero streamlib
+//! crates pulled, zero `skia-safe`, zero vulkanalia, zero
+//! rustc-version-coupled types. Skia bindings (`skia-safe`) are
+//! deliberately excluded — see "Audit findings — what does NOT cross
+//! the vtable" below.
+//!
+//! # Audited cdylib-callable surface
+//!
+//! The audit at pickup time (against
+//! `libs/streamlib-adapter-skia/src/`) enumerated:
+//!
+//! 1. `SurfaceAdapter` trait methods (from `streamlib-adapter-abi`)
+//!    implemented on both Skia adapter flavors: `acquire_read`,
+//!    `acquire_write`, `try_acquire_read`, `try_acquire_write`,
+//!    `end_read_access`, `end_write_access`.
+//! 2. RAII guard `Drop` paths (`ReadGuard::drop` / `WriteGuard::drop`)
+//!    route back through `SurfaceAdapter::end_*_access` — covered
+//!    by the same vtable slots.
+//!
+//! # Audit findings — what does NOT cross the vtable
+//!
+//! Skia is **host-side only** by deliberate architectural choice (per
+//! [`docs/architecture/subprocess-rhi-parity.md`]). Cdylibs do NOT
+//! depend on `streamlib-adapter-skia` in their Cargo dep graph;
+//! subprocess customers reach Skia surfaces through the wrapped
+//! Vulkan or OpenGL adapter's cdylib path. Consequently:
+//!
+//! - **No inherent registry methods** to expose. Unlike
+//!   `VulkanSurfaceAdapter` (which carries `register_host_surface`,
+//!   `unregister_host_surface`, `release_to_foreign`,
+//!   `surface_image_info`, `raw_handles`, `registered_count`), the
+//!   Skia adapters carry zero such inherent methods — registry
+//!   operations route through the inner Vulkan/OpenGL adapter via
+//!   the host-side `SkiaSurfaceAdapter::inner()` accessor (which is
+//!   itself not cdylib-callable since it returns
+//!   `&Arc<VulkanSurfaceAdapter<D>>`). Only `registered_count` has
+//!   a useful informational projection through the inner adapter;
+//!   it's included here for symmetry with the Vulkan/OpenGL ABI.
+//!
+//! - **No Skia-typed view accessors.** `SkiaWriteView` exposes
+//!   `&skia_safe::Surface`; `SkiaReadView` exposes
+//!   `&skia_safe::Image`. Both Skia types are `RCHandle<…>` raw
+//!   pointer wrappers tied to `skia-safe`'s `!Send + !Sync`
+//!   single-thread-affine `GrDirectContext`. Their internal layout
+//!   is **rustc-version-coupled and skia-safe-version-coupled** —
+//!   crossing them through an extern "C" boundary would defeat the
+//!   purpose of this ABI. Adding cross-DSO Skia view access is
+//!   future work (the Option C msgpack display-list shape recorded
+//!   on issue #889's body is a candidate; a per-method canvas
+//!   vtable is another).
+//!
+//! - **No `inner()` accessor.** The Vulkan / OpenGL inner adapters
+//!   are reachable through their own vtables — a cdylib that needs
+//!   raw GPU handles uses the Vulkan or OpenGL adapter's vtable
+//!   directly, not Skia's.
+//!
+//! # What this vtable does cover
+//!
+//! The scoping contract — acquire / release on a `StreamlibSurface`
+//! — is identical across every surface adapter and IS cross-DSO
+//! safe via the `surface_id`-only [`SkiaViewRepr`] payload. The
+//! vtable carries the trunk-pattern `clone_handle` /
+//! `drop_handle` lifetime slots plus all 6 `SurfaceAdapter` trait
+//! methods plus the informational `registered_count` projection.
+//!
+//! This is the minimum useful surface for a future cdylib Skia
+//! consumer that wants to pair its own host-side or
+//! escalate-IPC-mediated Skia draw flow with the host's surface
+//! lifecycle. The lifecycle bit is what the trunk pattern locks at
+//! ABI birth so the five sibling adapters share the same scoping
+//! shape.
+
+#![no_std]
+
+use core::ffi::c_void;
+
+// ============================================================================
+// Layout version constants
+// ============================================================================
+
+/// Layout version of [`SkiaSurfaceAdapterVTable`].
+///
+/// Pinned at offset 0 forever; new methods append to the end and
+/// bump this constant. Host wiring asserts equality at install
+/// time; cdylib code reads it before dereferencing any slot and
+/// refuses to proceed on mismatch.
+///
+/// - v1: trunk lift — handle lifetime (`clone_handle` /
+///   `drop_handle`) + `registered_count` + 6 `SurfaceAdapter` trait
+///   slots. Locked by
+///   [`tests::skia_surface_adapter_vtable_layout`] and the
+///   tier-1 null-handle tests next to the host wiring.
+pub const SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Layout version of [`SkiaGlSurfaceAdapterVTable`]. Same shape as
+/// [`SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`] but distinct so
+/// the two vtables version independently as their underlying
+/// adapters evolve.
+pub const SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+// ============================================================================
+// View payload — pure data the host writes into a caller-provided slot
+// ============================================================================
+
+/// `#[repr(C)]` payload returned by `acquire_read` / `acquire_write` /
+/// `try_acquire_*`.
+///
+/// Deliberately **minimal** compared to
+/// [`streamlib_adapter_vulkan_abi::VulkanViewRepr`]: Skia's view
+/// types (`skia_safe::Surface` / `skia_safe::Image`) are
+/// `RCHandle<…>` wrappers tied to the host's `skia-safe` version
+/// and `GrDirectContext` — they cannot be safely projected through
+/// an extern "C" boundary, so the only meaningful per-acquire data
+/// that travels here is the surface identity itself plus its
+/// dimensions (useful for the cdylib to gate scope-local
+/// pre/post bookkeeping without re-reading the
+/// `StreamlibSurface`).
+///
+/// Future expansion (Option C msgpack display-list submit, per-call
+/// canvas vtable) appends fields here and bumps the layout version;
+/// see this crate's module docs for the recorded alternatives.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SkiaViewRepr {
+    /// Surface identity the host's adapter associated with this
+    /// scope. Mirrors `WriteGuard::surface_id` / `ReadGuard::surface_id`
+    /// on the host side.
+    pub surface_id: u64,
+
+    /// Surface width in pixels. Copied from
+    /// `StreamlibSurface::width` for convenience.
+    pub width: u32,
+
+    /// Surface height in pixels. Copied from
+    /// `StreamlibSurface::height` for convenience.
+    pub height: u32,
+
+    /// Reserved bytes for additive ABI extensions. MUST be zeroed.
+    /// Sized so the struct rounds out to 32 bytes and any future
+    /// `u64` / pointer additions land naturally aligned.
+    pub _reserved: [u8; 16],
+}
+
+// ============================================================================
+// SkiaSurfaceAdapterVTable — Vulkan-backed Skia adapter, generic over D
+// ============================================================================
+
+/// Dispatch table for the host's `SkiaSurfaceAdapter<D>` (the
+/// Vulkan-backed Skia adapter).
+///
+/// The cdylib holds an opaque `*const c_void` handle (an
+/// `Arc::into_raw(Arc<SkiaSurfaceAdapter<D>>)`-shaped pointer
+/// produced by the host) plus a
+/// `*const SkiaSurfaceAdapterVTable` it reads from the
+/// `HostServices` payload when the cdylib β-shape lift lands
+/// (sibling slice to this trunk PR). Method-dispatch callbacks
+/// cover every cdylib-callable `SurfaceAdapter` trait method.
+///
+/// # Handle lifetime
+///
+/// `clone_handle` / `drop_handle` mirror the
+/// `GpuContextLimitedAccessVTable` v2 pattern from
+/// `streamlib-plugin-abi`: `clone_handle(borrowed) -> owned` bumps
+/// the host's `Arc<SkiaSurfaceAdapter<D>>` refcount;
+/// `drop_handle(owned)` releases. The owned handle remains valid
+/// even after the originating runtime context is dropped.
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. New methods
+/// append to the end and bump
+/// [`SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+///
+/// # Error crossing
+///
+/// Every fallible slot returns `i32` (0 = success, non-zero =
+/// error). On error the host writes a UTF-8 message into the
+/// caller-provided `err_buf` (clamped to `err_buf_cap`) and sets
+/// `*err_len` to the bytes written. Identical to
+/// `streamlib_adapter_vulkan_abi::VulkanSurfaceAdapterVTable`'s
+/// error convention.
+///
+/// Non-error sentinels: `try_acquire_*` distinguishes "contended,
+/// retry later" (status = 0, `*out_acquired = 0`) from "real
+/// failure" (status = 1, error written) so the host's `Ok(None)`
+/// vs `Err(...)` distinction survives the i32 crossing.
+#[repr(C)]
+pub struct SkiaSurfaceAdapterVTable {
+    /// Vtable layout version. Must equal
+    /// [`SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -----------------------------------------------------------------
+    // Handle lifetime
+    // -----------------------------------------------------------------
+
+    /// Take a borrowed handle and return a new owned handle with an
+    /// Arc refcount bump on the underlying
+    /// `Arc<SkiaSurfaceAdapter<D>>`. The owned handle remains valid
+    /// even after the originating context is dropped and MUST be
+    /// released exactly once via [`Self::drop_handle`]. Calling on
+    /// a null pointer returns null.
+    pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
+
+    /// Release an owned handle previously obtained from
+    /// [`Self::clone_handle`]. Calling on a null pointer is a
+    /// no-op.
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // -----------------------------------------------------------------
+    // Informational projection
+    // -----------------------------------------------------------------
+
+    /// Snapshot the inner Vulkan adapter's registry size (number of
+    /// currently-registered surfaces). Returns 0 on null handle.
+    /// The Skia adapter has no registry of its own — this projects
+    /// through `SkiaSurfaceAdapter::inner().registered_count()`.
+    pub registered_count: unsafe extern "C" fn(handle: *const c_void) -> usize,
+
+    // -----------------------------------------------------------------
+    // SurfaceAdapter trait methods
+    // -----------------------------------------------------------------
+
+    /// Blocking read acquire.
+    ///
+    /// `surface_ptr` is a `*const StreamlibSurface` borrowed from
+    /// the caller's stack; valid for the duration of the call. On
+    /// success writes the populated [`SkiaViewRepr`] into
+    /// `*out_view` and returns 0. The blocking variant never
+    /// returns the contended-but-not-error case (`try_acquire_*`
+    /// does).
+    pub acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Blocking write acquire. Same shape as [`Self::acquire_read`]
+    /// but exclusive-write semantics.
+    pub acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking read acquire.
+    ///
+    /// Returns 0 on success and writes `*out_acquired = 1` plus a
+    /// populated view. Returns 0 with `*out_acquired = 0` on
+    /// contention (Ok(None) shape) without writing the view.
+    /// Returns non-zero with an error message on real failure.
+    pub try_acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking write acquire. Same shape as
+    /// [`Self::try_acquire_read`].
+    pub try_acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Sealed: notify the Skia adapter that a read access scope has
+    /// ended. Called by the cdylib's `ReadGuard::drop`. Idempotent
+    /// against unknown surface IDs (the host logs and returns; no
+    /// error surfaced because Drop can't propagate).
+    ///
+    /// Note: `SkiaSurfaceAdapter::end_read_access` is a host-side
+    /// no-op by deliberate design (Skia's view drop hook is where
+    /// flush + inner-guard-drop happens), so this slot exists for
+    /// trunk-pattern symmetry and host-side observability rather
+    /// than functional release semantics.
+    pub end_read_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    /// Sealed: notify the Skia adapter that a write access scope
+    /// has ended. Called by the cdylib's `WriteGuard::drop`. Same
+    /// note as [`Self::end_read_access`] — host-side no-op today,
+    /// kept for trunk-pattern symmetry.
+    pub end_write_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+}
+
+// Safety: every field is a primitive integer or an `unsafe extern "C" fn`
+// pointer; no thread-local state, no interior mutability. The host
+// guarantees the pointed-at adapter state outlives every cdylib that
+// holds a clone of the handle via the loader's pinning shape.
+unsafe impl Send for SkiaSurfaceAdapterVTable {}
+unsafe impl Sync for SkiaSurfaceAdapterVTable {}
+
+// ============================================================================
+// SkiaGlSurfaceAdapterVTable — OpenGL-backed Skia adapter, non-generic
+// ============================================================================
+
+/// Dispatch table for the host's `SkiaGlSurfaceAdapter` (the
+/// OpenGL-backed Skia adapter).
+///
+/// Identical method surface to [`SkiaSurfaceAdapterVTable`] —
+/// `SkiaGlSurfaceAdapter` implements the same `SurfaceAdapter`
+/// trait — but the type is separate because the underlying adapter
+/// is non-generic (composes on `Arc<OpenGlSurfaceAdapter>`, which
+/// has no device-flavor parameterization). Versioning the two
+/// vtables independently keeps additive ABI extensions to the
+/// Vulkan-backed flavor (e.g. eventually exposing the inner
+/// adapter's Vulkan handles) from forcing a no-op bump on the GL
+/// flavor.
+///
+/// Layout discipline + error crossing are identical to
+/// [`SkiaSurfaceAdapterVTable`].
+#[repr(C)]
+pub struct SkiaGlSurfaceAdapterVTable {
+    /// Vtable layout version. Must equal
+    /// [`SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding.
+    pub _reserved_padding: u32,
+
+    /// Take a borrowed handle and return a new owned handle.
+    /// Mirrors [`SkiaSurfaceAdapterVTable::clone_handle`].
+    pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
+
+    /// Release an owned handle. Mirrors
+    /// [`SkiaSurfaceAdapterVTable::drop_handle`].
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    /// Snapshot the inner OpenGL adapter's registry size. Projects
+    /// through `SkiaGlSurfaceAdapter::inner().registered_count()`.
+    pub registered_count: unsafe extern "C" fn(handle: *const c_void) -> usize,
+
+    /// Blocking read acquire. See
+    /// [`SkiaSurfaceAdapterVTable::acquire_read`].
+    pub acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Blocking write acquire. See
+    /// [`SkiaSurfaceAdapterVTable::acquire_write`].
+    pub acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking read acquire. See
+    /// [`SkiaSurfaceAdapterVTable::try_acquire_read`].
+    pub try_acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking write acquire. See
+    /// [`SkiaSurfaceAdapterVTable::try_acquire_write`].
+    pub try_acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut SkiaViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Sealed: end-of-read-scope hook. See
+    /// [`SkiaSurfaceAdapterVTable::end_read_access`].
+    pub end_read_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    /// Sealed: end-of-write-scope hook. See
+    /// [`SkiaSurfaceAdapterVTable::end_write_access`].
+    pub end_write_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+}
+
+unsafe impl Send for SkiaGlSurfaceAdapterVTable {}
+unsafe impl Sync for SkiaGlSurfaceAdapterVTable {}
+
+// ============================================================================
+// Layout regression tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    /// `SkiaViewRepr` is `(u64, u32, u32, [u8; 16])` = 32 bytes,
+    /// align 8. Locks the byte offsets so a host built against
+    /// v1 and a cdylib built against v1 read the same fields at
+    /// the same offsets regardless of rustc-minor / dep-graph
+    /// drift. New fields append after `_reserved` (which then
+    /// shrinks accordingly) and the layout version bumps.
+    #[test]
+    fn skia_view_repr_layout() {
+        assert_eq!(offset_of!(SkiaViewRepr, surface_id), 0);
+        assert_eq!(offset_of!(SkiaViewRepr, width), 8);
+        assert_eq!(offset_of!(SkiaViewRepr, height), 12);
+        assert_eq!(offset_of!(SkiaViewRepr, _reserved), 16);
+        assert_eq!(size_of::<SkiaViewRepr>(), 32);
+        assert_eq!(align_of::<SkiaViewRepr>(), 8);
+    }
+
+    /// Locks the Vulkan-backed Skia vtable binary layout. Anchors
+    /// every method slot at a fixed byte offset.
+    ///
+    /// 9 method slots: 2 lifetime + 1 informational + 6
+    /// SurfaceAdapter trait. Header is `u32 layout_version` +
+    /// `u32 _reserved_padding` = 8 bytes. Total = 8 + 9*8 = 80
+    /// bytes, align 8.
+    #[test]
+    fn skia_surface_adapter_vtable_layout() {
+        assert_eq!(SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(size_of::<SkiaSurfaceAdapterVTable>(), 80);
+        assert_eq!(align_of::<SkiaSurfaceAdapterVTable>(), 8);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, layout_version), 0);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, clone_handle), 8);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, drop_handle), 16);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, registered_count), 24);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, acquire_read), 32);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, acquire_write), 40);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, try_acquire_read), 48);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, try_acquire_write), 56);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, end_read_access), 64);
+        assert_eq!(offset_of!(SkiaSurfaceAdapterVTable, end_write_access), 72);
+    }
+
+    /// Locks the OpenGL-backed Skia vtable binary layout. Same
+    /// shape and size as [`SkiaSurfaceAdapterVTable`] — the type
+    /// is separate so the two vtables can version independently as
+    /// their underlying adapters evolve.
+    #[test]
+    fn skia_gl_surface_adapter_vtable_layout() {
+        assert_eq!(SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(size_of::<SkiaGlSurfaceAdapterVTable>(), 80);
+        assert_eq!(align_of::<SkiaGlSurfaceAdapterVTable>(), 8);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, layout_version), 0);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, clone_handle), 8);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, drop_handle), 16);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, registered_count), 24);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, acquire_read), 32);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, acquire_write), 40);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, try_acquire_read), 48);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, try_acquire_write), 56);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, end_read_access), 64);
+        assert_eq!(offset_of!(SkiaGlSurfaceAdapterVTable, end_write_access), 72);
+    }
+
+    /// Compile-time witness that both vtables are `Send + Sync`.
+    /// A future regression that adds an interior-mutable or non-
+    /// thread-safe field would break the unsafe impls above and
+    /// trip this test at build time.
+    #[test]
+    fn vtables_are_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SkiaSurfaceAdapterVTable>();
+        assert_send_sync::<SkiaGlSurfaceAdapterVTable>();
+    }
+}

--- a/libs/streamlib-adapter-skia/Cargo.toml
+++ b/libs/streamlib-adapter-skia/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-skia-abi = { path = "../streamlib-adapter-skia-abi" }
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-skia/src/host_vtable.rs
+++ b/libs/streamlib-adapter-skia/src/host_vtable.rs
@@ -1,0 +1,1236 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side wiring of
+//! [`streamlib_adapter_skia_abi::SkiaSurfaceAdapterVTable`] and
+//! [`streamlib_adapter_skia_abi::SkiaGlSurfaceAdapterVTable`].
+//!
+//! Hosts that want to expose Skia surface adapters to a cdylib
+//! plugin do this:
+//!
+//! 1. Construct an `Arc<SkiaSurfaceAdapter<D>>` or
+//!    `Arc<SkiaGlSurfaceAdapter>` on the host side (compose on the
+//!    inner Vulkan / OpenGL adapter — same as today).
+//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//!    - `handle = Arc::into_raw(arc.clone())`
+//!    - `vtable = host_skia_surface_adapter_vtable::<D>()` (Vulkan
+//!      flavor) or `host_skia_gl_surface_adapter_vtable()` (GL
+//!      flavor)
+//! 3. The cdylib invokes the vtable methods exactly as if it held
+//!    a Rust `&SkiaSurfaceAdapter<D>` — every method dispatches
+//!    through host-compiled code, so layout drift between
+//!    rustc-minor versions and divergent dep graphs is contained
+//!    inside the host DSO.
+//!
+//! The Vulkan-flavor wiring is generic over
+//! `D: VulkanRhiDevice + 'static` so the same vtable works whether
+//! the host is exposing a `SkiaSurfaceAdapter<HostVulkanDevice>`
+//! (canonical host-side path) or a
+//! `SkiaSurfaceAdapter<ConsumerVulkanDevice>` (cdylib-internal
+//! subprocess adapter — same shape, different device flavor). Each
+//! monomorphization materializes its own `static` vtable; cdylib
+//! code never sees the type parameter — only the
+//! `*const SkiaSurfaceAdapterVTable` pointer.
+//!
+//! Panic guards inside each fn body mirror the
+//! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
+//! host code is caught at the FFI boundary and converted to a
+//! clean error return instead of corrupting the cdylib's stack.
+//! Tier-1 null-handle tests next to this module verify the guards
+//! fire correctly without an actual `Arc<SkiaSurfaceAdapter>`.
+//!
+//! # Host-side-only constraint
+//!
+//! Per [`docs/architecture/subprocess-rhi-parity.md`], Skia is
+//! host-side only — cdylibs do not depend on
+//! `streamlib-adapter-skia` in their Cargo dep graph; subprocess
+//! customers reach Skia surfaces through the wrapped Vulkan /
+//! OpenGL adapter's cdylib path. The vtables here cover the
+//! `SurfaceAdapter` trait scoping contract (acquire / release on a
+//! `StreamlibSurface`) only — view payload is the minimal
+//! [`SkiaViewRepr`] carrying `surface_id` + dimensions, never the
+//! Skia-typed `&skia_safe::Surface` / `&skia_safe::Image`. Skia's
+//! `RCHandle<…>` types are tied to the host's `skia-safe` version
+//! and single-thread-affine `GrDirectContext`; projecting them
+//! through an extern "C" boundary would defeat the purpose of this
+//! ABI. Future cross-DSO Skia draw support is its own design
+//! problem (e.g. the msgpack display-list pattern recorded on
+//! issue #889's body, a per-method canvas vtable, etc.).
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    AdapterError, StreamlibSurface, SurfaceAdapter,
+};
+use streamlib_adapter_skia_abi::{
+    SkiaGlSurfaceAdapterVTable, SkiaSurfaceAdapterVTable, SkiaViewRepr,
+    SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+    SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+};
+use streamlib_consumer_rhi::VulkanRhiDevice;
+
+use crate::adapter::SkiaSurfaceAdapter;
+use crate::gl_adapter::SkiaGlSurfaceAdapter;
+
+// =============================================================================
+// Public host-side entry points
+// =============================================================================
+
+/// Returns a `*const SkiaSurfaceAdapterVTable` whose method slots
+/// dispatch against an `Arc<SkiaSurfaceAdapter<D>>`-shaped handle.
+///
+/// The vtable is `const`-initialized per `D` monomorphization;
+/// every call for the same `D` returns the same pointer. Multiple
+/// `D`s coexist in the same host process with their own vtables.
+pub fn host_skia_surface_adapter_vtable<D: VulkanRhiDevice + 'static>(
+) -> *const SkiaSurfaceAdapterVTable {
+    &VkMonoVTable::<D>::VTABLE
+}
+
+/// Returns a `*const SkiaGlSurfaceAdapterVTable` whose method
+/// slots dispatch against an `Arc<SkiaGlSurfaceAdapter>`-shaped
+/// handle.
+///
+/// Non-generic — `SkiaGlSurfaceAdapter` composes on the
+/// non-generic `OpenGlSurfaceAdapter`. Returns the same pointer on
+/// every call.
+pub fn host_skia_gl_surface_adapter_vtable() -> *const SkiaGlSurfaceAdapterVTable {
+    &GL_VTABLE
+}
+
+// =============================================================================
+// Vulkan-flavor monomorphizer
+// =============================================================================
+
+/// Type-keyed monomorphizer. The `const VTABLE` is materialized at
+/// codegen time for each `D` that calls
+/// [`host_skia_surface_adapter_vtable`] elsewhere in the binary;
+/// the fn-pointer slots resolve to the matching monomorphizations
+/// of the free fns below.
+struct VkMonoVTable<D: VulkanRhiDevice + 'static>(PhantomData<D>);
+
+impl<D: VulkanRhiDevice + 'static> VkMonoVTable<D> {
+    const VTABLE: SkiaSurfaceAdapterVTable = SkiaSurfaceAdapterVTable {
+        layout_version: SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        clone_handle: host_vk_clone_handle::<D>,
+        drop_handle: host_vk_drop_handle::<D>,
+        registered_count: host_vk_registered_count::<D>,
+        acquire_read: host_vk_acquire_read::<D>,
+        acquire_write: host_vk_acquire_write::<D>,
+        try_acquire_read: host_vk_try_acquire_read::<D>,
+        try_acquire_write: host_vk_try_acquire_write::<D>,
+        end_read_access: host_vk_end_read_access::<D>,
+        end_write_access: host_vk_end_write_access::<D>,
+    };
+}
+
+// =============================================================================
+// OpenGL-flavor static vtable
+// =============================================================================
+
+static GL_VTABLE: SkiaGlSurfaceAdapterVTable = SkiaGlSurfaceAdapterVTable {
+    layout_version: SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+    _reserved_padding: 0,
+    clone_handle: host_gl_clone_handle,
+    drop_handle: host_gl_drop_handle,
+    registered_count: host_gl_registered_count,
+    acquire_read: host_gl_acquire_read,
+    acquire_write: host_gl_acquire_write,
+    try_acquire_read: host_gl_try_acquire_read,
+    try_acquire_write: host_gl_try_acquire_write,
+    end_read_access: host_gl_end_read_access,
+    end_write_access: host_gl_end_write_access,
+};
+
+// =============================================================================
+// FFI helpers — error buffer writer + panic guard
+// =============================================================================
+
+/// Catch panics at the extern "C" boundary so a host-side panic
+/// doesn't unwind into cdylib code. On panic the body returns
+/// `default_on_panic`; the panic message is logged via `tracing`
+/// for post-mortem visibility.
+#[inline]
+fn run_host_extern_c<F, T>(callback_name: &'static str, body: F, default_on_panic: T) -> T
+where
+    F: FnOnce() -> T,
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            tracing::error!(
+                target: "streamlib_adapter_skia::ffi",
+                callback = callback_name,
+                panic = %msg,
+                "host extern \"C\" callback panicked; FFI boundary converted panic to default return"
+            );
+            default_on_panic
+        }
+    }
+}
+
+/// Write a UTF-8 error message into a caller-provided buffer.
+/// Truncates to `cap`; sets `*err_len` to the bytes actually
+/// written. Null pointers are tolerated (the message is simply
+/// dropped).
+unsafe fn write_err(msg: &str, err_buf: *mut u8, err_buf_cap: usize, err_len: *mut usize) {
+    if err_buf.is_null() || err_buf_cap == 0 {
+        if !err_len.is_null() {
+            unsafe { *err_len = 0 };
+        }
+        return;
+    }
+    let bytes = msg.as_bytes();
+    let n = bytes.len().min(err_buf_cap);
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), err_buf, n);
+        if !err_len.is_null() {
+            *err_len = n;
+        }
+    }
+}
+
+// =============================================================================
+// Vulkan-flavor — handle borrow helper
+// =============================================================================
+
+/// Borrow the adapter from a `*const c_void` handle. Returns
+/// `None` on null.
+///
+/// SAFETY: caller asserts the handle is one of: (a) a borrowed
+/// pointer produced by `Arc::as_ptr` against a live host-owned
+/// `Arc<SkiaSurfaceAdapter<D>>`, or (b) an owned pointer minted by
+/// [`host_vk_clone_handle`] still in its valid lifetime. Both are
+/// dereferenceable for read while the underlying Arc has at least
+/// one strong refcount; the panic guard wrapping every call site
+/// converts any UB-shaped mistake into a clean tracing log + the
+/// callback's default return.
+unsafe fn vk_adapter_borrow<'a, D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> Option<&'a SkiaSurfaceAdapter<D>> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const SkiaSurfaceAdapter<D>) })
+}
+
+// =============================================================================
+// Vulkan-flavor — clone_handle / drop_handle
+// =============================================================================
+
+unsafe extern "C" fn host_vk_clone_handle<D: VulkanRhiDevice + 'static>(
+    borrowed_handle: *const c_void,
+) -> *const c_void {
+    run_host_extern_c(
+        "skia_surface_adapter::clone_handle",
+        || {
+            if borrowed_handle.is_null() {
+                return core::ptr::null();
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<SkiaSurfaceAdapter<D>>)-shaped.
+            unsafe {
+                Arc::increment_strong_count(borrowed_handle as *const SkiaSurfaceAdapter<D>);
+            }
+            borrowed_handle
+        },
+        core::ptr::null(),
+    )
+}
+
+unsafe extern "C" fn host_vk_drop_handle<D: VulkanRhiDevice + 'static>(
+    owned_handle: *const c_void,
+) {
+    run_host_extern_c(
+        "skia_surface_adapter::drop_handle",
+        || {
+            if owned_handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<SkiaSurfaceAdapter<D>>)-shaped
+            // with at least one host-side refcount remaining.
+            unsafe {
+                Arc::decrement_strong_count(owned_handle as *const SkiaSurfaceAdapter<D>);
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Vulkan-flavor — registered_count
+// =============================================================================
+
+unsafe extern "C" fn host_vk_registered_count<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> usize {
+    run_host_extern_c(
+        "skia_surface_adapter::registered_count",
+        || {
+            let adapter = match unsafe { vk_adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return 0usize,
+            };
+            // Skia adapter has no registry of its own — project
+            // through the inner Vulkan adapter.
+            adapter.inner().registered_count()
+        },
+        0usize,
+    )
+}
+
+// =============================================================================
+// Vulkan-flavor — SurfaceAdapter trait methods
+// =============================================================================
+
+/// Common shape for `acquire_read` / `acquire_write` /
+/// `try_acquire_*`: borrow the adapter, validate the surface
+/// pointer, call the inner method, write the view + status.
+///
+/// The closure receives the adapter + a `&StreamlibSurface` and
+/// returns either:
+///   - `Ok(Some(SkiaViewRepr))` → status 0, `*out_acquired = 1`,
+///                                view written
+///   - `Ok(None)`               → status 0, `*out_acquired = 0`
+///                                (try_* only; blocking variants
+///                                never produce Ok(None))
+///   - `Err(msg)`               → status 1, error message written
+///
+/// Skia's view types are not cross-DSO-safe (see module docs), so
+/// the returned view payload only carries `surface_id` + width +
+/// height — the host's actual `WriteGuard` is dropped at the end
+/// of the host-side acquire callback (the scope is the callback
+/// itself; this is intentional, see end_*_access for the rationale).
+///
+/// NOTE on guard lifecycle: Skia's view types own
+/// `ManuallyDrop<WriteGuard>` and run flush+timeline-signal in
+/// their own `Drop`. Returning the WriteGuard to a cdylib would
+/// require crossing `skia_safe::Surface` through extern "C", which
+/// is unsound. Today the host-side acquire callback completes the
+/// full scope synchronously: the cdylib receives only the
+/// `SkiaViewRepr` identity payload and the surface is released by
+/// the time the call returns. A future shape (Option C msgpack
+/// display-list) would buffer the cdylib's draw commands and
+/// replay them under a real host-side scope.
+unsafe fn run_vk_acquire<D, F>(
+    callback_name: &'static str,
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: Option<*mut u32>,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    body: F,
+) -> i32
+where
+    D: VulkanRhiDevice + 'static,
+    F: FnOnce(
+        &SkiaSurfaceAdapter<D>,
+        &StreamlibSurface,
+    ) -> Result<Option<SkiaViewRepr>, String>,
+{
+    run_host_extern_c(
+        callback_name,
+        || {
+            if let Some(p) = out_acquired {
+                if !p.is_null() {
+                    unsafe { *p = 0 };
+                }
+            }
+            let adapter = match unsafe { vk_adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            &format!("{callback_name}: null adapter handle"),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if surface_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        &format!("{callback_name}: null surface pointer"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // StreamlibSurface valid for the call duration.
+            let surface: &StreamlibSurface =
+                unsafe { &*(surface_ptr as *const StreamlibSurface) };
+            match body(adapter, surface) {
+                Ok(Some(view)) => {
+                    if !out_view.is_null() {
+                        unsafe { *out_view = view };
+                    }
+                    if let Some(p) = out_acquired {
+                        if !p.is_null() {
+                            unsafe { *p = 1 };
+                        }
+                    }
+                    0
+                }
+                Ok(None) => 0,
+                Err(msg) => {
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+fn skia_view_repr_from_surface(surface_id: u64, surface: &StreamlibSurface) -> SkiaViewRepr {
+    SkiaViewRepr {
+        surface_id,
+        width: surface.width,
+        height: surface.height,
+        _reserved: [0u8; 16],
+    }
+}
+
+/// Run a Skia VK acquire-write scope and drop the WriteGuard
+/// before returning. Skia's drop hook fires flush + inner-guard
+/// release inside the closure body so the surface is fully
+/// released by the time the cdylib receives the
+/// [`SkiaViewRepr`] response. The closure's actual return value
+/// is just the view's identity payload — no Skia types cross the
+/// boundary.
+fn run_skia_vk_write_scope<D: VulkanRhiDevice + 'static>(
+    adapter: &SkiaSurfaceAdapter<D>,
+    surface: &StreamlibSurface,
+) -> Result<SkiaViewRepr, AdapterError> {
+    let guard = adapter.acquire_write(surface)?;
+    let surface_id = guard.surface_id();
+    // Drop the guard explicitly so the flush + inner release runs
+    // synchronously inside the FFI scope. The cdylib customer's
+    // SurfaceAdapter trait contract guarantees that on `Ok` return
+    // the surface has been written (and synchronized) — same as a
+    // synchronous Rust-side `acquire_write` followed by drop.
+    drop(guard);
+    Ok(skia_view_repr_from_surface(u64::from(surface_id), surface))
+}
+
+fn run_skia_vk_read_scope<D: VulkanRhiDevice + 'static>(
+    adapter: &SkiaSurfaceAdapter<D>,
+    surface: &StreamlibSurface,
+) -> Result<SkiaViewRepr, AdapterError> {
+    let guard = adapter.acquire_read(surface)?;
+    let surface_id = guard.surface_id();
+    drop(guard);
+    Ok(skia_view_repr_from_surface(u64::from(surface_id), surface))
+}
+
+unsafe extern "C" fn host_vk_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_vk_acquire::<D, _>(
+            "skia_surface_adapter::acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match run_skia_vk_read_scope(adapter, surface) {
+                Ok(view) => Ok(Some(view)),
+                Err(e) => Err(format!("acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_vk_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_vk_acquire::<D, _>(
+            "skia_surface_adapter::acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match run_skia_vk_write_scope(adapter, surface) {
+                Ok(view) => Ok(Some(view)),
+                Err(e) => Err(format!("acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_vk_try_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_vk_acquire::<D, _>(
+            "skia_surface_adapter::try_acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_read(surface) {
+                Ok(Some(guard)) => {
+                    let surface_id = guard.surface_id();
+                    drop(guard);
+                    Ok(Some(skia_view_repr_from_surface(
+                        u64::from(surface_id),
+                        surface,
+                    )))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_vk_try_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_vk_acquire::<D, _>(
+            "skia_surface_adapter::try_acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_write(surface) {
+                Ok(Some(guard)) => {
+                    let surface_id = guard.surface_id();
+                    drop(guard);
+                    Ok(Some(skia_view_repr_from_surface(
+                        u64::from(surface_id),
+                        surface,
+                    )))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_vk_end_read_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "skia_surface_adapter::end_read_access",
+        || {
+            let adapter = match unsafe { vk_adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            // SkiaSurfaceAdapter::end_read_access is a host-side
+            // no-op by design (the view's drop hook is where the
+            // flush + inner-guard-drop happens). The release
+            // already happened inside the host-side acquire
+            // closure above; this slot exists for trunk-pattern
+            // symmetry / observability if a future host wires
+            // additional teardown logic here.
+            adapter.end_read_access(surface_id);
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_vk_end_write_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "skia_surface_adapter::end_write_access",
+        || {
+            let adapter = match unsafe { vk_adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_write_access(surface_id);
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// OpenGL-flavor — handle borrow helper
+// =============================================================================
+
+unsafe fn gl_adapter_borrow<'a>(handle: *const c_void) -> Option<&'a SkiaGlSurfaceAdapter> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const SkiaGlSurfaceAdapter) })
+}
+
+// =============================================================================
+// OpenGL-flavor — clone_handle / drop_handle
+// =============================================================================
+
+unsafe extern "C" fn host_gl_clone_handle(borrowed_handle: *const c_void) -> *const c_void {
+    run_host_extern_c(
+        "skia_gl_surface_adapter::clone_handle",
+        || {
+            if borrowed_handle.is_null() {
+                return core::ptr::null();
+            }
+            unsafe {
+                Arc::increment_strong_count(borrowed_handle as *const SkiaGlSurfaceAdapter);
+            }
+            borrowed_handle
+        },
+        core::ptr::null(),
+    )
+}
+
+unsafe extern "C" fn host_gl_drop_handle(owned_handle: *const c_void) {
+    run_host_extern_c(
+        "skia_gl_surface_adapter::drop_handle",
+        || {
+            if owned_handle.is_null() {
+                return;
+            }
+            unsafe {
+                Arc::decrement_strong_count(owned_handle as *const SkiaGlSurfaceAdapter);
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// OpenGL-flavor — registered_count
+// =============================================================================
+
+unsafe extern "C" fn host_gl_registered_count(handle: *const c_void) -> usize {
+    run_host_extern_c(
+        "skia_gl_surface_adapter::registered_count",
+        || {
+            let adapter = match unsafe { gl_adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return 0usize,
+            };
+            adapter.inner().registered_count()
+        },
+        0usize,
+    )
+}
+
+// =============================================================================
+// OpenGL-flavor — SurfaceAdapter trait methods
+// =============================================================================
+
+unsafe fn run_gl_acquire<F>(
+    callback_name: &'static str,
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: Option<*mut u32>,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    body: F,
+) -> i32
+where
+    F: FnOnce(
+        &SkiaGlSurfaceAdapter,
+        &StreamlibSurface,
+    ) -> Result<Option<SkiaViewRepr>, String>,
+{
+    run_host_extern_c(
+        callback_name,
+        || {
+            if let Some(p) = out_acquired {
+                if !p.is_null() {
+                    unsafe { *p = 0 };
+                }
+            }
+            let adapter = match unsafe { gl_adapter_borrow(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            &format!("{callback_name}: null adapter handle"),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if surface_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        &format!("{callback_name}: null surface pointer"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            let surface: &StreamlibSurface =
+                unsafe { &*(surface_ptr as *const StreamlibSurface) };
+            match body(adapter, surface) {
+                Ok(Some(view)) => {
+                    if !out_view.is_null() {
+                        unsafe { *out_view = view };
+                    }
+                    if let Some(p) = out_acquired {
+                        if !p.is_null() {
+                            unsafe { *p = 1 };
+                        }
+                    }
+                    0
+                }
+                Ok(None) => 0,
+                Err(msg) => {
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+fn run_skia_gl_read_scope(
+    adapter: &SkiaGlSurfaceAdapter,
+    surface: &StreamlibSurface,
+) -> Result<SkiaViewRepr, AdapterError> {
+    let guard = adapter.acquire_read(surface)?;
+    let surface_id = guard.surface_id();
+    drop(guard);
+    Ok(skia_view_repr_from_surface(u64::from(surface_id), surface))
+}
+
+fn run_skia_gl_write_scope(
+    adapter: &SkiaGlSurfaceAdapter,
+    surface: &StreamlibSurface,
+) -> Result<SkiaViewRepr, AdapterError> {
+    let guard = adapter.acquire_write(surface)?;
+    let surface_id = guard.surface_id();
+    drop(guard);
+    Ok(skia_view_repr_from_surface(u64::from(surface_id), surface))
+}
+
+unsafe extern "C" fn host_gl_acquire_read(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_gl_acquire(
+            "skia_gl_surface_adapter::acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match run_skia_gl_read_scope(adapter, surface) {
+                Ok(view) => Ok(Some(view)),
+                Err(e) => Err(format!("acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_gl_acquire_write(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_gl_acquire(
+            "skia_gl_surface_adapter::acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match run_skia_gl_write_scope(adapter, surface) {
+                Ok(view) => Ok(Some(view)),
+                Err(e) => Err(format!("acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_gl_try_acquire_read(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_gl_acquire(
+            "skia_gl_surface_adapter::try_acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_read(surface) {
+                Ok(Some(guard)) => {
+                    let surface_id = guard.surface_id();
+                    drop(guard);
+                    Ok(Some(skia_view_repr_from_surface(
+                        u64::from(surface_id),
+                        surface,
+                    )))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_gl_try_acquire_write(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut SkiaViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_gl_acquire(
+            "skia_gl_surface_adapter::try_acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_write(surface) {
+                Ok(Some(guard)) => {
+                    let surface_id = guard.surface_id();
+                    drop(guard);
+                    Ok(Some(skia_view_repr_from_surface(
+                        u64::from(surface_id),
+                        surface,
+                    )))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_gl_end_read_access(handle: *const c_void, surface_id: u64) {
+    run_host_extern_c(
+        "skia_gl_surface_adapter::end_read_access",
+        || {
+            let adapter = match unsafe { gl_adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_read_access(surface_id);
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_gl_end_write_access(handle: *const c_void, surface_id: u64) {
+    run_host_extern_c(
+        "skia_gl_surface_adapter::end_write_access",
+        || {
+            let adapter = match unsafe { gl_adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_write_access(surface_id);
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Tier-1 host-side wire-format tests (null-handle guards)
+// =============================================================================
+//
+// Each test invokes a vtable slot directly with a null handle and
+// asserts the slot's documented null-handle behaviour fires. The
+// success-path tests require an actual `Arc<SkiaSurfaceAdapter>` /
+// `Arc<SkiaGlSurfaceAdapter>` and live in the existing
+// `streamlib-adapter-skia/tests/` integration tests as those
+// scenarios get wired through the vtables in follow-up issues.
+
+#[cfg(test)]
+mod tier1_null_handle_tests {
+    use super::*;
+    use streamlib_consumer_rhi::ConsumerVulkanDevice;
+
+    // Pick a concrete D to materialize the monomorphized Vulkan
+    // vtable. The null-handle tests don't care which D — they
+    // exercise the panic guards before any device-shape work fires.
+    type D = ConsumerVulkanDevice;
+
+    fn vk_vtable() -> &'static SkiaSurfaceAdapterVTable {
+        // SAFETY: the returned pointer is `&'static`-shaped per the
+        // `const VTABLE` construction in `VkMonoVTable<D>`.
+        unsafe { &*host_skia_surface_adapter_vtable::<D>() }
+    }
+
+    fn gl_vtable() -> &'static SkiaGlSurfaceAdapterVTable {
+        unsafe { &*host_skia_gl_surface_adapter_vtable() }
+    }
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_msg(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    // -----------------------------------------------------------------
+    // Layout version sanity
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn vk_layout_version_matches_constant() {
+        assert_eq!(
+            vk_vtable().layout_version,
+            SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION
+        );
+        assert_eq!(vk_vtable()._reserved_padding, 0);
+    }
+
+    #[test]
+    fn gl_layout_version_matches_constant() {
+        assert_eq!(
+            gl_vtable().layout_version,
+            SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION
+        );
+        assert_eq!(gl_vtable()._reserved_padding, 0);
+    }
+
+    // -----------------------------------------------------------------
+    // Vulkan-flavor null-handle tests
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn vk_clone_handle_returns_null_on_null_input() {
+        unsafe {
+            let out = (vk_vtable().clone_handle)(core::ptr::null());
+            assert!(out.is_null());
+        }
+    }
+
+    #[test]
+    fn vk_drop_handle_null_is_no_op() {
+        unsafe { (vk_vtable().drop_handle)(core::ptr::null()) };
+    }
+
+    #[test]
+    fn vk_registered_count_null_handle_returns_zero() {
+        let n = unsafe { (vk_vtable().registered_count)(core::ptr::null()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn vk_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let rc = unsafe {
+            (vk_vtable().acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn vk_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let rc = unsafe {
+            (vk_vtable().acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn vk_try_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vk_vtable().try_acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn vk_try_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vk_vtable().try_acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn vk_end_read_access_null_handle_is_no_op() {
+        unsafe { (vk_vtable().end_read_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn vk_end_write_access_null_handle_is_no_op() {
+        unsafe { (vk_vtable().end_write_access)(core::ptr::null(), 42) };
+    }
+
+    // -----------------------------------------------------------------
+    // OpenGL-flavor null-handle tests
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn gl_clone_handle_returns_null_on_null_input() {
+        unsafe {
+            let out = (gl_vtable().clone_handle)(core::ptr::null());
+            assert!(out.is_null());
+        }
+    }
+
+    #[test]
+    fn gl_drop_handle_null_is_no_op() {
+        unsafe { (gl_vtable().drop_handle)(core::ptr::null()) };
+    }
+
+    #[test]
+    fn gl_registered_count_null_handle_returns_zero() {
+        let n = unsafe { (gl_vtable().registered_count)(core::ptr::null()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn gl_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let rc = unsafe {
+            (gl_vtable().acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gl_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let rc = unsafe {
+            (gl_vtable().acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gl_try_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (gl_vtable().try_acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gl_try_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: SkiaViewRepr = SkiaViewRepr::default();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (gl_vtable().try_acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gl_end_read_access_null_handle_is_no_op() {
+        unsafe { (gl_vtable().end_read_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn gl_end_write_access_null_handle_is_no_op() {
+        unsafe { (gl_vtable().end_write_access)(core::ptr::null(), 42) };
+    }
+}

--- a/libs/streamlib-adapter-skia/src/lib.rs
+++ b/libs/streamlib-adapter-skia/src/lib.rs
@@ -34,6 +34,7 @@ mod error;
 mod gl_adapter;
 mod gl_context;
 mod gl_view;
+mod host_vtable;
 mod skia_internal;
 mod view;
 
@@ -43,4 +44,5 @@ pub use error::SkiaAdapterError;
 pub use gl_adapter::SkiaGlSurfaceAdapter;
 pub use gl_context::SkiaGlContext;
 pub use gl_view::{SkiaGlReadView, SkiaGlWriteView};
+pub use host_vtable::{host_skia_gl_surface_adapter_vtable, host_skia_surface_adapter_vtable};
 pub use view::{SkiaReadView, SkiaWriteView};


### PR DESCRIPTION
## Summary

- Leaf of the #887 trunk (PR #994). Adds new dep-free `streamlib-adapter-skia-abi` crate carrying `SkiaSurfaceAdapterVTable` (Vulkan-backed, generic over `D`) and `SkiaGlSurfaceAdapterVTable` (OpenGL-backed, non-generic), plus host wiring in `streamlib-adapter-skia::host_vtable`.
- Both vtables are 80 bytes (8 B header + 9 fn pointer slots): 2 lifetime (`clone_handle` / `drop_handle`) + 1 informational (`registered_count`) + 6 `SurfaceAdapter` trait slots (`acquire_read`, `acquire_write`, `try_acquire_read`, `try_acquire_write`, `end_read_access`, `end_write_access`).
- View payload is a minimal 32-byte `SkiaViewRepr` (surface_id + width + height + reserved) — Skia-typed view accessors deliberately excluded (see "Audit findings" below).

Closes #889.

## Audit findings — Skia is host-side only

Per [`docs/architecture/subprocess-rhi-parity.md`](https://github.com/tatolab/streamlib/blob/main/docs/architecture/subprocess-rhi-parity.md), Skia is host-side only. Cdylibs do NOT depend on `streamlib-adapter-skia` in their Cargo dep graph (confirmed: `cargo tree -p streamlib-python-native | grep -c streamlib-adapter-skia` returns 0). Subprocess customers reach Skia surfaces through the wrapped Vulkan/OpenGL adapter's cdylib path. Consequently:

1. **No inherent registry methods** to expose. Unlike `VulkanSurfaceAdapter` (which carries `register_host_surface`, `unregister_host_surface`, `release_to_foreign`, `surface_image_info`, `raw_handles`, `registered_count`), the Skia adapters carry zero such inherent methods — registry operations route through the inner Vulkan/OpenGL adapter via the host-side `.inner()` accessor. Only `registered_count` has a useful informational projection (through the inner adapter); it's included here for trunk-pattern symmetry.

2. **No Skia-typed view accessors.** `SkiaWriteView` exposes `&skia_safe::Surface`; `SkiaReadView` exposes `&skia_safe::Image`. Both are `RCHandle<…>` wrappers tied to `skia-safe`'s `!Send + !Sync` single-thread-affine `GrDirectContext`. Their internal layout is **rustc-version-coupled and skia-safe-version-coupled** — crossing them through an extern "C" boundary would defeat the purpose of this ABI. The vtable surface here covers only the `SurfaceAdapter` trait scoping contract; future cross-DSO Skia draw support (Option C msgpack display-list shape recorded on the issue body, per-method canvas vtable, etc.) is its own design problem.

3. **No `inner()` accessor on the vtable.** Cdylibs that need raw GPU handles use the Vulkan or OpenGL adapter's vtable directly.

The only cdylib-callable surface in scope is the 6 `SurfaceAdapter` trait methods plus the trunk-pattern lifetime helpers — this is what the vtable covers. The view-accessor incompatibility means the host-side `acquire_*` callback completes the full scope synchronously (drops the guard before returning the `SkiaViewRepr` identity payload); the cdylib's `end_*_access` calls become effective no-ops because `SkiaSurfaceAdapter::end_*_access` is itself a no-op (Skia's view-drop hook is where flush + inner-guard-release happens). This is deliberate and documented in `host_vtable.rs`'s module docs.

## Reference to the trunk (PR #994)

This PR mirrors PR #994's mechanical shape for the new crate / vtable:

- New dep-free `streamlib-adapter-skia-abi` crate added to workspace.
- `#[repr(C)]` vtables with `layout_version: u32 @ 0` + `_reserved_padding: u32 @ 4` header.
- Layout version constants: `SKIA_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION = 1`, `SKIA_GL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION = 1` (versioned independently).
- Generic host fn `host_skia_surface_adapter_vtable::<D>()` with `VkMonoVTable<D>(PhantomData<D>)` per-monomorphization `const VTABLE` for the Vulkan-backed flavor; non-generic `host_skia_gl_surface_adapter_vtable()` returning a single `static` for the GL-backed flavor.
- Panic guards on every callback (mirrors #994's `run_host_extern_c`), `tracing` target `streamlib_adapter_skia::ffi` (underscore — `streamlib::ffi` would fail the boundary check).
- Error crossing via `i32` + UTF-8 `err_buf` trio.
- `try_acquire_*` non-error sentinel distinction via `out_acquired` u32.
- `clone_handle` returns null on null input; `drop_handle` no-op on null.

## Test coverage

- **4 layout regression tests** in the abi crate locking `SkiaViewRepr` (32 B / align 8), `SkiaSurfaceAdapterVTable` (80 B / align 8), `SkiaGlSurfaceAdapterVTable` (80 B / align 8), and the `Send + Sync` witnesses.
- **20 tier-1 null-handle tests** in `streamlib-adapter-skia` (10 per vtable flavor): layout version sanity + null-handle behaviour for every vtable slot, mirroring #994's pattern. Exercises the panic guards before any device-shape work fires; uses `ConsumerVulkanDevice` to materialize the Vulkan-backed monomorphization.
- 24 new tests total. `cargo test --workspace --lib` stays green.

## Boundary discipline

- `cargo tree -p streamlib-adapter-skia-abi | grep -c "^streamlib v"` returns 0 — abi crate has zero streamlib deps (pure ABI, no streamlib-engine, no skia-safe, no vulkanalia).
- `cargo xtask check-boundaries` clean (4165 files scanned, no violations).
- `cargo tree -p streamlib-python-native | grep -c streamlib-adapter-skia` returns 0 — confirms the host-side-only constraint holds for Python cdylib (and by extension Deno).
- Host wiring lives in `streamlib-adapter-skia` which is permitted to use vulkanalia / skia-safe per existing dep graph; no new boundary crossings.

## Trunk-vs-slice cut

This PR delivers ONLY the ABI vtable + host wiring. **NO HostServices field added** — that's a separate sibling slice. Five siblings (#887 / #888 / #889 / #890 / #891 / #894) landing HostServices fields in parallel would conflict; the slice-up happens once all trunk PRs are locked. This mirrors PR #994's trunk-vs-slice posture exactly.

## Issue body — supersession notes (already applied)

Both deferral framings on issue #889's body — the 2026-05-20 "Resolved design — defer pending consumer" section AND its Option C "Future shape if/when a consumer materializes" recommendation — were **superseded** in the issue body per [CLAUDE.md's markdown editing rules](https://github.com/tatolab/streamlib/blob/main/CLAUDE.md#editing-markdown-documentation), per the user goal file `.claude/goals/04-adapter-callback-tables.md` ("EXECUTE IN ANY ORDER (all 6 independent) … 3. #889 — skia adapter callback table"). The goal file restates the milestone's pre-planning posture per CLAUDE.md's `feedback_consumer_first_rule_softened.md`: a filed issue is sufficient consumer attestation; the right `SurfaceAdapter` trait shape lands now so the sibling adapters follow this shape mechanically.

## Test plan

- [x] `cargo test -p streamlib-adapter-skia-abi --lib` — 4/4 layout tests pass
- [x] `cargo test -p streamlib-adapter-skia --lib` — 20/20 tier-1 null-handle tests pass
- [x] `cargo test --workspace --lib --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — full baseline green
- [x] `cargo build --workspace --lib` — clean
- [x] `cargo xtask check-boundaries` — 4165 files scanned, no violations
- [x] `cargo tree -p streamlib-adapter-skia-abi | grep -c "^streamlib v"` returns 0
- [x] `cargo tree -p streamlib-python-native | grep -c streamlib-adapter-skia` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)