### PR TITLE
refactor(examples): batch 2 of #792 — migrate 5 polyglot examples

### DIFF
--- a/examples/polyglot-cuda-inference/Cargo.toml
+++ b/examples/polyglot-cuda-inference/Cargo.toml
@@ -11,5 +11,4 @@ publish = false
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
 streamlib-adapter-cuda = { path = "../../libs/streamlib-adapter-cuda" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"

--- a/examples/polyglot-cuda-inference/src/main.rs
+++ b/examples/polyglot-cuda-inference/src/main.rs
@@ -62,7 +62,7 @@ use streamlib::sdk::engine::host_rhi::{
     HostVulkanTimelineSemaphore,
 };
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
+use streamlib::sdk::schema_ident;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
 use streamlib_adapter_abi::SurfaceId;
@@ -182,7 +182,14 @@ fn main() -> Result<()> {
         });
     }
 
-    // Load the polyglot package.
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
+    // Load the polyglot CUDA-inference processor (Python or Deno subprocess host).
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -216,21 +223,18 @@ fn main() -> Result<()> {
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
 
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 

--- a/examples/polyglot-opengl-fragment-shader/Cargo.toml
+++ b/examples/polyglot-opengl-fragment-shader/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-opengl-fragment-shader/src/main.rs
+++ b/examples/polyglot-opengl-fragment-shader/src/main.rs
@@ -38,9 +38,9 @@ use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
 
 /// UUID the host registers the render-target surface under. The
 /// polyglot processor reads it from its config and passes it to
@@ -220,7 +220,14 @@ fn main() -> Result<()> {
         });
     }
 
-    // Load the polyglot package.
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
+    // Load the polyglot fragment-shader processor (Python or Deno subprocess host).
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -253,21 +260,18 @@ fn main() -> Result<()> {
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
 
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 

--- a/examples/polyglot-skia-canvas/Cargo.toml
+++ b/examples/polyglot-skia-canvas/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 

--- a/examples/polyglot-skia-canvas/src/main.rs
+++ b/examples/polyglot-skia-canvas/src/main.rs
@@ -59,7 +59,7 @@ use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::error::Error;
 use streamlib::sdk::engine::host_rhi::{HostVulkanTimelineSemaphore, VulkanTextureReadback};
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
+use streamlib::sdk::schema_ident;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
 
@@ -181,6 +181,13 @@ fn main() -> Result<()> {
         });
     }
 
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let slpkg_path =
         manifest_dir.join("python/polyglot-skia-canvas-0.1.0.slpkg");
@@ -195,21 +202,18 @@ fn main() -> Result<()> {
 
     let fixture_path =
         write_trigger_fixture().map_err(Error::Configuration)?;
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: FPS,
-            frame_count: FRAME_COUNT,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": FPS,
+            "frame_count": FRAME_COUNT,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 

--- a/examples/polyglot-vulkan-graphics/Cargo.toml
+++ b/examples/polyglot-vulkan-graphics/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"

--- a/examples/polyglot-vulkan-graphics/src/main.rs
+++ b/examples/polyglot-vulkan-graphics/src/main.rs
@@ -87,7 +87,7 @@ use streamlib::sdk::engine::host_rhi::{
     VulkanTextureReadback,
 };
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
+use streamlib::sdk::schema_ident;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
 
@@ -658,6 +658,13 @@ fn main() -> Result<()> {
         });
     }
 
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -685,21 +692,18 @@ fn main() -> Result<()> {
 
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 

--- a/examples/polyglot-vulkan-ray-tracing/Cargo.toml
+++ b/examples/polyglot-vulkan-ray-tracing/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 streamlib-adapter-abi = { path = "../../libs/streamlib-adapter-abi" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
 serde_json = "1.0"
 png = "0.17"
 parking_lot = "0.12"

--- a/examples/polyglot-vulkan-ray-tracing/src/main.rs
+++ b/examples/polyglot-vulkan-ray-tracing/src/main.rs
@@ -80,7 +80,7 @@ use streamlib::sdk::engine::host_rhi::{
     VulkanTextureReadback,
 };
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_debug_utilities::BgraFileSourceProcessor;
+use streamlib::sdk::schema_ident;
 use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
 
@@ -637,6 +637,13 @@ fn main() -> Result<()> {
         });
     }
 
+    // Load the BgraFileSource processor from `@tatolab/debug-utilities`
+    // at runtime — `cargo xtask build-plugins --package @tatolab/debug-utilities`
+    // must have run first.
+    runtime
+        .load_workspace_packages(["@tatolab/debug-utilities"])
+        .map_err(streamlib::sdk::error::Error::from)?;
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     match runtime_kind {
         RuntimeKind::Python => {
@@ -664,21 +671,18 @@ fn main() -> Result<()> {
 
     let fixture_path = write_trigger_fixture()
         .map_err(Error::Configuration)?;
-    let source = runtime.add_processor(BgraFileSourceProcessor::Processor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: fixture_path
-                .to_str()
-                .ok_or_else(|| {
-                    Error::Configuration(
-                        "fixture path has non-utf8 component".into(),
-                    )
-                })?
-                .to_string(),
-            width: 4,
-            height: 4,
-            fps: 5,
-            frame_count: 3,
-        },
+    let fixture_path_str = fixture_path
+        .to_str()
+        .ok_or_else(|| Error::Configuration("fixture path has non-utf8 component".into()))?;
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": fixture_path_str,
+            "width": 4,
+            "height": 4,
+            "fps": 5,
+            "frame_count": 3,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 


### PR DESCRIPTION
## Summary

Batch 2 of #792. Five polyglot examples each drop their last processor-package Cargo dep (\`streamlib-debug-utilities\`) and load \`@tatolab/debug-utilities\` at runtime via \`Runner::load_workspace_packages\`. All five used \`BgraFileSourceProcessor\` as a trigger source — uniform migration shape per the audio-mixer-demo reference (#881) and batch 1.

- polyglot-opengl-fragment-shader
- polyglot-skia-canvas
- polyglot-vulkan-graphics
- polyglot-vulkan-ray-tracing
- polyglot-cuda-inference

Each example's post-migration \`[dependencies]\` carries only \`streamlib\` (SDK) + adapter / sub-crate (SDK-tier) + leaf utilities. Zero processor-package deps remain.

Cumulative progress on #792: 9 of ~20 examples migrated (audio-mixer-demo via #881; api-server, polyglot-cpu-readback-blur, polyglot-vulkan-compute via batch 1; this batch's 5).

## Test plan

- [x] All 5 examples build cleanly.
- [x] Workspace baseline: 1752 passed, 2 pre-existing polyglot-manual-source failures unrelated to this change, 131 ignored.
- [x] Migration shape verified uniform across the 5 examples: \`schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0")\` + JSON config matching the JTD schema at \`packages/debug-utilities/schemas/bgra_file_source_config.yaml\`; \`load_workspace_packages\` call positioned before the polyglot subprocess load in every example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)