### PR TITLE
feat(runtime): imperative Runner::add_module + ModuleIdent (closes #878)

### DIFF
--- a/examples/api-server/src/main.rs
+++ b/examples/api-server/src/main.rs
@@ -19,7 +19,17 @@
 //! Run prerequisite: `cargo xtask build-plugins --package @tatolab/api-server`
 //! so the runtime can find the staged cdylib at
 //! `target/streamlib-plugins/tatolab__api-server/`.
+//!
+//! Loads `@tatolab/api-server` through the imperative
+//! [`Runner::add_module`] API — the typed counterpart to the
+//! yaml-driven `load_project`. The fully spelled out
+//! [`streamlib::sdk::module_ident!`] call is one of four
+//! ergonomic shapes; the other three (split + any-version,
+//! joined + version, joined + any-version) are equally valid and
+//! resolve to the same `ModuleIdent::new(...)` expression at
+//! expansion time.
 
+use streamlib::sdk::module_ident;
 use streamlib::sdk::processors::ProcessorSpec;
 use streamlib::sdk::runtime::Runner;
 use streamlib::sdk::schema_ident;
@@ -28,7 +38,12 @@ use streamlib::sdk::schema_ident;
 async fn main() -> streamlib::sdk::error::Result<()> {
     let runtime = Runner::new()?;
 
-    runtime.load_workspace_packages(["@tatolab/api-server"])?;
+    // Imperative module load — REST-endpoint-friendly counterpart
+    // to `Runner::load_project` / `Runner::load_package`. The
+    // runtime resolves the ident against the workspace stage dir
+    // or installed-package cache, verifies the semver range, then
+    // drives the same internal module-loading machinery.
+    runtime.add_module(module_ident!("tatolab", "api-server", "^1.0.0"))?;
 
     let config = serde_json::json!({
         "host": "127.0.0.1",
@@ -47,4 +62,44 @@ async fn main() -> streamlib::sdk::error::Result<()> {
     runtime.wait_for_signal()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Compile-checks for the four `module_ident*!` macro shapes —
+    //! every shape must expand to a valid `ModuleIdent` against the
+    //! same `streamlib::sdk::descriptors::*` paths. The runtime
+    //! resolution of these idents is exercised in the engine's
+    //! `add_module_tests` module against fixture-staged packages.
+    use streamlib::sdk::descriptors::{ModuleIdent, SemVerRange};
+    use streamlib::sdk::{
+        module_ident, module_ident_any_version, module_ident_joined,
+        module_ident_joined_any_version,
+    };
+
+    #[test]
+    fn module_ident_split_with_version_round_trips() {
+        let id: ModuleIdent = module_ident!("tatolab", "api-server", "^1.0.0");
+        assert_eq!(id.to_string(), "@tatolab/api-server@^1.0.0");
+    }
+
+    #[test]
+    fn module_ident_split_any_version_emits_star_range() {
+        let id: ModuleIdent = module_ident_any_version!("tatolab", "api-server");
+        assert_eq!(id.to_string(), "@tatolab/api-server@*");
+        assert_eq!(id.version, SemVerRange::Any);
+    }
+
+    #[test]
+    fn module_ident_joined_with_version_round_trips() {
+        let id: ModuleIdent = module_ident_joined!("@tatolab/api-server", "~1.0.0");
+        assert_eq!(id.to_string(), "@tatolab/api-server@~1.0.0");
+    }
+
+    #[test]
+    fn module_ident_joined_any_version_emits_star_range() {
+        let id: ModuleIdent = module_ident_joined_any_version!("@tatolab/api-server");
+        assert_eq!(id.to_string(), "@tatolab/api-server@*");
+        assert_eq!(id.version, SemVerRange::Any);
+    }
 }

--- a/libs/streamlib-engine/src/core/descriptors.rs
+++ b/libs/streamlib-engine/src/core/descriptors.rs
@@ -5,7 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 pub use streamlib_processor_schema::{
-    Org, Package, PortSchemaSpec, ProcessorScheduling, SchemaIdent, SemVer, TypeName,
+    ModuleIdent, Org, Package, PortSchemaSpec, ProcessorScheduling, SchemaIdent, SemVer,
+    SemVerRange, TypeName,
 };
 
 /// Lossless wire-format mirror of [`PortSchemaSpec`] used at the cdylib

--- a/libs/streamlib-engine/src/core/runtime/mod.rs
+++ b/libs/streamlib-engine/src/core/runtime/mod.rs
@@ -11,7 +11,8 @@ mod status;
 
 pub use operations::{BoxFuture, RuntimeOperations};
 pub use runtime::{
-    extract_slpkg_to_cache, host_target_triple, LoadWorkspacePackagesError, Runner,
+    extract_slpkg_to_cache, host_target_triple, AddModuleError, LoadWorkspacePackagesError,
+    RemoveModuleError, Runner,
 };
 pub use runtime_unique_id::RuntimeUniqueId;
 pub use status::RuntimeStatus;

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -2205,7 +2205,30 @@ fn resolve_module_source(
     pkg_ref: &streamlib_idents::PackageRef,
 ) -> std::result::Result<ResolvedModuleSource, AddModuleError> {
     // 1. Workspace stage dir, when a workspace is locatable.
-    if let Ok(workspace_root) = resolve_workspace_root() {
+    //
+    // Distinguish "env var set but invalid" (user typo'd
+    // `STREAMLIB_WORKSPACE_ROOT` — their stated intent is broken,
+    // surface it) from "no env var, no workspace nearby" (no intent
+    // expressed, silently fall through to the installed cache).
+    // Mirrors the `STREAMLIB_WORKSPACE_ROOT errors when env var path
+    // does not exist` precedent on `load_workspace_packages`.
+    let env_workspace_root = std::env::var("STREAMLIB_WORKSPACE_ROOT").ok();
+    let workspace_root = if let Some(env_root) = env_workspace_root.as_deref() {
+        let path = std::path::PathBuf::from(env_root);
+        if !path.is_dir() {
+            return Err(AddModuleError::WorkspaceRootInvalid {
+                env_value: env_root.to_string(),
+            });
+        }
+        Some(path)
+    } else {
+        // No env var: best-effort cargo-locate-project (in-workspace
+        // cargo invocations find the workspace; non-workspace callers
+        // silently miss and fall through to the installed cache).
+        resolve_workspace_root().ok()
+    };
+
+    if let Some(workspace_root) = workspace_root {
         let staged_dir = workspace_root
             .join("target")
             .join("streamlib-plugins")
@@ -2301,6 +2324,18 @@ pub enum AddModuleError {
     /// run. Catches I/O / parse failures distinct from "no entry."
     #[error("Failed to load installed-package cache: {detail}")]
     InstalledCacheLoadFailed { detail: String },
+
+    /// `STREAMLIB_WORKSPACE_ROOT` was set but its value isn't a
+    /// directory. Treats the env var as the user's stated intent —
+    /// don't silently fall through to the installed cache when the
+    /// override is broken. Mirrors `load_workspace_packages`'s
+    /// `WorkspaceRootNotFound` behavior on env-var-set-but-invalid.
+    #[error(
+        "STREAMLIB_WORKSPACE_ROOT is set to `{env_value}` but that path \
+         is not a directory. Fix the env var or unset it (in which case \
+         the resolver falls through to the installed-package cache)."
+    )]
+    WorkspaceRootInvalid { env_value: String },
 
     /// `Runner::load_project` rejected the resolved source path.
     #[error("load_project failed for '{module}': {source}")]
@@ -3873,114 +3908,211 @@ package:
         use super::*;
         use streamlib_idents::{ModuleIdent, Org, Package, SemVer, SemVerRange};
 
-        /// Build a schemas-only `streamlib.yaml` at `dir` with the given
-        /// org/name/version. Schemas-only avoids the dylib-loading branch
-        /// — `add_module` resolution + version-range matching is what we
-        /// want to lock here, not the cdylib mechanics that
-        /// `load_workspace_packages` already covers.
+        /// RAII guard that restores `STREAMLIB_WORKSPACE_ROOT` and
+        /// `STREAMLIB_HOME` to their pre-test values on drop. Every
+        /// `add_module` test isolates both env vars to a tempdir to
+        /// keep the host's real workspace / installed cache out of the
+        /// test surface (per the side-effect-cleanup discipline in
+        /// `docs/testing.md` — flag tests that mutate global state).
+        struct AddModuleEnvGuard {
+            workspace_prev: Option<std::ffi::OsString>,
+            home_prev: Option<std::ffi::OsString>,
+        }
+
+        impl AddModuleEnvGuard {
+            fn install(workspace_root: &std::path::Path, home_root: &std::path::Path) -> Self {
+                let workspace_prev = std::env::var_os("STREAMLIB_WORKSPACE_ROOT");
+                let home_prev = std::env::var_os("STREAMLIB_HOME");
+                unsafe {
+                    std::env::set_var("STREAMLIB_WORKSPACE_ROOT", workspace_root);
+                    std::env::set_var("STREAMLIB_HOME", home_root);
+                }
+                Self { workspace_prev, home_prev }
+            }
+        }
+
+        impl Drop for AddModuleEnvGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    match self.workspace_prev.take() {
+                        Some(v) => std::env::set_var("STREAMLIB_WORKSPACE_ROOT", v),
+                        None => std::env::remove_var("STREAMLIB_WORKSPACE_ROOT"),
+                    }
+                    match self.home_prev.take() {
+                        Some(v) => std::env::set_var("STREAMLIB_HOME", v),
+                        None => std::env::remove_var("STREAMLIB_HOME"),
+                    }
+                }
+            }
+        }
+
+        /// Build a schemas-only `streamlib.yaml` at `dir` with the
+        /// given org/name/version. Schemas-only avoids the dylib-
+        /// loading branch — `add_module` resolution + version-range
+        /// matching is what we want to lock here, not the cdylib
+        /// mechanics that `load_workspace_packages` already covers.
+        ///
+        /// When `schema` is provided, emits a `schemas:` block plus
+        /// the named schema YAML under `schemas/<type_snake>.yaml`
+        /// so post-load callers can verify the schema actually
+        /// registered (locks "`load_project` ran" — not just "resolver
+        /// + range check ran").
         fn write_schemas_only_manifest(
             dir: &std::path::Path,
             org: &str,
             name: &str,
             version: &str,
+            schema: Option<&str>,
         ) {
-            std::fs::write(
-                dir.join("streamlib.yaml"),
+            let body = if let Some(type_name) = schema {
+                let stem = type_name.to_ascii_lowercase();
+                std::fs::create_dir_all(dir.join("schemas")).unwrap();
+                std::fs::write(
+                    dir.join("schemas").join(format!("{stem}.yaml")),
+                    format!(
+                        "metadata:\n  type: {type_name}\n  max_payload_bytes: 4096\n"
+                    ),
+                )
+                .unwrap();
+                format!(
+                    "package:\n  org: {org}\n  name: {name}\n  version: \"{version}\"\n\
+                     schemas:\n  {type_name}:\n    file: schemas/{stem}.yaml\n"
+                )
+            } else {
                 format!(
                     "package:\n  org: {org}\n  name: {name}\n  version: \"{version}\"\n"
-                ),
-            )
-            .expect("write streamlib.yaml");
+                )
+            };
+            std::fs::write(dir.join("streamlib.yaml"), body)
+                .expect("write streamlib.yaml");
         }
 
-        /// Stage a package under `<workspace>/target/streamlib-plugins/<org>__<name>/`
-        /// and return the staged dir path. Mirrors what
+        /// Stage a package under
+        /// `<workspace>/target/streamlib-plugins/<org>__<name>/`
+        /// and return the staged dir. Mirrors what
         /// `cargo xtask build-plugins` produces.
         fn stage_workspace_package(
             workspace_root: &std::path::Path,
             org: &str,
             name: &str,
             version: &str,
+            schema: Option<&str>,
         ) -> std::path::PathBuf {
             let staged = workspace_root
                 .join("target")
                 .join("streamlib-plugins")
                 .join(format!("{org}__{name}"));
             std::fs::create_dir_all(&staged).expect("mkdir staged");
-            write_schemas_only_manifest(&staged, org, name, version);
+            write_schemas_only_manifest(&staged, org, name, version, schema);
             staged
         }
 
         #[test]
         #[serial]
         fn add_module_resolves_workspace_stage_and_loads() {
+            // The schema name is unique to this test so the runtime
+            // schema registry (a process-wide static) can be probed
+            // after `add_module` to confirm load_project actually
+            // ran — mentally reverting the `self.load_project(...)`
+            // call inside `add_module` to `Ok(())` would leave the
+            // earlier (resolver-only) assertion green but make the
+            // post-load schema lookup fail.
+            const TYPE_NAME: &str = "AddModuleResolvesStageSchema";
             let tmp = tempfile::tempdir().unwrap();
-            let _staged =
-                stage_workspace_package(tmp.path(), "tatolab", "add-module-stage", "1.2.3");
+            let home = tempfile::tempdir().unwrap();
+            let _staged = stage_workspace_package(
+                tmp.path(),
+                "tatolab",
+                "add-module-stage",
+                "1.2.3",
+                Some(TYPE_NAME),
+            );
 
-            let key = "STREAMLIB_WORKSPACE_ROOT";
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, tmp.path()); }
-
+            let _guard = AddModuleEnvGuard::install(tmp.path(), home.path());
             let runtime = Runner::new().expect("Runner::new");
-            let result = runtime.add_module(ModuleIdent::new(
-                Org::new("tatolab").unwrap(),
-                Package::new("add-module-stage").unwrap(),
-                SemVerRange::Caret(SemVer::new(1, 0, 0)),
-            ));
 
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
+            // Pre-condition: schema is NOT in the registry yet.
+            let canonical = format!("@tatolab/add-module-stage/{TYPE_NAME}");
+            assert!(
+                crate::core::embedded_schemas::get_embedded_schema_definition(&canonical)
+                    .is_none(),
+                "schema must not exist before add_module"
+            );
 
-            result.expect("workspace-staged add_module must succeed");
+            runtime
+                .add_module(ModuleIdent::new(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-stage").unwrap(),
+                    SemVerRange::Caret(SemVer::new(1, 0, 0)),
+                ))
+                .expect("workspace-staged add_module must succeed");
+
+            // Post-condition: schema IS registered. This is the
+            // "load_project actually ran" assertion the resolver-only
+            // tests didn't lock.
+            assert!(
+                crate::core::embedded_schemas::get_embedded_schema_definition(&canonical)
+                    .is_some(),
+                "schema must be registered after add_module — load_project did not run if this fails"
+            );
         }
 
         #[test]
         #[serial]
         fn add_module_any_version_succeeds_against_staged_v1() {
+            const TYPE_NAME: &str = "AddModuleAnyVersionSchema";
             let tmp = tempfile::tempdir().unwrap();
-            let _staged =
-                stage_workspace_package(tmp.path(), "tatolab", "add-module-any", "0.4.0");
+            let home = tempfile::tempdir().unwrap();
+            let _staged = stage_workspace_package(
+                tmp.path(),
+                "tatolab",
+                "add-module-any",
+                "0.4.0",
+                Some(TYPE_NAME),
+            );
 
-            let key = "STREAMLIB_WORKSPACE_ROOT";
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, tmp.path()); }
-
+            let _guard = AddModuleEnvGuard::install(tmp.path(), home.path());
             let runtime = Runner::new().expect("Runner::new");
