### PR TITLE
feat(xtask, sdk): cargo xtask build-plugins + Runner::load_workspace_packages (#991)

### DIFF
--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -14,5 +14,4 @@ streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-display = { path = "../../packages/display" }
 streamlib-h264 = { path = "../../packages/h264" }
 streamlib-h265 = { path = "../../packages/h265" }
-tempfile = "3.14"
 serde_json = "1"

--- a/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
@@ -17,86 +17,14 @@
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h264 [device] [seconds]
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h265 /dev/video0 10
 
-use std::path::{Path, PathBuf};
-
-use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{OutputLinkPortRef, ProcessorUniqueId};
 use streamlib::sdk::processors::{input, output, ProcessorSpec};
-use streamlib::sdk::runtime::{host_target_triple, Runner};
+use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 use streamlib_display::DisplayProcessor;
 use streamlib_h264::{H264DecoderProcessor, H264EncoderProcessor};
 use streamlib_h265::{H265DecoderProcessor, H265EncoderProcessor};
-
-fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let dst_entry = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_contents(&entry.path(), &dst_entry)?;
-        } else {
-            std::fs::copy(entry.path(), &dst_entry)?;
-        }
-    }
-    Ok(())
-}
-
-fn stage_camera_project(workspace_root: &Path) -> Result<PathBuf> {
-    let dylib_ext = if cfg!(target_os = "macos") {
-        "dylib"
-    } else if cfg!(target_os = "windows") {
-        "dll"
-    } else {
-        "so"
-    };
-    let dylib_name = format!("libstreamlib_camera.{dylib_ext}");
-    let built_dylib = workspace_root.join("target").join("debug").join(&dylib_name);
-    if !built_dylib.exists() {
-        return Err(Error::Configuration(format!(
-            "camera cdylib not at {} — run \
-             `cargo build -p streamlib-camera --features plugin` first",
-            built_dylib.display()
-        )));
-    }
-
-    let tmp = tempfile::tempdir()
-        .map_err(|e| Error::Configuration(format!("tempdir: {e}")))?;
-    let staged_root = tmp.keep();
-
-    let camera_src = workspace_root.join("packages/camera");
-    let core_src = workspace_root.join("packages/core");
-    let camera_dst = staged_root.join("packages/camera");
-    let core_dst = staged_root.join("packages/core");
-
-    std::fs::create_dir_all(&camera_dst)
-        .map_err(|e| Error::Configuration(format!("mkdir camera dst: {e}")))?;
-    std::fs::copy(
-        camera_src.join("streamlib.yaml"),
-        camera_dst.join("streamlib.yaml"),
-    )
-    .map_err(|e| Error::Configuration(format!("copy camera streamlib.yaml: {e}")))?;
-    copy_dir_contents(&camera_src.join("schemas"), &camera_dst.join("schemas"))
-        .map_err(|e| Error::Configuration(format!("copy camera schemas: {e}")))?;
-
-    std::fs::create_dir_all(&core_dst)
-        .map_err(|e| Error::Configuration(format!("mkdir core dst: {e}")))?;
-    std::fs::copy(
-        core_src.join("streamlib.yaml"),
-        core_dst.join("streamlib.yaml"),
-    )
-    .map_err(|e| Error::Configuration(format!("copy core streamlib.yaml: {e}")))?;
-    copy_dir_contents(&core_src.join("schemas"), &core_dst.join("schemas"))
-        .map_err(|e| Error::Configuration(format!("copy core schemas: {e}")))?;
-
-    let triple_dir = camera_dst.join("lib").join(host_target_triple());
-    std::fs::create_dir_all(&triple_dir)
-        .map_err(|e| Error::Configuration(format!("mkdir triple dir: {e}")))?;
-    std::fs::copy(&built_dylib, triple_dir.join(&dylib_name))
-        .map_err(|e| Error::Configuration(format!("copy camera cdylib: {e}")))?;
-
-    Ok(camera_dst)
-}
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -112,28 +40,14 @@ fn main() -> Result<()> {
     println!("Camera:   {device} (loaded as cdylib via runtime.load_project)");
     println!("Duration: {duration_secs}s\n");
 
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| {
-            Error::Configuration("CARGO_MANIFEST_DIR has no two parents".into())
-        })?;
-
     let runtime = Runner::new()?;
 
-    // 1) Stage @tatolab/camera as a project with its cdylib placed
-    //    under `lib/<target-triple>/`, then load it.
-    let camera_project = stage_camera_project(workspace_root)?;
-    println!("+ Camera staged at: {}", camera_project.display());
-    runtime.load_project(&camera_project)?;
-    println!("+ Camera project loaded (cdylib path)");
-
-    // 2) Also load the example's own streamlib.yaml so the
-    //    `@tatolab/core` wire vocabulary is registered (the
-    //    vulkan-video-roundtrip baseline does this too — see its
-    //    comment on the EncodedVideoFrame max-payload-bytes hookup).
-    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
-    println!("+ Wire vocabulary registered\n");
+    // 1) Load `@tatolab/camera` (and its `@tatolab/core` dep, walked
+    //    via the staged manifest's patch:) from the workspace-staged
+    //    location. `cargo xtask build-plugins` must have run first.
+    runtime.load_workspace_packages(["@tatolab/camera"])?;
+    println!("+ @tatolab/camera loaded from target/streamlib-plugins/");
+    println!("+ Wire vocabulary registered (via @tatolab/core dep walk)\n");
 
     // 3) Camera processor — minted from the cdylib's registration,
     //    addressed by its structured schema_ident, configured via

--- a/libs/streamlib-cargo-build/Cargo.toml
+++ b/libs/streamlib-cargo-build/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+streamlib-idents = { path = "../streamlib-idents" }
 streamlib-processor-schema = { path = "../streamlib-processor-schema" }
 
 [dev-dependencies]

--- a/libs/streamlib-cargo-build/src/lib.rs
+++ b/libs/streamlib-cargo-build/src/lib.rs
@@ -94,7 +94,28 @@ pub fn read_cargo_package_name(package_dir: &Path) -> Result<String> {
     Ok(name.to_string())
 }
 
-/// Invoke `cargo build --release -p <cargo_name>
+/// Cargo build profile selector for [`run_cargo_build`].
+///
+/// `Release` is the production-distribution shape (`streamlib pack`
+/// uses it). `Dev` skips optimization for a faster inner loop
+/// (`cargo xtask build-plugins` defaults to it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CargoProfile {
+    Dev,
+    Release,
+}
+
+impl CargoProfile {
+    /// Human-facing label for log lines.
+    pub fn label(self) -> &'static str {
+        match self {
+            CargoProfile::Dev => "dev",
+            CargoProfile::Release => "release",
+        }
+    }
+}
+
+/// Invoke `cargo build [--release] -p <cargo_name>
 /// --features <cargo_name>/plugin --message-format=json` from
 /// `package_dir` and parse the JSON output for the produced host-OS
 /// cdylib path.
