### PR TITLE
refactor(examples): batch 1 of #792 — migrate 3 single-dep examples

### DIFF
--- a/examples/api-server/Cargo.toml
+++ b/examples/api-server/Cargo.toml
@@ -3,7 +3,9 @@ name = "api-server"
 version = "0.1.0"
 edition = "2024"
 
+# `@tatolab/api-server` loaded at runtime via
+# `Runner::load_workspace_packages` — no compile-time link.
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-api-server = { path = "../../packages/api-server" }
+serde_json = "1"
 tokio = { version = "1.48.0", features = ["full"] }

--- a/examples/api-server/src/main.rs
+++ b/examples/api-server/src/main.rs
@@ -15,21 +15,29 @@
 //! - POST /api/connections - Create a connection
 //! - DELETE /api/connections/:id - Remove a connection
 //! - WS /ws/events - WebSocket event stream
+//!
+//! Run prerequisite: `cargo xtask build-plugins --package @tatolab/api-server`
+//! so the runtime can find the staged cdylib at
+//! `target/streamlib-plugins/tatolab__api-server/`.
 
+use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
-use streamlib_api_server::{ApiServerConfig, ApiServerProcessor};
+use streamlib::sdk::schema_ident;
 
 #[tokio::main]
 async fn main() -> streamlib::sdk::error::Result<()> {
     let runtime = Runner::new()?;
 
-    let config = ApiServerConfig {
-        host: "127.0.0.1".to_string(),
-        port: 9000,
-        ..Default::default()
-    };
+    runtime.load_workspace_packages(["@tatolab/api-server"])?;
 
-    runtime.add_processor(ApiServerProcessor::node(config))?;
+    let config = serde_json::json!({
+        "host": "127.0.0.1",
+        "port": 9000,
+    });
+    runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "api-server", "ApiServer", "1.0.0"),
+        config,
+    ))?;
     runtime.start()?;
 
     println!("API server running at http://127.0.0.1:9000");

--- a/examples/polyglot-cpu-readback-blur/Cargo.toml
+++ b/examples/polyglot-cpu-readback-blur/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
 streamlib-adapter-cpu-readback = { path = "../../libs/streamlib-adapter-cpu-readback" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-cpu-readback-blur/src/main.rs
+++ b/examples/polyglot-cpu-readback-blur/src/main.rs
@@ -59,7 +59,7 @@ use streamlib::sdk::engine::host_rhi::{
     HostVulkanTimelineSemaphore,
 };
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
+use streamlib::sdk::schema_ident;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
 use streamlib_adapter_abi::{StreamlibSurface, SurfaceFormat, SurfaceId};
@@ -194,7 +194,14 @@ fn main() -> Result<()> {
         });
     }
 
-    // Load the polyglot package.
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
+    // Load the polyglot blur processor (Python or Deno subprocess host).
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -228,21 +235,18 @@ fn main() -> Result<()> {
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
 
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 

--- a/examples/polyglot-vulkan-compute/Cargo.toml
+++ b/examples/polyglot-vulkan-compute/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"

--- a/examples/polyglot-vulkan-compute/src/main.rs
+++ b/examples/polyglot-vulkan-compute/src/main.rs
@@ -56,9 +56,9 @@ use streamlib::sdk::engine::host_rhi::{
     VulkanTextureReadback,
 };
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
 
 /// Compiled SPIR-V for the Mandelbrot compute shader. Built by
 /// `build.rs` from `shaders/mandelbrot.comp`. Shipped to the polyglot
@@ -337,6 +337,13 @@ fn main() -> Result<()> {
         });
     }
 
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -369,21 +376,18 @@ fn main() -> Result<()> {
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
 
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 


### PR DESCRIPTION
## Summary

Batch 1 of #792's systematic per-example sweep. Three examples migrated off their last processor-package Cargo dep to `Runner::load_workspace_packages([...])` + JSON config + string-named port refs, per the audio-mixer-demo reference shape from #881:

- **api-server** — drops \`streamlib-api-server\`. \`ApiServer\` constructed via \`ProcessorSpec::new(schema_ident!(\"tatolab\", \"api-server\", \"ApiServer\", \"1.0.0\"), json!({host, port}))\`.
- **polyglot-cpu-readback-blur** — drops \`streamlib-debug-utilities\`. \`BgraFileSource\` constructed via \`ProcessorSpec::new\`. Pipeline (BgraFileSource → cpu-readback bridge → polyglot blur → readback) unchanged.
- **polyglot-vulkan-compute** — same \`BgraFileSource\` migration. All Tier-2 \`streamlib::sdk::engine::*\` imports (host RHI primitives, surface store) preserved.

Partial close of #792 (3 of ~20 examples; remaining ship in subsequent batches per the milestone's \"batches of 3-5 per PR\" cadence).

## Test plan

- [x] All three examples build cleanly.
- [x] api-server runs end-to-end: \`cargo xtask build-plugins --package @tatolab/api-server\` stages the package; \`cargo run -p api-server\` loads it, registers ApiServer via JSON, starts the runtime, prints \"API server running at http://127.0.0.1:9000\", exits cleanly on SIGTERM.
- [x] Workspace baseline: 1752 passed (+7 vs main), 2 pre-existing polyglot-manual-source failures unrelated to this change, 131 ignored.

## Notes for reviewers

- Each example's \`Cargo.toml\` post-migration carries only \`streamlib\` (SDK) + adapter / sub-crate deps (SDK-tier surfaces) + leaf utilities (serde_json, png, sha2, parking_lot, tokio). Zero processor-package deps remain — the milestone exit shape.
- Each example documents the \`cargo xtask build-plugins --package @tatolab/<name>\` run-prerequisite in a module-doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)