-            let result = runtime.add_module(ModuleIdent::any(
-                Org::new("tatolab").unwrap(),
-                Package::new("add-module-any").unwrap(),
-            ));
 
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
+            let canonical = format!("@tatolab/add-module-any/{TYPE_NAME}");
+            assert!(
+                crate::core::embedded_schemas::get_embedded_schema_definition(&canonical)
+                    .is_none(),
+                "schema must not exist before add_module"
+            );
 
-            result.expect("any-version add_module must succeed against staged 0.4.0");
+            runtime
+                .add_module(ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-any").unwrap(),
+                ))
+                .expect("any-version add_module must succeed against staged 0.4.0");
+
+            assert!(
+                crate::core::embedded_schemas::get_embedded_schema_definition(&canonical)
+                    .is_some(),
+                "any-version add_module must invoke load_project; schema registry is the witness",
+            );
         }
 
         #[test]
         #[serial]
         fn add_module_rejects_version_range_mismatch() {
             // Staged 1.0.0 but ident asks for ^2.0.0 — must surface
-            // VersionRangeUnsatisfied, NOT a generic "module not found"
-            // or a silently-succeeded load. Mentally reverting the
-            // range check would let the wrong version load.
+            // VersionRangeUnsatisfied, NOT a generic "module not
+            // found" or a silently-succeeded load. Mentally reverting
+            // the range check would let the wrong version load.
             let tmp = tempfile::tempdir().unwrap();
-            let _staged =
-                stage_workspace_package(tmp.path(), "tatolab", "add-module-range", "1.0.0");
+            let home = tempfile::tempdir().unwrap();
+            let _staged = stage_workspace_package(
+                tmp.path(),
+                "tatolab",
+                "add-module-range",
+                "1.0.0",
+                None,
+            );
 
-            let key = "STREAMLIB_WORKSPACE_ROOT";
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, tmp.path()); }
-
+            let _guard = AddModuleEnvGuard::install(tmp.path(), home.path());
             let runtime = Runner::new().expect("Runner::new");
             let err = runtime
                 .add_module(ModuleIdent::new(
@@ -3989,13 +4121,6 @@ package:
                     SemVerRange::Caret(SemVer::new(2, 0, 0)),
                 ))
                 .expect_err("range mismatch must error");
-
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
 
             assert!(
                 matches!(err, AddModuleError::VersionRangeUnsatisfied { found, .. } if found == SemVer::new(1, 0, 0)),
@@ -4012,18 +4137,16 @@ package:
             // the manifest contents disagree. Surface
             // ManifestIdentityMismatch rather than blindly loading.
             let tmp = tempfile::tempdir().unwrap();
+            let home = tempfile::tempdir().unwrap();
             let staged = tmp
                 .path()
                 .join("target")
                 .join("streamlib-plugins")
                 .join("tatolab__add-module-identity");
             std::fs::create_dir_all(&staged).unwrap();
-            write_schemas_only_manifest(&staged, "vendor", "other", "1.0.0");
+            write_schemas_only_manifest(&staged, "vendor", "other", "1.0.0", None);
 
-            let key = "STREAMLIB_WORKSPACE_ROOT";
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, tmp.path()); }
-
+            let _guard = AddModuleEnvGuard::install(tmp.path(), home.path());
             let runtime = Runner::new().expect("Runner::new");
             let err = runtime
                 .add_module(ModuleIdent::any(
@@ -4031,13 +4154,6 @@ package:
                     Package::new("add-module-identity").unwrap(),
                 ))
                 .expect_err("clobbered staged manifest must error");
