### PR TITLE
refactor(examples): batch 6 of #792 — final 4 examples, closes #792

### DIFF
--- a/examples/camera-deno-subprocess/Cargo.toml
+++ b/examples/camera-deno-subprocess/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-camera = { path = "../../packages/camera" }
-streamlib-display = { path = "../../packages/display" }
 serde_json = "1.0"

--- a/examples/camera-deno-subprocess/src/main.rs
+++ b/examples/camera-deno-subprocess/src/main.rs
@@ -20,25 +20,30 @@
 //! ```
 
 use std::path::PathBuf;
+use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_camera::CameraProcessor;
-use streamlib_display::DisplayProcessor;
-use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let runtime = Runner::new()?;
     let project_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("deno");
 
-    // 1. Load processor package from streamlib.yaml
+    // 1. Load `@tatolab/camera` and `@tatolab/display` from the
+    //    workspace-staged location. `cargo xtask build-plugins
+    //    --package @tatolab/camera --package @tatolab/display` must
+    //    have run first.
+    runtime.load_workspace_packages(["@tatolab/camera", "@tatolab/display"])?;
+
+    // 2. Load the Deno halftone processor package from streamlib.yaml
     runtime.load_project(&project_path)?;
 
-    // 2. Add processors
-    let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
-        device_id: None,
-        ..Default::default()
-    }))?;
+    // 3. Add processors
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({}),
+    ))?;
 
     let halftone = runtime.add_processor(ProcessorSpec::new(
         streamlib::sdk::schema_ident_any_version!(
@@ -49,12 +54,14 @@ fn main() -> Result<()> {
         serde_json::json!({}),
     ))?;
 
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width: 1920,
-        height: 1080,
-        title: Some("Camera → TypeGPU Halftone → Display".to_string()),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": "Camera → TypeGPU Halftone → Display",
+        }),
+    ))?;
 
     // 3. Connect: Camera → Deno Halftone → Display
     runtime.connect(

--- a/examples/camera-python-subprocess/Cargo.toml
+++ b/examples/camera-python-subprocess/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-camera = { path = "../../packages/camera" }
-streamlib-display = { path = "../../packages/display" }
 serde_json = "1.0"

--- a/examples/camera-python-subprocess/src/main.rs
+++ b/examples/camera-python-subprocess/src/main.rs
@@ -22,26 +22,31 @@
 //! ```
 
 use std::path::PathBuf;
+use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_camera::CameraProcessor;
-use streamlib_display::DisplayProcessor;
-use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let runtime = Runner::new()?;
 
-    // 1. Load processors from .slpkg package bundle
+    // 1. Load `@tatolab/camera` and `@tatolab/display` from the
+    //    workspace-staged location. `cargo xtask build-plugins
+    //    --package @tatolab/camera --package @tatolab/display` must
+    //    have run first.
+    runtime.load_workspace_packages(["@tatolab/camera", "@tatolab/display"])?;
+
+    // 2. Load the Python grayscale processor from .slpkg package bundle
     let slpkg_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("python/camera-python-subprocess-0.1.0.slpkg");
     runtime.load_package(&slpkg_path)?;
 
-    // 2. Add processors
-    let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
-        device_id: None,
-        ..Default::default()
-    }))?;
+    // 3. Add processors
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({}),
+    ))?;
 
     let grayscale = runtime.add_processor(ProcessorSpec::new(
         streamlib::sdk::schema_ident_any_version!(
@@ -52,12 +57,14 @@ fn main() -> Result<()> {
         serde_json::json!({}),
     ))?;
 
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width: 1920,
-        height: 1080,
-        title: Some("Camera → Python Grayscale → Display".to_string()),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": "Camera → Python Grayscale → Display",
+        }),
+    ))?;
 
     // 3. Connect: Camera → Python Grayscale → Display
     runtime.connect(

--- a/examples/camera-rust-plugin/Cargo.toml
+++ b/examples/camera-rust-plugin/Cargo.toml
@@ -9,6 +9,4 @@ publish = false
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-camera = { path = "../../packages/camera" }
-streamlib-display = { path = "../../packages/display" }
 serde_json = "1.0"

--- a/examples/camera-rust-plugin/src/main.rs
+++ b/examples/camera-rust-plugin/src/main.rs
@@ -3,16 +3,25 @@
 
 //! Camera → Rust Grayscale Plugin → Display Pipeline Example
 //!
-//! Demonstrates loading a Rust cdylib processor via `load_project()`.
-//! The grayscale plugin accesses camera pixels through IOSurface shared memory,
-//! converts to grayscale using direct CVPixelBuffer access, and writes results
-//! to a new IOSurface.
+//! Demonstrates the in-tree cdylib plugin pattern: the example owns a
+//! sibling `plugin/` crate that builds as a cdylib carrying the
+//! `GrayscaleRust` processor, and the host manually stages that cdylib
+//! into `plugin/lib/<host_triple>/` before calling
+//! `runtime.load_project(plugin_dir)` to register it. This is the
+//! "build from source + load from path" shape, distinct from the
+//! `cargo xtask build-plugins` + `load_workspace_packages` flow that
+//! the other examples use for canonical workspace packages.
+//!
+//! `@tatolab/camera` and `@tatolab/display` themselves load via
+//! `load_workspace_packages` — only the example-local plugin subdir
+//! goes through the manual stage path.
 //!
 //! ## Prerequisites
 //!
-//! Build the plugin cdylib first:
+//! Build the plugin cdylib + stage the canonical packages:
 //! ```bash
 //! cargo build -p grayscale-plugin
+//! cargo xtask build-plugins --package @tatolab/camera --package @tatolab/display
 //! ```
 //!
 //! ## Usage
@@ -22,20 +31,26 @@
 //! ```
 
 use std::path::PathBuf;
+use streamlib::sdk::error::Result;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 use streamlib::sdk::processors::ProcessorSpec;
-use streamlib_camera::CameraProcessor;
-use streamlib_display::DisplayProcessor;
-use streamlib::sdk::error::Result;
 use streamlib::sdk::runtime::Runner;
+use streamlib::sdk::schema_ident;
 
 fn main() -> Result<()> {
     let runtime = Runner::new()?;
 
-    // 1. Copy built dylib into plugin/lib/<triple>/ so load_project()
-    //    can find it. The loader resolves the cdylib via the same
-    //    `lib/<triple>/` path produced by `streamlib pack`, so the
-    //    example mirrors that on-disk layout.
+    // 1. Load `@tatolab/camera` and `@tatolab/display` via the canonical
+    //    workspace-staged path. `cargo xtask build-plugins --package
+    //    @tatolab/camera --package @tatolab/display` must have run first.
+    runtime.load_workspace_packages(["@tatolab/camera", "@tatolab/display"])?;
+
+    // 2. Stage the example-local grayscale plugin cdylib at
+    //    `plugin/lib/<triple>/` so `load_project(plugin_dir)` resolves
+    //    it via the same triple-keyed convention `streamlib pack`
+    //    produces. The plugin lives in this example's repo (sibling
+    //    crate, not a workspace package) so the canonical xtask doesn't
+    //    stage it; the example handles its own copy step.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let plugin_dir = manifest_dir.join("plugin");
     let host_triple = streamlib::sdk::runtime::host_target_triple();
@@ -91,14 +106,15 @@ fn main() -> Result<()> {
     })?;
     println!("Copied plugin dylib to {}", dest_dylib.display());
 
-    // 2. Load plugin project (registers processors from the dylib)
+    // 3. Load the example-local plugin project (registers the
+    //    grayscale processor from the staged cdylib).
     runtime.load_project(&plugin_dir)?;
 
-    // 3. Add processors
-    let camera = runtime.add_processor(CameraProcessor::node(CameraProcessor::Config {
-        device_id: None,
-        ..Default::default()
-    }))?;
+    // 4. Add processors
+    let camera = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "camera", "Camera", "1.0.0"),
+        serde_json::json!({}),
+    ))?;
 
     let grayscale = runtime.add_processor(ProcessorSpec::new(
         streamlib::sdk::schema_ident_any_version!(
@@ -109,14 +125,16 @@ fn main() -> Result<()> {
         serde_json::Value::Null,
     ))?;
 
-    let display = runtime.add_processor(DisplayProcessor::node(DisplayProcessor::Config {
-        width: 1920,
-        height: 1080,
-        title: Some("Camera → Rust Grayscale → Display".to_string()),
-        ..Default::default()
-    }))?;
+    let display = runtime.add_processor(ProcessorSpec::new(
+        schema_ident!("tatolab", "display", "Display", "1.0.0"),
+        serde_json::json!({
+            "width": 1920,
+            "height": 1080,
+            "title": "Camera → Rust Grayscale → Display",
+        }),
+    ))?;
 
-    // 4. Connect: Camera → Grayscale → Display
+    // 5. Connect: Camera → Grayscale → Display
     runtime.connect(
         OutputLinkPortRef::new(&camera, "video"),
         InputLinkPortRef::new(&grayscale, "video_in"),
@@ -126,7 +144,7 @@ fn main() -> Result<()> {
         InputLinkPortRef::new(&display, "video"),
     )?;
 
-    // 5. Run
+    // 6. Run
     runtime.start()?;
     runtime.wait_for_signal()?;
 

--- a/examples/webrtc-cloudflare-stream/Cargo.toml
+++ b/examples/webrtc-cloudflare-stream/Cargo.toml
@@ -8,11 +8,6 @@ streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
-streamlib-audio = { path = "../../packages/audio" }
-streamlib-camera = { path = "../../packages/camera" }
-streamlib-h264 = { path = "../../packages/h264" }
-streamlib-opus = { path = "../../packages/opus" }
-streamlib-webrtc = { path = "../../packages/webrtc" }
 tokio = { version = "1.48.0", features = ["full"] }
 anyhow = "1.0.100"
 libc = "0.2"

--- a/examples/webrtc-cloudflare-stream/src/main.rs
+++ b/examples/webrtc-cloudflare-stream/src/main.rs
@@ -24,26 +24,15 @@ mod _generated_ {
 #[cfg(target_os = "linux")]
 use streamlib::sdk::permissions::{request_audio_permission, request_camera_permission};
 #[cfg(target_os = "linux")]
-use streamlib_camera::CameraProcessor;
-#[cfg(target_os = "linux")]
-use streamlib_h264::H264EncoderProcessor;
-#[cfg(target_os = "linux")]
-use streamlib_opus::OpusEncoderProcessor;
-#[cfg(target_os = "linux")]
-use streamlib_webrtc::WebRtcWhipProcessor;
-#[cfg(target_os = "linux")]
 use streamlib::sdk::error::Result;
+#[cfg(target_os = "linux")]
+use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
 #[cfg(target_os = "linux")]
 use streamlib::sdk::runtime::Runner;
 #[cfg(target_os = "linux")]
-use streamlib::sdk::processors::{input, output, ProcessorSpec};
+use streamlib::sdk::processors::ProcessorSpec;
 #[cfg(target_os = "linux")]
 use streamlib::sdk::schema_ident_any_version;
-#[cfg(target_os = "linux")]
-use streamlib_audio::{
-    AudioCaptureProcessor, AudioChannelConverterProcessor, AudioResamplerProcessor,
-    BufferRechunkerProcessor,
-};
 
 #[cfg(target_os = "linux")]
 use crate::_generated_::tatolab__camera::CameraConfig;
@@ -73,6 +62,14 @@ fn main() -> Result<()> {
     println!("=== WebRTC WHIP Streaming to Cloudflare Stream ===\n");
 
     let runtime = Runner::new()?;
+
+    runtime.load_workspace_packages([
+        "@tatolab/audio",
+        "@tatolab/camera",
+        "@tatolab/h264",
+        "@tatolab/opus",
+        "@tatolab/webrtc",
+    ])?;
 
     println!("🔒 Requesting camera permission...");
     if !request_camera_permission()? {
@@ -200,14 +197,14 @@ fn main() -> Result<()> {
     println!("🔗 Connecting pipeline:");
 
     runtime.connect(
-        output::<CameraProcessor::OutputLink::video>(&camera),
-        input::<H264EncoderProcessor::InputLink::video_in>(&h264_encoder),
+        OutputLinkPortRef::new(&camera, "video"),
+        InputLinkPortRef::new(&h264_encoder, "video_in"),
     )?;
     println!("   ✓ Camera → H.264 encoder");
 
     runtime.connect(
-        output::<H264EncoderProcessor::OutputLink::encoded_video_out>(&h264_encoder),
-        input::<WebRtcWhipProcessor::InputLink::encoded_video_in>(&webrtc),
+        OutputLinkPortRef::new(&h264_encoder, "encoded_video_out"),
+        InputLinkPortRef::new(&webrtc, "encoded_video_in"),
     )?;
     println!("   ✓ H.264 encoder → WebRTC\n");
 
@@ -215,24 +212,24 @@ fn main() -> Result<()> {
         &audio_pipeline
     {
         runtime.connect(
-            output::<AudioCaptureProcessor::OutputLink::audio>(audio_capture),
-            input::<AudioResamplerProcessor::InputLink::audio_in>(resampler),
+            OutputLinkPortRef::new(audio_capture, "audio"),
+            InputLinkPortRef::new(resampler, "audio_in"),
         )?;
         runtime.connect(
-            output::<AudioResamplerProcessor::OutputLink::audio_out>(resampler),
-            input::<AudioChannelConverterProcessor::InputLink::audio_in>(channel_converter),
+            OutputLinkPortRef::new(resampler, "audio_out"),
+            InputLinkPortRef::new(channel_converter, "audio_in"),
         )?;
         runtime.connect(
-            output::<AudioChannelConverterProcessor::OutputLink::audio_out>(channel_converter),
-            input::<BufferRechunkerProcessor::InputLink::audio_in>(rechunker),
+            OutputLinkPortRef::new(channel_converter, "audio_out"),
+            InputLinkPortRef::new(rechunker, "audio_in"),
         )?;
         runtime.connect(
-            output::<BufferRechunkerProcessor::OutputLink::audio_out>(rechunker),
-            input::<OpusEncoderProcessor::InputLink::audio_in>(opus_encoder),
+            OutputLinkPortRef::new(rechunker, "audio_out"),
+            InputLinkPortRef::new(opus_encoder, "audio_in"),
         )?;
         runtime.connect(
-            output::<OpusEncoderProcessor::OutputLink::encoded_audio_out>(opus_encoder),
-            input::<WebRtcWhipProcessor::InputLink::encoded_audio_in>(&webrtc),
+            OutputLinkPortRef::new(opus_encoder, "encoded_audio_out"),
+            InputLinkPortRef::new(&webrtc, "encoded_audio_in"),
         )?;
         println!("   ✓ Mic → resampler → converter → rechunker → Opus → WebRTC\n");
     } else {


### PR DESCRIPTION
## Summary

Final batch of #792. Four remaining examples migrated:

- **camera-rust-plugin** (2 deps): drops camera + display, keeps the example-local grayscale plugin's manual-copy + load_project demo (the in-tree cdylib pattern is the example's purpose).
- **camera-python-subprocess** (2 deps): drops camera + display.
- **camera-deno-subprocess** (2 deps): drops camera + display.
- **webrtc-cloudflare-stream** (5 deps): drops audio + camera + h264 + opus + webrtc. Typed port markers (e.g. \`CameraProcessor::OutputLink::video\`) replaced with string-named \`OutputLinkPortRef::new\` throughout. Also fixes a port-name shape (was using a typed marker; the schema-declared name is \"audio_out\").

**Closes #792**. All ~20 in-tree examples (workspace members under \`examples/\`) now Cargo-dep only \`streamlib\` (SDK) + tokio / serde_json / leaf utilities. Zero processor-package Cargo deps remain. The one exception is \`microphone-reverb-speaker\` (blocked on the deferred #993 ClapScanner SDK re-export).

## Test plan

- [x] All 4 examples build cleanly.
- [x] webrtc-cloudflare-stream + 3 subprocess examples remain excluded-from-baseline per \`docs/testing-baseline.md\` (TLS deps on fresh machines); their tests don't run but the migration shape matches the in-baseline examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)