### PR TITLE
test(plugin-abi): msgpack wire round-trip tests + silent-decode mitigation

### DIFF
--- a/libs/streamlib-engine/src/core/graph/edges/input_link_port_ref.rs
+++ b/libs/streamlib-engine/src/core/graph/edges/input_link_port_ref.rs
@@ -34,3 +34,30 @@ impl fmt::Display for InputLinkPortRef {
         write!(f, "{}.{}", self.processor_id, self.port_name)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// msgpack round-trip preserves both fields. Sibling of
+    /// `OutputLinkPortRef`'s round-trip test; locks the cdylib-side
+    /// encode path the plugin ABI takes when forwarding
+    /// `Runtime::connect` calls.
+    #[test]
+    fn msgpack_round_trip_preserves_full_value() {
+        let port_ref =
+            InputLinkPortRef::new(ProcessorUniqueId::from("Pdisplay"), "video_in");
+        let bytes = rmp_serde::to_vec_named(&port_ref).expect("encode");
+        let back: InputLinkPortRef = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(port_ref, back);
+    }
+
+    #[test]
+    fn msgpack_round_trip_empty_port_name() {
+        let port_ref =
+            InputLinkPortRef::new(ProcessorUniqueId::from("P0"), "");
+        let bytes = rmp_serde::to_vec_named(&port_ref).expect("encode");
+        let back: InputLinkPortRef = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(port_ref, back);
+    }
+}

--- a/libs/streamlib-engine/src/core/graph/edges/link_unique_id.rs
+++ b/libs/streamlib-engine/src/core/graph/edges/link_unique_id.rs
@@ -123,3 +123,26 @@ impl PartialEq<LinkUniqueId> for String {
         *self == other.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// msgpack round-trip preserves the bare-string transparent wire
+    /// shape — the same regression class `ProcessorUniqueId`'s test guards.
+    #[test]
+    fn msgpack_round_trip_preserves_transparent_shape() {
+        let id = LinkUniqueId::from("L-test-link");
+        let bytes = rmp_serde::to_vec_named(&id).expect("encode");
+        let back: LinkUniqueId = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(id, back);
+    }
+
+    /// Wire format is a bare msgpack string.
+    #[test]
+    fn msgpack_wire_is_bare_string_not_map() {
+        let id = LinkUniqueId::from("Labc");
+        let bytes = rmp_serde::to_vec_named(&id).expect("encode");
+        assert_eq!(bytes, vec![0xa4, b'L', b'a', b'b', b'c']);
+    }
+}

--- a/libs/streamlib-engine/src/core/graph/edges/output_link_port_ref.rs
+++ b/libs/streamlib-engine/src/core/graph/edges/output_link_port_ref.rs
@@ -34,3 +34,30 @@ impl fmt::Display for OutputLinkPortRef {
         write!(f, "{}.{}", self.processor_id, self.port_name)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// msgpack round-trip preserves both fields. Covers the
+    /// runtime-ops-shim encode path the plugin ABI takes when
+    /// forwarding `Runtime::connect` calls from cdylib code.
+    #[test]
+    fn msgpack_round_trip_preserves_full_value() {
+        let port_ref =
+            OutputLinkPortRef::new(ProcessorUniqueId::from("Pcam"), "video_out");
+        let bytes = rmp_serde::to_vec_named(&port_ref).expect("encode");
+        let back: OutputLinkPortRef = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(port_ref, back);
+    }
+
+    /// Empty port_name round-trips (no field-skipping shenanigans).
+    #[test]
+    fn msgpack_round_trip_empty_port_name() {
+        let port_ref =
+            OutputLinkPortRef::new(ProcessorUniqueId::from("P0"), "");
+        let bytes = rmp_serde::to_vec_named(&port_ref).expect("encode");
+        let back: OutputLinkPortRef = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(port_ref, back);
+    }
+}

