### PR TITLE
refactor(consumer-rhi): #[repr(...)] discipline + layout regression tests (closes #1039)

### DIFF
--- a/.github/workflows/check-consumer-rhi-repr.yml
+++ b/.github/workflows/check-consumer-rhi-repr.yml
@@ -1,0 +1,62 @@
+name: Check consumer-rhi #[repr(...)] discipline
+
+# CI gate for issue #1039's consumer-rhi POD layout-pin rule.
+# `cargo xtask check-consumer-rhi-repr` walks every `.rs` file under
+# `libs/streamlib-consumer-rhi/src/` and fails if:
+#
+#   - Any `pub enum` (unit-variant only — POD discriminant shape) is
+#     missing an explicit `#[repr(...)]`. Bare-enum repr is not stable
+#     across rustc versions; adapter vtables read these discriminants
+#     as bare scalars across the plugin FFI boundary.
+#
+#   - Any `pub struct X(T)` scalar tuple newtype is missing
+#     `#[repr(transparent)]` or `#[repr(C)]`. The newtype must be
+#     byte-equivalent to its inner scalar so adapter vtables can pass
+#     the raw value and the receiver reconstitutes via `X(raw)`.
+#
+# Multi-field Rust-internal wrapper structs (Arc / Vec / Mutex / etc.)
+# and error-style enums with String / structured payloads are
+# intentionally NOT flagged — they don't cross the FFI boundary by
+# value.
+#
+# See docs/architecture/subprocess-rhi-parity.md for the carve-out
+# shape this gate protects.
+#
+# Grep-shaped on purpose: builds only `xtask`, sub-second on a clean
+# runner.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-consumer-rhi-repr:
+    name: xtask check-consumer-rhi-repr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-consumer-rhi-repr
+        run: cargo xtask check-consumer-rhi-repr
+
+      - name: cargo test -p xtask check_consumer_rhi_repr (fixture tests)
+        run: cargo test -p xtask check_consumer_rhi_repr

--- a/libs/streamlib-consumer-rhi/src/device_capability.rs
+++ b/libs/streamlib-consumer-rhi/src/device_capability.rs
@@ -348,3 +348,26 @@ pub trait VulkanRhiDevice: Send + Sync {
         target: vk::ImageLayout,
     ) -> Result<()>;
 }
+
+#[cfg(test)]
+mod layout_tests {
+    //! Layout regression tests for the privilege markers.
+    //!
+    //! [`ConsumerMarker`] is a zero-sized typestate token used in
+    //! `Arc<P::TimelineSemaphore>` / `Arc<P::Texture>` /
+    //! `Arc<P::Buffer>` parameterizations across adapter code. The
+    //! marker never crosses the FFI boundary by value — it's a
+    //! compile-time-only privilege witness — but locking its ZST
+    //! property catches a future field accidentally being added to
+    //! the marker (which would silently change the size of every
+    //! `D: VulkanRhiDevice<Privilege = ConsumerMarker>` adapter
+    //! that holds it).
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn consumer_marker_is_zst() {
+        assert_eq!(size_of::<ConsumerMarker>(), 0);
+        assert_eq!(align_of::<ConsumerMarker>(), 1);
+    }
+}

--- a/libs/streamlib-consumer-rhi/src/formats.rs
+++ b/libs/streamlib-consumer-rhi/src/formats.rs
@@ -46,7 +46,16 @@ impl TextureFormat {
 }
 
 /// Texture usage flags.
