### PR TITLE
refactor(packages): drop plugin Cargo feature gate from every Rust-impl package

### DIFF
--- a/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
+++ b/examples/vulkan-video-roundtrip-cdylib-camera/Cargo.toml
@@ -5,10 +5,9 @@ edition = "2024"
 
 # Deliberately NOT taking streamlib-camera as a Rust dep. The camera
 # is loaded at runtime via `Runner::load_project(...)` against a
-# staged copy of `packages/camera/` (built with --features plugin).
-# Linking streamlib-camera as a Rust dep would auto-register the
-# `Camera` processor at link time, conflicting with the cdylib's
-# registration at load time.
+# staged copy of `packages/camera/`. Linking streamlib-camera as a
+# Rust dep would auto-register the `Camera` processor at link time,
+# conflicting with the cdylib's registration at load time.
 [dependencies]
 streamlib = { path = "../../libs/streamlib-sdk" }
 serde_json = "1"

--- a/libs/streamlib-cargo-build/src/lib.rs
+++ b/libs/streamlib-cargo-build/src/lib.rs
@@ -116,9 +116,8 @@ impl CargoProfile {
 }
 
 /// Invoke `cargo build [--release] -p <cargo_name>
-/// --features <cargo_name>/plugin --message-format=json` from
-/// `package_dir` and parse the JSON output for the produced host-OS
-/// cdylib path.
+/// --message-format=json` from `package_dir` and parse the JSON
+/// output for the produced host-OS cdylib path.
 ///
 /// `--message-format=json` is the canonical way to discover Cargo
 /// artifact paths — it survives `CARGO_TARGET_DIR` overrides,