-
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
 
             assert!(
                 matches!(err, AddModuleError::ManifestIdentityMismatch { ref actual, .. } if actual == "@vendor/other"),
@@ -4050,17 +4166,13 @@ package:
         fn add_module_reports_module_not_found_when_unstaged_and_uncached() {
             // No workspace stage AND no installed cache entry. Must
             // surface the actionable `ModuleNotFound` rather than a
-            // generic "load_project failed" or a panic.
-            //
-            // Side-effect: this test relies on no
-            // `@tatolab/add-module-missing` entry existing in the
-            // user's ~/.streamlib/packages.yaml. The name is
-            // deliberately unique to this test to avoid collisions.
+            // generic "load_project failed" or a panic. The
+            // `STREAMLIB_HOME` redirect isolates the test from the
+            // host's real installed cache — without it, a stale entry
+            // for the canary name would mask the failure.
             let tmp = tempfile::tempdir().unwrap();
-
-            let key = "STREAMLIB_WORKSPACE_ROOT";
-            let prev = std::env::var_os(key);
-            unsafe { std::env::set_var(key, tmp.path()); }
+            let home = tempfile::tempdir().unwrap();
+            let _guard = AddModuleEnvGuard::install(tmp.path(), home.path());
 
             let runtime = Runner::new().expect("Runner::new");
             let err = runtime
@@ -4070,16 +4182,55 @@ package:
                 ))
                 .expect_err("missing module must error");
 
+            assert!(
+                matches!(err, AddModuleError::ModuleNotFound { ref package } if package.org.as_str() == "tatolab" && package.name.as_str() == "add-module-missing"),
+                "expected ModuleNotFound(@tatolab/add-module-missing), got: {err:?}",
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_surfaces_workspace_root_typo() {
+            // STREAMLIB_WORKSPACE_ROOT pointing at a non-existent path
+            // is a user typo — surface it as WorkspaceRootInvalid
+            // rather than silently falling through to the installed
+            // cache (which would either find an unrelated entry, or
+            // mis-report ModuleNotFound when the real problem is the
+            // env var). Mirrors load_workspace_packages's behavior on
+            // the same condition.
+            let home = tempfile::tempdir().unwrap();
+            let workspace_prev = std::env::var_os("STREAMLIB_WORKSPACE_ROOT");
+            let home_prev = std::env::var_os("STREAMLIB_HOME");
             unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
+                std::env::set_var(
+                    "STREAMLIB_WORKSPACE_ROOT",
+                    "/nonexistent/path/that/does/not/exist",
+                );
+                std::env::set_var("STREAMLIB_HOME", home.path());
+            }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let err = runtime
+                .add_module(ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-typo-canary").unwrap(),
+                ))
+                .expect_err("typo'd env var must error");
+
+            unsafe {
+                match workspace_prev {
+                    Some(v) => std::env::set_var("STREAMLIB_WORKSPACE_ROOT", v),
+                    None => std::env::remove_var("STREAMLIB_WORKSPACE_ROOT"),
+                }
+                match home_prev {
+                    Some(v) => std::env::set_var("STREAMLIB_HOME", v),
+                    None => std::env::remove_var("STREAMLIB_HOME"),
                 }
             }
 
             assert!(
-                matches!(err, AddModuleError::ModuleNotFound { ref package } if package.org.as_str() == "tatolab" && package.name.as_str() == "add-module-missing"),
-                "expected ModuleNotFound(@tatolab/add-module-missing), got: {err:?}",
+                matches!(err, AddModuleError::WorkspaceRootInvalid { ref env_value } if env_value == "/nonexistent/path/that/does/not/exist"),
+                "expected WorkspaceRootInvalid, got: {err:?}",
             );
         }
 

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -4198,15 +4198,22 @@ package:
             // mis-report ModuleNotFound when the real problem is the
             // env var). Mirrors load_workspace_packages's behavior on
             // the same condition.
+            //
+            // Install the RAII env guard against a tempdir first (its
+            // Drop will restore both env vars on exit / panic), then
+            // override STREAMLIB_WORKSPACE_ROOT to the bogus path
+            // inside the guard's lifetime. If `add_module` or
+            // `expect_err` panics, the guard still restores the
+            // original values — no env leak into sibling tests.
             let home = tempfile::tempdir().unwrap();
-            let workspace_prev = std::env::var_os("STREAMLIB_WORKSPACE_ROOT");
-            let home_prev = std::env::var_os("STREAMLIB_HOME");
+            let placeholder_workspace = tempfile::tempdir().unwrap();
+            let _guard =
+                AddModuleEnvGuard::install(placeholder_workspace.path(), home.path());
             unsafe {
                 std::env::set_var(
                     "STREAMLIB_WORKSPACE_ROOT",
                     "/nonexistent/path/that/does/not/exist",
                 );
-                std::env::set_var("STREAMLIB_HOME", home.path());
             }
 
             let runtime = Runner::new().expect("Runner::new");
@@ -4216,17 +4223,6 @@ package:
                     Package::new("add-module-typo-canary").unwrap(),
                 ))
                 .expect_err("typo'd env var must error");
-
-            unsafe {
-                match workspace_prev {
-                    Some(v) => std::env::set_var("STREAMLIB_WORKSPACE_ROOT", v),
-                    None => std::env::remove_var("STREAMLIB_WORKSPACE_ROOT"),
-                }
-                match home_prev {
-                    Some(v) => std::env::set_var("STREAMLIB_HOME", v),
-                    None => std::env::remove_var("STREAMLIB_HOME"),
-                }
-            }
 
             assert!(
                 matches!(err, AddModuleError::WorkspaceRootInvalid { ref env_value } if env_value == "/nonexistent/path/that/does/not/exist"),

--- a/libs/streamlib-engine/src/core/runtime/runtime.rs
+++ b/libs/streamlib-engine/src/core/runtime/runtime.rs
@@ -1673,6 +1673,125 @@ impl Runner {
         };
         Ok(Some(get_cached_package_dir(&entry.cache_dir)))
     }
+
+    // =========================================================================
+    // Imperative module API
+    // =========================================================================
+
+    /// Load a `streamlib.yaml`-packaged module by typed
+    /// [`streamlib_idents::ModuleIdent`]. Resolves the identifier against
+    /// the workspace `target/streamlib-plugins/<org>__<name>/` staged
+    /// dir (dev / `cargo xtask build-plugins` flow) and the installed
+    /// `~/.streamlib/cache/packages/...` (installed slpkg flow); the
+    /// on-disk version must match the ident's [`SemVerRange`].
+    /// Transitive dependencies declared in the module's
+    /// `streamlib.yaml` are loaded recursively via [`Self::load_project`].
+    ///
+    /// **Imperative complement to the yaml-driven path.** Both
+    /// [`Self::load_project`] and this method drive into the same
+    /// internal module-loading machinery; the yaml form is for
+    /// declarative deployment manifests (containers / `streamlib install`
+    /// / dep solvers), the imperative form is for REST endpoints,
+    /// hot-reload tools, test setup, and composition-library wrapping.
+    ///
+    /// Calls are idempotent at the registry layer: re-loading a module
+    /// whose processors / schemas are already registered surfaces no
+    /// error and re-runs the dylib's plugin callback (which the engine
+    /// already tolerates per `register_dynamic`'s dedup semantics).
+    pub fn add_module(
+        &self,
+        module: streamlib_idents::ModuleIdent,
+    ) -> std::result::Result<(), AddModuleError> {
+        use streamlib_idents::Manifest;
+
+        let pkg_ref = module.package_ref();
+
+        // Resolution chain — workspace stage first (for dev /
+        // `cargo xtask build-plugins`), then installed cache.
+        let candidate = resolve_module_source(&pkg_ref)?;
+
+        let (source_path, on_disk_version) = match &candidate {
+            ResolvedModuleSource::WorkspaceStaged { path } => {
+                let manifest = Manifest::load(path).map_err(|e| {
+                    AddModuleError::ManifestLoadFailed {
+                        module: module.clone(),
+                        source_path: path.clone(),
+                        detail: e.to_string(),
+                    }
+                })?;
+                let metadata = manifest
+                    .package
+                    .as_ref()
+                    .ok_or_else(|| AddModuleError::ManifestLoadFailed {
+                        module: module.clone(),
+                        source_path: path.clone(),
+                        detail: "manifest has no `package:` block".into(),
+                    })?;
+                if metadata.org != module.org || metadata.name != module.name {
+                    return Err(AddModuleError::ManifestIdentityMismatch {
+                        module: module.clone(),
+                        source_path: path.clone(),
+                        actual: format!(
+                            "@{}/{}",
+                            metadata.org.as_str(),
+                            metadata.name.as_str()
+                        ),
+                    });
+                }
+                (path.clone(), metadata.version)
+            }
+            ResolvedModuleSource::InstalledCache {
+                path,
+                installed_version,
+            } => (path.clone(), *installed_version),
+        };
+
+        if !module.version.matches(on_disk_version) {
+            return Err(AddModuleError::VersionRangeUnsatisfied {
+                module: module.clone(),
+                found: on_disk_version,
+                source_path,
+            });
+        }
+
+        tracing::info!(
+            "add_module: resolving '{}' → {} (on-disk version {})",
+            module,
+            source_path.display(),
+            on_disk_version,
+        );
+
+        self.load_project(&source_path).map_err(|source| {
+            AddModuleError::LoadProjectFailed {
+                module,
+                source: Box::new(source),
+            }
+        })
+    }
+
+    /// Unload a previously-added module.
+    ///
+    /// **Not yet implemented.** Module-level unload requires the
+    /// hot-reload lifecycle work that's explicitly out of scope for
+    /// the current All-Dynamic Package Loading milestone — see the
+    /// milestone's "Explicitly out of scope (deferred to later
+    /// milestones)" section ("`unload_package` / hot-reload
+    /// lifecycle. Load-only, runtime-lifetime registration this
+    /// milestone."). The method exists as an explicit boundary
+    /// marker (rather than being absent) so AI agents and other
+    /// callers reaching for it from the `add_module` counterpart get
+    /// a typed error pointing at the milestone gap instead of a
+    /// `method not found` diagnostic.
+    ///
+    /// Calling this returns
+    /// [`RemoveModuleError::HotReloadLifecycleNotYetImplemented`]
+    /// without altering any runtime state.
+    pub fn remove_module(
+        &self,
+        module: streamlib_idents::ModuleIdent,
+    ) -> std::result::Result<(), RemoveModuleError> {
+        Err(RemoveModuleError::HotReloadLifecycleNotYetImplemented { module })
+    }
 }
 
 /// Iterate `config.schemas` map entries, registering each `Local` schema
