### PR TITLE
docs(plugin-abi): HostVulkanTexture cdylib-reachability invariant (#1015)

### DIFF
--- a/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
+++ b/libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs
@@ -153,6 +153,49 @@ impl Default for HostVkImageMeta {
 ///
 /// Wraps a VkImage with associated memory and metadata.
 /// Can be created from scratch or imported from an IOSurface via VK_EXT_metal_objects.
+///
+/// # Cdylib reachability
+///
+/// Two paths give workspace plugin cdylibs access to an
+/// `Arc<HostVulkanTexture>` for adapter `register_host_surface` calls
+/// (the opengl / skia / vulkan / cuda surface adapters' DMA-BUF
+/// render-target story):
+///
+/// 1. **High-level acquire (recommended for standard render-target
+///    use):** call
+///    `GpuContextFullAccess::acquire_render_target_dma_buf_image(w, h, format)`
+///    — backed by the FullAccess `acquire_render_target_dma_buf_image`
+///    vtable slot. Returns a `Texture` β-shape. Extract the underlying
+///    `Arc<HostVulkanTexture>` via the v10 `host_vulkan_texture_arc`
+///    bridge (`HostTextureExt::host_vulkan_texture_arc`). The slot's
+///    host-side body does FOURCC mapping, queries the device's RT-capable
+///    DRM modifier list, and allocates the VkImage through
+///    `new_render_target_dma_buf` internally — the cdylib never touches
+///    the modifier list directly for this path.
+///
+///    Once the cdylib holds the Arc, the `pub` methods
+///    [`Self::export_dma_buf_fd`], [`Self::dma_buf_plane_layout`], and
+///    [`Self::chosen_drm_format_modifier`] are all reachable for
+///    building the adapter's `HostSurfaceRegistration` (DMA-BUF FD +
+///    plane offset/stride + modifier).
+///
+/// 2. **Low-level allocation (advanced — for explicit modifier choice
+///    such as NVIDIA sampler-only `external_only=TRUE` modifiers):**
+///    obtain `Arc<HostVulkanDevice>` via the v9 `host_vulkan_device_arc`
+///    slot, query
+///    `device_arc.drm_modifier_table().rt_modifiers(fourcc)` for the
+///    candidate list (or build a custom list), and call
+///    `HostVulkanTexture::new_render_target_dma_buf(device_arc.device(), &desc, &modifiers)`
+///    directly. The constructor body uses only `pub` accessors on
+///    `HostVulkanDevice` (`allocator`, `dma_buf_image_pool_tiled`, …)
+///    plus `vulkanalia-vma` — no `host_inner()`, no β-shape deref.
+///
+/// Adding a `host_inner()` or `host_callbacks()` guard inside any of
+/// the `new*` constructor bodies (`new`, `new_render_target_dma_buf`,
+/// `new_opaque_fd_export`, etc.) would break path 2 silently — reviewers
+/// touching constructor bodies must keep them guard-free. The cdylib
+/// surface-adapter dlopen smoke tests exercise the full end-to-end
+/// path.
 pub struct HostVulkanTexture {
     /// HostVulkanDevice reference for tracked allocation/free through the RHI.
     vulkan_device: Option<Arc<HostVulkanDevice>>,


### PR DESCRIPTION
## Summary

Records the architectural decision for the last bridge in the
cdylib-side adapter-construction chain: cdylib code can construct
render-target DMA-BUF textures (and reach the DRM modifier list)
today through existing ABI surface; no new vtable slot ships.

Two cdylib paths to `Arc<HostVulkanTexture>`:

1. **High-level acquire** — existing
   `acquire_render_target_dma_buf_image` FullAccess vtable slot
   returns a `Texture` β-shape with the host-side FOURCC mapping,
   modifier discovery, and VMA-pool allocation handled internally.
   Cdylib extracts `Arc<HostVulkanTexture>` via the v10
   `host_vulkan_texture_arc` bridge and calls the `pub` methods
   `export_dma_buf_fd`, `dma_buf_plane_layout`, and
   `chosen_drm_format_modifier` to build the adapter's
   `HostSurfaceRegistration`.
2. **Low-level allocation** — cdylib obtains `Arc<HostVulkanDevice>`
   via v9 `host_vulkan_device_arc`, queries
   `device_arc.drm_modifier_table().rt_modifiers(fourcc)` directly,
   and calls `HostVulkanTexture::new_render_target_dma_buf(...)`.
   Escape hatch for explicit-modifier use cases (NVIDIA sampler-only
   `external_only=TRUE` modifiers).

## Changes

- `libs/streamlib-engine/src/vulkan/rhi/vulkan_texture.rs` —
  type-level `# Cdylib reachability` section documenting both paths
  and the regression-lock contract.
- No new ABI surface, no layout-version bump, no signature changes.

## Test plan

- [x] `cargo check -p streamlib-engine --lib` — clean (47 pre-existing
      warnings; zero new).
- Existing host-side tests
  (`libs/streamlib-adapter-opengl/tests/*`) cover the runtime
  construction path.
- Full end-to-end cdylib coverage rides the surface-adapter dlopen
  smoke tests in the dependent issue.

Closes #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)