### PR TITLE
feat(plugin-abi): opengl adapter callback table (#888)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "libs/streamlib-adapter-vulkan", # Vulkan-native surface adapter — canonical implementor of VulkanWritable / VulkanImageInfoExt (Linux)
     "libs/streamlib-adapter-vulkan-helpers", # Test-helper binaries for streamlib-adapter-vulkan — held in a dedicated crate so streamlib doesn't leak into adapter-vulkan's runtime dep graph (Linux)
     "libs/streamlib-adapter-opengl", # OpenGL/EGL surface adapter — canonical implementor of GlWritable; DMA-BUF + DRM modifier import (Linux)
+    "libs/streamlib-adapter-opengl-abi", # Cross-DSO callback table for streamlib-adapter-opengl — extern "C" vtable consumed by host wiring + cdylib shim (#888)
     "libs/streamlib-adapter-cpu-readback", # Explicit GPU→CPU surface adapter — sole implementor of CpuReadable / CpuWritable (Linux)
     "libs/streamlib-adapter-cpu-readback-helpers", # Test-helper binaries for streamlib-adapter-cpu-readback — held in a dedicated crate so streamlib doesn't leak into adapter-cpu-readback's runtime dep graph (Linux)
     "libs/streamlib-adapter-cuda", # CUDA surface adapter — Vulkan↔CUDA OPAQUE_FD interop foundation for GPU-resident AI inference (Linux, #587)

--- a/libs/streamlib-adapter-opengl-abi/Cargo.toml
+++ b/libs/streamlib-adapter-opengl-abi/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-opengl-abi"
+description = "Cross-DSO callback table for streamlib-adapter-opengl. Sibling of streamlib-plugin-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to OpenGlSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_opengl_abi"
+path = "src/lib.rs"
+
+# Pure ABI crate — same dep posture as streamlib-plugin-abi and the
+# sibling streamlib-adapter-vulkan-abi: no streamlib-engine, no glow,
+# no streamlib-adapter-opengl, no khronos-egl, no tokio. Keeps layout
+# regression tests trivially runnable on any host and the crate
+# cross-DSO-safe.
+[dependencies]
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-opengl-abi/src/lib.rs
+++ b/libs/streamlib-adapter-opengl-abi/src/lib.rs
@@ -1,0 +1,481 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO callback table for `streamlib-adapter-opengl`.
+//!
+//! Sibling of [`streamlib-plugin-abi`]'s
+//! `GpuContextLimitedAccessVTable` (issue #886) and
+//! [`streamlib-adapter-vulkan-abi`]'s `VulkanSurfaceAdapterVTable`
+//! (issue #887, the trunk piece this crate mirrors). Each adapter
+//! ABI follows the same shape mechanically.
+//!
+//! # What this crate is
+//!
+//! A pure ABI contract describing how a host (`streamlib-engine`)
+//! exposes its `OpenGlSurfaceAdapter` to a cdylib plugin without
+//! sharing any Rust types beyond `#[repr(C)]` payloads and
+//! `unsafe extern "C" fn` pointers. The cdylib carries a
+//! `(handle, vtable)` β-shape; the host dispatches every method
+//! through host-compiled code so layout drift between rustc-minor
+//! versions and divergent dep graphs is contained inside the host
+//! DSO.
+//!
+//! Dep posture mirrors [`streamlib-plugin-abi`]: zero streamlib
+//! crates pulled, zero EGL/GL bindings, zero rustc-version-coupled
+//! types. This keeps layout regression tests trivially runnable on
+//! any host and the crate cross-DSO-safe.
+//!
+//! # Audited cdylib-callable surface
+//!
+//! Every method on the cdylib-facing side of
+//! `OpenGlSurfaceAdapter` / `OpenGlContext` / its acquire guards is
+//! covered by exactly one slot below. The audit at pickup time
+//! (against `libs/streamlib-adapter-opengl/src/`) enumerated:
+//!
+//! 1. `SurfaceAdapter` trait methods (from
+//!    `streamlib-adapter-abi`) implemented on `OpenGlSurfaceAdapter`:
+//!    `acquire_read`, `acquire_write`, `try_acquire_read`,
+//!    `try_acquire_write`, `end_read_access`, `end_write_access`.
+//! 2. Inherent methods on `OpenGlSurfaceAdapter`:
+//!    `register_host_surface`, `register_external_oes_host_surface`,
+//!    `unregister_host_surface`, `registered_count`.
+//! 3. RAII guard `Drop` paths (`ReadGuard::drop` /
+//!    `WriteGuard::drop`) route back through
+//!    `SurfaceAdapter::end_*_access` — covered by the same vtable
+//!    slots.
+//! 4. View capability accessors (`OpenGlReadView::gl_texture_id`,
+//!    `target`; `OpenGlWriteView::gl_texture_id`, `target`;
+//!    `GlWritable::gl_texture_id`) are pure reads against the
+//!    [`OpenGlViewRepr`] payload returned by `acquire_*`. No vtable
+//!    hop on the view itself.
+//!
+//! `OpenGlContext` is a thin Clone-able convenience wrapper around
+//! `Arc<OpenGlSurfaceAdapter>` — every method forwards to the same
+//! adapter trait methods covered above. The vtable's handle is the
+//! adapter Arc directly; the cdylib's `OpenGlContext` β-shape holds
+//! the `(handle, vtable)` pair without an extra indirection.
+//!
+//! The `EglRuntime` accessor (`OpenGlSurfaceAdapter::runtime`) is
+//! NOT cdylib-callable — every subprocess constructs its own
+//! `EglRuntime` (the runtime owns thread-bound OpenGL contexts and
+//! cannot meaningfully cross a DSO boundary even within one
+//! process). No slot.
+
+#![no_std]
+
+use core::ffi::c_void;
+
+// ============================================================================
+// Layout version constants
+// ============================================================================
+
+/// Layout version of [`OpenGlSurfaceAdapterVTable`].
+///
+/// Pinned at offset 0 forever; new methods append to the end and
+/// bump this constant. Host wiring asserts equality at install
+/// time; cdylib code reads it before dereferencing any slot and
+/// refuses to proceed on mismatch.
+///
+/// - v1: trunk lift — handle lifetime (`clone_handle` /
+///   `drop_handle`) + 10 method slots covering the full
+///   cdylib-callable surface (audit above). Locked by
+///   [`tests::opengl_surface_adapter_vtable_layout`] and the
+///   tier-1 null-handle tests in the source adapter crate.
+pub const OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+// ============================================================================
+// View payload — pure data the host writes into a caller-provided slot
+// ============================================================================
+
+/// `#[repr(C)]` payload returned by `acquire_read` / `acquire_write` /
+/// `try_acquire_*`.
+///
+/// Carries the live GL texture id and the binding target
+/// (`GL_TEXTURE_2D` or `GL_TEXTURE_EXTERNAL_OES`). The cdylib's
+/// `OpenGlReadView` / `OpenGlWriteView` β-shapes deref these
+/// fields directly as POD reads (mirrors the cached-fields pattern
+/// on `Texture` / `PixelBuffer` from `streamlib-plugin-abi` and
+/// `VulkanViewRepr` from `streamlib-adapter-vulkan-abi`).
+///
+/// Lifetime: valid for the duration of the matching acquire scope
+/// — the host's underlying `OpenGlReadView<'g>` /
+/// `OpenGlWriteView<'g>` keeps the GL texture id alive via the
+/// adapter's registry until `end_*_access` is called.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct OpenGlViewRepr {
+    /// GL texture id (the `u32` returned by `glGenTextures`).
+    pub gl_texture_id: u32,
+    /// GL binding target enumerant — `GL_TEXTURE_2D` (`0x0DE1`) for
+    /// host-allocated render-target-capable surfaces, or
+    /// `GL_TEXTURE_EXTERNAL_OES` (`0x8D65`) for sampler-only
+    /// surfaces registered via
+    /// `register_external_oes_host_surface`.
+    pub target: u32,
+}
+
+/// `#[repr(C)]` mirror of `streamlib_adapter_opengl::HostSurfaceRegistration`.
+///
+/// Layout MUST match the source struct byte-for-byte — the host
+/// implementation populates this struct directly from the caller-
+/// provided value and the cdylib's mirror reads the same offsets.
+/// A cross-crate layout-equivalence test in
+/// `streamlib-adapter-opengl::host_vtable` locks the source layout
+/// (the abi crate is dep-free by design and cannot verify itself).
+///
+/// Adding fields requires a coordinated bump in both this crate AND
+/// `streamlib-adapter-opengl::HostSurfaceRegistration`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct HostSurfaceRegistrationRepr {
+    /// DMA-BUF file descriptor exported from a host-allocated
+    /// `VkImage`. The adapter dups it during EGL import; the
+    /// caller may close their copy after registration returns.
+    pub dma_buf_fd: i32,
+    pub width: u32,
+    pub height: u32,
+    /// `DRM_FORMAT_*` four-character code for the surface's pixel
+    /// layout.
+    pub drm_fourcc: u32,
+    /// DRM format modifier chosen by the host's allocator.
+    pub drm_format_modifier: u64,
+    pub plane_offset: u64,
+    pub plane_stride: u64,
+}
+
+// ============================================================================
+// OpenGlSurfaceAdapterVTable
+// ============================================================================
+
+/// Dispatch table for the host's `OpenGlSurfaceAdapter`.
+///
+/// The cdylib holds an opaque `*const c_void` handle (an
+/// `Arc::into_raw(Arc<OpenGlSurfaceAdapter>)`-shaped pointer produced
+/// by the host) plus a `*const OpenGlSurfaceAdapterVTable` it reads
+/// from the `HostServices` payload when the cdylib β-shape lift
+/// lands (sibling slice to this trunk PR). Method-dispatch callbacks
+/// cover every cdylib-callable inherent method on
+/// `OpenGlSurfaceAdapter` plus the `SurfaceAdapter` trait methods.
+///
+/// # Handle lifetime
+///
+/// `clone_handle` / `drop_handle` mirror the
+/// `GpuContextLimitedAccessVTable` v2 pattern from
+/// `streamlib-plugin-abi`: `clone_handle(borrowed) -> owned` bumps
+/// the host's `Arc<OpenGlSurfaceAdapter>` refcount;
+/// `drop_handle(owned)` releases. The owned handle remains valid
+/// even after the originating runtime context is dropped, which
+/// matches the existing `OpenGlContext: Clone` contract — a plugin
+/// can stash a clone in `setup()` and hand it to a worker thread
+/// that outlives the lifecycle call.
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. New methods
+/// append to the end and bump
+/// [`OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+///
+/// # Error crossing
+///
+/// Every fallible slot returns `i32` (0 = success, non-zero =
+/// error). On error the host writes a UTF-8 message into the
+/// caller-provided `err_buf` (clamped to `err_buf_cap`) and sets
+/// `*err_len` to the bytes written. The wire shape mirrors the
+/// host-side error-buffer convention already established by
+/// `GpuContextLimitedAccessVTable::acquire_texture` and
+/// `VulkanSurfaceAdapterVTable::acquire_read`; truncation never
+/// trips a panic.
+///
+/// Non-error sentinels: `try_acquire_*` distinguishes "contended,
+/// retry later" (status = 0, `*out_acquired = 0`) from "real
+/// failure" (status = 1, error written) so the host's `Ok(None)`
+/// vs `Err(...)` distinction survives the i32 crossing.
+#[repr(C)]
+pub struct OpenGlSurfaceAdapterVTable {
+    /// Vtable layout version. Must equal
+    /// [`OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -----------------------------------------------------------------
+    // Handle lifetime
+    // -----------------------------------------------------------------
+
+    /// Take a borrowed handle (typically minted by the host's
+    /// runtime context when wiring the cdylib-side `OpenGlContext`
+    /// β-shape) and return a new owned handle with an Arc refcount
+    /// bump on the underlying `Arc<OpenGlSurfaceAdapter>`. The
+    /// owned handle remains valid even after the originating
+    /// context is dropped and MUST be released exactly once via
+    /// [`Self::drop_handle`]. Calling on a null pointer returns
+    /// null.
+    pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
+
+    /// Release an owned handle previously obtained from
+    /// [`Self::clone_handle`]. Calling on a null pointer is a
+    /// no-op. Calling on the same owned handle twice is undefined
+    /// behaviour (double-free of the Arc refcount).
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // -----------------------------------------------------------------
+    // Registry management (inherent on OpenGlSurfaceAdapter)
+    // -----------------------------------------------------------------
+
+    /// Register a surface as a render-target-capable
+    /// `GL_TEXTURE_2D`.
+    ///
+    /// `registration` carries the DMA-BUF fd, dimensions, fourcc,
+    /// DRM modifier, plane offset, and plane stride. The host
+    /// dups the fd during EGL import; the caller may close their
+    /// copy after this returns.
+    ///
+    /// Returns 0 on success, non-zero on failure (e.g. surface_id
+    /// already registered, EGL import failed, modifier
+    /// `external_only=TRUE` so the resulting `EGLImage` cannot be
+    /// bound as a `GL_TEXTURE_2D`). On error writes a UTF-8
+    /// message into `err_buf`.
+    pub register_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        registration: *const HostSurfaceRegistrationRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Register a surface for sampler-only consumption via
+    /// `GL_TEXTURE_EXTERNAL_OES`.
+    ///
+    /// Same DMA-BUF import path as
+    /// [`Self::register_host_surface`], but binds the resulting
+    /// `EGLImage` via
+    /// `glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, ...)`.
+    /// Use this for surfaces the host did not (or could not)
+    /// allocate with a render-target-capable modifier — typically
+    /// camera ring textures whose underlying modifier is reported
+    /// `external_only=TRUE` by `eglQueryDmaBufModifiersEXT` on
+    /// NVIDIA.
+    ///
+    /// Returns 0 on success, non-zero on failure with a UTF-8
+    /// message in `err_buf`.
+    pub register_external_oes_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        registration: *const HostSurfaceRegistrationRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Drop a registered surface from the adapter. Idempotent —
+    /// missing entries return 0 via `*out_was_present = 0`. Calls
+    /// against a null handle return 0 with `*out_was_present = 0`.
+    pub unregister_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_was_present: *mut u32,
+    ),
+
+    /// Snapshot the adapter's registry size (number of currently-
+    /// registered surfaces). Returns 0 on null handle. Used for
+    /// host-side tests and observability; cdylibs can call it
+    /// today but the read is informational, not synchronizing.
+    pub registered_count: unsafe extern "C" fn(handle: *const c_void) -> usize,
+
+    // -----------------------------------------------------------------
+    // SurfaceAdapter trait methods
+    // -----------------------------------------------------------------
+
+    /// Blocking read acquire.
+    ///
+    /// `surface_ptr` is a `*const StreamlibSurface` borrowed from
+    /// the caller's stack; valid for the duration of the call. On
+    /// success writes the populated [`OpenGlViewRepr`] into
+    /// `*out_view` and returns 0. On contention the host returns 1
+    /// with a "writer contended" message; the blocking variant
+    /// never returns the contended-but-not-error case (`try_acquire_*`
+    /// does).
+    pub acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut OpenGlViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Blocking write acquire. Same shape as
+    /// [`Self::acquire_read`] but exclusive-write semantics; only
+    /// applies to render-target-capable (`GL_TEXTURE_2D`) surfaces
+    /// — `GL_TEXTURE_EXTERNAL_OES` surfaces return an error.
+    pub acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut OpenGlViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking read acquire.
+    ///
+    /// Returns 0 on success and writes `*out_acquired = 1` plus a
+    /// populated view. Returns 0 with `*out_acquired = 0` on
+    /// contention (Ok(None) shape) without writing the view.
+    /// Returns non-zero with an error message on real failure.
+    pub try_acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut OpenGlViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking write acquire. Same shape as
+    /// [`Self::try_acquire_read`].
+    pub try_acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut OpenGlViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Sealed: signal the release-side state for a read. Called by
+    /// the cdylib's `ReadGuard::drop`. Idempotent against unknown
+    /// surface IDs (the host logs and returns; no error surfaced
+    /// because Drop can't propagate).
+    pub end_read_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    /// Sealed: signal the release-side state for a write. Called
+    /// by the cdylib's `WriteGuard::drop`. The host issues
+    /// `glFinish` inside this callback to flush the GL command
+    /// stream so subsequent host Vulkan work sees the writes
+    /// through the DMA-BUF.
+    pub end_write_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+}
+
+// Safety: every field is a primitive integer or an `unsafe extern "C" fn`
+// pointer; no thread-local state, no interior mutability. The host
+// guarantees the pointed-at adapter state outlives every cdylib that
+// holds a clone of the handle via the loader's pinning shape.
+unsafe impl Send for OpenGlSurfaceAdapterVTable {}
+unsafe impl Sync for OpenGlSurfaceAdapterVTable {}
+
+// ============================================================================
+// Layout regression tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    /// `OpenGlViewRepr` carries (`gl_texture_id: u32`, `target: u32`).
+    /// 8 bytes, align 4 — the smallest cross-DSO view payload in the
+    /// adapter family.
+    #[test]
+    fn opengl_view_repr_layout() {
+        assert_eq!(offset_of!(OpenGlViewRepr, gl_texture_id), 0);
+        assert_eq!(offset_of!(OpenGlViewRepr, target), 4);
+        assert_eq!(size_of::<OpenGlViewRepr>(), 8);
+        assert_eq!(align_of::<OpenGlViewRepr>(), 4);
+    }
+
+    /// `HostSurfaceRegistrationRepr` MUST mirror
+    /// `streamlib_adapter_opengl::HostSurfaceRegistration`
+    /// byte-for-byte. The source layout is locked by a cross-crate
+    /// test in the adapter crate (this abi crate is dep-free).
+    ///
+    /// Field order: dma_buf_fd: i32 @ 0, width: u32 @ 4,
+    /// height: u32 @ 8, drm_fourcc: u32 @ 12, drm_format_modifier:
+    /// u64 @ 16, plane_offset: u64 @ 24, plane_stride: u64 @ 32.
+    /// Total: 40 bytes, align 8.
+    #[test]
+    fn host_surface_registration_repr_layout() {
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, dma_buf_fd), 0);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, width), 4);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, height), 8);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, drm_fourcc), 12);
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, drm_format_modifier),
+            16
+        );
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, plane_offset), 24);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, plane_stride), 32);
+        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 40);
+        assert_eq!(align_of::<HostSurfaceRegistrationRepr>(), 8);
+    }
+
+    /// Locks the vtable's binary layout. Anchors every method slot
+    /// at a fixed byte offset so a host built against vtable v1
+    /// and a cdylib built against vtable v1 dispatch through the
+    /// same offsets regardless of rustc-minor / dep-graph drift.
+    /// New methods must append after `end_write_access` and bump
+    /// [`OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    #[test]
+    fn opengl_surface_adapter_vtable_layout() {
+        // layout_version: u32 @ 0
+        // _reserved_padding: u32 @ 4
+        // 12 fn pointers (8 bytes each) @ 8..104
+        // total: 4 + 4 + 12*8 = 104 bytes, align 8
+        assert_eq!(OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(size_of::<OpenGlSurfaceAdapterVTable>(), 104);
+        assert_eq!(align_of::<OpenGlSurfaceAdapterVTable>(), 8);
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, layout_version), 0);
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, clone_handle), 8);
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, drop_handle), 16);
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, register_host_surface),
+            24
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, register_external_oes_host_surface),
+            32
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, unregister_host_surface),
+            40
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, registered_count),
+            48
+        );
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, acquire_read), 56);
+        assert_eq!(offset_of!(OpenGlSurfaceAdapterVTable, acquire_write), 64);
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, try_acquire_read),
+            72
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, try_acquire_write),
+            80
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, end_read_access),
+            88
+        );
+        assert_eq!(
+            offset_of!(OpenGlSurfaceAdapterVTable, end_write_access),
+            96
+        );
+    }
+
+    /// Compile-time witness that the vtable is `Send + Sync`. A
+    /// future regression that adds an interior-mutable or non-thread-
+    /// safe field would break the unsafe impl above and trip this
+    /// test at build time.
+    #[test]
+    fn vtable_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<OpenGlSurfaceAdapterVTable>();
+    }
+}

