### PR TITLE
test(plugin-abi): load_project ABI version mismatch rejection (#1019)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "packages/clap",             # @tatolab/clap — CLAP audio plugin host processor (Apple-only)
     "packages/screen-capture",   # @tatolab/screen-capture — screen capture processor (Apple-only today; Linux follows in #374)
     "packages/test-fixtures",    # @tatolab/test-fixtures — attribute-macro test fixtures (TestConfiguredProcessor)
+    "packages/test-fixtures-abi-mismatch", # @tatolab/test-fixtures-abi-mismatch — hand-crafted STREAMLIB_PLUGIN with tampered abi_version for the load_project rejection test
     "packages/debug-utilities",  # @tatolab/debug-utilities — utility processors for development, demos, and rigorous-input testing (BgraFileSource, SimplePassthrough)
     "packages/network",          # @tatolab/network — generic UDP source/sink processors (byte-level transport)
     "packages/mavlink",          # @tatolab/mavlink — MAVLink2 encoder + decoder processors (rust-mavlink wrapper)

--- a/libs/streamlib-engine/tests/load_project_dylib_abi_mismatch.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_abi_mismatch.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Load-project rejection test for the ABI-version mismatch path.
+//!
+//! Builds the `streamlib-test-fixtures-abi-mismatch` cdylib once per
+//! mismatch direction (`tamper-too-low` → `abi_version = 0`;
+//! `tamper-too-high` → `abi_version = u32::MAX`), assembles a minimal
+//! project directory, calls `runtime.load_project`, and asserts the
+//! returned error is `Error::Configuration` with the documented
+//! "ABI version mismatch" prefix.
+//!
+//! Both directions are covered to lock the equality check in
+//! `core/runtime/runtime.rs` — a future `<` or `>` regression would
+//! only catch one direction.
+//!
+//! Mental-revert: removing the `if decl.abi_version != STREAMLIB_ABI_VERSION`
+//! check in `load_project` would let the runtime invoke the fixture's
+//! no-op `register` stub, which never registers `AbiMismatchSentinel`.
+//! The runtime's subsequent "processor not registered" check would
+//! then surface a different error, regressing the contract this test
+//! locks.
+//!
+//! No GPU required.
+
+use std::path::Path;
+
+use serial_test::serial;
+use streamlib::sdk::error::Error;
+use streamlib::sdk::runtime::Runner;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+}
+
+fn build_tampered_cdylib(feature: &str) -> std::path::PathBuf {
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures-abi-mismatch",
+            "--no-default-features",
+            "--features",
+            feature,
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(
+        status.success(),
+        "cargo build of streamlib-test-fixtures-abi-mismatch --features {feature} must succeed"
+    );
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!(
+        "libstreamlib_test_fixtures_abi_mismatch.{}",
+        dylib_ext
+    );
+    workspace_root()
+        .join("target")
+        .join("debug")
+        .join(&dylib_name)
+}
+
+/// Build a project directory under `tmp` containing the fixture
+/// crate's `streamlib.yaml` (plus the `@tatolab/core` patch dep)
+/// and the tampered cdylib copied into `lib/<host_triple>/`.
+fn stage_project(tmp: &Path, source_dylib: &Path) -> std::path::PathBuf {
+    let fixture_src = workspace_root().join("packages/test-fixtures-abi-mismatch");
+    let core_src = workspace_root().join("packages/core");
+    let fixture_dst = tmp.join("test-fixtures-abi-mismatch");
+    let core_dst = tmp.join("core");
+
+    std::fs::create_dir_all(&fixture_dst).unwrap();
+    std::fs::copy(
+        fixture_src.join("streamlib.yaml"),
+        fixture_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixture_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    let dylib_dst = triple_dir.join(source_dylib.file_name().unwrap());
+    std::fs::copy(source_dylib, &dylib_dst).unwrap();
+
+    fixture_dst
+}
+
+fn assert_abi_mismatch_rejected(project_dir: &Path) {
+    let runtime = Runner::new().expect("Runner::new");
+    let err = runtime
+        .load_project(project_dir)
+        .expect_err("load_project must REJECT a tampered abi_version");
+
+    let msg = match err {
+        Error::Configuration(s) => s,
+        other => panic!(
+            "expected Error::Configuration with 'ABI version mismatch', \
+             got {other:?}"
+        ),
+    };
+
+    assert!(
+        msg.contains("ABI version mismatch"),
+        "rejection message must call out the abi_version mismatch — got: {msg}"
+    );
+    assert!(
+        msg.contains("Rebuild the plugin"),
+        "rejection message must include the rebuild hint — got: {msg}"
+    );
+}
+
+#[test]
+#[serial]
+fn load_project_rejects_abi_version_below_runtime() {
+    let dylib = build_tampered_cdylib("tamper-too-low");
+    let tmp = tempfile::tempdir().unwrap();
+    let project = stage_project(tmp.path(), &dylib);
+
+    assert_abi_mismatch_rejected(&project);
+}
+
+#[test]
+#[serial]
+fn load_project_rejects_abi_version_above_runtime() {
+    let dylib = build_tampered_cdylib("tamper-too-high");
+    let tmp = tempfile::tempdir().unwrap();
+    let project = stage_project(tmp.path(), &dylib);
+
+    assert_abi_mismatch_rejected(&project);
+}

--- a/packages/test-fixtures-abi-mismatch/Cargo.toml
+++ b/packages/test-fixtures-abi-mismatch/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "streamlib-test-fixtures-abi-mismatch"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license-file.workspace = true
+repository.workspace = true
+description = "Test-only cdylib emitting STREAMLIB_PLUGIN with a tampered abi_version — drives the load_project rejection-path integration test."
+keywords = ["streamlib", "test-fixtures", "abi"]
+categories = ["development-tools::testing"]
+
+[lib]
+name = "streamlib_test_fixtures_abi_mismatch"
+crate-type = ["cdylib"]
+
+[features]
+# Pick which mismatch direction to tamper with. The integration test
+# builds the crate twice — once with each feature — and asserts the
+# load_project rejection on both halves. Default is `tamper-too-low`
+# so a bare `cargo build -p streamlib-test-fixtures-abi-mismatch`
+# produces a usable fixture without extra flags.
+default = ["tamper-too-low"]
+# abi_version = 0 (below the runtime's expected version).
+tamper-too-low = []
+# abi_version = u32::MAX (above the runtime's expected version).
+tamper-too-high = []
+
+[dependencies]
+streamlib-plugin-abi = { path = "../../libs/streamlib-plugin-abi" }
+
+[lints]
+workspace = true

--- a/packages/test-fixtures-abi-mismatch/src/lib.rs
+++ b/packages/test-fixtures-abi-mismatch/src/lib.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Test-only cdylib emitting `STREAMLIB_PLUGIN` with a tampered
+//! `abi_version` so the load_project rejection path can be tested
+//! end-to-end. The `register` callback is a no-op stub the host never
+//! invokes — the runtime's `abi_version` mismatch check fires first
+//! and rejects with `Error::Configuration`.
+//!
+//! The mismatch direction is feature-gated:
+//! - `tamper-too-low` (default) → `abi_version = 0`
+//! - `tamper-too-high`          → `abi_version = u32::MAX`
+//!
+//! Both directions exist so the integration test covers
+//! `decl.abi_version < STREAMLIB_ABI_VERSION` and
+//! `> STREAMLIB_ABI_VERSION` independently, locking the equality check
+//! in `runtime.rs` (a future `<` or `>` regression would only catch one
+//! direction).
+
+#![cfg(target_os = "linux")]
+
+use streamlib_plugin_abi::PluginDeclaration;
+
+// At most one tamper-* feature may be enabled at a time. Cargo's
+// feature unification can land both on by accident — fail loudly
+// during the cdylib build rather than emit silently-wrong bytes.
+#[cfg(all(feature = "tamper-too-low", feature = "tamper-too-high"))]
+compile_error!(
+    "streamlib-test-fixtures-abi-mismatch: features `tamper-too-low` and \
+     `tamper-too-high` are mutually exclusive. Disable default features and \
+     pick exactly one."
+);
+
+#[cfg(not(any(feature = "tamper-too-low", feature = "tamper-too-high")))]
+compile_error!(
+    "streamlib-test-fixtures-abi-mismatch: enable exactly one of \
+     `tamper-too-low` (default) or `tamper-too-high`."
+);
+
+#[cfg(feature = "tamper-too-low")]
+const TAMPERED_ABI_VERSION: u32 = 0;
+#[cfg(feature = "tamper-too-high")]
+const TAMPERED_ABI_VERSION: u32 = u32::MAX;
+
+/// No-op register callback. The runtime's abi-version check rejects
+/// the plugin BEFORE invoking `register`, so this body is unreachable
+/// in practice. We keep it valid (rather than `unreachable!()`) so a
+/// future runtime change that decoupled the order of checks doesn't
+/// turn this stub into UB.
+unsafe extern "C" fn __streamlib_plugin_register_stub(
+    _host_services: *const ::core::ffi::c_void,
+) {
+    // Intentionally empty — no host services touched, no processors
+    // registered.
+}
+
+/// Hand-crafted `STREAMLIB_PLUGIN` static — bypasses
+/// [`streamlib_plugin_abi::export_plugin!`] which would always use the
+/// current `STREAMLIB_ABI_VERSION`. The runtime's loader reads this
+/// `abi_version` field directly and rejects the mismatch.
+#[unsafe(no_mangle)]
+pub static STREAMLIB_PLUGIN: PluginDeclaration = PluginDeclaration {
+    abi_version: TAMPERED_ABI_VERSION,
+    register: __streamlib_plugin_register_stub,
+};

--- a/packages/test-fixtures-abi-mismatch/streamlib.yaml
+++ b/packages/test-fixtures-abi-mismatch/streamlib.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=../../schemas/streamlib.schema.json
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Minimal manifest for the abi-version-mismatch test fixture. The
+# runtime's load_project walks the processors[] array and dlopens
+# the cdylib at lib/<triple>/lib*.so once per project; the abi_version
+# check rejects the plugin BEFORE any processor in this array gets
+# registered, so the entry below is structurally required but
+# functionally unreachable.
+
+package:
+  org: tatolab
+  name: test-fixtures-abi-mismatch
+  version: 1.0.0
+  description: "Test-only fixture cdylib that ships STREAMLIB_PLUGIN with a tampered abi_version. Used by the load_project rejection-path integration test."
+
+dependencies:
+  "@tatolab/core": "^1.0.0"
+
+patch:
+  "@tatolab/core":
+    path: ../core
+
+processors:
+  - name: AbiMismatchSentinel
+    version: 1.0.0
+    description: "Sentinel processor whose only job is to make load_project enter the Rust-dylib code path; never gets registered because the abi_version check rejects the plugin first."
+    execution: manual


### PR DESCRIPTION
## Summary

Adds a self-contained test-fixture cdylib that hand-crafts the
`STREAMLIB_PLUGIN` static with a tampered `abi_version` (bypassing
the `export_plugin!` macro), plus an integration test that loads it
via `runtime.load_project` and asserts the documented
`Error::Configuration` rejection.

Both mismatch directions are covered via mutually-exclusive features:
- `tamper-too-low` (default) → `abi_version = 0`
- `tamper-too-high`          → `abi_version = u32::MAX`

Both directions lock the equality check at `runtime.rs:612` —
a future `<` or `>` regression would only catch one direction.

## Changes

- `packages/test-fixtures-abi-mismatch/` — new fixture cdylib
  (Cargo.toml + src/lib.rs + streamlib.yaml + workspace entry).
  Hand-crafted `STREAMLIB_PLUGIN` static; no-op `register` stub
  the runtime never invokes (abi check rejects first). Dual
  `compile_error!` guards prevent misconfigured feature combos.
- `libs/streamlib-engine/tests/load_project_dylib_abi_mismatch.rs` —
  two integration tests, one per mismatch direction. Each builds
  the fixture with the appropriate feature, stages a temp project
  dir, calls `runtime.load_project`, and asserts the rejection
  message contains "ABI version mismatch" + "Rebuild the plugin".

## Test plan

- [x] `cargo test --test load_project_dylib_abi_mismatch -p streamlib-engine`
      — 2/2 PASS.
- [x] `cargo build -p streamlib-test-fixtures-abi-mismatch` — clean
      (default feature `tamper-too-low`).
- [x] `cargo build -p streamlib-test-fixtures-abi-mismatch --no-default-features --features tamper-too-high`
      — clean.
- [x] Mental-revert verified: removing the abi-version check at
      `runtime.rs:612` makes the runtime invoke the no-op stub, no
      processors register, and the runtime's downstream "Processor
      not registered" check surfaces a different message — both
      assertion substrings (`"ABI version mismatch"`,
      `"Rebuild the plugin"`) fail.

No GPU required.

Closes #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)