### PR TITLE
feat(plugin-abi): cpu-readback adapter callback table (#890)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "libs/streamlib-adapter-vulkan-helpers", # Test-helper binaries for streamlib-adapter-vulkan — held in a dedicated crate so streamlib doesn't leak into adapter-vulkan's runtime dep graph (Linux)
     "libs/streamlib-adapter-opengl", # OpenGL/EGL surface adapter — canonical implementor of GlWritable; DMA-BUF + DRM modifier import (Linux)
     "libs/streamlib-adapter-cpu-readback", # Explicit GPU→CPU surface adapter — sole implementor of CpuReadable / CpuWritable (Linux)
+    "libs/streamlib-adapter-cpu-readback-abi", # Cross-DSO callback table for streamlib-adapter-cpu-readback — extern "C" vtable consumed by host wiring + cdylib shim (#890)
     "libs/streamlib-adapter-cpu-readback-helpers", # Test-helper binaries for streamlib-adapter-cpu-readback — held in a dedicated crate so streamlib doesn't leak into adapter-cpu-readback's runtime dep graph (Linux)
     "libs/streamlib-adapter-cuda", # CUDA surface adapter — Vulkan↔CUDA OPAQUE_FD interop foundation for GPU-resident AI inference (Linux, #587)
     "libs/streamlib-adapter-cuda-helpers", # Test-helper crate for streamlib-adapter-cuda — held in a dedicated crate so streamlib (and the optional CUDA SDK) don't leak into adapter-cuda's runtime dep graph (Linux)

--- a/libs/streamlib-adapter-cpu-readback-abi/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback-abi/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+[package]
+name = "streamlib-adapter-cpu-readback-abi"
+description = "Cross-DSO callback table for streamlib-adapter-cpu-readback. Sibling of streamlib-adapter-vulkan-abi: pure extern \"C\" vtable + #[repr(C)] payloads consumed by host wiring (delegating to CpuReadbackSurfaceAdapter) and cdylib shims. No runtime Rust types cross the DSO boundary on the cdylib-callable surface."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+
+[lib]
+name = "streamlib_adapter_cpu_readback_abi"
+path = "src/lib.rs"
+
+# Pure ABI crate — same dep posture as streamlib-adapter-vulkan-abi:
+# no streamlib-engine, no vulkanalia, no streamlib-adapter-cpu-readback,
+# no tokio. Keeps layout regression tests trivially runnable on any
+# host and the crate cross-DSO-safe.
+[dependencies]
+
+[lints]
+workspace = true

--- a/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback-abi/src/lib.rs
@@ -1,0 +1,713 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Cross-DSO callback table for `streamlib-adapter-cpu-readback`.
+//!
+//! Sibling of [`streamlib-adapter-vulkan-abi`]'s
+//! `VulkanSurfaceAdapterVTable` (issue #887) — same shape applied to
+//! the explicit GPU→CPU readback adapter. Audit of the cdylib-callable
+//! surface is enumerated below.
+//!
+//! # What this crate is
+//!
+//! A pure ABI contract describing how a host exposes its
+//! `CpuReadbackSurfaceAdapter<D>` to a cdylib plugin without sharing
+//! any Rust types beyond `#[repr(C)]` payloads and
+//! `unsafe extern "C" fn` pointers. The cdylib carries a
+//! `(handle, vtable)` β-shape; the host dispatches every method
+//! through host-compiled code so layout drift between rustc-minor
+//! versions and divergent dep graphs is contained inside the host
+//! DSO.
+//!
+//! Dep posture mirrors [`streamlib-plugin-abi`] /
+//! [`streamlib-adapter-vulkan-abi`]: zero streamlib crates pulled,
+//! zero vulkanalia, zero rustc-version-coupled types.
+//!
+//! # Audited cdylib-callable surface
+//!
+//! Every method on the cdylib-facing side of
+//! `CpuReadbackSurfaceAdapter<D>` / `CpuReadbackContext<D>` / its
+//! acquire guards is covered by exactly one slot below. The audit
+//! at pickup time (against
+//! `libs/streamlib-adapter-cpu-readback/src/`) enumerated:
+//!
+//! 1. `SurfaceAdapter` trait methods (from
+//!    `streamlib-adapter-abi`) implemented on
+//!    `CpuReadbackSurfaceAdapter`: `acquire_read`, `acquire_write`,
+//!    `try_acquire_read`, `try_acquire_write`, `end_read_access`,
+//!    `end_write_access`.
+//! 2. Inherent methods on `CpuReadbackSurfaceAdapter<D>`:
+//!    `register_host_surface`, `unregister_host_surface`,
+//!    `registered_count`, `run_bridge_copy_image_to_buffer`,
+//!    `run_bridge_copy_buffer_to_image`.
+//! 3. RAII guard `Drop` paths (`ReadGuard::drop` /
+//!    `WriteGuard::drop`) route back through
+//!    `SurfaceAdapter::end_*_access` — covered by the same vtable
+//!    slots.
+//! 4. View capability accessors
+//!    (`CpuReadbackPlaneView::bytes` / `width` / `height` /
+//!    `bytes_per_pixel`, `CpuReadbackReadView::format` /
+//!    `plane_count` / `planes`) are pure POD reads against the
+//!    [`CpuReadbackViewRepr`] payload returned by `acquire_*`. No
+//!    vtable hop on the view itself.
+//!
+//! Methods deliberately not exposed (audit findings):
+//!
+//! - `CpuReadbackSurfaceAdapter::new` / `with_acquire_timeout` —
+//!   host-side construction / chaining-builder; cdylib receives a
+//!   vtable+handle, never constructs adapters.
+//! - `device()` — returns `&Arc<D>`, can't cross extern "C" without
+//!   `D` parameterization; cdylibs hold their own device.
+//! - `InProcessCpuReadbackCopyTrigger` / `CpuReadbackCopyTrigger` —
+//!   trigger flavor is selected at adapter construction (host wires
+//!   the in-process trigger; cdylibs wire an escalate-IPC trigger).
+//!   The trigger trait is private wiring inside the adapter, not a
+//!   cdylib-callable boundary.
+//!
+//! # Scope fence — escalate-IPC seam is out of scope here
+//!
+//! The cpu-readback adapter is special: per-acquire GPU work runs on
+//! the host via a thin `run_cpu_readback_copy(surface_id)` escalate-
+//! IPC trigger (see
+//! `docs/architecture/adapter-runtime-integration.md`). That trigger
+//! is **already cross-process** through escalate IPC + the host's
+//! `CpuReadbackBridge` trait on `GpuContext`. This vtable is for
+//! cdylib-resident processors that hold a CpuReadback-flavor adapter
+//! context (`Arc<CpuReadbackSurfaceAdapter<ConsumerVulkanDevice>>`)
+//! and call `adapter.acquire_read(surface)` directly — NOT for the
+//! host-side bridge. The bridge stays where it lives; this vtable
+//! covers the parallel "cdylib holds the adapter, talks to its own
+//! trigger" surface only.
+//!
+//! # Multi-plane views
+//!
+//! Unlike the vulkan adapter (whose view is a single `VkImage` +
+//! layout), cpu-readback's read/write views are multi-plane:
+//! single-plane for BGRA/RGBA (one tightly-packed staging buffer)
+//! and two-plane for NV12 (Y + UV). The wire shape carries up to
+//! [`MAX_PLANES`] plane slots in a fixed-size array plus an
+//! explicit `plane_count`; current in-tree formats need at most 2.
+//! Future YUV variants (NV21, I420, I422, I444) fit within
+//! `MAX_PLANES = 4` without bumping the layout version.
+
+#![no_std]
+
+use core::ffi::c_void;
+
+// ============================================================================
+// Layout version constants
+// ============================================================================
+
+/// Layout version of [`CpuReadbackSurfaceAdapterVTable`].
+///
+/// Pinned at offset 0 forever; new methods append to the end and
+/// bump this constant. Host wiring asserts equality at install time;
+/// cdylib code reads it before dereferencing any slot and refuses to
+/// proceed on mismatch.
+///
+/// - v1: trunk lift — handle lifetime (`clone_handle` /
+///   `drop_handle`) + 11 method slots covering the full
+///   cdylib-callable surface (audit above). Locked by
+///   [`tests::cpu_readback_surface_adapter_vtable_layout`] and the
+///   tier-1 null-handle tests in the host wiring crate.
+pub const CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION: u32 = 1;
+
+/// Maximum number of planes carried in [`CpuReadbackViewRepr`] and
+/// [`HostSurfaceRegistrationRepr`].
+///
+/// Today's `SurfaceFormat` values use at most 2 (NV12 Y + UV). 4
+/// provides headroom for the common forward-looking YUV variants
+/// (NV21, I420, I422, I444 — all ≤ 3 planes) without bumping the
+/// layout version when they land. A future format that needs more
+/// than 4 planes triggers a layout-version bump (the array grows
+/// and the size of [`CpuReadbackViewRepr`] /
+/// [`HostSurfaceRegistrationRepr`] changes; layout regression
+/// tests pin the count so a stealth bump trips at compile time).
+pub const MAX_PLANES: usize = 4;
+
+// ============================================================================
+// View payload — pure data the host writes into a caller-provided slot
+// ============================================================================
+
+/// Per-plane geometry + raw mapped pointer.
+///
+/// Mirrors the shape `CpuReadbackPlaneView` /
+/// `CpuReadbackPlaneViewMut` expose to in-process callers, flattened
+/// into a `#[repr(C)]` record. The `mapped_ptr` is the host's
+/// staging-buffer `vk::DeviceMemory` mapped address — for cpu-
+/// readback this is HOST_VISIBLE / HOST_COHERENT, so the cdylib
+/// reads / writes the bytes directly without any further FFI hop.
+/// `byte_size` is `width * height * bytes_per_pixel`, the tightly-
+/// packed plane byte count.
+///
+/// Layout: `u64 + u64 + u32 + u32 + u32 + u32` = 32 bytes, align 8.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CpuReadbackPlaneRepr {
+    /// Host-side mapped pointer for this plane's staging buffer.
+    /// Carried as `u64` (target-triple-stable) rather than
+    /// `*mut u8` so the wire shape is identical on every Linux
+    /// platform and the layout regression test doesn't depend on
+    /// pointer width.
+    pub mapped_ptr: u64,
+    /// Tightly-packed plane size in bytes (`width * height *
+    /// bytes_per_pixel`).
+    pub byte_size: u64,
+    /// Plane width in texels.
+    pub width: u32,
+    /// Plane height in texels.
+    pub height: u32,
+    /// Bytes per texel of this plane. BGRA/RGBA: 4, NV12 Y: 1,
+    /// NV12 UV: 2.
+    pub bytes_per_pixel: u32,
+    /// Reserved padding. MUST be zeroed.
+    pub _padding: u32,
+}
+
+impl CpuReadbackPlaneRepr {
+    /// Construct a zero-initialised plane repr (mapped pointer
+    /// null, geometry zero). Used to pre-populate the
+    /// `[CpuReadbackPlaneRepr; MAX_PLANES]` slot before passing it
+    /// to an `acquire_*` callback.
+    pub const fn zeroed() -> Self {
+        Self {
+            mapped_ptr: 0,
+            byte_size: 0,
+            width: 0,
+            height: 0,
+            bytes_per_pixel: 0,
+            _padding: 0,
+        }
+    }
+}
+
+/// `#[repr(C)]` payload returned by `acquire_read` / `acquire_write` /
+/// `try_acquire_*`.
+///
+/// Carries the surface-level format + dimensions and an
+/// `[CpuReadbackPlaneRepr; MAX_PLANES]` array of per-plane records,
+/// with the live plane count in `plane_count`. Slots beyond
+/// `plane_count` MUST be left zeroed by the host. The cdylib's
+/// `CpuReadbackReadView` / `CpuReadbackWriteView` β-shapes deref
+/// these fields directly as POD reads.
+///
+/// Lifetime: valid for the duration of the matching acquire scope —
+/// the host's underlying `CpuReadbackReadView<'g>` /
+/// `CpuReadbackWriteView<'g>` keeps the staging buffers' mapped
+/// pointers alive via the adapter's registry until `end_*_access`
+/// is called and the timeline release completes.
+///
+/// Layout: `u32×4 + [CpuReadbackPlaneRepr; 4] @ 16` =
+/// `16 + 128` = 144 bytes, align 8.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CpuReadbackViewRepr {
+    /// `SurfaceFormat` enumerant value
+    /// (`Bgra8 = 0` / `Rgba8 = 1` / `Nv12 = 2`). Mirrors
+    /// `streamlib_adapter_abi::SurfaceFormat`'s `#[repr(u32)]`
+    /// representation byte-for-byte.
+    pub format_raw: u32,
+    /// Surface width in pixels (= plane 0 width).
+    pub width: u32,
+    /// Surface height in pixels (= plane 0 height).
+    pub height: u32,
+    /// Number of populated entries in [`Self::planes`]. Slots
+    /// `[plane_count..MAX_PLANES]` are zeroed.
+    pub plane_count: u32,
+    /// Per-plane geometry + mapped pointer. Logical layout
+    /// matches the format's planes in declaration order — NV12:
+    /// `[Y, UV, zeroed, zeroed]`.
+    pub planes: [CpuReadbackPlaneRepr; MAX_PLANES],
+}
+
+impl CpuReadbackViewRepr {
+    /// Construct a zero-initialised view repr. Used by callers to
+    /// pre-populate an `out_view` slot before passing it to an
+    /// `acquire_*` callback.
+    pub const fn zeroed() -> Self {
+        Self {
+            format_raw: 0,
+            width: 0,
+            height: 0,
+            plane_count: 0,
+            planes: [CpuReadbackPlaneRepr::zeroed(); MAX_PLANES],
+        }
+    }
+}
+
+// ============================================================================
+// HostSurfaceRegistration payload — registration metadata + handle bundle
+// ============================================================================
+
+/// `#[repr(C)]` mirror of `HostSurfaceRegistration<P>` from
+/// `streamlib-adapter-cpu-readback::state`.
+///
+/// Carries the per-surface registration metadata plus the bundle of
+/// `Arc::into_raw`-shaped opaque handles the host needs to bump
+/// refcount: a (nullable) source-texture handle, a timeline handle,
+/// and an array of staging-buffer handles (one per plane). The host
+/// implementation increments the refcount on each non-null handle
+/// and stashes a clone in the registry; the caller's Arcs remain
+/// owned by the caller.
+///
+/// The handle field layout (`u64` for `*const c_void`-shaped
+/// pointers, target-triple-stable on every Linux platform) keeps
+/// the wire shape identical regardless of pointer width tracking;
+/// callers cast `*const c_void` to `u64` via `as u64` and back via
+/// `as *const c_void` on dispatch.
+///
+/// Layout: `u32×4 + i32 + u32 + u64×6` =
+/// `4 + 4 + 4 + 4 + 4 + 4 + 8 + 8 + 32` = 72 bytes, align 8.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct HostSurfaceRegistrationRepr {
+    /// `SurfaceFormat` enumerant value (mirror of
+    /// `SurfaceFormat::Bgra8 = 0` etc).
+    pub format_raw: u32,
+    /// Surface width in pixels.
+    pub width: u32,
+    /// Surface height in pixels.
+    pub height: u32,
+    /// Number of populated entries in [`Self::staging_handles`].
+    /// MUST equal the format's natural plane count
+    /// (Bgra8/Rgba8 → 1, Nv12 → 2). Slots
+    /// `[plane_count..MAX_PLANES]` MUST be 0.
+    pub plane_count: u32,
+    /// Initial `VkImageLayout` enumerant of the source texture at
+    /// registration time. `VK_IMAGE_LAYOUT_UNDEFINED` (0) for
+    /// freshly-allocated images.
+    pub initial_layout_raw: i32,
+    /// Reserved padding. MUST be zeroed.
+    pub _padding: u32,
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::Texture>)`-shaped
+    /// opaque handle for the source `VkImage`, or `0` if the
+    /// registration does not provide one. Consumer-flavor
+    /// registrations typically pass 0 (the consumer-side adapter
+    /// cannot reach the host's `VkImage` and never issues image
+    /// transitions itself; only the host-side trigger does, and
+    /// only on host-flavor registrations).
+    pub texture_handle: u64,
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore>)`-shaped
+    /// opaque handle for the cross-process timeline semaphore the
+    /// adapter waits / signals against. MUST be non-zero.
+    pub timeline_handle: u64,
+    /// `Arc::into_raw(Arc<<D::Privilege as DevicePrivilege>::Buffer>)`-shaped
+    /// opaque handles for each per-plane staging buffer. Logical
+    /// layout matches the format's planes in declaration order.
+    /// Slots `[plane_count..MAX_PLANES]` MUST be 0.
+    pub staging_handles: [u64; MAX_PLANES],
+}
+
+impl HostSurfaceRegistrationRepr {
+    /// Construct a zero-initialised registration repr. Callers
+    /// populate `format_raw`, `width`, `height`, `plane_count`,
+    /// `initial_layout_raw`, `timeline_handle`, and the leading
+    /// `plane_count` entries of `staging_handles` before dispatch.
+    pub const fn zeroed() -> Self {
+        Self {
+            format_raw: 0,
+            width: 0,
+            height: 0,
+            plane_count: 0,
+            initial_layout_raw: 0,
+            _padding: 0,
+            texture_handle: 0,
+            timeline_handle: 0,
+            staging_handles: [0; MAX_PLANES],
+        }
+    }
+}
+
+// ============================================================================
+// CpuReadbackSurfaceAdapterVTable
+// ============================================================================
+
+/// Dispatch table for the host's `CpuReadbackSurfaceAdapter<D>`.
+///
+/// The cdylib holds an opaque `*const c_void` handle (an
+/// `Arc::into_raw(Arc<CpuReadbackSurfaceAdapter<D>>)`-shaped pointer
+/// produced by the host) plus a
+/// `*const CpuReadbackSurfaceAdapterVTable` it reads from the
+/// `HostServices` payload when the cdylib β-shape lift lands
+/// (sibling slice to this trunk PR — see scope note below).
+/// Method-dispatch callbacks cover every cdylib-callable inherent
+/// method on `CpuReadbackSurfaceAdapter` plus the `SurfaceAdapter`
+/// trait methods.
+///
+/// # Handle lifetime
+///
+/// `clone_handle` / `drop_handle` mirror the
+/// [`streamlib-adapter-vulkan-abi`] v1 pattern:
+/// `clone_handle(borrowed) -> owned` bumps the host's
+/// `Arc<CpuReadbackSurfaceAdapter<D>>` refcount;
+/// `drop_handle(owned)` releases. The owned handle remains valid
+/// even after the originating runtime context is dropped, which
+/// matches the existing `CpuReadbackContext: Clone` contract — a
+/// plugin can stash a clone in `setup()` and hand it to a worker
+/// thread that outlives the lifecycle call.
+///
+/// # Layout discipline
+///
+/// `layout_version` is pinned at offset 0 forever. New methods
+/// append to the end and bump
+/// [`CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+///
+/// # Error crossing
+///
+/// Every fallible slot returns `i32` (0 = success, non-zero =
+/// error). On error the host writes a UTF-8 message into the
+/// caller-provided `err_buf` (clamped to `err_buf_cap`) and sets
+/// `*err_len` to the bytes written. The wire shape mirrors the
+/// host-side error-buffer convention already established by
+/// `streamlib_adapter_vulkan_abi::VulkanSurfaceAdapterVTable`'s
+/// fallible slots; truncation never trips a panic.
+///
+/// Non-error sentinels: `try_acquire_*` distinguishes "contended,
+/// retry later" (status = 0, `*out_acquired = 0`) from "real
+/// failure" (status = 1, error written) so the host's `Ok(None)`
+/// vs `Err(...)` distinction survives the i32 crossing.
+#[repr(C)]
+pub struct CpuReadbackSurfaceAdapterVTable {
+    /// Vtable layout version. Must equal
+    /// [`CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    pub layout_version: u32,
+
+    /// Reserved padding (keeps the following pointer naturally
+    /// aligned on 32-bit hosts; zero today, never read).
+    pub _reserved_padding: u32,
+
+    // -----------------------------------------------------------------
+    // Handle lifetime
+    // -----------------------------------------------------------------
+
+    /// Take a borrowed handle (typically minted by the host's
+    /// runtime context when wiring the cdylib-side
+    /// `CpuReadbackContext` β-shape) and return a new owned handle
+    /// with an Arc refcount bump on the underlying
+    /// `Arc<CpuReadbackSurfaceAdapter<D>>`. The owned handle
+    /// remains valid even after the originating context is
+    /// dropped and MUST be released exactly once via
+    /// [`Self::drop_handle`]. Calling on a null pointer returns
+    /// null.
+    pub clone_handle: unsafe extern "C" fn(borrowed_handle: *const c_void) -> *const c_void,
+
+    /// Release an owned handle previously obtained from
+    /// [`Self::clone_handle`]. Calling on a null pointer is a
+    /// no-op. Calling on the same owned handle twice is undefined
+    /// behaviour (double-free of the Arc refcount).
+    pub drop_handle: unsafe extern "C" fn(owned_handle: *const c_void),
+
+    // -----------------------------------------------------------------
+    // Registry management (inherent on CpuReadbackSurfaceAdapter)
+    // -----------------------------------------------------------------
+
+    /// Register a surface with the adapter.
+    ///
+    /// `registration_ptr` is a `*const HostSurfaceRegistrationRepr`
+    /// borrowed from the caller's stack; valid for the duration of
+    /// the call. The host implementation bumps the refcount on
+    /// each non-null handle in `registration` (texture if non-zero,
+    /// timeline, each staging buffer) and stashes the resulting
+    /// Arcs in the adapter's internal registry. The caller's
+    /// Arcs remain owned by the caller.
+    ///
+    /// Returns 0 on success, non-zero on failure (e.g. surface_id
+    /// already registered, plane_count mismatch, dim mismatch). On
+    /// error writes a UTF-8 message into `err_buf`.
+    pub register_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        registration_ptr: *const HostSurfaceRegistrationRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Drop a registered surface from the adapter. Idempotent —
+    /// missing entries return 0 via `*out_was_present = 0`. Calls
+    /// against a null handle return 0 with `*out_was_present = 0`.
+    pub unregister_host_surface: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_was_present: *mut u32,
+    ),
+
+    /// Snapshot the adapter's registry size (number of
+    /// currently-registered surfaces). Returns 0 on null handle.
+    /// Used for host-side tests and observability; cdylibs can
+    /// call it today but the read is informational, not
+    /// synchronizing.
+    pub registered_count: unsafe extern "C" fn(handle: *const c_void) -> usize,
+
+    // -----------------------------------------------------------------
+    // SurfaceAdapter trait methods
+    // -----------------------------------------------------------------
+
+    /// Blocking read acquire.
+    ///
+    /// `surface_ptr` is a `*const StreamlibSurface` borrowed from
+    /// the caller's stack; valid for the duration of the call. On
+    /// success writes the populated [`CpuReadbackViewRepr`] into
+    /// `*out_view` and returns 0. On contention (`Ok(None)` shape)
+    /// the host returns 1 with a "writer contended" message; the
+    /// blocking variant never returns the contended-but-not-error
+    /// case (`try_acquire_*` does).
+    pub acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut CpuReadbackViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Blocking write acquire. Same shape as [`Self::acquire_read`]
+    /// but exclusive-write semantics.
+    pub acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut CpuReadbackViewRepr,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking read acquire.
+    ///
+    /// Returns 0 on success and writes `*out_acquired = 1` plus a
+    /// populated view. Returns 0 with `*out_acquired = 0` on
+    /// contention (`Ok(None)` shape) without writing the view.
+    /// Returns non-zero with an error message on real failure.
+    pub try_acquire_read: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut CpuReadbackViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Non-blocking write acquire. Same shape as
+    /// [`Self::try_acquire_read`].
+    pub try_acquire_write: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_ptr: *const c_void,
+        out_view: *mut CpuReadbackViewRepr,
+        out_acquired: *mut u32,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Sealed: drop the read access counters for a surface. Called
+    /// by the cdylib's `ReadGuard::drop`. Idempotent against
+    /// unknown surface IDs (the host logs and returns; no error
+    /// surfaced because Drop can't propagate).
+    pub end_read_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    /// Sealed: drop the write access counters for a surface AND
+    /// run the post-write `vkCmdCopyBufferToImage` flush via the
+    /// adapter's trigger. Called by the cdylib's
+    /// `WriteGuard::drop`.
+    pub end_write_access: unsafe extern "C" fn(handle: *const c_void, surface_id: u64),
+
+    // -----------------------------------------------------------------
+    // Bridge entries — direct copy without registry-counter mutation
+    // -----------------------------------------------------------------
+
+    /// Bridge entry: run `vkCmdCopyImageToBuffer` for `surface_id`
+    /// without going through the in-process registry's
+    /// `try_begin_*` / `end_*_access` counters. Used today by the
+    /// host-side `CpuReadbackBridge` impl that the escalate
+    /// handler reaches when a subprocess sends
+    /// `run_cpu_readback_copy(direction=image_to_buffer)`. Cdylib
+    /// callers operating against a `ConsumerVulkanDevice`-shaped
+    /// adapter will error (the in-process trigger requires a
+    /// host-side `VkImage`, which the consumer flavor cannot
+    /// provide). Returns 0 on success with the signaled timeline
+    /// value in `*out_signaled_value`; non-zero with an error
+    /// message on failure.
+    pub run_bridge_copy_image_to_buffer: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_signaled_value: *mut u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+
+    /// Bridge entry: run `vkCmdCopyBufferToImage` for `surface_id`.
+    /// Mirror of [`Self::run_bridge_copy_image_to_buffer`] — same
+    /// semantics, opposite direction.
+    pub run_bridge_copy_buffer_to_image: unsafe extern "C" fn(
+        handle: *const c_void,
+        surface_id: u64,
+        out_signaled_value: *mut u64,
+        err_buf: *mut u8,
+        err_buf_cap: usize,
+        err_len: *mut usize,
+    ) -> i32,
+}
+
+// Safety: every field is a primitive integer or an `unsafe extern "C" fn`
+// pointer; no thread-local state, no interior mutability. The host
+// guarantees the pointed-at adapter state outlives every cdylib that
+// holds a clone of the handle via the loader's pinning shape.
+unsafe impl Send for CpuReadbackSurfaceAdapterVTable {}
+unsafe impl Sync for CpuReadbackSurfaceAdapterVTable {}
+
+// ============================================================================
+// Layout regression tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+
+    /// `CpuReadbackPlaneRepr` — `u64×2 + u32×4` = 32 bytes, align 8.
+    #[test]
+    fn cpu_readback_plane_repr_layout() {
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, mapped_ptr), 0);
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, byte_size), 8);
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, width), 16);
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, height), 20);
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, bytes_per_pixel), 24);
+        assert_eq!(offset_of!(CpuReadbackPlaneRepr, _padding), 28);
+        assert_eq!(size_of::<CpuReadbackPlaneRepr>(), 32);
+        assert_eq!(align_of::<CpuReadbackPlaneRepr>(), 8);
+    }
+
+    /// `CpuReadbackViewRepr` — `u32×4 + [CpuReadbackPlaneRepr; 4] @
+    /// 16` = `16 + 128` = 144 bytes, align 8.
+    #[test]
+    fn cpu_readback_view_repr_layout() {
+        assert_eq!(offset_of!(CpuReadbackViewRepr, format_raw), 0);
+        assert_eq!(offset_of!(CpuReadbackViewRepr, width), 4);
+        assert_eq!(offset_of!(CpuReadbackViewRepr, height), 8);
+        assert_eq!(offset_of!(CpuReadbackViewRepr, plane_count), 12);
+        assert_eq!(offset_of!(CpuReadbackViewRepr, planes), 16);
+        assert_eq!(size_of::<CpuReadbackViewRepr>(), 144);
+        assert_eq!(align_of::<CpuReadbackViewRepr>(), 8);
+    }
+
+    /// `HostSurfaceRegistrationRepr` — packed manifest layout.
+    /// `u32×4 + i32 + u32 + u64×6` =
+    /// `4+4+4+4 + 4+4 + 8+8 + 32` = 72 bytes, align 8.
+    #[test]
+    fn host_surface_registration_repr_layout() {
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, format_raw), 0);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, width), 4);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, height), 8);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, plane_count), 12);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, initial_layout_raw), 16);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, _padding), 20);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, texture_handle), 24);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, timeline_handle), 32);
+        assert_eq!(offset_of!(HostSurfaceRegistrationRepr, staging_handles), 40);
+        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 72);
+        assert_eq!(align_of::<HostSurfaceRegistrationRepr>(), 8);
+    }
+
+    /// MAX_PLANES is locked at 4 — future formats with more planes
+    /// require a layout-version bump because the array size
+    /// changes and the surrounding offsets shift.
+    #[test]
+    fn max_planes_constant() {
+        assert_eq!(MAX_PLANES, 4);
+    }
+
+    /// Locks the vtable's binary layout. Anchors every method slot
+    /// at a fixed byte offset so a host built against vtable v1
+    /// and a cdylib built against vtable v1 dispatch through the
+    /// same offsets regardless of rustc-minor / dep-graph drift.
+    /// New methods must append after `run_bridge_copy_buffer_to_image`
+    /// and bump
+    /// [`CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION`].
+    #[test]
+    fn cpu_readback_surface_adapter_vtable_layout() {
+        // layout_version: u32 @ 0
+        // _reserved_padding: u32 @ 4
+        // 13 fn pointers (8 bytes each) @ 8..112
+        // total: 4 + 4 + 13*8 = 112 bytes, align 8
+        assert_eq!(CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, 1);
+        assert_eq!(size_of::<CpuReadbackSurfaceAdapterVTable>(), 112);
+        assert_eq!(align_of::<CpuReadbackSurfaceAdapterVTable>(), 8);
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, layout_version), 0);
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, _reserved_padding), 4);
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, clone_handle), 8);
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, drop_handle), 16);
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, register_host_surface),
+            24
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, unregister_host_surface),
+            32
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, registered_count),
+            40
+        );
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, acquire_read), 48);
+        assert_eq!(offset_of!(CpuReadbackSurfaceAdapterVTable, acquire_write), 56);
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, try_acquire_read),
+            64
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, try_acquire_write),
+            72
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, end_read_access),
+            80
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, end_write_access),
+            88
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, run_bridge_copy_image_to_buffer),
+            96
+        );
+        assert_eq!(
+            offset_of!(CpuReadbackSurfaceAdapterVTable, run_bridge_copy_buffer_to_image),
+            104
+        );
+    }
+
+    /// Compile-time witness that the vtable is `Send + Sync`. A
+    /// future regression that adds an interior-mutable or
+    /// non-thread-safe field would break the unsafe impl above and
+    /// trip this test at build time.
+    #[test]
+    fn vtable_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CpuReadbackSurfaceAdapterVTable>();
+    }
+
+    /// Zeroed view constructor wipes all plane slots.
+    #[test]
+    fn cpu_readback_view_repr_zeroed_clears_planes() {
+        let v = CpuReadbackViewRepr::zeroed();
+        assert_eq!(v.format_raw, 0);
+        assert_eq!(v.plane_count, 0);
+        for p in &v.planes {
+            assert_eq!(p.mapped_ptr, 0);
+            assert_eq!(p.byte_size, 0);
+        }
+    }
+
+    /// Zeroed registration constructor wipes all staging slots.
+    #[test]
+    fn host_surface_registration_repr_zeroed_clears_handles() {
+        let r = HostSurfaceRegistrationRepr::zeroed();
+        assert_eq!(r.texture_handle, 0);
+        assert_eq!(r.timeline_handle, 0);
+        for h in &r.staging_handles {
+            assert_eq!(*h, 0);
+        }
+    }
+}