@@ -2057,6 +2176,176 @@ fn bring_up_surface_service(
     );
 
     Ok((Arc::new(Mutex::new(Some(service))), socket_path))
+}
+
+// =============================================================================
+// add_module / remove_module — typed errors + resolver
+// =============================================================================
+
+/// Where a [`streamlib_idents::ModuleIdent`] was resolved to.
+enum ResolvedModuleSource {
+    /// Workspace stage dir (`<workspace>/target/streamlib-plugins/<org>__<name>/`).
+    /// Used in dev / `cargo xtask build-plugins` flow. Manifest is read
+    /// at the call site to extract the on-disk version + verify identity.
+    WorkspaceStaged { path: std::path::PathBuf },
+    /// Installed-package cache (`~/.streamlib/cache/packages/<entry.cache_dir>`).
+    /// The cache manifest carries `installed_version` directly; no
+    /// re-parse needed.
+    InstalledCache {
+        path: std::path::PathBuf,
+        installed_version: streamlib_idents::SemVer,
+    },
+}
+
+/// Resolve a `@org/name` reference to a workspace stage dir or an
+/// installed-cache entry. Workspace wins on coexistence — same
+/// precedence as `cargo`'s `[patch]` (per-consumer workspace overrides
+/// installed registry).
+fn resolve_module_source(
+    pkg_ref: &streamlib_idents::PackageRef,
+) -> std::result::Result<ResolvedModuleSource, AddModuleError> {
+    // 1. Workspace stage dir, when a workspace is locatable.
+    if let Ok(workspace_root) = resolve_workspace_root() {
+        let staged_dir = workspace_root
+            .join("target")
+            .join("streamlib-plugins")
+            .join(format!(
+                "{}__{}",
+                pkg_ref.org.as_str(),
+                pkg_ref.name.as_str()
+            ));
+        if staged_dir.join("streamlib.yaml").exists() {
+            return Ok(ResolvedModuleSource::WorkspaceStaged { path: staged_dir });
+        }
+    }
+
+    // 2. Installed-package cache.
+    use crate::core::config::InstalledPackageManifest;
+    use crate::core::streamlib_home::get_cached_package_dir;
+
+    let manifest =
+        InstalledPackageManifest::load().map_err(|e| AddModuleError::InstalledCacheLoadFailed {
+            detail: e.to_string(),
+        })?;
+    if let Some(entry) = manifest.find_by_ref(pkg_ref) {
+        let path = get_cached_package_dir(&entry.cache_dir);
+        return Ok(ResolvedModuleSource::InstalledCache {
+            path,
+            installed_version: entry.version,
+        });
+    }
+
+    Err(AddModuleError::ModuleNotFound {
+        package: pkg_ref.clone(),
+    })
+}
+
+/// Per-failure-mode error returned by [`Runner::add_module`].
+#[derive(Debug, thiserror::Error)]
+pub enum AddModuleError {
+    /// No workspace stage dir AND no installed-package cache entry
+    /// matches `@org/name`. Surface the canonical ref so callers can
+    /// suggest `streamlib pkg install`, `cargo xtask build-plugins`,
+    /// or a typo fix.
+    #[error(
+        "Module '{package}' not found — no workspace stage dir at \
+         `target/streamlib-plugins/<org>__<name>/` and no installed-cache \
+         entry. Run `cargo xtask build-plugins --package {package}` (dev) \
+         or `streamlib pkg install <slpkg>` (distribution)."
+    )]
+    ModuleNotFound {
+        package: streamlib_idents::PackageRef,
+    },
+
+    /// Workspace stage dir or installed-cache entry was found but the
+    /// `streamlib.yaml` failed to parse / lacked a `package:` block.
+    #[error(
+        "Failed to load manifest for '{module}' from {}: {detail}",
+        source_path.display()
+    )]
+    ManifestLoadFailed {
+        module: streamlib_idents::ModuleIdent,
+        source_path: std::path::PathBuf,
+        detail: String,
+    },
+
+    /// Workspace stage dir was found but its `streamlib.yaml`'s
+    /// `package: { org, name }` doesn't match the requested ident
+    /// (manual clobbering, stale rename, wrong dir).
+    #[error(
+        "Module '{module}' identity mismatch at {}: \
+         staged manifest declares `{actual}`. \
+         Re-run `cargo xtask build-plugins` to regenerate.",
+        source_path.display()
+    )]
+    ManifestIdentityMismatch {
+        module: streamlib_idents::ModuleIdent,
+        source_path: std::path::PathBuf,
+        actual: String,
+    },
+
+    /// On-disk version doesn't satisfy the ident's [`SemVerRange`].
+    #[error(
+        "Module '{module}' resolved to version {found} at {} which doesn't \
+         satisfy the requested range. Install a matching version or relax \
+         the range.",
+        source_path.display()
+    )]
+    VersionRangeUnsatisfied {
+        module: streamlib_idents::ModuleIdent,
+        found: streamlib_idents::SemVer,
+        source_path: std::path::PathBuf,
+    },
+
+    /// `InstalledPackageManifest::load()` errored before lookup could
+    /// run. Catches I/O / parse failures distinct from "no entry."
+    #[error("Failed to load installed-package cache: {detail}")]
+    InstalledCacheLoadFailed { detail: String },
+
+    /// `Runner::load_project` rejected the resolved source path.
+    #[error("load_project failed for '{module}': {source}")]
+    LoadProjectFailed {
+        module: streamlib_idents::ModuleIdent,
+        #[source]
+        source: Box<Error>,
+    },
+}
+
+impl From<AddModuleError> for Error {
+    fn from(err: AddModuleError) -> Self {
+        match err {
+            AddModuleError::LoadProjectFailed { source, .. } => *source,
+            other => Error::Configuration(other.to_string()),
+        }
+    }
+}
+
+/// Per-failure-mode error returned by [`Runner::remove_module`].
+///
+/// Today the only variant is the milestone-deferral marker; new
+/// variants land when the hot-reload lifecycle work ships.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveModuleError {
+    /// Module unload requires the hot-reload lifecycle work that's
+    /// explicitly out of scope for the current All-Dynamic Package
+    /// Loading milestone. Calling `remove_module` returns this without
+    /// altering any runtime state — see [`Runner::remove_module`] for
+    /// the rationale.
+    #[error(
+        "remove_module('{module}') is not yet implemented — \
+         hot-reload lifecycle is deferred to a future milestone. \
+         The runtime currently supports load-only, runtime-lifetime \
+         module registration."
+    )]
+    HotReloadLifecycleNotYetImplemented {
+        module: streamlib_idents::ModuleIdent,
+    },
+}
+
+impl From<RemoveModuleError> for Error {
+    fn from(err: RemoveModuleError) -> Self {
+        Error::Configuration(err.to_string())
+    }
 }
 
 // =============================================================================
@@ -3573,6 +3862,248 @@ package:
                         .expect("round-trip");
                 assert!(resp.get("error").is_some());
             });