+///
+/// `#[repr(transparent)]` so the newtype is byte-equivalent to its
+/// inner `u32` across the plugin FFI boundary — adapter vtables
+/// frequently carry `usage_bits: u32` arguments that get reconstituted
+/// via [`Self::from_bits_truncate`] on the receiving side. Pinning the
+/// repr means a cdylib compiled with a different rustc/dep-graph than
+/// the host still reads / writes the bit pattern at the same byte
+/// offset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct TextureUsages(u32);
 
 impl TextureUsages {
@@ -92,5 +101,68 @@ impl std::ops::BitOr for TextureUsages {
 impl std::ops::BitOrAssign for TextureUsages {
     fn bitor_assign(&mut self, rhs: Self) {
         self.0 |= rhs.0;
+    }
+}
+
+#[cfg(test)]
+mod layout_tests {
+    //! Layout regression tests for the FFI-crossing format primitives.
+    //!
+    //! Mirrors the pattern in `streamlib-plugin-abi`'s `layout_tests`
+    //! module: every byte offset, size, and alignment is asserted so a
+    //! silent rustc / dep-graph drift fails CI loudly. The discriminant
+    //! values for [`TextureFormat`] are part of the wire contract —
+    //! adapter vtables in `streamlib-adapter-*` pass them as bare
+    //! `u32` ([`crate::TextureFormat`] then reconstitutes via an `as`
+    //! cast). Changing a discriminant silently re-maps existing
+    //! cdylibs' format payloads onto the wrong host-side variant; the
+    //! discriminant pins below are the regression lock for that.
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn texture_format_layout() {
+        assert_eq!(size_of::<TextureFormat>(), 4);
+        assert_eq!(align_of::<TextureFormat>(), 4);
+    }
+
+    #[test]
+    fn texture_format_discriminants_are_pinned() {
+        // Every variant's discriminant value IS the wire contract.
+        assert_eq!(TextureFormat::Rgba8Unorm as u32, 0);
+        assert_eq!(TextureFormat::Rgba8UnormSrgb as u32, 1);
+        assert_eq!(TextureFormat::Bgra8Unorm as u32, 2);
+        assert_eq!(TextureFormat::Bgra8UnormSrgb as u32, 3);
+        assert_eq!(TextureFormat::Rgba16Float as u32, 4);
+        assert_eq!(TextureFormat::Rgba32Float as u32, 5);
+        assert_eq!(TextureFormat::Nv12 as u32, 6);
+    }
+
+    #[test]
+    fn texture_usages_layout() {
+        // `#[repr(transparent)]` over `u32` — byte-equivalent to its
+        // single inner field so adapter vtables can pass a bare
+        // `u32` and the receiver can `TextureUsages::from_bits_truncate`
+        // it back without copying.
+        assert_eq!(size_of::<TextureUsages>(), size_of::<u32>());
+        assert_eq!(align_of::<TextureUsages>(), align_of::<u32>());
+    }
+
+    #[test]
+    fn texture_usages_bit_pattern_is_pinned() {
+        // The bit pattern IS the wire contract.
+        assert_eq!(TextureUsages::NONE.bits(), 0);
+        assert_eq!(TextureUsages::COPY_SRC.bits(), 1 << 0);
+        assert_eq!(TextureUsages::COPY_DST.bits(), 1 << 1);
+        assert_eq!(TextureUsages::TEXTURE_BINDING.bits(), 1 << 2);
+        assert_eq!(TextureUsages::STORAGE_BINDING.bits(), 1 << 3);
+        assert_eq!(TextureUsages::RENDER_ATTACHMENT.bits(), 1 << 4);
+    }
+
+    #[test]
+    fn texture_usages_from_bits_truncate_drops_unknown_bits() {
+        let known = TextureUsages::COPY_SRC | TextureUsages::COPY_DST;
+        let with_unknown = TextureUsages::from_bits_truncate(known.bits() | 0xFFFF_0000);
+        assert_eq!(with_unknown, known);
     }
 }

--- a/libs/streamlib-consumer-rhi/src/formats.rs
+++ b/libs/streamlib-consumer-rhi/src/formats.rs
@@ -143,7 +143,13 @@ mod layout_tests {
         // `#[repr(transparent)]` over `u32` — byte-equivalent to its
         // single inner field so adapter vtables can pass a bare
         // `u32` and the receiver can `TextureUsages::from_bits_truncate`
-        // it back without copying.
+        // it back without copying. Size + align alone would also hold
+        // under Rust's default single-field tuple layout, so these
+        // asserts mostly lock against a future "second field added"
+        // drift; the missing-`#[repr(transparent)]` regression itself
+        // is caught at the workspace level by `cargo xtask
+        // check-consumer-rhi-repr`. The bit-pattern test below is the
+        // load-bearing wire-contract lock.
         assert_eq!(size_of::<TextureUsages>(), size_of::<u32>());
         assert_eq!(align_of::<TextureUsages>(), align_of::<u32>());
     }

--- a/libs/streamlib-consumer-rhi/src/pixel_format.rs
+++ b/libs/streamlib-consumer-rhi/src/pixel_format.rs
@@ -142,3 +142,49 @@ impl PixelFormat {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod layout_tests {
+    //! Layout regression tests for the FFI-crossing pixel-format
+    //! primitive.
+    //!
+    //! `#[repr(u32)]` so the enum is byte-equivalent to a bare `u32`
+    //! across the plugin FFI boundary — adapter vtables in
+    //! `streamlib-adapter-cpu-readback` (and elsewhere) carry
+    //! `format_raw: u32` arguments that round-trip through
+    //! [`PixelFormat`] via an `as` cast. Discriminant values are
+    //! CVPixelFormatType FourCC constants — pinning them locks
+    //! against silent re-numbering.
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn pixel_format_layout() {
+        assert_eq!(size_of::<PixelFormat>(), 4);
+        assert_eq!(align_of::<PixelFormat>(), 4);
+    }
+
+    #[test]
+    fn pixel_format_discriminants_are_pinned() {
+        // CVPixelFormatType FourCC constants. Locked: a silent change
+        // in any of these silently re-maps cdylibs' format payloads
+        // onto the wrong host-side variant.
+        assert_eq!(PixelFormat::Bgra32 as u32, 0x42475241);
+        assert_eq!(PixelFormat::Rgba32 as u32, 0x52474241);
+        assert_eq!(PixelFormat::Argb32 as u32, 0x00000020);
+        assert_eq!(PixelFormat::Rgba64 as u32, 0x52476841);
+        assert_eq!(PixelFormat::Nv12VideoRange as u32, 0x34323076);
+        assert_eq!(PixelFormat::Nv12FullRange as u32, 0x34323066);
+        assert_eq!(PixelFormat::Uyvy422 as u32, 0x32767579);
+        assert_eq!(PixelFormat::Yuyv422 as u32, 0x79757673);
+        assert_eq!(PixelFormat::Gray8 as u32, 0x4C303038);
+        assert_eq!(PixelFormat::Unknown as u32, 0x00000000);
+    }
+
+    #[test]
+    fn pixel_format_default_is_bgra32() {
+        // The `Default` impl IS part of the wire contract for FFI
+        // payloads that default-initialize a buffer of `PixelFormat`.
+        assert_eq!(PixelFormat::default() as u32, PixelFormat::Bgra32 as u32);
+    }
+}

--- a/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
+++ b/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
@@ -16,7 +16,17 @@ use vulkanalia::vk;
 /// scenario binaries can construct registrations using
 /// [`VulkanLayout::UNDEFINED`] / [`VulkanLayout::GENERAL`] / etc.
 /// without depending on `vulkanalia`.
+///
+/// `#[repr(transparent)]` so the newtype is byte-equivalent to its
+/// inner `i32` across the plugin FFI boundary — adapter vtables (see
+/// `streamlib-adapter-{vulkan,cuda,cpu-readback}`) carry
+/// `initial_layout_raw: i32` / `post_release_layout_raw: i32` fields
+/// that get reconstituted as `VulkanLayout(raw)` on the receiving
+/// side. Pinning the repr means a cdylib compiled with a different
+/// rustc / dep-graph than the host still observes the same byte
+/// layout for any cross-DSO traffic.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[repr(transparent)]
 pub struct VulkanLayout(pub i32);
 
 impl VulkanLayout {
@@ -36,5 +46,54 @@ impl VulkanLayout {
     /// because they don't depend on `vulkanalia`.
     pub fn as_vk(self) -> vk::ImageLayout {
         vk::ImageLayout::from_raw(self.0)
+    }
+}
+
+#[cfg(test)]
+mod layout_tests {
+    //! Layout regression tests for the FFI-crossing layout primitive.
+    //!
+    //! `#[repr(transparent)]` over the `i32` `VkImageLayout` value, so
+    //! the newtype is byte-equivalent to its inner field — adapter
+    //! vtables in `streamlib-adapter-{vulkan,cuda,cpu-readback}` carry
+    //! `initial_layout_raw: i32` / `post_release_layout_raw: i32`
+    //! arguments that get reconstituted as `VulkanLayout(raw)` on the
+    //! receiving side. The known-constant values below pin the
+    //! Vulkan-spec discriminants the carve-out relies on; a silent
+    //! drift in vulkanalia's `vk::ImageLayout::*.as_raw()` mapping
+    //! would fail loudly here.
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn vulkan_layout_layout() {
+        assert_eq!(size_of::<VulkanLayout>(), size_of::<i32>());
+        assert_eq!(align_of::<VulkanLayout>(), align_of::<i32>());
+    }
+
+    #[test]
+    fn vulkan_layout_constants_match_vk_spec() {
+        // Vulkan spec — `VK_IMAGE_LAYOUT_*` enumerants. Locked so a
+        // vulkanalia upgrade can't silently re-number them.
+        assert_eq!(VulkanLayout::UNDEFINED.0, 0);
+        assert_eq!(VulkanLayout::GENERAL.0, 1);
+        assert_eq!(VulkanLayout::COLOR_ATTACHMENT_OPTIMAL.0, 2);
+        assert_eq!(VulkanLayout::SHADER_READ_ONLY_OPTIMAL.0, 5);
+        assert_eq!(VulkanLayout::TRANSFER_SRC_OPTIMAL.0, 6);
+        assert_eq!(VulkanLayout::TRANSFER_DST_OPTIMAL.0, 7);
+    }
+
+    #[test]
+    fn vulkan_layout_round_trips_through_vk() {
+        for layout in [
+            VulkanLayout::UNDEFINED,
+            VulkanLayout::GENERAL,
+            VulkanLayout::COLOR_ATTACHMENT_OPTIMAL,
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL,
+            VulkanLayout::TRANSFER_SRC_OPTIMAL,
+            VulkanLayout::TRANSFER_DST_OPTIMAL,
+        ] {
+            assert_eq!(VulkanLayout(layout.as_vk().as_raw()), layout);
+        }
     }
 }

--- a/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
+++ b/libs/streamlib-consumer-rhi/src/vulkan_layout.rs
@@ -67,6 +67,13 @@ mod layout_tests {
 
     #[test]
     fn vulkan_layout_layout() {
+        // Size + align alone would also hold under Rust's default
+        // single-field tuple layout, so these asserts mostly lock
+        // against a future "second field added" drift; the
+        // missing-`#[repr(transparent)]` regression itself is caught
+        // at the workspace level by `cargo xtask
+        // check-consumer-rhi-repr`. The constants + round-trip tests
+        // below are the load-bearing wire-contract locks.
         assert_eq!(size_of::<VulkanLayout>(), size_of::<i32>());
         assert_eq!(align_of::<VulkanLayout>(), align_of::<i32>());
     }

--- a/libs/streamlib-cross-rustc-fixture/src/lib.rs
+++ b/libs/streamlib-cross-rustc-fixture/src/lib.rs
@@ -67,7 +67,7 @@ use streamlib::sdk::rhi::{
     GraphicsShaderStageFlags, GraphicsStage, MultisampleState, NativeTextureHandle, PixelFormat,
     PrimitiveTopology, RasterizationState, RayTracingBindingSpec, RayTracingKernelDescriptor,
     RayTracingPushConstants, RayTracingShaderGroup, RayTracingShaderStageFlags, RayTracingStage,
-    TextureFormat, TextureUsages, VertexInputState,
+    TextureFormat, TextureUsages, VertexInputState, VulkanLayout,
 };
 
 #[cfg(target_os = "linux")]
@@ -381,6 +381,85 @@ fn run_beta_shape_round_trip(ctx: &RuntimeContextFullAccess<'_>) -> Result<Strin
         } else {
             summary.push_str("VulkanAccelerationStructure:SKIPPED_NO_RT_SUPPORT\n");
             summary.push_str("VulkanRayTracingKernel:SKIPPED_NO_RT_SUPPORT\n");
+        }
+
+        // -------- streamlib-consumer-rhi POD round-trip (#1039) --------
+        //
+        // The POD types in consumer-rhi (TextureFormat / TextureUsages /
+        // PixelFormat / VulkanLayout) cross the plugin FFI boundary as
+        // bare scalars: adapter and FullAccess vtables carry `u32` /
+        // `i32` payloads that get reconstituted on the receiving side
+        // via the type's `as`/`from_bits_truncate`/`VulkanLayout(raw)`
+        // round-trip. The consumer-rhi crate locks each type's
+        // discriminants / bit pattern at the data-structure level via
+        // `#[cfg(test)] mod layout_tests` (#1039); this block is the
+        // cross-rustc analogue — it constructs each POD instance
+        // *inside the divergently-compiled fixture* and asserts the
+        // discriminant matches the expected scalar. If a future drift
+        // in consumer-rhi changed the byte representation under the
+        // fixture's compilation but not the host's (or vice versa),
+        // the discriminant comparison fires here before any host code
+        // sees a mis-mapped enumerant.
+        //
+        // Run unconditionally (POD only — no GPU dependency, no
+        // platform gating).
+        let mut consumer_rhi_ok = true;
+        macro_rules! check {
+            ($cond:expr, $msg:expr) => {
+                if !($cond) {
+                    summary.push_str(&format!("ConsumerRhi:{}:FAIL\n", $msg));
+                    consumer_rhi_ok = false;
+                }
+            };
+        }
+        // TextureFormat: explicit u32 discriminants.
+        check!(TextureFormat::Rgba8Unorm as u32 == 0, "TextureFormat::Rgba8Unorm");
+        check!(TextureFormat::Rgba8UnormSrgb as u32 == 1, "TextureFormat::Rgba8UnormSrgb");
+        check!(TextureFormat::Bgra8Unorm as u32 == 2, "TextureFormat::Bgra8Unorm");
+        check!(TextureFormat::Bgra8UnormSrgb as u32 == 3, "TextureFormat::Bgra8UnormSrgb");
+        check!(TextureFormat::Rgba16Float as u32 == 4, "TextureFormat::Rgba16Float");
+        check!(TextureFormat::Rgba32Float as u32 == 5, "TextureFormat::Rgba32Float");
+        check!(TextureFormat::Nv12 as u32 == 6, "TextureFormat::Nv12");
+        // TextureUsages: bit-pattern + from_bits_truncate round-trip.
+        check!(TextureUsages::NONE.bits() == 0, "TextureUsages::NONE");
+        check!(TextureUsages::COPY_SRC.bits() == 1 << 0, "TextureUsages::COPY_SRC");
+        check!(TextureUsages::COPY_DST.bits() == 1 << 1, "TextureUsages::COPY_DST");
+        check!(TextureUsages::TEXTURE_BINDING.bits() == 1 << 2, "TextureUsages::TEXTURE_BINDING");
+        check!(TextureUsages::STORAGE_BINDING.bits() == 1 << 3, "TextureUsages::STORAGE_BINDING");
+        check!(TextureUsages::RENDER_ATTACHMENT.bits() == 1 << 4, "TextureUsages::RENDER_ATTACHMENT");
+        let usages_combined = TextureUsages::COPY_SRC | TextureUsages::COPY_DST;
+        check!(
+            TextureUsages::from_bits_truncate(usages_combined.bits()) == usages_combined,
+            "TextureUsages::from_bits_truncate round-trip"
+        );
+        // PixelFormat: FourCC discriminants.
+        check!(PixelFormat::Bgra32 as u32 == 0x42475241, "PixelFormat::Bgra32");
+        check!(PixelFormat::Rgba32 as u32 == 0x52474241, "PixelFormat::Rgba32");
+        check!(PixelFormat::Nv12VideoRange as u32 == 0x34323076, "PixelFormat::Nv12VideoRange");
+        check!(PixelFormat::Nv12FullRange as u32 == 0x34323066, "PixelFormat::Nv12FullRange");
+        check!(PixelFormat::Unknown as u32 == 0x00000000, "PixelFormat::Unknown");
+        // VulkanLayout: pinned VkImageLayout enumerants.
+        check!(VulkanLayout::UNDEFINED.0 == 0, "VulkanLayout::UNDEFINED");
+        check!(VulkanLayout::GENERAL.0 == 1, "VulkanLayout::GENERAL");
+        check!(
+            VulkanLayout::COLOR_ATTACHMENT_OPTIMAL.0 == 2,
+            "VulkanLayout::COLOR_ATTACHMENT_OPTIMAL"
+        );
+        check!(
+            VulkanLayout::SHADER_READ_ONLY_OPTIMAL.0 == 5,
+            "VulkanLayout::SHADER_READ_ONLY_OPTIMAL"
+        );
+        check!(
+            VulkanLayout::TRANSFER_SRC_OPTIMAL.0 == 6,
+            "VulkanLayout::TRANSFER_SRC_OPTIMAL"
+        );
+        check!(
+            VulkanLayout::TRANSFER_DST_OPTIMAL.0 == 7,
+            "VulkanLayout::TRANSFER_DST_OPTIMAL"
+        );
+
+        if consumer_rhi_ok {
+            summary.push_str("ConsumerRhiPodRoundTrip:OK\n");
         }
 
         Ok(summary)

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -309,6 +309,23 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
         );
     }
 
+    // Consumer-rhi POD round-trip (#1039): the divergently-compiled
+    // fixture asserts every `streamlib-consumer-rhi` POD type
+    // (TextureFormat / TextureUsages / PixelFormat / VulkanLayout)
+    // produces the same scalar discriminants the host expects.
+    // A failure here means a consumer-rhi POD got re-numbered under
+    // the fixture's compilation but not the host's (or vice versa) —
+    // the exact kind of silent drift `#[repr(...)]` + discriminant
+    // pinning exists to catch.
+    assert!(
+        contents.contains("ConsumerRhiPodRoundTrip:OK"),
+        "missing consumer-rhi POD round-trip line — full body:\n{contents}"
+    );
+    assert!(
+        !contents.contains("ConsumerRhi:") || contents.contains("ConsumerRhiPodRoundTrip:OK"),
+        "consumer-rhi POD round-trip emitted a FAIL line — full body:\n{contents}"
+    );
+
     // `Texture::native_handle` (#957, Phase F) is gated on EGL exposing
     // a render-target-capable DRM modifier
     // (`docs/learnings/nvidia-egl-dmabuf-render-target.md`). Accept

--- a/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
+++ b/libs/streamlib-engine/tests/load_project_dylib_cross_rustc.rs
@@ -316,14 +316,18 @@ fn dlopen_cross_rustc_fixture_round_trips_every_beta_shape() {
     // A failure here means a consumer-rhi POD got re-numbered under
     // the fixture's compilation but not the host's (or vice versa) —
     // the exact kind of silent drift `#[repr(...)]` + discriminant
-    // pinning exists to catch.
+    // pinning exists to catch. The fixture suppresses the OK line
+    // when any per-variant check fails, so the OK assert is
+    // sufficient to gate both shapes of failure (missing line / FAIL
+    // lines accumulated); the full body is included in the panic
+    // message so individual `ConsumerRhi:<name>:FAIL` lines surface
+    // in the failure report.
     assert!(
         contents.contains("ConsumerRhiPodRoundTrip:OK"),
-        "missing consumer-rhi POD round-trip line — full body:\n{contents}"
-    );
-    assert!(
-        !contents.contains("ConsumerRhi:") || contents.contains("ConsumerRhiPodRoundTrip:OK"),
-        "consumer-rhi POD round-trip emitted a FAIL line — full body:\n{contents}"
+        "missing consumer-rhi POD round-trip OK line — either the \
+         sweep never ran, or one or more per-variant checks failed \
+         (look for `ConsumerRhi:<name>:FAIL` lines below). Full \
+         body:\n{contents}"
     );
 
     // `Texture::native_handle` (#957, Phase F) is gated on EGL exposing

--- a/xtask/src/check_consumer_rhi_repr.rs
+++ b/xtask/src/check_consumer_rhi_repr.rs
@@ -1,0 +1,443 @@
+// Copyright (c) 2026 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI gate enforcing the `#[repr(...)]` discipline on POD types in
+//! `streamlib-consumer-rhi`.
+//!
+//! Why this exists: `streamlib-consumer-rhi` is the cross-FFI carve-out
+//! every adapter cdylib (vulkan / opengl / skia / cuda / cpu-readback)
+//! depends on. Adapter vtables pass POD discriminants across the
+//! plugin DSO boundary as bare scalars (`format_raw: u32`,
+//! `usage_bits: u32`, `initial_layout_raw: i32`, …) and reconstitute on
+//! the receiving side via `as`/`from_bits_truncate`/`VulkanLayout(raw)`
+//! round-trips. A `pub enum` without an explicit `#[repr(...)]` has
+//! unstable discriminant width and the receiving side reads the wrong
+//! bytes. A scalar-newtype `pub struct X(T)` without
+//! `#[repr(transparent)]` (or `#[repr(C)]`) has unstable layout
+//! relative to its inner field and the receiving side reads the wrong
+//! offset.
+//!
+//! Scope:
+//!
+//! - **Every `pub enum`** declared in `libs/streamlib-consumer-rhi/src/`
+//!   MUST carry an explicit `#[repr(...)]` attribute. Bare-enum repr is
+//!   NOT stable across rustc versions — explicit discriminant width is
+//!   non-negotiable.
+//! - **Every `pub struct X(T)` tuple newtype** where `T` is a scalar
+//!   (`u8` / `u16` / `u32` / `u64` / `i8` / `i16` / `i32` / `i64` /
+//!   `usize` / `isize`) MUST carry `#[repr(transparent)]` or
+//!   `#[repr(C)]`. This locks the newtype's byte layout to the inner
+//!   scalar so adapter vtables can pass the raw value and the
+//!   receiving side reconstitutes via `X(raw)` cleanly.
+//!
+//! Multi-field structs that genuinely cannot be `#[repr(C)]` (because
+//! they hold `Arc<...>` / `Vec<...>` / `Mutex<...>` / etc. — the
+//! consumer-side wrapper types like `ConsumerVulkanDevice`,
+//! `ConsumerVulkanTexture`, `ConsumerVulkanBuffer`,
+//! `ConsumerVulkanTimelineSemaphore`) are intentionally NOT flagged:
+//! they don't cross the FFI boundary by value — each cdylib statically
+//! links its own copy and uses it through methods, not direct field
+//! access. The Rust-internal struct layout doesn't matter as long as
+//! `Send + Sync` and the method-dispatch surface are honored. See
+//! `docs/architecture/subprocess-rhi-parity.md` for the carve-out
+//! shape.
+//!
+//! Per-file opt-out is via a single-line pragma at top of file:
+//!     // check-consumer-rhi-repr:allow-file
+//! Reserved for unusual cases reviewers approve explicitly.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CRATE_SRC: &str = "libs/streamlib-consumer-rhi/src";
+
+const ALLOW_FILE_PRAGMA: &str = "check-consumer-rhi-repr:allow-file";
+
+/// Scalar field types that trigger the `#[repr(transparent)]` /
+/// `#[repr(C)]` requirement on a `pub struct X(T)` tuple newtype.
+const SCALAR_TYPES: &[&str] = &[
+    "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64", "i128", "isize",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub file: PathBuf,
+    pub kind: ViolationKind,
+    pub name: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ViolationKind {
+    /// `pub enum` without explicit `#[repr(...)]`.
+    EnumMissingRepr,
+    /// `pub struct X(T)` tuple newtype over a scalar without
+    /// `#[repr(transparent)]` or `#[repr(C)]`.
+    ScalarNewtypeMissingRepr,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let crate_src = workspace_root.join(CRATE_SRC);
+    if !crate_src.exists() {
+        anyhow::bail!(
+            "check-consumer-rhi-repr: {} not found — has the crate moved?",
+            crate_src.display()
+        );
+    }
+
+    let violations = scan_dir(&crate_src)?;
+    if violations.is_empty() {
+        println!(
+            "✓ check-consumer-rhi-repr: every `pub enum` carries an explicit \
+             `#[repr(...)]` and every scalar-newtype `pub struct X(T)` carries \
+             `#[repr(transparent)]` / `#[repr(C)]` in `{CRATE_SRC}`."
+        );
+        return Ok(());
+    }
+    eprintln!(
+        "✗ check-consumer-rhi-repr: {} violation(s) — consumer-rhi POD type \
+         without explicit byte-layout pin:",
+        violations.len()
+    );
+    for v in &violations {
+        let what = match v.kind {
+            ViolationKind::EnumMissingRepr => "`pub enum` missing #[repr(...)]",
+            ViolationKind::ScalarNewtypeMissingRepr => {
+                "`pub struct X(T)` scalar newtype missing #[repr(transparent)] or #[repr(C)]"
+            }
+        };
+        eprintln!("  {}: {} → {}", v.file.display(), v.name, what);
+    }
+    eprintln!(
+        "\nFix:\n  \
+         consumer-rhi POD types cross the plugin FFI boundary as bare scalars; \
+         their byte layout is part of the wire contract. Add `#[repr(u32)]` or \
+         `#[repr(i32)]` to enums (matching the Vulkan enumerant they mirror), and \
+         `#[repr(transparent)]` to scalar-newtype `pub struct X(T)` types. See \
+         `docs/architecture/subprocess-rhi-parity.md` and the existing types in \
+         `libs/streamlib-consumer-rhi/src/{{formats,vulkan_layout,pixel_format}}.rs` \
+         for the canonical pattern."
+    );
+    anyhow::bail!("check-consumer-rhi-repr failed");
+}
+
+fn scan_dir(dir: &Path) -> Result<Vec<Violation>> {
+    let mut violations = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            violations.extend(scan_dir(&path)?);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        scan_file(&path, &mut violations)?;
+    }
+    Ok(violations)
+}
+
+fn scan_file(path: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    let body = fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    if body.contains(ALLOW_FILE_PRAGMA) {
+        return Ok(());
+    }
+    let file = match syn::parse_file(&body) {
+        Ok(f) => f,
+        Err(_) => return Ok(()),
+    };
+    for item in file.items {
+        match item {
+            syn::Item::Enum(e) => {
+                if !matches!(e.vis, syn::Visibility::Public(_)) {
+                    continue;
+                }
+                // Only POD-discriminant enums are FFI-crossing. An enum
+                // with any data-bearing variant (`Foo(String)` /
+                // `Bar { x: u32 }`) is a Rust-internal algebraic data
+                // type — error types in particular — and a
+                // `#[repr(u32)]` discriminant doesn't apply to its
+                // shape. Skip them; they don't cross FFI by value.
+                if !all_variants_are_unit(&e.variants) {
+                    continue;
+                }
+                if !has_explicit_repr(&e.attrs) {
+                    violations.push(Violation {
+                        file: path.to_path_buf(),
+                        kind: ViolationKind::EnumMissingRepr,
+                        name: e.ident.to_string(),
+                    });
+                }
+            }
+            syn::Item::Struct(s) => {
+                if !matches!(s.vis, syn::Visibility::Public(_)) {
+                    continue;
+                }
+                if !is_scalar_tuple_newtype(&s.fields) {
+                    continue;
+                }
+                if !has_transparent_or_c_repr(&s.attrs) {
+                    violations.push(Violation {
+                        file: path.to_path_buf(),
+                        kind: ViolationKind::ScalarNewtypeMissingRepr,
+                        name: s.ident.to_string(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// True if `fields` is a single-element tuple struct whose field type
+/// is one of the scalar primitives in [`SCALAR_TYPES`].
+fn is_scalar_tuple_newtype(fields: &syn::Fields) -> bool {
+    let syn::Fields::Unnamed(unnamed) = fields else {
+        return false;
+    };
+    if unnamed.unnamed.len() != 1 {
+        return false;
+    }
+    let field = &unnamed.unnamed[0];
+    let syn::Type::Path(p) = &field.ty else {
+        return false;
+    };
+    let Some(last) = p.path.segments.last() else {
+        return false;
+    };
+    SCALAR_TYPES.contains(&last.ident.to_string().as_str())
+}
+
+fn has_explicit_repr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("repr"))
+}
+
+/// True if every variant of `variants` is a bare unit variant
+/// (`A` or `A = 5` — no `A(T)` and no `A { x: T }`).
+fn all_variants_are_unit(
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+) -> bool {
+    variants.iter().all(|v| matches!(v.fields, syn::Fields::Unit))
+}
+
+fn has_transparent_or_c_repr(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        let Ok(list) = attr.meta.require_list() else {
+            continue;
+        };
+        for tt in list.tokens.clone() {
+            if let proc_macro2::TokenTree::Ident(id) = tt {
+                if id == "transparent" || id == "C" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn passes_on_well_formed_pod_types() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+#[repr(u32)]
+pub enum Format { A = 0, B = 1 }
+
+#[repr(transparent)]
+pub struct Usages(u32);
+
+#[repr(C)]
+pub struct AlsoFine(i32);
+
+// Non-POD wrapper structs are exempt.
+pub struct Wrapper {
+    inner: std::sync::Arc<u8>,
+}
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "got {v:?}");
+    }
+
+    #[test]
+    fn flags_pub_enum_without_repr() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub enum Drift { A, B }
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::EnumMissingRepr);
+        assert_eq!(v[0].name, "Drift");
+    }
+
+    #[test]
+    fn flags_scalar_tuple_newtype_without_repr() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub struct LayoutDrift(i32);
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::ScalarNewtypeMissingRepr);
+        assert_eq!(v[0].name, "LayoutDrift");
+    }
+
+    #[test]
+    fn skips_private_enum_without_repr() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+enum PrivateOk { A, B }
+
+pub(crate) enum CrateLocalOk { A, B }
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "private/crate-local enums are not FFI surface: {v:?}");
+    }
+
+    #[test]
+    fn skips_multi_field_struct() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub struct TwoFields(u32, u32);
+
+pub struct Named {
+    pub a: u32,
+}
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "multi-field structs are out of scope: {v:?}");
+    }
+
+    #[test]
+    fn skips_non_scalar_newtype() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub struct StringWrapper(String);
+
+pub struct ArcWrapper(std::sync::Arc<u8>);
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "non-scalar newtypes are out of scope: {v:?}");
+    }
+
+    #[test]
+    fn skips_file_with_allow_pragma() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+// check-consumer-rhi-repr:allow-file
+pub enum WouldOtherwiseFlag { A, B }
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "allow-file pragma should skip the file: {v:?}");
+    }
+
+    #[test]
+    fn skips_pub_enum_with_data_bearing_variants() {
+        // Error-style enums with `String` / structured payloads are
+        // Rust-internal — they can't be `#[repr(u32)]` and don't cross
+        // FFI by value. The gate must skip them.
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub enum InternalError {
+    Gpu(String),
+    Configuration(String),
+}
+
+pub enum Mixed {
+    Unit,
+    WithData(u32),
+}
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert!(v.is_empty(), "data-bearing enums are out of scope: {v:?}");
+    }
+
+    #[test]
+    fn flags_pub_enum_with_unit_variants_only_and_no_repr() {
+        // Unit-only enums are the FFI-crossing POD discriminant shape;
+        // they MUST carry an explicit `#[repr(...)]`.
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "lib.rs",
+            r#"
+pub enum DiscriminantOnly {
+    A,
+    B = 5,
+    C,
+}
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::EnumMissingRepr);
+        assert_eq!(v[0].name, "DiscriminantOnly");
+    }
+
+    #[test]
+    fn recurses_into_subdirs() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sub/inner.rs",
+            r#"
+pub enum NestedDrift { A, B }
+"#,
+        );
+        let v = scan_dir(tmp.path()).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].name, "NestedDrift");
+    }
+}

