### PR TITLE
hardening: cdylib-reachability AST check + architecture doc

### DIFF
--- a/.github/workflows/check-cdylib-reach.yml
+++ b/.github/workflows/check-cdylib-reach.yml
@@ -1,0 +1,49 @@
+name: Check Cdylib Reach
+
+# Cdylib-reachability invariant for the engine's `Host*` Vulkan RHI
+# primitives. Every constructor-class method (`new*` / `create*` /
+# `from_*`) on a `HostVulkan*` impl must remain reachable from
+# workspace plugin cdylibs without dispatching through `host_inner()`
+# or `host_callbacks()`. Adding either inside a constructor body
+# silently breaks the cdylib direct-call path documented at
+# `docs/architecture/cdylib-reachability.md`.
+#
+# `cargo xtask check-cdylib-reach` parses the engine's RHI files with
+# `syn` and walks the AST of every constructor-class method's body.
+# Sub-second on a clean runner, no full workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-cdylib-reach:
+    name: xtask check-cdylib-reach
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-cdylib-reach
+        run: cargo xtask check-cdylib-reach
+
+      - name: cargo test -p xtask check_cdylib_reach (unit tests)
+        run: cargo test -p xtask check_cdylib_reach

--- a/docs/architecture/cdylib-reachability.md
+++ b/docs/architecture/cdylib-reachability.md
@@ -1,0 +1,189 @@
+# Cdylib reachability
+
+> **Living document.** Validate, update, critique freely per
+> [CLAUDE.md's markdown editing rules](../../CLAUDE.md#editing-markdown-documentation).
+
+How to decide whether a new `Host*` Vulkan RHI primitive needs a
+FullAccess vtable slot, or can be reached directly from workspace
+plugin cdylib code through the existing v9 `host_vulkan_device_arc`
+bridge.
+
+## Why this doc exists
+
+The cdylib boundary has a known trap: seeing a `host_inner()` panic
+on one `Host*` β-shape (e.g., `Texture::host_inner()`) and assuming
+by analogy that every other `Host*` constructor on the engine needs
+a bridge. That assumption is wrong by default — most `Host*`
+constructors take only `&Arc<HostVulkanDevice>` plus primitives and
+touch only `pub` accessors on the device. Workspace plugin cdylibs
+that hold the device Arc (via the v9 bridge) can call them directly,
+no new ABI surface needed.
+
+This doc captures the decision tree, the route-1 vs route-2 split,
+and the enforcement layers — so a future agent picking up "the cdylib
+can't reach X" doesn't file a defensive bridge before reading the
+constructor body.
+
+## Decision tree
+
+```
+Workspace plugin cdylib needs Arc<HostX> (a new resource type, or a
+new constructor on an existing type).
+
+  ┌─────────────────────────────────────────────────────────┐
+  │ Q1: Does the constructor / extractor body reach for     │
+  │     `host_inner()` (β-shape deref) or                   │
+  │     `host_callbacks()` (cdylib-mode guard)?             │
+  └───────────────┬─────────────────────────────────────────┘
+                  │
+        ┌─────────┴─────────┐
+       no                  yes
+        │                   │
+        ▼                   ▼
+   Route 2 works       Route 1 needed
+   (direct call)       (new vtable slot)
+```
+
+## Route 2 — direct constructor call (preferred)
+
+Applies when:
+
+- The constructor takes only `&Arc<HostVulkanDevice>` (or other
+  cdylib-reachable Arcs) and POD primitives.
+- Its body uses only `pub` accessors on `HostVulkanDevice`
+  (`allocator`, `device`, `dma_buf_buffer_pool`,
+  `dma_buf_image_pool*`, `opaque_fd_buffer_pool*`,
+  `opaque_fd_image_pool*`, `drm_modifier_table`, etc.) plus
+  `vulkanalia-vma`.
+- No `host_inner()` deref, no `host_callbacks()` check, no β-shape
+  indirection.
+
+Cdylib path:
+
+```rust
+gpu.escalate(|full| {
+    let device_arc = full.host_vulkan_device_arc()?;
+    // Direct constructor call — same code the host calls.
+    let resource = HostVulkanXxx::new(&device_arc, ...args)?;
+    let arc = Arc::new(resource);
+    // ...use arc through the adapter...
+    Ok(())
+})
+```
+
+This is the cheapest path. No ABI surface ships; the cdylib-reachability
+invariant is captured in:
+
+- The type-level `# Cdylib reachability` docstring on each
+  `Host*` type, enumerating the two paths and warning reviewers
+  against introducing a guard inside the constructor body.
+- `cargo xtask check-cdylib-reach` (see
+  [Enforcement](#enforcement) below).
+- The `load_project_dylib_*_smoke.rs` integration tests, which
+  exercise the cdylib direct-call path against each surface adapter.
+
+The existing route-2 paths today (verified at the docstring sites):
+
+- `HostVulkanBuffer::new` / `::new_opaque_fd_export` / `::new_opaque_fd_export_device_local`.
+- `HostVulkanTimelineSemaphore::new` / `::new_exportable` (plus
+  the v6 `create_timeline_semaphore` slot for the non-exportable
+  flavor when the cdylib doesn't already hold the device Arc).
+- `HostVulkanTexture::new_render_target_dma_buf` (low-level
+  path; the high-level `acquire_render_target_dma_buf_image`
+  FullAccess slot is the recommended entry point for most adapters).
+
+## Route 1 — new vtable slot (only when route 2 doesn't fit)
+
+Applies when:
+
+- The constructor / extractor must touch host-private state
+  (`host_inner()` for β-shape deref, host-only registries, etc.).
+- Or: the resource crosses the FFI as a non-`Arc` opaque handle
+  (β-shape with `(handle, vtable, POD)` layout, like `Texture` /
+  `PixelBuffer` / `StorageBuffer`).
+
+Existing route-1 bridges:
+
+- **v9 `host_vulkan_device_arc`** — hands a cloned
+  `Arc<HostVulkanDevice>` raw pointer to the cdylib.
+- **v10 `host_vulkan_texture_arc`** — extracts an
+  `Arc<HostVulkanTexture>` from a `Texture` β-shape (the β-shape's
+  `host_inner()` panics in cdylib mode, hence the bridge).
+
+When adding a new slot:
+
+1. Bump `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`.
+2. Update the layout regression test
+   (`gpu_context_full_access_vtable_layout` in plugin-abi): assert
+   the new `offset_of!` and the new `size_of`.
+3. Update `host_services_layout_versions_pinned` with the bumped
+   version constant.
+4. Add at least one tier-1 wire-format test
+   (`HOST_GPU_CONTEXT_FULL_ACCESS_VTABLE.<slot>(null) == null`).
+5. Document the new version in the constant's docstring.
+
+## Trap class
+
+The mistake this doc exists to prevent: filing "bridge for X /
+bridge for Y / bridge for Z" issues defensively without verifying
+whether the constructor bodies actually need bridges. To the best
+of our current knowledge, the historical case that motivated this
+doc had three of four "bridges" proposed defensively turn out to
+be already-working via route 2 — only one extractor (the
+`Texture` β-shape's `host_inner()` deref) needed a real bridge.
+
+Before filing a "bridge needed for X" issue:
+
+1. **Read the constructor body** (and any internal helpers it
+   delegates to). Does it reach for `host_inner` or
+   `host_callbacks`?
+2. If no — route 2 already works. The right deliverable is a
+   docstring update + a smoke test, not a new vtable slot.
+3. If yes — route 1 is needed, follow the checklist above.
+
+## Enforcement
+
+Three layers protect the invariant:
+
+1. **`cargo xtask check-cdylib-reach`** — AST-level scan of every
+   `.rs` file under `libs/streamlib-engine/src/vulkan/rhi/`. For
+   each `impl HostVulkan*` block, walks every constructor-class
+   method's body (`new*` / `create*` / `from_*`) and fails the
+   build if any call expression references `host_inner` or
+   `host_callbacks`. Adding a new `HostVulkan*` type / new file
+   under the directory is covered automatically — the check
+   tracks the directory, not a curated file list. Wired into CI
+   as `check-cdylib-reach.yml`. Comments and string literals are
+   ignored automatically by `syn`'s tokenization.
+2. **Type-level docstrings** on `HostVulkanBuffer`,
+   `HostVulkanTimelineSemaphore`, `HostVulkanTexture`. Each
+   carries a `# Cdylib reachability` section enumerating the two
+   paths and warning reviewers against introducing a guard. The
+   docstring is what a reviewer sees first on a constructor
+   change; the xtask is the backstop when the reviewer skipped it.
+3. **Dlopen smoke tests** at
+   `libs/streamlib-engine/tests/load_project_dylib_*_smoke.rs`
+   (one per surface adapter: cpu-readback, vulkan, opengl, cuda).
+   Each test exercises the cdylib direct-call path end-to-end.
+   If a constructor regresses to host-private state, the matching
+   smoke fails at runtime via `run_host_extern_c`'s panic-safety
+   net surfacing the panic as `ERR:<msg>`. These tests are GPU-
+   required and run locally only (no GPU CI runner planned per
+   `project_ci_strategy_no_gpu`).
+
+The three layers are defense in depth: the xtask catches the
+syntactic regression before merge; the docstring deters the
+regression at review time; the smoke tests catch any semantic
+gap the xtask might miss.
+
+## Reference
+
+- `xtask/src/check_cdylib_reach.rs` — the AST scan + tests.
+- `.github/workflows/check-cdylib-reach.yml` — CI wiring.
+- `libs/streamlib-engine/src/vulkan/rhi/` — `# Cdylib reachability`
+  docstrings on the `Host*` types that documented the route-2
+  invariant (currently `HostVulkanBuffer`,
+  `HostVulkanTimelineSemaphore`, `HostVulkanTexture`).
+- `libs/streamlib-engine/tests/load_project_dylib_{cpu_readback,
+  vulkan, opengl, cuda}_smoke.rs` — end-to-end exercise of the
+  cdylib path.

--- a/xtask/src/check_cdylib_reach.rs
+++ b/xtask/src/check_cdylib_reach.rs
@@ -1,0 +1,384 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI gate enforcing the cdylib-reachability invariant on the engine's
+//! `Host*` Vulkan RHI primitives.
+//!
+//! The invariant: every constructor-class method (`new*`, `create*`,
+//! `from_*`) on a `HostVulkan*` impl in the engine's RHI files must be
+//! reachable from workspace plugin cdylibs without dispatching through
+//! the `host_inner()` β-shape deref or the `host_callbacks()` guard.
+//! Adding either inside a constructor body silently breaks the
+//! cdylib's direct-call path documented on each type's
+//! "Cdylib reachability" docstring (see
+//! `docs/architecture/cdylib-reachability.md`).
+//!
+//! The check parses each target file with `syn` and walks the AST of
+//! every constructor-class method's body, flagging any method-call
+//! whose method is `host_inner` and any path expression whose last
+//! segment is `host_inner` or `host_callbacks`. Comments and string
+//! literals are skipped automatically by `syn`'s tokenization.
+//!
+//! See `docs/architecture/cdylib-reachability.md` for the decision
+//! tree this check enforces.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use syn::visit::Visit;
+use walkdir::WalkDir;
+
+/// Engine RHI directory whose `HostVulkan*` impls the check walks.
+/// Every `.rs` file under this directory is parsed; only impls whose
+/// type name starts with `HostVulkan` are visited. Adding a new
+/// `Host*` type / new file under this tree is covered automatically
+/// — the check tracks the directory, not a curated file list.
+const TARGET_DIR: &str = "libs/streamlib-engine/src/vulkan/rhi";
+
+/// Identifiers banned inside constructor-class function bodies.
+const BANNED_IDENTS: &[&str] = &["host_inner", "host_callbacks"];
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub file: PathBuf,
+    pub impl_type: String,
+    pub method: String,
+    pub offending_ident: String,
+    pub line: usize,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let violations = scan_workspace(workspace_root)?;
+    if violations.is_empty() {
+        println!(
+            "✓ check-cdylib-reach: every Host* constructor in the engine RHI \
+             stays clear of host_inner() / host_callbacks() — cdylib direct-call \
+             path intact."
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "✗ check-cdylib-reach: {} violation(s) — Host* constructor reached for \
+         a host-private guard, breaking the cdylib direct-call path:",
+        violations.len()
+    );
+    for v in &violations {
+        eprintln!(
+            "  {}:{}: impl {} :: fn {} references `{}`",
+            v.file.display(),
+            v.line,
+            v.impl_type,
+            v.method,
+            v.offending_ident,
+        );
+    }
+    eprintln!(
+        "\nFix:\n  \
+         A `Host*::new*` / `create*` / `from_*` method body called `host_inner()` \
+         or `host_callbacks()`. The cdylib direct-call path (see\n  \
+         `docs/architecture/cdylib-reachability.md`) requires constructors to \
+         touch only `pub` accessors on `HostVulkanDevice` plus `vulkanalia-vma`.\n  \
+         Options:\n    \
+           1. Re-route the body through a `pub` accessor (preferred).\n    \
+           2. Promote the construction path to a FullAccess vtable slot \
+              (route 1) — bump `GPU_CONTEXT_FULL_ACCESS_VTABLE_LAYOUT_VERSION`, \
+              update the layout regression test, add a tier-1 wire-format test."
+    );
+    anyhow::bail!("check-cdylib-reach failed");
+}
+
+pub fn scan_workspace(workspace_root: &Path) -> Result<Vec<Violation>> {
+    let mut all = Vec::new();
+    let target_dir = workspace_root.join(TARGET_DIR);
+    for entry in WalkDir::new(&target_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let abs = entry.path();
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if abs.extension().map(|e| e != "rs").unwrap_or(true) {
+            continue;
+        }
+        let relpath = abs
+            .strip_prefix(workspace_root)
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|_| abs.to_path_buf());
+        let src = fs::read_to_string(abs)
+            .with_context(|| format!("reading {}", abs.display()))?;
+        let file = syn::parse_file(&src)
+            .with_context(|| format!("parsing {}", abs.display()))?;
+        let mut visitor = FileVisitor {
+            file_path: relpath,
+            current_impl_type: None,
+            violations: &mut all,
+        };
+        visitor.visit_file(&file);
+    }
+    Ok(all)
+}
+
+fn is_constructor_name(name: &str) -> bool {
+    name == "new"
+        || name.starts_with("new_")
+        || name == "create"
+        || name.starts_with("create_")
+        || name.starts_with("from_")
+}
+
+fn type_name(ty: &syn::Type) -> Option<String> {
+    if let syn::Type::Path(tp) = ty {
+        tp.path.segments.last().map(|s| s.ident.to_string())
+    } else {
+        None
+    }
+}
+
+struct FileVisitor<'a> {
+    file_path: PathBuf,
+    current_impl_type: Option<String>,
+    violations: &'a mut Vec<Violation>,
+}
+
+impl<'ast, 'a> Visit<'ast> for FileVisitor<'a> {
+    fn visit_item_impl(&mut self, item: &'ast syn::ItemImpl) {
+        // Only walk into `impl HostVulkanXxx` blocks. Other impls
+        // (traits, non-Host types) pass through untouched.
+        let ty = type_name(&item.self_ty).unwrap_or_default();
+        let is_target = ty.starts_with("HostVulkan");
+        if !is_target {
+            return;
+        }
+        let prev = self.current_impl_type.replace(ty);
+        syn::visit::visit_item_impl(self, item);
+        self.current_impl_type = prev;
+    }
+
+    fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+        let Some(impl_ty) = self.current_impl_type.clone() else {
+            return;
+        };
+        let name = f.sig.ident.to_string();
+        if !is_constructor_name(&name) {
+            return;
+        }
+        let mut body = BodyVisitor::default();
+        body.visit_block(&f.block);
+        for hit in body.hits {
+            self.violations.push(Violation {
+                file: self.file_path.clone(),
+                impl_type: impl_ty.clone(),
+                method: name.clone(),
+                offending_ident: hit.ident,
+                line: hit.line,
+            });
+        }
+    }
+}
+
+struct Hit {
+    ident: String,
+    line: usize,
+}
+
+#[derive(Default)]
+struct BodyVisitor {
+    hits: Vec<Hit>,
+}
+
+impl<'ast> Visit<'ast> for BodyVisitor {
+    fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+        let m = call.method.to_string();
+        if BANNED_IDENTS.contains(&m.as_str()) {
+            self.hits.push(Hit {
+                ident: m,
+                line: call.method.span().start().line,
+            });
+        }
+        syn::visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+        if let Some(seg) = path.path.segments.last() {
+            let n = seg.ident.to_string();
+            if BANNED_IDENTS.contains(&n.as_str()) {
+                self.hits.push(Hit {
+                    ident: n,
+                    line: seg.ident.span().start().line,
+                });
+            }
+        }
+        syn::visit::visit_expr_path(self, path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::visit::Visit;
+
+    fn scan_source(src: &str) -> Vec<Violation> {
+        let file = syn::parse_file(src).expect("parse");
+        let mut violations = Vec::new();
+        let mut visitor = FileVisitor {
+            file_path: PathBuf::from("test.rs"),
+            current_impl_type: None,
+            violations: &mut violations,
+        };
+        visitor.visit_file(&file);
+        violations
+    }
+
+    #[test]
+    fn flags_host_inner_in_constructor() {
+        let src = r#"
+            impl HostVulkanBuffer {
+                pub fn new(device: &u32) -> u32 {
+                    self.host_inner();
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].impl_type, "HostVulkanBuffer");
+        assert_eq!(v[0].method, "new");
+        assert_eq!(v[0].offending_ident, "host_inner");
+    }
+
+    #[test]
+    fn flags_host_callbacks_in_constructor() {
+        let src = r#"
+            impl HostVulkanTexture {
+                pub fn new_render_target_dma_buf() -> u32 {
+                    if host_callbacks().is_some() {
+                        panic!("nope");
+                    }
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].method, "new_render_target_dma_buf");
+        assert_eq!(v[0].offending_ident, "host_callbacks");
+    }
+
+    #[test]
+    fn flags_fully_qualified_host_callbacks() {
+        let src = r#"
+            impl HostVulkanTimelineSemaphore {
+                pub fn new_exportable() -> u32 {
+                    if crate::core::plugin::host_services::host_callbacks().is_some() {
+                        return 0;
+                    }
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].offending_ident, "host_callbacks");
+    }
+
+    #[test]
+    fn ignores_non_constructor_methods() {
+        // Non-constructor method names (like `wait`) are allowed to use
+        // host_callbacks for vtable dispatch — that's the documented
+        // shape for runtime methods.
+        let src = r#"
+            impl HostVulkanTimelineSemaphore {
+                pub fn wait(&self) -> u32 {
+                    if host_callbacks().is_some() {
+                        return self.wait_via_vtable();
+                    }
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert!(v.is_empty(), "wait() is not a constructor; allowed");
+    }
+
+    #[test]
+    fn ignores_non_host_impls() {
+        // The check only walks impls of `HostVulkanXxx` types. Other
+        // types in the same file get to use host_inner / host_callbacks
+        // freely.
+        let src = r#"
+            impl SomeOtherType {
+                pub fn new() -> u32 {
+                    self.host_inner();
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert!(v.is_empty(), "non-Host impl ignored");
+    }
+
+    #[test]
+    fn ignores_docstring_mentions() {
+        // The whole point of the AST walk: docstrings and comments
+        // never become Expr nodes.
+        let src = r#"
+            impl HostVulkanBuffer {
+                /// This constructor does NOT call host_inner() or
+                /// host_callbacks() — see docs.
+                pub fn new() -> u32 {
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert!(v.is_empty(), "docstring mentions are not call sites");
+    }
+
+    #[test]
+    fn ignores_string_literal_mentions() {
+        let src = r#"
+            impl HostVulkanBuffer {
+                pub fn new() -> Result<u32, String> {
+                    Err("host_inner failed (this is just a message)".into())
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert!(v.is_empty(), "string literal mentions are not call sites");
+    }
+
+    #[test]
+    fn flags_create_helper() {
+        // Internal helpers like `HostVulkanTimelineSemaphore::create`
+        // are part of the constructor chain — `new` / `new_exportable`
+        // both call them — so they're covered too.
+        let src = r#"
+            impl HostVulkanTimelineSemaphore {
+                fn create() -> u32 {
+                    self.host_inner();
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].method, "create");
+    }
+
+    #[test]
+    fn flags_from_helper() {
+        let src = r#"
+            impl HostVulkanBuffer {
+                pub fn from_dma_buf_fd() -> u32 {
+                    let x = host_callbacks();
+                    0
+                }
+            }
+        "#;
+        let v = scan_source(src);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].method, "from_dma_buf_fd");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use streamlib_jtd_codegen::{generate, GenerateOptions, RuntimeTarget};
 
 pub mod check_boundaries;
+pub mod check_cdylib_reach;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
 pub mod check_processor_spec_new;
@@ -98,6 +99,14 @@ enum Commands {
     /// `<Module>::schema_ident()`).
     CheckProcessorSpecNew,
 
+    /// CI gate for the cdylib-reachability invariant on engine `Host*`
+    /// constructors. Fails when any constructor-class method
+    /// (`new*` / `create*` / `from_*`) inside an `impl HostVulkan*`
+    /// block in the engine RHI references `host_inner()` or
+    /// `host_callbacks()` — those break the cdylib direct-call path
+    /// documented at `docs/architecture/cdylib-reachability.md`.
+    CheckCdylibReach,
+
     /// Regenerate `schemas/streamlib.schema.json` from the Rust
     /// [`StreamlibYaml`](streamlib_processor_schema::StreamlibYaml) source of
     /// truth (#714). Editors with `yaml-language-server` consume this schema
@@ -147,6 +156,7 @@ fn main() -> Result<()> {
         }
         Commands::CheckNoReverseDns => check_no_reverse_dns::run(&workspace_root()?)?,
         Commands::CheckProcessorSpecNew => check_processor_spec_new::run(&workspace_root()?)?,
+        Commands::CheckCdylibReach => check_cdylib_reach::run(&workspace_root()?)?,
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,
         Commands::CheckManifestSchema => manifest_schema::check(&workspace_root()?)?,
     }


### PR DESCRIPTION
## Summary

Locks the cdylib-reachability invariant the recent Phase H follow-up
sweep exposed: every constructor-class method on a `HostVulkan*`
impl in the engine's RHI must remain reachable from workspace plugin
cdylibs without dispatching through `host_inner()` (β-shape deref)
or `host_callbacks()` (cdylib-mode guard). Both would silently break
the cdylib direct-call path documented on each type's docstring.

This PR is opportunistic hardening — no issue, no behavior change.
Three new artifacts:

## Changes

1. **`cargo xtask check-cdylib-reach`** —
   `xtask/src/check_cdylib_reach.rs`. AST-level scan over every
   `.rs` file under `libs/streamlib-engine/src/vulkan/rhi/` (so a
   new `HostVulkan*` type / new file is covered automatically).
   For each `impl HostVulkan*` block, walks every constructor-class
   method body (`new*` / `create*` / `from_*`) and flags any
   `ExprMethodCall` or `ExprPath` referencing the banned
   identifiers. Comments and string literals are skipped
   automatically by `syn`'s tokenization. 9 unit tests cover
   positives + negatives.

2. **`.github/workflows/check-cdylib-reach.yml`** — CI gate
   wiring, mirrors `check-boundaries.yml`'s shape. Sub-second.

3. **`docs/architecture/cdylib-reachability.md`** — decision tree
   for route-1 (new vtable slot) vs route-2 (direct constructor
   call), the trap class the doc exists to prevent ("defensive
   bridge cascade"), and the three enforcement layers (xtask +
   docstrings + dlopen smoke tests).

## Test plan

- [x] `cargo test -p xtask check_cdylib_reach` — 9/9 PASS.
- [x] `cargo xtask check-cdylib-reach` — clean against current
      workspace (no constructor in any `HostVulkan*` impl references
      the banned idents).
- [x] Mental-revert verified: injecting `self.host_inner()` into
      `HostVulkanBuffer::new` makes the xtask fail with a clear
      violation message naming the file:line, impl type, method, and
      offending identifier. Reverting restores the green build.
- [x] Reviewer pass + fixes addressed (date qualifier removed from
      arch doc per CLAUDE.md "Architecture documentation discipline";
      tracker reference stripped; directory walk replaces the
      hard-coded 3-file list so all 7 `HostVulkan*` impls in the
      engine RHI are covered, not just the 3 that the original
      cdylib-reachability docstrings touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)