@@ -135,20 +134,12 @@ pub fn run_cargo_build(
     dylib_ext: &str,
     profile: CargoProfile,
 ) -> Result<PathBuf> {
-    // `--features <name>/plugin` enables the `export_plugin!` invocation
-    // in the package's `lib.rs`. The feature is default-off so force-link
-    // rlib consumers don't pull in the unmangled `STREAMLIB_PLUGIN`
-    // symbol (multiple rlibs with the same static collide at link time);
-    // pack / build-plugins flip it on so the produced cdylib carries the
-    // symbol the runtime dlopens.
-    let features_flag = format!("{}/plugin", cargo_name);
     let profile_label = profile.label();
     tracing::info!(
-        "Building {} ({} profile, cargo build -p {} --features {})",
+        "Building {} ({} profile, cargo build -p {})",
         cargo_name,
         profile_label,
         cargo_name,
-        features_flag
     );
     let mut command = Command::new("cargo");
     command.arg("build");
@@ -159,22 +150,19 @@ pub fn run_cargo_build(
         .arg("--message-format=json")
         .arg("-p")
         .arg(cargo_name)
-        .arg("--features")
-        .arg(&features_flag)
         .current_dir(package_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .output()
         .with_context(|| {
             format!(
-                "Failed to invoke `cargo build {} -p {} --features {}` in {}",
+                "Failed to invoke `cargo build {} -p {}` in {}",
                 if matches!(profile, CargoProfile::Release) {
                     "--release"
                 } else {
                     ""
                 },
                 cargo_name,
-                features_flag,
                 package_dir.display()
             )
         })?;

--- a/libs/streamlib-cli/src/commands/pack.rs
+++ b/libs/streamlib-cli/src/commands/pack.rs
@@ -185,10 +185,8 @@ pub fn pack(package_dir: &Path, output: Option<&Path>, no_build: bool) -> Result
             }
         } else if no_build {
             let cargo_hint = read_cargo_package_name(package_dir)
-                .map(|name| format!("cargo build --release -p {n} --features {n}/plugin", n = name))
-                .unwrap_or_else(|_| {
-                    "cargo build --release -p <name> --features <name>/plugin".to_string()
-                });
+                .map(|name| format!("cargo build --release -p {n}", n = name))
+                .unwrap_or_else(|_| "cargo build --release -p <name>".to_string());
             anyhow::bail!(
                 "Package at {} declares Rust runtime processors but {} contains no \
                  host-OS dylib (`*.{}`) for triple `{}` and `--no-build` was specified. \

--- a/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
+++ b/libs/streamlib-engine/tests/cdylib_owns_tokio_runtime.rs
@@ -56,14 +56,12 @@ fn dlopen_processor_owns_tokio_runtime_and_binds_tcp_listener() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_camera_smoke.rs
@@ -3,7 +3,7 @@
 
 //! Camera dlopen lifecycle smoke test (#958 / Phase D follow-up to #914).
 //!
-//! Builds `@tatolab/camera` as a cdylib (`--features plugin`), stages
+//! Builds `@tatolab/camera` as a cdylib, stages
 //! it as a streamlib project alongside `@tatolab/core`, dlopens it
 //! via `Runner::load_project`, then drives the camera processor
 //! through `setup()` + `start()` against vivid (`/dev/video0` on this
@@ -57,7 +57,7 @@
 //!
 //! What the test actually surfaces:
 //!
-//! - `cargo build -p streamlib-camera --features plugin` produces a
+//! - `cargo build -p streamlib-camera` produces a
 //!   `libstreamlib_camera.so` cdylib carrying the `STREAMLIB_PLUGIN`
 //!   symbol.
 //! - `Runner::load_project(...)` accepts the camera's project
@@ -120,19 +120,15 @@ fn dlopen_camera_processor_completes_lifecycle_against_vivid() {
         .unwrap()
         .parent()
         .unwrap();
-
     // Build streamlib-camera as a cdylib carrying the
-    // `STREAMLIB_PLUGIN` symbol. The `plugin` feature gates
-    // `streamlib_plugin_abi::export_plugin!` so multiple rlib
-    // consumers of the same processor type don't collide at link
-    // time on the unmangled static.
+    // `STREAMLIB_PLUGIN` symbol that the runtime dlopens.
     let status = std::process::Command::new(env!("CARGO"))
-        .args(["build", "-p", "streamlib-camera", "--features", "plugin"])
+        .args(["build", "-p", "streamlib-camera"])
         .status()
         .expect("invoking cargo build for streamlib-camera");
     assert!(
         status.success(),
-        "cargo build -p streamlib-camera --features plugin must succeed"
+        "cargo build -p streamlib-camera must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_compute_kernel_cpu_ref.rs
@@ -88,14 +88,12 @@ fn dlopen_processor_dispatches_compute_kernel_against_cpu_reference() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_concurrent_escalate.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_concurrent_escalate.rs
@@ -58,14 +58,12 @@ fn dlopen_concurrent_escalate_serializes_through_vtable() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cpu_readback_smoke.rs
@@ -67,14 +67,12 @@ fn dlopen_processor_round_trips_cpu_readback_adapter() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cuda_smoke.rs
@@ -50,8 +50,6 @@ fn dlopen_processor_round_trips_cuda_adapter() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");

--- a/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_escalate_smoke.rs
@@ -91,14 +91,12 @@ fn dlopen_processor_round_trips_escalate_vtable_callbacks() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_gpu_acquire.rs
@@ -77,14 +77,12 @@ fn dlopen_processor_round_trips_gpu_vtable_callbacks() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_graphics_kernel_smoke.rs
@@ -86,14 +86,12 @@ fn dlopen_processor_runs_graphics_kernel_offscreen_render_smoke() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_lifecycle.rs
@@ -54,14 +54,12 @@ fn dylib_processor_create_and_drop_round_trips_through_vtable() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_opengl_smoke.rs
@@ -55,8 +55,6 @@ fn dlopen_processor_round_trips_opengl_adapter() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");

--- a/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pause_resume.rs
@@ -74,14 +74,12 @@ fn dlopen_processor_pause_resume_hooks_fire_through_vtable() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_process_lifecycle.rs
@@ -59,14 +59,12 @@ fn dlopen_processor_process_hook_fires_through_vtable() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_processor_panic_safety.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_processor_panic_safety.rs
@@ -62,14 +62,12 @@ fn stage_fixtures_project() -> tempfile::TempDir {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_pubsub_bridge.rs
@@ -58,14 +58,12 @@ fn build_and_stage_test_fixtures_dylib() -> (tempfile::TempDir, std::path::PathB
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_ray_tracing_kernel_smoke.rs
@@ -93,14 +93,12 @@ fn dlopen_processor_runs_ray_tracing_kernel_trace_rays_smoke() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_smoke.rs
@@ -48,14 +48,12 @@ fn load_project_real_dylib_registers_processor_via_export_plugin() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_surface_share_escalate_consistency.rs
@@ -58,8 +58,6 @@ fn dlopen_processor_round_trips_surface_share_and_escalate_paths() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");

--- a/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_tracing_bridge.rs
@@ -54,14 +54,12 @@ fn build_and_stage_test_fixtures_dylib() -> (tempfile::TempDir, std::path::PathB
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_vulkan_smoke.rs
@@ -58,14 +58,12 @@ fn dlopen_processor_round_trips_vulkan_adapter() {
             "build",
             "-p",
             "streamlib-test-fixtures",
-            "--features",
-            "streamlib-test-fixtures/plugin",
         ])
         .status()
         .expect("invoking cargo build");
     assert!(
         status.success(),
-        "cargo build -p streamlib-test-fixtures --features plugin must succeed"
+        "cargo build -p streamlib-test-fixtures must succeed"
     );
 
     let dylib_ext = if cfg!(target_os = "macos") {

--- a/packages/api-server/Cargo.toml
+++ b/packages/api-server/Cargo.toml
@@ -19,11 +19,6 @@ path = "src/bin/generate_openapi.rs"
 
 [features]
 default = []
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-plugin = []
 moq = ["dep:streamlib-moq"]
 
 [build-dependencies]

--- a/packages/api-server/src/lib.rs
+++ b/packages/api-server/src/lib.rs
@@ -13,5 +13,4 @@ mod state;
 pub use _generated_::ApiServerConfig;
 pub use processor::ApiServerProcessor;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(crate::ApiServerProcessor::Processor);

--- a/packages/audio/Cargo.toml
+++ b/packages/audio/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::audio", "multimedia"]
 name = "streamlib_audio"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/audio/src/lib.rs
+++ b/packages/audio/src/lib.rs
@@ -51,10 +51,7 @@ pub use processor_audio_converter::{
     ProcessorAudioConverter, ProcessorAudioConverterStatus, ProcessorAudioConverterTargetFormat,
 };
 
-#[cfg(all(
-    feature = "plugin",
-    any(target_os = "linux", target_os = "macos", target_os = "ios")
-))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
 streamlib_plugin_abi::export_plugin!(
     crate::AudioChannelConverterProcessor::Processor,
     crate::AudioMixerProcessor::Processor,

--- a/packages/camera/Cargo.toml
+++ b/packages/camera/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_camera"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/camera/src/lib.rs
+++ b/packages/camera/src/lib.rs
@@ -19,8 +19,5 @@ pub mod apple;
 
 pub use camera::{CameraDevice, CameraProcessor};
 
-#[cfg(all(
-    feature = "plugin",
-    any(target_os = "linux", target_os = "macos", target_os = "ios")
-))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
 streamlib_plugin_abi::export_plugin!(crate::CameraProcessor::Processor);

--- a/packages/clap/Cargo.toml
+++ b/packages/clap/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::audio", "multimedia"]
 name = "streamlib_clap"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/clap/src/lib.rs
+++ b/packages/clap/src/lib.rs
@@ -38,5 +38,5 @@ pub use scanner::{ClapPluginInfo, ClapScanner};
 
 pub use _generated_::ClapEffectConfig;
 
-#[cfg(all(feature = "plugin", any(target_os = "macos", target_os = "ios")))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 streamlib_plugin_abi::export_plugin!(crate::ClapEffectProcessor::Processor);

--- a/packages/debug-utilities/Cargo.toml
+++ b/packages/debug-utilities/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["development-tools"]
 name = "streamlib_debug_utilities"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/debug-utilities/src/lib.rs
+++ b/packages/debug-utilities/src/lib.rs
@@ -27,7 +27,7 @@ pub use bgra_file_source::BgraFileSourceProcessor;
 #[cfg(target_os = "linux")]
 pub use jpeg_bytes_source::JpegBytesSourceProcessor;
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(
     crate::SimplePassthroughProcessor::Processor,
     crate::VideoFrameCounterProcessor::Processor,
@@ -35,7 +35,7 @@ streamlib_plugin_abi::export_plugin!(
     crate::JpegBytesSourceProcessor::Processor,
 );
 
-#[cfg(all(feature = "plugin", not(target_os = "linux")))]
+#[cfg(not(target_os = "linux"))]
 streamlib_plugin_abi::export_plugin!(
     crate::SimplePassthroughProcessor::Processor,
     crate::VideoFrameCounterProcessor::Processor,

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_display"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/display/src/lib.rs
+++ b/packages/display/src/lib.rs
@@ -23,5 +23,5 @@ pub mod linux;
 
 pub use display::{DisplayConfig, DisplayProcessor};
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(crate::DisplayProcessor::Processor);

--- a/packages/h264/Cargo.toml
+++ b/packages/h264/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_h264"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/h264/src/lib.rs
+++ b/packages/h264/src/lib.rs
@@ -19,7 +19,7 @@ pub use linux::{H264DecoderProcessor, H264EncoderProcessor};
 
 pub use _generated_::{H264DecoderConfig, H264EncoderConfig};
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(
     crate::H264DecoderProcessor::Processor,
     crate::H264EncoderProcessor::Processor,

--- a/packages/h265/Cargo.toml
+++ b/packages/h265/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_h265"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/h265/src/lib.rs
+++ b/packages/h265/src/lib.rs
@@ -18,7 +18,7 @@ pub use linux::{H265DecoderProcessor, H265EncoderProcessor};
 
 pub use _generated_::{H265DecoderConfig, H265EncoderConfig};
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(
     crate::H265DecoderProcessor::Processor,
     crate::H265EncoderProcessor::Processor,

--- a/packages/jpeg/Cargo.toml
+++ b/packages/jpeg/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::images", "multimedia"]
 name = "streamlib_jpeg"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/jpeg/src/lib.rs
+++ b/packages/jpeg/src/lib.rs
@@ -21,5 +21,5 @@ pub use linux::JpegDecoderProcessor;
 
 pub use _generated_::{EncodedJpegFrame, JpegDecoderConfig};
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(crate::JpegDecoderProcessor::Processor);

--- a/packages/mavlink/Cargo.toml
+++ b/packages/mavlink/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["aerospace::drones", "encoding", "multimedia"]
 name = "streamlib_mavlink"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/mavlink/src/lib.rs
+++ b/packages/mavlink/src/lib.rs
@@ -16,7 +16,6 @@ pub mod mavlink_encoder;
 pub use mavlink_decoder::MavlinkDecoderProcessor;
 pub use mavlink_encoder::MavlinkEncoderProcessor;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(
     crate::MavlinkDecoderProcessor::Processor,
     crate::MavlinkEncoderProcessor::Processor,

--- a/packages/moq/Cargo.toml
+++ b/packages/moq/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_moq"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/moq/src/lib.rs
+++ b/packages/moq/src/lib.rs
@@ -26,7 +26,6 @@ pub use moq_session::{
 };
 pub use moq_subscribe_track::MoqSubscribeTrackProcessor;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(
     crate::MoqPublishTrackProcessor::Processor,
     crate::MoqSubscribeTrackProcessor::Processor,

--- a/packages/mp4/Cargo.toml
+++ b/packages/mp4/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_mp4"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/mp4/src/lib.rs
+++ b/packages/mp4/src/lib.rs
@@ -23,5 +23,5 @@ mod _apple_impl_pending_;
 
 pub use _generated_::LinuxMp4WriterConfig;
 
-#[cfg(all(feature = "plugin", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 streamlib_plugin_abi::export_plugin!(crate::LinuxMp4WriterProcessor::Processor);

--- a/packages/network/Cargo.toml
+++ b/packages/network/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["network-programming", "multimedia"]
 name = "streamlib_network"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/network/src/lib.rs
+++ b/packages/network/src/lib.rs
@@ -16,7 +16,6 @@ pub mod udp_source;
 pub use udp_sink::UdpSinkProcessor;
 pub use udp_source::UdpSourceProcessor;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(
     crate::UdpSinkProcessor::Processor,
     crate::UdpSourceProcessor::Processor,

--- a/packages/opus/Cargo.toml
+++ b/packages/opus/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::audio", "multimedia"]
 name = "streamlib_opus"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/opus/src/lib.rs
+++ b/packages/opus/src/lib.rs
@@ -27,10 +27,7 @@ pub use opus_encoder::{
 
 pub use _generated_::{OpusDecoderConfig, OpusEncoderConfig};
 
-#[cfg(all(
-    feature = "plugin",
-    any(target_os = "macos", target_os = "ios", target_os = "linux")
-))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 streamlib_plugin_abi::export_plugin!(
     crate::OpusDecoderProcessor::Processor,
     crate::OpusEncoderProcessor::Processor,

--- a/packages/screen-capture/Cargo.toml
+++ b/packages/screen-capture/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_screen_capture"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/screen-capture/src/lib.rs
+++ b/packages/screen-capture/src/lib.rs
@@ -20,5 +20,5 @@ pub use apple::AppleScreenCaptureProcessor;
 pub use _generated_::ScreenCaptureConfig;
 pub use _generated_::tatolab__screen_capture::screen_capture_config::TargetType;
 
-#[cfg(all(feature = "plugin", any(target_os = "macos", target_os = "ios")))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 streamlib_plugin_abi::export_plugin!(crate::AppleScreenCaptureProcessor::Processor);

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["development-tools::testing"]
 name = "streamlib_test_fixtures"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/test-fixtures/src/lib.rs
+++ b/packages/test-fixtures/src/lib.rs
@@ -44,7 +44,6 @@ pub use tcp_bind_test_processor::TcpBindTest;
 pub use test_configured_processor::ConfiguredProcessor;
 pub use vulkan_smoke_test_processor::VulkanSmokeTest;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(
     crate::ConfiguredProcessor::Processor,
     crate::TcpBindTest::Processor,

--- a/packages/vadr-vision/Cargo.toml
+++ b/packages/vadr-vision/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["aerospace::drones", "encoding", "multimedia"]
 name = "streamlib_vadr_vision"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/vadr-vision/src/lib.rs
+++ b/packages/vadr-vision/src/lib.rs
@@ -18,5 +18,4 @@ pub mod reassembly;
 
 pub use depayloader::VadrVisionDepayloaderProcessor;
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(crate::VadrVisionDepayloaderProcessor::Processor);

--- a/packages/webrtc/Cargo.toml
+++ b/packages/webrtc/Cargo.toml
@@ -13,14 +13,6 @@ categories = ["multimedia::video", "multimedia"]
 name = "streamlib_webrtc"
 crate-type = ["rlib", "cdylib"]
 
-[features]
-# Gates the `export_plugin!` invocation so the `STREAMLIB_PLUGIN` symbol
-# only ends up in the cdylib output (multiple Rust-impl rlibs sharing
-# the same unmangled static collide at link time). `streamlib pack`
-# invokes `cargo build --features plugin` when packing.
-default = []
-plugin = []
-
 [build-dependencies]
 streamlib-jtd-codegen = { path = "../../libs/streamlib-jtd-codegen" }
 

--- a/packages/webrtc/src/lib.rs
+++ b/packages/webrtc/src/lib.rs
@@ -16,7 +16,6 @@ pub use webrtc_whip::WebRtcWhipProcessor;
 
 pub use _generated_::{WebrtcWhepConfig, WebrtcWhipConfig};
 
-#[cfg(feature = "plugin")]
 streamlib_plugin_abi::export_plugin!(
     crate::WebRtcWhepProcessor::Processor,
     crate::WebRtcWhipProcessor::Processor,


### PR DESCRIPTION
## Summary

Closes #875. Drop `[features] plugin = []` from all 18 Rust-impl `packages/<name>/Cargo.toml` files and remove `feature = "plugin"` from the `cfg(...)` gate above `streamlib_plugin_abi::export_plugin!` in each `lib.rs`, preserving any independent `target_os` clauses. Drop the matching `--features <name>/plugin` plumbing from `run_cargo_build`, the no-build error hint in `streamlib pack`, and the 20 `load_project_dylib_*.rs` integration tests that built the test-fixtures / camera cdylib through the gate.

## Why the gate was dead

`#[no_mangle] pub static STREAMLIB_PLUGIN` is read by the runtime via `dlsym` after `dlopen`-ing the cdylib, never by Rust source. Cargo's linker dead-strips unreferenced `#[no_mangle]` statics from rlib content — only cdylib output retains them, since cdylibs export every `#[no_mangle]` by construction. The gate was a precaution against duplicate-symbol errors that the linker happens to handle naturally.

Verified empirically: `streamlib-vadr-vision`'s integration test binary links 5 rlibs that all emit `STREAMLIB_PLUGIN` after this sweep (its own + 4 dev-dep packages: network, jpeg, display, debug-utilities), and `cargo test --workspace --no-run` builds clean. Pre-sweep, the same test binary would have refused to link 5 colliding `STREAMLIB_PLUGIN` definitions only if any one of them were referenced — none are, hence the empirical clean build.

## Residual workspace cross-link sites

Both safe by the dead-strip argument above:
- `microphone-reverb-speaker` Cargo-deps audio + clap; clap's `export_plugin!` is mac-only so on Linux only audio emits the symbol, and the Linux `main` is a stub anyway.
- `streamlib-vadr-vision` `[dev-dependencies]` cross-link 4 packages; per above, all 5 STREAMLIB_PLUGIN emissions get dead-stripped from the test binary.

The 4 examples that still appear in source but cross-dep multiple packages (`camera-audio-recorder`, `runtime-graph-json-demo`, `screen-recorder`, `whep-player`) are intentionally excluded from the workspace pending Apple impl reactivation (commented out in the root `Cargo.toml`).

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace --no-run --exclude vulkan-jpeg` — clean. (vulkan-jpeg's `simple_decoder.rs:149` has a pre-existing `surface_id`-method-as-field error on main, unrelated to this PR.)
- [x] `cargo test --workspace --lib --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — 1941 passed, 0 failed.
- [x] `cargo xtask build-plugins` — 21 packages staged.
- [x] `readelf -s target/streamlib-plugins/tatolab__audio/lib/x86_64-unknown-linux-gnu/libstreamlib_audio.so | grep STREAMLIB_PLUGIN` — symbol present. Same for camera.
- [x] `cargo xtask lint-logging` — clean.
- [x] `cargo xtask check-cdylib-reach` — clean.
- [x] `cargo xtask check-boundaries` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)