--- a/xtask/src/check_consumer_rhi_repr.rs
+++ b/xtask/src/check_consumer_rhi_repr.rs
@@ -42,6 +42,18 @@
 //! `docs/architecture/subprocess-rhi-parity.md` for the carve-out
 //! shape.
 //!
+//! Same rationale exempts enums with one or more data-bearing variants
+//! (`Foo(String)` / `Bar { x: u32 }`). They're Rust-internal algebraic
+//! data types (error enums in particular) and a `#[repr(u32)]`
+//! discriminant doesn't apply to their shape. **Footgun warning**: a
+//! contributor adding a single data variant to an otherwise unit-only
+//! `pub enum` in this crate will silently exempt it from the gate. If
+//! the enum genuinely crosses the FFI boundary, that's a regression
+//! the gate can't catch — keep new FFI-crossing enums unit-only and
+//! pass payloads alongside as separate fields. See
+//! `flags_pub_enum_with_unit_variants_only_and_no_repr` and
+//! `skips_pub_enum_with_data_bearing_variants` for the boundary.
+//!
 //! Per-file opt-out is via a single-line pragma at top of file:
 //!     // check-consumer-rhi-repr:allow-file
 //! Reserved for unusual cases reviewers approve explicitly.
@@ -116,7 +128,11 @@ pub fn run(workspace_root: &Path) -> Result<()> {
          `#[repr(transparent)]` to scalar-newtype `pub struct X(T)` types. See \
          `docs/architecture/subprocess-rhi-parity.md` and the existing types in \
          `libs/streamlib-consumer-rhi/src/{{formats,vulkan_layout,pixel_format}}.rs` \
-         for the canonical pattern."
+         for the canonical pattern.\n  \
+         Note: this gate only inspects unit-only enums and scalar tuple newtypes. \
+         An FFI-crossing `pub enum` that mixes in a data-bearing variant (e.g. \
+         `Foo(String)`) silently slips past — keep FFI-crossing enums unit-only \
+         and pass payloads alongside as separate fields."
     );
     anyhow::bail!("check-consumer-rhi-repr failed");
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,7 @@ use streamlib_jtd_codegen::{generate, GenerateOptions, RuntimeTarget};
 pub mod build_plugins;
 pub mod check_boundaries;
 pub mod check_cdylib_reach;