--- a/libs/streamlib-adapter-opengl/Cargo.toml
+++ b/libs/streamlib-adapter-opengl/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-opengl-abi = { path = "../streamlib-adapter-opengl-abi" }
 parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true

--- a/libs/streamlib-adapter-opengl/src/host_vtable.rs
+++ b/libs/streamlib-adapter-opengl/src/host_vtable.rs
@@ -1,0 +1,869 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side wiring of [`streamlib_adapter_opengl_abi::OpenGlSurfaceAdapterVTable`].
+//!
+//! Hosts that want to expose an `OpenGlSurfaceAdapter` to a cdylib
+//! plugin do this:
+//!
+//! 1. Construct an `Arc<OpenGlSurfaceAdapter>` on the host side
+//!    (allocate the EglRuntime, register surfaces, install setup
+//!    hook — same as today).
+//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//!    - `handle = Arc::into_raw(arc.clone())`
+//!    - `vtable = host_opengl_surface_adapter_vtable()`
+//! 3. The cdylib invokes the vtable methods exactly as if it held
+//!    a Rust `&OpenGlSurfaceAdapter` — every method dispatches
+//!    through host-compiled code, so layout drift between
+//!    rustc-minor versions and divergent dep graphs is contained
+//!    inside the host DSO.
+//!
+//! `OpenGlSurfaceAdapter` is not generic over a `DevicePrivilege`
+//! type the way `VulkanSurfaceAdapter<D>` is — the OpenGL adapter
+//! holds an `Arc<EglRuntime>` directly. The host wiring therefore
+//! materializes a single `static VTABLE` rather than the
+//! per-`D`-monomorphization shape used by the Vulkan sibling.
+//!
+//! Panic guards inside each fn body mirror the
+//! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
+//! host code is caught at the FFI boundary and converted to a
+//! clean error return instead of corrupting the cdylib's stack.
+//! Tier-1 null-handle tests next to this module verify the guards
+//! fire correctly without an actual `Arc<OpenGlSurfaceAdapter>`.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{StreamlibSurface, SurfaceAdapter};
+use streamlib_adapter_opengl_abi::{
+    HostSurfaceRegistrationRepr, OpenGlSurfaceAdapterVTable, OpenGlViewRepr,
+    OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+};
+
+use crate::adapter::OpenGlSurfaceAdapter;
+use crate::state::HostSurfaceRegistration;
+
+/// Returns the static `&'static OpenGlSurfaceAdapterVTable` whose
+/// method slots dispatch against an `Arc<OpenGlSurfaceAdapter>`-shaped
+/// handle.
+pub fn host_opengl_surface_adapter_vtable() -> *const OpenGlSurfaceAdapterVTable {
+    &HOST_VTABLE
+}
+
+static HOST_VTABLE: OpenGlSurfaceAdapterVTable = OpenGlSurfaceAdapterVTable {
+    layout_version: OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+    _reserved_padding: 0,
+    clone_handle: host_clone_handle,
+    drop_handle: host_drop_handle,
+    register_host_surface: host_register_host_surface,
+    register_external_oes_host_surface: host_register_external_oes_host_surface,
+    unregister_host_surface: host_unregister_host_surface,
+    registered_count: host_registered_count,
+    acquire_read: host_acquire_read,
+    acquire_write: host_acquire_write,
+    try_acquire_read: host_try_acquire_read,
+    try_acquire_write: host_try_acquire_write,
+    end_read_access: host_end_read_access,
+    end_write_access: host_end_write_access,
+};
+
+// =============================================================================
+// FFI helpers — error buffer writer + panic guard
+// =============================================================================
+
+/// Catch panics at the extern "C" boundary so a host-side panic
+/// doesn't unwind into cdylib code. On panic the body returns
+/// `default_on_panic`; the panic message is logged via `tracing`
+/// for post-mortem visibility.
+#[inline]
+fn run_host_extern_c<F, T>(callback_name: &'static str, body: F, default_on_panic: T) -> T
+where
+    F: FnOnce() -> T,
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            tracing::error!(
+                target: "streamlib_adapter_opengl::ffi",
+                callback = callback_name,
+                panic = %msg,
+                "host extern \"C\" callback panicked; FFI boundary converted panic to default return"
+            );
+            default_on_panic
+        }
+    }
+}
+
+/// Write a UTF-8 error message into a caller-provided buffer.
+/// Truncates to `cap`; sets `*err_len` to the bytes actually
+/// written. Null pointers are tolerated (the message is simply
+/// dropped).
+unsafe fn write_err(msg: &str, err_buf: *mut u8, err_buf_cap: usize, err_len: *mut usize) {
+    if err_buf.is_null() || err_buf_cap == 0 {
+        if !err_len.is_null() {
+            unsafe { *err_len = 0 };
+        }
+        return;
+    }
+    let bytes = msg.as_bytes();
+    let n = bytes.len().min(err_buf_cap);
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), err_buf, n);
+        if !err_len.is_null() {
+            *err_len = n;
+        }
+    }
+}
+
+/// Borrow the adapter from a `*const c_void` handle. Returns
+/// `None` on null. SAFETY: caller asserts the handle is one of:
+/// (a) a borrowed pointer produced by `Arc::as_ptr` against a live
+/// host-owned Arc, or (b) an owned pointer minted by
+/// [`host_clone_handle`] still in its valid lifetime. Both are
+/// dereferenceable for read while the underlying Arc has at least
+/// one strong refcount; the panic guard wrapping every call site
+/// converts any UB-shaped mistake into a clean tracing log + the
+/// callback's default return.
+unsafe fn adapter_borrow<'a>(handle: *const c_void) -> Option<&'a OpenGlSurfaceAdapter> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const OpenGlSurfaceAdapter) })
+}
+
+// =============================================================================
+// Handle lifetime (mirrors GpuContextLimitedAccessVTable::clone_handle / drop_handle)
+// =============================================================================
+
+unsafe extern "C" fn host_clone_handle(borrowed_handle: *const c_void) -> *const c_void {
+    run_host_extern_c(
+        "opengl_surface_adapter::clone_handle",
+        || {
+            if borrowed_handle.is_null() {
+                return core::ptr::null();
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<OpenGlSurfaceAdapter>)-shaped.
+            unsafe {
+                Arc::increment_strong_count(borrowed_handle as *const OpenGlSurfaceAdapter);
+            }
+            borrowed_handle
+        },
+        core::ptr::null(),
+    )
+}
+
+unsafe extern "C" fn host_drop_handle(owned_handle: *const c_void) {
+    run_host_extern_c(
+        "opengl_surface_adapter::drop_handle",
+        || {
+            if owned_handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is Arc::into_raw(Arc<OpenGlSurfaceAdapter>)-shaped
+            // with at least one host-side refcount remaining.
+            unsafe {
+                Arc::decrement_strong_count(owned_handle as *const OpenGlSurfaceAdapter);
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Registry management
+// =============================================================================
+
+fn registration_from_repr(repr: &HostSurfaceRegistrationRepr) -> HostSurfaceRegistration {
+    HostSurfaceRegistration {
+        dma_buf_fd: repr.dma_buf_fd,
+        width: repr.width,
+        height: repr.height,
+        drm_fourcc: repr.drm_fourcc,
+        drm_format_modifier: repr.drm_format_modifier,
+        plane_offset: repr.plane_offset,
+        plane_stride: repr.plane_stride,
+    }
+}
+
+unsafe extern "C" fn host_register_host_surface(
+    handle: *const c_void,
+    surface_id: u64,
+    registration: *const HostSurfaceRegistrationRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "opengl_surface_adapter::register_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "register_host_surface: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if registration.is_null() {
+                unsafe {
+                    write_err(
+                        "register_host_surface: null registration pointer",
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // HostSurfaceRegistrationRepr from its own stack/heap,
+            // valid for the duration of the call.
+            let repr = unsafe { &*registration };
+            let reg = registration_from_repr(repr);
+            match adapter.register_host_surface(surface_id, reg) {
+                Ok(()) => 0,
+                Err(e) => {
+                    let msg = format!("register_host_surface: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_register_external_oes_host_surface(
+    handle: *const c_void,
+    surface_id: u64,
+    registration: *const HostSurfaceRegistrationRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "opengl_surface_adapter::register_external_oes_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "register_external_oes_host_surface: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if registration.is_null() {
+                unsafe {
+                    write_err(
+                        "register_external_oes_host_surface: null registration pointer",
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // HostSurfaceRegistrationRepr from its own stack/heap,
+            // valid for the duration of the call.
+            let repr = unsafe { &*registration };
+            let reg = registration_from_repr(repr);
+            match adapter.register_external_oes_host_surface(surface_id, reg) {
+                Ok(()) => 0,
+                Err(e) => {
+                    let msg = format!("register_external_oes_host_surface: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_unregister_host_surface(
+    handle: *const c_void,
+    surface_id: u64,
+    out_was_present: *mut u32,
+) {
+    run_host_extern_c(
+        "opengl_surface_adapter::unregister_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => {
+                    if !out_was_present.is_null() {
+                        unsafe { *out_was_present = 0 };
+                    }
+                    return;
+                }
+            };
+            let was_present = adapter.unregister_host_surface(surface_id);
+            if !out_was_present.is_null() {
+                unsafe { *out_was_present = u32::from(was_present) };
+            }
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_registered_count(handle: *const c_void) -> usize {
+    run_host_extern_c(
+        "opengl_surface_adapter::registered_count",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return 0usize,
+            };
+            adapter.registered_count()
+        },
+        0usize,
+    )
+}
+
+// =============================================================================
+// SurfaceAdapter trait methods
+// =============================================================================
+
+/// Common shape for `acquire_read` / `acquire_write` /
+/// `try_acquire_*`: borrow the adapter, validate the surface
+/// pointer, call the inner method, write the view + status. The
+/// closure receives the adapter + a `&StreamlibSurface` and
+/// returns either:
+///   - `Ok(Some(view))`  → status 0, `*out_acquired = 1`, view written
+///   - `Ok(None)`        → status 0, `*out_acquired = 0` (try_* only;
+///                          blocking variants reject via the caller)
+///   - `Err(msg)`        → status 1, error message written
+unsafe fn run_acquire<F>(
+    callback_name: &'static str,
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut OpenGlViewRepr,
+    out_acquired: Option<*mut u32>,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    body: F,
+) -> i32
+where
+    F: FnOnce(
+        &OpenGlSurfaceAdapter,
+        &StreamlibSurface,
+    ) -> Result<Option<OpenGlViewRepr>, String>,
+{
+    run_host_extern_c(
+        callback_name,
+        || {
+            if let Some(p) = out_acquired {
+                if !p.is_null() {
+                    unsafe { *p = 0 };
+                }
+            }
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            &format!("{callback_name}: null adapter handle"),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if surface_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        &format!("{callback_name}: null surface pointer"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // StreamlibSurface from its own stack/heap, valid for
+            // the duration of the call.
+            let surface: &StreamlibSurface =
+                unsafe { &*(surface_ptr as *const StreamlibSurface) };
+            match body(adapter, surface) {
+                Ok(Some(view)) => {
+                    if !out_view.is_null() {
+                        unsafe { *out_view = view };
+                    }
+                    if let Some(p) = out_acquired {
+                        if !p.is_null() {
+                            unsafe { *p = 1 };
+                        }
+                    }
+                    0
+                }
+                Ok(None) => {
+                    // Contended — try_* shape. Blocking variants
+                    // never reach here (the body errors instead).
+                    0
+                }
+                Err(msg) => {
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+fn read_guard_to_repr(
+    guard: streamlib_adapter_abi::ReadGuard<'_, OpenGlSurfaceAdapter>,
+) -> OpenGlViewRepr {
+    let view = guard.view();
+    let view_repr = OpenGlViewRepr {
+        gl_texture_id: view.gl_texture_id(),
+        target: view.target(),
+    };
+    // SAFETY: we deliberately leak the guard's `end_read_access`
+    // signal — the cdylib will fire `end_read_access` itself from
+    // its own ReadGuard::drop via the vtable. Calling Drop here
+    // would double-signal.
+    core::mem::forget(guard);
+    view_repr
+}
+
+fn write_guard_to_repr(
+    guard: streamlib_adapter_abi::WriteGuard<'_, OpenGlSurfaceAdapter>,
+) -> OpenGlViewRepr {
+    let view = guard.view();
+    // OpenGlWriteView's target is always GL_TEXTURE_2D by construction
+    // (write acquires are rejected for GL_TEXTURE_EXTERNAL_OES surfaces
+    // inside the adapter's try_begin_write path). We surface it
+    // explicitly via the view's accessor so the contract is read
+    // off the live view, not hardcoded here.
+    let view_repr = OpenGlViewRepr {
+        gl_texture_id: view.gl_texture_id(),
+        target: view.target(),
+    };
+    core::mem::forget(guard);
+    view_repr
+}
+
+unsafe extern "C" fn host_acquire_read(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut OpenGlViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire(
+            "opengl_surface_adapter::acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_read(surface) {
+                Ok(guard) => Ok(Some(read_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_acquire_write(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut OpenGlViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire(
+            "opengl_surface_adapter::acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_write(surface) {
+                Ok(guard) => Ok(Some(write_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_read(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut OpenGlViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire(
+            "opengl_surface_adapter::try_acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_read(surface) {
+                Ok(Some(guard)) => Ok(Some(read_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_write(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut OpenGlViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire(
+            "opengl_surface_adapter::try_acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_write(surface) {
+                Ok(Some(guard)) => Ok(Some(write_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_end_read_access(handle: *const c_void, surface_id: u64) {
+    run_host_extern_c(
+        "opengl_surface_adapter::end_read_access",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_read_access(surface_id);
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_end_write_access(handle: *const c_void, surface_id: u64) {
+    run_host_extern_c(
+        "opengl_surface_adapter::end_write_access",
+        || {
+            let adapter = match unsafe { adapter_borrow(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_write_access(surface_id);
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Tier-1 host-side wire-format tests (null-handle guards)
+// =============================================================================
+//
+// Each test invokes a vtable slot directly with a null handle and
+// asserts the slot's documented null-handle behaviour fires. The
+// success-path tests require an actual `Arc<OpenGlSurfaceAdapter>`
+// + a live `EglRuntime` and live in the existing
+// `streamlib-adapter-opengl/tests/` integration tests as those
+// scenarios get wired through this vtable in follow-up issues.
+
+#[cfg(test)]
+mod tier1_null_handle_tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+    use streamlib_adapter_opengl_abi::HostSurfaceRegistrationRepr;
+
+    /// `HostSurfaceRegistrationRepr` (defined in
+    /// `streamlib-adapter-opengl-abi`) MUST mirror
+    /// `streamlib_adapter_opengl::HostSurfaceRegistration` byte-for-
+    /// byte. This crate has both in scope so it's the natural place
+    /// to lock the contract; the abi crate is dep-free by design
+    /// and can't import the source type itself.
+    #[test]
+    fn host_surface_registration_repr_matches_source_layout() {
+        assert_eq!(
+            size_of::<HostSurfaceRegistrationRepr>(),
+            size_of::<HostSurfaceRegistration>()
+        );
+        assert_eq!(
+            align_of::<HostSurfaceRegistrationRepr>(),
+            align_of::<HostSurfaceRegistration>()
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, dma_buf_fd),
+            offset_of!(HostSurfaceRegistration, dma_buf_fd)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, width),
+            offset_of!(HostSurfaceRegistration, width)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, height),
+            offset_of!(HostSurfaceRegistration, height)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, drm_fourcc),
+            offset_of!(HostSurfaceRegistration, drm_fourcc)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, drm_format_modifier),
+            offset_of!(HostSurfaceRegistration, drm_format_modifier)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, plane_offset),
+            offset_of!(HostSurfaceRegistration, plane_offset)
+        );
+        assert_eq!(
+            offset_of!(HostSurfaceRegistrationRepr, plane_stride),
+            offset_of!(HostSurfaceRegistration, plane_stride)
+        );
+    }
+
+    fn vtable() -> &'static OpenGlSurfaceAdapterVTable {
+        // SAFETY: the returned pointer is `&'static`-shaped per the
+        // `static HOST_VTABLE` construction above.
+        unsafe { &*host_opengl_surface_adapter_vtable() }
+    }
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_msg(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn layout_version_matches_constant() {
+        assert_eq!(
+            vtable().layout_version,
+            OPENGL_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION
+        );
+        assert_eq!(vtable()._reserved_padding, 0);
+    }
+
+    #[test]
+    fn clone_handle_returns_null_on_null_input() {
+        unsafe {
+            let out = (vtable().clone_handle)(core::ptr::null());
+            assert!(out.is_null());
+        }
+    }
+
+    #[test]
+    fn drop_handle_null_is_no_op() {
+        // Documented contract — must not crash on null.
+        unsafe {
+            (vtable().drop_handle)(core::ptr::null());
+        }
+    }
+
+    #[test]
+    fn register_host_surface_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (vtable().register_host_surface)(
+                core::ptr::null(),
+                42,
+                core::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("register_host_surface: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn register_external_oes_host_surface_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let rc = unsafe {
+            (vtable().register_external_oes_host_surface)(
+                core::ptr::null(),
+                42,
+                core::ptr::null(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("register_external_oes_host_surface: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unregister_host_surface_null_handle_returns_zero_was_present() {
+        let mut was_present: u32 = 0xFFFF_FFFF;
+        unsafe {
+            (vtable().unregister_host_surface)(core::ptr::null(), 42, &mut was_present);
+        }
+        assert_eq!(was_present, 0);
+    }
+
+    #[test]
+    fn registered_count_null_handle_returns_zero() {
+        let n = unsafe { (vtable().registered_count)(core::ptr::null()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: OpenGlViewRepr = unsafe { core::mem::zeroed() };
+        let rc = unsafe {
+            (vtable().acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(msg.contains("acquire_read: null adapter handle"), "got: {msg}");
+    }
+
+    #[test]
+    fn acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: OpenGlViewRepr = unsafe { core::mem::zeroed() };
+        let rc = unsafe {
+            (vtable().acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: OpenGlViewRepr = unsafe { core::mem::zeroed() };
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: OpenGlViewRepr = unsafe { core::mem::zeroed() };
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn end_read_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_read_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn end_write_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_write_access)(core::ptr::null(), 42) };
+    }
+}

--- a/libs/streamlib-adapter-opengl/src/lib.rs
+++ b/libs/streamlib-adapter-opengl/src/lib.rs
@@ -30,6 +30,7 @@
 mod adapter;
 mod context;
 mod egl;
+mod host_vtable;
 mod state;
 mod view;
 
@@ -39,5 +40,6 @@ pub use egl::{
     EglRuntime, EglRuntimeError, OwnedMakeCurrentGuard, DRM_FORMAT_ABGR8888,
     DRM_FORMAT_ARGB8888,
 };
+pub use host_vtable::host_opengl_surface_adapter_vtable;
 pub use state::HostSurfaceRegistration;
 pub use view::{OpenGlReadView, OpenGlWriteView, GL_TEXTURE_2D, GL_TEXTURE_EXTERNAL_OES};

--- a/libs/streamlib-adapter-opengl/src/state.rs
+++ b/libs/streamlib-adapter-opengl/src/state.rs
@@ -23,6 +23,14 @@ type EglImage = egl::Image;
 /// for the `VkImage` — per the NVIDIA EGL DMA-BUF render-target
 /// learning, the host MUST pick a tiled, render-target-capable
 /// modifier or the resulting GL texture is sampler-only.
+///
+/// `#[repr(C)]` so the layout matches
+/// [`streamlib_adapter_opengl_abi::HostSurfaceRegistrationRepr`]
+/// byte-for-byte — the host's cdylib-facing `register_host_surface`
+/// vtable slot reads the repr type and projects it to this struct
+/// without a per-field copy. Locked by
+/// `host_vtable::tier1_null_handle_tests::host_surface_registration_repr_matches_source_layout`.
+#[repr(C)]
 pub struct HostSurfaceRegistration {
     pub dma_buf_fd: i32,
     pub width: u32,


### PR DESCRIPTION
## Summary

Lifts the cdylib-callable public surface of `streamlib-adapter-opengl` to a pure extern "C" callback table. Sibling of #887 (vulkan adapter callback table, PR #994 — trunk piece this mirrors mechanically).

Closes #888.

## What changed

- **New crate `streamlib-adapter-opengl-abi/`** (dep-free) — owns the `OpenGlSurfaceAdapterVTable` (12 fn slots, 104 bytes), `OpenGlViewRepr` (8 bytes), and `HostSurfaceRegistrationRepr` (40 bytes). Mirror of the vulkan-abi shape; same `#[repr(C)]` + `unsafe extern "C" fn` posture; same `clone_handle` / `drop_handle` Arc-refcount pattern; same `i32` + `err_buf` error crossing.
- **Host wiring in `streamlib-adapter-opengl/src/host_vtable.rs`** — single `static HOST_VTABLE`. The OpenGL adapter is not generic over `DevicePrivilege` (concrete `Arc<OpenGlSurfaceAdapter>`), so no `MonoVTable<D>` machinery — simpler than vulkan-abi's per-monomorphization shape.
- **`#[repr(C)]` lock on `HostSurfaceRegistration`** — the cross-DSO repr type can project through without per-field copy. Locked by a cross-crate layout-equivalence test in the adapter crate (the abi crate is dep-free by design).
- **No `HostServices` field added** — trunk-vs-slice cut honored. The cdylib β-shape lift is a separate sibling slice (five adapter siblings landing fields in parallel would conflict).

## Audited cdylib-callable surface

Enumerated in the module-level docstring of `streamlib-adapter-opengl-abi/src/lib.rs`:

1. `SurfaceAdapter` trait methods: `acquire_read`, `acquire_write`, `try_acquire_read`, `try_acquire_write`, `end_read_access`, `end_write_access`.
2. Inherent methods on `OpenGlSurfaceAdapter`: `register_host_surface`, `register_external_oes_host_surface`, `unregister_host_surface`, `registered_count`.
3. View accessors (`OpenGlReadView::gl_texture_id` / `target`, etc.) — pure POD reads on the returned `OpenGlViewRepr`, no vtable hop on the view itself.
4. `OpenGlContext` is a Clone wrapper around `Arc<OpenGlSurfaceAdapter>`; the vtable handle is the adapter Arc directly.

The `EglRuntime` accessor (`OpenGlSurfaceAdapter::runtime`) is **not** cdylib-callable — every subprocess constructs its own `EglRuntime` (thread-bound OpenGL contexts can't meaningfully cross a DSO boundary).

## Test coverage

- `streamlib-adapter-opengl-abi`: 4 layout regression tests (vtable offsets, view layout, host registration repr layout, `Send + Sync` witness).
- `streamlib-adapter-opengl`: 14 tier-1 null-handle tests in `host_vtable::tier1_null_handle_tests` — every vtable slot exercised with a null handle, asserts the documented null-handle behavior (rc=1 + err_msg for fallible slots; no-op for `end_*` / `drop_handle`; zero-out-params for `registered_count` / `unregister_host_surface`).
- Cross-crate layout-equivalence test locks `HostSurfaceRegistrationRepr` against `HostSurfaceRegistration` (size, align, every field offset).

```
$ cargo test --lib -p streamlib-adapter-opengl-abi -p streamlib-adapter-opengl
test result: ok. 4 passed; 0 failed                                  (abi)
test result: ok. 17 passed; 0 failed                                 (opengl adapter, 14 of them new)
```

```
$ cargo xtask check-boundaries
check-boundaries: 4065 file(s) scanned, no violations
```

## Deferral supersession

The issue body's "Resolved design — defer pending consumer" section (researched 2026-05-20) has been struck through in place per CLAUDE.md markdown editing rules. Superseded by the user's "build the right shape end-to-end" rule (the consumer-first-rule-scoped-to-off-issue-scope-creep memory + CLAUDE.md "filed issue is itself sufficient sanction"). The sanctioned milestone wants every adapter lifted in parallel; the trunk PR #994 establishes the pattern.

## Follow-up

- HostServices field for the OpenGL vtable + cdylib β-shape lift — sibling slice, separate PR.
- Sibling adapter ABIs (#889 skia, #890 cpu-readback, #891 cuda) follow this same shape mechanically.

## Test plan

- [x] `cargo test --lib -p streamlib-adapter-opengl-abi` (4/4 pass)
- [x] `cargo test --lib -p streamlib-adapter-opengl` (17/17 pass, 14 new)
- [x] `cargo xtask check-boundaries` (4065 files, 0 violations)
- [x] `cargo build -p streamlib-adapter-opengl --tests` (integration test build clean)

Generated with [Claude Code](https://claude.com/claude-code)