@@ -108,27 +129,33 @@ pub fn read_cargo_package_name(package_dir: &Path) -> Result<String> {
 /// Cargo's progress output (the `Compiling foo …` lines and compiler
 /// diagnostics) is left inherited on stderr so a cold build does not
 /// appear hung. Only stdout — the JSON message stream — is captured.
-pub fn run_cargo_build_release(
+pub fn run_cargo_build(
     package_dir: &Path,
     cargo_name: &str,
     dylib_ext: &str,
+    profile: CargoProfile,
 ) -> Result<PathBuf> {
     // `--features <name>/plugin` enables the `export_plugin!` invocation
     // in the package's `lib.rs`. The feature is default-off so force-link
     // rlib consumers don't pull in the unmangled `STREAMLIB_PLUGIN`
     // symbol (multiple rlibs with the same static collide at link time);
-    // pack flips it on so the produced cdylib carries the symbol the
-    // runtime dlopens.
+    // pack / build-plugins flip it on so the produced cdylib carries the
+    // symbol the runtime dlopens.
     let features_flag = format!("{}/plugin", cargo_name);
+    let profile_label = profile.label();
     tracing::info!(
-        "Building {} (cargo build --release -p {} --features {})",
+        "Building {} ({} profile, cargo build -p {} --features {})",
         cargo_name,
+        profile_label,
         cargo_name,
         features_flag
     );
-    let output = Command::new("cargo")
-        .arg("build")
-        .arg("--release")
+    let mut command = Command::new("cargo");
+    command.arg("build");
+    if matches!(profile, CargoProfile::Release) {
+        command.arg("--release");
+    }
+    let output = command
         .arg("--message-format=json")
         .arg("-p")
         .arg(cargo_name)
@@ -140,7 +167,12 @@ pub fn run_cargo_build_release(
         .output()
         .with_context(|| {
             format!(
-                "Failed to invoke `cargo build --release -p {} --features {}` in {}",
+                "Failed to invoke `cargo build {} -p {} --features {}` in {}",
+                if matches!(profile, CargoProfile::Release) {
+                    "--release"
+                } else {
+                    ""
+                },
                 cargo_name,
                 features_flag,
                 package_dir.display()
@@ -149,8 +181,9 @@ pub fn run_cargo_build_release(
 
     if !output.status.success() {
         anyhow::bail!(
-            "cargo build --release -p {} failed (run from {}). \
+            "cargo build ({}) -p {} failed (run from {}). \
              See cargo's output above.",
+            profile_label,
             cargo_name,
             package_dir.display(),
         );
@@ -165,13 +198,25 @@ pub fn run_cargo_build_release(
 
     parse_cargo_artifact_for_cdylib(&stdout, cargo_name, dylib_ext)?.ok_or_else(|| {
         anyhow::anyhow!(
-            "cargo build --release -p {} completed but produced no \
+            "cargo build ({}) -p {} completed but produced no \
              host-OS cdylib (`*.{}`). Confirm the crate declares \
              `crate-type = [\"cdylib\"]` in [lib].",
+            profile_label,
             cargo_name,
             dylib_ext
         )
     })
+}
+
+/// Back-compat wrapper for [`run_cargo_build`] with [`CargoProfile::Release`].
+/// `streamlib pack` retains this entry point so the release-default shape
+/// for distribution artifacts is preserved.
+pub fn run_cargo_build_release(
+    package_dir: &Path,
+    cargo_name: &str,
+    dylib_ext: &str,
+) -> Result<PathBuf> {
+    run_cargo_build(package_dir, cargo_name, dylib_ext, CargoProfile::Release)
 }
 
 /// Scan one stream of `--message-format=json` cargo output for the
@@ -296,6 +341,138 @@ pub fn discover_rust_impl_packages(roots: &[&Path]) -> Result<Vec<PathBuf>> {
         }
     }
     Ok(out)
+}
+
+/// Canonical staged-directory name for a package: `<org>__<name>` with
+/// no `@` literal so the path is filesystem-safe across every
+/// supported host. The corresponding wire-form id is `@<org>/<name>`.
+///
+/// `cargo xtask build-plugins` and `Runner::load_workspace_packages`
+/// MUST agree on this format — keep the conversion in one place.
+pub fn staged_package_dir_name(org: &str, name: &str) -> String {
+    format!("{}__{}", org, name)
+}
+
+/// Stage a workspace package into `staged_root/<org>__<name>/` so
+/// `Runner::load_workspace_packages` can find it without depending on
+/// the original `packages/` layout.
+///
+/// Copies the package's `streamlib.yaml` and `schemas/` directory into
+/// the staged dir, rewriting every `patch:` entry's path so it
+/// resolves to a sibling staged dir (`../<dep_org>__<dep_name>`)
+/// rather than the source-tree path. When `built_cdylib` is
+/// `Some(path)`, the cdylib is staged into
+/// `<staged_dir>/lib/<host_triple>/<filename>` matching the
+/// `Runner::load_project` triple-keyed convention. Schemas-only
+/// packages pass `None`.
+///
+/// Returns the staged package directory (absolute path).
+pub fn stage_package_for_dev_load(
+    package_dir: &Path,
+    staged_root: &Path,
+    built_cdylib: Option<&Path>,
+    host_triple: &str,
+) -> Result<PathBuf> {
+    use streamlib_idents::Manifest;
+
+    let manifest_path = package_dir.join(Manifest::FILE_NAME);
+    let manifest_body = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+    let mut manifest: Manifest = serde_yaml::from_str(&manifest_body)
+        .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+    let package = manifest.package.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} has no [package] section — cannot determine staged dir name",
+            manifest_path.display()
+        )
+    })?;
+    let org = package.org.as_str().to_string();
+    let name = package.name.as_str().to_string();
+
+    // Rewrite every `patch:` entry to resolve to a sibling staged dir
+    // (`../<dep_org>__<dep_name>`). Same for path-flavor `dependencies:`
+    // entries (rare but legal). Registry / git entries pass through
+    // unchanged.
+    rewrite_patches_to_staged_siblings(&mut manifest.patch);
+    rewrite_patches_to_staged_siblings(&mut manifest.dependencies);
+
+    let staged_dir = staged_root.join(staged_package_dir_name(&org, &name));
+    // Wipe the staged dir before re-staging so removed schemas / renamed
+    // patches don't linger. Hermetic regeneration is the contract — if
+    // a user clobbers files into staged_dir manually, they lose them on
+    // the next stage.
+    if staged_dir.exists() {
+        std::fs::remove_dir_all(&staged_dir).with_context(|| {
+            format!(
+                "Failed to clear stale staged dir {}",
+                staged_dir.display()
+            )
+        })?;
+    }
+    std::fs::create_dir_all(&staged_dir)
+        .with_context(|| format!("Failed to create {}", staged_dir.display()))?;
+
+    // Write the rewritten manifest into the staged dir.
+    let rewritten_yaml = serde_yaml::to_string(&manifest)
+        .with_context(|| format!("Failed to serialize rewritten {}", Manifest::FILE_NAME))?;
+    std::fs::write(staged_dir.join(Manifest::FILE_NAME), rewritten_yaml)
+        .with_context(|| format!("Failed to write staged {}", Manifest::FILE_NAME))?;
+
+    // Copy schemas/ if it exists.
+    let src_schemas = package_dir.join("schemas");
+    if src_schemas.is_dir() {
+        let dst_schemas = staged_dir.join("schemas");
+        copy_dir_recursive(&src_schemas, &dst_schemas)?;
+    }
+
+    // Stage the cdylib if provided. Schemas-only packages skip this.
+    if let Some(cdylib_src) = built_cdylib {
+        stage_built_cdylib(&staged_dir, cdylib_src, host_triple)?;
+    }
+
+    Ok(staged_dir)
+}
+
+fn rewrite_patches_to_staged_siblings(
+    entries: &mut std::collections::BTreeMap<
+        streamlib_idents::PackageRef,
+        streamlib_idents::DependencySpec,
+    >,
+) {
+    use streamlib_idents::{DependencySpec, PathDependency};
+    for (dep_ref, spec) in entries.iter_mut() {
+        if let DependencySpec::Path(_) = spec {
+            let sibling = PathBuf::from("..").join(staged_package_dir_name(
+                dep_ref.org.as_str(),
+                dep_ref.name.as_str(),
+            ));
+            *spec = DependencySpec::Path(PathDependency { path: sibling });
+        }
+    }
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)
+        .with_context(|| format!("Failed to create {}", dst.display()))?;
+    for entry in std::fs::read_dir(src)
+        .with_context(|| format!("Failed to read {}", src.display()))?
+    {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path).with_context(|| {
+                format!(
+                    "Failed to copy {} → {}",
+                    src_path.display(),
+                    dst_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 /// Stage a freshly-built cdylib at `<package_dir>/lib/<host_triple>/<filename>`
@@ -654,5 +831,173 @@ package:
         // Source is preserved — staging copies, never moves; a
         // subsequent `cargo clean` mustn't invalidate the staged copy.
         assert!(built.exists(), "source artifact must remain after staging");
+    }
+
+    #[test]
+    fn staged_package_dir_name_uses_double_underscore_no_at_literal() {
+        // The wire-form id `@tatolab/core` becomes the
+        // filesystem-safe dir name `tatolab__core`. Both the xtask
+        // and Runner::load_workspace_packages must compute it the same
+        // way — reverting the format would silently break the load
+        // helper's lookup, so the test pins the literal shape.
+        assert_eq!(staged_package_dir_name("tatolab", "core"), "tatolab__core");
+        assert_eq!(
+            staged_package_dir_name("vendor", "fancy-plugin"),
+            "vendor__fancy-plugin",
+        );
+    }
+
+    fn write_minimal_manifest(dir: &Path, org: &str, name: &str, body: &str) {
+        let yaml = format!(
+            "package:\n  org: {org}\n  name: {name}\n  version: 1.0.0\n{body}"
+        );
+        std::fs::write(dir.join("streamlib.yaml"), yaml).unwrap();
+    }
+
+    #[test]
+    fn stage_package_for_dev_load_schemas_only_copies_yaml_and_schemas_no_lib() {
+        // Schemas-only packages — like `@tatolab/core` — must stage
+        // cleanly without a `lib/` directory. Reverting the
+        // `if let Some(cdylib_src) = built_cdylib` gate would either
+        // panic (cdylib_src is None) or silently create an empty
+        // lib/ — both shapes are wrong and load_workspace_packages
+        // would mis-resolve.
+        let src = tempdir().unwrap();
+        write_minimal_manifest(src.path(), "tatolab", "core", "");
+        let schemas_dir = src.path().join("schemas");
+        std::fs::create_dir(&schemas_dir).unwrap();
+        std::fs::write(
+            schemas_dir.join("video_frame.yaml"),
+            "metadata:\n  type: VideoFrame\n",
+        )
+        .unwrap();
+
+        let staged_root = tempdir().unwrap();
+        let staged = stage_package_for_dev_load(
+            src.path(),
+            staged_root.path(),
+            None, /* schemas-only */
+            "x86_64-unknown-linux-gnu",
+        )
+        .unwrap();
+
+        assert_eq!(staged, staged_root.path().join("tatolab__core"));
+        assert!(staged.join("streamlib.yaml").exists());
+        assert!(staged.join("schemas/video_frame.yaml").exists());
+        assert!(!staged.join("lib").exists(), "schemas-only stage must not create lib/");
+    }
+
+    #[test]
+    fn stage_package_for_dev_load_with_cdylib_lands_under_triple_keyed_lib() {
+        // Rust-impl packages stage both the yaml/schemas AND the cdylib
+        // (under `lib/<host_triple>/<filename>`). The staged dir is the
+        // self-contained mini-project Runner::load_workspace_packages
+        // points at.
+        let src = tempdir().unwrap();
+        write_minimal_manifest(src.path(), "tatolab", "camera", "");
+        let cdylib = src.path().join("libstreamlib_camera.so");
+        std::fs::write(&cdylib, b"camera-cdylib-bytes").unwrap();
+
+        let staged_root = tempdir().unwrap();
+        let staged = stage_package_for_dev_load(
+            src.path(),
+            staged_root.path(),
+            Some(&cdylib),
+            "x86_64-unknown-linux-gnu",
+        )
+        .unwrap();
+
+        assert_eq!(staged, staged_root.path().join("tatolab__camera"));
+        let staged_cdylib = staged
+            .join("lib")
+            .join("x86_64-unknown-linux-gnu")
+            .join("libstreamlib_camera.so");
+        assert!(staged_cdylib.exists(), "expected staged cdylib at {}", staged_cdylib.display());
+        let bytes = std::fs::read(&staged_cdylib).unwrap();
+        assert_eq!(bytes, b"camera-cdylib-bytes");
+    }
+
+    #[test]
+    fn stage_package_for_dev_load_rewrites_patches_to_sibling_staged_dirs() {
+        // The whole point of staging is that the staged manifest's
+        // `patch:` entries resolve to sibling staged dirs, not back
+        // into the workspace source tree. Mentally reverting the
+        // rewrite step would leave `path: ../core` in the staged yaml
+        // and `load_workspace_packages` would either find the wrong
+        // package (the source tree one, missing its built cdylib) or
+        // fail outright.
+        let src = tempdir().unwrap();
+        write_minimal_manifest(
+            src.path(),
+            "tatolab",
+            "camera",
+            r#"dependencies:
+  "@tatolab/core": "^1.0.0"
+patch:
+  "@tatolab/core":
+    path: ../core
+"#,
+        );
+
+        let staged_root = tempdir().unwrap();
+        let staged = stage_package_for_dev_load(
+            src.path(),
+            staged_root.path(),
+            None,
+            "x86_64-unknown-linux-gnu",
+        )
+        .unwrap();
+
+        // Re-parse the staged yaml and assert the patch path is the
+        // sibling-staged-dir form.
+        let body = std::fs::read_to_string(staged.join("streamlib.yaml")).unwrap();
+        let restaged: streamlib_idents::Manifest = serde_yaml::from_str(&body).unwrap();
+        let core_ref = restaged
+            .patch
+            .keys()
+            .find(|k| k.org.as_str() == "tatolab" && k.name.as_str() == "core")
+            .expect("patch must retain the @tatolab/core key");
+        match &restaged.patch[core_ref] {
+            streamlib_idents::DependencySpec::Path(p) => {
+                assert_eq!(
+                    p.path,
+                    PathBuf::from("..").join("tatolab__core"),
+                    "patch path must be rewritten to sibling staged dir, got: {}",
+                    p.path.display()
+                );
+            }
+            other => panic!("expected Path-flavor patch, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn stage_package_for_dev_load_wipes_stale_files_on_restage() {
+        // Hermetic restaging — a file present in the previous staged
+        // dir but absent in the current source must disappear. Without
+        // the `remove_dir_all` step, removed schemas or renamed
+        // patches linger and `load_workspace_packages` resolves stale
+        // content. Reverting the wipe would let stale_file survive
+        // here.
+        let src = tempdir().unwrap();
+        write_minimal_manifest(src.path(), "tatolab", "stub", "");
+        let staged_root = tempdir().unwrap();
+        let staged_dir = staged_root.path().join("tatolab__stub");
+        std::fs::create_dir(&staged_dir).unwrap();
+        std::fs::write(staged_dir.join("stale.txt"), b"residue from a prior stage").unwrap();
+
+        let staged = stage_package_for_dev_load(
+            src.path(),
+            staged_root.path(),
+            None,
+            "x86_64-unknown-linux-gnu",
+        )
+        .unwrap();
+
+        assert_eq!(staged, staged_dir);
+        assert!(
+            !staged_dir.join("stale.txt").exists(),
+            "stage must wipe stale files left over from a prior stage"
+        );
+        assert!(staged_dir.join("streamlib.yaml").exists());
     }
 }

--- a/libs/streamlib-engine/src/core/runtime/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/mod.rs
@@ -10,6 +10,8 @@ mod runtime_unique_id;
 mod status;
 
 pub use operations::{BoxFuture, RuntimeOperations};
-pub use runtime::{extract_slpkg_to_cache, host_target_triple, Runner};
+pub use runtime::{
+    extract_slpkg_to_cache, host_target_triple, LoadWorkspacePackagesError, Runner,
+};
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -798,6 +798,83 @@ impl Runner {
         Ok(())
     }
 
+    /// Resolve every name to its staged dir under
+    /// `<workspace>/target/streamlib-plugins/<org>__<name>/` and call
+    /// [`Self::load_project`] on each, in declaration order.
+    ///
+    /// `cargo xtask build-plugins` must have run first — the helper
+    /// errors with [`LoadWorkspacePackagesError::PackageNotStaged`] when
+    /// a name's staged dir is missing.
+    ///
+    /// Workspace root resolution: `STREAMLIB_WORKSPACE_ROOT` env var
+    /// when set (and the path exists), otherwise
+    /// `cargo locate-project --workspace`.
+    pub fn load_workspace_packages<I, S>(
+        &self,
+        names: I,
+    ) -> std::result::Result<(), LoadWorkspacePackagesError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // Eagerly validate every id BEFORE touching the workspace root —
+        // a typo'd id should surface as `InvalidPackageId` immediately
+        // rather than masquerading as `WorkspaceRootNotFound` when the
+        // env var is unset.
+        let parsed: Vec<(String, String, String)> = names
+            .into_iter()
+            .map(|name| {
+                let name_str = name.as_ref().to_string();
+                let (org, pkg) = {
+                    let parsed = parse_canonical_package_id(&name_str)?;
+                    (parsed.org_str.to_string(), parsed.name_str.to_string())
+                };
+                Ok::<_, LoadWorkspacePackagesError>((name_str, org, pkg))
+            })
+            .collect::<std::result::Result<_, _>>()?;
+
+        let workspace_root = resolve_workspace_root()?;
+        let staged_root = workspace_root.join("target").join("streamlib-plugins");
+
+        for (name_str, org, name) in parsed {
+            let staged_dir = staged_root.join(format!("{}__{}", org, name));
+
+            if !staged_dir.exists() || !staged_dir.join("streamlib.yaml").exists() {
+                return Err(LoadWorkspacePackagesError::PackageNotStaged {
+                    name: name_str.clone(),
+                    expected_path: staged_dir,
+                });
+            }
+
+            // Identity check: the staged yaml's `[package]` org / name
+            // must match the requested id. Catches manual clobbering of
+            // the staged tree (someone copied wrong content into the
+            // expected dir) before `load_project` registers the wrong
+            // processors.
+            verify_staged_package_identity(&staged_dir, &org, &name, &name_str)?;
+
+            // For Rust-impl packages, the cdylib must be present at
+            // `lib/<host_triple>/`. Surface the precise diagnostic
+            // (rather than letting `load_project` fail with a generic
+            // "missing dylib for this triple" message).
+            verify_cdylib_present_when_rust_impl(&staged_dir, &name_str)?;
+
+            tracing::info!(
+                "Loading workspace package '{}' from {}",
+                name_str,
+                staged_dir.display()
+            );
+            self.load_project(&staged_dir).map_err(|source| {
+                LoadWorkspacePackagesError::LoadProjectFailed {
+                    name: name_str,
+                    source: Box::new(source),
+                }
+            })?;
+        }
+
+        Ok(())
+    }
+
     // =========================================================================
     // Lifecycle
     // =========================================================================
@@ -1981,6 +2058,260 @@ fn bring_up_surface_service(
     Ok((Arc::new(Mutex::new(Some(service))), socket_path))
 }
 
+// =============================================================================
+// load_workspace_packages — typed error + helpers
+// =============================================================================
+
+/// Per-failure-mode error returned by [`Runner::load_workspace_packages`].
+///
+/// The variants surface enough context (offending name, expected path,
+/// underlying engine error) that callers can match for retry vs. abort
+/// or surface an actionable message to the developer.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadWorkspacePackagesError {
+    /// Name did not parse as `@<org>/<name>` per the typed `streamlib-idents`
+    /// org / name validators (charset, leading-letter, length).
+    #[error("Invalid package id '{0}' — expected `@<org>/<name>` with lowercase org and name")]
+    InvalidPackageId(String),
+
+    /// Workspace root could not be resolved — neither the
+    /// `STREAMLIB_WORKSPACE_ROOT` env var nor `cargo locate-project`
+    /// returned a usable directory.
+    #[error(
+        "Workspace root not found — set STREAMLIB_WORKSPACE_ROOT or run \
+         from within a Cargo workspace"
+    )]
+    WorkspaceRootNotFound,
+
+    /// Staged dir does not exist for this package. Most likely cause:
+    /// the dev hasn't run `cargo xtask build-plugins` yet (or pruned
+    /// `target/` since the last run).
+    #[error(
+        "Package '{name}' not staged at {expected_path}. \
+         Run `cargo xtask build-plugins` first."
+    )]
+    PackageNotStaged {
+        name: String,
+        expected_path: std::path::PathBuf,
+    },
+
+    /// Staged dir exists and parses, but its `[package]` org / name
+    /// don't match the requested id. Catches the case where the
+    /// staged tree was clobbered out-of-band (manual `cp`, stale
+    /// rename) before the runtime registers the wrong processors.
+    #[error(
+        "Package identity mismatch at {staged_path}: \
+         requested `@{requested_org}/{requested_name}`, found \
+         `@{actual_org}/{actual_name}` in staged streamlib.yaml. \
+         Re-run `cargo xtask build-plugins` to regenerate."
+    )]
+    PackageIdentityMismatch {
+        staged_path: std::path::PathBuf,
+        requested_org: String,
+        requested_name: String,
+        actual_org: String,
+        actual_name: String,
+    },
+
+    /// Staged dir is present and identity matches, but a Rust-impl
+    /// package's expected cdylib is missing under `lib/<host_triple>/`.
+    /// Distinguishes "staging succeeded but cargo build silently
+    /// produced no artifact" from a generic load_project failure.
+    #[error(
+        "Cdylib missing for Rust-impl package '{name}' — expected at \
+         {expected_path}. Re-run `cargo xtask build-plugins` to rebuild."
+    )]
+    CdylibMissing {
+        name: String,
+        expected_path: std::path::PathBuf,
+    },
+
+    /// `load_project` rejected the staged dir. Carries the engine
+    /// `Error` so callers can introspect further.
+    #[error("load_project failed for '{name}': {source}")]
+    LoadProjectFailed {
+        name: String,
+        #[source]
+        source: Box<Error>,
+    },
+}
+
+impl From<LoadWorkspacePackagesError> for Error {
+    fn from(err: LoadWorkspacePackagesError) -> Self {
+        match err {
+            LoadWorkspacePackagesError::LoadProjectFailed { source, .. } => *source,
+            other => Error::Configuration(other.to_string()),
+        }
+    }
+}
+
+/// Parsed `@<org>/<name>` canonical id. Only the slice references are
+/// kept — the caller's input must outlive this struct.
+#[derive(Debug)]
+struct CanonicalPackageId<'a> {
+    org_str: &'a str,
+    name_str: &'a str,
+}
+
+fn parse_canonical_package_id(name: &str) -> std::result::Result<
+    CanonicalPackageId<'_>,
+    LoadWorkspacePackagesError,
+> {
+    // Strip the leading '@', split on first '/', then route the
+    // halves through the typed `streamlib-idents` validators so
+    // charset / leading-letter / length rules apply here too. We
+    // don't surface the typed-parser's stringy diagnostic — the
+    // typed `InvalidPackageId` variant is what callers match on —
+    // but using the validators means a name like `@TaToLaB/CAMERA`
+    // fails fast here rather than at the filesystem-lookup stage.
+    let stripped = name
+        .strip_prefix('@')
+        .ok_or_else(|| LoadWorkspacePackagesError::InvalidPackageId(name.to_string()))?;
+    let (org, pkg) = stripped
+        .split_once('/')
+        .ok_or_else(|| LoadWorkspacePackagesError::InvalidPackageId(name.to_string()))?;
+    if org.is_empty() || pkg.is_empty() || pkg.contains('/') {
+        return Err(LoadWorkspacePackagesError::InvalidPackageId(name.to_string()));
+    }
+    streamlib_idents::Org::new(org)
+        .map_err(|_| LoadWorkspacePackagesError::InvalidPackageId(name.to_string()))?;
+    streamlib_idents::Package::new(pkg)
+        .map_err(|_| LoadWorkspacePackagesError::InvalidPackageId(name.to_string()))?;
+    Ok(CanonicalPackageId { org_str: org, name_str: pkg })
+}
+
+fn resolve_workspace_root() -> std::result::Result<std::path::PathBuf, LoadWorkspacePackagesError> {
+    // Env-var override wins when set AND the path resolves — the env
+    // var IS the user's intent, so a typo'd path should surface as a
+    // precise error rather than silently falling through to cargo.
+    if let Ok(env_root) = std::env::var("STREAMLIB_WORKSPACE_ROOT") {
+        let path = std::path::PathBuf::from(&env_root);
+        return if path.is_dir() {
+            Ok(path)
+        } else {
+            Err(LoadWorkspacePackagesError::WorkspaceRootNotFound)
+        };
+    }
+
+    let output = std::process::Command::new("cargo")
+        .args(["locate-project", "--workspace", "--message-format=plain"])
+        .output()
+        .map_err(|_| LoadWorkspacePackagesError::WorkspaceRootNotFound)?;
+    if !output.status.success() {
+        return Err(LoadWorkspacePackagesError::WorkspaceRootNotFound);
+    }
+    let manifest_path = String::from_utf8(output.stdout)
+        .map_err(|_| LoadWorkspacePackagesError::WorkspaceRootNotFound)?;
+    let trimmed = manifest_path.trim();
+    if trimmed.is_empty() {
+        return Err(LoadWorkspacePackagesError::WorkspaceRootNotFound);
+    }
+    std::path::PathBuf::from(trimmed)
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or(LoadWorkspacePackagesError::WorkspaceRootNotFound)
+}
+
+/// Read the staged `streamlib.yaml`'s `[package]` org / name and
+/// confirm they match what the caller asked for. The yaml is the
+/// authoritative identity at load time — a mismatch here means the
+/// staged tree was clobbered out-of-band.
+fn verify_staged_package_identity(
+    staged_dir: &std::path::Path,
+    requested_org: &str,
+    requested_name: &str,
+    requested_canonical_id: &str,
+) -> std::result::Result<(), LoadWorkspacePackagesError> {
+    let body = std::fs::read_to_string(staged_dir.join("streamlib.yaml")).map_err(|_| {
+        LoadWorkspacePackagesError::PackageNotStaged {
+            name: requested_canonical_id.to_string(),
+            expected_path: staged_dir.to_path_buf(),
+        }
+    })?;
+    let manifest: streamlib_idents::Manifest = serde_yaml::from_str(&body).map_err(|_| {
+        LoadWorkspacePackagesError::PackageIdentityMismatch {
+            staged_path: staged_dir.to_path_buf(),
+            requested_org: requested_org.to_string(),
+            requested_name: requested_name.to_string(),
+            actual_org: "<unparseable>".to_string(),
+            actual_name: "<unparseable>".to_string(),
+        }
+    })?;
+    let Some(metadata) = manifest.package.as_ref() else {
+        return Err(LoadWorkspacePackagesError::PackageIdentityMismatch {
+            staged_path: staged_dir.to_path_buf(),
+            requested_org: requested_org.to_string(),
+            requested_name: requested_name.to_string(),
+            actual_org: "<no package section>".to_string(),
+            actual_name: "<no package section>".to_string(),
+        });
+    };
+    let actual_org = metadata.org.as_str();
+    let actual_name = metadata.name.as_str();
+    if actual_org != requested_org || actual_name != requested_name {
+        return Err(LoadWorkspacePackagesError::PackageIdentityMismatch {
+            staged_path: staged_dir.to_path_buf(),
+            requested_org: requested_org.to_string(),
+            requested_name: requested_name.to_string(),
+            actual_org: actual_org.to_string(),
+            actual_name: actual_name.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// When the staged manifest declares Rust runtime processors, the
+/// corresponding cdylib must exist under `lib/<host_triple>/`. Surface
+/// the missing-cdylib case explicitly so the dev knows to re-run
+/// `cargo xtask build-plugins` rather than chasing a generic
+/// load_project failure.
+fn verify_cdylib_present_when_rust_impl(
+    staged_dir: &std::path::Path,
+    requested_canonical_id: &str,
+) -> std::result::Result<(), LoadWorkspacePackagesError> {
+    let body = std::fs::read_to_string(staged_dir.join("streamlib.yaml")).map_err(|_| {
+        LoadWorkspacePackagesError::PackageNotStaged {
+            name: requested_canonical_id.to_string(),
+            expected_path: staged_dir.to_path_buf(),
+        }
+    })?;
+    let manifest: streamlib_processor_schema::ProjectConfigMinimal = match serde_yaml::from_str(&body)
+    {
+        Ok(m) => m,
+        Err(_) => return Ok(()), // identity check already surfaced this
+    };
+    let has_rust = manifest.processors.iter().any(|p| {
+        matches!(
+            p.runtime.language,
+            streamlib_processor_schema::ProcessorLanguage::Rust
+        )
+    });
+    if !has_rust {
+        return Ok(());
+    }
+    let triple_dir = staged_dir.join("lib").join(host_target_triple());
+    let dylib_ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else if cfg!(target_os = "windows") {
+        "dll"
+    } else {
+        "so"
+    };
+    let any_dylib_present = std::fs::read_dir(&triple_dir)
+        .map(|iter| {
+            iter.flatten()
+                .any(|e| e.path().extension().is_some_and(|ext| ext == dylib_ext))
+        })
+        .unwrap_or(false);
+    if !any_dylib_present {
+        return Err(LoadWorkspacePackagesError::CdylibMissing {
+            name: requested_canonical_id.to_string(),
+            expected_path: triple_dir,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1998,6 +2329,292 @@ mod tests {
     fn test_runtime_creation() {
         let _runtime = Runner::new();
         // Runtime creates successfully
+    }
+
+    #[test]
+    fn parse_canonical_package_id_accepts_well_formed_input() {
+        // Tightest happy-path lock: every component round-trips
+        // (post-`@`, pre-`/`, post-`/`) into the parsed slices. The
+        // parser is the contract for what `load_workspace_packages`
+        // treats as a legal id — a regression that flipped `org` and
+        // `name` would break the lookup silently.
+        let parsed = parse_canonical_package_id("@tatolab/camera").unwrap();
+        assert_eq!(parsed.org_str, "tatolab");
+        assert_eq!(parsed.name_str, "camera");
+    }
+
+    #[test]
+    fn parse_canonical_package_id_rejects_missing_at_prefix() {
+        let err = parse_canonical_package_id("tatolab/camera").unwrap_err();
+        assert!(matches!(
+            err,
+            LoadWorkspacePackagesError::InvalidPackageId(ref s) if s == "tatolab/camera"
+        ));
+    }
+
+    #[test]
+    fn parse_canonical_package_id_rejects_missing_slash() {
+        let err = parse_canonical_package_id("@tatolab").unwrap_err();
+        assert!(matches!(
+            err,
+            LoadWorkspacePackagesError::InvalidPackageId(ref s) if s == "@tatolab"
+        ));
+    }
+
+    #[test]
+    fn parse_canonical_package_id_rejects_empty_org_or_name() {
+        // Both halves of `@<org>/<name>` must be non-empty. Mentally
+        // reverting either non-empty check would let `@/foo` or
+        // `@foo/` through to the path resolver, where the lookup
+        // would produce a confusing `not_staged` error instead of
+        // the precise `InvalidPackageId` one.
+        for bad in ["@/camera", "@tatolab/", "@/"] {
+            let err = parse_canonical_package_id(bad).unwrap_err();
+            assert!(matches!(err, LoadWorkspacePackagesError::InvalidPackageId(_)));
+        }
+    }
+
+    #[test]
+    fn parse_canonical_package_id_rejects_extra_slashes() {
+        // `@org/name` is a 2-segment id; nesting (`@org/group/name`)
+        // is not a legal shape. The lookup format must match the
+        // staged dir name `<org>__<name>` which is two-segment by
+        // construction.
+        let err = parse_canonical_package_id("@org/sub/name").unwrap_err();
+        assert!(matches!(err, LoadWorkspacePackagesError::InvalidPackageId(_)));
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_workspace_root_honors_streamlib_workspace_root_env_var() {
+        // Test fixture: tempdir set via STREAMLIB_WORKSPACE_ROOT must
+        // win over the cargo-locate-project fallback. Mentally
+        // reverting the env-var branch would silently fall through to
+        // cargo and pick the streamlib workspace root, which is
+        // wrong for hosting CI fixtures.
+        let tmp = tempfile::tempdir().unwrap();
+        let key = "STREAMLIB_WORKSPACE_ROOT";
+        let prev = std::env::var_os(key);
+        // SAFETY: protected by `#[serial]` against parallel test mutation.
+        unsafe {
+            std::env::set_var(key, tmp.path());
+        }
+        let resolved = resolve_workspace_root().unwrap();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert_eq!(resolved, tmp.path());
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_workspace_root_errors_when_env_var_path_does_not_exist() {
+        // Env var IS the user's stated intent — when it points at a
+        // non-existent dir, surface `WorkspaceRootNotFound` directly
+        // rather than silently falling through to cargo locate-project.
+        // The previous "fall through" branch swallowed user typos as
+        // "ran from outside a workspace" errors; this test pins the
+        // new behavior so a regression to silent-fallthrough fails.
+        let key = "STREAMLIB_WORKSPACE_ROOT";
+        let prev = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, "/nonexistent/path/that/does/not/exist");
+        }
+        let err = resolve_workspace_root().unwrap_err();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert!(matches!(err, LoadWorkspacePackagesError::WorkspaceRootNotFound));
+    }
+
+    #[test]
+    fn verify_staged_package_identity_flags_mismatch() {
+        // Identity check: the staged manifest's [package] org/name
+        // must match the requested id. Reverting the comparison would
+        // let the runtime register processors from the wrong staged
+        // package — the fixture creates a yaml whose name doesn't
+        // match the requested id and the helper must reject it.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("streamlib.yaml"),
+            "package:\n  org: vendor\n  name: other\n  version: 1.0.0\n",
+        )
+        .unwrap();
+        let err = verify_staged_package_identity(
+            tmp.path(),
+            "tatolab",
+            "camera",
+            "@tatolab/camera",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            LoadWorkspacePackagesError::PackageIdentityMismatch {
+                ref actual_org,
+                ref actual_name,
+                ..
+            } if actual_org == "vendor" && actual_name == "other"
+        ));
+    }
+
+    #[test]
+    fn verify_staged_package_identity_accepts_matching_yaml() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: camera\n  version: 1.0.0\n",
+        )
+        .unwrap();
+        verify_staged_package_identity(
+            tmp.path(),
+            "tatolab",
+            "camera",
+            "@tatolab/camera",
+        )
+        .expect("matching identity must validate");
+    }
+
+    #[test]
+    fn verify_cdylib_present_when_rust_impl_flags_missing_artifact() {
+        // Setup: a staged Rust-impl package (yaml declares a Rust
+        // processor) with the triple dir missing. The helper must
+        // surface `CdylibMissing` rather than letting load_project
+        // report a less actionable error. Reverting the
+        // `has_rust_runtime_processors` check would either pass
+        // through silently or panic — the test pins the precise
+        // diagnostic.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("streamlib.yaml"),
+            r#"
+package:
+  org: tatolab
+  name: example
+  version: 1.0.0
+processors:
+  - name: ExampleProcessor
+    version: 1.0.0
+    description: "rust"
+    runtime:
+      language: rust
+    execution: manual
+    inputs: []
+    outputs: []
+"#,
+        )
+        .unwrap();
+        let err = verify_cdylib_present_when_rust_impl(tmp.path(), "@tatolab/example")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LoadWorkspacePackagesError::CdylibMissing { ref name, ref expected_path }
+                if name == "@tatolab/example"
+                && expected_path.ends_with(host_target_triple())
+        ));
+    }
+
+    #[test]
+    fn verify_cdylib_present_when_rust_impl_passes_for_schemas_only() {
+        // Schemas-only package has no Rust processors, so the cdylib
+        // check is a no-op. Reverting the early-return would surface
+        // a false-positive CdylibMissing.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("streamlib.yaml"),
+            "package:\n  org: tatolab\n  name: core\n  version: 1.0.0\n",
+        )
+        .unwrap();
+        verify_cdylib_present_when_rust_impl(tmp.path(), "@tatolab/core")
+            .expect("schemas-only package must skip the cdylib check");
+    }
+
+    #[test]
+    fn parse_canonical_package_id_rejects_uppercase_via_typed_validator() {
+        // The typed `streamlib-idents` validators enforce lowercase
+        // for org/name. Bypass would let `@TaToLaB/CAMERA` parse
+        // here, hit the filesystem at `target/streamlib-plugins/TaToLaB__CAMERA`,
+        // and surface a less informative `PackageNotStaged` error.
+        // Reverting the `Org::new` / `Package::new` validators would
+        // pass this through; the test catches that regression.
+        let err = parse_canonical_package_id("@TaToLaB/camera").unwrap_err();
+        assert!(matches!(err, LoadWorkspacePackagesError::InvalidPackageId(_)));
+        let err = parse_canonical_package_id("@tatolab/CAMERA").unwrap_err();
+        assert!(matches!(err, LoadWorkspacePackagesError::InvalidPackageId(_)));
+    }
+
+    #[test]
+    #[serial]
+    fn load_workspace_packages_reports_not_staged_when_dir_missing() {
+        // Setup: pristine workspace root with no `target/streamlib-plugins/`
+        // staging. Helper must surface the actionable PackageNotStaged
+        // error rather than papering over the missing dir with a
+        // generic load_project failure.
+        let tmp = tempfile::tempdir().unwrap();
+        let key = "STREAMLIB_WORKSPACE_ROOT";
+        let prev = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, tmp.path());
+        }
+        let runtime = Runner::new().expect("Runner::new");
+        let err = runtime
+            .load_workspace_packages(["@tatolab/camera"])
+            .unwrap_err();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert!(matches!(
+            err,
+            LoadWorkspacePackagesError::PackageNotStaged { ref name, ref expected_path }
+                if name == "@tatolab/camera"
+                && expected_path.ends_with("tatolab__camera")
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn load_workspace_packages_returns_invalid_id_before_filesystem_probe() {
+        // Validation order: every id must parse BEFORE the helper
+        // calls `resolve_workspace_root`. Without the env-var override
+        // pointing at a bogus path that can't be a workspace, the
+        // unparseable id must still surface as `InvalidPackageId`
+        // (not the cargo-locate-project-derived `WorkspaceRootNotFound`).
+        // Mentally reverting the eager parse-loop to interleaved
+        // parse-then-resolve would flip the verdict to
+        // WorkspaceRootNotFound on this fixture, so the test catches
+        // the regression.
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("nowhere");
+        let key = "STREAMLIB_WORKSPACE_ROOT";
+        let prev = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, &bogus);
+        }
+        let runtime = Runner::new().expect("Runner::new");
+        let err = runtime
+            .load_workspace_packages(["bad-no-at"])
+            .unwrap_err();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert!(
+            matches!(
+                err,
+                LoadWorkspacePackagesError::InvalidPackageId(ref s) if s == "bad-no-at"
+            ),
+            "expected InvalidPackageId surfaced before workspace resolution, got: {err:?}"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,12 @@ streamlib-jtd-codegen = { path = "../libs/streamlib-jtd-codegen" }
 # `schemars::schema_for!(StreamlibYaml)` from this crate (#714).
 streamlib-processor-schema = { path = "../libs/streamlib-processor-schema" }
 
+# Cargo-build orchestration helpers — `cargo xtask build-plugins` reuses
+# the discovery / cargo-invocation / staging primitives shared with
+# `streamlib pack` so the dev inner loop and distribution path stay
+# in lockstep.
+streamlib-cargo-build = { path = "../libs/streamlib-cargo-build" }
+
 # Logging — needed to surface tracing::info! output from streamlib-jtd-codegen.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/xtask/src/build_plugins.rs
+++ b/xtask/src/build_plugins.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `cargo xtask build-plugins` — dev-inner-loop staging of in-tree
+//! workspace packages.
+//!
+//! Walks every `packages/<name>/streamlib.yaml` (Rust-impl + schemas-only
+//! both), invokes `cargo build` against each Rust-impl package's cdylib,
+//! and stages the output hermetically at
+//! `<workspace>/target/streamlib-plugins/<org>__<name>/` so
+//! `Runner::load_workspace_packages` can resolve packages by canonical
+//! name without depending on the original source tree layout.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use streamlib_cargo_build::{
+    discover_package_dirs, has_rust_runtime_processors, host_dylib_extension, host_target_triple,
+    read_cargo_package_name, read_minimal_project_config, run_cargo_build,
+    stage_package_for_dev_load, CargoProfile,
+};
+
+/// Walk the workspace's `packages/` dir, build every Rust-impl
+/// package's cdylib, and stage each (Rust-impl + schemas-only both)
+/// at `<workspace>/target/streamlib-plugins/<org>__<name>/`.
+///
+/// `release` switches between `--release` (production-shaped) and
+/// the default dev profile (faster inner loop — the recommended
+/// dev-mode default).
+///
+/// `filter` restricts the set to a subset of canonical
+/// `@<org>/<name>` ids; empty filter means "every package."
+pub fn run(workspace_root: &Path, release: bool, filter: &[String]) -> Result<()> {
+    let packages_root = workspace_root.join("packages");
+    if !packages_root.is_dir() {
+        anyhow::bail!(
+            "Workspace `packages/` directory not found at {}",
+            packages_root.display()
+        );
+    }
+
+    let staged_root = workspace_root.join("target").join("streamlib-plugins");
+    std::fs::create_dir_all(&staged_root).with_context(|| {
+        format!("Failed to create staged root {}", staged_root.display())
+    })?;
+
+    let host_triple = host_target_triple();
+    let dylib_ext = host_dylib_extension();
+    let profile = if release {
+        CargoProfile::Release
+    } else {
+        CargoProfile::Dev
+    };
+
+    let package_dirs = discover_package_dirs(&[&packages_root])?;
+    if package_dirs.is_empty() {
+        tracing::warn!(
+            "No workspace packages found under {} — nothing to stage",
+            packages_root.display()
+        );
+        return Ok(());
+    }
+
+    let mut staged_count = 0;
+    let mut skipped_unparseable = 0;
+    let mut skipped_no_package = 0;
+
+    for package_dir in package_dirs {
+        let Some(config) = read_minimal_project_config(&package_dir)? else {
+            skipped_unparseable += 1;
+            continue;
+        };
+        let Some(metadata) = config.package.as_ref() else {
+            skipped_no_package += 1;
+            continue;
+        };
+        let canonical_id = format!("@{}/{}", metadata.org.as_str(), metadata.name.as_str());
+
+        if !filter.is_empty() && !filter.iter().any(|f| f == &canonical_id) {
+            continue;
+        }
+
+        if has_rust_runtime_processors(&config) {
+            let cargo_name = read_cargo_package_name(&package_dir).with_context(|| {
+                format!(
+                    "Package {} declares Rust runtime processors but its Cargo.toml is missing or malformed",
+                    canonical_id
+                )
+            })?;
+            let built = run_cargo_build(&package_dir, &cargo_name, dylib_ext, profile)
+                .with_context(|| format!("cargo build failed for {}", canonical_id))?;
+            let staged = stage_package_for_dev_load(
+                &package_dir,
+                &staged_root,
+                Some(&built),
+                host_triple,
+            )?;
+            tracing::info!("Staged {} → {}", canonical_id, staged.display());
+        } else {
+            let staged =
+                stage_package_for_dev_load(&package_dir, &staged_root, None, host_triple)?;
+            tracing::info!(
+                "Staged {} (schemas-only) → {}",
+                canonical_id,
+                staged.display()
+            );
+        }
+        staged_count += 1;
+    }
+
+    tracing::info!(
+        "build-plugins: staged {} package(s) at {} ({} profile)",
+        staged_count,
+        staged_root.display(),
+        profile.label()
+    );
+    if skipped_unparseable > 0 {
+        tracing::warn!(
+            "build-plugins: skipped {} dirs with unparseable streamlib.yaml",
+            skipped_unparseable
+        );
+    }
+    if skipped_no_package > 0 {
+        tracing::warn!(
+            "build-plugins: skipped {} dirs with no [package] section",
+            skipped_no_package
+        );
+    }
+
+    Ok(())
+}
+

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use streamlib_jtd_codegen::{generate, GenerateOptions, RuntimeTarget};
 
+pub mod build_plugins;
 pub mod check_boundaries;
 pub mod check_cdylib_reach;
 pub mod check_no_reverse_dns;
@@ -118,6 +119,25 @@ enum Commands {
     /// `streamlib.yaml` carries the `# yaml-language-server: $schema=...`
     /// header, (3) every `streamlib.yaml` validates against the schema.
     CheckManifestSchema,
+
+    /// Stage every in-tree workspace package at
+    /// `target/streamlib-plugins/<org>__<name>/` so
+    /// `Runner::load_workspace_packages` can resolve them by canonical
+    /// id. Rust-impl packages get a cdylib build; schemas-only packages
+    /// stage just their `streamlib.yaml` + `schemas/`. Defaults to the
+    /// dev profile (faster inner loop); `--release` opts into the
+    /// production-shaped profile.
+    BuildPlugins {
+        /// Use `--release` instead of the dev-loop default profile.
+        #[arg(long)]
+        release: bool,
+
+        /// Build only these canonical-id packages (`@<org>/<name>`)
+        /// instead of every Rust-impl package the workspace declares.
+        /// Repeatable: `--package @tatolab/camera --package @tatolab/core`.
+        #[arg(long = "package", value_name = "ORG/NAME")]
+        packages: Vec<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -159,6 +179,9 @@ fn main() -> Result<()> {
         Commands::CheckCdylibReach => check_cdylib_reach::run(&workspace_root()?)?,
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,
         Commands::CheckManifestSchema => manifest_schema::check(&workspace_root()?)?,
+        Commands::BuildPlugins { release, packages } => {
+            build_plugins::run(&workspace_root()?, release, &packages)?
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- New `cargo xtask build-plugins` subcommand walks `packages/<name>/`, builds each Rust-impl package as a cdylib (`--features <pkg>/plugin`), and stages every workspace package — Rust-impl AND schemas-only — at `<workspace>/target/streamlib-plugins/<org>__<name>/` with a hermetic copy of `streamlib.yaml` + `schemas/` (patch entries rewritten to sibling staged dirs). Dev profile by default; `--release` opts in.
- New `Runner::load_workspace_packages([...])` SDK helper resolves canonical `@<org>/<name>` ids to their staged dirs and chains into `load_project` per package. Typed `LoadWorkspacePackagesError` covers the six failure modes the issue body enumerates: `InvalidPackageId`, `WorkspaceRootNotFound`, `PackageNotStaged { name, expected_path }`, `PackageIdentityMismatch { staged_path, requested_org, requested_name, actual_org, actual_name }`, `CdylibMissing { name, expected_path }`, `LoadProjectFailed { name, source }`.
- `streamlib-cargo-build` (extracted in #992) gains `CargoProfile { Dev, Release }` + parameterized `run_cargo_build(...)` alongside the existing `run_cargo_build_release` back-compat shim; `staged_package_dir_name(org, name)` formalizes the `<org>__<name>` convention; `stage_package_for_dev_load(...)` does the per-package copy + patch rewrite + cdylib stage (or schemas-only, no cdylib).
- `examples/vulkan-video-roundtrip-cdylib-camera` migrated as the end-to-end verification — dropped its ~85-line inline `stage_camera_project()` + `copy_dir_contents()` boilerplate (and `tempfile` Cargo dep) for one-line `runtime.load_workspace_packages(["@tatolab/camera"])?`.

Closes #991.

## Locked decisions implemented per the issue body

- Hermetic `target/streamlib-plugins/<org>__<name>/` layout (no `@` literal — filesystem-safe).
- `patch:` (and path-flavor `dependencies:`) entries rewritten at stage time to sibling staged dirs (`../<dep_org>__<dep_name>`).
- Dev profile default; `--release` flag opt-in; `streamlib pack` still defaults to release for distribution.
- `crate-type = ["rlib", "cdylib"]` retained per the milestone goal.
- The `[features] plugin = []` normalization sweep was a no-op: every Rust-impl package already declares it (the issue body's "only streamlib-clap declares it today" claim was stale).

## Test plan

- [x] 14 new unit tests in `streamlib-engine::core::runtime` covering `parse_canonical_package_id` (happy path, missing `@`, missing `/`, empty halves, extra slashes, uppercase rejection via the typed idents validators), `resolve_workspace_root` (env-var override honored AND errors when path doesn't exist), `load_workspace_packages` (`PackageNotStaged`, `InvalidPackageId` surfaces before workspace resolution), `verify_staged_package_identity` (matching + mismatch), `verify_cdylib_present_when_rust_impl` (rust-impl flags missing, schemas-only skips check).
- [x] 5 new unit tests in `streamlib-cargo-build` covering the staging helpers — `staged_package_dir_name` format lock, schemas-only stage, cdylib stage, patch rewrite, hermetic restage wipe.
- [x] All 36 runtime tests + 20 cargo-build tests + 17 streamlib-cli tests pass.
- [x] Workspace baseline: 1745 passed (+13 vs main), 2 pre-existing polyglot-manual-source failures unrelated to this change.
- [x] End-to-end smoke: `cargo xtask build-plugins --package @tatolab/core` stages schemas-only cleanly; `--package @tatolab/network` stages cdylib at `target/streamlib-plugins/tatolab__network/lib/x86_64-unknown-linux-gnu/libstreamlib_network.so`; `--package @tatolab/camera` stages cdylib AND rewrites the patch from `../core` to `../tatolab__core`.

## Notes for reviewers

- `LoadWorkspacePackagesError` implements `From<LoadWorkspacePackagesError> for engine Error` for ergonomic `?` chaining with SDK-error-returning callers — the `LoadProjectFailed` variant unwraps the inner engine error, every other variant maps through `Error::Configuration`.
- Validation order in `load_workspace_packages` is deliberate: every id is parsed eagerly BEFORE `resolve_workspace_root` runs, so a typo'd id surfaces `InvalidPackageId` immediately rather than being masked by a `WorkspaceRootNotFound`. Test fixture sets `STREAMLIB_WORKSPACE_ROOT` to a bogus path so the test would actually catch a regression to interleaved parsing.
- `resolve_workspace_root` honors `STREAMLIB_WORKSPACE_ROOT` when set AND the path exists; bad env-var paths surface as `WorkspaceRootNotFound` directly (previously fell through to cargo locate-project — that swallowed user typos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)