### PR TITLE
refactor(macros): remove `#[processor]` inventory submission + add CI gate (#793)

### DIFF
--- a/.github/workflows/check-no-inventory-submit.yml
+++ b/.github/workflows/check-no-inventory-submit.yml
@@ -1,0 +1,53 @@
+name: Check No inventory::submit!(FactoryRegistration)
+
+# CI gate for issue #793's all-dynamic registration rule.
+# `cargo xtask check-no-inventory-submit` walks every workspace `.rs`
+# file under `libs/`, `packages/`, and `examples/` and fails if any
+# non-`#[cfg(test)]` item reintroduces
+# `inventory::submit!(FactoryRegistration { ... })`. The
+# `#[processor]` macro no longer emits one, and reintroducing the
+# pattern would bypass the dynamic-load model from the All-Dynamic
+# Package Loading milestone (#20).
+#
+# `RuntimeInitHookRegistration` inventory submissions are a separate
+# registration system and are NOT flagged — only `FactoryRegistration`
+# is. Test code, doc strings, and `#[cfg(test)]`-gated items are
+# exempt via Rust AST walking.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-no-inventory-submit:
+    name: xtask check-no-inventory-submit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-no-inventory-submit
+        run: cargo xtask check-no-inventory-submit
+
+      - name: cargo test -p xtask check_no_inventory_submit (fixture tests)
+        run: cargo test -p xtask check_no_inventory_submit

--- a/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/libs/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -862,11 +862,10 @@ mod tests {
     /// Look up a registered mock processor's structured ident by its
     /// PascalCase short name. The mock processors live in
     /// [`crate::core::test_support`] and are registered explicitly via
-    /// `ensure_test_mocks_registered()` (no `inventory::submit!`
-    /// auto-discovery); their full ident is composed from the engine
-    /// `streamlib.yaml`'s `package:` block, so reading the version off
-    /// the registry rather than hardcoding it keeps these tests robust
-    /// to package-version bumps.
+    /// `ensure_test_mocks_registered()`; their full ident is composed
+    /// from the engine `streamlib.yaml`'s `package:` block, so reading
+    /// the version off the registry rather than hardcoding it keeps
+    /// these tests robust to package-version bumps.
     fn lookup_registered_ident(short: &str) -> SchemaIdent {
         crate::core::test_support::ensure_test_mocks_registered();
         PROCESSOR_REGISTRY

--- a/libs/streamlib-engine/src/core/processors/mod.rs
+++ b/libs/streamlib-engine/src/core/processors/mod.rs
@@ -25,8 +25,8 @@ pub use traits::{ContinuousProcessor, ManualProcessor, ReactiveProcessor};
 pub use __generated_private::{DynGeneratedProcessor, GeneratedProcessor};
 
 pub use processor_instance_factory::{
-    macro_codegen, DynamicProcessorConstructorFn, ProcessorInstance, ProcessorInstanceFactory,
-    RegisterResult, PROCESSOR_REGISTRY,
+    DynamicProcessorConstructorFn, ProcessorInstance, ProcessorInstanceFactory,
+    PROCESSOR_REGISTRY,
 };
 pub use processor_spec::ProcessorSpec;
 

--- a/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/libs/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -25,7 +25,8 @@ const VTABLE_ERR_BUF_CAP: usize = 512;
 
 /// A created processor instance for runtime use.
 ///
-/// Two-variant: cdylib + inventory-registered processors land in
+/// Two-variant: cdylib registrations (via `STREAMLIB_PLUGIN`) and
+/// in-process `PROCESSOR_REGISTRY.register::<P>()` calls both land in
 /// [`Self::VTable`] (dispatch via extern "C" fn pointers, retiring
 /// the dyn-trait crossing class); legacy non-generic registrations
 /// (subprocess host wrappers via [`ProcessorInstanceFactory::register_dynamic`])
@@ -43,10 +44,12 @@ const VTABLE_ERR_BUF_CAP: usize = 512;
 /// Connection-wiring code on the host operates on the inner Arc
 /// directly (no FFI hop).
 pub enum ProcessorInstance {
-    /// Cdylib- or inventory-registered processor. `instance_ptr` is
-    /// a `Box::into_raw(Box::<P>::new(...))` allocation on the
+    /// Vtable-dispatched processor — cdylib registrations (via
+    /// `STREAMLIB_PLUGIN`) and in-process `register::<P>()` calls
+    /// both land here. `instance_ptr` is a
+    /// `Box::into_raw(Box::<P>::new(...))` allocation on the
     /// registering DSO's heap (cdylib for cross-DSO loads, host for
-    /// inventory). Dropped via `vtable.destroy`.
+    /// in-process registration). Dropped via `vtable.destroy`.
     ///
     /// `any_placeholder` is a ZST anchor whose `&mut` reference
     /// satisfies the `as_any_mut() -> &mut dyn Any` shape without
@@ -592,18 +595,6 @@ impl ProcessorInstance {
     }
 }
 
-/// Types used by macro-generated code. Not for direct use.
-pub mod macro_codegen {
-    use super::ProcessorInstanceFactory;
-
-    /// Registration entry for auto-registration of processor factories via inventory.
-    pub struct FactoryRegistration {
-        pub register_fn: fn(&ProcessorInstanceFactory),
-    }
-
-    inventory::collect!(FactoryRegistration);
-}
-
 /// Legacy-path factory function signature used by
 /// [`ProcessorInstanceFactory::register_dynamic`] for subprocess
 /// host wrappers (Python / Deno) that don't fit the generic vtable
@@ -611,13 +602,6 @@ pub mod macro_codegen {
 pub type DynamicProcessorConstructorFn = Box<
     dyn Fn(&ProcessorNode) -> Result<Box<dyn DynGeneratedProcessor + Send>> + Send + Sync,
 >;
-
-/// Result of processor registration.
-#[derive(Debug, Clone)]
-pub struct RegisterResult {
-    /// Number of processors registered.
-    pub count: usize,
-}
 
 /// Per-type registration entry the factory stores.
 enum RegistrationKind {
@@ -648,15 +632,20 @@ pub struct ProcessorInstanceFactory {
 }
 
 /// Global processor registry for runtime lookups.
-/// Auto-registers all processors collected via inventory on first access.
-pub static PROCESSOR_REGISTRY: LazyLock<ProcessorInstanceFactory> = LazyLock::new(|| {
-    let factory = ProcessorInstanceFactory::new();
-    // Auto-register all processors; ignore errors here (Runner::new checks for empty registry)
-    for registration in inventory::iter::<macro_codegen::FactoryRegistration> {
-        (registration.register_fn)(&factory);
-    }
-    factory
-});
+///
+/// Starts empty. Callers populate it through one of two paths:
+///
+/// - **Cdylib packages** loaded via `runtime.load_project(...)` /
+///   `runtime.load_package(...)` register their processors through the
+///   plugin ABI's `STREAMLIB_PLUGIN` symbol, which calls the host's
+///   `processor_register` callback (see
+///   [`crate::core::plugin::host_services`]).
+/// - **In-process Rust callers** invoke
+///   [`ProcessorInstanceFactory::register`] (typed) or
+///   [`ProcessorInstanceFactory::register_dynamic`] (subprocess host
+///   wrappers) directly on the registry.
+pub static PROCESSOR_REGISTRY: LazyLock<ProcessorInstanceFactory> =
+    LazyLock::new(ProcessorInstanceFactory::new);
 
 impl Default for ProcessorInstanceFactory {
     fn default() -> Self {
@@ -672,19 +661,6 @@ impl ProcessorInstanceFactory {
             descriptors: RwLock::new(HashMap::new()),
             schemas: RwLock::new(HashSet::new()),
         }
-    }
-
-    /// Register all processors collected via inventory at link time.
-    /// Safe to call multiple times - duplicates are skipped. Empty
-    /// inventory is a valid state: apps that compose processors via
-    /// `load_project()` instead of compile-time inventory have an
-    /// empty registry at construction and populate it later.
-    pub fn register_all_processors(&self) -> RegisterResult {
-        for registration in inventory::iter::<macro_codegen::FactoryRegistration> {
-            (registration.register_fn)(self);
-        }
-        let count = self.registrations.read().len();
-        RegisterResult { count }
     }
 
     /// Register a processor type with the vtable shape. Monomorphizes a

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -2332,29 +2332,24 @@ mod tests {
         // Runtime creates successfully
     }
 
-    /// Locks the empty-substrate invariant from issue #793 / the
-    /// All-Dynamic Package Loading milestone: `Runner::new()` must NOT
-    /// populate the global `PROCESSOR_REGISTRY` from any
-    /// compile-time-linked source. Every processor reaches the registry
-    /// through `runtime.load_project(...)` /
-    /// `runtime.load_package(...)` (cdylib `STREAMLIB_PLUGIN` callback)
-    /// or via an explicit `PROCESSOR_REGISTRY.register::<P>()` call.
+    /// Locks one half of the empty-substrate invariant from issue
+    /// #793 / the All-Dynamic Package Loading milestone:
+    /// `Runner::new()` itself must not walk any compile-time-linked
+    /// registration source. The other half — the `#[processor]` macro
+    /// not emitting `inventory::submit!(FactoryRegistration { ... })`
+    /// — is locked by `xtask check-no-inventory-submit` in CI, not by
+    /// this test.
     ///
-    /// Reverting the `inventory::submit!` emission removal would flip
-    /// this assertion the moment any in-tree crate with a
-    /// `#[processor]`-decorated type linked into the engine's test
-    /// binary — which would be the regression the gate exists to
-    /// prevent. The engine substrate ships empty by construction.
+    /// Together the two locks make regression impossible: even if a
+    /// future agent re-introduces the macro emission, `Runner::new()`
+    /// has nothing to walk it with, and even if a future agent re-adds
+    /// a registry-walking call to `Runner::new()`, the CI gate refuses
+    /// any `inventory::submit!(FactoryRegistration ...)` for it to find.
     ///
-    /// NOTE: this test uses `register_descriptor_only` for any
-    /// engine-internal mock processors lazily registered by earlier
-    /// tests in the same binary — the assertion runs against the
-    /// registry's state immediately after `Runner::new()` returns,
-    /// before any test-local registration. Because `PROCESSOR_REGISTRY`
-    /// is a process-global `LazyLock` that earlier tests may have
-    /// populated, this test asserts the *delta* introduced by
-    /// `Runner::new()` is zero rather than asserting the absolute size
-    /// is zero — `Runner::new()` itself contributes no entries.
+    /// `PROCESSOR_REGISTRY` is a process-global `LazyLock` and earlier
+    /// tests in the same binary may have populated it, so the
+    /// assertion is over the *delta* `Runner::new()` introduces, not
+    /// the absolute size.
     #[test]
     #[serial]
     fn runner_new_registers_zero_processors() {

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -188,12 +188,13 @@ impl Runner {
         tracing::debug!("STREAMLIB_HOME: {}", streamlib_home.display());
         crate::core::runtime_hooks::run_init_hooks(&streamlib_home)?;
 
-        // Register all processors from inventory before any add_processor calls.
-        // This populates the global registry with link-time registered processors.
-        // Empty inventory is valid — apps that compose processors via `load_project()`
-        // start with `count == 0` and populate the registry afterwards.
-        let result = crate::core::processors::PROCESSOR_REGISTRY.register_all_processors();
-        tracing::debug!("Registered {} processors from inventory", result.count);
+        // The engine substrate is empty by construction — there are no
+        // compile-time-linked processors. Callers populate the
+        // `PROCESSOR_REGISTRY` after `Runner::new()` returns via
+        // `runtime.load_project(...)` / `runtime.load_package(...)` (which
+        // dlopen plugin cdylibs and register through the host's
+        // `processor_register` callback) or via direct
+        // `PROCESSOR_REGISTRY.register::<P>()` calls in-process.
 
         // Bridge iceoryx2's internal log records into streamlib tracing
         // before creating the iceoryx2 Node so any iceoryx2 emit at
@@ -2329,6 +2330,43 @@ mod tests {
     fn test_runtime_creation() {
         let _runtime = Runner::new();
         // Runtime creates successfully
+    }
+
+    /// Locks the empty-substrate invariant from issue #793 / the
+    /// All-Dynamic Package Loading milestone: `Runner::new()` must NOT
+    /// populate the global `PROCESSOR_REGISTRY` from any
+    /// compile-time-linked source. Every processor reaches the registry
+    /// through `runtime.load_project(...)` /
+    /// `runtime.load_package(...)` (cdylib `STREAMLIB_PLUGIN` callback)
+    /// or via an explicit `PROCESSOR_REGISTRY.register::<P>()` call.
+    ///
+    /// Reverting the `inventory::submit!` emission removal would flip
+    /// this assertion the moment any in-tree crate with a
+    /// `#[processor]`-decorated type linked into the engine's test
+    /// binary — which would be the regression the gate exists to
+    /// prevent. The engine substrate ships empty by construction.
+    ///
+    /// NOTE: this test uses `register_descriptor_only` for any
+    /// engine-internal mock processors lazily registered by earlier
+    /// tests in the same binary — the assertion runs against the
+    /// registry's state immediately after `Runner::new()` returns,
+    /// before any test-local registration. Because `PROCESSOR_REGISTRY`
+    /// is a process-global `LazyLock` that earlier tests may have
+    /// populated, this test asserts the *delta* introduced by
+    /// `Runner::new()` is zero rather than asserting the absolute size
+    /// is zero — `Runner::new()` itself contributes no entries.
+    #[test]
+    #[serial]
+    fn runner_new_registers_zero_processors() {
+        use crate::core::processors::PROCESSOR_REGISTRY;
+        let before = PROCESSOR_REGISTRY.list_registered().len();
+        let _runtime = Runner::new().expect("Runner::new");
+        let after = PROCESSOR_REGISTRY.list_registered().len();
+        assert_eq!(
+            after, before,
+            "Runner::new() must not register any processors — the engine \
+             substrate ships empty (issue #793). Delta: {before} → {after}."
+        );
     }
 
     #[test]

--- a/libs/streamlib-engine/src/core/test_support.rs
+++ b/libs/streamlib-engine/src/core/test_support.rs
@@ -5,16 +5,15 @@
 //!
 //! The TestMock processor types live here so engine tests can drive
 //! graph + compiler code without depending on any external package's
-//! processors. They are declared with `no_inventory` so registration
-//! is explicit (via [`ensure_test_mocks_registered`]) rather than
-//! happening at link-time via the macro's `inventory::submit!`.
+//! processors. The `#[processor]` macro never auto-registers; tests
+//! register the mocks explicitly via [`ensure_test_mocks_registered`].
 
 use std::sync::Once;
 
 use crate::core::processors::PROCESSOR_REGISTRY;
 
 /// Mock processor with two input ports + two output ports.
-#[crate::processor("TestMockProcessor", no_inventory)]
+#[crate::processor("TestMockProcessor", )]
 pub(crate) struct MockProcessor;
 
 impl crate::core::ManualProcessor for MockProcessor::Processor {
@@ -39,7 +38,7 @@ impl crate::core::ManualProcessor for MockProcessor::Processor {
 }
 
 /// Mock processor with only output ports.
-#[crate::processor("TestMockOutputOnlyProcessor", no_inventory)]
+#[crate::processor("TestMockOutputOnlyProcessor", )]
 pub(crate) struct MockOutputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
@@ -64,7 +63,7 @@ impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
 }
 
 /// Mock processor with only input ports.
-#[crate::processor("TestMockInputOnlyProcessor", no_inventory)]
+#[crate::processor("TestMockInputOnlyProcessor", )]
 pub(crate) struct MockInputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {

--- a/libs/streamlib-engine/src/core/test_support.rs
+++ b/libs/streamlib-engine/src/core/test_support.rs
@@ -13,7 +13,7 @@ use std::sync::Once;
 use crate::core::processors::PROCESSOR_REGISTRY;
 
 /// Mock processor with two input ports + two output ports.
-#[crate::processor("TestMockProcessor", )]
+#[crate::processor("TestMockProcessor")]
 pub(crate) struct MockProcessor;
 
 impl crate::core::ManualProcessor for MockProcessor::Processor {
@@ -38,7 +38,7 @@ impl crate::core::ManualProcessor for MockProcessor::Processor {
 }
 
 /// Mock processor with only output ports.
-#[crate::processor("TestMockOutputOnlyProcessor", )]
+#[crate::processor("TestMockOutputOnlyProcessor")]
 pub(crate) struct MockOutputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
@@ -63,7 +63,7 @@ impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
 }
 
 /// Mock processor with only input ports.
-#[crate::processor("TestMockInputOnlyProcessor", )]
+#[crate::processor("TestMockInputOnlyProcessor")]
 pub(crate) struct MockInputOnlyProcessor;
 
 impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {

--- a/libs/streamlib-engine/tests/attribute_macro_test.rs
+++ b/libs/streamlib-engine/tests/attribute_macro_test.rs
@@ -9,11 +9,12 @@
 use streamlib_engine::core::GeneratedProcessor;
 use streamlib_engine::core::{EmptyConfig, Result, RuntimeContextFullAccess};
 
-// Define a simple processor using YAML schema. `no_inventory` opts out
-// of the macro's `inventory::submit!` emission — this test only exercises
-// the macro's typed-API surface (descriptor + ident + port markers) and
-// doesn't need the processor in the global `PROCESSOR_REGISTRY`.
-#[streamlib::sdk::processor("TestProcessor", no_inventory)]
+// Define a simple processor using YAML schema. The macro emits the
+// type, port markers, descriptor, and `schema_ident()` accessor — it
+// never auto-registers. This test exercises the macro's typed-API
+// surface (descriptor + ident + port markers) and intentionally does
+// not register the processor in the global `PROCESSOR_REGISTRY`.
+#[streamlib::sdk::processor("TestProcessor")]
 pub struct TestProcessor;
 
 // User implements the Processor trait on the generated Processor struct

--- a/libs/streamlib-macros/src/codegen.rs
+++ b/libs/streamlib-macros/src/codegen.rs
@@ -80,7 +80,6 @@ pub fn generate_from_processor_schema(
     schema: &ProcessorSchema,
     schema_ident: &SchemaIdent,
     config_schema_id: Option<&str>,
-    no_inventory: bool,
 ) -> TokenStream {
     let module_name = &item.ident;
 
@@ -148,24 +147,6 @@ pub fn generate_from_processor_schema(
         quote! {}
     };
 
-    // Auto-registration via inventory crate. Suppressed when the
-    // processor attribute carries `no_inventory` — used by test-only
-    // mocks and any future processor that wants the consumer to
-    // register explicitly (via load_project / load_package or a direct
-    // PROCESSOR_REGISTRY.register::<P>() call) rather than relying on
-    // link-time auto-discovery.
-    let inventory_submit = if no_inventory {
-        quote! {}
-    } else {
-        quote! {
-            ::streamlib::sdk::inventory::submit! {
-                ::streamlib::sdk::processors::macro_codegen::FactoryRegistration {
-                    register_fn: |factory| factory.register::<Processor>(),
-                }
-            }
-        }
-    };
-
     quote! {
         #[allow(non_snake_case)]
         pub mod #module_name {
@@ -192,8 +173,6 @@ pub fn generate_from_processor_schema(
             #output_link_module
 
             #processor_impl
-
-            #inventory_submit
         }
     }
 }

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -50,22 +50,30 @@ use syn::{
 /// version: <package.version> }` when used inside a manifest declaring
 /// `package: { org: tatolab, name: streamlib, ... }`.
 ///
-/// An optional `no_inventory` flag suppresses the
-/// `inventory::submit!` emission so consumers can opt out of link-time
-/// auto-registration: `#[streamlib::processor("Foo", no_inventory)]`.
-/// The generated `Processor` type is unchanged; callers register it
-/// explicitly via `PROCESSOR_REGISTRY.register::<Foo::Processor>()`.
+/// The macro emits the processor's type, port markers, descriptor, and
+/// `schema_ident()` accessor — but does NOT register the processor in
+/// the global `PROCESSOR_REGISTRY`. Callers register processors through
+/// one of two paths:
+///
+/// - **Cdylib packages** declare `crate-type = ["rlib", "cdylib"]` and
+///   call `export_plugin!(...)` from `lib.rs`. The runtime `dlopen()`s
+///   the cdylib at `runtime.load_project(...)` / `load_package(...)`
+///   time; the plugin ABI's `STREAMLIB_PLUGIN` callback registers each
+///   processor via the host's `processor_register` callback.
+/// - **In-process Rust callers** invoke
+///   `PROCESSOR_REGISTRY.register::<Foo::Processor>()` directly. Tests
+///   and engine-internal mocks use this path.
 #[proc_macro_attribute]
 pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item_struct = parse_macro_input!(item as ItemStruct);
 
-    let parsed = match parse_processor_attr(attr) {
-        Ok(parsed) => parsed,
+    let short_name = match parse_processor_attr(attr) {
+        Ok(name) => name,
         Err(err) => return err.to_compile_error().into(),
     };
 
     let (schema, schema_ident, config_schema_id) =
-        match load_processor_schema(&parsed.short_name, &item_struct) {
+        match load_processor_schema(&short_name, &item_struct) {
             Ok(triple) => triple,
             Err(err) => return err.to_compile_error().into(),
         };
@@ -75,48 +83,33 @@ pub fn processor(attr: TokenStream, item: TokenStream) -> TokenStream {
         &schema,
         &schema_ident,
         config_schema_id.as_deref(),
-        parsed.no_inventory,
     );
 
     TokenStream::from(generated)
 }
 
-/// Parsed `#[processor(...)]` attribute arguments.
-struct ProcessorAttr {
-    short_name: String,
-    no_inventory: bool,
-}
-
-/// Parse the processor short name plus optional flags.
-fn parse_processor_attr(attr: TokenStream) -> syn::Result<ProcessorAttr> {
+/// Parse the processor's PascalCase short name out of the attribute
+/// arguments.
+fn parse_processor_attr(attr: TokenStream) -> syn::Result<String> {
     use syn::parse::Parser;
 
-    let parser = |input: syn::parse::ParseStream<'_>| -> syn::Result<ProcessorAttr> {
+    let parser = |input: syn::parse::ParseStream<'_>| -> syn::Result<String> {
         let name: LitStr = input.parse()?;
-        let mut no_inventory = false;
-        while !input.is_empty() {
+        if !input.is_empty() {
             input.parse::<Token![,]>()?;
-            if input.is_empty() {
-                break;
-            }
-            let flag: syn::Ident = input.parse()?;
-            match flag.to_string().as_str() {
-                "no_inventory" => no_inventory = true,
-                other => {
-                    return Err(syn::Error::new(
-                        flag.span(),
-                        format!(
-                            "unknown processor attribute flag `{}` (expected `no_inventory`)",
-                            other
-                        ),
-                    ));
-                }
+            if !input.is_empty() {
+                let extra: syn::Ident = input.parse()?;
+                return Err(syn::Error::new(
+                    extra.span(),
+                    format!(
+                        "unexpected processor attribute argument `{}` — the macro \
+                         takes only the PascalCase short name (e.g. `#[processor(\"Camera\")]`)",
+                        extra
+                    ),
+                ));
             }
         }
-        Ok(ProcessorAttr {
-            short_name: name.value(),
-            no_inventory,
-        })
+        Ok(name.value())
     };
     parser.parse(attr.into())
 }

--- a/libs/vulkan-jpeg/tests/simple_decoder.rs
+++ b/libs/vulkan-jpeg/tests/simple_decoder.rs
@@ -146,7 +146,7 @@ fn vulkan_compute_backend_eagerly_transitions_ring_slots_to_general_and_updates_
     for slot_index in 0..backend.ring().len() {
         let slot = backend.ring().slot(slot_index).expect("ring slot");
         let reg = gpu
-            .resolve_texture_registration_by_surface_id(&slot.surface_id, None, 64, 64)
+            .resolve_texture_registration_by_surface_id(&slot.surface_id(), None, 64, 64)
             .expect("registration in cache");
         assert_eq!(
             reg.current_layout(),

--- a/packages/vadr-vision/examples/jpeg_pipeline_demo.rs
+++ b/packages/vadr-vision/examples/jpeg_pipeline_demo.rs
@@ -24,19 +24,22 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
-use streamlib::sdk::processors::ProcessorSpec;
+use streamlib::sdk::processors::{ProcessorSpec, PROCESSOR_REGISTRY};
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
 use streamlib_vadr_vision::header::{ChunkHeader, encode};
 
-#[allow(unused_imports)]
-use streamlib_display::DisplayProcessor as _;
-#[allow(unused_imports)]
-use streamlib_jpeg::JpegDecoderProcessor as _;
-#[allow(unused_imports)]
-use streamlib_network::UdpSourceProcessor as _;
-#[allow(unused_imports)]
-use streamlib_vadr_vision::VadrVisionDepayloaderProcessor as _;
+/// Explicit typed registration for every processor this demo drives.
+/// The engine substrate ships empty — no link-time inventory walk
+/// auto-registers anything — so the demo populates the registry
+/// before any `runtime.add_processor` call.
+fn register_demo_processors() {
+    PROCESSOR_REGISTRY.register::<streamlib_network::UdpSourceProcessor::Processor>();
+    PROCESSOR_REGISTRY
+        .register::<streamlib_vadr_vision::VadrVisionDepayloaderProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_jpeg::JpegDecoderProcessor::Processor>();
+    PROCESSOR_REGISTRY.register::<streamlib_display::DisplayProcessor::Processor>();
+}
 
 const CHUNK_PAYLOAD_BYTES: usize = 1200;
 const SEND_FPS: u32 = 15;
@@ -117,6 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("UdpSource will bind: {bind_addr}");
 
     let runtime = Runner::new()?;
+    register_demo_processors();
 
     let source_id = runtime.add_processor(ProcessorSpec::new(
         schema_ident!("tatolab", "network", "UdpSource", "1.0.0"),

--- a/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
+++ b/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
@@ -14,9 +14,10 @@
 //! match the fixture. This locks the cross-process pieces the unit tests
 //! and state-machine integration tests don't: the iceoryx2 NetworkPacket →
 //! EncodedJpegFrame → VideoFrame byte-shape mailbox path, the
-//! `#[streamlib::sdk::processor]` macro wiring, the
-//! `inventory::submit!` factory registration, and the actual UDP path
-//! the deployed pipeline uses.
+//! `#[streamlib::sdk::processor]` macro wiring, the explicit
+//! `PROCESSOR_REGISTRY.register::<P>()` calls in `register_test_processors`
+//! that populate the factory, and the actual UDP path the deployed
+//! pipeline uses.
 //!
 //! Per-test setup registers the package processors explicitly via
 //! `PROCESSOR_REGISTRY.register::<P>()` — the engine substrate ships

--- a/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
+++ b/packages/vadr-vision/tests/udp_vadr_jpeg_e2e.rs
@@ -18,6 +18,11 @@
 //! `inventory::submit!` factory registration, and the actual UDP path
 //! the deployed pipeline uses.
 //!
+//! Per-test setup registers the package processors explicitly via
+//! `PROCESSOR_REGISTRY.register::<P>()` — the engine substrate ships
+//! empty and the `#[streamlib::sdk::processor]` macro never
+//! auto-registers.
+//!
 //! Marked `#[serial]` so multiple test binaries don't race on UDP port
 //! binding or the `VideoFrameCounter`'s process-global atomics.
 
@@ -222,7 +227,9 @@ fn run_pipeline(bind_addr: SocketAddr, jpeg: &[u8], frames: u32) {
 /// 2. `#[streamlib::sdk::processor]` macro plumbing — `setup` runs
 ///    with `FullAccess`, `process` runs with `LimitedAccess`, ports
 ///    `chunks_in` / `jpeg_out` are wired to the right schema variants,
-///    `inventory::submit!` factory is reachable from the link line.
+///    and the explicit `PROCESSOR_REGISTRY.register::<P>()` calls in
+///    `register_test_processors` populate the factory from the link
+///    line.
 /// 3. The real UDP path (`recv_loop` → `outputs.write` → iceoryx2 →
 ///    depayloader's `inputs.read`) — the udp_loopback test exercises
 ///    UdpSource + UdpSink only; this test exercises UdpSource +

--- a/xtask/src/check_no_inventory_submit.rs
+++ b/xtask/src/check_no_inventory_submit.rs
@@ -1,0 +1,466 @@
+// Copyright (c) 2026 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI gate enforcing the all-dynamic registration rule for processor
+//! factories.
+//!
+//! The engine substrate is an empty registry; processors land in
+//! `PROCESSOR_REGISTRY` through one of two paths:
+//!
+//! 1. Cdylib packages loaded via `runtime.load_project(...)` /
+//!    `runtime.load_package(...)`, which trip `STREAMLIB_PLUGIN` and
+//!    call the host's `processor_register` callback.
+//! 2. In-process Rust callers invoking
+//!    `PROCESSOR_REGISTRY.register::<P>()` directly.
+//!
+//! The link-time `inventory::submit!(FactoryRegistration { ... })`
+//! emission the `#[processor]` macro used to do is gone. Anyone
+//! reintroducing it would bypass the dynamic-load model — `Runner::new()`
+//! would silently grow non-empty in builds that link the offending crate,
+//! processors would register before any `load_project` call, and
+//! cross-rustc-version plugin builds would start to "work" via the
+//! force-link path that the milestone wants gone.
+//!
+//! This gate scans `.rs` files under `packages/`, `libs/`, and `examples/`
+//! and fails when any non-`#[cfg(test)]` item contains
+//! `inventory::submit!(FactoryRegistration ...)` (in macro-call or
+//! macro-token shape). The `RuntimeInitHookRegistration` inventory used
+//! by `core::runtime_hooks` is a separate registration system and is NOT
+//! flagged — only `FactoryRegistration` submissions are.
+//!
+//! Comments, doc strings, and `#[cfg(test)]`-gated code are exempt: the
+//! Rust AST walk skips them automatically by construction.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use syn::visit::Visit;
+use walkdir::WalkDir;
+
+const SCAN_PARENTS: &[&str] = &["libs", "packages", "examples"];
+
+const SKIP_PATH_FRAGMENTS: &[&str] = &[
+    "/target/",
+    "/_generated_/",
+    "/node_modules/",
+    "/.git/",
+];
+
+/// Marker comment that exempts an entire file from this gate. Reserved
+/// for the gate's own definition (which must contain the banned token
+/// literally) and any future legitimate-but-unusual case reviewers
+/// approve explicitly.
+const ALLOW_FILE_PRAGMA: &str = "check-no-inventory-submit:allow-file";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub file: PathBuf,
+    pub line: usize,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let violations = scan_workspace(workspace_root)?;
+    if violations.is_empty() {
+        println!(
+            "✓ check-no-inventory-submit: no `inventory::submit!(FactoryRegistration ...)` \
+             in live code — the engine substrate stays empty by construction."
+        );
+        return Ok(());
+    }
+    eprintln!(
+        "✗ check-no-inventory-submit: {} violation(s) — link-time \
+         processor registration reintroduced:",
+        violations.len()
+    );
+    for v in &violations {
+        eprintln!("  {}:{}: inventory::submit!(FactoryRegistration ...)", v.file.display(), v.line);
+    }
+    eprintln!(
+        "\nFix:\n  \
+         The engine substrate is empty by design. Register processors \
+         through one of:\n    \
+           1. Cdylib `export_plugin!(...)` — the runtime dlopens the \
+              cdylib and registers via the plugin ABI's STREAMLIB_PLUGIN \
+              callback.\n    \
+           2. In-process `PROCESSOR_REGISTRY.register::<P>()` — for \
+              engine-internal tests / mocks / inline registrations.\n  \
+         The `#[processor]` macro no longer emits any registration. See \
+         issue #793 + the All-Dynamic Package Loading milestone."
+    );
+    anyhow::bail!("check-no-inventory-submit failed");
+}
+
+pub fn scan_workspace(workspace_root: &Path) -> Result<Vec<Violation>> {
+    let mut violations = Vec::new();
+    for parent in SCAN_PARENTS {
+        let dir = workspace_root.join(parent);
+        if !dir.exists() {
+            continue;
+        }
+        scan_dir(&dir, &mut violations)?;
+    }
+    Ok(violations)
+}
+
+fn scan_dir(dir: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let path_str = path.to_string_lossy();
+        if SKIP_PATH_FRAGMENTS
+            .iter()
+            .any(|frag| path_str.contains(frag))
+        {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        scan_file(path, violations)?;
+    }
+    Ok(())
+}
+
+fn scan_file(path: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    let body = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    if body.contains(ALLOW_FILE_PRAGMA) {
+        return Ok(());
+    }
+    let file = match syn::parse_file(&body) {
+        Ok(f) => f,
+        Err(_) => return Ok(()), // unparseable — leave to rustc to surface
+    };
+    if file.attrs.iter().any(is_cfg_test_attr) {
+        return Ok(());
+    }
+    let mut visitor = RustVisitor {
+        path: path.to_path_buf(),
+        violations,
+    };
+    visitor.visit_file(&file);
+    Ok(())
+}
+
+struct RustVisitor<'a> {
+    path: PathBuf,
+    violations: &'a mut Vec<Violation>,
+}
+
+impl<'ast, 'a> Visit<'ast> for RustVisitor<'a> {
+    fn visit_attribute(&mut self, _attr: &'ast syn::Attribute) {
+        // Don't descend into attributes — skips `#[doc = "..."]` strings
+        // and other attribute literals that might mention the banned
+        // token in prose.
+    }
+
+    fn visit_item(&mut self, item: &'ast syn::Item) {
+        if let Some(attrs) = item_attrs(item) {
+            if attrs.iter().any(is_cfg_test_attr) {
+                return;
+            }
+        }
+        syn::visit::visit_item(self, item);
+    }
+
+    fn visit_impl_item(&mut self, item: &'ast syn::ImplItem) {
+        let attrs: &[syn::Attribute] = match item {
+            syn::ImplItem::Const(x) => &x.attrs,
+            syn::ImplItem::Fn(x) => &x.attrs,
+            syn::ImplItem::Type(x) => &x.attrs,
+            syn::ImplItem::Macro(x) => &x.attrs,
+            _ => &[],
+        };
+        if attrs.iter().any(is_cfg_test_attr) {
+            return;
+        }
+        syn::visit::visit_impl_item(self, item);
+    }
+
+    fn visit_item_macro(&mut self, mac: &'ast syn::ItemMacro) {
+        if mac.attrs.iter().any(is_cfg_test_attr) {
+            return;
+        }
+        // Fall through to `visit_macro` via the default traversal so
+        // we only count each macro invocation once.
+        syn::visit::visit_item_macro(self, mac);
+    }
+
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        check_macro(mac, &self.path, self.violations);
+        syn::visit::visit_macro(self, mac);
+    }
+}
+
+/// True iff `mac` is `inventory::submit!{...}` AND the token stream
+/// inside the braces references `FactoryRegistration`. Matches the
+/// macro's `path::path::submit` shape regardless of the leading
+/// `::streamlib::sdk::` qualifier — we only care that the final two
+/// segments are `inventory::submit`.
+fn check_macro(mac: &syn::Macro, path: &Path, violations: &mut Vec<Violation>) {
+    let segs = &mac.path.segments;
+    let n = segs.len();
+    if n < 2 {
+        return;
+    }
+    if segs[n - 2].ident != "inventory" || segs[n - 1].ident != "submit" {
+        return;
+    }
+    if !tokens_reference_factory_registration(mac.tokens.clone()) {
+        return;
+    }
+    violations.push(Violation {
+        file: path.to_path_buf(),
+        line: segs[n - 1].ident.span().start().line,
+    });
+}
+
+fn tokens_reference_factory_registration(stream: proc_macro2::TokenStream) -> bool {
+    for tt in stream {
+        match tt {
+            proc_macro2::TokenTree::Ident(i) if i == "FactoryRegistration" => return true,
+            proc_macro2::TokenTree::Group(g) => {
+                if tokens_reference_factory_registration(g.stream()) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// True if this `#[cfg(...)]` attribute contains a bare `test` predicate
+/// at any nesting level (`#[cfg(test)]`, `#[cfg(all(test, ...))]`,
+/// `#[cfg(any(test, ...))]`, etc.).
+fn is_cfg_test_attr(attr: &syn::Attribute) -> bool {
+    if !attr.path().is_ident("cfg") {
+        return false;
+    }
+    let Ok(list) = attr.meta.require_list() else {
+        return false;
+    };
+    tokens_contain_bare_test(list.tokens.clone())
+}
+
+fn tokens_contain_bare_test(stream: proc_macro2::TokenStream) -> bool {
+    for tt in stream {
+        match tt {
+            proc_macro2::TokenTree::Ident(i) if i == "test" => return true,
+            proc_macro2::TokenTree::Group(g) => {
+                if tokens_contain_bare_test(g.stream()) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn item_attrs(item: &syn::Item) -> Option<&[syn::Attribute]> {
+    Some(match item {
+        syn::Item::Const(x) => &x.attrs,
+        syn::Item::Enum(x) => &x.attrs,
+        syn::Item::ExternCrate(x) => &x.attrs,
+        syn::Item::Fn(x) => &x.attrs,
+        syn::Item::ForeignMod(x) => &x.attrs,
+        syn::Item::Impl(x) => &x.attrs,
+        syn::Item::Macro(x) => &x.attrs,
+        syn::Item::Mod(x) => &x.attrs,
+        syn::Item::Static(x) => &x.attrs,
+        syn::Item::Struct(x) => &x.attrs,
+        syn::Item::Trait(x) => &x.attrs,
+        syn::Item::TraitAlias(x) => &x.attrs,
+        syn::Item::Type(x) => &x.attrs,
+        syn::Item::Union(x) => &x.attrs,
+        syn::Item::Use(x) => &x.attrs,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn passes_on_clean_workspace() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+pub fn hello() -> &'static str { "world" }
+
+inventory::submit!(RuntimeInitHookRegistration::new::<MyHook>());
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn flags_factory_registration_submit() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+inventory::submit! {
+    FactoryRegistration {
+        register_fn: |factory| factory.register::<Processor>(),
+    }
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+    }
+
+    #[test]
+    fn flags_fully_qualified_submit() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+::streamlib::sdk::inventory::submit! {
+    ::streamlib::sdk::processors::macro_codegen::FactoryRegistration {
+        register_fn: |factory| factory.register::<Processor>(),
+    }
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+    }
+
+    #[test]
+    fn skips_runtime_init_hook_registration() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+inventory::submit! {
+    RuntimeInitHookRegistration::new::<MyHook>()
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn skips_cfg_test_item() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+pub fn ok() {}
+
+#[cfg(test)]
+mod tests {
+    inventory::submit! {
+        FactoryRegistration {
+            register_fn: |factory| factory.register::<Processor>(),
+        }
+    }
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn skips_doc_comment_mention() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+/// Historical: the macro used to emit
+/// `inventory::submit!(FactoryRegistration { ... })`.
+pub fn ok() {}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn skips_allow_file_pragma() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/src/lib.rs",
+            r#"
+// check-no-inventory-submit:allow-file
+inventory::submit! {
+    FactoryRegistration {
+        register_fn: |factory| factory.register::<Processor>(),
+    }
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn skips_target_and_generated_dirs() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "libs/foo/target/build/lib.rs",
+            r#"
+inventory::submit! {
+    FactoryRegistration { register_fn: |f| f.register::<P>() }
+}
+"#,
+        );
+        write(
+            tmp.path(),
+            "libs/foo/_generated_/whatever.rs",
+            r#"
+inventory::submit! {
+    FactoryRegistration { register_fn: |f| f.register::<P>() }
+}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert!(violations.is_empty(), "got {violations:?}");
+    }
+
+    #[test]
+    fn flags_violation_in_example() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "examples/demo/src/main.rs",
+            r#"
+inventory::submit! {
+    FactoryRegistration { register_fn: |f| f.register::<P>() }
+}
+
+fn main() {}
+"#,
+        );
+        let violations = scan_workspace(tmp.path()).unwrap();
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,7 @@ use streamlib_jtd_codegen::{generate, GenerateOptions, RuntimeTarget};
 pub mod build_plugins;
 pub mod check_boundaries;
 pub mod check_cdylib_reach;
+pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
 pub mod check_processor_spec_new;
@@ -92,6 +93,15 @@ enum Commands {
     /// `tests/`, `*_test{s}.rs`), and Rust comments are allowed. See
     /// `docs/architecture/schema-identity-and-packaging.md`.
     CheckNoReverseDns,
+
+    /// CI gate for #793's all-dynamic registration rule. Fails on any
+    /// `inventory::submit!(FactoryRegistration { ... })` in live code —
+    /// the `#[processor]` macro no longer emits one, and reintroducing
+    /// the pattern would bypass the dynamic-load model from milestone
+    /// `All-Dynamic Package Loading` (#20). `RuntimeInitHookRegistration`
+    /// inventory submissions are unaffected — only `FactoryRegistration`
+    /// is flagged.
+    CheckNoInventorySubmit,
 
     /// CI gate for the structured-everywhere `ProcessorSpec` rule from
     /// #707. Fails on `ProcessorSpec::new("PascalCase", ...)` — every
@@ -175,6 +185,7 @@ fn main() -> Result<()> {
             check_no_streamlib_metadata::run(&workspace_root()?)?
         }
         Commands::CheckNoReverseDns => check_no_reverse_dns::run(&workspace_root()?)?,
+        Commands::CheckNoInventorySubmit => check_no_inventory_submit::run(&workspace_root()?)?,
         Commands::CheckProcessorSpecNew => check_processor_spec_new::run(&workspace_root()?)?,
         Commands::CheckCdylibReach => check_cdylib_reach::run(&workspace_root()?)?,
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,


### PR DESCRIPTION
## Summary

Closes #793. Strips `inventory::submit!(FactoryRegistration { ... })` from the `#[processor]` attribute macro and lands a CI gate (`xtask check-no-inventory-submit`) preventing reintroduction. The engine substrate now ships empty by construction — `Runner::new()` exits with zero registered processors and every processor reaches `PROCESSOR_REGISTRY` through one of two explicit paths:

- Cdylib packages loaded via `runtime.load_project(...)` / `runtime.load_package(...)`, which trip `STREAMLIB_PLUGIN` and call the host's `processor_register` callback.
- In-process callers invoking `PROCESSOR_REGISTRY.register::<P>()` directly (tests, engine-internal mocks).

Combined with goal-09's `plugin` Cargo-feature removal (#1038), the cross-rustc-version plugin dream is real: a plugin author publishes a `.slpkg` from their own repo with their own rustc / Cargo dep graph, and any host that agrees on `streamlib-plugin-abi` + `streamlib-consumer-rhi` versions plus target triple dlopens it cleanly. No toolchain coordination required.

## Changes

**Macro (`libs/streamlib-macros/`):**
- Drop `inventory_submit` token emission + the `no_inventory` flag from the `#[processor]` macro. Macro now takes only the PascalCase short name; extra args become a clear compile error.

**Engine substrate (`libs/streamlib-engine/`):**
- Drop `macro_codegen::FactoryRegistration` + `inventory::collect!`, the `LazyLock` walk in `PROCESSOR_REGISTRY` init, and `register_all_processors`. The registry is now a plain `LazyLock<ProcessorInstanceFactory>` initialized from `ProcessorInstanceFactory::new` (empty).
- Drop the `register_all_processors()` call in `Runner::new()`.
- New `runner_new_registers_zero_processors` test in `runtime::tests` locks the engine-side half of the empty-substrate invariant; the CI gate locks the macro-emission half. Together unreachable.

**Sweep:**
- Drop `no_inventory` flag from three `test_support.rs` mocks and the `attribute_macro_test` fixture (flag is no-op now).
- Migrate `packages/vadr-vision/examples/jpeg_pipeline_demo.rs` off the legacy `use foo::Bar as _;` force-link pattern to explicit `PROCESSOR_REGISTRY.register::<P>()` calls. Last force-link site in the workspace.
- Update prose docstrings in `open_iceoryx2_service_op.rs` and `udp_vadr_jpeg_e2e.rs` to reflect the new registration model.

**CI gate (`xtask/src/check_no_inventory_submit.rs`):**
- AST-walks `.rs` files under `libs/`, `packages/`, `examples/` and fails on any non-`#[cfg(test)]` `inventory::submit!(FactoryRegistration ...)`. Doc strings, test items, `_generated_/`, and the unrelated `RuntimeInitHookRegistration` inventory are exempt; explicit `check-no-inventory-submit:allow-file` pragma available for the gate's own definition.
- 9 fixture tests cover positive / negative / exemption cases.
- `.github/workflows/check-no-inventory-submit.yml` wires it into CI alongside the other `xtask check-*` gates.

## Out of scope vs. issue body

The issue's last two exit criteria (`rust-toolchain.toml` pin + toolchain-mismatch CI gate) are **NOT** shipped — they contradict milestone #20's superseded note from 2026-05-22, which explicitly establishes cross-rustc-version plugin builds must work. The original framing was a permissive fallback while β-shape coverage was incomplete; the milestone direction now is "plugins from anywhere" and locking the host + plugin toolchains to a single pinned rustc would reverse that. I'll mark those criteria as superseded on the issue body after the PR opens.

## Pre-existing breakage observed during baseline (not introduced by this PR)

- `libs/vulkan-jpeg/tests/simple_decoder.rs:149` was using `slot.surface_id` as a field after `TextureRingSlot` made it a method in an earlier PR. One-character fix (`slot.surface_id` → `slot.surface_id()`) included so the workspace baseline can run end-to-end. Reproduces cleanly on `main`.
- `polyglot_manual_source_{deno,python}` integration tests fail with `"missing Rust artifact for this host"` — the plugin's flat `lib/<flat>.so` layout doesn't match the loader's expected `lib/<target-triple>/<flat>.so` path. Reproduces on `main` with no branch changes. Anticipated for fix in goal-11 (#870 / #871, container smoke + pack-then-load round-trip) — that goal's `PAUSE ON` explicitly calls out *"path-resolution bug in `Runner::load_package` / `extract_slpkg_to_cache` — engine-tier bug to fix at the substrate, not paper over in the fixture."*

## Test plan

- [x] `cargo build -p streamlib-macros` clean
- [x] `cargo build -p streamlib-engine` clean (47 warnings, all pre-existing)
- [x] `cargo build -p xtask` clean
- [x] `cargo test -p xtask check_no_inventory_submit` — 9 fixture tests pass
- [x] `cargo xtask check-no-inventory-submit` — clean on the live tree
- [x] `cargo test -p streamlib-engine --lib runner_new_registers_zero_processors` — passes
- [x] Workspace baseline (`cargo test --workspace --exclude api-server-demo --exclude camera-{deno,python,rust}-{subprocess,plugin} --exclude webrtc-cloudflare-stream`): **1753 passed, 2 failed (both pre-existing on main, unrelated), 131 ignored**

## Review cadence

**Engine-touching — DO NOT self-merge.** Per goal-10: full `pr-review-gate` + manual review before merge. The pre-merge `pr-review-gate` returned PASS with four DISCUSS nits, all addressed in the second commit (regression-test docstring tightening, trailing-comma cleanup, stale module-doc update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)