### PR TITLE
docs(plugin-abi): HostVulkanBuffer cdylib-reachability invariant (#1013)

### DIFF
--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs
@@ -80,6 +80,28 @@ pub struct VideoBitstreamBufferDescriptor<'a> {
 /// not on this type. Matches UE5 `FRHIBuffer` / wgpu `Buffer` / Vulkano
 /// `Buffer` / Granite `Buffer` shape: the bottom-layer primitive carries
 /// only `(size, usage, memory)`; role is a composition concern above.
+///
+/// # Cdylib reachability
+///
+/// All `new*` constructors take `&Arc<HostVulkanDevice>` plus primitives
+/// and return `HostVulkanBuffer`. They do **not** reach for `host_inner()`
+/// or any host-private state — they only call `pub` accessors on
+/// [`HostVulkanDevice`] (`allocator`, `dma_buf_buffer_pool`,
+/// `opaque_fd_buffer_pool*`) plus `vulkanalia-vma`. Workspace plugin
+/// cdylibs that hold an `Arc<HostVulkanDevice>` (via the
+/// `host_vulkan_device_arc` slot on `GpuContextFullAccessVTable`)
+/// therefore call these constructors directly, without a per-constructor
+/// FullAccess vtable slot. The escape-hatch path is
+/// `escalate(|full| full.host_vulkan_device_arc())` → directly invoke the
+/// desired constructor.
+///
+/// Adding a `host_inner()` panic guard inside any of these constructor
+/// bodies breaks the cdylib path silently — the cdylib path bypasses
+/// `host_inner()` by construction today, and a future guard would
+/// surface as a runtime panic from inside an `escalate` closure.
+/// Reviewers touching constructor bodies must keep them
+/// `host_inner()`-free; the cdylib surface-adapter dlopen smoke tests
+/// exercise the full end-to-end path.
 pub struct HostVulkanBuffer {
     /// HostVulkanDevice reference for tracked allocation/free through the RHI.
     vulkan_device: Arc<HostVulkanDevice>,


### PR DESCRIPTION
## Summary

Records the architectural decision that workspace plugin cdylibs can
construct `Arc<HostVulkanBuffer>` directly via
`HostVulkanBuffer::new(&device, size)` (and the OPAQUE_FD-exportable
siblings), without a per-constructor FullAccess vtable slot.

After verifying the constructor bodies of `new`,
`new_opaque_fd_export`, and `new_opaque_fd_export_device_local`, they
use only `pub` accessors on `HostVulkanDevice` (`allocator`,
`dma_buf_buffer_pool`, `opaque_fd_buffer_pool*`) plus `vulkanalia-vma`
— no `host_inner()` / `host_callbacks()` deref, no β-shape indirection,
no host-private path. Cdylibs hold the `Arc<HostVulkanDevice>` through
the existing `GpuContextFullAccessVTable::host_vulkan_device_arc` (v9)
bridge and can therefore call the constructors directly.

The new 22-line docstring on the `HostVulkanBuffer` type calls out the
invariant explicitly so a reviewer touching constructor bodies sees
the contract: introducing a `host_inner()` panic guard would break
the cdylib path silently.

## Changes

- `libs/streamlib-engine/src/vulkan/rhi/vulkan_buffer.rs` — type-level
  `# Cdylib reachability` section documenting the verified
  invariant and the regression-lock contract for future reviewers.
- No new ABI surface, no layout-version bump, no signature changes.

## Test plan

- [x] `cargo check -p streamlib-engine --lib` — clean (47 pre-existing
      warnings; zero new).
- [x] `cargo doc -p streamlib-engine --no-deps` — no new unresolved
      links from this PR.
- Existing hardware-gated tests
  (`test_pool_buffer_creation_1920x1080_bgra32`,
  `opaque_fd_export_round_trip_and_cross_flavor_rejection`,
  `opaque_fd_device_local_export_round_trip`) already exercise the
  constructors against a real `Arc<HostVulkanDevice>`.
- End-to-end cdylib coverage rides the surface-adapter dlopen smoke
  tests landing in the dependent issue.

Closes #1013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)