--- a/libs/streamlib-engine/src/core/graph/nodes/processor_unique_id.rs
+++ b/libs/streamlib-engine/src/core/graph/nodes/processor_unique_id.rs
@@ -125,3 +125,40 @@ impl PartialEq<ProcessorUniqueId> for String {
         *self == other.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// msgpack round-trip preserves the bare-string `#[serde(transparent)]`
+    /// wire shape. A regression to non-transparent would silently flip the
+    /// wire format to a `{0: "..."}` map.
+    #[test]
+    fn msgpack_round_trip_preserves_transparent_shape() {
+        let id = ProcessorUniqueId::from("P-test-id");
+        let bytes = rmp_serde::to_vec_named(&id).expect("encode");
+        let back: ProcessorUniqueId = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(id, back);
+    }
+
+    /// Wire format is a bare msgpack string, not a `{0: "..."}` map.
+    /// Locks the transparent serde representation.
+    #[test]
+    fn msgpack_wire_is_bare_string_not_map() {
+        let id = ProcessorUniqueId::from("Pabc");
+        let bytes = rmp_serde::to_vec_named(&id).expect("encode");
+        // msgpack `fixstr` for "Pabc": tag 0xa4 then bytes "Pabc"
+        assert_eq!(bytes, vec![0xa4, b'P', b'a', b'b', b'c']);
+    }
+
+    /// Empty-id and unicode-id both survive the wire.
+    #[test]
+    fn msgpack_round_trip_edge_cases() {
+        for s in ["", "P", "P-very-long-id-that-overflows-fixstr-limit-and-needs-str8", "P🎥-emoji"] {
+            let id = ProcessorUniqueId::from(s);
+            let bytes = rmp_serde::to_vec_named(&id).expect("encode");
+            let back: ProcessorUniqueId = rmp_serde::from_slice(&bytes).expect("decode");
+            assert_eq!(id, back);
+        }
+    }
+}

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -266,7 +266,16 @@ impl ProcessorInstance {
                     // back to default.
                     return ExecutionConfig::default();
                 }
-                rmp_serde::from_slice(&buf[..out_len]).unwrap_or_default()
+                match rmp_serde::from_slice(&buf[..out_len]) {
+                    Ok(cfg) => cfg,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "ProcessorInstance::execution_config: failed to decode msgpack payload; falling back to default",
+                        );
+                        ExecutionConfig::default()
+                    }
+                }
             }
             Self::LegacyDyn(inner) => inner.execution_config(),
         }
@@ -508,7 +517,16 @@ impl ProcessorInstance {
                         )
                     };
                 }
-                rmp_serde::from_slice(&buf[..out_len]).unwrap_or(serde_json::Value::Null)
+                match rmp_serde::from_slice(&buf[..out_len]) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "ProcessorInstance::to_runtime_json: failed to decode msgpack payload; returning Null",
+                        );
+                        serde_json::Value::Null
+                    }
+                }
             }
             Self::LegacyDyn(inner) => inner.to_runtime_json(),
         }
@@ -545,7 +563,16 @@ impl ProcessorInstance {
                         )
                     };
                 }
-                rmp_serde::from_slice(&buf[..out_len]).unwrap_or(serde_json::Value::Null)
+                match rmp_serde::from_slice(&buf[..out_len]) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "ProcessorInstance::config_json: failed to decode msgpack payload; returning Null",
+                        );
+                        serde_json::Value::Null
+                    }
+                }
             }
             Self::LegacyDyn(inner) => inner.config_json(),
         }

--- a/libs/streamlib-engine/src/core/processors/processor_spec.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_spec.rs
@@ -9,7 +9,7 @@ use crate::core::descriptors::SchemaIdent;
 ///
 /// Contains only what the user provides: processor identity and configuration.
 /// Internal details (id, ports) are resolved by the runtime.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessorSpec {
     /// Structured processor identity (matches the registered key in [`PROCESSOR_REGISTRY`](crate::core::processors::PROCESSOR_REGISTRY)).
     pub name: SchemaIdent,
@@ -107,5 +107,99 @@ mod tests {
         )
         .with_display_name("Camera A");
         assert_eq!(spec.display_name.as_deref(), Some("Camera A"));