+pub mod check_consumer_rhi_repr;
 pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
@@ -118,6 +119,16 @@ enum Commands {
     /// documented at `docs/architecture/cdylib-reachability.md`.
     CheckCdylibReach,
 
+    /// CI gate for issue #1039's consumer-rhi `#[repr(...)]` discipline.
+    /// Fails when any `pub enum` in `libs/streamlib-consumer-rhi/src/`
+    /// is missing an explicit `#[repr(...)]`, or when any
+    /// `pub struct X(T)` scalar tuple newtype is missing
+    /// `#[repr(transparent)]` / `#[repr(C)]`. Consumer-rhi POD types
+    /// cross the plugin FFI boundary as bare scalars; their byte
+    /// layout is part of the wire contract. See
+    /// `docs/architecture/subprocess-rhi-parity.md`.
+    CheckConsumerRhiRepr,
+
     /// Regenerate `schemas/streamlib.schema.json` from the Rust
     /// [`StreamlibYaml`](streamlib_processor_schema::StreamlibYaml) source of
     /// truth (#714). Editors with `yaml-language-server` consume this schema
@@ -188,6 +199,9 @@ fn main() -> Result<()> {
         Commands::CheckNoInventorySubmit => check_no_inventory_submit::run(&workspace_root()?)?,
         Commands::CheckProcessorSpecNew => check_processor_spec_new::run(&workspace_root()?)?,
         Commands::CheckCdylibReach => check_cdylib_reach::run(&workspace_root()?)?,
+        Commands::CheckConsumerRhiRepr => {
+            check_consumer_rhi_repr::run(&workspace_root()?)?
+        }
         Commands::EmitManifestSchema => manifest_schema::emit(&workspace_root()?)?,
         Commands::CheckManifestSchema => manifest_schema::check(&workspace_root()?)?,
         Commands::BuildPlugins { release, packages } => {


### PR DESCRIPTION
## Summary

- Pins byte layout of every FFI-crossing POD type in `streamlib-consumer-rhi` so cdylibs compiled with a different rustc / dep-graph than the host read and write the same scalar discriminants across the plugin boundary.
- Adds layout regression tests (size/align + discriminants + round-trips) mirroring `streamlib-plugin-abi`'s pattern.
- Extends the cross-rustc dlopen integration test to construct each POD type inside the divergently-compiled fixture and assert a `ConsumerRhiPodRoundTrip:OK` line.
- Adds `cargo xtask check-consumer-rhi-repr` plus the matching GitHub Actions workflow as a CI gate.

## Scope

**In scope** (POD types that cross FFI as bare scalars):
- `TextureFormat` — already `#[repr(u32)]`; locked with discriminant + size/align tests.
- `TextureUsages(u32)` — added `#[repr(transparent)]`; locked with bit-pattern + `from_bits_truncate` round-trip.
- `PixelFormat` — already `#[repr(u32)]`; locked with CVPixelFormatType FourCC discriminants + `Default` lock.
- `VulkanLayout(i32)` — added `#[repr(transparent)]`; locked with spec enumerant + `as_vk`/`from_raw` round-trip.
- `ConsumerMarker` — locked as ZST (typestate witness).

**Out of scope** (and documented in the PR / gate's docs):
The Arc/Vec/Mutex-bearing wrapper structs (`ConsumerVulkanDevice`, `ConsumerVulkanTexture`, `ConsumerVulkanBuffer`, `ConsumerVulkanTimelineSemaphore`) never cross FFI by value — each cdylib statically links its own copy of `consumer-rhi` and uses it through methods, not direct field access. `#[repr(C)]` is meaningless for them and incompatible with their `Arc<...>` / `Vec<...>` / `Mutex<...>` fields. This interpretation matches the issue body's "every public type **that crosses the FFI boundary**" wording. The CI gate enforces the rule on unit-only `pub enum` and scalar `pub struct X(T)` tuple newtypes; multi-field structs and data-bearing enums (like `ConsumerRhiError`) are intentionally skipped.

## Test plan

- [x] `cargo test -p streamlib-consumer-rhi --lib` (16 tests pass, including 11 new layout regression tests)
- [x] `cargo test -p streamlib-engine --test load_project_dylib_cross_rustc` (cross-rustc fixture round-trips, `ConsumerRhiPodRoundTrip:OK` line present in the divergently-compiled output)
- [x] `cargo test -p xtask check_consumer_rhi_repr` (10 fixture tests covering POD enum / scalar newtype / data-bearing enum / multi-field / private / allow-pragma)
- [x] `cargo run --bin xtask -- check-consumer-rhi-repr` (green on the current workspace)
- [x] Sentinel verification: temporarily removing `#[repr(transparent)]` from `VulkanLayout` trips the gate with a clear actionable message; restoring goes green
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo run --bin xtask -- check-boundaries` + `check-cdylib-reach` + `check-no-inventory-submit` all still green

## pr-review-gate verdict

PASS. Three DISCUSS items addressed in the follow-up commit:
1. Annotated the `texture_usages_layout` / `vulkan_layout_layout` tests to note that the workspace xtask gate is what catches missing-`#[repr]` (size/align asserts are second-field-drift guards; the bit-pattern + constants tests are the load-bearing wire-contract locks).
2. Added a footgun note to the xtask gate's module docs and failure message — keep FFI-crossing enums unit-only because a single data-bearing variant silently exempts the enum from the gate.
3. Dropped a redundant integration-test assert (the fixture suppresses the OK line on any failure, so one assert covers both failure shapes) and beefed the surviving message to mention `ConsumerRhi:<name>:FAIL` lines.

Closes #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)