--- a/libs/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/libs/streamlib-adapter-cpu-readback/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 streamlib-adapter-abi = { path = "../streamlib-adapter-abi" }
+streamlib-adapter-cpu-readback-abi = { path = "../streamlib-adapter-cpu-readback-abi" }
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/host_vtable.rs
@@ -1,0 +1,1125 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Host-side wiring of
+//! [`streamlib_adapter_cpu_readback_abi::CpuReadbackSurfaceAdapterVTable`].
+//!
+//! Hosts that want to expose a `CpuReadbackSurfaceAdapter<D>` to a
+//! cdylib plugin do this:
+//!
+//! 1. Construct an `Arc<CpuReadbackSurfaceAdapter<D>>` on the host
+//!    side (wire the in-process trigger, allocate the per-plane
+//!    staging buffers + timeline, register surfaces — same as
+//!    today).
+//! 2. Hand the cdylib a `(handle, vtable)` β-shape pair where:
+//!    - `handle = Arc::into_raw(arc.clone())`
+//!    - `vtable = host_cpu_readback_surface_adapter_vtable::<D>()`
+//! 3. The cdylib invokes the vtable methods exactly as if it held
+//!    a Rust `&CpuReadbackSurfaceAdapter<D>` — every method
+//!    dispatches through host-compiled code, so layout drift
+//!    between rustc-minor versions and divergent dep graphs is
+//!    contained inside the host DSO.
+//!
+//! Generic over `D: VulkanRhiDevice + 'static` so the same wiring
+//! works whether the host is exposing a host-flavor or
+//! consumer-flavor adapter. Each monomorphization materializes its
+//! own `static` vtable; cdylib code never sees the type parameter
+//! — only the `*const CpuReadbackSurfaceAdapterVTable` pointer.
+//!
+//! # Scope fence — escalate-IPC bridge is out of scope here
+//!
+//! The cpu-readback adapter is special: per-acquire GPU work runs
+//! on the host via a thin `run_cpu_readback_copy(surface_id)`
+//! escalate-IPC trigger (see
+//! `docs/architecture/adapter-runtime-integration.md`). That
+//! trigger is **already cross-process** through escalate IPC + the
+//! host's `CpuReadbackBridge` trait on `GpuContext`. This vtable
+//! wires the parallel "cdylib holds the adapter, talks to its own
+//! trigger" surface, NOT the host-side bridge. The bridge stays
+//! where it lives; vtable callers don't see it.
+//!
+//! Panic guards inside each fn body mirror the
+//! `streamlib-plugin-abi` `run_host_extern_c` shape: any panic in
+//! host code is caught at the FFI boundary and converted to a
+//! clean error return instead of corrupting the cdylib's stack.
+//! Tier-1 null-handle tests next to this module verify the guards
+//! fire correctly without an actual
+//! `Arc<CpuReadbackSurfaceAdapter>` or live device.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use streamlib_adapter_abi::{
+    ReadGuard, StreamlibSurface, SurfaceAdapter, SurfaceFormat, WriteGuard,
+};
+use streamlib_adapter_cpu_readback_abi::{
+    CpuReadbackPlaneRepr, CpuReadbackSurfaceAdapterVTable, CpuReadbackViewRepr,
+    HostSurfaceRegistrationRepr, CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION, MAX_PLANES,
+};
+use streamlib_consumer_rhi::{DevicePrivilege, VulkanLayout, VulkanRhiDevice};
+
+use crate::adapter::CpuReadbackSurfaceAdapter;
+use crate::state::HostSurfaceRegistration;
+use crate::view::{CpuReadbackReadView, CpuReadbackWriteView};
+
+/// Returns a `&'static CpuReadbackSurfaceAdapterVTable` whose
+/// method slots dispatch against an
+/// `Arc<CpuReadbackSurfaceAdapter<D>>`-shaped handle.
+///
+/// The vtable is `const`-initialized per `D` monomorphization;
+/// every call for the same `D` returns the same pointer. Multiple
+/// `D`s coexist in the same host process with their own vtables.
+pub fn host_cpu_readback_surface_adapter_vtable<D: VulkanRhiDevice + 'static>(
+) -> *const CpuReadbackSurfaceAdapterVTable {
+    &MonoVTable::<D>::VTABLE
+}
+
+/// Type-keyed monomorphizer. The `const VTABLE` is materialized at
+/// codegen time for each `D` that calls
+/// [`host_cpu_readback_surface_adapter_vtable`] elsewhere in the
+/// binary; the fn-pointer slots resolve to the matching
+/// monomorphizations of the free fns below.
+struct MonoVTable<D: VulkanRhiDevice + 'static>(PhantomData<D>);
+
+impl<D: VulkanRhiDevice + 'static> MonoVTable<D> {
+    const VTABLE: CpuReadbackSurfaceAdapterVTable = CpuReadbackSurfaceAdapterVTable {
+        layout_version: CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION,
+        _reserved_padding: 0,
+        clone_handle: host_clone_handle::<D>,
+        drop_handle: host_drop_handle::<D>,
+        register_host_surface: host_register_host_surface::<D>,
+        unregister_host_surface: host_unregister_host_surface::<D>,
+        registered_count: host_registered_count::<D>,
+        acquire_read: host_acquire_read::<D>,
+        acquire_write: host_acquire_write::<D>,
+        try_acquire_read: host_try_acquire_read::<D>,
+        try_acquire_write: host_try_acquire_write::<D>,
+        end_read_access: host_end_read_access::<D>,
+        end_write_access: host_end_write_access::<D>,
+        run_bridge_copy_image_to_buffer: host_run_bridge_copy_image_to_buffer::<D>,
+        run_bridge_copy_buffer_to_image: host_run_bridge_copy_buffer_to_image::<D>,
+    };
+}
+
+// =============================================================================
+// FFI helpers — error buffer writer + panic guard
+// =============================================================================
+
+/// Catch panics at the extern "C" boundary so a host-side panic
+/// doesn't unwind into cdylib code. On panic the body returns
+/// `default_on_panic`; the panic message is logged via `tracing`
+/// for post-mortem visibility.
+#[inline]
+fn run_host_extern_c<F, T>(callback_name: &'static str, body: F, default_on_panic: T) -> T
+where
+    F: FnOnce() -> T,
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            tracing::error!(
+                target: "streamlib_cpu_readback::ffi",
+                callback = callback_name,
+                panic = %msg,
+                "host extern \"C\" callback panicked; FFI boundary converted panic to default return"
+            );
+            default_on_panic
+        }
+    }
+}
+
+/// Write a UTF-8 error message into a caller-provided buffer.
+/// Truncates to `cap`; sets `*err_len` to the bytes actually
+/// written. Null pointers are tolerated (the message is simply
+/// dropped).
+unsafe fn write_err(msg: &str, err_buf: *mut u8, err_buf_cap: usize, err_len: *mut usize) {
+    if err_buf.is_null() || err_buf_cap == 0 {
+        if !err_len.is_null() {
+            unsafe { *err_len = 0 };
+        }
+        return;
+    }
+    let bytes = msg.as_bytes();
+    let n = bytes.len().min(err_buf_cap);
+    unsafe {
+        core::ptr::copy_nonoverlapping(bytes.as_ptr(), err_buf, n);
+        if !err_len.is_null() {
+            *err_len = n;
+        }
+    }
+}
+
+/// Borrow the adapter from a `*const c_void` handle. Returns
+/// `None` on null. SAFETY: caller asserts the handle is one of:
+/// (a) a borrowed pointer produced by `Arc::as_ptr` against a live
+/// host-owned Arc, or (b) an owned pointer minted by
+/// [`host_clone_handle`] still in its valid lifetime. Both are
+/// dereferenceable for read while the underlying Arc has at least
+/// one strong refcount; the panic guard wrapping every call site
+/// converts any UB-shaped mistake into a clean tracing log + the
+/// callback's default return.
+unsafe fn adapter_borrow<'a, D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> Option<&'a CpuReadbackSurfaceAdapter<D>> {
+    if handle.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(handle as *const CpuReadbackSurfaceAdapter<D>) })
+}
+
+/// Map a `SurfaceFormat` `#[repr(u32)]` value back to the enum.
+/// Returns `None` for unknown discriminants; the caller surfaces a
+/// validation error.
+fn surface_format_from_raw(raw: u32) -> Option<SurfaceFormat> {
+    match raw {
+        0 => Some(SurfaceFormat::Bgra8),
+        1 => Some(SurfaceFormat::Rgba8),
+        2 => Some(SurfaceFormat::Nv12),
+        _ => None,
+    }
+}
+
+// =============================================================================
+// View-projection helpers — CpuReadbackReadView / WriteView → repr
+// =============================================================================
+
+fn read_view_to_repr<'g>(view: &CpuReadbackReadView<'g>) -> CpuReadbackViewRepr {
+    let mut planes = [CpuReadbackPlaneRepr::zeroed(); MAX_PLANES];
+    let plane_count = view.plane_count().min(MAX_PLANES as u32);
+    for (i, p) in view.planes().iter().take(plane_count as usize).enumerate() {
+        let bytes = p.bytes();
+        planes[i] = CpuReadbackPlaneRepr {
+            mapped_ptr: bytes.as_ptr() as u64,
+            byte_size: bytes.len() as u64,
+            width: p.width(),
+            height: p.height(),
+            bytes_per_pixel: p.bytes_per_pixel(),
+            _padding: 0,
+        };
+    }
+    CpuReadbackViewRepr {
+        format_raw: view.format() as u32,
+        width: view.width(),
+        height: view.height(),
+        plane_count,
+        planes,
+    }
+}
+
+fn write_view_to_repr<'g>(view: &CpuReadbackWriteView<'g>) -> CpuReadbackViewRepr {
+    let mut planes = [CpuReadbackPlaneRepr::zeroed(); MAX_PLANES];
+    let plane_count = view.plane_count().min(MAX_PLANES as u32);
+    for (i, p) in view.planes().iter().take(plane_count as usize).enumerate() {
+        // bytes() is immutable here; mapped_ptr is the same address
+        // regardless of borrow flavor — the host's WriteView keeps
+        // the mut borrow alive via the leaked guard, so the cdylib
+        // can safely write through the same pointer for the
+        // duration of the acquire scope.
+        let bytes = p.bytes();
+        planes[i] = CpuReadbackPlaneRepr {
+            mapped_ptr: bytes.as_ptr() as u64,
+            byte_size: bytes.len() as u64,
+            width: p.width(),
+            height: p.height(),
+            bytes_per_pixel: p.bytes_per_pixel(),
+            _padding: 0,
+        };
+    }
+    CpuReadbackViewRepr {
+        format_raw: view.format() as u32,
+        width: view.width(),
+        height: view.height(),
+        plane_count,
+        planes,
+    }
+}
+
+fn read_guard_to_repr<D: VulkanRhiDevice + 'static>(
+    guard: ReadGuard<'_, CpuReadbackSurfaceAdapter<D>>,
+) -> CpuReadbackViewRepr {
+    let view_repr = read_view_to_repr(guard.view());
+    // SAFETY: we deliberately leak the guard's `end_read_access`
+    // signal — the cdylib will fire `end_read_access` itself from
+    // its own ReadGuard::drop via the vtable. Calling Drop here
+    // would double-decrement the read_holders counter.
+    core::mem::forget(guard);
+    view_repr
+}
+
+fn write_guard_to_repr<D: VulkanRhiDevice + 'static>(
+    guard: WriteGuard<'_, CpuReadbackSurfaceAdapter<D>>,
+) -> CpuReadbackViewRepr {
+    let view_repr = write_view_to_repr(guard.view());
+    // SAFETY: same rationale as `read_guard_to_repr` — the cdylib
+    // fires `end_write_access` itself via the vtable; running
+    // Drop here would issue the post-write flush twice.
+    core::mem::forget(guard);
+    view_repr
+}
+
+// =============================================================================
+// Handle lifetime
+// =============================================================================
+
+unsafe extern "C" fn host_clone_handle<D: VulkanRhiDevice + 'static>(
+    borrowed_handle: *const c_void,
+) -> *const c_void {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::clone_handle",
+        || {
+            if borrowed_handle.is_null() {
+                return core::ptr::null();
+            }
+            // SAFETY: handle is
+            // Arc::into_raw(Arc<CpuReadbackSurfaceAdapter<D>>)-shaped.
+            unsafe {
+                Arc::increment_strong_count(
+                    borrowed_handle as *const CpuReadbackSurfaceAdapter<D>,
+                );
+            }
+            borrowed_handle
+        },
+        core::ptr::null(),
+    )
+}
+
+unsafe extern "C" fn host_drop_handle<D: VulkanRhiDevice + 'static>(owned_handle: *const c_void) {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::drop_handle",
+        || {
+            if owned_handle.is_null() {
+                return;
+            }
+            // SAFETY: handle is
+            // Arc::into_raw(Arc<CpuReadbackSurfaceAdapter<D>>)-shaped
+            // with at least one host-side refcount remaining.
+            unsafe {
+                Arc::decrement_strong_count(
+                    owned_handle as *const CpuReadbackSurfaceAdapter<D>,
+                );
+            }
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Registry management
+// =============================================================================
+
+unsafe extern "C" fn host_register_host_surface<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    registration_ptr: *const HostSurfaceRegistrationRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::register_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "register_host_surface: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if registration_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        "register_host_surface: null registration pointer",
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is borrowed from
+            // their stack for the duration of this call.
+            let r: &HostSurfaceRegistrationRepr = unsafe { &*registration_ptr };
+            let format = match surface_format_from_raw(r.format_raw) {
+                Some(f) => f,
+                None => {
+                    let msg = format!(
+                        "register_host_surface: unknown SurfaceFormat enumerant {}",
+                        r.format_raw
+                    );
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    return 1;
+                }
+            };
+            let plane_count = r.plane_count as usize;
+            if plane_count == 0 || plane_count > MAX_PLANES {
+                let msg = format!(
+                    "register_host_surface: plane_count {plane_count} out of [1, {MAX_PLANES}]"
+                );
+                unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                return 1;
+            }
+            if r.timeline_handle == 0 {
+                unsafe {
+                    write_err(
+                        "register_host_surface: null timeline handle",
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts each non-zero handle is
+            // Arc::into_raw-shaped against the correct privilege
+            // family for D. The host bumps refcount and stashes
+            // clones in the registry; caller's Arcs remain owned
+            // by the caller.
+            let texture: Option<Arc<<D::Privilege as DevicePrivilege>::Texture>> =
+                if r.texture_handle == 0 {
+                    None
+                } else {
+                    let ptr = r.texture_handle
+                        as *const <D::Privilege as DevicePrivilege>::Texture;
+                    unsafe {
+                        Arc::increment_strong_count(ptr);
+                        Some(Arc::from_raw(ptr))
+                    }
+                };
+            let timeline: Arc<<D::Privilege as DevicePrivilege>::TimelineSemaphore> = unsafe {
+                let ptr = r.timeline_handle
+                    as *const <D::Privilege as DevicePrivilege>::TimelineSemaphore;
+                Arc::increment_strong_count(ptr);
+                Arc::from_raw(ptr)
+            };
+            let mut staging_planes: Vec<Arc<<D::Privilege as DevicePrivilege>::Buffer>> =
+                Vec::with_capacity(plane_count);
+            for i in 0..plane_count {
+                let raw = r.staging_handles[i];
+                if raw == 0 {
+                    let msg = format!(
+                        "register_host_surface: null staging handle at plane {i}"
+                    );
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    return 1;
+                }
+                let ptr = raw as *const <D::Privilege as DevicePrivilege>::Buffer;
+                unsafe {
+                    Arc::increment_strong_count(ptr);
+                    staging_planes.push(Arc::from_raw(ptr));
+                }
+            }
+            let registration: HostSurfaceRegistration<D::Privilege> = HostSurfaceRegistration {
+                texture,
+                staging_planes,
+                timeline,
+                initial_image_layout: VulkanLayout(r.initial_layout_raw),
+                format,
+                width: r.width,
+                height: r.height,
+            };
+            match adapter.register_host_surface(surface_id, registration) {
+                Ok(()) => 0,
+                Err(e) => {
+                    let msg = format!("register_host_surface: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_unregister_host_surface<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    out_was_present: *mut u32,
+) {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::unregister_host_surface",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    if !out_was_present.is_null() {
+                        unsafe { *out_was_present = 0 };
+                    }
+                    return;
+                }
+            };
+            let was_present = adapter.unregister_host_surface(surface_id);
+            if !out_was_present.is_null() {
+                unsafe { *out_was_present = u32::from(was_present) };
+            }
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_registered_count<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+) -> usize {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::registered_count",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return 0usize,
+            };
+            adapter.registered_count()
+        },
+        0usize,
+    )
+}
+
+// =============================================================================
+// SurfaceAdapter trait methods
+// =============================================================================
+
+/// Common shape for `acquire_*` / `try_acquire_*`: borrow the
+/// adapter, validate the surface pointer, call the inner method,
+/// write the view + status.
+unsafe fn run_acquire<D, F>(
+    callback_name: &'static str,
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut CpuReadbackViewRepr,
+    out_acquired: Option<*mut u32>,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+    body: F,
+) -> i32
+where
+    D: VulkanRhiDevice + 'static,
+    F: FnOnce(
+        &CpuReadbackSurfaceAdapter<D>,
+        &StreamlibSurface,
+    ) -> Result<Option<CpuReadbackViewRepr>, String>,
+{
+    run_host_extern_c(
+        callback_name,
+        || {
+            if let Some(p) = out_acquired {
+                if !p.is_null() {
+                    unsafe { *p = 0 };
+                }
+            }
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            &format!("{callback_name}: null adapter handle"),
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            if surface_ptr.is_null() {
+                unsafe {
+                    write_err(
+                        &format!("{callback_name}: null surface pointer"),
+                        err_buf,
+                        err_buf_cap,
+                        err_len,
+                    );
+                }
+                return 1;
+            }
+            // SAFETY: caller asserts the pointer is a borrowed
+            // StreamlibSurface from its own stack/heap, valid for
+            // the duration of the call.
+            let surface: &StreamlibSurface =
+                unsafe { &*(surface_ptr as *const StreamlibSurface) };
+            match body(adapter, surface) {
+                Ok(Some(view)) => {
+                    if !out_view.is_null() {
+                        unsafe { *out_view = view };
+                    }
+                    if let Some(p) = out_acquired {
+                        if !p.is_null() {
+                            unsafe { *p = 1 };
+                        }
+                    }
+                    0
+                }
+                Ok(None) => {
+                    // Contended — try_* shape. Blocking variants
+                    // never reach here (the body errors instead).
+                    0
+                }
+                Err(msg) => {
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut CpuReadbackViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "cpu_readback_surface_adapter::acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_read(surface) {
+                Ok(guard) => Ok(Some(read_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut CpuReadbackViewRepr,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "cpu_readback_surface_adapter::acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            None,
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.acquire_write(surface) {
+                Ok(guard) => Ok(Some(write_guard_to_repr(guard))),
+                Err(e) => Err(format!("acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_read<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut CpuReadbackViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "cpu_readback_surface_adapter::try_acquire_read",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_read(surface) {
+                Ok(Some(guard)) => Ok(Some(read_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_read: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_try_acquire_write<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_ptr: *const c_void,
+    out_view: *mut CpuReadbackViewRepr,
+    out_acquired: *mut u32,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    unsafe {
+        run_acquire::<D, _>(
+            "cpu_readback_surface_adapter::try_acquire_write",
+            handle,
+            surface_ptr,
+            out_view,
+            Some(out_acquired),
+            err_buf,
+            err_buf_cap,
+            err_len,
+            |adapter, surface| match adapter.try_acquire_write(surface) {
+                Ok(Some(guard)) => Ok(Some(write_guard_to_repr(guard))),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("try_acquire_write: {e}")),
+            },
+        )
+    }
+}
+
+unsafe extern "C" fn host_end_read_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::end_read_access",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_read_access(surface_id);
+        },
+        (),
+    )
+}
+
+unsafe extern "C" fn host_end_write_access<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+) {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::end_write_access",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => return,
+            };
+            adapter.end_write_access(surface_id);
+        },
+        (),
+    )
+}
+
+// =============================================================================
+// Bridge entries
+// =============================================================================
+
+unsafe extern "C" fn host_run_bridge_copy_image_to_buffer<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    out_signaled_value: *mut u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::run_bridge_copy_image_to_buffer",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "run_bridge_copy_image_to_buffer: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            match adapter.run_bridge_copy_image_to_buffer(surface_id) {
+                Ok(v) => {
+                    if !out_signaled_value.is_null() {
+                        unsafe { *out_signaled_value = v };
+                    }
+                    0
+                }
+                Err(e) => {
+                    let msg = format!("run_bridge_copy_image_to_buffer: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+unsafe extern "C" fn host_run_bridge_copy_buffer_to_image<D: VulkanRhiDevice + 'static>(
+    handle: *const c_void,
+    surface_id: u64,
+    out_signaled_value: *mut u64,
+    err_buf: *mut u8,
+    err_buf_cap: usize,
+    err_len: *mut usize,
+) -> i32 {
+    run_host_extern_c(
+        "cpu_readback_surface_adapter::run_bridge_copy_buffer_to_image",
+        || {
+            let adapter = match unsafe { adapter_borrow::<D>(handle) } {
+                Some(a) => a,
+                None => {
+                    unsafe {
+                        write_err(
+                            "run_bridge_copy_buffer_to_image: null adapter handle",
+                            err_buf,
+                            err_buf_cap,
+                            err_len,
+                        );
+                    }
+                    return 1;
+                }
+            };
+            match adapter.run_bridge_copy_buffer_to_image(surface_id) {
+                Ok(v) => {
+                    if !out_signaled_value.is_null() {
+                        unsafe { *out_signaled_value = v };
+                    }
+                    0
+                }
+                Err(e) => {
+                    let msg = format!("run_bridge_copy_buffer_to_image: {e}");
+                    unsafe { write_err(&msg, err_buf, err_buf_cap, err_len) };
+                    1
+                }
+            }
+        },
+        1,
+    )
+}
+
+// =============================================================================
+// Tier-1 host-side wire-format tests (null-handle guards) +
+// cross-crate layout-equivalence tests
+// =============================================================================
+//
+// Each test invokes a vtable slot directly with a null handle and
+// asserts the slot's documented null-handle behaviour fires. The
+// success-path tests require an actual `Arc<CpuReadbackSurfaceAdapter>`
+// + a live device + live staging buffers and timeline; those live
+// in the crate's `tests/` integration tests as those scenarios get
+// wired through this vtable in follow-up issues.
+
+#[cfg(test)]
+mod tier1_null_handle_tests {
+    use super::*;
+    use std::mem::{align_of, size_of};
+    use streamlib_consumer_rhi::ConsumerVulkanDevice;
+
+    // Pick a concrete D to materialize the monomorphized vtable.
+    // The null-handle tests don't care which D — they exercise the
+    // panic guards before any device-shape work fires.
+    type D = ConsumerVulkanDevice;
+
+    /// `SurfaceFormat` is declared `#[repr(u32)]` in
+    /// `streamlib-adapter-abi`. The vtable wire format mirrors
+    /// that representation in `CpuReadbackViewRepr::format_raw`
+    /// and `HostSurfaceRegistrationRepr::format_raw`. Locking the
+    /// discriminant values here ensures a stealth re-numbering
+    /// in `streamlib-adapter-abi` trips at this layer too.
+    #[test]
+    fn surface_format_discriminants_match_repr() {
+        assert_eq!(SurfaceFormat::Bgra8 as u32, 0);
+        assert_eq!(SurfaceFormat::Rgba8 as u32, 1);
+        assert_eq!(SurfaceFormat::Nv12 as u32, 2);
+    }
+
+    /// `surface_format_from_raw` round-trips the canonical
+    /// discriminants and rejects unknown values.
+    #[test]
+    fn surface_format_round_trip_through_raw() {
+        assert_eq!(surface_format_from_raw(0), Some(SurfaceFormat::Bgra8));
+        assert_eq!(surface_format_from_raw(1), Some(SurfaceFormat::Rgba8));
+        assert_eq!(surface_format_from_raw(2), Some(SurfaceFormat::Nv12));
+        assert_eq!(surface_format_from_raw(3), None);
+        assert_eq!(surface_format_from_raw(u32::MAX), None);
+    }
+
+    /// Cross-crate sanity: the abi crate is dep-light by design
+    /// and can't see `streamlib-adapter-abi`. This crate has both
+    /// in scope, so we lock the size/align consistency between
+    /// `CpuReadbackPlaneRepr` and its conceptual source (the
+    /// per-plane view shape) here as a witness — there's no
+    /// existing `#[repr(C)]` mirror in `streamlib-adapter-abi` to
+    /// compare against, but the size/align is the contract the
+    /// layout regression test in the abi crate locks. This test
+    /// fails loudly if a future refactor accidentally changes
+    /// either side without updating the other.
+    #[test]
+    fn cpu_readback_plane_repr_size_align_locked() {
+        assert_eq!(size_of::<CpuReadbackPlaneRepr>(), 32);
+        assert_eq!(align_of::<CpuReadbackPlaneRepr>(), 8);
+    }
+
+    /// Cross-crate sanity: `CpuReadbackViewRepr` size/align lock.
+    /// 144 bytes = `u32×4 + [CpuReadbackPlaneRepr; 4] @ 16`.
+    #[test]
+    fn cpu_readback_view_repr_size_align_locked() {
+        assert_eq!(size_of::<CpuReadbackViewRepr>(), 144);
+        assert_eq!(align_of::<CpuReadbackViewRepr>(), 8);
+    }
+
+    /// Cross-crate sanity: `HostSurfaceRegistrationRepr` size/align
+    /// lock. 72 bytes.
+    #[test]
+    fn host_surface_registration_repr_size_align_locked() {
+        assert_eq!(size_of::<HostSurfaceRegistrationRepr>(), 72);
+        assert_eq!(align_of::<HostSurfaceRegistrationRepr>(), 8);
+    }
+
+    fn vtable() -> &'static CpuReadbackSurfaceAdapterVTable {
+        // SAFETY: the returned pointer is `&'static`-shaped per the
+        // `const VTABLE` construction in `MonoVTable<D>`.
+        unsafe { &*host_cpu_readback_surface_adapter_vtable::<D>() }
+    }
+
+    fn make_err_buf() -> ([u8; 256], usize) {
+        ([0u8; 256], 0usize)
+    }
+
+    fn err_msg(buf: &[u8], len: usize) -> &str {
+        std::str::from_utf8(&buf[..len]).expect("UTF-8")
+    }
+
+    #[test]
+    fn layout_version_matches_constant() {
+        assert_eq!(
+            vtable().layout_version,
+            CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION
+        );
+        assert_eq!(vtable()._reserved_padding, 0);
+    }
+
+    #[test]
+    fn clone_handle_returns_null_on_null_input() {
+        unsafe {
+            let out = (vtable().clone_handle)(core::ptr::null());
+            assert!(out.is_null());
+        }
+    }
+
+    #[test]
+    fn drop_handle_null_is_no_op() {
+        // Documented contract — must not crash on null.
+        unsafe {
+            (vtable().drop_handle)(core::ptr::null());
+        }
+    }
+
+    #[test]
+    fn register_host_surface_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let reg = HostSurfaceRegistrationRepr::zeroed();
+        let rc = unsafe {
+            (vtable().register_host_surface)(
+                core::ptr::null(),
+                42,
+                &reg,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("register_host_surface: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    // NOTE: there's no tier-1 test for the
+    // `registration_ptr == null` guard inside `register_host_surface`
+    // because exercising it cleanly requires a valid Arc-shaped
+    // adapter handle (we'd need to build a fake-but-aligned dummy
+    // and risk a misaligned-pointer abort in debug builds, which
+    // bypasses the panic guard's `catch_unwind` because misalignment
+    // is non-unwinding). The integration test that wires a real
+    // `Arc<CpuReadbackSurfaceAdapter>` will cover the
+    // registration-pointer guard alongside the success path; in
+    // tier-1 the null-handle case (above) is the primary lock.
+
+    #[test]
+    fn unregister_host_surface_null_handle_returns_zero_was_present() {
+        let mut was_present: u32 = 0xFFFF_FFFF;
+        unsafe {
+            (vtable().unregister_host_surface)(core::ptr::null(), 42, &mut was_present);
+        }
+        assert_eq!(was_present, 0);
+    }
+
+    #[test]
+    fn registered_count_null_handle_returns_zero() {
+        let n = unsafe { (vtable().registered_count)(core::ptr::null()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: CpuReadbackViewRepr = CpuReadbackViewRepr::zeroed();
+        let rc = unsafe {
+            (vtable().acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(msg.contains("acquire_read: null adapter handle"), "got: {msg}");
+    }
+
+    #[test]
+    fn acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: CpuReadbackViewRepr = CpuReadbackViewRepr::zeroed();
+        let rc = unsafe {
+            (vtable().acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_read_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: CpuReadbackViewRepr = CpuReadbackViewRepr::zeroed();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_read)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_read: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_acquire_write_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut view: CpuReadbackViewRepr = CpuReadbackViewRepr::zeroed();
+        let mut acquired: u32 = 99;
+        let rc = unsafe {
+            (vtable().try_acquire_write)(
+                core::ptr::null(),
+                core::ptr::null(),
+                &mut view,
+                &mut acquired,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        assert_eq!(acquired, 0);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("try_acquire_write: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn end_read_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_read_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn end_write_access_null_handle_is_no_op() {
+        unsafe { (vtable().end_write_access)(core::ptr::null(), 42) };
+    }
+
+    #[test]
+    fn run_bridge_copy_image_to_buffer_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut signaled: u64 = 0;
+        let rc = unsafe {
+            (vtable().run_bridge_copy_image_to_buffer)(
+                core::ptr::null(),
+                42,
+                &mut signaled,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("run_bridge_copy_image_to_buffer: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn run_bridge_copy_buffer_to_image_returns_error_on_null_handle() {
+        let (mut buf, mut len) = make_err_buf();
+        let mut signaled: u64 = 0;
+        let rc = unsafe {
+            (vtable().run_bridge_copy_buffer_to_image)(
+                core::ptr::null(),
+                42,
+                &mut signaled,
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 1);
+        let msg = err_msg(&buf, len);
+        assert!(
+            msg.contains("run_bridge_copy_buffer_to_image: null adapter handle"),
+            "got: {msg}"
+        );
+    }
+}

--- a/libs/streamlib-adapter-cpu-readback/src/lib.rs
+++ b/libs/streamlib-adapter-cpu-readback/src/lib.rs
@@ -30,6 +30,7 @@
 
 mod adapter;
 mod context;
+mod host_vtable;
 mod state;
 mod view;
 
@@ -38,6 +39,7 @@ pub use adapter::{
     InProcessCpuReadbackCopyTrigger, TriggerPlane,
 };
 pub use context::CpuReadbackContext;
+pub use host_vtable::host_cpu_readback_surface_adapter_vtable;
 pub use state::HostSurfaceRegistration;
 pub use streamlib_consumer_rhi::VulkanLayout;
 pub use view::{


### PR DESCRIPTION
## Summary

- Trunk-shaped per-adapter vtable lift for the explicit GPU→CPU readback adapter (issue #890; sibling of #887's PR #994 trunk).
- New crate `streamlib-adapter-cpu-readback-abi` — pure ABI, dep-free, no streamlib-engine, no vulkanalia, no streamlib-adapter-cpu-readback. Same dep posture as `streamlib-plugin-abi` / `streamlib-adapter-vulkan-abi`.
- Host wiring `host_cpu_readback_surface_adapter_vtable::<D>()` in `streamlib-adapter-cpu-readback` delegates every extern "C" slot to the existing `CpuReadbackSurfaceAdapter<D>` impl. Per-monomorphization const vtable; cdylib never sees `D`.

Closes #890.

## What's in the vtable

Audited surface (enumerated in the new crate's module docs):

1. `SurfaceAdapter` trait methods on `CpuReadbackSurfaceAdapter`: `acquire_read`, `acquire_write`, `try_acquire_read`, `try_acquire_write`, `end_read_access`, `end_write_access`.
2. Inherent methods on `CpuReadbackSurfaceAdapter<D>`: `register_host_surface`, `unregister_host_surface`, `registered_count`, `run_bridge_copy_image_to_buffer`, `run_bridge_copy_buffer_to_image`.
3. RAII guard `Drop` paths (`ReadGuard::drop` / `WriteGuard::drop`) route back through the sealed `end_*_access` slots.
4. View accessors (`CpuReadbackReadView::format / width / height / plane_count / planes`, per-plane `bytes / width / height / bytes_per_pixel`) are pure POD reads against `CpuReadbackViewRepr` — no vtable hop on the view itself.

Methods deliberately not exposed (audit findings):

- `CpuReadbackSurfaceAdapter::new` / `with_acquire_timeout` — host-side construction / chaining-builder; cdylib receives a vtable+handle, doesn't construct adapters.
- `device()` — returns `&Arc<D>`, can't cross extern "C" without `D` parameterization; cdylibs hold their own device.
- `CpuReadbackCopyTrigger` / `InProcessCpuReadbackCopyTrigger` — trigger flavor is private wiring inside the adapter (host wires in-process trigger; cdylib wires escalate-IPC trigger), not a cdylib-callable boundary.

## Vtable shape

| Type | Size | Anchor offsets |
|---|---|---|
| `CpuReadbackSurfaceAdapterVTable` | 112 B (13 fn-pointer slots + 8 B header) | locked by `cpu_readback_surface_adapter_vtable_layout` |
| `CpuReadbackViewRepr` | 144 B | `format_raw @0`, `width @4`, `height @8`, `plane_count @12`, `planes: [PlaneRepr; 4] @16` |
| `CpuReadbackPlaneRepr` | 32 B | `mapped_ptr: u64 @0`, `byte_size: u64 @8`, `width: u32 @16`, `height @20`, `bytes_per_pixel @24`, `_padding @28` |
| `HostSurfaceRegistrationRepr` | 72 B | `format_raw @0`, `width @4`, `height @8`, `plane_count @12`, `initial_layout_raw: i32 @16`, `_padding @20`, `texture_handle: u64 @24`, `timeline_handle: u64 @32`, `staging_handles: [u64; 4] @40` |

`CPU_READBACK_SURFACE_ADAPTER_VTABLE_LAYOUT_VERSION = 1`. `MAX_PLANES = 4` covers today's formats (BGRA/RGBA = 1 plane, NV12 = 2) plus forward-looking YUV variants (NV21, I420, I422, I444 — all ≤ 3 planes) without bumping the layout version.

## Error / contention crossing

- Every fallible slot returns `i32` (0 = success, 1 = error). Error message written to caller's `err_buf` + `err_buf_cap` + `err_len`. Same shape as PR #994's vtable.
- `try_acquire_*` distinguishes "contended" from "failed" via `*out_acquired` (0 = contended, 1 = success), keeping the `Result<Option<Guard>, AdapterError>` semantics across the i32 boundary.
- Host-side panic guards on every callback via `run_host_extern_c` (mirrors `streamlib-plugin-abi`); `tracing::error!` target `streamlib_cpu_readback::ffi`.

## How cpu-readback differs from the vulkan trunk

- **Multi-plane payload.** `CpuReadbackViewRepr` carries up to `MAX_PLANES = 4` `CpuReadbackPlaneRepr` records (BGRA/RGBA fills 1 slot, NV12 fills 2). The vulkan adapter's view is a single `VkImage + layout`.
- **No `raw_handles` / `release_to_foreign` / `surface_image_info`.** cpu-readback doesn't expose Vulkan-aware power-user methods — customers operate against the staging buffer's CPU mapping.
- **Two bridge entries** (`run_bridge_copy_image_to_buffer` / `run_bridge_copy_buffer_to_image`) — these are public methods on `CpuReadbackSurfaceAdapter` that the cdylib forwards through. They return a timeline value; cdylib waits on the imported timeline through `streamlib-consumer-rhi`.

## Scope fence — escalate-IPC bridge is out of scope here

The cpu-readback adapter is special: per-acquire GPU work runs on the host via a thin `run_cpu_readback_copy(surface_id)` escalate-IPC trigger (see `docs/architecture/adapter-runtime-integration.md`). That trigger is **already cross-process** through escalate IPC + the host's `CpuReadbackBridge` trait on `GpuContext`. This vtable wires the parallel "cdylib holds the adapter, talks to its own trigger" surface, NOT the host-side bridge. The bridge stays where it lives; the `RunCpuReadbackCopy` escalate op is unchanged by this PR.

## Test coverage

- **8 layout regression tests** in the abi crate locking `CpuReadbackPlaneRepr` (32 B), `CpuReadbackViewRepr` (144 B), `HostSurfaceRegistrationRepr` (72 B), `CpuReadbackSurfaceAdapterVTable` (112 B) byte offsets + `MAX_PLANES = 4` constant + zeroed-constructor witnesses + `Send + Sync` witness.
- **19 tests in the host wiring crate**: 3 cross-crate size/align locks (so the abi crate's regression tests aren't the only line of defense) + `SurfaceFormat` discriminant lock + `surface_format_from_raw` round-trip + 14 tier-1 null-handle guards on every fallible slot (`clone_handle`, `drop_handle`, `register_host_surface`, `unregister_host_surface`, `registered_count`, `acquire_read/write`, `try_acquire_read/write`, `end_read/write_access`, `run_bridge_copy_*`).

27 new tests total. Success-path integration tests (real `Arc<CpuReadbackSurfaceAdapter>` + live staging buffers + timeline) get wired through this vtable in the follow-up sibling slice that adds the `HostServices` field append and cdylib β-shape forwarding.

## Boundary discipline

- `cargo tree -p streamlib-adapter-cpu-readback-abi | grep -c "^streamlib v"` returns 0 — abi crate has zero streamlib deps.
- `cargo xtask check-boundaries` clean (4065 files scanned, no violations).
- Host wiring lives in `streamlib-adapter-cpu-readback` which is already permitted to use vulkanalia + streamlib-consumer-rhi per the RHI-boundary rules.

## Architectural lock-in mirrors PR #994's

Every decision from PR #994's "Architectural lock-in for siblings" rides into this PR:

- New `-abi` crate per adapter (`streamlib-adapter-cpu-readback-abi`).
- `#[repr(C)] CpuReadbackSurfaceAdapterVTable { layout_version: u32, _reserved_padding: u32, fn pointers... }` with layout regression locking byte offsets.
- Generic host fn `host_cpu_readback_surface_adapter_vtable::<D>()` over `D: VulkanRhiDevice + 'static`.
- Per-monomorphization `const VTABLE` via a private `MonoVTable<D>(PhantomData<D>)` struct.
- Tier-1 null-handle tests on every slot following the `gpu_full_access_vtable_tests` pattern in `streamlib-plugin-abi` / PR #994.
- Cross-crate size/align tests in the host wiring crate (the abi crate is dep-light by design and can't see source-crate types directly).
- `tracing` target `streamlib_cpu_readback::ffi` (avoids `streamlib::*`).
- Panic guards on every callback via `run_host_extern_c`.

## Trunk-vs-slice cut (deliberate)

The issue body's exit criterion "Cdylib-side shims forward through the vtable" is the trunk-vs-slice cut, matching PR #994's split:

- **In this PR (trunk-shaped slice):** ABI vtable + host wiring + layout/null-handle tests. Locks the wire format end-to-end so the future cdylib β-shape can mechanically copy the shape.
- **Sibling slice (follow-up):** `HostServices` field append for `cpu_readback_surface_adapter_vtable`, `install_host_services` wiring, cdylib β-shape `CpuReadbackContext<ConsumerVulkanDevice>` forwarding through the vtable. Carved separately to avoid five sibling PRs (#888/#889/#890/#891/#894) all landing the same `HostServices` field append in parallel — `HostServices` is a contended resource.

## Issue body supersession

The 2026-05-20 "Resolved design — defer pending consumer" section in #890's body is **superseded** per `.claude/goals/04-adapter-callback-tables.md`:

> EXECUTE IN ANY ORDER (all 6 independent):
> 4. #890 — cpu-readback adapter callback table
>    (streamlib-adapter-cpu-readback). Uses escalate-IPC seam for the
>    per-acquire vkCmdCopyImageToBuffer trigger.

CLAUDE.md's `feedback_consumer_first_rule_softened.md` framing applies: a filed issue in an open milestone is sufficient consumer attestation; the per-adapter vtable lift is sanctioned engine work that should land now so the sibling adapters follow this shape mechanically. The issue body has been edited in place with the strike-through-with-evidence supersession marker per CLAUDE.md markdown rules.

## Test plan

- [x] `cargo test -p streamlib-adapter-cpu-readback-abi --lib` — 8/8 layout tests pass
- [x] `cargo test -p streamlib-adapter-cpu-readback --lib` — 19/19 tier-1 null-handle + cross-crate layout-equivalence tests pass
- [x] `cargo build --workspace --lib` — clean
- [x] `cargo xtask check-boundaries` — 4065 files scanned, no violations
- [x] `cargo tree -p streamlib-adapter-cpu-readback-abi | grep -c "^streamlib v"` returns 0