+    }
+
+    /// msgpack `to_vec_named` → `from_slice` round-trip preserves full
+    /// value equality. Mirrors the runtime-ops-shim encode path the
+    /// plugin ABI takes when forwarding `Runtime::add_processor` calls
+    /// from cdylib code to the host.
+    #[test]
+    fn msgpack_round_trip_preserves_full_value() {
+        let spec = ProcessorSpec::new(
+            ident("tatolab", "streamlib", "CameraProcessor", SemVer::new(1, 2, 3)),
+            serde_json::json!({
+                "width": 1920,
+                "height": 1080,
+                "nested": {"key": "value", "arr": [1, 2, 3]},
+            }),
+        )
+        .with_display_name("Camera A");
+
+        let bytes = rmp_serde::to_vec_named(&spec).expect("encode");
+        let back: ProcessorSpec = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(spec, back);
+    }
+
+    /// Empty config + absent display_name still round-trips.
+    #[test]
+    fn msgpack_round_trip_minimal_spec() {
+        let spec = ProcessorSpec::new(
+            ident("tatolab", "core", "VideoFrame", SemVer::new(0, 1, 0)),
+            serde_json::Value::Null,
+        );
+        let bytes = rmp_serde::to_vec_named(&spec).expect("encode");
+        let back: ProcessorSpec = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(spec, back);
+        assert!(back.display_name.is_none());
+    }
+
+    /// Unicode in display_name + config string values survives the
+    /// msgpack wire.
+    #[test]
+    fn msgpack_round_trip_unicode_preserved() {
+        let spec = ProcessorSpec::new(
+            ident("tatolab", "core", "VideoFrame", SemVer::new(1, 0, 0)),
+            serde_json::json!({"label": "カメラ — 中文 — emoji 🎥"}),
+        )
+        .with_display_name("こんにちは");
+
+        let bytes = rmp_serde::to_vec_named(&spec).expect("encode");
+        let back: ProcessorSpec = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(spec, back);
+    }
+
+    /// Documents what the `serde_json::Value` ↔ rmp_serde round-trip
+    /// actually preserves for the integer-typing axis. The wire is
+    /// stable IF the test author understands its quirks: positive
+    /// integers fitting in `u64` stay numerically equal, negative
+    /// integers round-trip via `i64`, and floats stay floats. Mixed
+    /// numeric containers are preserved at the value level.
+    #[test]
+    fn config_value_msgpack_round_trip_integer_axis() {
+        let cases = [
+            ("zero", serde_json::json!(0)),
+            ("small_positive", serde_json::json!(42u32)),
+            ("max_u32", serde_json::json!(u32::MAX)),
+            ("max_u64", serde_json::json!(u64::MAX)),
+            ("negative_small", serde_json::json!(-42i64)),
+            ("min_i64", serde_json::json!(i64::MIN)),
+            ("float", serde_json::json!(1.5f64)),
+            (
+                "mixed_array",
+                serde_json::json!([0i64, -1i64, u64::MAX, 1.5f64, "string"]),
+            ),
+            (
+                "nested",
+                serde_json::json!({
+                    "negative": -1i64,
+                    "huge": u64::MAX,
+                    "float": std::f64::consts::PI,
+                    "inner": {"flag": true, "null": null},
+                }),
+            ),
+        ];
+        for (name, payload) in cases {
+            let spec = ProcessorSpec::new(
+                ident("tatolab", "core", "T", SemVer::new(1, 0, 0)),
+                payload.clone(),
+            );
+            let bytes = rmp_serde::to_vec_named(&spec).expect("encode");
+            let back: ProcessorSpec = rmp_serde::from_slice(&bytes).expect("decode");
+            assert_eq!(
+                spec, back,
+                "{} round-trip lost equality at the Value level",
+                name
+            );
+        }
     }
 }

