### PR TITLE
test(plugin-abi): surface-share + escalate-IPC same-surface_id consistency (#1020)

### DIFF
--- a/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Dlopen-cdylib smoke test verifying surface-share and escalate-IPC
+//! paths agree on resource lifetime for the same `surface_id`.
+//!
+//! Loads the `SurfaceShareEscalateConsistencyTestProcessor` from
+//! test-fixtures and drives it through `start()`. The processor's body
+//! exercises every leg of the dual-registration / dual-lookup story
+//! from inside a cdylib `gpu.escalate(|full| ...)` closure (see the
+//! fixture's module docs for the full step list).
+//!
+//! Mental-revert: breaking the surface-share daemon's `lookup_texture`
+//! wire format OR the escalate `resolve_texture_registration_by_surface_id`
+//! vtable slot would surface as an `ERR:<msg>` line in the fixture's
+//! output. Breaking the dual-registration drop semantics (host-side
+//! `register_texture` / `register_texture_with_layout` double-counting
+//! the Arc) would surface as a panic during `runtime.stop()` —
+//! teardown is intentionally NOT silenced so a double-free shows up
+//! in the test binary's exit.
+//!
+//! Requires a Vulkan device (`acquire_render_target_dma_buf_image`).
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use serial_test::serial;
+use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
+use streamlib_engine::core::runtime::host_target_triple;
+
+fn copy_dir_contents(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dst_entry = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_contents(&entry.path(), &dst_entry);
+        } else {
+            std::fs::copy(entry.path(), &dst_entry).unwrap();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn dlopen_processor_round_trips_surface_share_and_escalate_paths() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "streamlib-test-fixtures",
+            "--features",
+            "streamlib-test-fixtures/plugin",
+        ])
+        .status()
+        .expect("invoking cargo build");
+    assert!(status.success(), "cargo build must succeed");
+
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let dylib_name = format!("libstreamlib_test_fixtures.{}", dylib_ext);
+    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixtures_src = workspace_root.join("packages/test-fixtures");
+    let core_src = workspace_root.join("packages/core");
+    let fixtures_dst = tmp.path().join("test-fixtures");
+    let core_dst = tmp.path().join("core");
+
+    std::fs::create_dir_all(&fixtures_dst).unwrap();
+    std::fs::copy(
+        fixtures_src.join("streamlib.yaml"),
+        fixtures_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&fixtures_src.join("schemas"), &fixtures_dst.join("schemas"));
+
+    std::fs::create_dir_all(&core_dst).unwrap();
+    std::fs::copy(
+        core_src.join("streamlib.yaml"),
+        core_dst.join("streamlib.yaml"),
+    )
+    .unwrap();
+    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"));
+
+    let triple_dir = fixtures_dst.join("lib").join(host_target_triple());
+    std::fs::create_dir_all(&triple_dir).unwrap();
+    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name)).unwrap();
+
+    let output_path = tmp.path().join("surface_share_escalate_smoke_result.txt");
+    let output_path_str = output_path.to_string_lossy().to_string();
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .load_project(&fixtures_dst)
+        .expect("load_project must succeed");
+
+    let ident = schema_ident!(
+        "tatolab",
+        "test-fixtures",
+        "SurfaceShareEscalateConsistencyTestProcessor",
+        "1.0.0"
+    );
+
+    runtime
+        .add_processor(ProcessorSpec::new(
+            ident,
+            json!({
+                "output_path": output_path_str,
+            }),
+        ))
+        .expect("add_processor must succeed");
+
+    runtime
+        .start()
+        .expect("runtime.start() must succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !output_path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // runtime.stop() runs all per-processor teardown plus the
+    // surface-share daemon's unbind. Any double-free / leak in the
+    // dual-registration path surfaces here as a panic; we don't
+    // .ok() it so it can propagate.
+    runtime.stop().expect("runtime.stop() must drain cleanly");
+
+    assert!(
+        output_path.exists(),
+        "fixture did not write {} within 10s",
+        output_path.display()
+    );
+
+    let contents = std::fs::read_to_string(&output_path).unwrap();
+    assert!(
+        !contents.starts_with("ERR:"),
+        "fixture reported an error: {contents}"
+    );
+
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(
+        lines.first().copied(),
+        Some("OK"),
+        "first line must be 'OK', got {contents:?}"
+    );
+
+    // Each of the four legs must report success.
+    let expected = [
+        "register_texture_with_layout=ok",
+        "surface_store_register_texture=ok",
+        "resolve_texture_registration=ok",
+        "surface_store_lookup_texture=ok",
+    ];
+    for tag in expected {
+        assert!(
+            lines.iter().any(|l| *l == tag),
+            "expected '{tag}' line in output, got {contents:?}"
+        );
+    }
+}

