### PR TITLE
refactor(examples): batch 4 of #792 — migrate 3 vulkan-video examples

### DIFF
--- a/examples/vulkan-video-psnr/Cargo.toml
+++ b/examples/vulkan-video-psnr/Cargo.toml
@@ -5,8 +5,5 @@ edition = "2024"
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-debug-utilities = { path = "../../packages/debug-utilities" }
-streamlib-display = { path = "../../packages/display" }
-streamlib-h264 = { path = "../../packages/h264" }
-streamlib-h265 = { path = "../../packages/h265" }
+serde_json = "1"
 anyhow = "1.0.100"

--- a/examples/vulkan-video-psnr/src/main.rs
+++ b/examples/vulkan-video-psnr/src/main.rs
@@ -10,14 +10,16 @@
 //!
 //! Usage:
 //!   vulkan-video-psnr <h264|h265> <bgra-path> <width> <height> <fps> <frame-count>
+//!
+//! Run prerequisite: `cargo xtask build-plugins --package @tatolab/debug-utilities
+//! --package @tatolab/display --package @tatolab/h264 --package @tatolab/h265`
+//! so the runtime can resolve each cdylib at load time.
 
-use streamlib_debug_utilities::BgraFileSourceProcessor;
-use streamlib_display::DisplayProcessor;
-use streamlib_h264::{H264DecoderProcessor, H264EncoderProcessor};
-use streamlib_h265::{H265DecoderProcessor, H265EncoderProcessor};
 use streamlib::sdk::error::Result;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::processors::{input, output};
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -38,20 +40,22 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
-    // honor each schema's `max_payload_bytes` instead of falling back to
-    // the 64 KiB default (which drops the encoder's first IDR with
-    // ExceedsMaxLoanSize and starves the decoder of SPS/PPS).
-    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+    runtime.load_workspace_packages([
+        "@tatolab/debug-utilities",
+        "@tatolab/display",
+        "@tatolab/h264",
+        "@tatolab/h265",
+    ])?;
 
-    let source = runtime.add_processor(BgraFileSourceProcessor::node(
-        BgraFileSourceProcessor::Config {
-            file_path: bgra_path,
-            width,
-            height,
-            fps,
-            frame_count,
-        },
+    let source = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "debug-utilities", "BgraFileSource", "1.0.0"),
+        serde_json::json!({
+            "file_path": bgra_path,
+            "width": width,
+            "height": height,
+            "fps": fps,
+            "frame_count": frame_count,
+        }),
     ))?;
     println!("+ BgraFileSource: {source}");
 
@@ -60,70 +64,56 @@ fn main() -> Result<()> {
     let effort_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_EFFORT_LEVEL")
         .ok()
         .and_then(|s| s.parse().ok());
-
-    let encoder = if is_h265 {
-        runtime.add_processor(H265EncoderProcessor::node(H265EncoderProcessor::Config {
-            width: Some(width),
-            height: Some(height),
-            effort_level,
-            ..Default::default()
-        }))?
+    let mut encoder_config = serde_json::Map::new();
+    encoder_config.insert("width".into(), serde_json::Value::from(width));
+    encoder_config.insert("height".into(), serde_json::Value::from(height));
+    if let Some(e) = effort_level {
+        encoder_config.insert("effort_level".into(), serde_json::Value::from(e));
+    }
+    let encoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Encoder", "1.0.0")
     } else {
-        runtime.add_processor(H264EncoderProcessor::node(H264EncoderProcessor::Config {
-            width: Some(width),
-            height: Some(height),
-            effort_level,
-            ..Default::default()
-        }))?
+        schema_ident!("tatolab", "h264", "H264Encoder", "1.0.0")
     };
+    let encoder = runtime.add_processor(ProcessorSpec::new(
+        encoder_ident,
+        serde_json::Value::Object(encoder_config),
+    ))?;
     println!("+ {}Encoder: {encoder}", codec.to_uppercase());
 
-    let decoder = if is_h265 {
-        runtime.add_processor(H265DecoderProcessor::node(
-            H265DecoderProcessor::Config::default(),
-        ))?
+    let decoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Decoder", "1.0.0")
     } else {
-        runtime.add_processor(H264DecoderProcessor::node(
-            H264DecoderProcessor::Config::default(),
-        ))?
+        schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
+    let decoder = runtime.add_processor(ProcessorSpec::new(
+        decoder_ident,
+        serde_json::json!({}),
+    ))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width,
-        height,
-        title: Some(format!("streamlib {} PSNR rig", codec.to_uppercase())),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": width,
+            "height": height,
+            "title": format!("streamlib {} PSNR rig", codec.to_uppercase()),
+        }),
+    ))?;
     println!("+ Display: {display}");
 