--- a/libs/streamlib-engine/src/core/pubsub/events.rs
+++ b/libs/streamlib-engine/src/core/pubsub/events.rs
@@ -34,7 +34,7 @@ pub trait EventListener: Send {
     fn on_event(&mut self, event: &Event) -> Result<()>;
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Event {
     RuntimeGlobal(RuntimeEvent),
     ProcessorEvent {
@@ -131,7 +131,7 @@ impl Event {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RuntimeEvent {
     // ===== Runtime Lifecycle =====
     /// Emitted when runtime is about to start
@@ -327,7 +327,7 @@ pub enum LinkPortDirection {
     Output,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ProcessorEvent {
     // ===== State Control Commands =====
     Start,
@@ -484,7 +484,7 @@ pub enum KeyCode {
 /// 2. KeyboardInput { key: KeyCode::A, modifiers: { shift: true }, state: Pressed }
 ///
 /// This matches web behavior where modifiers are both keys AND state.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Modifiers {
     pub shift: bool,
     pub ctrl: bool,
@@ -540,7 +540,7 @@ pub enum MouseState {
     Released,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WindowEventType {
     Resized { width: u32, height: u32 },
     Closed,
@@ -658,21 +658,38 @@ mod tests {
     #[test]
     fn test_event_serialization_roundtrip() {
         // Verify events can be serialized/deserialized via MessagePack
-        // (critical for iceoryx2 transport)
+        // (critical for iceoryx2 transport). Locks **full** value
+        // equality, not just topic/log_name — a regression where a
+        // discriminator is lost on the wire but topic()/log_name() are
+        // computed from a fallback variant would slip past the older
+        // assertion.
         let events = vec![
             Event::RuntimeGlobal(RuntimeEvent::RuntimeStarted),
             Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
             Event::processor("test-proc", ProcessorEvent::Started),
             Event::custom("my-topic", serde_json::json!({"key": "value"})),
             Event::keyboard(KeyCode::A, Modifiers::default(), KeyState::Pressed),
+            Event::mouse(
+                MouseButton::Left,
+                (100.5, 200.25),
+                MouseState::Pressed,
+            ),
+            Event::window(WindowEventType::Resized {
+                width: 1920,
+                height: 1080,
+            }),
+            Event::RuntimeGlobal(RuntimeEvent::RuntimeWillConnect {
+                from_processor: ProcessorUniqueId::from("Pcam"),
+                from_port: "video_out".into(),
+                to_processor: ProcessorUniqueId::from("Pdisplay"),
+                to_port: "video_in".into(),
+            }),
         ];
 
         for event in events {
             let bytes = rmp_serde::to_vec_named(&event).unwrap();
             let deserialized: Event = rmp_serde::from_slice(&bytes).unwrap();
-            // Verify round-trip preserves the event type
-            assert_eq!(event.topic(), deserialized.topic());
-            assert_eq!(event.log_name(), deserialized.log_name());
+            assert_eq!(event, deserialized, "round-trip mismatch");
         }
     }
 }

--- a/libs/streamlib-processor-schema/Cargo.toml
+++ b/libs/streamlib-processor-schema/Cargo.toml
@@ -19,5 +19,8 @@ streamlib-idents = { path = "../streamlib-idents" }
 thiserror = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support
 
+[dev-dependencies]
+rmp-serde = { workspace = true }
+
 [lints]
 workspace = true

--- a/libs/streamlib-processor-schema/src/execution_config.rs
+++ b/libs/streamlib-processor-schema/src/execution_config.rs
@@ -43,3 +43,28 @@ impl ExecutionConfig {
         Self::new(ProcessExecution::manual())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// msgpack round-trip preserves the full value for every standard
+    /// execution flavor. Mirrors the plugin-ABI encode path that
+    /// forwards `ProcessorInstance::execution_config()` queries from
+    /// the host to cdylib-registered processors.
+    #[test]
+    fn msgpack_round_trip_preserves_full_value() {
+        for cfg in [
+            ExecutionConfig::default(),
+            ExecutionConfig::continuous(),
+            ExecutionConfig::continuous_with_interval(33),
+            ExecutionConfig::reactive(),
+            ExecutionConfig::manual(),
+        ] {
+            let bytes = rmp_serde::to_vec_named(&cfg).expect("encode");
+            let back: ExecutionConfig =
+                rmp_serde::from_slice(&bytes).expect("decode");
+            assert_eq!(cfg, back, "round-trip mismatch for {:?}", cfg);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **6 msgpack round-trip tests** colocated with each cdylib-boundary type: `ProcessorSpec`, `ProcessorUniqueId`, `LinkUniqueId`, `OutputLinkPortRef`, `InputLinkPortRef`, `ExecutionConfig`. Each test does the production `rmp_serde::to_vec_named → from_slice` round-trip and asserts full value equality. `ProcessorUniqueId`/`LinkUniqueId` also lock the bare-string `#[serde(transparent)]` wire shape byte-for-byte (`0xa4 fixstr`) — blocks silent regression to `{0: "..."}` map form.
- **3 silent decode sites** in `processor_instance_factory.rs` now emit `tracing::warn!` with structured error context before falling back to default / Null. Was: `.unwrap_or_default()` / `.unwrap_or(Null)`.
- **Event round-trip strengthened** to full `assert_eq!(event, deserialized)`. Required adding `PartialEq` to `Event`, `RuntimeEvent`, `ProcessorEvent`, `Modifiers`, `WindowEventType`, and `ProcessorSpec`. Test scenario set expanded with mouse, window-resized, and `RuntimeWillConnect` — discriminator-drift regressions the old topic/log_name assertion would miss.
- **`serde_json::Value` integer-axis edge test** covering zero / u32::MAX / u64::MAX / i64::MIN / floats / mixed-numeric arrays / nested.

## Test plan

- [x] `cargo test -p streamlib-engine --lib` — 1358 passed (+13 new)
- [x] `cargo test -p streamlib-processor-schema --lib` — 23 passed (+1 new)
- [x] Each new test colocated with its type per CLAUDE.md convention.

## Caveats noted during pr-review-gate

- The integer-axis test cannot detect u64↔i64 representation collapse because `serde_json::Number`'s `PartialEq` treats `u64(N)` and `i64(N)` as equal for non-negative N. It DOES catch the regressions that actually matter at this layer (float-vs-int collapse, sign loss, u64::MAX overflow). This is a property of `serde_json::Number`, not a test-design gap.
- No test asserts that `tracing::warn!` actually fires on the silent-decode mitigation sites (would require `tracing-test` dev-dep). The issue body's bar was "at minimum a tracing::warn!" — met.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)