+        }
+    }
+
+    // =========================================================================
+    // add_module / remove_module — imperative module API
+    // =========================================================================
+
+    mod add_module_tests {
+        use super::*;
+        use streamlib_idents::{ModuleIdent, Org, Package, SemVer, SemVerRange};
+
+        /// Build a schemas-only `streamlib.yaml` at `dir` with the given
+        /// org/name/version. Schemas-only avoids the dylib-loading branch
+        /// — `add_module` resolution + version-range matching is what we
+        /// want to lock here, not the cdylib mechanics that
+        /// `load_workspace_packages` already covers.
+        fn write_schemas_only_manifest(
+            dir: &std::path::Path,
+            org: &str,
+            name: &str,
+            version: &str,
+        ) {
+            std::fs::write(
+                dir.join("streamlib.yaml"),
+                format!(
+                    "package:\n  org: {org}\n  name: {name}\n  version: \"{version}\"\n"
+                ),
+            )
+            .expect("write streamlib.yaml");
+        }
+
+        /// Stage a package under `<workspace>/target/streamlib-plugins/<org>__<name>/`
+        /// and return the staged dir path. Mirrors what
+        /// `cargo xtask build-plugins` produces.
+        fn stage_workspace_package(
+            workspace_root: &std::path::Path,
+            org: &str,
+            name: &str,
+            version: &str,
+        ) -> std::path::PathBuf {
+            let staged = workspace_root
+                .join("target")
+                .join("streamlib-plugins")
+                .join(format!("{org}__{name}"));
+            std::fs::create_dir_all(&staged).expect("mkdir staged");
+            write_schemas_only_manifest(&staged, org, name, version);
+            staged
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_resolves_workspace_stage_and_loads() {
+            let tmp = tempfile::tempdir().unwrap();
+            let _staged =
+                stage_workspace_package(tmp.path(), "tatolab", "add-module-stage", "1.2.3");
+
+            let key = "STREAMLIB_WORKSPACE_ROOT";
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, tmp.path()); }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let result = runtime.add_module(ModuleIdent::new(
+                Org::new("tatolab").unwrap(),
+                Package::new("add-module-stage").unwrap(),
+                SemVerRange::Caret(SemVer::new(1, 0, 0)),
+            ));
+
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+
+            result.expect("workspace-staged add_module must succeed");
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_any_version_succeeds_against_staged_v1() {
+            let tmp = tempfile::tempdir().unwrap();
+            let _staged =
+                stage_workspace_package(tmp.path(), "tatolab", "add-module-any", "0.4.0");
+
+            let key = "STREAMLIB_WORKSPACE_ROOT";
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, tmp.path()); }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let result = runtime.add_module(ModuleIdent::any(
+                Org::new("tatolab").unwrap(),
+                Package::new("add-module-any").unwrap(),
+            ));
+
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+
+            result.expect("any-version add_module must succeed against staged 0.4.0");
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_rejects_version_range_mismatch() {
+            // Staged 1.0.0 but ident asks for ^2.0.0 — must surface
+            // VersionRangeUnsatisfied, NOT a generic "module not found"
+            // or a silently-succeeded load. Mentally reverting the
+            // range check would let the wrong version load.
+            let tmp = tempfile::tempdir().unwrap();
+            let _staged =
+                stage_workspace_package(tmp.path(), "tatolab", "add-module-range", "1.0.0");
+
+            let key = "STREAMLIB_WORKSPACE_ROOT";
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, tmp.path()); }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let err = runtime
+                .add_module(ModuleIdent::new(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-range").unwrap(),
+                    SemVerRange::Caret(SemVer::new(2, 0, 0)),
+                ))
+                .expect_err("range mismatch must error");
+
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+
+            assert!(
+                matches!(err, AddModuleError::VersionRangeUnsatisfied { found, .. } if found == SemVer::new(1, 0, 0)),
+                "expected VersionRangeUnsatisfied(1.0.0), got: {err:?}",
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_rejects_identity_mismatch_on_staged_yaml() {
+            // Staged dir says `@vendor/other` but the requested ident
+            // is `@tatolab/add-module-identity`. The directory-name
+            // convention (`<org>__<name>/`) would point us there, but
+            // the manifest contents disagree. Surface
+            // ManifestIdentityMismatch rather than blindly loading.
+            let tmp = tempfile::tempdir().unwrap();
+            let staged = tmp
+                .path()
+                .join("target")
+                .join("streamlib-plugins")
+                .join("tatolab__add-module-identity");
+            std::fs::create_dir_all(&staged).unwrap();
+            write_schemas_only_manifest(&staged, "vendor", "other", "1.0.0");
+
+            let key = "STREAMLIB_WORKSPACE_ROOT";
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, tmp.path()); }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let err = runtime
+                .add_module(ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-identity").unwrap(),
+                ))
+                .expect_err("clobbered staged manifest must error");
+
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+
+            assert!(
+                matches!(err, AddModuleError::ManifestIdentityMismatch { ref actual, .. } if actual == "@vendor/other"),
+                "expected ManifestIdentityMismatch(@vendor/other), got: {err:?}",
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn add_module_reports_module_not_found_when_unstaged_and_uncached() {
+            // No workspace stage AND no installed cache entry. Must
+            // surface the actionable `ModuleNotFound` rather than a
+            // generic "load_project failed" or a panic.
+            //
+            // Side-effect: this test relies on no
+            // `@tatolab/add-module-missing` entry existing in the
+            // user's ~/.streamlib/packages.yaml. The name is
+            // deliberately unique to this test to avoid collisions.
+            let tmp = tempfile::tempdir().unwrap();
+
+            let key = "STREAMLIB_WORKSPACE_ROOT";
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, tmp.path()); }
+
+            let runtime = Runner::new().expect("Runner::new");
+            let err = runtime
+                .add_module(ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("add-module-missing").unwrap(),
+                ))
+                .expect_err("missing module must error");
+
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+
+            assert!(
+                matches!(err, AddModuleError::ModuleNotFound { ref package } if package.org.as_str() == "tatolab" && package.name.as_str() == "add-module-missing"),
+                "expected ModuleNotFound(@tatolab/add-module-missing), got: {err:?}",
+            );
+        }
+
+        #[test]
+        fn remove_module_returns_hot_reload_lifecycle_deferral() {
+            // The stub returns a typed error rather than silently
+            // succeeding or panicking. AI agents reading `add_module`
+            // will reach for `remove_module`; the typed error points
+            // them at the milestone boundary.
+            let runtime = Runner::new().expect("Runner::new");
+            let err = runtime
+                .remove_module(ModuleIdent::any(
+                    Org::new("tatolab").unwrap(),
+                    Package::new("remove-module-stub").unwrap(),
+                ))
+                .expect_err("remove_module must error until hot-reload ships");
+            assert!(
+                matches!(
+                    err,
+                    RemoveModuleError::HotReloadLifecycleNotYetImplemented { ref module }
+                        if module.name.as_str() == "remove-module-stub"
+                ),
+                "got: {err:?}",
+            );
         }
     }
 }

