### PR TITLE
feat(plugin-abi): host_vulkan_texture_arc vtable slot (#1012)

### DIFF
--- a/libs/streamlib-engine/src/core/plugin/host_services.rs
+++ b/libs/streamlib-engine/src/core/plugin/host_services.rs
@@ -6609,6 +6609,50 @@ unsafe extern "C" fn host_gpu_full_host_vulkan_device_arc(
     std::ptr::null()
 }
 
+/// Clone the host's `Arc<HostVulkanTexture>` backing a `Texture`
+/// β-shape and return the raw `Arc::into_raw` pointer. Second bridge
+/// of the cdylib-side adapter-construction chain: cdylibs can't
+/// reach `Texture::host_inner()` (panics in cdylib mode), so they
+/// dispatch through this slot to obtain a real
+/// `Arc<HostVulkanTexture>` for calls like
+/// `OpenGlSurfaceAdapter::register_host_surface`. On null
+/// `texture_handle` returns a null pointer.
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn host_gpu_full_host_vulkan_texture_arc(
+    texture_handle: *const c_void,
+) -> *const c_void {
+    run_host_extern_c(
+        "host_gpu_full_host_vulkan_texture_arc",
+        || -> *const c_void {
+            if texture_handle.is_null() {
+                return std::ptr::null();
+            }
+            // SAFETY: `texture_handle` is the same opaque
+            // `Arc::into_raw(Arc<TextureInner>)` pointer cached on the
+            // `Texture` β-shape's `handle` field (see
+            // `Texture::from_arc_into_raw`). The leaked strong count
+            // keeps the `TextureInner` alive at least until the
+            // β-shape's `Drop` runs. We borrow without taking
+            // ownership, clone the inner `Arc<HostVulkanTexture>`, and
+            // return its raw pointer with the strong count bumped by 1.
+            let inner = unsafe {
+                &*(texture_handle
+                    as *const crate::core::rhi::texture::TextureInner)
+            };
+            let arc = Arc::clone(&inner.inner);
+            Arc::into_raw(arc) as *const c_void
+        },
+        std::ptr::null(),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+unsafe extern "C" fn host_gpu_full_host_vulkan_texture_arc(
+    _texture_handle: *const c_void,
+) -> *const c_void {
+    std::ptr::null()
+}
+
 pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
     GpuContextFullAccessVTable {
         layout_version: GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION,
@@ -6649,6 +6693,7 @@ pub static HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE: GpuContextFullAccessVTable =
         create_timeline_semaphore: host_gpu_full_create_timeline_semaphore,
         import_dma_buf_storage_buffer: host_gpu_full_import_dma_buf_storage_buffer,
         host_vulkan_device_arc: host_gpu_full_host_vulkan_device_arc,
+        host_vulkan_texture_arc: host_gpu_full_host_vulkan_texture_arc,
     };
 
 /// Pointer to the [`GpuContextFullAccessVTable`] this DSO should
@@ -12483,6 +12528,41 @@ mod gpu_full_access_vtable_tests {
             HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.layout_version,
             streamlib_plugin_abi::GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION
         );
+    }
+
+    // v9 slot: host_vulkan_device_arc takes a scope token (not an
+    // err-buf). The null-token case bottoms out in
+    // `with_scope(0, ...) → None`, so the callback returns a null
+    // pointer. Mental-revert: stub the callback body to call
+    // `Arc::into_raw(...)` directly on a freshly-cloned Arc without
+    // checking the token; this test trips on the resulting non-null
+    // return and the unmatched `from_raw` would Drop the Arc, lowering
+    // the refcount on the host's actual `Arc<HostVulkanDevice>`.
+    #[test]
+    fn host_vulkan_device_arc_returns_null_on_null_token() {
+        let raw = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.host_vulkan_device_arc)(
+                std::ptr::null(),
+            )
+        };
+        assert!(raw.is_null(), "null scope token must yield null pointer");
+    }
+
+    // v10 slot: host_vulkan_texture_arc takes a raw texture handle
+    // (not an err-buf). The null-handle case short-circuits in the
+    // wrapper before any deref, returning a null pointer. Mental-
+    // revert: remove the `if texture_handle.is_null()` guard inside
+    // `host_gpu_full_host_vulkan_texture_arc`; the wrapper would then
+    // UB-deref the null pointer as `*const TextureInner` and the test
+    // runner would SIGSEGV.
+    #[test]
+    fn host_vulkan_texture_arc_returns_null_on_null_handle() {
+        let raw = unsafe {
+            (HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.host_vulkan_texture_arc)(
+                std::ptr::null(),
+            )
+        };
+        assert!(raw.is_null(), "null texture handle must yield null pointer");
     }
 
     #[test]