--- a/packages/test-fixtures/schemas/surface_share_escalate_consistency_test_processor_config.yaml
+++ b/packages/test-fixtures/schemas/surface_share_escalate_consistency_test_processor_config.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Test-only config schema for the surface-share + escalate consistency
+# smoke test.
+
+metadata:
+  type: SurfaceShareEscalateConsistencyTestProcessorConfig
+  description: "Test config schema for the surface-share / escalate-IPC same-surface_id consistency fixture."
+
+properties:
+  output_path:
+    metadata:
+      description: "Filesystem path where the processor writes its result. Format on success: 'OK\nregister_texture_with_layout=ok\nsurface_store_register_texture=ok\nresolve_texture_registration=ok\nsurface_store_lookup_texture=ok'. Format on failure: 'ERR:<message>'."
+    type: string

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -21,6 +21,7 @@ pub mod lifecycle_probe_processor;
 pub mod opengl_smoke_test_processor;
 pub mod panicking_lifecycle_processor;
 pub mod ray_tracing_kernel_smoke_test_processor;
+pub mod surface_share_escalate_consistency_test_processor;
 pub mod tcp_bind_test_processor;
 pub mod test_configured_processor;
 pub mod vulkan_smoke_test_processor;
@@ -38,6 +39,7 @@ pub use panicking_lifecycle_processor::{
     PanickingContinuousLifecycle, PanickingManualLifecycle,
 };
 pub use ray_tracing_kernel_smoke_test_processor::RayTracingKernelSmokeTest;
+pub use surface_share_escalate_consistency_test_processor::SurfaceShareEscalateConsistencyTest;
 pub use tcp_bind_test_processor::TcpBindTest;
 pub use test_configured_processor::ConfiguredProcessor;
 pub use vulkan_smoke_test_processor::VulkanSmokeTest;
@@ -59,4 +61,5 @@ streamlib_plugin_abi::export_plugin!(
     crate::VulkanSmokeTest::Processor,
     crate::OpenGlSmokeTest::Processor,
     crate::CudaSmokeTest::Processor,
+    crate::SurfaceShareEscalateConsistencyTest::Processor,
 );