--- a/libs/streamlib-engine/src/lib.rs
+++ b/libs/streamlib-engine/src/lib.rs
@@ -56,7 +56,10 @@ pub mod schemas {
 // Re-export attribute macros for processor syntax:
 // - #[streamlib::processor("Camera")] - Processor definition by name lookup in streamlib.yaml
 // - #[derive(ConfigDescriptor)] - Config field metadata derive macro
-pub use streamlib_macros::{processor, schema_ident, schema_ident_any_version, ConfigDescriptor};
+pub use streamlib_macros::{
+    module_ident, module_ident_any_version, module_ident_joined, module_ident_joined_any_version,
+    processor, schema_ident, schema_ident_any_version, ConfigDescriptor,
+};
 
 pub use core::{
     are_synchronized,
@@ -261,7 +264,10 @@ pub mod sdk {
     pub use crate::serde_json;
     pub use crate::crossbeam_channel;
 
-    pub use streamlib_macros::{processor, schema_ident, schema_ident_any_version, ConfigDescriptor};
+    pub use streamlib_macros::{
+    module_ident, module_ident_any_version, module_ident_joined, module_ident_joined_any_version,
+    processor, schema_ident, schema_ident_any_version, ConfigDescriptor,
+};
 
     pub mod permissions {
         pub use crate::{

--- a/libs/streamlib-idents/src/error.rs
+++ b/libs/streamlib-idents/src/error.rs
@@ -40,6 +40,9 @@ pub enum IdentError {
 
     #[error("invalid semver range `{0}`: {1}")]
     InvalidSemVerRange(String, String),
+
+    #[error("invalid module identifier `{0}`: {1}")]
+    InvalidModuleIdent(String, String),
 }
 
 pub type ResolverResult<T> = Result<T, ResolverError>;

--- a/libs/streamlib-idents/src/ident.rs
+++ b/libs/streamlib-idents/src/ident.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 use crate::error::{IdentError, IdentResult};
-use crate::semver::SemVer;
+use crate::semver::{SemVer, SemVerRange};
 
 /// Org segment of an identifier (the `@org` part).
 ///
@@ -340,6 +340,121 @@ impl fmt::Display for SchemaIdent {
     }
 }
 
+/// Imperative-API identifier for a `streamlib.yaml`-packaged module
+/// (`@org/name@<range>`).
+///
+/// Carries the same `@org/name` pair as [`PackageRef`] plus a semver
+/// [`SemVerRange`] for version resolution. Constructed via [`ModuleIdent::new`]
+/// (already-typed segments), the `module_ident!` proc-macro
+/// (compile-time-validated string literals), or typed deserialization. No
+/// `parse` API by design — see `docs/architecture/schema-identity-and-packaging.md`.
+///
+/// Wire form is `@org/name@<range>` (e.g. `@tatolab/core@^1.0.0`,
+/// `@tatolab/audio@*`); `Display` emits it, `Deserialize` reads it. The
+/// version-suffix is required in the joined wire form — bare `@org/name`
+/// strings parse as a [`PackageRef`], not a `ModuleIdent`.
+///
+/// ```compile_fail
+/// use streamlib_idents::ModuleIdent;
+/// let _ = ModuleIdent::parse("@tatolab/core@^1.0.0");
+/// ```
+///
+/// ```compile_fail
+/// use streamlib_idents::ModuleIdent;
+/// let _: ModuleIdent = "@tatolab/core@^1.0.0".parse().unwrap();
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleIdent {
+    pub org: Org,
+    pub name: Package,
+    pub version: SemVerRange,
+}
+
+impl ModuleIdent {
+    /// Construct from already-validated segments.
+    pub fn new(org: Org, name: Package, version: SemVerRange) -> Self {
+        Self { org, name, version }
+    }
+
+    /// Convenience: any-version constructor (`@org/name@*`). Equivalent to
+    /// `ModuleIdent::new(org, name, SemVerRange::Any)`.
+    pub fn any(org: Org, name: Package) -> Self {
+        Self::new(org, name, SemVerRange::Any)
+    }
+
+    /// `@org/name` projection — the canonical [`PackageRef`] without the
+    /// version range.
+    pub fn package_ref(&self) -> PackageRef {
+        PackageRef::new(self.org.clone(), self.name.clone())
+    }
+}
+
+impl fmt::Display for ModuleIdent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@{}/{}@{}", self.org, self.name, self.version)
+    }
+}
+
+impl Serialize for ModuleIdent {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for ModuleIdent {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        parse_module_ident_wire(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+impl JsonSchema for ModuleIdent {
+    fn schema_name() -> String {
+        "ModuleIdent".into()
+    }
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("streamlib_idents::ModuleIdent")
+    }
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        ident_string_schema(
+            "Imperative-API module identifier of the form `@org/name@<range>` \
+             where `<range>` is a SemVerRange (`*`, `=1.2.3`, `>=1.2.3`, `^1.2.3`, \
+             `~1.2.3`, or bare `1.2.3`).",
+            r"^@[a-z][a-z0-9-]*/[a-z][a-z0-9-]*@(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+)$",
+        )
+    }
+}
+
+/// Parse `@org/name@<range>` into a [`ModuleIdent`]. Used by typed
+/// deserialization and the `module_ident!` macro's joined-form arm —
+/// callers building from already-typed segments go through
+/// [`ModuleIdent::new`] / [`ModuleIdent::any`] instead, so no `parse`
+/// surface leaks into general use.
+pub(crate) fn parse_module_ident_wire(raw: &str) -> IdentResult<ModuleIdent> {
+    let stripped = raw.strip_prefix('@').ok_or_else(|| {
+        IdentError::InvalidModuleIdent(
+            raw.to_string(),
+            "must start with '@'".into(),
+        )
+    })?;
+    let (org_str, rest) = stripped.split_once('/').ok_or_else(|| {
+        IdentError::InvalidModuleIdent(
+            raw.to_string(),
+            "must contain '/' between org and name".into(),
+        )
+    })?;
+    let (name_str, range_str) = rest.split_once('@').ok_or_else(|| {
+        IdentError::InvalidModuleIdent(
+            raw.to_string(),
+            "must contain '@' before the version range (e.g. `@org/name@^1.0.0`)".into(),
+        )
+    })?;
+    let org = Org::new(org_str)?;
+    let name = Package::new(name_str)?;
+    let version = SemVerRange::from_str(range_str)?;
+    Ok(ModuleIdent { org, name, version })
+}
+
 /// Validate an org segment per the grammar: `[a-z][a-z0-9-]*`.
 pub fn validate_org(s: &str) -> IdentResult<()> {
     if s.is_empty() {
@@ -621,6 +736,106 @@ version: 1.0.0
         // SchemaIdent shape (which has its own typed deserialization).
         let res: Result<PackageRef, _> = serde_yaml::from_str(r#""@tatolab/core/extra""#);
         assert!(res.is_err());
+    }
+
+    fn module_ident(org: &str, pkg: &str, range: &str) -> ModuleIdent {
+        ModuleIdent::new(
+            Org::new(org).unwrap(),
+            Package::new(pkg).unwrap(),
+            SemVerRange::from_str(range).unwrap(),
+        )
+    }
+
+    #[test]
+    fn module_ident_display_round_trips_wire_form() {
+        let id = module_ident("tatolab", "core", "^1.0.0");
+        assert_eq!(id.to_string(), "@tatolab/core@^1.0.0");
+
+        let yaml = serde_yaml::to_string(&id).unwrap();
+        let back: ModuleIdent = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn module_ident_any_renders_star_suffix() {
+        let id = ModuleIdent::any(Org::new("tatolab").unwrap(), Package::new("core").unwrap());
+        assert_eq!(id.to_string(), "@tatolab/core@*");
+        assert_eq!(id.version, SemVerRange::Any);
+    }
+
+    #[test]
+    fn module_ident_parses_each_range_flavor() {
+        // `(input wire form, expected typed range, canonical Display form)` —
+        // bare `1.2.3` normalizes to `=1.2.3` on Display (existing SemVerRange
+        // behavior).
+        let cases = [
+            ("@tatolab/core@*", SemVerRange::Any, "@tatolab/core@*"),
+            (
+                "@tatolab/core@1.2.3",
+                SemVerRange::Exact(SemVer::new(1, 2, 3)),
+                "@tatolab/core@=1.2.3",
+            ),
+            (
+                "@tatolab/core@=1.2.3",
+                SemVerRange::Exact(SemVer::new(1, 2, 3)),
+                "@tatolab/core@=1.2.3",
+            ),
+            (
+                "@tatolab/core@>=1.0.0",
+                SemVerRange::AtLeast(SemVer::new(1, 0, 0)),
+                "@tatolab/core@>=1.0.0",
+            ),
+            (
+                "@tatolab/core@^1.0.0",
+                SemVerRange::Caret(SemVer::new(1, 0, 0)),
+                "@tatolab/core@^1.0.0",
+            ),
+            (
+                "@tatolab/core@~1.2.0",
+                SemVerRange::Tilde(SemVer::new(1, 2, 0)),
+                "@tatolab/core@~1.2.0",
+            ),
+        ];
+        for (wire, expected_range, expected_display) in cases {
+            let id: ModuleIdent = serde_yaml::from_str(&format!("'{}'", wire)).unwrap();
+            assert_eq!(id.version, expected_range, "wire form: {wire}");
+            assert_eq!(id.to_string(), expected_display, "display for: {wire}");
+        }
+    }
+
+    #[test]
+    fn module_ident_rejects_missing_at_prefix() {
+        let res: Result<ModuleIdent, _> = serde_yaml::from_str(r#""tatolab/core@^1.0.0""#);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn module_ident_rejects_missing_version_suffix() {
+        // Bare `@org/name` parses as a PackageRef, not a ModuleIdent — the
+        // version segment is mandatory in the joined wire form.
+        let res: Result<ModuleIdent, _> = serde_yaml::from_str(r#""@tatolab/core""#);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn module_ident_rejects_invalid_org() {
+        let res: Result<ModuleIdent, _> = serde_yaml::from_str(r#""@Tatolab/core@^1.0.0""#);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn module_ident_rejects_invalid_range() {
+        let res: Result<ModuleIdent, _> = serde_yaml::from_str(r#""@tatolab/core@^1.2.x""#);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn module_ident_package_ref_projection_drops_version() {
+        let id = module_ident("tatolab", "core", "^1.0.0");
+        let pr = id.package_ref();
+        assert_eq!(pr.to_string(), "@tatolab/core");
+        assert_eq!(pr.org.as_str(), "tatolab");
+        assert_eq!(pr.name.as_str(), "core");
     }
 
     #[test]

--- a/libs/streamlib-idents/src/lib.rs
+++ b/libs/streamlib-idents/src/lib.rs
@@ -19,7 +19,8 @@ mod semver;
 pub use error::{IdentError, IdentResult, ResolverError, ResolverResult};
 pub use git::fetch_git;
 pub use ident::{
-    validate_org, validate_package, validate_type, Org, Package, PackageRef, SchemaIdent, TypeName,
+    validate_org, validate_package, validate_type, ModuleIdent, Org, Package, PackageRef,
+    SchemaIdent, TypeName,
 };
 pub use lockfile::{
     compute_content_hash, hash_content, read_lockfile, write_lockfile, Lockfile, LockfileEntry,

--- a/libs/streamlib-idents/src/semver.rs
+++ b/libs/streamlib-idents/src/semver.rs
@@ -114,6 +114,7 @@ impl JsonSchema for SemVer {
 /// SemVer range matcher. Supported operators (npm-flavoured subset chosen for
 /// what `streamlib.yaml` actually needs):
 ///
+/// - `*` wildcard — matches any version
 /// - `=1.2.3` exact
 /// - `>=1.2.3` lower bound
 /// - `^1.2.3` caret — same major, version >= input (npm semantics)
@@ -123,6 +124,9 @@ impl JsonSchema for SemVer {
 /// and `^0.0.3` matches exactly `0.0.3`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemVerRange {
+    /// `*` — matches every version. The imperative module API uses this when
+    /// the caller doesn't pin a version range.
+    Any,
     Exact(SemVer),
     AtLeast(SemVer),
     Caret(SemVer),
@@ -130,8 +134,15 @@ pub enum SemVerRange {
 }
 
 impl SemVerRange {
-    pub(crate) fn from_str(s: &str) -> IdentResult<Self> {
+    /// Parse a range string. Accepts `*` (any), `=1.2.3` (exact),
+    /// `>=1.2.3` (lower bound), `^1.2.3` (caret, npm), `~1.2.3` (tilde),
+    /// and bare `1.2.3` (exact). Surfaces [`IdentError::InvalidSemVer`]
+    /// on malformed inputs.
+    pub fn from_str(s: &str) -> IdentResult<Self> {
         let s = s.trim();
+        if s == "*" {
+            return Ok(Self::Any);
+        }
         if let Some(rest) = s.strip_prefix("^") {
             return Ok(Self::Caret(SemVer::from_dotted(rest.trim())?));
         }
@@ -150,6 +161,7 @@ impl SemVerRange {
 
     pub fn matches(&self, v: SemVer) -> bool {
         match *self {
+            Self::Any => true,
             Self::Exact(req) => v == req,
             Self::AtLeast(req) => v >= req,
             Self::Caret(req) => caret_matches(req, v),
@@ -176,6 +188,7 @@ fn caret_matches(req: SemVer, v: SemVer) -> bool {
 impl fmt::Display for SemVerRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Any => f.write_str("*"),
             Self::Exact(v) => write!(f, "={}", v),
             Self::AtLeast(v) => write!(f, ">={}", v),
             Self::Caret(v) => write!(f, "^{}", v),
@@ -206,8 +219,8 @@ impl JsonSchema for SemVerRange {
     }
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         semver_string_schema(
-            "SemVer range matcher: `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
-            r"^(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+$",
+            "SemVer range matcher: `*` (any), `=1.2.3` exact, `>=1.2.3` lower bound, `^1.2.3` caret (npm), `~1.2.3` tilde, or bare `1.2.3` (exact).",
+            r"^(\*|(\^|~|>=|=)?[0-9]+\.[0-9]+\.[0-9]+)$",
         )
     }
 }
@@ -308,6 +321,24 @@ mod tests {
     #[test]
     fn range_round_trip_through_yaml() {
         let r = SemVerRange::from_str("^1.2.3").unwrap();
+        let s = serde_yaml::to_string(&r).unwrap();
+        let back: SemVerRange = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn range_any_matches_every_version() {
+        let r = SemVerRange::from_str("*").unwrap();
+        assert_eq!(r, SemVerRange::Any);
+        assert!(r.matches(SemVer::new(0, 0, 0)));
+        assert!(r.matches(SemVer::new(1, 2, 3)));
+        assert!(r.matches(SemVer::new(u32::MAX, u32::MAX, u32::MAX)));
+        assert_eq!(r.to_string(), "*");
+    }
+
+    #[test]
+    fn range_any_round_trips_through_yaml() {
+        let r = SemVerRange::Any;
         let s = serde_yaml::to_string(&r).unwrap();
         let back: SemVerRange = serde_yaml::from_str(&s).unwrap();
         assert_eq!(r, back);

--- a/libs/streamlib-macros/src/lib.rs
+++ b/libs/streamlib-macros/src/lib.rs
@@ -33,6 +33,11 @@ use streamlib_processor_schema::{
     Org, Package, PackageMetadata, PortSchemaSpec, ProcessorSchema, ProjectConfigMinimal,
     SchemaIdent, SemVer, TypeName,
 };
+
+// Range parsing for `module_ident!*` macros. The streamlib_idents crate
+// owns the SemVerRange grammar; the macro just forwards the input through
+// it at expansion time so invalid ranges surface as compile errors.
+use streamlib_idents::SemVerRange;
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input, DeriveInput, ItemStruct, LitStr, Token,
@@ -573,6 +578,255 @@ fn expand_schema_ident(args: &SchemaIdentArgs) -> syn::Result<proc_macro2::Token
             ::streamlib::sdk::descriptors::Package::new(#package_str).expect("validated by macro"),
             ::streamlib::sdk::descriptors::TypeName::new(#type_str).expect("validated by macro"),
             ::streamlib::sdk::descriptors::SemVer::new(#major, #minor, #patch),
+        )
+    })
+}
+
+// =============================================================================
+// module_ident! / module_ident_any_version! / module_ident_joined! /
+// module_ident_joined_any_version! — imperative-API ModuleIdent builders.
+// =============================================================================
+//
+// Four macros, one identifier shape:
+//
+// - `module_ident!("org", "name", "^1.0.0")` — split args, with version.
+// - `module_ident_any_version!("org", "name")` — split args, any version (`*`).
+// - `module_ident_joined!("@org/name", "^1.0.0")` — joined org/name, with version.
+// - `module_ident_joined_any_version!("@org/name")` — joined org/name, any version.
+//
+// Each macro validates inputs at expansion time (invalid org / name /
+// semver range becomes a `compile_error!`) and expands to a
+// `streamlib::sdk::descriptors::ModuleIdent::new(...)` expression.
+
+/// `module_ident!("org", "name", "^1.0.0")` — split args, version required.
+///
+/// Validates org / name / semver range at compile time; expands to a
+/// `ModuleIdent::new(...)` expression. Use [`module_ident_any_version!`]
+/// when the version isn't pinned, [`module_ident_joined!`] when the
+/// `@org/name` is already a single string.
+#[proc_macro]
+pub fn module_ident(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as ModuleIdentArgs);
+    match expand_module_ident_split(&args.org, &args.name, Some(&args.version)) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// `module_ident_any_version!("org", "name")` — split args, any version.
+///
+/// Equivalent to `module_ident!("org", "name", "*")`. Use when the
+/// caller doesn't pin a version range — the runtime resolver picks the
+/// highest installed `SemVer` matching `(@org/name)`.
+#[proc_macro]
+pub fn module_ident_any_version(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as ModuleIdentAnyArgs);
+    match expand_module_ident_split(&args.org, &args.name, None) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// `module_ident_joined!("@org/name", "^1.0.0")` — joined org/name, version required.
+///
+/// The `@org/name` literal is parsed into typed [`Org`] / [`Package`]
+/// segments at compile time; version is validated as a [`SemVerRange`].
+/// Use [`module_ident_joined_any_version!`] when the version isn't
+/// pinned, [`module_ident!`] when the org and name are already separate
+/// string literals.
+#[proc_macro]
+pub fn module_ident_joined(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as ModuleIdentJoinedArgs);
+    match expand_module_ident_joined(&args.joined, Some(&args.version)) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// `module_ident_joined_any_version!("@org/name")` — joined org/name, any version.
+///
+/// Equivalent to `module_ident_joined!("@org/name", "*")`.
+#[proc_macro]
+pub fn module_ident_joined_any_version(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as ModuleIdentJoinedAnyArgs);
+    match expand_module_ident_joined(&args.joined, None) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+struct ModuleIdentArgs {
+    org: LitStr,
+    name: LitStr,
+    version: LitStr,
+}
+
+impl Parse for ModuleIdentArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let org: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let name: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let version: LitStr = input.parse()?;
+        let _ = input.parse::<Token![,]>();
+        Ok(Self { org, name, version })
+    }
+}
+
+struct ModuleIdentAnyArgs {
+    org: LitStr,
+    name: LitStr,
+}
+
+impl Parse for ModuleIdentAnyArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let org: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let name: LitStr = input.parse()?;
+        let _ = input.parse::<Token![,]>();
+        Ok(Self { org, name })
+    }
+}
+
+struct ModuleIdentJoinedArgs {
+    joined: LitStr,
+    version: LitStr,
+}
+
+impl Parse for ModuleIdentJoinedArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let joined: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let version: LitStr = input.parse()?;
+        let _ = input.parse::<Token![,]>();
+        Ok(Self { joined, version })
+    }
+}
+
+struct ModuleIdentJoinedAnyArgs {
+    joined: LitStr,
+}
+
+impl Parse for ModuleIdentJoinedAnyArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let joined: LitStr = input.parse()?;
+        let _ = input.parse::<Token![,]>();
+        Ok(Self { joined })
+    }
+}
+
+/// Expand the split-args variants. `version` is `None` for any-version
+/// (`*`); `Some` for pinned. Each segment is validated at expansion time.
+fn expand_module_ident_split(
+    org: &LitStr,
+    name: &LitStr,
+    version: Option<&LitStr>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let org_str = org.value();
+    let name_str = name.value();
+
+    Org::new(&org_str).map_err(|e| {
+        syn::Error::new(
+            org.span(),
+            format!("invalid org `{}`: {}", org_str, e),
+        )
+    })?;
+    Package::new(&name_str).map_err(|e| {
+        syn::Error::new(
+            name.span(),
+            format!("invalid package `{}`: {}", name_str, e),
+        )
+    })?;
+
+    emit_module_ident(&org_str, &name_str, version)
+}
+
+/// Expand the joined-args variants. The `@org/name` literal is split at
+/// the first `/`; `@` prefix is required. `version` is `None` for
+/// any-version (`*`); `Some` for pinned.
+fn expand_module_ident_joined(
+    joined: &LitStr,
+    version: Option<&LitStr>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let raw = joined.value();
+    let stripped = raw.strip_prefix('@').ok_or_else(|| {
+        syn::Error::new(
+            joined.span(),
+            format!(
+                "invalid joined module ref `{}`: must start with '@' (e.g. `\"@org/name\"`)",
+                raw
+            ),
+        )
+    })?;
+    let (org_str, name_str) = stripped.split_once('/').ok_or_else(|| {
+        syn::Error::new(
+            joined.span(),
+            format!(
+                "invalid joined module ref `{}`: must contain '/' between org and name \
+                 (e.g. `\"@org/name\"`)",
+                raw
+            ),
+        )
+    })?;
+    if name_str.contains('@') || name_str.contains('/') {
+        return Err(syn::Error::new(
+            joined.span(),
+            format!(
+                "invalid joined module ref `{}`: name segment must not contain '@' or '/' \
+                 (the version goes in the second arg, e.g. `module_ident_joined!(\"@org/name\", \"^1.0.0\")`)",
+                raw
+            ),
+        ));
+    }
+
+    Org::new(org_str).map_err(|e| {
+        syn::Error::new(
+            joined.span(),
+            format!("invalid org `{}` in `{}`: {}", org_str, raw, e),
+        )
+    })?;
+    Package::new(name_str).map_err(|e| {
+        syn::Error::new(
+            joined.span(),
+            format!("invalid package `{}` in `{}`: {}", name_str, raw, e),
+        )
+    })?;
+
+    emit_module_ident(org_str, name_str, version)
+}
+
+/// Validate the version range (if any) and emit the
+/// `ModuleIdent::new(...)` expression. The runtime types
+/// (`Org` / `Package` / `SemVerRange` / `ModuleIdent`) are re-validated
+/// at runtime via the canonical `*::new` / `from_str` constructors —
+/// the macro just guarantees they'll succeed.
+fn emit_module_ident(
+    org_str: &str,
+    name_str: &str,
+    version: Option<&LitStr>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let version_expr = match version {
+        Some(lit) => {
+            let v_str = lit.value();
+            SemVerRange::from_str(&v_str).map_err(|e| {
+                syn::Error::new(
+                    lit.span(),
+                    format!("invalid semver range `{}`: {}", v_str, e),
+                )
+            })?;
+            quote! {
+                ::streamlib::sdk::descriptors::SemVerRange::from_str(#v_str)
+                    .expect("validated by macro")
+            }
+        }
+        None => quote! { ::streamlib::sdk::descriptors::SemVerRange::Any },
+    };
+
+    Ok(quote! {
+        ::streamlib::sdk::descriptors::ModuleIdent::new(
+            ::streamlib::sdk::descriptors::Org::new(#org_str).expect("validated by macro"),
+            ::streamlib::sdk::descriptors::Package::new(#name_str).expect("validated by macro"),
+            #version_expr,
         )
     })
 }

--- a/libs/streamlib-processor-schema/src/lib.rs
+++ b/libs/streamlib-processor-schema/src/lib.rs
@@ -30,7 +30,8 @@ pub use processor_schema_parser::{parse_processor_yaml, parse_processor_yaml_fil
 // loaders) reach `SchemaIdent`, `Org`, `Package`, etc. through this crate
 // without depending on `streamlib-idents` directly.
 pub use streamlib_idents::{
-    Org, Package, PackageMetadata, PackageRef, SchemaIdent, SemVer, TypeName,
+    ModuleIdent, Org, Package, PackageMetadata, PackageRef, SchemaIdent, SemVer, SemVerRange,
+    TypeName,
 };
 
 /// Minimal project config for the macro: surfaces the `package:` block (so

--- a/libs/streamlib-sdk/src/lib.rs
+++ b/libs/streamlib-sdk/src/lib.rs
@@ -163,6 +163,29 @@ pub mod sdk {
     /// [`schema_ident_any_version!`].
     pub use streamlib_engine::schema_ident;
 
+    /// `streamlib::sdk::module_ident!("org", "name", "^1.0.0")` —
+    /// imperative-API module identifier with a pinned semver range.
+    /// Validates org / name / semver range at compile time; expands to
+    /// a [`ModuleIdent::new`](descriptors::ModuleIdent::new)
+    /// expression. Pair with [`crate::sdk::runtime::Runner::add_module`].
+    pub use streamlib_engine::module_ident;
+
+    /// `streamlib::sdk::module_ident_any_version!("org", "name")` —
+    /// any-installed-version variant of [`module_ident!`]. Equivalent
+    /// to `module_ident!("org", "name", "*")`.
+    pub use streamlib_engine::module_ident_any_version;
+
+    /// `streamlib::sdk::module_ident_joined!("@org/name", "^1.0.0")` —
+    /// joined-org/name variant of [`module_ident!`]. Same identifier;
+    /// different call-site ergonomics for callers that already have
+    /// the canonical `"@org/name"` string in hand.
+    pub use streamlib_engine::module_ident_joined;
+
+    /// `streamlib::sdk::module_ident_joined_any_version!("@org/name")` —
+    /// joined-org/name + any-version variant. Equivalent to
+    /// `module_ident_joined!("@org/name", "*")`.
+    pub use streamlib_engine::module_ident_joined_any_version;
+
     // ---- Permission helpers ----
 
     pub mod permissions {


### PR DESCRIPTION
## Summary

Closes #878. Adds the imperative module-loading API that complements the yaml-driven `Runner::load_project` / `Runner::load_package`: REST endpoints, hot-reload tools, test setup, and composition-library wrappers can now load `streamlib.yaml`-packaged modules by typed identifier without writing a yaml first.

- **`streamlib_idents::ModuleIdent`** (`org`, `name`, `version: SemVerRange`) lives next to `SchemaIdent`. Wire form `@org/name@<range>`. Adds `SemVerRange::Any` (`*`) for unpinned ranges.
- **Four `module_ident!*` proc-macros** covering each ergonomic call shape — self-documenting names so AI agents read the suffix and know both call shape AND version mode:
  - `module_ident!("org","name","^1.0.0")` — split, with version
  - `module_ident_any_version!("org","name")` — split, any version
  - `module_ident_joined!("@org/name","^1.0.0")` — joined org/name, with version
  - `module_ident_joined_any_version!("@org/name")` — joined org/name, any version
- **`Runner::add_module(ModuleIdent)`** resolves against the workspace stage dir (`target/streamlib-plugins/<org>__<name>/`) or installed-package cache, verifies the on-disk `SemVer` satisfies the ident's range, then drives the same internal machinery `load_project` uses for transitive deps. Typed `AddModuleError` surfaces `ModuleNotFound`, `ManifestLoadFailed`, `ManifestIdentityMismatch`, `VersionRangeUnsatisfied`, `InstalledCacheLoadFailed`, `WorkspaceRootInvalid`, and `LoadProjectFailed`.
- **`Runner::remove_module(ModuleIdent)`** is intentionally a typed stub returning `RemoveModuleError::HotReloadLifecycleNotYetImplemented`. Milestone-20 explicitly defers `unload_package / hot-reload lifecycle`, but the method exists as a boundary marker (per discussion in the goal) so AI agents reaching for the counterpart to `add_module` get a typed error pointing at the gap rather than a `method not found` diagnostic. Not a no-op or silently-failing stub — every call returns `Err` without altering runtime state.
- **`examples/api-server`** migrated off `load_workspace_packages(["@tatolab/api-server"])` to `runtime.add_module(module_ident!("tatolab","api-server","^1.0.0"))`. Four colocated `#[cfg(test)]` exercises cover each macro call shape through the SDK paths.

## Out of scope

- **`unload_module` / hot-reload lifecycle** — explicitly deferred by milestone-20. `remove_module` ships as a typed deferral marker only. Hot-reload's real work (per-module processor enumeration, safe `Library` drop ordering, captured-fn-pointer invalidation) lives in a future milestone.

## Design notes that surfaced during the planning loop

- **Semver type**: reused the existing `streamlib_idents::SemVerRange` (which already powers `RegistryDependency.version` in `streamlib.yaml`) rather than adding the `semver` crate as a new workspace dep. #878's body claimed `semver` was transitively present — verified at pickup and that wasn't true. Added `SemVerRange::Any` for the `*` wildcard.
- **Macro count**: four macros rather than one overloaded macro, per discussion. Self-documenting suffixes (`_any_version`, `_joined`) so agents and humans both read the name and know exactly what call shape it expects, with zero arg-counting ambiguity.
- **`load_project` refactor**: #878 listed "reimplement `load_project` internally as a thin wrapper that drives `add_module` for each declared dep" as an exit criterion. The recursive walk inside `load_project` already calls `resolve_dependency_path` + re-enters itself, so the underlying mechanism is shared — the imperative `add_module` lives next to that recursion rather than replacing the recursion's call site. Functionally equivalent; smaller diff that doesn't touch the dependency-walking hot path. Worth noting if a future refactor wants to literally collapse the recursion through `add_module`.

## Test plan

- [x] `cargo test -p streamlib-idents --lib` — 77 passed (added round-trip + `Any` variant tests for `SemVerRange` and `ModuleIdent`)
- [x] `cargo test -p streamlib-engine --lib add_module_tests` — 7 passed (workspace-stage resolve, any-version, range mismatch, identity mismatch, module-not-found, workspace-root-typo, remove-module deferral)
- [x] `cargo test -p api-server` — 4 passed (one per macro shape)
- [x] Workspace baseline `cargo test --workspace --exclude api-server-demo --exclude camera-deno-subprocess --exclude camera-python-subprocess --exclude camera-rust-plugin --exclude webrtc-cloudflare-stream` — green except for a pre-existing environmental skip (`polyglot_manual_source_python` / `_deno` fail because `cargo xtask build-plugins` hasn't been run on this machine; fails identically on `main` as confirmed via `git stash` + re-run)
- [x] Mental-revert check on happy-path tests: short-circuiting `self.load_project(&source_path)` to `Ok(())` was verified to fail the schema-registry post-condition in both `add_module_resolves_workspace_stage_and_loads` and `add_module_any_version_succeeds_against_staged_v1` (not just the resolver path)
- [x] `pr-review-gate` ran twice; the round-2 verdict caught a panic-safety regression in the new typo test (manual env restore vs. RAII guard), addressed in commit `fdb55144`

🤖 Generated with [Claude Code](https://claude.com/claude-code)