-    if is_h265 {
-        runtime.connect(
-            output::<BgraFileSourceProcessor::OutputLink::video>(&source),
-            input::<H265EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output::<H265EncoderProcessor::OutputLink::encoded_video_out>(&encoder),
-            input::<H265DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output::<H265DecoderProcessor::OutputLink::video_out>(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    } else {
-        runtime.connect(
-            output::<BgraFileSourceProcessor::OutputLink::video>(&source),
-            input::<H264EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output::<H264EncoderProcessor::OutputLink::encoded_video_out>(&encoder),
-            input::<H264DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output::<H264DecoderProcessor::OutputLink::video_out>(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    }
+    runtime.connect(
+        OutputLinkPortRef::new(&source, "video"),
+        InputLinkPortRef::new(&encoder, "video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&encoder, "encoded_video_out"),
+        InputLinkPortRef::new(&decoder, "encoded_video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&decoder, "video_out"),
+        InputLinkPortRef::new(&display, "video"),
+    )?;
     println!("\nPipeline: bgra_file_source -> encoder -> decoder -> display\n");
 
     // Frame throttling in BgraFileSource is real-time, so the run length is

--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -11,7 +11,4 @@ edition = "2024"
 # registration at load time.
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-display = { path = "../../packages/display" }
-streamlib-h264 = { path = "../../packages/h264" }
-streamlib-h265 = { path = "../../packages/h265" }
 serde_json = "1"

--- a/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/src/main.rs
@@ -3,28 +3,27 @@
 
 //! Vulkan Video Encode/Decode Roundtrip Pipeline — camera-as-cdylib variant.
 //!
-//! Sibling of `examples/vulkan-video-roundtrip` that loads the
-//! `@tatolab/camera` processor via `runtime.load_project(...)` (the
-//! cdylib plugin path) instead of taking `streamlib-camera` as a
-//! Rust dep. Exists to exercise the v12 + v13 + Phase E Slice A
-//! (`RhiColorConverterMethodsVTable`) + Phase E Slice B
-//! (`RhiCommandRecorderMethodsVTable`) cdylib dispatch end-to-end
-//! through the encode → decode → display pipeline.
+//! Sibling of `examples/vulkan-video-roundtrip` that loads every
+//! processor as a cdylib via `runtime.load_workspace_packages(...)`.
+//! Exists to exercise the cdylib FFI surface (Phase E
+//! `RhiColorConverterMethodsVTable` + `RhiCommandRecorderMethodsVTable`)
+//! end-to-end through the encode → decode → display pipeline.
 //!
-//!   CameraProcessor (cdylib) → Encoder → Decoder → Display
+//!   CameraProcessor (cdylib) → Encoder (cdylib) → Decoder (cdylib) → Display (cdylib)
 //!
 //! Usage:
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h264 [device] [seconds]
 //!   cargo run -p vulkan-video-roundtrip-cdylib-camera -- h265 /dev/video0 10
+//!
+//! Run prerequisite: `cargo xtask build-plugins --package @tatolab/camera
+//! --package @tatolab/display --package @tatolab/h264 --package @tatolab/h265`
+//! so the runtime can resolve each cdylib at load time.
 
 use streamlib::sdk::error::Result;
-use streamlib::sdk::graph::{OutputLinkPortRef, ProcessorUniqueId};
-use streamlib::sdk::processors::{input, output, ProcessorSpec};
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
-use streamlib_display::DisplayProcessor;
-use streamlib_h264::{H264DecoderProcessor, H264EncoderProcessor};
-use streamlib_h265::{H265DecoderProcessor, H265EncoderProcessor};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -34,113 +33,91 @@ fn main() -> Result<()> {
     let is_h265 = codec == "h265";
 
     println!(
-        "=== Vulkan Video {} Roundtrip (cdylib camera) ===",
+        "=== Vulkan Video {} Roundtrip (all-cdylib) ===",
         codec.to_uppercase()
     );
-    println!("Camera:   {device} (loaded as cdylib via runtime.load_project)");
+    println!("Camera:   {device} (loaded as cdylib via load_workspace_packages)");
     println!("Duration: {duration_secs}s\n");
 
     let runtime = Runner::new()?;
 
-    // 1) Load `@tatolab/camera` (and its `@tatolab/core` dep, walked
-    //    via the staged manifest's patch:) from the workspace-staged
-    //    location. `cargo xtask build-plugins` must have run first.
-    runtime.load_workspace_packages(["@tatolab/camera"])?;
-    println!("+ @tatolab/camera loaded from target/streamlib-plugins/");
+    runtime.load_workspace_packages([
+        "@tatolab/camera",
+        "@tatolab/display",
+        "@tatolab/h264",
+        "@tatolab/h265",
+    ])?;
+    println!("+ Camera / Display / H264 / H265 loaded from target/streamlib-plugins/");
     println!("+ Wire vocabulary registered (via @tatolab/core dep walk)\n");
 
-    // 3) Camera processor — minted from the cdylib's registration,
-    //    addressed by its structured schema_ident, configured via
-    //    JSON payload (matches camera_config.yaml).
-    let camera_ident = schema_ident!("tatolab", "camera", "Camera", "1.0.0");
-    let camera_config = serde_json::json!({
-        "device_id": device,
-        "max_width": std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(1920),
-        "max_height": std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(1080),
-    });
-    let camera = runtime.add_processor(ProcessorSpec::new(camera_ident, camera_config))?;
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({
+            "device_id": device,
+            "max_width": std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(1920),
+            "max_height": std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(1080),
+        }),
+    ))?;
     println!("+ Camera (cdylib): {camera}");
 
-    // 4) Encoder / decoder / display — typed Rust deps as in the
-    //    baseline vulkan-video-roundtrip.
     let effort_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_EFFORT_LEVEL")
         .ok()
         .and_then(|s| s.parse().ok());
-
-    let encoder = if is_h265 {
-        runtime.add_processor(H265EncoderProcessor::node(
-            H265EncoderProcessor::Config {
-                effort_level,
-                ..Default::default()
-            },
-        ))?
+    let mut encoder_config = serde_json::Map::new();
+    if let Some(e) = effort_level {
+        encoder_config.insert("effort_level".into(), serde_json::Value::from(e));
+    }
+    let encoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Encoder", "1.0.0")
     } else {
-        runtime.add_processor(H264EncoderProcessor::node(
-            H264EncoderProcessor::Config {
-                effort_level,
-                ..Default::default()
-            },
-        ))?
+        schema_ident!("tatolab", "h264", "H264Encoder", "1.0.0")
     };
+    let encoder = runtime.add_processor(ProcessorSpec::new(
+        encoder_ident,
+        serde_json::Value::Object(encoder_config),
+    ))?;
     println!("+ {}Encoder: {encoder}", codec.to_uppercase());
 
-    let decoder = if is_h265 {
-        runtime.add_processor(H265DecoderProcessor::node(
-            H265DecoderProcessor::Config::default(),
-        ))?
+    let decoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Decoder", "1.0.0")
     } else {
-        runtime.add_processor(H264DecoderProcessor::node(
-            H264DecoderProcessor::Config::default(),
-        ))?
+        schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
+    let decoder = runtime.add_processor(ProcessorSpec::new(
+        decoder_ident,
+        serde_json::json!({}),
+    ))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width: 1920,
-        height: 1080,
-        title: Some(format!("streamlib {} Roundtrip (cdylib camera)", codec.to_uppercase())),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": format!("streamlib {} Roundtrip (all-cdylib)", codec.to_uppercase()),
+        }),
+    ))?;
     println!("+ Display: {display}");
 
-    // 5) Wire — the camera output uses the runtime-typed
-    //    `OutputLinkPortRef::new(camera_id, "video")` form since the
-    //    cdylib-loaded camera has no compile-time-typed
-    //    `CameraProcessor::OutputLink::video` symbol in this crate.
-    if is_h265 {
-        runtime.connect(
-            OutputLinkPortRef::new(&camera, "video"),
-            input::<H265EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output_typed_h265_encoder(&encoder),
-            input::<H265DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output_typed_h265_decoder(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    } else {
-        runtime.connect(
-            OutputLinkPortRef::new(&camera, "video"),
-            input::<H264EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output_typed_h264_encoder(&encoder),
-            input::<H264DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output_typed_h264_decoder(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    }
-    println!("\nPipeline: camera(cdylib) -> encoder -> decoder -> display");
+    runtime.connect(
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&encoder, "video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&encoder, "encoded_video_out"),
+        InputLinkPortRef::new(&decoder, "encoded_video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&decoder, "video_out"),
+        InputLinkPortRef::new(&display, "video"),
+    )?;
+    println!("\nPipeline: camera(cdylib) -> encoder(cdylib) -> decoder(cdylib) -> display(cdylib)");
 
     println!("Starting pipeline for {duration_secs}s...\n");
     runtime.start()?;
@@ -151,35 +128,4 @@ fn main() -> Result<()> {
     runtime.stop()?;
 
     Ok(())
-}
-
-// Small typed-output helpers so the main flow reads symmetrically
-// with the runtime-typed camera output.
-
-fn output_typed_h264_encoder(
-    encoder: &ProcessorUniqueId,
-) -> impl Into<OutputLinkPortRef> {
-    output::<H264EncoderProcessor::OutputLink::encoded_video_out>(
-        encoder,
-    )
-}
-
-fn output_typed_h264_decoder(
-    decoder: &ProcessorUniqueId,
-) -> impl Into<OutputLinkPortRef> {
-    output::<H264DecoderProcessor::OutputLink::video_out>(decoder)
-}
-
-fn output_typed_h265_encoder(
-    encoder: &ProcessorUniqueId,
-) -> impl Into<OutputLinkPortRef> {
-    output::<H265EncoderProcessor::OutputLink::encoded_video_out>(
-        encoder,
-    )
-}
-
-fn output_typed_h265_decoder(
-    decoder: &ProcessorUniqueId,
-) -> impl Into<OutputLinkPortRef> {
-    output::<H265DecoderProcessor::OutputLink::video_out>(decoder)
 }

--- a/examples/vulkan-video-roundtrip/Cargo.toml
+++ b/examples/vulkan-video-roundtrip/Cargo.toml
@@ -5,8 +5,5 @@ edition = "2024"
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-camera = { path = "../../packages/camera" }
-streamlib-display = { path = "../../packages/display" }
-streamlib-h264 = { path = "../../packages/h264" }
-streamlib-h265 = { path = "../../packages/h265" }
+serde_json = "1"
 anyhow = "1.0.100"

--- a/examples/vulkan-video-roundtrip/src/main.rs
+++ b/examples/vulkan-video-roundtrip/src/main.rs
@@ -12,14 +12,16 @@
 //! Usage:
 //!   cargo run -p vulkan-video-roundtrip -- h264 [device] [seconds]
 //!   cargo run -p vulkan-video-roundtrip -- h265 /dev/video2 10
+//!
+//! Run prerequisite: `cargo xtask build-plugins --package @tatolab/camera
+//! --package @tatolab/display --package @tatolab/h264 --package @tatolab/h265`
+//! so the runtime can find each cdylib at load time.
 
-use streamlib_camera::CameraProcessor;
-use streamlib_display::DisplayProcessor;
-use streamlib_h264::{H264DecoderProcessor, H264EncoderProcessor};
-use streamlib_h265::{H265DecoderProcessor, H265EncoderProcessor};
 use streamlib::sdk::error::Result;
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
+use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
-use streamlib::sdk::processors::{input, output};
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -34,28 +36,39 @@ fn main() -> Result<()> {
 
     let runtime = Runner::new()?;
 
-    // Register the `@tatolab/core` wire vocabulary so iceoryx2 publishers
-    // honor `EncodedVideoFrame.max_payload_bytes` instead of falling back
-    // to the 64 KiB default (which would drop the first IDR via
-    // ExceedsMaxLoanSize and starve the decoder of SPS/PPS).
-    runtime.load_project(env!("CARGO_MANIFEST_DIR"))?;
+    // Load all four processor packages at runtime. `@tatolab/core` is
+    // pulled in transitively by each — its wire-vocabulary schemas
+    // (`EncodedVideoFrame.max_payload_bytes` in particular) are
+    // load-bearing for iceoryx2 publisher sizing.
+    runtime.load_workspace_packages([
+        "@tatolab/camera",
+        "@tatolab/display",
+        "@tatolab/h264",
+        "@tatolab/h265",
+    ])?;
 
     // --- Camera ---
     // STREAMLIB_CAMERA_MAX_WIDTH / STREAMLIB_CAMERA_MAX_HEIGHT cap V4L2
     // negotiation below the camera's advertised maximum. Useful for
     // exercising non-1080p paths on devices that prefer 1080p.
-    let max_width = std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
+    let max_width: Option<u32> = std::env::var("STREAMLIB_CAMERA_MAX_WIDTH")
         .ok()
         .and_then(|s| s.parse().ok());
-    let max_height = std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
+    let max_height: Option<u32> = std::env::var("STREAMLIB_CAMERA_MAX_HEIGHT")
         .ok()
         .and_then(|s| s.parse().ok());
-    let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
-        device_id: Some(device.to_string()),
-        max_width,
-        max_height,
-        ..Default::default()
-    }))?;
+    let mut camera_config = serde_json::Map::new();
+    camera_config.insert("device_id".into(), serde_json::Value::String(device.to_string()));
+    if let Some(w) = max_width {
+        camera_config.insert("max_width".into(), serde_json::Value::from(w));
+    }
+    if let Some(h) = max_height {
+        camera_config.insert("max_height".into(), serde_json::Value::from(h));
+    }
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::Value::Object(camera_config),
+    ))?;
     println!("+ Camera: {camera}");
 
     // --- Encoder ---
@@ -64,76 +77,57 @@ fn main() -> Result<()> {
     let effort_level: Option<u32> = std::env::var("STREAMLIB_ENCODER_EFFORT_LEVEL")
         .ok()
         .and_then(|s| s.parse().ok());
-
-    // Encoder dimensions come from the first VideoFrame the camera produces,
-    // so the example runs at whatever resolution V4L2 negotiates (capped by
-    // CameraConfig::max_width / max_height; default 1920×1080).
-    let encoder = if is_h265 {
-        runtime.add_processor(H265EncoderProcessor::node(
-            H265EncoderProcessor::Config {
-                effort_level,
-                ..Default::default()
-            },
-        ))?
+    let mut encoder_config = serde_json::Map::new();
+    if let Some(e) = effort_level {
+        encoder_config.insert("effort_level".into(), serde_json::Value::from(e));
+    }
+    let encoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Encoder", "1.0.0")
     } else {
-        runtime.add_processor(H264EncoderProcessor::node(
-            H264EncoderProcessor::Config {
-                effort_level,
-                ..Default::default()
-            },
-        ))?
+        schema_ident!("tatolab", "h264", "H264Encoder", "1.0.0")
     };
+    let encoder = runtime.add_processor(ProcessorSpec::new(
+        encoder_ident,
+        serde_json::Value::Object(encoder_config),
+    ))?;
     println!("+ {}Encoder: {encoder}", codec.to_uppercase());
 
     // --- Decoder ---
-    let decoder = if is_h265 {
-        runtime.add_processor(H265DecoderProcessor::node(
-            H265DecoderProcessor::Config::default(),
-        ))?
+    let decoder_ident = if is_h265 {
+        schema_ident!("tatolab", "h265", "H265Decoder", "1.0.0")
     } else {
-        runtime.add_processor(H264DecoderProcessor::node(
-            H264DecoderProcessor::Config::default(),
-        ))?
+        schema_ident!("tatolab", "h264", "H264Decoder", "1.0.0")
     };
+    let decoder = runtime.add_processor(ProcessorSpec::new(
+        decoder_ident,
+        serde_json::json!({}),
+    ))?;
     println!("+ {}Decoder: {decoder}", codec.to_uppercase());
 
     // --- Display ---
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width: 1920,
-        height: 1080,
-        title: Some(format!("streamlib {} Roundtrip", codec.to_uppercase())),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": format!("streamlib {} Roundtrip", codec.to_uppercase()),
+        }),
+    ))?;
     println!("+ Display: {display}");
 
     // --- Wire: Camera → Encoder → Decoder → Display ---
-    if is_h265 {
-        runtime.connect(
-            output::<CameraProcessor::OutputLink::video>(&camera),
-            input::<H265EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output::<H265EncoderProcessor::OutputLink::encoded_video_out>(&encoder),
-            input::<H265DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output::<H265DecoderProcessor::OutputLink::video_out>(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    } else {
-        runtime.connect(
-            output::<CameraProcessor::OutputLink::video>(&camera),
-            input::<H264EncoderProcessor::InputLink::video_in>(&encoder),
-        )?;
-        runtime.connect(
-            output::<H264EncoderProcessor::OutputLink::encoded_video_out>(&encoder),
-            input::<H264DecoderProcessor::InputLink::encoded_video_in>(&decoder),
-        )?;
-        runtime.connect(
-            output::<H264DecoderProcessor::OutputLink::video_out>(&decoder),
-            input::<DisplayProcessor::InputLink::video>(&display),
-        )?;
-    }
+    runtime.connect(
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&encoder, "video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&encoder, "encoded_video_out"),
+        InputLinkPortRef::new(&decoder, "encoded_video_in"),
+    )?;
+    runtime.connect(
+        OutputLinkPortRef::new(&decoder, "video_out"),
+        InputLinkPortRef::new(&display, "video"),
+    )?;
     println!("\nPipeline: camera -> encoder -> decoder -> display");
 
     // --- Run until duration or window close ---


### PR DESCRIPTION
## Summary

Batch 4 of #792. Three vulkan-video examples migrated to all-runtime-loading:

- **vulkan-video-roundtrip**: drops camera, display, h264, h265 (4 deps).
- **vulkan-video-roundtrip-cdylib-camera**: completes the partial migration from #991 — every processor now cdylib-loaded (was only the camera). Old typed-port helper fns (\`output_typed_h264_encoder\` etc.) deleted; string-named PortRefs throughout.
- **vulkan-video-psnr**: drops debug-utilities, display, h264, h265 (4 deps).

Cumulative #792: 15 of ~20 examples (audio-mixer-demo via #881; batches 1–4 here).

## Test plan

- [x] All 3 examples build cleanly. Only \`streamlib\` (SDK) + serde_json + anyhow remain in their Cargo.toml.
- [x] Each example documents the \`cargo xtask build-plugins --package @tatolab/<name>\` run-prerequisite in module docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)