--- a/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
+++ b/packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Dlopen-cdylib smoke fixture verifying surface-share daemon and
+//! escalate-IPC paths agree on resource lifetime for the same
+//! `surface_id`.
+//!
+//! Exercises every leg of the two coordination paths from inside a
+//! cdylib's `start()` → `escalate(|full| ...)` closure:
+//!
+//!   1. Acquire a render-target DMA-BUF VkImage + exportable timeline.
+//!   2. Register via `gpu.surface_store().register_texture(...)` —
+//!      the cross-process (surface-share daemon) channel.
+//!   3. **Dual-register** via `gpu.register_texture_with_layout(...)` —
+//!      the in-process `texture_cache` channel (per
+//!      `docs/architecture/adapter-runtime-integration.md`'s
+//!      "Dual-registration for in-process consumers" recipe).
+//!   4. Resolve via `gpu.resolve_texture_registration_by_surface_id(...)`
+//!      — the in-process / escalate-IPC resolve path (Path 1 hits the
+//!      texture cache; Path 2 would fall back to `lookup_texture` and
+//!      QFOT acquire).
+//!   5. Look up via `gpu.surface_store().lookup_texture(...)` — the
+//!      cross-process channel's symmetric reader.
+//!
+//! On stop / teardown, both registrations release their hold on the
+//! shared Arc<HostVulkanTexture>; the integration test's
+//! `runtime.stop()` would surface any double-free as a panic in the
+//! test binary teardown.
+//!
+//! Output:
+//!   - "OK\nregister_texture_with_layout=ok\nsurface_store_register_texture=ok\nresolve_texture_registration=ok\nsurface_store_lookup_texture=ok"
+//!   - "ERR:<msg>" on any step failure.
+
+use streamlib::sdk::context::{
+    RuntimeContextFullAccess, RuntimeContextLimitedAccess,
+};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::processors::ManualProcessor;
+
+#[cfg(target_os = "linux")]
+use streamlib::sdk::engine::host_rhi::HostVulkanTimelineSemaphore;
+#[cfg(target_os = "linux")]
+use streamlib::sdk::engine::HostSurfaceStoreExt;
+#[cfg(target_os = "linux")]
+use streamlib::sdk::rhi::TextureFormat;
+#[cfg(target_os = "linux")]
+use streamlib::engine_internal::sdk::rhi::VulkanLayout;
+
+#[streamlib::sdk::processor("SurfaceShareEscalateConsistencyTestProcessor")]
+pub struct SurfaceShareEscalateConsistencyTest {}
+
+impl ManualProcessor for SurfaceShareEscalateConsistencyTest::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn start(&mut self, ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let output_path = self.config.output_path.clone();
+        const W: u32 = 64;
+        const H: u32 = 64;
+        const SURFACE_ID: &str = "surface-share-escalate-smoke";
+
+        let line = match run_smoke(ctx, SURFACE_ID, W, H) {
+            Ok(()) => "OK\n\
+                       register_texture_with_layout=ok\n\
+                       surface_store_register_texture=ok\n\
+                       resolve_texture_registration=ok\n\
+                       surface_store_lookup_texture=ok"
+                .to_string(),
+            Err(e) => format!("ERR:{e}"),
+        };
+        std::fs::write(&output_path, &line).map_err(|e| {
+            Error::Runtime(format!(
+                "SurfaceShareEscalateConsistencyTest: write {output_path}: {e}"
+            ))
+        })?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        let output_path = self.config.output_path.clone();
+        std::fs::write(
+            &output_path,
+            "ERR:surface-share+escalate consistency smoke is linux-only",
+        )
+        .map_err(|e| {
+            Error::Runtime(format!(
+                "SurfaceShareEscalateConsistencyTest: write {output_path}: {e}"
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn stop(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn on_pause(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    fn on_resume(&mut self, _ctx: &RuntimeContextLimitedAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_smoke(
+    ctx: &RuntimeContextFullAccess<'_>,
+    surface_id: &str,
+    width: u32,
+    height: u32,
+) -> Result<()> {
+    ctx.gpu_limited_access().escalate(|full| {
+        // Step 1: allocate texture + exportable timeline (the resource
+        // pair both registration paths bind to).
+        let host_device = full.host_vulkan_device_arc()?;
+        let texture = full.acquire_render_target_dma_buf_image(
+            width,
+            height,
+            TextureFormat::Bgra8Unorm,
+        )?;
+        let timeline = HostVulkanTimelineSemaphore::new_exportable(
+            host_device.device(),
+            0,
+        )
+        .map_err(|e| {
+            Error::GpuError(format!(
+                "HostVulkanTimelineSemaphore::new_exportable: {e}"
+            ))
+        })?;
+
+        // Step 2: register via the cross-process (surface-share daemon)
+        // channel.
+        let store = full
+            .surface_store()
+            .ok_or_else(|| Error::GpuError("surface_store unavailable".into()))?;
+        store
+            .register_texture(
+                surface_id,
+                &texture,
+                Some(&timeline),
+                VulkanLayout::UNDEFINED,
+            )
+            .map_err(|e| {
+                Error::GpuError(format!(
+                    "surface_store.register_texture: {e}"
+                ))
+            })?;
+
+        // Step 3: dual-register via the in-process texture_cache
+        // channel so the Path-1 resolve below hits the fast path.
+        // Cloning the Texture β-shape bumps the underlying
+        // Arc<TextureInner> via the LimitedAccess `clone_texture` slot.
+        let texture_cache_clone = texture.clone();
+        full.register_texture_with_layout(
+            surface_id,
+            texture_cache_clone,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+        );
+
+        // Step 4: resolve via the in-process / escalate-IPC path.
+        // Returns a TextureRegistration handle the cdylib never mutates;
+        // we just verify the call succeeds. `texture_layout=None`
+        // tells the resolver to read the producer's published layout
+        // from the registration rather than override per-frame.
+        let _registration = full
+            .resolve_texture_registration_by_surface_id(
+                surface_id,
+                None,
+                width,
+                height,
+            )
+            .map_err(|e| {
+                Error::GpuError(format!(
+                    "resolve_texture_registration_by_surface_id: {e}"
+                ))
+            })?;
+
+        // Step 5: look up via the cross-process (surface-share daemon)
+        // path. Returns a fresh Texture β-shape over the same imported
+        // VkImage. Both texture handles release on scope exit; the
+        // host-side Arcs drop in inverse-construction order.
+        let (looked_up_texture, looked_up_layout) =
+            store.lookup_texture(surface_id).map_err(|e| {
+                Error::GpuError(format!(
+                    "surface_store.lookup_texture: {e}"
+                ))
+            })?;
+        // Sanity: the looked-up texture's dimensions must agree with
+        // the original — locks the dimensions half of the round-trip
+        // wire format.
+        if looked_up_texture.width() != width
+            || looked_up_texture.height() != height
+        {
+            return Err(Error::GpuError(format!(
+                "lookup_texture returned mismatched dimensions: \
+                 expected {width}x{height}, got {}x{}",
+                looked_up_texture.width(),
+                looked_up_texture.height()
+            )));
+        }
+        // And the layout — locks the layout half of the wire format.
+        // The producer registered `VulkanLayout::UNDEFINED`; the
+        // daemon round-trips the raw `i32` enumerant through msgpack
+        // and the consumer-side wrapper decodes it back.
+        if looked_up_layout != VulkanLayout::UNDEFINED {
+            return Err(Error::GpuError(format!(
+                "lookup_texture returned mismatched layout: \
+                 expected UNDEFINED (0), got {:?}",
+                looked_up_layout
+            )));
+        }
+
+        // All five legs succeeded. Drop everything explicitly so the
+        // host-side Arc refcounts drain inside the escalate closure
+        // rather than at processor stop.
+        drop(looked_up_texture);
+        drop(_registration);
+        drop(texture);
+        drop(timeline);
+        drop(host_device);
+
+        Ok(())
+    })
+}

--- a/packages/test-fixtures/streamlib.yaml
+++ b/packages/test-fixtures/streamlib.yaml
@@ -48,6 +48,8 @@ schemas:
     file: schemas/opengl_smoke_test_processor_config.yaml
   CudaSmokeTestProcessorConfig:
     file: schemas/cuda_smoke_test_processor_config.yaml
+  SurfaceShareEscalateConsistencyTestProcessorConfig:
+    file: schemas/surface_share_escalate_consistency_test_processor_config.yaml
 
 processors:
   - name: TestConfiguredProcessor
@@ -169,3 +171,11 @@ processors:
     config:
       name: config
       schema: CudaSmokeTestProcessorConfig
+
+  - name: SurfaceShareEscalateConsistencyTestProcessor
+    version: 1.0.0
+    description: "Dlopen-cdylib smoke fixture verifying surface-share daemon and escalate-IPC paths agree on resource lifetime for the same surface_id. Registers a texture via both the cross-process surface_store.register_texture channel and the in-process gpu.register_texture_with_layout texture cache; resolves via both gpu.resolve_texture_registration_by_surface_id (Path 1 / escalate-IPC) and surface_store.lookup_texture (cross-process)."
+    execution: manual
+    config:
+      name: config
+      schema: SurfaceShareEscalateConsistencyTestProcessorConfig


### PR DESCRIPTION
## Summary

Final Phase H follow-up. Adds a cdylib fixture + integration test
verifying the surface-share daemon and escalate-IPC paths agree on
resource lifetime for the same `surface_id`, with double-free
detection on `runtime.stop()`.

Inside the fixture's `start()` → `gpu.escalate(|full| ...)` closure:

1. Allocate a render-target DMA-BUF VkImage + exportable timeline.
2. Register via `gpu.surface_store().register_texture(...)` —
   the cross-process surface-share daemon channel.
3. Dual-register via `gpu.register_texture_with_layout(...)` —
   the in-process texture_cache (per
   `docs/architecture/adapter-runtime-integration.md`'s
   dual-registration recipe).
4. Resolve via `gpu.resolve_texture_registration_by_surface_id(...)`.
5. Look up via `gpu.surface_store().lookup_texture(...)`; assert
   dimensions AND layout round-trip (locks both halves of the wire
   format).

The integration test asserts the fixture's OK output, then asserts
`runtime.stop().expect(...)` — any double-free in the dual-
registration Arc bookkeeping surfaces as a panic in teardown.

## Changes

- `packages/test-fixtures/src/surface_share_escalate_consistency_test_processor.rs`
  — new fixture processor.
- `packages/test-fixtures/schemas/surface_share_escalate_consistency_test_processor_config.yaml`
  — config schema.
- `packages/test-fixtures/streamlib.yaml` + `src/lib.rs` —
  registration + export_plugin!.
- `libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs`
  — integration test.

## Test plan

- [x] `cargo test --test load_project_dylib_surface_share_escalate_consistency -p streamlib-engine`
      — PASS.
- [x] Mental-revert verified:
  - Breaking `surface_store.lookup_texture` wire format → fixture
    detects via dimension / layout equality check → `ERR:<msg>` line.
  - Breaking the escalate `resolve_texture_registration_by_surface_id`
    vtable slot → fixture's `?` operator propagates → `ERR:<msg>`.
  - Breaking dual-registration drop semantics → `runtime.stop()`
    panics in test binary teardown.
- Reviewer pass + lightweight follow-ups addressed (layout assertion
  added; step-numbering normalized).

No GPU CI runner planned; runs locally.

Closes #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)