--- a/libs/streamlib-engine/src/host_rhi.rs
+++ b/libs/streamlib-engine/src/host_rhi.rs
@@ -66,6 +66,7 @@ pub use crate::vulkan::rhi::{PresentFrame, VulkanPresentTarget, MAX_FRAMES_IN_FL
 
 pub use vulkanalia::vk::GeometryInstanceFlagsKHR;
 
+use crate::core::error::{Error, Result};
 use crate::core::rhi::texture::TextureInner;
 use crate::core::rhi::{GpuDevice, PixelBufferRef, Texture};
 
@@ -85,8 +86,30 @@ pub trait HostTextureExt {
 
     /// Borrow the underlying [`HostVulkanTexture`] for raw `VkImage`
     /// access, DRM-modifier introspection, and adapter-side layout
-    /// transitions.
+    /// transitions. **Host-only** — panics in cdylib mode through
+    /// `Texture::host_inner()`. Workspace plugin cdylibs that need an
+    /// owned `Arc<HostVulkanTexture>` use
+    /// [`HostTextureExt::host_vulkan_texture_arc`] instead, which
+    /// dispatches through the v10 FullAccess vtable slot.
     fn vulkan_inner(&self) -> &Arc<HostVulkanTexture>;
+
+    /// Clone the underlying `Arc<HostVulkanTexture>` and hand back an
+    /// owned strong count. Dispatches through the v10
+    /// `host_vulkan_texture_arc` FullAccess vtable slot in cdylib mode;
+    /// in host mode reaches `vulkan_inner()` directly. Used by
+    /// workspace plugin cdylibs that need to call
+    /// `XxxSurfaceAdapter::register_host_surface` with a real
+    /// `Arc<HostVulkanTexture>` from a `Texture` β-shape (the
+    /// `host_inner()` path panics in cdylib mode).
+    ///
+    /// **Rustc-version coupling.** `HostVulkanTexture` is not
+    /// `#[repr(C)]`; the cross-DSO Arc transit is safe only when the
+    /// cdylib shares the host's rustc version and the engine's dep
+    /// graph (workspace plugin cdylibs do; subprocess cdylibs
+    /// — `streamlib-python-native`, `streamlib-deno-native` — don't
+    /// dep on `streamlib-engine` and can't import `HostVulkanTexture`,
+    /// so they can't reach this method at all).
+    fn host_vulkan_texture_arc(&self) -> Result<Arc<HostVulkanTexture>>;
 }
 
 impl HostTextureExt for Texture {
@@ -101,6 +124,44 @@ impl HostTextureExt for Texture {
 
     fn vulkan_inner(&self) -> &Arc<HostVulkanTexture> {
         &self.host_inner().inner
+    }
+
+    fn host_vulkan_texture_arc(&self) -> Result<Arc<HostVulkanTexture>> {
+        // Host mode: `host_callbacks()` is None; reach the inner Arc
+        // directly. Cdylib mode: `host_callbacks()` is Some; dispatch
+        // through the v10 FullAccess vtable slot. The branching mirrors
+        // `Texture::host_inner()`'s panic guard.
+        if crate::core::plugin::host_services::host_callbacks().is_none() {
+            return Ok(Arc::clone(self.vulkan_inner()));
+        }
+
+        let vtable =
+            crate::core::plugin::host_services::host_gpu_context_full_access_vtable();
+        if vtable.is_null() {
+            return Err(Error::GpuError(
+                "host_vulkan_texture_arc: GpuContextFullAccess vtable pointer is \
+                 null (host did not wire the vtable into HostServices)"
+                    .into(),
+            ));
+        }
+        // SAFETY: host wired the v10 slot at static initialization; the
+        // cdylib path uses `host_callbacks().gpu_context_full_access_vtable`,
+        // which is non-null per the boundary check above. We pass the
+        // raw `texture_handle` that lives on `self.handle`.
+        let raw = unsafe { ((*vtable).host_vulkan_texture_arc)(self.handle) };
+        if raw.is_null() {
+            return Err(Error::GpuError(
+                "host_vulkan_texture_arc: host returned null pointer (likely null \
+                 texture_handle or host-side panic)"
+                    .into(),
+            ));
+        }
+        // SAFETY: host's wrapper called `Arc::into_raw` on a freshly
+        // cloned `Arc<HostVulkanTexture>`. The cdylib shares the host's
+        // rustc version + dep graph per the workspace-plugin cdylib
+        // contract documented on the method.
+        let arc = unsafe { Arc::from_raw(raw as *const HostVulkanTexture) };
+        Ok(arc)
     }
 }
 

--- a/libs/streamlib-plugin-abi/src/lib.rs
+++ b/libs/streamlib-plugin-abi/src/lib.rs
@@ -328,7 +328,18 @@ pub const GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 13;
 ///   workspace plugin cdylibs to construct host-flavor surface
 ///   adapters (`CpuReadbackSurfaceAdapter<HostVulkanDevice>` etc.)
 ///   for #1004's dlopen smoke tests.
-pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 9;
+/// - v10: `host_vulkan_texture_arc(texture_handle)` slot returning an
+///   `Arc::into_raw(Arc<HostVulkanTexture>)` raw pointer. Second
+///   bridge of the cdylib-side adapter-construction chain — gives
+///   workspace plugin cdylibs a non-panicking path to
+///   `Arc<HostVulkanTexture>` from a `Texture` β-shape (the existing
+///   `Texture::host_inner()` and `HostTextureExt::vulkan_inner()`
+///   panic in cdylib mode). Same rustc-version-coupling caveat as
+///   v9: `HostVulkanTexture` is not `#[repr(C)]`, so the Arc-raw
+///   pointer transit is safe only when the cdylib shares the host's
+///   rustc version and dep graph. Subprocess cdylibs don't dep on
+///   `streamlib-engine` and can't reach this slot in the first place.
+pub const GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION: u32 = 10;
 
 /// Layout version of [`TextureRingMethodsVTable`].
 ///
@@ -2949,6 +2960,36 @@ pub struct GpuContextFullAccessVTable {
     /// allocation) cover the supported cross-DSO surface.
     pub host_vulkan_device_arc:
         unsafe extern "C" fn(gpu_handle: *const c_void) -> *const c_void,
+
+    // -------------------------------------------------------------------------
+    // v10: cdylib-reachable HostVulkanTexture Arc accessor.
+    // -------------------------------------------------------------------------
+
+    /// Clone the host's `Arc<HostVulkanTexture>` backing a `Texture`
+    /// β-shape and return the raw `Arc::into_raw` pointer on success.
+    ///
+    /// `texture_handle` is the same opaque `Arc::into_raw(Arc<TextureInner>)`
+    /// pointer cached on the `Texture` β-shape's `handle` field; the
+    /// host dereferences it without taking ownership, clones the
+    /// inner `Arc<HostVulkanTexture>`, and returns its raw pointer
+    /// with the strong count bumped by 1. The caller is responsible
+    /// for `Arc::from_raw` to reconstitute the Arc and matching its
+    /// eventual `Drop`. On a null `texture_handle` (or any host-side
+    /// failure caught by `catch_unwind`) returns `std::ptr::null()`.
+    ///
+    /// **Rustc-version coupling.** `HostVulkanTexture`'s layout isn't
+    /// `#[repr(C)]`; the returned pointer is valid only when the cdylib
+    /// shares the host's rustc version AND the engine's dep graph
+    /// (workspace plugin cdylibs do; subprocess cdylibs don't dep on
+    /// `streamlib-engine` so they can't reach `HostVulkanTexture` in
+    /// the first place).
+    ///
+    /// Used by the dlopen smoke fixtures for the OpenGL / Skia /
+    /// Vulkan surface adapters, which need to call
+    /// `XxxSurfaceAdapter::register_host_surface` with a real
+    /// `Arc<HostVulkanTexture>` to exercise `acquire_*` paths.
+    pub host_vulkan_texture_arc:
+        unsafe extern "C" fn(texture_handle: *const c_void) -> *const c_void,
 }
 
 unsafe impl Send for GpuContextFullAccessVTable {}
@@ -5090,7 +5131,7 @@ mod layout_tests {
         assert_eq!(RUNTIME_OPS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(GPU_CONTEXT_LIMITED_ACCESS_VTABLE_LAYOUT_VERSION, 13);
         assert_eq!(SURFACE_STORE_VTABLE_LAYOUT_VERSION, 1);
-        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 9);
+        assert_eq!(GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION, 10);
         assert_eq!(TEXTURE_RING_METHODS_VTABLE_LAYOUT_VERSION, 2);
         assert_eq!(VULKAN_COMPUTE_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 4);
         assert_eq!(VULKAN_GRAPHICS_KERNEL_METHODS_VTABLE_LAYOUT_VERSION, 3);
@@ -5930,10 +5971,10 @@ mod layout_tests {
 
     #[test]
     fn gpu_context_full_access_vtable_layout() {
-        // layout_version (u32) + _reserved_padding (u32) + 33 fn
-        // pointers (8 bytes each) = 4 + 4 + 264 = 272 bytes, align = 8.
+        // layout_version (u32) + _reserved_padding (u32) + 34 fn
+        // pointers (8 bytes each) = 4 + 4 + 272 = 280 bytes, align = 8.
         //
-        // 33 entries = 1 drop_handle + 7 clone/drop pairs (14 fn
+        // 34 entries = 1 drop_handle + 7 clone/drop pairs (14 fn
         // pointers for the 7 β-shape return types: compute / graphics /
         // ray-tracing kernels, texture ring, color converter,
         // acceleration structure, command recorder) + 4 create_* method
@@ -5944,8 +5985,9 @@ mod layout_tests {
         // create_command_recorder, build_triangles_blas, build_tlas,
         // supports_ray_tracing_pipeline, check_in_surface)
         // + 1 gpu_capabilities + 1 create_timeline_semaphore
-        // + 1 import_dma_buf_storage_buffer + 1 host_vulkan_device_arc.
-        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 272);
+        // + 1 import_dma_buf_storage_buffer + 1 host_vulkan_device_arc
+        // + 1 host_vulkan_texture_arc.
+        assert_eq!(size_of::<GpuContextFullAccessVTable>(), 280);
         assert_eq!(align_of::<GpuContextFullAccessVTable>(), 8);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, layout_version), 0);
         assert_eq!(offset_of!(GpuContextFullAccessVTable, _reserved_padding), 4);
@@ -6096,6 +6138,11 @@ mod layout_tests {
         assert_eq!(
             offset_of!(GpuContextFullAccessVTable, host_vulkan_device_arc),
             264
+        );
+        // v10: host_vulkan_texture_arc.
+        assert_eq!(
+            offset_of!(GpuContextFullAccessVTable, host_vulkan_texture_arc),
+            272
         );
     }
 


### PR DESCRIPTION
## Summary

Adds v10 `host_vulkan_texture_arc(texture_handle)` slot to
`GpuContextFullAccessVTable` — the second bridge in the cdylib-side
adapter-construction chain after #1004's `host_vulkan_device_arc`.

Existing path to `Arc<HostVulkanTexture>` from a `Texture` β-shape
routes through `Texture::host_inner()` / `HostTextureExt::vulkan_inner()`,
both of which panic in cdylib mode. The new slot gives workspace plugin
cdylibs a non-panicking path:

- Host wires `host_gpu_full_host_vulkan_texture_arc` which dereferences
  the `Arc::into_raw'd TextureInner` handle without taking ownership,
  clones the inner `Arc<HostVulkanTexture>`, and returns its raw pointer
  with the strong count bumped.
- Cdylib accessor `HostTextureExt::host_vulkan_texture_arc()`
  reconstitutes via `Arc::from_raw`. Host mode short-circuits to
  `vulkan_inner()` directly.

Same rustc-version-coupling caveat as v9: `HostVulkanTexture` isn't
`#[repr(C)]`, so the cross-DSO Arc transit only holds when the cdylib
shares the host's rustc version + dep graph (workspace plugin cdylibs
do; subprocess cdylibs don't dep on `streamlib-engine` and can't
import `HostVulkanTexture` to reach the slot at all).

## Changes

- `libs/streamlib-plugin-abi/src/lib.rs` — layout-version bump 9 → 10,
  new field, struct size 272 → 280, offset 272 locked.
- `libs/streamlib-engine/src/core/plugin/host_services.rs` — new
  extern "C" wrapper (Linux + non-Linux stub) + static-init wire-up +
  two tier-1 wire-format tests (texture slot's null-handle guard, plus
  the missing v9 device-slot null-token guard).
- `libs/streamlib-engine/src/host_rhi.rs` — extended `HostTextureExt`
  trait with the new cdylib-safe accessor + implementation.

## Test plan

- [x] `cargo test -p streamlib-plugin-abi --lib` — 52/52 pass
      (layout regression locks new offset 272 + size 280, version
      pin updated to 10).
- [x] `cargo test -p streamlib-engine --lib gpu_full_access_vtable_tests`
      — 21/21 pass including the two new tier-1 tests.
- [x] `cargo test -p streamlib-engine --lib` — 1361/1361 pass.
- [x] `cargo check --workspace` — clean.
- Cdylib end-to-end mental-revert (reverting slot → cdylib trips
  `Texture::host_inner()` panic) covered by #1016's dlopen smoke
  tests, which depend on this slot.

Closes #1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)